### PR TITLE
fix(dashboard): reorder empty response slot on first stream_delta (#4297)

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -662,6 +662,228 @@ describe('dashboard message-handler dispatch', () => {
       const ids = ss.messages.map((m: any) => m.id)
       expect(new Set(ids).size).toBe(ids.length)
     })
+
+    // #4297 — claude TUI fires stream_start at turn-start (per #4010), creating
+    // an empty response slot at position 0. Tool events that follow append at
+    // positions 1, 2, … . Then the final summary stream_delta arrives and the
+    // text accumulates into the position-0 slot — making claude's wrap-up
+    // appear ABOVE the tool groups it summarized. Fix: on the first delta for
+    // an empty response slot, move that slot to the current end of the
+    // messages array so chat order matches Output-tab order.
+    describe('first-delta reorders empty response slot (#4297)', () => {
+      it('moves the empty response slot to the end on first delta when tools were appended after stream_start', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        // Turn opens: stream_start fires first (#4010), creating empty response.
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        // Tools fire while response slot is still empty.
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: { command: 'ls' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'tool_result',
+            toolUseId: 'toolu_a',
+            result: 'foo bar',
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_b',
+            tool: 'Read',
+            toolUseId: 'toolu_b',
+            input: { path: '/tmp' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'tool_result',
+            toolUseId: 'toolu_b',
+            result: 'baz',
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        // Finally, the summary text streams in.
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-1', sessionId: 's1', delta: 'All done.' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        // Response message must sit AFTER the two tool bubbles, not at index 0.
+        const lastMsg = ss.messages[ss.messages.length - 1]
+        expect(lastMsg.id).toBe('resp-1')
+        expect(lastMsg.type).toBe('response')
+        expect(lastMsg.content).toBe('All done.')
+        // Tool bubbles preserved in order before the response.
+        expect(ss.messages[0].id).toBe('toolu_a')
+        expect(ss.messages[1].id).toBe('toolu_b')
+      })
+
+      it('leaves response slot in place when text streams immediately (no interleaved tools)', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-2', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-2', sessionId: 's1', delta: 'hi' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        expect(ss.messages).toHaveLength(1)
+        expect(ss.messages[0].id).toBe('resp-2')
+        expect(ss.messages[0].content).toBe('hi')
+      })
+
+      it('does not reorder when a tool fires AFTER the first delta', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-3', sessionId: 's1' },
+          ctx() as any,
+        )
+        // Preamble text streams BEFORE any tool — response anchors at index 0.
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-3', sessionId: 's1', delta: 'Let me check…' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_after',
+            tool: 'Bash',
+            toolUseId: 'toolu_after',
+            input: { command: 'ls' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+
+        const ss = (store.getState() as any).sessionStates.s1
+        // Preamble response at index 0, tool at index 1 — chronological order
+        // matches the wire arrival.
+        expect(ss.messages[0].id).toBe('resp-3')
+        expect(ss.messages[1].id).toBe('toolu_after')
+      })
+
+      it('does not reorder a non-empty (reconnect-replayed) response slot', () => {
+        // Simulate reconnect replay where a previous turn's response is
+        // already populated. A subsequent delta on it should NOT reorder.
+        const replayedResp = {
+          id: 'resp-replay',
+          type: 'response' as const,
+          content: 'Existing replayed content. ',
+          timestamp: 1,
+        }
+        const tool = { id: 'toolu_x', type: 'tool_use' as const, content: 'ls', timestamp: 2 }
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: {
+              s1: { ...createEmptySessionState(), messages: [replayedResp, tool] },
+            },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-replay', sessionId: 's1', delta: 'more text' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        // Response stays at index 0 (the reorder gate is content === '').
+        expect(ss.messages[0].id).toBe('resp-replay')
+        expect(ss.messages[0].content).toBe('Existing replayed content. more text')
+        expect(ss.messages[1].id).toBe('toolu_x')
+      })
+
+      it('reorders empty response slot in flat-state branch (legacy/pre-session bootstrap)', () => {
+        const flatBase = baseState({
+          activeSessionId: null,
+          sessions: [],
+          sessionStates: {},
+          messages: [],
+        }) as Record<string, unknown>
+        flatBase.addMessage = (m: unknown) => {
+          const s = store.getState() as { messages: unknown[] }
+          ;(store as { setState: (p: Record<string, unknown>) => void }).setState({
+            messages: [...s.messages, m],
+          })
+        }
+        store = createMockStore(flatBase)
+        setStore(store)
+
+        handleMessage({ type: 'stream_start', messageId: 'flat-resp' }, ctx() as any)
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'flat-tool',
+            tool: 'Bash',
+            toolUseId: 'flat-tool',
+            input: { command: 'ls' },
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'flat-resp', delta: 'flat summary' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const flat = (store.getState() as any).messages
+        const last = flat[flat.length - 1]
+        expect(last.id).toBe('flat-resp')
+        expect(last.content).toBe('flat summary')
+        expect(flat[0].id).toBe('flat-tool')
+      })
+    })
   })
 
   describe('malformed input', () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1281,6 +1281,57 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
     get().appendTerminalData(msg.delta);
   }
 
