### PR TITLE
test(server): add cross-provider transition test for sendSessionInfo (#4315)

### DIFF
--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -583,6 +583,41 @@ describe('sendSessionInfo', () => {
       assert.ok(modelsMsg, 'available_models was not sent on session switch')
       assert.equal(modelsMsg.provider, null)
     })
+
+    // #4315 — follow-up to #4310/#4302. The two tests above verify the
+    // end-state for a single sendSessionInfo call, but the original bug
+    // scenario is a *transition* between providers across two consecutive
+    // switches. Without re-tagging on every switch, the dashboard's
+    // `availableModelsProvider` would stay pinned to whichever provider
+    // the client saw first and `modelsMatchProvider` (App.tsx) would
+    // suppress the model picker for the second session. A future refactor
+    // that suppresses the push when the provider hasn't changed must
+    // still fire one when it has — this test pins that behaviour.
+    it('re-tags available_models when switching between different-provider sessions', () => {
+      const { manager, sessionsMap } = createMockSessionManager([
+        { id: 'sess-tui', name: 'TUI', cwd: '/tui' },
+        { id: 'sess-cli', name: 'CLI', cwd: '/cli' },
+      ])
+      sessionsMap.get('sess-tui').provider = 'claude-tui'
+      sessionsMap.get('sess-cli').provider = 'claude-cli'
+      const ws = makeFakeWs()
+      const ctx = makeCtx({ sessionManager: manager })
+      registerClient(ctx, ws)
+
+      // First switch: TUI session
+      sendSessionInfo(ctx, ws, 'sess-tui')
+      const firstModels = ctx._sends.find(m => m.type === 'available_models')
+      assert.ok(firstModels, 'available_models was not sent for first session')
+      assert.equal(firstModels.provider, 'claude-tui')
+
+      // Clear sends, then switch to a different-provider session
+      ctx._sends.length = 0
+
+      sendSessionInfo(ctx, ws, 'sess-cli')
+      const secondModels = ctx._sends.find(m => m.type === 'available_models')
+      assert.ok(secondModels, 'available_models was not sent for second session')
+      assert.equal(secondModels.provider, 'claude-cli', 'cross-provider switch must re-tag available_models')
+    })
   })
 
   it('sends model_changed with null when session has no model', () => {


### PR DESCRIPTION
## Summary

Adds a test under `describe('available_models on session switch (#4302)', ...)` that verifies the cross-provider transition scenario — the exact wire sequence the original #4302 bug reproduces against.

The two tests added in #4310 verify the end-state of `sendSessionInfo` for a single session, but they don't cover the actual bug scenario: a client whose `availableModelsProvider` was tagged for one provider then sees a `switch_session` to a different-provider session.

The new test:

- Creates two mock sessions tagged `claude-tui` and `claude-cli`
- Calls `sendSessionInfo` for the TUI session and asserts the emitted `available_models` carries `provider: 'claude-tui'`
- Clears the recorded sends, calls `sendSessionInfo` for the CLI session, and asserts the new `available_models` is re-tagged with `provider: 'claude-cli'`

Without re-tagging on every switch, the dashboard's `availableModelsProvider` stays pinned to the first provider and `modelsMatchProvider` (App.tsx) suppresses the model picker. A future refactor that suppresses the push when the provider hasn't changed must still fire one when it has — this test pins that behaviour.

## Test plan

- [x] `node --experimental-test-module-mocks --test packages/server/tests/ws-history.test.js` — 61/61 pass (60 existing + 1 new)
- [x] New test runs under the expected `available_models on session switch (#4302)` block

Closes #4315