### PR TITLE
fix(dashboard): reset skipPermissions on provider switch

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -247,6 +247,18 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
     }
   }, [open, availableProviders, provider])
 
+  // #4245: reset skipPermissions whenever the provider changes. The
+  // checkbox is hidden for non-TUI providers, but the underlying state
+  // survives a provider switch — so a user who ticks the box for
+  // claude-tui, tabs to claude-sdk, then tabs back to claude-tui would
+  // see the checkbox pre-checked with no fresh warning. Force a
+  // re-confirmation by clearing the state on every provider change. The
+  // submit-time guard (`provider === 'claude-tui' && skipPermissions`)
+  // still acts as belt + braces in case this reset races a submit.
+  useEffect(() => {
+    setSkipPermissions(false)
+  }, [provider])
+
   // #4340: gate the Create button on the selected provider being ready.
   // Pre-#4340 the dropdown disabled unready options so they couldn't be
   // selected; now we let the user navigate to any provider to read its

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -262,7 +262,7 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
   // submit-time guard (`provider === 'claude-tui' && skipPermissions`)
   // still acts as belt + braces in case this reset races a submit.
   useEffect(() => {
-    setSkipPermissions(false)
+    setSkipPermissions('inherit')
   }, [provider])
 
   // #4340: gate the Create button on the selected provider being ready.

--- a/packages/dashboard/src/components/CreateSessionModalSkipPermissions.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalSkipPermissions.test.tsx
@@ -148,4 +148,77 @@ describe('CreateSessionModal skip-permissions checkbox (#4208)', () => {
     expect(onCreate).toHaveBeenCalledTimes(1)
     expect(onCreate.mock.calls[0]![0].skipPermissions).toBeUndefined()
   })
+
+  // #4245: the skipPermissions state must reset when the user switches
+  // provider. Before the fix, ticking the box for claude-tui, switching to
+  // claude-sdk, then switching back to claude-tui would leave the checkbox
+  // pre-checked with no fresh warning — a security-UX wart. The submit
+  // guard caught the cross-provider case at submit time, but the user
+  // wouldn't be re-prompted to confirm the dangerous flag.
+  describe('provider-switch reset (#4245)', () => {
+    it('resets skipPermissions to false when switching from claude-tui to claude-sdk and back', async () => {
+      mockStore('claude-tui')
+      const CreateSessionModal = await loadModal()
+      const onCreate = vi.fn()
+      render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+      openAdvanced()
+      // Tick the checkbox under claude-tui
+      const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
+      fireEvent.click(cb)
+      expect(cb.checked).toBe(true)
+      // Switch to claude-sdk — checkbox hides
+      const select = screen.getByLabelText(/select provider/i) as HTMLSelectElement
+      fireEvent.change(select, { target: { value: 'claude-sdk' } })
+      expect(screen.queryByTestId('skip-permissions-checkbox')).not.toBeInTheDocument()
+      // Switch back to claude-tui — checkbox renders again, must be unchecked
+      fireEvent.change(select, { target: { value: 'claude-tui' } })
+      const cb2 = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
+      expect(cb2.checked).toBe(false)
+    })
+
+    it('resets skipPermissions when switching away from claude-tui even without coming back', async () => {
+      mockStore('claude-tui')
+      const CreateSessionModal = await loadModal()
+      const onCreate = vi.fn()
+      render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+      openAdvanced()
+      const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
+      fireEvent.click(cb)
+      expect(cb.checked).toBe(true)
+      // Switch to claude-sdk and submit — the submit guard already strips
+      // the flag on non-TUI providers, but the underlying state should
+      // also be reset so the UX is consistent.
+      const select = screen.getByLabelText(/select provider/i) as HTMLSelectElement
+      fireEvent.change(select, { target: { value: 'claude-sdk' } })
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+      expect(onCreate).toHaveBeenCalledTimes(1)
+      expect(onCreate.mock.calls[0]![0]).toMatchObject({
+        provider: 'claude-sdk',
+      })
+      expect(onCreate.mock.calls[0]![0].skipPermissions).toBeUndefined()
+    })
+
+    it('does NOT reset skipPermissions when the provider stays the same (state survives unrelated re-renders)', async () => {
+      mockStore('claude-tui')
+      const CreateSessionModal = await loadModal()
+      const onCreate = vi.fn()
+      render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
+      openAdvanced()
+      const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
+      fireEvent.click(cb)
+      expect(cb.checked).toBe(true)
+      // An unrelated state change (typing in the session name) must not
+      // reset the checkbox — only provider changes do.
+      const nameInput = screen.getByLabelText(/session name/i) as HTMLInputElement
+      fireEvent.change(nameInput, { target: { value: 'my-session' } })
+      const cbAfter = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
+      expect(cbAfter.checked).toBe(true)
+      fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+      expect(onCreate).toHaveBeenCalledTimes(1)
+      expect(onCreate.mock.calls[0]![0]).toMatchObject({
+        provider: 'claude-tui',
+        skipPermissions: true,
+      })
+    })
+  })
 })

