### PR TITLE
feat(dashboard,store-core): name active tool + spinner in activity indicator (#4308)

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.inflight.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.inflight.test.tsx
@@ -236,6 +236,158 @@ describe('ActivityIndicator — in-flight tool naming (#4308)', () => {
     expect(label.textContent).toMatch(/Running\s+List Files/)
     expect(label.textContent).not.toMatch(/fs/)
   })
+
+  // #4308 — activeTools-driven path (preferred over the messages walk when
+  // present). These tests pin the precedence: activeTools wins over a tool
+  // resolved via the messages walk; sub-agent description wins over both.
+  describe('activeTools / activeAgents state slot (#4308)', () => {
+    it('prefers the activeTools slot over the messages walk', () => {
+      const now = Date.now()
+      // messages walk would pick `Read`, but activeTools says `WebFetch` is
+      // the current in-flight tool — activeTools wins.
+      storeState = {
+        activeSessionId: 'sess-1',
+        serverResultTimeoutMs: 30 * 60 * 1000,
+        sessionStates: {
+          'sess-1': {
+            isIdle: false,
+            lastClientActivityAt: now - 3_000,
+            messages: [
+              { id: 'm1', type: 'tool_use', tool: 'Read', timestamp: now - 6_000, content: '', toolUseId: 'tu-walk' },
+            ],
+            activeTools: [
+              { toolUseId: 'tu-1', tool: 'WebFetch', startedAt: now - 4_000 },
+            ],
+            inactivityWarning: null,
+          },
+        },
+      }
+      render(<ActivityIndicator />)
+      const label = screen.getByTestId('activity-indicator-label')
+      expect(label.textContent).toMatch(/Running\s+WebFetch/)
+      expect(label.textContent).not.toMatch(/Read/)
+    })
+
+    it('uses the most-recent activeTools entry when multiple are in flight', () => {
+      const now = Date.now()
+      storeState = {
+        activeSessionId: 'sess-1',
+        serverResultTimeoutMs: 30 * 60 * 1000,
+        sessionStates: {
+          'sess-1': {
+            isIdle: false,
+            lastClientActivityAt: now - 2_000,
+            messages: [],
+            activeTools: [
+              { toolUseId: 'tu-1', tool: 'Bash', startedAt: now - 10_000 },
+              { toolUseId: 'tu-2', tool: 'WebFetch', startedAt: now - 3_000 },
+            ],
+            inactivityWarning: null,
+          },
+        },
+      }
+      render(<ActivityIndicator />)
+      const label = screen.getByTestId('activity-indicator-label')
+      expect(label.textContent).toMatch(/Running\s+WebFetch/)
+    })
+
+    it('falls through to the messages walk when activeTools is empty', () => {
+      const now = Date.now()
+      storeState = {
+        activeSessionId: 'sess-1',
+        serverResultTimeoutMs: 30 * 60 * 1000,
+        sessionStates: {
+          'sess-1': {
+            isIdle: false,
+            lastClientActivityAt: now - 2_000,
+            messages: [
+              { id: 'm1', type: 'tool_use', tool: 'Read', timestamp: now - 4_000, content: '', toolUseId: 'tu-1' },
+            ],
+            activeTools: [],
+            inactivityWarning: null,
+          },
+        },
+      }
+      render(<ActivityIndicator />)
+      const label = screen.getByTestId('activity-indicator-label')
+      expect(label.textContent).toMatch(/Running\s+Read/)
+    })
+
+    it('surfaces an active sub-agent description, taking precedence over the in-flight tool', () => {
+      const now = Date.now()
+      // Parent agent's Task tool is in flight, but a sub-agent is running.
+      // The chip should name the sub-agent's description, not "Task".
+      storeState = {
+        activeSessionId: 'sess-1',
+        serverResultTimeoutMs: 30 * 60 * 1000,
+        sessionStates: {
+          'sess-1': {
+            isIdle: false,
+            lastClientActivityAt: now - 2_000,
+            messages: [],
+            activeTools: [
+              { toolUseId: 'tu-task', tool: 'Task', startedAt: now - 5_000 },
+            ],
+            activeAgents: [
+              { toolUseId: 'tu-sub', description: 'audit-pr', startedAt: now - 5_000 },
+            ],
+            inactivityWarning: null,
+          },
+        },
+      }
+      render(<ActivityIndicator />)
+      const label = screen.getByTestId('activity-indicator-label')
+      expect(label.textContent).toMatch(/Running\s+audit-pr/)
+      expect(label.textContent).not.toMatch(/Task/)
+    })
+
+    it('uses the most-recent activeAgents entry when multiple sub-agents are running', () => {
+      const now = Date.now()
+      storeState = {
+        activeSessionId: 'sess-1',
+        serverResultTimeoutMs: 30 * 60 * 1000,
+        sessionStates: {
+          'sess-1': {
+            isIdle: false,
+            lastClientActivityAt: now - 2_000,
+            messages: [],
+            activeTools: [],
+            activeAgents: [
+              { toolUseId: 'tu-a', description: 'first-task', startedAt: now - 10_000 },
+              { toolUseId: 'tu-b', description: 'second-task', startedAt: now - 3_000 },
+            ],
+            inactivityWarning: null,
+          },
+        },
+      }
+      render(<ActivityIndicator />)
+      const label = screen.getByTestId('activity-indicator-label')
+      expect(label.textContent).toMatch(/Running\s+second-task/)
+    })
+
+    it('surfaces sub-agent description during the lastActivityAt-null connect race', () => {
+      const now = Date.now()
+      storeState = {
+        activeSessionId: 'sess-1',
+        serverResultTimeoutMs: 30 * 60 * 1000,
+        sessionStates: {
+          'sess-1': {
+            isIdle: false,
+            lastClientActivityAt: null,
+            messages: [],
+            activeTools: [],
+            activeAgents: [
+              { toolUseId: 'tu-a', description: 'do-thing', startedAt: now - 2_000 },
+            ],
+            inactivityWarning: null,
+          },
+        },
+      }
+      render(<ActivityIndicator />)
+      const label = screen.getByTestId('activity-indicator-label')
+      expect(label.textContent).toMatch(/Running\s+do-thing/)
+    })
+  })
 })
 
 /**

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -124,18 +124,49 @@ export function ActivityIndicator() {
   // `useShallow` selector runs the walk ONCE and lets zustand do a shallow
   // compare on the returned object — same re-render guarantee, one walk per
   // update, and a cleaner consumer shape.
-  const { tool: inFlightTool, startedAt: inFlightStartedAt, serverName: inFlightServerName } =
-    useConnectionStore(
-      useShallow((s) => {
-        const id = s.activeSessionId
-        const inFlight = id ? findInFlightToolUse(s.sessionStates[id]?.messages) : null
-        return {
-          tool: inFlight?.tool ?? null,
-          startedAt: inFlight?.startedAt ?? null,
-          serverName: inFlight?.serverName ?? null,
-        }
-      }),
-    )
+  //
+  // #4308 (this PR) — prefer `activeTools` (state slot driven by tool_start /
+  // tool_result) over the derive-from-messages walk when present. The walk
+  // is kept as a fallback so history-replay / pre-state-bootstrap paths that
+  // never fired tool_start still surface a tool name. Also subscribe to the
+  // active sub-agent (most-recent activeAgents entry) so the chip can name
+  // sub-agent work via its description rather than just a count.
+  const {
+    tool: inFlightTool,
+    startedAt: inFlightStartedAt,
+    serverName: inFlightServerName,
+    agentDescription,
+    agentStartedAt,
+  } = useConnectionStore(
+    useShallow((s) => {
+      const id = s.activeSessionId
+      const ss = id ? s.sessionStates[id] : null
+      // Prefer the structured activeTools slot — most-recent entry is the
+      // visible in-flight tool when the renderer has room for one label.
+      const activeTools = ss?.activeTools
+      const fromState = activeTools && activeTools.length > 0
+        ? activeTools[activeTools.length - 1]!
+        : null
+      // Fall back to the messages walk when activeTools is empty (replay,
+      // pre-bootstrap, or a tool_use rendered from history without a live
+      // tool_start). #4337 — exported helper, exercised by inflight tests.
+      const fromMessages = fromState
+        ? null
+        : findInFlightToolUse(ss?.messages)
+      const inFlight = fromState ?? fromMessages
+      const activeAgents = ss?.activeAgents
+      const mostRecentAgent = activeAgents && activeAgents.length > 0
+        ? activeAgents[activeAgents.length - 1]!
+        : null
+      return {
+        tool: inFlight?.tool ?? null,
+        startedAt: inFlight?.startedAt ?? null,
+        serverName: inFlight?.serverName ?? null,
+        agentDescription: mostRecentAgent?.description ?? null,
+        agentStartedAt: mostRecentAgent?.startedAt ?? null,
+      }
+    }),
+  )
   const referenceTimeoutMs = useConnectionStore(
     (s) => s.serverResultTimeoutMs ?? FALLBACK_TIMEOUT_MS,
   )
@@ -162,8 +193,15 @@ export function ActivityIndicator() {
     // the user sees "Running Bash" instead of a generic "Working…". No
     // elapsed value here because we have no clock anchor — startedAt is
     // a server timestamp and clock-skew makes a "Ns" suffix unreliable.
+    //
+    // #4308 (this PR) — when an active sub-agent is present, surface its
+    // description first ("Running my-sub-agent" / "Waiting on …"). Sub-agent
+    // work is the more specific named activity; the parent's in-flight tool
+    // is usually `Task` while a sub-agent runs.
     const label =
-      inFlightTool != null
+      agentDescription != null
+        ? `Running ${agentDescription}`
+        : inFlightTool != null
         ? `Running ${formatToolName(inFlightTool, inFlightServerName ?? undefined)}`
         : 'Working…'
     return (
@@ -179,13 +217,25 @@ export function ActivityIndicator() {
   const approaching = remaining > 0 && remaining <= 60_000
   const klass = statusClass(elapsed, referenceTimeoutMs)
 
-  // #4308 — name the in-flight tool when one is running. Falls back to
-  // the original "Working… last activity" label when no tool is in
-  // flight (e.g. waiting on assistant text between tool calls).
-  const label =
-    inFlightTool != null && inFlightStartedAt != null
-      ? `Running ${formatToolName(inFlightTool, inFlightServerName ?? undefined)} · ${formatDuration(now - inFlightStartedAt)}`
-      : `Working… last activity ${formatElapsed(elapsed)}`
+  // #4308 — preference order:
+  //   1. Active sub-agent (description + elapsed since its startedAt) — more
+  //      specific than the parent's `Task` tool wrapper.
+  //   2. In-flight tool (name + elapsed since its startedAt) — both
+  //      activeTools (live) and the derive-from-messages fallback.
+  //   3. Generic "Working… last activity Ns ago" — no current named work.
+  //
+  // TODO(#4307): when the server lands background-shell task tracking, slot
+  // pending background work between #2 and #3 here ("1 background task
+  // running"). Schema lives in #4307; the activeTools[]-style array should
+  // be sufficient.
+  let label: string
+  if (agentDescription != null && agentStartedAt != null) {
+    label = `Running ${agentDescription} · ${formatDuration(now - agentStartedAt)}`
+  } else if (inFlightTool != null && inFlightStartedAt != null) {
+    label = `Running ${formatToolName(inFlightTool, inFlightServerName ?? undefined)} · ${formatDuration(now - inFlightStartedAt)}`
+  } else {
+    label = `Working… last activity ${formatElapsed(elapsed)}`
+  }
 
   return (
     <div className={`activity-indicator ${klass}`} aria-label="Agent is working">

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -205,6 +205,9 @@ const EMPTY_AGENTS: never[] = [];
 const EMPTY_PROMPTS: never[] = [];
 const EMPTY_MCP_SERVERS: never[] = [];
 const EMPTY_DEV_PREVIEWS: never[] = [];
+// #4308: stable empty reference for `activeTools` in the flat-state
+// fallback. Same `useShallow` stability rationale as the others above.
+const EMPTY_ACTIVE_TOOLS: never[] = [];
 
 /** Delay before auto-reconnecting after an unexpected socket close (ms) */
 const AUTO_RECONNECT_DELAY = 1500;
