### PR TITLE
fix(dashboard): keep trailing ToolGroup expanded so Chat matches Output (#4305)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1431,12 +1431,24 @@ export function App() {
   )
 
   // Custom message renderer for permission prompts and tool bubbles
+  const chatTailMessageId = chatMessages.length > 0
+    ? chatMessages[chatMessages.length - 1]!.id
+    : null
   const renderMessage = useCallback((msg: ChatViewMessage) => {
     // Tool-group synthetic row (#3747) — id is a group key, not a store id.
     if (msg.type === 'tool_group') {
       const payload = chatToolGroupPayloads.get(msg.id)
       if (!payload) return null
-      return <ToolGroup messages={payload.messages} isActive={payload.isActive} />
+      // #4305 — keep the trailing group expanded so the Chat tab matches
+      // Output-tab chronology when a turn ends on a tool run with no
+      // follow-up summary.
+      return (
+        <ToolGroup
+          messages={payload.messages}
+          isActive={payload.isActive}
+          isTail={msg.id === chatTailMessageId}
+        />
+      )
     }
     const storeMsg = storeMsgMap.get(msg.id)
     if (!storeMsg) return null
@@ -1506,7 +1518,7 @@ export function App() {
 
     // Default rendering
     return null
-  }, [storeMsgMap, chatToolGroupPayloads, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered])
+  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered])
 
   const SHORTCUTS: ShortcutEntry[] = useMemo(() => {
     // #2883: author entries with canonical `Cmd+...` labels and rewrite to

--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -174,6 +174,53 @@ describe('ToolGroup', () => {
     expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
   })
 
+  // #4305 — when a turn ends on a tool run with no follow-up assistant
+  // text, the trailing group must stay visible so the Chat tab matches
+  // Output-tab chronology. Pre-fix the on-completion auto-collapse
+  // silently hid the user's most recent action.
+  describe('tail-group behavior (#4305)', () => {
+    it('keeps the group expanded after isActive flips to false when isTail', () => {
+      const messages = [tool('1', 'Bash'), tool('2', 'Read')]
+      const { rerender } = render(
+        <ToolGroup messages={messages} isActive={true} isTail={true} />,
+      )
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+      rerender(<ToolGroup messages={messages} isActive={false} isTail={true} />)
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('starts expanded even when not active if the group is tail', () => {
+      const messages = [tool('1', 'Bash'), tool('2', 'Read')]
+      render(<ToolGroup messages={messages} isActive={false} isTail={true} />)
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('does not retroactively collapse when isTail later flips to false', () => {
+      // Turn ends on tool run (tail, expanded). Then a response message
+      // arrives and the group is no longer tail. Expansion state must
+      // not retroactively change — the user might have left it open.
+      const messages = [tool('1', 'Bash'), tool('2', 'Read')]
+      const { rerender } = render(
+        <ToolGroup messages={messages} isActive={false} isTail={true} />,
+      )
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+      rerender(<ToolGroup messages={messages} isActive={false} isTail={false} />)
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('still auto-collapses when isActive flips to false and isTail is false', () => {
+      // Regression: the existing on-completion collapse must still fire
+      // when the group is NOT the tail (i.e., a response follows).
+      const messages = [tool('1', 'Bash')]
+      const { rerender } = render(
+        <ToolGroup messages={messages} isActive={true} isTail={false} />,
+      )
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+      rerender(<ToolGroup messages={messages} isActive={false} isTail={false} />)
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'false')
+    })
+  })
+
   // #4279: per-entry expansion. Clicking an inner entry must reveal the full
   // toolInput + toolResult for that entry WITHOUT collapsing the whole group
   // — pre-fix the entry click bubbled to the outer `onClick={toggle}` and

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -19,6 +19,11 @@ import {
 export interface ToolGroupProps {
   messages: ChatMessage[]
   isActive: boolean
+  // #4305 — when true, the group is the last item in the chat list and has
+  // no follow-up assistant text summarizing it. Skips the on-completion
+  // auto-collapse so trailing tool runs stay visible (matching the Output
+  // tab's chronology) until the user explicitly collapses them.
+  isTail?: boolean
 }
 
 function getInputSummary(input: ChatMessage['toolInput']): string {
@@ -165,14 +170,25 @@ function ToolGroupEntry({
   )
 }
 
-export function ToolGroup({ messages, isActive }: ToolGroupProps) {
+export function ToolGroup({ messages, isActive, isTail = false }: ToolGroupProps) {
   // Auto-collapse on completion: expand while active, collapse when the
   // run ends. Subsequent expand state lives in component state so a user
   // who toggled stays toggled until the run lifecycle flips again.
-  const [expanded, setExpanded] = useState(isActive)
+  // #4305 — tail groups (no follow-up summary) start expanded and skip
+  // the on-completion collapse, so trailing tools remain visible.
+  const [expanded, setExpanded] = useState(isActive || isTail)
   const wasActiveRef = useRef(isActive)
+  // Read isTail at the moment of the activity flip via a ref so changing
+  // isTail later (e.g. a response message arrives after the user has
+  // already seen the group expanded) doesn't retroactively collapse it.
+  const isTailRef = useRef(isTail)
   useEffect(() => {
-    if (wasActiveRef.current && !isActive) setExpanded(false)
+    isTailRef.current = isTail
+  })
+  useEffect(() => {
+    if (wasActiveRef.current && !isActive) {
+      if (!isTailRef.current) setExpanded(false)
+    }
     if (!wasActiveRef.current && isActive) setExpanded(true)
     wasActiveRef.current = isActive
   }, [isActive])


### PR DESCRIPTION
## Summary

Fixes the Bug A half of #4305: a turn that ends on a tool run with no follow-up assistant text was silently hidden in the Chat tab while the Output tab kept showing the trailing tools. The two tabs disagreed on the same turn.

Root cause: `ToolGroup`'s on-completion auto-collapse (`ToolGroup.tsx:174-178`) fires for the tail group exactly like any other group. `applyStreamingOverlay` marks the tail `isActive` only while streaming, so `stream_end` flipped `isActive` false and the useEffect collapsed what the user had just seen.

## Approach

Added `isTail?: boolean` to `ToolGroup`. `App.tsx` passes `isTail=true` for whichever synthetic tool_group's id matches the tail of `chatMessages`. Tail groups:

- Start expanded (`useState(isActive || isTail)`)
- Skip the `wasActive→!isActive` collapse
- Don't retroactively collapse if `isTail` later flips to `false` (response arrives) — `isTail` is read through a ref captured at the activity flip

Non-tail groups keep the existing auto-collapse behavior — when claude summarizes the tools in text, the tools fold away as before. #4305 follow-up (Bug B state-preservation across tab remounts) stays open; the tail mounting expanded mitigates the visible "appear then re-fold" jump as a side-effect, but the full lift-state-to-store refactor for non-tail groups + per-entry toggles is a separate piece of work.

## Test plan

- [x] 4 new `ToolGroup` tests under "tail-group behavior (#4305)":
  - keeps expanded after isActive flips to false when isTail
  - starts expanded when not active if isTail
  - does not retroactively collapse when isTail flips false
  - still auto-collapses when isActive flips false and isTail false (regression)
- [x] 29/29 `ToolGroup.test.tsx` pass
- [x] 1911/1911 full dashboard suite pass (was 1907; +4 new tests)
- [x] `tsc --noEmit` clean

## Related

- Direct follow-on to #4297 (Chat renders final summary above earlier tool groups) and #4296 (Output-tab answer visibility) — bundled in v0.9.5.
- Bug B (state lost on tab remount) — visible-jump piece is mitigated by this fix; full state preservation deferred to a follow-up.