### PR TITLE
feat(dashboard): surface pending background shells in ActivityIndicator (#4418)

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * ActivityIndicator pending-background-shell surfacing (#4418).
+ *
+ * PR #4416 landed the server-side tracking + protocol surface for backgrounded
+ * Bash shells. The dashboard store populates `sessionStates[id]
+ * .pendingBackgroundShells` via `handleBackgroundWorkChanged` and the
+ * `session_list` seed. This test locks in the ActivityIndicator's renderer
+ * half: when an idle session is still waiting on background work, the chip
+ * surfaces "Waiting on background work" with the command text, rather than
+ * disappearing entirely. During an active turn the existing "Running <tool>"
+ * label dominates — pending shells are SECONDARY.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ActivityIndicator } from './ActivityIndicator'
+
+let storeState: Record<string, unknown> = {}
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: unknown) => unknown) => {
+    const sessionStates: Record<string, unknown> = (storeState.sessionStates as Record<string, unknown>) ?? {}
+    const store = {
+      activeSessionId: storeState.activeSessionId ?? 'sess-1',
+      sessionStates,
+      serverResultTimeoutMs: storeState.serverResultTimeoutMs ?? 30 * 60 * 1000,
+    }
+    return selector(store)
+  },
+}))
+
+// Same useShallow pass-through pattern the inflight tests use — the mocked
+// store selector returns the projection object directly.
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: (fn: unknown) => fn,
+}))
+
+afterEach(() => cleanup())
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('ActivityIndicator — pending background shells (#4418)', () => {
+  it('renders "Waiting on background work" with the command text when idle and one shell is pending', () => {
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'brk57kt6pm', command: 'npm run build', startedAt: now - 10_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toMatch(/Waiting on background work/)
+    expect(label.textContent).toMatch(/npm run build/)
+  })
+
+  it('uses the most-recently-started shell when multiple are pending', () => {
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'oldid01', command: 'sleep 60', startedAt: now - 30_000 },
+            { shellId: 'newid02', command: 'npm test', startedAt: now - 5_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toMatch(/Waiting on background work/)
+    expect(label.textContent).toMatch(/npm test/)
+    expect(label.textContent).not.toMatch(/sleep 60/)
+  })
+
+  it('falls back to the shellId when the command text is empty', () => {
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'brk57kt6pm', command: '', startedAt: now - 4_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toMatch(/Waiting on background work/)
+    expect(label.textContent).toMatch(/brk57kt6pm/)
+  })
+
+  it('does not shadow the "Running <tool>" label during an active turn', () => {
+    // _isBusy=true (isIdle=false) with both an in-flight tool AND a pending
+    // background shell: the existing tool label must win. Pending shells are
+    // SECONDARY during a live turn — they only surface when the turn ends.
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: false,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [
+            { toolUseId: 'tu-1', tool: 'WebFetch', startedAt: now - 3_000 },
+          ],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'brk57kt6pm', command: 'npm run build', startedAt: now - 10_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toMatch(/Running\s+WebFetch/)
+    expect(label.textContent).not.toMatch(/Waiting on background work/)
+  })
+
+  it('renders nothing when idle with no pending background shells (regression)', () => {
+    // Pre-#4418 behaviour: idle session renders nothing. Pin this so the new
+    // surface only activates when shells are actually pending.
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: Date.now() - 1_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [],
+          inactivityWarning: null,
+        },
+      },
+    }
+    const { container } = render(<ActivityIndicator />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when idle with pendingBackgroundShells undefined (pre-#4307 server)', () => {
+    // Older servers omit the field entirely — consumers must treat undefined
+    // as "no pending work" rather than crashing or rendering a chip.
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: Date.now() - 1_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          inactivityWarning: null,
+        },
+      },
+    }
+    const { container } = render(<ActivityIndicator />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -137,6 +137,8 @@ export function ActivityIndicator() {
     serverName: inFlightServerName,
     agentDescription,
     agentStartedAt,
+    pendingShellCommand,
+    pendingShellId,
   } = useConnectionStore(
     useShallow((s) => {
       const id = s.activeSessionId
@@ -158,12 +160,26 @@ export function ActivityIndicator() {
       const mostRecentAgent = activeAgents && activeAgents.length > 0
         ? activeAgents[activeAgents.length - 1]!
         : null
+      // #4418 — surface the most-recently-started pending background shell so
+      // the chip can say "Waiting on background work" when the turn ends but
+      // the session is still parked on a backgrounded Bash command. We project
+      // only the visible primitives (command + shellId) so `useShallow` bails
+      // out on no-op `pendingBackgroundShells[]` reference swaps (e.g. when
+      // another session's `background_work_changed` re-seeds the slot).
+      const pendingShells = ss?.pendingBackgroundShells
+      const mostRecentShell = pendingShells && pendingShells.length > 0
+        ? pendingShells.reduce((latest, s) =>
+            s.startedAt > latest.startedAt ? s : latest,
+          )
+        : null
       return {
         tool: inFlight?.tool ?? null,
         startedAt: inFlight?.startedAt ?? null,
         serverName: inFlight?.serverName ?? null,
         agentDescription: mostRecentAgent?.description ?? null,
         agentStartedAt: mostRecentAgent?.startedAt ?? null,
+        pendingShellCommand: mostRecentShell?.command ?? null,
+        pendingShellId: mostRecentShell?.shellId ?? null,
       }
     }),
   )
@@ -182,7 +198,37 @@ export function ActivityIndicator() {
     return () => window.clearInterval(id)
   }, [isIdle])
 
-  if (isIdle) return null
+  if (isIdle) {
+    // #4418 — when the turn ends but the agent backgrounded a Bash shell, the
+    // session is still effectively waiting on work. Surface that as a chip so
+    // the user can tell "idle and done" from "idle but parked on a long-
+    // running shell". We project the most-recently-started shell's command
+    // (falling back to its shellId when the command string is empty) — the
+    // full list is a deferred stretch goal per #4418's body. The chip uses
+    // the same neutral green styling as the connect-race fallback rather
+    // than the elapsed-driven color escalation; pending shells aren't a
+    // timeout candidate the way an agent turn is.
+    if (pendingShellCommand != null || pendingShellId != null) {
+      const detail = (pendingShellCommand && pendingShellCommand.length > 0)
+        ? pendingShellCommand
+        : pendingShellId!
+      return (
+        <div
+          className="activity-indicator activity-indicator--green"
+          aria-label="Waiting on background work"
+        >
+          <span className="activity-indicator__dot" aria-hidden="true" />
+          <span
+            className="activity-indicator__label"
+            data-testid="activity-indicator-label"
+          >
+            Waiting on background work · {detail}
+          </span>
+        </div>
+      )
+    }
+    return null
+  }
   if (lastActivityAt == null) {
     // Busy but we haven't seen an activity event yet (race on connect).
     // Render the indicator in its baseline green state without an elapsed
@@ -217,17 +263,17 @@ export function ActivityIndicator() {
   const approaching = remaining > 0 && remaining <= 60_000
   const klass = statusClass(elapsed, referenceTimeoutMs)
 
-  // #4308 — preference order:
+  // #4308 — preference order during an active turn (`_isBusy === true`):
   //   1. Active sub-agent (description + elapsed since its startedAt) — more
   //      specific than the parent's `Task` tool wrapper.
   //   2. In-flight tool (name + elapsed since its startedAt) — both
   //      activeTools (live) and the derive-from-messages fallback.
   //   3. Generic "Working… last activity Ns ago" — no current named work.
   //
-  // TODO(#4307): when the server lands background-shell task tracking, slot
-  // pending background work between #2 and #3 here ("1 background task
-  // running"). Schema lives in #4307; the activeTools[]-style array should
-  // be sufficient.
+  // #4418 — pending background shells are surfaced ONLY when the session is
+  // idle (handled above). During an active turn the live tool/agent label
+  // dominates; pending shells are SECONDARY per the issue's acceptance
+  // criteria and intentionally do not enter the preference order here.
   let label: string
   if (agentDescription != null && agentStartedAt != null) {
     label = `Running ${agentDescription} · ${formatDuration(now - agentStartedAt)}`


### PR DESCRIPTION
Closes #4418

## Summary

Resolves the `TODO(#4307)` marker in `packages/dashboard/src/components/ActivityIndicator.tsx`. PR #4416 landed the server-side tracking + protocol surface for backgrounded Bash shells; this PR is the dashboard renderer half.

When a session is idle (`_isBusy === false`) AND `pendingBackgroundShells.length > 0`, the ActivityIndicator now renders a chip:

> Waiting on background work · `<command text or shellId>`

Picks the most-recently-started shell by `startedAt` rather than insertion order so a re-seed from `session_list` lands on the user-visible "newest" entry. Falls back to `shellId` when the command text is empty.

## Behaviour

- **Idle + 0 shells** → renders nothing (unchanged from pre-#4418).
- **Idle + 1+ shells** → chip with most-recently-started command.
- **Busy + 1+ shells** → existing `Running <tool>` / sub-agent label dominates. Pending shells are SECONDARY per the issue's acceptance criteria.
- **Pre-#4307 server (field undefined)** → treated as empty, renders nothing.

## Tests

6 new cases in `ActivityIndicator.pendingShells.test.tsx`:
- single shell renders command text
- multiple shells render the most-recently-started one
- empty command text falls back to shellId
- active turn's `Running <tool>` is NOT shadowed
- regression: idle + empty array renders nothing
- backwards-compat: idle + undefined renders nothing

## Deferred

The mobile-app surface (`SessionListItem` / chat header) is explicitly deferred per #4418's body — separate sub-task.

The "full list visible on expand/hover" stretch goal is deferred per the issue body. The chip surfaces the most-recently-started one only.

## Test plan

- [x] `cd packages/dashboard && npm test -- --run` — 2177 passed
- [x] `cd packages/dashboard && npm run typecheck` — clean
- [ ] Manually verify in dashboard that backgrounding a long-running `sleep 60 &` Bash shell from Claude Code surfaces the chip after turn end and clears when the agent calls `BashOutput`