### PR TITLE
fix(server,dashboard): tighten thinking-keyword regex to horizontal whitespace + reuse module regex (#4402, #4404)

### DIFF
--- a/packages/dashboard/src/components/thinking-keyword-tokens.test.ts
+++ b/packages/dashboard/src/components/thinking-keyword-tokens.test.ts
@@ -104,10 +104,31 @@ describe('tokenizeThinkingKeywords', () => {
       ])
     })
 
-    it('matches "think\\nharder" across a newline', () => {
+    it('matches "think\\tharder" with a tab', () => {
+      expect(tokenizeThinkingKeywords('please think\tharder')).toEqual([
+        { kind: 'text', text: 'please ' },
+        { kind: 'keyword', text: 'think\tharder' },
+      ])
+    })
+
+    // #4402: `\s+` used to swallow newlines, so the user pressing Enter
+    // between unrelated thoughts ("think.\n\nNow go harder.") false-
+    // positived. Horizontal whitespace only now — overlay still highlights
+    // the bare `think` (the budget mirrored server-side), but the multi-
+    // word keyword does NOT span a newline.
+    it('does NOT match "think\\nharder" across a newline — falls back to bare "think" (#4402)', () => {
       expect(tokenizeThinkingKeywords('please think\nharder')).toEqual([
         { kind: 'text', text: 'please ' },
-        { kind: 'keyword', text: 'think\nharder' },
+        { kind: 'keyword', text: 'think' },
+        { kind: 'text', text: '\nharder' },
+      ])
+    })
+
+    it('does NOT match "think\\n\\nharder" across a paragraph boundary (#4402)', () => {
+      expect(tokenizeThinkingKeywords('please think\n\nharder')).toEqual([
+        { kind: 'text', text: 'please ' },
+        { kind: 'keyword', text: 'think' },
+        { kind: 'text', text: '\n\nharder' },
       ])
     })
   })
@@ -119,6 +140,40 @@ describe('tokenizeThinkingKeywords', () => {
         { kind: 'keyword', text: 'ultrathink' },
         { kind: 'text', text: ' then ' },
         { kind: 'keyword', text: 'think hard' },
+      ])
+    })
+  })
+
+  describe('reuses module-level regex across calls (#4404)', () => {
+    // The module-level `THINKING_KEYWORD_RE` carries the `g` flag, which
+    // stores `lastIndex` iteration state on the regex object itself. If
+    // the function forgot to reset `lastIndex` between calls — or if it
+    // resumed using a stale state — the second call would skip the start
+    // of its input and miss matches that appear before the previous
+    // call's last match position.
+    it('produces the same tokens when called repeatedly with the same input', () => {
+      const input = 'please ultrathink then think hard'
+      const first = tokenizeThinkingKeywords(input)
+      const second = tokenizeThinkingKeywords(input)
+      const third = tokenizeThinkingKeywords(input)
+      expect(second).toEqual(first)
+      expect(third).toEqual(first)
+    })
+
+    it('does not leak state when a long input is followed by a short one', () => {
+      // The long input drives the regex's `lastIndex` deep into the
+      // string. If state leaked, the short input's `think` (at index 0)
+      // would be missed.
+      tokenizeThinkingKeywords('a b c d e f g h ultrathink i j k l m n o think hard')
+      expect(tokenizeThinkingKeywords('think')).toEqual([
+        { kind: 'keyword', text: 'think' },
+      ])
+    })
+
+    it('still finds a match in a short string after a previous no-match call', () => {
+      tokenizeThinkingKeywords('no keywords here at all')
+      expect(tokenizeThinkingKeywords('ultrathink')).toEqual([
+        { kind: 'keyword', text: 'ultrathink' },
       ])
     })
   })

--- a/packages/dashboard/src/components/thinking-keyword-tokens.ts
+++ b/packages/dashboard/src/components/thinking-keyword-tokens.ts
@@ -31,11 +31,18 @@ export type ThinkingKeywordToken =
  *   - `g`  — global (advance lastIndex on each match)
  *   - `i`  — case-insensitive
  *
