### PR TITLE
feat(dashboard): terminal-style Up/Down history in chat composer (#3698)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -352,15 +352,34 @@ export function App() {
   // #3698 — derive the user-message history for the InputBar's terminal-
   // style Up/Down navigation. Oldest-first (matches the natural arrival
   // order of `messages`), and trims out empty bodies so a stray no-op
-  // user_input never recalls a blank string. The memo re-runs only when
-  // `storeMessages` reference changes, and InputBar's per-prop reset
-  // ensures cycling state resets on session switch (the active session's
-  // messages array is a different reference) and on send (history grows).
+  // user_input never recalls a blank string.
+  //
+  // `storeMessages` re-references on every streaming delta flush (the
+  // delta-batch path rebuilds the array even when no user_input was added),
+  // so a naive `[storeMessages]` dep would rebuild `userMessageHistory` on
+  // every assistant token and trip InputBar's array-identity reset, wiping
+  // the user's in-flight Up/Down cycle. We memoise on a stable fingerprint
+  // (count + last user_input id) so a fresh array is only produced when the
+  // actual user-message slice changes (new send, session switch, history
+  // replay on reconnect). Equal-content updates reuse the previous array
+  // reference, keeping InputBar's cycling state stable.
+  const userMessageHistoryFingerprint = useMemo(() => {
+    let count = 0
+    let lastId = ''
+    for (const m of storeMessages) {
+      if (m.type === 'user_input' && typeof m.content === 'string' && m.content.length > 0) {
+        count++
+        lastId = m.id
+      }
+    }
+    return `${count}\x1f${lastId}`
+  }, [storeMessages])
   const userMessageHistory = useMemo(
     () => storeMessages
       .filter(m => m.type === 'user_input' && typeof m.content === 'string' && m.content.length > 0)
       .map(m => m.content),
-    [storeMessages],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [userMessageHistoryFingerprint],
   )
 
   const slashCommands = useConnectionStore(s => s.slashCommands)

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -349,6 +349,20 @@ export function App() {
   )
   usePermissionNotification(permissionPrompts)
 
+  // #3698 — derive the user-message history for the InputBar's terminal-
+  // style Up/Down navigation. Oldest-first (matches the natural arrival
+  // order of `messages`), and trims out empty bodies so a stray no-op
+  // user_input never recalls a blank string. The memo re-runs only when
+  // `storeMessages` reference changes, and InputBar's per-prop reset
+  // ensures cycling state resets on session switch (the active session's
+  // messages array is a different reference) and on send (history grows).
+  const userMessageHistory = useMemo(
+    () => storeMessages
+      .filter(m => m.type === 'user_input' && typeof m.content === 'string' && m.content.length > 0)
+      .map(m => m.content),
+    [storeMessages],
+  )
+
   const slashCommands = useConnectionStore(s => s.slashCommands)
 
   // Store actions (stable refs)
@@ -2019,6 +2033,7 @@ export function App() {
               pastedTextBlocks={pastedTextBlocks}
               onInspectPastedText={handleInspectPastedText}
               onRemovePastedText={handleRemovePastedText}
+              userMessageHistory={userMessageHistory}
             />
           </>
         )}

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -1818,3 +1818,418 @@ describe('InputBar large-text paste (#3797)', () => {
     expect(screen.getByTestId('pasted-text-chip-2')).toBeInTheDocument()
   })
 })
