### PR TITLE
fix(dashboard): hide ToolBubble pulse for images-only tool results (#4317)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1513,6 +1513,7 @@ export function App() {
           result={storeMsg.toolResult}
           serverName={storeMsg.serverName}
           isTail={msg.id === chatTailMessageId}
+          resultImages={storeMsg.toolResultImages}
         />
       )
     }

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -317,6 +317,37 @@ describe('ToolBubble', () => {
       )
       expect(screen.queryByTestId('tool-bubble-pulse-tu-3')).toBeNull()
     })
+
+    // #4317: tools that resolve with images-only (computer-use
+    // screenshots, browser tools returning base64 PNGs) leave
+    // `result === undefined` but populate `resultImages`. Pre-fix the
+    // pulse rendered forever; the predicate now mirrors ToolGroup's
+    // `hasResult` and ActivityIndicator's in-flight check.
+    it('omits the pulse dot when result is images-only (no text result)', () => {
+      render(
+        <ToolBubble
+          toolName="screenshot"
+          toolUseId="tu-4"
+          input={{ url: 'https://example.com' }}
+          resultImages={[{ mediaType: 'image/png', data: 'iVBORw0KGgo=' }]}
+        />,
+      )
+      expect(screen.queryByTestId('tool-bubble-pulse-tu-4')).toBeNull()
+    })
+
+    it('still renders the pulse dot when resultImages is an empty array (not resolved)', () => {
+      // Defensive: an empty array should be treated like no images at
+      // all — the tool is still in-flight.
+      render(
+        <ToolBubble
+          toolName="screenshot"
+          toolUseId="tu-5"
+          input={{ url: 'https://example.com' }}
+          resultImages={[]}
+        />,
+      )
+      expect(screen.getByTestId('tool-bubble-pulse-tu-5')).toBeInTheDocument()
+    })
   })
 
   // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -29,6 +29,7 @@ import {
   getPartialSummary,
   tryParseCompleteJson,
 } from '@chroxy/store-core'
