### PR TITLE
fix(server): close phase-1 / phase-2 abort race in byok _processToolBlocks

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -695,31 +695,20 @@ export class ClaudeByokSession extends BaseSession {
     // executions while preserving model-emit order in the final array.
     const toolResults = new Array(toolBlocks.length)
     const gateDecisions = new Array(toolBlocks.length)
-    let abortedDuringGate = false
     let firstUngatedIndex = toolBlocks.length
 
-    // PHASE 1 — sequential permission gating.
-    for (let i = 0; i < toolBlocks.length; i++) {
-      if (signal?.aborted) {
-        abortedDuringGate = true
-        firstUngatedIndex = i
-        break
-      }
-      gateDecisions[i] = await this._gateToolBlock({
-        block: toolBlocks[i],
-        messageId,
-      })
-    }
-
-    // If abort fired mid-gate, fill synthetic 'Interrupted' tool_results
-    // for the unscheduled remainder. The early-aborted blocks never
-    // emitted a tool_start (we didn't even get to the executor), but
-    // the SDK already emitted tool_start when streaming the assistant
-    // turn — so the bubble would hang in 'running…' without a closing
-    // tool_result event (#4108 review).
-    if (abortedDuringGate) {
+    // Synthetic-fill helper (#4108, #4247). Used both for the mid-gate
+    // remainder (blocks that never entered the gate) AND the
+    // inter-phase race (every block was gated, but the signal tripped
+    // before phase 2 schedules — without this guard, write-side tools
+    // that ignore the signal would execute AFTER the user pressed Stop).
+    const fillInterrupted = (startIndex) => {
       const interrupted = 'Interrupted by user before execution'
-      for (let j = firstUngatedIndex; j < toolBlocks.length; j++) {
+      for (let j = startIndex; j < toolBlocks.length; j++) {
+        // Skip slots that already carry a real result (defensive — the
+        // inter-phase guard fires when startIndex === 0, but only the
+        // blocks that *would* have executed in phase 2 need filling).
+        if (toolResults[j]) continue
         const remaining = toolBlocks[j]
         this.emit('tool_result', {
           messageId,
@@ -734,6 +723,48 @@ export class ClaudeByokSession extends BaseSession {
           is_error: true,
         }
       }
+    }
+
+    // PHASE 1 — sequential permission gating.
+    for (let i = 0; i < toolBlocks.length; i++) {
+      if (signal?.aborted) {
+        firstUngatedIndex = i
+        break
+      }
+      gateDecisions[i] = await this._gateToolBlock({
+        block: toolBlocks[i],
+        messageId,
+      })
+    }
+
+    // Mid-gate abort: fill synthetic 'Interrupted' tool_results for the
+    // unscheduled remainder (#4108). The early-aborted blocks never
+    // emitted a tool_start (we didn't even get to the executor), but
+    // the SDK already emitted tool_start when streaming the assistant
+    // turn — so the bubble would hang in 'running…' without a closing
+    // tool_result event.
+    if (firstUngatedIndex < toolBlocks.length) {
+      fillInterrupted(firstUngatedIndex)
+    }
+
+    // Inter-phase race guard (#4247): if the signal tripped while the
+    // last gate was awaiting — or any time after phase 1's loop check
+    // and before phase 2 schedules — short-circuit the remainder into
+    // synthetic-fills rather than launching write-side tools (Read,
+    // Write, Edit, TodoWrite) that don't honour the signal and would
+    // run to completion AFTER the user pressed Stop. Pre-fix, the
+    // sequential-loop's bottom-of-iteration check caught this; the
+    // parallel refactor (#4062) opened a window between phase 1 and
+    // phase 2 where the abort could go unobserved.
+    //
+    // Only applies when phase 1 completed fully (every block was
+    // successfully gated). The mid-gate path above already handled
+    // the partial-gate case and must keep block N's execution — its
+    // gate ran BEFORE the abort tripped, so the user's permission
+    // answer would be wasted if we re-synthesized it here.
+    if (signal?.aborted && firstUngatedIndex === toolBlocks.length) {
+      fillInterrupted(0)
+      firstUngatedIndex = 0
     }
 
     // PHASE 2 — parallel execution of every successfully-gated block.

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -1611,6 +1611,229 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('does NOT schedule phase-2 executions when abort fires between phase 1 and phase 2 (#4247)', async () => {
+      // The race the issue describes: every gate auto-resolves
+      // synchronously (e.g. permissionMode=auto), then the user hits
+      // Stop in the microtask window AFTER phase 1 completes but
+      // BEFORE phase 2 fans out into Promise.all. Pre-fix, the
+      // already-gated decisions still flow into _executeToolBlock for
+      // every block — and tools like Write/Edit/Read/TodoWrite ignore
+      // the signal, so they run to completion AFTER the user said stop.
+      //
+      // We model the race deterministically by aborting at the END of
+      // the last gate call. The gate already returned 'allow' for every
+      // block, so phase 1 considers the round fully gated (no mid-gate
+      // synthetic fill). The new guard must re-check signal.aborted
+      // before scheduling phase 2 and short-circuit every block into a
+      // synthetic 'Interrupted' tool_result.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      let gateCalls = 0
+      session._gateToolBlock = async function ({ block }) {
+        gateCalls += 1
+        // Approve every block. Abort AFTER the last gate resolves so
+        // phase 1 completes cleanly (firstUngatedIndex = N), but the
+        // signal trips before phase 2 schedules executions.
+        if (gateCalls === 3) {
+          this._abortController.abort()
+        }
+        return { behavior: 'allow', updatedInput: block.input || {} }
+      }
+      let executeCalls = 0
+      session._executeToolBlock = async function () {
+        executeCalls += 1
+        throw new Error('phase 2 must not schedule any executions after abort between phases')
+      }
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+              {
+                stop_reason: 'tool_use',
+                content: [
+                  { type: 'tool_use', id: 'tu_w1', name: 'Write', input: { file_path: '/a', content: 'x' } },
+                  { type: 'tool_use', id: 'tu_w2', name: 'Write', input: { file_path: '/b', content: 'y' } },
+                  { type: 'tool_use', id: 'tu_w3', name: 'Write', input: { file_path: '/c', content: 'z' } },
+                ],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            ),
+        },
+      }
+      const captured = captureEvents(session)
+      await session.start()
+      await session.sendMessage('parallel writes')
+      // The whole point: zero real executions after the inter-phase abort.
+      assert.equal(executeCalls, 0,
+        'phase-2 schedule must observe the abort that fired between phase 1 and phase 2')
+      // History invariant (#4061) still holds: N tool_use → N tool_result.
+      const userTurns = session._history.filter((m) => m.role === 'user' && Array.isArray(m.content))
+      const toolResultTurn = userTurns[userTurns.length - 1]
+      assert.ok(toolResultTurn, 'tool_result user-turn must be pushed even on inter-phase abort')
+      const ids = toolResultTurn.content.map((b) => b.tool_use_id).sort()
+      assert.deepEqual(ids, ['tu_w1', 'tu_w2', 'tu_w3'],
+        'every tool_use id must have a matching tool_result block (history invariant)')
+      for (const b of toolResultTurn.content) {
+        assert.equal(b.type, 'tool_result')
+        assert.equal(b.is_error, true, 'synthetic tool_result must mark is_error')
+        assert.match(b.content, /[Ii]nterrupted/, 'synthetic content references the abort')
+      }
+      // The dashboard / mobile tool-call bubble closes on `tool_result`
+      // events — without one per synthetic, all three Write bubbles
+      // would stay in 'running…' forever (#4108).
+      const toolResultEvents = captured.filter((e) => e.name === 'tool_result')
+      const eventIds = toolResultEvents.map((e) => e.payload.toolUseId).sort()
+      assert.deepEqual(eventIds, ['tu_w1', 'tu_w2', 'tu_w3'],
+        'one closing tool_result event per ungated block')
+      for (const ev of toolResultEvents) {
+        assert.equal(ev.payload.isError, true)
+        assert.match(ev.payload.result, /[Ii]nterrupted/)
+        assert.ok(!('toolName' in ev.payload),
+          'inter-phase synthetic tool_result must not carry the legacy `toolName` key (#4261)')
+      }
+      await session.destroy()
+    })
+
+    it('still short-circuits when abort fires DURING phase 1 (regression guard for #4247 fix)', async () => {
+      // Regression: the existing mid-gate synthetic-fill path
+      // (firstUngatedIndex < N) must keep working unchanged after we
+      // add the between-phase guard. The two paths share the
+      // synthetic-fill helper but diverge on `firstUngatedIndex` — pin
+      // it so a future refactor that collapses them can't silently
+      // drop the mid-gate semantics.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      let gateCalls = 0
+      session._gateToolBlock = async function ({ block }) {
+        gateCalls += 1
+        if (gateCalls === 1) {
+          // Trip abort INSIDE the gate so the next iteration's top-of-loop
+          // check sees signal.aborted and bails — block 1 still ran the
+          // gate (firstUngatedIndex = 1, blocks 2/3 synthetic-filled).
+          this._abortController.abort()
+          return { behavior: 'allow', updatedInput: block.input || {} }
+        }
+        throw new Error('gate must not run after mid-gate abort')
+      }
+      let executeCalls = 0
+      session._executeToolBlock = async function ({ block, messageId }) {
+        executeCalls += 1
+        // Mirror the real emit so the dashboard bubble closes for the
+        // one block that actually ran (block 1).
+        this.emit('tool_result', {
+          messageId,
+          toolUseId: block.id,
+          result: 'ok',
+          isError: false,
+        })
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+              {
+                stop_reason: 'tool_use',
+                content: [
+                  { type: 'tool_use', id: 'tu_m1', name: 'Read', input: { file_path: '/a' } },
+                  { type: 'tool_use', id: 'tu_m2', name: 'Read', input: { file_path: '/b' } },
+                  { type: 'tool_use', id: 'tu_m3', name: 'Read', input: { file_path: '/c' } },
+                ],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            ),
+        },
+      }
+      await session.start()
+      await session.sendMessage('go')
+      // Mid-gate semantics preserved: block 1 ran exactly once; blocks
+      // 2/3 were synthetic-filled. The new inter-phase guard must NOT
+      // double-fill block 1 or skip its execution.
+      assert.equal(executeCalls, 1, 'only block 1 executes after mid-gate abort')
+      const userTurns = session._history.filter((m) => m.role === 'user' && Array.isArray(m.content))
+      const toolResultTurn = userTurns[userTurns.length - 1]
+      const ids = toolResultTurn.content.map((b) => b.tool_use_id)
+      assert.deepEqual(ids, ['tu_m1', 'tu_m2', 'tu_m3'], 'history order preserved')
+      assert.equal(toolResultTurn.content[0].is_error, false, 'block 1 is a real success')
+      assert.equal(toolResultTurn.content[1].is_error, true)
+      assert.equal(toolResultTurn.content[2].is_error, true)
+      assert.match(toolResultTurn.content[1].content, /[Ii]nterrupted/)
+      assert.match(toolResultTurn.content[2].content, /[Ii]nterrupted/)
+      await session.destroy()
+    })
+
+    it('still honours in-flight abort during phase 2 execution (regression guard for #4247 fix)', async () => {
+      // The third path: abort fires AFTER phase 2 has scheduled. The
+      // existing behavior is that executions that accepted the signal
+      // (Bash/Glob/Grep/WebFetch) can short-circuit; others run to
+      // completion. We don't change that — but we must prove the new
+      // inter-phase guard doesn't accidentally swallow this case
+      // either (e.g. by re-checking too aggressively and converting
+      // already-scheduled executions to synthetics).
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._gateToolBlock = async function ({ block }) {
+        return { behavior: 'allow', updatedInput: block.input || {} }
+      }
+      // Phase 2 executor that aborts FROM INSIDE itself (after
+      // scheduling), so the abort fires strictly during execution —
+      // not between phases. All three executor calls still happen
+      // because Promise.all already scheduled them when the first
+      // one began running.
+      let executeCalls = 0
+      let firstStarted
+      session._executeToolBlock = async function ({ block, messageId }) {
+        executeCalls += 1
+        if (executeCalls === 1) {
+          firstStarted = true
+          // Trip the abort once the parallel batch has begun. By this
+          // point all three executions are already in-flight (their
+          // promises were pushed in the for-loop before Promise.all
+          // awaited). The new inter-phase guard must NOT retroactively
+          // cancel them — they've passed the gate AND been scheduled.
+          this._abortController.abort()
+        }
+        this.emit('tool_result', { messageId, toolUseId: block.id, result: 'ok', isError: false })
+        return { type: 'tool_result', tool_use_id: block.id, content: 'ok', is_error: false }
+      }
+      session._client = {
+        messages: {
+          stream: () =>
+            fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }, { type: 'message_stop' }],
+              {
+                stop_reason: 'tool_use',
+                content: [
+                  { type: 'tool_use', id: 'tu_p1', name: 'Read', input: {} },
+                  { type: 'tool_use', id: 'tu_p2', name: 'Read', input: {} },
+                  { type: 'tool_use', id: 'tu_p3', name: 'Read', input: {} },
+                ],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            ),
+        },
+      }
+      await session.start()
+      await session.sendMessage('go')
+      assert.equal(firstStarted, true, 'phase 2 must have started — abort tested in-flight, not between phases')
+      assert.equal(executeCalls, 3,
+        'in-flight abort does not retroactively cancel already-scheduled phase-2 executions')
+      const userTurns = session._history.filter((m) => m.role === 'user' && Array.isArray(m.content))
+      const toolResultTurn = userTurns[userTurns.length - 1]
+      const ids = toolResultTurn.content.map((b) => b.tool_use_id)
+      assert.deepEqual(ids, ['tu_p1', 'tu_p2', 'tu_p3'])
+      // All three are real successes because the stub executor doesn't
+      // honour the signal (just like Read/Write/Edit/TodoWrite in
+      // production). The point is: no synthetic-fill kicked in for
+      // already-scheduled work.
+      for (const b of toolResultTurn.content) {
+        assert.equal(b.is_error, false, 'in-flight executions complete normally — no synthetic overwrite')
+      }
+      await session.destroy()
+    })
+
     it('executes parallel tool_use blocks concurrently — wall clock < sequential (#4062)', async () => {
       // Three Read tool_use blocks in one assistant turn. Each executor
       // sleeps 100ms. Sequential would take ~300ms; Promise.all should


### PR DESCRIPTION
## Summary

The parallelism refactor (#4062) split byok-session's tool orchestrator into a sequential gate phase and a parallel execute phase. The gate-loop's `signal.aborted` check only fires AT THE TOP of each iteration, so an abort that trips while the last gate is awaiting — or in the microtask window between phase 1 completing and `Promise.all` scheduling phase 2 — goes unobserved. Phase 2 then schedules every approved block, and write-side tools (Read, Write, Edit, TodoWrite) ignore the signal and run to completion AFTER the user pressed Stop. Pre-#4062 the sequential loop's bottom-of-iteration check caught this case; the refactor lost it.

This PR adds an inter-phase race guard in `_processToolBlocks` (`packages/server/src/byok-session.js`): after phase 1 completes successfully (every block gated), re-check `signal.aborted` before scheduling phase 2. If tripped, synthetic-fill every block via the extracted `fillInterrupted()` helper so:

- the #4061 history invariant holds (N `tool_use` -> N `tool_result`)
- the #4108 closing `tool_result` event fires for each bubble (no "running..." hang)
- no write-side tool runs after Stop

The mid-gate path (`firstUngatedIndex < N`) is preserved — block N's gate ran before the abort, so its execution still proceeds.

## Test plan

- [x] New byok-session test: abort fires between phase 1 and phase 2 (stub `_gateToolBlock` to allow all three blocks, abort at the end of gate 3). Asserts zero `_executeToolBlock` calls, three synthetic `tool_result` entries, three closing `tool_result` events, all marked `is_error` with "Interrupted" content. Fails pre-fix (3 executions instead of 0), passes post-fix.
- [x] Regression guard: abort during phase 1 (mid-gate). Asserts the existing synthetic-fill semantics — block 1 still executes, blocks 2/3 synthetic — are unchanged. Catches any future collapse of the two paths.
- [x] Regression guard: abort during in-flight phase 2. Already-scheduled executions complete normally; the new guard does not retroactively cancel them.
- [x] Full `packages/server/tests/byok-*.test.js` suite: 216/216 pass.

## Related

- #4062 — original parallelism refactor that opened the race
- #4061 — N `tool_use` -> N `tool_result` history invariant
- #4108 — closing `tool_result` event emission requirement

Closes #4247