### PR TITLE
fix(server): preflight recognises codex/gemini OAuth login state

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -494,9 +494,25 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
             {availableProviders.length > 0
               ? availableProviders.map(p => {
                   const unready = p.auth?.ready === false
+                  // #4301: surface the diagnostic (auth.detail / auth.hint)
+                  // for disabled options too — a disabled <option> can't be
+                  // selected so the user wouldn't otherwise see the live
+                  // billing-hint line below. We append the hint inline AND
+                  // mirror it via title= so hover tooltips also work.
+                  const baseLabel = PROVIDER_LABELS[p.name] || p.name
+                  const unreadyHint = unready ? (p.auth?.hint || 'credentials missing') : ''
+                  const optionLabel = unready
+                    ? `${baseLabel} — ${unreadyHint}`
+                    : baseLabel
+                  const tooltip = unready ? (p.auth?.detail || unreadyHint) : undefined
                   return (
-                    <option key={p.name} value={p.name} disabled={unready}>
-                      {(PROVIDER_LABELS[p.name] || p.name) + (unready ? ' — credentials missing' : '')}
+                    <option
+                      key={p.name}
+                      value={p.name}
+                      disabled={unready}
+                      title={tooltip}
+                    >
+                      {optionLabel}
                     </option>
                   )
                 })

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -318,6 +318,33 @@ function getProviderAuthInfo(name, ProviderClass) {
     }
   }
 
+  // #4301: Codex and Gemini CLIs authenticate via their own `login` flows
+  // and cache OAuth tokens under `~/.codex/auth.json` / `~/.gemini/...`.
+  // The Codex CLI also runs fine when `OPENAI_API_KEY` is null in that file
+  // because the `tokens` block carries the access/refresh tokens. The
+  // env-var-only preflight misreported these providers as "credentials
+  // missing" whenever users authed via the CLI instead of exporting a key.
+  if (name === 'codex' && _hasCodexOAuthCreds()) {
+    return {
+      ready: true,
+      source: 'oauth',
+      envVar: null,
+      envVars,
+      hint,
+      detail: `${describeBillingIdentity(name, null)} (OAuth from \`codex login\`)`,
+    }
+  }
+  if (name === 'gemini' && _hasGeminiOAuthCreds()) {
+    return {
+      ready: true,
+      source: 'oauth',
+      envVar: null,
+      envVars,
+      hint,
+      detail: `${describeBillingIdentity(name, null)} (OAuth from \`gemini login\`)`,
+    }
+  }
+
   // No env var matched — optional creds (host claude-sdk) can fall back to
   // an OAuth subscription cached on disk by `claude login`. Earlier code
   // optimistically reported ready=true here, but #3674 caught that this
@@ -347,14 +374,26 @@ function getProviderAuthInfo(name, ProviderClass) {
   }
 
   // Required creds missing — provider can't run.
+  // #4301: codex/gemini also support an OAuth login flow, so the hint should
+  // mention both paths so the user doesn't think the env var is the only fix.
+  let resolvedHint = hint
+  if (name === 'codex') {
+    resolvedHint = hint
+      ? `${hint} or run \`codex login\``
+      : 'run `codex login` or set OPENAI_API_KEY'
+  } else if (name === 'gemini') {
+    resolvedHint = hint
+      ? `${hint} or run \`gemini login\``
+      : 'run `gemini login` or set GEMINI_API_KEY'
+  }
   return {
     ready: false,
     source: 'none',
     envVar: null,
     envVars,
-    hint,
+    hint: resolvedHint,
     detail: envVars.length
-      ? `Not configured — ${hint}`
+      ? `Not configured — ${resolvedHint}`
       : 'Not configured',
   }
 }
@@ -415,37 +454,131 @@ function _probeClaudeOAuthCreds() {
 }
 
 /**
- * 5s TTL cache around `_probeClaudeOAuthCreds()` (#3678).
+ * Best-effort probe for `codex login` OAuth state on disk (#4301).
  *
- * `listProviders()` is called from `handleListProviders` on every dashboard
- * `list_providers` WS request and once per `auth_ok` from `ws-history.js`.
- * Each call performs three `existsSync` + an optional small `readFileSync` +
- * `JSON.parse`. The cache is keyed on the override env vars so a test (or a
- * runtime tweak) that changes `CHROXY_CLAUDE_HOME` / `CHROXY_CLAUDE_CONFIG`
- * naturally invalidates the previous result.
+ * The Codex CLI caches its login tokens in `~/.codex/auth.json`. The file is
+ * always present after a `codex login` run; what matters for "user is authed"
+ * is the `tokens` block being populated. The Codex CLI itself works fine
+ * even when the file's `OPENAI_API_KEY` field is `null` because the OAuth
+ * tokens carry the credential round-trip.
+ *
+ * Override path for tests / atypical installs:
+ *   - `CHROXY_CODEX_HOME` — overrides the directory used to locate auth.json
+ *
+ * @returns {boolean}
  */
