### PR TITLE
feat(dashboard): tri-state skip-permissions on CreateSessionModal

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -160,11 +160,17 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [permissionMode, setPermissionMode] = useState('')
   const [worktree, setWorktree] = useState(false)
-  // #4208: TUI-only opt-in to spawn claude with
-  // --dangerously-skip-permissions. Reset to false whenever the modal
-  // re-opens (alongside permissionMode / worktree below) so a previous
-  // session's choice doesn't leak into the next create.
-  const [skipPermissions, setSkipPermissions] = useState(false)
+  // #4208/#4244: TUI-only opt-in to spawn claude with
+  // --dangerously-skip-permissions. Tri-state (#4244) so the modal can
+  // submit an explicit `false` and override a server-wide
+  // `defaultSkipPermissions: true` (#4209) on a per-session basis:
+  //   - 'inherit' → emits undefined; server applies defaultSkipPermissions
+  //   - 'on'      → emits true; always skip prompts
+  //   - 'off'     → emits false; never skip prompts, even if server default is true
+  // Reset to 'inherit' whenever the modal re-opens (alongside permissionMode
+  // / worktree below) so a previous session's choice doesn't leak into the
+  // next create.
+  const [skipPermissions, setSkipPermissions] = useState<'inherit' | 'on' | 'off'>('inherit')
   const [environmentId, setEnvironmentId] = useState('')
   const environments = useConnectionStore(s => s.environments)
   const [showSuggestions, setShowSuggestions] = useState(false)
@@ -221,7 +227,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     setShowAdvanced(false)
     setPermissionMode('')
     setWorktree(false)
-    setSkipPermissions(false)
+    setSkipPermissions('inherit')
     setShowSuggestions(false)
     setSelectedSuggestion(-1)
     setBrowsing(false)
@@ -268,13 +274,18 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     // depth (e.g. keyboard activation racing a store update).
     if (selectedProviderUnready) return
     const model = resolveCreateSessionModel(provider, defaultModel, availableModels, availableModelsProvider)
-    // #4208: gate on the TUI provider at submit time as well as in the UI.
-    // The checkbox is hidden for non-TUI providers, but a user who flips
-    // provider AFTER ticking the box would otherwise carry the stale flag
-    // forward — and the server-side handler doesn't gate by provider
+    // #4208/#4244: gate on the TUI provider at submit time as well as in the
+    // UI. The radio group is hidden for non-TUI providers, but a user who
+    // flips provider AFTER changing state would otherwise carry the stale
+    // value forward — and the server-side handler doesn't gate by provider
     // (forwards via providerOpts; non-TUI providers ignore it). Belt +
     // braces: undefined unless the active provider is `claude-tui`.
-    const skipPermissionsOut = provider === 'claude-tui' && skipPermissions ? true : undefined
+    // Tri-state mapping: 'inherit' → undefined (server default wins), 'on'
+    // → true (force skip), 'off' → false (force require, overrides a server
+    // launched with --dangerously-skip-permissions).
+    const skipPermissionsOut: boolean | undefined = provider === 'claude-tui'
+      ? (skipPermissions === 'on' ? true : skipPermissions === 'off' ? false : undefined)
+      : undefined
     onCreate({ name: trimmed, cwd: cwdValRef.current.trim(), provider, permissionMode: permissionMode || undefined, model, worktree: worktree || undefined, environmentId: environmentId || undefined, skipPermissions: skipPermissionsOut })
   }, [onCreate, provider, permissionMode, defaultModel, availableModels, availableModelsProvider, worktree, environmentId, skipPermissions, selectedProviderUnready])
 
@@ -728,30 +739,57 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
                 : 'Runs in an isolated git worktree — requires a git repo CWD'}
             </span>
           </div>