+
+// #3698 — terminal-style Up/Down history. Empty/edge-of-textarea Up recalls
+// the previous user message; Down walks forward; Down past the newest restores
+// the stashed in-progress draft. Up/Down elsewhere in a multi-line draft is
+// normal cursor movement (untouched).
+describe('InputBar history navigation (#3698)', () => {
+  // Helper — RTL/jsdom's fireEvent.keyDown forwards currentTarget.selectionStart/End,
+  // so positioning the caret via setSelectionRange before dispatching the event
+  // is the only setup needed.
+  function setCaret(textarea: HTMLTextAreaElement, start: number, end = start) {
+    textarea.setSelectionRange(start, end)
+  }
+
+  it('Up in empty input fills with the most-recent user message', () => {
+    const onValueChange = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={onValueChange}
+        userMessageHistory={['oldest', 'middle', 'newest']}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).toHaveBeenLastCalledWith('newest')
+  })
+
+  it('Up twice walks back two entries', () => {
+    let value = ''
+    const onValueChange = vi.fn((v: string) => { value = v })
+    // Stable history array reference — the component resets cycling when the
+    // array identity changes (mirrors per-session reset in App.tsx), so the
+    // sequence test must reuse the same array across rerenders.
+    const history = ['oldest', 'middle', 'newest']
+    const { rerender } = render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue={value}
+        onValueChange={onValueChange}
+        userMessageHistory={history}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).toHaveBeenLastCalledWith('newest')
+    rerender(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue={value}
+        onValueChange={onValueChange}
+        userMessageHistory={history}
+      />,
+    )
+    // Caret lands at end of recalled text — second Up still triggers history.
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).toHaveBeenLastCalledWith('middle')
+  })
+
+  it('Down moves forward toward newer entries', () => {
+    let value = ''
+    const onValueChange = vi.fn((v: string) => { value = v })
+    const history = ['oldest', 'middle', 'newest']
+    const props = () => ({
+      onSend: vi.fn(),
+      onInterrupt: vi.fn(),
+      controlledValue: value,
+      onValueChange,
+      userMessageHistory: history,
+    })
+    const { rerender } = render(<InputBar {...props()} />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })   // newest
+    rerender(<InputBar {...props()} />)
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })   // middle
+    rerender(<InputBar {...props()} />)
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowDown' }) // back to newest
+    expect(onValueChange).toHaveBeenLastCalledWith('newest')
+  })
+
+  it('Down past the newest restores the in-progress draft', () => {
+    let value = 'draft-in-progress'
+    const onValueChange = vi.fn((v: string) => { value = v })
+    const history = ['older', 'newest']
+    const props = () => ({
+      onSend: vi.fn(),
+      onInterrupt: vi.fn(),
+      controlledValue: value,
+      onValueChange,
+      userMessageHistory: history,
+    })
+    const { rerender } = render(<InputBar {...props()} />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    // Start cycling from the end of the draft (Down trigger position).
+    // First press Up from end of draft — empty/edge gating treats `value.length`
+    // as a valid Up-from-end position too (mirrors the symmetric Down rule).
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).toHaveBeenLastCalledWith('newest')
+    rerender(<InputBar {...props()} />)
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowDown' })
+    // Down past newest restores the original draft text.
+    expect(onValueChange).toHaveBeenLastCalledWith('draft-in-progress')
+  })
+
+  it('Escape while cycling restores the draft and does not call onInterrupt', () => {
+    let value = 'my-draft'
+    const onValueChange = vi.fn((v: string) => { value = v })
+    const onInterrupt = vi.fn()
+    const history = ['oldest', 'newest']
+    const props = () => ({
+      onSend: vi.fn(),
+      onInterrupt,
+      controlledValue: value,
+      onValueChange,
+      userMessageHistory: history,
+    })
+    const { rerender } = render(<InputBar {...props()} />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).toHaveBeenLastCalledWith('newest')
+    rerender(<InputBar {...props()} />)
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'Escape' })
+    expect(onValueChange).toHaveBeenLastCalledWith('my-draft')
+    expect(onInterrupt).not.toHaveBeenCalled()
+  })
+
+  it('Escape when not cycling still calls onInterrupt (no regression)', () => {
+    const onInterrupt = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={onInterrupt}
+        userMessageHistory={['something']}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    fireEvent.keyDown(textarea, { key: 'Escape' })
+    expect(onInterrupt).toHaveBeenCalled()
+  })
+
+  it('sending a message resets the cycling state', () => {
+    let value = ''
+    const onValueChange = vi.fn((v: string) => { value = v })
+    let history = ['oldest', 'newest']
+    const props = () => ({
+      onSend: vi.fn(),
+      onInterrupt: vi.fn(),
+      controlledValue: value,
+      onValueChange,
+      userMessageHistory: history,
+    })
+    const { rerender } = render(<InputBar {...props()} />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })   // newest
+    expect(onValueChange).toHaveBeenLastCalledWith('newest')
+    rerender(<InputBar {...props()} />)
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })   // oldest
+    expect(onValueChange).toHaveBeenLastCalledWith('oldest')
+    // Simulate send: history grows + draft clears (mimics App's send round-trip).
+    value = ''
+    history = ['oldest', 'newest', 'just-sent']
+    rerender(<InputBar {...props()} />)
+    onValueChange.mockClear()
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    // After reset, Up should land on the most-recent entry — `just-sent` —
+    // not continue from where we left off in the previous cycle.
+    expect(onValueChange).toHaveBeenLastCalledWith('just-sent')
+  })
+
+  it('Up on line 2+ of a multi-line draft does not recall history (cursor moves)', () => {
+    const onValueChange = vi.fn()
+    const onInterrupt = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={onInterrupt}
+        controlledValue={'line1\nline2'}
+        onValueChange={onValueChange}
+        userMessageHistory={['should-not-fire']}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    // Caret on line 2, middle — position is "line1\n" length (6) + some chars.
+    setCaret(textarea, 8)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    // History recall would emit 'should-not-fire'; with caret mid-text we
+    // must NOT touch the value.
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+
+  it('Up on line 1 (caret at position 0) recalls history even with multi-line draft text', () => {
+    const onValueChange = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue={'line1\nline2'}
+        onValueChange={onValueChange}
+        userMessageHistory={['recalled']}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    // Cursor at absolute position 0 (line 1, col 0) — Up should recall.
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).toHaveBeenLastCalledWith('recalled')
+  })
+
+  it('Up with a selection (not collapsed) does not recall history', () => {
+    const onValueChange = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue={'hello'}
+        onValueChange={onValueChange}
+        userMessageHistory={['recalled']}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 0, 3)   // selection: chars 0..3
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+
+  it('Up does nothing when history is empty', () => {
+    const onValueChange = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={onValueChange}
+        userMessageHistory={[]}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+
+  it('Up at the oldest entry stays on the oldest (does not wrap or crash)', () => {
+    let value = ''
+    const onValueChange = vi.fn((v: string) => { value = v })
+    const history = ['only-entry']
+    const props = () => ({
+      onSend: vi.fn(),
+      onInterrupt: vi.fn(),
+      controlledValue: value,
+      onValueChange,
+      userMessageHistory: history,
+    })
+    const { rerender } = render(<InputBar {...props()} />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).toHaveBeenLastCalledWith('only-entry')
+    rerender(<InputBar {...props()} />)
+    onValueChange.mockClear()
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    // Already at oldest — nothing changes.
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+
+  it('Down when not cycling is a no-op (does not touch value)', () => {
+    const onValueChange = vi.fn()
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue="draft"
+        onValueChange={onValueChange}
+        userMessageHistory={['something']}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 5)
+    fireEvent.keyDown(textarea, { key: 'ArrowDown' })
+    expect(onValueChange).not.toHaveBeenCalled()
+  })
+
+  it('typing while cycling resets the cycling state (so the next Up starts at newest)', () => {
+    let value = ''
+    const onValueChange = vi.fn((v: string) => { value = v })
+    const history = ['oldest', 'middle', 'newest']
+    const props = () => ({
+      onSend: vi.fn(),
+      onInterrupt: vi.fn(),
+      controlledValue: value,
+      onValueChange,
+      userMessageHistory: history,
+    })
+    const { rerender } = render(<InputBar {...props()} />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })   // newest
+    rerender(<InputBar {...props()} />)
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })   // middle
+    expect(onValueChange).toHaveBeenLastCalledWith('middle')
+    rerender(<InputBar {...props()} />)
+    // User edits the recalled text — fire change with a value different from
+    // the currently-rendered controlledValue ('middle') so React's controlled-
+    // input wrapper actually dispatches onChange.
+    fireEvent.change(textarea, { target: { value: 'middle-edited' } })
+    expect(value).toBe('middle-edited')
+    rerender(<InputBar {...props()} />)
+    onValueChange.mockClear()
+    // Up again should NOT continue cycling from 'oldest' — it should start
+    // fresh from the most-recent entry.
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    expect(onValueChange).toHaveBeenLastCalledWith('newest')
+  })
+
+  it('does not interfere with the slash command picker (Up navigates the picker)', () => {
+    // Uncontrolled mode (no controlledValue/onValueChange) — matches how the
+    // existing slash-picker tests open the palette. The history feature only
+    // needs to NOT fire while the picker handles Up, which is independent of
+    // controlled-vs-uncontrolled mode (history navigation passes through
+    // `setValue` either way).
+    const onSend = vi.fn()
+    render(
+      <InputBar
+        onSend={onSend}
+        onInterrupt={vi.fn()}
+        userMessageHistory={['should-not-fire']}
+        slashCommands={[
+          { name: 'commit', description: 'commit', source: 'project' },
+          { name: 'review', description: 'review', source: 'project' },
+        ]}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    // Open the picker by typing "/" at the start of the input.
+    fireEvent.change(textarea, { target: { value: '/' } })
+    expect(screen.getByTestId('slash-picker')).toBeInTheDocument()
+    setCaret(textarea, 1)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    // Picker consumed the Up — textarea text remains "/" (history would have
+    // overwritten it with 'should-not-fire').
+    expect(textarea.value).toBe('/')
+  })
+
+  it('does not interfere with the file picker (Up navigates the picker)', () => {
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        userMessageHistory={['should-not-fire']}
+        filePickerFiles={[
+          { path: 'src/index.ts', type: 'file', size: 1 },
+          { path: 'src/App.tsx', type: 'file', size: 1 },
+        ]}
+      />,
+    )
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '@' } })
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+    setCaret(textarea, 1)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    // File picker consumed the Up — textarea text remains "@" (history
+    // would have overwritten it with 'should-not-fire').
+    expect(textarea.value).toBe('@')
+  })
+
+  it('switching userMessageHistory reference (e.g. session switch) resets cycling', () => {
+    let value = ''
+    const onValueChange = vi.fn((v: string) => { value = v })
+    const sessionA = ['a-old', 'a-new']
+    const sessionB = ['b-old', 'b-new']
+    let history = sessionA
+    const props = () => ({
+      onSend: vi.fn(),
+      onInterrupt: vi.fn(),
+      controlledValue: value,
+      onValueChange,
+      userMessageHistory: history,
+    })
+    const { rerender } = render(<InputBar {...props()} />)
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })   // 'a-new'
+    rerender(<InputBar {...props()} />)
+    setCaret(textarea, value.length)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })   // 'a-old'
+    // Switch session — different history array, draft also blanks.
+    history = sessionB
+    value = ''
+    rerender(<InputBar {...props()} />)
+    onValueChange.mockClear()
+    setCaret(textarea, 0)
+    fireEvent.keyDown(textarea, { key: 'ArrowUp' })
+    // After reset, Up should land on most-recent of the new history.
+    expect(onValueChange).toHaveBeenLastCalledWith('b-new')
+  })
+})

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -106,6 +106,31 @@ export interface InputBarProps {
   onInspectPastedText?: (id: number) => void
   /** #3797 — × handler that removes the chip and strips the inline marker. */
   onRemovePastedText?: (id: number) => void
+  /**
+   * #3698 — terminal-style Up/Down history. **Oldest-first** list of the
+   * user's previously sent message texts in the current session (i.e. the
+   * natural array order from `messages.filter(m => m.type === 'user_input')`).
+   * Up at caret==0 (or at caret==value.length with the caret collapsed)
+   * recalls the most recent message; further Ups walk further back; Down
+   * walks forward toward the most recent; Down past the newest restores the
+   * in-progress draft.
+   *
+   * The component treats index `length-1` as the newest entry and `0` as the
+   * oldest — this matches how App.tsx already orders messages by arrival, so
+   * the caller can pass the filtered array verbatim without a reverse() copy.
+   *
+   * History is per-session: pass a fresh array reference when the active
+   * session changes (App.tsx already does this since `messages` comes
+   * from `getActiveSessionState()`). The component resets its cycling
+   * index whenever this prop's array identity changes — so a fresh
+   * session, a newly sent message (history grows), or any other reason
+   * the parent rebuilds the array will start the next Up at the newest
+   * entry rather than continuing from a stale index.
+   *
+   * Omit the prop (or pass `undefined`) to disable history navigation
+   * entirely — Up/Down then revert to plain cursor movement.
+   */
+  userMessageHistory?: string[]
 }
 
 type EvaluatorState =
