### PR TITLE
refactor(server): rename TUI respondToQuestion local payload to avoid hook-event collision (#4294)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1319,7 +1319,7 @@ export class ClaudeTuiSession extends BaseSession {
     // freeform text), fall through to typing the answer literally —
     // claude TUI's Other-path may still mis-parse that, tracked in
     // #4288 as a separate concern.
-    let payload = text
+    let writeText = text
     if (Array.isArray(options) && options.length > 0) {
       const matchIdx = options.findIndex((o) => o && o.label === text)
       // #4292: single-digit guard (1..9). Multi-digit hotkeys
@@ -1331,13 +1331,13 @@ export class ClaudeTuiSession extends BaseSession {
       // mode-jump way) without silently sending a hotkey we can't
       // trust. Vanishingly rare in practice.
       if (matchIdx >= 0 && matchIdx < 9) {
-        payload = String(matchIdx + 1)
+        writeText = String(matchIdx + 1)
       }
     }
     // Fire-and-forget — the write is async due to the per-char throttle,
     // but the caller (handleUserQuestionResponse) is sync. Errors here
     // are non-fatal; worst case the user re-sends the answer.
-    this._writePtyTextThrottled(payload).catch((err) => {
+    this._writePtyTextThrottled(writeText).catch((err) => {
       log.warn(`respondToQuestion PTY write failed: ${err.message}`)
     })
   }


### PR DESCRIPTION
## Summary

Follow-up nit from review of PR #4291. In `claude-tui-session.js#respondToQuestion`, the local variable named `payload` (the string to write to the PTY) collides semantically with the file-wide `payload` parameter used throughout the hook-event helpers (`_emitToolHookEvent`, `payload.tool_input`, `payload.tool_response`, etc.). A future reader greppping `payload` to trace hook flow gets a stray hit on this unrelated local.

Renamed the local to `writeText`. Pure rename — no behavior change.

## Changes

- `packages/server/src/claude-tui-session.js`: `let payload = text` → `let writeText = text` inside `respondToQuestion`. Two reassignment sites and the `_writePtyTextThrottled(...)` call updated.

## Test plan

- [x] `packages/server` `claude-tui-session.test.js` suite still green (98/98 pass).
- [ ] No behavior change — TUI hotkey vs literal-label path verified by the existing #4290/#4292 tests.

Closes #4294