### PR TITLE
fix(desktop): track APPLE_KEYCHAIN_PATH in speech-helper build cache (#4252)

### DIFF
--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -58,6 +58,10 @@ fn main() {
         // consistent even if speech-helper.swift is temporarily absent.
         println!("cargo:rerun-if-changed={}", swift_src);
         println!("cargo:rerun-if-env-changed=APPLE_SIGNING_IDENTITY");
+        // APPLE_KEYCHAIN_PATH is passed to `codesign --keychain` below; toggling
+        // it between cargo invocations must invalidate the speech-helper cache
+        // marker so the binary is re-signed against the new keychain (#4252).
+        println!("cargo:rerun-if-env-changed=APPLE_KEYCHAIN_PATH");
 
         // Helper: run a command, panic with captured stderr on failure.
         fn run(label: &str, cmd: &mut std::process::Command) {
@@ -85,6 +89,9 @@ fn main() {
             //     but cargo's tracker is per-target_dir; the universal build
             //     uses two target dirs so we re-check explicitly here)
             //   - APPLE_SIGNING_IDENTITY (signature changes when identity does)
+            //   - APPLE_KEYCHAIN_PATH (#4252: passed to codesign --keychain;
+            //     swapping the keychain must re-sign the binary against the
+            //     new identity-resolution scope)
             //   - swiftc toolchain version (#3950: Xcode/Swift updates produce
             //     binaries with different runtime requirements; without this,
             //     a stale cache would silently ship a binary compiled against
@@ -103,11 +110,18 @@ fn main() {
             let swift_cache = format!("{}.cache", swift_out);
             // Track the cache marker so `rm <swift_cache>` reliably forces a
             // rebuild: without this, cargo only re-runs the build script when
-            // a tracked input changes (currently `swift_src` and
-            // `APPLE_SIGNING_IDENTITY`), so deleting the cache marker alone
-            // would be silently ignored on the next `cargo build`.
+            // a tracked input changes (currently `swift_src`,
+            // `APPLE_SIGNING_IDENTITY`, and `APPLE_KEYCHAIN_PATH`), so
+            // deleting the cache marker alone would be silently ignored on
+            // the next `cargo build`.
             println!("cargo:rerun-if-changed={}", swift_cache);
             let identity_for_cache = std::env::var("APPLE_SIGNING_IDENTITY").unwrap_or_default();
+            // Include the (possibly empty) keychain path in the cache key so a
+            // swap of APPLE_KEYCHAIN_PATH between two cargo invocations forces
+            // a re-sign even on a warm cache (#4252). On CI this is moot
+            // (fresh runner), but it matters for local experiments with
+            // alternate keychains.
+            let keychain_for_cache = std::env::var("APPLE_KEYCHAIN_PATH").unwrap_or_default();
             let src_mtime_secs = std::fs::metadata(&swift_src)
                 .ok()
                 .and_then(|m| m.modified().ok())
@@ -130,8 +144,8 @@ fn main() {
                 })
                 .unwrap_or_else(|| "unknown".to_string());
             let cache_key = format!(
-                "v2\nsrc_mtime={}\nidentity={}\nswiftc={}\n",
-                src_mtime_secs, identity_for_cache, swiftc_version,
+                "v3\nsrc_mtime={}\nidentity={}\nkeychain={}\nswiftc={}\n",
+                src_mtime_secs, identity_for_cache, keychain_for_cache, swiftc_version,
             );
 
             let cached = std::path::Path::new(&swift_out).exists()


### PR DESCRIPTION
## Summary

Follow-up from #4231 review (Copilot catch). #4231 added `APPLE_KEYCHAIN_PATH` to the `codesign` args in `packages/desktop/src-tauri/build.rs` but the speech-helper cache marker still didn't track it, so:

- No `cargo:rerun-if-env-changed=APPLE_KEYCHAIN_PATH` directive — cargo wouldn't re-run the build script when the env var toggled.
- The `cache_key` fingerprint included `APPLE_SIGNING_IDENTITY` + `swiftc --version` but not the keychain path. With a warm cache, the marker matched and we skipped swiftc+lipo+codesign entirely — meaning a changed keychain value didn't cause a re-sign.

## Changes

- Add `println!("cargo:rerun-if-env-changed=APPLE_KEYCHAIN_PATH");` next to the existing `APPLE_SIGNING_IDENTITY` directive.
- Add `keychain_for_cache = env::var("APPLE_KEYCHAIN_PATH").unwrap_or_default()` and include it in the `cache_key` fingerprint.
- Bump cache prefix from `v2` to `v3` so existing on-disk markers auto-invalidate on rollout.
- Update neighboring comments to document the new tracked input.

No equivalent cache exists for the node-pty re-sign block, so only the speech-helper cache key needed updating.

CI is unaffected (fresh runner per build); this matters for:
- A developer experimenting locally with `APPLE_KEYCHAIN_PATH` between cargo invocations.
- Future workflow changes that swap the keychain location without bumping anything else.

Closes #4252

## Test Plan

- [x] `cargo check` clean (only pre-existing deprecation warnings)
- [ ] Verify cache marker invalidates on `APPLE_KEYCHAIN_PATH` toggle between two builds locally
- [ ] CI macOS build still passes

## Related

- #4231 — PR adding `APPLE_KEYCHAIN_PATH`
- #3833 / #3950 — original speech-helper cache + swiftc-version invalidation