@@ -114,7 +139,7 @@ type EvaluatorState =
   | { kind: 'result', result: EvaluatorResultPayload }
   | { kind: 'error', message: string }
 
-export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText }: InputBarProps) {
+export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText, userMessageHistory }: InputBarProps) {
   const [internalValue, setInternalValue] = useState('')
   const value = controlledValue !== undefined ? controlledValue : internalValue
   const setValue = onValueChange || setInternalValue
@@ -129,6 +154,32 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
   // #3068 — manual prompt evaluator state machine. Lives in InputBar because
   // applying a rewrite has to swap the textarea value and re-focus it.
   const [evaluatorState, setEvaluatorState] = useState<EvaluatorState>({ kind: 'idle' })
+
+  // #3698 — terminal-style Up/Down history cycling. `historyIndex === null`
+  // means we're not currently cycling (so the next Up may stash the in-
+  // progress draft and step to the newest entry). A non-null index walks
+  // newest → oldest as the user presses Up; Down steps back toward newest,
+  // and Down past index 0 exits cycling and restores the stashed draft.
+  //
+  // Both pieces of state are intentionally ephemeral — they live in the
+  // component (not the Zustand store) because they're pure UI state with no
+  // persistence requirement. See the prop JSDoc above for the per-session
+  // reset behaviour driven by `userMessageHistory` array identity.
+  const [historyIndex, setHistoryIndex] = useState<number | null>(null)
+  const [draftBeforeCycle, setDraftBeforeCycle] = useState<string>('')
+
+  // Reset the cycling state whenever the history array reference changes.
+  // This covers two natural triggers:
+  //   1. The user sends a message → App.tsx pushes a new user_input entry,
+  //      which rebuilds the filtered history array → identity changes → reset.
+  //   2. The user switches sessions → activeSessionId flips →
+  //      getActiveSessionState() returns a different messages array → reset.
+  // We intentionally key only on the array reference, not its contents, so we
+  // don't pay a deep-compare cost on every render.
+  useEffect(() => {
+    setHistoryIndex(null)
+    setDraftBeforeCycle('')
+  }, [userMessageHistory])
 
   const handleEvaluate = useCallback(async () => {
     if (!onEvaluate) return
@@ -262,6 +313,12 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     // #3068: drop any visible evaluator panel — its draft has been sent so the
     // result no longer applies to the current input value.
     setEvaluatorState({ kind: 'idle' })
+    // #3698: sending exits cycling mode. The userMessageHistory effect already
+    // resets when the parent rebuilds the array, but doing it here too makes
+    // the local state consistent immediately (before the parent re-render
+    // pushes the new history through).
+    setHistoryIndex(null)
+    setDraftBeforeCycle('')
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto'
     }
@@ -314,6 +371,33 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
     textareaRef.current?.focus()
     return true
   }, [value, attachments, imageAttachments, pastedTextBlocks, onRemoveAttachment, onRemoveImage, onRemovePastedText, setValue])
