### PR TITLE
fix(dashboard): focus sidebar row before opening context menu (#4372)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -1083,16 +1083,53 @@ describe('App', () => {
       const row = screen.getByTestId('session-item-s1')
       fireEvent.contextMenu(row)
       // Sanity: the menu is open and its first item should be focused.
-      expect(screen.getByRole('menu')).toBeInTheDocument()
+      const menu = screen.getByRole('menu')
+      expect(menu).toBeInTheDocument()
 
       // Esc dismisses the menu. SessionContextMenu listens at document scope
-      // for keydown — fire on the menu element so the event bubbles.
-      fireEvent.keyDown(document, { key: 'Escape' })
+      // for keydown today; firing on the menu element (rather than directly
+      // on `document`) lets the event bubble through the standard user-facing
+      // path, so this test stays green if the listener is later scoped to
+      // the menu itself.
+      fireEvent.keyDown(menu, { key: 'Escape' })
 
       // The menu should be gone, and focus restored to the row (NOT the
       // textarea, which would indicate the pre-#4372 bug).
       expect(screen.queryByRole('menu')).not.toBeInTheDocument()
       expect(document.activeElement).toBe(row)
+    })
+
+    // Parallel to the session-row case above, but for repo headers — the
+    // case the first pass of #4372 missed because the onContextMenu listener
+    // used to be on the inner `.sidebar-repo-header` (no tabIndex, no role)
+    // instead of the outer `.sidebar-repo` treeitem. Without the Sidebar
+    // structural fix, this test would fail: focus would stay on the textarea
+    // (because focus() on the unfocusable header is a no-op) and Esc would
+    // land focus on document.body or the textarea, not the treeitem.
+    it('returns focus to the repo treeitem when the menu is dismissed (Esc)', () => {
+      stateOverrides = connectedState
+      render(<App />)
+      const textarea = screen.getByRole('textbox', { name: /message input/i }) as HTMLTextAreaElement
+      textarea.focus()
+      expect(document.activeElement).toBe(textarea)
+
+      // App derives repos from sessions; our s1 session cwd is /tmp/repo,
+      // which produces a `repo-header-/tmp/repo` testid on the header.
+      const header = screen.getByTestId('repo-header-/tmp/repo')
+      const treeitem = header.closest('[role="treeitem"]') as HTMLElement | null
+      expect(treeitem).not.toBeNull()
+
+      // Right-click on the inner header. The listener now lives on the
+      // outer treeitem, so the contextmenu event bubbles up and the
+      // handler's event.currentTarget is the focusable treeitem.
+      fireEvent.contextMenu(header)
+      const menu = screen.getByRole('menu')
+      expect(menu).toBeInTheDocument()
+
+      fireEvent.keyDown(menu, { key: 'Escape' })
+
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      expect(document.activeElement).toBe(treeitem)
     })
   })
 })

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -1037,4 +1037,62 @@ describe('App', () => {
       expect(screen.getByTestId('pasted-text-chips')).toBeInTheDocument()
     })
   })
