### PR TITLE
feat(dashboard): echo AskUserQuestion answers to Output tab (#4296)

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1291,6 +1291,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket } = get();
     const payload: Record<string, string> = { type: 'user_question_response', answer };
     if (toolUseId) payload.toolUseId = toolUseId;
+    // #4296: echo the resolved answer to the terminal buffer so the Output
+    // tab shows a visible "User answered: X" line between the AskUserQuestion
+    // tool_input JSON and the next event. Cyan (\x1b[36m) distinguishes the
+    // line from yellow user-prompt echoes (\x1b[33m in sendInput). Skipped
+    // for empty answers — nothing meaningful to render. Fires before the
+    // wire send so the echo is present even when the socket queues.
+    if (answer) {
+      get().appendTerminalData(`\r\n\x1b[36m> User answered: ${answer}\x1b[0m\r\n`);
+    }
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, payload);
       return 'sent';

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1271,6 +1271,117 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #4296 — Output tab visibility for AskUserQuestion answers
+// ---------------------------------------------------------------------------
+// The Output tab is synthesized from a narrow set of sources (user-prompt
+// echo via appendTerminalData + chat-text deltas). Pre-#4296, picking an
+// option in QuestionPrompt sent the answer over the wire but left NO trace
+// in the Output tab — the question JSON appeared, then immediately the next
+// tool fired with no record of what the user picked. Fix: echo the resolved
+// answer to the terminal buffer in cyan so the Output tab shows a visible
+// "User answered: <label>" line in the chronological stream.
+describe('sendUserQuestionResponse Output-tab echo (#4296)', () => {
+  it('echoes "User answered: <answer>" to the terminal buffer in cyan when the wire send succeeds', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse('All three', 'toolu_abc');
+
+    // Wire payload still goes out unchanged
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      type: 'user_question_response',
+      answer: 'All three',
+      toolUseId: 'toolu_abc',
+    });
+
+    // Raw buffer carries the cyan-tinted echo so xterm.js renders it
+    const { terminalBuffer, terminalRawBuffer } = useConnectionStore.getState();
+    expect(terminalRawBuffer).toContain('\x1b[36m');
+    expect(terminalRawBuffer).toContain('> User answered: All three');
+    expect(terminalRawBuffer).toContain('\x1b[0m');
+    // Stripped buffer (for plain-text consumers) carries the message without ANSI
+    expect(terminalBuffer).toContain('User answered: All three');
+    expect(terminalBuffer).not.toContain('\x1b[');
+  });
+
+  it('echoes freeform "Other" custom-text answers identically', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse('something else entirely', 'toolu_xyz');
+
+    const { terminalBuffer } = useConnectionStore.getState();
+    expect(terminalBuffer).toContain('User answered: something else entirely');
+  });
+
+  it('still echoes when the wire send is queued (socket not open)', async () => {
+    // Queued path: when the socket is not OPEN, the response is enqueued for
+    // replay on reconnect. The Output-tab echo must still fire so the user
+    // sees their answer locally even before the server roundtrips it back.
+    const { useConnectionStore } = await import('./connection');
+
+    useConnectionStore.setState({
+      socket: null,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    const result = useConnectionStore.getState().sendUserQuestionResponse('queued answer', 'toolu_q');
+    expect(result).toBe('queued');
+
+    const { terminalBuffer } = useConnectionStore.getState();
+    expect(terminalBuffer).toContain('User answered: queued answer');
+  });
+
+  it('does not echo when the answer string is empty (defensive)', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse('', 'toolu_empty');
+
+    const { terminalRawBuffer } = useConnectionStore.getState();
+    // No echo for an empty answer — the wire send still happens (server
+    // schema may accept it) but we don't render an "answered:" line for
+    // nothing.
+    expect(terminalRawBuffer).not.toContain('User answered:');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // PTY dead code removal (#1759)
 // ---------------------------------------------------------------------------
 describe('PTY dead code removal', () => {


### PR DESCRIPTION
Closes #4296

## Symptom

After answering an AskUserQuestion prompt from the dashboard's QuestionPrompt UI, the **Output** tab shows the raw tool_input (question + options JSON) followed directly by the next tool's invocation — there is no visible record of what answer was sent back to claude. Users see their question, then claude's next tool, but no \"User selected: X\" trace in between.

## Root cause

The Output tab is synthesized from a narrow set of sources — local user-prompt echo (\`appendTerminalData\` in \`sendInput\`) and chat-text deltas. It does NOT include the \`user_question_response\` payload the dashboard fires when the user picks an option. So the user's answer is invisible in the Output stream even though the data exists on the wire.

## Fix

In \`sendUserQuestionResponse\`, append a cyan-tinted \`> User answered: <answer>\\` line to the terminal buffer before the wire send:

\`\`\`ts
if (answer) {
  get().appendTerminalData(\`\\r\\n\\x1b[36m> User answered: \${answer}\\x1b[0m\\r\\n\`);
}
\`\`\`

- Cyan (\`\\x1b[36m\`) distinguishes the echo from yellow user-prompt echoes (\`\\x1b[33m\` in \`sendInput\`)
- Skipped for empty answers (defensive — no useful UX to render)
- Fires BEFORE the wire send so the echo is present even when the socket queues (offline / reconnect)
- Works for both option-pick (resolved label) and freeform \"Other\" (custom text) — both paths converge on \`sendUserQuestionResponse\`

## Tests

4 new tests in \`store.test.ts > sendUserQuestionResponse Output-tab echo (#4296)\`:

1. Option-pick answer: wire payload preserved, terminalRawBuffer has cyan ANSI + the echoed line, terminalBuffer (stripped) has the text without ANSI
2. Freeform \"Other\" answer: same echo behavior
3. Queued (socket-not-open) path: echo still fires
4. Empty answer: no echo (defensive)

Before the fix: 3 of 4 tests fail (one trivially passes because no echo exists). After: 4/4 pass, 1857/1857 across the dashboard.

## Test plan

- [ ] Trigger a TUI AskUserQuestion with multiple options
- [ ] Pick one in the dashboard and confirm the Output tab shows \`> User answered: <label>\` in cyan between the question JSON and the next tool
- [ ] Pick \"Other\" with custom freeform text — same echo behavior
- [ ] Pre-reconnect: answer while disconnected, confirm echo still shows locally