### PR TITLE
feat(dashboard): touch-friendly disclosure for sidebar cost-gap tooltip

### DIFF
--- a/packages/dashboard/src/components/SidebarTokenView.test.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.test.tsx
@@ -379,6 +379,39 @@ describe('SidebarTokenView (#4303 v0)', () => {
         // pointer moves away.
         expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
       })
+
+      // #4362 regression guard: touch browsers synthesize mouseenter then click
+      // on a single tap. Treating the synthetic mouseenter as a hover-open
+      // would flip the popover closed on the very tap that's supposed to
+      // surface it — re-introducing the issue this PR fixes. The trigger must
+      // open and stay open on a single tap.
+      it('opens on a single tap on touch devices (no flip-flop)', () => {
+        render(<SidebarTokenView sessions={sessions} />)
+        const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+        // Simulate a touch tap: pointerdown(touch) -> mouseenter -> click.
+        fireEvent.pointerDown(trigger, { pointerType: 'touch' })
+        fireEvent.mouseEnter(trigger)
+        fireEvent.click(trigger)
+        // Popover should be open after the tap.
+        expect(screen.getByTestId('sidebar-token-view-cost-info-popover')).toBeInTheDocument()
+        expect(trigger.getAttribute('aria-expanded')).toBe('true')
+      })
+
+      // Second tap on touch should close (toggle behavior).
+      it('closes on a second tap on touch devices', () => {
+        render(<SidebarTokenView sessions={sessions} />)
+        const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+        // First tap to open.
+        fireEvent.pointerDown(trigger, { pointerType: 'touch' })
+        fireEvent.mouseEnter(trigger)
+        fireEvent.click(trigger)
+        expect(screen.getByTestId('sidebar-token-view-cost-info-popover')).toBeInTheDocument()
+
+        // Second tap should close.
+        fireEvent.pointerDown(trigger, { pointerType: 'touch' })
+        fireEvent.click(trigger)
+        expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+      })
     })
   })
 })