--- a/packages/dashboard/src/components/CreateSessionModalSkipPermissions.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalSkipPermissions.test.tsx
@@ -217,24 +217,24 @@ describe('CreateSessionModal skip-permissions tri-state (#4208, #4244)', () => {
   // guard caught the cross-provider case at submit time, but the user
   // wouldn't be re-prompted to confirm the dangerous flag.
   describe('provider-switch reset (#4245)', () => {
-    it('resets skipPermissions to false when switching from claude-tui to claude-sdk and back', async () => {
+    it('resets skipPermissions to inherit when switching from claude-tui to claude-sdk and back', async () => {
       mockStore('claude-tui')
       const CreateSessionModal = await loadModal()
       const onCreate = vi.fn()
       render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
       openAdvanced()
-      // Tick the checkbox under claude-tui
-      const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
-      fireEvent.click(cb)
-      expect(cb.checked).toBe(true)
-      // Switch to claude-sdk — checkbox hides
+      // Select 'on' under claude-tui
+      const on = screen.getByTestId('skip-permissions-radio-on') as HTMLInputElement
+      fireEvent.click(on)
+      expect(on.checked).toBe(true)
+      // Switch to claude-sdk — radio group hides
       const select = screen.getByLabelText(/select provider/i) as HTMLSelectElement
       fireEvent.change(select, { target: { value: 'claude-sdk' } })
-      expect(screen.queryByTestId('skip-permissions-checkbox')).not.toBeInTheDocument()
-      // Switch back to claude-tui — checkbox renders again, must be unchecked
+      expect(screen.queryByTestId('skip-permissions-radio-on')).not.toBeInTheDocument()
+      // Switch back to claude-tui — radio group renders again, must be back to 'inherit'
       fireEvent.change(select, { target: { value: 'claude-tui' } })
-      const cb2 = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
-      expect(cb2.checked).toBe(false)
+      const inherit2 = screen.getByTestId('skip-permissions-radio-inherit') as HTMLInputElement
+      expect(inherit2.checked).toBe(true)
     })
 
     it('resets skipPermissions when switching away from claude-tui even without coming back', async () => {
@@ -243,9 +243,9 @@ describe('CreateSessionModal skip-permissions tri-state (#4208, #4244)', () => {
       const onCreate = vi.fn()
       render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
       openAdvanced()
-      const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
-      fireEvent.click(cb)
-      expect(cb.checked).toBe(true)
+      const on = screen.getByTestId('skip-permissions-radio-on') as HTMLInputElement
+      fireEvent.click(on)
+      expect(on.checked).toBe(true)
       // Switch to claude-sdk and submit — the submit guard already strips
       // the flag on non-TUI providers, but the underlying state should
       // also be reset so the UX is consistent.
@@ -265,15 +265,15 @@ describe('CreateSessionModal skip-permissions tri-state (#4208, #4244)', () => {
       const onCreate = vi.fn()
       render(<CreateSessionModal {...baseProps} onCreate={onCreate} />)
       openAdvanced()
-      const cb = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
-      fireEvent.click(cb)
-      expect(cb.checked).toBe(true)
+      const on = screen.getByTestId('skip-permissions-radio-on') as HTMLInputElement
+      fireEvent.click(on)
+      expect(on.checked).toBe(true)
       // An unrelated state change (typing in the session name) must not
-      // reset the checkbox — only provider changes do.
+      // reset the selection — only provider changes do.
       const nameInput = screen.getByLabelText(/session name/i) as HTMLInputElement
       fireEvent.change(nameInput, { target: { value: 'my-session' } })
-      const cbAfter = screen.getByTestId('skip-permissions-checkbox') as HTMLInputElement
-      expect(cbAfter.checked).toBe(true)
+      const onAfter = screen.getByTestId('skip-permissions-radio-on') as HTMLInputElement
+      expect(onAfter.checked).toBe(true)
       fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
       expect(onCreate).toHaveBeenCalledTimes(1)
       expect(onCreate.mock.calls[0]![0]).toMatchObject({


### PR DESCRIPTION
## Summary

The `skipPermissions` checkbox on `CreateSessionModal` is hidden for non-TUI providers, but the underlying state survived a provider switch. A user who ticked the box under `claude-tui`, switched to `claude-sdk`, then switched back to `claude-tui` would see the checkbox pre-checked with no fresh warning — a security-UX wart for an opt-in to `--dangerously-skip-permissions`.

The submit-time guard (`provider === 'claude-tui' && skipPermissions`) caught the cross-provider case, so this isn't a correctness bug, but the user wasn't re-prompted to confirm the dangerous flag.

## Changes

- `CreateSessionModal.tsx`: add a `useEffect` keyed on `provider` that clears `skipPermissions` on every provider change. Existing submit-time guard remains as belt + braces.
- `CreateSessionModalSkipPermissions.test.tsx`: 3 new tests covering the provider-switch reset:
  - Switch claude-tui to claude-sdk and back to claude-tui resets the checkbox to unchecked
  - Switch claude-tui to claude-sdk submits with no `skipPermissions` field
  - Unrelated state changes (typing in session name) do NOT reset the checkbox

## Test plan

- [x] `npx vitest run src/components/CreateSessionModalSkipPermissions` — 9 passed (was 6)
- [x] `npx vitest run src/components/CreateSessionModal` — 67 passed across 11 files
- [x] `npx vitest run` (full dashboard suite) — 1987 passed across 118 files
- [x] `npx tsc --noEmit` — clean

Closes #4245