### PR TITLE
chore(dashboard): bundle ActivityIndicator followups (#4336, #4337, #4339)

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.inflight.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.inflight.test.tsx
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
-import { ActivityIndicator } from './ActivityIndicator'
+import { ActivityIndicator, findInFlightToolUse, type InFlightMessage } from './ActivityIndicator'
 
 let storeState: Record<string, unknown> = {}
 
@@ -26,6 +26,14 @@ vi.mock('../store/connection', () => ({
     }
     return selector(store)
   },
+}))
+
+// #4336 — the production component reads via `useShallow`. Stub the hook to
+// a pass-through so the mocked store-selector path above continues to work
+// unchanged — `useShallow(fn)` is invoked as the selector itself, and the
+// test mock calls it once with our snapshot. Same pattern App.test.tsx uses.
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (fn: unknown) => fn,
 }))
 
 afterEach(() => cleanup())
@@ -183,103 +191,164 @@ describe('ActivityIndicator — in-flight tool naming (#4308)', () => {
     // formatToolName converts `mcp__github__list_repos` → `Github: List Repos`.
     expect(label.textContent).toMatch(/Running\s+Github: List Repos/)
   })
+
+  // #4339 — the MCP test above only exercises the `mcp__`-prefix branch of
+  // `formatToolName`, which IGNORES the second `serverName` arg entirely.
+  // The non-MCP branch is the only path where `serverName` is observable in
+  // the output (`${serverName} ${formatted}`). These fixtures lock that path
+  // in so a regression that drops `serverName` propagation fails loudly.
+  it('prefixes a non-MCP tool name with serverName when provided (#4339)', () => {
+    const now = Date.now()
+    setStore([
+      {
+        id: 'm1',
+        type: 'tool_use',
+        tool: 'list_files',
+        serverName: 'fs',
+        timestamp: now - 5_000,
+        content: '',
+        toolUseId: 'tu-1',
+      },
+    ])
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    // formatToolName('list_files', 'fs') → 'fs List Files'.
+    expect(label.textContent).toMatch(/Running\s+fs List Files/)
+  })
+
+  it('renders a non-MCP tool name without prefix when serverName is omitted (#4339 control)', () => {
+    // Control fixture for the case above: same tool, no `serverName` → the
+    // server prefix must NOT appear. Pins the conditional in
+    // `formatToolName(name, serverName)` so a default-on regression flips this test.
+    const now = Date.now()
+    setStore([
+      {
+        id: 'm1',
+        type: 'tool_use',
+        tool: 'list_files',
+        timestamp: now - 5_000,
+        content: '',
+        toolUseId: 'tu-1',
+      },
+    ])
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toMatch(/Running\s+List Files/)
+    expect(label.textContent).not.toMatch(/fs/)
+  })
 })
 
 /**
- * #4319 — Narrow-selector contract for ActivityIndicator.
+ * #4319 / #4336 — Narrow-selector contract for ActivityIndicator.
  *
- * Pre-fix the component subscribed to `sessionStates[id]?.messages` — every
+ * Pre-#4319 the component subscribed to `sessionStates[id]?.messages` — every
  * `stream_delta` / `tool_input_delta` swapped the array reference and forced
- * a re-render even when the in-flight tool was unchanged. The fix replaces
- * that with two primitive selectors that project the messages array down to
- * `inFlightTool: string | null` and `inFlightStartedAt: number | null`.
+ * a re-render even when the in-flight tool was unchanged. The fix narrows
+ * the subscription to a `useShallow` projection of `{ tool, startedAt,
+ * serverName }` — React only re-renders when those primitives change.
  *
  * We can't measure React render count from here without wrapping the export,
  * but we CAN lock in the contract that drives the perf win: when a no-op
  * store update happens (a brand-new messages array with the same in-flight
- * tool), both selector return values are stable under ===. That is the
- * mechanism by which zustand bails out and skips the render — so this test
+ * tool), the projection's primitives are === stable. That is the mechanism
+ * by which `useShallow` bails out and skips the render — so this test
  * indirectly guarantees the perf property the issue calls out.
+ *
+ * #4337 — These assertions now run against the REAL exported
+ * `findInFlightToolUse` predicate so a change to the production resolved /
+ * in-flight gate (e.g. a new `toolError` field counted as resolved) breaks
+ * the test rather than silently keeping a stale inline copy passing.
  */
