### PR TITLE
feat(app): surface pending background shells on mobile SessionListItem + chat header (#4422)

### DIFF
--- a/packages/app/src/__tests__/components/SessionPickerPendingShells.test.ts
+++ b/packages/app/src/__tests__/components/SessionPickerPendingShells.test.ts
@@ -1,0 +1,62 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * SessionPicker pill chip — pending-background-shell badge (#4422).
+ *
+ * Companion to the dashboard's ActivityIndicator pending-shells surface
+ * (#4419 / #4418). The mobile parity surface lives in two places:
+ *
+ *  1. The ActivityIndicator (active-session chat header) — covered by
+ *     packages/app/src/components/__tests__/ActivityIndicator.pendingShells.test.tsx.
+ *  2. The SessionPicker pill (sessions-list row) — covered here.
+ *
+ * The pill renders a small "z" badge when a session is otherwise idle but
+ * has pendingBackgroundShells, so users on the phone can spot "idle and
+ * done" vs "idle but parked on a backgrounded shell" without opening the
+ * session. Source-text assertions follow the existing
+ * SessionPickerProviderBadge.test.ts pattern.
+ */
+describe('SessionPicker pill chip — pending-background-shell badge (#4422)', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../components/SessionPicker.tsx'),
+    'utf-8',
+  );
+
+  const pillStartIdx = source.indexOf('function SessionPill');
+  const pillEndIdx = source.indexOf('interface SessionPickerProps', pillStartIdx);
+  if (pillStartIdx < 0 || pillEndIdx < 0 || pillEndIdx <= pillStartIdx) {
+    throw new Error(
+      'Unable to locate the SessionPill render block in SessionPicker.tsx',
+    );
+  }
+  const pillSection = source.slice(pillStartIdx, pillEndIdx);
+
+  it('takes a pendingShellCount prop on the pill so the badge gates on it', () => {
+    // The picker passes pendingBackgroundShells.length down from
+    // sessionStates — the pill component needs the value plumbed in.
+    expect(pillSection).toMatch(/pendingShellCount/);
+  });
+
+  it('only renders the pending-shells indicator when idle (showBusy=false) and the count > 0', () => {
+    // Pending shells are SECONDARY: when the session is actively busy,
+    // the existing PulsingDot wins. Pre-merge regression lock — match
+    // the gate so a future refactor that flips it gets caught.
+    expect(pillSection).toMatch(/!showBusy[\s\S]*pendingShellCount\s*>\s*0/);
+  });
+
+  it('renders a pendingShellsDot inside the indicators view with its dedicated style', () => {
+    expect(pillSection).toMatch(/styles\.pendingShellsDot/);
+  });
+
+  it('SessionPicker passes pendingBackgroundShells.length to the pill', () => {
+    // The picker reads sessionStates[sessionId]?.pendingBackgroundShells
+    // and projects the length down to the pill. Source-text check that
+    // the wiring is in place.
+    expect(source).toMatch(/pendingBackgroundShells\?\.length/);
+  });
+
+  it('styles.pendingShellsDot is defined in the StyleSheet', () => {
+    expect(source).toMatch(/pendingShellsDot:\s*\{/);
+  });
+});

--- a/packages/app/src/components/ActivityIndicator.tsx
+++ b/packages/app/src/components/ActivityIndicator.tsx
@@ -80,6 +80,15 @@ export function ActivityIndicator() {
     const id = s.activeSessionId;
     return id ? s.sessionStates[id]?.messages ?? null : null;
   });
+  // #4422 — subscribe to pendingBackgroundShells so the idle-state surface
+  // can name the most-recently-started backgrounded shell. Mirrors the
+  // dashboard's #4419 surface but adapted to React Native. The store
+  // immutably swaps this array on `background_work_changed`, so this only
+  // re-renders when the slot actually mutates.
+  const pendingBackgroundShells = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id ? s.sessionStates[id]?.pendingBackgroundShells ?? null : null;
+  });
   const referenceTimeoutMs = useConnectionLifecycleStore(
     (s) => s.serverResultTimeoutMs ?? FALLBACK_TIMEOUT_MS,
   );
