### PR TITLE
feat(server,dashboard): thinking-keyword escalation + inline highlight (#4306)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2016,6 +2016,13 @@ export function App() {
               onInspectPastedText={handleInspectPastedText}
               onRemovePastedText={handleRemovePastedText}
               userMessageHistory={userMessageHistory}
+              // #4306 — only highlight when the active provider actually
+              // honours the magic thinking keyword. Reuses `showThinkingLevel`
+              // (capabilities.thinkingLevel) as the truth-source: if the
+              // dropdown is hidden because the provider can't take a thinking
+              // budget, the keyword wouldn't escalate either — so we must
+              // not visually imply otherwise.
+              highlightThinkingKeywords={dropdownFlags.showThinkingLevel}
             />
           </>
         )}

--- a/packages/dashboard/src/components/InputBar.test.tsx
+++ b/packages/dashboard/src/components/InputBar.test.tsx
@@ -2233,3 +2233,129 @@ describe('InputBar history navigation (#3698)', () => {
     expect(onValueChange).toHaveBeenLastCalledWith('b-new')
   })
 })
+
+// #4306 — thinking-keyword highlight overlay. The overlay is gated on a
+// `highlightThinkingKeywords` prop driven by the active provider's
+// `capabilities.thinkingLevel` flag, so providers that can't honour the
+// keyword (CLI `-p`, codex, gemini) get no highlight — otherwise we'd
+// imply an escalation that isn't happening server-side.
+describe('InputBar — thinking-keyword highlight overlay (#4306)', () => {
+  it('does NOT render the overlay when highlightThinkingKeywords is omitted (default)', () => {
+    render(<InputBar onSend={vi.fn()} onInterrupt={vi.fn()} />)
+    expect(screen.queryByTestId('thinking-keyword-overlay')).not.toBeInTheDocument()
+  })
+
+  it('does NOT render the overlay when highlightThinkingKeywords is false', () => {
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue="please ultrathink this"
+        onValueChange={vi.fn()}
+        highlightThinkingKeywords={false}
+      />,
+    )
+    // Even with a matching keyword in the value, the overlay stays absent
+    // — this is the "do not lie to the user" gate for non-escalating
+    // providers.
+    expect(screen.queryByTestId('thinking-keyword-overlay')).not.toBeInTheDocument()
+    expect(screen.queryAllByTestId('thinking-keyword')).toHaveLength(0)
+  })
+
+  it('renders the overlay when highlightThinkingKeywords is true', () => {
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue=""
+        onValueChange={vi.fn()}
+        highlightThinkingKeywords
+      />,
+    )
+    // Overlay container is present even when empty — necessary so the
+    // mirror div is mounted before the first keystroke fires onChange.
+    expect(screen.getByTestId('thinking-keyword-overlay')).toBeInTheDocument()
+    // …but with no keywords typed yet, there are no matched spans.
+    expect(screen.queryAllByTestId('thinking-keyword')).toHaveLength(0)
+  })
+
+  it('wraps a matched keyword in a highlight span', () => {
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue="please ultrathink the architecture"
+        onValueChange={vi.fn()}
+        highlightThinkingKeywords
+      />,
+    )
+    const spans = screen.getAllByTestId('thinking-keyword')
+    expect(spans).toHaveLength(1)
+    expect(spans[0]!.textContent).toBe('ultrathink')
+  })
+
+  it('wraps multiple keywords in the same input', () => {
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue="first ultrathink then think harder"
+        onValueChange={vi.fn()}
+        highlightThinkingKeywords
+      />,
+    )
+    const spans = screen.getAllByTestId('thinking-keyword')
+    expect(spans).toHaveLength(2)
+    expect(spans.map(s => s.textContent)).toEqual(['ultrathink', 'think harder'])
+  })
+
+  it('does NOT wrap substrings inside other words (word boundary)', () => {
+    // `unthinkingly` contains `think` as a substring but not at a word
+    // boundary — the overlay must agree with the server-side detection
+    // (which is the gating contract for #4306) and NOT highlight here.
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue="I unthinkingly committed this"
+        onValueChange={vi.fn()}
+        highlightThinkingKeywords
+      />,
+    )
+    expect(screen.queryAllByTestId('thinking-keyword')).toHaveLength(0)
+  })
+
+  it('preserves the user`s original casing inside the highlight span', () => {
+    // The overlay carries the user's literal characters — case-folded
+    // matching only governs WHETHER something is a keyword, never what
+    // is displayed. This matters because the textarea (behind the
+    // overlay) still has the original characters and the overlay must
+    // align with them character-for-character.
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue="ULTRATHINK now"
+        onValueChange={vi.fn()}
+        highlightThinkingKeywords
+      />,
+    )
+    const spans = screen.getAllByTestId('thinking-keyword')
+    expect(spans).toHaveLength(1)
+    expect(spans[0]!.textContent).toBe('ULTRATHINK')
+  })
+
+  it('marks the overlay aria-hidden so the textarea is the only accessible input', () => {
+    render(
+      <InputBar
+        onSend={vi.fn()}
+        onInterrupt={vi.fn()}
+        controlledValue="ultrathink"
+        onValueChange={vi.fn()}
+        highlightThinkingKeywords
+      />,
+    )
+    const overlay = screen.getByTestId('thinking-keyword-overlay')
+    expect(overlay.getAttribute('aria-hidden')).toBe('true')
+  })
+})

--- a/packages/dashboard/src/components/InputBar.tsx
+++ b/packages/dashboard/src/components/InputBar.tsx
@@ -14,6 +14,7 @@ import type { SlashCommand, EvaluatorResultPayload } from '../store/types'
 import { filterImageFiles } from '../utils/image-utils'
 import { shouldCollapsePaste, findActiveMarkerIds } from '@chroxy/store-core'
 import { PastedTextChip } from './PastedTextChip'
