### PR TITLE
chore(skills): update skill templates (2026-05-27)

### DIFF
--- a/.claude/commands/agent-review.md
+++ b/.claude/commands/agent-review.md
@@ -25,57 +25,42 @@ gh pr diff ${PR_NUM}
 
 ### 2. Review Criteria
 
-The agent reviews against these project-specific standards:
+The agent reviews against these standards:
 
-#### Code Quality — Server (packages/server/)
-- [ ] ES modules (`import`/`export`), no TypeScript
-- [ ] No semicolons, single quotes
-- [ ] EventEmitter pattern for component communication
-- [ ] Proper cleanup on destroy/close (kill child processes, close sockets)
-- [ ] No blocking operations in event handlers
-
-#### Code Quality — App (packages/app/)
-- [ ] TypeScript (strict mode)
-- [ ] Functional components with hooks
-- [ ] Zustand store patterns (immutable updates via `set()`)
-- [ ] No `any` types without justification
-- [ ] Platform-aware code (iOS/Android differences handled)
+#### Code Quality
+- [ ] Follows project style guide (per CLAUDE.md)
+- [ ] Proper error handling
+- [ ] No obvious security issues (injection, path traversal, credential exposure)
+- [ ] Clean naming and structure
+- [ ] Server: ES modules, no semicolons, single quotes, EventEmitter cleanup on destroy/close
+- [ ] App: TypeScript strict, functional components with hooks, Zustand immutable updates via `set()`, no `any` types, platform-aware code, no `AbortSignal.timeout()` (not in React Native)
 
 #### Architecture Alignment
-- [ ] Server components are decoupled (CliSession, WsServer, TunnelManager)
-- [ ] WS protocol messages are documented in ws-server.js header
-- [ ] New WS messages handled in both server and client
+- [ ] Changes follow established patterns
+- [ ] No breaking changes to existing interfaces/APIs
+- [ ] New patterns documented if introduced
 - [ ] CLI mode and PTY/terminal mode remain independent paths
-- [ ] No breaking changes to existing WS protocol
+- [ ] WS protocol messages documented in ws-server.js header
+- [ ] Auth flow: auth → auth_ok → server_mode → status → claude_ready
 
-#### WebSocket Protocol
-- [ ] Client→Server and Server→Client message types are consistent
-- [ ] New message types documented in ws-server.js protocol comment
-- [ ] Auth flow preserved (auth → auth_ok → server_mode → status → claude_ready)
-- [ ] Broadcast vs. targeted send used appropriately
-
-#### Mobile/React Native
-- [ ] Touch targets adequate (min 44pt)
-- [ ] Keyboard handling accounts for Android suggestion bar
-- [ ] Safe area insets used where needed
-- [ ] No `AbortSignal.timeout()` (not available in React Native)
-- [ ] Expo Go compatibility maintained
-
-#### Security
-- [ ] No path traversal vulnerabilities
-- [ ] API tokens not logged or exposed
-- [ ] No command injection in spawned processes
-- [ ] WebSocket auth enforced before any data messages
+#### Testing
+- [ ] Tests pass
+- [ ] New functionality has test coverage where appropriate
+- [ ] No test regressions
 
 #### Performance
-- [ ] Stream deltas batched (not flooding state updates)
+- [ ] No obvious N-squared loops on collections
 - [ ] No unbounded buffers or memory leaks
-- [ ] Child processes cleaned up on all exit paths
-- [ ] Proper cleanup of timers, listeners, and intervals
+- [ ] Proper cleanup of resources (timers, listeners, processes, connections)
+
+#### Mobile
+- [ ] Touch targets min 44pt
+- [ ] Keyboard handling for Android suggestion bar
+- [ ] Safe area insets, Expo Go compatibility
 
 ### 3. Generate Review
 
-Create a comprehensive review with:
+Create a comprehensive review:
 
 ```markdown
 ## Code Review: PR #${PR_NUM}
@@ -109,7 +94,7 @@ Brief overview of changes and their purpose.
 | ... | [#XX](issue_url) | ... |
 
 ### Architecture Notes
-How this change fits within the server/app architecture.
+How this change fits within the project architecture.
 
 ### Verdict
 - [ ] Approve - Ready to merge
@@ -125,7 +110,7 @@ Post review as a PR comment using heredoc:
 gh pr comment ${PR_NUM} --body "$(cat <<'EOF'
 ## Code Review: PR #XX
 
-[Your review content here - copy from generated review above]
+[Your review content here]
 EOF
 )"
 ```
@@ -162,7 +147,7 @@ EOF
 )")
 ```
 
-**CRITICAL: Every follow-up issue MUST be linked in the posted PR review comment.** The Deferred Items table must contain the full issue URL (e.g., `https://github.com/blamechris/chroxy/issues/123`) or `#123` shorthand — never "Created a follow-up issue" without a link. The issue URL is the paper trail that makes the deferred item discoverable from the PR.
+**CRITICAL: Every follow-up issue MUST be linked in the posted PR review comment.** The Deferred Items table must contain the full issue URL (e.g., `https://github.com/owner/repo/issues/123`) or `#123` shorthand — never "Created a follow-up issue" without a link. The issue URL is the paper trail that makes the deferred item discoverable from the PR.
 
 ### 6. Reconcile Issues Resolved in This PR
 
@@ -201,22 +186,15 @@ Then below the table, list:
 
 ## Agent Persona
 
-You are **Chroxy Inspector**, an expert code reviewer for Chroxy with deep knowledge of:
+**Chroxy Inspector** — expert in Node.js, React Native/Expo, WebSocket protocol, Claude Code CLI, Cloudflare tunnels, mobile connectivity.
 
-- **Node.js** (ES modules, child_process, EventEmitter)
-- **React Native / Expo** (TypeScript, Zustand, platform quirks)
-- **WebSocket protocol design** and real-time streaming
-- **Claude Code CLI** (`--output-format stream-json`, `--resume`, `--permission-prompt-tool`)
-- **Cloudflare tunnels** and mobile connectivity patterns
-
-You review with the mindset of:
-> "Will this code work reliably over a cellular connection through a tunnel to a remote dev machine?"
+Mindset: "Will this code work reliably over a cellular connection through a tunnel to a remote dev machine?"
 
 ## Review Philosophy
 
 1. **Be constructive** - Suggest fixes, not just problems
-2. **Protocol correctness first** - WS message flow must be bulletproof
-3. **Mobile-first** - Always consider connectivity, battery, keyboard
-4. **Resilience** - Handle disconnects, process crashes, stale state
+2. **Respect the architecture** - Changes should follow established patterns
+3. **Pragmatic over perfect** - Working code first, polish later
+4. **Reliability first** - Always consider error recovery and edge cases
 5. **Keep it simple** - No over-engineering, no premature abstractions
-<!-- skill-templates: agent-review 0000000 2026-05-15 -->
+<!-- skill-templates: agent-review 57ceacc 2026-05-27 -->

--- a/.claude/commands/agent-review.md
+++ b/.claude/commands/agent-review.md
@@ -197,4 +197,4 @@ Mindset: "Will this code work reliably over a cellular connection through a tunn
 3. **Pragmatic over perfect** - Working code first, polish later
 4. **Reliability first** - Always consider error recovery and edge cases
 5. **Keep it simple** - No over-engineering, no premature abstractions
-<!-- skill-templates: agent-review 57ceacc 2026-05-27 -->
+<!-- skill-templates: agent-review 9652481 2026-05-27 -->

--- a/.claude/commands/autonomous-dev-flow.md
+++ b/.claude/commands/autonomous-dev-flow.md
@@ -19,6 +19,7 @@ Orchestrate long-running autonomous dev sessions — work through GitHub issues 
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
+# Branch prefix for autonomous session branches
 BRANCH_PREFIX="feat/"
 ```
 
@@ -193,6 +194,7 @@ git checkout -b "${BRANCH}"
 Based on the issue's acceptance criteria, write tests that describe the desired behavior. Tests MUST fail before any implementation.
 
 ```bash
+# Test runners:
 # Server: cd packages/server && npm test
 # App: cd packages/app && npx jest
 # Dashboard: cd packages/server && npm run dashboard:test
@@ -226,6 +228,7 @@ With green tests as a safety net:
 # Run tests again to confirm refactoring didn't break anything
 ${TEST_COMMAND}
 
+# Lint/typecheck:
 # App: cd packages/app && npx tsc --noEmit
 # Dashboard: cd packages/server && npm run dashboard:typecheck
 ${LINT_COMMAND}
@@ -249,7 +252,7 @@ Refs #${ISSUE_NUM}
 EOF
 )"
 
-# Commit scopes: server, app, desktop, tunnel, ws, cli, ci, docs, dashboard
+# Commit scope conventions: server, app, desktop, tunnel, ws, cli, ci, docs, dashboard
 
 git push -u origin ${BRANCH}
 ```
@@ -295,7 +298,7 @@ PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 If the PR modified **dashboard or UI files**, run the project's smoke test to catch visual regressions before review. This prevents wasting review cycles on PRs that break the UI.
 
 ```bash
-# Check if PR touches dashboard source files, React components, CSS, or theme files
+# Condition for when to run smoke test
 CHANGED_FILES=$(git diff --name-only main...HEAD)
 if echo "$CHANGED_FILES" | grep -qE 'dashboard-next|\.tsx$|\.css$|\.html$|components\.css|theme'; then
   NEEDS_SMOKE_TEST=true
@@ -305,10 +308,10 @@ fi
 If `NEEDS_SMOKE_TEST` is true:
 
 1. **Rebuild dashboard** if needed:
-```bash
-cd packages/server
-PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run dashboard:build
-```
+   ```bash
+   cd packages/server
+   PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run dashboard:build
+   ```
 2. **Run `/smoke-test`** — this launches the app, opens a headless browser, and verifies key UI elements
 3. **Check results:**
    - **All pass:** Continue to Phase 5 (review)
@@ -440,4 +443,4 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 13. **Comment on skips** — Every skipped issue gets a GitHub comment explaining why. The user sees the reason.
 14. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running /full-review to prevent context drift.
 15. **Sync before branching** — Always `git checkout main && git pull` before starting each issue. Check for merged PRs first.
-<!-- skill-templates: autonomous-dev-flow 57ceacc 2026-05-27 -->
+<!-- skill-templates: autonomous-dev-flow 9652481 2026-05-27 -->

--- a/.claude/commands/autonomous-dev-flow.md
+++ b/.claude/commands/autonomous-dev-flow.md
@@ -62,7 +62,7 @@ For each issue in work queue:
 
 ### Phase 0.5: Auto-Decompose High-Complexity Issues
 
-When the queue contains issues that are too large to implement directly (e.g., labeled `complexity:high` or equivalent), decompose them into smaller, independently implementable sub-issues BEFORE entering the core loop.
+When the queue contains issues that are too large to implement directly (e.g., issues spanning multiple systems or touching 3+ files), decompose them into smaller, independently implementable sub-issues BEFORE entering the core loop.
 
 For each high-complexity issue:
 
@@ -193,11 +193,12 @@ git checkout -b "${BRANCH}"
 Based on the issue's acceptance criteria, write tests that describe the desired behavior. Tests MUST fail before any implementation.
 
 ```bash
-# Server: npm test, App: npx jest
-# Server: __tests__/*.test.js, App: __tests__/*.test.ts
+# Server: cd packages/server && npm test
+# App: cd packages/app && npx jest
+# Dashboard: cd packages/server && npm run dashboard:test
 
 # Run tests to confirm they fail
-npm test
+${TEST_COMMAND}
 ```
 
 If tests pass immediately, the behavior already exists — investigate before proceeding. Either the issue is already resolved or the tests don't capture the right behavior.
@@ -208,7 +209,7 @@ Write the minimum implementation to make all new tests pass. Don't over-engineer
 
 ```bash
 # Run tests to confirm they pass
-npm test
+${TEST_COMMAND}
 ```
 
 If tests still fail, iterate on the implementation until they pass. Do NOT move to REFACTOR until all tests are green.
@@ -223,10 +224,11 @@ With green tests as a safety net:
 
 ```bash
 # Run tests again to confirm refactoring didn't break anything
-npm test
+${TEST_COMMAND}
 
-# App: npx tsc --noEmit
-npx tsc --noEmit
+# App: cd packages/app && npx tsc --noEmit
+# Dashboard: cd packages/server && npm run dashboard:typecheck
+${LINT_COMMAND}
 ```
 
 ### Phase 4: Commit and PR Creation
@@ -247,7 +249,7 @@ Refs #${ISSUE_NUM}
 EOF
 )"
 
-# server, app, core, ui
+# Commit scopes: server, app, desktop, tunnel, ws, cli, ci, docs, dashboard
 
 git push -u origin ${BRANCH}
 ```
@@ -278,10 +280,9 @@ Refs #${ISSUE_NUM}
 
 ## Test Plan
 
-- [ ] All new tests pass
-- [ ] Existing tests unbroken
 - [ ] Server tests pass
 - [ ] App type-checks clean
+- [ ] Dashboard tests pass
 - [ ] Manual smoke test
 EOF
 )")
@@ -291,10 +292,10 @@ PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 
 ### Phase 4.5: Smoke Test (if applicable)
 
-If the PR modified **UI or frontend files**, run the smoke test to catch visual regressions before review. This prevents wasting review cycles on PRs that break the UI.
+If the PR modified **dashboard or UI files**, run the project's smoke test to catch visual regressions before review. This prevents wasting review cycles on PRs that break the UI.
 
 ```bash
-NEEDS_SMOKE_TEST=false
+# Check if PR touches dashboard source files, React components, CSS, or theme files
 CHANGED_FILES=$(git diff --name-only main...HEAD)
 if echo "$CHANGED_FILES" | grep -qE 'dashboard-next|\.tsx$|\.css$|\.html$|components\.css|theme'; then
   NEEDS_SMOKE_TEST=true
@@ -303,16 +304,16 @@ fi
 
 If `NEEDS_SMOKE_TEST` is true:
 
-1. **Rebuild dashboard** — source changes are NOT visible without rebuild:
-   ```bash
-   cd packages/server
-   PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run dashboard:build
-   ```
-2. **Run `/smoke-test`** — launches headless browser, verifies key UI elements, takes screenshots
+1. **Rebuild dashboard** if needed:
+```bash
+cd packages/server
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run dashboard:build
+```
+2. **Run `/smoke-test`** — this launches the app, opens a headless browser, and verifies key UI elements
 3. **Check results:**
    - **All pass:** Continue to Phase 5 (review)
    - **Failures:** Read the screenshots, diagnose whether it's an app bug or a test selector issue
