### PR TITLE
fix(dashboard): add aria-orientation=vertical to SessionContextMenu (#4373)

### DIFF
--- a/packages/dashboard/src/components/SessionContextMenu.test.tsx
+++ b/packages/dashboard/src/components/SessionContextMenu.test.tsx
@@ -176,6 +176,18 @@ describe('SessionContextMenu', () => {
       expect(close).toHaveAttribute('role', 'menuitem')
     })
 
+    // #4373: WAI-ARIA Authoring Practices recommend declaring the menu's
+    // orientation explicitly when it responds to vertical arrow keys (which
+    // ours does, after #4369). aria-orientation="vertical" tells assistive
+    // tech how the arrow-key navigation maps to spatial layout.
+    it('sets aria-orientation="vertical" on the menu container (#4373)', () => {
+      render(
+        <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,
+      )
+      const menu = screen.getByTestId('session-context-menu')
+      expect(menu).toHaveAttribute('aria-orientation', 'vertical')
+    })
+
     it('focuses the first item on mount', () => {
       render(
         <SessionContextMenu x={0} y={0} items={makeItems()} onDismiss={vi.fn()} />,

--- a/packages/dashboard/src/components/SessionContextMenu.tsx
+++ b/packages/dashboard/src/components/SessionContextMenu.tsx
@@ -169,6 +169,10 @@ export function SessionContextMenu({
       className="session-context-menu"
       data-testid="session-context-menu"
       role="menu"
+      // #4373: WAI-ARIA Authoring Practices recommend declaring orientation
+      // explicitly for menus that respond to vertical arrow keys (we wire
+      // ArrowUp/ArrowDown to roving focus in the keyDown handler below).
+      aria-orientation="vertical"
       style={{
         position: 'fixed',
         left: initialLeft,


### PR DESCRIPTION
## Summary

Adds `aria-orientation="vertical"` to the `<ul role="menu">` in `SessionContextMenu`. The menu wires ArrowUp/ArrowDown to roving focus (#4248, #4369), so WAI-ARIA Authoring Practices recommend declaring the orientation explicitly — without it, assistive tech falls back to its own default and may announce the wrong navigation affordance.

## Changes

- `packages/dashboard/src/components/SessionContextMenu.tsx` — one-line attribute on the menu container with a comment pointing to the #4248/#4369 keyboard-nav wiring.
- `packages/dashboard/src/components/SessionContextMenu.test.tsx` — test asserts `getByTestId('session-context-menu')` carries `aria-orientation="vertical"`.

## Test plan

- [x] `npm test -- --run` in `packages/dashboard` (2059 tests pass, including the new RED-then-GREEN assertion)
- [x] `npm run typecheck` in `packages/dashboard` (clean)
- [x] No visual / styling change — `aria-orientation` is announced by screen readers only

Closes #4373