### PR TITLE
feat(app): mobile parity for in-flight activity indicator + tool bubble pulse (#4321)

### DIFF
--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -9,14 +9,23 @@
  * Mobile companion to packages/dashboard/src/components/ActivityIndicator.tsx
  * — same selector + tick-once-per-second pattern, React Native styling.
  *
+ * #4321 / #4308 — also names the most-recent in-flight tool when one is
+ * running ("Running Bash · 12s"), derived from the active session's
+ * messages[]. Mirrors the dashboard's derive-from-messages approach —
+ * no protocol change, no state-shape work, no parallel-tool tracking;
+ * the most-recent unresolved tool_use is the one named. Falls back to
+ * the original "Working… last activity" label when every tool has
+ * resolved or no tool is in flight.
+ *
  * Color escalation:
  *   0-30s         green   (active)
  *   30-60s        yellow  (quiet)
  *   60s-threshold orange  (slow)
  *   approaching   red     (last 60s before timeout)
  */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { formatToolName } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { COLORS } from '../constants/colors';
@@ -35,6 +44,19 @@ function formatElapsed(ms: number): string {
   return `${h}h ${m % 60}m ago`;
 }
 
+// #4321 / #4308 — duration without the "ago" suffix, used for the
+// "Running X · 12s" label (the named tool is current, not past, so
+// "ago" is wrong). Mirrors the dashboard helper.
+function formatDuration(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const remS = s % 60;
+  if (m < 60) return remS === 0 ? `${m}m` : `${m}m ${remS}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
 export function statusColor(elapsedMs: number, timeoutMs: number): string {
   if (elapsedMs >= timeoutMs - 60_000) return COLORS.accentRed500;
   if (elapsedMs >= 60_000) return COLORS.accentOrange500;
@@ -51,9 +73,36 @@ export function ActivityIndicator() {
     const id = s.activeSessionId;
     return id ? s.sessionStates[id]?.lastClientActivityAt ?? null : null;
   });
+  // #4321 / #4308 — subscribe to the active session's messages so the
+  // indicator can name the in-flight tool. The store mutates `messages`
+  // immutably, so this only re-renders when the array reference changes.
+  const messages = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id ? s.sessionStates[id]?.messages ?? null : null;
+  });
   const referenceTimeoutMs = useConnectionLifecycleStore(
     (s) => s.serverResultTimeoutMs ?? FALLBACK_TIMEOUT_MS,
   );
+
+  // #4321 / #4308 — walk back through messages to find the most-recent
+  // tool_use that has no result attached. `toolResult === undefined`
+  // plus a check on `toolResultImages` mirrors the same "no result yet"
+  // predicate the ToolBubble header pulse uses (#4308). Returns null
+  // when every tool call has resolved — the indicator falls back to
+  // the original "Working… last activity" label.
+  const inFlight = useMemo<{ tool: string; startedAt: number; serverName?: string } | null>(() => {
+    if (!messages) return null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i]!;
+      if (m.type !== 'tool_use') continue;
+      const hasResult =
+        m.toolResult !== undefined || (m.toolResultImages?.length ?? 0) > 0;
+      if (!hasResult) {
+        return { tool: m.tool ?? 'tool', startedAt: m.timestamp, serverName: m.serverName };
+      }
+    }
+    return null;
+  }, [messages]);
 
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -78,11 +127,22 @@ export function ActivityIndicator() {
   const approaching = remaining > 0 && remaining <= 60_000;
   const color = statusColor(elapsed, referenceTimeoutMs);
 
+  // #4321 / #4308 — name the in-flight tool when one is running. Falls
+  // back to the original "Working… last activity" label when no tool is
+  // in flight (e.g. waiting on assistant text between tool calls).
+  const label = inFlight
+    ? `Running ${formatToolName(inFlight.tool, inFlight.serverName)} · ${formatDuration(now - inFlight.startedAt)}`
+    : `Working… last activity ${formatElapsed(elapsed)}`;
+
   return (
     <View style={styles.container}>
       <View style={[styles.dot, { backgroundColor: color }]} />
-      <Text style={[styles.label, { color }]} accessibilityRole="text">
-        Working… last activity {formatElapsed(elapsed)}
+      <Text
+        style={[styles.label, { color }]}
+        accessibilityRole="text"
+        testID="activity-indicator-label"
+      >
+        {label}
       </Text>
       {approaching && (
         <Text style={[styles.warning, { color }]}>

--- a/packages/app/src/components/__tests__/ActivityIndicator.inflight.test.tsx
+++ b/packages/app/src/components/__tests__/ActivityIndicator.inflight.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * ActivityIndicator in-flight tool naming on mobile (#4321 — #4308 mobile parity).
+ *
+ * Mirrors packages/dashboard/src/components/ActivityIndicator.inflight.test.tsx
+ * to lock in the derive-from-messages approach on the mobile app: the
+ * indicator walks the active session's `messages[]` backwards to find the
+ * most-recent `tool_use` with no result, and surfaces that tool's name +
+ * elapsed time. When every tool has resolved (waiting on assistant text
+ * between tool runs) the indicator falls back to the original
+ * "Working… last activity" label.
+ *
+ * Pattern matches the sibling ActivityIndicator.test.tsx — react-test-renderer
+ * + act, Zustand stores driven via setState (not mocked).
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { useConnectionStore } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { createEmptySessionState } from '../../store/utils';
+import type { ChatMessage } from '../../store/connection';
+
+const SESSION_ID = 's-test';
+const TIMEOUT_30MIN = 30 * 60_000;
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root.findAllByType(Text).map((node) => {
+    const c = node.props.children;
+    if (typeof c === 'string' || typeof c === 'number') return String(c);
+    if (Array.isArray(c)) {
+      return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+    }
+    return '';
+  }).join(' ');
+}
+
+function setStore(opts: { isIdle?: boolean; lastClientActivityAt?: number | null; messages: ChatMessage[] }) {
+  const base = createEmptySessionState();
+  useConnectionStore.setState({
+    activeSessionId: SESSION_ID,
+    sessionStates: {
+      [SESSION_ID]: {
+        ...base,
+        isIdle: opts.isIdle ?? false,
+        lastClientActivityAt: opts.lastClientActivityAt ?? Date.now() - 3_000,
+        messages: opts.messages,
+      },
+    },
+  });
+}
+
+describe('ActivityIndicator — in-flight tool naming (#4321 / #4308)', () => {
+  let activeTree: renderer.ReactTestRenderer | null = null;
+
+  function render(): renderer.ReactTestRenderer {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => { tree = renderer.create(<ActivityIndicator />); });
+    activeTree = tree;
+    return tree;
+  }
+
+  beforeEach(() => {
+    useConnectionStore.setState({ activeSessionId: null, sessionStates: {} });
+    useConnectionLifecycleStore.setState({ serverResultTimeoutMs: TIMEOUT_30MIN });
+  });
+
+  afterEach(() => {
+    if (activeTree) {
+      act(() => { activeTree!.unmount(); });
+      activeTree = null;
+    }
+    jest.useRealTimers();
+  });
+
+  it('names the most-recent tool_use without a result and shows elapsed time', () => {
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      lastClientActivityAt: now - 3_000,
+      messages: [
+        // Earlier resolved tool — should NOT be picked.
+        { id: 'm1', type: 'tool_use', tool: 'Read', timestamp: now - 60_000, toolResult: 'contents', content: '', toolUseId: 'tu-1' },
+        // Most-recent unresolved tool — this is what the indicator names.
+        { id: 'm2', type: 'tool_use', tool: 'Bash', timestamp: now - 5_000, content: '', toolUseId: 'tu-2' },
+      ],
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    expect(text).toMatch(/Running\s+Bash/);
+    expect(text).toMatch(/5s$|5s\s/);
+    expect(text).not.toMatch(/Working… last activity/);
+  });
+
+  it('falls back to the original "Working… last activity" label when no tool is in flight', () => {
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      lastClientActivityAt: now - 5_000,
+      messages: [
+        { id: 'm1', type: 'tool_use', tool: 'Bash', timestamp: now - 20_000, toolResult: 'done', content: '', toolUseId: 'tu-1' },
+      ],
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    expect(text).toMatch(/Working… last activity/);
+    expect(text).not.toMatch(/Running/);
+  });
+
+  it('treats an empty-string toolResult as resolved (no in-flight indicator)', () => {
+    // A tool that finished with no output (toolResult === '') must NOT
+    // be picked as in-flight. Same predicate the ToolBubble pulse uses.
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      lastClientActivityAt: now - 5_000,
+      messages: [
+        { id: 'm1', type: 'tool_use', tool: 'Bash', timestamp: now - 5_000, toolResult: '', content: '', toolUseId: 'tu-1' },
+      ],
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    expect(text).not.toMatch(/Running/);
+  });
+
+  it('treats toolResultImages-only resolution as resolved (no in-flight indicator)', () => {
+    // Some tools resolve with images and no toolResult string. Match
+    // the dashboard `hasResult` predicate so these aren't shown as
+    // in-flight.
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      lastClientActivityAt: now - 5_000,
+      messages: [
+        {
+          id: 'm1',
+          type: 'tool_use',
+          tool: 'Bash',
+          timestamp: now - 5_000,
+          content: '',
+          toolUseId: 'tu-1',
+          toolResultImages: [{ data: 'x', mediaType: 'image/png' }],
+        },
+      ],
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    expect(text).not.toMatch(/Running/);
+  });
+
+  it('renders nothing when the session is idle (no indicator even with an unresolved tool)', () => {
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      isIdle: true,
+      lastClientActivityAt: now - 1_000,
+      messages: [
+        { id: 'm1', type: 'tool_use', tool: 'Bash', timestamp: now - 1_000, content: '', toolUseId: 'tu-1' },
+      ],
+    });
+    const tree = render();
+    expect(tree.toJSON()).toBeNull();
+  });
+
+  it('formats MCP-style tool names via the shared formatter (mobile parity with dashboard)', () => {
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      lastClientActivityAt: now - 3_000,
+      messages: [
+        { id: 'm1', type: 'tool_use', tool: 'mcp__github__list_repos', timestamp: now - 5_000, content: '', toolUseId: 'tu-1' },
+      ],
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    // formatToolName converts `mcp__github__list_repos` → `Github: List Repos`.
+    expect(text).toMatch(/Running\s+Github: List Repos/);
+  });
+});

--- a/packages/app/src/components/__tests__/ToolBubble.test.tsx
+++ b/packages/app/src/components/__tests__/ToolBubble.test.tsx
@@ -150,3 +150,53 @@ describe('ToolBubble — TodoWrite integration (#4180)', () => {
     expect(findByTestId(root, 'todo-list-header')).toHaveLength(0);
   });
 });
+
+/**
+ * In-flight pulse marker tests (#4321 / #4308 mobile parity).
+ *
+ * Mirrors the dashboard ToolBubble pulse tests — the pulse dot renders
+ * only when `toolResult === undefined` (and no images have arrived).
+ * An empty-string `toolResult` is a legitimate finished state and must
+ * NOT render as in-flight. Same predicate the ActivityIndicator uses
+ * so the two surfaces stay in sync.
+ */
+describe('ToolBubble — in-flight pulse marker (#4321 / #4308)', () => {
+  function makeInflightMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+    return {
+      id: 'tool-inflight',
+      type: 'tool_use',
+      content: 'Bash',
+      tool: 'Bash',
+      toolUseId: 'tu-inflight',
+      // toolResult intentionally omitted — that's what "in flight" means.
+      timestamp: 0,
+      ...overrides,
+    };
+  }
+
+  it('renders the pulse dot when no result has arrived', () => {
+    const root = renderBubble(makeInflightMessage());
+    expect(findByTestId(root, 'tool-bubble-pulse-tu-inflight')[0]).toBeTruthy();
+  });
+
+  it('omits the pulse dot once a result has arrived', () => {
+    const root = renderBubble(makeInflightMessage({ toolResult: 'total 0' }));
+    expect(findByTestId(root, 'tool-bubble-pulse-tu-inflight')).toHaveLength(0);
+  });
+
+  it('omits the pulse dot for an empty-string result (tool finished, no output)', () => {
+    // toolResult: '' is a legitimate finished state — the tool ran and
+    // produced no output. Must not look in-flight.
+    const root = renderBubble(makeInflightMessage({ toolResult: '' }));
+    expect(findByTestId(root, 'tool-bubble-pulse-tu-inflight')).toHaveLength(0);
+  });
+
+  it('omits the pulse dot when the tool resolved with images only (no toolResult string)', () => {
+    // Mirrors the ActivityIndicator + dashboard predicate — image-only
+    // resolution counts as resolved.
+    const root = renderBubble(
+      makeInflightMessage({ toolResultImages: [{ data: 'x', mediaType: 'image/png' }] }),
+    );
+    expect(findByTestId(root, 'tool-bubble-pulse-tu-inflight')).toHaveLength(0);
+  });
+});

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -66,6 +66,17 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
 
   const displayTool = formatToolName(message.tool);
 
+  // #4321 / #4308 — in-flight pulse marker. The collapsed header was
+  // visually identical for running vs. completed tools pre-fix; a small
+  // blue dot in the header (mirroring the dashboard `tool-bubble-pulse`)
+  // distinguishes them at a glance. Checked against `toolResult ===
+  // undefined` (not `!toolResult`) so a tool that finished with no
+  // output (`toolResult === ''`) does NOT render as in-flight. Mirrors
+  // the same predicate used by the ActivityIndicator above.
+  const hasResult =
+    message.toolResult !== undefined || (message.toolResultImages?.length ?? 0) > 0;
+  const inFlight = !hasResult;
+
   const handlePress = () => {
     // Suppress the tap that fires on release after a long-press
     if (longPressedRef.current) {
@@ -148,6 +159,14 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
     >
       <View style={styles.toolHeader}>
         {expanded ? <Icon name="chevronDown" size={12} color={COLORS.textMuted} /> : <Icon name="chevronRight" size={12} color={COLORS.textMuted} />}
+        {inFlight && (
+          <View
+            style={styles.pulse}
+            testID={`tool-bubble-pulse-${message.toolUseId ?? message.id}`}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+          />
+        )}
         <Text style={styles.senderLabelTool}>
           {message.serverName ? (
             <>
@@ -187,6 +206,15 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
+  },
+  // #4321 / #4308 — in-flight marker, mirrors the dashboard's
+  // `.tool-bubble-pulse` (6px blue dot, slightly transparent).
+  pulse: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: COLORS.accentBlue,
+    opacity: 0.8,
   },
   senderLabelTool: {
     color: COLORS.accentPurple,


### PR DESCRIPTION
## Summary

Mobile parity for PR #4311 — surfaces the in-flight tool name in the activity chip and adds a per-bubble pulse dot on running tool messages in the React Native app.

## Approach (derive-from-messages, no protocol change)

Mirrors the dashboard exactly: both surfaces derive from `messages[]` using the same `hasResult` predicate (`toolResult !== undefined || toolResultImages?.length`), so the chip and bubbles stay in lockstep without any new state.

**ActivityIndicator** (`packages/app/src/components/ActivityIndicator.tsx`)
- Subscribes to the active session's `messages` and walks backwards to find the most-recent `tool_use` with no result.
- Surfaces `Running <tool> · <elapsed>` via the shared `formatToolName` from `@chroxy/store-core` (so MCP-prefixed tools render like `Github: List Repos` instead of raw `mcp__github__list_repos`).
- Falls back to the original `Working… last activity Ns ago` label when no tool is in flight. Reuses the existing 1Hz `setInterval` — no new timers.

**ToolBubble** (`packages/app/src/components/chat/ToolBubble.tsx`)
- Adds a 6px blue pulse dot in the header when `toolResult === undefined` (and no images). Checked against presence, not truthiness, so a tool that finished with empty output does NOT appear in-flight.
- Styled to match the dashboard `.tool-bubble-pulse` (6px blue dot, opacity 0.8).

## Acceptance criteria (from #4321)

- [x] Mobile ToolBubble shows a pulse marker while the tool is in-flight
- [x] Mobile activity indicator names the in-flight tool (`Running Bash · 12s`)
- [x] Same `hasResult` predicate as the dashboard — shared via `@chroxy/store-core` types (`ChatMessage.toolResult` / `.toolResultImages`)

## Test plan

- [x] 6 new `ActivityIndicator.inflight.test.tsx` tests: named tool, empty-string resolution, image-only resolution, fallback label, idle session, MCP formatter routing
- [x] 4 new `ToolBubble` pulse tests: rendered when undefined, omitted when result present, omitted when `result === ''`, omitted on image-only resolution
- [x] `1142/1142` mobile suite pass (3 pre-existing failures from missing `xterm-bundle.generated` are unrelated)
- [x] `tsc --noEmit` clean (one pre-existing unrelated `xterm-bundle.generated` error)

## Related

- #4311 — dashboard implementation this mirrors
- #4308 — parent issue (mobile parity acceptance criterion)

Closes #4321