### PR TITLE
fix(dashboard): keep trailing tool group expanded and preserve it across tab switches (#4305)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -19,6 +19,21 @@ vi.mock('./hooks/usePathAutocomplete', () => ({
 // exercise the handler-level `if (!session) return` guard).
 let capturedOnRestart: ((sessionId: string) => void) | null = null
 
+// #4305 — Chat and Output are now ALWAYS mounted (display:none toggle
+// instead of conditional render) so user-set expand state on tool
+// groups + chat scroll position survive a tab switch. That means
+// `MultiTerminalView` mounts even in tests where `viewMode === 'chat'`,
+// which previously hid it behind a conditional. xterm.js's real
+// `Terminal.open()` (via `TerminalView`) calls `matchMedia` and other
+// JSDOM-incompatible browser APIs and would throw on every test. A
+// shallow stub keeps the App tests focused on App behaviour while
+// MultiTerminalView's own tests cover its production wiring.
+vi.mock('./components/MultiTerminalView', () => ({
+  MultiTerminalView: (props: { className?: string }) => (
+    <div data-testid="multi-terminal-view-mock" className={props.className} />
+  ),
+}))
+
 vi.mock('./components/StdinDisabledBanner', () => ({
   StdinDisabledBanner: (props: {
     visible: boolean
@@ -469,6 +484,91 @@ describe('App', () => {
       render(<App />)
       const systemTab = screen.getByRole('button', { name: /system/i })
       expect(systemTab.querySelector('.system-badge')).toBeInTheDocument()
+    })
+  })
+
+  // #4305 — switching between Chat and Output (terminal) tabs must not
+  // unmount the ChatView. Pre-fix, the panes were rendered with
+  // `{viewMode === 'chat' && <ChatView .../>}` / `{viewMode === 'terminal'
+  // && <MultiTerminalView .../>}`, so a tab switch unmounted the inactive
+  // pane and reset every ToolGroup/ToolBubble's local `expanded` state
+  // (and the scroll position). The fix keeps both panes mounted at all
+  // times and toggles visibility with display:none on a wrapper div, so
+  // React's reconciler keeps the same component instances and their
+  // hooks-local state survives the switch.
+  describe('chat/output tab switch preserves mount (#4305)', () => {
+    const connectedState = {
+      connectionPhase: 'connected' as const,
+      sessions: [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }],
+      activeSessionId: 's1',
+    }
+
+    it('keeps both chat-pane and terminal-pane mounted regardless of viewMode', () => {
+      stateOverrides = { ...connectedState, viewMode: 'chat' }
+      const { rerender } = render(<App />)
+      expect(screen.getByTestId('chat-pane')).toBeInTheDocument()
+      expect(screen.getByTestId('terminal-pane')).toBeInTheDocument()
+
+      // Switch to terminal — both panes still mounted, just hidden/shown.
+      stateOverrides = { ...connectedState, viewMode: 'terminal' }
+      rerender(<App />)
+      expect(screen.getByTestId('chat-pane')).toBeInTheDocument()
+      expect(screen.getByTestId('terminal-pane')).toBeInTheDocument()
+    })
+
+    it('hides the inactive pane with display:none and shows the active one', () => {
+      stateOverrides = { ...connectedState, viewMode: 'chat' }
+      const { rerender } = render(<App />)
+      const chatPane = screen.getByTestId('chat-pane')
+      const terminalPane = screen.getByTestId('terminal-pane')
+      // Active pane uses `display: contents` so its child participates
+      // in the parent flex/grid layout exactly as the original
+      // conditional render did; inactive pane is `display: none`.
+      expect(chatPane.style.display).toBe('contents')
+      expect(terminalPane.style.display).toBe('none')
+
+      stateOverrides = { ...connectedState, viewMode: 'terminal' }
+      rerender(<App />)
+      // Same node references — proves React did NOT unmount/remount.
+      expect(screen.getByTestId('chat-pane')).toBe(chatPane)
+      expect(screen.getByTestId('terminal-pane')).toBe(terminalPane)
+      expect(chatPane.style.display).toBe('none')
+      expect(terminalPane.style.display).toBe('contents')
+    })
+
+    it('ChatView DOM persists across tab switch (no unmount/remount jump)', () => {
+      stateOverrides = {
+        ...connectedState,
+        getActiveSessionState: () => ({
+          messages: [
+            { id: 'msg-1', type: 'response', content: 'Hello from Claude', timestamp: 1 },
+          ],
+          streamingMessageId: null,
+          activeModel: null,
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+        }),
+        viewMode: 'chat',
+      }
+      const { rerender } = render(<App />)
+      const chatViewBefore = screen.getByTestId('chat-view')
+
+      // Flip to terminal then back to chat.
+      stateOverrides = { ...stateOverrides, viewMode: 'terminal' }
+      rerender(<App />)
+      // chat-view is still in the DOM (just hidden via the wrapper) —
+      // pre-fix it was unmounted and so would be missing.
+      expect(screen.getByTestId('chat-view')).toBe(chatViewBefore)
+
+      stateOverrides = { ...stateOverrides, viewMode: 'chat' }
+      rerender(<App />)
+      // And still the same node reference after coming back — no
+      // remount happened across the round-trip.
+      expect(screen.getByTestId('chat-view')).toBe(chatViewBefore)
     })
   })
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1903,21 +1903,45 @@ export function App() {
                   />
                 ) : (
                   <>
-                    {viewMode === 'chat' && (
+                    {/*
+                      #4305 — Chat and Output stay mounted; the inactive
+                      pane is hidden with display:none rather than
+                      unmounted. Previously each tab switch unmounted
+                      ChatView, which reset every ToolGroup/ToolBubble's
+                      local `expanded` state (and dropped scroll position)
+                      causing the visible "re-fold jump" the issue
+                      describes. Keeping both mounted preserves
+                      user-toggled expand state, the isTail-driven
+                      tail-expanded state, and the chat scroll position
+                      across tab switches. Mirrors the same pattern
+                      MultiTerminalView already uses to preserve per-
+                      session terminal state.
+                    */}
+                    <div
+                      data-testid="chat-pane"
+                      style={{
+                        display: viewMode === 'chat' ? 'contents' : 'none',
+                      }}
+                    >
                       <ChatView
                         messages={chatMessages}
                         isStreaming={streamingMessageId !== null}
                         isBusy={!isIdle}
                         renderMessage={renderMessage}
                       />
-                    )}
-                    {viewMode === 'terminal' && (
+                    </div>
+                    <div
+                      data-testid="terminal-pane"
+                      style={{
+                        display: viewMode === 'terminal' ? 'contents' : 'none',
+                      }}
+                    >
                       <MultiTerminalView
                         sessions={sessions}
                         activeSessionId={activeSessionId}
                         className="terminal-container"
                       />
-                    )}
+                    </div>
                   </>
                 )}
                 {viewMode === 'files' && connectionPhase !== 'connecting' && !isSwitchingSession && (


### PR DESCRIPTION
Closes #4305

Two bugs in the dashboard session view; this PR fixes the second and adds regression coverage that the first stays fixed across tab switches.

## Bug A — Chat tab silently folds the trailing tool group at turn end

Already fixed in `main` via the `isTail` prop wired through `App.tsx` to `ToolGroup` and `ToolBubble` (#4309, #4314). When a turn ends on a tool run with no following assistant text, the tail group/bubble starts expanded and the on-completion auto-collapse is skipped. The latching `wasTailRef` snapshot handles the same-commit `isActive: true→false` + `isTail: true→false` flip (response message arrives in the same batched store update as `stream_end`).

This PR does not change Bug A's behaviour; existing tests in `ToolGroup.test.tsx` (`tail-group behavior (#4305)` describe block) and `ToolBubble.test.tsx` continue to pin the contract.

## Bug B — Tab switch re-folds tool calls with a visible jump

Pre-fix, the main content area conditionally rendered Chat and Output:

```tsx
{viewMode === 'chat' && <ChatView ... />}
{viewMode === 'terminal' && <MultiTerminalView ... />}
```

Each switch unmounted the inactive pane, which reset every `ToolGroup`/`ToolBubble`'s hook-local `expanded` state — including the tail-expanded state Bug A relies on — and dropped the chat scroll position. The user saw their just-completed tool run silently re-fold the moment they peeked at Output and came back.

**Fix:** wrap each pane in a sibling `<div>` and toggle `display: contents` (active) vs `display: none` (inactive) instead of mounting/unmounting. React keeps the same component instances across the switch, hook-local expand state is preserved, and the chat scroll position survives the round-trip. This mirrors the same pattern `MultiTerminalView` already uses to preserve per-session terminal state.

`display: contents` on the active wrapper makes it transparent to the parent's layout, so existing flex/grid styling on `.main-content-primary` keeps working exactly as it did before.

## Test plan

- [x] `cd packages/dashboard && npm test -- --run` — 119 files / 2071 tests pass
- [x] `cd packages/dashboard && npm run typecheck` — clean
- [x] New `App.test.tsx > chat/output tab switch preserves mount (#4305)` block
  - both panes stay mounted regardless of `viewMode`
  - active pane uses `display: contents`, inactive uses `display: none`
  - `chat-view` testid resolves to the same DOM node before / after a chat → terminal → chat round-trip (proves React did not remount)
- [x] Existing `ToolGroup.test.tsx tail-group behavior (#4305)` tests still pin Bug A — `isTail` keeps the trailing group expanded after stream end, even when `isTail` flips false later, and even on a same-commit `isActive` + `isTail` double flip

## Acceptance criteria

- [x] Trailing tool calls visible in Output tab are also visible in Chat tab (Bug A, already in main)
- [x] Tab switch doesn't change which groups are expanded (this PR — display:none toggle keeps `ToolGroup` mounted)
- [x] User-set expand/collapse state survives tab switch (this PR)
- [x] Regression coverage for `summary text → trailing tool run` shape — tail-group describe block in `ToolGroup.test.tsx` plus new tab-switch describe block in `App.test.tsx`

## Notes

`App.test.tsx` gains a shallow `MultiTerminalView` mock because the real component now mounts in every connected-state test (xterm.js `Terminal.open()` touches `matchMedia` and other browser APIs JSDOM does not implement). `MultiTerminalView`'s own tests still cover its production wiring.