### PR TITLE
docs(server): document pendingBackgroundShells as transient (#4417)

### DIFF
--- a/packages/server/src/background-shells.js
+++ b/packages/server/src/background-shells.js
@@ -15,6 +15,13 @@
  * We do not depend on the format of the surrounding sentence — only on
  * the canonical `Command running in background with ID: <token>` opener,
  * which has been stable across the claude versions chroxy targets.
+ *
+ * #4417: the pending-shells map populated via these helpers lives in
+ * memory only and is intentionally NOT persisted across server
+ * restart. See `BaseSession._pendingBackgroundShells` for the full
+ * rationale — short version: the OS-level shells are owned by claude,
+ * not chroxy, so a restored map would be stale and the activity
+ * indicator would lie. Dropping the map on restart is the safe choice.
  */
 
 // `[A-Za-z0-9_-]+` is intentionally tight — every shell id observed so

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -204,6 +204,28 @@ export class BaseSession extends EventEmitter {
     // sidecar lifecycle problem, out of scope).
     // TUI provider: same parity — the agent's next turn surfaces the
     // BashOutput call and clears the entry naturally.
+    //
+    // #4417: TRANSIENT BY DESIGN — this map is in-memory only and is
+    // NOT serialized to `~/.chroxy/session-state.json`. A server
+    // restart drops every entry. This is the correct behaviour, not an
+    // oversight:
+    //   - The actual OS-level background shells are owned by the
+    //     claude TUI / SDK runtime, not by chroxy. On server restart
+    //     those processes have either died with the parent or have
+    //     been orphaned beyond chroxy's ability to correlate (we never
+    //     held the PID, only the opaque shellId Claude printed).
+    //   - Persisting the list would therefore re-surface a "waiting
+    //     on <command>" indicator that is at best stale and at worst a
+    //     UX lie — chroxy can't deliver a clear signal because the
+    //     shellId is meaningless to the new claude process.
+    //   - The agent re-discovers reality on its next turn via its own
+    //     context (a fresh `BashOutput` poll, or a `Bash` re-dispatch).
+    //     The user-facing consequence of dropping the map is that the
+    //     activity chip briefly shows idle until the next agent turn —
+    //     a minor, recoverable UX nit, not data loss.
+    // If a future change ever needs to persist this state, it MUST
+    // also reconcile with the (unknown) post-restart claude side —
+    // blindly restoring a stale Map will lock the indicator on forever.
     this._pendingBackgroundShells = new Map()
     // #4307: ephemeral map of recent `Bash` tool_uses dispatched with
     // `run_in_background: true`, keyed by toolUseId. Used to recover the


### PR DESCRIPTION
## Summary

Closes #4417.

PR #4416 (which closed #4307) added `_pendingBackgroundShells: Map<shellId, {shellId, command, startedAt}>` to `BaseSession`. The map is in-memory only — it is not written to `~/.chroxy/session-state.json` and is dropped on server restart. #4417 asked us to either persist it or explicitly document why we don't.

This PR takes the document-as-transient path (option A in #4417). Rationale captured in the new JSDoc:

- OS-level background shells are owned by the claude TUI / SDK runtime, not chroxy. After a restart their PIDs are either dead or orphaned beyond chroxy's ability to correlate — we never held the PID, only the opaque shellId Claude printed.
- Persisting the map would re-surface a "waiting on `<command>`" activity chip that chroxy can never clear, because the shellId is meaningless to the new claude process. That's a worse UX than briefly showing idle until the agent's next turn re-syncs reality.
- Documenting the choice in-code stops a future PR from re-adding "persist for safety" without first solving the claude-side reconciliation problem.

## Changes

- `packages/server/src/base-session.js` — extended the JSDoc block on `_pendingBackgroundShells` with a `#4417: TRANSIENT BY DESIGN` section explaining the non-persistence rationale and the user-facing consequence (briefly-stale activity chip, not data loss).
- `packages/server/src/background-shells.js` — added a short module-level pointer to the BaseSession comment so the helper module is self-documenting too.

## Test plan

- [x] `node --test tests/background-shells.test.js tests/base-session.test.js` — 115 tests pass
- [x] Diff is comment-only, no behaviour change