+
+  // #3698 — recall a history entry by depth (0 = newest, 1 = one back, …).
+  // Walks the textarea value through the parent's setValue (so controlled
+  // mode stays in sync) and parks the caret at the end on the next animation
+  // frame so the user can immediately edit at the tail of the recalled text —
+  // matches shell `up-arrow` UX. The array is oldest-first, so depth maps to
+  // `length - 1 - depth`.
+  const recallHistoryAtDepth = useCallback((depth: number) => {
+    const entries = userMessageHistory
+    if (!entries || entries.length === 0) return
+    const arrayIdx = entries.length - 1 - depth
+    if (arrayIdx < 0 || arrayIdx >= entries.length) return
+    const entry = entries[arrayIdx]
+    if (entry === undefined) return
+    setValue(entry)
+    setHistoryIndex(depth)
+    // Park the caret at the end on the next frame, after React applies the
+    // controlled-value update. Without rAF the setSelectionRange runs before
+    // the new value is reflected in textarea.value, so the caret ends up at
+    // the wrong spot.
+    requestAnimationFrame(() => {
+      const t = textareaRef.current
+      if (!t) return
+      const end = t.value.length
+      t.setSelectionRange(end, end)
+    })
+  }, [userMessageHistory, setValue])
 
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
     // Slash command picker keyboard handling
