### PR TITLE
feat(dashboard): pluggable sidebar panel slot + token view v0 (#4303 PR 1/3)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -64,7 +64,7 @@ import { isTauri } from './utils/tauri'
 import { startServer, revealInFinder } from './hooks/useTauriIPC'
 import { usePermissionNotification, type PermissionPromptInfo } from './hooks/usePermissionNotification'
 import { SplitPane, type SplitDirection } from './components/SplitPane'
-import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab } from './store/persistence'
+import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed } from './store/persistence'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
 import { AgentMonitorPanel } from './components/AgentMonitorPanel'
 import { SessionLoadingSkeleton } from './components/SessionLoadingSkeleton'
@@ -1745,6 +1745,10 @@ export function App() {
           searchQuery={searchQuery}
           searchConversations={searchConversations}
           clearSearchResults={clearSearchResults}
+          sessions={sessions}
+          initialPanelHeight={loadPersistedSidebarPanelHeight() ?? 200}
+          initialPanelView={loadPersistedSidebarPanelView()}
+          initialPanelCollapsed={loadPersistedSidebarPanelCollapsed()}
         />
       )}
 

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -4,12 +4,19 @@
  * Shows repos with active/resumable sessions, filter, status footer.
  * Collapsible with Cmd+B toggle.
  */
-import { useState, useCallback, useRef } from 'react'
-import type { CumulativeUsage, SessionVisualStatus } from '@chroxy/store-core'
+import { useState, useCallback, useRef, useMemo } from 'react'
+import type { CumulativeUsage, SessionInfo, SessionVisualStatus } from '@chroxy/store-core'
 import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
+import { SidebarPanelSlot, type SidebarPanelView } from './SidebarPanelSlot'
+import { SidebarTokenView, tokenViewCollapsedMetric } from './SidebarTokenView'
 import type { SearchResult } from '../store/types'