+import type { ToolResultImage } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
 
 export interface ToolBubbleProps {
@@ -51,23 +52,19 @@ export interface ToolBubbleProps {
   serverName?: string
   /**
    * #4313 — when true, this bubble is the last item in the chat list
-   * (a trailing singleton tool_use, not a multi-tool group). The
-   * #4309 `ToolGroup` mitigation kept tail groups expanded so the
-   * Chat tab matched Output-tab chronology — but singleton activity
-   * runs bypass `ToolGroup` entirely (see `App.tsx:894-902`: groups
-   * only collapse into a `tool_group` row when there are 2+ messages
-   * worth collapsing). So a turn shaped `summary text -> 1 trailing
-   * tool` still showed the tool collapsed in Chat while Output
-   * rendered it inline. Mounting tail bubbles expanded closes that
-   * 1-tool gap.
-   *
-   * Initial-state only: read at mount via `useState`'s initializer so
-   * a later `isTail` flip to false (e.g. a response message lands
-   * after the user has already seen the bubble expanded) does NOT
-   * retroactively collapse it. Matches the `isTailRef` pattern in
-   * ToolGroup — see ToolGroup.tsx:181-187.
+   * (a trailing singleton tool_use, not a multi-tool group). Mounted
+   * expanded to match #4309 tail-group behavior. Initial-state only;
+   * later flips do not retroactively re-collapse. See ToolGroup.tsx:181-187.
    */
   isTail?: boolean
+  /**
+   * #4317: tools can resolve with images-only (e.g. computer-use
+   * screenshots, browser tools returning base64 PNGs) and leave
+   * `result === undefined`. The pulse marker must treat that as
+   * resolved — mirror the `hasResult` predicate used by ToolGroup
+   * (#3794) and ActivityIndicator (#4311) so all three surfaces agree.
+   */
+  resultImages?: ToolResultImage[]
 }
 
 // #4243: `getInputSummary` and `getPartialSummary` now live in
@@ -81,16 +78,17 @@ export interface ToolBubbleProps {
 // previously this file had a local copy that ignored `serverName`, so
 // MCP-tool headers could disagree with the ActivityIndicator chip.
 
-export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName, isTail = false }: ToolBubbleProps) {
+export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName, isTail = false, resultImages }: ToolBubbleProps) {
   // #4313 — tail bubbles mount expanded so the singleton trailing-tool
-  // case matches the #4309 tail-group behavior. Initial-only via the
-  // lazy `useState` initializer: subsequent `isTail` flips do NOT
-  // retroactively re-open or close the bubble (the user may have
-  // already toggled it). Same shape as ToolGroup's
-  // `useState(isActive || isTail)` + `isTailRef` pattern — we don't
-  // need a ref here because ToolBubble has no `isActive` lifecycle to
-  // react to, so reading `isTail` only at mount is sufficient.
+  // case matches the #4309 tail-group behavior. Initial-state only via
+  // the lazy `useState` initializer.
   const [expanded, setExpanded] = useState(isTail)
+  // #4317: a tool that resolved with images-only (no text) still leaves
+  // `result === undefined`. Treat that as resolved so the pulse marker
+  // hides — same shape as ToolGroup's `hasResult` and
+  // ActivityIndicator's in-flight predicate. Without this the header
+  // pulses forever for computer-use / screenshot tools.
+  const hasResult = result !== undefined || (resultImages?.length ?? 0) > 0
   // #4081: prefer the structured `input` summary when present (server
   // gave us the full final input, e.g. via legacy non-streaming
   // providers or after `tool_result` lands). Otherwise fall back to the
@@ -167,8 +165,11 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
           completed one at a glance; pre-fix the collapsed header looked
           identical in both states. Tested with `result === undefined`
           (not `!result`) so an empty-string result — a tool that
-          finished with no output — does not render as in-flight. */}
-      {result === undefined && (
+          finished with no output — does not render as in-flight.
+          #4317 — also treat images-only resolutions as done so the
+          pulse hides for computer-use / screenshot tools that return
+          base64 PNGs and no text. */}
+      {!hasResult && (
         <span
           className="tool-bubble-pulse"
           data-testid={`tool-bubble-pulse-${toolUseId}`}


### PR DESCRIPTION
## Summary

Closes #4317.

`ToolBubble` predicate for the in-flight pulse was `result === undefined`, while the caller (`App.tsx`) only passed `result={storeMsg.toolResult}` and not `toolResultImages`. When a tool resolved with images-only (computer-use screenshots, browser tools returning base64 PNGs and no text), `storeMsg.toolResult` stayed `undefined` so the bubble continued to pulse as if in-flight — even though the tool was done.

This change mirrors the `hasResult` predicate used by `ToolGroup` (#3794) and `ActivityIndicator` (#4311), so all three surfaces now agree on what "resolved" means.

## Changes

- `ToolBubble`: new optional `resultImages?: ToolResultImage[]` prop; derive `const hasResult = result !== undefined || (resultImages?.length ?? 0) > 0` and gate the pulse marker on `!hasResult` (was `result === undefined`).
- `App.tsx`: pass `resultImages={storeMsg.toolResultImages}` to `<ToolBubble>` at the chat render site.
- `ToolBubble.test.tsx`: two new cases in the existing `#4308` pulse-marker block — images-only resolution hides the pulse, and an empty `resultImages` array still pulses (defensive: empty array = not resolved).

## Test plan

- [x] `npx vitest run src/components/ToolBubble.test.tsx` — 32 pass (30 prior + 2 new).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: trigger an images-only tool result (e.g. computer-use screenshot via mock-server) and confirm the bubble's pulse hides as soon as `tool_result` lands.

## Notes

- Predicate now matches `ToolGroup.tsx:86-88` and `ActivityIndicator` exactly. The acceptance note about factoring the predicate into `@chroxy/store-core` for mobile is out of scope for this PR — left intentionally; that's a follow-up since the mobile `ToolBubble` doesn't currently consume `toolResultImages` and would need its own audit.