### PR TITLE
docs(skills): surface external contributor PRs in session-start + tackle-issues pre-flight

### DIFF
--- a/.claude/commands/tackle-issues.md
+++ b/.claude/commands/tackle-issues.md
@@ -54,11 +54,23 @@ Build the initial queue using the same logic as `/autonomous-dev-flow` Phase 0:
 - Filter out assigned issues
 - Apply sort and cap
 
+**Pre-queue: check for existing PRs covering each issue.** Before declaring the queue final, scan open PRs for closing-keyword references to each queued issue. If any hit, mark that issue as `Existing PR — defer` and remove it from the worker queue. This prevents worktree agents from duplicating an external contributor's work (or your own stale branch).
+
+```bash
+for ISSUE_NUM in "${QUEUE[@]}"; do
+  HITS=$(gh pr list --state open --search "Closes #${ISSUE_NUM} OR Fixes #${ISSUE_NUM} OR Resolves #${ISSUE_NUM}" --json number,title,author --jq '.[] | "#\(.number) by @\(.author.login): \(.title)"')
+  if [ -n "$HITS" ]; then
+    echo "Issue #${ISSUE_NUM} already has open PR(s): $HITS"
+    # Drop from worker queue; surface in the marathon-queue display as deferred
+  fi
+done
+```
+
 **Validate:**
 - At least 1 issue must be open and unassigned
 - If 0 issues match, report and stop
 
-Display the marathon queue:
+Display the marathon queue (deferred issues shown but greyed/marked, so the user can decide whether to override):
 
 ```markdown
 ## Marathon Session — {N} issues, up to {W} waves
@@ -69,6 +81,7 @@ Display the marathon queue:
 | 2 | #15 — Add leaderboard | complexity:high | Decompose → sub-issues |
 | 3 | #18 — Auth integration tests | testing | Implement |
 | — | #16 — Refactor auth module | enhancement | Assigned to @user (skipped) |
+| — | #21 — MCP config parser | from-review | Existing PR #4082 by @external — defer |
 
 **Mode:** Unattended marathon (up to {W} waves)
 **Merge after:** {Yes/No}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,9 @@ npx chroxy tunnel setup
 **When user says "Resume" or "Let's start":**
 1. `cat CLAUDE.md` - Read this file
 2. `git status && git log --oneline -5` - Check current state
-3. Review any open PRs: `gh pr list`
+3. Review open PRs, **separated by author** so external contributions don't get lost in your own queue:
+   - Yours: `gh pr list --state open --author @me`
+   - **External:** `gh pr list --state open --search "-author:@me"` — flag any results for review attention before starting new marathons (an open external PR may already cover an issue you'd otherwise queue)
 4. Check for skill template updates: `~/Projects/skill-templates/sync.sh chroxy`
 
 ### Skill Templates


### PR DESCRIPTION
## Summary

Two process tweaks motivated by PR #4082 (an external contributor's PR for #4076 BYOK MCP config discovery) sitting unreviewed for 5 days while we nearly queued the same issue for a marathon.

### CLAUDE.md — Session Start Protocol
Split the open-PR review step into **yours** vs **external**:
- `gh pr list --author @me` — your own queue
- `gh pr list --search "-author:@me"` — flagged for review attention

A unified `gh pr list` view buries strangers' PRs at whatever position the list sorts them. Splitting forces explicit acknowledgement before starting work that might overlap.

### /tackle-issues — Phase 0 pre-queue scan
Before declaring the marathon queue final, scan open PRs for closing-keyword references (`Closes #N`, `Fixes #N`, `Resolves #N`) to each queued issue. If a hit exists, mark the issue as `Existing PR — defer` and remove it from the worker queue, so worktree agents don't duplicate work already in flight.

## Test plan

Both changes are docs-only — no code. Verification on the next session:
- [ ] On next Resume, the `gh pr list` step now shows two queries.
- [ ] On next `/tackle-issues` with an issue that has an open PR, the queue display shows the deferred row instead of dispatching a worker agent.

Docs-only / skill-files-only — eligible for the /merge docs carve-out, no review required.