+  // #4297 — TUI fires stream_start at turn-start (#4010), creating an empty
+  // response slot. Tool events that follow append AFTER the slot. If the
+  // turn ends with a summary stream_delta, the text would otherwise materialize
+  // at the early slot position — making claude's wrap-up appear ABOVE the tool
+  // groups it summarized. On the first delta for an empty response slot, move
+  // it to the current end of the messages array. We gate on content === '' so
+  // a reconnect-replayed response (already populated) is never shifted, and
+  // run BEFORE the post-permission / collision branches below so their
+  // suffixed-response paths (which already append at the end) skip the
+  // reorder by virtue of the deltaId remap.
+  if (typeof deltaId === 'string'
+      && !_postPermissionSplits.has(deltaId)
+      && !_deltaIdRemaps.has(deltaId)
+      && !pendingDeltas.has(deltaId)) {
+    const targetForReorder = (capturedSessionId && get().sessionStates[capturedSessionId])
+      ? capturedSessionId
+      : null;
+    if (targetForReorder) {
+      const ss = get().sessionStates[targetForReorder]!;
+      const idx = ss.messages.findIndex((m) => m.id === deltaId);
+      if (idx >= 0 && idx < ss.messages.length - 1) {
+        const slot = ss.messages[idx]!;
+        if (slot.type === 'response' && slot.content === '') {
+          updateSession(targetForReorder, (s) => ({
+            messages: [
+              ...s.messages.slice(0, idx),
+              ...s.messages.slice(idx + 1),
+              slot,
+            ],
+          }));
+        }
+      }
+    } else {
+      // Flat-messages fallback (pre-session bootstrap)
+      const flat = get().messages;
+      const idx = flat.findIndex((m) => m.id === deltaId);
+      if (idx >= 0 && idx < flat.length - 1) {
+        const slot = flat[idx]!;
+        if (slot.type === 'response' && slot.content === '') {
+          set((state) => ({
+            messages: [
+              ...state.messages.slice(0, idx),
+              ...state.messages.slice(idx + 1),
+              slot,
+            ],
+          }));
+        }
+      }
+    }
+  }
+
   // Permission boundary split: first delta after a split creates a new message
   if (_postPermissionSplits.has(deltaId)) {
     _postPermissionSplits.delete(deltaId);


### PR DESCRIPTION
Closes #4297

## Symptom

In TUI sessions, claude's final summary text renders ABOVE the tool groups that came chronologically before it. The Output tab shows the right order; only the Chat tab is wrong. To users, claude's wrap-up looks like it came before the work — confusing and looks like the response is missing.

## Root cause

`claude-tui-session.js:756` emits `stream_start` at turn-start (#4010) so the Stop button shows up the moment a turn begins, even when the turn opens with a tool call (no preamble text). The dashboard's `handleStreamStart` appends an empty response slot at the end of `messages[]` immediately. Subsequent `tool_start`/`tool_result` events then append AFTER that slot. When the final summary `stream_delta` arrives, the text accumulates into the empty slot's existing array position — leaving claude's wrap-up at the index where the response was originally placed, with all the tool work piled up behind it.

The Output tab synthesizes from real-time appends to a flat terminal buffer (no anchoring), so chronological order is preserved there.

## Fix

On the first `stream_delta` for a response slot whose `content === ''`, move that slot to the current end of `messages[]`. Gated tightly:

- Runs **before** the existing `_postPermissionSplits` / `_deltaIdRemaps` branches so their suffixed-response paths (which already append at the end) are skipped via the deltaId-remap check
- Only fires on first delta (detected via `!pendingDeltas.has(deltaId)`)
- Only fires when `content === ''` so reconnect-replayed responses (already populated) are never shifted
- Only fires when the slot is NOT already at the end (no-op for text-only turns where stream_start → stream_delta arrive back-to-back with no interleaving)

Covers both the session-state and flat-state (legacy/pre-bootstrap) paths.

## Tests

5 new tests in `message-handler.test.ts > stream_delta dispatch > first-delta reorders empty response slot (#4297)`:

1. Moves empty slot to end when tools were appended in between (the bug case)
2. Leaves slot in place when text streams immediately (no interleaved tools)
3. Doesn't reorder when a tool fires AFTER the first delta (preamble text scenario)
4. Doesn't reorder a non-empty (reconnect-replayed) slot
5. Same fix applies in the flat-state branch

Before the fix: tests 1 and 5 fail with the exact symptom. After: 132/132 pass in the message-handler suite, 1853/1853 across the dashboard.

## Test plan

- [ ] Run a TUI session that opens with tools (e.g. "investigate X then summarize")
- [ ] Confirm the Chat tab shows tool groups first, summary text at the bottom
- [ ] Confirm the Output tab still shows correct chronological order
- [ ] Confirm a text-only response (no tools) renders normally
- [ ] Confirm a preamble text → tool → more text turn still streams in arrival order