+import { tokenizeThinkingKeywords } from './thinking-keyword-tokens'
 
 /**
  * Convert a clipboard HTML payload to plain text. Used as a fallback when
@@ -131,6 +132,19 @@ export interface InputBarProps {
    * entirely — Up/Down then revert to plain cursor movement.
    */
   userMessageHistory?: string[]
+  /**
+   * #4306 — when true, render the inline "thinking keyword" highlight
+   * overlay (matches `ultrathink`, `megathink`, `think harder`, `think hard`,
+   * `think` case-insensitively at word boundaries). Caller MUST gate this
+   * on whether the active session's provider actually supports the
+   * server-side escalation — currently the SDK provider only. Highlighting
+   * on a provider that ignores the keyword would imply an escalation the
+   * server does not perform; see #4306's "do not lie to the user" gate.
+   *
+   * When omitted / false, the overlay renders nothing and the textarea
+   * behaves exactly as before (plain visible text, no transparency hack).
+   */
+  highlightThinkingKeywords?: boolean
 }
 
 type EvaluatorState =
@@ -139,7 +153,7 @@ type EvaluatorState =
   | { kind: 'result', result: EvaluatorResultPayload }
   | { kind: 'error', message: string }
 
-export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText, userMessageHistory }: InputBarProps) {
+export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, placeholder, filePickerFiles, onFileTrigger, attachments, onRemoveAttachment, slashCommands, onSlashTrigger, onImagePaste, onImageDrop, imageAttachments, onRemoveImage, onFileAttach, controlledValue, onValueChange, sendOnEnter, voiceInput, onEvaluate, onLargePaste, pastedTextBlocks, onInspectPastedText, onRemovePastedText, userMessageHistory, highlightThinkingKeywords }: InputBarProps) {
   const [internalValue, setInternalValue] = useState('')
   const value = controlledValue !== undefined ? controlledValue : internalValue
   const setValue = onValueChange || setInternalValue
@@ -150,6 +164,21 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
   const [selectedIndex, setSelectedIndex] = useState(0)
   const shortcutsId = useId()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // #4306 — thinking-keyword highlight overlay. Mirror div behind a
+  // transparent-text textarea; identical box metrics in CSS (font, padding,
+  // line-height, white-space) so the overlay's <span>-wrapped keywords line
+  // up pixel-perfect with the user's literal text.
+  //
+  // We hold an overlayRef and `useLayoutEffect`-sync `scrollTop` from the
+  // textarea so multi-line drafts scroll the highlight along with the cursor.
+  // (No `useState` for scrollTop — we'd re-render on every keystroke for a
+  // value the DOM owns.)
+  const overlayRef = useRef<HTMLDivElement>(null)
+  const tokens = useMemo(
+    () => highlightThinkingKeywords ? tokenizeThinkingKeywords(value) : null,
+    [value, highlightThinkingKeywords]
+  )
 
   // #3068 — manual prompt evaluator state machine. Lives in InputBar because
   // applying a rewrite has to swap the textarea value and re-focus it.
@@ -830,18 +859,54 @@ export function InputBar({ onSend, onInterrupt, disabled, isBusy, isStreaming, p
           onDismiss={dismissEvaluator}
         />
       )}
-      <textarea
-        ref={textareaRef}
-        value={value}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        onPaste={handlePaste}
-        disabled={disabled}
-        placeholder={isBusy ? 'Type to send follow-up...' : placeholder}
-        aria-label="Message input"
-        aria-describedby={shortcutsId}
-        rows={1}
-      />
+      <div className={`input-bar-textarea-wrap${tokens ? ' has-overlay' : ''}`}>
+        {tokens && (
+          // Mirror div behind the textarea (#4306). Identical box metrics
+          // (font, padding, line-height, white-space) are enforced in CSS
+          // via the .input-bar-textarea-wrap.has-overlay selector pair so
+          // the overlay characters land in the same x/y as the textarea's
+          // own characters. aria-hidden because the textarea is the
+          // authoritative input — the overlay is purely visual.
+          <div
+            ref={overlayRef}
+            className="input-bar-textarea-overlay"
+            aria-hidden="true"
+            data-testid="thinking-keyword-overlay"
+          >
+            {tokens.map((tok, i) => (
+              tok.kind === 'keyword'
+                ? <span key={i} className="thinking-keyword" data-testid="thinking-keyword">{tok.text}</span>
+                : <span key={i}>{tok.text}</span>
+            ))}
+            {/* Trailing whitespace handling: a trailing newline at the end
+                of the textarea content doesn't create a new line in a
+                contenteditable-style div without an explicit terminator.
+                Append a zero-width space inside a span so the overlay's
+                height matches the textarea's when the user ends with `\n`. */}
+            {value.endsWith('\n') && <span>{'​'}</span>}
+          </div>
+        )}
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+          onScroll={tokens ? (e) => {
+            // Scroll-sync the overlay to the textarea so multi-line drafts
+            // keep keyword highlights aligned as the user scrolls within
+            // the textarea. Direct DOM write (not state) — same reason as
+            // the auto-resize logic in handleChange.
+            const ov = overlayRef.current
+            if (ov) ov.scrollTop = e.currentTarget.scrollTop
+          } : undefined}
+          disabled={disabled}
+          placeholder={isBusy ? 'Type to send follow-up...' : placeholder}
+          aria-label="Message input"
+          aria-describedby={shortcutsId}
+          rows={1}
+        />
+      </div>
       <div className="input-bar-actions">
         {voiceInput?.isAvailable && (
           <button

--- a/packages/dashboard/src/components/thinking-keyword-tokens.test.ts
+++ b/packages/dashboard/src/components/thinking-keyword-tokens.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for tokenizeThinkingKeywords (#4306). The tokens drive the overlay's
+ * inline highlight; the must-haves are:
+ *   - case-insensitive whole-word matching (must mirror server-side)
+ *   - longest-match wins (`think harder` before `think hard` before `think`)
+ *   - whitespace tolerance (multi-space + newline between "think" + "harder")
+ *   - concatenating tokens reproduces the original input verbatim
+ */
+import { describe, it, expect } from 'vitest'
+import { tokenizeThinkingKeywords } from './thinking-keyword-tokens'
+
+describe('tokenizeThinkingKeywords', () => {
+  describe('no-match cases', () => {
+    it('returns a single empty text token for empty string', () => {
+      expect(tokenizeThinkingKeywords('')).toEqual([{ kind: 'text', text: '' }])
+    })
+
+    it('returns a single text token when no keyword present', () => {
+      expect(tokenizeThinkingKeywords('hello world')).toEqual([
+        { kind: 'text', text: 'hello world' },
+      ])
+    })
+
+    it('does not match inside other words (word boundary)', () => {
+      expect(tokenizeThinkingKeywords('rethinking the approach')).toEqual([
+        { kind: 'text', text: 'rethinking the approach' },
+      ])
+      expect(tokenizeThinkingKeywords('unthinkingly added')).toEqual([
+        { kind: 'text', text: 'unthinkingly added' },
+      ])
+    })
+  })
+
+  describe('individual keyword matches', () => {
+    it('tokenises "think" as a keyword mid-sentence', () => {
+      expect(tokenizeThinkingKeywords('please think about this')).toEqual([
+        { kind: 'text', text: 'please ' },
+        { kind: 'keyword', text: 'think' },
+        { kind: 'text', text: ' about this' },
+      ])
+    })
+
+    it('tokenises "ultrathink" at the start', () => {
+      expect(tokenizeThinkingKeywords('ultrathink please')).toEqual([
+        { kind: 'keyword', text: 'ultrathink' },
+        { kind: 'text', text: ' please' },
+      ])
+    })
+
+    it('tokenises "ultrathink" at the very end (no trailing text token)', () => {
+      expect(tokenizeThinkingKeywords('please ultrathink')).toEqual([
+        { kind: 'text', text: 'please ' },
+        { kind: 'keyword', text: 'ultrathink' },
+      ])
+    })
+  })
+
+  describe('longest-match-wins (mirrors server)', () => {
+    // Critical: without ordered alternation, the regex would match `think`
+    // first and leave a stray `hard`/`harder` text run — the highlight
+    // would lie about what was escalated.
+    it('matches "think harder" as a single keyword token', () => {
+      expect(tokenizeThinkingKeywords('think harder now')).toEqual([
+        { kind: 'keyword', text: 'think harder' },
+        { kind: 'text', text: ' now' },
+      ])
+    })
+
+    it('matches "think hard" as a single keyword token', () => {
+      expect(tokenizeThinkingKeywords('think hard now')).toEqual([
+        { kind: 'keyword', text: 'think hard' },
+        { kind: 'text', text: ' now' },
+      ])
+    })
+  })
+
+  describe('case-insensitive', () => {
+    it('matches ULTRATHINK uppercase and preserves the original casing in the token', () => {
+      // The token must carry the user's original casing so the overlay
+      // can render exactly what they typed — only the styling differs.
+      expect(tokenizeThinkingKeywords('ULTRATHINK now')).toEqual([
+        { kind: 'keyword', text: 'ULTRATHINK' },
+        { kind: 'text', text: ' now' },
+      ])
+    })
+
+    it('matches mixed-case "Think Harder"', () => {
+      expect(tokenizeThinkingKeywords('Think Harder please')).toEqual([
+        { kind: 'keyword', text: 'Think Harder' },
+        { kind: 'text', text: ' please' },
+      ])
+    })
+  })
+
+  describe('whitespace tolerance', () => {
+    it('matches "think  harder" with extra spaces (collapses inside the keyword token)', () => {
+      // The mirror overlay relies on the keyword token preserving the
+      // exact substring (including the embedded double space) so its
+      // wrapped <span> spans the same visual width as the textarea's
+      // run of double-spaced text.
+      expect(tokenizeThinkingKeywords('please think  harder')).toEqual([
+        { kind: 'text', text: 'please ' },
+        { kind: 'keyword', text: 'think  harder' },
+      ])
+    })
+
+    it('matches "think\\nharder" across a newline', () => {
+      expect(tokenizeThinkingKeywords('please think\nharder')).toEqual([
+        { kind: 'text', text: 'please ' },
+        { kind: 'keyword', text: 'think\nharder' },
+      ])
+    })
+  })
+
+  describe('multiple matches in the same input', () => {
+    it('tokenises both ultrathink AND think hard', () => {
+      expect(tokenizeThinkingKeywords('first ultrathink then think hard')).toEqual([
+        { kind: 'text', text: 'first ' },
+        { kind: 'keyword', text: 'ultrathink' },
+        { kind: 'text', text: ' then ' },
+        { kind: 'keyword', text: 'think hard' },
+      ])
+    })
+  })
+
+  describe('round-trip invariant', () => {
+    // The overlay only lines up with the textarea if the concatenated
+    // token text matches the input character-for-character. Any drift
+    // here will shift the highlight by N characters and look broken.
+    const samples = [
+      'hello world',
+      'please think about this',
+      'ULTRATHINK now',
+      'first ultrathink then think hard',
+      'please think  harder',
+      'please think\nharder',
+      'rethinking the approach',
+      '',
+      'ultrathink',
+    ]
+    for (const sample of samples) {
+      it(`concatenating tokens reproduces input: ${JSON.stringify(sample)}`, () => {
+        const tokens = tokenizeThinkingKeywords(sample)
+        expect(tokens.map(t => t.text).join('')).toBe(sample)
+      })
+    }
+  })
+})

--- a/packages/dashboard/src/components/thinking-keyword-tokens.ts
+++ b/packages/dashboard/src/components/thinking-keyword-tokens.ts
@@ -1,0 +1,80 @@
+/**
+ * Tokenise input text for the InputBar "thinking keyword" highlight overlay
+ * (#4306). The dashboard renders an `aria-hidden` mirror div behind the
+ * textarea; each matched keyword is wrapped in a styled `<span>` so the user
+ * sees their `ultrathink` / `think harder` etc. light up inline — matching
+ * the native Claude Code REPL UX.
+ *
+ * The matching rules MUST mirror the server-side `detectThinkingKeyword`
+ * (packages/server/src/detect-thinking-keyword.js):
+ *
+ *   - case-insensitive
+ *   - whole-word match (word boundaries)
+ *   - LONGEST match wins per position so `think harder` is preferred over
+ *     `think hard` is preferred over `think`. The single regex below does
+ *     this naturally because regex alternation is ordered and we list the
+ *     longest patterns first.
+ *
+ * If the server-side detection changes (new keyword, different budget map,
+ * different boundary rules), this helper must change in lockstep — otherwise
+ * the dashboard would highlight a word the server doesn't escalate, or vice
+ * versa, both of which silently lie to the user.
+ */
+
+export type ThinkingKeywordToken =
+  | { kind: 'text'; text: string }
+  | { kind: 'keyword'; text: string }
+
+/**
+ * Build the matcher once at module load — the regex is global so successive
+ * `exec()` calls walk forward through the input. Flags:
+ *   - `g`  — global (advance lastIndex on each match)
+ *   - `i`  — case-insensitive
+ *
+ * The `\s+` between the multi-word entries collapses any run of whitespace
+ * (spaces, tabs, newlines) so `think  harder` and `think\nharder` still
+ * match the same way they do server-side.
+ */
+const THINKING_KEYWORD_RE = /\b(?:ultrathink|megathink|think\s+harder|think\s+hard|think)\b/gi
+
+/**
+ * Split `text` into an ordered list of tokens. Adjacent text runs are not
+ * merged; the only invariant the consumer needs is that concatenating every
+ * token's `.text` yields the original input verbatim — required for the
+ * overlay to line up with the textarea's visible text.
+ *
+ * Returns `[{ kind: 'text', text: '' }]` for an empty string so the mirror
+ * div always has at least one child node (otherwise the empty container
+ * collapses below the line-height baseline and the textarea's first line
+ * sits a pixel off from the overlay).
+ */
+export function tokenizeThinkingKeywords(text: string): ThinkingKeywordToken[] {
+  if (typeof text !== 'string' || text.length === 0) {
+    return [{ kind: 'text', text: '' }]
+  }
+
+  const tokens: ThinkingKeywordToken[] = []
+  // `exec()`-based loop instead of `String.matchAll` because we also need
+  // the gap-text (the run between consecutive matches) — `matchAll` would
+  // give us match arrays but not the inter-match slices without bookkeeping
+  // we'd need either way.
+  const re = new RegExp(THINKING_KEYWORD_RE.source, THINKING_KEYWORD_RE.flags)
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = re.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      tokens.push({ kind: 'text', text: text.slice(lastIndex, match.index) })
+    }
+    tokens.push({ kind: 'keyword', text: match[0] })
+    lastIndex = match.index + match[0].length
+    // Defend against zero-length matches — shouldn't be possible with the
+    // current regex (no `*` or `?` quantifiers on the alternation as a
+    // whole) but a future edit could regress this and produce an infinite
+    // loop. Cheap belt-and-braces.
+    if (match[0].length === 0) re.lastIndex++
+  }
+  if (lastIndex < text.length) {
+    tokens.push({ kind: 'text', text: text.slice(lastIndex) })
+  }
+  return tokens
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2968,6 +2968,78 @@
   line-height: 1.4;
 }
 
+/* ---- Thinking-keyword overlay (#4306) ----
+ * The wrap sits in the flex slot where the textarea used to live and
+ * stacks the overlay (absolute) under the textarea (relative). Both
+ * children share identical box metrics — font, padding, border, line-
+ * height, white-space — so character cells align pixel-perfect.
+ *
+ * Only `.has-overlay` flips the textarea to transparent text; without
+ * the overlay, the wrap is transparent and the textarea renders normally,
+ * preserving the visual baseline for sessions/providers that don't gate
+ * the highlight on. */
+.input-bar-textarea-wrap {
+  position: relative;
+  flex: 1;
+  display: flex;
+  min-width: 0;
+}
+
+.input-bar-textarea-wrap > textarea {
+  flex: 1;
+  position: relative;
+  z-index: 1;
+  background: transparent;
+}
+
+.input-bar-textarea-wrap.has-overlay > textarea {
+  /* Safari ignores `color: transparent` for the textarea text but respects
+   * -webkit-text-fill-color. Set both for cross-browser parity. The caret
+   * follows `caret-color`, which we restore so the user still sees where
+   * they're typing. */
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  caret-color: var(--text-primary);
+}
+
+.input-bar-textarea-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  /* Mirror the textarea's box metrics so each character lands in the
+   * same x/y. Any drift between these values and `.input-bar textarea`
+   * will shift the highlight relative to the user's typed text. */
+  padding: 10px 14px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  font-size: var(--text-md);
+  font-family: inherit;
+  line-height: 1.4;
+  /* Reproduce textarea wrapping behaviour: pre-wrap preserves whitespace
+   * (including the leading spaces a user types) and wraps on the same
+   * soft-wrap rules the textarea uses. */
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  word-break: break-word;
+  overflow: hidden;
+  color: var(--text-primary);
+}
+
+.input-bar-textarea-overlay .thinking-keyword {
+  /* Accent colour + soft tinted background. Critically we do NOT change
+   * the font-weight, font-style, or text-transform because any of those
+   * would alter the glyph advance widths and the overlay would drift one
+   * keyword width out of sync with the textarea's caret/selection. The
+   * native CLI gets its "ALL CAPS" look from a monospace context where
+   * widths are uniform; in our proportional textarea we use colour +
+   * background tint to convey the same signal without breaking
+   * alignment. */
+  color: var(--accent-blue);
+  background-color: color-mix(in srgb, var(--accent-blue) 14%, transparent);
+  border-radius: 3px;
+}
+
 .input-bar textarea:focus {
   outline: none;
   border-color: var(--accent-blue);

--- a/packages/server/src/detect-thinking-keyword.js
+++ b/packages/server/src/detect-thinking-keyword.js
@@ -1,0 +1,64 @@
+/**
+ * Detect Claude Code "thinking keywords" in a user prompt.
+ *
+ * The native Claude Code CLI's interactive REPL scans for magic keywords
+ * (`think`, `think hard`, `think harder`, `megathink`, `ultrathink`) and
+ * escalates the model's `maxThinkingTokens` budget for that turn. The
+ * `query()` path Chroxy's SdkSession uses does NOT do this — the scanner
+ * lives in the REPL, not the SDK. Issue #4306 makes the same affordance
+ * work through Chroxy: detect the keyword server-side, bump
+ * `maxThinkingTokens` for the turn via the existing escalation path.
+ *
+ * Matching rules:
+ *   - case-insensitive
+ *   - whole-word match (word boundaries) so `unthinkingly` does NOT match
+ *   - longest match wins so `think harder` is preferred over `think`
+ *
+ * Budget mapping mirrors the native CLI rough buckets:
+ *   - `think`         →  4_000   (low)
+ *   - `think hard`    → 10_000   (medium)
+ *   - `think harder`  → 32_000   (high — same as SdkSession's `high` level)
+ *   - `megathink`     → 32_000   (alias often documented alongside `think harder`)
+ *   - `ultrathink`    → 128_000  (max — same as SdkSession's `max` level)
+ *
+ * @typedef {Object} DetectedThinkingKeyword
+ * @property {string} keyword - The matched keyword (lowercased, canonical form)
+ * @property {number} budget  - Token budget to pass to setMaxThinkingTokens
+ *
+ * @param {string} text
+ * @returns {DetectedThinkingKeyword | null}
+ */
+export function detectThinkingKeyword(text) {
+  if (typeof text !== 'string' || text.length === 0) return null
+
+  // Longest first so `think harder` wins over `think hard` wins over `think`.
+  // Each entry is `[canonicalKeyword, regex, budget]`. The regex uses
+  // word-boundary anchors on both sides; the multi-word entries collapse
+  // any run of whitespace between words so `think  harder` (double space)
+  // and `think\nharder` still match.
+  const PATTERNS = [
+    ['ultrathink', /\bultrathink\b/i, 128_000],
+    ['megathink', /\bmegathink\b/i, 32_000],
+    ['think harder', /\bthink\s+harder\b/i, 32_000],
+    ['think hard', /\bthink\s+hard\b/i, 10_000],
+    ['think', /\bthink\b/i, 4_000],
+  ]
+
+  for (const [keyword, regex, budget] of PATTERNS) {
+    if (regex.test(text)) return { keyword, budget }
+  }
+  return null
+}
+
+/**
+ * Token-budget map keyed by canonical keyword. Useful when callers already
+ * know the keyword (e.g. dashboard wants to render the badge) and just need
+ * the budget without re-running the regex sweep.
+ */
+export const THINKING_KEYWORD_BUDGETS = Object.freeze({
+  'think': 4_000,
+  'think hard': 10_000,
+  'think harder': 32_000,
+  'megathink': 32_000,
+  'ultrathink': 128_000,
+})

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -11,6 +11,7 @@ import { createLogger } from './logger.js'
 import { PermissionManager } from './permission-manager.js'
 import { formatBytes } from './utils/format-bytes.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
+import { detectThinkingKeyword } from './detect-thinking-keyword.js'
 
 const log = createLogger('sdk')
 
@@ -491,6 +492,34 @@ export class SdkSession extends BaseSession {
     if (this._thinkingLevel) {
       const budget = SdkSession.THINKING_BUDGETS[this._thinkingLevel]
       if (budget != null) options.maxThinkingTokens = budget
+    }
+
+    // #4306 — magic thinking-keyword escalation. The native Claude Code CLI's
+    // interactive REPL scans the user's prompt for keywords (`think`,
+    // `think hard`, `think harder`, `megathink`, `ultrathink`) and escalates
+    // the thinking budget for that turn. The Agent SDK's `query()` path does
+    // NOT do this — the scanner lives in the REPL only. Re-implement it here
+    // so the keyword behaviour is consistent between Chroxy and the native CLI.
+    //
+    // Important: the keyword detection runs against the ORIGINAL prompt
+    // (`prompt`), not the transformed one. Voice / typo / etc. transforms
+    // (#3203, MessageTransformPipeline) may legitimately rewrite the user's
+    // input, but the keyword is a user-intent signal that must come from
+    // their literal typed text.
+    //
+    // The detected budget takes precedence over the dropdown-driven level
+    // ONLY when the keyword's budget is larger — otherwise a `think` keyword
+    // could *lower* a session that the user already set to `max`. Matches
+    // the native CLI's "more thinking, never less" semantic.
+    const detectedKeyword = typeof prompt === 'string' ? detectThinkingKeyword(prompt) : null
+    if (detectedKeyword) {
+      const existing = options.maxThinkingTokens ?? 0
+      if (detectedKeyword.budget > existing) {
+        options.maxThinkingTokens = detectedKeyword.budget
+        log.info(`Thinking keyword "${detectedKeyword.keyword}" detected — escalating maxThinkingTokens to ${detectedKeyword.budget} for this turn`)
+      } else {
+        log.debug(`Thinking keyword "${detectedKeyword.keyword}" detected but session already at higher budget (${existing}) — leaving unchanged`)
+      }
     }
 
     // Sandbox settings (lightweight isolation without Docker)

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -351,6 +351,28 @@ describe('CliSession properties', () => {
   })
 })
 
+// #4306 — thinking-keyword escalation is implemented in SdkSession only.
+// CliSession runs `claude -p` (non-interactive, stream-json) and declares
+// `thinkingLevel: false` in its capabilities (cli-session.js:90); the
+// dashboard hides the dropdown for this provider, and there is no
+// per-turn maxThinkingTokens hook in the stream-json wire. Re-asserting
+// the structural no-op so future refactors do not accidentally bolt a
+// keyword handler onto the CLI provider without also wiring a budget
+// control to honour it. (Otherwise the dashboard's highlight gate —
+// see #4306 Part 2 — and the keyword would silently disagree.)
+describe('CliSession — thinking keyword is a structural no-op (#4306)', () => {
+  it('declares thinkingLevel: false in static capabilities', () => {
+    assert.equal(CliSession.capabilities.thinkingLevel, false,
+      'cli-session has no per-turn thinking budget hook; keyword escalation must remain a no-op')
+  })
+
+  it('does not expose setThinkingLevel on session instances', () => {
+    const session = createSession()
+    assert.equal(typeof session.setThinkingLevel, 'undefined',
+      'no setThinkingLevel method means handleSetThinkingLevel returns "not supported" and the keyword cannot escalate either way')
+  })
+})
+
 describe('CliSession agent tracking', () => {
   it('tracks Task tool as agent_spawned', () => {
     const session = createReadySession()

--- a/packages/server/tests/detect-thinking-keyword.test.js
+++ b/packages/server/tests/detect-thinking-keyword.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests for detectThinkingKeyword (#4306).
+ *
+ * The helper must:
+ *   - return null for non-matching / empty / non-string inputs
+ *   - match case-insensitively
+ *   - match only whole words (so `unthinkingly` is NOT a match)
+ *   - prefer the LONGEST match (`think harder` over `think hard` over `think`)
+ *   - return the expected budget per keyword
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { detectThinkingKeyword, THINKING_KEYWORD_BUDGETS } from '../src/detect-thinking-keyword.js'
+
+describe('detectThinkingKeyword', () => {
+  describe('null / no-match cases', () => {
+    it('returns null for empty string', () => {
+      assert.equal(detectThinkingKeyword(''), null)
+    })
+
+    it('returns null for non-string', () => {
+      assert.equal(detectThinkingKeyword(null), null)
+      assert.equal(detectThinkingKeyword(undefined), null)
+      assert.equal(detectThinkingKeyword(42), null)
+      assert.equal(detectThinkingKeyword({}), null)
+    })
+
+    it('returns null when no keyword present', () => {
+      assert.equal(detectThinkingKeyword('hello world'), null)
+      assert.equal(detectThinkingKeyword('please help me debug this'), null)
+    })
+
+    it('does not match inside other words (word boundary)', () => {
+      // `think` is a substring of these — must NOT match.
+      assert.equal(detectThinkingKeyword('rethinking the approach'), null)
+      assert.equal(detectThinkingKeyword('unthinkingly added'), null)
+      assert.equal(detectThinkingKeyword('overthink'), null)
+    })
+  })
+
+  describe('individual keyword matches', () => {
+    it('matches "think" as a whole word', () => {
+      const result = detectThinkingKeyword('please think about this')
+      assert.deepEqual(result, { keyword: 'think', budget: 4_000 })
+    })
+
+    it('matches "think hard"', () => {
+      const result = detectThinkingKeyword('think hard about it')
+      assert.deepEqual(result, { keyword: 'think hard', budget: 10_000 })
+    })
+
+    it('matches "think harder"', () => {
+      const result = detectThinkingKeyword('think harder about edge cases')
+      assert.deepEqual(result, { keyword: 'think harder', budget: 32_000 })
+    })
+
+    it('matches "megathink"', () => {
+      const result = detectThinkingKeyword('megathink this one')
+      assert.deepEqual(result, { keyword: 'megathink', budget: 32_000 })
+    })
+
+    it('matches "ultrathink"', () => {
+      const result = detectThinkingKeyword('ultrathink the architecture')
+      assert.deepEqual(result, { keyword: 'ultrathink', budget: 128_000 })
+    })
+  })
+
+  describe('case-insensitive', () => {
+    it('matches ULTRATHINK uppercase', () => {
+      assert.deepEqual(detectThinkingKeyword('ULTRATHINK now'), {
+        keyword: 'ultrathink', budget: 128_000,
+      })
+    })
+
+    it('matches mixed case Think Harder', () => {
+      assert.deepEqual(detectThinkingKeyword('Think Harder please'), {
+        keyword: 'think harder', budget: 32_000,
+      })
+    })
+  })
+
+  describe('longest-match wins', () => {
+    // The native CLI prefers the longest matching keyword so users typing
+    // "think harder" don't get the (much smaller) "think" budget. The
+    // helper must mirror this — without longest-first ordering, the
+    // single-word "think" regex would match first and shortchange the
+    // user's intent.
+    it('prefers "think harder" over "think hard" over "think"', () => {
+      assert.equal(detectThinkingKeyword('think harder now').keyword, 'think harder')
+      assert.equal(detectThinkingKeyword('think hard now').keyword, 'think hard')
+      assert.equal(detectThinkingKeyword('think now').keyword, 'think')
+    })
+
+    it('prefers "ultrathink" over "think" when both could match', () => {
+      // `ultrathink` contains no `think` substring at a word boundary
+      // (the `u` is not whitespace), so this also defends the word-
+      // boundary contract — without it, the regex sweep might fall
+      // through to a `think` match instead.
+      assert.equal(detectThinkingKeyword('ultrathink this').keyword, 'ultrathink')
+    })
+  })
+
+  describe('whitespace tolerance', () => {
+    it('matches "think  harder" with extra spaces', () => {
+      assert.equal(detectThinkingKeyword('please think  harder').keyword, 'think harder')
+    })
+
+    it('matches "think\\nharder" across a newline', () => {
+      assert.equal(detectThinkingKeyword('please think\nharder').keyword, 'think harder')
+    })
+  })
+
+  describe('embedded in longer prompts', () => {
+    it('matches when keyword is at the end', () => {
+      assert.equal(detectThinkingKeyword('debug this and ultrathink').keyword, 'ultrathink')
+    })
+
+    it('matches when keyword is mid-sentence with punctuation', () => {
+      assert.equal(detectThinkingKeyword('please, think harder, about it.').keyword, 'think harder')
+    })
+  })
+})
+
+describe('THINKING_KEYWORD_BUDGETS', () => {
+  it('exposes all canonical keywords with the same budgets', () => {
+    assert.equal(THINKING_KEYWORD_BUDGETS['think'], 4_000)
+    assert.equal(THINKING_KEYWORD_BUDGETS['think hard'], 10_000)
+    assert.equal(THINKING_KEYWORD_BUDGETS['think harder'], 32_000)
+    assert.equal(THINKING_KEYWORD_BUDGETS['megathink'], 32_000)
+    assert.equal(THINKING_KEYWORD_BUDGETS['ultrathink'], 128_000)
+  })
+
+  it('is frozen so downstream callers cannot mutate the budget map', () => {
+    assert.throws(() => { THINKING_KEYWORD_BUDGETS['think'] = 999 }, TypeError)
+  })
+})

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -1068,6 +1068,121 @@ describe('SdkSession', () => {
     })
   })
 
+  // -- thinking keyword escalation (#4306) --
+
+  describe('thinking keyword escalation (#4306)', () => {
+    // The native CLI's REPL scans user prompts for magic thinking keywords
+    // ("think", "think hard", "think harder", "megathink", "ultrathink") and
+    // escalates maxThinkingTokens for that turn. SdkSession's query() path
+    // does NOT do this — the scanner lives in the REPL, not the SDK. These
+    // tests assert that Chroxy detects the keyword server-side and bumps
+    // maxThinkingTokens on the per-turn options object before the query
+    // generator is invoked.
+    function setupCapturingSession(opts = {}) {
+      const s = createSession(opts)
+      s._processReady = true
+      const captured = []
+      s._callQuery = (args) => {
+        captured.push(args)
+        return (async function* () {
+          yield { type: 'result', session_id: 'test', total_cost_usd: 0, duration_ms: 0, usage: {} }
+        })()
+      }
+      return { s, captured }
+    }
+
+    it('does NOT set maxThinkingTokens when no keyword present', async () => {
+      const { s, captured } = setupCapturingSession()
+      await s.sendMessage('please refactor this function')
+      s.destroy()
+      assert.equal(captured.length, 1)
+      assert.equal(captured[0].options.maxThinkingTokens, undefined,
+        'plain prompts must not bump the SDK thinking budget')
+    })
+
+    it('escalates to 4_000 for bare "think"', async () => {
+      const { s, captured } = setupCapturingSession()
+      await s.sendMessage('please think about this')
+      s.destroy()
+      assert.equal(captured[0].options.maxThinkingTokens, 4_000)
+    })
+
+    it('escalates to 10_000 for "think hard"', async () => {
+      const { s, captured } = setupCapturingSession()
+      await s.sendMessage('think hard about edge cases')
+      s.destroy()
+      assert.equal(captured[0].options.maxThinkingTokens, 10_000)
+    })
+
+    it('escalates to 32_000 for "think harder" (prefers over "think hard")', async () => {
+      const { s, captured } = setupCapturingSession()
+      await s.sendMessage('think harder please')
+      s.destroy()
+      // Without longest-match-first, this would fall through to `think hard`
+      // (which is also a substring) and shortchange the user's intent.
+      assert.equal(captured[0].options.maxThinkingTokens, 32_000)
+    })
+
+    it('escalates to 128_000 for "ultrathink"', async () => {
+      const { s, captured } = setupCapturingSession()
+      await s.sendMessage('ultrathink the architecture trade-offs')
+      s.destroy()
+      assert.equal(captured[0].options.maxThinkingTokens, 128_000)
+    })
+
+    it('case-insensitive: ULTRATHINK still escalates', async () => {
+      const { s, captured } = setupCapturingSession()
+      await s.sendMessage('ULTRATHINK now')
+      s.destroy()
+      assert.equal(captured[0].options.maxThinkingTokens, 128_000)
+    })
+
+    it('does NOT match `think` inside `unthinkingly` (word boundary)', async () => {
+      const { s, captured } = setupCapturingSession()
+      await s.sendMessage('I unthinkingly committed this')
+      s.destroy()
+      assert.equal(captured[0].options.maxThinkingTokens, undefined,
+        'substring matches must not trigger escalation — the user did not type a keyword')
+    })
+
+    // The dropdown-driven thinking level (#2263) and the per-turn keyword
+    // escalation are layered: the keyword must never DOWNgrade an explicit
+    // max-level session. Mirrors the native CLI's "more thinking, never less"
+    // semantic — typing `think` on a session you already cranked to `max`
+    // should leave it at max for that turn, not drop it to 4_000.
+    it('keyword does NOT lower an already-elevated dropdown level', async () => {
+      const { s, captured } = setupCapturingSession()
+      s._thinkingLevel = 'max' // dropdown set to 128_000
+      await s.sendMessage('please think about this')
+      s.destroy()
+      assert.equal(captured[0].options.maxThinkingTokens, 128_000,
+        'dropdown-level budget must win when it is higher than the keyword budget')
+    })
+
+    it('keyword DOES raise above the dropdown level when bigger', async () => {
+      const { s, captured } = setupCapturingSession()
+      s._thinkingLevel = 'high' // dropdown set to 32_000
+      await s.sendMessage('ultrathink this one')
+      s.destroy()
+      assert.equal(captured[0].options.maxThinkingTokens, 128_000,
+        'a stronger keyword must override a weaker dropdown level for the turn')
+    })
+
+    it('keyword escalation is per-turn and does NOT mutate the session-wide level', async () => {
+      const { s, captured } = setupCapturingSession()
+      // First turn: keyword present.
+      await s.sendMessage('ultrathink this design')
+      assert.equal(captured[0].options.maxThinkingTokens, 128_000)
+      assert.equal(s._thinkingLevel, null, 'session-wide level must remain unchanged')
+
+      // Second turn: no keyword — must drop back to no escalation.
+      await s.sendMessage('now write the code')
+      s.destroy()
+      assert.equal(captured[1].options.maxThinkingTokens, undefined,
+        'per-turn escalation must NOT bleed into subsequent turns without the keyword')
+    })
+  })
+
   // -- destroy --
 
   describe('destroy', () => {


### PR DESCRIPTION
Closes #4306

## Part 1 — Server: keywords now escalate (SdkSession)

Detect magic thinking keywords (`think`, `think hard`, `think harder`,
`megathink`, `ultrathink`) in `SdkSession.sendMessage` and bump
`maxThinkingTokens` for THAT TURN via the existing escalation path.
Mirrors the native Claude Code REPL's keyword scanner — the Agent
SDK's `query()` path does not do this, and grepping the SDK bundle
for `ultrathink|megathink|think hard(er)` returns zero matches (per
the issue body's investigation).

Match rules mirror the native CLI:
- case-insensitive
- whole-word (word-boundary anchors) — `unthinkingly` does NOT match
- longest-match-first — `think harder` wins over `think hard` wins
  over `think`

Budget mapping:
- `think` → 4,000
- `think hard` → 10,000
- `think harder` → 32,000
- `megathink` → 32,000
- `ultrathink` → 128,000

The keyword is detected on the user's literal prompt (not the
transform-pipeline-rewritten one) so voice/typo transforms can't
trigger an escalation the user didn't ask for. The keyword's budget
also never DOWNGRADES an already-elevated dropdown level — matches
the native CLI's "more thinking, never less" semantic.

CLI provider (claude-tui, `thinkingLevel: false`) silently skips —
the stream-json wire has no per-turn budget hook to thread the
budget through. Tests pin this as a structural no-op.

## Part 2 — Dashboard: inline highlight (InputBar)

Standard overlay/mirror technique: positioned `aria-hidden` div
behind a `color: transparent` (+ `-webkit-text-fill-color: transparent`)
textarea with identical box metrics (font, padding, line-height,
white-space, wrapping) so the overlay's `<span>`-wrapped keywords
land pixel-perfect over the user's typed text. Caret restored via
`caret-color`. Scroll-synced to the textarea's `scrollTop` for
multi-line drafts.

Critical "do not lie to the user" gate: the highlight is gated on
the active provider's `capabilities.thinkingLevel` (reusing the same
`showThinkingLevel` derivation that hides the manual dropdown for
non-escalating providers). When a session is on a provider that
can't honour the keyword, the overlay is not rendered — preventing
the UI from implying an escalation that isn't happening server-side.

Styling: accent colour + tinted background. No font-weight,
font-style, or text-transform changes because any of those would
shift the proportional-font glyph advance widths and the overlay
would drift one keyword width out of sync with the textarea caret.

## Tests added

- `detect-thinking-keyword.test.js` — 19 cases (null/no-match,
  each keyword, case-insensitive, longest-match, whitespace
  tolerance, mid-sentence placement, frozen budget map)
- `sdk-session.test.js` — 10 new cases (no-keyword, each budget,
  case-insensitive, word-boundary, dropdown-vs-keyword layering
  both ways, per-turn isolation across consecutive sendMessages)
- `cli-session.test.js` — 2 new cases pinning the structural no-op
  (`thinkingLevel: false` capability + no `setThinkingLevel` method)
- `thinking-keyword-tokens.test.ts` — 17 cases (tokeniser mirrors
  server-side match rules, round-trip invariant on a sample set)
- `InputBar.test.tsx` — 7 new cases (overlay absent by default and
  when `highlightThinkingKeywords` is false, present + spans the
  matched keyword when true, word-boundary respect, casing
  preserved, `aria-hidden`)

All server + dashboard tests pass (197 + 170 respectively); dashboard
typecheck clean.

## Acceptance criteria

- [x] Typing a recognised keyword escalates the SDK session's thinking
  budget for that turn
- [x] CLI provider treats the keyword as a no-op silently
- [x] When the keyword would take effect, it's highlighted inline
- [x] Caret, selection, scrolling behave normally with the overlay
- [x] Non-effecting providers: keyword is NOT highlighted