-let _credsCache = { value: null, expiresAt: 0, key: null }
-
-function _hasClaudeOAuthCreds() {
-  const key = `${process.env.CHROXY_CLAUDE_HOME ?? ''}|${process.env.CHROXY_CLAUDE_CONFIG ?? ''}`
-  const now = Date.now()
-  if (_credsCache.key === key && _credsCache.expiresAt > now) {
-    return _credsCache.value
+function _probeCodexOAuthCreds() {
+  try {
+    const codexHome = process.env.CHROXY_CODEX_HOME || join(homedir(), '.codex')
+    const authPath = join(codexHome, 'auth.json')
+    if (!existsSync(authPath)) return false
+    try {
+      const parsed = JSON.parse(readFileSync(authPath, 'utf-8'))
+      if (!parsed || typeof parsed !== 'object') return false
+      // Either: populated `tokens` block (OAuth login), or a real string
+      // OPENAI_API_KEY embedded in the file (CLI also accepts this).
+      if (parsed.tokens && typeof parsed.tokens === 'object') {
+        const t = parsed.tokens
+        if (typeof t.access_token === 'string' && t.access_token.length > 0) return true
+        if (typeof t.refresh_token === 'string' && t.refresh_token.length > 0) return true
+        if (typeof t.id_token === 'string' && t.id_token.length > 0) return true
+      }
+      if (typeof parsed.OPENAI_API_KEY === 'string' && parsed.OPENAI_API_KEY.length > 0) {
+        return true
+      }
+    } catch {
+      // Malformed JSON — treat as absent.
+    }
+  } catch {
+    // Any unexpected fs error → behave as if no creds.
   }
-  const value = _probeClaudeOAuthCreds()
-  _credsCache = { value, expiresAt: now + 5_000, key }
-  return value
+  return false
 }
 
 /**
- * Test-only hook to drop the cached creds-probe result so suites that mutate
- * the override env vars (or write/delete files under `CHROXY_CLAUDE_HOME`
+ * Best-effort probe for `gemini login` OAuth state on disk (#4301).
+ *
+ * The Gemini CLI caches OAuth state under `~/.gemini/`. The exact filename
+ * has shifted between CLI versions; we cover the names observed in the
+ * wild and treat presence of any of them as evidence of a completed login:
+ *
+ *   - `~/.gemini/oauth_creds.json`     — typical for `gemini login`
+ *   - `~/.gemini/google_accounts.json` — older variant
+ *
+ * Override path for tests / atypical installs:
+ *   - `CHROXY_GEMINI_HOME` — overrides the directory used for the lookups
+ *
+ * @returns {boolean}
+ */
+function _probeGeminiOAuthCreds() {
+  try {
+    const geminiHome = process.env.CHROXY_GEMINI_HOME || join(homedir(), '.gemini')
+    if (existsSync(join(geminiHome, 'oauth_creds.json'))) return true
+    if (existsSync(join(geminiHome, 'google_accounts.json'))) return true
+  } catch {
+    // Any unexpected fs error → behave as if no creds.
+  }
+  return false
+}
+
+/**
+ * 5s TTL cache around the on-disk creds probes (#3678).
+ *
+ * `listProviders()` is called from `handleListProviders` on every dashboard
+ * `list_providers` WS request and once per `auth_ok` from `ws-history.js`.
+ * Each call performs several `existsSync` + optional small `readFileSync` +
+ * `JSON.parse`. The cache is keyed on the override env vars so a test (or a
+ * runtime tweak) that changes any of the `CHROXY_*_HOME` variables naturally
+ * invalidates the previous result.
+ *
+ * Per-provider entries so a mutation under one provider's home doesn't blow
+ * away the cached result for another (#4301 added codex + gemini).
+ */
+let _credsCache = {
+  claude: { value: null, expiresAt: 0, key: null },
+  codex: { value: null, expiresAt: 0, key: null },
+  gemini: { value: null, expiresAt: 0, key: null },
+}
+
+function _cachedProbe(slot, key, probe) {
+  const now = Date.now()
+  const entry = _credsCache[slot]
+  if (entry.key === key && entry.expiresAt > now) {
+    return entry.value
+  }
+  const value = probe()
+  _credsCache[slot] = { value, expiresAt: now + 5_000, key }
+  return value
+}
+
+function _hasClaudeOAuthCreds() {
+  const key = `${process.env.CHROXY_CLAUDE_HOME ?? ''}|${process.env.CHROXY_CLAUDE_CONFIG ?? ''}`
+  return _cachedProbe('claude', key, _probeClaudeOAuthCreds)
+}
+
+function _hasCodexOAuthCreds() {
+  const key = `${process.env.CHROXY_CODEX_HOME ?? ''}`
+  return _cachedProbe('codex', key, _probeCodexOAuthCreds)
+}
+
+function _hasGeminiOAuthCreds() {
+  const key = `${process.env.CHROXY_GEMINI_HOME ?? ''}`
+  return _cachedProbe('gemini', key, _probeGeminiOAuthCreds)
+}
+
+/**
+ * Test-only hook to drop the cached creds-probe results so suites that mutate
+ * the override env vars (or write/delete files under any `CHROXY_*_HOME`
  * without changing the env-var values) start from a clean slate. Production
  * code should never call this — the natural env-var-keyed invalidation plus
  * the 5s TTL is what users see.
  */
 export function _resetCredsCacheForTest() {
-  _credsCache = { value: null, expiresAt: 0, key: null }
+  _credsCache = {
+    claude: { value: null, expiresAt: 0, key: null },
+    codex: { value: null, expiresAt: 0, key: null },
+    gemini: { value: null, expiresAt: 0, key: null },
+  }
 }
 
 function describeBillingIdentity(name, envVar) {

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -106,9 +106,11 @@ describe('Provider Registry', () => {
   // so the dashboard can grey-out unusable providers and show a billing-
   // identity confidence panel without making the user run `chroxy doctor`.
   describe('auth status (#3404 audit)', () => {
-    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG']
+    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME']
     const saved = {}
     let _tmpClaudeHome = null
+    let _tmpCodexHome = null
+    let _tmpGeminiHome = null
 
     function clearKeys() {
       for (const k of ENV_KEYS) {
@@ -122,6 +124,13 @@ describe('Provider Registry', () => {
       _tmpClaudeHome = mkdtempSync(join(tmpdir(), 'chroxy-claude-home-'))
       process.env.CHROXY_CLAUDE_HOME = _tmpClaudeHome
       process.env.CHROXY_CLAUDE_CONFIG = join(_tmpClaudeHome, '.claude.json')
+      // #4301: same isolation pattern for the new codex/gemini OAuth probes —
+      // point them at empty tmpdirs so neither the developer's real ~/.codex
+      // or ~/.gemini state nor any prior test leftover leaks in.
+      _tmpCodexHome = mkdtempSync(join(tmpdir(), 'chroxy-codex-home-'))
+      process.env.CHROXY_CODEX_HOME = _tmpCodexHome
+      _tmpGeminiHome = mkdtempSync(join(tmpdir(), 'chroxy-gemini-home-'))
+      process.env.CHROXY_GEMINI_HOME = _tmpGeminiHome
       // #3678: drop the cached creds-probe result. The env-var-keyed cache
       // already invalidates on key change, but tests sometimes write/delete
       // files under CHROXY_CLAUDE_HOME after clearKeys() runs — explicitly
@@ -136,6 +145,14 @@ describe('Provider Registry', () => {
       if (_tmpClaudeHome) {
         try { rmSync(_tmpClaudeHome, { recursive: true, force: true }) } catch {}
         _tmpClaudeHome = null
+      }
+      if (_tmpCodexHome) {
+        try { rmSync(_tmpCodexHome, { recursive: true, force: true }) } catch {}
+        _tmpCodexHome = null
+      }
+      if (_tmpGeminiHome) {
+        try { rmSync(_tmpGeminiHome, { recursive: true, force: true }) } catch {}
+        _tmpGeminiHome = null
       }
       // #3678: drop the cache so the next test (or a parallel describe block)
       // doesn't see a value bound to an env-var combo we just unset.
@@ -261,7 +278,7 @@ describe('Provider Registry', () => {
       }
     })
 
-    it('codex reports ready=false and source=none when OPENAI_API_KEY is missing', () => {
+    it('codex reports ready=false and source=none when OPENAI_API_KEY is missing AND no codex login', () => {
       try {
         clearKeys()
         const list = listProviders()
@@ -270,6 +287,109 @@ describe('Provider Registry', () => {
         assert.equal(codex.auth.ready, false)
         assert.equal(codex.auth.source, 'none')
         assert.match(codex.auth.detail, /OPENAI_API_KEY/)
+        // #4301: hint must now mention the `codex login` OAuth path too so the
+        // user knows env var isn't the only way to authenticate.
+        assert.match(codex.auth.hint, /codex login/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    // #4301: Codex CLI's `codex login` writes a JSON auth file under ~/.codex/
+    // with a populated `tokens` block. The CLI works fine even when the file's
+    // OPENAI_API_KEY field is null because the OAuth tokens carry the round-
+    // trip. The preflight must recognise this state as ready, not "credentials
+    // missing".
+    it('codex reports ready=true source=oauth when ~/.codex/auth.json has tokens (#4301)', () => {
+      try {
+        clearKeys()
+        writeFileSync(
+          join(_tmpCodexHome, 'auth.json'),
+          JSON.stringify({
+            OPENAI_API_KEY: null,
+            tokens: {
+              id_token: 'fake.id.token',
+              access_token: 'fake-access-token',
+              refresh_token: 'fake-refresh-token',
+              account_id: 'fake-account',
+            },
+            last_refresh: '2026-05-26T00:00:00.000Z',
+          }),
+        )
+        const list = listProviders()
+        const codex = list.find(p => p.name === 'codex')
+        if (!codex) return
+        assert.equal(codex.auth.ready, true)
+        assert.equal(codex.auth.source, 'oauth')
+        assert.equal(codex.auth.envVar, null)
+        assert.match(codex.auth.detail, /OAuth from `codex login`/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('codex reports ready=true source=oauth when auth.json embeds OPENAI_API_KEY string (#4301)', () => {
+      try {
+        clearKeys()
+        writeFileSync(
+          join(_tmpCodexHome, 'auth.json'),
+          JSON.stringify({ OPENAI_API_KEY: 'sk-from-file', tokens: null }),
+        )
+        const list = listProviders()
+        const codex = list.find(p => p.name === 'codex')
+        if (!codex) return
+        assert.equal(codex.auth.ready, true)
+        assert.equal(codex.auth.source, 'oauth')
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('codex stays ready=false when auth.json exists but tokens block is null/empty (#4301)', () => {
+      try {
+        clearKeys()
+        writeFileSync(
+          join(_tmpCodexHome, 'auth.json'),
+          JSON.stringify({ OPENAI_API_KEY: null, tokens: null }),
+        )
+        const list = listProviders()
+        const codex = list.find(p => p.name === 'codex')
+        if (!codex) return
+        assert.equal(codex.auth.ready, false)
+        assert.equal(codex.auth.source, 'none')
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('codex stays ready=false when ~/.codex/auth.json is malformed JSON (#4301)', () => {
+      try {
+        clearKeys()
+        writeFileSync(join(_tmpCodexHome, 'auth.json'), 'this is not { valid json')
+        const list = listProviders()
+        const codex = list.find(p => p.name === 'codex')
+        if (!codex) return
+        assert.equal(codex.auth.ready, false)
+        assert.equal(codex.auth.source, 'none')
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('codex env var still wins over OAuth file (env reported as source=env) (#4301)', () => {
+      try {
+        clearKeys()
+        process.env.OPENAI_API_KEY = 'sk-from-env'
+        writeFileSync(
+          join(_tmpCodexHome, 'auth.json'),
+          JSON.stringify({ tokens: { access_token: 'fake' } }),
+        )
+        const list = listProviders()
+        const codex = list.find(p => p.name === 'codex')
+        if (!codex) return
+        assert.equal(codex.auth.ready, true)
+        assert.equal(codex.auth.source, 'env')
+        assert.equal(codex.auth.envVar, 'OPENAI_API_KEY')
       } finally {
         restoreKeys()
       }
@@ -300,6 +420,71 @@ describe('Provider Registry', () => {
         assert.equal(gemini.auth.ready, true)
         assert.equal(gemini.auth.source, 'env')
         assert.equal(gemini.auth.envVar, 'GOOGLE_API_KEY')
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    // #4301: Gemini CLI's `gemini login` caches OAuth state under ~/.gemini/
+    // (filename varies between CLI versions — oauth_creds.json or
+    // google_accounts.json). Preflight must recognise either as authed.
+    it('gemini reports ready=true source=oauth when ~/.gemini/oauth_creds.json exists (#4301)', () => {
+      try {
+        clearKeys()
+        writeFileSync(join(_tmpGeminiHome, 'oauth_creds.json'), '{}')
+        const list = listProviders()
+        const gemini = list.find(p => p.name === 'gemini')
+        if (!gemini) return
+        assert.equal(gemini.auth.ready, true)
+        assert.equal(gemini.auth.source, 'oauth')
+        assert.equal(gemini.auth.envVar, null)
+        assert.match(gemini.auth.detail, /OAuth from `gemini login`/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('gemini reports ready=true source=oauth when ~/.gemini/google_accounts.json exists (#4301)', () => {
+      try {
+        clearKeys()
+        writeFileSync(join(_tmpGeminiHome, 'google_accounts.json'), '{}')
+        const list = listProviders()
+        const gemini = list.find(p => p.name === 'gemini')
+        if (!gemini) return
+        assert.equal(gemini.auth.ready, true)
+        assert.equal(gemini.auth.source, 'oauth')
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('gemini reports ready=false with combined hint when no env var AND no login state (#4301)', () => {
+      try {
+        clearKeys()
+        const list = listProviders()
+        const gemini = list.find(p => p.name === 'gemini')
+        if (!gemini) return
+        assert.equal(gemini.auth.ready, false)
+        assert.equal(gemini.auth.source, 'none')
+        // Hint must now mention both env vars AND `gemini login`.
+        assert.match(gemini.auth.hint, /GEMINI_API_KEY|GOOGLE_API_KEY/)
+        assert.match(gemini.auth.hint, /gemini login/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('gemini env var still wins over OAuth file (source=env) (#4301)', () => {
+      try {
+        clearKeys()
+        process.env.GEMINI_API_KEY = 'gem-from-env'
+        writeFileSync(join(_tmpGeminiHome, 'oauth_creds.json'), '{}')
+        const list = listProviders()
+        const gemini = list.find(p => p.name === 'gemini')
+        if (!gemini) return
+        assert.equal(gemini.auth.ready, true)
+        assert.equal(gemini.auth.source, 'env')
+        assert.equal(gemini.auth.envVar, 'GEMINI_API_KEY')
       } finally {
         restoreKeys()
       }


### PR DESCRIPTION
## Summary

- `providers.js`: add OAuth fallback probes for `codex` and `gemini` so the preflight reports `ready: true` when the user has authed via `codex login` / `gemini login` instead of exporting an env var. Mirrors the `_hasClaudeOAuthCreds()` pattern used for `claude-sdk`.
- When env-var creds are missing, the `auth.hint` now mentions both the env var **and** the CLI login flow so the user knows there's a second path.
- `CreateSessionModal.tsx`: render `auth.hint` inline on disabled `<option>`s and mirror `auth.detail` via `title=` so users can see *why* a provider is greyed out without having to select it (today's UX hides the diagnostic for disabled options).

The Codex CLI's `~/.codex/auth.json` always has an `OPENAI_API_KEY: null` field after a fresh `codex login`; what makes the CLI work is the populated `tokens` block. The probe accepts either a populated `tokens` block (access/refresh/id token) or an embedded string `OPENAI_API_KEY`. Malformed JSON and empty token blocks correctly stay `ready=false`.

For Gemini we accept `~/.gemini/oauth_creds.json` or `~/.gemini/google_accounts.json` — the filename has shifted between CLI versions.

Both probes are gated behind a per-provider 5s TTL cache keyed on new `CHROXY_CODEX_HOME` / `CHROXY_GEMINI_HOME` overrides so tests can isolate the host's real config dirs.

## Test plan

- [x] `node --test tests/providers.test.js` — 50/50 pass, includes 9 new tests covering: tokens-block recognition, embedded-key recognition, malformed JSON, empty tokens block, env-var precedence, combined hint when no creds, plus gemini oauth_creds.json and google_accounts.json acceptance
- [x] `node --test tests/handlers/session-handlers.test.js` — 34/34 pass (no regression)
- [ ] Manual: run dashboard with `codex login` completed but `OPENAI_API_KEY` unset; verify Codex option is enabled in CreateSessionModal and `auth.detail` shows "OpenAI API (OAuth from \`codex login\`)"
- [ ] Manual: hover a disabled provider option; tooltip surfaces the full `auth.detail`

Closes #4301