### PR TITLE
feat(dashboard): richer fix-hint affordance for disabled providers (#4340)

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -91,6 +91,40 @@ const CAPABILITY_BADGES: [keyof import('../store/types').ProviderCapabilities, s
   ['terminal', 'Terminal'],
 ]
 
+/**
+ * Render a hint string with backtick-wrapped tokens promoted to `<code>` so
+ * snippets like `codex login` or `OPENAI_API_KEY` format as code rather
+ * than rendering as literal backticks (#4340). A pure helper so the parsed
+ * tree is easy to unit-test.
+ *
+ * Only single-backtick code spans are recognised — that's all the server
+ * hint strings use today. Backtick handling is intentionally tolerant: an
+ * unmatched trailing backtick falls back to literal text so an
+ * accidentally-malformed hint still renders.
+ */
+export function renderHintWithCode(hint: string): Array<string | { code: string }> {
+  if (!hint) return []
+  const out: Array<string | { code: string }> = []
+  let i = 0
+  while (i < hint.length) {
+    const start = hint.indexOf('`', i)
+    if (start === -1) {
+      out.push(hint.slice(i))
+      break
+    }
+    if (start > i) out.push(hint.slice(i, start))
+    const end = hint.indexOf('`', start + 1)
+    if (end === -1) {
+      // Unmatched backtick — fall back to literal text, including the tick.
+      out.push(hint.slice(start))
+      break
+    }
+    out.push({ code: hint.slice(start + 1, end) })
+    i = end + 1
+  }
+  return out
+}
+
 export function resolveCreateSessionModel(
   provider: string,
   defaultModel: string | null | undefined,
@@ -213,12 +247,26 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     }
   }, [open, availableProviders, provider])
 