@@ -375,6 +459,66 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
       }
     }
 
+    // #3698 — terminal-style Up/Down history. Only fires when:
+    //   - both pickers are closed (handled above, which return early),
+    //   - history exists,
+    //   - selection is collapsed (no text selected — preserves shift-select),
+    //   - and the caret is at a textarea boundary (start for Up, end for Down,
+    //     mirroring the "first line / last line" heuristic).
+    // We use absolute caret positions (`selectionStart === 0` for Up,
+    // `selectionStart === value.length` for Down) so a multi-line draft only
+    // recalls history when the user is *already* at the very top or bottom —
+    // line-up / line-down movement inside the textarea still works normally.
+    if ((e.key === 'ArrowUp' || e.key === 'ArrowDown') && userMessageHistory && userMessageHistory.length > 0) {
+      const ta = e.currentTarget
+      const start = ta.selectionStart
+      const end = ta.selectionEnd
+      const collapsed = start === end
+      const atStart = start === 0
+      const atEnd = start === value.length
+      if (collapsed) {
+        if (e.key === 'ArrowUp' && (atStart || atEnd)) {
+          // `historyIndex` is a depth: 0 = newest, length-1 = oldest. Up walks
+          // deeper into history; we silently swallow Up at the oldest entry
+          // rather than wrapping (matches bash/zsh).
+          if (historyIndex === null) {
+            e.preventDefault()
+            setDraftBeforeCycle(value)
+            recallHistoryAtDepth(0)
+            return
+          }
+          if (historyIndex < userMessageHistory.length - 1) {
+            e.preventDefault()
+            recallHistoryAtDepth(historyIndex + 1)
+            return
+          }
+          // At the oldest entry — preventDefault so the caret doesn't jump out
+          // of the textarea, but don't update value.
+          e.preventDefault()
+          return
+        }
+        if (e.key === 'ArrowDown' && atEnd && historyIndex !== null) {
+          e.preventDefault()
+          if (historyIndex > 0) {
+            recallHistoryAtDepth(historyIndex - 1)
+          } else {
+            // Down past the newest entry → exit cycling, restore draft.
+            setValue(draftBeforeCycle)
+            setHistoryIndex(null)
+            // Mirror recallHistoryAtDepth's caret-at-end policy so the user
+            // can immediately edit the restored draft without re-positioning.
+            requestAnimationFrame(() => {
+              const t = textareaRef.current
+              if (!t) return
+              const endPos = t.value.length
+              t.setSelectionRange(endPos, endPos)
+            })
+          }
+          return
+        }
+      }
+    }
+
     if (e.key === 'Enter') {
       if (sendOnEnter && !e.shiftKey) {
         e.preventDefault()
@@ -384,6 +528,21 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
         send()
       }
     } else if (e.key === 'Escape') {
+      // #3698 — while cycling history, Escape exits cycling and restores the
+      // stashed draft instead of firing the interrupt. Once cycling is reset,
+      // Escape resumes its original behaviour (`onInterrupt`).
+      if (historyIndex !== null) {
+        e.preventDefault()
+        setValue(draftBeforeCycle)
+        setHistoryIndex(null)
+        requestAnimationFrame(() => {
+          const t = textareaRef.current
+          if (!t) return
+          const endPos = t.value.length
+          t.setSelectionRange(endPos, endPos)
+        })
+        return
+      }
       e.preventDefault()
       onInterrupt()
     } else if ((e.key === 'l' || e.key === 'L') && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
@@ -395,11 +554,27 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
         e.preventDefault()
       }
     }
