### PR TITLE
fix(server): push available_models on session switch (#4302)

### DIFF
--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -267,6 +267,21 @@ export function sendSessionInfo(ctx, ws, sessionId) {
   if (session.isReady) {
     send(ws, { type: 'claude_ready', sessionId })
   }
+  // #4302: push the new session's provider-scoped model list on every
+  // switch. Without this, the dashboard's `availableModelsProvider` stays
+  // tagged with whichever provider the client saw last (set on auth via
+  // `sendPostAuthInfo`), and `modelsMatchProvider` in App.tsx suppresses
+  // the model picker for any session whose provider differs from the
+  // initial one — most visibly, a claude-cli session created after a
+  // TUI/SDK session loses its picker entirely.
+  const activeProvider = entry.provider || null
+  const activeRegistry = getRegistryForProvider(activeProvider)
+  send(ws, {
+    type: 'available_models',
+    models: activeRegistry.getModels(),
+    defaultModel: activeRegistry.getDefaultModelId(),
+    provider: activeProvider,
+  })
   send(ws, {
     type: 'model_changed',
     // #3687: prefer the user's explicit override (`model`) so a later

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -544,6 +544,47 @@ describe('sendSessionInfo', () => {
     assert.equal(modelMsg.model, 'sonnet')
   })
 
+  // #4302 — sendSessionInfo runs on every switch_session. Pre-fix it did
+  // not push available_models, so the dashboard's availableModelsProvider
+  // stayed tagged with whichever provider sendPostAuthInfo set at auth.
+  // A claude-cli session created after a TUI/SDK session lost its model
+  // picker via the modelsMatchProvider guard in App.tsx.
+  describe('available_models on session switch (#4302)', () => {
+    it('sends available_models tagged with the switched-to session provider', () => {
+      const { manager, sessionsMap } = createMockSessionManager([
+        { id: 'sess-cli', name: 'CLI', cwd: '/cli' },
+      ])
+      sessionsMap.get('sess-cli').provider = 'claude-cli'
+      const ws = makeFakeWs()
+      const ctx = makeCtx({ sessionManager: manager })
+      registerClient(ctx, ws)
+
+      sendSessionInfo(ctx, ws, 'sess-cli')
+      const modelsMsg = ctx._sends.find(m => m.type === 'available_models')
+      assert.ok(modelsMsg, 'available_models was not sent on session switch')
+      assert.equal(modelsMsg.provider, 'claude-cli')
+      assert.ok(Array.isArray(modelsMsg.models), 'models must be an array')
+      assert.ok(modelsMsg.models.length > 0, 'claude-cli registry must yield non-empty models')
+    })
+
+    it('uses a null provider when the session entry has none', () => {
+      // No mock provider — getRegistryForProvider falls back to the
+      // Claude default registry, and the payload's provider is null so
+      // the dashboard handler skips overwriting availableModelsProvider.
+      const { manager } = createMockSessionManager([
+        { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+      ])
+      const ws = makeFakeWs()
+      const ctx = makeCtx({ sessionManager: manager })
+      registerClient(ctx, ws)
+
+      sendSessionInfo(ctx, ws, 'sess-1')
+      const modelsMsg = ctx._sends.find(m => m.type === 'available_models')
+      assert.ok(modelsMsg, 'available_models was not sent on session switch')
+      assert.equal(modelsMsg.provider, null)
+    })
+  })
+
   it('sends model_changed with null when session has no model', () => {
     const { manager, sessionsMap } = createMockSessionManager([
       { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },


### PR DESCRIPTION
## Summary

Fixes #4302. A claude-cli session created after a TUI/SDK session was already active had no model selector — the Sonnet/Opus/Haiku dropdown didn't render even though the CLI provider supports model switching.

## Root cause

\`sendSessionInfo\` (ws-history.js) runs on every \`switch_session\` and pushes \`claude_ready\`, \`model_changed\`, \`permission_mode_changed\`, \`thinking_level_changed\`, and \`permission_rules_updated\` — **but never \`available_models\`**. The dashboard's \`availableModelsProvider\` stays tagged with whichever provider \`sendPostAuthInfo\` pushed at auth time. App.tsx:325 gates the picker behind \`modelsMatchProvider\`, so any session whose provider differs from the initial one gets the picker suppressed.

## Fix

Push provider-scoped \`available_models\` from \`sendSessionInfo\` using the same \`getRegistryForProvider(entry.provider)\` pattern \`sendPostAuthInfo\` already uses. Payload carries \`provider: activeProvider\` so the dashboard's handler updates \`availableModelsProvider\` to match. Picker appears for claude-cli — and any future provider — consistent with TUI/SDK sessions.

## Test plan

- [x] 2 new tests under \`available_models on session switch (#4302)\`:
  - sends payload tagged with the switched-to session provider (\`claude-cli\`)
  - falls back to null provider when entry has none (handler skips overwrite)
- [x] 60/60 \`ws-history.test.js\` pass
- [x] 3 pre-existing unrelated suite failures (service / web-task-manager) confirmed present on \`main\` HEAD without this change
- [ ] Dogfood verification: create CLI session after TUI session — picker should appear

## Related

- App.tsx:325 \`modelsMatchProvider\` (the consumer this fix unblocks)
- ws-history.js:225 \`sendPostAuthInfo\` (the pattern this mirrors)
- #4301 — same dogfood session, separate root cause (credentials preflight)