### PR TITLE
feat(app): catch-all hint for unknown permission mode (parity with dashboard #4019)

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -377,7 +377,14 @@ export function SettingsBar({
                     hint = 'Default. Each tool call gates on your approval in the dashboard or mobile app.';
                   }
                 }
-                if (!hint) return null;
+                // #4251: parity with dashboard CreateSessionModal.tsx #4019
+                // catch-all. When a future provider adds a permission mode the
+                // mobile build doesn't recognise AND the server didn't send a
+                // description, surface the same explanatory copy the dashboard
+                // shows instead of hiding the hint entirely.
+                if (!hint) {
+                  hint = 'Uses whatever the server’s --default-permission-mode was set to (usually Approve).';
+                }
                 return (
                   <Text
                     style={styles.permissionModeHint}

--- a/packages/app/src/components/__tests__/SettingsBarPermissionModeHint.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarPermissionModeHint.test.tsx
@@ -114,7 +114,12 @@ describe('SettingsBar permission-mode hint (#4213)', () => {
     expect(() => root.findByProps({ testID: 'permission-mode-hint' })).toThrow();
   });
 
-  it('hides the hint when the selected mode has neither server nor fallback copy', () => {
+  // #4251: parity with dashboard #4019 — when the selected mode has neither
+  // a server-supplied description nor a hardcoded fallback (e.g. a future
+  // provider added a new mode the mobile build doesn't recognise), the
+  // hint must render the same catch-all string CreateSessionModal.tsx
+  // emits at the end of its fallback chain.
+  it('renders catch-all hint when the selected mode has neither server nor fallback copy', () => {
     let tree: renderer.ReactTestRenderer | null = null;
     act(() => {
       tree = renderer.create(
@@ -129,6 +134,9 @@ describe('SettingsBar permission-mode hint (#4213)', () => {
       );
     });
     const root = tree!.root;
-    expect(() => root.findByProps({ testID: 'permission-mode-hint' })).toThrow();
+    const hint = root.findByProps({ testID: 'permission-mode-hint' });
+    expect(collectVisibleText(hint)).toContain(
+      'Uses whatever the server’s --default-permission-mode was set to (usually Approve).',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Mobile `SettingsBar` previously hid the permission-mode hint when the selected mode had neither a server-supplied `description` nor a hardcoded fallback. Dashboard `CreateSessionModal` (#4019) instead renders a friendly catch-all:

> Uses whatever the server's `--default-permission-mode` was set to (usually Approve).

This PR adds the same string at the end of `SettingsBar.tsx`'s fallback chain so the two surfaces render identical text for the same `(permissionMode, availablePermissionModes)` input — closing the divergence flagged in the #4232 review.

## Changes

- `packages/app/src/components/SettingsBar.tsx` — append catch-all fallback after the per-mode hardcoded strings (same curly-apostrophe wording as the dashboard line at `CreateSessionModal.tsx:720`).
- `packages/app/src/components/__tests__/SettingsBarPermissionModeHint.test.tsx` — rename the divergence-codifying test from `'hides the hint when ...'` to `'renders catch-all hint when ...'` and assert the catch-all string.

## Test plan

- [x] `npx jest src/components/__tests__/SettingsBarPermissionModeHint.test.tsx` — 4 / 4 pass (failed on red as expected before the implementation).
- [x] Full mobile suite: `npx jest --no-coverage` — 96 suites, 1299 tests pass.
- [x] `npx tsc --noEmit` clean.

Closes #4251