### PR TITLE
refactor(dashboard): remove dead onKeyDown on Thinking ToolGroupEntry (#4284)

### DIFF
--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -317,6 +317,18 @@ describe('ToolGroup', () => {
       expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
     })
 
+    // #4284: the Thinking entry is a plain <div> with no role/tabIndex, so
+    // it can never receive keyboard focus — any onKeyDown handler attached
+    // to it would be dead code. Assert the entry is non-focusable so future
+    // refactors don't reintroduce an unreachable keyboard handler without
+    // also making the row focusable + announced.
+    it('Thinking entry is non-focusable (no tabIndex, no role=button)', () => {
+      render(<ToolGroup messages={[thinking('t1')]} isActive={true} />)
+      const entry = screen.getByTestId('tool-group-entry-t1')
+      expect(entry).not.toHaveAttribute('tabindex')
+      expect(entry).not.toHaveAttribute('role', 'button')
+    })
+
     it('keyboard: Enter on a focused row toggles its detail without collapsing the group', () => {
       const messages = [
         tool('1', 'Bash', { toolInput: { command: 'ls' }, toolResult: 'a b c' }),

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -65,13 +65,16 @@ function ToolGroupEntry({
   // so a misclick on a Thinking row doesn't collapse the parent group, but
   // we never set onToggle — the row has no expanded state.
   if (message.type === 'thinking') {
-    const swallow = (e: React.MouseEvent | React.KeyboardEvent) => e.stopPropagation()
+    // The div is non-interactive (no role/tabIndex), so keyboard focus
+    // never lands here — only the click handler is reachable. We swallow
+    // clicks so a misclick on a Thinking row doesn't collapse the parent
+    // group.
+    const swallow = (e: React.MouseEvent) => e.stopPropagation()
     return (
       <div
         className="tool-group-entry tool-group-entry--thinking"
         data-testid={`tool-group-entry-${message.id}`}
         onClick={swallow}
-        onKeyDown={swallow}
       >
         <span className="tool-group-entry-name">Thinking</span>
       </div>


### PR DESCRIPTION
## Summary

The Thinking entry in `ToolGroup` is a plain `<div>` with no `role` or `tabIndex`, so it can never receive keyboard focus — the previous `onKeyDown={swallow}` handler was unreachable dead code. Identified during review of #4280.

## Changes

- `packages/dashboard/src/components/ToolGroup.tsx`: drop the `onKeyDown` prop on the Thinking entry, narrow the swallow handler signature from `React.MouseEvent | React.KeyboardEvent` to `React.MouseEvent`. Comment refreshed to reflect that only the click handler is reachable.
- `packages/dashboard/src/components/ToolGroup.test.tsx`: add a regression test asserting the Thinking entry has no `tabindex` and no `role="button"`, so a future refactor doesn't reintroduce an unreachable keyboard handler without also wiring focus + role.

## Test plan

- [x] `npx vitest run src/components/ToolGroup.test.tsx` — 30/30 pass
- [x] `npx tsc --noEmit` — clean

Closes #4284