### PR TITLE
fix(server): correct misleading comment in sendSessionInfo null-provider test (#4316)

### DIFF
--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -570,7 +570,9 @@ describe('sendSessionInfo', () => {
     it('uses a null provider when the session entry has none', () => {
       // No mock provider — getRegistryForProvider falls back to the
       // Claude default registry, and the payload's provider is null so
-      // the dashboard handler skips overwriting availableModelsProvider.
+      // the dashboard handler resets availableModelsProvider to null,
+      // which unblocks the picker via the `availableModelsProvider == null`
+      // branch in App.tsx:326.
       const { manager } = createMockSessionManager([
         { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
       ])


### PR DESCRIPTION
## Summary

Follow-up to #4310. The second test in the `available_models on session switch` block had a misleading comment claiming the dashboard handler skips overwriting `availableModelsProvider` when the payload provider is `null`. The handler at `packages/dashboard/src/store/message-handler.ts:2395` actually computes:

```ts
const availableModelsProvider = typeof msg.provider === 'string' ? msg.provider : null;
set({ availableModels, availableModelsProvider, defaultModelId });
```

So the slot is **overwritten to `null`**, not preserved. The net behavior is still correct (the `availableModelsProvider == null` branch in `App.tsx:326` unblocks the picker), but the old comment would mislead the next person tracing model-picker bugs.

## Changes

- `packages/server/tests/ws-history.test.js`: update the comment in the null-provider case to describe the actual handler behavior and reference the App.tsx unblock branch.

No code change; documentation/comment only.

## Test plan

- [x] `node --experimental-test-module-mocks --test tests/ws-history.test.js` — 60/60 pass

Closes #4316