- * The `\s+` between the multi-word entries collapses any run of whitespace
- * (spaces, tabs, newlines) so `think  harder` and `think\nharder` still
- * match the same way they do server-side.
+ * The `[ \t]+` between the multi-word entries allows a run of horizontal
+ * whitespace (spaces / tabs only — NOT newlines) so `think  harder` still
+ * matches but `think\n\nharder` (paragraph boundary) does not. Mirrors the
+ * server-side regex tightening in #4402 — if either side drifts the overlay
+ * lies about what got escalated.
+ *
+ * The regex is reused directly by `tokenizeThinkingKeywords` below (#4404),
+ * which resets `lastIndex` at the top of the function — the `g` flag stores
+ * iteration state on the regex object itself, so a re-entrant call would
+ * otherwise resume from wherever the previous call left off.
  */
-const THINKING_KEYWORD_RE = /\b(?:ultrathink|megathink|think\s+harder|think\s+hard|think)\b/gi
+const THINKING_KEYWORD_RE = /\b(?:ultrathink|megathink|think[ \t]+harder|think[ \t]+hard|think)\b/gi
 
 /**
  * Split `text` into an ordered list of tokens. Adjacent text runs are not
@@ -58,10 +65,14 @@ export function tokenizeThinkingKeywords(text: string): ThinkingKeywordToken[] {
   // the gap-text (the run between consecutive matches) — `matchAll` would
   // give us match arrays but not the inter-match slices without bookkeeping
   // we'd need either way.
-  const re = new RegExp(THINKING_KEYWORD_RE.source, THINKING_KEYWORD_RE.flags)
+  //
+  // Reuse the module-level regex directly (#4404) instead of cloning per
+  // call — but reset `lastIndex` first because the `g` flag stores
+  // iteration state on the regex object across calls.
+  THINKING_KEYWORD_RE.lastIndex = 0
   let lastIndex = 0
   let match: RegExpExecArray | null
-  while ((match = re.exec(text)) !== null) {
+  while ((match = THINKING_KEYWORD_RE.exec(text)) !== null) {
     if (match.index > lastIndex) {
       tokens.push({ kind: 'text', text: text.slice(lastIndex, match.index) })
     }
@@ -71,7 +82,7 @@ export function tokenizeThinkingKeywords(text: string): ThinkingKeywordToken[] {
     // current regex (no `*` or `?` quantifiers on the alternation as a
     // whole) but a future edit could regress this and produce an infinite
     // loop. Cheap belt-and-braces.
-    if (match[0].length === 0) re.lastIndex++
+    if (match[0].length === 0) THINKING_KEYWORD_RE.lastIndex++
   }
   if (lastIndex < text.length) {
     tokens.push({ kind: 'text', text: text.slice(lastIndex) })

--- a/packages/server/src/detect-thinking-keyword.js
+++ b/packages/server/src/detect-thinking-keyword.js
@@ -33,14 +33,17 @@ export function detectThinkingKeyword(text) {
 
   // Longest first so `think harder` wins over `think hard` wins over `think`.
   // Each entry is `[canonicalKeyword, regex, budget]`. The regex uses
-  // word-boundary anchors on both sides; the multi-word entries collapse
-  // any run of whitespace between words so `think  harder` (double space)
-  // and `think\nharder` still match.
+  // word-boundary anchors on both sides; the multi-word entries allow a
+  // run of horizontal whitespace (space/tab only — NOT `\s`) between
+  // words so `think  harder` (double space) still matches but
+  // `think\n\nharder` (paragraph boundary) does not. See #4402: `\s+`
+  // matched arbitrary newline runs and false-positived on unrelated
+  // thoughts the user happened to type on consecutive lines.
   const PATTERNS = [
     ['ultrathink', /\bultrathink\b/i, 128_000],
     ['megathink', /\bmegathink\b/i, 32_000],
-    ['think harder', /\bthink\s+harder\b/i, 32_000],
-    ['think hard', /\bthink\s+hard\b/i, 10_000],
+    ['think harder', /\bthink[ \t]+harder\b/i, 32_000],
+    ['think hard', /\bthink[ \t]+hard\b/i, 10_000],
     ['think', /\bthink\b/i, 4_000],
   ]
 

--- a/packages/server/tests/detect-thinking-keyword.test.js
+++ b/packages/server/tests/detect-thinking-keyword.test.js
@@ -105,8 +105,30 @@ describe('detectThinkingKeyword', () => {
       assert.equal(detectThinkingKeyword('please think  harder').keyword, 'think harder')
     })
 
-    it('matches "think\\nharder" across a newline', () => {
-      assert.equal(detectThinkingKeyword('please think\nharder').keyword, 'think harder')
+    it('matches "think\\tharder" with a tab', () => {
+      assert.equal(detectThinkingKeyword('please think\tharder').keyword, 'think harder')
+    })
+
+    // #4402: `\s+` used to swallow newlines, falsely matching unrelated
+    // thoughts on consecutive lines (e.g. "think.\n\nNow let's go harder.").
+    // Horizontal whitespace only now — single-line space/tab runs only.
+    it('does NOT match "think\\nharder" across a newline (#4402)', () => {
+      // `think` on its own is still a whole-word match, so the result here
+      // is the single-word `think` budget, NOT the escalated `think harder`.
+      const result = detectThinkingKeyword('please think\nharder')
+      assert.equal(result.keyword, 'think')
+    })
+
+    it('does NOT match "think\\n\\nharder" across a paragraph boundary (#4402)', () => {
+      const result = detectThinkingKeyword('please think\n\nharder')
+      assert.equal(result.keyword, 'think')
+    })
+
+    it('does NOT match "think hard" split across lines as "think\\nhard" (#4402)', () => {
+      // Same rationale — `\n` between `think` and `hard` is no longer
+      // considered a keyword boundary; falls back to bare `think`.
+      const result = detectThinkingKeyword('please think\nhard about it')
+      assert.equal(result.keyword, 'think')
     })
   })
 


### PR DESCRIPTION
## Summary

Two follow-ups to PR #4401 (#4306 implementation), bundled into one PR because both touch `packages/dashboard/src/components/thinking-keyword-tokens.ts`.

### #4402 — Tighten `\s+` to `[ \t]+`

`detect-thinking-keyword.js` and `thinking-keyword-tokens.ts` used `\s+` between multi-word entries (`think\s+harder`). `\s` matches newlines, so a user typing:

```
I want to think.

Now I need to go harder.
```

…false-positived as `think harder` (32k budget escalation) across an unrelated paragraph boundary.

Fix: switch to `[ \t]+` — horizontal whitespace (space/tab) only. The keyword can no longer span a newline. `think` alone still matches as a whole word so the user gets the 4k `think` budget for the leading sentence; the trailing `harder` is just text.

### #4404 — Reuse module-level regex in `tokenizeThinkingKeywords`

The module-level `THINKING_KEYWORD_RE` was cloned per call:

```ts
const re = new RegExp(THINKING_KEYWORD_RE.source, THINKING_KEYWORD_RE.flags)
```

…which defeated the "build once at module load" comment. Now the function reuses the constant directly and resets `lastIndex = 0` at the top (necessary because the `g` flag stores iteration state on the regex object — without the reset, a re-entrant call would resume from wherever the previous call left off).

## Tests

**Server** (`packages/server/tests/detect-thinking-keyword.test.js`):
- Tab-separated `think\tharder` still matches
- `think\nharder` does NOT match as `think harder` — falls back to bare `think`
- `think\n\nharder` (paragraph boundary) — same: falls back to bare `think`
- `think\nhard` — same: falls back to bare `think`

**Dashboard** (`packages/dashboard/src/components/thinking-keyword-tokens.test.ts`):
- Tab-separated `think\tharder` tokenises as one keyword token
- `think\nharder` tokenises as `please ` + keyword `think` + text `\nharder`
- `think\n\nharder` (paragraph boundary) — same shape with `\n\nharder` text run
- Re-entrancy: repeated calls with the same input produce identical tokens
- Re-entrancy: a long input followed by a short one — `lastIndex` doesn't leak
- Re-entrancy: a no-match call followed by a match call still finds the match

## Test plan

- [x] `node --test packages/server/tests/detect-thinking-keyword.test.js` — 22/22 pass
- [x] `vitest run src/components/thinking-keyword-tokens.test.ts` — 27/27 pass
- [x] Server + dashboard parity: same regex semantics on both sides

Closes #4402
Closes #4404