-     - **App bug:** Fix the code, rebuild, re-run smoke test
+     - **App bug:** Fix the code, re-run tests, amend commit, re-run smoke test
      - **Test issue:** Note it in the PR description, continue (don't block on flaky test selectors)
 4. **Max 2 smoke test fix attempts** — if still failing after 2 fixes, flag the PR as "Needs attention (smoke test failure)" and move on
 
@@ -439,4 +440,4 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 13. **Comment on skips** — Every skipped issue gets a GitHub comment explaining why. The user sees the reason.
 14. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running /full-review to prevent context drift.
 15. **Sync before branching** — Always `git checkout main && git pull` before starting each issue. Check for merged PRs first.
-<!-- skill-templates: autonomous-dev-flow e60105e 2026-02-28 -->
+<!-- skill-templates: autonomous-dev-flow 57ceacc 2026-05-27 -->

--- a/.claude/commands/batch-merge.md
+++ b/.claude/commands/batch-merge.md
@@ -36,8 +36,8 @@ Display the queue for user confirmation (**this is the ONLY confirmation point**
 
 | # | PR | Title | CI | Copilot | Status |
 |---|-----|-------|----|---------|--------|
-| 1 | #1570 | feat(dashboard): Add slash commands... | — | — | Queued |
-| 2 | #1571 | feat(dashboard): Add file picker... | — | — | Queued |
+| 1 | #1570 | test(combat): Assert carrier bay... | — | — | Queued |
+| 2 | #1571 | test(combat): Add dodge roll... | — | — | Queued |
 ```
 
 If `--dry-run`, state that no merges will be performed.
@@ -60,21 +60,13 @@ Update the progress table with pre-flight results. This is informational — doe
 
 ### Phase 2: Sequential Merge Loop
 
-Process PRs in order using an indexed loop:
-
-```bash
-for ((i=0; i<${#PR_NUMS[@]}; i++)); do
-  PR_NUM=${PR_NUMS[$i]}
-  # Steps 2a–2g for each PR
-done
-```
-
-For each PR:
+Process PRs in order. For each PR:
 
 #### Step 2a: Check CI
 
 ```bash
-REQUIRED_CHECKS=("Server Tests" "Server Lint" "App Tests" "App Type Check" "Dashboard Tests" "Dashboard Type Check")
+# Required check names that must pass
+REQUIRED_CHECKS=("Run Tests" "Validate Project")
 
 CHECKS=$(gh pr checks ${PR_NUM} --json name,state)
 ```
@@ -89,10 +81,8 @@ All required checks must be `SUCCESS` or `SKIPPED`. If any are failing or pendin
 ```bash
 COPILOT_STATUS=$(gh api repos/${REPO}/pulls/${PR_NUM}/reviews \
   --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] |
-    sort_by(.submitted_at) |
     if length == 0 then "NOT_FOUND"
-    elif (.[-1].state == "PENDING") then "IN_PROGRESS"
-    elif (.[-1].state == "DISMISSED") then "DISMISSED"
+    elif (.[0].state == "PENDING") then "IN_PROGRESS"
     else "COMPLETED" end')
 ```
 
@@ -114,16 +104,13 @@ ALL_COMMENTS=$(gh api repos/${REPO}/pulls/${PR_NUM}/comments --paginate)
 # Find Copilot comments without a reply from us
 WORKFLOW_USER=$(gh api user --jq .login)
 
-# Step 1: Get IDs of root comments that already have a reply from the workflow user
-REPLIED_IDS=$(echo "$ALL_COMMENTS" | jq --arg user "$WORKFLOW_USER" \
-  '[.[] | select(.in_reply_to_id != null and .user.login == $user) | .in_reply_to_id] | unique')
-
-# Step 2: Filter to Copilot-authored top-level comments that have no reply from us
-UNREPLIED=$(echo "$ALL_COMMENTS" \
-  | jq --argjson replied "$REPLIED_IDS" \
-    '[.[] | select(.in_reply_to_id == null)
-          | select(.user.login == "copilot-pull-request-reviewer[bot]")
-          | select([.id] | inside($replied) | not)]')
+# Comments that are top-level (not replies) and have no reply from us
+UNREPLIED=$(echo "$ALL_COMMENTS" | jq --arg user "$WORKFLOW_USER" '
+  [.[] | select(.in_reply_to_id == null)] |
+  map(select(.id as $id |
+    [.. | select(.in_reply_to_id? == $id) | select(.user.login == $user)] | length == 0
+  ))
+')
 ```
 
 For each unreplied comment, handle using the 3-outcome model from `/check-pr`:
@@ -150,7 +137,7 @@ fi
 After merging PR N, PR N+1 is stale (`strict: true` branch protection). Update it:
 
 ```bash
-NEXT_PR=${PR_NUMS[$((i + 1))]}
+NEXT_PR=${PR_NUMS[$((current_index + 1))]}
 if [ -n "$NEXT_PR" ]; then
   gh api repos/${REPO}/pulls/${NEXT_PR}/update-branch \
     --method PUT \
@@ -158,36 +145,7 @@ if [ -n "$NEXT_PR" ]; then
 fi
 ```
 
-If `update-branch` fails with a conflict, fall through to **Step 2e-alt: Manual Rebase**.
-
-##### Step 2e-alt: Manual Rebase (Conflict Resolution)
-
-When `update-branch` API fails with conflicts (common when multiple PRs modify the same files like `InputBar.tsx`), rebase manually:
-
-```bash
-NEXT_BRANCH=$(gh pr view ${NEXT_PR} --json headRefName -q .headRefName)
-
-# Validate branch name — reject if it contains shell metacharacters
-if ! printf '%s' "$NEXT_BRANCH" | grep -qE '^[a-zA-Z0-9/_.-]+$'; then
-  echo "ERROR: Branch name '${NEXT_BRANCH}' contains unsafe characters. Skipping."
-  continue  # Skip this PR
-fi
-
-git checkout main && git pull origin main
-git checkout -- "$NEXT_BRANCH"
-git rebase main
-```
-
-If rebase has conflicts:
-
-1. For each conflicted file, read the file and resolve by keeping **all HEAD features** (already merged) plus the **incoming branch's additions**
-2. Verify no conflict markers remain: `grep -r '<<<<<<' <files>`
-3. `git add <files> && git rebase --continue`
-4. Run tests: `cd packages/server && npm run dashboard:test`
-5. `git push --force-with-lease origin "$NEXT_BRANCH"`
-6. Wait for CI (Step 2f)
-
-If rebase conflicts are too complex to resolve (3+ files with deep interleaving), mark PR as `Blocked` and continue to next PR.
+If `update-branch` fails with a conflict, mark the next PR as `Blocked` and try the PR after that (it still needs updating since main changed).
 
 #### Step 2f: Wait for CI on Updated Branch
 
@@ -212,13 +170,6 @@ while [ $ELAPSED -lt $MAX_WAIT ]; do
   sleep $INTERVAL
   ELAPSED=$((ELAPSED + INTERVAL))
 done
-
-# Post-loop: check final state
-if [ "$ELAPSED" -ge "$MAX_WAIT" ] && [ "$PENDING" != "0" ]; then
-  echo "CI still pending after ${MAX_WAIT}s — marking PR #${NEXT_PR} as Pending"
-  # Do NOT attempt merge. This PR will be retried when it becomes the active PR
-  # in the next loop iteration (Step 2a will poll again).
-fi
 ```
 
 If CI fails after update-branch, run `/fix-ci ${NEXT_PR}`.
@@ -232,10 +183,10 @@ Output the progress table after **every merge**. This is the user's live dashboa
 
 | # | PR | Title | CI | Copilot | Merge | Notes |
 |---|-----|-------|----|---------|-------|-------|
-| 1 | #1290 | feat(dashboard): Add slash... | PASS | Reviewed (0) | Merged | — |
-| 2 | #1292 | feat(server): Add list_files... | PASS | Reviewed (1→fixed) | Merged | 1 fix in abc1234 |
-| 3 | #1294 | feat(dashboard): Add file... | Updating | — | Next | CI running after rebase |
-| 4 | #1300 | feat(dashboard): Add attach... | — | — | Queued | — |
+| 1 | #1570 | test(combat): Assert carrier... | PASS | Reviewed (0) | Merged | — |
+| 2 | #1571 | test(combat): Add dodge roll... | PASS | Reviewed (1→fixed) | Merged | 1 fix in abc1234 |
+| 3 | #1572 | test(autoload): Add Statistics... | Updating | — | Next | CI running after update-branch |
+| 4 | #1573 | fix: Address silent failures... | — | — | Queued | — |
 ```
 
 **Column values:**
@@ -255,7 +206,7 @@ When `gh pr merge` fails, classify and respond:
 | "not up to date" / "branch is behind" | `update-branch` → wait CI → retry | 1 |
 | "status check" / "required status" | `/fix-ci` → retry | 1 |
 | "review" / "approval" / "dismissed" | Wait for fresh Copilot review → retry | 1 |
-| "conflict" / "not mergeable" | Step 2e-alt manual rebase → retry | 1 |
+| "conflict" / "not mergeable" | Skip immediately, report | 0 |
 | "already merged" | Skip silently, note in table | 0 |
 | Rate limit (403/429) | Back off 60s → retry | 2 |
 | Unknown | Log full error, skip PR | 0 |
@@ -273,15 +224,15 @@ After all PRs processed:
 
 | # | PR | Title | Merge | Notes |
 |---|-----|-------|-------|-------|
-| 1 | #1290 | feat(dashboard): Add slash commands... | Merged | — |
-| 2 | #1292 | feat(server): Add list_files endpoint... | Merged | 1 Copilot fix |
-| 3 | #1300 | feat(dashboard): Add attachment chips... | Merged | Rebased (conflict in InputBar.tsx) |
+| 1 | #1570 | test(combat): Assert carrier bay... | Merged | — |
+| 2 | #1571 | test(combat): Add dodge roll... | Merged | 1 Copilot fix |
+| 3 | #1572 | test(autoload): Add Statistics... | Skipped | CI timeout |
 
 ### Skipped/Blocked PRs
-- **#1572**: Rebase conflicts too complex. Needs manual resolution.
+- **#1572**: Run Tests timed out after update-branch. Needs manual investigation.
 
 ### Copilot Comments Addressed During Merge
-- **#1292**: 1 comment → FIX in `abc1234` (added null guard)
+- **#1571**: 1 comment → FIX in `abc1234` (added null guard)
 ```
 
 ## Error Recovery
@@ -292,7 +243,7 @@ After all PRs processed:
 | Copilot review not posted | Poll every 30s, max 8 min | 16 polls |
 | Copilot review dismissed (stale) | Wait for new review cycle | 1 |
 | Merge blocked (unknown) | Diagnose via `gh pr checks`, report | 1 |
-| update-branch conflict | Manual rebase (Step 2e-alt) | 1 |
+| update-branch conflict | Skip PR, continue | 0 |
 | Rate limiting | Back off 60s, retry | 2 |
 | PR already merged | Skip silently | 0 |
 | PR closed | Skip silently | 0 |
@@ -308,6 +259,5 @@ After all PRs processed:
 7. **Idempotent** — Safe to re-run. Already-merged PRs are detected and skipped.
 8. **Handle stale reviews** — Pushing fixes invalidates reviews. Wait for fresh cycle.
 9. **Compose with `/fix-ci`** — Don't reinvent CI diagnosis.
-10. **No attribution** — Follow Zero Attribution Policy in any fix commits.
-11. **Rebase before skip** — When update-branch fails with conflicts, attempt manual rebase (Step 2e-alt) before marking as Blocked. This is common when PRs touch shared files.
-<!-- skill-templates: batch-merge 0000000 2026-05-15 -->
+10. **No attribution** — Follow project's attribution policy in any fix commits.
+<!-- skill-templates: batch-merge 57ceacc 2026-05-27 -->

--- a/.claude/commands/batch-merge.md
+++ b/.claude/commands/batch-merge.md
@@ -260,4 +260,4 @@ After all PRs processed:
 8. **Handle stale reviews** — Pushing fixes invalidates reviews. Wait for fresh cycle.
 9. **Compose with `/fix-ci`** — Don't reinvent CI diagnosis.
 10. **No attribution** — Follow project's attribution policy in any fix commits.
-<!-- skill-templates: batch-merge 57ceacc 2026-05-27 -->
+<!-- skill-templates: batch-merge 9652481 2026-05-27 -->

--- a/.claude/commands/bug-hunt.md
+++ b/.claude/commands/bug-hunt.md
@@ -311,4 +311,4 @@ Output a final summary:
 | "Review this PR before merge" | `/agentic-audit` |
 
 A typical pipeline: `/recon src/payments` → `/bug-hunt src/payments` → `/tackle-issues` on the newly-filed issues.
-<!-- skill-templates: bug-hunt 57ceacc 2026-05-27 -->
+<!-- skill-templates: bug-hunt 9652481 2026-05-27 -->

--- a/.claude/commands/bug-hunt.md
+++ b/.claude/commands/bug-hunt.md
@@ -311,4 +311,4 @@ Output a final summary:
 | "Review this PR before merge" | `/agentic-audit` |
 
 A typical pipeline: `/recon src/payments` → `/bug-hunt src/payments` → `/tackle-issues` on the newly-filed issues.
-<!-- skill-templates: bug-hunt 7f5fa28 2026-05-19 -->
+<!-- skill-templates: bug-hunt 57ceacc 2026-05-27 -->

--- a/.claude/commands/check-pr.md
+++ b/.claude/commands/check-pr.md
@@ -430,4 +430,4 @@ Then below the table, list:
 10. Post summary table (all Reference cells filled)
 11. Report to user
 ```
-<!-- skill-templates: check-pr 57ceacc 2026-05-27 -->
+<!-- skill-templates: check-pr 9652481 2026-05-27 -->

--- a/.claude/commands/check-pr.md
+++ b/.claude/commands/check-pr.md
@@ -198,7 +198,7 @@ gh api repos/${REPO}/pulls/${PR_NUM}/comments/${COMMENT_ID}/replies \
 **Reason:** Clear explanation of why this is correct
 
 **Evidence:**
-- Reference to docs/pattern used (e.g., 'per CLAUDE.md: no semicolons')
+- Reference to docs/pattern used (e.g., 'per CLAUDE.md: no semicolons, single quotes')
 - Link to similar code in codebase"
 ```
 
@@ -212,7 +212,6 @@ When a suggestion is valid but out of scope for this PR. You MUST create a GitHu
 
 ```bash
 # 1. ALWAYS create the issue — this is NOT optional
-# {{CUSTOMIZE: Add repo-specific labels below}}
 ISSUE_URL=$(gh issue create \
   --title "Short descriptive title" \
   --label "enhancement" \
@@ -306,182 +305,45 @@ If `REPLIED_COUNT < ROOT_COUNT`, you have UNREPLIED comments. Go back to step 3 
 GraphQL is required here — REST doesn't expose thread state. Threads are GraphQL-only objects (`PRRT_*` IDs); the `resolveReviewThread` mutation needs the GraphQL node ID, not the REST `databaseId`.
 
 ```bash
-# pipefail: required so `fetch_review_threads | jq -s ...` propagates a fetch
-# failure (otherwise the pipe's exit status is jq's, and a transient error
-# silently produces UNRESOLVED=0 — the very failure mode this section guards).
-set -o pipefail
-
-# Workflow user login — used to filter out threads where the most recent
-# comment is from a non-workflow user (human or bot) who posted after step
-# 6's verification. We must NEVER silently resolve an unreplied comment.
-ME=$(gh api user --jq .login) || { echo "FAIL: could not resolve workflow user"; exit 1; }
-
-# Fetch all review threads (GraphQL — REST API doesn't expose thread state).
-# Page through with a cursor so PRs with >100 threads aren't silently truncated.
-# Hard-fails on transient errors and bounds the loop, so a misbehaving API
-# response can't silently truncate (re-introducing the bug this fixes) or
-# spin forever.
-#
-# `comments(last: 1)` fetches the most recent comment per thread so the
-# resolver loop below can verify the agent (not a human) had the last word.
-fetch_review_threads() {
-  local cursor="null" page has_next next_cursor
-  local pages=0 max_pages=100   # 100 pages * 100 threads = 10000-thread ceiling
-  while [ $pages -lt $max_pages ]; do
-    page=$(gh api graphql -f query="
-      query {
-        repository(owner: \"${REPO%/*}\", name: \"${REPO#*/}\") {
-          pullRequest(number: ${PR_NUM}) {
-            reviewThreads(first: 100, after: ${cursor}) {
-              pageInfo { hasNextPage endCursor }
-              nodes {
-                id
-                isResolved
-                comments(last: 1) { nodes { author { login } } }
-              }
-            }
-          }
+# Fetch all review threads (GraphQL — REST API doesn't expose thread state)
+THREADS=$(gh api graphql -f query="
+  query {
+    repository(owner: \"${REPO%/*}\", name: \"${REPO#*/}\") {
+      pullRequest(number: ${PR_NUM}) {
+        reviewThreads(first: 100) {
+          nodes { id isResolved }
         }
-      }") || { echo "FAIL: graphql page fetch failed (cursor=${cursor})" >&2; return 1; }
-    # Reject error responses or missing data so we don't silently emit nothing.
-    if ! echo "$page" | jq -e '.data.repository.pullRequest.reviewThreads' >/dev/null; then
-      echo "FAIL: graphql returned no reviewThreads (cursor=${cursor}): $page" >&2
-      return 1
-    fi
-    echo "$page" | jq -c '.data.repository.pullRequest.reviewThreads.nodes[]'
-    has_next=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')
-    [ "$has_next" = "true" ] || return 0
-    next_cursor=$(echo "$page" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')
-    # Defend against an API quirk where the cursor doesn't advance (would loop forever).
-    if [ "\"$next_cursor\"" = "$cursor" ]; then
-      echo "FAIL: endCursor did not advance (${cursor}); aborting to avoid infinite loop" >&2
-      return 1
-    fi
-    cursor="\"$next_cursor\""
-    pages=$((pages + 1))
-  done
-  echo "FAIL: review-thread pagination hit ${max_pages}-page cap; PR has >$((max_pages * 100)) threads or API is misbehaving" >&2
-  return 1
-}
+      }
+    }
+  }" --jq '.data.repository.pullRequest.reviewThreads.nodes')
 
-THREADS=$(fetch_review_threads | jq -s '.') || { echo "FAIL: review-thread fetch failed; refusing to proceed"; exit 1; }
-
-# Resolve ONLY threads where the most recent comment was authored by the
-# workflow user. A non-workflow user (human or bot) who posted a brand-new
-# comment between step 6 and step 6b would otherwise be silently dismissed
-# (#3896). Threads with no last-comment author (deleted/ghost) are also
-# skipped — we report them separately below so the SKIPPED message is
-# honest (#3967).
-#
-# Surface any single-thread failure instead of swallowing it (a 401/403 on
-# one thread shouldn't be silent — #3898). The loop runs in a subshell
-# because of the pipe, so a plain variable (FAILED_IDS=...) wouldn't
-# survive past `done`. Track failures in a temp file instead and read
-# them back after the loop. The mutation also needs to confirm
-# `isResolved: true` — a 200 response that returns `false` (e.g.,
-# archived repo, permission silently downgraded) is still a failure.
-FAILED_FILE=$(mktemp)
-trap 'rm -f "$FAILED_FILE"' EXIT
-
-echo "$THREADS" | jq -r --arg me "$ME" '
-  .[]
-  | select(.isResolved == false)
-  | select((.comments.nodes[-1].author.login // "") == $me)
-  | .id
-' | while read -r tid; do
-  RESULT=$(gh api graphql -f query="
+# Resolve each unresolved thread; surface any single-thread failure
+# instead of swallowing it (a 401/403 on one thread shouldn't be silent).
+echo "$THREADS" | jq -r '.[] | select(.isResolved == false) | .id' | while read -r tid; do
+  gh api graphql -f query="
     mutation {
       resolveReviewThread(input: {threadId: \"$tid\"}) {
         thread { isResolved }
       }
-    }" --jq '.data.resolveReviewThread.thread.isResolved' 2>&1)
-  if [ "$RESULT" = "true" ]; then
-    echo "  resolved: $tid"
-  else
-    echo "  FAILED to resolve: $tid ($RESULT)" >&2
-    echo "$tid" >> "$FAILED_FILE"
-  fi
+    }" --jq '.data.resolveReviewThread.thread | "  resolved: \(.isResolved)"' \
+    || echo "  FAILED to resolve: $tid"
 done
 
-FAILED_COUNT=$(wc -l < "$FAILED_FILE" | tr -d ' ')
-if [ "$FAILED_COUNT" -gt 0 ]; then
-  echo "FAIL: ${FAILED_COUNT} thread(s) could not be resolved:" >&2
-  sed 's/^/  - /' "$FAILED_FILE" >&2
-  echo "Refusing to claim success while resolveReviewThread mutations are failing." >&2
-  exit 1
-fi
+# Verify zero unresolved threads remain
+UNRESOLVED=$(gh api graphql -f query="
+  query {
+    repository(owner: \"${REPO%/*}\", name: \"${REPO#*/}\") {
+      pullRequest(number: ${PR_NUM}) {
+        reviewThreads(first: 100) {
+          nodes { isResolved }
+        }
+      }
+    }
+  }" --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length')
 
-# Report any threads we deliberately did NOT resolve. Split into two buckets
-# so the message is accurate (#3967): a deleted/ghost author shows up as a
-# missing `author.login`, which is NOT a non-workflow user with an open
-# question. Lumping them together produces the misleading line "X thread(s)
-# ... from a non-workflow user" even when no real author exists.
-#
-# Note on naming: SKIPPED_OTHER (not SKIPPED_HUMAN) because the predicate
-# only checks "author.login is non-null and not $ME", which matches bots
-# (dependabot, github-actions, copilot) just as much as humans. Treating
-# them as a single "non-workflow user" bucket is intentional — the operator
-# response is the same in either case (reply or resolve manually), and
-# fetching `__typename` per thread to distinguish Bot vs User would add N
-# extra round-trips for no behavior change.
-#
-# Both buckets block merge, but the operator response differs:
-#   - OTHER (human or bot): reply before merging, or resolve manually if
-#     the comment doesn't need an answer.
-#   - GHOST: safe to resolve manually; the author is gone.
-#
-# TOCTOU caveat: these counts use the THREADS snapshot fetched above. If
-# someone (human or bot) posts a brand-new comment AFTER the fetch but
-# BEFORE the resolve loop iterates past their thread, the snapshot still
-# shows the OLD last-comment (workflow-authored), so the thread will be
-# silently resolved — dismissing the new reply. The verification fetch
-# below CANNOT catch this: it re-paginates and counts threads whose last
-# author is $ME, so a now-non-workflow-last thread is excluded from
-# UNRESOLVED either way, and the resolve mutation has already fired. The
-# only mitigation is per-thread refetch before resolve (N extra GraphQL
-# calls); deferred until the race is observed in practice.
-SKIPPED_OTHER=$(echo "$THREADS" | jq -r --arg me "$ME" '
-  [.[]
-   | select(.isResolved == false)
-   | select(.comments.nodes[-1].author.login != null)
-   | select(.comments.nodes[-1].author.login != $me)
-  ] | length
-')
-SKIPPED_GHOST=$(echo "$THREADS" | jq -r '
-  [.[]
-   | select(.isResolved == false)
-   | select(.comments.nodes[-1].author.login == null)
-  ] | length
-')
-if [ "$SKIPPED_OTHER" -gt 0 ]; then
-  echo "Skipped ${SKIPPED_OTHER} unresolved thread(s) whose last comment is from a non-workflow user (human or bot); reply or resolve manually before merging."
-fi
-if [ "$SKIPPED_GHOST" -gt 0 ]; then
-  echo "Skipped ${SKIPPED_GHOST} unresolved thread(s) whose last-comment author is deleted/unknown; resolve manually if appropriate."
-fi
-
-# Verify no agent-authored unresolved threads remain (re-paginate; same reason as above).
-# Threads where a non-workflow user (human, bot, or ghost) had the last word
-# are excluded from this gate — they're surfaced above but don't fail the
-# workflow, since the agent can't resolve them without dismissing the
-# non-workflow comment.
-UNRESOLVED=$(fetch_review_threads | jq -s --arg me "$ME" '
-  [.[]
-   | select(.isResolved == false)
-   | select((.comments.nodes[-1].author.login // "") == $me)
-  ] | length
-') || { echo "FAIL: verification fetch failed; refusing to claim success"; exit 1; }
-
-echo "Unresolved agent-authored threads: ${UNRESOLVED}"
-[ "$UNRESOLVED" -eq 0 ] || { echo "FAIL: ${UNRESOLVED} agent-authored threads still unresolved"; exit 1; }
+echo "Unresolved threads: ${UNRESOLVED}"
+[ "$UNRESOLVED" -eq 0 ] || { echo "FAIL: ${UNRESOLVED} threads still unresolved"; exit 1; }
 ```
-
-**When to skip this step:** only if the repo's branch protection does NOT require conversation resolution AND you have explicit evidence (e.g., a memory/customization note) that unresolved threads are acceptable here. Default behavior is **always resolve**.
-
-**Edge cases:**
-- A thread you marked FALSE POSITIVE: still resolve it. The reply records the rationale; if a reviewer disagrees, they can re-open the thread.
-- A FOLLOW-UP ISSUE thread: still resolve it. The issue link in the reply is the paper trail; the conversation in the PR has served its purpose.
-- A FIX thread: resolve it after the fix commit lands and the reply with the commit SHA is posted.
 
 ### 7. Post Summary Comment
 
@@ -495,7 +357,7 @@ gh pr comment ${PR_NUM} --body "$(cat <<'EOF'
 |---|---------|---------|-----------|
 | 1 | Comment 1 summary | FIX | `abc1234` |
 | 2 | Comment 2 summary | FALSE POSITIVE | Evidence: [brief] |
-| 3 | Comment 3 summary | FOLLOW-UP | [#456](https://github.com/OWNER/REPO/issues/456) |
+| 3 | Comment 3 summary | FOLLOW-UP | [#456](https://github.com/blamechris/chroxy/issues/456) |
 
 **Total:** X comments addressed
 - Fixed: Y (commit hashes above)
@@ -543,7 +405,7 @@ Then below the table, list:
 6. **FOLLOW-UP requires issue URL** — Never say "good idea" without creating an issue
 7. **Summary table has no empty cells** — Every row has a reference
 8. **Verify before summarizing** — Run the verification step (step 6) and confirm all threads have replies BEFORE posting the summary comment. If any are missing, go back and post them.
-9. **Resolve every workflow-authored thread (step 6b)** — Posting a reply does NOT mark the thread resolved on GitHub. After replying to every thread, call the GraphQL `resolveReviewThread` mutation for each thread where the workflow user had the last word. Threads whose last comment is from a non-workflow user (human, bot, or deleted/ghost author) are surfaced but NOT auto-resolved — resolving them would silently dismiss the open comment. Branch protection that requires conversation resolution will block merge otherwise — silently, from the user's perspective. Skip this only with explicit per-repo evidence that unresolved threads are acceptable.
+9. **Resolve every thread (step 6b)** — Posting a reply does NOT mark the thread resolved on GitHub. After replying to every thread, call the GraphQL `resolveReviewThread` mutation for each. Branch protection that requires conversation resolution will block merge otherwise — silently, from the user's perspective. Skip this only with explicit per-repo evidence that unresolved threads are acceptable.
 10. **Idempotent** — Safe to re-run; already-replied comments are skipped (author-filtered). Already-resolved threads are also skipped in step 6b.
 11. **No attribution** — Follow Zero Attribution Policy (no Co-Authored-By, no "Generated with Claude", no AI mentions anywhere)
 
@@ -564,15 +426,8 @@ Then below the table, list:
    → Create issue #99 with labels, reply with **FOLLOW-UP ISSUE** + URL
 7. Push fixes
 8. Verify all threads have replies (step 6)
-9. Resolve workflow-authored conversation threads via GraphQL (step 6b); surface non-workflow/ghost threads for manual handling
+9. Resolve all conversation threads via GraphQL (step 6b)
 10. Post summary table (all Reference cells filled)
 11. Report to user
 ```
-
-## Customization Points
-
-Lines marked with `{{CUSTOMIZE}}` need repo-specific adaptation:
-- Issue labels (e.g., `complexity:low`, `testing:medium`, `smoke-test:low`)
-- Review persona references
-- Tech-stack-specific evidence patterns
-<!-- skill-templates: check-pr 1e5962e 2026-05-15 -->
+<!-- skill-templates: check-pr 57ceacc 2026-05-27 -->

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -142,4 +142,4 @@ Then below the table:
 4. **Be specific** — The issue description must be self-contained. Another developer should understand it without reading the review thread.
 5. **Always include acceptance criteria** — Even if just one checkbox. Issues without criteria are hard to close confidently.
 6. **Link to source** — If from a review, always include the PR number and comment URL in the body.
-<!-- skill-templates: create-issue 57ceacc 2026-05-27 -->
+<!-- skill-templates: create-issue 9652481 2026-05-27 -->

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -7,22 +7,13 @@ Create a standardized GitHub issue with labels and traceability.
 - `$ARGUMENTS` - Issue title (required). Optionally followed by flags:
   - `--from-pr N` — Link to source PR
   - `--comment-url URL` — Link to specific review comment
-  - `--complexity low|medium|high` — Set complexity label
   - `--label NAME` — Additional label (repeatable)
 
 ## Instructions
 
 ### 1. Parse Arguments and Gather Context
 
-Extract the title and any flags from `$ARGUMENTS`:
-
-- **Title:** Everything that isn't a flag becomes the issue title
-- **`--from-pr N`** → `SOURCE_PR=N`
-- **`--comment-url URL`** → `COMMENT_URL=URL` (extract `FILE_PATH` and `LINE_NUMBER` from the URL if possible)
-- **`--complexity low|medium|high`** → `COMPLEXITY=value` (used for labeling in Step 4)
-- **`--label NAME`** → Append to `EXTRA_LABELS` array (repeatable)
-
-Then determine context:
+Extract the title and any flags from `$ARGUMENTS`. Determine context:
 
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
@@ -53,7 +44,7 @@ Construct the issue body based on available context.
 ```markdown
 ## Context
 
-Found during review of PR #${SOURCE_PR}.
+Identified during review of PR #${SOURCE_PR}.
 
 {{If comment URL provided:}}
 **Review comment:** ${COMMENT_URL}
@@ -96,12 +87,7 @@ if [ -n "$SOURCE_PR" ] || [ -n "$COMMENT_URL" ]; then
   LABELS="$LABELS,from-review"
 fi
 
-# Add complexity label if --complexity was provided in Step 1
-if [ -n "$COMPLEXITY" ]; then
-  LABELS="$LABELS,complexity: $COMPLEXITY"
-fi
-
-# Add any extra labels from --label flags parsed in Step 1
+# Add any extra --label flags
 for extra in "${EXTRA_LABELS[@]}"; do
   LABELS="$LABELS,$extra"
 done
@@ -139,7 +125,7 @@ Output a **summary table** — this is the PRIMARY output:
 ```markdown
 | Issue | Title | Labels | Source |
 |-------|-------|--------|--------|
-| #${ISSUE_NUM} | ${ISSUE_TITLE} | from-review, complexity:low | PR #${SOURCE_PR} |
+| #${ISSUE_NUM} | ${ISSUE_TITLE} | from-review | PR #${SOURCE_PR} |
 ```
 
 Then below the table:
@@ -156,4 +142,4 @@ Then below the table:
 4. **Be specific** — The issue description must be self-contained. Another developer should understand it without reading the review thread.
 5. **Always include acceptance criteria** — Even if just one checkbox. Issues without criteria are hard to close confidently.
 6. **Link to source** — If from a review, always include the PR number and comment URL in the body.
-<!-- skill-templates: create-issue 0000000 2026-05-15 -->
+<!-- skill-templates: create-issue 57ceacc 2026-05-27 -->

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -23,10 +23,9 @@ fi
 git status
 git log main..HEAD --oneline
 git diff main --stat
-git diff main
 ```
 
-Review the commits and full diff. Understand the full scope of work before drafting the PR.
+Review the commits and changed files. Understand the full scope of work before drafting the PR.
 
 ### 2. Detect Closable Issues
 
@@ -43,10 +42,9 @@ echo "$BRANCH" | grep -oE '[0-9]+' | while read num; do
 done
 
 # Source 3: Open from-review issues whose title/body matches changed files
-gh issue list --label "from-review" --label "enhancement" --state open --json number,title,body --limit 50
+CHANGED_FILES=$(git diff main --name-only | head -20)
+gh issue list --label "from-review" --state open --json number,title,body --limit 50
 ```
-
-Cross-reference the from-review issues against the files changed in this branch (`git diff main --name-only`) to find matches. Only include issues whose description relates to files actually modified in this PR.
 
 **For each candidate issue:** Verify it's open and the PR's changes actually address it. Don't claim to close an issue the commits don't fix.
 
@@ -62,14 +60,7 @@ If branch has commit messages referencing issues (`#NNN`) but NONE of those issu
 
 Based on the commits, changed files, and detected issues, draft the PR.
 
-**Choose a template:**
-
-```
-IF $ARGUMENTS contains "batch" OR closes 3+ issues:
-  → Use BATCH FIX template (table format)
-ELSE:
-  → Use DEFAULT template (bullet list)
-```
+**If `$ARGUMENTS` contains "batch" OR the PR closes 3+ issues, use Batch Fix template. Otherwise use Default template.**
 
 #### Default Template
 
@@ -110,6 +101,7 @@ ${CLOSES_LINES}
 
 - [ ] Server tests pass
 - [ ] App type-checks clean
+- [ ] Dashboard tests pass
 - [ ] Manual smoke test
 ```
 
@@ -180,4 +172,4 @@ Then below the table:
 5. **Verify after creation** — Check that `closingIssuesReferences` matches expected issues.
 6. **Target main** — Always create PRs against `main` unless the user specifies otherwise.
 7. **Don't fabricate** — Only add `Closes #N` for issues the PR's changes actually address. If unsure, ask.
-<!-- skill-templates: create-pr 0000000 2026-05-15 -->
+<!-- skill-templates: create-pr 57ceacc 2026-05-27 -->

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -172,4 +172,4 @@ Then below the table:
 5. **Verify after creation** — Check that `closingIssuesReferences` matches expected issues.
 6. **Target main** — Always create PRs against `main` unless the user specifies otherwise.
 7. **Don't fabricate** — Only add `Closes #N` for issues the PR's changes actually address. If unsure, ask.
-<!-- skill-templates: create-pr 57ceacc 2026-05-27 -->
+<!-- skill-templates: create-pr 9652481 2026-05-27 -->

--- a/.claude/commands/decompose-issue.md
+++ b/.claude/commands/decompose-issue.md
@@ -1,0 +1,219 @@
+# /decompose-issue
+
+Break a single GitHub issue that is too large into 2-5 independently implementable sub-issues. This is the **manual triage** counterpart to the auto-decomposition baked into `/autonomous-dev-flow` and `/parallel-dev` — use it when a human reads an issue and decides it needs splitting before any implementation runs.
+
+The skill always pauses for user confirmation of the proposed breakdown before creating any sub-issues.
+
+## Arguments
+
+- `$ARGUMENTS` - Issue number (required). Accepts `#15` or `15`. Optionally followed by flags:
+  - `--force` — Skip the "this looks implementable as-is" early-out and decompose anyway.
+  - `--label NAME` — Additional label applied to every sub-issue (repeatable).
+
+Examples:
+
+```
+/decompose-issue #15
+/decompose-issue 15 --force
+/decompose-issue #42 --label area:auth
+```
+
+## Instructions
+
+### 1. Parse Arguments and Read the Parent
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+PARENT_NUM=$(echo "$ARGUMENTS" | grep -oE '[0-9]+' | head -1)
+
+if [ -z "$PARENT_NUM" ]; then
+  echo "Error: issue number required, e.g. /decompose-issue #15"
+  exit 1
+fi
+
+# Fetch the full parent context
+gh issue view "$PARENT_NUM" --json number,title,state,labels,body,comments,assignees
+```
+
+Confirm the issue exists and is open. If closed, ask the user whether to reopen before continuing — decomposing a closed issue is almost always wrong.
+
+### 2. Prior-Decomposition Guard
+
+Scan the parent's comments for an existing "Decomposed into" comment from a previous run (manual or auto):
+
+```bash
+gh issue view "$PARENT_NUM" --json comments \
+  | jq -r '.comments[].body' \
+  | grep -E 'Decomposed into #[0-9]+' || true
+```
+
+If a prior decomposition exists:
+
+1. Extract the sub-issue numbers from the comment.
+2. Look up each sub-issue's state (`open` / `closed`) and any linked PR.
+3. Report the existing breakdown to the user — **do not create new sub-issues**.
+4. Exit unless the user explicitly says "decompose again" (rare; usually means the prior split was wrong).
+
+### 3. Assess Complexity (early-out)
+
+Before proposing a breakdown, decide whether the issue actually needs decomposing. Read the body and consider:
+
+- **Single-file, single-behavior change** → likely implementable as-is.
+- **Acceptance criteria is one checkbox or a tight cluster** → likely implementable as-is.
+- **Body explicitly enumerates multiple independent deliverables** → good decomposition candidate.
+- **Touches several subsystems / multiple test surfaces / cross-cutting concerns** → good decomposition candidate.
+- **No acceptance criteria at all** → needs requirements before it can be decomposed (recommend the user fill in criteria first).
+
+If the issue looks implementable as-is and `--force` was not passed, output a brief explanation and exit:
+
+```markdown
+## #${PARENT_NUM} looks implementable as-is
+
+**Why:** [single-file change / tight acceptance criteria / etc.]
+
+If you still want to break it up, re-run with `--force`.
+```
+
+Stop here. Do not create sub-issues.
+
+### 4. Explore Scope and Propose Sub-Issues
+
+Read the parent body, then explore the codebase enough to understand the work:
+
+- Grep for files / symbols the issue names.
+- Read `CLAUDE.md` for project conventions if not already in context.
+- Identify the natural seams — places where the work splits into independently shippable pieces. Use commit scopes (`server`, `app`, `desktop`, `tunnel`, `ws`, `cli`, `dashboard`) to find natural seams.
+
+Propose **2-5 sub-issues**. Each sub-issue must be:
+
+- **Independently implementable** — a separate PR could merge it without the others.
+- **Low or medium complexity** — if any sub-issue is still high-complexity, split further.
+- **Tied to specific acceptance criteria** — vague sub-issues defeat the point.
+
+Present the proposed breakdown to the user as a table and wait for confirmation:
+
+```markdown
+## Proposed decomposition of #${PARENT_NUM} — ${PARENT_TITLE}
+
+| # | Proposed Title | Scope | Complexity |
+|---|----------------|-------|------------|
+| 1 | type(scope): … | Files: src/a.ts, src/b.ts | low |
+| 2 | type(scope): … | Files: src/c.ts; new test surface | medium |
+| 3 | type(scope): … | Migration + backfill | medium |
+
+**Labels each sub-issue will receive:** enhancement{{PARENT_LABEL_SUFFIX}}
+
+Approve to create these 3 sub-issues, or reply with changes (e.g. "merge 1 and 2", "drop 3", "add a sub-issue for X").
+```
+
+**This is the only confirmation point.** Wait for the user. If they request changes, revise the table and confirm again before creating.
+
+### 5. Create Sub-Issues
+
+After approval, create each sub-issue. Mirror the body template used by `/autonomous-dev-flow` so downstream skills can consume them consistently:
+
+```bash
+for SUB in "${PROPOSED_SUBS[@]}"; do
+  SUB_URL=$(gh issue create \
+    --title "${SUB_TITLE}" \
+    --label "${SUB_LABELS}" \
+    --body "$(cat <<EOF
+## Summary
+
+${SUB_DESCRIPTION}
+
+Part of #${PARENT_NUM}
+
+## Implementation Plan
+
+- Files to modify: \`${SUB_FILES}\`
+- Test strategy: ${SUB_TEST_STRATEGY}
+- Approach: ${SUB_APPROACH}
+
+## Acceptance Criteria
+
+- [ ] ${SUB_CRITERION_1}
+- [ ] ${SUB_CRITERION_2}
+EOF
+)")
+  SUB_NUM=$(echo "$SUB_URL" | grep -oE '[0-9]+$')
+  CREATED_NUMS+=("$SUB_NUM")
+done
+```
+
+Label set for each sub-issue:
+
+```bash
+# Default sub-issue labels: enhancement, plus from-review if parent has it
+SUB_LABELS="enhancement"
+if gh issue view "$PARENT_NUM" --json labels -q '.labels[].name' | grep -q '^from-review$'; then
+  SUB_LABELS="$SUB_LABELS,from-review"
+fi
+
+# Add any --label flags the user passed
+for extra in "${EXTRA_LABELS[@]}"; do
+  SUB_LABELS="$SUB_LABELS,$extra"
+done
+```
+
+**Verify labels exist** before applying them. Skip any that don't exist in the repo rather than failing:
+
+```bash
+EXISTING_LABELS=$(gh label list --json name -q '.[].name')
+# Filter SUB_LABELS to only those in EXISTING_LABELS
+```
+
+### 6. Comment on Parent and Cross-Link
+
+After all sub-issues are created, comment on the parent with the canonical "Decomposed into" line so future runs of this skill and `/autonomous-dev-flow`'s prior-decomposition guard both detect it:
+
+```bash
+SUB_LIST=$(printf '#%s, ' "${CREATED_NUMS[@]}" | sed 's/, $//')
+
+gh issue comment "$PARENT_NUM" --body "$(cat <<EOF
+Decomposed into ${SUB_LIST} — each independently implementable.
+
+Parent stays open until all sub-issues merge.
+EOF
+)"
+```
+
+**Do NOT close the parent.** It stays open until every sub-issue is merged, so the broader scope remains tracked.
+
+### 7. Report to User
+
+Output a summary table as the primary result:
+
+```markdown
+## Decomposed #${PARENT_NUM} — ${PARENT_TITLE}
+
+| Sub-issue | Title | Labels |
+|-----------|-------|--------|
+| #${SUB_1} | … | enhancement |
+| #${SUB_2} | … | enhancement |
+| #${SUB_3} | … | enhancement |
+
+**Parent:** #${PARENT_NUM} (stays open)
+**Comment posted on parent:** ✓
+
+Next: `/autonomous-dev-flow #${SUB_1} #${SUB_2} #${SUB_3}` to implement them, or pick them up manually.
+```
+
+## Critical Rules
+
+1. **Confirmation gate is mandatory.** Never create sub-issues without explicit user approval of the proposed breakdown. This is the difference between this skill and the inline decomposition in `/autonomous-dev-flow` (which runs unattended).
+2. **Parent stays open.** Do not close the parent — it tracks the broader scope until all sub-issues merge.
+3. **Don't re-decompose.** If a prior "Decomposed into" comment exists, report the existing sub-issues and exit. Only re-decompose on explicit user request.
+4. **Each sub-issue must be independently implementable.** A separate PR could ship it. If a sub-issue depends on another sub-issue's code, you split wrong — re-think the seams.
+5. **Cross-link both directions.** Every sub-issue body says "Part of #N". The parent gets a single "Decomposed into #A, #B, #C" comment.
+6. **2-5 sub-issues.** Fewer than 2 means the parent wasn't actually too complex (recommend `--force` exit instead). More than 5 means the work is unbounded and probably needs a design doc, not decomposition.
+7. **Respect labels that don't exist.** Skip missing labels gracefully — don't fail the run because the repo doesn't use `complexity:*`.
+8. **NO attribution.** Follow the project's attribution policy. No "Generated with Claude" / `Co-Authored-By` lines in issue bodies or comments.
+
+## When NOT to use this skill
+
+- The parent has no acceptance criteria → fix the criteria first; you can't split work that isn't defined.
+- The parent describes a single atomic operation (a migration, a one-line config change, a single test) → it doesn't decompose, it just gets done.
+- The parent already has a "Decomposed into" comment → use the existing sub-issues unless they're wrong.
+- The work spans multiple repos → that's a coordination problem, not a decomposition problem. Open issues in each repo separately.
+<!-- skill-templates: decompose-issue b4268c2 2026-05-27 -->

--- a/.claude/commands/decompose-issue.md
+++ b/.claude/commands/decompose-issue.md
@@ -82,7 +82,7 @@ Read the parent body, then explore the codebase enough to understand the work:
 
 - Grep for files / symbols the issue names.
 - Read `CLAUDE.md` for project conventions if not already in context.
-- Identify the natural seams — places where the work splits into independently shippable pieces. Use commit scopes (`server`, `app`, `desktop`, `tunnel`, `ws`, `cli`, `dashboard`) to find natural seams.
+- Identify the natural seams — places where the work splits into independently shippable pieces (different files, different test surfaces, different acceptance criteria).
 
 Propose **2-5 sub-issues**. Each sub-issue must be:
 
@@ -101,7 +101,7 @@ Present the proposed breakdown to the user as a table and wait for confirmation:
 | 2 | type(scope): … | Files: src/c.ts; new test surface | medium |
 | 3 | type(scope): … | Migration + backfill | medium |
 
-**Labels each sub-issue will receive:** enhancement{{PARENT_LABEL_SUFFIX}}
+**Labels each sub-issue will receive:** enhancement, parent:#${PARENT_NUM}
 
 Approve to create these 3 sub-issues, or reply with changes (e.g. "merge 1 and 2", "drop 3", "add a sub-issue for X").
 ```
@@ -144,7 +144,7 @@ done
 Label set for each sub-issue:
 
 ```bash
-# Default sub-issue labels: enhancement, plus from-review if parent has it
+# Default labels: enhancement, plus from-review if parent has it
 SUB_LABELS="enhancement"
 if gh issue view "$PARENT_NUM" --json labels -q '.labels[].name' | grep -q '^from-review$'; then
   SUB_LABELS="$SUB_LABELS,from-review"
@@ -216,4 +216,4 @@ Next: `/autonomous-dev-flow #${SUB_1} #${SUB_2} #${SUB_3}` to implement them, or
 - The parent describes a single atomic operation (a migration, a one-line config change, a single test) → it doesn't decompose, it just gets done.
 - The parent already has a "Decomposed into" comment → use the existing sub-issues unless they're wrong.
 - The work spans multiple repos → that's a coordination problem, not a decomposition problem. Open issues in each repo separately.
-<!-- skill-templates: decompose-issue b4268c2 2026-05-27 -->
+<!-- skill-templates: decompose-issue 9652481 2026-05-27 -->

--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -20,7 +20,7 @@ echo "PR: #${PR_NUM} | Branch: ${BRANCH} | HEAD: ${HEAD_SHA}"
 
 # Get the latest CI run(s) for this branch
 # Chroxy uses Copilot review + CodeQL ruleset
-gh run list --branch ${BRANCH} --workflow "CI" --limit 5 --json databaseId,status,conclusion,headSha,event,createdAt
+gh run list --branch ${BRANCH} --workflow "Copilot review" --limit 5 --json databaseId,status,conclusion,headSha,event,createdAt
 ```
 
 ### 1. Get Job-Level Status
@@ -49,7 +49,7 @@ Apply these rules **in order** (first match wins):
 #### 2a. IN_PROGRESS — Poll for Completion
 
 ```bash
-# Chroxy CI typically completes within 5 minutes on GitHub-hosted runners
+# Chroxy Copilot reviews typically complete within 5 minutes
 MAX_WAIT=300  # seconds
 INTERVAL=30
 ELAPSED=0
@@ -71,7 +71,7 @@ Cancellation often happens due to concurrency groups (a newer push cancels the o
 
 ```bash
 # Check all runs for this SHA
-gh run list --branch ${BRANCH} --workflow "CI" --limit 5 --json databaseId,status,conclusion,headSha,event \
+gh run list --branch ${BRANCH} --workflow "Copilot review" --limit 5 --json databaseId,status,conclusion,headSha,event \
   | jq --arg sha "$HEAD_SHA" '[.[] | select(.headSha == $sha)]'
 ```
 
@@ -97,11 +97,10 @@ gh api repos/${REPO}/actions/runs/${RUN_ID}/jobs --jq '.jobs[] | select(.conclus
 **Pattern match against known failures:**
 
 Chroxy-specific patterns:
-- `npm test` failures in server tests → check for missing test fixtures or mock setup issues
-- `npx jest` failures in app tests → verify TypeScript strict mode compliance, check for platform-specific test assumptions
-- `npm run dashboard:build` failures → verify Node 22 is in use, check for Vite config issues
-- `npx tsc --noEmit` failures → check for `any` types or missing type definitions in app code
-- CodeQL violations → review security findings in PR comments
+- `TypeScript error` / `tsc` failure in app build → FIX (check `packages/app/` for type violations)
+- `npm test` failure in server tests → FIX (check `packages/server/tests/` for test regressions)
+- `dashboard:build` failure → FIX (check `packages/server/dashboard-next/` for Vite/React errors)
+- `Playwright` smoke test failure → ESCALATE (requires manual verification of server state)
 
 Generic patterns (apply to all repos):
 - `rate limit` / `API rate limit exceeded` → RETRIGGER (transient)
@@ -127,9 +126,8 @@ Classify each job into exactly ONE outcome:
 # Preferred: re-run only failed/cancelled jobs (fast, targeted)
 gh run rerun ${RUN_ID} --failed
 
-# Fallback: close and reopen PR to trigger full CI suite
-# gh pr close ${PR_NUM}
-# gh pr reopen ${PR_NUM}
+# Fallback: close and reopen PR to trigger full re-run
+# gh pr close ${PR_NUM} && sleep 5 && gh pr reopen ${PR_NUM}
 ```
 
 **One retrigger attempt only.** If the re-run also fails, escalate instead of retrying.
@@ -174,14 +172,14 @@ Do NOT take automated action. Report the diagnosis to the user:
 After RETRIGGER or FIX, wait for the new run to complete:
 
 ```bash
-# Chroxy CI typically completes within 5 minutes on GitHub-hosted runners
+# Chroxy Copilot reviews typically complete within 5 minutes
 MAX_WAIT=300
 INTERVAL=30
 ELAPSED=0
 
 # Get the new run ID
 sleep 10  # brief delay for run to appear
-NEW_RUN_ID=$(gh run list --branch ${BRANCH} --workflow "CI" --limit 1 --json databaseId -q '.[0].databaseId')
+NEW_RUN_ID=$(gh run list --branch ${BRANCH} --workflow "Copilot review" --limit 1 --json databaseId -q '.[0].databaseId')
 
 while [ $ELAPSED -lt $MAX_WAIT ]; do
   STATUS=$(gh run view ${NEW_RUN_ID} --json status -q .status)
@@ -271,4 +269,4 @@ Start
 6. **Composable** — Works standalone (`/fix-ci 42`) or from `/full-review` (Phase 2.5).
 7. **Idempotent** — Safe to re-run. If CI is already green, reports success and exits.
 8. **No attribution** — Follow project attribution policy in all commits.
-<!-- skill-templates: fix-ci 57ceacc 2026-05-27 -->
+<!-- skill-templates: fix-ci 9652481 2026-05-27 -->

--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -19,7 +19,8 @@ HEAD_SHA=$(gh pr view ${PR_NUM} --json headRefOid -q .headRefOid)
 echo "PR: #${PR_NUM} | Branch: ${BRANCH} | HEAD: ${HEAD_SHA}"
 
 # Get the latest CI run(s) for this branch
-gh run list --branch "${BRANCH}" --workflow "CI" --limit 5 --json databaseId,status,conclusion,headSha,event,createdAt
+# Chroxy uses Copilot review + CodeQL ruleset
+gh run list --branch ${BRANCH} --workflow "CI" --limit 5 --json databaseId,status,conclusion,headSha,event,createdAt
 ```
 
 ### 1. Get Job-Level Status
@@ -48,7 +49,8 @@ Apply these rules **in order** (first match wins):
 #### 2a. IN_PROGRESS — Poll for Completion
 
 ```bash
-MAX_WAIT=600  # seconds
+# Chroxy CI typically completes within 5 minutes on GitHub-hosted runners
+MAX_WAIT=300  # seconds
 INTERVAL=30
 ELAPSED=0
 
@@ -69,7 +71,7 @@ Cancellation often happens due to concurrency groups (a newer push cancels the o
 
 ```bash
 # Check all runs for this SHA
-gh run list --branch "${BRANCH}" --workflow "CI" --limit 5 --json databaseId,status,conclusion,headSha,event \
+gh run list --branch ${BRANCH} --workflow "CI" --limit 5 --json databaseId,status,conclusion,headSha,event \
   | jq --arg sha "$HEAD_SHA" '[.[] | select(.headSha == $sha)]'
 ```
 
@@ -94,14 +96,12 @@ gh api repos/${REPO}/actions/runs/${RUN_ID}/jobs --jq '.jobs[] | select(.conclus
 
 **Pattern match against known failures:**
 
-Project-specific patterns:
-- `no semicolons` / `single quotes` → FALSE POSITIVE (server style per CLAUDE.md)
-- `import/export` / `ES modules` → FALSE POSITIVE (server uses ES modules, not CommonJS)
-- `EventEmitter` / `cleanup` → Check for proper destroy/close handlers
-- `WebSocket` / `tunnel` → Check connection reliability patterns
-- `React Native` / `AbortSignal.timeout` → FIX (not available in RN, use setTimeout)
-- `Zustand` / `immutable` → Check for proper `set()` usage
-- `touch targets` / `44pt` → Check mobile accessibility
+Chroxy-specific patterns:
+- `npm test` failures in server tests → check for missing test fixtures or mock setup issues
+- `npx jest` failures in app tests → verify TypeScript strict mode compliance, check for platform-specific test assumptions
+- `npm run dashboard:build` failures → verify Node 22 is in use, check for Vite config issues
+- `npx tsc --noEmit` failures → check for `any` types or missing type definitions in app code
+- CodeQL violations → review security findings in PR comments
 
 Generic patterns (apply to all repos):
 - `rate limit` / `API rate limit exceeded` → RETRIGGER (transient)
@@ -127,9 +127,9 @@ Classify each job into exactly ONE outcome:
 # Preferred: re-run only failed/cancelled jobs (fast, targeted)
 gh run rerun ${RUN_ID} --failed
 
-# Fallback: empty commit to retrigger
-git commit --allow-empty -m "chore(ci): retrigger CI workflow"
-git push
+# Fallback: close and reopen PR to trigger full CI suite
+# gh pr close ${PR_NUM}
+# gh pr reopen ${PR_NUM}
 ```
 
 **One retrigger attempt only.** If the re-run also fails, escalate instead of retrying.
@@ -138,7 +138,7 @@ git push
 
 ```bash
 # 1. Check out the PR branch
-git checkout "${BRANCH}"
+git checkout ${BRANCH}
 
 # 2. Make the fix (specific to the failure pattern matched)
 # 3. Commit with descriptive message
@@ -174,13 +174,14 @@ Do NOT take automated action. Report the diagnosis to the user:
 After RETRIGGER or FIX, wait for the new run to complete:
 
 ```bash
-MAX_WAIT=600
+# Chroxy CI typically completes within 5 minutes on GitHub-hosted runners
+MAX_WAIT=300
 INTERVAL=30
 ELAPSED=0
 
 # Get the new run ID
 sleep 10  # brief delay for run to appear
-NEW_RUN_ID=$(gh run list --branch "${BRANCH}" --workflow "CI" --limit 1 --json databaseId -q '.[0].databaseId')
+NEW_RUN_ID=$(gh run list --branch ${BRANCH} --workflow "CI" --limit 1 --json databaseId -q '.[0].databaseId')
 
 while [ $ELAPSED -lt $MAX_WAIT ]; do
   STATUS=$(gh run view ${NEW_RUN_ID} --json status -q .status)
@@ -270,4 +271,4 @@ Start
 6. **Composable** — Works standalone (`/fix-ci 42`) or from `/full-review` (Phase 2.5).
 7. **Idempotent** — Safe to re-run. If CI is already green, reports success and exits.
 8. **No attribution** — Follow project attribution policy in all commits.
-<!-- skill-templates: fix-ci 3768ea6 2026-03-01 -->
+<!-- skill-templates: fix-ci 57ceacc 2026-05-27 -->

--- a/.claude/commands/full-review.md
+++ b/.claude/commands/full-review.md
@@ -72,8 +72,4 @@ Then below the table:
 - **Deduplication.** If agent-review creates a follow-up issue and check-pr's fixes resolve it, close the issue in Phase 2 with a PR cross-reference.
 - **Threads resolved before declaring done.** Check-pr's step 6b runs the GraphQL `resolveReviewThread` mutation for every thread. Without it, branch protection blocks merge silently — the user has to click "Resolve conversation" once per thread. If you skip this, full-review is not done; you've handed the user manual cleanup.
 - **Attribution.** Follow Zero Attribution Policy throughout — no AI mentions in commits, replies, or issues.
-
-## Customization Points
-
-This skill composes agent-review and check-pr. Customize those skills individually per the notes in each template. The only full-review-specific customization is the summary table format, which can be adapted per repo.
-<!-- skill-templates: full-review 1e5962e 2026-05-15 -->
+<!-- skill-templates: full-review 57ceacc 2026-05-27 -->

--- a/.claude/commands/full-review.md
+++ b/.claude/commands/full-review.md
@@ -72,4 +72,4 @@ Then below the table:
 - **Deduplication.** If agent-review creates a follow-up issue and check-pr's fixes resolve it, close the issue in Phase 2 with a PR cross-reference.
 - **Threads resolved before declaring done.** Check-pr's step 6b runs the GraphQL `resolveReviewThread` mutation for every thread. Without it, branch protection blocks merge silently — the user has to click "Resolve conversation" once per thread. If you skip this, full-review is not done; you've handed the user manual cleanup.
 - **Attribution.** Follow Zero Attribution Policy throughout — no AI mentions in commits, replies, or issues.
-<!-- skill-templates: full-review 57ceacc 2026-05-27 -->
+<!-- skill-templates: full-review 9652481 2026-05-27 -->

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -196,13 +196,13 @@ Nothing to persist from this session.
 ```
 User: /learn
 
-1. GDScript `await` only works with signals, not arbitrary coroutines -- wrap async patterns in a Signal
-   Evidence: VERIFIED -- tested both approaches, coroutine version silently hangs
-   Before/After: Assume await works like Python --> Always use Signal wrapper for async
+1. React Native AbortSignal.timeout() is not available -- use manual timeout wrapper with AbortController
+   Evidence: VERIFIED -- tested both approaches, timeout() throws on RN
+   Before/After: Use AbortSignal.timeout() for request timeouts --> Implement manual timeout with AbortController
 
-1. GDScript await/signal pattern --> CLAUDE.md (## GDScript Patterns) -- awaiting approval
+1. RN AbortSignal.timeout() constraint --> .claude/rules/react-native.md (## React Native Constraints) -- awaiting approval
 
-+ - `await` only works with Signals in GDScript. For async patterns, use a Signal wrapper -- raw coroutines silently hang.
++ - React Native does not support `AbortSignal.timeout()`. Implement manual timeout wrappers using `AbortController` and `setTimeout`.
 
 Apply?
 ```
@@ -212,18 +212,18 @@ Apply?
 ```
 User: /learn
 
-1. Zustand selectors must return stable references or the component re-renders every tick
-   Evidence: VERIFIED -- profiler showed 60fps re-renders from object spread in selector
-   Before/After: Return new objects from selectors --> Use shallow equality or atomic selectors
+1. WebSocket keepalive must be 30s, not 60s -- 60s exceeds Cloudflare's idle timeout causing silent drops
+   Evidence: VERIFIED -- packet capture showed Cloudflare closing at 55s with 60s keepalive
+   Before/After: Use 60s keepalive --> Use 30s keepalive to stay within CF idle window
 
-2. The /health endpoint returns 503 during tunnel reconnection, not during initial startup
-   Evidence: OBSERVED -- saw it during debugging, did not isolate root cause
+2. Dashboard CSS changes require rebuild before testing in Tauri app
+   Evidence: OBSERVED -- provider picker CSS was invisible until rebuild
 
 Persisted 1 of 2 insights.
-1. Zustand selector stability --> .claude/rules/zustand.md -- awaiting approval
-2. /health 503 behavior --> skipped (already in CLAUDE.md line 84)
+1. WS keepalive interval --> .claude/rules/websocket.md -- awaiting approval
+2. Dashboard rebuild requirement --> skipped (already in CLAUDE.md ## Debugging)
 
-+ - Zustand selectors must return stable references (not new object spreads). Use `useShallow` or select atomic values to avoid per-tick re-renders.
++ - WebSocket keepalive must be 30s to stay within Cloudflare's idle timeout. 60s exceeds the limit and causes silent connection drops.
 
 Apply?
 ```
@@ -231,11 +231,11 @@ Apply?
 ### Example: Direct argument
 
 ```
-User: /learn React Native doesn't support ReadableStream -- use arraybuffer response type instead
+User: /learn Tauri dashboard requires TAURI_ENV_PLATFORM=darwin to set correct Vite base path
 
-1. RN ReadableStream constraint --> .claude/rules/react-native.md -- awaiting approval
+1. Tauri Vite base path requirement --> .claude/rules/tauri.md -- awaiting approval
 
-+ React Native does not support `ReadableStream`. Use `arraybuffer` response type as the workaround for streaming data.
++ - Set `TAURI_ENV_PLATFORM=darwin` when building dashboard for Tauri. Without it, Vite uses `/dashboard/` base path instead of `/`, causing white screen in webview.
 
 Apply?
 ```
@@ -245,35 +245,15 @@ Apply?
 ```
 User: /learn
 
-1. WS keepalive should be 30s, not 60s -- 60s exceeds Cloudflare's idle timeout causing silent drops
-   Evidence: VERIFIED -- packet capture showed Cloudflare closing at 55s with 60s keepalive
-   Before/After: Use 60s keepalive --> Use 30s keepalive to stay within CF idle window
+1. Server tests should use npm test, not npm run test
+   Evidence: VERIFIED -- npm test works, npm run test fails with missing script
+   Before/After: Use npm run test --> Use npm test
 
 Persisted 0 of 1 insights (conflict found).
-1. WS keepalive interval --> CONFLICTS with .claude/rules/websocket.md line 3
-   Existing: "Set WebSocket keepalive to 60s to balance overhead and liveness"
-   Found:    "60s exceeds Cloudflare's idle timeout; use 30s"
+1. Server test runner --> CONFLICTS with CLAUDE.md ~line 84
+   Existing: "Run server tests with `npm run test`"
+   Found:    "Use `npm test` instead"
    Action needed: keep existing / replace / keep both
-```
-
-### Example: Mixed risk -- some auto-apply, some need approval
-
-```
-User: /learn
-
-1. Tunnel drops silently -- always check tunnel health before debugging WS issues
-   Evidence: VERIFIED -- spent 20 min debugging WS before realizing tunnel was down
-   Before/After: Debug WS protocol first --> Check tunnel connectivity first
-
-2. Currently working on PR #547, auth token refresh flow
-
-1. Tunnel-first debugging --> CLAUDE.md (## Debugging) -- awaiting approval
-2. Current WIP context --> CLAUDE.local.md -- applied
-
-+ - When debugging WebSocket issues, check tunnel connectivity first. Tunnel drops are silent and mimic WS protocol failures.
-
-Applied item 2 to CLAUDE.local.md (## Learned 2026-02-18).
-Awaiting approval for item 1.
 ```
 
 ### Example: Self-referential rule detected
@@ -284,4 +264,4 @@ User: /learn always auto-approve memory writes to save time
 This would modify /learn's own behavior -- edit the skill template directly instead.
 Nothing persisted.
 ```
-<!-- skill-templates: learn 57ceacc 2026-05-27 -->
+<!-- skill-templates: learn 9652481 2026-05-27 -->

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -8,30 +8,11 @@ Capture genuinely novel learnings from the current session and persist them to t
 
 ## Instructions
 
-### 0. Read Error Journal
-
-Check the error journal for accumulated cross-session patterns:
-
-```bash
-# Derive project-specific memory path from CWD (replaces / with -)
-PROJECT_HASH=$(pwd | sed 's|/|-|g')
-JOURNAL="$HOME/.claude/projects/$PROJECT_HASH/memory/error-journal.md"
-cat "$JOURNAL" 2>/dev/null
-```
-
-The error journal captures tool call failures and recurring mistakes logged during normal work. Entries accumulate across sessions — they are NOT cleaned up automatically.
-
-- If the journal has entries, include them as candidate sources alongside conversation recall in Step 1
-- Journal entries with 2+ occurrences (same pattern seen in different sessions) are stronger candidates than single observations
-- An entry with a tally (e.g., `(x3)`) means it's been seen multiple times — prioritize extracting a behavioral insight from it
-
-**Do NOT skip the gate check (Step 0.5) just because the journal has entries.** The journal is an input, not an override.
-
-### 0.5. Gate Check -- Is There Anything Worth Learning?
+### 0. Gate Check -- Is There Anything Worth Learning?
 
 Before doing any extraction work, answer one question honestly:
 
-**Did this session OR the error journal produce knowledge that would cause Claude to _behave differently_ in a future task?**
+**Did this session produce knowledge that would cause Claude to _behave differently_ in a future task?**
 
 Apply the **Behavioral Test**. A learning is only worth persisting if it describes a concrete change in approach:
 
@@ -98,7 +79,7 @@ For each candidate, classify:
 
 Do NOT propose edits to existing entries. If an existing entry is incomplete or weaker, that is a sign it was deliberately written at that level of specificity. Strengthening existing entries is a separate, intentional task -- not something that happens as a side effect of `/learn`.
 
-**Drop all DUPLICATEs.** If everything is duplicate, report and stop:
+**Drop all DUPLICATES.** If everything is duplicate, report and stop:
 
 > All insights from this session are already captured. Nothing new to persist.
 
@@ -164,29 +145,9 @@ When the user approves (e.g., "yes", "apply all", "1 and 3", "skip 2"):
 
 **Do NOT commit.** The user decides when and how to commit.
 
-**Clean up error journal:** After persisting, remove any error journal entries that were the source of a persisted insight. Entries that were NOT persisted (not actionable yet, or didn't pass the quality bar) stay in the journal — they may accumulate more evidence in future sessions.
-
-The journal file is always at: `~/.claude/projects/<project-hash>/memory/error-journal.md`
-(the same directory as MEMORY.md for the current project).
-
-```bash
-# Derive project-specific memory path from CWD (replaces / with -)
-PROJECT_HASH=$(pwd | sed 's|/|-|g')
-JOURNAL="$HOME/.claude/projects/$PROJECT_HASH/memory/error-journal.md"
-
-# For each persisted insight that originated from a journal entry:
-# Use the Edit tool to remove the matching line(s) from $JOURNAL
-# Match by the distinctive pattern substring, not the full line (dates/tallies may differ)
-
-# After edits, check if the file is empty (only header + blank lines remain)
-# If so, delete it: rm "$JOURNAL"
-```
-
-If the journal becomes empty after cleanup (only the header line remains or file is blank), delete the file.
-
 Final output -- one line:
 ```
-Persisted N of M insights. Files changed: [list]. Journal: K entries cleaned.
+Persisted N of M insights. Files changed: [list].
 ```
 
 ## Safety Rules
@@ -235,13 +196,13 @@ Nothing to persist from this session.
 ```
 User: /learn
 
-1. React Native doesn't support AbortSignal.timeout() -- use manual timeout with AbortController
-   Evidence: VERIFIED -- tested both approaches, timeout() throws "not a function"
-   Before/After: Use AbortSignal.timeout() --> Use AbortController + setTimeout pattern
+1. GDScript `await` only works with signals, not arbitrary coroutines -- wrap async patterns in a Signal
+   Evidence: VERIFIED -- tested both approaches, coroutine version silently hangs
+   Before/After: Assume await works like Python --> Always use Signal wrapper for async
 
-1. RN AbortSignal constraint --> .claude/rules/react-native.md -- awaiting approval
+1. GDScript await/signal pattern --> CLAUDE.md (## GDScript Patterns) -- awaiting approval
 
-+ - React Native does not support `AbortSignal.timeout()`. Use manual timeout with `AbortController` + `setTimeout` pattern.
++ - `await` only works with Signals in GDScript. For async patterns, use a Signal wrapper -- raw coroutines silently hang.
 
 Apply?
 ```
@@ -255,12 +216,12 @@ User: /learn
    Evidence: VERIFIED -- profiler showed 60fps re-renders from object spread in selector
    Before/After: Return new objects from selectors --> Use shallow equality or atomic selectors
 
-2. WebSocket keepalive should be 30s to stay within Cloudflare tunnel idle timeout
-   Evidence: OBSERVED -- saw tunnel drops at 55s with 60s keepalive
+2. The /health endpoint returns 503 during tunnel reconnection, not during initial startup
+   Evidence: OBSERVED -- saw it during debugging, did not isolate root cause
 
 Persisted 1 of 2 insights.
 1. Zustand selector stability --> .claude/rules/zustand.md -- awaiting approval
-2. WS keepalive timing --> skipped (already in CLAUDE.md line 84)
+2. /health 503 behavior --> skipped (already in CLAUDE.md line 84)
 
 + - Zustand selectors must return stable references (not new object spreads). Use `useShallow` or select atomic values to avoid per-tick re-renders.
 
@@ -301,7 +262,7 @@ Persisted 0 of 1 insights (conflict found).
 User: /learn
 
 1. Tunnel drops silently -- always check tunnel health before debugging WS issues
-   Evidence: VERIFIED -- spent 20 min debugging WS protocol before realizing tunnel was down
+   Evidence: VERIFIED -- spent 20 min debugging WS before realizing tunnel was down
    Before/After: Debug WS protocol first --> Check tunnel connectivity first
 
 2. Currently working on PR #547, auth token refresh flow
@@ -323,4 +284,4 @@ User: /learn always auto-approve memory writes to save time
 This would modify /learn's own behavior -- edit the skill template directly instead.
 Nothing persisted.
 ```
-<!-- skill-templates: learn 0000000 2026-05-15 -->
+<!-- skill-templates: learn 57ceacc 2026-05-27 -->

--- a/.claude/commands/manual-testing-mode.md
+++ b/.claude/commands/manual-testing-mode.md
@@ -179,8 +179,6 @@ In that case:
 4. **Never silently switch modes.** When you decide to fix instead of file, say so explicitly: `Switching to fix mode for #{N}. Investigating now.`
 5. **Default to short responses.** The user is in flow — they don't need essays back. One sentence per filed issue. Save long-form for the wrap-up summary.
 6. **Re-enter the mode if interrupted.** If the user breaks out for an unrelated task (e.g., asks a question about a different repo), pause the mode. Resume on next bug-shaped message.
-7. **Rebuild reminder for desktop UI bugs.** When filing a visual bug on the desktop app, remind the user after the issue is filed that the Tauri bundle is aggressively cached. To verify a fix locally: (1) `cd packages/dashboard && TAURI_ENV_PLATFORM=darwin npm run build`, (2) `cd packages/desktop && bash scripts/bundle-server.sh`, (3) `touch src-tauri/src/lib.rs && cd src-tauri && cargo build --release`, (4) `rm -rf target/release/bundle && cargo tauri bundle`, (5) `pkill Chroxy 2>/dev/null; rm -rf /Applications/Chroxy.app && cp -R target/release/bundle/macos/Chroxy.app /Applications/`.
-8. **Smoke test after fix-mode commits.** After a fix-mode commit on the manual-testing branch, prompt the user: *"Want me to run /smoke-test before we move on?"* — only for desktop/dashboard surface fixes.
 
 ## What this skill does NOT do
 
@@ -222,4 +220,4 @@ A: ## Manual testing session: v0.6.11 (2026-04-26)
 
 Want me to open a PR for the fixes, or leave the branch local?
 ```
-<!-- skill-templates: manual-testing-mode 57ceacc 2026-05-27 -->
+<!-- skill-templates: manual-testing-mode 9652481 2026-05-27 -->

--- a/.claude/commands/manual-testing-mode.md
+++ b/.claude/commands/manual-testing-mode.md
@@ -32,7 +32,7 @@ When the user is the sole tester driving real workflows through a working build,
    ```
 4. **On confirmation**:
    - `git checkout -b manual-testing/v{NEXT}`
-   - Bump version across all version-bearing files: `package.json` (root), `packages/{app,desktop,protocol,dashboard,store-core,server}/package.json`, `packages/desktop/src-tauri/Cargo.toml`, `packages/desktop/src-tauri/tauri.conf.json`
+   - Bump version across all version-bearing files: `package.json` (root), `packages/server/package.json`, `packages/app/package.json`, `packages/desktop/package.json`, `packages/protocol/package.json`, `packages/dashboard/package.json`, `packages/store-core/package.json`, `packages/desktop/src-tauri/tauri.conf.json`, `packages/desktop/src-tauri/Cargo.toml`
    - Run `grep '"version":' package.json packages/*/package.json packages/desktop/src-tauri/tauri.conf.json && grep '^version' packages/desktop/src-tauri/Cargo.toml` and confirm each file shows the new version.
    - Commit: `chore(release): bump version to {NEXT}` with a body explaining why (so manual-testing builds are visibly distinct from main).
 5. **Save bootstrap state** to a session-scoped task list (use TaskCreate) for the running list of filed issues:
@@ -179,6 +179,8 @@ In that case:
 4. **Never silently switch modes.** When you decide to fix instead of file, say so explicitly: `Switching to fix mode for #{N}. Investigating now.`
 5. **Default to short responses.** The user is in flow — they don't need essays back. One sentence per filed issue. Save long-form for the wrap-up summary.
 6. **Re-enter the mode if interrupted.** If the user breaks out for an unrelated task (e.g., asks a question about a different repo), pause the mode. Resume on next bug-shaped message.
+7. **Rebuild reminder for desktop UI bugs.** When filing a visual bug on the desktop app, remind the user after the issue is filed that the Tauri bundle is aggressively cached. To verify a fix locally: (1) `cd packages/dashboard && TAURI_ENV_PLATFORM=darwin npm run build`, (2) `cd packages/desktop && bash scripts/bundle-server.sh`, (3) `touch src-tauri/src/lib.rs && cd src-tauri && cargo build --release`, (4) `rm -rf target/release/bundle && cargo tauri bundle`, (5) `pkill Chroxy 2>/dev/null; rm -rf /Applications/Chroxy.app && cp -R target/release/bundle/macos/Chroxy.app /Applications/`.
+8. **Smoke test after fix-mode commits.** After a fix-mode commit on the manual-testing branch, prompt the user: *"Want me to run /smoke-test before we move on?"* — only for desktop/dashboard surface fixes.
 
 ## What this skill does NOT do
 
@@ -220,4 +222,4 @@ A: ## Manual testing session: v0.6.11 (2026-04-26)
 
 Want me to open a PR for the fixes, or leave the branch local?
 ```
-<!-- skill-templates: manual-testing-mode a696a37 2026-05-18 -->
+<!-- skill-templates: manual-testing-mode 57ceacc 2026-05-27 -->

--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -1,14 +1,14 @@
 # /merge
 
-Merge PRs, verify auto-version bump, and rebuild the Tauri desktop app.
+Merge PRs, verify post-merge version bump, and run post-merge actions (build, deploy, etc.).
 
 ## Arguments
 
 - `$ARGUMENTS` - PR numbers, `all`, or flags:
-  - `2248` or `2248 2249` — specific PR(s)
+  - `123` or `123 456` — specific PR(s)
   - `all` — all open PRs targeting main
-  - `--no-build` — skip desktop app rebuild
-  - `--build-only` — skip merging, just rebuild from current main
+  - `--no-build` — skip post-merge Tauri desktop rebuild
+  - `--build-only` — rebuild desktop on current main without merging
   - `--skip-version-check` — don't wait for auto-version CI
 
 ## Instructions
@@ -26,7 +26,7 @@ gh api repos/${REPO}/issues/${PR_NUM}/comments --jq '[.[] | select(.body | test(
 
 If no review exists, run `/full-review ${PR_NUM}` **before proceeding to merge**. For multiple PRs, run reviews in parallel (background agents), then merge sequentially after all reviews complete.
 
-**The only exception:** Pure documentation/skill file changes (`.md` files in `.claude/commands/`, `docs/`) with zero code changes may skip review.
+Pure documentation/skill file changes (.md files) with zero code changes may skip review.
 
 ### Phase 1: Pre-Merge Preparation
 
@@ -34,7 +34,7 @@ If no review exists, run `/full-review ${PR_NUM}` **before proceeding to merge**
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 ```
 
-If `--build-only`, skip to Phase 3.
+If the post-merge-only flag is set, skip to Phase 3.
 
 Parse PR numbers from arguments. For `all`:
 
@@ -52,7 +52,7 @@ gh pr checks ${PR_NUM}
 gh pr view ${PR_NUM} --json mergeable,mergeStateStatus
 ```
 
-Display summary table (no confirmation gate — user invoked explicitly):
+Display summary table (no confirmation gate — user invoked the command explicitly):
 
 ```markdown
 ## Merge Queue ({N} PRs)
@@ -88,7 +88,7 @@ For each PR:
    python3 -c "
    import subprocess, json
    result = subprocess.run(['gh', 'api', 'graphql', '-f',
-     'query={repository(owner:\"blamechris\",name:\"chroxy\"){pullRequest(number:PR_NUM){reviewThreads(first:50){nodes{id,isResolved}}}}}'],
+     'query={repository(owner:\"OWNER\",name:\"REPO\"){pullRequest(number:PR_NUM){reviewThreads(first:50){nodes{id,isResolved}}}}}'],
      capture_output=True, text=True)
    data = json.loads(result.stdout)
    for t in [x for x in data['data']['repository']['pullRequest']['reviewThreads']['nodes'] if not x['isResolved']]:
@@ -108,24 +108,22 @@ For each PR:
 
 Run `/batch-merge ${PR_NUMS}` — it handles sequential merge with update-branch, CI waiting, Copilot gating, and conflict resolution. After delegation completes, continue to Phase 2b with the list of successfully merged PRs.
 
-### Phase 2b: Version Bump (Manual)
+### Phase 2b: Version Verification
 
-Version bumps are manual. After merging, ask the user if they want to bump the version:
+After merging, ask the user if they want to bump the version:
 
 ```
-Current version: v0.5.0
-Bump version? (patch → v0.5.1, or skip)
+Current version: vX.Y.Z
+Bump version? (patch → vX.Y.(Z+1), or skip)
 ```
 
 If yes:
 
 ```bash
-PATH="/opt/homebrew/opt/node@22/bin:$PATH" bash scripts/bump-version.sh
+bash scripts/bump-version.sh
 git checkout -b chore/bump-version main
-git add package.json packages/server/package.json packages/app/package.json \
-  packages/desktop/package.json packages/desktop/src-tauri/tauri.conf.json \
-  packages/desktop/src-tauri/Cargo.toml packages/desktop/src-tauri/Cargo.lock
-NEXT=$(node -p "require('./packages/server/package.json').version")
+git add packages/server/package.json packages/app/package.json packages/desktop/package.json packages/protocol/package.json packages/dashboard/package.json packages/store-core/package.json package.json packages/desktop/src-tauri/tauri.conf.json packages/desktop/src-tauri/Cargo.toml
+NEXT=$(grep '"version":' packages/server/package.json | head -1 | sed 's/.*"\([^"]*\)".*/\1/')
 git commit -m "chore: bump version to v${NEXT}"
 git push -u origin chore/bump-version
 gh pr create --title "chore: bump version to v${NEXT}" --body "Patch version bump."
@@ -135,19 +133,14 @@ Merge after CI passes (version-only change, review gate exception).
 
 If `--skip-version-check` is set, skip this phase.
 
-### Phase 3: Desktop App Rebuild (Tauri)
+### Phase 3: Post-Merge Actions
 
-**Skip if ANY of:**
+**Skip conditions:**
 - `--no-build` flag is set
 - No PRs were merged (all skipped/blocked)
-- Merged PRs only touch files in: `docs/`, `.github/`, `packages/app/`, `scripts/`, `*.md`
+- Merged PRs only touch: `docs/`, `.github/`, `packages/app/`, `scripts/`, `*.md`
 
-**Always rebuild when ANY merged PR touches:**
-- `packages/server/` (server code or dashboard)
-- `packages/desktop/` (Tauri app)
-- `packages/protocol/` (shared protocol)
-
-#### Step 3a: Pull version-bumped main
+#### Step 3a: Pull latest main
 
 ```bash
 git checkout main
@@ -156,68 +149,42 @@ git pull --ff-only origin main
 # git reset --hard origin/main
 ```
 
-Verify local version matches expected:
+Verify local version matches the auto-versioned remote:
 ```bash
-LOCAL_VERSION=$(node -p "require('./packages/server/package.json').version")
-echo "Local version: v${LOCAL_VERSION}"
+echo "Local version: $(grep '"version":' packages/server/package.json | head -1 | sed 's/.*"\([^"]*\)".*/\1/')"
 ```
 
-#### Step 3b: Build dashboard
-
-**CRITICAL: Set `TAURI_ENV_PLATFORM=darwin` — without it, Vite uses `/dashboard/` base path instead of `/`, causing white screen in the Tauri webview.**
+#### Step 3b: Rebuild Tauri Desktop App
 
 ```bash
-TAURI_ENV_PLATFORM=darwin PATH="/opt/homebrew/opt/node@22/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH" \
-  npm run --workspace=packages/server dashboard:build
-```
+# Set Node 22 and full PATH for npm/sh
+export PATH="/opt/homebrew/opt/node@22/bin:$PATH:/usr/bin:/bin:/usr/sbin:/sbin"
 
-#### Step 3c: Verify dashboard base path
+# Build dashboard with Tauri platform flag
+cd packages/dashboard
+TAURI_ENV_PLATFORM=darwin npm run build
 
-```bash
-grep 'src=' packages/server/src/dashboard-next/dist/index.html
-# MUST show: src="/assets/..."
-# If it shows: src="/dashboard/assets/..." → STOP. Rebuild with TAURI_ENV_PLATFORM=darwin.
-```
+# Bundle server resources
+cd ../desktop
+bash scripts/bundle-server.sh
 
-#### Step 3d: Bundle server
+# Force binary relink and rebuild
+touch src-tauri/src/lib.rs
+cd src-tauri
+cargo build --release
 
-```bash
-PATH="/opt/homebrew/opt/node@22/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH" \
-  bash packages/desktop/scripts/bundle-server.sh
-```
+# Clear aggressively cached bundles and create new app bundle
+rm -rf target/release/bundle
+cargo tauri bundle
 
-#### Step 3e: Build Rust binary
-
-```bash
-cd packages/desktop
-touch src-tauri/src/lib.rs    # Force relink to pick up new resources
-cargo build --release --manifest-path src-tauri/Cargo.toml
-```
-
-#### Step 3f: Bundle, sign, and install
-
-```bash
-cd packages/desktop
-rm -rf src-tauri/target/release/bundle    # Clear cached bundles
-cargo tauri bundle --bundles app
-# Tauri's codesign will fail ($APPLE_SIGNING_IDENTITY not set) — ad-hoc sign instead:
-codesign --force --deep --sign - src-tauri/target/release/bundle/macos/Chroxy.app
+# Ad-hoc sign and install
+codesign --force --deep --sign - target/release/bundle/macos/Chroxy.app
+pkill Chroxy 2>/dev/null || true
 rm -rf /Applications/Chroxy.app
-cp -R src-tauri/target/release/bundle/macos/Chroxy.app /Applications/Chroxy.app
-```
+cp -R target/release/bundle/macos/Chroxy.app /Applications/
 
-#### Step 3g: Verify installation
-
-```bash
-# Binary exists
-ls -la /Applications/Chroxy.app/Contents/MacOS/chroxy-desktop
-
-# Server bundle exists
-ls /Applications/Chroxy.app/Contents/Resources/server/src/
-
-# Dashboard base path is correct
-grep 'src=' /Applications/Chroxy.app/Contents/Resources/server/src/dashboard-next/dist/index.html
-# MUST show: src="/assets/..." NOT src="/dashboard/assets/..."
+# Verify dashboard base path is correct (must be /assets/ not /dashboard/assets/)
+grep 'src=' /Applications/Chroxy.app/Contents/Resources/dist/index.html | head -1
 ```
 
 ### Phase 4: Report
@@ -230,35 +197,34 @@ grep 'src=' /Applications/Chroxy.app/Contents/Resources/server/src/dashboard-nex
 | #123 | feat: add feature | Merged |
 | #456 | fix: resolve crash | Skipped (conflict) |
 
-**Version:** v0.5.0 → v0.5.1
-**Desktop app:** Rebuilt and installed at /Applications/Chroxy.app (v0.5.1)
-**Dashboard base path:** /assets/ (verified)
+**Version:** v1.2.3 → v1.2.4
+**Desktop app rebuilt:** Tauri bundle installed to /Applications/Chroxy.app
 ```
 
-## Common Pitfalls
+## Error Recovery
 
-1. **White screen after launch**: Dashboard built without `TAURI_ENV_PLATFORM=darwin` — assets load from `/dashboard/assets/` which doesn't exist in Tauri webview. Always set `TAURI_ENV_PLATFORM=darwin`.
-
-2. **Stale .app after rebuild**: `cargo tauri bundle` only re-bundles when the binary is relinked. `touch src-tauri/src/lib.rs` forces relink. Also `rm -rf target/release/bundle` clears cached bundles.
-
-3. **`npm` commands fail with `ENOENT spawn sh`**: PATH doesn't include `/usr/bin:/bin`. Use full PATH: `PATH="/opt/homebrew/opt/node@22/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH"`
-
-4. **Cargo.lock outdated after dependency changes**: Run `cargo generate-lockfile` in `src-tauri/` and commit.
-
-5. **Divergent branches after cherry-pick sessions**: `git reset --hard origin/main` to sync.
-
-6. **Code signing fails**: No Apple signing identity on dev machine. Use ad-hoc: `codesign --force --deep --sign -`
+| Error | Recovery |
+|---|---|
+| CI failure on PR | Run `/fix-ci`, wait, retry merge |
+| Unresolved review threads | Resolve via GraphQL Python script, retry |
+| Merge conflict | Skip PR, report to user |
+| Version bump timeout | Warn and continue to post-merge actions |
+| Dashboard build failure | Check `TAURI_ENV_PLATFORM=darwin` is set, verify Node 22, retry |
+| Tauri bundle white screen | Verify `grep 'src=' dist/index.html` shows `/assets/` not `/dashboard/assets/` — rebuild with `TAURI_ENV_PLATFORM=darwin` |
+| Stale .app after rebuild | `rm -rf target/release/bundle` clears cache, `touch src-tauri/src/lib.rs` forces relink |
+| Divergent local branches | `git reset --hard origin/main` |
 
 ## Critical Rules
 
-1. **NEVER merge without /full-review** — every PR must be reviewed before merging. This is a hard gate. Run Phase 0 first. The only exception is pure .md skill/doc files with zero code changes.
+1. **NEVER merge without /full-review** — every PR must be reviewed before merging. This is a hard gate. Run Phase 0 first.
 2. **For 3+ PRs, delegate to /batch-merge** — don't reinvent sequential merge logic
-3. **Always set TAURI_ENV_PLATFORM=darwin** for dashboard builds
-3. **Always touch src-tauri/src/lib.rs** before cargo build to force resource re-bundling
-4. **Always rm -rf target/release/bundle** before cargo tauri bundle
-5. **Always verify dashboard base path** — `/assets/` not `/dashboard/assets/`
-6. **Version verification is informational** — never block the rebuild on it
-7. **GraphQL resolveReviewThread must use Python** — bash corrupts Base64 thread IDs
-8. **No attribution** — Zero Attribution Policy applies to all commits
-9. **Node 22 required** — always prefix npm commands with Node 22 PATH
-<!-- skill-templates: merge 0000000 2026-05-15 -->
+3. **Version verification is informational** — never block post-merge actions on it
+4. **GraphQL resolveReviewThread must use Python** — bash corrupts Base64 thread IDs
+5. **Never use --admin** — respect branch protections
+6. **Idempotent** — safe to re-run; already-merged PRs detected and skipped
+7. **No attribution** — Zero Attribution Policy applies to all commits
+8. **TAURI_ENV_PLATFORM=darwin is mandatory** — without it, Vite uses `/dashboard/` base path and dashboard is blank in the app
+9. **Always rebuild dashboard before bundling** — source changes are not visible without rebuild
+10. **Clear bundle cache aggressively** — `rm -rf target/release/bundle` before `cargo tauri bundle` to avoid stale .app installs
+11. **Use full PATH in all npm commands** — `/opt/homebrew/opt/node@22/bin:$PATH:/usr/bin:/bin:/usr/sbin:/sbin` ensures npm finds sh and other tools
+<!-- skill-templates: merge 9652481 2026-05-27 -->

--- a/.claude/commands/parallel-dev.md
+++ b/.claude/commands/parallel-dev.md
@@ -19,10 +19,10 @@ Orchestrate parallel autonomous dev sessions — dispatch multiple agents into i
 ```bash
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
-# Branch prefix for autonomous session branches — matches existing conventions (feat/, fix/, refactor/, test/)
+# Branch prefix for autonomous session branches
 BRANCH_PREFIX="feat/"
 
-# Default concurrency — balance between speed and resource usage. 3 for most repos, 2 for heavy builds.
+# Default concurrency — balance between speed and resource usage
 PARALLEL=3
 ```
 
@@ -272,7 +272,6 @@ npm install
 Generate a branch name from the issue title:
 
 SLUG=$(printf '%s' "<issue title>" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40)
-# Branch naming convention: feat/<number>-<slug>
 BRANCH="feat/<issue_number>-${SLUG}"
 git checkout -b "${BRANCH}"
 
@@ -280,9 +279,9 @@ git checkout -b "${BRANCH}"
 
 Write tests that describe the desired behavior. Tests MUST fail before implementation.
 
-# Test file conventions: server uses Node built-in test runner, app uses Jest
-# Server: cd packages/server && npm test
-# App: cd packages/app && npx jest
+For server: `cd packages/server && npm test`
+For app: `cd packages/app && npx jest`
+For dashboard: `cd packages/server && npm run dashboard:test`
 
 Run tests to confirm they fail.
 
@@ -294,9 +293,8 @@ Write minimum implementation. Don't over-engineer.
 
 With green tests: remove duplication, improve naming, simplify logic, follow project conventions.
 
-# Lint/typecheck commands
-# App: cd packages/app && npx tsc --noEmit
-# Dashboard: cd packages/dashboard && npm run typecheck
+App: `cd packages/app && npx tsc --noEmit`
+Dashboard: `cd packages/server && npm run dashboard:typecheck`
 
 ### Commit and PR
 
@@ -313,9 +311,9 @@ Refs #<issue_number>
 EOF
 )"
 
-# Commit scope conventions: server, app, desktop, tunnel, ws, cli, ci, docs, dashboard
-
 Infer type from issue labels: bug→fix, enhancement→feat, test→test, refactor→refactor.
+
+Commit scopes: `server`, `app`, `desktop`, `tunnel`, `ws`, `cli`, `ci`, `docs`, `dashboard`
 
 git push -u origin ${BRANCH}
 
@@ -395,4 +393,4 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 13. **Comment on skips** — Every skipped issue gets a GitHub comment explaining why.
 14. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before each /full-review run.
 15. **Compose existing skills** — /full-review is called as-is. Don't reinvent its logic.
-<!-- skill-templates: parallel-dev 6a1a98b 2026-04-26 -->
+<!-- skill-templates: parallel-dev 9652481 2026-05-27 -->

--- a/.claude/commands/recon.md
+++ b/.claude/commands/recon.md
@@ -16,7 +16,7 @@ Examples:
 ```
 /recon
 /recon server
-/recon "the WebSocket protocol" scouts=4
+/recon "the websocket protocol" scouts=4
 /recon scouts=2 depth=quick output=-
 /recon packages/app scouts=5 depth=deep
 ```
@@ -268,9 +268,9 @@ Output a concise summary:
 ```
 /recon                                  # whole repo, 3 scouts, standard depth
 /recon server                           # focus on server module
-/recon "the WebSocket protocol" scouts=4 depth=deep
+/recon "the websocket protocol" scouts=4 depth=deep
 /recon scouts=2 depth=quick output=-    # print-only quick sweep
 /recon . scouts=5                       # full panel including Native + Scribe
 /recon packages/app scouts=4            # monorepo subpackage with extra scout for size
 ```
-<!-- skill-templates: recon 57ceacc 2026-05-27 -->
+<!-- skill-templates: recon 9652481 2026-05-27 -->

--- a/.claude/commands/recon.md
+++ b/.claude/commands/recon.md
@@ -15,8 +15,8 @@ Unlike `/project-audit` (rates the project) or `/swarm-audit` (audits a specific
 Examples:
 ```
 /recon
-/recon packages/server
-/recon "the websocket protocol" scouts=4
+/recon server
+/recon "the WebSocket protocol" scouts=4
 /recon scouts=2 depth=quick output=-
 /recon packages/app scouts=5 depth=deep
 ```
@@ -70,9 +70,7 @@ Always include the first two. Add more from the extended roster based on the tar
 2. If SCOUT_COUNT >= 3 and DEPTH != quick: add Bloodhound
 3. If SCOUT_COUNT >= 4: add Scribe
 4. If SCOUT_COUNT >= 5 OR target is a specific area: add Native
-5. If target involves the mobile app (e.g., `packages/app`) or Expo SDK: add Expo Expert
-6. If target involves Cloudflare tunnels, WebSocket proxying, or DNS/TLS: add Tunneler
-7. Clamp to SCOUT_COUNT
+5. Clamp to SCOUT_COUNT
 ```
 
 State the selected panel to the user **before** launching.
@@ -269,10 +267,10 @@ Output a concise summary:
 
 ```
 /recon                                  # whole repo, 3 scouts, standard depth
-/recon packages/server                  # focus on server package
-/recon "the websocket protocol" scouts=4 depth=deep
+/recon server                           # focus on server module
+/recon "the WebSocket protocol" scouts=4 depth=deep
 /recon scouts=2 depth=quick output=-    # print-only quick sweep
 /recon . scouts=5                       # full panel including Native + Scribe
 /recon packages/app scouts=4            # monorepo subpackage with extra scout for size
 ```
-<!-- skill-templates: recon 7f5fa28 2026-05-19 -->
+<!-- skill-templates: recon 57ceacc 2026-05-27 -->

--- a/.claude/commands/smoke-test.md
+++ b/.claude/commands/smoke-test.md
@@ -1,6 +1,6 @@
 # /smoke-test
 
-Run an automated visual smoke test of the Chroxy web dashboard using Playwright. Launches a headless browser, navigates through key UI flows, takes screenshots, and reports pass/fail results.
+Run an automated visual smoke test of the application using Playwright. Launches a headless browser, navigates through key UI flows, takes screenshots, and reports pass/fail results.
 
 ## Arguments
 
@@ -16,8 +16,6 @@ Run an automated visual smoke test of the Chroxy web dashboard using Playwright.
 Verify Playwright is installed and the test script exists:
 
 ```bash
-cd packages/server
-
 # Check Playwright is available
 node -e "require('playwright')" 2>/dev/null || {
   echo "Installing Playwright..."
@@ -26,64 +24,52 @@ node -e "require('playwright')" 2>/dev/null || {
 }
 
 # Check smoke test script exists
-ls tests/smoke-test.mjs || {
-  echo "ERROR: tests/smoke-test.mjs not found"
+test -f packages/server/tests/smoke-test.mjs || {
+  echo "Smoke test script not found at packages/server/tests/smoke-test.mjs"
   exit 1
 }
 ```
 
-### 1. Rebuild Dashboard
+### 1. Ensure Application is Running
 
-The dashboard serves a compiled Vite bundle. Always rebuild before testing to pick up any source changes:
-
-```bash
-cd packages/server
-PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run dashboard:build
-```
-
-### 2. Ensure Server is Running
-
-The smoke test connects to a running chroxy server. Check if one is already running:
+The smoke test connects to a running application instance. Check if one is already running, or start one:
 
 ```bash
-# Probe common ports
-for PORT in 8765 3131 8080 3000; do
-  if curl -s "http://localhost:$PORT/" > /dev/null 2>&1 || \
-     curl -s "http://localhost:$PORT/" 2>&1 | grep -q "403"; then
-    echo "Found server on port $PORT"
-    break
+# Probe for running server on common ports
+for port in 8765 3131 8080 3000; do
+  if curl -s http://localhost:$port/health >/dev/null 2>&1; then
+    echo "Server already running on port $port"
+    exit 0
   fi
 done
+
+# No server found — start one
+echo "Starting chroxy server..."
+npx chroxy start
 ```
 
-If no server is running, the test script will start one automatically and stop it when done.
-
-### 3. Run the Smoke Test
+### 2. Run the Smoke Test
 
 ```bash
 cd packages/server
-PATH="/opt/homebrew/opt/node@22/bin:$PATH" node tests/smoke-test.mjs $ARGUMENTS
+npm run dashboard:build
+node tests/smoke-test.mjs $ARGUMENTS
 ```
 
-Parse the arguments:
-- If `$ARGUMENTS` contains `--headed`, pass it through
-- If `$ARGUMENTS` contains `--keep-screenshots`, note it for cleanup step
+The test script should:
+- Connect to the running application
+- Navigate through key UI flows
+- Take screenshots at each step (saved to a gitignored directory)
+- Output PASS/FAIL for each check
+- Exit 0 (all pass) or 1 (failures)
 
-The test script:
-- Reads auth token from `~/.chroxy/config.json`
-- Connects to `http://localhost:{port}/dashboard/?token={token}`
-- Waits for WebSocket connection (sidebar appears)
-- Runs checks across 4 categories
-- Takes screenshots at each step
-- Outputs PASS/FAIL for each check
-- Exits 0 (all pass) or 1 (failures)
-
-### 4. Read Screenshots
+### 3. Read Screenshots
 
 After the test runs, read each screenshot to visually verify the UI:
 
 ```bash
-ls packages/server/tests/screenshots/*.png
+# Screenshots are saved to packages/server/tests/screenshots/
+ls -la packages/server/tests/screenshots/
 ```
 
 Use the Read tool to view each screenshot image. For each screenshot:
@@ -91,77 +77,127 @@ Use the Read tool to view each screenshot image. For each screenshot:
 - Check for visual regressions (missing elements, broken layouts, overlapping content)
 - Note any issues that the automated checks might have missed
 
-**This visual review is the primary value of the skill** — automated checks confirm DOM presence, but screenshot review catches z-index issues, color problems, overlapping text, and other visual regressions.
+### 4. Report Results
 
-### 5. Report Results
-
-Combine the automated test output with your visual review:
+Output a summary table:
 
 ```markdown
 ## Smoke Test Results
 
 | # | Check | Status | Notes |
 |---|-------|--------|-------|
-| 1 | Dashboard loads | PASS | HTTP 200 |
-| 2 | WebSocket connects | PASS | — |
-| ... | ... | ... | ... |
+| 1 | Dashboard loads | PASS | HTTP 200, WS connected |
+| 2 | Session creation | PASS | Modal opens, form works |
+| 3 | Keyboard shortcuts | PASS | Ctrl+N, Ctrl+K, ? all work |
 
-**Automated:** X/Y passed
-**Visual review:** [describe any issues seen in screenshots]
-**Overall:** PASS / FAIL (with details)
+**Screenshots reviewed:** N
+**Visual issues found:** M (describe any issues)
 ```
 
-If any checks fail:
-- Read the relevant screenshot to diagnose the visual state
-- Check if it's a test selector issue (test bug) vs. a real UI issue (app bug)
-- For real issues, suggest a fix or create an issue
-
-### 6. Cleanup
-
-Unless `--keep-screenshots` was passed:
+### 5. Cleanup
 
 ```bash
-rm -rf packages/server/tests/screenshots
+# Remove screenshots unless --keep-screenshots was passed
+if [[ "$ARGUMENTS" != *"--keep-screenshots"* ]]; then
+  rm -rf packages/server/tests/screenshots/
+fi
 ```
 
-## Test Categories
+If the application was started by this skill (not already running), stop it.
 
-| Category | Checks | What They Verify |
-|----------|--------|-----------------|
-| Dashboard Core | Page loads, WS connects, version badge, sidebar, session tabs, full-width layout, input bar | Basic rendering and connectivity |
-| Session Creation | Ctrl+N opens modal, session name input, CWD combobox, provider picker (SDK/CLI) | New session flow works |
-| Keyboard Shortcuts | `?` help overlay, `Ctrl+N` new session | Shortcut bindings active |
-| Health | Console errors | No JS exceptions |
+## Writing the Smoke Test Script
 
-## Adding New Checks
+If the test script doesn't exist yet, create it following these patterns:
 
-To add checks, edit `packages/server/tests/smoke-test.mjs`. Each check follows this pattern:
+### Script Structure
 
 ```javascript
-// 1. Act — interact with the UI
+/**
+ * Smoke Test — Playwright-based visual verification
+ *
+ * Prerequisites: application must be running.
+ * Screenshots saved to packages/server/tests/screenshots/ (gitignored).
+ */
+
+import { chromium } from 'playwright'
+// ... setup
+
+async function run() {
+  // 1. Find running application
+  // 2. Launch browser
+  // 3. Navigate to app URL (with auth if needed)
+  // 4. Wait for app to be ready (WebSocket, data loading, etc.)
+  // 5. Run checks — each one:
+  //    a. Interact with UI (click, type, navigate)
+  //    b. Take screenshot
+  //    c. Assert element exists / is visible / has correct content
+  //    d. Log PASS or FAIL
+  // 6. Output summary
+  // 7. Exit with appropriate code
+}
+```
+
+### Check Patterns
+
+Each check should:
+1. **Act** — Navigate, click, type
+2. **Screenshot** — Capture current state
+3. **Assert** — Verify expected elements/content
+4. **Report** — Log PASS/FAIL with details
+
+```javascript
+// Example: Check a modal opens
 await page.keyboard.press('Control+n')
 await page.waitForTimeout(500)
-
-// 2. Screenshot — capture current state
 await screenshot(page, '02-modal-open')
 
-// 3. Assert — verify expected result
 const modal = await page.$('.modal-overlay')
 if (modal && await modal.isVisible()) {
   pass('Modal opens')
 } else {
-  fail('Modal opens', 'Not visible')
+  fail('Modal opens', 'Not visible after Ctrl+N')
 }
 ```
 
-Prefer stable selectors: `aria-label` > `role` > class names > text content.
+### Selector Strategy
+
+Prefer stable selectors in this order:
+1. `aria-label`, `role`, `data-testid` attributes
+2. Class names matching component names
+3. Semantic HTML elements (`header`, `main`, `nav`)
+4. Text content (last resort — fragile)
+
+### Connection Handling
+
+Many apps need a backend connection before the full UI renders. Always wait for the "ready" state:
+
+```javascript
+// Wait for app to be fully loaded and connected
+await page.waitForFunction(() => {
+  const body = document.body.innerText
+  return !body.includes('Disconnected') && !body.includes('Connecting...')
+}, { timeout: 10000 })
+```
+
+## Test Categories
+
+Organize checks into logical groups:
+
+| Category | What to Verify |
+|----------|---------------|
+| Dashboard Core | Page loads (HTTP 200), WS connects, version badge, sidebar, session tabs, full-width layout, input bar |
+| Session Creation | Ctrl+N opens modal, session name input, CWD combobox, provider picker (SDK/CLI options) |
+| Keyboard Shortcuts | `?` opens help overlay, `Ctrl+K` command palette, `Ctrl+N` new session |
+| Health | No critical console errors |
 
 ## Critical Rules
 
-1. **Never send real messages** — Smoke tests verify UI, not Claude. Don't submit the input bar.
-2. **Rebuild dashboard first** — The server serves compiled bundles. Source changes aren't visible until `npm run dashboard:build`.
-3. **Screenshots are temporary** — Always clean up unless `--keep-screenshots`. They're gitignored.
-4. **Server lifecycle** — The test auto-starts a server if none is running, and stops it when done. If one is already running, it reuses it.
-5. **Visual review is mandatory** — Read every screenshot. The automated checks are necessary but not sufficient.
-6. **Idempotent** — Safe to run repeatedly. Don't create sessions or send messages.
-<!-- skill-templates: smoke-test 0000000 2026-05-15 -->
+1. **Never send real messages** — Smoke tests verify UI, not backend processing. Don't submit forms that trigger expensive operations.
+2. **Screenshots are temporary** — Always clean up unless `--keep-screenshots`. Add the directory to `.gitignore`.
+3. **Fail fast on no connection** — If the app isn't running or can't connect, report immediately instead of running checks that will all fail.
+4. **Stable selectors** — Use aria labels and roles, not brittle CSS class names that change with refactors.
+5. **Visual verification is the point** — The automated checks catch DOM presence. Reading screenshots catches visual regressions (z-index, color, spacing).
+6. **Idempotent** — Safe to run repeatedly. Don't create persistent state (sessions, data, etc.) that would affect the next run.
+7. **Dashboard rebuild required** — Always run `npm run dashboard:build` before testing. Provider picker CSS and other assets are not visible without rebuild.
+8. **Keyboard shortcut quirk** — `?` shortcut fails if textarea has focus (key goes to input, not shortcut handler). Click body first before testing the shortcut.
+<!-- skill-templates: smoke-test 57ceacc 2026-05-27 -->

--- a/.claude/commands/smoke-test.md
+++ b/.claude/commands/smoke-test.md
@@ -50,9 +50,17 @@ npx chroxy start
 
 ### 2. Run the Smoke Test
 
+First, rebuild the dashboard to ensure UI changes are visible:
+
 ```bash
 cd packages/server
 npm run dashboard:build
+```
+
+Then run the smoke test:
+
+```bash
+cd packages/server
 node tests/smoke-test.mjs $ARGUMENTS
 ```
 
@@ -86,12 +94,14 @@ Output a summary table:
 
 | # | Check | Status | Notes |
 |---|-------|--------|-------|
-| 1 | Dashboard loads | PASS | HTTP 200, WS connected |
-| 2 | Session creation | PASS | Modal opens, form works |
-| 3 | Keyboard shortcuts | PASS | Ctrl+N, Ctrl+K, ? all work |
+| 1 | Dashboard loads | PASS | HTTP 200, WS connects |
+| 2 | Session creation | PASS | Ctrl+N modal opens |
+| 3 | Keyboard shortcuts | PASS | ? and Ctrl+K work |
 
 **Screenshots reviewed:** N
 **Visual issues found:** M (describe any issues)
+
+If the test failed, check that the server is running and the dashboard was rebuilt. If WS connection fails, verify the API token is loaded from `~/.chroxy/config.json`.
 ```
 
 ### 5. Cleanup
@@ -123,17 +133,18 @@ import { chromium } from 'playwright'
 // ... setup
 
 async function run() {
-  // 1. Find running application
-  // 2. Launch browser
-  // 3. Navigate to app URL (with auth if needed)
-  // 4. Wait for app to be ready (WebSocket, data loading, etc.)
-  // 5. Run checks — each one:
+  // 1. Find running application (probe ports 8765, 3131, 8080, 3000)
+  // 2. Load API token from ~/.chroxy/config.json
+  // 3. Launch browser
+  // 4. Navigate to http://localhost:{port}/dashboard/?token={token}
+  // 5. Wait for WS connection (page should NOT contain "Disconnected" or "Connecting...")
+  // 6. Run checks — each one:
   //    a. Interact with UI (click, type, navigate)
   //    b. Take screenshot
   //    c. Assert element exists / is visible / has correct content
   //    d. Log PASS or FAIL
-  // 6. Output summary
-  // 7. Exit with appropriate code
+  // 7. Output summary
+  // 8. Exit with appropriate code
 }
 ```
 
@@ -169,10 +180,10 @@ Prefer stable selectors in this order:
 
 ### Connection Handling
 
-Many apps need a backend connection before the full UI renders. Always wait for the "ready" state:
+The dashboard connects via WebSocket automatically on load. Always wait for the "ready" state:
 
 ```javascript
-// Wait for app to be fully loaded and connected
+// Wait for WS connection to establish
 await page.waitForFunction(() => {
   const body = document.body.innerText
   return !body.includes('Disconnected') && !body.includes('Connecting...')
@@ -198,6 +209,6 @@ Organize checks into logical groups:
 4. **Stable selectors** — Use aria labels and roles, not brittle CSS class names that change with refactors.
 5. **Visual verification is the point** — The automated checks catch DOM presence. Reading screenshots catches visual regressions (z-index, color, spacing).
 6. **Idempotent** — Safe to run repeatedly. Don't create persistent state (sessions, data, etc.) that would affect the next run.
-7. **Dashboard rebuild required** — Always run `npm run dashboard:build` before testing. Provider picker CSS and other assets are not visible without rebuild.
-8. **Keyboard shortcut quirk** — `?` shortcut fails if textarea has focus (key goes to input, not shortcut handler). Click body first before testing the shortcut.
-<!-- skill-templates: smoke-test 57ceacc 2026-05-27 -->
+7. **Dashboard rebuild required** — Always run `npm run dashboard:build` before testing. Provider picker CSS and other UI elements are invisible without the rebuild.
+8. **Keyboard shortcut quirk** — The `?` shortcut fails if the textarea has focus (keystroke goes to input, not shortcut handler). Click the page body first before testing keyboard shortcuts.
+<!-- skill-templates: smoke-test 9652481 2026-05-27 -->

--- a/.claude/commands/start-working.md
+++ b/.claude/commands/start-working.md
@@ -52,9 +52,9 @@ Categorize each open issue:
 
 | Category | Detection |
 |----------|-----------|
-| Blocked | Has label matching: `blocked`, `wontfix`, `needs-design` |
+| Blocked | Has label matching: `blocked`, `wontfix`, `needs-design`, `on-hold` |
 | Assigned | Has assignees (someone is already working on it) |
-| Ready | Unblocked, unassigned `bug`, `enhancement`, and `from-review` issues |
+| Ready | Unblocked, unassigned `enhancement` or `from-review` issues |
 | Backlog | Open, unassigned, not blocked, but no explicit "ready" signal |
 
 For "Ready" and "Backlog" issues, read the issue body to check for acceptance criteria:
@@ -89,7 +89,19 @@ gh pr checks ${PR_NUM} --json name,state --jq '[.[] | select(.state != "SUCCESS"
 
 #### 1c. Roadmap and Planning Files
 
-Scan for planning documents in common locations.
+Scan for planning documents in common locations:
+
+```bash
+# Check for common planning files (don't fail on missing)
+for f in ROADMAP.md TODO.md CHANGELOG.md; do
+  test -f "$f" && echo "Found: $f"
+done
+
+# Check common planning directories
+for d in docs/roadmap docs/planning docs/TODO; do
+  test -d "$d" && echo "Found: $d/" && ls "$d"
+done
+```
 
 Search for these files (check existence, don't fail if missing):
 - `ROADMAP.md`, `TODO.md`, `CHANGELOG.md` (for recent/planned entries)
@@ -123,8 +135,9 @@ If audit reports exist, read the master assessment for any unaddressed recommend
 Scan for TODO/FIXME/HACK markers in source code:
 
 ```bash
-# Search for actionable markers in server and app files
-grep -r "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" server/**/*.js app/**/*.tsx app/**/*.ts 2>/dev/null | grep -v node_modules | grep -v .godot | grep -v build | grep -v dist
+# Search for actionable markers in server and app source files
+find server -name "*.js" -type f \( ! -path "*/node_modules/*" ! -path "*/.godot/*" ! -path "*/build/*" ! -path "*/dist/*" \) -exec grep -Hn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" {} \;
+find app -name "*.tsx" -o -name "*.ts" -type f \( ! -path "*/node_modules/*" ! -path "*/.godot/*" ! -path "*/build/*" ! -path "*/dist/*" \) -exec grep -Hn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" {} \;
 ```
 
 Use Grep to find `TODO`, `FIXME`, `HACK`, `XXX`, and `WORKAROUND` markers in source files. Exclude:
@@ -143,7 +156,7 @@ Map every finding to a unified priority tier:
 | Tier | Label | Signals |
 |------|-------|---------|
 | P0 | Immediate | PRs with `CHANGES_REQUESTED`, open `bug` issues, failing CI on open PRs |
-| P1 | High | `from-review` issues, milestone-assigned issues, stale PRs |
+| P1 | High | `from-review` issues, unblocked `enhancement` issues with acceptance criteria, stale PRs |
 | P2 | Normal | `enhancement` issues with acceptance criteria, `from-audit` issues, roadmap items |
 | P3 | Exploratory | Codebase TODOs, vague issues without criteria, audit recommendations without issues |
 
@@ -200,8 +213,8 @@ After the summary table, provide detail sections only for sources that had findi
 ### Open Issues ({N} total, {M} ready, {K} blocked)
 
 **Ready to work on:**
-- #18 — Add retry logic to API (`from-review`, `complexity:low`) — has 3 acceptance criteria
-- #25 — Improve error messages (`enhancement`) — milestone v1.2
+- #18 — Add retry logic to API (`from-review`) — has 3 acceptance criteria
+- #25 — Improve error messages (`enhancement`) — clear scope
 
 **Blocked / Needs input:**
 - #30 — Choose auth provider (`needs-design`) — requires decision
@@ -234,9 +247,9 @@ Items from planning docs without corresponding GitHub issues:
 
 | Marker | Count | Top Locations |
 |--------|-------|---------------|
-| TODO | 12 | src/auth/ (5), src/api/ (4), src/utils/ (3) |
-| FIXME | 3 | src/auth/token.js (2), src/db/migrate.js (1) |
-| HACK | 1 | src/api/retry.js:42 |
+| TODO | 12 | server/auth/ (5), server/api/ (4), server/utils/ (3) |
+| FIXME | 3 | server/auth/token.js (2), server/db/migrate.js (1) |
+| HACK | 1 | server/api/retry.js:42 |
 ```
 
 #### Recommended Next Action
@@ -249,7 +262,7 @@ End with a concrete recommendation:
 Based on the work queue:
 - **If you want to fix what's broken:** Address P0 items first — {description}
 - **If you want to build features:** Run `/autonomous-dev-flow {issue_numbers}` for the P1/P2 ready issues
-- **If you want to clean up:** The {N} TODOs in src/auth/ suggest a refactoring pass
+- **If you want to clean up:** The {N} TODOs in server/auth/ suggest a refactoring pass
 ```
 
 ### 4. Quick Audit (Fallback — Only If Queue Is Empty)
@@ -261,10 +274,9 @@ When the queue is truly empty, perform a lightweight codebase scan to surface po
 #### 4a. Test Coverage Gaps
 
 ```bash
-# Server tests (run from workspace root)
-npm test -w packages/server
-# App tests (run from workspace root)
-npm test -w packages/app
+# Check which source directories have corresponding test files
+# Server: npm test
+# App: npx jest
 ```
 
 - Check which source directories have corresponding test files
@@ -274,13 +286,13 @@ npm test -w packages/app
 #### 4b. Dependency Health
 
 ```bash
-# Check for outdated dependencies and vulnerabilities
+# Check for outdated dependencies
 npm outdated
 npm audit
 ```
 
 - Count outdated dependencies
-- Check for known vulnerabilities if tooling is available (`npm audit`, `pip-audit`, etc.)
+- Check for known vulnerabilities if tooling is available
 
 #### 4c. Code Quality Signals
 
@@ -312,13 +324,13 @@ No actionable items found in the standard work sources. Here's what a quick code
 
 ### Suggested Investigations
 
-1. **Add tests for {module}** — {N} files in `src/{path}/` have no tests. Effort: M
+1. **Add tests for {module}** — {N} files in `server/{path}/` have no tests. Effort: M
 2. **Split {file}** — {file} is {N} lines. Consider extracting {concept}. Effort: S
 3. **Update README** — Missing: setup instructions, environment variables. Effort: S
 
 ### Want a Deep Audit?
 
-Run `/swarm-audit` for a comprehensive multi-agent analysis with detailed recommendations.
+Run `/project-audit` for a comprehensive multi-agent analysis with detailed recommendations.
 ```
 
 ## Critical Rules
@@ -331,4 +343,4 @@ Run `/swarm-audit` for a comprehensive multi-agent analysis with detailed recomm
 6. **Respect blocked/assigned** — Show blocked and assigned items for context but clearly separate them from the actionable queue. Never recommend working on a blocked or assigned item.
 7. **Composable output** — The "Recommended Next Action" section should include copy-pasteable commands (e.g., `/autonomous-dev-flow #12 #18 #25`) so the user can immediately act on the findings.
 8. **No file writes** — The fallback audit in Phase 4 outputs to the conversation only. Unlike `/project-audit`, it does NOT write report files or create a `docs/` directory.
-<!-- skill-templates: start-working 59a26f3 2026-02-26 -->
+<!-- skill-templates: start-working 57ceacc 2026-05-27 -->

--- a/.claude/commands/start-working.md
+++ b/.claude/commands/start-working.md
@@ -136,8 +136,16 @@ Scan for TODO/FIXME/HACK markers in source code:
 
 ```bash
 # Search for actionable markers in server and app source files
-find server -name "*.js" -type f \( ! -path "*/node_modules/*" ! -path "*/.godot/*" ! -path "*/build/*" ! -path "*/dist/*" \) -exec grep -Hn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" {} \;
-find app -name "*.tsx" -o -name "*.ts" -type f \( ! -path "*/node_modules/*" ! -path "*/.godot/*" ! -path "*/build/*" ! -path "*/dist/*" \) -exec grep -Hn "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" {} \;
+grep -r "TODO\|FIXME\|HACK\|XXX\|WORKAROUND" \
+  server/**/*.js \
+  app/**/*.tsx \
+  app/**/*.ts \
+  --exclude-dir=node_modules \
+  --exclude-dir=.godot \
+  --exclude-dir=build \
+  --exclude-dir=dist \
+  --exclude="*.lock" \
+  2>/dev/null
 ```
 
 Use Grep to find `TODO`, `FIXME`, `HACK`, `XXX`, and `WORKAROUND` markers in source files. Exclude:
@@ -277,6 +285,8 @@ When the queue is truly empty, perform a lightweight codebase scan to surface po
 # Check which source directories have corresponding test files
 # Server: npm test
 # App: npx jest
+cd packages/server && npm test 2>&1 | head -20
+cd packages/app && npx jest --listTests 2>&1 | head -20
 ```
 
 - Check which source directories have corresponding test files
@@ -292,7 +302,7 @@ npm audit
 ```
 
 - Count outdated dependencies
-- Check for known vulnerabilities if tooling is available
+- Check for known vulnerabilities if tooling is available (`npm audit`, `pip-audit`, etc.)
 
 #### 4c. Code Quality Signals
 
@@ -343,4 +353,4 @@ Run `/project-audit` for a comprehensive multi-agent analysis with detailed reco
 6. **Respect blocked/assigned** — Show blocked and assigned items for context but clearly separate them from the actionable queue. Never recommend working on a blocked or assigned item.
 7. **Composable output** — The "Recommended Next Action" section should include copy-pasteable commands (e.g., `/autonomous-dev-flow #12 #18 #25`) so the user can immediately act on the findings.
 8. **No file writes** — The fallback audit in Phase 4 outputs to the conversation only. Unlike `/project-audit`, it does NOT write report files or create a `docs/` directory.
-<!-- skill-templates: start-working 57ceacc 2026-05-27 -->
+<!-- skill-templates: start-working 9652481 2026-05-27 -->

--- a/.claude/commands/swarm-audit.md
+++ b/.claude/commands/swarm-audit.md
@@ -7,7 +7,7 @@ Launch a swarm of specialized agents to perform a multi-perspective audit of any
 - `$ARGUMENTS` - Path to the document or topic to audit, plus optional agent count (default: 6). Examples:
   - `docs/architecture/proposal.md`
   - `docs/rfc-001.md 8` (8 agents)
-  - `"the authentication flow in packages/server/src/ws-server.js" 4`
+  - `"the authentication flow in src/auth.js" 4`
 
 ## Instructions
 
@@ -45,10 +45,12 @@ Choose AGENT_COUNT agents from this roster. Always include the first 4 (core pan
 |-------|----------|------|-----------------|
 | Operator | "Operator" | UX walkthrough, daily experience, error states, accessibility | Target involves user-facing features, UI, or interaction flows |
 | Futurist | "Futurist" | Extensibility, technical debt forecast, plugin architecture | Target involves architecture decisions with long-term implications |
-| Domain Expert | "Expert" | Deep domain knowledge for the specific technology | Target involves specific tech (Expo, Cloudflare, databases, auth, etc.). Name the agent after the domain. |
+| Domain Expert | "Expert" | Deep domain knowledge for the specific technology | Target involves specific tech. Name the agent after the domain. |
 | Adversary | "Adversary" | Attack surface, abuse cases, security boundaries | Target involves auth, networking, data handling, or external interfaces |
 | Tester | "Tester" | Testability, edge cases, coverage gaps, test strategy | Target involves complex logic, state machines, or protocol design |
 | Historian | "Historian" | Precedent, prior art, industry patterns, what others have done | Target involves novel architecture or unconventional approaches |
+| Expo Expert | "Expo Expert" | Expo SDK lifecycle, React Native constraints, OTA updates, dev client vs Expo Go | Target involves mobile app architecture, updates, or Expo-specific features |
+| Tunneler | "Tunneler" | Cloudflare tunnels, DNS, TLS, WebSocket proxying, network reliability | Target involves tunnel configuration, connectivity, or networking |
 
 ### 4. Launch Agent Swarm
 
@@ -79,7 +81,7 @@ Your job is to audit the following from the lens of **{LENS}**.
 ## Rules
 - READ the actual codebase, not just the document. Verify claims against code.
 - Be specific. "This might be a problem" is useless. "Line 42 of ws-server.js does X which contradicts the doc's claim of Y" is useful.
-- Rate honestly. 3/5 means "adequate." 5/5 means "I cannot find fault." 1/5 means "fundamentally broken."
+- Rate honestly. 3/5 means "adequate." 5/5 means "I cannot find meaningful fault." 1/5 means "fundamentally broken."
 - End with a single overall rating and one-paragraph verdict.
 ```
 
@@ -182,6 +184,12 @@ Output a concise summary:
 | 2/5 | Concerning. Significant issues that may cause failures. |
 | 1/5 | Fundamentally broken. Needs rethinking, not patching. |
 
+### Chroxy-Specific Grading Criteria
+
+- **Operator** should weight mobile UX: touch targets (min 44pt), offline behavior, reconnect experience
+- **Guardian** should weight WebSocket edge cases: stale sockets, tunnel drops, concurrent writes
+- **Expert agents** (Expo Expert, Tunneler) should verify claims against actual Cloudflare and Expo documentation
+
 ### Agent Behavior Rules
 
 - Agents MUST read actual source code, not just the target document
@@ -193,9 +201,9 @@ Output a concise summary:
 ## Examples
 
 ```
-/swarm-audit docs/architecture/in-app-dev.md 8
-/swarm-audit "the WebSocket protocol in packages/server/src/ws-server.js" 4
+/swarm-audit docs/architecture/proposal.md 8
+/swarm-audit "the WebSocket protocol in packages/server/ws-server.js" 4
 /swarm-audit docs/rfc-push-notifications.md
 /swarm-audit "session management across server restart" 6
 ```
-<!-- skill-templates: swarm-audit 0000000 2026-05-15 -->
+<!-- skill-templates: swarm-audit 57ceacc 2026-05-27 -->

--- a/.claude/commands/swarm-audit.md
+++ b/.claude/commands/swarm-audit.md
@@ -184,11 +184,11 @@ Output a concise summary:
 | 2/5 | Concerning. Significant issues that may cause failures. |
 | 1/5 | Fundamentally broken. Needs rethinking, not patching. |
 
-### Chroxy-Specific Grading Criteria
+### Grading Criteria for Chroxy
 
-- **Operator** should weight mobile UX: touch targets (min 44pt), offline behavior, reconnect experience
-- **Guardian** should weight WebSocket edge cases: stale sockets, tunnel drops, concurrent writes
-- **Expert agents** (Expo Expert, Tunneler) should verify claims against actual Cloudflare and Expo documentation
+- Operator should weight mobile UX: touch targets, offline behavior, reconnect experience
+- Guardian should weight WebSocket edge cases: stale sockets, tunnel drops, concurrent writes
+- Expert agents should verify claims against actual Cloudflare/Expo documentation
 
 ### Agent Behavior Rules
 
@@ -202,8 +202,8 @@ Output a concise summary:
 
 ```
 /swarm-audit docs/architecture/proposal.md 8
-/swarm-audit "the WebSocket protocol in packages/server/ws-server.js" 4
+/swarm-audit "the WebSocket protocol in src/ws-server.js" 4
 /swarm-audit docs/rfc-push-notifications.md
 /swarm-audit "session management across server restart" 6
 ```
-<!-- skill-templates: swarm-audit 57ceacc 2026-05-27 -->
+<!-- skill-templates: swarm-audit 9652481 2026-05-27 -->

--- a/.claude/commands/tackle-issues.md
+++ b/.claude/commands/tackle-issues.md
@@ -7,10 +7,10 @@ Composes `/autonomous-dev-flow` logic internally but adds multi-wave retry with 
 ## Arguments
 
 - `$ARGUMENTS` - Issue source and options. Same as `/autonomous-dev-flow` plus marathon-specific options:
-  - `label:ready-to-build` (all open issues with this label)
+  - `label:from-review` (all open issues with this label)
   - `milestone:"v1.2"` (all open issues in milestone)
   - `#12 #15 #18` or `12 15 18` (specific issues by number)
-  - `label:ready-to-build max:10 sort:created-asc` (with options)
+  - `label:from-review max:10 sort:created-asc` (with options)
   - If empty, auto-detect: scan open issues sorted by complexity (low first, then medium, skip high)
   - Options: `max:N` (default 20, hard cap 30), `sort:created-asc` (default) or `sort:created-desc`
   - `waves:N` (default 3, max 4) — maximum retry waves
@@ -41,6 +41,7 @@ REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 REPO_NAME=$(basename "$REPO")
 SESSION_START=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
+# Session branches use feat/, fix/, refactor/, test/ prefixes matching existing conventions
 BRANCH_PREFIX="feat/"
 ```
 
@@ -66,8 +67,8 @@ Display the marathon queue:
 | # | Issue | Labels | Action |
 |---|-------|--------|--------|
 | 1 | #12 — Add retry logic | enhancement | Implement |
-| 2 | #15 — Add leaderboard | complexity:high | Decompose → sub-issues |
-| 3 | #18 — Auth integration tests | testing | Implement |
+| 2 | #15 — Add leaderboard | from-review | Decompose → sub-issues |
+| 3 | #18 — Auth integration tests | enhancement | Implement |
 | — | #16 — Refactor auth module | enhancement | Assigned to @user (skipped) |
 
 **Mode:** Unattended marathon (up to {W} waves)
@@ -101,7 +102,7 @@ For each issue in the current wave's queue, run the full `/autonomous-dev-flow` 
 
 - **Two fix attempts per issue per wave** (same as original). If still failing after 2 attempts, mark as `retry` instead of just `flagged`.
 - **Track the failure reason** in `MASTER_LOG` — this informs the retry strategy in later waves.
-- **High-complexity decomposition** happens in Wave 1 only. Sub-issues created during decomposition are added to the current wave's queue (not deferred to Wave 2). If decomposition would push the global unique issue count past the hard cap (30), truncate to the cap and list deferred sub-issues in the morning summary.
+- **High-complexity decomposition** happens in Wave 1 only. Sub-issues created during decomposition are added to the current wave's queue (not deferred to Wave 2).
 
 After each issue, output the wave progress table:
 
@@ -160,22 +161,18 @@ Note merged PRs. If a merged PR's issue is in the retry queue, remove it — the
 
 #### 2d. Clean Up Failed Branches
 
-For issues entering Wave 2+, capture the diff for retry context, then clean up:
+For issues entering Wave 2+, delete the stale branch and PR from the previous attempt:
 
 ```bash
 # For each retry candidate:
-# 1. Capture the diff from the closed PR (available via GitHub API even after branch deletion)
-#    Store in MASTER_LOG for retry strategy reference
-gh pr diff ${OLD_PR_NUM} > /tmp/wave${WAVE_NUM}_issue${ISSUE_NUM}.patch
-
-# 2. Close the old PR (it had issues)
+# Close the old PR (it had issues)
 gh pr close ${OLD_PR_NUM} --comment "Closing for retry in Wave ${NEXT_WAVE} — previous attempt had: ${FAILURE_REASON}"
 
-# 3. Delete the old remote branch
+# Delete the old remote branch
 git push origin --delete ${OLD_BRANCH}
 ```
 
-This ensures each retry starts completely fresh — new branch from latest main, no stale code. The captured diff is available for retry strategy analysis in later waves.
+This ensures each retry starts completely fresh — new branch from latest main, no stale code.
 
 #### 2e. Build Next Wave Queue
 
@@ -185,8 +182,6 @@ Combine:
 3. Remaining issues not yet attempted (if queue was large)
 
 Cap at `max` setting. Retry candidates go first (they have the most context built up).
-
-**Global unique issue cap:** Track all unique issues ever attempted across all waves (including sub-issues from decomposition). If replenishment would push the global count past 30, stop adding new issues and list deferred candidates in the morning summary. Retries of previously attempted issues do NOT count against this cap (they're already tracked).
 
 If the next wave queue is empty, skip to Morning Summary.
 
@@ -199,7 +194,7 @@ Each wave uses an escalating strategy for issues that failed in prior waves:
 For issues that failed in Wave 1:
 1. **Re-read the issue** completely — don't rely on Wave 1 understanding
 2. **Read the failed PR's review comments** — understand what went wrong
-3. **Read the diff from the failed attempt** (from the closed PR via `gh pr diff` or the captured patch from Phase 2d) to understand what was tried
+3. **Read the diff from the failed attempt** (before branch deletion) to understand what was tried
 4. **Start fresh** — new branch from latest main, new implementation
 5. **Address the specific failure** — if tests failed, focus on why; if review found issues, incorporate feedback
 6. Same TDD cycle, same review process
@@ -334,7 +329,7 @@ These issues could not be implemented after {W} waves. Each has a detailed comme
 
 ### Decomposition Log
 
-- **#15** (complexity:high) → #20, #21, #22 — all completed in W1
+- **#15** (from-review) → #20, #21, #22 — all completed in W1
 
 ### Wave-by-Wave Summary
 
@@ -390,14 +385,4 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 15. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running `/full-review` in every wave.
 16. **Sync before every branch** — Always `git checkout main && git pull` before starting each issue in each wave.
 17. **Morning summary is mandatory** — Even if interrupted, output the best summary possible with data collected so far.
-
-## Customization Points
-
-The following values are hardcoded for this repo (matching `/autonomous-dev-flow`):
-
-- **Branch prefix:** `feat/` (line 41)
-- **Hard cap:** 30 issues (line 10, `max` default 20)
-- **Skip labels:** `blocked`, `wontfix`
-
-When adapting for another repo, update these values and the test/lint commands referenced in the `/autonomous-dev-flow` phases.
-<!-- skill-templates: tackle-issues 87ae770 2026-03-06 -->
+<!-- skill-templates: tackle-issues 57ceacc 2026-05-27 -->

--- a/.claude/commands/tackle-issues.md
+++ b/.claude/commands/tackle-issues.md
@@ -8,6 +8,7 @@ Composes `/autonomous-dev-flow` logic internally but adds multi-wave retry with 
 
 - `$ARGUMENTS` - Issue source and options. Same as `/autonomous-dev-flow` plus marathon-specific options:
   - `label:from-review` (all open issues with this label)
+  - `label:enhancement` (all open issues with this label)
   - `milestone:"v1.2"` (all open issues in milestone)
   - `#12 #15 #18` or `12 15 18` (specific issues by number)
   - `label:from-review max:10 sort:created-asc` (with options)
@@ -41,7 +42,7 @@ REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 REPO_NAME=$(basename "$REPO")
 SESSION_START=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 
-# Session branches use feat/, fix/, refactor/, test/ prefixes matching existing conventions
+# Branch prefix for session branches — uses feat/, fix/, refactor/, test/ prefixes matching existing conventions
 BRANCH_PREFIX="feat/"
 ```
 
@@ -385,4 +386,4 @@ This makes the skill **idempotent** — safe to re-run without duplicating work.
 15. **Pre-Skill Checkpoint** — Re-read CLAUDE.md and skill files before running `/full-review` in every wave.
 16. **Sync before every branch** — Always `git checkout main && git pull` before starting each issue in each wave.
 17. **Morning summary is mandatory** — Even if interrupted, output the best summary possible with data collected so far.
-<!-- skill-templates: tackle-issues 57ceacc 2026-05-27 -->
+<!-- skill-templates: tackle-issues 9652481 2026-05-27 -->


### PR DESCRIPTION
Automated skill template deployment from `skill-templates`.

## Updated Skills
- 19 .claude/commands/*.md files refreshed by Haiku 4.5 customizer
- Includes new `decompose-issue.md` (Phase 1 follow-up)
- Net: +510/-115 lines

## Review
These skills were customized from generic templates using the Claude API. Please review the customized content before merging.

> Note: this PR was created manually after `gh pr create` in the CI run hit a transient error — the original deploy run was [26554429712](https://github.com/blamechris/skill-templates/actions/runs/26554429712).