### PR TITLE
fix(dashboard): populate sidebar context menu for resumable rows (#4249)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -552,7 +552,6 @@ export function App() {
       conversationHistory,
       isTauri: isTauri(),
       createSession,
-      destroySession,
       resumeConversation,
       revealInFinder,
       onRevealError: (message) => {
@@ -581,7 +580,6 @@ export function App() {
     sessions,
     conversationHistory,
     createSession,
-    destroySession,
     resumeConversation,
     handleCloseSession,
   ])

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -22,6 +22,7 @@ import type { ChatViewMessage } from './components/ChatView'
 
 import { Sidebar, type RepoNode, type ContextMenuTarget } from './components/Sidebar'
 import { SessionContextMenu, type ContextMenuItem } from './components/SessionContextMenu'
+import { buildSidebarContextMenuItems } from './sidebarContextMenuItems'
 import { CommandPalette } from './components/CommandPalette'
 import { useCommands, recordMruCommand, getMruCommands } from './store/commands'
 import { ChatView } from './components/ChatView'
@@ -538,96 +539,52 @@ export function App() {
     setSidebarContextMenu(null)
   }, [])
 
-  // #4045: build the menu item list for the currently-targeted sidebar row.
-  // Items are capability-gated:
-  //   - "Open in Finder" only appears under Tauri (we shell out to `open`
-  //     / `explorer` / `xdg-open` via the reveal_in_finder Rust command —
-  //     no server-side endpoint exists for the browser dashboard).
-  //   - "Archive" is intentionally omitted; the server has no archive
-  //     store yet (#4045 splits this into a follow-up).
+  // #4045/#4249: build the menu item list for the currently-targeted sidebar
+  // row. Branching by target.type and capability-gating ("Open in Finder"
+  // only under Tauri; resumable "Open in Finder" only when the conversation
+  // record carries a cwd) lives in buildSidebarContextMenuItems so the
+  // per-branch logic is unit-testable without rendering App.
   const sidebarContextMenuItems = useMemo<ContextMenuItem[]>(() => {
     if (!sidebarContextMenu) return []
-    const { target } = sidebarContextMenu
-    const tauriRuntime = isTauri()
-
-    if (target.type === 'session' && target.sessionId) {
-      const session = sessions.find(s => s.sessionId === target.sessionId)
-      if (!session) return []
-      return [
-        {
-          id: 'duplicate',
-          label: 'Duplicate Session',
-          onClick: () => {
-            createSession({
-              name: session.name,
-              cwd: session.cwd || undefined,
-              provider: session.provider,
-              model: session.model || undefined,
-              permissionMode: session.permissionMode || undefined,
-              worktree: session.worktree,
-            })
-          },
-        },
-        {
-          id: 'reveal',
-          label: 'Open in Finder',
-          onClick: tauriRuntime && session.cwd
-            ? () => {
-                // #4045: surface Rust-side errors (missing path, spawn
-                // failure, restricted-window rejection) as a toast so the
-                // user knows the action failed instead of getting an
-                // unhandled promise rejection in the console.
-                const cwd = session.cwd
-                revealInFinder(cwd).catch((err: unknown) => {
-                  useConnectionStore.getState().addServerError(
-                    `Failed to reveal in Finder: ${err instanceof Error ? err.message : String(err)}`,
-                  )
-                })
-              }
-            : undefined,
-        },
-        {
-          id: 'close',
-          label: 'Close Session',
-          destructive: true,
-          separatorAbove: true,
-          onClick: () => handleCloseSession(session.sessionId),
-        },
-      ]
-    }
-
-    if (target.type === 'repo' && target.path) {
-      const repoPath = target.path
-      return [
-        {
-          id: 'new-session',
-          label: 'New Session Here',
-          onClick: () => {
-            setPendingCwd(repoPath)
-            setShowCreateSession(true)
-          },
-        },
-        {
-          id: 'reveal',
-          label: 'Open in Finder',
-          onClick: tauriRuntime
-            ? () => {
-                // #4045: see session-row reveal — same pattern, surface
-                // Rust-side errors as a toast instead of an unhandled
-                // promise rejection.
-                revealInFinder(repoPath).catch((err: unknown) => {
-                  useConnectionStore.getState().addServerError(
-                    `Failed to reveal in Finder: ${err instanceof Error ? err.message : String(err)}`,
-                  )
-                })
-              }
-            : undefined,
-        },
-      ]
-    }
-
-    return []
-  }, [sidebarContextMenu, sessions, createSession, handleCloseSession])
+    return buildSidebarContextMenuItems({
+      target: sidebarContextMenu.target,
+      sessions,
+      conversationHistory,
+      isTauri: isTauri(),
+      createSession,
+      destroySession,
+      resumeConversation,
+      revealInFinder,
+      onRevealError: (message) => {
+        useConnectionStore.getState().addServerError(message)
+      },
+      copyToClipboard: (text) => {
+        // navigator.clipboard is undefined in non-secure contexts and some
+        // embedded webviews; mirror the same guard handleCopyTranscript
+        // uses (see the comment block on that callback) so this menu item
+        // doesn't throw out of the synchronous click handler.
+        if (!navigator.clipboard) return
+        void navigator.clipboard.writeText(text).catch(() => {
+          // Clipboard rejected (user denied permission) — fail quietly.
+          // The user can still see the conversation id by hovering or
+          // re-running the search.
+        })
+      },
+      openCreateSessionAt: (cwd) => {
+        setPendingCwd(cwd)
+        setShowCreateSession(true)
+      },
+      confirmCloseSession: handleCloseSession,
+    })
+  }, [
+    sidebarContextMenu,
+    sessions,
+    conversationHistory,
+    createSession,
+    destroySession,
+    resumeConversation,
+    handleCloseSession,
+  ])
 
   /**
    * Append processed image attachments to the composer's pending-image

--- a/packages/dashboard/src/sidebarContextMenuItems.test.ts
+++ b/packages/dashboard/src/sidebarContextMenuItems.test.ts
@@ -12,7 +12,7 @@
  * after extracting the builder out of App.tsx the per-branch wiring is
  * unit-testable without a render tree.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import type { SessionInfo, ConversationSummary } from '@chroxy/store-core'
 import {
   buildSidebarContextMenuItems,
@@ -61,7 +61,6 @@ function makeArgs(
     conversationHistory: [makeConversation()],
     isTauri: false,
     createSession: vi.fn(),
-    destroySession: vi.fn(),
     resumeConversation: vi.fn(),
     revealInFinder: vi.fn(() => Promise.resolve()),
     onRevealError: vi.fn(),
@@ -189,10 +188,12 @@ describe('buildSidebarContextMenuItems', () => {
         makeArgs({ isTauri: true, revealInFinder, onRevealError }),
       )
       items.find(i => i.id === 'reveal')?.onClick?.()
-      // Let the rejected promise's .catch microtask run.
-      await Promise.resolve()
-      await Promise.resolve()
-      expect(onRevealError).toHaveBeenCalledTimes(1)
+      // vi.waitFor flushes microtasks until the assertion passes; sturdier
+      // than counting `await Promise.resolve()` ticks if the promise chain
+      // ever grows.
+      await vi.waitFor(() => {
+        expect(onRevealError).toHaveBeenCalledTimes(1)
+      })
       expect(onRevealError.mock.calls[0]![0]).toContain('boom')
     })
 
@@ -210,10 +211,6 @@ describe('buildSidebarContextMenuItems', () => {
   })
 
   describe('session branch (#4045 contract)', () => {
-    beforeEach(() => {
-      // no-op — each test builds its own args via makeArgs.
-    })
-
     it('returns [] when the session id no longer matches any live session', () => {
       const items = buildSidebarContextMenuItems(
         makeArgs({

--- a/packages/dashboard/src/sidebarContextMenuItems.test.ts
+++ b/packages/dashboard/src/sidebarContextMenuItems.test.ts
@@ -1,0 +1,325 @@
+/**
+ * sidebarContextMenuItems tests (#4045, #4249).
+ *
+ * The resumable branch is the headline coverage here — #4249 was a silent
+ * dead-click bug: Sidebar fired `onContextMenu` for resumable rows but App's
+ * builder returned `[]`, so SessionContextMenu rendered nothing and the
+ * browser's native menu was swallowed. These tests pin that the resumable
+ * branch now yields a real menu (Resume + Copy ID + Open in Finder) and
+ * that activating each item invokes the matching callback.
+ *
+ * The `session` / `repo` branches keep their existing #4045 contracts —
+ * after extracting the builder out of App.tsx the per-branch wiring is
+ * unit-testable without a render tree.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { SessionInfo, ConversationSummary } from '@chroxy/store-core'
+import {
+  buildSidebarContextMenuItems,
+  type BuildSidebarContextMenuItemsArgs,
+} from './sidebarContextMenuItems'
+
+function makeSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    sessionId: 's1',
+    name: 'Test',
+    cwd: '/home/user/projects/api',
+    type: 'cli',
+    hasTerminal: true,
+    model: null,
+    permissionMode: null,
+    isBusy: false,
+    createdAt: Date.now(),
+    conversationId: null,
+    provider: 'claude-sdk',
+    ...overrides,
+  } as SessionInfo
+}
+
+function makeConversation(
+  overrides: Partial<ConversationSummary> = {},
+): ConversationSummary {
+  return {
+    conversationId: 'conv-123',
+    project: '/home/user/projects/api',
+    projectName: 'api',
+    modifiedAt: '2026-03-01',
+    modifiedAtMs: Date.parse('2026-03-01'),
+    sizeBytes: 1024,
+    preview: 'Fix auth bug',
+    cwd: '/home/user/projects/api',
+    ...overrides,
+  }
+}
+
+function makeArgs(
+  overrides: Partial<BuildSidebarContextMenuItemsArgs> = {},
+): BuildSidebarContextMenuItemsArgs {
+  return {
+    target: { type: 'resumable', conversationId: 'conv-123' },
+    sessions: [],
+    conversationHistory: [makeConversation()],
+    isTauri: false,
+    createSession: vi.fn(),
+    destroySession: vi.fn(),
+    resumeConversation: vi.fn(),
+    revealInFinder: vi.fn(() => Promise.resolve()),
+    onRevealError: vi.fn(),
+    copyToClipboard: vi.fn(),
+    openCreateSessionAt: vi.fn(),
+    confirmCloseSession: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('buildSidebarContextMenuItems', () => {
+  describe('resumable branch (#4249)', () => {
+    it('returns a non-empty menu — fixes the silent dead-click', () => {
+      const items = buildSidebarContextMenuItems(makeArgs())
+      expect(items.length).toBeGreaterThan(0)
+      // Visible items (those with onClick) must also be > 0 — empty
+      // visibleItems is what SessionContextMenu uses to decide to render
+      // nothing.
+      const visible = items.filter(i => typeof i.onClick === 'function')
+      expect(visible.length).toBeGreaterThan(0)
+    })
+
+    it('includes Resume Conversation, Copy Conversation ID, and Open in Finder', () => {
+      const items = buildSidebarContextMenuItems(makeArgs({ isTauri: true }))
+      const labels = items.map(i => i.label)
+      expect(labels).toContain('Resume Conversation')
+      expect(labels).toContain('Copy Conversation ID')
+      expect(labels).toContain('Open in Finder')
+    })
+
+    it('Resume calls resumeConversation with the conversationId and cwd from history', () => {
+      const resumeConversation = vi.fn()
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'resumable', conversationId: 'conv-123' },
+          conversationHistory: [makeConversation({ cwd: '/home/user/projects/web' })],
+          resumeConversation,
+        }),
+      )
+      const resume = items.find(i => i.id === 'resume')
+      resume?.onClick?.()
+      expect(resumeConversation).toHaveBeenCalledWith('conv-123', '/home/user/projects/web')
+    })
+
+    it('Resume passes undefined cwd when conversation is not in history', () => {
+      const resumeConversation = vi.fn()
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'resumable', conversationId: 'unknown-conv' },
+          conversationHistory: [],
+          resumeConversation,
+        }),
+      )
+      const resume = items.find(i => i.id === 'resume')
+      // Resume should still be enabled even without history — the server
+      // can fall back to the cwd recorded in the JSONL transcript.
+      expect(typeof resume?.onClick).toBe('function')
+      resume?.onClick?.()
+      expect(resumeConversation).toHaveBeenCalledWith('unknown-conv', undefined)
+    })
+
+    it('Resume passes undefined cwd when conversation record has null cwd', () => {
+      const resumeConversation = vi.fn()
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'resumable', conversationId: 'conv-123' },
+          conversationHistory: [makeConversation({ cwd: null })],
+          resumeConversation,
+        }),
+      )
+      items.find(i => i.id === 'resume')?.onClick?.()
+      expect(resumeConversation).toHaveBeenCalledWith('conv-123', undefined)
+    })
+
+    it('Copy Conversation ID calls copyToClipboard with the conversationId', () => {
+      const copyToClipboard = vi.fn()
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'resumable', conversationId: 'conv-abc' },
+          copyToClipboard,
+        }),
+      )
+      items.find(i => i.id === 'copy-id')?.onClick?.()
+      expect(copyToClipboard).toHaveBeenCalledWith('conv-abc')
+    })
+
+    it('Open in Finder is gated off when not running under Tauri', () => {
+      const items = buildSidebarContextMenuItems(makeArgs({ isTauri: false }))
+      const reveal = items.find(i => i.id === 'reveal')
+      // The item still exists in the array but with no onClick —
+      // SessionContextMenu filters items without an onClick at render time.
+      expect(reveal).toBeDefined()
+      expect(reveal?.onClick).toBeUndefined()
+    })
+
+    it('Open in Finder is gated off under Tauri when no cwd is known', () => {
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          isTauri: true,
+          target: { type: 'resumable', conversationId: 'no-history' },
+          conversationHistory: [],
+        }),
+      )
+      const reveal = items.find(i => i.id === 'reveal')
+      expect(reveal?.onClick).toBeUndefined()
+    })
+
+    it('Open in Finder calls revealInFinder with the conversation cwd when Tauri + cwd', () => {
+      const revealInFinder = vi.fn(() => Promise.resolve())
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          isTauri: true,
+          conversationHistory: [makeConversation({ cwd: '/some/path' })],
+          revealInFinder,
+        }),
+      )
+      items.find(i => i.id === 'reveal')?.onClick?.()
+      expect(revealInFinder).toHaveBeenCalledWith('/some/path')
+    })
+
+    it('Open in Finder reports failure through onRevealError instead of unhandled rejection', async () => {
+      const onRevealError = vi.fn()
+      const revealInFinder = vi.fn(() => Promise.reject(new Error('boom')))
+      const items = buildSidebarContextMenuItems(
+        makeArgs({ isTauri: true, revealInFinder, onRevealError }),
+      )
+      items.find(i => i.id === 'reveal')?.onClick?.()
+      // Let the rejected promise's .catch microtask run.
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(onRevealError).toHaveBeenCalledTimes(1)
+      expect(onRevealError.mock.calls[0]![0]).toContain('boom')
+    })
+
+    it('returns [] when target.conversationId is missing', () => {
+      // Defensive guard — the Sidebar always passes a conversationId for
+      // resumable rows, but the builder should not produce a menu with
+      // undefined-id items if the target is malformed.
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'resumable' /* no conversationId */ },
+        }),
+      )
+      expect(items).toEqual([])
+    })
+  })
+
+  describe('session branch (#4045 contract)', () => {
+    beforeEach(() => {
+      // no-op — each test builds its own args via makeArgs.
+    })
+
+    it('returns [] when the session id no longer matches any live session', () => {
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'session', sessionId: 'ghost' },
+          sessions: [],
+        }),
+      )
+      expect(items).toEqual([])
+    })
+
+    it('Duplicate calls createSession with the session fields', () => {
+      const createSession = vi.fn()
+      const session = makeSession({ sessionId: 's42', name: 'API', worktree: true })
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'session', sessionId: 's42' },
+          sessions: [session],
+          createSession,
+        }),
+      )
+      items.find(i => i.id === 'duplicate')?.onClick?.()
+      expect(createSession).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'API', cwd: '/home/user/projects/api', worktree: true }),
+      )
+    })
+
+    it('Close calls confirmCloseSession (not destroySession directly)', () => {
+      // The session-row Close goes through the App-level confirm wrapper so
+      // the window.confirm prompt fires; tests pin that the builder still
+      // delegates to that wrapper rather than the raw destroy action.
+      const confirmCloseSession = vi.fn()
+      const session = makeSession({ sessionId: 's42' })
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'session', sessionId: 's42' },
+          sessions: [session],
+          confirmCloseSession,
+        }),
+      )
+      items.find(i => i.id === 'close')?.onClick?.()
+      expect(confirmCloseSession).toHaveBeenCalledWith('s42')
+    })
+
+    it('Close item is flagged destructive with a separator above', () => {
+      const session = makeSession({ sessionId: 's42' })
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'session', sessionId: 's42' },
+          sessions: [session],
+        }),
+      )
+      const close = items.find(i => i.id === 'close')
+      expect(close?.destructive).toBe(true)
+      expect(close?.separatorAbove).toBe(true)
+    })
+  })
+
+  describe('repo branch (#4045 contract)', () => {
+    it('returns [] when target.path is missing', () => {
+      const items = buildSidebarContextMenuItems(
+        makeArgs({ target: { type: 'repo' /* no path */ } }),
+      )
+      expect(items).toEqual([])
+    })
+
+    it('New Session Here calls openCreateSessionAt with the repo path', () => {
+      const openCreateSessionAt = vi.fn()
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'repo', path: '/home/user/projects/api' },
+          openCreateSessionAt,
+        }),
+      )
+      items.find(i => i.id === 'new-session')?.onClick?.()
+      expect(openCreateSessionAt).toHaveBeenCalledWith('/home/user/projects/api')
+    })
+
+    it('Open in Finder is gated off when not running under Tauri', () => {
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'repo', path: '/home/user/projects/api' },
+          isTauri: false,
+        }),
+      )
+      expect(items.find(i => i.id === 'reveal')?.onClick).toBeUndefined()
+    })
+
+    it('Open in Finder reveals the repo path under Tauri', () => {
+      const revealInFinder = vi.fn(() => Promise.resolve())
+      const items = buildSidebarContextMenuItems(
+        makeArgs({
+          target: { type: 'repo', path: '/home/user/projects/api' },
+          isTauri: true,
+          revealInFinder,
+        }),
+      )
+      items.find(i => i.id === 'reveal')?.onClick?.()
+      expect(revealInFinder).toHaveBeenCalledWith('/home/user/projects/api')
+    })
+  })
+
+  it('returns [] for an unknown target type', () => {
+    const items = buildSidebarContextMenuItems(
+      // @ts-expect-error — intentional bad type to verify the fall-through
+      makeArgs({ target: { type: 'unknown' } }),
+    )
+    expect(items).toEqual([])
+  })
+})

