### PR TITLE
fix(dashboard): collapse AskUserQuestion options post-answer + optimistic busy state (#4312)

### DIFF
--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -61,10 +61,14 @@ describe('QuestionPrompt', () => {
         onSelect={vi.fn()}
       />
     )
-    expect(screen.getByText('Option A')).toBeInTheDocument()
-    // All buttons should be disabled when answered
-    const buttons = screen.getAllByRole('button')
-    buttons.forEach(btn => expect(btn).toBeDisabled())
+    // Post-#4312: option list is collapsed by default; expand it to assert
+    // that every option button still renders disabled.
+    fireEvent.click(screen.getByTestId('question-answered-summary'))
+    const optionButtons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.classList.contains('question-option'))
+    expect(optionButtons).toHaveLength(3)
+    optionButtons.forEach((btn) => expect(btn).toBeDisabled())
   })
 
   it('highlights the chosen option', () => {
@@ -76,7 +80,15 @@ describe('QuestionPrompt', () => {
         onSelect={vi.fn()}
       />
     )
-    expect(screen.getByText('Option B').closest('button')).toHaveClass('chosen')
+    // Expand the collapsed summary (#4312) to inspect the chosen-button styling.
+    fireEvent.click(screen.getByTestId('question-answered-summary'))
+    // "Option B" appears both inside the expanded summary's label span and on
+    // the disabled option button — pick the button explicitly via class.
+    const chosenButton = screen
+      .getAllByText('Option B')
+      .map((el) => el.closest('button'))
+      .find((btn) => btn?.classList.contains('question-option'))
+    expect(chosenButton).toHaveClass('chosen')
   })
 
   it('does not call onSelect when already answered', () => {
@@ -89,7 +101,16 @@ describe('QuestionPrompt', () => {
         onSelect={onSelect}
       />
     )
-    fireEvent.click(screen.getByText('Option B'))
+    // Expand first (#4312) so the option button is reachable.
+    fireEvent.click(screen.getByTestId('question-answered-summary'))
+    // Click the disabled option button (filter to the .question-option
+    // matching "Option B"; the summary's label span also contains "Option A"
+    // but it's not the click target here).
+    const optionB = screen
+      .getAllByText('Option B')
+      .map((el) => el.closest('button'))
+      .find((btn) => btn?.classList.contains('question-option'))!
+    fireEvent.click(optionB)
     expect(onSelect).not.toHaveBeenCalled()
   })
 
@@ -184,6 +205,56 @@ describe('QuestionPrompt', () => {
     fireEvent.change(screen.getByPlaceholderText('Type your response…'), { target: { value: 'hello' } })
     const sendBtn = screen.getByRole('button', { name: 'Send' })
     expect(sendBtn).not.toBeDisabled()
+  })
+
+  describe('post-answer collapse (#4312)', () => {
+    it('renders a collapsed ✓ <chosen-label> summary by default once answered', () => {
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={options}
+          answered="b"
+          onSelect={vi.fn()}
+        />
+      )
+      const summary = screen.getByTestId('question-answered-summary')
+      expect(summary).toBeInTheDocument()
+      // Marker + chosen label live inside the summary row.
+      expect(summary.textContent).toContain('✓')
+      expect(summary.textContent).toContain('Option B')
+      // Collapsed: the disabled option list is NOT rendered yet (Option A / C
+      // would only appear once the user clicks the summary to expand).
+      expect(screen.queryByText('Option A')).not.toBeInTheDocument()
+      expect(screen.queryByText('Option C')).not.toBeInTheDocument()
+      // Summary advertises its collapsed state to assistive tech.
+      expect(summary).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('clicking the chevron expands back to the full disabled-button list', () => {
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={options}
+          answered="b"
+          onSelect={vi.fn()}
+        />
+      )
+      // Click the collapsed summary to expand.
+      fireEvent.click(screen.getByTestId('question-answered-summary'))
+      // Every option renders, all disabled, with the chosen one marked.
+      const optionButtons = screen
+        .getAllByRole('button')
+        .filter((btn) => btn.classList.contains('question-option'))
+      expect(optionButtons).toHaveLength(3)
+      const labels = optionButtons.map((b) => b.textContent)
+      expect(labels).toEqual(['Option A', 'Option B', 'Option C'])
+      optionButtons.forEach((btn) => expect(btn).toBeDisabled())
+      const chosenButton = optionButtons.find((btn) => btn.textContent === 'Option B')
+      expect(chosenButton).toHaveClass('chosen')
+      // Summary now reports expanded; clicking again collapses.
+      const summary = screen.getByTestId('question-answered-summary')
+      expect(summary).toHaveAttribute('aria-expanded', 'true')
+    })
   })
 
   describe('Other / free-text escape hatch (#3746)', () => {

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -6,6 +6,11 @@
  * When no options are provided, shows a free-text input (#1245).
  * The "Other" sentinel option (#3746) swaps the button row for a
  * free-text input so the user can always supply a custom answer.
+ *
+ * After an answer is recorded (#4312), the option block collapses to a
+ * one-line "✓ <chosen>" summary with a chevron to re-expand the full
+ * disabled-button list for inspection. Claude's prose preamble is
+ * rendered by the parent and remains visible at all times.
  */
 import { useState, useRef, useEffect } from 'react'
 import { OTHER_OPTION_VALUE } from '@chroxy/store-core'
@@ -20,6 +25,11 @@ export interface QuestionPromptProps {
 export function QuestionPrompt({ question, options, answered, onSelect }: QuestionPromptProps) {
   const [text, setText] = useState('')
   const [otherActive, setOtherActive] = useState(false)
+  // #4312: post-answer the option block collapses to a one-line summary;
+  // user can re-expand to inspect the full disabled-button list. Default
+  // collapsed once `answered` is set, including the remote-answered case
+  // (markPromptAnsweredByRequestId) since render keys off `answered`.
+  const [optionsExpanded, setOptionsExpanded] = useState(false)
   const submittedRef = useRef(false)
 
   // Reset "Other" UI mode when the prompt becomes answered (#3746 review).
@@ -72,23 +82,61 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
     options.length > 0 && !isFreeTextAnswered &&
     (answered != null || !otherActive)
 
+  // #4312: once answered, default to a collapsed one-line summary. The
+  // disabled-button list still renders behind a chevron toggle for users
+  // who want to re-inspect the original options.
+  const isAnsweredWithOption = answered != null && answeredMatchesOption
+  const chosenLabel = isAnsweredWithOption
+    ? (options.find((o) => o.value === answered)?.label ?? answered)
+    : undefined
+  const showCollapsedSummary = isAnsweredWithOption && !optionsExpanded
+  const showExpandedOptions = showOptions && (answered == null || optionsExpanded)
+
   return (
     <div className="question-prompt" data-testid="question-prompt">
       <div className="question-text">{question}</div>
-      {showOptions && (
-        <div className="question-options">
-          {options.map((opt) => (
+      {showCollapsedSummary && (
+        <button
+          type="button"
+          className="question-answered-summary"
+          data-testid="question-answered-summary"
+          aria-expanded={false}
+          onClick={() => setOptionsExpanded(true)}
+        >
+          <span className="question-answered-marker" aria-hidden="true">✓</span>
+          <span className="question-answered-label">{chosenLabel}</span>
+          <span className="question-answered-chevron" aria-hidden="true">▸</span>
+        </button>
+      )}
+      {showExpandedOptions && (
+        <>
+          {isAnsweredWithOption && (
             <button
-              key={opt.value}
-              className={`question-option${answered === opt.value ? ' chosen' : ''}`}
-              disabled={answered != null}
-              onClick={() => handleOptionClick(opt.value)}
               type="button"
+              className="question-answered-summary question-answered-summary--expanded"
+              data-testid="question-answered-summary"
+              aria-expanded={true}
+              onClick={() => setOptionsExpanded(false)}
             >
-              {opt.label}
+              <span className="question-answered-marker" aria-hidden="true">✓</span>
+              <span className="question-answered-label">{chosenLabel}</span>
+              <span className="question-answered-chevron" aria-hidden="true">▾</span>
             </button>
-          ))}
-        </div>
+          )}
+          <div className="question-options">
+            {options.map((opt) => (
+              <button
+                key={opt.value}
+                className={`question-option${answered === opt.value ? ' chosen' : ''}`}
+                disabled={answered != null}
+                onClick={() => handleOptionClick(opt.value)}
+                type="button"
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </>
       )}
       {showFreeText && (
         <div className="question-freetext">
@@ -120,7 +168,10 @@ export function QuestionPrompt({ question, options, answered, onSelect }: Questi
         </div>
       )}
       {isFreeTextAnswered && (
-        <div className="question-answered">{answered}</div>
+        <div className="question-answered" data-testid="question-answered-summary">
+          <span className="question-answered-marker" aria-hidden="true">✓</span>
+          <span className="question-answered-label">{answered}</span>
+        </div>
       )}
     </div>
   )

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1288,7 +1288,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   sendUserQuestionResponse: (answer: string, toolUseId?: string) => {
-    const { socket } = get();
+    const { socket, activeSessionId, sessionStates } = get();
     const payload: Record<string, string> = { type: 'user_question_response', answer };
     if (toolUseId) payload.toolUseId = toolUseId;
     // #4296: echo the resolved answer to the terminal buffer so the Output
@@ -1299,6 +1299,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // wire send so the echo is present even when the socket queues.
     if (answer) {
       get().appendTerminalData(`\r\n\x1b[36m> User answered: ${answer}\x1b[0m\r\n`);
+    }
+    // #4312: optimistically flip the active session into "running" so the
+    // ActivityIndicator + per-session busy dot light up immediately on
+    // answer-send, matching the symmetry of sendInput. Without this, the
+    // dashboard reads idle in the gap between answer-send and the next
+    // server-emitted stream/tool event, making the answer look dropped.
+    // Once a server event arrives, the bump is a no-op (server is
+    // authoritative); the timestamp is overwritten in dispatch-activity.
+    if (activeSessionId && sessionStates[activeSessionId]) {
+      updateActiveSession(() => ({
+        isIdle: false,
+        lastClientActivityAt: Date.now(),
+      }));
     }
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, payload);

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1435,6 +1435,55 @@ describe('sendUserQuestionResponse Output-tab echo (#4296)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #4312 — optimistic busy-state bump on answer send
+// ---------------------------------------------------------------------------
+// sendInput (the regular chat path) implicitly puts the dashboard into a
+// "running" visual state via the input-bump path; sendUserQuestionResponse
+// historically skipped this, so the per-session activity dot + ActivityIndicator
+// stayed idle in the gap between answer-send and the next server-emitted
+// stream/tool event. The fix mirrors sendInput by flipping isIdle:false and
+// stamping lastClientActivityAt on the active session before the wire send.
+describe('sendUserQuestionResponse optimistic activity bump (#4312)', () => {
+  it('flips active session to running (isIdle:false) and bumps lastClientActivityAt', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const mockSocket = {
+      readyState: 1,
+      send: () => { /* swallow */ },
+    };
+
+    const beforeNow = Date.now();
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          isIdle: true,
+          lastClientActivityAt: null,
+        },
+      },
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse('Option A', 'toolu_abc');
+
+    const ss = useConnectionStore.getState().sessionStates.s1!;
+    expect(ss.isIdle).toBe(false);
+    expect(ss.lastClientActivityAt).not.toBeNull();
+    expect(ss.lastClientActivityAt!).toBeGreaterThanOrEqual(beforeNow);
+
+    // Clean up so unrelated tests don't see stale active session state.
+    useConnectionStore.setState({
+      activeSessionId: null,
+      sessionStates: {},
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // PTY dead code removal (#1759)
 // ---------------------------------------------------------------------------
 describe('PTY dead code removal', () => {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2154,6 +2154,58 @@
   color: var(--text-secondary);
   font-style: italic;
   padding: 4px 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* #4312 — post-answer collapsed summary. Mirrors the tool-group-header
+   vocabulary (chevron + summary row) so the collapse affordance reads
+   consistently with the rest of the chat list. */
+.question-answered-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: none;
+  padding: 6px 0;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-family: inherit;
+  text-align: left;
+  width: 100%;
+}
+
+.question-answered-summary:hover {
+  color: var(--text-primary);
+}
+
+.question-answered-summary:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.question-answered-summary--expanded {
+  margin-bottom: 4px;
+}
+
+.question-answered-marker {
+  color: var(--accent-green, var(--accent-purple));
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.question-answered-label {
+  flex: 1;
+  font-weight: 500;
+}
+
+.question-answered-chevron {
+  color: var(--text-muted);
+  font-size: 12px;
+  flex-shrink: 0;
 }
 
 .perm-countdown {


### PR DESCRIPTION
## Summary

Two related glitches in the Chat tab right after the user picks an AskUserQuestion option, both fixed here.

### Part A — Collapse option block post-answer (`QuestionPrompt.tsx`)

Pre-fix: the full option list remained rendered (disabled, with the chosen one styled) so the question never visually resolved.

Post-fix: when `answered != null`, the option block collapses by default to a one-line `✓ <chosen-label>` summary with a chevron. Clicking the chevron re-expands the full disabled-button list for inspection. Mirrors the ToolGroup collapsible-header visual vocabulary (chevron ▸ / ▾, summary row, hover/focus styling). Free-text answers (Other / no-options) also pick up the `✓` marker so the resolved state is visually consistent across all answer shapes.

Remote-answer collapse works via the existing `markPromptAnsweredByRequestId` path — collapse keys off the `answered` prop, not local UI state, so a non-local client answer mid-flight also collapses on this client.

Claude's prose preamble (rendered by the parent ChatView path) remains visible at all times.

### Part B — Optimistic busy-state on answer send (`connection.ts`)

`sendUserQuestionResponse` now bumps the active session to `isIdle: false` and stamps `lastClientActivityAt: Date.now()` before the wire send. Without this, the dashboard's `ActivityIndicator` and per-session busy dot stayed idle in the gap between answer-send and the next server-emitted stream/tool event, making the answer look dropped or timed out.

Restores symmetry with `sendInput` (the regular chat path). Once a server event arrives, the bump is a no-op — server is authoritative; the timestamp is overwritten in `dispatch-activity`.

## Test plan

- [x] `npx vitest run src/components/QuestionPrompt.test.tsx src/store` — 409 pass
- [x] Full dashboard suite — 1923 pass
- [x] `npx tsc --noEmit` — clean
- [x] QuestionPrompt — new `describe('post-answer collapse (#4312)')` covers collapsed default + chevron expansion (assertions on `aria-expanded`, label, marker, full button list on expand)
- [x] connection.ts — new test verifies `sendUserQuestionResponse` flips `isIdle: false` and bumps `lastClientActivityAt`
- [ ] Manual smoke: pick an AskUserQuestion option, verify (a) the option block collapses to `✓ <chosen>`, chevron expands it back; (b) `ActivityIndicator` lights up immediately, doesn't wait for next server event

Closes #4312