### PR TITLE
fix(dashboard): expand trailing singleton tool_use to match Output tab (#4313)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1495,6 +1495,15 @@ export function App() {
 
     // Tool bubble
     if (storeMsg.type === 'tool_use' && storeMsg.toolUseId) {
+      // #4313 — singleton activity runs (a single trailing tool_use)
+      // bypass the ToolGroup path entirely: `chatToolGroupPayloads`
+      // only collapses contiguous runs of 2+ messages (see above,
+      // ~line 897). Pass the same `isTail` signal that ToolGroup uses
+      // (#4309) so the Chat tab's last item matches Output-tab
+      // chronology in the 1-tool case too. Without this, a turn
+      // shaped `summary text -> 1 trailing tool` skipped the #4309
+      // mitigation entirely and the trailing tool rendered collapsed
+      // while Output still showed it inline.
       return (
         <ToolBubble
           toolName={storeMsg.tool || 'Tool'}
@@ -1503,6 +1512,7 @@ export function App() {
           inputPartial={storeMsg.toolInputPartial}
           result={storeMsg.toolResult}
           serverName={storeMsg.serverName}
+          isTail={msg.id === chatTailMessageId}
         />
       )
     }

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -318,4 +318,106 @@ describe('ToolBubble', () => {
       expect(screen.queryByTestId('tool-bubble-pulse-tu-3')).toBeNull()
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // #4313 — tail-bubble behavior. Singleton trailing tool_use rows bypass
+  // the ToolGroup path entirely (`chatToolGroupPayloads` only collapses runs
+  // of 2+ — App.tsx:894-902), so the #4309 ToolGroup tail mitigation never
+  // fires for 1-tool tails. Mirroring the prop on ToolBubble closes that gap.
+  // ---------------------------------------------------------------------------
+  describe('tail-bubble behavior (#4313)', () => {
+    it('mounts expanded when isTail is true (singleton trailing tool with result)', () => {
+      render(
+        <ToolBubble
+          toolName="Read"
+          toolUseId="tu-tail-1"
+          input="/file"
+          result="contents"
+          isTail
+        />,
+      )
+      expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true')
+      // Result panel renders immediately — no click needed.
+      expect(screen.getByText('contents')).toBeInTheDocument()
+    })
+
+    it('mounts expanded when isTail is true and tool is still in-flight (no result)', () => {
+      // Tail singleton with no result yet — bubble should still mount
+      // expanded so the user sees what is running. Mirrors the #4309
+      // behavior for groups where the trailing tool may still be active.
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="tu-tail-pending"
+          inputPartial='{"command":"ls"}'
+          isTail
+        />,
+      )
+      expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true')
+      // Partial preview is visible without a click.
+      expect(screen.getByTestId('tool-input-partial-tu-tail-pending')).toBeInTheDocument()
+    })
+
+    it('mounts collapsed when isTail is false (default behavior)', () => {
+      // Regression: non-tail bubbles must still mount collapsed.
+      render(
+        <ToolBubble
+          toolName="Read"
+          toolUseId="tu-non-tail"
+          input="/file"
+          result="contents"
+        />,
+      )
+      expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false')
+      expect(screen.queryByText('contents')).not.toBeInTheDocument()
+    })
+
+    it('does not retroactively collapse when isTail flips to false later', () => {
+      // Turn ends on a singleton tool (tail, expanded). A follow-up
+      // response message then arrives and the bubble is no longer tail.
+      // The expansion state must NOT retroactively change — the user
+      // may have already seen and engaged with the expanded result.
+      // Matches the `isTailRef` shape from ToolGroup.tsx:181-187.
+      const { rerender } = render(
+        <ToolBubble
+          toolName="Read"
+          toolUseId="tu-tail-flip"
+          input="/file"
+          result="contents"
+          isTail
+        />,
+      )
+      expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true')
+      rerender(
+        <ToolBubble
+          toolName="Read"
+          toolUseId="tu-tail-flip"
+          input="/file"
+          result="contents"
+          isTail={false}
+        />,
+      )
+      expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('user-collapsed tail bubble stays collapsed after a re-render', () => {
+      // Tail bubble mounts expanded; user clicks to collapse. The
+      // collapsed state must survive subsequent re-renders even while
+      // isTail remains true — initial-state-only semantics.
+      render(
+        <ToolBubble
+          toolName="Read"
+          toolUseId="tu-tail-toggle"
+          input="/file"
+          result="contents"
+          isTail
+        />,
+      )
+      const toggle = screen.getByRole('button')
+      expect(toggle).toHaveAttribute('aria-expanded', 'true')
+      fireEvent.click(toggle)
+      expect(toggle).toHaveAttribute('aria-expanded', 'false')
+      expect(screen.queryByText('contents')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -49,6 +49,25 @@ export interface ToolBubbleProps {
    * ActivityIndicator chip and ToolGroup header.
    */
   serverName?: string
+  /**
+   * #4313 — when true, this bubble is the last item in the chat list
+   * (a trailing singleton tool_use, not a multi-tool group). The
+   * #4309 `ToolGroup` mitigation kept tail groups expanded so the
+   * Chat tab matched Output-tab chronology — but singleton activity
+   * runs bypass `ToolGroup` entirely (see `App.tsx:894-902`: groups
+   * only collapse into a `tool_group` row when there are 2+ messages
+   * worth collapsing). So a turn shaped `summary text -> 1 trailing
+   * tool` still showed the tool collapsed in Chat while Output
+   * rendered it inline. Mounting tail bubbles expanded closes that
+   * 1-tool gap.
+   *
+   * Initial-state only: read at mount via `useState`'s initializer so
+   * a later `isTail` flip to false (e.g. a response message lands
+   * after the user has already seen the bubble expanded) does NOT
+   * retroactively collapse it. Matches the `isTailRef` pattern in
+   * ToolGroup — see ToolGroup.tsx:181-187.
+   */
+  isTail?: boolean
 }
 
 // #4243: `getInputSummary` and `getPartialSummary` now live in
@@ -62,8 +81,16 @@ export interface ToolBubbleProps {
 // previously this file had a local copy that ignored `serverName`, so
 // MCP-tool headers could disagree with the ActivityIndicator chip.
 
-export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName }: ToolBubbleProps) {
-  const [expanded, setExpanded] = useState(false)
+export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName, isTail = false }: ToolBubbleProps) {
+  // #4313 — tail bubbles mount expanded so the singleton trailing-tool
+  // case matches the #4309 tail-group behavior. Initial-only via the
+  // lazy `useState` initializer: subsequent `isTail` flips do NOT
+  // retroactively re-open or close the bubble (the user may have
+  // already toggled it). Same shape as ToolGroup's
+  // `useState(isActive || isTail)` + `isTailRef` pattern — we don't
+  // need a ref here because ToolBubble has no `isActive` lifecycle to
+  // react to, so reading `isTail` only at mount is sufficient.
+  const [expanded, setExpanded] = useState(isTail)
   // #4081: prefer the structured `input` summary when present (server
   // gave us the full final input, e.g. via legacy non-streaming
   // providers or after `tool_result` lands). Otherwise fall back to the


### PR DESCRIPTION
## Summary

Follow-up to #4309. That PR routed `isTail` only through the `tool_group` render branch, but `chatToolGroupPayloads` is populated only for contiguous activity runs of 2+ messages (`App.tsx:894-902`). Singleton activity groups (one trailing `tool_use`) pass through as plain `tool_use` rows rendered by `ToolBubble`, so the #4309 tail-expanded mitigation never fired for turns shaped `summary text -> 1 trailing tool` — the Chat/Output mismatch #4305 targets still appeared in the 1-tool case.

## Changes

- `ToolBubble`: add `isTail?: boolean` prop. When true, mount expanded via the `useState(isTail)` initializer.
- Initial-state-only semantics: a later `isTail` flip to false (e.g. a follow-up response message) does NOT retroactively collapse the bubble. Mirrors the `isTailRef` shape in `ToolGroup` (#4309).
- `App.tsx renderMessage` `tool_use` branch: wire `isTail={msg.id === chatTailMessageId}` from the existing `chatTailMessageId`.

## Test plan

- [x] `vitest run src/components/ToolBubble.test.tsx` — 35/35 pass, includes 5 new tail-bubble cases
- [x] Full dashboard `vitest run` — 1925/1925 pass
- [x] `tsc --noEmit` clean
- [ ] Manual: turn shaped `summary -> 1 trailing tool` shows the tool expanded in Chat (matches Output chronology)
- [ ] Manual: turn shaped `1 trailing tool -> response follows` keeps user's explicit collapse choice

Closes #4313