### PR TITLE
refactor(app): convert store/connection re-export imports to import type (#4250)

### DIFF
--- a/packages/app/__tests__/ComponentRendering.test.ts
+++ b/packages/app/__tests__/ComponentRendering.test.ts
@@ -113,7 +113,7 @@ describe('ChatView component', () => {
   })
 
   test('imports ChatMessage type from store', () => {
-    expect(chatViewSrc).toMatch(/import\s*\{.*ChatMessage.*\}\s*from\s+['"]\.\.\/store\/connection['"]/)
+    expect(chatViewSrc).toMatch(/import\s+(?:type\s+)?\{.*ChatMessage.*\}\s*from\s+['"]\.\.\/store\/connection['"]/)
   })
 
   test('imports child components (MessageBubble, ActivityGroup, ToolDetailModal)', () => {

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -10,7 +10,7 @@ import {
   NativeScrollEvent,
   AccessibilityInfo,
 } from 'react-native';
-import { ChatMessage, ToolResultImage } from '../store/connection';
+import type { ChatMessage, ToolResultImage } from '../store/connection';
 import { ImageViewer } from './ImageViewer';
 import { AnimatedMessage } from './AnimatedMessage';
 import { ICON_CHEVRON_RIGHT } from '../constants/icons';

--- a/packages/app/src/components/DiffViewer.tsx
+++ b/packages/app/src/components/DiffViewer.tsx
@@ -10,7 +10,8 @@ import {
   ScrollView,
   Platform,
 } from 'react-native';
-import { useConnectionStore, DiffResult, DiffFile, DiffHunk } from '../store/connection';
+import { useConnectionStore } from '../store/connection';
+import type { DiffResult, DiffFile, DiffHunk } from '../store/connection';
 import { COLORS } from '../constants/colors';
 import { ICON_DIFF } from '../constants/icons';
 import { Icon } from './Icon';

--- a/packages/app/src/components/FileBrowser.tsx
+++ b/packages/app/src/components/FileBrowser.tsx
@@ -11,7 +11,8 @@ import {
   Platform,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useConnectionStore, FileListing, FileContent } from '../store/connection';
+import { useConnectionStore } from '../store/connection';
+import type { FileListing, FileContent } from '../store/connection';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { COLORS } from '../constants/colors';
 import { Icon } from './Icon';

--- a/packages/app/src/components/FolderBrowser.tsx
+++ b/packages/app/src/components/FolderBrowser.tsx
@@ -7,7 +7,8 @@ import {
   ActivityIndicator,
   StyleSheet,
 } from 'react-native';
-import { useConnectionStore, DirectoryListing } from '../store/connection';
+import { useConnectionStore } from '../store/connection';
+import type { DirectoryListing } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
 

--- a/packages/app/src/components/SessionNotificationBanner.tsx
+++ b/packages/app/src/components/SessionNotificationBanner.tsx
@@ -6,7 +6,8 @@ import {
   StyleSheet,
   Platform,
 } from 'react-native';
-import { useConnectionStore, SessionNotification } from '../store/connection';
+import { useConnectionStore } from '../store/connection';
+import type { SessionNotification } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
 

--- a/packages/app/src/components/SessionPicker.tsx
+++ b/packages/app/src/components/SessionPicker.tsx
@@ -11,7 +11,8 @@ import {
   Animated,
   LayoutChangeEvent,
 } from 'react-native';
-import { useConnectionStore, SessionInfo, SessionHealth } from '../store/connection';
+import { useConnectionStore } from '../store/connection';
+import type { SessionInfo, SessionHealth } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
 import { getProviderInfo } from '../constants/providers';

--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -4,7 +4,7 @@ import * as Clipboard from 'expo-clipboard';
 import { DEFAULT_CONTEXT_WINDOW } from '@chroxy/store-core';
 import type { CumulativeUsage, PendingPermissionConfirm } from '@chroxy/store-core';
 import { formatCostBadge } from '@chroxy/store-core';
-import { ModelInfo, ContextUsage, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer, PermissionMode } from '../store/connection';
+import type { ModelInfo, ContextUsage, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer, PermissionMode } from '../store/connection';
 import { Icon } from './Icon';
 import { COLORS } from '../constants/colors';
 

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -16,7 +16,8 @@ import {
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useConnectionStore, selectMessages, selectClaudeReady, selectStreamingMessageId, selectActiveModel, selectPermissionMode, selectContextUsage, selectLastResultCost, selectLastResultDuration, selectIsIdle, ChatMessage, ConnectionPhase, AgentInfo, McpServer, DevPreview, stripAnsi, nextMessageId } from '../store/connection';
+import { useConnectionStore, selectMessages, selectClaudeReady, selectStreamingMessageId, selectActiveModel, selectPermissionMode, selectContextUsage, selectLastResultCost, selectLastResultDuration, selectIsIdle, stripAnsi, nextMessageId } from '../store/connection';
+import type { ChatMessage, ConnectionPhase, AgentInfo, McpServer, DevPreview } from '../store/connection';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { SessionPicker } from '../components/SessionPicker';
 import { CreateSessionModal } from '../components/CreateSessionModal';


### PR DESCRIPTION
## Summary

Converts value imports of type-only symbols from `../store/connection` into `import type` (or splits mixed imports into value + type pairs). No behavior change — purely a TypeScript treeshaking / `isolatedModules` correctness cleanup.

Spun out of #4232 review (Copilot inline comment on `SettingsBar.tsx:7`).

Eight consumer files were importing types as values:
- `ChatView`, `SettingsBar` — pure type-only imports, converted in place
- `FolderBrowser`, `SessionPicker`, `SessionNotificationBanner`, `DiffViewer`, `FileBrowser` — split into value + type imports
- `SessionScreen` — split (store hook, selectors, and util fns stay as values; `ChatMessage` / `ConnectionPhase` / `AgentInfo` / `McpServer` / `DevPreview` move to `import type`)

One source-scan regex (`ComponentRendering.test.ts`) was updated to accept the optional `type` keyword.

`connection.ts` itself already uses `export type` for its re-exports — no changes there.

Closes #4250

## Test Plan

- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 96/96 suites, 1299/1299 tests pass
- [x] Diff is 9 files / +15 / -9 lines — no spillover refactor