### PR TITLE
chore: bump version to 0.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.10] - 2026-05-28
+
+Same-day follow-up to v0.9.9. Same theme — dashboard polish and dogfood-driven correctness — picking up everything #4396 spilled over, plus stale Codex context-window values, customizable keyboard shortcuts, and three small follow-ups to v0.9.9's thinking-keyword work.
+
+### Added
+
+- **Customizable keyboard shortcuts via Settings UI (#3852 / #4410):** shortcut registry (`packages/dashboard/src/shortcuts/`) with default bindings, rebind UI in the existing `ShortcutHelp` cheat sheet, key-capture input for capturing combos, conflict detection, and persistence across restarts. Scope-reduced from "migrate every shortcut" to "register one shortcut end-to-end + UI"; [#4412](https://github.com/blamechris/chroxy/issues/4412) tracks migrating the remaining hand-rolled shortcuts (Cmd+1-9, Cmd+Shift+[/], Cmd+W, etc.). In-PR critical fix: `App.tsx`'s `SHORTCUTS` useMemo dep was the stable registry reference, so a rebind didn't recompute the cheat sheet — now keyed on the effective bindings.
+- **Codex context-window learn-loop + 100% compact-suggestion CTA (#3857 / #4411):** server now ratchets the registered context window upward when a Codex session reports a higher token total (capped at 2,000,000 with NaN/Infinity/negative input rejection), and the dashboard footer meter shows a "Try /compact" CTA when usage hits 100% — `prefers-reduced-motion` honoured on the over-budget pulse. Follow-ups [#4413](https://github.com/blamechris/chroxy/issues/4413) (persist ratchets across server restart) and [#4414](https://github.com/blamechris/chroxy/issues/4414) (extend to Gemini) are tracked.
+
+### Fixed
+
+- **ChatView state preserved across System-tab switch + skip hidden re-renders (#4397 + #4398 / #4408):** picks up the two follow-ups #4396 spilled over from #4305. The System tab now uses the same `display: contents` / `display: none` keep-alive pattern as Chat/Output, so `ToolGroup`/`ToolBubble` expand state survives switching to System and back. Separately, `ChatView` is wrapped in `React.memo` with a `Boolean(prev.hidden) && Boolean(next.hidden)` comparator that skips `renderMessage` entirely while hidden — long sessions no longer pay the re-render cost for the inactive pane. Always re-renders with latest props on the visible transition.
+- **Thinking-keyword regex tightened to horizontal whitespace + reuse module-level regex (#4402 + #4404 / #4409):** v0.9.9's `\s+` between multi-word entries (`think\s+harder`) matched arbitrary newline runs, so "think" + Enter + "harder" across two lines would falsely escalate. Replaced with `[ \t]+` in both `detect-thinking-keyword.js` and `thinking-keyword-tokens.ts`. Also fixed the dashboard tokenizer cloning the module-level regex per call — it now reuses the module-level instance with `lastIndex = 0` between calls.
+
+### Performance
+
+- **InputBar overlay onScroll handler memoised (#4403 / #4407):** previously created fresh per render as an inline arrow function. Now wrapped in `useCallback` with a stable reference — same change applied to the gate's `tokens ? ... : undefined` form.
+
 ## [0.9.9] - 2026-05-28
 
 Dashboard UX bug-bundle release. Focus areas: making the working session look alive (in-flight tool naming, spinners, thinking-keyword escalation) and fixing two long-standing chat/output rendering bugs that made dogfooded TUI sessions feel broken. Also adds the keyboard-only third leg of the sidebar context menu story (Shift+F10 / ContextMenu key) and several skill-template / process improvements for handling external contributors.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.9"
+      "version": "0.9.10"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.9",
+    "version": "0.9.10",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.9</string>
+    <string>0.9.10</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.9"
+version = "0.9.10"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.9",
+      "version": "0.9.10",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump from 0.9.9 → 0.9.10.

Same-day follow-up to v0.9.9 picking up everything #4396 spilled over plus the v0.9.9 thinking-keyword micro-tightening:

- **Added:** customizable keyboard shortcuts (#3852 / #4410), Codex context-window learn-loop + compact CTA (#3857 / #4411)
- **Fixed:** System tab ChatView preservation + memo skip (#4397+#4398 / #4408), thinking-keyword regex tightened to `[ \t]+` + module-level regex reuse (#4402+#4404 / #4409)
- **Performance:** InputBar onScroll memoise (#4403 / #4407)

15 files bumped by `scripts/bump-version.sh 0.9.10`.

## Test plan

- [ ] CI green across all required checks
- [ ] CHANGELOG entry reads cleanly (Added / Fixed / Performance)