### PR TITLE
fix(server): track pending background shells so waiting sessions aren't reaped (#4307)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -91,6 +91,7 @@ import {
   handleGitCommitResult as sharedGitCommitResult,
   handleAgentSpawned as sharedAgentSpawned,
   handleAgentCompleted as sharedAgentCompleted,
+  handleBackgroundWorkChanged as sharedBackgroundWorkChanged,
   handleAvailableModels as sharedAvailableModels,
   handleMcpServers as sharedMcpServers,
   handleCostUpdate as sharedCostUpdate,
@@ -1219,6 +1220,24 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             });
           }
         }
+        // #4307: seed pendingBackgroundShells from the snapshot so the
+        // app catches up on any sessions already waiting on background
+        // work without waiting for the next `background_work_changed`
+        // event. The shared handler's reference-equality short-circuit
+        // suppresses no-op re-renders.
+        for (const s of sessionList) {
+          if (!get().sessionStates[s.sessionId]) continue;
+          const builder = sharedBackgroundWorkChanged(
+            { sessionId: s.sessionId, pending: s.pendingBackgroundShells ?? [] },
+            get().activeSessionId,
+          );
+          updateSession(s.sessionId, (ss) => {
+            const next = builder.applyTo(ss.pendingBackgroundShells);
+            return next === ss.pendingBackgroundShells
+              ? {}
+              : { pendingBackgroundShells: next };
+          });
+        }
         // Persist the active session's conversationId for auto-resume on server restart.
         // Use the activeSessionId if set, otherwise fall back to the first session in the list.
         const resolvedActiveId = get().activeSessionId ?? (sessionList[0]?.sessionId ?? null);
@@ -1777,6 +1796,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         updateSession(builder.sessionId, (ss) => {
           const next = builder.applyTo(ss.activeAgents);
           return next === ss.activeAgents ? {} : { activeAgents: next };
+        });
+      }
+      break;
+    }
+
+    case 'background_work_changed': {
+      // #4307 — pending-background-shells snapshot updated for a
+      // session. Full-snapshot protocol; the shared handler returns
+      // the same reference when next === current to skip re-renders.
+      const builder = sharedBackgroundWorkChanged(msg, get().activeSessionId);
+      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
+        updateSession(builder.sessionId, (ss) => {
+          const next = builder.applyTo(ss.pendingBackgroundShells);
+          return next === ss.pendingBackgroundShells
+            ? {}
+            : { pendingBackgroundShells: next };
         });
       }
       break;

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -208,6 +208,9 @@ const EMPTY_DEV_PREVIEWS: never[] = [];
 // #4308: stable empty reference for `activeTools` in the flat-state
 // fallback. Same `useShallow` stability rationale as the others above.
 const EMPTY_ACTIVE_TOOLS: never[] = [];
+// #4307: stable empty reference for `pendingBackgroundShells` —
+// same `useShallow` stability rationale as the others above.
+const EMPTY_PENDING_BACKGROUND_SHELLS: never[] = [];
 
 /** Delay before auto-reconnecting after an unexpected socket close (ms) */
 const AUTO_RECONNECT_DELAY = 1500;
@@ -498,6 +501,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #4308: parity with the BaseSessionState shape; no live tool tracking
       // in flat-state fallback (only populated once a real SessionState lands).
       activeTools: EMPTY_ACTIVE_TOOLS,
+      // #4307: parity with the BaseSessionState shape; no live
+      // background-shell tracking in the flat-state fallback.
+      pendingBackgroundShells: EMPTY_PENDING_BACKGROUND_SHELLS,
       isPlanPending: false,
       planAllowedPrompts: EMPTY_PROMPTS,
       primaryClientId: null,

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -74,6 +74,7 @@ import {
   handleGitStatusResult as sharedGitStatusResult,
   handleAgentSpawned as sharedAgentSpawned,
   handleAgentCompleted as sharedAgentCompleted,
+  handleBackgroundWorkChanged as sharedBackgroundWorkChanged,
   handleEnvironmentList as sharedEnvironmentList,
   handleEnvironmentError as sharedEnvironmentError,
   handleAvailableModels as sharedAvailableModels,
@@ -2182,6 +2183,28 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             });
           }
         }
+        // #4307: seed pendingBackgroundShells from the snapshot so a
+        // fresh tab / reconnect catches up to any sessions already
+        // waiting on background work without needing the next
+        // background_work_changed event to arrive. The
+        // `handleBackgroundWorkChanged` builder does the
+        // same-reference short-circuit so duplicate seeds don't
+        // re-render. The field is optional on `SessionInfo` because
+        // older servers omit it; treat `undefined` as "no waiting
+        // work" (empty array passthrough).
+        for (const s of sessionList) {
+          if (!get().sessionStates[s.sessionId]) continue;
+          const builder = sharedBackgroundWorkChanged(
+            { sessionId: s.sessionId, pending: s.pendingBackgroundShells ?? [] },
+            get().activeSessionId,
+          );
+          updateSession(s.sessionId, (ss) => {
+            const next = builder.applyTo(ss.pendingBackgroundShells);
+            return next === ss.pendingBackgroundShells
+              ? {}
+              : { pendingBackgroundShells: next };
+          });
+        }
       }
       break;
     }
@@ -2462,6 +2485,23 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         updateSession(builder.sessionId, (ss) => {
           const next = builder.applyTo(ss.activeAgents);
           return next === ss.activeAgents ? {} : { activeAgents: next };
+        });
+      }
+      break;
+    }
+
+    case 'background_work_changed': {
+      // #4307 — pending-background-shells snapshot updated for a
+      // session. Full-snapshot protocol, so the builder replaces the
+      // slot wholesale; the shared handler returns the same reference
+      // when next == current to suppress no-op renders.
+      const builder = sharedBackgroundWorkChanged(msg, get().activeSessionId);
+      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
+        updateSession(builder.sessionId, (ss) => {
+          const next = builder.applyTo(ss.pendingBackgroundShells);
+          return next === ss.pendingBackgroundShells
+            ? {}
+            : { pendingBackgroundShells: next };
         });
       }
       break;

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -269,6 +269,51 @@ export const ServerAgentCompletedSchema = z.object({
   toolUseId: z.string(),
 })
 