@@ -492,6 +495,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       health: 'healthy' as const,
       terminalRawBuffer: get().terminalRawBuffer,
       activeAgents: EMPTY_AGENTS,
+      // #4308: parity with the BaseSessionState shape; no live tool tracking
+      // in flat-state fallback (only populated once a real SessionState lands).
+      activeTools: EMPTY_ACTIVE_TOOLS,
       isPlanPending: false,
       planAllowedPrompts: EMPTY_PROMPTS,
       primaryClientId: null,

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1546,6 +1546,153 @@ describe('dashboard message-handler dispatch', () => {
   // The 5s safety timer in sendInput used to recover this case but was bypassed
   // by #3170. agent_idle is now the recovery hook: it must clear streamingMessageId
   // so the stop button hides.
+  describe('activeTools wiring (#4308)', () => {
+    it('pushes an ActiveTool entry on tool_start', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          input: { command: 'ls' },
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.activeTools).toHaveLength(1)
+      expect(ss.activeTools[0].toolUseId).toBe('tu-1')
+      expect(ss.activeTools[0].tool).toBe('Bash')
+      expect(ss.activeTools[0].input).toEqual({ command: 'ls' })
+      expect(typeof ss.activeTools[0].startedAt).toBe('number')
+    })
+
+    it('removes the matching entry on tool_result', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          input: { command: 'ls' },
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      handleMessage(
+        { type: 'tool_result', toolUseId: 'tu-1', result: 'out', sessionId: 's1' },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.activeTools).toEqual([])
+    })
+
+    it('supports parallel in-flight tools (multiple tool_start before any tool_result)', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-2',
+          tool: 'Read',
+          toolUseId: 'tu-2',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.activeTools.map((t: any) => t.toolUseId)).toEqual(['tu-1', 'tu-2'])
+      // Resolving tu-1 leaves tu-2 still in flight.
+      handleMessage(
+        { type: 'tool_result', toolUseId: 'tu-1', result: 'ok', sessionId: 's1' },
+        ctx() as any,
+      )
+      const ss2 = (store.getState() as any).sessionStates.s1
+      expect(ss2.activeTools.map((t: any) => t.toolUseId)).toEqual(['tu-2'])
+    })
+
+    it('clears activeTools on agent_idle as a safety net', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      // tool_result never arrives; agent_idle fires (e.g. abnormal SDK shutdown).
+      handleMessage({ type: 'agent_idle', sessionId: 's1' }, ctx() as any)
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.activeTools).toEqual([])
+    })
+
+    it('clears activeTools on result as a safety net', () => {
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessions: [{ sessionId: 's1', name: 'S1' } as any],
+          sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      handleMessage({ type: 'result', sessionId: 's1' }, ctx() as any)
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.activeTools).toEqual([])
+    })
+  })
+
   describe('agent_idle clears streamingMessageId (#3171)', () => {
     it('clears streamingMessageId when agent_idle fires mid-stream', () => {
       store = createMockStore(

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1490,6 +1490,13 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
       if (ss.streamingMessageId === 'pending') {
         patch.streamingMessageId = toolMsg.id;
       }
+      // #4308 — track the in-flight tool in activeTools[]. Same-reference
+      // no-op (dedup by toolUseId) is honoured so a duplicate broadcast
+      // doesn't churn state.
+      const nextActiveTools = result.applyToActiveTools(ss.activeTools);
+      if (nextActiveTools !== ss.activeTools) {
+        patch.activeTools = nextActiveTools;
+      }
       return patch;
     });
   } else {
@@ -1541,8 +1548,13 @@ function handleToolResult(msg: Record<string, unknown>, get: MsgGet, set: MsgSet
   if (targetId && get().sessionStates[targetId]) {
     updateSession(targetId, (ss: SessionState) => {
       const updated = result.applyTo(ss.messages);
-      if (updated === ss.messages) return {};
-      return { messages: updated };
+      // #4308 — drop the resolved entry from activeTools[]. Same-reference
+      // no-op (tool not currently tracked) is honoured to skip the write.
+      const nextActiveTools = result.applyToActiveTools(ss.activeTools);
+      const patch: Partial<SessionState> = {};
+      if (updated !== ss.messages) patch.messages = updated;
+      if (nextActiveTools !== ss.activeTools) patch.activeTools = nextActiveTools;
+      return patch;
     });
   } else {
     const updated = result.applyTo(get().messages);
@@ -2259,6 +2271,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       updateActiveSession((ss) => {
         const patch: Partial<SessionState> = {};
         if (ss.activeAgents.length > 0) patch.activeAgents = [];
+        // #4308 — same rationale: in-flight tools never survive a replay
+        // boundary; the live tool_start broadcasts that follow rebuild
+        // activeTools as needed.
+        if (ss.activeTools.length > 0) patch.activeTools = [];
         if (ss.isPlanPending) {
           patch.isPlanPending = false;
           patch.planAllowedPrompts = [];
@@ -2394,10 +2410,18 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (targetId && get().sessionStates[targetId]) {
         // Force a new messages array reference so selectors detect the change,
         // even when flushPendingDeltas() was a no-op (timer already flushed).
-        updateSession(targetId, (ss) => ({
-          ...resultPatch,
-          messages: [...ss.messages],
-        }));
+        updateSession(targetId, (ss) => {
+          // #4308 — `result` is a guaranteed turn boundary; any still-tracked
+          // activeTools are a missed tool_result (server crash, dropped
+          // broadcast) and must be dropped so the activity indicator can't
+          // get stuck on a phantom "Running X". Mirror in agent_idle.
+          const patch: Partial<SessionState> = {
+            ...resultPatch,
+            messages: [...ss.messages],
+          };
+          if (ss.activeTools.length > 0) patch.activeTools = [];
+          return patch;
+        });
       } else {
         set((s) => ({ ...resultPatch, messages: [...s.messages] }));
       }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -92,6 +92,7 @@ import {
 } from './index'
 import { nextMessageId } from '../utils'
 import type {
+  ActiveTool,
   AgentInfo,
   ChatMessage,
   Checkpoint,
@@ -354,8 +355,16 @@ describe('handleClaudeReady', () => {
 // handleAgentIdle / handleAgentBusy
 // ---------------------------------------------------------------------------
 describe('handleAgentIdle', () => {
-  it('returns isIdle: true and clears streamingMessageId', () => {
-    expect(handleAgentIdle()).toEqual({ isIdle: true, streamingMessageId: null })
+  it('returns isIdle: true and clears streamingMessageId + activeTools', () => {
+    // #4308 — agent_idle is a guaranteed turn boundary, so it's also the
+    // safety-net clear for activeTools. Any still-tracked in-flight tools
+    // (missed result, server crash mid-turn) are dropped so the activity
+    // indicator can't get stuck on a phantom "Running X".
+    expect(handleAgentIdle()).toEqual({
+      isIdle: true,
+      streamingMessageId: null,
+      activeTools: [],
+    })
   })
 })
 
@@ -5143,6 +5152,139 @@ describe('handleToolStart', () => {
     )
     expect(out.sessionId).toBe('sess-active')
   })
+
+  // #4308 — activeTools tracking
+  describe('activeTools (#4308)', () => {
+    it('emits an ActiveTool entry with tool name, toolUseId, input, startedAt', () => {
+      const out = handleToolStart(
+        {
+          messageId: 'srv-tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          input: { cmd: 'ls' },
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.activeTool).not.toBeNull()
+      expect(out.activeTool!.toolUseId).toBe('tu-1')
+      expect(out.activeTool!.tool).toBe('Bash')
+      expect(out.activeTool!.input).toEqual({ cmd: 'ls' })
+      expect(typeof out.activeTool!.startedAt).toBe('number')
+      expect(out.activeTool!.startedAt).toBeGreaterThan(0)
+    })
+
+    it('omits serverName when not present on the wire', () => {
+      const out = handleToolStart(
+        { messageId: 'srv-tool-1', tool: 'Bash', toolUseId: 'tu-1' },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.activeTool!.serverName).toBeUndefined()
+    })
+
+    it('forwards serverName for MCP tools', () => {
+      const out = handleToolStart(
+        {
+          messageId: 'srv-tool-1',
+          tool: 'mcp__chrome_devtools__take_snapshot',
+          toolUseId: 'tu-1',
+          serverName: 'chrome_devtools',
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.activeTool!.serverName).toBe('chrome_devtools')
+    })
+
+    it('returns null activeTool when toolUseId is missing', () => {
+      // Without a stable toolUseId we cannot dedup or remove on tool_result,
+      // so skip the push rather than orphan an entry.
+      const out = handleToolStart(
+        { messageId: 'srv-tool-1', tool: 'Bash' },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.activeTool).toBeNull()
+    })
+
+    it('returns null activeTool during replay dedup', () => {
+      const cached: ChatMessage[] = [
+        { id: 'srv-tool-1', type: 'tool_use', content: '', timestamp: 1 },
+      ]
+      const out = handleToolStart(
+        { messageId: 'srv-tool-1', tool: 'Bash', toolUseId: 'tu-1' },
+        'sess-active',
+        true,
+        cached,
+      )
+      expect(out.shouldDispatch).toBe(false)
+      expect(out.activeTool).toBeNull()
+    })
+
+    it('applyToActiveTools pushes the new entry onto the array', () => {
+      const out = handleToolStart(
+        { messageId: 'srv-tool-1', tool: 'Bash', toolUseId: 'tu-1' },
+        'sess-active',
+        false,
+        [],
+      )
+      const next = out.applyToActiveTools([])
+      expect(next).toHaveLength(1)
+      expect(next[0]!.toolUseId).toBe('tu-1')
+      expect(next[0]!.tool).toBe('Bash')
+    })
+
+    it('applyToActiveTools dedupes by toolUseId (same reference on duplicate)', () => {
+      const existing: ActiveTool[] = [
+        { toolUseId: 'tu-1', tool: 'Bash', startedAt: 1 },
+      ]
+      const out = handleToolStart(
+        { messageId: 'srv-tool-1', tool: 'Bash', toolUseId: 'tu-1' },
+        'sess-active',
+        false,
+        [],
+      )
+      const next = out.applyToActiveTools(existing)
+      expect(next).toBe(existing)
+    })
+
+    it('applyToActiveTools is a no-op when activeTool is null (no toolUseId)', () => {
+      const existing: ActiveTool[] = [
+        { toolUseId: 'tu-0', tool: 'Read', startedAt: 1 },
+      ]
+      const out = handleToolStart(
+        { messageId: 'srv-tool-1', tool: 'Bash' }, // no toolUseId
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.activeTool).toBeNull()
+      expect(out.applyToActiveTools(existing)).toBe(existing)
+    })
+
+    it('supports parallel in-flight tools (multiple distinct toolUseIds)', () => {
+      const out1 = handleToolStart(
+        { messageId: 'srv-tool-1', tool: 'Bash', toolUseId: 'tu-1' },
+        'sess-active',
+        false,
+        [],
+      )
+      const out2 = handleToolStart(
+        { messageId: 'srv-tool-2', tool: 'Read', toolUseId: 'tu-2' },
+        'sess-active',
+        false,
+        [],
+      )
+      const step1 = out1.applyToActiveTools([])
+      const step2 = out2.applyToActiveTools(step1)
+      expect(step2.map((t) => t.toolUseId)).toEqual(['tu-1', 'tu-2'])
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -5338,6 +5480,40 @@ describe('handleToolResult', () => {
       )
       const updated = out!.applyTo(baseMessages)
       expect(updated[1]!.toolResultImages).toEqual(images)
+    })
+  })
+
+  // #4308 — activeTools removal
+  describe('applyToActiveTools (#4308)', () => {
+    it('removes the entry whose toolUseId matches', () => {
+      const out = handleToolResult({ toolUseId: 'tu-1', result: 'ok' }, 'sess-active')
+      const before: ActiveTool[] = [
+        { toolUseId: 'tu-1', tool: 'Bash', startedAt: 1 },
+        { toolUseId: 'tu-2', tool: 'Read', startedAt: 2 },
+      ]
+      const after = out!.applyToActiveTools(before)
+      expect(after).toHaveLength(1)
+      expect(after[0]!.toolUseId).toBe('tu-2')
+    })
+
+    it('returns same array reference when toolUseId is not present (no-op)', () => {
+      const out = handleToolResult({ toolUseId: 'tu-missing', result: 'ok' }, 'sess-active')
+      const before: ActiveTool[] = [
+        { toolUseId: 'tu-1', tool: 'Bash', startedAt: 1 },
+      ]
+      const after = out!.applyToActiveTools(before)
+      expect(after).toBe(before)
+    })
+
+    it('removes only the matching entry when multiple in-flight tools exist', () => {
+      const out = handleToolResult({ toolUseId: 'tu-2', result: 'ok' }, 'sess-active')
+      const before: ActiveTool[] = [
+        { toolUseId: 'tu-1', tool: 'Bash', startedAt: 1 },
+        { toolUseId: 'tu-2', tool: 'Read', startedAt: 2 },
+        { toolUseId: 'tu-3', tool: 'WebFetch', startedAt: 3 },
+      ]
+      const after = out!.applyToActiveTools(before)
+      expect(after.map((t) => t.toolUseId)).toEqual(['tu-1', 'tu-3'])
     })
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -10,6 +10,7 @@
  */
 
 import type {
+  ActiveTool,
   AgentInfo,
   ChatMessage,
   Checkpoint,
@@ -239,9 +240,19 @@ export function handleClaudeReady(): { claudeReady: true } {
  * shutdown). Pre-#3170 the 5s safety timer in `sendInput` recovered this
  * case; post-#3170 the timer is bypassed once `tool_start` bumps the value,
  * so `agent_idle` is the remaining recovery hook. See #3171.
+ *
+ * #4308 — also clears `activeTools` as a safety net: a missed `tool_result`
+ * (server crash mid-turn, dropped broadcast, etc.) would otherwise leave a
+ * phantom "Running X" indicator visible for the rest of the session. Idle
+ * is a guaranteed turn-boundary, so it's the right place to drop any
+ * still-tracked in-flight tools.
  */
-export function handleAgentIdle(): { isIdle: true; streamingMessageId: null } {
-  return { isIdle: true, streamingMessageId: null }
+export function handleAgentIdle(): {
+  isIdle: true
+  streamingMessageId: null
+  activeTools: ActiveTool[]
+} {
+  return { isIdle: true, streamingMessageId: null, activeTools: [] }
 }
 
 /** State patch for `agent_busy`. */
@@ -3210,6 +3221,24 @@ export interface ToolStartPayload {
    * dashboard's terminal-data side-effect at the call site. Always a string.
    */
   toolName: string
+  /**
+   * #4308 — ActiveTool entry the caller should push onto the target session's
+   * `activeTools[]` array. `null` when the message would not produce a fresh
+   * tool_use bubble (replay dedup, missing toolUseId), so the caller can skip
+   * the push in lockstep with the `shouldDispatch` check.
+   *
+   * `applyTo` dedupes by `toolUseId`: if a matching entry is already present
+   * (e.g. duplicate tool_start broadcasts), the same array reference is
+   * returned and no new entry is pushed.
+   */
+  activeTool: ActiveTool | null
+  /**
+   * #4308 — apply the new ActiveTool to a session's `activeTools[]`. Dedupes
+   * by `toolUseId`. Returns the same array reference (no-op) when
+   * `activeTool === null` or when the entry already exists, so callers can
+   * skip the state write in lockstep with the rest of this payload.
+   */
+  applyToActiveTools: (current: ActiveTool[]) => ActiveTool[]
 }
 
 /**
@@ -3254,10 +3283,23 @@ export function handleToolStart(
   const toolName = tool || 'tool'
   const messageId = typeof msg.messageId === 'string' ? msg.messageId : null
   const toolId = messageId || nextMessageId('tool')
+  const toolUseId = typeof msg.toolUseId === 'string' ? msg.toolUseId : undefined
+  const serverName = typeof msg.serverName === 'string' ? msg.serverName : undefined
+
+  // #4308 — noop applyTo for the early-return paths so the call site can
+  // unconditionally invoke `applyToActiveTools` without a presence check.
+  const noopApply = (current: ActiveTool[]) => current
 
   if (receivingHistoryReplay) {
     if (cachedMessages.some((m) => m.id === toolId)) {
-      return { shouldDispatch: false, sessionId, chatMessage: null, toolName }
+      return {
+        shouldDispatch: false,
+        sessionId,
+        chatMessage: null,
+        toolName,
+        activeTool: null,
+        applyToActiveTools: noopApply,
+      }
     }
   }
 
@@ -3266,12 +3308,42 @@ export function handleToolStart(
     type: 'tool_use',
     content: msg.input ? JSON.stringify(msg.input) : tool || '',
     tool,
-    toolUseId: typeof msg.toolUseId === 'string' ? msg.toolUseId : undefined,
-    serverName: typeof msg.serverName === 'string' ? msg.serverName : undefined,
+    toolUseId,
+    serverName,
     timestamp: Date.now(),
   }
 
-  return { shouldDispatch: true, sessionId, chatMessage, toolName }
+  // #4308 — build the ActiveTool entry. Skip when `toolUseId` is missing
+  // (non-string / absent): the wire schema requires it (#121 server.ts),
+  // but be defensive — without a stable id we can't dedup or remove the
+  // entry on tool_result.
+  const activeTool: ActiveTool | null = toolUseId
+    ? {
+        toolUseId,
+        tool: toolName,
+        ...(serverName !== undefined ? { serverName } : {}),
+        ...(msg.input !== undefined ? { input: msg.input } : {}),
+        startedAt: chatMessage.timestamp,
+      }
+    : null
+
+  const applyToActiveTools = (current: ActiveTool[]): ActiveTool[] => {
+    if (!activeTool) return current
+    // Dedup by toolUseId — duplicate tool_start broadcasts (history replay
+    // landing alongside a live event, server retry, etc.) must not create
+    // ghost entries the activity indicator would surface forever.
+    if (current.some((t) => t.toolUseId === activeTool.toolUseId)) return current
+    return [...current, activeTool]
+  }
+
+  return {
+    shouldDispatch: true,
+    sessionId,
+    chatMessage,
+    toolName,
+    activeTool,
+    applyToActiveTools,
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -3299,6 +3371,14 @@ export interface ToolResultPayload {
    * no-op).
    */
   applyTo: (messages: ChatMessage[]) => ChatMessage[]
+  /**
+   * #4308 — remove the matching entry (by `toolUseId`) from a session's
+   * `activeTools[]`. Returns the same array reference (no-op) when no
+   * matching entry is present, so callers can skip the state write when
+   * nothing changed. Mirrors the no-match no-op contract used by
+   * {@link applyTo} for `messages`.
+   */
+  applyToActiveTools: (current: ActiveTool[]) => ActiveTool[]
 }
 
 /**
@@ -3357,6 +3437,11 @@ export function handleToolResult(
       const updated = [...messages]
       updated[idx] = { ...updated[idx]!, ...patch }
       return updated
+    },
+    // #4308 — remove the in-flight ActiveTool entry by toolUseId.
+    applyToActiveTools: (current) => {
+      const filtered = current.filter((t) => t.toolUseId !== toolUseId)
+      return filtered.length === current.length ? current : filtered
     },
   }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -24,6 +24,9 @@ export type {
   ModelInfo,
   SessionInfo,
   AgentInfo,
+  // #4308: ActiveTool — one entry per in-flight tool call, kept on
+  // BaseSessionState.activeTools and driven by tool_start / tool_result.
+  ActiveTool,
   ConnectedClient,
   SessionHealth,
   SessionContext,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -207,6 +207,38 @@ export interface AgentInfo {
   startedAt: number;
 }
 
+/**
+ * #4308 — one entry per in-flight tool call. Pushed when `tool_start`
+ * arrives, removed (by `toolUseId`) when the matching `tool_result` lands,
+ * and cleared en-masse on `agent_idle` / `result` as a safety net so a
+ * dropped/missed result can't leave a phantom running indicator.
+ *
+ * An array (not a singleton) because there can legitimately be multiple
+ * in-flight tools at once: a sub-agent's tool call while the parent agent
+ * is still mid-turn, or parallel tool calls from a single assistant turn.
+ * Renderers that only have room for one label can use
+ * `activeTools[activeTools.length - 1]` to surface the most-recent.
+ *
+ * Distinct from `messages[].type === 'tool_use'` (which derives in-flight
+ * state by walking the array): `activeTools` is a small, fast slot driven
+ * by the wire events directly. The derive-from-messages path remains a
+ * fallback for history replay and other paths that don't fire tool_start
+ * (#4319 / #4337).
+ *
+ * `tool` is the tool's logical name (`'Bash'`, `'Read'`, etc.) — same value
+ * the server sends on `tool_start`. `serverName` is set only for MCP tools
+ * so renderers can route through `formatToolName(tool, serverName)`. `input`
+ * is the raw tool input verbatim from the wire (best-effort; may be missing
+ * when the input streams via `tool_input_delta`).
+ */
+export interface ActiveTool {
+  toolUseId: string;
+  tool: string;
+  serverName?: string;
+  input?: unknown;
+  startedAt: number;
+}
+
 export interface ConnectedClient {
   clientId: string;
   deviceName: string | null;
@@ -476,6 +508,19 @@ export interface BaseSessionState {
   lastClientActivityAt: number | null;
   health: SessionHealth;
   activeAgents: AgentInfo[];
+  /**
+   * #4308 — in-flight tool calls for this session, in arrival order. See
+   * {@link ActiveTool}. Driven by tool_start / tool_result; cleared on
+   * agent_idle / result as a safety net. Empty when the session is idle
+   * or between tool calls.
+   *
+   * TODO(#4307): when the server starts tracking background-shell tasks,
+   * surface them here too (or in a sibling `activeBackgroundTasks` slot)
+   * so the activity indicator can name pending background work the same
+   * way it names in-flight tools. The exact shape depends on the
+   * server-side schema landed by #4307.
+   */
+  activeTools: ActiveTool[];
   isPlanPending: boolean;
   planAllowedPrompts: { tool: string; prompt: string }[];
   primaryClientId: string | null;

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -25,6 +25,7 @@ describe('createEmptyBaseSessionState', () => {
       lastClientActivityAt: null,
       health: 'healthy',
       activeAgents: [],
+      activeTools: [],
       isPlanPending: false,
       planAllowedPrompts: [],
       primaryClientId: null,
@@ -43,6 +44,7 @@ describe('createEmptyBaseSessionState', () => {
     expect(a).not.toBe(b)
     expect(a.messages).not.toBe(b.messages)
     expect(a.activeAgents).not.toBe(b.activeAgents)
+    expect(a.activeTools).not.toBe(b.activeTools)
     expect(a.planAllowedPrompts).not.toBe(b.planAllowedPrompts)
     expect(a.mcpServers).not.toBe(b.mcpServers)
     expect(a.devPreviews).not.toBe(b.devPreviews)

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -80,6 +80,7 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     lastClientActivityAt: null,
     health: 'healthy',
     activeAgents: [],
+    activeTools: [],
     isPlanPending: false,
     planAllowedPrompts: [],
     primaryClientId: null,


### PR DESCRIPTION
## Summary

Completes the remaining acceptance criteria from #4308 after the initial chip + bubble cut shipped in #4311 (which deferred the structured-state work and sub-agent description surfacing).

Adds `activeTools: ActiveTool[]` to `BaseSessionState` — driven by `tool_start` / `tool_result`, cleared on `agent_idle` / `result` as a safety net. The ActivityIndicator now prefers the new state slot, with the messages-walk approach (#4319/#4337) kept as a fallback for replay / pre-bootstrap paths. Sub-agent descriptions are surfaced over the parent's `Task` wrapper tool.

A TODO(#4307) extension point is left in `BaseSessionState.activeTools` JSDoc and in `ActivityIndicator`'s render-precedence comment so the background-shell surface can slot in once #4307 lands the server-side tracking.

## Acceptance criteria (from #4308)

- [x] **In-flight tool named with elapsed time** — already shipped in #4311; this PR upgrades the data source from a messages walk to a structured state slot. The walk remains as a fallback.
- [x] **Running tool bubble shows a spinner** — already shipped in #4311 (no changes here).
- [x] **Active sub-agent surfaces its description** — ActivityIndicator now reads `activeAgents` and uses the most-recent entry's description in the chip label, taking precedence over the in-flight tool (which is typically `Task` while a sub-agent runs).
- [x] **Background work extension point** — `TODO(#4307)` comments in the new `activeTools` JSDoc and the indicator's render-precedence block.
- [ ] **Mobile app handler parity** — **deferred**. Rationale: store-core ships the new field via `createEmptyBaseSessionState`, so the mobile app state shape is already correct (typechecks clean). The mobile app's `message-handler.ts` does not yet push/pop `activeTools` — but the mobile `ActivityIndicator` does not exist yet either, so no user-visible regression. Mobile parity is a separate small PR if desired.

## State shape

```ts
interface ActiveTool {
  toolUseId: string
  tool: string
  serverName?: string
  input?: unknown
  startedAt: number
}

// on BaseSessionState
activeTools: ActiveTool[]
```

Array (not singleton) because parallel in-flight tools are legitimate: a sub-agent's tool while the parent is mid-turn, or parallel Anthropic SDK tool_use blocks. Renderers with room for one label use `activeTools[activeTools.length - 1]`.

## Test plan

- [x] **store-core**: 12 new tests across `handleToolStart` (activeTool emit, MCP serverName forwarding, missing-toolUseId skip, replay dedup, applyTo push/dedup/no-op, parallel tools) and `handleToolResult` (remove-by-toolUseId, no-op-on-no-match, multi-in-flight surgical removal). Plus the existing `handleAgentIdle` test now asserts `activeTools: []` in the safety-net clear.
- [x] **dashboard message-handler**: 5 new tests covering the wire-path — push on `tool_start`, pop on `tool_result`, parallel `tool_start`s + selective pop, `agent_idle` clear, `result` clear.
- [x] **dashboard ActivityIndicator**: 6 new tests — activeTools wins over messages walk, most-recent wins for parallel tools, fallback when activeTools empty, sub-agent description wins over in-flight tool, most-recent sub-agent wins, sub-agent works through the lastActivityAt-null connect race.
- [x] `npm test` clean in both packages (856 + 2079 = 2935 tests pass).
- [x] `npm run typecheck` clean in store-core, dashboard, and mobile app.

## Related

- Builds on #4311 (chip naming + bubble pulse, derive-from-messages MVP).
- Hooks for #4307 (background-shell tracking) — extension point marked but not implemented.
- Earlier in the activity indicator series: #3758 / #4010 / #4319 / #4320 / #4336 / #4337 / #4339.

Closes #4308