### PR TITLE
fix(dashboard): preserve ChatView state + skip hidden re-renders (#4397, #4398)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -434,10 +434,13 @@ describe('App', () => {
         viewMode: 'chat',
       }
       render(<App />)
-      // System messages should NOT appear in chat
-      expect(screen.queryByText('iPhone connected')).not.toBeInTheDocument()
-      // Regular messages should appear
-      expect(screen.getByText('Hello from Claude')).toBeInTheDocument()
+      // #4397 — the system-pane is now kept mounted (hidden) alongside the
+      // chat-pane, so 'iPhone connected' renders into the hidden system
+      // ChatView. Scope the assertion to the visible chat-pane so we still
+      // pin the filtering contract for the chat tab specifically.
+      const chatPane = screen.getByTestId('chat-pane')
+      expect(within(chatPane).queryByText('iPhone connected')).not.toBeInTheDocument()
+      expect(within(chatPane).getByText('Hello from Claude')).toBeInTheDocument()
     })
 
     it('shows system messages in system view', () => {
@@ -555,20 +558,104 @@ describe('App', () => {
         viewMode: 'chat',
       }
       const { rerender } = render(<App />)
-      const chatViewBefore = screen.getByTestId('chat-view')
+      // #4397 — system-pane is now also kept mounted, so `chat-view` is a
+      // multi-match testid. Scope to the chat-pane wrapper to assert on
+      // the chat tab's ChatView specifically.
+      const chatPane = screen.getByTestId('chat-pane')
+      const chatViewBefore = within(chatPane).getByTestId('chat-view')
 
       // Flip to terminal then back to chat.
       stateOverrides = { ...stateOverrides, viewMode: 'terminal' }
       rerender(<App />)
       // chat-view is still in the DOM (just hidden via the wrapper) —
       // pre-fix it was unmounted and so would be missing.
-      expect(screen.getByTestId('chat-view')).toBe(chatViewBefore)
+      expect(within(screen.getByTestId('chat-pane')).getByTestId('chat-view')).toBe(chatViewBefore)
 
       stateOverrides = { ...stateOverrides, viewMode: 'chat' }
       rerender(<App />)
       // And still the same node reference after coming back — no
       // remount happened across the round-trip.
-      expect(screen.getByTestId('chat-view')).toBe(chatViewBefore)
+      expect(within(screen.getByTestId('chat-pane')).getByTestId('chat-view')).toBe(chatViewBefore)
+    })
+  })
+
+  // #4397 — same display:none kept-alive treatment for the System tab.
+  // Pre-fix the system tab was a plain conditional render
+  // (`{viewMode === 'system' && <ChatView .../>}`), so switching
+  // chat → system → chat unmounted the system ChatView and dropped its
+  // scroll position + any expand state on system-side tool groups.
+  describe('system tab preserves mount (#4397)', () => {
+    const connectedState = {
+      connectionPhase: 'connected' as const,
+      sessions: [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }],
+      activeSessionId: 's1',
+    }
+
+    it('keeps system-pane mounted whenever the connection is ready, regardless of viewMode', () => {
+      stateOverrides = { ...connectedState, viewMode: 'chat' }
+      const { rerender } = render(<App />)
+      expect(screen.getByTestId('system-pane')).toBeInTheDocument()
+
+      stateOverrides = { ...connectedState, viewMode: 'system' }
+      rerender(<App />)
+      expect(screen.getByTestId('system-pane')).toBeInTheDocument()
+
+      stateOverrides = { ...connectedState, viewMode: 'terminal' }
+      rerender(<App />)
+      expect(screen.getByTestId('system-pane')).toBeInTheDocument()
+    })
+
+    it('hides system-pane with display:none unless viewMode === "system"', () => {
+      stateOverrides = { ...connectedState, viewMode: 'chat' }
+      const { rerender } = render(<App />)
+      expect(screen.getByTestId('system-pane').style.display).toBe('none')
+
+      stateOverrides = { ...connectedState, viewMode: 'system' }
+      rerender(<App />)
+      expect(screen.getByTestId('system-pane').style.display).toBe('contents')
+
+      stateOverrides = { ...connectedState, viewMode: 'terminal' }
+      rerender(<App />)
+      expect(screen.getByTestId('system-pane').style.display).toBe('none')
+    })
+
+    it('system ChatView DOM node survives a chat → system → chat round-trip', () => {
+      stateOverrides = {
+        ...connectedState,
+        getActiveSessionState: () => ({
+          messages: [
+            { id: 'sys-1', type: 'system', content: 'iPhone connected', timestamp: 1 },
+          ],
+          streamingMessageId: null,
+          activeModel: null,
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+        }),
+        viewMode: 'system',
+      }
+      const { rerender } = render(<App />)
+      const systemPane = screen.getByTestId('system-pane')
+      const systemViewBefore = within(systemPane).getByTestId('chat-view')
+
+      // Switch to chat — system-pane stays mounted (hidden).
+      stateOverrides = { ...stateOverrides, viewMode: 'chat' }
+      rerender(<App />)
+      expect(within(screen.getByTestId('system-pane')).getByTestId('chat-view')).toBe(systemViewBefore)
+
+      // Switch back to system — same node, no remount.
+      stateOverrides = { ...stateOverrides, viewMode: 'system' }
+      rerender(<App />)
+      expect(within(screen.getByTestId('system-pane')).getByTestId('chat-view')).toBe(systemViewBefore)
+    })
+
+    it('does not mount system-pane while connecting (no flicker before connection settles)', () => {
+      stateOverrides = { connectionPhase: 'connecting' }
+      render(<App />)
+      expect(screen.queryByTestId('system-pane')).not.toBeInTheDocument()
     })
   })
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1928,6 +1928,7 @@ export function App() {
                         isStreaming={streamingMessageId !== null}
                         isBusy={!isIdle}
                         renderMessage={renderMessage}
+                        hidden={viewMode !== 'chat'}
                       />
                     </div>
                     <div
@@ -1947,13 +1948,31 @@ export function App() {
                 {viewMode === 'files' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <FileBrowserPanel />
                 )}
-                {viewMode === 'system' && connectionPhase !== 'connecting' && !isSwitchingSession && (
-                  <ChatView
-                    messages={systemMessages}
-                    isStreaming={false}
-                    isBusy={false}
-                    renderMessage={renderMessage}
-                  />
+                {/*
+                  #4397 — system tab uses the same display:none kept-alive
+                  pattern as the chat/output toggle above (#4305). Pre-fix,
+                  switching chat → system → chat unmounted the system
+                  ChatView and dropped its scroll position + any expand
+                  state on system-side tool groups. The wrapper is mounted
+                  whenever the connection is ready, so React preserves the
+                  ChatView instance (and its hooks-local scroll state)
+                  across tab switches in either direction.
+                */}
+                {connectionPhase !== 'connecting' && !isSwitchingSession && (
+                  <div
+                    data-testid="system-pane"
+                    style={{
+                      display: viewMode === 'system' ? 'contents' : 'none',
+                    }}
+                  >
+                    <ChatView
+                      messages={systemMessages}
+                      isStreaming={false}
+                      isBusy={false}
+                      renderMessage={renderMessage}
+                      hidden={viewMode !== 'system'}
+                    />
+                  </div>
                 )}
                 {viewMode === 'console' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <ConsolePage />

--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -222,6 +222,109 @@ describe('ChatView', () => {
     )
     expect(screen.getByText('Fallback content')).toBeInTheDocument()
   })
+
+  // #4398 — when the parent passes `hidden`, ChatView is memoized so a
+  // stream of prop changes (new messages, fresh renderMessage callback,
+  // etc.) does NOT re-render the hidden component. The first render
+  // where `hidden` flips back to `false` always proceeds with the
+  // latest props, so the user sees the up-to-date view immediately on
+  // tab switch.
+  describe('hidden memoization (#4398)', () => {
+    it('skips renderMessage invocations while hidden=true on subsequent renders', () => {
+      const renderMessage = vi.fn(() => null)
+      const initial: ChatViewMessage[] = [
+        { id: 'msg-1', type: 'response', content: 'First', timestamp: 1 },
+      ]
+      const { rerender } = render(
+        <ChatView messages={initial} isStreaming={false} hidden renderMessage={renderMessage} />
+      )
+      // First mount renders once — establishes the baseline.
+      expect(renderMessage).toHaveBeenCalledTimes(1)
+      renderMessage.mockClear()
+
+      // Re-render with new messages while still hidden — memo comparator
+      // returns true, so renderMessage is NOT invoked.
+      const updated: ChatViewMessage[] = [
+        ...initial,
+        { id: 'msg-2', type: 'response', content: 'Second', timestamp: 2 },
+      ]
+      rerender(
+        <ChatView messages={updated} isStreaming={false} hidden renderMessage={renderMessage} />
+      )
+      expect(renderMessage).not.toHaveBeenCalled()
+    })
+
+    it('re-renders with latest props when hidden flips false', () => {
+      const renderMessage = vi.fn((m: ChatViewMessage) => <span>{`custom:${m.content}`}</span>)
+      const initial: ChatViewMessage[] = [
+        { id: 'msg-1', type: 'response', content: 'First', timestamp: 1 },
+      ]
+      const { rerender } = render(
+        <ChatView messages={initial} isStreaming={false} hidden renderMessage={renderMessage} />
+      )
+      renderMessage.mockClear()
+
+      // Accumulate updates while hidden — none should reach the render tree.
+      const updated: ChatViewMessage[] = [
+        ...initial,
+        { id: 'msg-2', type: 'response', content: 'Second', timestamp: 2 },
+      ]
+      rerender(
+        <ChatView messages={updated} isStreaming={false} hidden renderMessage={renderMessage} />
+      )
+      expect(renderMessage).not.toHaveBeenCalled()
+      expect(screen.queryByText('custom:Second')).not.toBeInTheDocument()
+
+      // Flip hidden=false — memo lets the render through with latest props.
+      rerender(
+        <ChatView messages={updated} isStreaming={false} hidden={false} renderMessage={renderMessage} />
+      )
+      expect(renderMessage).toHaveBeenCalled()
+      expect(screen.getByText('custom:Second')).toBeInTheDocument()
+    })
+
+    it('renders normally when hidden is omitted (default visible)', () => {
+      const renderMessage = vi.fn(() => null)
+      const initial: ChatViewMessage[] = [
+        { id: 'msg-1', type: 'response', content: 'First', timestamp: 1 },
+      ]
+      const { rerender } = render(
+        <ChatView messages={initial} isStreaming={false} renderMessage={renderMessage} />
+      )
+      renderMessage.mockClear()
+
+      const updated: ChatViewMessage[] = [
+        ...initial,
+        { id: 'msg-2', type: 'response', content: 'Second', timestamp: 2 },
+      ]
+      rerender(
+        <ChatView messages={updated} isStreaming={false} renderMessage={renderMessage} />
+      )
+      // Without `hidden`, memo comparator returns false → normal re-render.
+      expect(renderMessage).toHaveBeenCalled()
+    })
+
+    it('does not skip render on the visible→hidden transition (so display:none takes effect)', () => {
+      const renderMessage = vi.fn(() => null)
+      const initial: ChatViewMessage[] = [
+        { id: 'msg-1', type: 'response', content: 'First', timestamp: 1 },
+      ]
+      const { rerender } = render(
+        <ChatView messages={initial} isStreaming={false} hidden={false} renderMessage={renderMessage} />
+      )
+      renderMessage.mockClear()
+
+      // visible → hidden — comparator's `prev.hidden && next.hidden`
+      // is false (prev.hidden=false), so this render proceeds. That
+      // matters because the parent's display:none wrapper takes effect
+      // in the same commit, and we want the latest props applied right
+      // before we go dark.
+      rerender(
+        <ChatView messages={initial} isStreaming={false} hidden renderMessage={renderMessage} />
+      )
+      expect(renderMessage).toHaveBeenCalled()
+    })
+  })
 })
 
 describe('ThinkingDots', () => {

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -6,7 +6,7 @@
  * - Shows scroll-to-bottom button when scrolled up
  * - Deduplicates messages by id for reconnect replay
  */
-import { useRef, useState, useCallback, useEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
+import { memo, useRef, useState, useCallback, useEffect, useMemo, type ReactNode, type CSSProperties } from 'react'
 import { ThinkingDots } from './ThinkingDots'
 import { renderMarkdown } from '../lib/markdown'
 
@@ -99,6 +99,20 @@ export interface ChatViewProps {
   isBusy?: boolean
   /** Optional custom renderer. Return a node to override default rendering, or null to fall back. */
   renderMessage?: (msg: ChatViewMessage) => ReactNode | null
+  /**
+   * #4398 — when true, the ChatView is mounted but hidden via a parent
+   * `display:none` wrapper (sibling-tab kept-alive pattern from #4305).
+   * The memo wrapper below uses this flag to skip re-renders entirely
+   * while hidden: parent prop changes from store updates won't trigger
+   * markdown re-parsing or renderMessage invocations. On the first render
+   * after `hidden` flips back to false, React applies the latest props
+   * in a single batch, so user-visible state is up-to-date instantly.
+   *
+   * Hook-local state (`userScrolledUp`, scroll position, child
+   * `ToolGroup`/`ToolBubble` expand state) is preserved across the
+   * hidden window because the component instance never unmounts.
+   */
+  hidden?: boolean
 }
 
 const TYPE_CLASS: Record<string, string> = {
@@ -121,7 +135,7 @@ function formatTime(ts: number): string {
   return `${h}:${m} ${ampm}`
 }
 
-export function ChatView({ messages, isStreaming, isBusy, renderMessage }: ChatViewProps) {
+function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
@@ -278,4 +292,28 @@ export function ChatView({ messages, isStreaming, isBusy, renderMessage }: ChatV
     </div>
   )
 }
+
+/**
+ * #4398 — skip re-rendering while the parent has hidden us. After #4305
+ * (Bug B) we stay mounted across tab switches so user-set expand state
+ * survives the round-trip, but the trade-off was that every store
+ * update still flowed in and re-rendered the off-screen ChatView. On
+ * long sessions that doubled the per-update render cost (markdown
+ * re-parse, dedup pass, renderMessage callbacks for every tool group)
+ * for work nobody could see.
+ *
+ * This comparator returns `true` (skip re-render) only when we were
+ * hidden AND we're still hidden. The first render where `hidden` flips
+ * to `false` always proceeds — at that point React has already
+ * committed the latest props, so the user sees an up-to-date view in
+ * the very same frame they switched tabs. Going from visible → hidden
+ * still renders once so the wrapper transition completes cleanly.
+ *
+ * Note: a parent that wants the hidden ChatView to skip work MUST pass
+ * `hidden={true}`. Without the prop (e.g. SplitPane path), every render
+ * proceeds — the optimization is opt-in.
+ */
+export const ChatView = memo(ChatViewImpl, (prev, next) => {
+  return Boolean(prev.hidden) && Boolean(next.hidden)
+})
 


### PR DESCRIPTION
Two follow-ups to PR #4396 (which fixed Bug B from #4305 by switching Chat <-> Output from conditional render to `display: none` toggling). Bundled because both touch the same files.

Closes #4397
Closes #4398

## #4397 — Preserve System tab ChatView state across tab switches

#4396 fixed Chat <-> Output, but the System tab was still a conditional mount (`{viewMode === 'system' && <ChatView .../>}`), so switching `chat -> system -> chat` (or `system -> chat -> system`) unmounted the system ChatView and dropped its scroll position + any expand state on system-side tool groups.

This PR applies the same display:none kept-alive pattern to the System tab:
- New `system-pane` wrapper div mounts whenever the connection is ready
- `display: 'contents'` when `viewMode === 'system'`, `display: 'none'` otherwise
- React preserves the ChatView instance + hooks-local state across switches in either direction
- `system-pane` does not mount during `connectionPhase === 'connecting'` (consistent with chat-pane / terminal-pane)

## #4398 — Hidden ChatView still re-renders on every store update

After #4396 the hidden ChatView remained subscribed via its parent and re-rendered on every store update (markdown re-parse, dedup pass, renderMessage callbacks for every tool group). For long sessions on the Terminal tab that was doubled render cost for work nobody could see.

ChatView now accepts an optional `hidden` prop and is wrapped in `React.memo` with a comparator that returns `true` (skip re-render) only when **both** the previous and next render have `hidden=true`. Behaviour summary:

| transition | comparator returns | behaviour |
|---|---|---|
| visible -> visible | `false` | normal re-render |
| visible -> hidden | `false` | render once so the parent's display:none wrapper sees the latest props |
| hidden -> hidden | `true` | **skipped** — props change is held until next un-hide |
| hidden -> visible | `false` | render with the latest props in the same frame the user switches tabs |

Hook-local state (scroll position, `userScrolledUp`, child `ToolGroup`/`ToolBubble` expand state) is preserved across the hidden window because the component instance never unmounts.

App.tsx passes `hidden={viewMode !== 'chat'}` to the chat-pane ChatView and `hidden={viewMode !== 'system'}` to the system-pane. The SplitPane path omits the prop (optimization is opt-in — both panes are visible at once in split mode).

## Test plan

- [x] `cd packages/dashboard && npm test -- --run` — 120 files / 2125 tests pass
- [x] `cd packages/dashboard && npm run typecheck` — clean
- [x] New `system tab preserves mount (#4397)` describe block in `App.test.tsx`:
  - system-pane stays mounted across all viewMode transitions
  - `display:contents`/`display:none` toggle on `viewMode === 'system'`
  - `chat-view` DOM node inside system-pane survives a `system -> chat -> system` round-trip
  - system-pane does not mount during `connecting`
- [x] New `hidden memoization (#4398)` describe block in `ChatView.test.tsx`:
  - renderMessage NOT invoked on hidden -> hidden re-renders
  - re-renders with the latest accumulated props when `hidden` flips to false
  - renders normally when `hidden` is omitted (default visible)
  - renders once on visible -> hidden so the wrapper transition takes effect
- [x] Existing `filters system messages out of chat view` and `ChatView DOM persists across tab switch` tests updated to scope assertions via `within(chatPane)` — the system-pane is now mounted alongside the chat-pane, so `chat-view` is a multi-match testid (called out in #4397's acceptance criteria)

## Out of scope

#4397 mentions Files / Console / Environments / Diff panes as candidates for the same treatment "if the scroll-preservation goal is uniform across the dashboard". Those panes are not `ChatView` instances and their scroll preservation goal can be revisited separately.