### PR TITLE
chore: bump version to 0.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.11] - 2026-05-28
+
+Focused release shipping the long-standing dogfood pain point: TUI / SDK sessions waiting on a backgrounded shell no longer look idle/dead and can no longer be reaped by `CHROXY_SESSION_TIMEOUT`. Closes #4307 (the `priority:high` server bug) plus its dashboard renderer follow-up #4418, completing the user-visible feature in a single version.
+
+### Added
+
+- **Server tracks pending `run_in_background` shells per session (#4307 / #4416):** new `background-shells.js` module + Zod schema in `@chroxy/protocol`. `BaseSession._pendingBackgroundShells` is populated when a `Bash` tool result carries `"Command running in background with ID: <id>"`, cleared when a matching `BashOutput` arrives, and cleared on `destroy()`. Both `claude-tui` (PTY) and SDK providers ship with full parity. Exposed to clients via a new WS event `background_work_changed` *and* extended the session-list snapshot field so late-joiners catch up — store-core handlers mirror the `activeTools` pattern from #4308. Two follow-ups tracked: [#4417](https://github.com/blamechris/chroxy/issues/4417) (persist across restart or document as transient) and [#4418](https://github.com/blamechris/chroxy/issues/4418) (renderer — landed in this release).
+- **ActivityIndicator surfaces "Waiting on background work" with command text (#4418 / #4419):** renderer companion to #4307. When `isIdle && pendingBackgroundShells.length > 0`, the dashboard chip shows the pending shell instead of "Idle". When `_isBusy === true`, the existing "Running <tool>" path still wins — pending shells are a secondary indicator during an active turn. Multi-shell case picks the most-recently-started one for the chip; full-list disclosure deferred to [#4421](https://github.com/blamechris/chroxy/issues/4421). Mobile-app surface deferred to [#4422](https://github.com/blamechris/chroxy/issues/4422); chip text overflow handling deferred to [#4420](https://github.com/blamechris/chroxy/issues/4420).
+
+### Fixed
+
+- **Waiting sessions are no longer reaped by `CHROXY_SESSION_TIMEOUT` (#4307 / #4416):** `BaseSession.isRunning` now also reports true when `_pendingBackgroundShells.size > 0`, so the idle-timeout skip-check in `SessionTimeoutManager` treats waiting sessions as not-idle. Operators running with the timeout enabled will no longer lose long-running background work. The 2h hard-cap (`base-session.js:53`) still applies — the assumption is that a real foreground turn will resume before then to surface the completion notification.
+
 ## [0.9.10] - 2026-05-28
 
 Same-day follow-up to v0.9.9. Same theme — dashboard polish and dogfood-driven correctness — picking up everything #4396 spilled over, plus stale Codex context-window values, customizable keyboard shortcuts, and three small follow-ups to v0.9.9's thinking-keyword work.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.10"
+      "version": "0.9.11"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.10",
+    "version": "0.9.11",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.10</string>
+    <string>0.9.11</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.10"
+version = "0.9.11"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump from 0.9.10 → 0.9.11.

Ships the full #4307 user-visible feature in one version: server tracks pending background shells (#4416), waiting sessions no longer reaped, and the dashboard ActivityIndicator renderer surfaces them (#4419).

- **Added:** server-side tracking + WS event + snapshot field (#4307 / #4416), ActivityIndicator chip (#4418 / #4419)
- **Fixed:** waiting sessions can't be reaped by `CHROXY_SESSION_TIMEOUT` (#4307 / #4416)

15 files bumped by `scripts/bump-version.sh 0.9.11`.

## Test plan

- [ ] CI green
- [ ] CHANGELOG reads cleanly