### PR TITLE
feat(dashboard): cap pending-shell command text + show full list on expand (#4420, #4421)

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
@@ -11,7 +11,7 @@
  * label dominates — pending shells are SECONDARY.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { ActivityIndicator } from './ActivityIndicator'
 
 let storeState: Record<string, unknown> = {}
@@ -189,5 +189,177 @@ describe('ActivityIndicator — pending background shells (#4418)', () => {
     }
     const { container } = render(<ActivityIndicator />)
     expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('ActivityIndicator — pending-shell command truncation (#4420)', () => {
+  it('renders the full command when it fits inside the cap', () => {
+    const now = Date.now()
+    const cmd = 'npm test'
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'brk57kt6pm', command: cmd, startedAt: now - 10_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toContain(cmd)
+    expect(label.textContent).not.toMatch(/…/)
+  })
+
+  it('truncates long commands with a tail-ellipsis and exposes the full command via title', () => {
+    const now = Date.now()
+    const longCmd =
+      'npm test -- --coverage --reporter=json --bail --testPathPattern=foo --runInBand --silent'
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'brk57kt6pm', command: longCmd, startedAt: now - 10_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const label = screen.getByTestId('activity-indicator-label')
+    // Truncated form: ends with the ellipsis marker, does NOT contain the full command.
+    expect(label.textContent).toMatch(/…/)
+    expect(label.textContent).not.toContain(longCmd)
+    // Start of the command (the binary name) is preserved.
+    expect(label.textContent).toContain('npm test')
+    // The full command is still reachable via the `title` attribute on the chip
+    // so the truncation isn't lossy.
+    const chip = screen.getByLabelText('Waiting on background work')
+    expect(chip.getAttribute('title')).toBe(longCmd)
+  })
+})
+
+describe('ActivityIndicator — pending-shell disclosure for multiple shells (#4421)', () => {
+  it('renders a "+N more" badge when multiple shells are pending', () => {
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'old01', command: 'sleep 60', startedAt: now - 30_000 },
+            { shellId: 'mid02', command: 'tail -f /var/log/system.log', startedAt: now - 20_000 },
+            { shellId: 'new03', command: 'npm test', startedAt: now - 5_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const more = screen.getByTestId('activity-indicator-more-badge')
+    // 3 total - 1 already in the headline label = +2 more.
+    expect(more.textContent).toContain('+2')
+  })
+
+  it('omits the "+N more" badge when only one shell is pending', () => {
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'only01', command: 'npm test', startedAt: now - 5_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    expect(screen.queryByTestId('activity-indicator-more-badge')).toBeNull()
+  })
+
+  it('toggles a popover listing every pending shell when the disclosure button is clicked', () => {
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'old01', command: 'sleep 60', startedAt: now - 30_000 },
+            { shellId: 'new02', command: 'npm test', startedAt: now - 5_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    // Popover is closed by default.
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeNull()
+    // Click the disclosure button to open it.
+    const toggle = screen.getByTestId('activity-indicator-disclosure')
+    fireEvent.click(toggle)
+    const popover = screen.getByTestId('activity-indicator-popover')
+    // Every pending shell is listed (by command).
+    expect(popover.textContent).toContain('sleep 60')
+    expect(popover.textContent).toContain('npm test')
+    // Clicking again closes the popover.
+    fireEvent.click(toggle)
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeNull()
+  })
+
+  it('does not render the disclosure button when only one shell is pending', () => {
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'only01', command: 'npm test', startedAt: now - 5_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    expect(screen.queryByTestId('activity-indicator-disclosure')).toBeNull()
   })
 })

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -21,10 +21,31 @@
  * payload (#3760), falling back to BaseSession.DEFAULT_RESULT_TIMEOUT_MS
  * (30 min) when connected to an older server that doesn't broadcast it.
  */
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { formatToolName } from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
+
+/**
+ * #4420 — Tail-ellipsis truncation for the pending-shell command label. User-
+ * controlled shell commands can be arbitrarily long (`npm test -- --coverage
+ * --reporter=json --bail …`). Without a cap they wrap or stretch the chip,
+ * breaking the pill shape and pushing siblings around on narrow viewports.
+ *
+ * Strategy: tail-ellipsis (preserve the start). The command's prefix is what
+ * identifies it ("npm test", "docker run", "pytest"). The trailing flags are
+ * still reachable via the chip's `title` attribute (hover tooltip), so the
+ * truncation isn't lossy. 40 chars matches the chip's comfortable single-line
+ * width at the dashboard's xs font size without forcing a max-width that
+ * fights the inline-flex layout.
+ */
+export const PENDING_SHELL_COMMAND_MAX_LEN = 40
+
+export function truncatePendingShellCommand(cmd: string): string {
+  if (cmd.length <= PENDING_SHELL_COMMAND_MAX_LEN) return cmd
+  // -1 to leave room for the single ellipsis char.
+  return cmd.slice(0, PENDING_SHELL_COMMAND_MAX_LEN - 1) + '…'
+}
 
 /**
  * #4319 — Walk a session's `messages[]` backwards looking for the most-recent
@@ -137,8 +158,7 @@ export function ActivityIndicator() {
     serverName: inFlightServerName,
     agentDescription,
     agentStartedAt,
-    pendingShellCommand,
-    pendingShellId,
+    pendingShells,
   } = useConnectionStore(
     useShallow((s) => {
       const id = s.activeSessionId
@@ -160,29 +180,53 @@ export function ActivityIndicator() {
       const mostRecentAgent = activeAgents && activeAgents.length > 0
         ? activeAgents[activeAgents.length - 1]!
         : null
-      // #4418 — surface the most-recently-started pending background shell so
-      // the chip can say "Waiting on background work" when the turn ends but
-      // the session is still parked on a backgrounded Bash command. We project
-      // only the visible primitives (command + shellId) so `useShallow` bails
-      // out on no-op `pendingBackgroundShells[]` reference swaps (e.g. when
-      // another session's `background_work_changed` re-seeds the slot).
-      const pendingShells = ss?.pendingBackgroundShells
-      const mostRecentShell = pendingShells && pendingShells.length > 0
-        ? pendingShells.reduce((latest, s) =>
-            s.startedAt > latest.startedAt ? s : latest,
-          )
-        : null
+      // #4418 / #4421 — surface the full pending-background-shell list so the
+      // chip can show the most-recently-started one as the headline AND offer
+      // a click-to-expand popover with every shell when there's more than one.
+      // We pass the array reference straight through — `useShallow` does an
+      // identity check on the projection object's top-level keys, so a no-op
+      // `background_work_changed` from another session won't re-render this
+      // component (the store keeps the array reference stable when nothing
+      // changes). The render-side `useMemo` below projects the array down to
+      // the headline / overflow primitives.
       return {
         tool: inFlight?.tool ?? null,
         startedAt: inFlight?.startedAt ?? null,
         serverName: inFlight?.serverName ?? null,
         agentDescription: mostRecentAgent?.description ?? null,
         agentStartedAt: mostRecentAgent?.startedAt ?? null,
-        pendingShellCommand: mostRecentShell?.command ?? null,
-        pendingShellId: mostRecentShell?.shellId ?? null,
+        pendingShells: ss?.pendingBackgroundShells ?? null,
       }
     }),
   )
+
+  // #4421 — split the pending shells into "headline" (most-recently-started,
+  // shown inline on the chip) and "overflow" (everything else, shown in the
+  // click-to-expand popover). Memoised against the array reference so we don't
+  // re-sort on every clock tick.
+  const { headlineShell, overflowShells } = useMemo(() => {
+    if (!pendingShells || pendingShells.length === 0) {
+      return { headlineShell: null, overflowShells: [] as NonNullable<typeof pendingShells> }
+    }
+    // Most-recently-started wins the headline slot — matches #4418's behaviour.
+    let headline = pendingShells[0]!
+    for (let i = 1; i < pendingShells.length; i++) {
+      if (pendingShells[i]!.startedAt > headline.startedAt) headline = pendingShells[i]!
+    }
+    const overflow = pendingShells.filter((s) => s !== headline)
+    // Sort overflow by most-recent first so the popover reads top-down newest→oldest.
+    overflow.sort((a, b) => b.startedAt - a.startedAt)
+    return { headlineShell: headline, overflowShells: overflow }
+  }, [pendingShells])
+
+  // #4421 — popover open/closed state. Click the disclosure button to toggle.
+  // Defaulting to closed keeps the chip's resting footprint small; the user
+  // opts into the full list only when they care about the overflow.
+  const [popoverOpen, setPopoverOpen] = useState(false)
+  // Auto-close the popover when the overflow goes away (e.g. shells finish).
+  useEffect(() => {
+    if (overflowShells.length === 0 && popoverOpen) setPopoverOpen(false)
+  }, [overflowShells.length, popoverOpen])
   const referenceTimeoutMs = useConnectionStore(
     (s) => s.serverResultTimeoutMs ?? FALLBACK_TIMEOUT_MS,
   )
@@ -202,20 +246,32 @@ export function ActivityIndicator() {
     // #4418 — when the turn ends but the agent backgrounded a Bash shell, the
     // session is still effectively waiting on work. Surface that as a chip so
     // the user can tell "idle and done" from "idle but parked on a long-
-    // running shell". We project the most-recently-started shell's command
-    // (falling back to its shellId when the command string is empty) — the
-    // full list is a deferred stretch goal per #4418's body. The chip uses
-    // the same neutral green styling as the connect-race fallback rather
-    // than the elapsed-driven color escalation; pending shells aren't a
-    // timeout candidate the way an agent turn is.
-    if (pendingShellCommand != null || pendingShellId != null) {
-      const detail = (pendingShellCommand && pendingShellCommand.length > 0)
-        ? pendingShellCommand
-        : pendingShellId!
+    // running shell". The most-recently-started shell wins the headline slot
+    // (falling back to its shellId when the command string is empty). The
+    // chip uses the same neutral green styling as the connect-race fallback
+    // rather than the elapsed-driven color escalation; pending shells aren't
+    // a timeout candidate the way an agent turn is.
+    //
+    // #4420 — the command is user-controlled and unbounded, so the inline
+    // headline gets a tail-ellipsis cap to keep the pill shape intact on
+    // narrow viewports. The full command is still reachable via the chip's
+    // `title` attribute (hover tooltip).
+    //
+    // #4421 — when there's more than one pending shell, a "+N more" badge +
+    // disclosure button reveal a popover listing every pending shell with
+    // its full command and elapsed time. The disclosure is a real <button>
+    // so it's keyboard-navigable (Enter/Space toggle), not hover-only.
+    if (headlineShell) {
+      const rawDetail = headlineShell.command && headlineShell.command.length > 0
+        ? headlineShell.command
+        : headlineShell.shellId
+      const detail = truncatePendingShellCommand(rawDetail)
+      const overflowCount = overflowShells.length
       return (
         <div
           className="activity-indicator activity-indicator--green"
           aria-label="Waiting on background work"
+          title={rawDetail}
         >
           <span className="activity-indicator__dot" aria-hidden="true" />
           <span
@@ -224,6 +280,49 @@ export function ActivityIndicator() {
           >
             Waiting on background work · {detail}
           </span>
+          {overflowCount > 0 && (
+            <button
+              type="button"
+              className="activity-indicator__disclosure"
+              data-testid="activity-indicator-disclosure"
+              aria-expanded={popoverOpen}
+              aria-label={`Show ${overflowCount} additional pending background shell${overflowCount === 1 ? '' : 's'}`}
+              onClick={() => setPopoverOpen((v) => !v)}
+            >
+              <span data-testid="activity-indicator-more-badge">
+                +{overflowCount} more
+              </span>
+            </button>
+          )}
+          {popoverOpen && overflowCount > 0 && (
+            <div
+              className="activity-indicator__popover"
+              data-testid="activity-indicator-popover"
+              role="dialog"
+              aria-label="Pending background shells"
+            >
+              <ul className="activity-indicator__popover-list">
+                {[headlineShell, ...overflowShells].map((shell) => {
+                  const cmd = shell.command && shell.command.length > 0
+                    ? shell.command
+                    : shell.shellId
+                  const elapsed = formatDuration(Math.max(0, now - shell.startedAt))
+                  return (
+                    <li
+                      key={shell.shellId}
+                      className="activity-indicator__popover-item"
+                      data-testid={`activity-indicator-popover-item-${shell.shellId}`}
+                    >
+                      <code className="activity-indicator__popover-command" title={cmd}>
+                        {cmd}
+                      </code>
+                      <span className="activity-indicator__popover-elapsed">{elapsed}</span>
+                    </li>
+                  )
+                })}
+              </ul>
+            </div>
+          )}
         </div>
       )
     }

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -6806,6 +6806,85 @@
 .activity-indicator--orange { color: var(--accent-orange-500); border-color: color-mix(in srgb, var(--accent-orange-500) 50%, transparent); }
 .activity-indicator--red    { color: var(--accent-red-500);    border-color: color-mix(in srgb, var(--accent-red-500) 55%, transparent); }
 
+/* #4421 — disclosure button + popover for the pending-background-shells list.
+   When more than one shell is parked we surface a "+N more" badge inside the
+   activity chip; clicking it opens a popover listing every shell with its
+   command + elapsed time. The chip is `position: relative` so the popover
+   can anchor to it via absolute positioning without escaping the InputBar
+   layout flow. */
+.activity-indicator { position: relative; }
+
+.activity-indicator__disclosure {
+  appearance: none;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+  border-radius: 8px;
+  padding: 1px 6px;
+  font-size: var(--text-2xs, 10px);
+  line-height: 1.4;
+  color: inherit;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+.activity-indicator__disclosure:hover,
+.activity-indicator__disclosure:focus-visible {
+  background: color-mix(in srgb, currentColor 22%, transparent);
+  outline: none;
+}
+
+.activity-indicator__popover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  min-width: 240px;
+  max-width: min(420px, 90vw);
+  padding: 6px;
+  border-radius: 8px;
+  background: var(--bg-elevated, rgba(20, 20, 20, 0.96));
+  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
+  color: var(--text-default, #e6e6e6);
+}
+
+.activity-indicator__popover-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.activity-indicator__popover-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: var(--text-xs);
+}
+
+.activity-indicator__popover-item:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.activity-indicator__popover-command {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-indicator__popover-elapsed {
+  flex: 0 0 auto;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
 /* #3899 — CheckInChip: surfaces an inactivity_warning with a one-click
    prefab follow-up. Same chip shape as activity-indicator so the two
    stack naturally above the InputBar. Amber palette to signal "quiet,


### PR DESCRIPTION
## Summary

Two follow-ups to #4419 (the ActivityIndicator chip for pending background shells). Bundled because both touch the same component — splitting them would force a rebase conflict.

### #4420 — Cap pending-shell command text

Long shell commands (e.g. `npm test -- --coverage --reporter=json --bail --testPathPattern=foo --runInBand --silent`) embedded in the chip were unbounded and could wrap or stretch the pill shape on narrow viewports.

**Decision: tail-ellipsis with a 40-char cap.** Preserves the prefix (the binary name that identifies the command). The full command stays reachable via the chip's `title` attribute (hover tooltip), so the truncation isn't lossy. Simpler than middle-ellipsis and more predictable than a CSS `max-width` fighting the inline-flex layout.

### #4421 — Full pending-shell list on expand

Sessions with multiple parked shells previously surfaced only the most-recently-started one in the chip; the rest were unreachable from the UI.

**Decision: click-to-expand popover.** When `pendingBackgroundShells.length > 1`, render a `+N more` disclosure button next to the headline. Clicking toggles a popover listing every shell with its command + elapsed time. The disclosure is a real `<button>` (keyboard-navigable via Enter / Space), not hover-only. Popover auto-closes when the overflow drains.

## Implementation notes

- Selector now passes the full `pendingBackgroundShells[]` reference through `useShallow`; a render-side `useMemo` splits headline / overflow so the sort runs once per array reference swap, not once per clock tick
- Popover anchors via absolute positioning above the chip — does not push InputBar siblings around
- `truncatePendingShellCommand` exported alongside `PENDING_SHELL_COMMAND_MAX_LEN` so future renderers can reuse the same cap

Closes #4420
Closes #4421

## Test plan

- [x] `npm test -- --run` in `packages/dashboard` — 2183 / 2183 pass (45 / 45 ActivityIndicator tests)
- [x] `npm run typecheck` in `packages/dashboard` — clean
- 6 new tests added to `ActivityIndicator.pendingShells.test.tsx`:
  - #4420: short command renders untruncated, long command gets ellipsis + title attr
  - #4421: `+N more` badge present for multi-shell / absent for single-shell, popover toggles on click and lists every shell, no disclosure button when only one shell is pending