### PR TITLE
refactor(dashboard): use shared formatToolName in ToolBubble (#4318)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1502,6 +1502,7 @@ export function App() {
           input={storeMsg.toolInput}
           inputPartial={storeMsg.toolInputPartial}
           result={storeMsg.toolResult}
+          serverName={storeMsg.serverName}
         />
       )
     }

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -84,7 +84,7 @@ export function ActivityIndicator() {
   // ToolBubble header uses (#4308 spinner). Returns null when every tool
   // call has resolved — the indicator falls back to the original
   // "Working… last activity" label.
-  const inFlight = useMemo<{ tool: string; startedAt: number } | null>(() => {
+  const inFlight = useMemo<{ tool: string; serverName?: string; startedAt: number } | null>(() => {
     if (!messages) return null
     for (let i = messages.length - 1; i >= 0; i--) {
       const m = messages[i]!
@@ -92,7 +92,10 @@ export function ActivityIndicator() {
       const hasResult =
         m.toolResult !== undefined || (m.toolResultImages?.length ?? 0) > 0
       if (!hasResult) {
-        return { tool: m.tool ?? 'tool', startedAt: m.timestamp }
+        // #4318: capture `serverName` too so MCP tools render with the
+        // server prefix preserved — keeps the chip's label in sync with
+        // the ToolBubble header and ToolGroup summary.
+        return { tool: m.tool ?? 'tool', serverName: m.serverName, startedAt: m.timestamp }
       }
     }
     return null
@@ -131,7 +134,7 @@ export function ActivityIndicator() {
   // the original "Working… last activity" label when no tool is in
   // flight (e.g. waiting on assistant text between tool calls).
   const label = inFlight
-    ? `Running ${formatToolName(inFlight.tool)} · ${formatDuration(now - inFlight.startedAt)}`
+    ? `Running ${formatToolName(inFlight.tool, inFlight.serverName)} · ${formatDuration(now - inFlight.startedAt)}`
     : `Working… last activity ${formatElapsed(elapsed)}`
 
   return (

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -23,7 +23,12 @@
  * is one short chunk), we pretty-print it for legibility.
  */
 import { useState, useMemo } from 'react'
-import { getInputSummary, getPartialSummary, tryParseCompleteJson } from '@chroxy/store-core'
+import {
+  formatToolName,
+  getInputSummary,
+  getPartialSummary,
+  tryParseCompleteJson,
+} from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
 
 export interface ToolBubbleProps {
@@ -37,6 +42,13 @@ export interface ToolBubbleProps {
    */
   inputPartial?: string
   result?: string
+  /**
+   * #4318: MCP server name from the wire message (`storeMsg.serverName`).
+   * Forwarded to the shared `formatToolName` so MCP tools render with the
+   * server prefix preserved — same source-of-truth used by the
+   * ActivityIndicator chip and ToolGroup header.
+   */
+  serverName?: string
 }
 
 // #4243: `getInputSummary` and `getPartialSummary` now live in
@@ -46,24 +58,11 @@ export interface ToolBubbleProps {
 // #4242: `getPartialSummary` routes its parse through
 // `tryParseCompleteJson` internally to amortise N-1 throws across a
 // streaming `tool_input_delta` accumulator.
+// #4318: `formatToolName` is the shared store-core helper too —
+// previously this file had a local copy that ignored `serverName`, so
+// MCP-tool headers could disagree with the ActivityIndicator chip.
 
-const capitalize = (word: string) => (word ? word.charAt(0).toUpperCase() + word.slice(1) : '')
-
-function formatToolName(name: string): string {
-  const MCP_PREFIX = 'mcp__'
-  if (name.startsWith(MCP_PREFIX)) {
-    const withoutPrefix = name.slice(MCP_PREFIX.length)
-    const sep = withoutPrefix.indexOf('__')
-    if (sep > 0) {
-      const server = withoutPrefix.slice(0, sep).split('_').filter(Boolean).map(capitalize).join(' ')
-      const tool = withoutPrefix.slice(sep + 2).split('_').filter(Boolean).map(capitalize).join(' ')
-      return tool ? `${server}: ${tool}` : server
-    }
-  }
-  return name.split('_').filter(Boolean).map(capitalize).join(' ')
-}
-
-export function ToolBubble({ toolName, toolUseId, input, inputPartial, result }: ToolBubbleProps) {
+export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName }: ToolBubbleProps) {
   const [expanded, setExpanded] = useState(false)
   // #4081: prefer the structured `input` summary when present (server
   // gave us the full final input, e.g. via legacy non-streaming
@@ -149,7 +148,7 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result }:
           aria-hidden="true"
         />
       )}
-      <span className="tool-name">{formatToolName(toolName)}</span>
+      <span className="tool-name">{formatToolName(toolName, serverName)}</span>
       {summary && (
         <span className="tool-input" data-testid="tool-input-summary" style={{ color: '#666' }}>
           {summary}


### PR DESCRIPTION
## Summary

`packages/dashboard/src/components/ToolBubble.tsx` had a local `formatToolName` that duplicated the exported helper in `@chroxy/store-core/group-messages.ts`. The shared version also accepts an optional `serverName` to preserve MCP server prefixes (#3794 lineage); the local copy ignored it entirely, so an MCP tool's bubble header and the `ActivityIndicator` chip could disagree on how the same tool name was displayed.

- Delete the local `formatToolName` + `capitalize` helper in `ToolBubble.tsx`.
- Import `formatToolName` from `@chroxy/store-core` (same import the `ActivityIndicator` already uses after #4308 / #4311).
- Add `serverName` to `ToolBubbleProps`; forward `storeMsg.serverName` from `App.tsx` so MCP-tool bubble headers render with the server prefix preserved.
- Capture `serverName` on the `ActivityIndicator` `inFlight` memo too and pass it through to `formatToolName` so the running-tool chip matches the bubble header and `ToolGroup` summary (acceptance criterion in the issue).

Single source of truth in `@chroxy/store-core`; all three call sites (ToolBubble header, ToolGroup summary, ActivityIndicator chip) now go through the same helper with the same signature.

Closes #4318

## Test plan

- [x] `vitest run src/components/ToolBubble.test.tsx` — 30/30 pass (existing `formatToolName` suite still green via the shared helper)
- [x] `vitest run src/components/ActivityIndicator.inflight.test.tsx` — 6/6 pass
- [x] `tsc --noEmit` clean
- [ ] Manual: MCP tool (e.g. `mcp__github__list_repos`) renders the same formatted name in the chip header, ToolBubble header, and ToolGroup summary