### PR TITLE
fix(dashboard): ToolGroup expanded detail falls through to toolInputPartial for streaming tools

### DIFF
--- a/packages/dashboard/src/components/ToolGroup.test.tsx
+++ b/packages/dashboard/src/components/ToolGroup.test.tsx
@@ -371,6 +371,79 @@ describe('ToolGroup', () => {
       expect(detail).toHaveTextContent('(no result yet)')
     })
 
+    // #4341 — in-flight streaming tools (e.g. Agent / Task) accumulate
+    // chunks into `toolInputPartial` but `toolInput` stays empty until
+    // the final delta arrives. Pre-fix the expanded detail showed
+    // "(no input)" even though the buffer was filling — same UX gap
+    // ToolBubble closed for the collapsed-summary path in #4081.
+    describe('streaming input (#4341)', () => {
+      it('renders toolInputPartial verbatim while toolInput is undefined', () => {
+        const messages = [
+          tool('1', 'Task', { toolInputPartial: '{"description":"Investigate' }),
+        ]
+        render(<ToolGroup messages={messages} isActive={true} />)
+        fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+        const detail = screen.getByTestId('tool-group-entry-detail-1')
+        expect(detail).toHaveTextContent('{"description":"Investigate')
+        expect(detail).not.toHaveTextContent('(no input)')
+        // Marks the panel as streaming so styling can hint "still
+        // arriving" — same affordance ToolBubble uses via data-parsed.
+        expect(detail).toHaveAttribute('data-streaming', 'true')
+      })
+
+      it('pretty-prints toolInputPartial when the buffer is already complete JSON', () => {
+        const messages = [
+          tool('1', 'Task', { toolInputPartial: '{"command":"ls"}' }),
+        ]
+        render(<ToolGroup messages={messages} isActive={true} />)
+        fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+        const detail = screen.getByTestId('tool-group-entry-detail-1')
+        // Pretty-printed (two-space indent) when the partial happens
+        // to be a complete JSON document — matches ToolBubble's
+        // `tryParseCompleteJson` path.
+        expect(detail).toHaveTextContent('"command": "ls"')
+      })
+
+      it('prefers structured toolInput when present, ignoring toolInputPartial', () => {
+        // Once the final input lands, the structured render takes over —
+        // the partial buffer becomes informational only and must not
+        // override the canonical structured panel.
+        const messages = [
+          tool('1', 'Task', {
+            toolInput: { command: 'ls -la' },
+            toolInputPartial: '{"command":"ls', // stale half-buffer
+          }),
+        ]
+        render(<ToolGroup messages={messages} isActive={true} />)
+        fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+        const detail = screen.getByTestId('tool-group-entry-detail-1')
+        expect(detail).toHaveTextContent('"command": "ls -la"')
+        // The streaming attribute is only for the partial-only path.
+        expect(detail).not.toHaveAttribute('data-streaming', 'true')
+      })
+
+      it('still shows "(no input)" when both toolInput and toolInputPartial are absent', () => {
+        // Regression guard for the existing placeholder behavior — a
+        // truly inputless tool still shows the placeholder.
+        const messages = [tool('1', 'Bash')]
+        render(<ToolGroup messages={messages} isActive={true} />)
+        fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+        const detail = screen.getByTestId('tool-group-entry-detail-1')
+        expect(detail).toHaveTextContent('(no input)')
+      })
+
+      it('still shows "(no input)" when toolInputPartial is an empty string', () => {
+        // Empty-string partials must not flip the panel into the
+        // streaming path — only content counts.
+        const messages = [tool('1', 'Bash', { toolInputPartial: '' })]
+        render(<ToolGroup messages={messages} isActive={true} />)
+        fireEvent.click(screen.getByTestId('tool-group-entry-row-1'))
+        const detail = screen.getByTestId('tool-group-entry-detail-1')
+        expect(detail).toHaveTextContent('(no input)')
+        expect(detail).not.toHaveAttribute('data-streaming', 'true')
+      })
+    })
+
     // #4281: agent-review caught that the previous implementation made the
     // OUTER entry the click target, so a click inside the expanded detail
     // panel (e.g. selecting `<pre>` text to copy a Bash output) bubbled to

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -14,6 +14,7 @@ import {
   summarizeToolCounts,
   formatToolBreakdown,
   formatToolName,
+  tryParseCompleteJson,
 } from '@chroxy/store-core'
 
 export interface ToolGroupProps {
@@ -49,6 +50,22 @@ function formatInputForDetail(input: ChatMessage['toolInput']): string {
     // String() so the user still sees something instead of an empty panel.
     return String(input)
   }
+}
+
+/**
+ * #4341: format the streaming `toolInputPartial` accumulator for the
+ * expanded detail panel. Mirrors `ToolBubble`'s partial-preview path
+ * (#4081): if the buffer happens to be a complete JSON document, pretty-
+ * print it via `tryParseCompleteJson` (cheap gate avoids the N-1 throws
+ * #4242 amortised); otherwise render verbatim so the user sees the
+ * field assembling. Returns '' for empty/whitespace input so the caller
+ * can preserve the "(no input)" placeholder for truly inputless tools.
+ */
+function formatPartialForDetail(partial: string | undefined): string {
+  if (!partial) return ''
+  const parsed = tryParseCompleteJson(partial)
+  if (parsed !== undefined) return JSON.stringify(parsed, null, 2)
+  return partial
 }
 
 function ToolGroupEntry({
@@ -107,7 +124,20 @@ function ToolGroupEntry({
     }
   }
 
-  const inputDetail = formatInputForDetail(message.toolInput)
+  const structuredInputDetail = formatInputForDetail(message.toolInput)
+  // #4341: fall through to the streaming `toolInputPartial` accumulator
+  // when the structured `toolInput` is empty. Pre-fix the expanded panel
+  // showed "(no input)" for in-flight Agent/Task tools even though
+  // `tool_input_delta` chunks were piling into `toolInputPartial` —
+  // ToolBubble had already closed this gap for the collapsed summary
+  // (#4081), so the expanded view now mirrors the same fallback.
+  // `isStreamingInput` flags the panel as still arriving so styling can
+  // hint at the in-flight state (data-streaming="true").
+  const partialInputDetail = structuredInputDetail
+    ? ''
+    : formatPartialForDetail(message.toolInputPartial)
+  const inputDetail = structuredInputDetail || partialInputDetail
+  const isStreamingInput = !structuredInputDetail && partialInputDetail !== ''
   const resultDetail = message.toolResult ?? ''
   // Distinguish "tool finished with empty output" from "tool still running".
   // hasResult covers both toolResult presence and image results.
@@ -149,6 +179,12 @@ function ToolGroupEntry({
         <div
           className="tool-group-entry-detail"
           data-testid={`tool-group-entry-detail-${message.id}`}
+          // #4341: surfaces the in-flight state to styling so a CSS
+          // hook can hint "still arriving" (e.g. subtle pulse on the
+          // Input section). Only set when the panel is rendering the
+          // streaming partial buffer rather than the final structured
+          // input.
+          data-streaming={isStreamingInput ? 'true' : undefined}
           // Detail clicks must not bubble to the outer group's
           // onClick={toggle} — otherwise selecting/copying `<pre>` text
           // collapses the entire group. The row already handles its own


### PR DESCRIPTION
## Context

Observed in the v0.9.5 dogfood after answering an AskUserQuestion prompt that launched a long-running Agent tool. Expanding the ToolGroup entry for an in-flight Agent showed:

```
INPUT
(no input)

RESULT
(no result yet)
```

`Result` was correctly pending — but `Input` was misleading. The tool *does* have an input; `tool_input_delta` chunks accumulate into `toolInputPartial`, but the structured `toolInput` stays undefined until the final delta arrives. `ToolBubble` already closed this gap for the collapsed-summary path in #4081; this PR mirrors the same fallback for `ToolGroupEntry`'s expanded detail.

## Changes

`packages/dashboard/src/components/ToolGroup.tsx`
- Added `formatPartialForDetail(partial)` helper. Returns `''` for empty/undefined input so the caller can preserve the `(no input)` placeholder for truly inputless tools. If the buffer is a complete JSON document (gated cheaply by `tryParseCompleteJson` from #4242), pretty-prints; otherwise renders verbatim so users see the field forming.
- `ToolGroupEntry` now computes `structuredInputDetail` first, then falls through to `formatPartialForDetail(message.toolInputPartial)` only when the structured input is empty. `inputDetail` defaults to whichever has content; the `(no input)` placeholder fires only when both are empty.
- The expanded detail panel sets `data-streaming="true"` while rendering the partial buffer, so styling can hint at the in-flight state.

`packages/dashboard/src/components/ToolGroup.test.tsx`
- Added a `streaming input (#4341)` describe block under the existing `per-entry expansion (#4279)` suite with 5 cases:
  - in-flight tool with `toolInputPartial` set + `toolInput` undefined → partial rendered, no `(no input)`, `data-streaming="true"`
  - complete JSON in `toolInputPartial` → pretty-printed
  - both `toolInput` and `toolInputPartial` present → structured `toolInput` wins, `data-streaming` not set
  - regression guard: truly inputless tool (`toolInput` undefined AND `toolInputPartial` undefined) → still shows `(no input)`
  - empty-string `toolInputPartial` → still shows `(no input)`, `data-streaming` not set

## Acceptance Criteria

- [x] Expanded `ToolGroupEntry` for an in-flight tool with populated `toolInputPartial` shows the partial input (NOT `(no input)`)
- [x] Once the final `toolInput` arrives, the panel switches to the structured render (existing path)
- [x] Empty-string `toolInputPartial` and `toolInputPartial: undefined` both still render `(no input)`
- [x] No regression in the existing "no input ever provided" test
- [x] Added vitests covering the in-flight Agent case (`toolInput` undefined + `toolInputPartial` populated -> renders the partial)

## Verification

- `npx vitest run src/components/ToolGroup` -> 36 passed (5 new)
- `npx tsc --noEmit` -> clean

Closes #4341