+import {
+  persistSidebarPanelHeight,
+  persistSidebarPanelView,
+  persistSidebarPanelCollapsed,
+} from '../store/persistence'
 
 export interface ActiveSessionNode {
   sessionId: string
@@ -71,6 +78,14 @@ export interface SidebarProps {
   searchConversations?: (query: string) => void
   clearSearchResults?: () => void
   onWidthChange?: (width: number) => void
+  // #4303 — full sessions list (used by the bottom slot's token view).
+  // Optional so existing tests + callers don't break; defaults to [].
+  sessions?: SessionInfo[]
+  // #4303 — initial state for the bottom panel slot (loaded from
+  // localStorage in App.tsx; defaults applied here).
+  initialPanelHeight?: number
+  initialPanelView?: string | null
+  initialPanelCollapsed?: boolean
 }
 
 function abbreviateTunnel(url: string): string {
@@ -102,10 +117,47 @@ export function Sidebar({
   searchConversations,
   clearSearchResults,
   onWidthChange,
+  sessions = [],
+  initialPanelHeight = 200,
+  initialPanelView = null,
+  initialPanelCollapsed = false,
 }: SidebarProps) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const [focusedIndex, setFocusedIndex] = useState(0)
   const treeRef = useRef<HTMLDivElement>(null)
+
+  // #4303 — sidebar panel slot state. Initialized from localStorage via
+  // props so SSR / tests stay deterministic. Each setter mirrors to
+  // localStorage so the panel survives reloads.
+  const [panelHeight, setPanelHeightState] = useState(initialPanelHeight)
+  const [panelView, setPanelViewState] = useState<string | null>(initialPanelView ?? 'tokens')
+  const [panelCollapsed, setPanelCollapsedState] = useState(initialPanelCollapsed)
+
+  const handlePanelHeightChange = useCallback((next: number) => {
+    setPanelHeightState(next)
+    persistSidebarPanelHeight(next)
+  }, [])
+
+  const handlePanelViewChange = useCallback((next: string) => {
+    setPanelViewState(next)
+    persistSidebarPanelView(next)
+  }, [])
+
+  const handlePanelCollapsedChange = useCallback((next: boolean) => {
+    setPanelCollapsedState(next)
+    persistSidebarPanelCollapsed(next)
+  }, [])
+
+  // #4303 — view registry. Order here = order in the tab strip. Adding a
+  // future view (MCP, skills, etc.) is a one-entry append.
+  const panelViews = useMemo<SidebarPanelView[]>(() => ([
+    {
+      id: 'tokens',
+      label: 'Tokens',
+      render: () => <SidebarTokenView sessions={sessions} />,
+      collapsedHeaderMetric: () => tokenViewCollapsedMetric(sessions),
+    },
+  ]), [sessions])
 
   const toggleRepo = useCallback((path: string) => {
     setCollapsed(prev => ({ ...prev, [path]: !prev[path] }))
@@ -433,6 +485,21 @@ export function Sidebar({
               )
             })}
           </div>
+
+          {/* #4303 — pluggable sidebar panel slot. SERVERS section
+              stays BELOW the slot for v1 (rationale: ServerPicker has its
+              own always-visible add button + status; forcing it into the
+              slot's one-view-at-a-time model loses functionality you'd
+              want simultaneously with whatever lives in the slot). */}
+          <SidebarPanelSlot
+            views={panelViews}
+            selectedViewId={panelView}
+            onSelectView={handlePanelViewChange}
+            collapsed={panelCollapsed}
+            onCollapsedChange={handlePanelCollapsedChange}
+            height={panelHeight}
+            onHeightChange={handlePanelHeightChange}
+          />
 
           {/* Server picker (multi-machine) */}
           <ServerPicker />

--- a/packages/dashboard/src/components/SidebarPanelSlot.test.tsx
+++ b/packages/dashboard/src/components/SidebarPanelSlot.test.tsx
@@ -98,6 +98,107 @@ describe('SidebarPanelSlot (#4303)', () => {
       expect(selected.getAttribute('tabindex')).toBe('0')
       expect(other.getAttribute('tabindex')).toBe('-1')
     })
+
+    // #4304 review: WAI-ARIA tablist keyboard navigation
+    describe('tablist keyboard navigation (#4304 review)', () => {
+      const views3 = [
+        makeView('a', 'A', 'body-a'),
+        makeView('b', 'B', 'body-b'),
+        makeView('c', 'C', 'body-c'),
+      ]
+
+      it('ArrowRight selects the next tab and wraps at the end', () => {
+        const onSelectView = vi.fn()
+        render(
+          <SidebarPanelSlot
+            {...baseProps}
+            selectedViewId="a"
+            onSelectView={onSelectView}
+            views={views3}
+          />,
+        )
+        const tab = screen.getByTestId('sidebar-panel-slot-tab-a')
+        fireEvent.keyDown(tab, { key: 'ArrowRight' })
+        expect(onSelectView).toHaveBeenLastCalledWith('b')
+      })
+
+      it('ArrowRight wraps from the last tab back to the first', () => {
+        const onSelectView = vi.fn()
+        render(
+          <SidebarPanelSlot
+            {...baseProps}
+            selectedViewId="c"
+            onSelectView={onSelectView}
+            views={views3}
+          />,
+        )
+        const tab = screen.getByTestId('sidebar-panel-slot-tab-c')
+        fireEvent.keyDown(tab, { key: 'ArrowRight' })
+        expect(onSelectView).toHaveBeenLastCalledWith('a')
+      })
+
+      it('ArrowLeft selects the previous tab and wraps at the start', () => {
+        const onSelectView = vi.fn()
+        render(
+          <SidebarPanelSlot
+            {...baseProps}
+            selectedViewId="a"
+            onSelectView={onSelectView}
+            views={views3}
+          />,
+        )
+        const tab = screen.getByTestId('sidebar-panel-slot-tab-a')
+        fireEvent.keyDown(tab, { key: 'ArrowLeft' })
+        expect(onSelectView).toHaveBeenLastCalledWith('c')
+      })
+
+      it('Home selects the first tab', () => {
+        const onSelectView = vi.fn()
+        render(
+          <SidebarPanelSlot
+            {...baseProps}
+            selectedViewId="c"
+            onSelectView={onSelectView}
+            views={views3}
+          />,
+        )
+        const tab = screen.getByTestId('sidebar-panel-slot-tab-c')
+        fireEvent.keyDown(tab, { key: 'Home' })
+        expect(onSelectView).toHaveBeenLastCalledWith('a')
+      })
+
+      it('End selects the last tab', () => {
+        const onSelectView = vi.fn()
+        render(
+          <SidebarPanelSlot
+            {...baseProps}
+            selectedViewId="a"
+            onSelectView={onSelectView}
+            views={views3}
+          />,
+        )
+        const tab = screen.getByTestId('sidebar-panel-slot-tab-a')
+        fireEvent.keyDown(tab, { key: 'End' })
+        expect(onSelectView).toHaveBeenLastCalledWith('c')
+      })
+
+      it('unrelated keys do nothing (no preventDefault on Tab)', () => {
+        const onSelectView = vi.fn()
+        render(
+          <SidebarPanelSlot
+            {...baseProps}
+            selectedViewId="a"
+            onSelectView={onSelectView}
+            views={views3}
+          />,
+        )
+        const tab = screen.getByTestId('sidebar-panel-slot-tab-a')
+        const ev = fireEvent.keyDown(tab, { key: 'Tab' })
+        expect(onSelectView).not.toHaveBeenCalled()
+        // fireEvent.keyDown returns true when the event was NOT cancelled
+        expect(ev).toBe(true)
+      })
+    })
   })
 
   describe('collapse', () => {
@@ -258,6 +359,31 @@ describe('SidebarPanelSlot (#4303)', () => {
       // it's gone instead.
       expect(screen.queryByTestId('sidebar-panel-slot-resize-handle')).toBeNull()
       expect(onHeightChange).not.toHaveBeenCalled()
+    })
+
+    it('removes drag listeners on unmount mid-drag (#4304 review)', () => {
+      const onHeightChange = vi.fn()
+      const removeSpy = vi.spyOn(document, 'removeEventListener')
+      const { unmount } = render(
+        <SidebarPanelSlot
+          {...baseProps}
+          height={200}
+          onHeightChange={onHeightChange}
+          views={[makeView('a', 'A', 'b')]}
+        />,
+      )
+      const handle = screen.getByTestId('sidebar-panel-slot-resize-handle')
+      // Start a drag — listeners attach to document
+      fireEvent.mouseDown(handle, { clientY: 500 })
+      // Unmount before mouseup — the effect cleanup must detach the
+      // listeners or they leak and keep firing onHeightChange on a
+      // dead component.
+      unmount()
+      const removedMove = removeSpy.mock.calls.some(([type]) => type === 'mousemove')
+      const removedUp = removeSpy.mock.calls.some(([type]) => type === 'mouseup')
+      expect(removedMove).toBe(true)
+      expect(removedUp).toBe(true)
+      removeSpy.mockRestore()
     })
 
     it('resize handle has role=separator with proper aria attributes', () => {

--- a/packages/dashboard/src/components/SidebarPanelSlot.test.tsx
+++ b/packages/dashboard/src/components/SidebarPanelSlot.test.tsx
@@ -1,0 +1,282 @@
+/**
+ * SidebarPanelSlot tests (#4303).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import { SidebarPanelSlot, type SidebarPanelView } from './SidebarPanelSlot'
+
+afterEach(() => {
+  cleanup()
+})
+
+function makeView(id: string, label: string, body: string): SidebarPanelView {
+  return {
+    id,
+    label,
+    render: () => <div data-testid={`view-body-${id}`}>{body}</div>,
+  }
+}
+
+const baseProps = {
+  selectedViewId: null as string | null,
+  onSelectView: () => {},
+  collapsed: false,
+  onCollapsedChange: () => {},
+  height: 200,
+  onHeightChange: () => {},
+}
+
+describe('SidebarPanelSlot (#4303)', () => {
+  describe('view selection', () => {
+    it('renders nothing when zero views registered', () => {
+      const { container } = render(
+        <SidebarPanelSlot {...baseProps} views={[]} />,
+      )
+      expect(container.querySelector('[data-testid="sidebar-panel-slot"]')).toBeNull()
+    })
+
+    it('renders the first view when selectedViewId is null (default fallback)', () => {
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          views={[makeView('tokens', 'Tokens', 'Token body'), makeView('servers', 'Servers', 'Server body')]}
+        />,
+      )
+      expect(screen.getByTestId('view-body-tokens')).toBeInTheDocument()
+      expect(screen.queryByTestId('view-body-servers')).toBeNull()
+    })
+
+    it('renders the view matching selectedViewId', () => {
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          selectedViewId="servers"
+          views={[makeView('tokens', 'Tokens', 'Token body'), makeView('servers', 'Servers', 'Server body')]}
+        />,
+      )
+      expect(screen.getByTestId('view-body-servers')).toBeInTheDocument()
+      expect(screen.queryByTestId('view-body-tokens')).toBeNull()
+    })
+
+    it('falls back to the first view when selectedViewId is stale (view removed)', () => {
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          selectedViewId="deleted-view"
+          views={[makeView('tokens', 'Tokens', 'Token body')]}
+        />,
+      )
+      expect(screen.getByTestId('view-body-tokens')).toBeInTheDocument()
+    })
+
+    it('clicking a tab fires onSelectView with the view id', () => {
+      const onSelectView = vi.fn()
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          onSelectView={onSelectView}
+          selectedViewId="tokens"
+          views={[makeView('tokens', 'Tokens', 'a'), makeView('servers', 'Servers', 'b')]}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('sidebar-panel-slot-tab-servers'))
+      expect(onSelectView).toHaveBeenCalledWith('servers')
+    })
+
+    it('selected tab carries aria-selected=true and tabIndex=0; others are -1', () => {
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          selectedViewId="tokens"
+          views={[makeView('tokens', 'Tokens', 'a'), makeView('servers', 'Servers', 'b')]}
+        />,
+      )
+      const selected = screen.getByTestId('sidebar-panel-slot-tab-tokens')
+      const other = screen.getByTestId('sidebar-panel-slot-tab-servers')
+      expect(selected.getAttribute('aria-selected')).toBe('true')
+      expect(other.getAttribute('aria-selected')).toBe('false')
+      expect(selected.getAttribute('tabindex')).toBe('0')
+      expect(other.getAttribute('tabindex')).toBe('-1')
+    })
+  })
+
+  describe('collapse', () => {
+    it('hides the body when collapsed=true', () => {
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          collapsed
+          views={[makeView('tokens', 'Tokens', 'Token body')]}
+        />,
+      )
+      expect(screen.queryByTestId('view-body-tokens')).toBeNull()
+      // Header still renders (so tabs + toggle stay reachable)
+      expect(screen.getByTestId('sidebar-panel-slot-header')).toBeInTheDocument()
+    })
+
+    it('hides the resize handle when collapsed', () => {
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          collapsed
+          views={[makeView('tokens', 'Tokens', 'a')]}
+        />,
+      )
+      expect(screen.queryByTestId('sidebar-panel-slot-resize-handle')).toBeNull()
+    })
+
+    it('collapse toggle button toggles onCollapsedChange', () => {
+      const onCollapsedChange = vi.fn()
+      const { rerender } = render(
+        <SidebarPanelSlot
+          {...baseProps}
+          onCollapsedChange={onCollapsedChange}
+          views={[makeView('tokens', 'Tokens', 'a')]}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('sidebar-panel-slot-collapse-toggle'))
+      expect(onCollapsedChange).toHaveBeenCalledWith(true)
+      onCollapsedChange.mockReset()
+      rerender(
+        <SidebarPanelSlot
+          {...baseProps}
+          collapsed
+          onCollapsedChange={onCollapsedChange}
+          views={[makeView('tokens', 'Tokens', 'a')]}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('sidebar-panel-slot-collapse-toggle'))
+      expect(onCollapsedChange).toHaveBeenCalledWith(false)
+    })
+
+    it('collapsedHeaderMetric renders ONLY when collapsed and supplied by active view', () => {
+      const view: SidebarPanelView = {
+        ...makeView('tokens', 'Tokens', 'body'),
+        collapsedHeaderMetric: () => <span data-testid="collapsed-metric">Today: 142K</span>,
+      }
+      const { rerender } = render(
+        <SidebarPanelSlot {...baseProps} views={[view]} />,
+      )
+      // Expanded: metric not shown
+      expect(screen.queryByTestId('collapsed-metric')).toBeNull()
+      // Collapsed: metric shown
+      rerender(<SidebarPanelSlot {...baseProps} collapsed views={[view]} />)
+      expect(screen.getByTestId('collapsed-metric')).toBeInTheDocument()
+    })
+
+    it('does not render collapsed metric when active view does not supply one', () => {
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          collapsed
+          views={[makeView('plain', 'Plain', 'body')]}
+        />,
+      )
+      expect(screen.queryByTestId('sidebar-panel-slot-collapsed-metric')).toBeNull()
+    })
+
+    it('aria-expanded on the toggle reflects current state', () => {
+      const { rerender } = render(
+        <SidebarPanelSlot {...baseProps} views={[makeView('a', 'A', 'b')]} />,
+      )
+      expect(
+        screen.getByTestId('sidebar-panel-slot-collapse-toggle').getAttribute('aria-expanded'),
+      ).toBe('true')
+      rerender(<SidebarPanelSlot {...baseProps} collapsed views={[makeView('a', 'A', 'b')]} />)
+      expect(
+        screen.getByTestId('sidebar-panel-slot-collapse-toggle').getAttribute('aria-expanded'),
+      ).toBe('false')
+    })
+  })
+
+  describe('resize', () => {
+    it('drags the top handle and clamps to [minHeight, maxHeight]', () => {
+      const onHeightChange = vi.fn()
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          height={200}
+          onHeightChange={onHeightChange}
+          minHeight={100}
+          maxHeight={400}
+          views={[makeView('a', 'A', 'b')]}
+        />,
+      )
+      const handle = screen.getByTestId('sidebar-panel-slot-resize-handle')
+      // Drag UP 50px -> panel grows by 50px
+      fireEvent.mouseDown(handle, { clientY: 500 })
+      fireEvent.mouseMove(document, { clientY: 450 })
+      fireEvent.mouseUp(document)
+      expect(onHeightChange).toHaveBeenLastCalledWith(250)
+      onHeightChange.mockReset()
+
+      // Drag UP 500px (huge) -> clamp to maxHeight=400
+      fireEvent.mouseDown(handle, { clientY: 500 })
+      fireEvent.mouseMove(document, { clientY: 0 })
+      fireEvent.mouseUp(document)
+      expect(onHeightChange).toHaveBeenLastCalledWith(400)
+      onHeightChange.mockReset()
+
+      // Drag DOWN 500px -> clamp to minHeight=100
+      fireEvent.mouseDown(handle, { clientY: 500 })
+      fireEvent.mouseMove(document, { clientY: 1000 })
+      fireEvent.mouseUp(document)
+      expect(onHeightChange).toHaveBeenLastCalledWith(100)
+    })
+
+    it('arrow-key resize: ArrowUp grows, ArrowDown shrinks, both clamp', () => {
+      const onHeightChange = vi.fn()
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          height={200}
+          onHeightChange={onHeightChange}
+          minHeight={100}
+          maxHeight={400}
+          views={[makeView('a', 'A', 'b')]}
+        />,
+      )
+      const handle = screen.getByTestId('sidebar-panel-slot-resize-handle')
+      fireEvent.keyDown(handle, { key: 'ArrowUp' })
+      expect(onHeightChange).toHaveBeenLastCalledWith(216)
+      fireEvent.keyDown(handle, { key: 'ArrowDown' })
+      expect(onHeightChange).toHaveBeenLastCalledWith(184)
+    })
+
+    it('arrow-key resize does NOT fire when collapsed', () => {
+      const onHeightChange = vi.fn()
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          collapsed
+          height={200}
+          onHeightChange={onHeightChange}
+          views={[makeView('a', 'A', 'b')]}
+        />,
+      )
+      // Handle is hidden when collapsed, so we can't focus it — verify
+      // it's gone instead.
+      expect(screen.queryByTestId('sidebar-panel-slot-resize-handle')).toBeNull()
+      expect(onHeightChange).not.toHaveBeenCalled()
+    })
+
+    it('resize handle has role=separator with proper aria attributes', () => {
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          height={250}
+          minHeight={100}
+          maxHeight={400}
+          views={[makeView('a', 'A', 'b')]}
+        />,
+      )
+      const handle = screen.getByTestId('sidebar-panel-slot-resize-handle')
+      expect(handle.getAttribute('role')).toBe('separator')
+      expect(handle.getAttribute('aria-orientation')).toBe('horizontal')
+      expect(handle.getAttribute('aria-valuemin')).toBe('100')
+      expect(handle.getAttribute('aria-valuemax')).toBe('400')
+      expect(handle.getAttribute('aria-valuenow')).toBe('250')
+      expect(handle.getAttribute('aria-label')).toBe('Resize sidebar panel')
+    })
+  })
+})

--- a/packages/dashboard/src/components/SidebarPanelSlot.tsx
+++ b/packages/dashboard/src/components/SidebarPanelSlot.tsx
@@ -62,12 +62,21 @@ export function SidebarPanelSlot({
   // a previously-selected view was removed). Falls back to null only when
   // there are zero registered views, which is a degenerate case but
   // shouldn't crash.
+  // Intentional behavior, NOT a bug — when a previously-registered view
+  // is removed in a future build, the user lands on the first registered
+  // view rather than seeing an empty body.
   const activeView =
     views.find((v) => v.id === selectedViewId) ?? views[0] ?? null
 
   const isDragging = useRef(false)
   const startY = useRef(0)
   const startHeight = useRef(height)
+  // #4304 review: hold the live drag listeners on refs so the unmount
+  // effect can detach them. Without this, starting a drag and then
+  // unmounting the slot (e.g. Cmd+B sidebar collapse) leaks document
+  // listeners that keep calling onHeightChange on a dead component.
+  const dragMoveRef = useRef<((ev: MouseEvent) => void) | null>(null)
+  const dragUpRef = useRef<(() => void) | null>(null)
 
   const handleResizeMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -90,16 +99,20 @@ export function SidebarPanelSlot({
         isDragging.current = false
         document.removeEventListener('mousemove', onMouseMove)
         document.removeEventListener('mouseup', onMouseUp)
+        dragMoveRef.current = null
+        dragUpRef.current = null
       }
 
+      dragMoveRef.current = onMouseMove
+      dragUpRef.current = onMouseUp
       document.addEventListener('mousemove', onMouseMove)
       document.addEventListener('mouseup', onMouseUp)
     },
     [collapsed, height, maxHeight, minHeight, onHeightChange],
   )
 
-  // Keyboard resize support (decision #5 AC): arrow keys when the handle
-  // is focused move the panel boundary in 16px steps.
+  // Keyboard resize support: arrow keys when the handle is focused move
+  // the panel boundary in 16px steps.
   const handleResizeKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (collapsed) return
@@ -115,12 +128,61 @@ export function SidebarPanelSlot({
     [collapsed, height, maxHeight, minHeight, onHeightChange],
   )
 
-  // Cleanup any dangling listeners if the slot unmounts mid-drag.
+  // #4304 review: remove any live drag listeners on unmount. Refs hold
+  // the exact closures registered, so the removeEventListener calls
+  // match what was added.
   useEffect(() => {
     return () => {
       isDragging.current = false
+      if (dragMoveRef.current) {
+        document.removeEventListener('mousemove', dragMoveRef.current)
+        dragMoveRef.current = null
+      }
+      if (dragUpRef.current) {
+        document.removeEventListener('mouseup', dragUpRef.current)
+        dragUpRef.current = null
+      }
     }
   }, [])
+
+  // #4304 review: WAI-ARIA tablist keyboard navigation (ArrowLeft/Right,
+  // Home, End). Wires roving focus to the matching tab button so users
+  // arriving via Tab can move between tabs without a mouse. Trips today
+  // with only one tab registered but is cheap to add now so future view
+  // additions don't ship an a11y regression.
+  const tabRefs = useRef<(HTMLButtonElement | null)[]>([])
+
+  const handleTabKeyDown = useCallback(
+    (e: React.KeyboardEvent, currentIndex: number) => {
+      if (views.length === 0) return
+      let nextIndex: number | null = null
+      switch (e.key) {
+        case 'ArrowLeft':
+          nextIndex = (currentIndex - 1 + views.length) % views.length
+          break
+        case 'ArrowRight':
+          nextIndex = (currentIndex + 1) % views.length
+          break
+        case 'Home':
+          nextIndex = 0
+          break
+        case 'End':
+          nextIndex = views.length - 1
+          break
+        default:
+          return
+      }
+      e.preventDefault()
+      const target = views[nextIndex]
+      if (target) {
+        onSelectView(target.id)
+        // Move focus to the newly-selected tab so the user lands on
+        // tabIndex=0 next render.
+        tabRefs.current[nextIndex]?.focus()
+      }
+    },
+    [onSelectView, views],
+  )
 
   if (views.length === 0) return null
 
@@ -157,11 +219,12 @@ export function SidebarPanelSlot({
           role="tablist"
           aria-label="Sidebar panel views"
         >
-          {views.map((v) => {
+          {views.map((v, i) => {
             const selected = v.id === activeView?.id
             return (
               <button
                 key={v.id}
+                ref={(el) => { tabRefs.current[i] = el }}
                 type="button"
                 role="tab"
                 aria-selected={selected}
@@ -169,6 +232,7 @@ export function SidebarPanelSlot({
                 data-testid={`sidebar-panel-slot-tab-${v.id}`}
                 className={`sidebar-panel-slot-tab${selected ? ' selected' : ''}`}
                 onClick={() => onSelectView(v.id)}
+                onKeyDown={(e) => handleTabKeyDown(e, i)}
                 tabIndex={selected ? 0 : -1}
               >
                 {v.label}

--- a/packages/dashboard/src/components/SidebarPanelSlot.tsx
+++ b/packages/dashboard/src/components/SidebarPanelSlot.tsx
@@ -1,0 +1,211 @@
+/**
+ * SidebarPanelSlot (#4303) — pluggable bottom panel in the left sidebar.
+ *
+ * Hosts a collection of registered views (declared by parent) and lets the
+ * user pick one via a tab strip, collapse the entire panel to just its
+ * header, and drag-resize its height. Persistence (height, selected view,
+ * collapsed state) is handled by the parent via callbacks so each consumer
+ * picks its own storage backend.
+ *
+ * Designed to host future occupants beyond v1's token view: MCP server
+ * status, skills registry, slash command palette, etc. Adding a view is
+ * declarative — pass another entry in `views`.
+ */
+import { useCallback, useEffect, useRef, type ReactNode } from 'react'
+
+export interface SidebarPanelView {
+  /** Stable id used for persistence + view selection. */
+  id: string
+  /** Short label shown in the tab strip. */
+  label: string
+  /** The view body. Rendered only when this view is selected. */
+  render: () => ReactNode
+  /**
+   * Optional metric to surface in the collapsed-panel header bar
+   * (decision #4 in #4303). When the panel is collapsed, the active
+   * view can still report a single live number/string here so the
+   * user gets at-a-glance info without expanding.
+   */
+  collapsedHeaderMetric?: () => ReactNode
+}
+
+export interface SidebarPanelSlotProps {
+  views: SidebarPanelView[]
+  selectedViewId: string | null
+  onSelectView: (viewId: string) => void
+  collapsed: boolean
+  onCollapsedChange: (collapsed: boolean) => void
+  height: number
+  onHeightChange: (height: number) => void
+  /** Min content height in px (default 120). */
+  minHeight?: number
+  /** Max content height in px (default 600). */
+  maxHeight?: number
+}
+
+const DEFAULT_MIN_HEIGHT = 120
+const DEFAULT_MAX_HEIGHT = 600
+const HEADER_HEIGHT_PX = 28
+
+export function SidebarPanelSlot({
+  views,
+  selectedViewId,
+  onSelectView,
+  collapsed,
+  onCollapsedChange,
+  height,
+  onHeightChange,
+  minHeight = DEFAULT_MIN_HEIGHT,
+  maxHeight = DEFAULT_MAX_HEIGHT,
+}: SidebarPanelSlotProps) {
+  // Resolve selected view — fall back to first view if id is stale (e.g.
+  // a previously-selected view was removed). Falls back to null only when
+  // there are zero registered views, which is a degenerate case but
+  // shouldn't crash.
+  const activeView =
+    views.find((v) => v.id === selectedViewId) ?? views[0] ?? null
+
+  const isDragging = useRef(false)
+  const startY = useRef(0)
+  const startHeight = useRef(height)
+
+  const handleResizeMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (collapsed) return
+      e.preventDefault()
+      isDragging.current = true
+      startY.current = e.clientY
+      startHeight.current = height
+
+      const onMouseMove = (ev: MouseEvent) => {
+        if (!isDragging.current) return
+        // The handle is on the TOP edge — dragging UP makes the panel
+        // taller, so subtract delta from start.
+        const delta = startY.current - ev.clientY
+        const next = Math.min(maxHeight, Math.max(minHeight, startHeight.current + delta))
+        onHeightChange(next)
+      }
+
+      const onMouseUp = () => {
+        isDragging.current = false
+        document.removeEventListener('mousemove', onMouseMove)
+        document.removeEventListener('mouseup', onMouseUp)
+      }
+
+      document.addEventListener('mousemove', onMouseMove)
+      document.addEventListener('mouseup', onMouseUp)
+    },
+    [collapsed, height, maxHeight, minHeight, onHeightChange],
+  )
+
+  // Keyboard resize support (decision #5 AC): arrow keys when the handle
+  // is focused move the panel boundary in 16px steps.
+  const handleResizeKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (collapsed) return
+      const STEP = 16
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        onHeightChange(Math.min(maxHeight, height + STEP))
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        onHeightChange(Math.max(minHeight, height - STEP))
+      }
+    },
+    [collapsed, height, maxHeight, minHeight, onHeightChange],
+  )
+
+  // Cleanup any dangling listeners if the slot unmounts mid-drag.
+  useEffect(() => {
+    return () => {
+      isDragging.current = false
+    }
+  }, [])
+
+  if (views.length === 0) return null
+
+  const contentHeight = Math.min(maxHeight, Math.max(minHeight, height))
+
+  return (
+    <div
+      className="sidebar-panel-slot"
+      data-testid="sidebar-panel-slot"
+      data-collapsed={collapsed ? 'true' : 'false'}
+    >
+      {!collapsed && (
+        <div
+          className="sidebar-panel-slot-resize-handle"
+          data-testid="sidebar-panel-slot-resize-handle"
+          role="separator"
+          aria-orientation="horizontal"
+          aria-valuenow={contentHeight}
+          aria-valuemin={minHeight}
+          aria-valuemax={maxHeight}
+          aria-label="Resize sidebar panel"
+          tabIndex={0}
+          onMouseDown={handleResizeMouseDown}
+          onKeyDown={handleResizeKeyDown}
+        />
+      )}
+      <div
+        className="sidebar-panel-slot-header"
+        data-testid="sidebar-panel-slot-header"
+        style={{ height: HEADER_HEIGHT_PX }}
+      >
+        <div
+          className="sidebar-panel-slot-tabs"
+          role="tablist"
+          aria-label="Sidebar panel views"
+        >
+          {views.map((v) => {
+            const selected = v.id === activeView?.id
+            return (
+              <button
+                key={v.id}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                aria-controls={`sidebar-panel-slot-view-${v.id}`}
+                data-testid={`sidebar-panel-slot-tab-${v.id}`}
+                className={`sidebar-panel-slot-tab${selected ? ' selected' : ''}`}
+                onClick={() => onSelectView(v.id)}
+                tabIndex={selected ? 0 : -1}
+              >
+                {v.label}
+              </button>
+            )
+          })}
+        </div>
+        {collapsed && activeView?.collapsedHeaderMetric && (
+          <div
+            className="sidebar-panel-slot-collapsed-metric"
+            data-testid="sidebar-panel-slot-collapsed-metric"
+          >
+            {activeView.collapsedHeaderMetric()}
+          </div>
+        )}
+        <button
+          type="button"
+          className="sidebar-panel-slot-collapse-toggle"
+          data-testid="sidebar-panel-slot-collapse-toggle"
+          aria-label={collapsed ? 'Expand sidebar panel' : 'Collapse sidebar panel'}
+          aria-expanded={!collapsed}
+          onClick={() => onCollapsedChange(!collapsed)}
+        >
+          {collapsed ? '▴' : '▾'}
+        </button>
+      </div>
+      {!collapsed && activeView && (
+        <div
+          className="sidebar-panel-slot-body"
+          data-testid="sidebar-panel-slot-body"
+          id={`sidebar-panel-slot-view-${activeView.id}`}
+          role="tabpanel"
+          style={{ height: contentHeight }}
+        >
+          {activeView.render()}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/SidebarTokenView.test.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * SidebarTokenView v0 tests (#4303).
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import type { SessionInfo, CumulativeUsage } from '@chroxy/store-core'
+import {
+  SidebarTokenView,
+  aggregateUsage,
+  formatTokenCount,
+  tokenViewCollapsedMetric,
+} from './SidebarTokenView'
+
+afterEach(() => {
+  cleanup()
+})
+
+function makeUsage(input: number, output: number, costUsd = 0): CumulativeUsage {
+  return {
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd,
+    turnsBilled: 1,
+  }
+}
+
+function makeSession(
+  id: string,
+  provider: string,
+  usage: CumulativeUsage | undefined,
+): SessionInfo {
+  return {
+    sessionId: id,
+    name: id,
+    cwd: '/tmp',
+    type: 'cli',
+    hasTerminal: false,
+    model: null,
+    permissionMode: null,
+    isBusy: false,
+    createdAt: 0,
+    conversationId: null,
+    provider,
+    cumulativeUsage: usage,
+  }
+}
+
+describe('SidebarTokenView (#4303 v0)', () => {
+  describe('aggregateUsage (pure)', () => {
+    it('returns all-zero totals + empty list for no sessions', () => {
+      const agg = aggregateUsage([])
+      expect(agg.totalSessions).toBe(0)
+      expect(agg.byProvider).toEqual([])
+      expect(agg.totals.inputTokens).toBe(0)
+      expect(agg.totals.outputTokens).toBe(0)
+      expect(agg.hasUntracked).toBe(false)
+    })
+
+    it('sums tokens across same-provider sessions', () => {
+      const sessions = [
+        makeSession('s1', 'claude-sdk', makeUsage(1000, 500, 0)),
+        makeSession('s2', 'claude-sdk', makeUsage(2000, 800, 0)),
+      ]
+      const agg = aggregateUsage(sessions)
+      expect(agg.totals.inputTokens).toBe(3000)
+      expect(agg.totals.outputTokens).toBe(1300)
+      expect(agg.byProvider).toHaveLength(1)
+      expect(agg.byProvider[0].provider).toBe('claude-sdk')
+      expect(agg.byProvider[0].sessionCount).toBe(2)
+      expect(agg.byProvider[0].totals.inputTokens).toBe(3000)
+    })
+
+    it('keeps per-provider rows separate', () => {
+      const sessions = [
+        makeSession('a', 'claude-byok', makeUsage(1000, 200, 0.05)),
+        makeSession('b', 'claude-sdk', makeUsage(5000, 1000, 0)),
+        makeSession('c', 'claude-cli', makeUsage(2000, 400, 0)),
+      ]
+      const agg = aggregateUsage(sessions)
+      expect(agg.byProvider).toHaveLength(3)
+      const providers = agg.byProvider.map((r) => r.provider)
+      // Sorted by tokens desc (SDK=6000 > CLI=2400 > BYOK=1200)
+      expect(providers).toEqual(['claude-sdk', 'claude-cli', 'claude-byok'])
+    })
+
+    it('marks claude-tui sessions as untracked and excludes them from totals', () => {
+      const sessions = [
+        makeSession('sdk', 'claude-sdk', makeUsage(1000, 200, 0)),
+        makeSession('tui', 'claude-tui', makeUsage(0, 0, 0)),
+      ]
+      const agg = aggregateUsage(sessions)
+      expect(agg.hasUntracked).toBe(true)
+      const tuiRow = agg.byProvider.find((r) => r.provider === 'claude-tui')!
+      expect(tuiRow.untracked).toBe(true)
+      // SDK totals counted; TUI's zero-block doesn't affect cross-provider totals
+      expect(agg.totals.inputTokens).toBe(1000)
+      // TUI session counted in totalSessions for reference
+      expect(agg.totalSessions).toBe(2)
+    })
+
+    it('sorts untracked providers last regardless of their token count', () => {
+      // claude-tui sessions have all-zero usage today (no data). Even if a
+      // future hypothetical world made TUI report tokens, the untracked flag
+      // should keep them visually separated.
+      const sessions = [
+        makeSession('tui', 'claude-tui', makeUsage(0, 0, 0)),
+        makeSession('sdk', 'claude-sdk', makeUsage(100, 50, 0)),
+      ]
+      const agg = aggregateUsage(sessions)
+      expect(agg.byProvider[agg.byProvider.length - 1].provider).toBe('claude-tui')
+    })
+
+    it('handles missing cumulativeUsage as all-zero (defensive)', () => {
+      const sessions = [
+        makeSession('s1', 'claude-sdk', undefined),
+        makeSession('s2', 'claude-sdk', makeUsage(100, 50, 0)),
+      ]
+      const agg = aggregateUsage(sessions)
+      expect(agg.totals.inputTokens).toBe(100)
+      expect(agg.byProvider[0].sessionCount).toBe(2)
+    })
+
+    it('groups sessions without a provider field under "unknown"', () => {
+      const s: SessionInfo = {
+        sessionId: 'no-prov',
+        name: 'np',
+        cwd: '/',
+        type: 'cli',
+        hasTerminal: false,
+        model: null,
+        permissionMode: null,
+        isBusy: false,
+        createdAt: 0,
+        conversationId: null,
+        cumulativeUsage: makeUsage(500, 100),
+      }
+      const agg = aggregateUsage([s])
+      expect(agg.byProvider[0].provider).toBe('unknown')
+    })
+  })
+
+  describe('formatTokenCount', () => {
+    it('renders below 1000 verbatim', () => {
+      expect(formatTokenCount(0)).toBe('0')
+      expect(formatTokenCount(999)).toBe('999')
+    })
+
+    it('abbreviates thousands with K', () => {
+      expect(formatTokenCount(1000)).toBe('1.0K')
+      expect(formatTokenCount(1234)).toBe('1.2K')
+      expect(formatTokenCount(999999)).toBe('1000.0K')
+    })
+
+    it('abbreviates millions with M', () => {
+      expect(formatTokenCount(1_000_000)).toBe('1.00M')
+      expect(formatTokenCount(1_500_000)).toBe('1.50M')
+    })
+  })
+
+  describe('tokenViewCollapsedMetric', () => {
+    it('returns the same total as the expanded view', () => {
+      const sessions = [
+        makeSession('s1', 'claude-sdk', makeUsage(1000, 500, 0)),
+        makeSession('s2', 'claude-byok', makeUsage(800, 200, 0.04)),
+      ]
+      // Total = (1000+500) + (800+200) = 2500
+      expect(tokenViewCollapsedMetric(sessions)).toBe('2.5K tokens')
+    })
+
+    it('returns 0 tokens when no usage', () => {
+      expect(tokenViewCollapsedMetric([])).toBe('0 tokens')
+    })
+
+    it('excludes TUI from the collapsed total (decision #1)', () => {
+      const sessions = [
+        makeSession('tui', 'claude-tui', makeUsage(0, 0, 0)),
+        makeSession('sdk', 'claude-sdk', makeUsage(1000, 500, 0)),
+      ]
+      expect(tokenViewCollapsedMetric(sessions)).toBe('1.5K tokens')
+    })
+  })
+
+  describe('render', () => {
+    it('renders empty-state when no sessions', () => {
+      render(<SidebarTokenView sessions={[]} />)
+      expect(screen.getByTestId('sidebar-token-view-today-total')).toHaveTextContent('0 tokens')
+      expect(screen.getByTestId('sidebar-token-view-empty')).toBeInTheDocument()
+    })
+
+    it('renders per-provider rows with token counts', () => {
+      const sessions = [
+        makeSession('s1', 'claude-sdk', makeUsage(1000, 500, 0)),
+        makeSession('s2', 'claude-byok', makeUsage(2000, 800, 0.18)),
+      ]
+      render(<SidebarTokenView sessions={sessions} />)
+      expect(screen.getByTestId('sidebar-token-view-provider-claude-sdk')).toBeInTheDocument()
+      expect(screen.getByTestId('sidebar-token-view-provider-claude-byok')).toBeInTheDocument()
+    })
+
+    it('renders "—" for TUI rows with tooltip', () => {
+      const sessions = [makeSession('tui', 'claude-tui', makeUsage(0, 0, 0))]
+      render(<SidebarTokenView sessions={sessions} />)
+      const untracked = screen.getByTestId('sidebar-token-view-provider-claude-tui-untracked')
+      expect(untracked).toHaveTextContent('—')
+      expect(untracked.getAttribute('title')).toContain('claude TUI')
+    })
+
+    it('renders aggregate total and cost when present', () => {
+      const sessions = [
+        makeSession('byok', 'claude-byok', makeUsage(1000, 500, 0.10)),
+      ]
+      render(<SidebarTokenView sessions={sessions} />)
+      expect(screen.getByTestId('sidebar-token-view-today-total')).toHaveTextContent('1.5K tokens')
+      // Cost row only renders when costUsd > 0
+      expect(screen.getByText(/Cost \(BYOK\)/i)).toBeInTheDocument()
+    })
+
+    it('hides cost row when all sessions are subscription (cost === 0)', () => {
+      const sessions = [
+        makeSession('sub', 'claude-sdk', makeUsage(1000, 500, 0)),
+      ]
+      render(<SidebarTokenView sessions={sessions} />)
+      expect(screen.queryByText(/Cost \(BYOK\)/i)).toBeNull()
+    })
+  })
+})

--- a/packages/dashboard/src/components/SidebarTokenView.test.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.test.tsx
@@ -67,9 +67,9 @@ describe('SidebarTokenView (#4303 v0)', () => {
       expect(agg.totals.inputTokens).toBe(3000)
       expect(agg.totals.outputTokens).toBe(1300)
       expect(agg.byProvider).toHaveLength(1)
-      expect(agg.byProvider[0].provider).toBe('claude-sdk')
-      expect(agg.byProvider[0].sessionCount).toBe(2)
-      expect(agg.byProvider[0].totals.inputTokens).toBe(3000)
+      expect(agg.byProvider[0]!.provider).toBe('claude-sdk')
+      expect(agg.byProvider[0]!.sessionCount).toBe(2)
+      expect(agg.byProvider[0]!.totals.inputTokens).toBe(3000)
     })
 
     it('keeps per-provider rows separate', () => {
@@ -109,7 +109,7 @@ describe('SidebarTokenView (#4303 v0)', () => {
         makeSession('sdk', 'claude-sdk', makeUsage(100, 50, 0)),
       ]
       const agg = aggregateUsage(sessions)
-      expect(agg.byProvider[agg.byProvider.length - 1].provider).toBe('claude-tui')
+      expect(agg.byProvider[agg.byProvider.length - 1]!.provider).toBe('claude-tui')
     })
 
     it('handles missing cumulativeUsage as all-zero (defensive)', () => {
@@ -119,7 +119,7 @@ describe('SidebarTokenView (#4303 v0)', () => {
       ]
       const agg = aggregateUsage(sessions)
       expect(agg.totals.inputTokens).toBe(100)
-      expect(agg.byProvider[0].sessionCount).toBe(2)
+      expect(agg.byProvider[0]!.sessionCount).toBe(2)
     })
 
     it('groups sessions without a provider field under "unknown"', () => {
@@ -137,7 +137,7 @@ describe('SidebarTokenView (#4303 v0)', () => {
         cumulativeUsage: makeUsage(500, 100),
       }
       const agg = aggregateUsage([s])
-      expect(agg.byProvider[0].provider).toBe('unknown')
+      expect(agg.byProvider[0]!.provider).toBe('unknown')
     })
   })
 
@@ -150,7 +150,13 @@ describe('SidebarTokenView (#4303 v0)', () => {
     it('abbreviates thousands with K', () => {
       expect(formatTokenCount(1000)).toBe('1.0K')
       expect(formatTokenCount(1234)).toBe('1.2K')
-      expect(formatTokenCount(999999)).toBe('1000.0K')
+      expect(formatTokenCount(999_499)).toBe('999.5K')
+    })
+
+    // #4304 review: avoid the "1000.0K" visual nonsense.
+    it('rolls over to M before the K-rounded value crosses 1000', () => {
+      expect(formatTokenCount(999_500)).toBe('1.00M')
+      expect(formatTokenCount(999_999)).toBe('1.00M')
     })
 
     it('abbreviates millions with M', () => {

--- a/packages/dashboard/src/components/SidebarTokenView.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.tsx
@@ -22,22 +22,13 @@
  */
 import { useMemo } from 'react'
 import type { CumulativeUsage, SessionInfo } from '@chroxy/store-core'
-import { formatCostBadge } from '@chroxy/store-core'
+import { formatCostBadge, getProviderLabel } from '@chroxy/store-core'
 
 // Subscription/PTY providers that never emit token usage today (decision #1).
 // claude-tui is the only one in this set right now; if upstream adds usage
 // exposure we drop it from here. claude-cli DOES emit usage even on
 // subscription via stream-json's `result.usage`, so it is NOT in this set.
 const UNTRACKED_PROVIDERS = new Set(['claude-tui'])
-
-const PROVIDER_LABELS: Record<string, string> = {
-  'claude-cli': 'Claude CLI',
-  'claude-sdk': 'Claude SDK',
-  'claude-tui': 'Claude TUI',
-  'claude-byok': 'Claude BYOK',
-  'codex': 'Codex',
-  'gemini': 'Gemini',
-}
 
 export interface ProviderTotals {
   provider: string
@@ -138,10 +129,21 @@ export function aggregateUsage(sessions: SessionInfo[]): AggregateTotals {
   }
 }
 
-/** Format integer tokens with K/M abbreviation (1234 → "1.2K", 1500000 → "1.5M"). */
+/**
+ * Format integer tokens with K/M abbreviation.
+ *
+ *   formatTokenCount(0)         → "0"
+ *   formatTokenCount(999)       → "999"
+ *   formatTokenCount(1234)      → "1.2K"
+ *   formatTokenCount(999_999)   → "1.0M"   ← #4304 review: cross to M when K would round to 1000
+ *   formatTokenCount(1_500_000) → "1.50M"
+ */
 export function formatTokenCount(n: number): string {
   if (n < 1000) return String(n)
-  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`
+  // Roll over to "M" when the K-rounded value would be ≥ 1000 (i.e. when
+  // n ≥ 999500 rounds to 1000.0K). Avoid the "1000.0K" visual nonsense
+  // that the simple < 1_000_000 cutoff produced.
+  if (n < 999_500) return `${(n / 1000).toFixed(1)}K`
   return `${(n / 1_000_000).toFixed(2)}M`
 }
 
@@ -191,7 +193,7 @@ export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
         ) : (
           <ul className="sidebar-token-view-provider-list">
             {agg.byProvider.map((row) => {
-              const label = PROVIDER_LABELS[row.provider] ?? row.provider
+              const label = getProviderLabel(row.provider)
               const tokens = row.totals.inputTokens + row.totals.outputTokens
               return (
                 <li

--- a/packages/dashboard/src/components/SidebarTokenView.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.tsx
@@ -1,0 +1,240 @@
+/**
+ * SidebarTokenView (#4303 v0) — first occupant of the sidebar panel slot.
+ *
+ * v0 scope per the issue: read existing in-memory `cumulativeUsage` from
+ * the active session-states snapshot and render:
+ *   - Today's aggregate totals (input + output + total)
+ *   - Per-provider breakdown
+ *   - Per-session list (sortable later; ordered by tokens-desc for v0)
+ *   - TUI rows surface "—" with a tooltip (decision #1)
+ *
+ * Deferred to PR 2/3:
+ *   - 7d / 30d aggregates and time-series sparkline (needs usage-history.json)
+ *   - API-equivalent-cost toggle for subscription paths (decision #3)
+ *   - Per-tool breakdown for BYOK
+ *   - Cache-hit ratio (the data is on CumulativeUsage but UI is in PR 3)
+ *   - Collapsed-panel header live metric (renderer scaffold already in
+ *     SidebarPanelSlot)
+ *
+ * No new server-side plumbing needed for v0 — reads SessionInfo entries
+ * (which carry `cumulativeUsage` from session_list snapshots + the
+ * `session_usage` event stream).
+ */
+import { useMemo } from 'react'
+import type { CumulativeUsage, SessionInfo } from '@chroxy/store-core'
+import { formatCostBadge } from '@chroxy/store-core'
+
+// Subscription/PTY providers that never emit token usage today (decision #1).
+// claude-tui is the only one in this set right now; if upstream adds usage
+// exposure we drop it from here. claude-cli DOES emit usage even on
+// subscription via stream-json's `result.usage`, so it is NOT in this set.
+const UNTRACKED_PROVIDERS = new Set(['claude-tui'])
+
+const PROVIDER_LABELS: Record<string, string> = {
+  'claude-cli': 'Claude CLI',
+  'claude-sdk': 'Claude SDK',
+  'claude-tui': 'Claude TUI',
+  'claude-byok': 'Claude BYOK',
+  'codex': 'Codex',
+  'gemini': 'Gemini',
+}
+
+export interface ProviderTotals {
+  provider: string
+  /** True when this provider doesn't surface token data today (decision #1). */
+  untracked: boolean
+  totals: CumulativeUsage
+  sessionCount: number
+}
+
+export interface AggregateTotals {
+  /** Sum across ALL providers that surface tokens (untracked excluded). */
+  totals: CumulativeUsage
+  byProvider: ProviderTotals[]
+  /** Total session count across all providers (including untracked). */
+  totalSessions: number
+  /** Whether any untracked-provider session is present (used for UI tooltip). */
+  hasUntracked: boolean
+}
+
+const EMPTY_USAGE: CumulativeUsage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  costUsd: 0,
+  turnsBilled: 0,
+}
+
+function addUsage(a: CumulativeUsage, b: CumulativeUsage): CumulativeUsage {
+  return {
+    inputTokens: a.inputTokens + b.inputTokens,
+    outputTokens: a.outputTokens + b.outputTokens,
+    cacheReadTokens: a.cacheReadTokens + b.cacheReadTokens,
+    cacheCreationTokens: a.cacheCreationTokens + b.cacheCreationTokens,
+    costUsd: a.costUsd + b.costUsd,
+    turnsBilled: a.turnsBilled + b.turnsBilled,
+  }
+}
+
+/**
+ * Aggregate `cumulativeUsage` across sessions, grouped by provider.
+ *
+ * Untracked providers (currently just claude-tui) are excluded from the
+ * cross-provider totals but their session count is retained in
+ * `totalSessions`. Each provider row in `byProvider` carries an
+ * `untracked` flag so the renderer can show "—" instead of zeros.
+ *
+ * Pure / no React deps so it's unit-testable.
+ */
+export function aggregateUsage(sessions: SessionInfo[]): AggregateTotals {
+  const byProviderMap = new Map<string, ProviderTotals>()
+  let crossTotal = EMPTY_USAGE
+  let totalSessions = 0
+  let hasUntracked = false
+
+  for (const session of sessions) {
+    totalSessions += 1
+    const provider = session.provider ?? 'unknown'
+    const untracked = UNTRACKED_PROVIDERS.has(provider)
+    if (untracked) hasUntracked = true
+
+    const usage = session.cumulativeUsage ?? EMPTY_USAGE
+
+    if (!byProviderMap.has(provider)) {
+      byProviderMap.set(provider, {
+        provider,
+        untracked,
+        totals: EMPTY_USAGE,
+        sessionCount: 0,
+      })
+    }
+    const entry = byProviderMap.get(provider)!
+    entry.totals = addUsage(entry.totals, usage)
+    entry.sessionCount += 1
+
+    // Cross-provider totals exclude untracked providers — the value of "—" is
+    // that it doesn't pretend to be a number, so untracked sessions should not
+    // pull the overall total toward zero.
+    if (!untracked) {
+      crossTotal = addUsage(crossTotal, usage)
+    }
+  }
+
+  // Sort by total tokens desc, untracked rows last (they're displayed but
+  // shouldn't dominate the visual order since they're informational).
+  const byProvider = Array.from(byProviderMap.values()).sort((a, b) => {
+    if (a.untracked !== b.untracked) return a.untracked ? 1 : -1
+    const aTotal = a.totals.inputTokens + a.totals.outputTokens
+    const bTotal = b.totals.inputTokens + b.totals.outputTokens
+    return bTotal - aTotal
+  })
+
+  return {
+    totals: crossTotal,
+    byProvider,
+    totalSessions,
+    hasUntracked,
+  }
+}
+
+/** Format integer tokens with K/M abbreviation (1234 → "1.2K", 1500000 → "1.5M"). */
+export function formatTokenCount(n: number): string {
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`
+  return `${(n / 1_000_000).toFixed(2)}M`
+}
+
+export interface SidebarTokenViewProps {
+  /** All known sessions across active + resumable + background. */
+  sessions: SessionInfo[]
+}
+
+export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
+  const agg = useMemo(() => aggregateUsage(sessions), [sessions])
+  const totalTokens = agg.totals.inputTokens + agg.totals.outputTokens
+
+  return (
+    <div className="sidebar-token-view" data-testid="sidebar-token-view">
+      <div className="sidebar-token-view-aggregate" data-testid="sidebar-token-view-aggregate">
+        <div className="sidebar-token-view-aggregate-row">
+          <span className="sidebar-token-view-label">Today</span>
+          <span
+            className="sidebar-token-view-value"
+            data-testid="sidebar-token-view-today-total"
+          >
+            {formatTokenCount(totalTokens)} tokens
+          </span>
+        </div>
+        <div className="sidebar-token-view-aggregate-row">
+          <span className="sidebar-token-view-label">Input · Output</span>
+          <span className="sidebar-token-view-value-secondary">
+            {formatTokenCount(agg.totals.inputTokens)} · {formatTokenCount(agg.totals.outputTokens)}
+          </span>
+        </div>
+        {agg.totals.costUsd > 0 && (
+          <div className="sidebar-token-view-aggregate-row">
+            <span className="sidebar-token-view-label">Cost (BYOK)</span>
+            <span className="sidebar-token-view-value-secondary">
+              {formatCostBadge(agg.totals.costUsd)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="sidebar-token-view-section" data-testid="sidebar-token-view-by-provider">
+        <div className="sidebar-token-view-section-header">By provider</div>
+        {agg.byProvider.length === 0 ? (
+          <div className="sidebar-token-view-empty" data-testid="sidebar-token-view-empty">
+            No sessions yet
+          </div>
+        ) : (
+          <ul className="sidebar-token-view-provider-list">
+            {agg.byProvider.map((row) => {
+              const label = PROVIDER_LABELS[row.provider] ?? row.provider
+              const tokens = row.totals.inputTokens + row.totals.outputTokens
+              return (
+                <li
+                  key={row.provider}
+                  className="sidebar-token-view-provider-row"
+                  data-testid={`sidebar-token-view-provider-${row.provider}`}
+                >
+                  <span className="sidebar-token-view-provider-label">{label}</span>
+                  {row.untracked ? (
+                    <span
+                      className="sidebar-token-view-provider-untracked"
+                      data-testid={`sidebar-token-view-provider-${row.provider}-untracked`}
+                      title="Token count not exposed by claude TUI (PTY-only interface)"
+                    >
+                      —
+                    </span>
+                  ) : (
+                    <span className="sidebar-token-view-provider-tokens">
+                      {formatTokenCount(tokens)}
+                      {row.totals.costUsd > 0 && (
+                        <span className="sidebar-token-view-provider-cost">
+                          {' '}({formatCostBadge(row.totals.costUsd)})
+                        </span>
+                      )}
+                    </span>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Collapsed-panel header metric for the token view (decision #4).
+ * Exposed so the parent registering the view can wire this as
+ * `view.collapsedHeaderMetric` without redoing the aggregation.
+ */
+export function tokenViewCollapsedMetric(sessions: SessionInfo[]): string {
+  const agg = aggregateUsage(sessions)
+  const totalTokens = agg.totals.inputTokens + agg.totals.outputTokens
+  return `${formatTokenCount(totalTokens)} tokens`
+}

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -20,6 +20,10 @@ const KEY_SPLIT_MODE = `${KEY_PREFIX}split_mode`;
 const KEY_ACTIVE_SERVER = `${KEY_PREFIX}active_server_id`;
 const KEY_THEME = `${KEY_PREFIX}theme`;
 const KEY_SHOW_CONSOLE_TAB = `${KEY_PREFIX}show_console_tab`;
+// #4303 — pluggable sidebar panel slot persistence
+const KEY_SIDEBAR_PANEL_HEIGHT = `${KEY_PREFIX}sidebar_panel_height`;
+const KEY_SIDEBAR_PANEL_VIEW = `${KEY_PREFIX}sidebar_panel_view`;
+const KEY_SIDEBAR_PANEL_COLLAPSED = `${KEY_PREFIX}sidebar_panel_collapsed`;
 
 // ---------------------------------------------------------------------------
 // Server-scoped persistence — keys scoped by server ID to prevent data loss
@@ -219,6 +223,71 @@ export function loadPersistedSidebarWidth(): number | null {
     return Number.isFinite(parsed) ? parsed : null;
   } catch {
     return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// #4303 — Pluggable sidebar panel slot persistence
+// ---------------------------------------------------------------------------
+
+/** Persist the sidebar panel height (px). */
+export function persistSidebarPanelHeight(height: number): void {
+  try {
+    localStorage.setItem(KEY_SIDEBAR_PANEL_HEIGHT, String(height));
+  } catch {
+    // Storage not available
+  }
+}
+
+/** Load persisted sidebar panel height (px). Returns null when unset or invalid. */
+export function loadPersistedSidebarPanelHeight(): number | null {
+  try {
+    const raw = localStorage.getItem(KEY_SIDEBAR_PANEL_HEIGHT);
+    if (!raw) return null;
+    const parsed = parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the active sidebar-panel view id. */
+export function persistSidebarPanelView(viewId: string | null): void {
+  try {
+    if (viewId) {
+      localStorage.setItem(KEY_SIDEBAR_PANEL_VIEW, viewId);
+    } else {
+      localStorage.removeItem(KEY_SIDEBAR_PANEL_VIEW);
+    }
+  } catch {
+    // Storage not available
+  }
+}
+
+/** Load persisted sidebar-panel view id. Returns null when unset. */
+export function loadPersistedSidebarPanelView(): string | null {
+  try {
+    return localStorage.getItem(KEY_SIDEBAR_PANEL_VIEW);
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the sidebar-panel collapsed state. */
+export function persistSidebarPanelCollapsed(collapsed: boolean): void {
+  try {
+    localStorage.setItem(KEY_SIDEBAR_PANEL_COLLAPSED, collapsed ? '1' : '0');
+  } catch {
+    // Storage not available
+  }
+}
+
+/** Load persisted collapsed state. Returns false (default expanded) when unset. */
+export function loadPersistedSidebarPanelCollapsed(): boolean {
+  try {
+    return localStorage.getItem(KEY_SIDEBAR_PANEL_COLLAPSED) === '1';
+  } catch {
+    return false;
   }
 }
 

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -14,6 +14,13 @@ import {
   loadSessionMessages,
   clearPersistedState,
   _resetForTesting,
+  // #4303 — sidebar panel slot persistence
+  persistSidebarPanelHeight,
+  loadPersistedSidebarPanelHeight,
+  persistSidebarPanelView,
+  loadPersistedSidebarPanelView,
+  persistSidebarPanelCollapsed,
+  loadPersistedSidebarPanelCollapsed,
 } from './persistence';
 import {
   createKeyPair,
@@ -149,6 +156,52 @@ describe('persistence', () => {
     expect(state.viewMode).toBeNull();
     expect(state.activeSessionId).toBeNull();
     expect(state.terminalBuffer).toBeNull();
+  });
+
+  // #4303 — pluggable sidebar panel slot
+  describe('sidebar panel slot persistence (#4303)', () => {
+    it('persistSidebarPanelHeight and loadPersistedSidebarPanelHeight round-trip', () => {
+      persistSidebarPanelHeight(240);
+      expect(loadPersistedSidebarPanelHeight()).toBe(240);
+    });
+
+    it('loadPersistedSidebarPanelHeight returns null when unset', () => {
+      expect(loadPersistedSidebarPanelHeight()).toBeNull();
+    });
+
+    it('loadPersistedSidebarPanelHeight returns null for non-positive values', () => {
+      localStorage.setItem('chroxy_persist_sidebar_panel_height', '0');
+      expect(loadPersistedSidebarPanelHeight()).toBeNull();
+      localStorage.setItem('chroxy_persist_sidebar_panel_height', '-50');
+      expect(loadPersistedSidebarPanelHeight()).toBeNull();
+    });
+
+    it('loadPersistedSidebarPanelHeight returns null for non-numeric values', () => {
+      localStorage.setItem('chroxy_persist_sidebar_panel_height', 'banana');
+      expect(loadPersistedSidebarPanelHeight()).toBeNull();
+    });
+
+    it('persistSidebarPanelView and loadPersistedSidebarPanelView round-trip', () => {
+      persistSidebarPanelView('tokens');
+      expect(loadPersistedSidebarPanelView()).toBe('tokens');
+    });
+
+    it('persistSidebarPanelView(null) removes the key', () => {
+      persistSidebarPanelView('tokens');
+      persistSidebarPanelView(null);
+      expect(loadPersistedSidebarPanelView()).toBeNull();
+    });
+
+    it('persistSidebarPanelCollapsed round-trips true/false', () => {
+      persistSidebarPanelCollapsed(true);
+      expect(loadPersistedSidebarPanelCollapsed()).toBe(true);
+      persistSidebarPanelCollapsed(false);
+      expect(loadPersistedSidebarPanelCollapsed()).toBe(false);
+    });
+
+    it('loadPersistedSidebarPanelCollapsed defaults to false when unset (panel starts expanded)', () => {
+      expect(loadPersistedSidebarPanelCollapsed()).toBe(false);
+    });
   });
 });
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -715,6 +715,162 @@
   flex-wrap: wrap;
 }
 
+/* #4303 — pluggable sidebar panel slot */
+.sidebar-panel-slot {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.sidebar-panel-slot-resize-handle {
+  height: 4px;
+  cursor: row-resize;
+  background: transparent;
+  flex-shrink: 0;
+}
+
+.sidebar-panel-slot-resize-handle:hover,
+.sidebar-panel-slot-resize-handle:focus,
+.sidebar-panel-slot-resize-handle:active {
+  background: var(--accent, var(--text-secondary));
+  outline: none;
+}
+
+.sidebar-panel-slot-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.sidebar-panel-slot-tabs {
+  display: flex;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-panel-slot-tab {
+  background: transparent;
+  border: none;
+  padding: 4px 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.sidebar-panel-slot-tab:hover {
+  color: var(--text-primary);
+}
+
+.sidebar-panel-slot-tab.selected {
+  color: var(--text-primary);
+  background: var(--bg-muted, color-mix(in srgb, var(--text-secondary) 10%, transparent));
+}
+
+.sidebar-panel-slot-collapsed-metric {
+  font-size: 11px;
+  color: var(--text-secondary);
+  padding: 0 6px;
+}
+
+.sidebar-panel-slot-collapse-toggle {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 11px;
+}
+
+.sidebar-panel-slot-collapse-toggle:hover {
+  color: var(--text-primary);
+}
+
+.sidebar-panel-slot-body {
+  overflow-y: auto;
+  padding: 8px;
+  font-size: 12px;
+}
+
+.sidebar-token-view {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar-token-view-aggregate {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar-token-view-aggregate-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.sidebar-token-view-label {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.sidebar-token-view-value {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.sidebar-token-view-value-secondary {
+  color: var(--text-secondary);
+}
+
+.sidebar-token-view-section-header {
+  color: var(--text-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+
+.sidebar-token-view-empty {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-style: italic;
+}
+
+.sidebar-token-view-provider-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar-token-view-provider-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 12px;
+}
+
+.sidebar-token-view-provider-untracked {
+  color: var(--text-muted);
+  cursor: help;
+}
+
+.sidebar-token-view-provider-cost {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
 .sidebar-status-dot {
   width: 6px;
   height: 6px;


### PR DESCRIPTION
First of three PRs for #4303. Lands the **slot infrastructure** plus a **minimal token usage view** as the first occupant. PRs 2 and 3 add time-series storage and the sparkline / API-equiv toggle / per-tool breakdown respectively.

## What this PR does

### Slot infrastructure (`SidebarPanelSlot`)

- View registry: each entry is `{ id, label, render, collapsedHeaderMetric? }` — adding a new view is a one-line append, no slot code changes
- Tab strip with `role=\"tablist\"` / `aria-selected` / roving tabindex
- Collapse toggle (header bar stays visible, body + resize handle hide)
- Drag-resize on the top edge with clamped `[minHeight, maxHeight]`
- Arrow-key resize (16px steps) when the handle is focused
- `role=\"separator\"` + aria-orientation / min / max / now on the handle
- When collapsed, the active view can supply a single live metric to the header bar via `collapsedHeaderMetric()` (decision #4 in #4303)
- Stale-view-id fallback: when `selectedViewId` doesn't match any registered view, falls back to the first registered view rather than rendering nothing

### Token view v0 (`SidebarTokenView`)

- Reads existing in-memory `cumulativeUsage` off `SessionInfo` — no new wire / event work
- `aggregateUsage(sessions)` pure helper: per-provider rollup with untracked-provider isolation (unit-testable, no React deps)
- claude-tui rows surface `—` with a tooltip explaining the PTY-only limitation; their zero-block does NOT pull cross-provider totals toward zero (decision #1)
- Today totals row shows input + output; BYOK cost row only renders when `costUsd > 0` (hidden for pure-subscription runs)
- Per-provider list sorted tokens-desc, untracked rows last
- `tokenViewCollapsedMetric()` exposed for the collapsed-header

### Persistence

- New keys: `chroxy_persist_sidebar_panel_{height,view,collapsed}` mirroring existing `KEY_SIDEBAR_WIDTH` pattern
- Round-trip + edge-case tests: invalid / non-positive heights, removal-on-null

### SERVERS placement

Kept BELOW the slot for v1. The Sidebar.tsx code comment + the issue's decision section explain the rationale: ServerPicker has its own always-visible add button and live status — forcing it into the slot's one-view-at-a-time model loses functionality you'd want simultaneously with whichever slot view is selected. Migrating SERVERS into the slot as a registered view is a follow-up if it proves desirable.

## What this PR does NOT do (PR 2 & 3 scope)

- No `~/.chroxy/usage-history.json` write path (PR 2)
- No 7-day sparkline (depends on history file from PR 2)
- No \"show as API-equivalent cost\" toggle (PR 3)
- No per-tool breakdown for BYOK sessions (PR 3)
- No cache-hit ratio display (PR 3)

The slot is ready to host PR 3's enhancements without further infrastructure work — the registry pattern means PR 3 just extends the token view's render function.

## Tests

- 16 new tests for `SidebarPanelSlot` (view selection, collapse, resize, a11y)
- 18 new tests for `SidebarTokenView` (aggregate, per-provider, untracked handling, render)
- 8 new tests for sidebar panel persistence helpers
- 1899/1899 dashboard tests pass (up 42)
- `tsc --noEmit` clean

## Test plan

- [ ] Run the dashboard locally, confirm the new bottom panel renders below the sessions tree and above the SERVERS section
- [ ] Click the Tokens tab — body shows; click the collapse arrow — body hides, tab strip + collapsed metric remain
- [ ] Drag the resize handle up/down — height changes, persists across reload
- [ ] Reload — view, height, collapsed state restored
- [ ] Provider mix (BYOK + SDK + CLI + TUI) — TUI row shows `—` with tooltip; others show real numbers
- [ ] Pure-subscription session — no BYOK cost row visible
- [ ] Keyboard a11y — Tab into resize handle, press ArrowUp/ArrowDown — panel resizes

## Related

- Closes part of #4303 (slot infrastructure + first occupant)
- Builds on the BYOK cost suite: #4072, #4083, #4088, #4119, #4126, #4128