### PR TITLE
fix(server): TUI AskUserQuestion writes option-index, not label (#4290)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1050,7 +1050,19 @@ export class ClaudeTuiSession extends BaseSession {
         const questions = (payload.tool_input && Array.isArray(payload.tool_input.questions))
           ? payload.tool_input.questions
           : []
-        this._pendingUserAnswer = { toolUseId }
+        // #4290: stash the options array alongside toolUseId so
+        // respondToQuestion() can look up the chosen label's index and
+        // write the numbered TUI shortcut instead of the label text.
+        // claude TUI's prompt single-character-jump-navigates when fed
+        // raw label text (v0.9.3 finding) — the index hits the
+        // shortcut path directly. Pull options off the FIRST question
+        // (claude TUI shows one question at a time; multi-question
+        // AskUserQuestion would need per-prompt sequencing which is
+        // out of scope here).
+        const options = (questions[0] && Array.isArray(questions[0].options))
+          ? questions[0].options
+          : []
+        this._pendingUserAnswer = { toolUseId, options }
         this.emit('user_question', { toolUseId, questions })
       }
       return
@@ -1294,12 +1306,30 @@ export class ClaudeTuiSession extends BaseSession {
   respondToQuestion(text, _answersMap) {
     if (!this._pendingUserAnswer) return
     if (typeof text !== 'string' || text.length === 0) return
+    const { options } = this._pendingUserAnswer
     this._pendingUserAnswer = null
     if (!this._term) return
+    // #4290: if the chosen label matches one of the structured options
+    // exactly, write the 1-indexed TUI shortcut (e.g. "2") instead of
+    // the label text. v0.9.3 wrote the raw label and claude TUI's
+    // prompt parser single-character-jump-navigated through the menu,
+    // landing on "Other" (see #4288 for the empirical trace). Numbered
+    // shortcuts hit claude TUI's hotkey path directly. When no exact
+    // match is found (user picked "Other" in the dashboard and typed
+    // freeform text), fall through to typing the answer literally —
+    // claude TUI's Other-path may still mis-parse that, tracked in
+    // #4288 as a separate concern.
+    let payload = text
+    if (Array.isArray(options) && options.length > 0) {
+      const matchIdx = options.findIndex((o) => o && o.label === text)
+      if (matchIdx >= 0) {
+        payload = String(matchIdx + 1)
+      }
+    }
     // Fire-and-forget — the write is async due to the per-char throttle,
     // but the caller (handleUserQuestionResponse) is sync. Errors here
     // are non-fatal; worst case the user re-sends the answer.
-    this._writePtyTextThrottled(text).catch((err) => {
+    this._writePtyTextThrottled(payload).catch((err) => {
       log.warn(`respondToQuestion PTY write failed: ${err.message}`)
     })
   }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1322,7 +1322,15 @@ export class ClaudeTuiSession extends BaseSession {
     let payload = text
     if (Array.isArray(options) && options.length > 0) {
       const matchIdx = options.findIndex((o) => o && o.label === text)
-      if (matchIdx >= 0) {
+      // #4292: single-digit guard (1..9). Multi-digit hotkeys
+      // (10+) are NOT assumed to work on claude TUI's prompt — most
+      // single-keystroke menus commit on the first digit and the
+      // second char would either be a spurious next-prompt input
+      // or get dropped. Falling through to the label-text path for
+      // 10+ options preserves v0.9.3 behavior (broken in the same
+      // mode-jump way) without silently sending a hotkey we can't
+      // trust. Vanishingly rare in practice.
+      if (matchIdx >= 0 && matchIdx < 9) {
         payload = String(matchIdx + 1)
       }
     }

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1908,6 +1908,43 @@ describe('ClaudeTuiSession', () => {
       assert.equal(charWrites.join(''), text, 'chars reproduce the freeform answer')
     })
 
+    // #4293 (review of #4290): boundary check on the index lookup.
+    // First option → "1"; ninth option → "9" (the last single-digit
+    // index supported per the #4292 guard). Pre-fix an off-by-one in
+    // the index → string conversion would shift every selection.
+    it('respondToQuestion: first option → "1", ninth option → "9" (boundary)', async () => {
+      const options = Array.from({ length: 9 }, (_, i) => ({ label: `opt-${i}` }))
+      session._term = { write: () => {}, kill: () => {} }
+
+      const expectations = [
+        { label: 'opt-0', digit: '1' },
+        { label: 'opt-8', digit: '9' },
+      ]
+      for (const { label, digit } of expectations) {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        session._pendingUserAnswer = { toolUseId: 'toolu-boundary', options }
+        session.respondToQuestion(label)
+        await new Promise((resolve) => setTimeout(resolve, 30))
+        assert.equal(writes[1], digit, `option "${label}" maps to digit "${digit}"`)
+      }
+    })
+
+    it('respondToQuestion falls through to label text when matchIdx >= 9 (multi-digit hotkey guard #4292)', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      const options = Array.from({ length: 12 }, (_, i) => ({ label: `opt-${i}` }))
+      session._pendingUserAnswer = { toolUseId: 'toolu-10', options }
+      // opt-9 is index 9 (would be "10" — multi-digit), so we must NOT
+      // write "10\\r" (most single-keystroke menus commit on the first
+      // digit). Fall through to label-text path.
+      session.respondToQuestion('opt-9')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      // First write is mode-disable; second is the first char of "opt-9".
+      assert.equal(writes[0], '\x1b[?2004l')
+      assert.equal(writes[1], 'o', 'multi-digit hotkey not used; falls through to label text')
+    })
+
     it('respondToQuestion writes the text when options array is missing or empty (free-text-only AskUserQuestion)', async () => {
       const writes = []
       session._term = { write: (data) => { writes.push(data) }, kill: () => {} }

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1840,43 +1840,88 @@ describe('ClaudeTuiSession', () => {
       assert.equal(toolStartEvents[0].tool, 'AskUserQuestion')
     })
 
-    it('tracks _pendingUserAnswer so respondToQuestion knows the pending toolUseId', () => {
+    it('tracks _pendingUserAnswer with toolUseId AND the options array (#4290)', () => {
+      // The options array is needed at respondToQuestion time so we can
+      // look up the chosen label's index and write the numbered shortcut
+      // (e.g. "2\\r") rather than the raw label text. v0.9.3 wrote the
+      // label text and claude TUI's prompt parser mis-resolved it to
+      // "Other" — see #4288.
+      const options = [{ label: 'App runners only (2)' }, { label: 'App + docs (all 3)' }]
       session._emitToolHookEvent('PreToolUse', {
         tool_use_id: 'toolu_aq_2',
         tool_name: 'AskUserQuestion',
-        tool_input: { questions: [{ question: 'Q?', options: [{ label: 'A' }] }] },
+        tool_input: { questions: [{ question: 'Q?', options }] },
       }, 'msg-aq')
       assert.ok(session._pendingUserAnswer, 'pending answer tracked')
       assert.equal(session._pendingUserAnswer.toolUseId, 'toolu_aq_2')
+      assert.deepEqual(session._pendingUserAnswer.options, options, 'options stashed for index lookup')
     })
 
-    it('respondToQuestion writes the answer character-by-character to the PTY then \\r, and clears pending', async () => {
+    // #4290 — the v0.9.3 strategy (write the label text) caused claude
+    // TUI's prompt to single-character-jump-navigate through the menu,
+    // landing on "Other" with empty custom text. New strategy: when the
+    // chosen answer matches an option label exactly, write the 1-indexed
+    // option number — most TUI menus map "1", "2", "3" as direct hotkeys.
+    it('respondToQuestion writes the 1-indexed option number when the answer matches a label (#4290)', async () => {
       const writes = []
-      session._term = {
-        write: (data) => { writes.push(data) },
-        kill: () => {},
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      session._pendingUserAnswer = {
+        toolUseId: 'toolu_aq_idx',
+        options: [
+          { label: 'App runners only (2)' },
+          { label: 'App + docs (all 3)' },
+          { label: 'Other' },
+        ],
       }
-      session._pendingUserAnswer = { toolUseId: 'toolu_aq_3' }
 
-      session.respondToQuestion('Patch')
-      // Drain the throttled write loop. PROMPT_CHAR_DELAY_MS = 1, so wait
-      // 'Patch'.length + a little extra for the trailing \r + mode toggle.
+      session.respondToQuestion('App + docs (all 3)')
       await new Promise((resolve) => setTimeout(resolve, 50))
 
-      // Same shape as the prompt-write tests in this file: disable + N chars
-      // + \r + enable. The throttle is what defeats claude's paste detector
-      // (#4269) — reusing it for the answer write too.
-      assert.ok(writes.length >= 5 + 3, `expected per-char writes, got ${writes.length}: ${JSON.stringify(writes)}`)
-      assert.equal(writes[0], '\x1b[?2004l', 'first write is bracketed-paste-disable')
-      // Find the chars 'P','a','t','c','h' in order
-      const expectChars = 'Patch'.split('')
-      const charWrites = writes.slice(1, 1 + expectChars.length)
-      assert.equal(charWrites.join(''), 'Patch', 'chars reproduce the answer text')
-      assert.equal(writes[1 + expectChars.length], '\r', 'submit comes after the answer')
-      assert.equal(writes[2 + expectChars.length], '\x1b[?2004h', 're-enable comes last')
+      // disable + '2' + \\r + enable = 4 writes
+      assert.equal(writes.length, 4, `expected 4 writes for index path, got ${writes.length}: ${JSON.stringify(writes)}`)
+      assert.equal(writes[0], '\x1b[?2004l', 'first is bracketed-paste-disable')
+      assert.equal(writes[1], '2', 'second is the 1-indexed option number as a single char')
+      assert.equal(writes[2], '\r', 'third is submit')
+      assert.equal(writes[3], '\x1b[?2004h', 'fourth is re-enable')
+      assert.equal(session._pendingUserAnswer, null, 'pending cleared')
+    })
 
-      // _pendingUserAnswer cleared so a second response is a no-op.
-      assert.equal(session._pendingUserAnswer, null)
+    it('respondToQuestion writes the label text when the answer does NOT match any option (custom / Other path)', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      session._pendingUserAnswer = {
+        toolUseId: 'toolu_aq_other',
+        options: [{ label: 'Patch' }, { label: 'Minor' }],
+      }
+
+      session.respondToQuestion('Brand new freeform answer')
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // No match → fall through to typing the text per the v0.9.3 behavior.
+      // (claude TUI's Other-path may still mis-parse this; tracked at #4288
+      // as a separate problem. The point of THIS PR is to make the
+      // happy-path label-match case work.)
+      assert.ok(writes.length > 4, `expected per-char writes for fallback path, got ${writes.length}`)
+      assert.equal(writes[0], '\x1b[?2004l', 'disable mode first')
+      const text = 'Brand new freeform answer'
+      const charWrites = writes.slice(1, 1 + text.length)
+      assert.equal(charWrites.join(''), text, 'chars reproduce the freeform answer')
+    })
+
+    it('respondToQuestion writes the text when options array is missing or empty (free-text-only AskUserQuestion)', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      session._pendingUserAnswer = { toolUseId: 'toolu_aq_free' /* no options */ }
+
+      session.respondToQuestion('hello')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Same shape as a regular throttled write — disable + 5 chars + \\r + enable.
+      assert.ok(writes.length >= 5 + 3)
+      assert.equal(writes[0], '\x1b[?2004l')
+      const text = 'hello'
+      const charWrites = writes.slice(1, 1 + text.length)
+      assert.equal(charWrites.join(''), text)
     })
 
     it('respondToQuestion is a no-op when no pending answer (defensive)', () => {


### PR DESCRIPTION
## Summary

Replaces the v0.9.3 strategy of writing the chosen label text back to claude TUI's prompt with the **1-indexed option number** (e.g. \`2\r\`). claude TUI accepts numbered shortcuts as direct hotkey selection; label text triggered single-character jump-navigation that mis-resolved to the wrong option.

Closes #4290

## Why

v0.9.3 (#4285) dogfood: user picked "App + docs (all 3)" from a structured 3-option AskUserQuestion. \`respondToQuestion\` wrote the label text. claude TUI interpreted it as **"Other" with empty custom text** — the chars \`A\`, \`p\`, \`d\`, \`o\` (\`o\` from "docs") shifted the menu highlight to "Other" before \`\r\` submitted. Full empirical trace: #4288.

## Fix

| Concern | Implementation |
|---------|----------------|
| Know which option was picked | PreToolUse for AskUserQuestion now stashes the structured \`options\` array on \`_pendingUserAnswer\` (was: only \`toolUseId\`). |
| Numbered shortcut for menu options | \`respondToQuestion\` finds the chosen label's index in that array; on exact match, writes the 1-indexed number (\`2\\r\`) instead of the label text. |
| Custom / Other path | When the label doesn't match (user picked "Other" in the dashboard and typed freeform), falls through to typing the answer literally — v0.9.3 behavior preserved. claude TUI's Other-path may still mis-parse; tracked at #4288. |

The per-character throttled write (#4269) is unchanged — claude TUI's paste detector applies to all PTY writes, including a single-digit answer.

## Test plan

- [x] \`node --test packages/server/tests/claude-tui-session.test.js\` — **96 / 96 pass** (3 new tests: matched-label → index write, custom text → text write, free-text AskUserQuestion → text write)
- [ ] Live TUI dogfood (v0.9.4): same repro as v0.9.3 — trigger a multi-option AskUserQuestion, pick option 2, confirm claude TUI resolves to the correct label and the tool completes cleanly (no "you picked Other but text didn't come through" rejection).

## MVP caveats

- **Assumes claude TUI exposes numbered shortcuts on its menu.** Most inquirer-style prompts do; if claude TUI uses arrow-key-only navigation, the same symptom will surface and we escalate to Option B from #4288 (arrow-key escape sequences).
- **Custom-text / Other path remains broken** the same way it was in v0.9.3 — separate follow-up needed (two-stage write: navigate to Other → \\r → type text → \\r).
- SDK session AskUserQuestion path unchanged.

Related: #4269 (throttle reused), #4278/#4285 (initial AskUserQuestion handler), #4288 (empirical research).