+/**
+ * #4307 — one entry per backgrounded `Bash` shell the session is still
+ * waiting on. Pushed when the agent dispatches a `Bash` tool call with
+ * `run_in_background: true` (the matching tool_result carries the
+ * canonical `Command running in background with ID: <id>` text); cleared
+ * when the agent calls `BashOutput` (acknowledged) or the session is
+ * destroyed.
+ *
+ * `shellId` is the short alphanumeric token Claude prints (e.g.
+ * `brk57kt6pm`). `command` is the original Bash command text the agent
+ * dispatched, stashed at tool_use time so the dashboard can render
+ * "waiting on `<command>`" without a separate roundtrip. `startedAt` is
+ * the server-side wall-clock at the moment the tool_result was parsed —
+ * lets the dashboard surface elapsed wait time without trusting the
+ * client clock.
+ */
+export const ServerPendingBackgroundShellSchema = z.object({
+  shellId: z.string(),
+  command: z.string(),
+  startedAt: z.number().int().nonnegative(),
+})
+
+/**
+ * #4307 — transient event: the pending-background-shells snapshot for a
+ * session changed. Emitted both on push (a new `run_in_background` shell
+ * was registered) and on clear (`BashOutput` acknowledged or the session
+ * was destroyed). The full snapshot is on the wire (not a delta) so a
+ * late-joining client sees canonical state.
+ *
+ * Why a full snapshot instead of an event per delta: pending work is a
+ * tiny set (typically 0 or 1 entries) and the event fires rarely, so
+ * the wire cost is negligible. A delta protocol would force every
+ * client to also reconcile against `pendingBackgroundShells` on the
+ * `session_list` snapshot — the full-snapshot shape avoids that.
+ *
+ * Late joiners: `session_list` carries the same `pendingBackgroundShells`
+ * field on each entry, so a client that connects between
+ * `background_work_changed` events catches up via the next snapshot.
+ */
+export const ServerBackgroundWorkChangedSchema = z.object({
+  type: z.literal('background_work_changed'),
+  sessionId: z.string(),
+  pending: z.array(ServerPendingBackgroundShellSchema),
+})
+
 export const ServerClientFocusChangedSchema = z.object({
   type: z.literal('client_focus_changed'),
   clientId: z.string(),
@@ -410,6 +455,12 @@ export const ServerSessionListEntrySchema = z.object({
   // running total, and a session that received only refunds could
   // legitimately end up with a negative cumulative.
   cumulativeUsage: CumulativeUsageSchema.optional(),
+  // #4307: pending backgrounded shells. Empty array when no work is
+  // pending — never `undefined` from a #4307-aware server (mirrors the
+  // `cumulativeUsage` shape, which always carries a zero block once
+  // present). Optional in the schema so pre-#4307 servers that omit
+  // the field still parse; consumers should treat `undefined` as `[]`.
+  pendingBackgroundShells: z.array(ServerPendingBackgroundShellSchema).optional(),
 }).passthrough()
 
 export const ServerSessionListSchema = z.object({

--- a/packages/server/src/background-shells.js
+++ b/packages/server/src/background-shells.js
@@ -1,0 +1,82 @@
+/**
+ * #4307 — helpers for tracking `Bash` tool calls dispatched with
+ * `run_in_background: true`. Both SdkSession (assistant tool_use →
+ * user tool_result) and ClaudeTuiSession (PreToolUse hook → PostToolUse
+ * hook) flow their inputs / results through a small parsing surface so
+ * BaseSession can record the resulting shell id and survive turn-end.
+ *
+ * The canonical tool_result text Claude emits when a Bash call returns
+ * with `run_in_background: true` is:
+ *
+ *   "Command running in background with ID: brk57kt6pm. Output is being
+ *    written to: /private/tmp/claude-501/…/tasks/br57k6pm.output. You
+ *    will be notified when it completes."
+ *
+ * We do not depend on the format of the surrounding sentence — only on
+ * the canonical `Command running in background with ID: <token>` opener,
+ * which has been stable across the claude versions chroxy targets.
+ */
+
+// `[A-Za-z0-9_-]+` is intentionally tight — every shell id observed so
+// far is short alphanumeric (`brk57kt6pm`). A non-whitespace match would
+// also swallow a trailing period or sentence-end punctuation. Keep this
+// narrow: malformed payloads return null and the wait is invisible.
+const SHELL_ID_RE = /Command running in background with ID:\s+([A-Za-z0-9_-]+)/
+
+/**
+ * Parse the shell id from a tool_result text. Returns the id when the
+ * canonical pattern matches, else null.
+ *
+ * Defensive against non-string / empty inputs so callers can hand the
+ * raw `tool_result.result` field through without pre-checking.
+ *
+ * @param {unknown} text
+ * @returns {string | null}
+ */
+export function parseBackgroundShellId(text) {
+  if (typeof text !== 'string' || text.length === 0) return null
+  const m = SHELL_ID_RE.exec(text)
+  return m ? m[1] : null
+}
+
+/**
+ * Returns true when a tool_use block represents a Bash call dispatched
+ * with `run_in_background: true`. Used by providers to stash the
+ * command text against the tool_use_id so the matching tool_result can
+ * record it with its shell id.
+ *
+ * Strict-boolean on the `run_in_background` field — a malformed input
+ * (truthy non-bool) is rejected so a buggy SDK payload can't poison the
+ * pending map with a non-background call.
+ *
+ * @param {string} toolName
+ * @param {unknown} input
+ * @returns {boolean}
+ */
+export function isRunInBackgroundInput(toolName, input) {
+  if (toolName !== 'Bash') return false
+  if (!input || typeof input !== 'object') return false
+  return input.run_in_background === true
+}
+
+/**
+ * Returns true when a tool_use block represents a `BashOutput` poll. The
+ * `bash_id` field identifies the shell whose pending entry should clear
+ * — the agent calling BashOutput means it has seen the completion (or
+ * is at least aware of the shell), so we drop the entry. If the same
+ * shell is still incomplete the agent will poll again later; recording
+ * a fresh entry would require parsing claude's BashOutput response
+ * format and is intentionally out of scope (issue #4307 documents
+ * BashOutput as the canonical clear signal).
+ *
+ * @param {string} toolName
+ * @param {unknown} input
+ * @returns {string | null} bash_id when this is a BashOutput call, else null
+ */
+export function parseBashOutputShellId(toolName, input) {
+  if (toolName !== 'BashOutput') return null
+  if (!input || typeof input !== 'object') return null
+  const id = input.bash_id
+  if (typeof id !== 'string' || id.length === 0) return null
+  return id
+}

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -187,6 +187,33 @@ export class BaseSession extends EventEmitter {
 
     this._isBusy = false
     this._processReady = false
+    // #4307: per-session map of backgrounded Bash shells the agent is
+    // still waiting on. Keyed by the shellId Claude prints in the
+    // `Command running in background with ID: <id>` tool_result. Lives
+    // beyond `_clearMessageState` (turn-end) on purpose — the whole
+    // point of #4307 is that a session waiting on background work is
+    // distinct from an idle session and must NOT be reaped by
+    // `SessionTimeoutManager`. Entries clear in two paths:
+    //   1. Matching `BashOutput` tool call (the agent acknowledged the
+    //      shell — either it polled and saw output, or it asked to be
+    //      killed; either way our model of pending work is stale).
+    //   2. `destroy()` (no leak — see `_destroyPendingBackgroundShells`).
+    // SDK provider: if the agent never calls `BashOutput`, the entry
+    // persists until destroy. Documented behaviour — we deliberately do
+    // not try to tail the output file ourselves (that's a separate
+    // sidecar lifecycle problem, out of scope).
+    // TUI provider: same parity — the agent's next turn surfaces the
+    // BashOutput call and clears the entry naturally.
+    this._pendingBackgroundShells = new Map()
+    // #4307: ephemeral map of recent `Bash` tool_uses dispatched with
+    // `run_in_background: true`, keyed by toolUseId. Used to recover the
+    // command string when the matching tool_result lands carrying the
+    // shellId — the command string is informational (surfaced in the
+    // dashboard "waiting on …" chip). Cleared on `_clearMessageState`
+    // because once a turn ends, any tool_use blocks that did not see a
+    // result this turn are stranded; the agent's next turn re-emits a
+    // fresh `tool_use` if it cares to wait again.
+    this._pendingBackgroundCommands = new Map()
     this._messageCounter = 0
     // Boot-unique prefix mixed into every emitted messageId (#3700).
     // The dashboard caches up to 100 messages per session in localStorage
@@ -477,8 +504,106 @@ export class BaseSession extends EventEmitter {
     return true
   }
 
+  /**
+   * #4307: a session is "running" — i.e. NOT idle, NOT subject to
+   * `SessionTimeoutManager` reaping — when EITHER:
+   *   - `_isBusy` is true (the model is mid-turn), OR
+   *   - the pending-background-shells map is non-empty (the agent
+   *     dispatched a `run_in_background` Bash and is waiting on it).
+   *
+   * The second clause is the #4307 fix: previously a session that
+   * kicked off a long-running background shell and returned looked
+   * indistinguishable from a finished session — `_isBusy` had cleared
+   * at turn-end. Now it stays "running" until the agent acknowledges
+   * the shell (via a `BashOutput` call) or the session is destroyed.
+   */
   get isRunning() {
-    return this._isBusy
+    if (this._isBusy) return true
+    return this._pendingBackgroundShells.size > 0
+  }
+
+  /**
+   * #4307: read-only snapshot of pending background shells, ordered by
+   * insertion (so the dashboard surfaces the most-recently-started shell
+   * last). Returns a plain array of `{ shellId, startedAt, command }`
+   * objects so the caller can stringify directly onto a wire payload.
+   */
+  getPendingBackgroundShells() {
+    return Array.from(this._pendingBackgroundShells.values())
+  }
+
+  /**
+   * #4307: record a new pending background shell. Idempotent on
+   * shellId — re-registering an existing id is a no-op (preserves the
+   * original startedAt + command so a duplicate tool_result, which
+   * does happen on certain claude paths, can't bump the timestamp or
+   * overwrite the original command text).
+   *
+   * Emits `background_work_changed` with the full pending snapshot
+   * after a change. `SessionManager` proxies this transient event onto
+   * the WS wire (see `customEvents`-style integration).
+   *
+   * @param {{ shellId: string, command?: string }} opts
+   * @returns {boolean} true if a new entry was added
+   */
+  trackBackgroundShell({ shellId, command } = {}) {
+    if (typeof shellId !== 'string' || shellId.length === 0) return false
+    if (this._pendingBackgroundShells.has(shellId)) return false
+    this._pendingBackgroundShells.set(shellId, {
+      shellId,
+      startedAt: Date.now(),
+      command: typeof command === 'string' ? command : '',
+    })
+    this._emitBackgroundWorkChanged()
+    return true
+  }
+
+  /**
+   * #4307: clear a pending background shell by id. Returns true when
+   * an entry actually existed, false when the id was not tracked —
+   * matches the idempotent contract of other BaseSession setters so
+   * the caller can decide whether to log / emit.
+   *
+   * Emits `background_work_changed` with the post-clear snapshot when
+   * the change is observable (entry actually existed).
+   *
+   * @param {string} shellId
+   * @returns {boolean}
+   */
+  clearBackgroundShell(shellId) {
+    if (typeof shellId !== 'string' || shellId.length === 0) return false
+    if (!this._pendingBackgroundShells.delete(shellId)) return false
+    this._emitBackgroundWorkChanged()
+    return true
+  }
+
+  /**
+   * #4307: emit the current pending-shells snapshot on the
+   * `background_work_changed` event. Pulled into a helper so both
+   * `trackBackgroundShell` and `clearBackgroundShell` use one shape.
+   * The full snapshot is sent on each change (not just the delta) so a
+   * late-joining client subscribed to the event sees the canonical
+   * state without needing to replay a delta stream.
+   *
+   * @private
+   */
+  _emitBackgroundWorkChanged() {
+    this.emit('background_work_changed', {
+      pending: this.getPendingBackgroundShells(),
+    })
+  }
+
+  /**
+   * #4307: clear the pending map on session destroy. Pulled into a
+   * helper so subclasses can call it from their own `destroy()` after
+   * the existing teardown — keeping the map alive past destroy would
+   * leak memory and confuse late session-list snapshots.
+   *
+   * @private
+   */
+  _destroyPendingBackgroundShells() {
+    this._pendingBackgroundShells.clear()
+    this._pendingBackgroundCommands.clear()
   }
 
   /** Current thinking level. Override in subclasses that support it. */
@@ -790,6 +915,15 @@ export class BaseSession extends EventEmitter {
   _clearMessageState() {
     this._isBusy = false
     this._currentMessageId = null
+
+    // #4307: clear the ephemeral tool_use→command lookup. NOT the
+    // pending-shells map — those entries survive turn-end intentionally
+    // (the whole point of #4307: a session waiting on background work
+    // is distinct from an idle session). The commands map is only used
+    // to recover the command text for the next tool_result of the SAME
+    // turn — once the turn ends, any unmatched entries are stranded
+    // and a fresh tool_use would re-populate.
+    this._pendingBackgroundCommands.clear()
 
     // Emit completions for any tracked agents so the app clears badges
     if (this._activeAgents.size > 0) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -9,6 +9,11 @@ import { resolveBinary } from './utils/resolve-binary.js'
 import { createLogger } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { materializeAttachments, buildAttachmentsPromptSuffix } from './claude-tui-attachments.js'
+import {
+  parseBackgroundShellId,
+  isRunInBackgroundInput,
+  parseBashOutputShellId,
+} from './background-shells.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -1090,6 +1095,23 @@ export class ClaudeTuiSession extends BaseSession {
     }
 
     if (kind === 'PreToolUse') {
+      // #4307: stash the command text so the matching PostToolUse can
+      // record the resulting shellId with the original command. Same
+      // behaviour as sdk-session.js _handleToolUseBlock — keeps TUI
+      // parity for the dashboard "waiting on …" chip.
+      if (isRunInBackgroundInput(toolName, payload.tool_input)) {
+        const cmd = typeof payload.tool_input?.command === 'string'
+          ? payload.tool_input.command : ''
+        this._pendingBackgroundCommands.set(toolUseId, cmd)
+      }
+      // #4307: a BashOutput call means the agent has acknowledged the
+      // backgrounded shell. Clear the pending entry so the session is
+      // no longer reported as waiting (the agent saw the output or is
+      // about to act on it — either way our pending model is stale).
+      const bashOutputShellId = parseBashOutputShellId(toolName, payload.tool_input)
+      if (bashOutputShellId) {
+        this.clearBackgroundShell(bashOutputShellId)
+      }
       this.emit('tool_start', {
         messageId: toolUseId,
         toolUseId,
@@ -1161,6 +1183,25 @@ export class ClaudeTuiSession extends BaseSession {
       result,
       truncated,
     })
+
+    // #4307: scan PostToolUse output for the canonical "Command running
+    // in background with ID: <id>" pattern. The PostToolUse hook
+    // payload runs through stringify above, so the same regex SDK uses
+    // matches against the resulting JSON (the shellId pattern is
+    // unique enough that a false positive on stringified-quoted text
+    // is improbable). Pull the command stashed at PreToolUse so the
+    // pending-shell entry carries it. Note we parse from the
+    // post-truncation text intentionally: the canonical message is
+    // ~60 chars and lands at the FRONT of the response, so truncation
+    // never strips it (and if it ever did we'd accept that — the
+    // result event already carries truncated=true, the dashboard chip
+    // would just lack the command).
+    const shellId = parseBackgroundShellId(result)
+    if (shellId) {
+      const command = this._pendingBackgroundCommands.get(toolUseId) || ''
+      this._pendingBackgroundCommands.delete(toolUseId)
+      this.trackBackgroundShell({ shellId, command })
+    }
   }
 
   _finishTurnError(message, callerMessageId) {
@@ -1431,5 +1472,11 @@ export class ClaudeTuiSession extends BaseSession {
     this._permissionModeFile = null
     this._consumedFiles.clear()
     this._clearMessageState()
+    // #4307: drop any pending background-shell entries so the session-
+    // list snapshot doesn't carry phantom entries past destroy. Done
+    // after _clearMessageState (which preserves the pending shells —
+    // the #4307 core invariant); the explicit destroy hook is the only
+    // path that removes them.
+    this._destroyPendingBackgroundShells()
   }
 }

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -145,6 +145,27 @@ Object.assign(EVENT_MAP, {
     }],
   }),
 
+  // #4307: pending-background-shells snapshot changed for a session.
+  // BaseSession emits this on both push (run_in_background tool_result
+  // observed) and clear (BashOutput tool_use observed). Full snapshot
+  // is on the wire so a client subscribed to this event but missing
+  // earlier broadcasts (e.g. just-reconnected, late-listener) sees the
+  // canonical state without needing a delta protocol. The
+  // session_list snapshot carries the same field for the late-joining
+  // path. Also pushes a session_list side effect so the SessionInfo
+  // entry's `pendingBackgroundShells` slot refreshes for clients that
+  // render off the list rather than subscribing to the event directly.
+  background_work_changed: (data, ctx) => ({
+    messages: [{
+      msg: {
+        type: 'background_work_changed',
+        sessionId: ctx.sessionId,
+        pending: Array.isArray(data?.pending) ? data.pending : [],
+      },
+    }],
+    sideEffects: [{ type: 'session_list' }],
+  }),
+
   mcp_servers: (data) => ({
     messages: [{
       msg: { type: 'mcp_servers', servers: data.servers },

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -6,6 +6,11 @@ import { BaseSession } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
+import {
+  parseBackgroundShellId,
+  isRunInBackgroundInput,
+  parseBashOutputShellId,
+} from './background-shells.js'
 import { parseMcpToolName } from './mcp-tools.js'
 import { createLogger } from './logger.js'
 import { PermissionManager } from './permission-manager.js'
@@ -717,6 +722,15 @@ export class SdkSession extends BaseSession {
           case 'user': {
             // Tool result content blocks appear in user-role messages during the tool loop
             emitToolResults(msg.message?.content, this)
+            // #4307: scan tool_result blocks for the canonical
+            // "Command running in background with ID: <id>" pattern so
+            // we can record the shell as pending background work. Done
+            // alongside emitToolResults rather than inside it so the
+            // tracker stays out of the existing image-extraction /
+            // truncation surface (tool-result.js is also used by
+            // CliSession + GeminiSession, which don't share this
+            // BaseSession path).
+            this._recordBackgroundShellsFromToolResults(msg.message?.content)
             break
           }
 
@@ -1006,6 +1020,25 @@ export class SdkSession extends BaseSession {
       return
     }
 
+    // #4307: stash the command text against the tool_use_id so the
+    // matching tool_result (carrying the shellId Claude prints) can
+    // recover it. Strict-boolean run_in_background check; non-Bash
+    // tools and missing inputs are no-ops. The map is the ephemeral
+    // turn-local one — entries that never see a tool_result clear at
+    // turn-end.
+    if (isRunInBackgroundInput(block.name, block.input)) {
+      const cmd = typeof block.input?.command === 'string' ? block.input.command : ''
+      this._pendingBackgroundCommands.set(block.id, cmd)
+    }
+    // #4307: when the agent calls BashOutput on a previously-tracked
+    // shell, drop the pending entry. Whether output was complete or
+    // not, the agent has acknowledged the shell — our local model of
+    // "session is waiting on background work" is stale either way.
+    const bashOutputId = parseBashOutputShellId(block.name, block.input)
+    if (bashOutputId) {
+      this.clearBackgroundShell(bashOutputId)
+    }
+
     if (block.name === 'Task') {
       const input = block.input || {}
       const description = (typeof input.description === 'string'
@@ -1017,6 +1050,42 @@ export class SdkSession extends BaseSession {
       }
       this._activeAgents.set(block.id, agentInfo)
       this.emit('agent_spawned', agentInfo)
+    }
+  }
+
+  /**
+   * #4307: scan a user-role message's tool_result content blocks for
+   * the canonical `Command running in background with ID: <id>` text
+   * and register each pending background shell against the matching
+   * command stashed earlier by `_handleToolUseBlock`.
+   *
+   * Defensive against non-array content (the SDK sometimes ships a
+   * single string for content) and content blocks without `tool_use_id`
+   * (no-op) — the standard tool-loop flow always populates both.
+   *
+   * @param {unknown} content
+   * @private
+   */
+  _recordBackgroundShellsFromToolResults(content) {
+    if (!Array.isArray(content)) return
+    for (const block of content) {
+      if (block?.type !== 'tool_result' || !block.tool_use_id) continue
+      // Flatten the result text the same way `emitToolResults` does so
+      // a shellId in a multi-block content array still matches.
+      let text = ''
+      if (typeof block.content === 'string') {
+        text = block.content
+      } else if (Array.isArray(block.content)) {
+        text = block.content
+          .filter((b) => b?.type === 'text')
+          .map((b) => b.text)
+          .join('\n')
+      }
+      const shellId = parseBackgroundShellId(text)
+      if (!shellId) continue
+      const command = this._pendingBackgroundCommands.get(block.tool_use_id) || ''
+      this._pendingBackgroundCommands.delete(block.tool_use_id)
+      this.trackBackgroundShell({ shellId, command })
     }
   }
 
@@ -1321,6 +1390,14 @@ export class SdkSession extends BaseSession {
 
     // Emit completions for any tracked agents and clear busy state
     this._clearMessageState()
+
+    // #4307: drop any pending background-shell entries so the session-
+    // list snapshot doesn't carry phantom entries for a destroyed
+    // session and the map can't leak. Done after _clearMessageState so
+    // the canonical "turn-end keeps pending shells" invariant from
+    // _clearMessageState is preserved — the explicit destroy hook is
+    // the only path that removes them.
+    this._destroyPendingBackgroundShells()
 
     // Clean up permission manager
     this._permissions.destroy()

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -857,6 +857,22 @@ export class SessionManager extends EventEmitter {
         // this stays zero — the UI uses `turnsBilled === 0` or
         // `costUsd === 0` to suppress the cost badge.
         cumulativeUsage: { ...makeZeroCumulativeUsage(), ...(entry.cumulativeUsage || {}) },
+        // #4307: hydrate pending background-shell entries so a client
+        // joining mid-flight (fresh tab, server reconnect, app
+        // resume) sees the waiting-on-shell state without needing to
+        // wait for the next `background_work_changed` event. Always
+        // an array — sessions with no pending work serialize as `[]`
+        // (no defensive `undefined` on the wire, mirrors how
+        // `cumulativeUsage` always carries a zero block). Empty array
+        // is the common path; the dashboard's renderer treats it as
+        // "no waiting indicator." Defensive guard: providers that
+        // skip BaseSession's field initialiser (older custom
+        // providers, hypothetical) round-trip an empty array rather
+        // than crashing `getPendingBackgroundShells()` on undefined.
+        pendingBackgroundShells:
+          typeof entry.session.getPendingBackgroundShells === 'function'
+            ? entry.session.getPendingBackgroundShells()
+            : [],
       })
     }
     return list
@@ -1561,7 +1577,7 @@ export class SessionManager extends EventEmitter {
     // without the event being replayed on every reconnect (the loader re-checks
     // the hash every time skills are scanned, so the latest state is always
     // canonical).
-    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted', 'inactivity_warning']
+    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted', 'inactivity_warning', 'background_work_changed']
     const customEvents = Array.isArray(session.constructor.customEvents) ? session.constructor.customEvents : []
     const TRANSIENT_EVENTS = [...new Set([...builtinTransient, ...customEvents])]
     for (const event of TRANSIENT_EVENTS) {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -357,6 +357,7 @@ function _isSecureRequest(req) {
  *   { type: 'rate_limited', message }                   — client rate-limited
  *   { type: 'agent_spawned', sessionId, agentId, parentToolId, model } — background agent spawned
  *   { type: 'agent_completed', sessionId, agentId, parentToolId }       — background agent completed
+ *   { type: 'background_work_changed', sessionId, pending } — pending background shells snapshot changed (#4307, transient; `pending: [{ shellId, command, startedAt }, …]`)
  *   { type: 'provider_list', providers }                — available providers
  *   { type: 'byok_credentials_status', requestId?, status, source, masked?, reason? } — BYOK credentials state for the dashboard (#4052)
  *   { type: 'skills_list', skills }                     — active skills (name, description, activation, active per entry)

--- a/packages/server/tests/background-shells.test.js
+++ b/packages/server/tests/background-shells.test.js
@@ -1,0 +1,252 @@
+/**
+ * #4307 — pending background-shell tracking on BaseSession + provider-side
+ * wiring on SdkSession (assistant tool_use[run_in_background] → tool_result
+ * with shell id) and ClaudeTuiSession (PreToolUse[run_in_background] →
+ * PostToolUse with tool_response containing shellId).
+ *
+ * Invariants pinned here:
+ *   - parsing the shell id from the tool_result text
+ *   - isRunning is TRUE when _isBusy is false AND pending shells exist
+ *   - destroy() clears the pending map (no leak)
+ *   - SessionTimeoutManager skips sessions with pending background work
+ *   - background_work_changed event fires on push AND clear
+ *   - the session-list snapshot includes pendingBackgroundShells
+ *   - turn-end (`_clearMessageState`) does NOT clear pending shells
+ *   - the BashOutput tool clears the matching entry
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { BaseSession } from '../src/base-session.js'
+import {
+  parseBackgroundShellId,
+  isRunInBackgroundInput,
+} from '../src/background-shells.js'
+import { SessionTimeoutManager } from '../src/session-timeout-manager.js'
+
+let emptySkillsDir
+
+function makeSession() {
+  return new BaseSession({
+    cwd: '/tmp',
+    skillsDir: emptySkillsDir,
+    repoSkillsDir: null,
+  })
+}
+
+describe('background-shells helpers (#4307)', () => {
+  beforeEach(() => {
+    emptySkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bg-skills-'))
+  })
+
+  afterEach(() => {
+    if (emptySkillsDir) rmSync(emptySkillsDir, { recursive: true, force: true })
+    emptySkillsDir = null
+  })
+
+  describe('parseBackgroundShellId', () => {
+    it('extracts the id from the canonical message', () => {
+      const text = 'Command running in background with ID: brk57kt6pm. Output…'
+      assert.equal(parseBackgroundShellId(text), 'brk57kt6pm')
+    })
+
+    it('tolerates leading/trailing whitespace and newlines', () => {
+      const text = '\n   Command running in background with ID: abc_123-XYZ\n   '
+      assert.equal(parseBackgroundShellId(text), 'abc_123-XYZ')
+    })
+
+    it('returns null when the message does not match', () => {
+      assert.equal(parseBackgroundShellId('Random Bash output'), null)
+      assert.equal(parseBackgroundShellId(''), null)
+      assert.equal(parseBackgroundShellId(null), null)
+      assert.equal(parseBackgroundShellId(undefined), null)
+      assert.equal(parseBackgroundShellId(42), null)
+    })
+
+    it('refuses ids with whitespace (defensive against malformed payloads)', () => {
+      assert.equal(
+        parseBackgroundShellId('Command running in background with ID:    \n\n'),
+        null,
+      )
+    })
+  })
+
+  describe('isRunInBackgroundInput', () => {
+    it('returns true for Bash tools with run_in_background:true', () => {
+      assert.equal(
+        isRunInBackgroundInput('Bash', { command: 'sleep 60', run_in_background: true }),
+        true,
+      )
+    })
+
+    it('rejects non-Bash tools (the flag is Bash-specific)', () => {
+      assert.equal(
+        isRunInBackgroundInput('Read', { run_in_background: true }),
+        false,
+      )
+    })
+
+    it('is strict-boolean — truthy non-bool inputs are not enough', () => {
+      assert.equal(isRunInBackgroundInput('Bash', { run_in_background: 1 }), false)
+      assert.equal(isRunInBackgroundInput('Bash', { run_in_background: 'yes' }), false)
+    })
+
+    it('returns false on missing / non-object input', () => {
+      assert.equal(isRunInBackgroundInput('Bash', null), false)
+      assert.equal(isRunInBackgroundInput('Bash', undefined), false)
+      assert.equal(isRunInBackgroundInput('Bash', 'string'), false)
+    })
+  })
+})
+
+describe('BaseSession background-shell tracking (#4307)', () => {
+  let session
+
+  beforeEach(() => {
+    emptySkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bg-skills-'))
+    session = makeSession()
+  })
+
+  afterEach(() => {
+    if (emptySkillsDir) rmSync(emptySkillsDir, { recursive: true, force: true })
+    emptySkillsDir = null
+  })
+
+  it('initialises _pendingBackgroundShells as an empty Map', () => {
+    assert.ok(session._pendingBackgroundShells instanceof Map)
+    assert.equal(session._pendingBackgroundShells.size, 0)
+  })
+
+  it('trackBackgroundShell records id+startedAt+command and emits change event', () => {
+    const events = []
+    session.on('background_work_changed', (data) => events.push(data))
+    const now = Date.now()
+    session.trackBackgroundShell({ shellId: 'brk57kt6pm', command: 'sleep 600' })
+    assert.equal(session._pendingBackgroundShells.size, 1)
+    const entry = session._pendingBackgroundShells.get('brk57kt6pm')
+    assert.equal(entry.shellId, 'brk57kt6pm')
+    assert.equal(entry.command, 'sleep 600')
+    assert.ok(entry.startedAt >= now)
+    assert.equal(events.length, 1)
+    assert.equal(events[0].pending.length, 1)
+    assert.equal(events[0].pending[0].shellId, 'brk57kt6pm')
+  })
+
+  it('trackBackgroundShell is a no-op for empty / non-string ids', () => {
+    const events = []
+    session.on('background_work_changed', (data) => events.push(data))
+    session.trackBackgroundShell({ shellId: '', command: 'x' })
+    session.trackBackgroundShell({ shellId: null, command: 'x' })
+    session.trackBackgroundShell({})
+    assert.equal(session._pendingBackgroundShells.size, 0)
+    assert.equal(events.length, 0)
+  })
+
+  it('trackBackgroundShell is idempotent on the same id', () => {
+    const events = []
+    session.on('background_work_changed', (data) => events.push(data))
+    session.trackBackgroundShell({ shellId: 'a', command: 'first' })
+    session.trackBackgroundShell({ shellId: 'a', command: 'second' })
+    assert.equal(session._pendingBackgroundShells.size, 1)
+    // Original entry preserved — startedAt + command from first call wins
+    assert.equal(session._pendingBackgroundShells.get('a').command, 'first')
+    assert.equal(events.length, 1) // only the first emit
+  })
+
+  it('clearBackgroundShell removes the entry and emits change event', () => {
+    const events = []
+    session.trackBackgroundShell({ shellId: 'a', command: 'x' })
+    session.on('background_work_changed', (data) => events.push(data))
+    const result = session.clearBackgroundShell('a')
+    assert.equal(result, true)
+    assert.equal(session._pendingBackgroundShells.size, 0)
+    assert.equal(events.length, 1)
+    assert.equal(events[0].pending.length, 0)
+  })
+
+  it('clearBackgroundShell returns false + does not emit when id was not tracked', () => {
+    const events = []
+    session.on('background_work_changed', (data) => events.push(data))
+    assert.equal(session.clearBackgroundShell('unknown'), false)
+    assert.equal(events.length, 0)
+  })
+
+  it('getPendingBackgroundShells returns a plain array snapshot', () => {
+    session.trackBackgroundShell({ shellId: 'a', command: '1' })
+    session.trackBackgroundShell({ shellId: 'b', command: '2' })
+    const snap = session.getPendingBackgroundShells()
+    assert.ok(Array.isArray(snap))
+    assert.equal(snap.length, 2)
+    assert.deepEqual(
+      snap.map((e) => e.shellId).sort(),
+      ['a', 'b'],
+    )
+  })
+
+  describe('isRunning waiting-state semantics', () => {
+    it('is true when _isBusy is false but pending shells exist', () => {
+      assert.equal(session.isRunning, false)
+      session.trackBackgroundShell({ shellId: 'a', command: 'x' })
+      assert.equal(session.isRunning, true)
+    })
+
+    it('returns to false once the pending entry clears', () => {
+      session.trackBackgroundShell({ shellId: 'a', command: 'x' })
+      assert.equal(session.isRunning, true)
+      session.clearBackgroundShell('a')
+      assert.equal(session.isRunning, false)
+    })
+
+    it('stays true while _isBusy=true even with empty pending map', () => {
+      session._isBusy = true
+      assert.equal(session.isRunning, true)
+    })
+  })
+
+  describe('lifecycle: turn-end vs destroy', () => {
+    it('_clearMessageState does NOT clear pending shells (they survive turn-end — #4307 core invariant)', () => {
+      session.trackBackgroundShell({ shellId: 'a', command: 'x' })
+      session._isBusy = true
+      session._clearMessageState()
+      assert.equal(session._isBusy, false)
+      // The whole point of #4307 — entries survive turn-end:
+      assert.equal(session._pendingBackgroundShells.size, 1)
+      // And the session is reported running while they live:
+      assert.equal(session.isRunning, true)
+    })
+
+    it('_destroyPendingBackgroundShells clears the map (no leak on destroy)', () => {
+      session.trackBackgroundShell({ shellId: 'a', command: 'x' })
+      session.trackBackgroundShell({ shellId: 'b', command: 'y' })
+      assert.equal(session._pendingBackgroundShells.size, 2)
+      session._destroyPendingBackgroundShells()
+      assert.equal(session._pendingBackgroundShells.size, 0)
+    })
+  })
+})
+
+describe('SessionTimeoutManager honours pending background work (#4307)', () => {
+  let mgr
+  afterEach(() => {
+    if (mgr) { mgr.destroy(); mgr = null }
+  })
+
+  it('skips sessions whose isRunningFn reports waiting (pending background shells)', () => {
+    mgr = new SessionTimeoutManager({ sessionTimeoutMs: 10_000 })
+    mgr._lastActivity.set('s1', Date.now() - 60_000)
+    // Caller (SessionManager) wires isRunning to entry.session.isRunning,
+    // which BaseSession now returns true when pending shells exist.
+    mgr.setIsRunningFn((id) => id === 's1')
+
+    const timeouts = []
+    mgr.on('timeout', (data) => timeouts.push(data))
+    mgr._checkTimeouts()
+    assert.equal(timeouts.length, 0)
+    // Touching activity is the existing skip path — the session stays
+    // tracked so a later state change (work done) re-enables timeout
+    // checks naturally.
+    assert.ok(Date.now() - mgr._lastActivity.get('s1') < 1_000)
+  })
+})

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2059,6 +2059,94 @@ describe('ClaudeTuiSession', () => {
       // Must not throw.
       session._emitToolHookEvent('PreToolUse', { tool_name: 'Bash' }, 'msg-1')
     })
+
+    // #4307: parity with SdkSession — PreToolUse with Bash +
+    // run_in_background stashes the command; PostToolUse with the
+    // canonical "Command running in background with ID:" text
+    // promotes it to a pending shell.
+    describe('#4307 — background-shell tracking', () => {
+      it('records a pending shell when PreToolUse + PostToolUse pair carries a backgrounded Bash', () => {
+        const events = []
+        session.on('background_work_changed', (e) => events.push(e))
+
+        session._emitToolHookEvent('PreToolUse', {
+          tool_use_id: 'toolu_bg_1',
+          tool_name: 'Bash',
+          tool_input: { command: 'sleep 600', run_in_background: true },
+        }, 'msg-bg-1')
+        session._emitToolHookEvent('PostToolUse', {
+          tool_use_id: 'toolu_bg_1',
+          tool_name: 'Bash',
+          tool_response: 'Command running in background with ID: tui-shell-1. Output…',
+        }, 'msg-bg-1')
+
+        assert.equal(session._pendingBackgroundShells.size, 1)
+        const entry = session._pendingBackgroundShells.get('tui-shell-1')
+        assert.equal(entry.command, 'sleep 600')
+        assert.equal(events.length, 1)
+        assert.equal(events[0].pending[0].shellId, 'tui-shell-1')
+        // isRunning reports waiting even with _isBusy=false (default).
+        assert.equal(session._isBusy, false)
+        assert.equal(session.isRunning, true)
+      })
+
+      it('PostToolUse without the canonical text is a no-op for the pending map', () => {
+        session._emitToolHookEvent('PreToolUse', {
+          tool_use_id: 'toolu_bg_2',
+          tool_name: 'Bash',
+          tool_input: { command: 'ls', run_in_background: true },
+        }, 'msg-bg-2')
+        session._emitToolHookEvent('PostToolUse', {
+          tool_use_id: 'toolu_bg_2',
+          tool_name: 'Bash',
+          tool_response: 'random output, no shell id',
+        }, 'msg-bg-2')
+        assert.equal(session._pendingBackgroundShells.size, 0)
+      })
+
+      it('BashOutput PreToolUse clears the matching pending shell', () => {
+        const events = []
+        // Seed a pending shell.
+        session._emitToolHookEvent('PreToolUse', {
+          tool_use_id: 'toolu_bg_3',
+          tool_name: 'Bash',
+          tool_input: { command: 'sleep 600', run_in_background: true },
+        }, 'msg-bg-3')
+        session._emitToolHookEvent('PostToolUse', {
+          tool_use_id: 'toolu_bg_3',
+          tool_name: 'Bash',
+          tool_response: 'Command running in background with ID: tui-shell-3. Output…',
+        }, 'msg-bg-3')
+        session.on('background_work_changed', (e) => events.push(e))
+
+        // Agent polls — clears.
+        session._emitToolHookEvent('PreToolUse', {
+          tool_use_id: 'toolu_bo_1',
+          tool_name: 'BashOutput',
+          tool_input: { bash_id: 'tui-shell-3' },
+        }, 'msg-bg-3')
+        assert.equal(session._pendingBackgroundShells.size, 0)
+        assert.equal(events.length, 1)
+        assert.equal(events[0].pending.length, 0)
+        assert.equal(session.isRunning, false)
+      })
+
+      it('destroy() clears the pending map', async () => {
+        session._emitToolHookEvent('PreToolUse', {
+          tool_use_id: 'toolu_bg_4',
+          tool_name: 'Bash',
+          tool_input: { command: 'sleep 600', run_in_background: true },
+        }, 'msg-bg-4')
+        session._emitToolHookEvent('PostToolUse', {
+          tool_use_id: 'toolu_bg_4',
+          tool_name: 'Bash',
+          tool_response: 'Command running in background with ID: tui-shell-4. Output…',
+        }, 'msg-bg-4')
+        assert.equal(session._pendingBackgroundShells.size, 1)
+        await session.destroy()
+        assert.equal(session._pendingBackgroundShells.size, 0)
+      })
+    })
   })
 
   // #4278: TUI sessions previously had ZERO handling for AskUserQuestion.

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -495,6 +495,160 @@ describe('SdkSession', () => {
       assert.equal(errors.length, 1)
       s.destroy()
     })
+
+    // #4307: background-shell tracking wired through SdkSession's
+    // tool_use → tool_result loop. Asserts: command stashing at
+    // tool_use time, BashOutput-triggered clearing, ignoring non-Bash
+    // run_in_background:false calls.
+    describe('#4307 — background-shell tracking', () => {
+      it('stashes the command on a run_in_background Bash tool_use', () => {
+        session._handleToolUseBlock('msg-1', {
+          name: 'Bash',
+          id: 'tu-bg-1',
+          input: { command: 'sleep 600', run_in_background: true },
+        })
+        assert.equal(session._pendingBackgroundCommands.get('tu-bg-1'), 'sleep 600')
+        // No shell registered yet — that happens on the matching tool_result.
+        assert.equal(session._pendingBackgroundShells.size, 0)
+      })
+
+      it('does not stash on a regular Bash call (no run_in_background flag)', () => {
+        session._handleToolUseBlock('msg-1', {
+          name: 'Bash',
+          id: 'tu-bg-2',
+          input: { command: 'ls' },
+        })
+        assert.equal(session._pendingBackgroundCommands.size, 0)
+      })
+
+      it('does not stash on a non-Bash tool with run_in_background:true (defensive)', () => {
+        // The flag is Bash-specific in Claude's tool surface — a non-Bash
+        // call with the field is a malformed payload; reject without
+        // poisoning the pending-commands map.
+        session._handleToolUseBlock('msg-1', {
+          name: 'Edit',
+          id: 'tu-bg-3',
+          input: { file_path: '/foo', run_in_background: true },
+        })
+        assert.equal(session._pendingBackgroundCommands.size, 0)
+      })
+
+      it('records a pending shell when the matching tool_result carries the canonical id', () => {
+        const events = []
+        session.on('background_work_changed', (e) => events.push(e))
+        session._handleToolUseBlock('msg-1', {
+          name: 'Bash',
+          id: 'tu-bg-4',
+          input: { command: 'sleep 600', run_in_background: true },
+        })
+        session._recordBackgroundShellsFromToolResults([
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu-bg-4',
+            content: 'Command running in background with ID: brk57kt6pm. Output…',
+          },
+        ])
+        assert.equal(session._pendingBackgroundShells.size, 1)
+        const entry = session._pendingBackgroundShells.get('brk57kt6pm')
+        assert.equal(entry.command, 'sleep 600')
+        assert.equal(entry.shellId, 'brk57kt6pm')
+        assert.ok(entry.startedAt > 0)
+        // The ephemeral command stash drops once promoted to a pending shell.
+        assert.equal(session._pendingBackgroundCommands.has('tu-bg-4'), false)
+        // background_work_changed fired with the new snapshot.
+        assert.equal(events.length, 1)
+        assert.equal(events[0].pending[0].shellId, 'brk57kt6pm')
+      })
+
+      it('extracts the id from an array-form content block (text-only blocks)', () => {
+        session._handleToolUseBlock('msg-1', {
+          name: 'Bash',
+          id: 'tu-bg-5',
+          input: { command: 'long-running', run_in_background: true },
+        })
+        session._recordBackgroundShellsFromToolResults([
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu-bg-5',
+            content: [
+              { type: 'text', text: 'Command running in background with ID: bg-abc-1.' },
+            ],
+          },
+        ])
+        assert.equal(session._pendingBackgroundShells.size, 1)
+        assert.ok(session._pendingBackgroundShells.has('bg-abc-1'))
+      })
+
+      it('isRunning reports waiting (true) once _isBusy clears but the shell is pending', () => {
+        session._handleToolUseBlock('msg-1', {
+          name: 'Bash',
+          id: 'tu-bg-6',
+          input: { command: 'sleep 600', run_in_background: true },
+        })
+        session._recordBackgroundShellsFromToolResults([
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu-bg-6',
+            content: 'Command running in background with ID: bg-6-id. Output…',
+          },
+        ])
+        // Simulate turn-end: _clearMessageState happens after `result`.
+        session._isBusy = true
+        session._clearMessageState()
+        assert.equal(session._isBusy, false)
+        // The waiting-on-background-work signal: isRunning stays true.
+        assert.equal(session.isRunning, true)
+        assert.equal(session._pendingBackgroundShells.size, 1)
+      })
+
+      it('clears the pending entry when the agent calls BashOutput with the matching bash_id', () => {
+        const events = []
+        // Set up a pending shell.
+        session._handleToolUseBlock('msg-1', {
+          name: 'Bash',
+          id: 'tu-bg-7',
+          input: { command: 'sleep 600', run_in_background: true },
+        })
+        session._recordBackgroundShellsFromToolResults([
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu-bg-7',
+            content: 'Command running in background with ID: shell-77. Output…',
+          },
+        ])
+        session.on('background_work_changed', (e) => events.push(e))
+        // Now the agent calls BashOutput on shell-77.
+        session._handleToolUseBlock('msg-2', {
+          name: 'BashOutput',
+          id: 'tu-bo-1',
+          input: { bash_id: 'shell-77' },
+        })
+        assert.equal(session._pendingBackgroundShells.size, 0)
+        assert.equal(session.isRunning, false)
+        assert.equal(events.length, 1)
+        assert.equal(events[0].pending.length, 0)
+      })
+
+      it('destroy() clears the pending map (no leak)', () => {
+        session._handleToolUseBlock('msg-1', {
+          name: 'Bash',
+          id: 'tu-bg-8',
+          input: { command: 'sleep 600', run_in_background: true },
+        })
+        session._recordBackgroundShellsFromToolResults([
+          {
+            type: 'tool_result',
+            tool_use_id: 'tu-bg-8',
+            content: 'Command running in background with ID: shell-88. Output…',
+          },
+        ])
+        assert.equal(session._pendingBackgroundShells.size, 1)
+        session.destroy()
+        assert.equal(session._pendingBackgroundShells.size, 0)
+        // Re-create one for the afterEach destroy to not double-destroy.
+        session = createSession()
+      })
+    })
   })
 
   // -- _clearMessageState --

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -1273,6 +1273,48 @@ describe('SessionManager.listSessions includes stdinDroppedTotals (#3573)', () =
   })
 })
 
+// #4307: pending-background-shells snapshot in session_list. A client
+// joining mid-flight (fresh tab, server reconnect, app resume) must
+// see the waiting state through the session-list snapshot without
+// waiting for the next `background_work_changed` event.
+describe('SessionManager.listSessions includes pendingBackgroundShells (#4307)', () => {
+  it('reads getPendingBackgroundShells() and surfaces the entries', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const pending = [
+      { shellId: 'a', command: 'sleep 600', startedAt: 100 },
+      { shellId: 'b', command: 'tail -f log', startedAt: 200 },
+    ]
+    const session = new EventEmitter()
+    session.isRunning = true
+    session.model = null
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.getPendingBackgroundShells = () => pending
+    session.destroy = () => {}
+    mgr._sessions.set('s-bg', { session, name: 'Waiting', cwd: '/tmp', createdAt: Date.now() })
+
+    const [entry] = mgr.listSessions()
+    assert.ok(Array.isArray(entry.pendingBackgroundShells))
+    assert.equal(entry.pendingBackgroundShells.length, 2)
+    assert.equal(entry.pendingBackgroundShells[0].shellId, 'a')
+    assert.equal(entry.pendingBackgroundShells[1].shellId, 'b')
+  })
+
+  it('defaults to an empty array for providers without the getter', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.model = null
+    session.permissionMode = 'approve'
+    Object.defineProperty(session, 'resumeSessionId', { get: () => null })
+    session.destroy = () => {}
+    mgr._sessions.set('s-old', { session, name: 'NoGetter', cwd: '/tmp', createdAt: Date.now() })
+
+    const [entry] = mgr.listSessions()
+    assert.deepEqual(entry.pendingBackgroundShells, [])
+  })
+})
+
 describe('SessionManager provider support', () => {
   it('defaults to claude-sdk provider', () => {
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -65,6 +65,7 @@ import {
   handleGitCommitResult,
   handleAgentSpawned,
   handleAgentCompleted,
+  handleBackgroundWorkChanged,
   handleEnvironmentList,
   handleEnvironmentError,
   handleAvailableModels,
@@ -100,6 +101,7 @@ import type {
   ConversationSummary,
   DevPreview,
   ModelInfo,
+  PendingBackgroundShell,
   SessionInfo,
 } from '../types'
 
@@ -3213,6 +3215,110 @@ describe('handleAgentCompleted', () => {
       'tu-1',
       'tu-3',
     ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #4307 — handleBackgroundWorkChanged
+// ---------------------------------------------------------------------------
+describe('handleBackgroundWorkChanged (#4307)', () => {
+  it('replaces the pending list with the server snapshot', () => {
+    const existing: PendingBackgroundShell[] = [
+      { shellId: 'old', command: 'sleep 1', startedAt: 100 },
+    ]
+    const builder = handleBackgroundWorkChanged(
+      {
+        sessionId: 'sess-1',
+        pending: [
+          { shellId: 'new', command: 'sleep 60', startedAt: 200 },
+        ],
+      },
+      'active-1',
+    )
+    expect(builder.sessionId).toBe('sess-1')
+    expect(builder.applyTo(existing)).toEqual([
+      { shellId: 'new', command: 'sleep 60', startedAt: 200 },
+    ])
+  })
+
+  it('returns the same array reference when the snapshot matches the current list', () => {
+    const existing: PendingBackgroundShell[] = [
+      { shellId: 'a', command: 'cmd-a', startedAt: 100 },
+      { shellId: 'b', command: 'cmd-b', startedAt: 200 },
+    ]
+    const builder = handleBackgroundWorkChanged(
+      {
+        pending: [
+          { shellId: 'a', command: 'cmd-a', startedAt: 100 },
+          { shellId: 'b', command: 'cmd-b', startedAt: 200 },
+        ],
+      },
+      'active-1',
+    )
+    const result = builder.applyTo(existing)
+    expect(result).toBe(existing)
+  })
+
+  it('returns an empty list when pending is empty (the "clear" path)', () => {
+    const existing: PendingBackgroundShell[] = [
+      { shellId: 'a', command: 'cmd-a', startedAt: 100 },
+    ]
+    const builder = handleBackgroundWorkChanged(
+      { pending: [] },
+      'active-1',
+    )
+    expect(builder.applyTo(existing)).toEqual([])
+  })
+
+  it('treats missing pending field as empty list (defensive fail-soft)', () => {
+    const builder = handleBackgroundWorkChanged({}, 'active-1')
+    expect(builder.applyTo([])).toEqual([])
+  })
+
+  it('drops entries missing shellId without rejecting the whole snapshot', () => {
+    const builder = handleBackgroundWorkChanged(
+      {
+        pending: [
+          { shellId: 'good', command: 'cmd', startedAt: 100 },
+          { command: 'no id', startedAt: 100 },
+          { shellId: '', command: 'empty', startedAt: 100 },
+        ],
+      },
+      'active-1',
+    )
+    const out = builder.applyTo([])
+    expect(out).toHaveLength(1)
+    expect(out[0]?.shellId).toBe('good')
+  })
+
+  it('defaults missing command to empty string', () => {
+    const builder = handleBackgroundWorkChanged(
+      { pending: [{ shellId: 'a', startedAt: 100 }] },
+      'active-1',
+    )
+    expect(builder.applyTo([])[0]?.command).toBe('')
+  })
+
+  it('defaults missing startedAt to current time', () => {
+    const before = Date.now()
+    const builder = handleBackgroundWorkChanged(
+      { pending: [{ shellId: 'a', command: 'cmd' }] },
+      'active-1',
+    )
+    const out = builder.applyTo([])
+    const after = Date.now()
+    expect(out[0]?.startedAt).toBeGreaterThanOrEqual(before)
+    expect(out[0]?.startedAt).toBeLessThanOrEqual(after)
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const builder = handleBackgroundWorkChanged({ pending: [] }, 'active-1')
+    expect(builder.sessionId).toBe('active-1')
+  })
+
+  it('returns null sessionId when neither is available', () => {
+    const builder = handleBackgroundWorkChanged({ pending: [] }, null)
+    expect(builder.sessionId).toBeNull()
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -25,6 +25,7 @@ import type {
   GitBranch,
   GitFileStatus,
   ModelInfo,
+  PendingBackgroundShell,
   SearchResult,
   ServerError,
   SessionInfo,
@@ -2265,6 +2266,98 @@ export function handleAgentCompleted(
       const filtered = current.filter((a) => a.toolUseId !== toolUseId)
       if (filtered.length === current.length) return current
       return filtered
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// #4307 — background_work_changed
+//
+// Snapshot-replacement: each event carries the full pending list for the
+// targeted session. The handler returns a builder mirroring the
+// agent_spawned/completed shape so the caller can gate on
+// `sessionStates[sessionId]` (a known session) before applying, matching
+// the surrounding handler conventions. Defensive against missing /
+// non-array `pending` field (returns []), missing session id (caller
+// treats as no-op), and malformed entries (skips fail-soft).
+// ---------------------------------------------------------------------------
+
+/**
+ * Builder returned by {@link handleBackgroundWorkChanged}. Mirrors
+ * {@link AgentInfoBuilder} / {@link ActiveToolBuilder}: callers gate
+ * on `sessionStates[sessionId]` and call `applyTo` with the current
+ * value to produce the next array (same reference when no change).
+ */
+export interface PendingBackgroundShellsBuilder {
+  sessionId: string | null
+  applyTo: (current: PendingBackgroundShell[]) => PendingBackgroundShell[]
+}
+
+/**
+ * Parse a `background_work_changed` message into a builder that
+ * replaces the session's `pendingBackgroundShells` slot with the
+ * server's authoritative snapshot.
+ *
+ * Why snapshot-replace (rather than per-id diff): the wire event always
+ * carries the full pending list (full-snapshot protocol — see
+ * `ServerBackgroundWorkChangedSchema` doc-comment), so the handler can
+ * be a flat replace. Late joiners catch up via `session_list`'s
+ * `pendingBackgroundShells` field; live updates come through this
+ * handler.
+ *
+ * Malformed entries (missing/non-string shellId, missing/non-number
+ * startedAt, missing/non-string command) are filtered out fail-soft so
+ * one bad row from a hypothetical future server can't make the whole
+ * list disappear.
+ */
+export function handleBackgroundWorkChanged(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): PendingBackgroundShellsBuilder {
+  const rawPending = Array.isArray(msg.pending) ? msg.pending : []
+  const next: PendingBackgroundShell[] = []
+  for (const raw of rawPending) {
+    if (!raw || typeof raw !== 'object') continue
+    const entry = raw as Record<string, unknown>
+    const shellId = typeof entry.shellId === 'string' ? entry.shellId : null
+    if (!shellId) continue
+    const command = typeof entry.command === 'string' ? entry.command : ''
+    const startedAt = typeof entry.startedAt === 'number' && entry.startedAt >= 0
+      ? entry.startedAt
+      : Date.now()
+    next.push({ shellId, command, startedAt })
+  }
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    applyTo: (current) => {
+      // Reference-equality short-circuit: same length AND same
+      // (shellId, startedAt, command) per index means no observable
+      // change. The dashboard's `updateSession` skips re-renders when
+      // the patch yields the same reference, so this matters for
+      // duplicate emissions (idempotent server pushes from
+      // pre-existing flows or reconnect-replay races).
+      if (next.length === current.length) {
+        let same = true
+        for (let i = 0; i < next.length; i++) {
+          const a = next[i]
+          const b = current[i]
+          // Index-in-bounds guard satisfies TS strict-null: `next` /
+          // `current` are equal length but `noUncheckedIndexedAccess`
+          // still types the element as `T | undefined`. The `!a || !b`
+          // path is unreachable given the bounds; treat as mismatch
+          // defensively.
+          if (!a || !b) {
+            same = false
+            break
+          }
+          if (a.shellId !== b.shellId || a.startedAt !== b.startedAt || a.command !== b.command) {
+            same = false
+            break
+          }
+        }
+        if (same) return current
+      }
+      return next
     },
   }
 }

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -27,6 +27,11 @@ export type {
   // #4308: ActiveTool — one entry per in-flight tool call, kept on
   // BaseSessionState.activeTools and driven by tool_start / tool_result.
   ActiveTool,
+  // #4307: PendingBackgroundShell — one entry per backgrounded Bash
+  // shell the session is still waiting on. Survives turn-end (the
+  // whole point of #4307); clears when the agent calls BashOutput or
+  // the session is destroyed.
+  PendingBackgroundShell,
   ConnectedClient,
   SessionHealth,
   SessionContext,
@@ -224,6 +229,7 @@ export type {
   ThinkingLevel,
   DevPreviewBuilder,
   AgentInfoBuilder,
+  PendingBackgroundShellsBuilder,
   ServerMode,
   AuthOkPayload,
   CheckpointRestoredPayload,
@@ -338,6 +344,7 @@ export {
   handleGitCommitResult,
   handleAgentSpawned,
   handleAgentCompleted,
+  handleBackgroundWorkChanged,
   handleEnvironmentList,
   handleEnvironmentError,
   handleAvailableModels,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -199,6 +199,15 @@ export interface SessionInfo {
   // because older servers don't include the field; renderers should
   // treat `undefined` as "no data, hide the badge."
   cumulativeUsage?: CumulativeUsage;
+  /**
+   * #4307: snapshot of backgrounded shells the session is still waiting
+   * on. Optional because pre-#4307 servers omit the field; consumers
+   * should treat `undefined` as `[]`. Always an array when present
+   * (#4307-aware servers send `[]` when no work is pending). The
+   * SessionInfo entry's value is the late-joiner seed; the live update
+   * channel is the `background_work_changed` event.
+   */
+  pendingBackgroundShells?: PendingBackgroundShell[];
 }
 
 export interface AgentInfo {
@@ -236,6 +245,30 @@ export interface ActiveTool {
   tool: string;
   serverName?: string;
   input?: unknown;
+  startedAt: number;
+}
+
+/**
+ * #4307 — one entry per backgrounded `Bash` shell the session is still
+ * waiting on. Mirrors the server-side `ServerPendingBackgroundShellSchema`.
+ *
+ * Driven by the `background_work_changed` event and seeded from the
+ * `session_list` snapshot's `pendingBackgroundShells` field for late
+ * joiners. The entry persists across turn-end (the whole point: the
+ * agent's turn finished but the shell is still running); it clears when
+ * the agent calls `BashOutput` on the matching id, or when the session
+ * is destroyed.
+ *
+ * `shellId` is the short alphanumeric token Claude prints in its
+ * "Command running in background with ID: <id>" tool_result (e.g.
+ * `brk57kt6pm`). `command` is the original Bash command text so the
+ * activity indicator can show "waiting on `<command>`" without a
+ * round-trip. `startedAt` is the server-side wall-clock at register
+ * time so elapsed-time display doesn't depend on client clock skew.
+ */
+export interface PendingBackgroundShell {
+  shellId: string;
+  command: string;
   startedAt: number;
 }
 
@@ -521,6 +554,21 @@ export interface BaseSessionState {
    * server-side schema landed by #4307.
    */
   activeTools: ActiveTool[];
+  /**
+   * #4307 — backgrounded shells the session is still waiting on. See
+   * {@link PendingBackgroundShell}. Driven by the
+   * `background_work_changed` event and seeded from the `session_list`
+   * snapshot for late joiners. Empty array when no work is pending —
+   * never `null` so the renderer's `.length` check is safe.
+   *
+   * Distinct from `activeTools`: those are in-flight tool calls in the
+   * CURRENT turn; pending background shells persist ACROSS turns until
+   * the agent acknowledges them (via `BashOutput`) or the session is
+   * destroyed. A session with no `activeTools` but a non-empty
+   * `pendingBackgroundShells` is the "waiting on background work"
+   * state the activity indicator surfaces.
+   */
+  pendingBackgroundShells: PendingBackgroundShell[];
   isPlanPending: boolean;
   planAllowedPrompts: { tool: string; prompt: string }[];
   primaryClientId: string | null;

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -26,6 +26,9 @@ describe('createEmptyBaseSessionState', () => {
       health: 'healthy',
       activeAgents: [],
       activeTools: [],
+      // #4307: empty array on init — populated by background_work_changed
+      // events and/or session_list snapshot seed.
+      pendingBackgroundShells: [],
       isPlanPending: false,
       planAllowedPrompts: [],
       primaryClientId: null,
@@ -45,6 +48,7 @@ describe('createEmptyBaseSessionState', () => {
     expect(a.messages).not.toBe(b.messages)
     expect(a.activeAgents).not.toBe(b.activeAgents)
     expect(a.activeTools).not.toBe(b.activeTools)
+    expect(a.pendingBackgroundShells).not.toBe(b.pendingBackgroundShells)
     expect(a.planAllowedPrompts).not.toBe(b.planAllowedPrompts)
     expect(a.mcpServers).not.toBe(b.mcpServers)
     expect(a.devPreviews).not.toBe(b.devPreviews)

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -81,6 +81,10 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     health: 'healthy',
     activeAgents: [],
     activeTools: [],
+    // #4307: empty until the first background_work_changed event or
+    // session_list snapshot arrives; null would force every renderer to
+    // .length-check against null, so an empty array is the safer default.
+    pendingBackgroundShells: [],
     isPlanPending: false,
     planAllowedPrompts: [],
     primaryClientId: null,


### PR DESCRIPTION
Closes #4307

## Summary

Chroxy now models backgrounded `Bash` shells (`run_in_background: true`) per session so a session waiting on background work is **distinct from idle** and is **never reaped** by `CHROXY_SESSION_TIMEOUT`. The dashboard / app get both a live `background_work_changed` event and a `pendingBackgroundShells` field on every `session_list` entry so late joiners catch up without a delta protocol.

This is the server / lifecycle half of #4307 (companion #4308 — the dashboard activity indicator — already shipped via PR #4399).

## What changes

### Server
- New `background-shells.js` helper: parses the canonical `Command running in background with ID: <id>` tool_result text, recognises `Bash` + `run_in_background: true`, and `BashOutput`'s `bash_id`.
- `BaseSession`:
  - Adds `_pendingBackgroundShells: Map<shellId, { shellId, command, startedAt }>` and an ephemeral `_pendingBackgroundCommands` (tool_use_id → command).
  - `trackBackgroundShell` / `clearBackgroundShell` / `getPendingBackgroundShells` with idempotent semantics; both push + clear emit `background_work_changed` carrying the full snapshot.
  - **`isRunning` now returns `_isBusy || pendingBackgroundShells.size > 0`** — the canonical change that prevents `SessionTimeoutManager` reaping.
  - `_clearMessageState` deliberately does **not** clear pending shells (the whole point — they survive turn-end). The only paths that clear are matching `BashOutput` or `destroy()`.
- `SdkSession`: `_handleToolUseBlock` stashes the command on `run_in_background:true` and clears on `BashOutput`; new `_recordBackgroundShellsFromToolResults` registers the shell when the matching tool_result lands. `destroy()` calls `_destroyPendingBackgroundShells`.
- `ClaudeTuiSession`: parity via `_emitToolHookEvent` — `PreToolUse` stashes / handles `BashOutput`, `PostToolUse` parses the canonical shellId text.
- `SessionManager`:
  - `background_work_changed` added to `builtinTransient` so the event proxies transparently.
  - `listSessions()` includes `pendingBackgroundShells: session.getPendingBackgroundShells()` (defaults to `[]` for providers without the getter).
- `event-normalizer.js`: new normaliser route for `background_work_changed` that emits the wire message **and** a `session_list` side effect (refreshes the SessionInfo snapshot for clients that render off the list).
- `ws-server.js`: documents the new event in the Server -> Client doc-comment (satisfies `handler-coverage.test.js`).

### Protocol
- New `ServerPendingBackgroundShellSchema` (`shellId`, `command`, `startedAt`).
- New `ServerBackgroundWorkChangedSchema` (`sessionId`, `pending[]`).
- `ServerSessionListEntrySchema.pendingBackgroundShells` optional array.

### store-core
- New `PendingBackgroundShell` type.
- `BaseSessionState.pendingBackgroundShells: PendingBackgroundShell[]` — defaulted to `[]` in `createEmptyBaseSessionState`.
- `SessionInfo.pendingBackgroundShells?` (optional for pre-#4307 servers).
- New `handleBackgroundWorkChanged` builder (snapshot replacement) with reference-equality short-circuit when next === current.

### Dashboard + App
- Both message-handlers dispatch `background_work_changed` to the shared handler and seed the slot from `session_list`. Dashboard adds a stable `EMPTY_PENDING_BACKGROUND_SHELLS` for the flat-state fallback (matches the #4308 pattern).

## Design decisions

- **Event + snapshot field (both)** — per the issue's "recommend doing both". Late joiners get `pendingBackgroundShells` on every `session_list` snapshot; live updates flow through `background_work_changed`.
- **Full snapshot on each event (no delta protocol)** — pending sets are tiny (typically 0 or 1 entries) and events fire rarely; the wire cost is negligible and the consumer logic is a flat replace.
- **SDK no-next-turn behaviour: entry persists until `destroy()` or a matching `BashOutput` call.** Documented as the issue requested. We deliberately do NOT try to tail the output file ourselves — that's a separate sidecar lifecycle problem the issue body explicitly flagged as out of scope.
- **TUI parity shipped in this PR.** The PreToolUse / PostToolUse hook flow already exists for tool_start / tool_result; layering the same parser surface was small and avoided a split-PR follow-up.
- **Pending shells survive `_clearMessageState` (turn-end) by construction** — clearing them there would defeat the whole purpose of #4307. The only clear paths are the agent's `BashOutput` (acknowledged the shell) or `destroy()` (no leak).
- **No per-turn time decay.** The agent owns the lifecycle signal; if the agent forgets to `BashOutput`, the entry sits there until destroy. That's the documented contract.

## Test plan

- [x] `node --test packages/server/tests/background-shells.test.js` — 21 new tests
- [x] `node --test packages/server/tests/sdk-session.test.js` — 8 new SDK-side tests
- [x] `node --test packages/server/tests/claude-tui-session.test.js` — 4 new TUI-side tests
- [x] `node --test packages/server/tests/session-manager.test.js` — 2 new listSessions tests
- [x] `vitest run packages/store-core/src/handlers/handlers.test.ts` — 9 new handler tests
- [x] `tsc --noEmit` clean across protocol / store-core / dashboard
- [x] Full server test suite: 5739/5745 pass (the 2 failures — `WebTaskManager` feature detection and `encryption integration` — are pre-existing flaky tests; both pass when run standalone)
- [x] Full dashboard suite: 2171/2171 pass
- [x] Full store-core suite: 865/865 pass
- [x] Full app suite: 1299/1299 pass
- [x] Full protocol suite: 139/139 pass (handler-coverage contract enforced)

Key invariants pinned by the new tests:
- Parser: canonical text → shellId; whitespace-only / non-matching → null
- `isRunning` is `true` when `_isBusy=false` AND `pendingBackgroundShells.size > 0`
- `_clearMessageState` (turn-end) does NOT clear pending shells
- `destroy()` clears the pending map (no leak)
- `SessionTimeoutManager` skips waiting sessions
- `background_work_changed` event fires on push AND clear
- `session_list` snapshot includes `pendingBackgroundShells`
- TUI + SDK paths produce parity behaviour