+
+  // #4372 — a11y: handleSidebarContextMenu must move focus to the row before
+  // opening the SessionContextMenu. PR #4369 added focus restoration on
+  // menu unmount that returns focus to whatever was document.activeElement
+  // at open time; a right-click does not move focus by default, so without
+  // this the captured "trigger" is whatever was last clicked (often the
+  // composer textarea) and Esc lands focus there, not on the row.
+  describe('right-click focuses the sidebar row before opening the menu (#4372)', () => {
+    const connectedState = {
+      connectionPhase: 'connected' as const,
+      sessions: [
+        { sessionId: 's1', name: 'Alpha', cwd: '/tmp/repo', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null },
+      ],
+      activeSessionId: 's1',
+    }
+
+    it('calls focus() on the right-clicked row before opening the menu', () => {
+      // We can't assert `document.activeElement === row` after the contextMenu
+      // event finishes — SessionContextMenu's mount effect focuses its first
+      // item, so by the time the assertion runs the menu has stolen focus.
+      // What we *can* pin down is that the handler invokes `focus()` on the
+      // row element itself (so SessionContextMenu's mount-effect capture of
+      // `document.activeElement` lands on the row). Spy on the row's focus.
+      stateOverrides = connectedState
+      render(<App />)
+      const row = screen.getByTestId('session-item-s1')
+      const focusSpy = vi.spyOn(row, 'focus')
+      fireEvent.contextMenu(row)
+      expect(focusSpy).toHaveBeenCalled()
+    })
+
+    it('returns focus to the row when the menu is dismissed (Esc)', () => {
+      // End-to-end: the user right-clicks the row from the composer textarea,
+      // navigates the menu, then dismisses with Esc. PR #4369 added the
+      // focus-restoration cleanup; #4372 ensures the *captured* trigger is
+      // the row (not the composer) by focusing it first in the handler. We
+      // assert both halves: the menu opens, then Esc lands focus on the row.
+      stateOverrides = connectedState
+      render(<App />)
+      const textarea = screen.getByRole('textbox', { name: /message input/i }) as HTMLTextAreaElement
+      textarea.focus()
+      expect(document.activeElement).toBe(textarea)
+
+      const row = screen.getByTestId('session-item-s1')
+      fireEvent.contextMenu(row)
+      // Sanity: the menu is open and its first item should be focused.
+      expect(screen.getByRole('menu')).toBeInTheDocument()
+
+      // Esc dismisses the menu. SessionContextMenu listens at document scope
+      // for keydown — fire on the menu element so the event bubbles.
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      // The menu should be gone, and focus restored to the row (NOT the
+      // textarea, which would indicate the pre-#4372 bug).
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument()
+      expect(document.activeElement).toBe(row)
+    })
+  })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -565,7 +565,15 @@ export function App() {
   // #4045: sidebar right-click context menu open + dismiss handlers. The
   // open path stashes the click target + viewport coordinates so the
   // SessionContextMenu can render at the cursor. Dismiss clears state.
+  // #4372: move focus to the row before opening the menu. A right-click
+  // does not move focus by default, so without this the SessionContextMenu's
+  // `previouslyFocused` capture (PR #4369) lands on whatever the user last
+  // clicked (often the composer textarea) and Esc returns focus there
+  // instead of to the row.
   const handleSidebarContextMenu = useCallback((target: ContextMenuTarget, event: React.MouseEvent) => {
+    if (event.currentTarget instanceof HTMLElement) {
+      event.currentTarget.focus()
+    }
     setSidebarContextMenu({ target, x: event.clientX, y: event.clientY })
   }, [])
   const dismissSidebarContextMenu = useCallback(() => {

--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -379,6 +379,39 @@ describe('Sidebar', () => {
       fireEvent.contextMenu(row)
       expect(document.activeElement).toBe(row)
     })
+
+    // Repo headers are the case the original PR missed: the onContextMenu
+    // listener used to be bound to the inner `.sidebar-repo-header` div
+    // (no tabIndex, no role) — so event.currentTarget.focus() was a no-op
+    // and document.activeElement stayed on <body>. The fix moves the
+    // listener up to the outer `.sidebar-repo` treeitem wrapper, which
+    // owns the roving tabIndex. This test asserts:
+    //   (a) onContextMenu receives the outer treeitem as currentTarget
+    //       even when the right-click originates on the inner header,
+    //   (b) the App-style `currentTarget.focus()` actually lands focus
+    //       on the outer treeitem.
+    it('focuses the outer treeitem when the user right-clicks a repo header', () => {
+      const observed: { currentTarget: EventTarget | null } = { currentTarget: null }
+      const onContextMenu = vi.fn((_target, event: React.MouseEvent) => {
+        observed.currentTarget = event.currentTarget
+        if (event.currentTarget instanceof HTMLElement) {
+          event.currentTarget.focus()
+        }
+      })
+      renderSidebar({ onContextMenu })
+      const header = screen.getByTestId('repo-header-/home/user/projects/api')
+      const treeitem = header.closest('[role="treeitem"]') as HTMLElement | null
+      expect(treeitem).not.toBeNull()
+      // Sanity: nothing focused yet.
+      expect(document.activeElement).not.toBe(treeitem)
+      // Right-click on the inner header — bubbles to the outer treeitem,
+      // which is where the listener now lives. currentTarget should be the
+      // outer treeitem (not the header), and focus() should land there.
+      fireEvent.contextMenu(header)
+      expect(onContextMenu).toHaveBeenCalledTimes(1)
+      expect(observed.currentTarget).toBe(treeitem)
+      expect(document.activeElement).toBe(treeitem)
+    })
   })
 
   describe('stdin forwarding disabled badge (#3567)', () => {

--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Sidebar component tests (#1102)
  */
+import type React from 'react'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { Sidebar, type SidebarProps, type RepoNode } from './Sidebar'
@@ -310,6 +311,74 @@ describe('Sidebar', () => {
   it('shows Running label when server is connected', () => {
     renderSidebar({ serverStatus: 'connected' })
     expect(screen.getByTestId('sidebar-footer')).toHaveTextContent('Running')
+  })
+
+  // #4372: a11y — focus the right-clicked sidebar row before opening the
+  // SessionContextMenu so unmount focus-restoration lands back on the row
+  // (a right-click does not move focus by default).
+  describe('right-click focus on sidebar rows (#4372)', () => {
+    it('renders session rows with tabIndex (focusable)', () => {
+      renderSidebar()
+      // The active session row owns tabIndex=0; others sit at -1 (roving
+      // tabindex). What matters for #4372 is that the row is *focusable*
+      // (tabIndex is set, not absent), so the App handler's .focus() call
+      // can actually move focus to it.
+      const row = screen.getByTestId('session-item-s1')
+      expect(row).toHaveAttribute('tabindex')
+      expect(Number(row.getAttribute('tabindex'))).toBeGreaterThanOrEqual(-1)
+    })
+
+    it('renders repo header rows with tabIndex (focusable)', () => {
+      renderSidebar()
+      const repoTreeitem = screen
+        .getByTestId('repo-header-/home/user/projects/api')
+        .closest('[role="treeitem"]')
+      expect(repoTreeitem).not.toBeNull()
+      expect(repoTreeitem).toHaveAttribute('tabindex')
+    })
+
+    it('renders resumable rows with tabIndex (focusable)', () => {
+      renderSidebar()
+      const row = screen.getByTestId('resumable-item-c1')
+      expect(row).toHaveAttribute('tabindex')
+    })
+
+    it('passes the right-clicked row as event.currentTarget to onContextMenu', () => {
+      // The App-level handler will call event.currentTarget.focus() before
+      // opening the menu. We assert that the event handed to onContextMenu
+      // has the *row* (the element bound to the listener) as currentTarget,
+      // not some descendant — otherwise focusing currentTarget would target
+      // an unfocusable child. NB: React pools the event after the handler
+      // returns, so we must read currentTarget synchronously inside the
+      // listener.
+      let observed: EventTarget | null = null
+      const onContextMenu = vi.fn((_target, event: React.MouseEvent) => {
+        observed = event.currentTarget
+      })
+      renderSidebar({ onContextMenu })
+      const row = screen.getByTestId('session-item-s1')
+      fireEvent.contextMenu(row)
+      expect(onContextMenu).toHaveBeenCalledTimes(1)
+      expect(observed).toBe(row)
+    })
+
+    it('focuses the row when the App-style handler runs on right-click', () => {
+      // Simulates the App-side handler (`event.currentTarget.focus()`) and
+      // verifies it actually moves document.activeElement to the row. This
+      // is the regression guard for #4372: if the row drops tabIndex, this
+      // .focus() call becomes a no-op.
+      const onContextMenu = vi.fn((_target, event: React.MouseEvent) => {
+        if (event.currentTarget instanceof HTMLElement) {
+          event.currentTarget.focus()
+        }
+      })
+      renderSidebar({ onContextMenu })
+      const row = screen.getByTestId('session-item-s1')
+      // Sanity: row is not focused before the right-click.
+      expect(document.activeElement).not.toBe(row)
+      fireEvent.contextMenu(row)
+      expect(document.activeElement).toBe(row)
+    })
   })
 
   describe('stdin forwarding disabled badge (#3567)', () => {

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -356,15 +356,27 @@ export function Sidebar({
             {filteredRepos.map(repo => {
               const isCollapsed = filter ? false : (collapsed[repo.path] ?? false)
               return (
-                <div key={repo.path} className="sidebar-repo" role="treeitem" aria-expanded={!isCollapsed} tabIndex={visibleIds.indexOf(`repo:${repo.path}`) === focusedIndex ? 0 : -1}>
+                <div
+                  key={repo.path}
+                  className="sidebar-repo"
+                  role="treeitem"
+                  aria-expanded={!isCollapsed}
+                  tabIndex={visibleIds.indexOf(`repo:${repo.path}`) === focusedIndex ? 0 : -1}
+                  // #4372: bind onContextMenu on the outer treeitem (not the
+                  // inner .sidebar-repo-header) so that App's handler can
+                  // call `event.currentTarget.focus()` on a focusable element.
+                  // The header is a bare <div> without tabIndex/role, so a
+                  // focus() call on it would be a no-op and leave
+                  // document.activeElement on <body>.
+                  onContextMenu={e => {
+                    e.preventDefault()
+                    onContextMenu({ type: 'repo', path: repo.path }, e)
+                  }}
+                >
                   <div
                     className={`sidebar-repo-header${!repo.exists ? ' missing' : ''}`}
                     data-testid={`repo-header-${repo.path}`}
                     onClick={() => toggleRepo(repo.path)}
-                    onContextMenu={e => {
-                      e.preventDefault()
-                      onContextMenu({ type: 'repo', path: repo.path }, e)
-                    }}
                   >
                     <span className="sidebar-chevron">{isCollapsed ? '\u25B6' : '\u25BC'}</span>
                     <span className="sidebar-repo-name">{repo.name}</span>
@@ -405,7 +417,15 @@ export function Sidebar({
                             data-testid={`session-item-${session.sessionId}`}
                             onClick={() => onSessionClick(session.sessionId)}
                             onContextMenu={e => {
+                              // #4372: stopPropagation so the right-click
+                              // does not bubble to the outer .sidebar-repo
+                              // treeitem (which also listens since the fix).
+                              // Without this the App handler fires twice and
+                              // the *outer* listener wins for focus(),
+                              // landing focus on the repo wrapper instead of
+                              // the session row.
                               e.preventDefault()
+                              e.stopPropagation()
                               onContextMenu({ type: 'session', sessionId: session.sessionId }, e)
                             }}
                           >
@@ -468,7 +488,12 @@ export function Sidebar({
                           data-testid={`resumable-item-${conv.conversationId}`}
                           onClick={() => onResumeSession(conv.conversationId)}
                           onContextMenu={e => {
+                            // #4372: stopPropagation so the right-click does
+                            // not bubble to the outer .sidebar-repo
+                            // treeitem (see matching comment on session
+                            // rows above).
                             e.preventDefault()
+                            e.stopPropagation()
                             onContextMenu({ type: 'resumable', conversationId: conv.conversationId }, e)
                           }}
                         >

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -586,6 +586,25 @@
   color: var(--text-primary);
 }
 
+/* #4372 — visible focus ring on sidebar treeitem rows. The App's
+ * `handleSidebarContextMenu` focuses the right-clicked row before opening
+ * the SessionContextMenu so unmount focus-restoration lands back on it;
+ * the user needs a visible indicator that the row is the focused element
+ * once the menu dismisses (matches the dashboard's standard 2px outline
+ * pattern used by buttons, tabs, and CheckpointTimeline rows). */
+.sidebar-session-item:focus-visible,
+.sidebar-resumable-item:focus-visible,
+.sidebar-repo-header:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: -2px;
+}
+
+.sidebar-repo:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: -2px;
+  border-radius: 3px;
+}
+
 /* SessionContextMenu (#4045) — right-click context menu overlay for sidebar
  * items. Positioned fixed at the click coordinates; the component itself
  * handles outside-click / Escape / blur dismissal. */

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -591,18 +591,17 @@
  * the SessionContextMenu so unmount focus-restoration lands back on it;
  * the user needs a visible indicator that the row is the focused element
  * once the menu dismisses (matches the dashboard's standard 2px outline
- * pattern used by buttons, tabs, and CheckpointTimeline rows). */
+ * pattern used by buttons, tabs, and CheckpointTimeline rows).
+ *
+ * `.sidebar-repo` is the outer treeitem wrapper (also the onContextMenu
+ * binding target); `.sidebar-session-item` / `.sidebar-resumable-item` are
+ * the leaf treeitems. The bare wrapper has no border-radius normally, so
+ * we keep the outline rectangular for consistency. */
+.sidebar-repo:focus-visible,
 .sidebar-session-item:focus-visible,
-.sidebar-resumable-item:focus-visible,
-.sidebar-repo-header:focus-visible {
+.sidebar-resumable-item:focus-visible {
   outline: 2px solid var(--border-focus);
   outline-offset: -2px;
-}
-
-.sidebar-repo:focus-visible {
-  outline: 2px solid var(--border-focus);
-  outline-offset: -2px;
-  border-radius: 3px;
 }
 
 /* SessionContextMenu (#4045) — right-click context menu overlay for sidebar


### PR DESCRIPTION
## Summary

- PR #4369 added focus restoration on `SessionContextMenu` unmount: the menu captures `document.activeElement` at open time and restores focus to it on Esc/outside-click. The gap was on the consumer side — a **right-click does not move focus by default**, so the captured "trigger" was whatever the user last clicked (often the composer textarea), and Esc landed focus there instead of the right-clicked row.
- `handleSidebarContextMenu` in `App.tsx` now calls `event.currentTarget.focus()` before opening the menu, so `SessionContextMenu`'s mount-effect capture lands on the row and unmount focus-restoration returns there.
- Added a `:focus-visible` outline on session, resumable, and repo-header sidebar rows so the focused row is visible after dismiss. The existing WAI-ARIA roving-tabindex pattern (focused row = `tabIndex={0}`, others = `-1`) already makes every row programmatically focusable — no Sidebar.tsx changes needed for that.

## Test plan

- [x] New Sidebar tests assert rows are focusable (`tabindex` attribute present) and that `event.currentTarget` in `onContextMenu` is the row.
- [x] New App tests cover (a) `handleSidebarContextMenu` invokes `focus()` on the row, and (b) end-to-end: composer textarea is focused → right-click row → Esc → focus lands on the row, not the composer (the regression the issue describes).
- [x] `npm test -- --run` in `packages/dashboard` — 2065/2065 pass.
- [x] `npm run typecheck` in `packages/dashboard` — clean.

Closes #4372