--- a/packages/dashboard/src/sidebarContextMenuItems.ts
+++ b/packages/dashboard/src/sidebarContextMenuItems.ts
@@ -1,0 +1,167 @@
+/**
+ * Builder for the sidebar right-click context menu items (#4045, #4249).
+ *
+ * Extracted from `App.tsx` so the branch logic per `ContextMenuTarget.type`
+ * is pure and unit-testable without bootstrapping the whole App tree. The
+ * useMemo inside App.tsx now just calls this with the live dependencies.
+ *
+ * Per-branch items:
+ *   - `session` — Duplicate Session, Open in Finder (Tauri+cwd), Close Session
+ *   - `repo`    — New Session Here, Open in Finder (Tauri)
+ *   - `resumable` (#4249) — Resume Conversation, Copy Conversation ID,
+ *     Open in Finder (Tauri+cwd). cwd is looked up from `conversationHistory`
+ *     so the resume + reveal actions point at the same project the
+ *     conversation lived in.
+ *
+ * Capability-gated items use a falsy `onClick` so `SessionContextMenu`
+ * filters them at render time (no caller-side filtering needed).
+ */
+import type { SessionInfo, ConversationSummary } from '@chroxy/store-core'
+import type { ContextMenuItem } from './components/SessionContextMenu'
+import type { ContextMenuTarget } from './components/Sidebar'
+
+export interface BuildSidebarContextMenuItemsArgs {
+  /** Current right-click target. */
+  target: ContextMenuTarget
+  /** Live sessions list (for the `session` branch lookup). */
+  sessions: SessionInfo[]
+  /** Conversation history (for the `resumable` branch cwd lookup). */
+  conversationHistory: ConversationSummary[]
+  /** True when running under the Tauri desktop shell. */
+  isTauri: boolean
+
+  // Action dependencies — passed in so the helper stays pure. Mirrors the
+  // shape of ConnectionStore.createSession so App.tsx can pass the store
+  // method through unchanged.
+  createSession: (opts: {
+    name: string
+    cwd?: string
+    provider?: string
+    model?: string
+    permissionMode?: string
+    worktree?: boolean
+    environmentId?: string
+    skipPermissions?: boolean
+  }) => void
+  destroySession: (sessionId: string) => void
+  resumeConversation: (conversationId: string, cwd?: string) => void
+  revealInFinder: (path: string) => Promise<unknown>
+  /** Surface a Rust-side reveal failure as a toast (matches App.tsx pattern). */
+  onRevealError: (message: string) => void
+  /** Imperative copy-to-clipboard helper (callable from a sync click). */
+  copyToClipboard: (text: string) => void
+  /** Open the CreateSessionModal at a given cwd (for the repo branch). */
+  openCreateSessionAt: (cwd: string) => void
+  /** Wrapper around `destroySession` that prompts the user first. */
+  confirmCloseSession: (sessionId: string) => void
+}
+
+export function buildSidebarContextMenuItems(
+  args: BuildSidebarContextMenuItemsArgs,
+): ContextMenuItem[] {
+  const {
+    target,
+    sessions,
+    conversationHistory,
+    isTauri,
+    createSession,
+    resumeConversation,
+    revealInFinder,
+    onRevealError,
+    copyToClipboard,
+    openCreateSessionAt,
+    confirmCloseSession,
+  } = args
+
+  // Reveal helper that mirrors the App.tsx error-toast pattern so each
+  // branch isn't repeating the same try/catch shim.
+  const reveal = (path: string) => {
+    revealInFinder(path).catch((err: unknown) => {
+      onRevealError(
+        `Failed to reveal in Finder: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    })
+  }
+
+  if (target.type === 'session' && target.sessionId) {
+    const session = sessions.find(s => s.sessionId === target.sessionId)
+    if (!session) return []
+    return [
+      {
+        id: 'duplicate',
+        label: 'Duplicate Session',
+        onClick: () => {
+          createSession({
+            name: session.name,
+            cwd: session.cwd || undefined,
+            provider: session.provider,
+            model: session.model || undefined,
+            permissionMode: session.permissionMode || undefined,
+            worktree: session.worktree,
+          })
+        },
+      },
+      {
+        id: 'reveal',
+        label: 'Open in Finder',
+        onClick: isTauri && session.cwd ? () => reveal(session.cwd) : undefined,
+      },
+      {
+        id: 'close',
+        label: 'Close Session',
+        destructive: true,
+        separatorAbove: true,
+        onClick: () => confirmCloseSession(session.sessionId),
+      },
+    ]
+  }
+
+  if (target.type === 'repo' && target.path) {
+    const repoPath = target.path
+    return [
+      {
+        id: 'new-session',
+        label: 'New Session Here',
+        onClick: () => openCreateSessionAt(repoPath),
+      },
+      {
+        id: 'reveal',
+        label: 'Open in Finder',
+        onClick: isTauri ? () => reveal(repoPath) : undefined,
+      },
+    ]
+  }
+
+  if (target.type === 'resumable' && target.conversationId) {
+    // #4249: prior to this, the resumable branch fell through to `return []`
+    // which left SessionContextMenu rendering nothing while still swallowing
+    // the browser's native menu — a silent dead-click on the row.
+    const conversationId = target.conversationId
+    const conv = conversationHistory.find(c => c.conversationId === conversationId)
+    // cwd is opportunistic: a conversation row can be shown for a project
+    // whose history record we haven't fetched yet. The resume call still
+    // works server-side without cwd (the server falls back to the project
+    // recorded in the JSONL transcript) — we only pass cwd along when we
+    // already have it.
+    const cwd = conv?.cwd ?? undefined
+    return [
+      {
+        id: 'resume',
+        label: 'Resume Conversation',
+        onClick: () => resumeConversation(conversationId, cwd),
+      },
+      {
+        id: 'copy-id',
+        label: 'Copy Conversation ID',
+        onClick: () => copyToClipboard(conversationId),
+      },
+      {
+        id: 'reveal',
+        label: 'Open in Finder',
+        onClick: isTauri && cwd ? () => reveal(cwd) : undefined,
+      },
+    ]
+  }
+
+  return []
+}

--- a/packages/dashboard/src/sidebarContextMenuItems.ts
+++ b/packages/dashboard/src/sidebarContextMenuItems.ts
@@ -43,7 +43,6 @@ export interface BuildSidebarContextMenuItemsArgs {
     environmentId?: string
     skipPermissions?: boolean
   }) => void
-  destroySession: (sessionId: string) => void
   resumeConversation: (conversationId: string, cwd?: string) => void
   revealInFinder: (path: string) => Promise<unknown>
   /** Surface a Rust-side reveal failure as a toast (matches App.tsx pattern). */
@@ -52,7 +51,10 @@ export interface BuildSidebarContextMenuItemsArgs {
   copyToClipboard: (text: string) => void
   /** Open the CreateSessionModal at a given cwd (for the repo branch). */
   openCreateSessionAt: (cwd: string) => void
-  /** Wrapper around `destroySession` that prompts the user first. */
+  /**
+   * Wrapper around the store's `destroySession` that prompts the user first
+   * (the session-row Close action must not destroy without confirmation).
+   */
   confirmCloseSession: (sessionId: string) => void
 }
 


### PR DESCRIPTION
## Summary

Fixes #4249 — sidebar right-click on resumable conversation rows fired `onContextMenu` but `App.tsx` only built items for the `repo` and `session` branches. The `resumable` branch fell through to `[]`, so `SessionContextMenu` rendered nothing while still swallowing the browser's native menu (silent dead-click).

## Changes

- **Extract** `buildSidebarContextMenuItems` from `App.tsx` into `packages/dashboard/src/sidebarContextMenuItems.ts` so the per-branch logic is pure / unit-testable.
- **Add the `resumable` branch** with three items:
  - **Resume Conversation** — calls `resumeConversation(conversationId, cwd?)`, with `cwd` looked up from `conversationHistory` (falls back to `undefined` so the server uses the cwd recorded in the JSONL transcript).
  - **Copy Conversation ID** — clipboard write, guarded the same way `handleCopyTranscript` already guards for non-secure contexts.
  - **Open in Finder** — Tauri + cwd capability-gated; reveal errors surface as a toast (matches the `session` / `repo` branch pattern).
- Re-pin the existing `session` / `repo` contracts after extraction.

## Test plan

- [x] `npx vitest run sidebarContextMenuItems` — 20 new tests pass.
- [x] `npx vitest run` (dashboard) — 2004 / 2004 pass; no regressions in App, Sidebar, or SessionContextMenu tests.
- [x] `npx tsc --noEmit` (dashboard) — clean.

Closes #4249