### PR TITLE
feat(dashboard): SessionContextMenu keyboard navigation (#4248)

### DIFF
--- a/packages/dashboard/src/components/SessionContextMenu.test.tsx
+++ b/packages/dashboard/src/components/SessionContextMenu.test.tsx
@@ -159,6 +159,203 @@ describe('SessionContextMenu', () => {
     expect(onDismiss).toHaveBeenCalled()
   })
 
+  // #4248: keyboard navigation (WAI-ARIA menu pattern). Items must be
+  // focusable, arrow keys cycle focus (with wrap-around), Enter/Space
+  // activate the focused item, and focus returns to the originating
+  // trigger element when the menu closes.
+  describe('keyboard navigation (#4248)', () => {
+    it('exposes role="menu" on the container and role="menuitem" on items', () => {
+      render(
+        <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+      )
+      const menu = screen.getByTestId('session-context-menu')
+      expect(menu).toHaveAttribute('role', 'menu')
+      const dup = screen.getByTestId('session-context-menu-item-duplicate')
+      const close = screen.getByTestId('session-context-menu-item-close')
+      expect(dup).toHaveAttribute('role', 'menuitem')
+      expect(close).toHaveAttribute('role', 'menuitem')
+    })
+
+    it('focuses the first item on mount', () => {
+      render(
+        <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+      )
+      const first = screen.getByTestId('session-context-menu-item-duplicate')
+      expect(document.activeElement).toBe(first)
+    })
+
+    it('makes items focusable (tabIndex)', () => {
+      render(
+        <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+      )
+      const first = screen.getByTestId('session-context-menu-item-duplicate')
+      const second = screen.getByTestId('session-context-menu-item-close')
+      // At least one of them must be tab-focusable so screen-reader / keyboard
+      // users can reach the menu. The component uses a roving-tabindex pattern
+      // where exactly one item is focusable at a time.
+      const tabIndices = [first.tabIndex, second.tabIndex]
+      expect(tabIndices).toContain(0)
+    })
+
+    it('ArrowDown moves focus to the next item', () => {
+      render(
+        <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+      )
+      const first = screen.getByTestId('session-context-menu-item-duplicate')
+      const second = screen.getByTestId('session-context-menu-item-close')
+      fireEvent.keyDown(first, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(second)
+    })
+
+    it('ArrowUp moves focus to the previous item', () => {
+      render(
+        <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+      )
+      const first = screen.getByTestId('session-context-menu-item-duplicate')
+      const second = screen.getByTestId('session-context-menu-item-close')
+      // Move down then back up.
+      fireEvent.keyDown(first, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(second)
+      fireEvent.keyDown(second, { key: 'ArrowUp' })
+      expect(document.activeElement).toBe(first)
+    })
+
+    it('ArrowDown wraps from last to first', () => {
+      render(
+        <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+      )
+      const first = screen.getByTestId('session-context-menu-item-duplicate')
+      const second = screen.getByTestId('session-context-menu-item-close')
+      fireEvent.keyDown(first, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(second)
+      fireEvent.keyDown(second, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(first)
+    })
+
+    it('ArrowUp wraps from first to last', () => {
+      render(
+        <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+      )
+      const first = screen.getByTestId('session-context-menu-item-duplicate')
+      const second = screen.getByTestId('session-context-menu-item-close')
+      fireEvent.keyDown(first, { key: 'ArrowUp' })
+      expect(document.activeElement).toBe(second)
+    })
+
+    it('Home jumps to the first item', () => {
+      const items: ContextMenuItem[] = [
+        { id: 'a', label: 'A', onClick: vi.fn() },
+        { id: 'b', label: 'B', onClick: vi.fn() },
+        { id: 'c', label: 'C', onClick: vi.fn() },
+      ]
+      render(<SessionContextMenu x={0} y={0} items={items} onDismiss={vi.fn()} />)
+      const a = screen.getByTestId('session-context-menu-item-a')
+      const c = screen.getByTestId('session-context-menu-item-c')
+      fireEvent.keyDown(a, { key: 'End' })
+      expect(document.activeElement).toBe(c)
+      fireEvent.keyDown(c, { key: 'Home' })
+      expect(document.activeElement).toBe(a)
+    })
+
+    it('End jumps to the last item', () => {
+      const items: ContextMenuItem[] = [
+        { id: 'a', label: 'A', onClick: vi.fn() },
+        { id: 'b', label: 'B', onClick: vi.fn() },
+        { id: 'c', label: 'C', onClick: vi.fn() },
+      ]
+      render(<SessionContextMenu x={0} y={0} items={items} onDismiss={vi.fn()} />)
+      const a = screen.getByTestId('session-context-menu-item-a')
+      const c = screen.getByTestId('session-context-menu-item-c')
+      fireEvent.keyDown(a, { key: 'End' })
+      expect(document.activeElement).toBe(c)
+    })
+
+    it('Enter activates the focused item and dismisses', () => {
+      const dup = vi.fn()
+      const onDismiss = vi.fn()
+      render(
+        <SessionContextMenu
+          x={0}
+          y={0}
+          items={[{ id: 'duplicate', label: 'Duplicate', onClick: dup }]}
+          onDismiss={onDismiss}
+        />,
+      )
+      const first = screen.getByTestId('session-context-menu-item-duplicate')
+      fireEvent.keyDown(first, { key: 'Enter' })
+      expect(dup).toHaveBeenCalledTimes(1)
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+    })
+
+    it('Space activates the focused item and dismisses', () => {
+      const dup = vi.fn()
+      const onDismiss = vi.fn()
+      render(
+        <SessionContextMenu
+          x={0}
+          y={0}
+          items={[{ id: 'duplicate', label: 'Duplicate', onClick: dup }]}
+          onDismiss={onDismiss}
+        />,
+      )
+      const first = screen.getByTestId('session-context-menu-item-duplicate')
+      fireEvent.keyDown(first, { key: ' ' })
+      expect(dup).toHaveBeenCalledTimes(1)
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+    })
+
+    it('Enter activates the second item after ArrowDown', () => {
+      const dup = vi.fn()
+      const close = vi.fn()
+      const onDismiss = vi.fn()
+      render(
+        <SessionContextMenu
+          x={0}
+          y={0}
+          items={[
+            { id: 'duplicate', label: 'Duplicate', onClick: dup },
+            { id: 'close', label: 'Close', onClick: close, destructive: true },
+          ]}
+          onDismiss={onDismiss}
+        />,
+      )
+      const first = screen.getByTestId('session-context-menu-item-duplicate')
+      fireEvent.keyDown(first, { key: 'ArrowDown' })
+      const second = screen.getByTestId('session-context-menu-item-close')
+      expect(document.activeElement).toBe(second)
+      fireEvent.keyDown(second, { key: 'Enter' })
+      expect(close).toHaveBeenCalledTimes(1)
+      expect(dup).not.toHaveBeenCalled()
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+    })
+
+    it('returns focus to the trigger element on unmount', () => {
+      // Simulate the real consumer pattern: a button is the right-click
+      // origin, so when the menu closes focus should land back on it.
+      const trigger = document.createElement('button')
+      trigger.setAttribute('data-testid', 'trigger')
+      document.body.appendChild(trigger)
+      trigger.focus()
+      expect(document.activeElement).toBe(trigger)
+
+      const { unmount } = render(
+        <SessionContextMenu
+          x={0}
+          y={0}
+          items={makeItems()}
+          onDismiss={vi.fn()}
+        />,
+      )
+      // Menu mounts and steals focus to the first item.
+      expect(document.activeElement).not.toBe(trigger)
+      unmount()
+      // After dismissal, focus is restored.
+      expect(document.activeElement).toBe(trigger)
+
+      document.body.removeChild(trigger)
+    })
+  })
+
   it('clamps menu position to viewport on first render', () => {
     // Set a viewport so we can predict the clamp.
     const originalInnerWidth = window.innerWidth

--- a/packages/dashboard/src/components/SessionContextMenu.tsx
+++ b/packages/dashboard/src/components/SessionContextMenu.tsx
@@ -19,7 +19,7 @@
  * No third-party library — the menu is a `<ul>` with click handlers and a
  * single `useEffect` that wires the dismiss listeners.
  */
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export interface ContextMenuItem {
   /** Stable id used as React key and `data-testid` suffix. */
@@ -56,6 +56,15 @@ export function SessionContextMenu({
   onDismiss,
 }: SessionContextMenuProps) {
   const menuRef = useRef<HTMLUListElement>(null)
+  // #4248: per-item refs so arrow-key handlers can move focus between
+  // <li> nodes without round-tripping through state. A ref array is
+  // cheaper than reading from the DOM by selector and avoids the
+  // testid-as-API coupling that querySelector would introduce.
+  const itemRefs = useRef<(HTMLLIElement | null)[]>([])
+  // #4248: roving tabindex — exactly one item is tab-focusable at a time
+  // so external Tab key presses don't have to walk through every menu
+  // entry, per WAI-ARIA Authoring Practices for the menu role.
+  const [focusedIndex, setFocusedIndex] = useState(0)
   const visibleItems = items.filter(i => typeof i.onClick === 'function')
 
   // Adjust position so the menu stays inside the viewport. We can't know the
@@ -108,7 +117,51 @@ export function SessionContextMenu({
     }
   }, [onDismiss])
 
+  // #4248: focus the first item on mount and restore focus to whatever
+  // element triggered the menu (typically the right-clicked sidebar row)
+  // when the menu unmounts. This is the focus-return half of the WAI-ARIA
+  // menu pattern and keeps keyboard-only users oriented after Esc.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    const first = itemRefs.current[0]
+    if (first) first.focus()
+    return () => {
+      // Guard against the trigger having been removed from the DOM (the
+      // sidebar row might be unmounted in another effect during the same
+      // render cycle). focus() on a detached node is a no-op but the
+      // `isConnected` check makes the intent explicit.
+      if (previouslyFocused && previouslyFocused.isConnected) {
+        previouslyFocused.focus()
+      }
+    }
+    // Intentionally empty deps — we want this to run once on mount, with
+    // the cleanup running once on unmount. x/y changes don't re-focus.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // #4248: when the focused index changes (via arrow keys / Home / End),
+  // imperatively focus the matching DOM node. We can't rely on the
+  // tabIndex={0} attribute alone — that only governs Tab traversal, not
+  // programmatic focus.
+  useEffect(() => {
+    const target = itemRefs.current[focusedIndex]
+    if (target && document.activeElement !== target) {
+      target.focus()
+    }
+  }, [focusedIndex])
+
   if (visibleItems.length === 0) return null
+
+  // #4248: activate the current item the same way the click handler does
+  // (try/finally so a throwing handler still dismisses the menu). Shared
+  // by Enter / Space and the mouse click path.
+  const activate = (item: ContextMenuItem) => {
+    try {
+      item.onClick?.()
+    } finally {
+      onDismiss()
+    }
+  }
 
   return (
     <ul
@@ -123,21 +176,63 @@ export function SessionContextMenu({
         zIndex: 1000,
       }}
     >
-      {visibleItems.map(item => (
+      {visibleItems.map((item, index) => (
         <li
           key={item.id}
+          ref={(node) => {
+            itemRefs.current[index] = node
+          }}
           role="menuitem"
+          // #4248: roving tabindex — only the currently-focused item is in
+          // the Tab order. The rest are programmatically focusable via the
+          // arrow-key handler but won't be reached by a stray Tab press
+          // from outside the menu.
+          tabIndex={focusedIndex === index ? 0 : -1}
           data-testid={`session-context-menu-item-${item.id}`}
           className={`session-context-menu-item${item.destructive ? ' destructive' : ''}${item.separatorAbove ? ' separator-above' : ''}`}
-          onClick={() => {
-            // #4045 review: try/finally so a throwing item handler doesn't
-            // leave the menu stuck open. The error still propagates to the
-            // React error boundary / window.onerror — we only guarantee
-            // dismissal here.
-            try {
-              item.onClick?.()
-            } finally {
-              onDismiss()
+          onClick={() => activate(item)}
+          onKeyDown={(e) => {
+            switch (e.key) {
+              case 'ArrowDown': {
+                e.preventDefault()
+                e.stopPropagation()
+                // Wrap-around: last → first.
+                setFocusedIndex((i) => (i + 1) % visibleItems.length)
+                break
+              }
+              case 'ArrowUp': {
+                e.preventDefault()
+                e.stopPropagation()
+                // Wrap-around: first → last.
+                setFocusedIndex((i) => (i - 1 + visibleItems.length) % visibleItems.length)
+                break
+              }
+              case 'Home': {
+                e.preventDefault()
+                e.stopPropagation()
+                setFocusedIndex(0)
+                break
+              }
+              case 'End': {
+                e.preventDefault()
+                e.stopPropagation()
+                setFocusedIndex(visibleItems.length - 1)
+                break
+              }
+              case 'Enter':
+              case ' ': {
+                // Both Enter and Space activate the focused item — matches
+                // the WAI-ARIA menuitem pattern. preventDefault on Space
+                // avoids the default scroll-the-page behaviour.
+                e.preventDefault()
+                e.stopPropagation()
+                activate(item)
+                break
+              }
+              // Escape is handled by the document-level listener so it
+              // still fires when focus has drifted away from the menu.
+              default:
+                break
             }
           }}
         >


### PR DESCRIPTION
## Summary

Adds full keyboard support to the sidebar right-click context menu (introduced in #4045 / #4236), per the WAI-ARIA Authoring Practices menu pattern. Previously the menu was mouse-only.

- ArrowDown / ArrowUp move focus between items with wrap-around at both ends
- Home / End jump to first / last item
- Enter and Space activate the focused item (shared `try/finally` path with the existing click handler so a throwing `onClick` still dismisses the menu)
- First item receives focus automatically on mount
- Focus is restored to the originating trigger element on unmount, guarded by `isConnected` so a detached trigger is a no-op
- Roving-tabindex pattern (`tabIndex={0}` on focused item, `-1` on the rest) so external Tab presses don't walk through every menu entry
- Escape continues to be handled by the existing document-level listener so it still fires when focus has drifted outside the menu

Closes #4248.

## Test plan

- [x] `npx vitest run SessionContextMenu` — 25 passed (13 existing + 12 new for keyboard nav)
- [x] `npx vitest run` (whole dashboard) — 1997 / 1997 passed
- [x] `npx tsc --noEmit` — no new errors (pre-existing `commands.test.ts` `any`-inference errors on main are unrelated)
- [ ] Manual: right-click a sidebar row, navigate menu entirely via keyboard (arrows → focus moves, Enter activates, Esc closes, focus returns to the row)

## Out of scope

Keeping this PR focused on a11y per the instructions — does **not** add new menu items. Sibling issues #4249 (resumable rows missing menu items) and #4268 (Copy path item) will land separately.