--- a/packages/dashboard/src/components/SidebarTokenView.test.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.test.tsx
@@ -2,7 +2,7 @@
  * SidebarTokenView v0 tests (#4303).
  */
 import { describe, it, expect, afterEach } from 'vitest'
-import { render, cleanup, screen } from '@testing-library/react'
+import { render, cleanup, screen, fireEvent } from '@testing-library/react'
 import type { SessionInfo, CumulativeUsage } from '@chroxy/store-core'
 import {
   SidebarTokenView,
@@ -205,12 +205,23 @@ describe('SidebarTokenView (#4303 v0)', () => {
       expect(screen.getByTestId('sidebar-token-view-provider-claude-byok')).toBeInTheDocument()
     })
 
-    it('renders "—" for TUI rows with tooltip', () => {
+    it('renders "—" for TUI rows with tap-to-disclose explanation', () => {
       const sessions = [makeSession('tui', 'claude-tui', makeUsage(0, 0, 0))]
       render(<SidebarTokenView sessions={sessions} />)
       const untracked = screen.getByTestId('sidebar-token-view-provider-claude-tui-untracked')
       expect(untracked).toHaveTextContent('—')
-      expect(untracked.getAttribute('title')).toContain('claude TUI')
+      // #4362: native title= doesn't fire on tap, so the trigger must be a
+      // button + popover so touch users can surface the explanation.
+      expect(untracked.tagName).toBe('BUTTON')
+      // Closed by default
+      expect(
+        screen.queryByTestId('sidebar-token-view-provider-claude-tui-untracked-popover'),
+      ).toBeNull()
+      fireEvent.click(untracked)
+      const popover = screen.getByTestId(
+        'sidebar-token-view-provider-claude-tui-untracked-popover',
+      )
+      expect(popover.textContent ?? '').toContain('claude TUI')
     })
 
     it('renders aggregate total and cost when present', () => {
@@ -231,24 +242,29 @@ describe('SidebarTokenView (#4303 v0)', () => {
       expect(screen.queryByText(/Cost \(BYOK\)/i)).toBeNull()
     })
 
-    // #4348: visible-tokens-vs-billed-cost optical illusion.
-    // The sidebar shows user-visible token counts (new content per turn) but
-    // BYOK cost is computed from full per-call billed tokens (which include
-    // the re-sent context). Without an affordance, the apparent $/token rate
-    // looks wildly off Anthropic's published pricing.
-    it('explains the visible-vs-billed-tokens distinction on the cost badge', () => {
+    // #4348 / #4362: visible-tokens-vs-billed-cost optical illusion. The
+    // sidebar shows user-visible token counts (new content per turn) but BYOK
+    // cost is computed from full per-call billed tokens (which include the
+    // re-sent context). The disclosure surfaces the explanation on tap (not
+    // just hover) so it works on touch devices.
+    it('explains the visible-vs-billed-tokens distinction in the cost popover', () => {
       const sessions = [
         makeSession('byok', 'claude-byok', makeUsage(12_800, 134_400, 87.48)),
       ]
       render(<SidebarTokenView sessions={sessions} />)
-      const costInfo = screen.getByTestId('sidebar-token-view-cost-info')
-      const tooltip = costInfo.getAttribute('title') ?? ''
+      const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+      // Popover closed by default
+      expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+
+      fireEvent.click(trigger)
+      const popover = screen.getByTestId('sidebar-token-view-cost-info-popover')
+      const text = popover.textContent ?? ''
       // Mentions "billed" tokens specifically (the key distinction)
-      expect(tooltip.toLowerCase()).toContain('billed')
+      expect(text.toLowerCase()).toContain('billed')
       // Mentions Anthropic pricing (so it's clear cost is faithful to invoice)
-      expect(tooltip).toContain('Anthropic')
+      expect(text).toContain('Anthropic')
       // Mentions the re-sent context (the cause of the gap)
-      expect(tooltip.toLowerCase()).toContain('context')
+      expect(text.toLowerCase()).toContain('context')
     })
 
     it('renders the info marker next to the cost badge when cost > 0', () => {
@@ -265,6 +281,104 @@ describe('SidebarTokenView (#4303 v0)', () => {
       ]
       render(<SidebarTokenView sessions={sessions} />)
       expect(screen.queryByTestId('sidebar-token-view-cost-info')).toBeNull()
+    })
+
+    // #4362: touch-friendly disclosure replaces the hover-only `title=`
+    // attribute. The trigger must be a button so touch users get tap-to-
+    // disclose, with click-outside and Escape both dismissing the popover.
+    // Hover behavior is preserved for pointer users.
+    describe('cost-info disclosure (#4362)', () => {
+      const sessions = [
+        makeSession('byok', 'claude-byok', makeUsage(1000, 500, 0.10)),
+      ]
+
+      it('renders the trigger as a button with accessible name', () => {
+        render(<SidebarTokenView sessions={sessions} />)
+        const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+        expect(trigger.tagName).toBe('BUTTON')
+        // The original aria-label intent is preserved (issue acceptance criteria).
+        expect(trigger.getAttribute('aria-label')).toMatch(/cost|match|token/i)
+        // aria-expanded should reflect closed state initially.
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+      })
+
+      it('toggles the popover on click (tap)', () => {
+        render(<SidebarTokenView sessions={sessions} />)
+        const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+
+        // Initially closed
+        expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+
+        // First click opens
+        fireEvent.click(trigger)
+        expect(screen.getByTestId('sidebar-token-view-cost-info-popover')).toBeInTheDocument()
+        expect(trigger.getAttribute('aria-expanded')).toBe('true')
+
+        // Second click closes
+        fireEvent.click(trigger)
+        expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+      })
+
+      it('exposes the popover with an appropriate ARIA role', () => {
+        render(<SidebarTokenView sessions={sessions} />)
+        fireEvent.click(screen.getByTestId('sidebar-token-view-cost-info'))
+        const popover = screen.getByTestId('sidebar-token-view-cost-info-popover')
+        // Either role="dialog" or role="tooltip" is acceptable for a small
+        // explanatory popover; both surface the content to AT users.
+        const role = popover.getAttribute('role')
+        expect(role === 'dialog' || role === 'tooltip').toBe(true)
+      })
+
+      it('dismisses the popover when Escape is pressed', () => {
+        render(<SidebarTokenView sessions={sessions} />)
+        const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+        fireEvent.click(trigger)
+        expect(screen.getByTestId('sidebar-token-view-cost-info-popover')).toBeInTheDocument()
+
+        fireEvent.keyDown(document, { key: 'Escape' })
+        expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+        expect(trigger.getAttribute('aria-expanded')).toBe('false')
+      })
+
+      it('dismisses the popover when clicking outside', () => {
+        render(
+          <div>
+            <SidebarTokenView sessions={sessions} />
+            <button type="button" data-testid="outside-button">outside</button>
+          </div>,
+        )
+        const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+        fireEvent.click(trigger)
+        expect(screen.getByTestId('sidebar-token-view-cost-info-popover')).toBeInTheDocument()
+
+        // mousedown is the typical click-outside trigger (fires before focus).
+        fireEvent.mouseDown(screen.getByTestId('outside-button'))
+        expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+      })
+
+      it('does not dismiss when clicking inside the popover', () => {
+        render(<SidebarTokenView sessions={sessions} />)
+        fireEvent.click(screen.getByTestId('sidebar-token-view-cost-info'))
+        const popover = screen.getByTestId('sidebar-token-view-cost-info-popover')
+        fireEvent.mouseDown(popover)
+        // Still open after clicking inside.
+        expect(screen.getByTestId('sidebar-token-view-cost-info-popover')).toBeInTheDocument()
+      })
+
+      it('opens on mouseenter so hover users keep the same affordance', () => {
+        render(<SidebarTokenView sessions={sessions} />)
+        const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+        // Hover should reveal the popover (matches the pre-#4362 hover-only UX
+        // for desktop pointer users).
+        fireEvent.mouseEnter(trigger)
+        expect(screen.getByTestId('sidebar-token-view-cost-info-popover')).toBeInTheDocument()
+        fireEvent.mouseLeave(trigger)
+        // And hide on mouseleave so the popover doesn't linger after the
+        // pointer moves away.
+        expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+      })
     })
   })
 })

--- a/packages/dashboard/src/components/SidebarTokenView.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.tsx
@@ -188,10 +188,16 @@ function InfoDisclosure({
   const [open, setOpen] = useState(false)
   const popoverId = useId()
   const containerRef = useRef<HTMLSpanElement | null>(null)
-  // Track whether the most recent open was via hover so a subsequent tap
-  // on the trigger toggles correctly without flickering on touch screens
-  // that synthesize mouseenter just before click.
-  const hoveredRef = useRef(false)
+  // Track whether the popover was opened via hover (mouse) so a subsequent
+  // mouseleave can close it. Click-opened popovers stay until explicit
+  // dismissal (Escape, click-outside, or second click).
+  const openedByHoverRef = useRef(false)
+  // Touch interactions on mobile browsers synthesize `mouseenter` -> `click`
+  // on a single tap. If we treat the synthesized `mouseenter` as a hover-open
+  // we'd flip-flop on the very tap that's supposed to surface the popover.
+  // Pointer Events expose `pointerType` so we can gate hover-open to genuine
+  // mouse pointers and let the click handler own the toggle on touch.
+  const pointerTypeRef = useRef<string>('mouse')
 
   // Click-outside + Escape handlers. Only attached when the popover is open
   // so we don't leak listeners on every mount of the sidebar.
@@ -202,17 +208,23 @@ function InfoDisclosure({
         setOpen(false)
       }
     }
-    function onMouseDown(e: MouseEvent) {
+    function onPointerDown(e: PointerEvent) {
       const target = e.target as Node | null
       if (!target) return
       if (containerRef.current && containerRef.current.contains(target)) return
       setOpen(false)
     }
     document.addEventListener('keydown', onKeyDown)
-    document.addEventListener('mousedown', onMouseDown)
+    // pointerdown covers both mouse and touch click-outside in one listener.
+    // Tests still use fireEvent.mouseDown which dispatches a MouseEvent that
+    // browsers also fire alongside pointerdown — so we listen to mousedown
+    // as well to stay compatible with the jsdom test harness.
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('mousedown', onPointerDown as EventListener)
     return () => {
       document.removeEventListener('keydown', onKeyDown)
-      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('mousedown', onPointerDown as EventListener)
     }
   }, [open])
 
@@ -225,22 +237,35 @@ function InfoDisclosure({
         aria-label={ariaLabel}
         aria-expanded={open}
         aria-controls={open ? popoverId : undefined}
+        onPointerDown={(e) => {
+          // Record the pointer type so the upcoming click handler can decide
+          // whether to honor a hover-open it just triggered. Touch synthesizes
+          // mouseenter+click on the same tap, which would otherwise flip the
+          // popover closed immediately on touch devices (the bug we're
+          // fixing).
+          pointerTypeRef.current = e.pointerType || 'mouse'
+        }}
         onClick={() => {
-          // If hover already opened it, a click should close (toggle).
-          // Otherwise a tap opens it.
+          // On touch, the synthetic mouseenter may have just opened the
+          // popover. Ignore that and treat the click as the "open" action.
+          if (pointerTypeRef.current === 'touch' && openedByHoverRef.current) {
+            openedByHoverRef.current = false
+            setOpen(true)
+            return
+          }
           setOpen((prev) => !prev)
-          hoveredRef.current = false
+          openedByHoverRef.current = false
         }}
         onMouseEnter={() => {
-          hoveredRef.current = true
+          openedByHoverRef.current = true
           setOpen(true)
         }}
         onMouseLeave={() => {
           // Only auto-close on mouseleave if it was opened via hover —
           // a click-opened popover should stay until explicit dismissal.
-          if (hoveredRef.current) {
+          if (openedByHoverRef.current) {
             setOpen(false)
-            hoveredRef.current = false
+            openedByHoverRef.current = false
           }
         }}
       >

--- a/packages/dashboard/src/components/SidebarTokenView.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.tsx
@@ -20,7 +20,7 @@
  * (which carry `cumulativeUsage` from session_list snapshots + the
  * `session_usage` event stream).
  */
-import { useMemo } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { CumulativeUsage, SessionInfo } from '@chroxy/store-core'
 import { formatCostBadge, getProviderLabel } from '@chroxy/store-core'
 
@@ -147,6 +147,132 @@ export function formatTokenCount(n: number): string {
   return `${(n / 1_000_000).toFixed(2)}M`
 }
 
+/**
+ * #4362: touch-friendly disclosure for explanatory tooltips.
+ *
+ * The native `title=` attribute renders a hover-only tooltip that doesn't
+ * fire on tap, leaving touch users (iPad dashboard, mobile WebView) without
+ * a way to surface the explanation. This component renders a small button
+ * trigger that:
+ *   - Toggles the popover on click/tap (the touch-friendly affordance)
+ *   - Opens on mouseenter / closes on mouseleave (preserves hover UX for
+ *     pointer users; matches the pre-#4362 desktop behavior)
+ *   - Closes on Escape (keyboard dismissal)
+ *   - Closes on click outside (standard popover dismissal)
+ *   - Carries `aria-label` for screen readers and `aria-expanded` for state
+ *
+ * The popover content is rendered inline as a sibling rather than via a
+ * portal — the sidebar panel is already a flex column and the explanatory
+ * text is short, so we don't need positioning trickery.
+ */
+interface InfoDisclosureProps {
+  /** Marker text shown inside the trigger (e.g. "ⓘ" or "—"). */
+  triggerText: string
+  /** Accessible name for the trigger button. */
+  ariaLabel: string
+  /** Class name applied to the trigger button. */
+  triggerClassName: string
+  /** Test id base — popover gets `${testIdBase}-popover`. */
+  testIdBase: string
+  /** Explanation content. Plain text or a node. */
+  children: React.ReactNode
+}
+
+function InfoDisclosure({
+  triggerText,
+  ariaLabel,
+  triggerClassName,
+  testIdBase,
+  children,
+}: InfoDisclosureProps) {
+  const [open, setOpen] = useState(false)
+  const popoverId = useId()
+  const containerRef = useRef<HTMLSpanElement | null>(null)
+  // Track whether the most recent open was via hover so a subsequent tap
+  // on the trigger toggles correctly without flickering on touch screens
+  // that synthesize mouseenter just before click.
+  const hoveredRef = useRef(false)
+
+  // Click-outside + Escape handlers. Only attached when the popover is open
+  // so we don't leak listeners on every mount of the sidebar.
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false)
+      }
+    }
+    function onMouseDown(e: MouseEvent) {
+      const target = e.target as Node | null
+      if (!target) return
+      if (containerRef.current && containerRef.current.contains(target)) return
+      setOpen(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    document.addEventListener('mousedown', onMouseDown)
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.removeEventListener('mousedown', onMouseDown)
+    }
+  }, [open])
+
+  return (
+    <span className="sidebar-token-view-disclosure" ref={containerRef}>
+      <button
+        type="button"
+        className={triggerClassName}
+        data-testid={testIdBase}
+        aria-label={ariaLabel}
+        aria-expanded={open}
+        aria-controls={open ? popoverId : undefined}
+        onClick={() => {
+          // If hover already opened it, a click should close (toggle).
+          // Otherwise a tap opens it.
+          setOpen((prev) => !prev)
+          hoveredRef.current = false
+        }}
+        onMouseEnter={() => {
+          hoveredRef.current = true
+          setOpen(true)
+        }}
+        onMouseLeave={() => {
+          // Only auto-close on mouseleave if it was opened via hover —
+          // a click-opened popover should stay until explicit dismissal.
+          if (hoveredRef.current) {
+            setOpen(false)
+            hoveredRef.current = false
+          }
+        }}
+      >
+        {triggerText}
+      </button>
+      {open && (
+        <span
+          id={popoverId}
+          className="sidebar-token-view-popover"
+          data-testid={`${testIdBase}-popover`}
+          role="tooltip"
+        >
+          {children}
+        </span>
+      )}
+    </span>
+  )
+}
+
+const COST_INFO_EXPLANATION =
+  // #4348: the optical illusion is that visible tokens ÷ cost yields a rate
+  // nowhere near Anthropic's published pricing. Spell out the gap between
+  // visible and billed tokens here.
+  'Token counts above are user-visible (new content per turn). ' +
+  'BYOK cost is computed from billed tokens, which include the ' +
+  'full conversation context re-sent on every API call — so ' +
+  'long agentic sessions bill far more input than the visible ' +
+  'count suggests. Pricing follows Anthropic’s published rates.'
+
+const TUI_UNTRACKED_EXPLANATION =
+  'Token count not exposed by claude TUI (PTY-only interface)'
+
 export interface SidebarTokenViewProps {
   /** All known sessions across active + resumable + background. */
   sessions: SessionInfo[]
@@ -178,23 +304,14 @@ export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
           <div className="sidebar-token-view-aggregate-row">
             <span className="sidebar-token-view-label">
               Cost (BYOK){' '}
-              <span
-                className="sidebar-token-view-info"
-                data-testid="sidebar-token-view-cost-info"
-                aria-label="Why doesn't this cost match the visible token count?"
-                title={
-                  // #4348: the optical illusion is that visible tokens ÷ cost
-                  // yields a rate nowhere near Anthropic's published pricing.
-                  // Spell out the gap between visible and billed tokens here.
-                  'Token counts above are user-visible (new content per turn). ' +
-                  'BYOK cost is computed from billed tokens, which include the ' +
-                  'full conversation context re-sent on every API call — so ' +
-                  'long agentic sessions bill far more input than the visible ' +
-                  'count suggests. Pricing follows Anthropic’s published rates.'
-                }
+              <InfoDisclosure
+                triggerText={'ⓘ'}
+                ariaLabel="Why doesn't this cost match the visible token count?"
+                triggerClassName="sidebar-token-view-info"
+                testIdBase="sidebar-token-view-cost-info"
               >
-                {'ⓘ'}
-              </span>
+                {COST_INFO_EXPLANATION}
+              </InfoDisclosure>
             </span>
             <span className="sidebar-token-view-value-secondary">
               {formatCostBadge(agg.totals.costUsd)}
@@ -222,13 +339,14 @@ export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
                 >
                   <span className="sidebar-token-view-provider-label">{label}</span>
                   {row.untracked ? (
-                    <span
-                      className="sidebar-token-view-provider-untracked"
-                      data-testid={`sidebar-token-view-provider-${row.provider}-untracked`}
-                      title="Token count not exposed by claude TUI (PTY-only interface)"
+                    <InfoDisclosure
+                      triggerText="—"
+                      ariaLabel={`Why does ${label} not show a token count?`}
+                      triggerClassName="sidebar-token-view-provider-untracked"
+                      testIdBase={`sidebar-token-view-provider-${row.provider}-untracked`}
                     >
-                      —
-                    </span>
+                      {TUI_UNTRACKED_EXPLANATION}
+                    </InfoDisclosure>
                   ) : (
                     <span className="sidebar-token-view-provider-tokens">
                       {formatTokenCount(tokens)}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -861,16 +861,57 @@
   font-size: 12px;
 }
 
+/* #4362: untracked-provider trigger is now a button (tap-to-disclose). */
 .sidebar-token-view-provider-untracked {
   color: var(--text-muted);
   cursor: help;
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  line-height: inherit;
 }
 
+/* #4362: cost-info trigger is a button (tap-to-disclose). Style it to look
+ * like the prior inline marker so the affordance isn't visually noisy. */
 .sidebar-token-view-info {
   color: var(--text-muted);
   cursor: help;
   font-size: 10px;
   margin-left: 2px;
+  background: none;
+  border: 0;
+  padding: 0;
+  line-height: inherit;
+}
+
+.sidebar-token-view-info:focus-visible,
+.sidebar-token-view-provider-untracked:focus-visible {
+  outline: 1px dotted var(--text-muted);
+  outline-offset: 2px;
+}
+
+/* #4362: inline popover container — anchors the popover near the trigger
+ * without a portal. The popover itself wraps onto its own line so it
+ * doesn't disrupt the row layout. */
+.sidebar-token-view-disclosure {
+  position: relative;
+  display: inline;
+}
+
+.sidebar-token-view-popover {
+  display: block;
+  margin-top: 4px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: var(--bg-panel, var(--bg-secondary, #1f2128));
+  color: var(--text-primary);
+  font-size: 11px;
+  line-height: 1.4;
+  font-weight: normal;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+  max-width: 240px;
+  white-space: normal;
 }
 
 .sidebar-token-view-provider-cost {


### PR DESCRIPTION
## Summary

PR #4352 added an info-tooltip on the BYOK cost badge in `SidebarTokenView` that explains the visible-vs-billed token gap. That tooltip used a native HTML `title=` attribute, which only fires on hover and is unreachable on touch devices (iPad dashboard, mobile WebView).

This replaces the bare `title=` with an explicit tap-to-disclose button + popover:

- **Tap toggles visibility** — the touch-friendly affordance the issue asked for
- **Hover still works on pointer devices** — opens on `mouseenter`, closes on `mouseleave`
- **Escape dismisses** the popover (keyboard support)
- **Click-outside dismisses** the popover (standard popover behavior)
- **`aria-label` preserved** on the trigger button + `aria-expanded` reflects state
- **Popover has `role="tooltip"`** so AT users get the explanation
- **Same pattern applied to the untracked-provider "—" marker** — issue called out that it had the same hover-only limitation
- **No regression to conditional rendering** — cost row still only renders when `costUsd > 0`

## Implementation

A small `InfoDisclosure` component is introduced inside `SidebarTokenView.tsx`. It owns the open/closed state and the document-level `keydown` / `mousedown` listeners (attached only while open so they don't leak). The popover renders inline as a sibling of the trigger; no portal needed because the sidebar is already a flex column and the explanation text is short. Light styling lives in `components.css` (button reset + popover surface).

## Test plan

- [x] Unit tests cover: button trigger renders, popover toggles on click, click-outside dismisses, Escape dismisses, hover opens + mouseleave closes, role + aria-expanded wired correctly, popover does not dismiss on inside-click
- [x] `npx vitest run` — 1991 dashboard tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — clean production bundle
- [ ] Manual smoke on touch device (iPad / mobile WebView) — verify tap opens, second tap closes, tap outside closes

Closes #4362