-          {/* #4208: TUI-only opt-in to spawn `claude --dangerously-skip-permissions`.
+          {/* #4208/#4244: TUI-only opt-in to spawn `claude --dangerously-skip-permissions`.
               Hidden for non-TUI providers because:
                 - claude-sdk / claude-byok don't accept the flag (different bin)
                 - claude-cli already has its own `--dangerously-skip-permissions`
                   wiring on `chroxy resume`, not on create_session
                 - docker-* and codex/gemini don't have a comparable concept
-              The checkbox only renders when the active provider is `claude-tui`,
-              and the submit handler double-checks the provider before
-              forwarding the flag. */}
+              Tri-state radio group (#4244) so the user can submit an explicit
+              `false` to override a server launched with
+              `chroxy start --dangerously-skip-permissions` (server-wide
+              defaultSkipPermissions: true). The submit handler double-checks
+              the provider before forwarding the flag. */}
           {provider === 'claude-tui' && (
-            <div className="form-field form-field--checkbox" data-testid="skip-permissions-field">
-              <label className="checkbox-label">
+            <div className="form-field" data-testid="skip-permissions-field" role="radiogroup" aria-labelledby="skip-permissions-legend" aria-describedby="skip-permissions-hint">
+              <span id="skip-permissions-legend" className="form-field-label">
+                Permission prompts
+              </span>
+              <label className="radio-label">
                 <input
-                  type="checkbox"
-                  id="skip-permissions-checkbox"
-                  data-testid="skip-permissions-checkbox"
-                  checked={skipPermissions}
-                  onChange={e => setSkipPermissions(e.target.checked)}
-                  aria-describedby="skip-permissions-hint"
+                  type="radio"
+                  name="skip-permissions"
+                  data-testid="skip-permissions-radio-inherit"
+                  value="inherit"
+                  checked={skipPermissions === 'inherit'}
+                  onChange={() => setSkipPermissions('inherit')}
+                />
+                Use server default
+              </label>
+              <label className="radio-label">
+                <input
+                  type="radio"
+                  name="skip-permissions"
+                  data-testid="skip-permissions-radio-off"
+                  value="off"
+                  checked={skipPermissions === 'off'}
+                  onChange={() => setSkipPermissions('off')}
+                />
+                Require permission prompts (override server default)
+              </label>
+              <label className="radio-label">
+                <input
+                  type="radio"
+                  name="skip-permissions"
+                  data-testid="skip-permissions-radio-on"
+                  value="on"
+                  checked={skipPermissions === 'on'}
+                  onChange={() => setSkipPermissions('on')}
                 />
                 Skip permission prompts (dangerous)
               </label>
               <span id="skip-permissions-hint" className="form-hint form-hint--warning">
-                Spawns the claude TUI with <code>--dangerously-skip-permissions</code> and
+                &ldquo;Skip&rdquo; spawns the claude TUI with <code>--dangerously-skip-permissions</code> and
                 disables chroxy&rsquo;s tool-call gate entirely. Every tool runs with no
                 prompt and no audit trail. Use only in trusted contexts (e.g. isolated
                 workspace, throwaway worktree, or container).

--- a/packages/dashboard/src/components/CreateSessionModalSkipPermissions.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalSkipPermissions.test.tsx
@@ -1,18 +1,26 @@
 /**
- * Tests for the TUI-only "Skip permission prompts" checkbox on the Create
- * Session modal (#4208).
+ * Tests for the TUI-only skip-permissions control on the Create Session modal
+ * (#4208, #4244).
  *
- * The checkbox MUST:
+ * The control is a tri-state radio group (#4244):
+ *   - 'inherit' (default) — emits `skipPermissions: undefined`, server applies
+ *     its `defaultSkipPermissions` (#4209)
+ *   - 'on' — emits `skipPermissions: true`, session spawns with
+ *     `--dangerously-skip-permissions` regardless of server default
+ *   - 'off' — emits `skipPermissions: false`, explicitly blocks the flag even
+ *     when the server was launched with `chroxy start
+ *     --dangerously-skip-permissions`. This is the case the pre-#4244 checkbox
+ *     could not represent.
+ *
+ * The control MUST:
  *   - render only when the active provider is `claude-tui`
- *   - default to unchecked on fresh modal open
- *   - forward `skipPermissions: true` on onCreate when checked
- *   - omit `skipPermissions` entirely when unchecked (so the server-side
- *     `defaultSkipPermissions` from #4209 still wins on a server launched
- *     with --dangerously-skip-permissions)
- *   - NOT forward the flag even when checked if the user switches provider
- *     to something other than claude-tui before submit (belt + braces; the
- *     checkbox hides on provider change, but the underlying state could
- *     theoretically persist mid-render — the submit guard catches it)
+ *   - default to 'inherit' on fresh modal open
+ *   - forward the correct `skipPermissions` value (undefined / true / false)
+ *     for each state
+ *   - NOT forward the flag even when 'on' is selected if the user switches
+ *     provider to something other than claude-tui before submit (belt +
+ *     braces; the group hides on provider change, but the underlying state
+ *     could theoretically persist mid-render — the submit guard catches it)
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup, fireEvent } from '@testing-library/react'
@@ -75,27 +83,41 @@ function openAdvanced() {
   fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
 }
 
-describe('CreateSessionModal skip-permissions checkbox (#4208)', () => {
-  it('renders the checkbox when active provider is claude-tui', async () => {
+describe('CreateSessionModal skip-permissions tri-state (#4208, #4244)', () => {
+  it('renders the tri-state radio group when active provider is claude-tui', async () => {
     mockStore('claude-tui')
     const CreateSessionModal = await loadModal()
     render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
     openAdvanced()
-    const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
-    expect(cb).toBeInTheDocument()
-    expect(cb.checked).toBe(false)
+    expect(screen.getByTestId('skip-permissions-field')).toBeInTheDocument()
+    expect(screen.getByTestId('skip-permissions-radio-inherit')).toBeInTheDocument()
+    expect(screen.getByTestId('skip-permissions-radio-on')).toBeInTheDocument()
+    expect(screen.getByTestId('skip-permissions-radio-off')).toBeInTheDocument()
   })
 
-  it('does NOT render the checkbox for non-TUI providers (claude-sdk)', async () => {
+  it('defaults to "inherit" on fresh open', async () => {
+    mockStore('claude-tui')
+    const CreateSessionModal = await loadModal()
+    render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
+    openAdvanced()
+    const inherit = screen.getByTestId('skip-permissions-radio-inherit') as HTMLInputElement
+    const on = screen.getByTestId('skip-permissions-radio-on') as HTMLInputElement
+    const off = screen.getByTestId('skip-permissions-radio-off') as HTMLInputElement
+    expect(inherit.checked).toBe(true)
+    expect(on.checked).toBe(false)
+    expect(off.checked).toBe(false)
+  })
+
+  it('does NOT render the radio group for non-TUI providers (claude-sdk)', async () => {
     mockStore('claude-sdk')
     const CreateSessionModal = await loadModal()
     render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
     openAdvanced()
-    expect(screen.queryByTestId('skip-permissions-checkbox')).not.toBeInTheDocument()
     expect(screen.queryByTestId('skip-permissions-field')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('skip-permissions-radio-inherit')).not.toBeInTheDocument()
   })
 
-  it('warning copy calls out the danger explicitly', async () => {
+  it('warning copy on the "on" option calls out the danger explicitly', async () => {
     mockStore('claude-tui')
     const CreateSessionModal = await loadModal()
     render(<CreateSessionModal {...baseProps} onCreate={vi.fn()} />)
@@ -105,15 +127,26 @@ describe('CreateSessionModal skip-permissions checkbox (#4208)', () => {
     expect(hint.textContent).toMatch(/dangerously-skip-permissions/i)
   })
 
-  it('forwards skipPermissions: true on onCreate when checked', async () => {
+  it('emits skipPermissions: undefined when "inherit" is selected (default)', async () => {
+    mockStore('claude-tui')
+    const CreateSessionModal = await loadModal()
+    const onCreate = vi.fn()
+    render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+    // Don't open Advanced; the default state is 'inherit'. Submit straight away.
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    expect(onCreate).toHaveBeenCalledTimes(1)
+    expect(onCreate.mock.calls[0]![0].skipPermissions).toBeUndefined()
+  })
+
+  it('emits skipPermissions: true when "on" is selected', async () => {
     mockStore('claude-tui')
     const CreateSessionModal = await loadModal()
     const onCreate = vi.fn()
     render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
     openAdvanced()
-    const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
-    fireEvent.click(cb)
-    expect(cb.checked).toBe(true)
+    const on = screen.getByTestId('skip-permissions-radio-on') as HTMLInputElement
+    fireEvent.click(on)
+    expect(on.checked).toBe(true)
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
     expect(onCreate).toHaveBeenCalledTimes(1)
     expect(onCreate.mock.calls[0]![0]).toMatchObject({
@@ -122,24 +155,52 @@ describe('CreateSessionModal skip-permissions checkbox (#4208)', () => {
     })
   })
 
-  it('omits skipPermissions on onCreate when checkbox stays unchecked', async () => {
+  it('emits skipPermissions: false when "off" is selected (#4244 — overrides server default)', async () => {
     mockStore('claude-tui')
     const CreateSessionModal = await loadModal()
     const onCreate = vi.fn()
     render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
-    // Don't open Advanced; just submit. The field must be undefined so the
-    // server-side default (set via `chroxy start --dangerously-skip-permissions`
-    // per #4209) is still the source of truth.
+    openAdvanced()
+    const off = screen.getByTestId('skip-permissions-radio-off') as HTMLInputElement
+    fireEvent.click(off)
+    expect(off.checked).toBe(true)
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
     expect(onCreate).toHaveBeenCalledTimes(1)
+    // CRITICAL: must be literal `false`, not `undefined`. Server-side
+    // defaultSkipPermissions: true would be honoured if we emitted undefined.
+    expect(onCreate.mock.calls[0]![0]).toMatchObject({
+      provider: 'claude-tui',
+      skipPermissions: false,
+    })
+    expect(onCreate.mock.calls[0]![0].skipPermissions).toBe(false)
+  })
+
+  it('user can flip across all three states; final selection wins', async () => {
+    mockStore('claude-tui')
+    const CreateSessionModal = await loadModal()
+    const onCreate = vi.fn()
+    render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+    openAdvanced()
+    const on = screen.getByTestId('skip-permissions-radio-on') as HTMLInputElement
+    const off = screen.getByTestId('skip-permissions-radio-off') as HTMLInputElement
+    const inherit = screen.getByTestId('skip-permissions-radio-inherit') as HTMLInputElement
+    fireEvent.click(on)
+    expect(on.checked).toBe(true)
+    fireEvent.click(off)
+    expect(off.checked).toBe(true)
+    expect(on.checked).toBe(false)
+    fireEvent.click(inherit)
+    expect(inherit.checked).toBe(true)
+    expect(off.checked).toBe(false)
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
     expect(onCreate.mock.calls[0]![0].skipPermissions).toBeUndefined()
   })
 
   it('omits skipPermissions when provider is NOT claude-tui (defence in depth)', async () => {
     // Reload with the SDK provider as default and no TUI in the list so
-    // the checkbox can't even be rendered, then submit. The submit guard
-    // (`provider === 'claude-tui' && skipPermissions`) must keep
-    // skipPermissions undefined.
+    // the group can't even be rendered, then submit. The submit guard
+    // (`provider === 'claude-tui' ? ... : undefined`) must keep
+    // skipPermissions undefined regardless of the underlying state.
     mockStore('claude-sdk', [SDK_PROVIDER])
     const CreateSessionModal = await loadModal()
     const onCreate = vi.fn()

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3543,6 +3543,30 @@
   cursor: pointer;
 }
 
+/* #4244: tri-state radio group for skip-permissions. Stacks vertically with
+   the existing form-field rhythm; label color/font match checkbox-label so
+   the modal looks consistent. */
+.advanced-section .radio-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: unset;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.advanced-section .radio-label input[type='radio'] {
+  cursor: pointer;
+}
+
+.advanced-section .form-field-label {
+  display: block;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  margin-bottom: 2px;
+}
+
 .form-hint {
   font-size: 11px;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary

- Replace the boolean skipPermissions checkbox with a tri-state radio group so a dashboard user can submit an explicit `false` and override a server-wide `defaultSkipPermissions: true` on a per-session basis.
- Tri-state mapping:
  - **Use server default** (inherit) -> emits `skipPermissions: undefined`
  - **Require permission prompts** (off) -> emits `skipPermissions: false`
  - **Skip permission prompts** (on) -> emits `skipPermissions: true`
- Defaults to `inherit` on fresh open; hidden for non-TUI providers; submit double-checks the provider before forwarding the flag (belt + braces).

The store (`connection.ts`) and `SessionManager` already preserve a strict boolean `false` over the wire; this PR closes the loop at the modal layer.

## Why

Pre-#4244 the modal could only emit `true` or `undefined`, so a user on a server launched with `chroxy start --dangerously-skip-permissions` had no way to opt a single session out. The acceptance criteria in #4244 calls for a tri-state submit.

## Scope notes

Intentionally minimal/additive per the issue's "related work in Batch B/C" note (#4245 provider-switch reset, #4246 config danger message). I did NOT surface server `defaultSkipPermissions` to the dashboard yet — the inherit label says "Use server default" which is accurate without the extra plumbing; that addition can be a follow-up if we want to label the resolved default.

## Test plan

- [x] `npx vitest run src/components/CreateSessionModal` — 67 tests pass (9 in the skip-permissions tri-state suite, including new explicit-false case, default-inherit case, and round-trip across all three states)
- [x] `npm run typecheck` — clean
- [x] Full dashboard suite — 2000 tests pass
- [ ] Manual: open New Session modal with claude-tui provider, expand Advanced, verify three radios render, default is "Use server default", switching to "Require permission prompts" + create -> server gets `skipPermissions: false`

Closes #4244