### PR TITLE
fix(server): restore bracketed-paste mode in finally for TUI throttled write (#4287)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -975,19 +975,25 @@ export class ClaudeTuiSession extends BaseSession {
    */
   async _writePtyTextThrottled(text, { onAbort } = {}) {
     this._term.write('\x1b[?2004l')
-    for (const ch of text) {
-      if (this._activeTurn?.aborted) {
-        onAbort?.()
-        return false
+    try {
+      for (const ch of text) {
+        if (this._activeTurn?.aborted) {
+          onAbort?.()
+          return false
+        }
+        this._term.write(ch)
+        if (ClaudeTuiSession.PROMPT_CHAR_DELAY_MS > 0) {
+          await new Promise((resolve) => setTimeout(resolve, ClaudeTuiSession.PROMPT_CHAR_DELAY_MS))
+        }
       }
-      this._term.write(ch)
-      if (ClaudeTuiSession.PROMPT_CHAR_DELAY_MS > 0) {
-        await new Promise((resolve) => setTimeout(resolve, ClaudeTuiSession.PROMPT_CHAR_DELAY_MS))
-      }
+      this._term.write('\r')
+      return true
+    } finally {
+      // Always restore bracketed-paste mode, even on abort/throw. Write may
+      // throw if PTY has exited mid-loop (#4287) — swallow so we don't mask
+      // the original error path.
+      try { this._term.write('\x1b[?2004h') } catch {}
     }
-    this._term.write('\r')
-    this._term.write('\x1b[?2004h')
-    return true
   }
 
   /**

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1075,6 +1075,96 @@ describe('ClaudeTuiSession', () => {
 
       rmSync(sinkDir, { recursive: true, force: true })
     })
+
+    // #4287 follow-up to #4285: when `_activeTurn?.aborted` trips
+    // mid-loop, `_writePtyTextThrottled` previously returned early
+    // WITHOUT writing the `\x1b[?2004h` re-enable, leaving the PTY in
+    // bracketed-paste-disabled mode for subsequent writes. The fix
+    // wraps the for-loop in try/finally so the re-enable always runs.
+    it('_writePtyTextThrottled: aborted mid-loop still writes bracketed-paste re-enable in finally (#4287)', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const writes = []
+      session._activeTurn = { messageId: 'm-abort', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      let charsSeen = 0
+      session._term = {
+        write: (data) => {
+          writes.push(data)
+          if (data.length === 1 && /^[a-z]$/.test(data)) {
+            charsSeen += 1
+            // Flip aborted after the 3rd char — next loop tick observes it.
+            if (charsSeen === 3) session._activeTurn.aborted = true
+          }
+        },
+        kill: () => {},
+      }
+
+      let onAbortCalled = false
+      const completed = await session._writePtyTextThrottled('abcdefgh', {
+        onAbort: () => { onAbortCalled = true },
+      })
+
+      assert.equal(completed, false, 'aborted mid-loop returns false')
+      assert.equal(onAbortCalled, true, 'onAbort callback fires')
+      assert.equal(writes[0], '\x1b[?2004l', 'first write is bracketed-paste-disable')
+      assert.equal(writes[writes.length - 1], '\x1b[?2004h',
+        'final write is bracketed-paste re-enable even though loop aborted early')
+      assert.equal(writes.includes('\r'), false, 'no submit on abort path')
+    })
+
+    it('_writePtyTextThrottled: throw inside loop still writes bracketed-paste re-enable in finally (#4287)', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const writes = []
+      let charsSeen = 0
+      session._term = {
+        write: (data) => {
+          writes.push(data)
+          if (data.length === 1 && /^[a-z]$/.test(data)) {
+            charsSeen += 1
+            if (charsSeen === 2) throw new Error('PTY exited mid-write')
+          }
+        },
+        kill: () => {},
+      }
+      session._activeTurn = { messageId: 'm-throw', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+
+      await assert.rejects(
+        () => session._writePtyTextThrottled('abcdef'),
+        /PTY exited mid-write/,
+        'underlying throw propagates to the caller',
+      )
+
+      assert.equal(writes[0], '\x1b[?2004l', 'first write is bracketed-paste-disable')
+      // The finally block runs the re-enable. The spy only throws on
+      // single lowercase letters; the re-enable byte sequence (length>1)
+      // pushes cleanly.
+      assert.equal(writes[writes.length - 1], '\x1b[?2004h',
+        'final write is bracketed-paste re-enable even though loop threw')
+    })
+
+    it('_writePtyTextThrottled: finally swallows a re-enable write that itself throws (PTY exited) (#4287)', async () => {
+      // If the PTY exited entirely, term.write may throw on the
+      // re-enable byte sequence too. The finally block must swallow
+      // that so it does not mask the underlying loop error.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const writes = []
+      session._term = {
+        write: (data) => {
+          writes.push(data)
+          if (data === 'a') throw new Error('loop-error')
+          if (data === '\x1b[?2004h') throw new Error('reenable-error-should-be-swallowed')
+        },
+        kill: () => {},
+      }
+      session._activeTurn = { messageId: 'm-double', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+
+      await assert.rejects(
+        () => session._writePtyTextThrottled('a'),
+        /loop-error/,
+        'original loop error surfaces, not the swallowed re-enable error',
+      )
+      assert.deepEqual(writes, ['\x1b[?2004l', 'a', '\x1b[?2004h'],
+        'finally always attempts the re-enable even if it will throw')
+    })
   })
 
   describe('attachment-cap warn lines (#4216)', () => {


### PR DESCRIPTION
## Summary

Follow-up to #4285 (review-identified gap). `_writePtyTextThrottled` writes `\x1b[?2004l` before the loop and `\x1b[?2004h` after, but when `_activeTurn?.aborted` tripped mid-loop the function returned early WITHOUT the re-enable — leaving the PTY in bracketed-paste-disabled mode for subsequent writes. Same gap if `this._term.write(ch)` threw partway through. Defense-in-depth from #4269 was silently broken on the abort/throw paths until the next full successful write cycle.

## Change

Wrap the for-loop in `try { ... } finally { try { this._term.write('\x1b[?2004h') } catch {} }` — the re-enable now ALWAYS runs. The nested try/catch around the re-enable handles the case where the PTY exited entirely (term.write itself throws), so the original loop error still surfaces rather than being masked.

Happy-path behavior is unchanged — same byte sequence in the same order.

Closes #4287

## Test plan
- [x] `node --test tests/claude-tui-session.test.js` — 101/101 pass (3 new tests)
- [x] New test: aborted mid-loop still writes `\x1b[?2004h` (no `\r`)
- [x] New test: throw mid-loop still writes `\x1b[?2004h`
- [x] New test: finally swallows a re-enable write that itself throws; original loop error surfaces