### PR TITLE
feat(dashboard): invoke sidebar context menu via ContextMenu key / Shift+F10 (#4392)

### DIFF
--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -414,6 +414,114 @@ describe('Sidebar', () => {
     })
   })
 
+  // #4392: a11y — invoke the sidebar context menu via keyboard. PR #4369
+  // added keyboard nav WITHIN the open menu, #4372 added focus restoration
+  // on close. The missing third leg: arrow-key users navigating the
+  // sidebar can't OPEN the menu without a mouse. ContextMenu key + Shift+F10
+  // (the two platform-standard shortcuts) bound on each treeitem row fix
+  // this.
+  describe('keyboard invocation of context menu (#4392)', () => {
+    // Helper — stub getBoundingClientRect so the synthesized position is
+    // deterministic. jsdom returns all-zero rects by default, which is fine
+    // for asserting "non-zero / right-edge math is applied" but we want a
+    // concrete check that the math used the rect we set.
+    function stubRect(el: Element, rect: { left: number; top: number; width: number; height: number }) {
+      ;(el as HTMLElement).getBoundingClientRect = () => ({
+        left: rect.left,
+        top: rect.top,
+        width: rect.width,
+        height: rect.height,
+        right: rect.left + rect.width,
+        bottom: rect.top + rect.height,
+        x: rect.left,
+        y: rect.top,
+        toJSON: () => ({}),
+      })
+    }
+
+    it('opens the menu when ContextMenu key is pressed on a session row', () => {
+      const onContextMenu = vi.fn()
+      renderSidebar({ onContextMenu })
+      const row = screen.getByTestId('session-item-s1')
+      stubRect(row, { left: 10, top: 40, width: 200, height: 24 })
+      fireEvent.keyDown(row, { key: 'ContextMenu' })
+      expect(onContextMenu).toHaveBeenCalledTimes(1)
+      expect(onContextMenu).toHaveBeenCalledWith(
+        { type: 'session', sessionId: 's1' },
+        expect.objectContaining({
+          // right-edge center: x = rect.right - 10, y = rect.top + height/2
+          clientX: 200,
+          clientY: 52,
+        }),
+      )
+    })
+
+    it('opens the menu when Shift+F10 is pressed on the outer repo treeitem', () => {
+      const onContextMenu = vi.fn()
+      renderSidebar({ onContextMenu })
+      const treeitem = screen
+        .getByTestId('repo-header-/home/user/projects/api')
+        .closest('[role="treeitem"]') as HTMLElement
+      stubRect(treeitem, { left: 0, top: 0, width: 240, height: 30 })
+      fireEvent.keyDown(treeitem, { key: 'F10', shiftKey: true })
+      expect(onContextMenu).toHaveBeenCalledTimes(1)
+      expect(onContextMenu).toHaveBeenCalledWith(
+        { type: 'repo', path: '/home/user/projects/api' },
+        expect.objectContaining({
+          clientX: 230,
+          clientY: 15,
+        }),
+      )
+    })
+
+    it('opens the menu when Shift+F10 is pressed on a resumable row', () => {
+      const onContextMenu = vi.fn()
+      renderSidebar({ onContextMenu })
+      const row = screen.getByTestId('resumable-item-c1')
+      stubRect(row, { left: 0, top: 100, width: 240, height: 24 })
+      fireEvent.keyDown(row, { key: 'F10', shiftKey: true })
+      expect(onContextMenu).toHaveBeenCalledTimes(1)
+      expect(onContextMenu).toHaveBeenCalledWith(
+        { type: 'resumable', conversationId: 'c1' },
+        expect.objectContaining({
+          clientX: 230,
+          clientY: 112,
+        }),
+      )
+    })
+
+    it('does not open the menu on plain F10 (without Shift)', () => {
+      const onContextMenu = vi.fn()
+      renderSidebar({ onContextMenu })
+      const row = screen.getByTestId('session-item-s1')
+      fireEvent.keyDown(row, { key: 'F10' })
+      expect(onContextMenu).not.toHaveBeenCalled()
+    })
+
+    it('does not also fire the tree-level React keydown handler (handleTreeKeyDown)', () => {
+      // The row handler calls stopPropagation() so handleTreeKeyDown
+      // (bound on the .sidebar-tree wrapper) does not also process the
+      // event. We assert this behavior end-to-end by pressing one of the
+      // keys handleTreeKeyDown DOES handle — `Enter` — first as a control
+      // (no row handler interception → onSessionClick fires via the tree
+      // handler's `focused.click()`), then by establishing the keyboard
+      // shortcut path. The contract we encode here: pressing ContextMenu
+      // on a focused row invokes onContextMenu exactly once and does not
+      // trigger onSessionClick (which would happen if Enter leaked).
+      const onContextMenu = vi.fn()
+      const onSessionClick = vi.fn()
+      renderSidebar({ onContextMenu, onSessionClick })
+      const row = screen.getByTestId('session-item-s1') as HTMLElement
+      row.focus()
+      fireEvent.keyDown(row, { key: 'ContextMenu' })
+      expect(onContextMenu).toHaveBeenCalledTimes(1)
+      // The tree handler does not handle ContextMenu today, so this is
+      // belt-and-suspenders, but: if a future change adds ContextMenu to
+      // the tree switch and forgets stopPropagation, this fails.
+      expect(onSessionClick).not.toHaveBeenCalled()
+    })
+  })
+
   describe('stdin forwarding disabled badge (#3567)', () => {
     it('renders the badge on rows whose session has the latched flag', () => {
       const repos: RepoNode[] = [

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -224,6 +224,47 @@ export function Sidebar({
     })
   }, [])
 
+  // #4392: a11y — invoke the sidebar context menu via keyboard. PR #4369
+  // added arrow-key nav WITHIN the open menu, #4372 returned focus to the
+  // row on close. This is the missing third leg: keyboard users navigating
+  // the sidebar (Tab/ArrowDown) couldn't OPEN the menu without a mouse.
+  //
+  // Two platform-standard shortcuts:
+  //   - `ContextMenu` key (dedicated menu key on most PC keyboards)
+  //   - Shift+F10 (Windows/Linux convention; harmless on macOS where the
+  //     key normally only adjusts speaker volume — Shift+F10 isn't bound)
+  //
+  // The handler synthesizes a position from the row's bounding rect
+  // (right-edge center) and forwards a MouseEvent-shaped payload to the
+  // existing onContextMenu prop. App.tsx reads `clientX/clientY` and
+  // `currentTarget.focus()` from the event — both are stubbed here so the
+  // keyboard path lights up the same code as a real right-click.
+  const invokeContextMenuFromKey = useCallback((
+    e: React.KeyboardEvent<HTMLElement>,
+    target: ContextMenuTarget,
+  ) => {
+    if (!(e.key === 'ContextMenu' || (e.key === 'F10' && e.shiftKey))) return
+    e.preventDefault()
+    e.stopPropagation()
+    const row = e.currentTarget
+    const rect = row.getBoundingClientRect()
+    // Right-edge center: places the menu's top-left near the visible
+    // right side of the row, which lines up well with a left-to-right
+    // sidebar where the menu opens into the editor area.
+    const x = rect.right - 10
+    const y = rect.top + rect.height / 2
+    const synthetic = {
+      clientX: x,
+      clientY: y,
+      currentTarget: row,
+      target: row,
+      preventDefault: () => e.preventDefault(),
+      stopPropagation: () => e.stopPropagation(),
+      nativeEvent: e.nativeEvent,
+    } as unknown as React.MouseEvent
+    onContextMenu(target, synthetic)
+  }, [onContextMenu])
+
   // Keyboard handler for WAI-ARIA TreeView pattern
   const handleTreeKeyDown = useCallback((e: React.KeyboardEvent) => {
     const items = getVisibleItems()
@@ -372,6 +413,11 @@ export function Sidebar({
                     e.preventDefault()
                     onContextMenu({ type: 'repo', path: repo.path }, e)
                   }}
+                  // #4392: keyboard invocation of the context menu via the
+                  // ContextMenu key or Shift+F10. invokeContextMenuFromKey
+                  // is a no-op for any other key, so this does not
+                  // interfere with the tree-level arrow nav.
+                  onKeyDown={e => invokeContextMenuFromKey(e, { type: 'repo', path: repo.path })}
                 >
                   <div
                     className={`sidebar-repo-header${!repo.exists ? ' missing' : ''}`}
@@ -428,6 +474,11 @@ export function Sidebar({
                               e.stopPropagation()
                               onContextMenu({ type: 'session', sessionId: session.sessionId }, e)
                             }}
+                            // #4392: keyboard invocation (ContextMenu /
+                            // Shift+F10). stopPropagation inside the helper
+                            // keeps the event from also reaching the outer
+                            // repo treeitem's onKeyDown.
+                            onKeyDown={e => invokeContextMenuFromKey(e, { type: 'session', sessionId: session.sessionId })}
                           >
                             <span className={`sidebar-session-dot status-${status}`} title={statusTitle} />
                             <span className="sidebar-session-name">{session.name}</span>
@@ -496,6 +547,10 @@ export function Sidebar({
                             e.stopPropagation()
                             onContextMenu({ type: 'resumable', conversationId: conv.conversationId }, e)
                           }}
+                          // #4392: keyboard invocation (ContextMenu /
+                          // Shift+F10), see matching binding on session
+                          // rows above.
+                          onKeyDown={e => invokeContextMenuFromKey(e, { type: 'resumable', conversationId: conv.conversationId })}
                         >
                           <span className="sidebar-resumable-dot" title="Resumable conversation" />
                           <span className="sidebar-session-name">


### PR DESCRIPTION
Closes #4392

## Summary

Keyboard users navigating the sidebar (Tab / ArrowDown) couldn't OPEN the context menu without a mouse. #4369 added keyboard nav WITHIN the menu, #4390 (#4372) restored focus to the row on close — this PR is the missing third leg: keyboard-driven invocation.

## Change

Bind an `onKeyDown` handler on all three treeitem row types in `Sidebar.tsx`:

| Row type | DOM element |
|----------|-------------|
| repo | outer `.sidebar-repo` treeitem wrapper (where the right-click handler was moved in #4372) |
| session | `.sidebar-session-item` |
| resumable | `.sidebar-resumable-item` |

On `ContextMenu` key (dedicated menu key on PC keyboards) or `Shift+F10` (Windows/Linux convention; unbound on macOS so no conflict), the handler:

1. `preventDefault()` + `stopPropagation()`
2. Computes a position from the row's `getBoundingClientRect()`: `{ x: rect.right - 10, y: rect.top + rect.height / 2 }` — right-edge center, so the menu opens into the editor area
3. Synthesizes a `MouseEvent`-shaped payload (`clientX`, `clientY`, `currentTarget`, `preventDefault`, `stopPropagation`) and forwards it to the existing `onContextMenu` prop

App.tsx's `handleSidebarContextMenu` reads `event.clientX/clientY` and calls `event.currentTarget.focus()` exactly the same way for both code paths, so #4372's focus-restoration flow lights up unchanged.

`stopPropagation` keeps the event from reaching the tree-level `handleTreeKeyDown` (no overlap with arrow / Enter / Home / End today, but a guard against future shortcuts).

## Tests

5 new tests in `Sidebar.test.tsx` covering:

- ContextMenu key on session row opens menu with `{ type: 'session', sessionId }` at the rect-derived position
- Shift+F10 on the outer repo treeitem opens menu with `{ type: 'repo', path }`
- Shift+F10 on resumable row opens menu with `{ type: 'resumable', conversationId }`
- Plain F10 (without Shift) is a no-op
- stopPropagation contract — pressing ContextMenu doesn't fall through to onSessionClick

Esc dismissal is already covered by `SessionContextMenu.test.tsx` (unmodified).

## Test plan

- [x] `npm test -- --run` — full dashboard suite (2079 passed)
- [x] `npm run typecheck` — clean
- [ ] Manual: focus a sidebar row in the dashboard, press the ContextMenu key — menu opens at the row's right edge
- [ ] Manual: focus a sidebar row, press Shift+F10 — same result
- [ ] Manual: with menu open, press Esc — menu closes and focus returns to the row