-describe('ActivityIndicator — narrow in-flight selectors (#4319)', () => {
-  it('selectors return === stable primitives when messages[] reference changes but the in-flight tool does not', async () => {
-    // Reach for the unmocked module path so we test the real component's
-    // selector wiring, not the test-file's static `storeState` shim. We
-    // import the source's selector helper indirectly by re-running the
-    // same predicate the component uses.
+describe('ActivityIndicator — narrow in-flight selector (#4319, #4336)', () => {
+  it('findInFlightToolUse returns === stable primitives when messages[] reference changes (#4337)', async () => {
     const mod = await import('./ActivityIndicator')
-    // Sanity: the export should still exist (smoke check the refactor
-    // didn't rename the component).
+    // Sanity: both exports the test depends on must still exist.
     expect(typeof mod.ActivityIndicator).toBe('function')
+    expect(typeof mod.findInFlightToolUse).toBe('function')
 
-    // Simulate two consecutive "store snapshots" that differ ONLY in the
-    // messages[] reference — same in-flight tool object semantics, fresh
-    // array (e.g. a `stream_delta` that appended text but didn't change
-    // the running tool). Run the same selectors the component runs.
+    // Two snapshots differ ONLY in the messages[] reference — same in-flight
+    // tool object semantics, fresh array (the `stream_delta` perf case).
+    // Both run through the production predicate so any divergence between
+    // the test's expectations and the real walk surfaces here.
     const now = Date.now()
-    const toolMsg = {
-      id: 'm1',
-      type: 'tool_use' as const,
+    const toolMsg: InFlightMessage = {
+      type: 'tool_use',
       tool: 'Bash',
       timestamp: now - 5_000,
-      content: '',
-      toolUseId: 'tu-1',
     }
-    type Snapshot = {
-      activeSessionId: string
-      sessionStates: Record<string, { messages: Array<typeof toolMsg> }>
-    }
-    const snapshotA: Snapshot = {
-      activeSessionId: 'sess-1',
-      sessionStates: { 'sess-1': { messages: [toolMsg] } },
-    }
-    const snapshotB: Snapshot = {
-      activeSessionId: 'sess-1',
-      // Brand-new array reference, same logical content.
-      sessionStates: { 'sess-1': { messages: [{ ...toolMsg }] } },
-    }
+    const messagesA: InFlightMessage[] = [toolMsg]
+    // Brand-new array reference, same logical content.
+    const messagesB: InFlightMessage[] = [{ ...toolMsg }]
 
-    // Re-implement the component's two selectors inline. This is the
-    // contract under test: regardless of the messages[] reference,
-    // the projected primitives stay ===.
-    const toolSel = (s: Snapshot): string | null => {
-      const id = s.activeSessionId
-      const messages = id ? s.sessionStates[id]?.messages : undefined
-      if (!messages) return null
-      for (let i = messages.length - 1; i >= 0; i--) {
-        const m = messages[i]!
-        if (m.type !== 'tool_use') continue
-        const hasResult = (m as { toolResult?: unknown }).toolResult !== undefined
-        if (!hasResult) return m.tool ?? 'tool'
-      }
-      return null
-    }
-    const startedAtSel = (s: Snapshot): number | null => {
-      const id = s.activeSessionId
-      const messages = id ? s.sessionStates[id]?.messages : undefined
-      if (!messages) return null
-      for (let i = messages.length - 1; i >= 0; i--) {
-        const m = messages[i]!
-        if (m.type !== 'tool_use') continue
-        const hasResult = (m as { toolResult?: unknown }).toolResult !== undefined
-        if (!hasResult) return m.timestamp
-      }
-      return null
-    }
+    const a = findInFlightToolUse(messagesA)
+    const b = findInFlightToolUse(messagesB)
 
-    // Selectors return identical primitive values across both snapshots —
-    // this is what zustand checks via === to skip a re-render.
-    expect(toolSel(snapshotA)).toBe(toolSel(snapshotB))
-    expect(startedAtSel(snapshotA)).toBe(startedAtSel(snapshotB))
-    expect(toolSel(snapshotA)).toBe('Bash')
-    expect(startedAtSel(snapshotA)).toBe(now - 5_000)
+    // Primitives projected by the production predicate are === stable
+    // across the no-op messages[] reference swap — this is the property
+    // the `useShallow` projection in the component relies on.
+    expect(a?.tool).toBe(b?.tool)
+    expect(a?.startedAt).toBe(b?.startedAt)
+    expect(a?.tool).toBe('Bash')
+    expect(a?.startedAt).toBe(now - 5_000)
+  })
+
+  it('findInFlightToolUse skips resolved tools and returns the most-recent in-flight one (#4337)', () => {
+    // Locks in the predicate's walk semantics: earlier resolved tool is
+    // skipped, later unresolved tool is returned. Mirrors the top-of-file
+    // "names the most-recent tool_use" render test — but against the
+    // predicate directly so a regression in the resolved-gate breaks here,
+    // not just in the rendered label.
+    const now = Date.now()
+    const result = findInFlightToolUse([
+      { type: 'tool_use', tool: 'Read', timestamp: now - 60_000, toolResult: 'contents' },
+      { type: 'tool_use', tool: 'Bash', timestamp: now - 5_000 },
+    ])
+    expect(result?.tool).toBe('Bash')
+    expect(result?.startedAt).toBe(now - 5_000)
+  })
+
+  it('findInFlightToolUse treats empty-string toolResult AND images-only resolutions as resolved (#4337)', () => {
+    // Pin the two "non-obvious resolved" branches against the imported
+    // predicate. If the gate changes (e.g. images-only is suddenly NOT
+    // counted as resolved), the test fails directly on the predicate.
+    expect(
+      findInFlightToolUse([
+        { type: 'tool_use', tool: 'Bash', timestamp: 0, toolResult: '' },
+      ]),
+    ).toBeNull()
+    expect(
+      findInFlightToolUse([
+        {
+          type: 'tool_use',
+          tool: 'screenshot',
+          timestamp: 0,
+          toolResultImages: [{ data: 'x', mediaType: 'image/png' }],
+        },
+      ]),
+    ).toBeNull()
+  })
+
+  it('findInFlightToolUse returns null for null/undefined/empty input (#4337)', () => {
+    expect(findInFlightToolUse(null)).toBeNull()
+    expect(findInFlightToolUse(undefined)).toBeNull()
+    expect(findInFlightToolUse([])).toBeNull()
+  })
+
+  it('findInFlightToolUse preserves serverName on the in-flight tool (#4337, #4339)', () => {
+    // The predicate must propagate `serverName` so the component can pass
+    // it into `formatToolName` for the non-MCP prefix path (#4339).
+    const result = findInFlightToolUse([
+      { type: 'tool_use', tool: 'list_files', serverName: 'fs', timestamp: 0 },
+    ])
+    expect(result?.tool).toBe('list_files')
+    expect(result?.serverName).toBe('fs')
   })
 
   it('rendering across no-op store updates yields the same label text (proxy for stable selectors)', () => {
     // Stronger end-to-end check: render the component, swap the messages
     // array for a fresh-reference copy with the same logical content, and
     // re-render. The visible label must be identical — which is only true
-    // if the selectors produced the same primitives both times.
+    // if the `useShallow` projection produced the same primitives both times.
     const now = Date.now()
     const baseTool = { id: 'm1', type: 'tool_use', tool: 'Bash', timestamp: now - 5_000, content: '', toolUseId: 'tu-1' }
     setStore([baseTool])

--- a/packages/dashboard/src/components/ActivityIndicator.stack.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.stack.test.tsx
@@ -48,6 +48,13 @@ vi.mock('../store/connection', () => ({
   },
 }))
 
+// #4336 — ActivityIndicator now wraps its store selector in `useShallow`.
+// Stub the hook to a pass-through so the mocked `useConnectionStore` above
+// still drives the selector directly (matches App.test.tsx's pattern).
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (fn: unknown) => fn,
+}))
+
 const css = readFileSync(resolve(__dirname, '../theme/components.css'), 'utf-8')
 
 afterEach(() => cleanup())

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -22,6 +22,7 @@
  * (30 min) when connected to an older server that doesn't broadcast it.
  */
 import { useEffect, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import { formatToolName } from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
 
@@ -31,20 +32,28 @@ import { useConnectionStore } from '../store/connection'
  * tool (typical case: the in-flight tool is at the tail of the array, so the
  * walk is O(1) in practice). Returns `null` when every tool has resolved.
  *
- * Used by the in-flight selectors below — the selectors project the result
- * down to primitives (`tool`, `startedAt`) so React only re-renders when
- * those primitives change, not on every `messages[]` reference churn from
- * `stream_delta` / `tool_input_delta` updates.
+ * Used by the in-flight selector below — the selector projects the result
+ * down to primitives (`tool`, `startedAt`, `serverName`) so React only
+ * re-renders when those primitives change, not on every `messages[]`
+ * reference churn from `stream_delta` / `tool_input_delta` updates.
+ *
+ * #4337 — Exported so the in-flight tests
+ * (`ActivityIndicator.inflight.test.tsx`) exercise the production predicate
+ * directly instead of re-implementing the same shape inline. A change to
+ * the "resolved" gate (e.g. a new `toolError` field counted as resolved)
+ * must cause the imported assertions to fail.
  */
-function findInFlightToolUse(
-  messages: ReadonlyArray<{
-    type: string
-    tool?: string
-    serverName?: string
-    timestamp: number
-    toolResult?: unknown
-    toolResultImages?: ReadonlyArray<unknown>
-  }> | null | undefined,
+export type InFlightMessage = {
+  type: string
+  tool?: string
+  serverName?: string
+  timestamp: number
+  toolResult?: unknown
+  toolResultImages?: ReadonlyArray<unknown>
+}
+
+export function findInFlightToolUse(
+  messages: ReadonlyArray<InFlightMessage> | null | undefined,
 ): { tool: string; serverName?: string; startedAt: number } | null {
   if (!messages) return null
   for (let i = messages.length - 1; i >= 0; i--) {
@@ -101,36 +110,32 @@ export function ActivityIndicator() {
     const id = s.activeSessionId
     return id ? s.sessionStates[id]?.lastClientActivityAt ?? null : null
   })
-  // #4319 — Narrow selectors that project the active session's in-flight
-  // tool down to two primitives. Subscribing to the whole `messages` array
-  // (the #4308 approach) re-rendered this component on every stream_delta /
-  // tool_input_delta because the store immutably swaps the array reference
-  // on each update. By selecting only the primitives we depend on, React
-  // re-renders ONLY when the in-flight tool actually changes — the walk
-  // still happens, but inside the selector, and zustand bails on === checks
-  // so no render is triggered when the primitive output is stable.
+  // #4319 / #4336 — Single `useShallow` selector that projects the active
+  // session's in-flight tool down to a plain object of primitives. Subscribing
+  // to the whole `messages` array (the #4308 approach) re-rendered this
+  // component on every stream_delta / tool_input_delta because the store
+  // immutably swaps the array reference on each update. By selecting only
+  // the primitives we depend on, React re-renders ONLY when the in-flight
+  // tool actually changes.
   //
-  // Why two selectors instead of one returning an object: returning a fresh
-  // `{ tool, startedAt }` object from a selector defeats zustand's default
-  // === equality and triggers a render on every store update. We could fix
-  // that with `useShallow`, but two primitive selectors are simpler and
-  // every consumer below uses the values independently anyway.
-  const inFlightTool = useConnectionStore((s) => {
-    const id = s.activeSessionId
-    return id ? findInFlightToolUse(s.sessionStates[id]?.messages)?.tool ?? null : null
-  })
-  const inFlightStartedAt = useConnectionStore((s) => {
-    const id = s.activeSessionId
-    return id ? findInFlightToolUse(s.sessionStates[id]?.messages)?.startedAt ?? null : null
-  })
-  // #4318 — capture serverName via a third narrowed selector so MCP tools
-  // (e.g. `mcp__github__list_repos`) render with the server prefix
-  // preserved in the chip label. Kept as its own primitive selector for
-  // consistency with the other two narrowed reads above (#4319).
-  const inFlightServerName = useConnectionStore((s) => {
-    const id = s.activeSessionId
-    return id ? findInFlightToolUse(s.sessionStates[id]?.messages)?.serverName ?? null : null
-  })
+  // Why one `useShallow` object instead of N primitive selectors: pre-#4336
+  // this called `findInFlightToolUse` three separate times (once per primitive
+  // selector), walking the messages array three times per store update. The
+  // `useShallow` selector runs the walk ONCE and lets zustand do a shallow
+  // compare on the returned object — same re-render guarantee, one walk per
+  // update, and a cleaner consumer shape.
+  const { tool: inFlightTool, startedAt: inFlightStartedAt, serverName: inFlightServerName } =
+    useConnectionStore(
+      useShallow((s) => {
+        const id = s.activeSessionId
+        const inFlight = id ? findInFlightToolUse(s.sessionStates[id]?.messages) : null
+        return {
+          tool: inFlight?.tool ?? null,
+          startedAt: inFlight?.startedAt ?? null,
+          serverName: inFlight?.serverName ?? null,
+        }
+      }),
+    )
   const referenceTimeoutMs = useConnectionStore(
     (s) => s.serverResultTimeoutMs ?? FALLBACK_TIMEOUT_MS,
   )

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -142,6 +142,34 @@ describe('ToolBubble', () => {
       render(<ToolBubble toolName="mcp__fs__read_file" toolUseId="tool-fmt-mcp-1" />)
       expect(screen.getByText('Fs: Read File')).toBeInTheDocument()
     })
+
+    // #4339 — the existing MCP test uses an `mcp__`-prefixed name, which
+    // exercises the prefix branch of `formatToolName` and IGNORES the
+    // second `serverName` arg entirely. These fixtures pin the non-MCP
+    // branch — the only path where `serverName` is observable in the
+    // rendered header — so a regression that drops `serverName`
+    // propagation through ToolBubble fails loudly here.
+    it('prefixes a non-MCP tool name with serverName when provided (#4339)', () => {
+      render(
+        <ToolBubble
+          toolName="list_files"
+          toolUseId="tool-fmt-server-1"
+          serverName="fs"
+        />,
+      )
+      // formatToolName('list_files', 'fs') → 'fs List Files'.
+      expect(screen.getByText('fs List Files')).toBeInTheDocument()
+    })
+
+    it('renders a non-MCP tool name without prefix when serverName is omitted (#4339 control)', () => {
+      // Control fixture for the case above: same tool, no `serverName` → the
+      // prefix must NOT appear. Pins the
+      // `serverName ? ${serverName} ${formatted} : formatted`
+      // conditional so a default-on regression flips this test.
+      render(<ToolBubble toolName="list_files" toolUseId="tool-fmt-server-2" />)
+      expect(screen.getByText('List Files')).toBeInTheDocument()
+      expect(screen.queryByText(/^fs /)).not.toBeInTheDocument()
+    })
   })
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Three small follow-ups to the recently-merged ActivityIndicator work (#4319, #4308, #4318), bundled because they touch the same files.

## #4336 — single useShallow selector

Pre-change `ActivityIndicator` called three primitive `useConnectionStore` selectors, each invoking `findInFlightToolUse` once and walking the active session's `messages[]`. Per store update the walk ran three times.

The new selector runs the walk once and projects to `{tool, startedAt, serverName}`, wrapped in `useShallow` so React only re-renders when those primitives change — same re-render guarantee, one walk per update, cleaner consumer shape.

Closes #4336

## #4337 — exported predicate, real-fixtures test

`findInFlightToolUse` (plus the `InFlightMessage` type) is now exported so `ActivityIndicator.inflight.test.tsx` exercises the production predicate directly instead of re-implementing the same shape inline. The `#4319` test block calls the imported predicate, so a change to the resolved gate (e.g. adding a new `toolError` field counted as resolved) fails the test rather than silently keeping a stale inline copy passing.

New cases also pin:
- empty-string `toolResult` resolved branch
- images-only resolved branch
- null/undefined/empty input
- `serverName` preservation onto the projected in-flight tool

Closes #4337

## #4339 — non-MCP serverName fixtures

The existing MCP fixtures (`mcp__github__list_repos` → `Github: List Repos`) exercise the `mcp__`-prefix branch of `formatToolName`, which IGNORES the second `serverName` arg entirely. The non-MCP branch (`${serverName} ${formatted}`) is the only path where `serverName` is observable in the rendered label.

New fixtures cover both surfaces:
- `ActivityIndicator.inflight.test.tsx` — `tool: 'list_files', serverName: 'fs'` → `Running fs List Files`, plus a control fixture with `serverName` omitted
- `ToolBubble.test.tsx` — same pair as a `ToolBubble` prop assertion (`fs List Files` in the rendered header, plus the no-prefix control)

Closes #4339

## Test plan
- [x] `cd packages/dashboard && PATH=\".../node@22/bin:$PATH\" npx tsc --noEmit` — clean
- [x] `cd packages/dashboard && PATH=\".../node@22/bin:$PATH\" npx vitest run src/components/ActivityIndicator src/components/ToolBubble` — 66 / 66 pass
- [x] `cd packages/dashboard && PATH=\".../node@22/bin:$PATH\" npx vitest run` (full suite) — 1944 / 1944 pass