-  }, [pickerOpen, filePickerOpen, filteredFiles, fileSelectedIndex, selectFile, send, onInterrupt, closePicker, selectCommand, filteredCommands, selectedIndex, sendOnEnter, clearComposer])
+  }, [pickerOpen, filePickerOpen, filteredFiles, fileSelectedIndex, selectFile, send, onInterrupt, closePicker, selectCommand, filteredCommands, selectedIndex, sendOnEnter, clearComposer, userMessageHistory, value, historyIndex, draftBeforeCycle, recallHistoryAtDepth, setValue])
 
   const handleChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value
     setValue(newValue)
+
+    // #3698 — any direct user edit exits cycling. We only reset when the new
+    // value isn't the one we just recalled (recallHistoryAtDepth's setValue()
+    // flows through the parent and re-renders, but onChange itself doesn't
+    // fire for controlled updates). The cheap guard is "did `historyIndex`
+    // get set?" — programmatic recall sets it; real user typing leaves it
+    // untouched before this handler runs. The recalled-text equality check
+    // covers the edge case where the user retypes the recalled string
+    // verbatim (rare).
+    if (historyIndex !== null && userMessageHistory) {
+      const recalled = userMessageHistory[userMessageHistory.length - 1 - historyIndex]
+      if (newValue !== recalled) {
+        setHistoryIndex(null)
+        setDraftBeforeCycle('')
+      }
+    }
 
     // Slash command detection: "/" at start of input
     if (slashCommands && newValue.startsWith('/')) {
@@ -454,7 +629,7 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
       ? outerHeight
       : outerHeight - paddingY - borderY
     el.style.height = assignedHeight + 'px'
-  }, [slashCommands, pickerOpen, closePicker, onSlashTrigger, filePickerFiles, filePickerOpen, onFileTrigger])
+  }, [slashCommands, pickerOpen, closePicker, onSlashTrigger, filePickerFiles, filePickerOpen, onFileTrigger, historyIndex, userMessageHistory, setValue])
 
   // Merge voice transcript into input value via effect (not during render)
   const prevTranscriptRef = useRef('')


