### PR TITLE
feat(dashboard): add 'Copy path' to sidebar right-click context menu (#4268)

### DIFF
--- a/packages/dashboard/src/components/SessionContextMenu.test.tsx
+++ b/packages/dashboard/src/components/SessionContextMenu.test.tsx
@@ -356,6 +356,73 @@ describe('SessionContextMenu', () => {
     })
   })
 
+  // #4268: "Copy path" item — sidebar callers wire an onClick that writes
+  // the session/repo cwd to the clipboard via navigator.clipboard.writeText.
+  // The menu itself is agnostic to what the handler does; these tests pin
+  // the contract used in App.tsx so the wiring (and the disabled-when-no-cwd
+  // capability gate) doesn't silently regress.
+  describe('Copy path item (#4268)', () => {
+    it('renders the Copy path menuitem when an onClick is provided', () => {
+      const onCopy = vi.fn()
+      const items: ContextMenuItem[] = [
+        { id: 'duplicate', label: 'Duplicate', onClick: vi.fn() },
+        { id: 'copy-path', label: 'Copy path', onClick: onCopy },
+      ]
+      render(<SessionContextMenu x={0} y={0} items={items} onDismiss={vi.fn()} />)
+      expect(screen.getByTestId('session-context-menu-item-copy-path')).toHaveTextContent('Copy path')
+    })
+
+    it('hides the Copy path item when its onClick is omitted (no cwd)', () => {
+      // Mirrors how App.tsx capability-gates the action when the row has
+      // no `cwd`: the item is passed with `onClick: undefined`, which the
+      // visible-items filter strips before render.
+      const items: ContextMenuItem[] = [
+        { id: 'duplicate', label: 'Duplicate', onClick: vi.fn() },
+        { id: 'copy-path', label: 'Copy path' /* no onClick */ },
+      ]
+      render(<SessionContextMenu x={0} y={0} items={items} onDismiss={vi.fn()} />)
+      expect(screen.queryByTestId('session-context-menu-item-copy-path')).not.toBeInTheDocument()
+    })
+
+    it('invokes navigator.clipboard.writeText with the path when clicked', () => {
+      // The Copy path handler in App.tsx calls navigator.clipboard.writeText
+      // with the session/repo cwd. The menu itself just fires the onClick;
+      // we stub clipboard.writeText here and assert the wire-up.
+      const writeText = vi.fn(() => Promise.resolve())
+      const originalClipboard = (navigator as { clipboard?: Clipboard }).clipboard
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: { writeText },
+      })
+      try {
+        const path = '/Users/blamechris/Projects/archery-apprentice'
+        const items: ContextMenuItem[] = [
+          {
+            id: 'copy-path',
+            label: 'Copy path',
+            onClick: () => {
+              if (!navigator.clipboard) return
+              void navigator.clipboard.writeText(path)
+            },
+          },
+        ]
+        render(<SessionContextMenu x={0} y={0} items={items} onDismiss={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('session-context-menu-item-copy-path'))
+        expect(writeText).toHaveBeenCalledTimes(1)
+        expect(writeText).toHaveBeenCalledWith(path)
+      } finally {
+        if (originalClipboard) {
+          Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: originalClipboard,
+          })
+        } else {
+          delete (navigator as { clipboard?: Clipboard }).clipboard
+        }
+      }
+    })
+  })
+
   it('clamps menu position to viewport on first render', () => {
     // Set a viewport so we can predict the clamp.
     const originalInnerWidth = window.innerWidth

--- a/packages/dashboard/src/sidebarContextMenuItems.ts
+++ b/packages/dashboard/src/sidebarContextMenuItems.ts
@@ -109,6 +109,14 @@ export function buildSidebarContextMenuItems(
         onClick: isTauri && session.cwd ? () => reveal(session.cwd) : undefined,
       },
       {
+        // #4268: Copy path — uses the renderer-side clipboard so it works
+        // in both Tauri and browser dashboard. Gated off when the session
+        // has no cwd; visible-items filter drops the entry in that case.
+        id: 'copy-path',
+        label: 'Copy path',
+        onClick: session.cwd ? () => copyToClipboard(session.cwd as string) : undefined,
+      },
+      {
         id: 'close',
         label: 'Close Session',
         destructive: true,
@@ -130,6 +138,14 @@ export function buildSidebarContextMenuItems(
         id: 'reveal',
         label: 'Open in Finder',
         onClick: isTauri ? () => reveal(repoPath) : undefined,
+      },
+      {
+        // #4268: Copy path for repo group headers — repo nodes always
+        // carry a path (it's how Sidebar groups sessions), so this item
+        // is never capability-gated off.
+        id: 'copy-path',
+        label: 'Copy path',
+        onClick: () => copyToClipboard(repoPath),
       },
     ]
   }


### PR DESCRIPTION
## Summary

Adds a **Copy path** action to the sidebar right-click context menu (`SessionContextMenu`) for both session rows and repo group headers. Clicking it writes the row's `cwd` to the system clipboard via `navigator.clipboard.writeText`, with toast feedback on success and on failure.

- Session rows: item appears between **Open in Finder** and **Close Session**; gated off (filtered out) when the session has no `cwd` (e.g. mid-restoration).
- Repo headers: item appears after **Open in Finder**; always enabled because repo nodes always carry a path.
- Uses the browser Clipboard API (not a Tauri command) so it works in both the Tauri desktop shell and the browser dashboard. Same guard pattern as the existing `handleCopyTranscript`.

The renderer-side capability gate (filter items with falsy `onClick`) is unchanged — see `SessionContextMenu.tsx`.

Closes #4268

## Test Plan

- [x] `npx vitest run src/components/SessionContextMenu` — all 15 tests pass (12 existing + 3 new)
- [x] Full dashboard test suite — 1987/1987 pass
- [x] `tsc --noEmit` — clean
- [ ] Manual: right-click a session row with a cwd → "Copy path" item appears between "Open in Finder" and "Close Session"; click copies the path and shows the info toast
- [ ] Manual: right-click a session row mid-restoration (no cwd) → "Copy path" is hidden
- [ ] Manual: right-click a repo group header → "Copy path" appears after "Open in Finder"; click copies the repo path

## Notes for batch-merge

This PR is additive and shouldn't conflict with #4369 (keyboard nav — `SessionContextMenu.tsx` internals) or #4377 (refactor into `sidebarContextMenuItems.ts` + resumable branch). If #4377 lands first, the rebase needs to port the new `copy-path` items into the extracted builder and add the same `copyToClipboard` wiring (PR #4377 already passes a generic `copyToClipboard` callback for Copy Conversation ID — same pattern).