### PR TITLE
fix(dashboard): handle ToolGroup tail same-render flip (#4314)

### DIFF
--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -219,6 +219,26 @@ describe('ToolGroup', () => {
       rerender(<ToolGroup messages={messages} isActive={false} isTail={false} />)
       expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'false')
     })
+
+    // #4314 — same-commit flip. If a single store update both ends the
+    // stream (isActive: true -> false) AND shifts the tail away from this
+    // group (isTail: true -> false) — e.g. a `response` message arrives in
+    // the same batch as `stream_end` — the on-completion collapse must
+    // still respect the *prior* tail status. Reading isTail via a ref
+    // updated on every render snapshots the post-flip value (false), so
+    // without a guard the group collapses immediately — the same UX bug
+    // #4309 was meant to fix, just on a faster turn.
+    it('does not collapse when isActive and isTail flip false in the same render', () => {
+      const messages = [tool('1', 'Bash'), tool('2', 'Read')]
+      const { rerender } = render(
+        <ToolGroup messages={messages} isActive={true} isTail={true} />,
+      )
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+      // Both flips land in a single render — the response and stream_end
+      // arrived in the same batched store update.
+      rerender(<ToolGroup messages={messages} isActive={false} isTail={false} />)
+      expect(screen.getByTestId('tool-group')).toHaveAttribute('aria-expanded', 'true')
+    })
   })
 
   // #4279: per-entry expansion. Clicking an inner entry must reveal the full

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -178,16 +178,21 @@ export function ToolGroup({ messages, isActive, isTail = false }: ToolGroupProps
   // the on-completion collapse, so trailing tools remain visible.
   const [expanded, setExpanded] = useState(isActive || isTail)
   const wasActiveRef = useRef(isActive)
-  // Read isTail at the moment of the activity flip via a ref so changing
-  // isTail later (e.g. a response message arrives after the user has
-  // already seen the group expanded) doesn't retroactively collapse it.
-  const isTailRef = useRef(isTail)
-  useEffect(() => {
-    isTailRef.current = isTail
-  })
+  // Latch isTail while the group is still active so the on-completion
+  // collapse path reads the *pre-flip* tail status. #4314 — if a single
+  // render flips both isActive: true -> false AND isTail: true -> false
+  // (response message arrives in the same batched store update as
+  // stream_end), an effect-updated ref would already reflect the new
+  // isTail=false by the time the [isActive] effect runs (effects fire in
+  // declaration order on the same commit), and the trailing group would
+  // collapse immediately — the same symptom #4309 fixed. Updating inline
+  // during render guarantees the latch only advances while the group is
+  // observably the tail of an active run.
+  const wasTailRef = useRef(isTail)
+  if (isActive) wasTailRef.current = isTail
   useEffect(() => {
     if (wasActiveRef.current && !isActive) {
-      if (!isTailRef.current) setExpanded(false)
+      if (!wasTailRef.current) setExpanded(false)
     }
     if (!wasActiveRef.current && isActive) setExpanded(true)
     wasActiveRef.current = isActive


### PR DESCRIPTION
## Summary

Follow-up to #4309. When a single render flips both `isActive: true -> false` AND `isTail: true -> false` — e.g. a `response` message arrives in the same batched store update as `stream_end` — the previous effect-updated `isTailRef` already reflected the new `isTail=false` by the time the `[isActive]` effect ran (effects fire in declaration order on the same commit), so the trailing tool group collapsed immediately. Same UX symptom #4305 / #4309 set out to fix, just on a faster turn.

Latch a `wasTailRef` inline during render only while `isActive` is true, so the on-completion collapse path always reads the *pre-flip* tail status — no dependency on render scheduling or effect order.

## Changes

- `ToolGroup.tsx`: replace effect-updated `isTailRef` with render-time `wasTailRef` that only advances while the group is active.
- `ToolGroup.test.tsx`: add same-render-flip regression test under the existing `tail-group behavior (#4305)` block. Test was added first and fails on `main` (group collapses to `aria-expanded="false"` instead of staying open), confirming the bug.

## Test plan

- [x] New regression test fails before the fix, passes after
- [x] All 30 `ToolGroup.test.tsx` tests pass
- [x] Full dashboard suite green (1921 tests)
- [x] `tsc --noEmit` clean

Closes #4314