### PR TITLE
fix(dashboard): surface inFlight tool on ActivityIndicator connect race (#4320)

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.inflight.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.inflight.test.tsx
@@ -125,6 +125,54 @@ describe('ActivityIndicator — in-flight tool naming (#4308)', () => {
     expect(container.firstChild).toBeNull()
   })
 
+  it('names the in-flight tool during the lastActivityAt-null connect race (#4320)', () => {
+    // Busy session with an unresolved tool_use but no activity event has
+    // updated lastClientActivityAt yet (the race observed when tool_start
+    // arrives before any event that bumps the activity timestamp). The
+    // indicator must still name the running tool rather than fall through
+    // to a generic "Working…" label. No elapsed suffix is rendered because
+    // we have no clock anchor in this branch.
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: false,
+          lastClientActivityAt: null,
+          messages: [
+            { id: 'm1', type: 'tool_use', tool: 'Bash', timestamp: now - 2_000, content: '', toolUseId: 'tu-1' },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toMatch(/Running\s+Bash/)
+    expect(label.textContent).not.toMatch(/Working…/)
+  })
+
+  it('falls back to "Working…" during the connect race when no tool is in flight (#4320)', () => {
+    // Busy with no tool_use in messages and no activity timestamp yet —
+    // the original baseline label is what the user should see.
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: false,
+          lastClientActivityAt: null,
+          messages: [],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toBe('Working…')
+  })
+
   it('formats MCP-style tool names via the shared formatter', () => {
     const now = Date.now()
     setStore([

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -114,10 +114,17 @@ export function ActivityIndicator() {
     // Busy but we haven't seen an activity event yet (race on connect).
     // Render the indicator in its baseline green state without an elapsed
     // value so users still see "Working…" rather than nothing.
+    //
+    // #4320 — if a tool_use already landed (tool_start can arrive before
+    // any event that updates lastClientActivityAt), surface its name so
+    // the user sees "Running Bash" instead of a generic "Working…". No
+    // elapsed value here because we have no clock anchor — startedAt is
+    // a server timestamp and clock-skew makes a "Ns" suffix unreliable.
+    const label = inFlight ? `Running ${formatToolName(inFlight.tool)}` : 'Working…'
     return (
       <div className="activity-indicator activity-indicator--green" aria-label="Agent is working">
         <span className="activity-indicator__dot" aria-hidden="true" />
-        <span className="activity-indicator__label">Working…</span>
+        <span className="activity-indicator__label" data-testid="activity-indicator-label">{label}</span>
       </div>
     )
   }


### PR DESCRIPTION
## Summary

ActivityIndicator's early-return on the connect race (`lastActivityAt == null`) rendered a plain "Working…" label without ever consulting the messages array. If `tool_start` flipped the busy flag before any event bumped `lastClientActivityAt`, the user briefly saw "Working…" instead of "Running Bash".

Now the `lastActivityAt == null` branch checks `inFlight` too — if a `tool_use` is in flight, render "Running <tool>" (no elapsed suffix, since there is no clock anchor in this branch). Otherwise the existing "Working…" baseline applies.

## Changes

- `packages/dashboard/src/components/ActivityIndicator.tsx` — early-return now reads `inFlight` and renders the running tool name when present. Adds the `data-testid="activity-indicator-label"` hook for parity with the populated branch.
- `packages/dashboard/src/components/ActivityIndicator.inflight.test.tsx` — two new tests covering the race: in-flight tool surfaces during `lastActivityAt=null`, and falls back to "Working…" when no tool is in flight.

## Test plan

- [x] `npx vitest run src/components/ActivityIndicator` — 19 pass (was 17)
- [x] `npx tsc --noEmit` clean

Closes #4320