### PR TITLE
security(ci): bump repo-relay to v1.0.1 (SHA-pinned setup-node)

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -21,7 +21,7 @@ jobs:
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - uses: blamechris/repo-relay@7d09c257e5456511ab26d08b7ad21d8657d4594b # v1
+      - uses: blamechris/repo-relay@b238b3f06628720308cf993ffed3990b82350eda # v1.0.1
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
           channel_prs: ${{ secrets.DISCORD_CHANNEL_PRS }}


### PR DESCRIPTION
## Summary

- Bump `blamechris/repo-relay` from `7d09c257` (v1) to `b238b3f0` (v1.0.1) which pulls in [blamechris/repo-relay#125](https://github.com/blamechris/repo-relay/pull/125) — SHA-pins `actions/setup-node@v4` inside the composite `action.yml`.
- Unblocks re-enabling repo-level `sha_pinning_required: true`, restoring the hardening from #3815 that was rolled back in #3819.

## Context

When `sha_pinning_required: true` was enabled at the repo level, every fire of `.github/workflows/repo-relay.yml` failed transitively because the upstream composite action used an unpinned `actions/setup-node@v4`:

```
##[error]The action actions/setup-node@v4 is not allowed in blamechris/chroxy because all actions must be pinned to a full-length commit SHA.
```

That upstream is now fixed (verified — CI on PR #125 passed, `v1` fast-forwarded to `b238b3f0`, new `v1.0.1` tag points to the same commit).

## Test plan

- [ ] CI green on this PR — the `notify` job runs successfully against the new SHA
- [ ] After merge, re-enable repo-level enforcement:
  ```bash
  gh api -X PUT repos/blamechris/chroxy/actions/permissions \
    -F enabled=true -F allowed_actions=all -F sha_pinning_required=true
  ```
- [ ] Verify a subsequent PR's `notify` job still runs with enforcement on

Closes #3819