+  // #4340: gate the Create button on the selected provider being ready.
+  // Pre-#4340 the dropdown disabled unready options so they couldn't be
+  // selected; now we let the user navigate to any provider to read its
+  // fix-hint, but still refuse to submit until auth.ready === true. We
+  // resolve `selectedProviderUnready` once and reuse it for the panel +
+  // submit gate + button disabled state.
+  const selectedProviderInfo = availableProviders.find(p => p.name === provider)
+  const selectedProviderUnready = selectedProviderInfo?.auth?.ready === false
+
   const submit = useCallback(() => {
     const trimmed = nameValRef.current.trim()
     if (!trimmed) {
       flushSync(() => setNameError('Session name is required'))
       return
     }
+    // #4340: refuse to create a session against an unready provider. The
+    // fix-hint panel tells the user what to do; the Create button is also
+    // visually disabled, but the click path checks here for defence in
+    // depth (e.g. keyboard activation racing a store update).
+    if (selectedProviderUnready) return
     const model = resolveCreateSessionModel(provider, defaultModel, availableModels, availableModelsProvider)
     // #4208: gate on the TUI provider at submit time as well as in the UI.
     // The checkbox is hidden for non-TUI providers, but a user who flips
@@ -228,7 +276,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     // braces: undefined unless the active provider is `claude-tui`.
     const skipPermissionsOut = provider === 'claude-tui' && skipPermissions ? true : undefined
     onCreate({ name: trimmed, cwd: cwdValRef.current.trim(), provider, permissionMode: permissionMode || undefined, model, worktree: worktree || undefined, environmentId: environmentId || undefined, skipPermissions: skipPermissionsOut })
-  }, [onCreate, provider, permissionMode, defaultModel, availableModels, availableModelsProvider, worktree, environmentId, skipPermissions])
+  }, [onCreate, provider, permissionMode, defaultModel, availableModels, availableModelsProvider, worktree, environmentId, skipPermissions, selectedProviderUnready])
 
   const selectSuggestion = useCallback((path: string) => {
     setCwd(path)
@@ -494,22 +542,26 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
             {availableProviders.length > 0
               ? availableProviders.map(p => {
                   const unready = p.auth?.ready === false
-                  // #4301: surface the diagnostic (auth.detail / auth.hint)
-                  // for disabled options too — a disabled <option> can't be
-                  // selected so the user wouldn't otherwise see the live
-                  // billing-hint line below. We append the hint inline AND
-                  // mirror it via title= so hover tooltips also work.
+                  // #4340: keep <option> labels short. Pre-#4340 the full
+                  // auth.hint was inlined here ("Codex (CLI) — set
+                  // OPENAI_API_KEY or run `codex login`"); native <select>
+                  // rendering truncated long labels in some browser/OS
+                  // combos and backticks rendered as literal characters.
+                  // The hint now surfaces in the help panel below the
+                  // dropdown — see provider-fix-hint. We keep the option
+                  // enabled (vs the pre-#4340 disabled=true) so the user
+                  // can navigate to any provider to read its fix-hint;
+                  // submit is gated separately on auth.ready.
                   const baseLabel = PROVIDER_LABELS[p.name] || p.name
-                  const unreadyHint = unready ? (p.auth?.hint || 'credentials missing') : ''
-                  const optionLabel = unready
-                    ? `${baseLabel} — ${unreadyHint}`
-                    : baseLabel
-                  const tooltip = unready ? (p.auth?.detail || unreadyHint) : undefined
+                  const optionLabel = unready ? `${baseLabel} (unavailable)` : baseLabel
+                  // Mirror the live detail via title= so desktop hover
+                  // tooltips still work for users who don't navigate to
+                  // the option. Mobile/touch users see the panel instead.
+                  const tooltip = unready ? (p.auth?.detail || p.auth?.hint || 'credentials missing') : undefined
                   return (
                     <option
                       key={p.name}
                       value={p.name}
-                      disabled={unready}
                       title={tooltip}
                     >
                       {optionLabel}
@@ -524,8 +576,11 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
           </select>
           {/* Live auth detail from the server (#3404 audit F5) wins over the
               static PROVIDER_BILLING fallback so the user sees the actual
-              billing identity, not a generic "uses API credits" hint. */}
-          {(() => {
+              billing identity, not a generic "uses API credits" hint.
+              Suppressed when the selected provider is unready — the
+              fix-hint panel below replaces it so the user isn't reading
+              billing copy for a provider they can't even launch. */}
+          {selectedProviderUnready ? null : (() => {
             const live = availableProviders.find(p => p.name === provider)?.auth
             const text = live?.detail || PROVIDER_BILLING[provider]
             if (!text) return null
@@ -540,6 +595,44 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
             )
           })()}
         </div>
+        {/* #4340: richer fix-hint affordance for disabled providers. The
+            pre-#4340 inline `<option>` label couldn't render long hints
+            cleanly (truncation + literal backticks + hover-only title).
+            This panel appears under the dropdown when the selected
+            provider is unready, surfacing the full auth.detail / auth.hint
+            with backtick-wrapped tokens promoted to `<code>` so commands
+            like `codex login` look like commands. */}
+        {selectedProviderUnready && (() => {
+          const live = availableProviders.find(p => p.name === provider)?.auth
+          const hint = live?.hint || 'credentials missing'
+          const detail = live?.detail
+          return (
+            <div
+              className="provider-fix-hint"
+              data-testid="provider-fix-hint"
+              role="status"
+              aria-live="polite"
+            >
+              <span className="provider-fix-hint-label">How to enable:</span>{' '}
+              <span className="provider-fix-hint-body">
+                {renderHintWithCode(hint).map((part, i) =>
+                  typeof part === 'string'
+                    ? <span key={i}>{part}</span>
+                    : <code key={i}>{part.code}</code>,
+                )}
+              </span>
+              {detail && detail !== hint && (
+                <span className="provider-fix-hint-detail">
+                  {renderHintWithCode(detail).map((part, i) =>
+                    typeof part === 'string'
+                      ? <span key={i}>{part}</span>
+                      : <code key={i}>{part.code}</code>,
+                  )}
+                </span>
+              )}
+            </div>
+          )
+        })()}
         {availableProviders.length > 0 && (() => {
           const selected = availableProviders.find(p => p.name === provider)
           if (!selected?.capabilities) return null
@@ -692,7 +785,13 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
         <button className="btn-modal-cancel" onClick={onClose} type="button">
           Cancel
         </button>
-        <button className="btn-modal-create" onClick={submit} type="button" disabled={isCreating}>
+        <button
+          className="btn-modal-create"
+          onClick={submit}
+          type="button"
+          disabled={isCreating || selectedProviderUnready}
+          title={selectedProviderUnready ? 'Selected provider is not configured — see fix-hint above' : undefined}
+        >
           {isCreating ? 'Creating...' : 'Create'}
         </button>
       </div>

--- a/packages/dashboard/src/components/CreateSessionModalProviderFixHint.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalProviderFixHint.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Tests for the richer fix-hint affordance on the Create Session modal when
+ * the selected provider is unready (#4340).
+ *
+ * Pre-#4340 the disabled `<option>` carried the full hint inline ("Codex
+ * (CLI) — set OPENAI_API_KEY or run `codex login`"). That worked for short
+ * hints but:
+ *   - native `<select>` rendering truncated long labels on some browser/OS
+ *     combos
+ *   - backticks rendered as literal characters, not `<code>` formatting
+ *   - `title=` tooltip only fired on hover (no touch support)
+ *
+ * #4340 moves the hint to an inline help panel below the dropdown that
+ * renders ONLY when the selected provider's auth.ready is false. The panel:
+ *   - exposes the full hint with backtick-wrapped tokens promoted to `<code>`
+ *   - is keyed under `data-testid="provider-fix-hint"` for assertions
+ *   - is warning-toned so it stands apart from the billing-hint
+ *   - keeps the existing `title=` hover affordance intact for desktop users
+ *   - keeps `<option>` text short (provider name + "(unavailable)" suffix)
+ *     so native rendering doesn't truncate it
+ *
+ * Pins:
+ *   1. selected-unready-shows-panel — when defaultProvider is unready, the
+ *      fix-hint panel renders with the full auth.hint text on first mount
+ *   2. selected-ready-no-panel — when the selected provider is ready, the
+ *      panel does not render
+ *   3. backticks-render-as-code — backtick-wrapped tokens in the hint are
+ *      promoted to `<code>` elements so `codex login` formats as code
+ *   4. option-label-stays-short — disabled options use the "(unavailable)"
+ *      suffix instead of inlining the full hint
+ *   5. switching-to-unready-shows-panel — selecting an unready provider via
+ *      the dropdown surfaces the panel for that provider
+ *   6. create-disabled-for-unready — the Create button must refuse to
+ *      submit while an unready provider is selected (defence in depth)
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, fireEvent, cleanup, screen } from '@testing-library/react'
+
+const mockStoreState: Record<string, unknown> = {}
+
+vi.mock('../hooks/usePathAutocomplete', () => ({
+  usePathAutocomplete: () => ({ suggestions: [] }),
+}))
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector(mockStoreState),
+}))
+
+import { CreateSessionModal, type CreateSessionModalProps } from './CreateSessionModal'
+
+const SDK_READY = {
+  name: 'claude-sdk',
+  capabilities: {},
+  auth: { ready: true, source: 'env', envVar: 'ANTHROPIC_API_KEY', envVars: ['ANTHROPIC_API_KEY'], detail: 'API key (env ANTHROPIC_API_KEY)', hint: '' },
+}
+const CODEX_UNREADY = {
+  name: 'codex',
+  capabilities: {},
+  auth: {
+    ready: false,
+    source: 'none',
+    envVar: null,
+    envVars: ['OPENAI_API_KEY'],
+    detail: 'Not configured — set OPENAI_API_KEY or run `codex login`',
+    hint: 'set OPENAI_API_KEY or run `codex login`',
+  },
+}
+const GEMINI_UNREADY = {
+  name: 'gemini',
+  capabilities: {},
+  auth: {
+    ready: false,
+    source: 'none',
+    envVar: null,
+    envVars: ['GEMINI_API_KEY'],
+    detail: 'Not configured — set GEMINI_API_KEY or run `gemini login`',
+    hint: 'set GEMINI_API_KEY or run `gemini login`',
+  },
+}
+
+beforeEach(() => {
+  for (const k of Object.keys(mockStoreState)) delete mockStoreState[k]
+  Object.assign(mockStoreState, {
+    defaultProvider: 'claude-sdk',
+    defaultModel: null,
+    availableModels: [],
+    availableModelsProvider: null,
+    availableProviders: [SDK_READY, CODEX_UNREADY, GEMINI_UNREADY],
+    availablePermissionModes: [],
+    environments: [],
+    requestDirectoryListing: () => {},
+    setDirectoryListingCallback: () => {},
+    defaultCwd: null,
+  })
+})
+
+afterEach(cleanup)
+
+function renderModal(props: Partial<CreateSessionModalProps> = {}) {
+  const onCreate = vi.fn()
+  const onClose = vi.fn()
+  const defaultProps: CreateSessionModalProps = {
+    open: true,
+    onClose,
+    onCreate,
+    initialCwd: '/Users/me/projects',
+    knownCwds: [],
+    existingNames: [],
+    ...props,
+  }
+  return { ...render(<CreateSessionModal {...defaultProps} />), onCreate }
+}
+
+describe('CreateSessionModal provider fix-hint panel (#4340)', () => {
+  it('renders the fix-hint panel when the selected provider is unready', () => {
+    // Default to an unready provider so the panel surfaces on first mount.
+    mockStoreState.defaultProvider = 'codex'
+    renderModal()
+    const panel = screen.getByTestId('provider-fix-hint')
+    expect(panel).toBeInTheDocument()
+    expect(panel.textContent).toMatch(/set OPENAI_API_KEY/)
+    expect(panel.textContent).toMatch(/codex login/)
+  })
+
+  it('does NOT render the fix-hint panel when the selected provider is ready', () => {
+    mockStoreState.defaultProvider = 'claude-sdk'
+    renderModal()
+    expect(screen.queryByTestId('provider-fix-hint')).not.toBeInTheDocument()
+  })
+
+  it('promotes backtick-wrapped tokens in the hint to <code> elements', () => {
+    mockStoreState.defaultProvider = 'codex'
+    renderModal()
+    const panel = screen.getByTestId('provider-fix-hint')
+    // The hint contains `codex login` — that token must be a <code> child,
+    // not a literal backtick run in the text. The server-provided hint
+    // string from providers.js only wraps the CLI command in backticks
+    // (env-var names are left bare), so we just pin the command token.
+    expect(panel.textContent).not.toMatch(/`codex login`/)
+    const codeNodes = panel.querySelectorAll('code')
+    const codeTexts = Array.from(codeNodes).map(n => n.textContent)
+    expect(codeTexts).toContain('codex login')
+  })
+
+  it('renders an unmatched trailing backtick as literal text (helper robustness)', () => {
+    // Defensive: if the server ever ships a malformed hint with an
+    // unbalanced backtick, the panel must still render rather than throw
+    // or eat the rest of the string. Exercise the helper via a fixture
+    // with an unmatched backtick.
+    const MALFORMED = {
+      ...CODEX_UNREADY,
+      auth: {
+        ...CODEX_UNREADY.auth,
+        hint: 'set OPENAI_API_KEY or run `codex login (oops unmatched',
+        detail: 'Not configured — see hint',
+      },
+    }
+    mockStoreState.availableProviders = [SDK_READY, MALFORMED]
+    mockStoreState.defaultProvider = 'codex'
+    renderModal()
+    const panel = screen.getByTestId('provider-fix-hint')
+    expect(panel.textContent).toMatch(/codex login \(oops unmatched/)
+  })
+
+  it('keeps the <option> label short by using the "(unavailable)" suffix', () => {
+    renderModal()
+    const select = screen.getByLabelText('Select provider') as HTMLSelectElement
+    const codexOption = Array.from(select.options).find(o => o.value === 'codex')
+    expect(codexOption).toBeTruthy()
+    // The label must mark unavailability but NOT inline the full hint —
+    // otherwise we're back to the pre-#4340 wall of text.
+    expect(codexOption!.textContent).toMatch(/unavailable/i)
+    expect(codexOption!.textContent).not.toMatch(/OPENAI_API_KEY/)
+    expect(codexOption!.textContent).not.toMatch(/codex login/)
+  })
+
+  it('updates the fix-hint panel when the user switches providers in the dropdown', () => {
+    // Start on a ready provider — no panel.
+    mockStoreState.defaultProvider = 'claude-sdk'
+    renderModal()
+    expect(screen.queryByTestId('provider-fix-hint')).not.toBeInTheDocument()
+    // Switch to an unready provider — panel appears with that provider's hint.
+    const select = screen.getByLabelText('Select provider') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'gemini' } })
+    const panel = screen.getByTestId('provider-fix-hint')
+    expect(panel.textContent).toMatch(/GEMINI_API_KEY/)
+    expect(panel.textContent).toMatch(/gemini login/)
+  })
+
+  it('refuses to submit when the selected provider is unready', () => {
+    mockStoreState.defaultProvider = 'codex'
+    const { onCreate } = renderModal()
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onCreate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3557,6 +3557,49 @@
   margin-top: -4px;
 }
 
+/* #4340: fix-hint panel for unready providers. Replaces the pre-#4340
+   inline `<option>` hint (which truncated on narrow viewports and
+   couldn't render code formatting). Warning-toned so it stands apart
+   from the neutral billing-hint above. */
+.provider-fix-hint {
+  display: block;
+  margin-top: 6px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--warning-bg-subtle, #fbbf2422);
+  border-left: 3px solid var(--warning-fg, #fbbf24);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+}
+
+.provider-fix-hint-label {
+  font-weight: 600;
+  color: var(--warning-fg, #fbbf24);
+}
+
+.provider-fix-hint-body {
+  color: var(--text-primary);
+}
+
+.provider-fix-hint-body code {
+  background: var(--bg-session-bar, var(--bg-tertiary));
+  border: 1px solid var(--border-primary);
+  border-radius: 3px;
+  padding: 0 4px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.92em;
+  color: var(--text-primary);
+}
+
+.provider-fix-hint-detail {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-style: italic;
+}
+
 .provider-select label {
   color: var(--text-secondary);
   font-size: var(--text-sm);


### PR DESCRIPTION
Closes #4340.

## Summary

The Create Session modal's provider dropdown used to inline the full fix-hint on disabled `<option>` labels — that produced a wall of text like *"Codex (CLI) — set OPENAI_API_KEY or run \`codex login\`"* which:

- truncated on some browser/OS combos (Chrome on macOS, Firefox on narrow Linux viewports)
- rendered backticks as literal characters instead of code formatting
- only exposed the hint via `title=` hover, which touch users never see

This PR moves the hint to a dedicated help panel below the dropdown.

## What changed

**`<option>` label is now short.** Disabled providers render as *"Codex (CLI) (unavailable)"* — no truncation, no backtick run-on.

**New fix-hint panel** (`data-testid="provider-fix-hint"`) appears below the dropdown when the *selected* provider is unready. It:

- shows the full `auth.hint` text with single-backtick spans promoted to `<code>` — `\`codex login\`` becomes a real `<code>codex login</code>` element
- adds the longer `auth.detail` underneath in muted italics when it differs from the hint
- uses warning-tone styling (`--warning-fg` / `--warning-bg-subtle`) so it visually distinguishes from the neutral billing-hint above
- is `role="status"` + `aria-live="polite"` so screen readers announce the change on provider switch

**Unready options are now selectable** so the user can navigate to any provider to read its fix-hint. Submit is gated on `auth.ready` (the Create button is disabled with a tooltip pointing at the fix-hint, and the submit handler short-circuits as defence in depth).

**`renderHintWithCode()`** — a tiny pure helper that parses single-backtick spans. Tolerant: an unmatched trailing backtick falls back to literal text so a malformed server hint still renders.

## Acceptance criteria

- [x] Disabled providers expose the full hint without relying on native `<option>` truncation behavior — panel below dropdown, no truncation
- [x] No regression on the basic enable/disable + `title=` hover behavior added by #4335 — `title=` still mirrors the detail, billing-hint still renders for ready providers
- [x] Backticks render as `<code>` instead of literal characters
- [x] Touch users see the affordance (no longer hover-only)

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 117 files / 1943 tests pass (8 unrelated WIP failures in `ActivityIndicator.stack.test.tsx` exist on main, not introduced here)
- [x] New file: `CreateSessionModalProviderFixHint.test.tsx` — 7 tests covering panel visibility, code formatting, option-label brevity, dropdown-switch reactivity, malformed-hint robustness, and submit-gating
- [ ] Manual: launch dashboard, leave `OPENAI_API_KEY` unset, open New Session modal, pick Codex from dropdown — fix-hint panel renders with `codex login` formatted as code
- [ ] Manual: pick a ready provider (e.g. claude-sdk with `ANTHROPIC_API_KEY` set) — no panel, billing-hint shows normally