### PR TITLE
fix(server,dashboard): bump Codex context window + add 100% compact suggestion (#3857)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2072,6 +2072,11 @@ export function App() {
         onShareSession={isConnected && activeSessionId ? handleShareSession : undefined}
         provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
         contextWindow={(availableModels.find(m => m.id === activeModel || m.fullId === activeModel)?.contextWindow) ?? DEFAULT_CONTEXT_WINDOW}
+        // #3857: surface a clickable "/compact" suggestion past 80% so the
+        // user gets a remedy hint rather than just a red bar. Only enabled
+        // when there's an active session to route the input through — without
+        // that, the chip would have nowhere to send /compact to.
+        onCompact={isConnected && activeSessionId ? () => sendInput('/compact') : undefined}
       />
 
       {/* Settings panel */}

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -66,11 +66,24 @@ describe('FooterBar', () => {
     expect(screen.getByText('45%')).toBeInTheDocument()
   })
 
-  it('clamps context percentage display at 100%', () => {
+  // #3857: the bar FILL is still clamped to 100% width (a bar can't render
+  // wider than its container), but the LABEL now shows the true over-budget
+  // percent so the user gets a real signal that they're past the window.
+  // The aria-valuenow stays clamped because aria-valuemax is 100 and exceeding
+  // it would be invalid ARIA — the label carries the over-budget delta.
+  it('shows true over-budget percent in the label past 100% (#3857)', () => {
     const { container } = render(<FooterBar {...baseProps} context="250k tokens" contextPercent={134} />)
     const bar = container.querySelector('.footer-context-bar')
+    // aria-valuenow stays clamped because aria-valuemax is 100 — exceeding
+    // it would violate the ARIA progressbar spec.
     expect(bar).toHaveAttribute('aria-valuenow', '100')
-    expect(screen.getByText('100%')).toBeInTheDocument()
+    // Label shows true value so the user knows they're over budget.
+    expect(screen.getByText('134%')).toBeInTheDocument()
+    // Bar fill width stays clamped at 100% (it's a bar, not a number).
+    const fill = container.querySelector('.footer-context-fill') as HTMLElement
+    expect(fill.style.width).toBe('100%')
+    // Bar gets an over-budget marker class so the visual matches the label.
+    expect(bar?.classList.contains('over-budget')).toBe(true)
   })
 
   it('applies medium class for context usage 50-80%', () => {
@@ -209,5 +222,66 @@ describe('FooterBar', () => {
     render(<FooterBar {...baseProps} onShowQr={onShowQr} />)
     screen.getByLabelText('Show QR code').click()
     expect(onShowQr).toHaveBeenCalledOnce()
+  })
+
+  // -----------------------------------------------------------------
+  // #3857 — high-utilization compact-suggestion chip
+  // -----------------------------------------------------------------
+  describe('#3857 compact suggestion at high context utilization', () => {
+    it('does not render the compact chip below 80%', () => {
+      render(<FooterBar {...baseProps} context="100k tokens" contextPercent={50} onCompact={vi.fn()} />)
+      expect(screen.queryByTestId('btn-compact-session')).not.toBeInTheDocument()
+    })
+
+    it('renders the compact chip at 80%', () => {
+      render(<FooterBar {...baseProps} context="320k tokens" contextPercent={80} onCompact={vi.fn()} />)
+      expect(screen.getByTestId('btn-compact-session')).toBeInTheDocument()
+    })
+
+    it('renders the compact chip at 100%+', () => {
+      render(<FooterBar {...baseProps} context="400k tokens" contextPercent={100} onCompact={vi.fn()} />)
+      expect(screen.getByTestId('btn-compact-session')).toBeInTheDocument()
+    })
+
+    it('hides the compact chip when onCompact is undefined (read-only embed)', () => {
+      render(<FooterBar {...baseProps} context="400k tokens" contextPercent={100} />)
+      // No CTA should render when the consumer can't route it anywhere.
+      expect(screen.queryByTestId('btn-compact-session')).not.toBeInTheDocument()
+    })
+
+    it('fires onCompact when the chip is clicked', () => {
+      const onCompact = vi.fn()
+      render(<FooterBar {...baseProps} context="400k tokens" contextPercent={100} onCompact={onCompact} />)
+      screen.getByTestId('btn-compact-session').click()
+      expect(onCompact).toHaveBeenCalledOnce()
+    })
+
+    it('chip carries an explanatory tooltip + accessible label', () => {
+      render(<FooterBar {...baseProps} context="350k tokens" contextPercent={90} onCompact={vi.fn()} />)
+      const chip = screen.getByTestId('btn-compact-session')
+      expect(chip.getAttribute('title')).toMatch(/\/compact/i)
+      expect(chip.getAttribute('aria-label')).toMatch(/compact/i)
+    })
+
+    it('chip tooltip distinguishes near-limit vs over-budget', () => {
+      // Near-limit case
+      const { rerender } = render(
+        <FooterBar {...baseProps} context="320k tokens" contextPercent={85} onCompact={vi.fn()} />
+      )
+      const near = screen.getByTestId('btn-compact-session')
+      expect(near.getAttribute('title')).toMatch(/filling up/i)
+      expect(near.classList.contains('over-budget')).toBe(false)
+
+      // Over-budget case — more urgent copy + distinct class.
+      rerender(<FooterBar {...baseProps} context="500k tokens" contextPercent={125} onCompact={vi.fn()} />)
+      const over = screen.getByTestId('btn-compact-session')
+      expect(over.getAttribute('title')).toMatch(/full|truncating/i)
+      expect(over.classList.contains('over-budget')).toBe(true)
+    })
+
+    it('chip is hidden when contextPercent is null (no usage data yet)', () => {
+      render(<FooterBar {...baseProps} context="0 tokens" contextPercent={null} onCompact={vi.fn()} />)
+      expect(screen.queryByTestId('btn-compact-session')).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -39,6 +39,15 @@ export interface FooterBarProps {
   provider?: string
   /** #3858: model context window in tokens for the model tooltip. */
   contextWindow?: number
+  /**
+   * #3857: invoked when the user clicks the high-utilization "/compact"
+   * suggestion chip. Receives the literal text the chip would send (always
+   * `/compact`) so the consumer can route it through whatever input pipe
+   * is current (sendInput in App.tsx). Undefined hides the chip entirely
+   * — read-only dashboards (e.g. archived-session previews) should not
+   * surface a CTA that won't fire.
+   */
+  onCompact?: () => void
 }
 
 /** Abbreviate a full path to the last 2 segments: /Users/foo/Projects/bar → Projects/bar */
@@ -54,6 +63,16 @@ const STATUS_LABELS: Record<string, string> = {
   server_restarting: 'Restarting',
   disconnected: 'Disconnected',
 }
+
+/**
+ * #3857: high-water threshold for surfacing the `/compact` suggestion chip.
+ * Mirrors the Claude Code CLI's own "near limit" cue (~80%). Exported so
+ * tests don't re-hardcode the magic number.
+ */
+export const FOOTER_COMPACT_SUGGEST_THRESHOLD = 80
+
+/** #3857: hard threshold past which the meter is in "over-budget" mode. */
+export const FOOTER_OVER_BUDGET_THRESHOLD = 100
 
 export function FooterBar({
   connectionPhase,
@@ -74,6 +93,7 @@ export function FooterBar({
   onShareSession,
   provider,
   contextWindow,
+  onCompact,
 }: FooterBarProps) {
   const version = serverVersion ?? (typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0')
 
@@ -173,7 +193,15 @@ export function FooterBar({
             {contextPercent != null ? (
               <>
                 <span
-                  className={`footer-context-bar${contextPercent >= 80 ? ' high' : contextPercent >= 50 ? ' medium' : ''}`}
+                  className={`footer-context-bar${
+                    contextPercent >= FOOTER_OVER_BUDGET_THRESHOLD
+                      ? ' high over-budget'
+                      : contextPercent >= FOOTER_COMPACT_SUGGEST_THRESHOLD
+                        ? ' high'
+                        : contextPercent >= 50
+                          ? ' medium'
+                          : ''
+                  }`}
                   role="progressbar"
                   aria-label="Context window usage"
                   aria-valuenow={Math.min(Math.round(contextPercent), 100)}
@@ -182,10 +210,47 @@ export function FooterBar({
                 >
                   <span className="footer-context-fill" style={{ width: `${Math.min(contextPercent, 100)}%` }} />
                 </span>
-                <span className="footer-context-label">{Math.min(Math.round(contextPercent), 100)}%</span>
+                {/*
+                 * #3857: show the *true* percent in the label (not the clamped
+                 * value) once we cross 100% so the user gets a real over-budget
+                 * signal. The bar fill stays clamped at 100% width — a bar
+                 * wider than its container is just visual noise — but the
+                 * numeric label is what tells the user "you're 18% over".
+                 * Sub-100% renders unchanged (Math.min returns the original).
+                 */}
+                <span className="footer-context-label">
+                  {Math.round(contextPercent)}%
+                </span>
               </>
             ) : context}
           </span>
+        )}
+        {/*
+         * #3857: clickable "/compact" suggestion chip surfaces at >=80% so
+         * users get a remedy hint before the meter pegs at red. Hidden when
+         * onCompact is undefined (read-only embeds) so a CTA that won't fire
+         * never renders. Rendered AFTER the context chip so the spatial
+         * relationship reads as "you're at 90% → here's what to do".
+         */}
+        {contextPercent != null
+          && contextPercent >= FOOTER_COMPACT_SUGGEST_THRESHOLD
+          && onCompact && (
+          <button
+            type="button"
+            className={`footer-compact-suggest${
+              contextPercent >= FOOTER_OVER_BUDGET_THRESHOLD ? ' over-budget' : ''
+            }`}
+            onClick={onCompact}
+            data-testid="btn-compact-session"
+            title={
+              contextPercent >= FOOTER_OVER_BUDGET_THRESHOLD
+                ? 'Context window full — send /compact to free space (the model may already be silently truncating older context).'
+                : 'Context is filling up — send /compact to summarise older turns and free space.'
+            }
+            aria-label="Compact session — send /compact to free context space"
+          >
+            /compact
+          </button>
         )}
       </div>
     </footer>

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3444,8 +3444,62 @@
   background: var(--accent-red, #e53e3e);
 }
 
+/*
+ * #3857: distinct "over-budget" visual so the user can tell "exactly at 100%"
+ * apart from "30% over the registered window". Adds a subtle pulse on the
+ * fill so the bar reads as "this is actively wrong" rather than "this is the
+ * limit". Pulsing only triggers past 100% to avoid alarm fatigue at the
+ * common 95%+ case where the meter is correct.
+ */
+.footer-context-bar.over-budget .footer-context-fill {
+  background: var(--accent-red-dark, #c53030);
+  animation: footerContextOverBudgetPulse 2s ease-in-out infinite;
+}
+
+@keyframes footerContextOverBudgetPulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.55; }
+}
+
 .footer-context-label {
   font-size: 11px;
+}
+
+/*
+ * #3857: "/compact" suggestion chip — surfaces at >=80% context usage to give
+ * the user a one-click remedy instead of just a red bar with no signal. Styled
+ * to match the .footer-qr-btn aesthetic so it reads as a footer-bar control
+ * rather than a notification.
+ */
+.footer-compact-suggest {
+  appearance: none;
+  background: var(--bg-tertiary, #1a1a2e);
+  color: var(--accent-yellow, #ecc94b);
+  border: 1px solid var(--accent-yellow, #ecc94b);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  padding: 3px 8px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.footer-compact-suggest:hover {
+  background: var(--accent-yellow, #ecc94b);
+  color: var(--bg-tertiary, #1a1a2e);
+}
+
+.footer-compact-suggest.over-budget {
+  color: var(--accent-red, #e53e3e);
+  border-color: var(--accent-red, #e53e3e);
+  animation: footerContextOverBudgetPulse 2s ease-in-out infinite;
+}
+
+.footer-compact-suggest.over-budget:hover {
+  background: var(--accent-red, #e53e3e);
+  color: #fff;
+  animation: none;
 }
 
 .footer-agents {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3502,6 +3502,19 @@
   animation: none;
 }
 
+/*
+ * Respect prefers-reduced-motion (#3857) — the pulse is a redundant cue
+ * (the .over-budget class also recolors and the label still shows the
+ * over-budget percent), so disabling it doesn't lose information for users
+ * who opt out of motion.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .footer-context-bar.over-budget .footer-context-fill,
+  .footer-compact-suggest.over-budget {
+    animation: none;
+  }
+}
+
 .footer-agents {
   color: var(--text-secondary);
 }

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -3,6 +3,7 @@ import { homedir } from 'os'
 import { join } from 'path'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
+import { getRegistryForProvider } from './models.js'
 
 /**
  * Manages a Codex CLI session using `codex exec --json`.
@@ -211,9 +212,20 @@ export function buildCodexArgs(text, model, threadId = null) {
 // Context-window values come from the OpenAI model docs; `contextWindow` is
 // used both in the token-usage HUD and as the Codex-side override for the
 // generic 200k default shipped by `models.js`.
+//
+// #3857: gpt-5 / gpt-5-codex bumped from 272k → 400k. The 272k value was an
+// internal pre-launch limit that was never updated when OpenAI shipped the
+// public 400k Codex window — surfaced as a permanent 100% footer meter at
+// ~321k tokens even though Codex kept responding coherently (issue #3857,
+// also captured upstream in openai/codex#19319 + community.openai.com:
+// "Input tokens exceed the configured limit of 272,000 tokens"). The runtime
+// learn-loop in `_processJsonlLine` ratchets these upward when the SDK
+// reports an `input_tokens` value larger than the static entry, so a future
+// upstream bump (1M variants on certain plans) self-corrects without
+// requiring another source-code change.
 const CODEX_MODEL_METADATA = Object.freeze({
-  'gpt-5-codex': { label: 'GPT-5 Codex', contextWindow: 272_000 },
-  'gpt-5':       { label: 'GPT-5',        contextWindow: 272_000 },
+  'gpt-5-codex': { label: 'GPT-5 Codex', contextWindow: 400_000 },
+  'gpt-5':       { label: 'GPT-5',        contextWindow: 400_000 },
   'gpt-4.1':     { label: 'GPT-4.1',      contextWindow: 1_000_000 },
   'gpt-4o':      { label: 'GPT-4o',       contextWindow: 128_000 },
   'o1':          { label: 'o1',           contextWindow: 200_000 },
@@ -231,6 +243,67 @@ const CODEX_FALLBACK_MODELS = Object.freeze(CODEX_ALLOWED_MODELS.map(id => {
     contextWindow: meta.contextWindow,
   })
 }))
+
+/**
+ * Headroom multiplier for the learn-loop. When `input_tokens` exceeds the
+ * registered window for a model, we ratchet to `inputTokens * HEADROOM`
+ * so the next turn has slack before it pegs the meter again.
+ *
+ * Exported so the test suite can verify the exact ratchet target instead
+ * of recomputing the magic number.
+ */
+export const CODEX_CONTEXT_WINDOW_HEADROOM = 1.1
+
+/**
+ * #3857 learn-loop helper. When Codex's reported `input_tokens` for the
+ * most-recent turn exceeds the registered context window for the active
+ * model, bump the registry entry to `inputTokens * CODEX_CONTEXT_WINDOW_HEADROOM`
+ * (rounded up to the nearest 1k for a clean number) and emit
+ * `models_updated` so connected dashboards refresh the meter.
+ *
+ * No-op when:
+ *   - the model isn't in the registry (unknown / custom deploy — caller
+ *     handles via the registry's deriveId/resolveContextWindow fallback)
+ *   - `input_tokens` is at or below the registered window (no drift signal)
+ *   - the model lacks a fullId we can resolve
+ *
+ * Extracted from `_processJsonlLine` so the logic is testable in isolation
+ * — the real method runs as part of the readline pipeline, which is messy
+ * to stub directly from a unit test.
+ *
+ * @param {import('events').EventEmitter} session  The CodexSession instance
+ * @param {string} modelId  Short id or fullId of the active Codex model
+ * @param {number} inputTokens  `usage.input_tokens` from `turn.completed`
+ * @returns {boolean}  true when the registry was updated, false when no-op
+ */
+export function _maybeRatchetContextWindow(session, modelId, inputTokens) {
+  const registry = getRegistryForProvider('codex')
+  if (!registry) return false
+
+  // Look up the active model in the registry to read its current window.
+  // Match on either short id or fullId — the registry stores both.
+  const models = registry.getModels()
+  const entry = models.find(m => m.id === modelId || m.fullId === modelId)
+  if (!entry) return false
+  if (typeof entry.contextWindow !== 'number' || entry.contextWindow <= 0) return false
+
+  if (inputTokens <= entry.contextWindow) return false
+
+  // Round the bumped value up to the nearest 1k so the meter shows a clean
+  // number ("440k" not "440231") and we don't write a fresh cache entry on
+  // every single turn for sub-1k variation.
+  const raw = inputTokens * CODEX_CONTEXT_WINDOW_HEADROOM
+  const bumped = Math.ceil(raw / 1000) * 1000
+
+  const changed = registry.updateContextWindow(modelId, bumped)
+  if (!changed) return false
+
+  // Mirror sdk-session.js:763 — broadcast the corrected registry so the
+  // dashboard's `availableModels` (and therefore the footer meter) picks
+  // up the new window without waiting for the next refresh.
+  session.emit('models_updated', { models: registry.getModels() })
+  return true
+}
 
 export class CodexSession extends JsonlSubprocessSession {
   // ------------------------------------------------------------------
@@ -427,12 +500,31 @@ export class CodexSession extends JsonlSubprocessSession {
           ctx.didStreamStart = false
         }
         const usage = event.usage || {}
+        const inputTokens = usage.input_tokens || 0
+        const outputTokens = usage.output_tokens || 0
+        // #3857 learn-loop: when Codex reports an `input_tokens` value that
+        // exceeds the registered context window for the active model, the
+        // static window is stale (this is exactly how we found the original
+        // 272k drift — 321k turns kept succeeding past 100%). Ratchet the
+        // registry upward to at least `input_tokens * 1.1` so the next turn's
+        // meter reflects reality, and emit `models_updated` so connected
+        // dashboards pick up the corrected value without waiting for a
+        // refresh. Mirrors the Claude path in sdk-session.js:741 — except
+        // the SDK there has an explicit `contextWindow` field; here we infer
+        // it from the observed token count.
+        //
+        // Only ratchets *up* — a single small turn must never shrink the
+        // registered window (the model didn't change, only the prompt size
+        // for this one turn did).
+        if (this.model && inputTokens > 0) {
+          _maybeRatchetContextWindow(this, this.model, inputTokens)
+        }
         this.emit('result', {
           cost: null,
           duration: null,
           usage: {
-            input_tokens: usage.input_tokens || 0,
-            output_tokens: usage.output_tokens || 0,
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
           },
           sessionId: this.resumeSessionId,
         })

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -255,6 +255,17 @@ const CODEX_FALLBACK_MODELS = Object.freeze(CODEX_ALLOWED_MODELS.map(id => {
 export const CODEX_CONTEXT_WINDOW_HEADROOM = 1.1
 
 /**
+ * Sanity cap on the learn-loop ratchet target — a single `turn.completed`
+ * event with a corrupt or malicious `input_tokens` value (overflow, JSONL
+ * parse glitch, future Codex CLI bug) must not be able to balloon the
+ * registered window to an absurd number. 2,000,000 tokens is well above
+ * today's largest published Codex window (1M for gpt-4.1 / certain 1M
+ * GPT-5 variants on plan tiers) — any legit future model that exceeds
+ * this should bump this constant, not silently leak through.
+ */
+export const CODEX_CONTEXT_WINDOW_RATCHET_CAP = 2_000_000
+
+/**
  * #3857 learn-loop helper. When Codex's reported `input_tokens` for the
  * most-recent turn exceeds the registered context window for the active
  * model, bump the registry entry to `inputTokens * CODEX_CONTEXT_WINDOW_HEADROOM`
@@ -265,6 +276,7 @@ export const CODEX_CONTEXT_WINDOW_HEADROOM = 1.1
  *   - the model isn't in the registry (unknown / custom deploy — caller
  *     handles via the registry's deriveId/resolveContextWindow fallback)
  *   - `input_tokens` is at or below the registered window (no drift signal)
+ *   - `input_tokens` is not a finite positive number (corrupt JSONL)
  *   - the model lacks a fullId we can resolve
  *
  * Extracted from `_processJsonlLine` so the logic is testable in isolation
@@ -277,6 +289,13 @@ export const CODEX_CONTEXT_WINDOW_HEADROOM = 1.1
  * @returns {boolean}  true when the registry was updated, false when no-op
  */
 export function _maybeRatchetContextWindow(session, modelId, inputTokens) {
+  // Defensive guard against corrupt/malicious JSONL — a non-finite or
+  // negative `input_tokens` must not feed the ratchet math (NaN * 1.1 = NaN,
+  // Infinity * 1.1 = Infinity → unbounded growth). The caller in
+  // `_processJsonlLine` already gates on `>0`, but we re-check here so the
+  // helper is safe to call from any future caller too.
+  if (!Number.isFinite(inputTokens) || inputTokens <= 0) return false
+
   const registry = getRegistryForProvider('codex')
   if (!registry) return false
 
@@ -291,8 +310,10 @@ export function _maybeRatchetContextWindow(session, modelId, inputTokens) {
 
   // Round the bumped value up to the nearest 1k so the meter shows a clean
   // number ("440k" not "440231") and we don't write a fresh cache entry on
-  // every single turn for sub-1k variation.
-  const raw = inputTokens * CODEX_CONTEXT_WINDOW_HEADROOM
+  // every single turn for sub-1k variation. Capped at
+  // CODEX_CONTEXT_WINDOW_RATCHET_CAP so a single corrupt turn can't balloon
+  // the registry to an absurd value.
+  const raw = Math.min(inputTokens * CODEX_CONTEXT_WINDOW_HEADROOM, CODEX_CONTEXT_WINDOW_RATCHET_CAP)
   const bumped = Math.ceil(raw / 1000) * 1000
 
   const changed = registry.updateContextWindow(modelId, bumped)

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -6,7 +6,7 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { spawn } from 'child_process'
 import { createInterface } from 'readline'
-import { CodexSession, buildCodexArgs, resolveCodexSandbox, CODEX_SANDBOX_MODES, CODEX_DEFAULT_SANDBOX, CODEX_CONTEXT_WINDOW_HEADROOM, _maybeRatchetContextWindow } from '../src/codex-session.js'
+import { CodexSession, buildCodexArgs, resolveCodexSandbox, CODEX_SANDBOX_MODES, CODEX_DEFAULT_SANDBOX, CODEX_CONTEXT_WINDOW_HEADROOM, CODEX_CONTEXT_WINDOW_RATCHET_CAP, _maybeRatchetContextWindow } from '../src/codex-session.js'
 import { SkillsTrustStore } from '../src/skills-trust.js'
 import { getRegistryForProvider } from '../src/models.js'
 import { waitFor } from './test-helpers.js'
@@ -1678,5 +1678,34 @@ describe('CodexSession', () => {
       assert.equal(changed, false, 'unknown models should be a silent no-op, not a throw')
       assert.equal(emitted.length, 0)
     })
+
+    // The cap exists to make a single corrupt turn unable to balloon the
+    // registry to an absurd number — a JSONL parse glitch or future Codex
+    // CLI bug must not blow up the meter math downstream. 2M is well above
+    // today's largest published windows, so anything above suggests bad data.
+    it('caps the ratchet target at CODEX_CONTEXT_WINDOW_RATCHET_CAP', () => {
+      const fakeSession = { model: 'gpt-5-codex', emit: () => {} }
+      // A wildly high observed value — e.g. CLI bug or overflow
+      _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 10_000_000)
+      const r = getRegistryForProvider('codex')
+      const m = r.getModels().find(x => x.fullId === 'gpt-5-codex')
+      assert.ok(m)
+      assert.ok(m.contextWindow <= CODEX_CONTEXT_WINDOW_RATCHET_CAP,
+        `expected ratchet capped at ${CODEX_CONTEXT_WINDOW_RATCHET_CAP}, got ${m.contextWindow}`)
+    })
+
+    // Defensive guards: a corrupt usage payload (NaN, Infinity, negative)
+    // must not feed the ratchet math. NaN * 1.1 = NaN; Infinity * 1.1 =
+    // Infinity → unbounded growth (or NaN propagation through the
+    // registry → meter showing NaN%). Silent no-op is the right failure.
+    for (const bad of [NaN, Infinity, -Infinity, -1, 0]) {
+      it(`no-op when input_tokens is invalid (${bad})`, () => {
+        const emitted = []
+        const fakeSession = { model: 'gpt-5-codex', emit: (e, d) => emitted.push({ e, d }) }
+        const changed = _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', bad)
+        assert.equal(changed, false)
+        assert.equal(emitted.length, 0)
+      })
+    }
   })
 })

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -6,9 +6,16 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { spawn } from 'child_process'
 import { createInterface } from 'readline'
-import { CodexSession, buildCodexArgs, resolveCodexSandbox, CODEX_SANDBOX_MODES, CODEX_DEFAULT_SANDBOX } from '../src/codex-session.js'
+import { CodexSession, buildCodexArgs, resolveCodexSandbox, CODEX_SANDBOX_MODES, CODEX_DEFAULT_SANDBOX, CODEX_CONTEXT_WINDOW_HEADROOM, _maybeRatchetContextWindow } from '../src/codex-session.js'
 import { SkillsTrustStore } from '../src/skills-trust.js'
+import { getRegistryForProvider } from '../src/models.js'
 import { waitFor } from './test-helpers.js'
+// Importing providers.js triggers built-in provider registration so
+// getRegistryForProvider('codex') can wire to CodexSession's static hooks
+// when this suite runs in isolation. Without this the registry falls back
+// to the default Claude registry and the learn-loop ratchet tests below
+// would silently no-op.
+import '../src/providers.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1568,6 +1575,108 @@ describe('CodexSession', () => {
       assert.equal(toolResults.length, 1)
       assert.equal(toolResults[0].toolUseId, 'tc-99')
       assert.equal(toolResults[0].result, 'file.txt')
+    })
+  })
+
+  // -------------------------------------------------------------------
+  // #3857 — Codex context-window registry + learn-loop
+  // -------------------------------------------------------------------
+  //
+  // The static MODEL_INFO table was last bumped pre-launch and shipped 272k
+  // for both gpt-5 and gpt-5-codex even though OpenAI publishes 400k for
+  // Codex on every paid plan. The first fix is the static bump; the second
+  // is a runtime learn-loop that catches future drift the same way
+  // sdk-session.js corrects Claude windows from `SDKResultSuccess.modelUsage`.
+  describe('#3857 context-window source-of-truth', () => {
+    it('gpt-5-codex ships the current OpenAI-documented 400k window', () => {
+      const meta = CodexSession.getModelMetadata('gpt-5-codex')
+      assert.ok(meta)
+      assert.equal(meta.contextWindow, 400_000,
+        'gpt-5-codex should ship the 400k Codex window OpenAI publishes for all paid plans')
+    })
+
+    it('gpt-5 ships the current OpenAI-documented 400k window', () => {
+      const meta = CodexSession.getModelMetadata('gpt-5')
+      assert.ok(meta)
+      assert.equal(meta.contextWindow, 400_000,
+        'gpt-5 should ship the 400k window — was 272k pre-launch (#3857)')
+    })
+
+    it('every shipped fallback model carries a positive contextWindow', () => {
+      for (const m of CodexSession.getFallbackModels()) {
+        assert.ok(typeof m.contextWindow === 'number' && m.contextWindow > 0,
+          `${m.fullId} should have a numeric contextWindow > 0`)
+      }
+    })
+  })
+
+  describe('#3857 learn-loop — _maybeRatchetContextWindow()', () => {
+    // The codex provider registry is module-cached; reset before each test
+    // so the pollution from a previous ratchet doesn't bleed in.
+    beforeEach(() => {
+      const r = getRegistryForProvider('codex')
+      r.resetModels()
+    })
+
+    it('no-op when input_tokens is at or below the registered window', () => {
+      const emitted = []
+      const fakeSession = { model: 'gpt-5-codex', emit: (e, d) => emitted.push({ e, d }) }
+      // 400k window — a 100k turn should not trigger.
+      const changed = _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 100_000)
+      assert.equal(changed, false)
+      assert.equal(emitted.length, 0)
+    })
+
+    it('ratchets up when input_tokens exceeds the registered window', () => {
+      const emitted = []
+      const fakeSession = { model: 'gpt-5-codex', emit: (e, d) => emitted.push({ e, d }) }
+      // 500k input on a 400k registered window → bump to >= 500k * 1.1 = 550k.
+      const changed = _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 500_000)
+      assert.equal(changed, true)
+
+      const r = getRegistryForProvider('codex')
+      const m = r.getModels().find(x => x.fullId === 'gpt-5-codex')
+      assert.ok(m)
+      assert.ok(m.contextWindow >= 500_000 * CODEX_CONTEXT_WINDOW_HEADROOM,
+        `expected ratcheted window >= ${500_000 * CODEX_CONTEXT_WINDOW_HEADROOM}, got ${m.contextWindow}`)
+      // Round-to-1k cleanliness check — meter should not display "550127".
+      assert.equal(m.contextWindow % 1000, 0,
+        `expected ratcheted window rounded up to nearest 1k, got ${m.contextWindow}`)
+    })
+
+    it('emits models_updated with the updated registry when ratcheted', () => {
+      const emitted = []
+      const fakeSession = { model: 'gpt-5-codex', emit: (e, d) => emitted.push({ e, d }) }
+      _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 500_000)
+      const evt = emitted.find(x => x.e === 'models_updated')
+      assert.ok(evt, 'should emit models_updated so dashboards refresh')
+      assert.ok(Array.isArray(evt.d.models))
+      const m = evt.d.models.find(x => x.fullId === 'gpt-5-codex')
+      assert.ok(m && m.contextWindow >= 500_000 * CODEX_CONTEXT_WINDOW_HEADROOM)
+    })
+
+    it('only ratchets up — never shrinks the registered window', () => {
+      const r = getRegistryForProvider('codex')
+      // Ratchet up first.
+      const fakeSession = { model: 'gpt-5-codex', emit: () => {} }
+      _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 800_000)
+      const after = r.getModels().find(x => x.fullId === 'gpt-5-codex').contextWindow
+      assert.ok(after > 400_000, 'sanity: ratchet should have raised the window')
+
+      // Now a small turn comes in. Must NOT ratchet down.
+      const changed = _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 50_000)
+      assert.equal(changed, false)
+      const stable = r.getModels().find(x => x.fullId === 'gpt-5-codex').contextWindow
+      assert.equal(stable, after,
+        'a small follow-up turn must not shrink the ratcheted window')
+    })
+
+    it('no-op for an unknown model id', () => {
+      const emitted = []
+      const fakeSession = { model: 'gpt-99-future', emit: (e, d) => emitted.push({ e, d }) }
+      const changed = _maybeRatchetContextWindow(fakeSession, 'gpt-99-future', 999_999_999)
+      assert.equal(changed, false, 'unknown models should be a silent no-op, not a throw')
+      assert.equal(emitted.length, 0)
     })
   })
 })

--- a/packages/server/tests/models-per-provider.test.js
+++ b/packages/server/tests/models-per-provider.test.js
@@ -91,12 +91,14 @@ describe('provider static metadata hooks', () => {
 
 describe('createModelsRegistry(providerHooks)', () => {
   it('honors provider-supplied fallback models for a non-Claude provider', () => {
+    // #3857: 400k is the OpenAI-documented Codex window for gpt-5 / gpt-5-codex
+    // across paid plans; was 272k pre-launch and never bumped.
     const fallback = Object.freeze([
-      Object.freeze({ id: 'gpt-5-codex', label: 'GPT-5 Codex', fullId: 'gpt-5-codex', contextWindow: 272_000 }),
+      Object.freeze({ id: 'gpt-5-codex', label: 'GPT-5 Codex', fullId: 'gpt-5-codex', contextWindow: 400_000 }),
     ])
     const r = createModelsRegistry({
       fallbackModels: fallback,
-      getModelMetadata: (id) => ({ id, label: id, fullId: id, contextWindow: 272_000 }),
+      getModelMetadata: (id) => ({ id, label: id, fullId: id, contextWindow: 400_000 }),
     })
     const models = r.getModels()
     assert.equal(models.length, 1)


### PR DESCRIPTION
Closes #3857

## Summary

The footer context meter was pinned at 100% red for Codex sessions at ~321k
tokens even though Codex kept responding coherently — strongly suggesting
the registered context window for GPT-5 Codex was stale. Two adjacent gaps,
both fixed here:

### 1. Stale Codex context windows (server)

`packages/server/src/codex-session.js` shipped 272_000 for both `gpt-5` and
`gpt-5-codex`. The 272k value was a pre-launch internal limit that was
never updated when OpenAI shipped the public 400k Codex window — also
captured upstream in [openai/codex#19319](https://github.com/openai/codex/issues/19319)
and the OpenAI community thread "Input tokens exceed the configured limit
of 272,000 tokens".

Both models now ship `400_000`, the current OpenAI-documented Codex window
across all paid plans.

A runtime learn-loop catches future drift: when Codex's reported
`usage.input_tokens` for the most-recent turn exceeds the registered
window, the registry ratchets upward to `inputTokens * 1.1` (10% headroom,
rounded up to the nearest 1k for a clean meter value) and emits
`models_updated` so connected dashboards refresh without waiting for a
manual reload. Mirrors the Claude path in `sdk-session.js:741` (which
reads `SDKResultSuccess.modelUsage.contextWindow`) — except Codex's
`turn.completed` event has no `contextWindow` field, so we infer drift from
the observed token count instead. Only ratchets *up* — a small follow-up
turn must never shrink the registered window.

### 2. Footer meter UX at high utilization (dashboard)

`FooterBar.tsx` previously clamped both the bar fill AND the displayed
percent at 100%. Past the registered window, the meter pegged silently
with no remedy hint.

- **True percent past 100%**: the label now shows `134%` instead of
  clamping to `100%`. The bar fill stays clamped at 100% width (a bar
  can't render wider than its container) and `aria-valuenow` stays clamped
  to honor `aria-valuemax=100`, but the numeric label and a new
  `.over-budget` visual class carry the over-budget delta.
- **`/compact` suggestion chip**: surfaces at >=80% usage. Clicking sends
  `/compact` to the active session via `sendInput`. Hidden when
  `onCompact` is undefined (read-only embeds) so a CTA that won't fire
  never renders. Tooltip copy distinguishes near-limit ("filling up — send
  /compact to summarise older turns") from over-budget ("Context window
  full — send /compact to free space (the model may already be silently
  truncating older context)").

### Tests

- `packages/server/tests/codex-session.test.js`:
  - `gpt-5-codex` / `gpt-5` ship 400k
  - learn-loop ratchets up on an over-budget turn
  - learn-loop never ratchets down on a small follow-up turn
  - emits `models_updated` with the corrected registry
  - no-op on an unknown model id (silent, no throw)
- `packages/dashboard/src/components/FooterBar.test.tsx`:
  - compact chip renders at 80% / 100%+; hidden below 80%
  - chip hidden when `onCompact` is undefined or `contextPercent` is null
  - clicking fires `onCompact`
  - tooltip copy + `.over-budget` class differ between near-limit and over-budget
  - bar shows true label past 100%, with `.over-budget` marker class

### Verified context-window value

- 400k for `gpt-5-codex` / `gpt-5` in Codex matches OpenAI's published
  documentation for all paid plans (Plus, Pro, Business, Enterprise, Edu, Go).
  Cross-referenced via [openai/codex#19319](https://github.com/openai/codex/issues/19319):
  "OpenAI's GPT-5.5 launch page says GPT-5.5 in Codex has a `400K` context window."

### Out of scope (deferred, noted in #3857)

- **Server-side auto-compact triggering** — the user owns when to compact;
  we just make the suggestion more visible.
- **Per-provider cache persistence of the learned window** — the in-memory
  ratchet works for the lifetime of the process and re-learns on the next
  over-budget turn after restart. Persisting via a codex-specific cache
  file requires a cache-path-per-provider refactor and is deferred to a
  follow-up PR.
- **"Learn-loop" for other Codex models** — the same helper applies to
  any Codex model in the registry, but only `gpt-5` / `gpt-5-codex` had
  the documented drift. `o1` / `o3` / `gpt-4.1` / `gpt-4o` remain at
  their public values.

## Test plan

- [x] `cd packages/server && PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --test tests/codex-session.test.js tests/models-per-provider.test.js` — 144 tests pass
- [x] `cd packages/dashboard && npx vitest run` — 2125 tests pass (36 in FooterBar.test.tsx)
- [x] `cd packages/dashboard && npm run typecheck` — clean
- [ ] Open a Codex session, drive it past 80% context — chip appears
- [ ] Drive it past 100% — label shows true percent, bar fill stays clamped, chip styling distinguishes over-budget
- [ ] Click chip — `/compact` sent to session