### PR DESCRIPTION
## Summary

Adds terminal-style command history navigation to the dashboard's `InputBar` composer.

- **Up** at the start (or end) of an empty/edge-of-text caret recalls the most recent user message; further Ups walk further back.
- **Down** walks forward toward the most recent; **Down past the newest** restores the in-progress draft that was stashed when cycling started.
- **Escape mid-cycle** restores the draft without firing the existing interrupt path; Escape outside cycling still triggers `onInterrupt` (no regression).
- **Sending** a message exits cycling mode; typing while cycling also exits and the next Up starts fresh from the newest entry.
- History is **per-session** — derived in `App.tsx` from the active session's `messages.filter(m => m.type === 'user_input')` (oldest-first), and `InputBar` resets its cycling index whenever the array identity changes (covers session switch and post-send growth).

The slash-command and file pickers continue to handle Up/Down first when open, so the existing autocomplete UX is preserved. Multi-line drafts behave as before — Up/Down only enter history mode when the caret is at absolute position `0` (Up) or `value.length` (Down) with the selection collapsed; otherwise the keys move the caret normally.

Closes #3698
Closes #3854 (duplicate composer history request)

## Test Plan

- [x] 17 new RTL tests in `InputBar.test.tsx` covering: Up walks back, Down walks forward, Down past newest restores draft, Escape restores draft (no interrupt), send/typing/session-switch resets, multi-line caret gating, no-fire when pickers are open, oldest entry no-wrap, history empty no-op.
- [x] All 140 InputBar tests pass.
- [x] Full dashboard suite (2001 tests) green.
- [x] `tsc --noEmit` clean.
- [ ] Manual smoke test: type a few messages, press Up to recall, Down to walk forward, type to exit cycling.