@@ -104,6 +113,20 @@ export function ActivityIndicator() {
     return null;
   }, [messages]);
 
+  // #4422 — most-recently-started pending background shell, projected so the
+  // idle-state surface can name it. Mirrors the dashboard's #4419 approach:
+  // when the turn ends but a shell is still parked in the background, the
+  // chip says "Waiting on background work · <command>" instead of vanishing.
+  // We fall back to the shellId when the command string is empty so the chip
+  // always has something concrete to show.
+  const pendingShell = useMemo<{ command: string; shellId: string } | null>(() => {
+    if (!pendingBackgroundShells || pendingBackgroundShells.length === 0) return null;
+    const latest = pendingBackgroundShells.reduce((acc, s) =>
+      s.startedAt > acc.startedAt ? s : acc,
+    );
+    return { command: latest.command, shellId: latest.shellId };
+  }, [pendingBackgroundShells]);
+
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     if (isIdle) return;
@@ -111,7 +134,39 @@ export function ActivityIndicator() {
     return () => clearInterval(id);
   }, [isIdle]);
 
-  if (isIdle) return null;
+  if (isIdle) {
+    // #4422 — when the turn ends but the agent backgrounded a Bash shell, the
+    // session is still effectively waiting on work. Surface that as a chip so
+    // the user can tell "idle and done" from "idle but parked on a long-
+    // running shell". Single-shell case: project the most-recently-started
+    // shell's command (falling back to its shellId when the command is
+    // empty). Multi-shell expand UI is deferred per #4418's body — for now
+    // the full command list rides on the chip's accessibilityLabel so screen-
+    // reader users still hear every entry. Pending shells are SECONDARY:
+    // during an active turn the live tool label wins (the busy branch below
+    // handles that).
+    if (pendingShell) {
+      const detail = pendingShell.command.length > 0 ? pendingShell.command : pendingShell.shellId;
+      const fullList = (pendingBackgroundShells ?? [])
+        .map((s) => (s.command.length > 0 ? s.command : s.shellId))
+        .join(', ');
+      return (
+        <View style={styles.container}>
+          <View style={[styles.dot, { backgroundColor: COLORS.accentGreen }]} />
+          <Text
+            style={[styles.label, { color: COLORS.accentGreen }]}
+            accessibilityRole="text"
+            accessibilityLabel={`Waiting on background work: ${fullList}`}
+            testID="activity-indicator-label"
+            numberOfLines={1}
+          >
+            Waiting on background work · {detail}
+          </Text>
+        </View>
+      );
+    }
+    return null;
+  }
 
   if (lastActivityAt == null) {
     return (

--- a/packages/app/src/components/SessionPicker.tsx
+++ b/packages/app/src/components/SessionPicker.tsx
@@ -50,16 +50,29 @@ interface SessionPillProps {
   isActive: boolean;
   health: SessionHealth;
   notificationCount: number;
+  // #4422 — number of backgrounded shells the session is still waiting on.
+  // Projected from sessionStates[id]?.pendingBackgroundShells?.length so the
+  // pill can surface a "z" dot when the session is idle but parked on a
+  // long-running shell. SECONDARY to the busy pulse — the busy dot wins
+  // during an active turn.
+  pendingShellCount: number;
   onPress: () => void;
   onLongPress: () => void;
   onLayout: (e: LayoutChangeEvent) => void;
 }
 
-function SessionPill({ session, isActive, health, notificationCount, onPress, onLongPress, onLayout }: SessionPillProps) {
+function SessionPill({ session, isActive, health, notificationCount, pendingShellCount, onPress, onLongPress, onLayout }: SessionPillProps) {
   const isCrashed = health === 'crashed';
   const hasNotification = notificationCount > 0 && !isActive;
   const showBusy = !isCrashed && session.isBusy;
-  const hasIndicators = isCrashed || showBusy || hasNotification;
+  // #4422 — only surface the pending-shells dot when the session is idle
+  // (showBusy=false). During an active turn the busy pulse already conveys
+  // "work happening"; the pending-shells indicator is for the "idle but
+  // waiting on background work" gap the dashboard ActivityIndicator now
+  // surfaces (#4419). Skip on crashed too — a crashed session's red dot is
+  // the more urgent signal.
+  const showPendingShells = !isCrashed && !showBusy && pendingShellCount > 0;
+  const hasIndicators = isCrashed || showBusy || hasNotification || showPendingShells;
   // Mobile parity with dashboard SessionBar chips (#3940): surface the
   // provider's short label as a small badge on the pill so claude-tui,
   // codex, gemini, docker-cli, etc. are distinguishable at-a-glance
@@ -82,14 +95,15 @@ function SessionPill({ session, isActive, health, notificationCount, onPress, on
       onLayout={onLayout}
       activeOpacity={0.7}
       accessibilityRole="tab"
-      accessibilityLabel={`Session ${session.name}${providerInfo ? `, ${providerInfo.short} provider` : ''}${session.worktree ? ', isolated worktree' : ''}`}
+      accessibilityLabel={`Session ${session.name}${providerInfo ? `, ${providerInfo.short} provider` : ''}${session.worktree ? ', isolated worktree' : ''}${showPendingShells ? `, waiting on ${pendingShellCount} background ${pendingShellCount === 1 ? 'shell' : 'shells'}` : ''}`}
       accessibilityState={{ selected: isActive }}
-      accessibilityHint={isCrashed ? 'Session has crashed and needs attention' : showBusy ? 'Session is currently processing' : undefined}
+      accessibilityHint={isCrashed ? 'Session has crashed and needs attention' : showBusy ? 'Session is currently processing' : showPendingShells ? 'Session is idle but waiting on a backgrounded shell' : undefined}
     >
       {hasIndicators && (
         <View style={styles.indicators} importantForAccessibility="no-hide-descendants" accessibilityElementsHidden>
           {isCrashed && <View style={styles.crashDot} />}
           {showBusy && <PulsingDot />}
+          {showPendingShells && <View style={styles.pendingShellsDot} />}
           {hasNotification && <NotificationBadge count={notificationCount} />}
         </View>
       )}
@@ -283,6 +297,11 @@ export function SessionPicker({ onCreatePress }: SessionPickerProps) {
             isActive={session.sessionId === activeSessionId}
             health={sessionStates[session.sessionId]?.health || 'healthy'}
             notificationCount={notificationCounts.get(session.sessionId) || 0}
+            // #4422 — project the per-session pendingBackgroundShells count
+            // from sessionStates. `?? 0` covers both pre-#4307 servers (field
+            // is undefined) and sessions whose state slot hasn't been seeded
+            // yet (no entry in sessionStates).
+            pendingShellCount={sessionStates[session.sessionId]?.pendingBackgroundShells?.length ?? 0}
             onPress={() => switchSession(session.sessionId)}
             onLongPress={() => handleLongPress(session)}
             onLayout={(e) => handlePillLayout(session.sessionId, e)}
@@ -427,6 +446,17 @@ const styles = StyleSheet.create({
     height: 6,
     borderRadius: 3,
     backgroundColor: COLORS.accentBlue,
+  },
+  // #4422 — pending-background-shell dot. Static (no pulse) and styled
+  // green to match the dashboard ActivityIndicator chip (#4419) — both
+  // surfaces say the same thing in the same colour: "idle, but parked on
+  // backgrounded work". Distinct from the blue busyDot (pulsing) so users
+  // can tell the two states apart at-a-glance.
+  pendingShellsDot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: COLORS.accentGreen,
   },
   badge: {
     minWidth: 16,

--- a/packages/app/src/components/__tests__/ActivityIndicator.pendingShells.test.tsx
+++ b/packages/app/src/components/__tests__/ActivityIndicator.pendingShells.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * ActivityIndicator pending-background-shell surfacing on mobile (#4422).
+ *
+ * Mobile parity for the dashboard ActivityIndicator pending-shells surface
+ * landed in #4419 (dashboard tests live at
+ * `packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx`).
+ *
+ * The store-core slice already populates
+ * `sessionStates[id].pendingBackgroundShells` via `handleBackgroundWorkChanged`
+ * and the `session_list` seed (#4416 / #4307). This test locks in the
+ * mobile renderer half: when an idle session is still waiting on background
+ * work, the chip surfaces "Waiting on background work" with the command
+ * text rather than disappearing entirely. During an active turn the existing
+ * "Running <tool>" label dominates — pending shells are SECONDARY.
+ *
+ * Pattern matches the sibling ActivityIndicator.test.tsx — react-test-renderer
+ * + act, Zustand stores driven via setState (not mocked).
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { ActivityIndicator } from '../ActivityIndicator';
+import { useConnectionStore } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+import { createEmptySessionState } from '../../store/utils';
+import type { ChatMessage } from '../../store/connection';
+
+const SESSION_ID = 's-test';
+const TIMEOUT_30MIN = 30 * 60_000;
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root.findAllByType(Text).map((node) => {
+    const c = node.props.children;
+    if (typeof c === 'string' || typeof c === 'number') return String(c);
+    if (Array.isArray(c)) {
+      return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+    }
+    return '';
+  }).join(' ');
+}
+
+type PendingShellsTestState = {
+  isIdle: boolean;
+  lastClientActivityAt: number | null;
+  messages?: ChatMessage[];
+  pendingBackgroundShells?: { shellId: string; command: string; startedAt: number }[];
+  activeTools?: { toolUseId: string; tool: string; startedAt: number }[];
+};
+
+function setStore(opts: PendingShellsTestState) {
+  const base = createEmptySessionState();
+  useConnectionStore.setState({
+    activeSessionId: SESSION_ID,
+    sessionStates: {
+      [SESSION_ID]: {
+        ...base,
+        isIdle: opts.isIdle,
+        lastClientActivityAt: opts.lastClientActivityAt,
+        messages: opts.messages ?? [],
+        pendingBackgroundShells: opts.pendingBackgroundShells ?? [],
+        activeTools: opts.activeTools ?? [],
+      },
+    },
+  });
+}
+
+describe('ActivityIndicator — pending background shells on mobile (#4422)', () => {
+  let activeTree: renderer.ReactTestRenderer | null = null;
+
+  function render(): renderer.ReactTestRenderer {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => { tree = renderer.create(<ActivityIndicator />); });
+    activeTree = tree;
+    return tree;
+  }
+
+  beforeEach(() => {
+    useConnectionStore.setState({ activeSessionId: null, sessionStates: {} });
+    useConnectionLifecycleStore.setState({ serverResultTimeoutMs: TIMEOUT_30MIN });
+  });
+
+  afterEach(() => {
+    if (activeTree) {
+      act(() => { activeTree!.unmount(); });
+      activeTree = null;
+    }
+    jest.useRealTimers();
+  });
+
+  it('renders "Waiting on background work" with the command text when idle and one shell is pending', () => {
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      isIdle: true,
+      lastClientActivityAt: now - 2_000,
+      pendingBackgroundShells: [
+        { shellId: 'brk57kt6pm', command: 'npm run build', startedAt: now - 10_000 },
+      ],
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Waiting on background work');
+    expect(text).toContain('npm run build');
+  });
+
+  it('uses the most-recently-started shell when multiple are pending', () => {
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      isIdle: true,
+      lastClientActivityAt: now - 2_000,
+      pendingBackgroundShells: [
+        { shellId: 'oldid01', command: 'sleep 60', startedAt: now - 30_000 },
+        { shellId: 'newid02', command: 'npm test', startedAt: now - 5_000 },
+      ],
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Waiting on background work');
+    expect(text).toContain('npm test');
+    expect(text).not.toContain('sleep 60');
+  });
+
+  it('falls back to the shellId when the command text is empty', () => {
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      isIdle: true,
+      lastClientActivityAt: now - 2_000,
+      pendingBackgroundShells: [
+        { shellId: 'brk57kt6pm', command: '', startedAt: now - 4_000 },
+      ],
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Waiting on background work');
+    expect(text).toContain('brk57kt6pm');
+  });
+
+  it('does not shadow the "Running <tool>" label during an active turn (regression)', () => {
+    // _isBusy=true (isIdle=false) with both an in-flight tool AND a pending
+    // background shell: the existing tool label must win. Pending shells are
+    // SECONDARY during a live turn — they only surface when the turn ends.
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      isIdle: false,
+      lastClientActivityAt: now - 2_000,
+      activeTools: [
+        { toolUseId: 'tu-1', tool: 'WebFetch', startedAt: now - 3_000 },
+      ],
+      pendingBackgroundShells: [
+        { shellId: 'brk57kt6pm', command: 'npm run build', startedAt: now - 10_000 },
+      ],
+      messages: [
+        // The mobile indicator derives the in-flight name from the messages
+        // walk (no `activeTools` slot is consulted) — seed a tool_use with no
+        // result so it surfaces "Running WebFetch".
+        {
+          id: 'm-1',
+          role: 'assistant',
+          type: 'tool_use',
+          tool: 'WebFetch',
+          content: '',
+          timestamp: now - 3_000,
+        } as ChatMessage,
+      ],
+    });
+    const tree = render();
+    const text = collectVisibleText(tree.root);
+    expect(text).toMatch(/Running\s+WebFetch/);
+    expect(text).not.toContain('Waiting on background work');
+  });
+
+  it('renders nothing when idle with no pending background shells (regression)', () => {
+    // Pre-#4422 behaviour: idle session renders nothing. Pin this so the new
+    // surface only activates when shells are actually pending.
+    const now = 1_700_000_000_000;
+    jest.useFakeTimers().setSystemTime(now);
+    setStore({
+      isIdle: true,
+      lastClientActivityAt: now - 1_000,
+      pendingBackgroundShells: [],
+    });
+    const tree = render();
+    expect(tree.toJSON()).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #4422

## Summary

Mobile parity for the dashboard ActivityIndicator pending-shells surface that landed in #4419 (which closed the dashboard half of #4418). PR #4416 (#4307) populated `sessionStates[id].pendingBackgroundShells` on the mobile store-core slice; this PR adds the renderer half so phone users can tell "idle and done" from "idle but parked on a backgrounded shell".

### ActivityIndicator (chat-header surface)

- When `isIdle` and `pendingBackgroundShells.length > 0`, render a "Waiting on background work · <command>" chip instead of returning null. Most-recently-started shell wins; full list rides on the chip's `accessibilityLabel` for screen-reader users (multi-shell expand UI is deferred per #4418's body — no native popover).
- Falls back to the `shellId` when the command string is empty.
- Pending shells are SECONDARY: during an active turn the existing "Running <tool>" / "Working…" labels dominate. Locked in by a regression test.

### SessionPicker (sessions-list pill chip)

- Plumbs `pendingShellCount` through `SessionPill` props.
- Renders a static green dot in the indicators view when the session is idle (`!showBusy`) AND has pending shells. The busy pulse wins during an active turn; the crashed dot wins on a crashed session.
- `accessibilityLabel` + `accessibilityHint` announce the pending shell count and the "idle but waiting on a backgrounded shell" state.

## Test plan

- [x] `cd packages/app && npx jest` — 1309/1309 pass
- [x] `cd packages/app && npx tsc --noEmit` — clean
- [x] New `ActivityIndicator.pendingShells.test.tsx` — 5 cases: single shell, most-recent of multiple, shellId fallback, busy-turn regression (tool label wins), idle+empty regression (null render)
- [x] New `SessionPickerPendingShells.test.ts` — source-text assertions on the pill's gate, style wiring, and `pendingShellCount` projection