### PR TITLE
feat(dashboard): migrate remaining shortcuts to registry (#4412)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -277,6 +277,102 @@ describe('App', () => {
     expect(event).toBe(true)
   })
 
+  // ── #4412: migrated shortcuts fire through the registry-driven
+  // dispatch table. Each test pins one branch end-to-end: a real
+  // keydown event reaches the App handler, the registry matches it
+  // to the id, the dispatch arm calls the right store action /
+  // setter. We assert on the observable side-effect (store action
+  // spy, modal text, or rendered state) rather than poking React
+  // internals.
+  describe('registry-driven shortcut dispatch (#4412)', () => {
+    const oneSession = [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli', hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }]
+    const twoSessions = [
+      { sessionId: 's1', name: 'One', cwd: '/tmp', type: 'cli', hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null },
+      { sessionId: 's2', name: 'Two', cwd: '/tmp', type: 'cli', hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null },
+    ]
+
+    it('Cmd+. dispatches session.interrupt', () => {
+      const sendInterrupt = vi.fn()
+      stateOverrides = { connectionPhase: 'connected', sessions: oneSession, activeSessionId: 's1', sendInterrupt }
+      render(<App />)
+      fireEvent.keyDown(window, { key: '.', metaKey: true })
+      expect(sendInterrupt).toHaveBeenCalled()
+    })
+
+    it('Cmd+Shift+D toggles between chat and terminal view', () => {
+      const setViewMode = vi.fn()
+      stateOverrides = { connectionPhase: 'connected', sessions: oneSession, activeSessionId: 's1', setViewMode, viewMode: 'chat' }
+      render(<App />)
+      fireEvent.keyDown(window, { key: 'd', metaKey: true, shiftKey: true })
+      expect(setViewMode).toHaveBeenCalledWith('terminal')
+    })
+
+    it('Cmd+2 switches to the second session', () => {
+      const switchSession = vi.fn()
+      stateOverrides = { connectionPhase: 'connected', sessions: twoSessions, activeSessionId: 's1', switchSession }
+      render(<App />)
+      fireEvent.keyDown(window, { key: '2', metaKey: true })
+      expect(switchSession).toHaveBeenCalledWith('s2')
+    })
+
+    it('Cmd+1 with no sessions does NOT call switchSession (no preventDefault, OS gets the key)', () => {
+      const switchSession = vi.fn()
+      stateOverrides = { connectionPhase: 'connected', sessions: [], activeSessionId: null, switchSession }
+      render(<App />)
+      fireEvent.keyDown(window, { key: '1', metaKey: true })
+      expect(switchSession).not.toHaveBeenCalled()
+    })
+
+    it('Cmd+Shift+] (next tab) wraps from last back to first', () => {
+      const switchSession = vi.fn()
+      stateOverrides = { connectionPhase: 'connected', sessions: twoSessions, activeSessionId: 's2', switchSession }
+      render(<App />)
+      fireEvent.keyDown(window, { key: ']', metaKey: true, shiftKey: true })
+      expect(switchSession).toHaveBeenCalledWith('s1')
+    })
+
+    it('Cmd+Shift+[ (prev tab) wraps from first back to last', () => {
+      const switchSession = vi.fn()
+      stateOverrides = { connectionPhase: 'connected', sessions: twoSessions, activeSessionId: 's1', switchSession }
+      render(<App />)
+      fireEvent.keyDown(window, { key: '[', metaKey: true, shiftKey: true })
+      expect(switchSession).toHaveBeenCalledWith('s2')
+    })
+
+    it('Shift+Tab toggles plan mode when focus is OUTSIDE a text input', () => {
+      const setPermissionMode = vi.fn()
+      stateOverrides = { connectionPhase: 'connected', sessions: oneSession, activeSessionId: 's1', setPermissionMode, permissionMode: 'approve' }
+      render(<App />)
+      fireEvent.keyDown(window, { key: 'Tab', shiftKey: true })
+      expect(setPermissionMode).toHaveBeenCalledWith('plan')
+    })
+
+    it('Shift+Tab does NOT toggle plan mode while focus is in the textarea (allows native reverse-tab)', () => {
+      const setPermissionMode = vi.fn()
+      stateOverrides = { connectionPhase: 'connected', sessions: oneSession, activeSessionId: 's1', setPermissionMode, permissionMode: 'approve' }
+      render(<App />)
+      const textarea = screen.getByRole('textbox', { name: /message input/i })
+      fireEvent.keyDown(textarea, { key: 'Tab', shiftKey: true })
+      expect(setPermissionMode).not.toHaveBeenCalled()
+    })
+
+    it('Cmd+Shift+P (VSCode palette alias) opens the command palette', () => {
+      stateOverrides = { connectionPhase: 'connected', sessions: oneSession, activeSessionId: 's1' }
+      render(<App />)
+      expect(screen.queryByTestId('command-palette')).not.toBeInTheDocument()
+      fireEvent.keyDown(window, { key: 'p', metaKey: true, shiftKey: true })
+      expect(screen.getByTestId('command-palette')).toBeInTheDocument()
+    })
+
+    it('Cmd+W does NOT close the only tab (lets the desktop window-close path take over)', () => {
+      const destroySession = vi.fn()
+      stateOverrides = { connectionPhase: 'connected', sessions: oneSession, activeSessionId: 's1', destroySession }
+      render(<App />)
+      fireEvent.keyDown(window, { key: 'w', metaKey: true })
+      expect(destroySession).not.toHaveBeenCalled()
+    })
+  })
+
   it('shows session loading skeleton when connecting', () => {
     stateOverrides = { connectionPhase: 'connecting' }
     render(<App />)

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -693,130 +693,127 @@ export function App() {
         })()
         return
       }
-      // #3852: customizable shortcuts win first. The registry holds the
-      // user-rebindable subset (palette, sidebar, settings, new
-      // session). Each shortcut's id maps to a stable action below; if
-      // the user has rewired Cmd+K to Cmd+J the registry's matchEvent
-      // returns 'palette.toggle' for the new combo. Hardcoded fallbacks
-      // for shortcuts NOT yet in the registry (Cmd+1-9, Cmd+\, etc.)
-      // remain below. Note: we deliberately do NOT gate on text-input
-      // focus — that matches the legacy ladder's behavior (Cmd+K in a
-      // textarea still toggles the palette).
+      // #3852 / #4412: customizable shortcuts win first. The registry
+      // is the single source of truth for the entire global keydown
+      // ladder — every dispatch below is a registry id, never a raw
+      // combo, so user rebinds in Settings propagate automatically.
+      // The registry already evaluates `disabledInTextInput` and
+      // `enabled` predicates internally (see registry.ts matchEvent),
+      // so the per-branch text-input gates the old ladder did inline
+      // are gone — they live on the ShortcutDef instead.
+      //
+      // Note: we deliberately do NOT gate ALL shortcuts on text-input
+      // focus — palette / sidebar / settings / new-session / etc.
+      // should fire even when a textarea has focus. Only shortcuts
+      // declared with `disabledInTextInput: true` are suppressed by
+      // the registry (Shift+Tab, ?).
       const matchedId = shortcutRegistry.matchEvent(e, 'global')
       if (matchedId) {
-        e.preventDefault()
-        if (matchedId === 'palette.toggle') setPaletteOpen(prev => !prev)
-        else if (matchedId === 'sidebar.toggle') setSidebarOpen(prev => !prev)
-        else if (matchedId === 'settings.open') setSettingsOpen(prev => !prev)
-        else if (matchedId === 'session.new') setShowCreateSession(true)
-        return
-      }
-      // Cmd+Shift+P: toggle command palette (VSCode-style alias)
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'p') {
-        e.preventDefault()
-        setPaletteOpen(prev => !prev)
-        return
-      }
-      // Cmd+Shift+D: toggle view mode (chat ↔ terminal)
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'd') {
-        e.preventDefault()
-        setViewMode(viewMode === 'chat' ? 'terminal' : 'chat')
-        return
-      }
-      // Cmd+1-9: switch to tab by index
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key >= '1' && e.key <= '9') {
-        e.preventDefault()
-        const idx = parseInt(e.key, 10) - 1
-        const target = sessions[idx]
-        if (target) handleSwitchSession(target.sessionId)
-        return
-      }
-      // Cmd+Shift+[ / ]: prev/next tab
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === '[' || e.key === ']')) {
-        e.preventDefault()
-        const currentIdx = sessions.findIndex(s => s.sessionId === activeSessionId)
-        if (currentIdx < 0) return
-        const nextIdx = e.key === '['
-          ? (currentIdx - 1 + sessions.length) % sessions.length
-          : (currentIdx + 1) % sessions.length
-        handleSwitchSession(sessions[nextIdx]!.sessionId)
-        return
-      }
-      // Cmd+W: close active tab (if more than 1 session) — Tauri only (#1378)
-      if (isTauri() && (e.metaKey || e.ctrlKey) && e.key === 'w' && !e.shiftKey) {
-        if (activeSessionId && sessions.length > 1) {
-          e.preventDefault()
-          handleCloseSession(activeSessionId)
+        // session.switch.N — index from id suffix; preventDefault only
+        // when we actually have a session for that slot so unused
+        // slots don't swallow OS-level Cmd+digit shortcuts.
+        if (matchedId.startsWith('session.switch.')) {
+          const idx = parseInt(matchedId.slice('session.switch.'.length), 10) - 1
+          const target = sessions[idx]
+          if (target) {
+            e.preventDefault()
+            handleSwitchSession(target.sessionId)
+          }
+          return
         }
-      }
-      // Cmd+B (sidebar) handled by the registry above (#3852).
-      // Cmd+Shift+P: command palette (VSCode alias)
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'p') {
-        e.preventDefault()
-        setPaletteOpen(prev => !prev)
-        return
-      }
-      // Cmd+Shift+D: toggle chat/terminal view
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'd') {
-        e.preventDefault()
-        setViewMode(viewMode === 'chat' ? 'terminal' : 'chat')
-        return
-      }
-      // Cmd+\: cycle split mode (none → horizontal → vertical → none)
-      if ((e.metaKey || e.ctrlKey) && e.key === '\\') {
-        e.preventDefault()
-        setSplitMode(prev => {
-          const next = prev === null ? 'horizontal' : prev === 'horizontal' ? 'vertical' : null
-          persistSplitMode(next)
-          return next
-        })
-        return
-      }
-      // Cmd+, (settings) handled by the registry above (#3852).
-      // Cmd+Shift+T: copy chat transcript (#3073)
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 't') {
-        e.preventDefault()
-        handleCopyTranscript()
-        return
-      }
-      // Cmd+.: interrupt active session
-      if ((e.metaKey || e.ctrlKey) && e.key === '.') {
-        e.preventDefault()
-        sendInterrupt()
-        return
-      }
-      // Shift+Tab: toggle plan mode
-      if (e.shiftKey && e.key === 'Tab' && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        const tag = (e.target as HTMLElement).tagName
-        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return  // Allow native reverse-tab
-        e.preventDefault()
-        const state = useConnectionStore.getState()
-        const currentMode = state.permissionMode
-        if (currentMode === 'plan') {
-          // Switch back to previous mode (default to 'approve')
-          setPermissionMode(state.previousPermissionMode || 'approve')
-        } else {
-          // Switch to plan mode
-          setPermissionMode('plan')
+        // session.close (Cmd+W) — Tauri-only via registry `enabled`
+        // predicate. Additional in-action guard: only close when more
+        // than one session exists, otherwise let the event bubble so
+        // Cmd+W still closes the desktop window when there's nothing
+        // left to close inside the app.
+        if (matchedId === 'session.close') {
+          if (activeSessionId && sessions.length > 1) {
+            e.preventDefault()
+            handleCloseSession(activeSessionId)
+          }
+          return
         }
-        return
-      }
-      // ?: toggle shortcut help (no modifiers, not in text input)
-      if (e.key === '?' && !e.metaKey && !e.ctrlKey && !e.altKey) {
-        const tag = (e.target as HTMLElement).tagName
-        if (tag !== 'INPUT' && tag !== 'TEXTAREA' && !(e.target as HTMLElement).isContentEditable) {
+        // help.toggle — registry already gates text-input focus, but
+        // the overlay-stack check is App-state knowledge it can't
+        // own. Keep it here.
+        if (matchedId === 'help.toggle') {
           const overlays = document.querySelectorAll('[data-modal-overlay]')
           const onlyShortcutHelp = overlays.length === 1 && overlays[0]?.classList.contains('shortcut-help-overlay')
           if (overlays.length === 0 || onlyShortcutHelp) {
             e.preventDefault()
             setShortcutHelpOpen(prev => !prev)
           }
+          return
         }
+        e.preventDefault()
+        switch (matchedId) {
+          case 'palette.toggle':
+          case 'palette.toggle.vscode':
+            setPaletteOpen(prev => !prev)
+            break
+          case 'sidebar.toggle':
+            setSidebarOpen(prev => !prev)
+            break
+          case 'settings.open':
+            setSettingsOpen(prev => !prev)
+            break
+          case 'session.new':
+            setShowCreateSession(true)
+            break
+          case 'view.toggleChatTerminal':
+            setViewMode(viewMode === 'chat' ? 'terminal' : 'chat')
+            break
+          case 'view.cycleSplit':
+            setSplitMode(prev => {
+              const next = prev === null ? 'horizontal' : prev === 'horizontal' ? 'vertical' : null
+              persistSplitMode(next)
+              return next
+            })
+            break
+          case 'session.copyTranscript':
+            handleCopyTranscript()
+            break
+          case 'session.interrupt':
+            sendInterrupt()
+            break
+          case 'session.prev':
+          case 'session.next': {
+            const currentIdx = sessions.findIndex(s => s.sessionId === activeSessionId)
+            if (currentIdx < 0) break
+            const nextIdx = matchedId === 'session.prev'
+              ? (currentIdx - 1 + sessions.length) % sessions.length
+              : (currentIdx + 1) % sessions.length
+            handleSwitchSession(sessions[nextIdx]!.sessionId)
+            break
+          }
+          case 'session.togglePlanMode': {
+            const state = useConnectionStore.getState()
+            const currentMode = state.permissionMode
+            if (currentMode === 'plan') {
+              // Switch back to previous mode (default to 'approve')
+              setPermissionMode(state.previousPermissionMode || 'approve')
+            } else {
+              setPermissionMode('plan')
+            }
+            break
+          }
+          default:
+            // Unknown registry id reached the dispatch table — most
+            // likely a definition was added in defaults.ts without an
+            // App-side handler. Fail loud in dev so the gap is
+            // obvious; silently ignore in prod so a stray
+            // localStorage override can't brick the app.
+            if (import.meta.env?.DEV) {
+              // eslint-disable-next-line no-console
+              console.warn(`[shortcuts] no handler for matched id "${matchedId}"`)
+            }
+        }
+        return
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [sessions, activeSessionId, handleSwitchSession, handleCloseSession, viewMode, setViewMode, sendInterrupt, handleCopyTranscript, shortcutRegistry])
+  }, [sessions, activeSessionId, handleSwitchSession, handleCloseSession, viewMode, setViewMode, sendInterrupt, handleCopyTranscript, shortcutRegistry, appendImageAttachments, setPermissionMode])
 
   const trackedCommands = useMemo(
     () => commands.map(cmd => ({
@@ -1532,56 +1529,76 @@ export function App() {
     return null
   }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered])
 
-  // #3852: pull the effective bindings for the four registry-managed
-  // shortcuts out into render-time locals so the useMemo below can
-  // observe them in its dep array. Reading `shortcutRegistry` alone is
-  // not enough — the registry reference is stable, so a dep of
-  // `[shortcutRegistry]` would skip recomputation after a rebind and
-  // the cheat sheet would show stale combos. The hook (re-)renders us
-  // whenever a binding changes, so reading getBinding() here picks up
-  // the new value on that render.
+  // #4412: registry-driven cheat sheet. Recomputed on every render —
+  // not memoised, by design. The shortcut registry hook re-renders
+  // whenever a binding changes, so reading registry.list() inside
+  // the body picks up the new combos automatically. Memoising on
+  // [shortcutRegistry] would silently skip rebinds because the
+  // registry reference is stable. The work is cheap (constant-size
+  // arrays, simple map) so re-running it per render is fine.
   const isMacForCheatsheet = isMacPlatform()
-  const paletteBindingDisplay = formatBindingForDisplay(shortcutRegistry.getBinding('palette.toggle'), isMacForCheatsheet)
-  const sidebarBindingDisplay = formatBindingForDisplay(shortcutRegistry.getBinding('sidebar.toggle'), isMacForCheatsheet)
-  const settingsBindingDisplay = formatBindingForDisplay(shortcutRegistry.getBinding('settings.open'), isMacForCheatsheet)
-  const newSessionBindingDisplay = formatBindingForDisplay(shortcutRegistry.getBinding('session.new'), isMacForCheatsheet)
-
-  const SHORTCUTS: ShortcutEntry[] = useMemo(() => {
-    // #2883: author entries with canonical `Cmd+...` labels and rewrite to
-    // `Ctrl+...` at render time on non-Mac platforms so the cheat-sheet
-    // matches the modifier the user can actually press.
-    const rawEntries: ShortcutEntry[] = [
-      { keys: '?', description: 'Show keyboard shortcuts', section: 'Global' },
-      { keys: paletteBindingDisplay || 'Cmd+K', description: 'Command palette', section: 'Global' },
-      { keys: 'Cmd+Shift+P', description: 'Command palette (VSCode)', section: 'Global' },
-      { keys: newSessionBindingDisplay || 'Cmd+N', description: 'New session', section: 'Global' },
-      { keys: sidebarBindingDisplay || 'Cmd+B', description: 'Toggle sidebar', section: 'Global' },
-      { keys: settingsBindingDisplay || 'Cmd+,', description: 'Settings', section: 'Global' },
-      { keys: 'Cmd+.', description: 'Interrupt session', section: 'Session' },
-      { keys: 'Cmd+Shift+D', description: 'Toggle chat / terminal', section: 'Session' },
-      { keys: 'Cmd+\\', description: 'Cycle split view', section: 'Session' },
-      { keys: 'Cmd+1-9', description: 'Switch to tab by number', section: 'Session' },
-      { keys: 'Cmd+Shift+[', description: 'Previous tab', section: 'Session' },
-      { keys: 'Cmd+Shift+]', description: 'Next tab', section: 'Session' },
-      { keys: 'Cmd+W', description: 'Close tab (desktop)', section: 'Session' },
-      { keys: 'Shift+Tab', description: 'Toggle plan mode', section: 'Session' },
+  const SHORTCUTS: ShortcutEntry[] = (() => {
+    // Section labels mirror the Settings panel groupings so the cheat
+    // sheet and customization UI stay coherent.
+    const CATEGORY_TO_SECTION: Record<string, string> = {
+      navigation: 'Global',
+      view: 'Global',
+      session: 'Session',
+      composer: 'Input',
+      other: 'Global',
+    }
+    // Cmd+1-9 collapse: nine separate rows would bloat the cheat
+    // sheet without adding signal. Emit a single "Cmd+1-9" row whose
+    // keys reflect the registry's current first-digit binding so a
+    // rebind (e.g. moving them to Alt+1-9) is still visible.
+    const tabSwitch1 = shortcutRegistry.get('session.switch.1')
+    const tabSwitchKeys = tabSwitch1
+      ? formatBindingForDisplay(tabSwitch1.binding, isMacForCheatsheet).replace(/1$/, '1-9')
+      : 'Cmd+1-9'
+    const registryRows: ShortcutEntry[] = []
+    for (const entry of shortcutRegistry.list()) {
+      // Skip the 2..9 tab-switch entries — collapsed into one row
+      // below. Keep session.switch.1 as the canonical source so its
+      // override drives the collapsed row's display string.
+      if (/^session\.switch\.[2-9]$/.test(entry.id)) continue
+      if (entry.id === 'session.switch.1') {
+        registryRows.push({
+          keys: tabSwitchKeys,
+          description: 'Switch to tab by number',
+          section: CATEGORY_TO_SECTION[entry.category] || 'Global',
+        })
+        continue
+      }
+      registryRows.push({
+        keys: formatBindingForDisplay(entry.binding, isMacForCheatsheet),
+        description: entry.description,
+        section: CATEGORY_TO_SECTION[entry.category] || 'Global',
+      })
+    }
+    // Non-registry entries: permission shortcuts (handled inside the
+    // permission prompt UI), composer send (handled in InputBar),
+    // Escape (handled per-modal), and the Tauri image-paste shortcut.
+    // None of these live in the global keydown ladder so they don't
+    // belong in the registry.
+    const extraEntries: ShortcutEntry[] = [
       { keys: 'Cmd+Y', description: 'Allow current permission prompt', section: 'Session' },
       { keys: 'Cmd+Shift+Y', description: 'Allow current permission prompt for this session (rule-eligible tools)', section: 'Session' },
       { keys: 'Cmd+Enter', description: 'Send message', section: 'Input' },
       { keys: 'Escape', description: 'Close modal / cancel', section: 'Global' },
     ]
-    // #3748 — Ctrl+V (image-paste) only works in the Tauri desktop on macOS,
-    // since on other platforms Ctrl+V is the native text-paste shortcut.
-    // Show the entry only where the shortcut is actually wired.
+    // #3748 — Ctrl+V (image-paste) only works in the Tauri desktop on
+    // macOS; on other platforms Ctrl+V is the native text-paste
+    // shortcut. Show the entry only where the shortcut is actually
+    // wired.
     if (isTauri() && isMacPlatform()) {
-      rawEntries.push({
+      extraEntries.push({
         keys: 'Ctrl+V',
         description: 'Paste image from clipboard (Cmd+V stays as text paste)',
         section: 'Input',
       })
     }
-    return rawEntries.map(entry => ({ ...entry, keys: formatShortcutKeys(entry.keys) }))
-  }, [paletteBindingDisplay, sidebarBindingDisplay, settingsBindingDisplay, newSessionBindingDisplay])
+    return [...registryRows, ...extraEntries].map(entry => ({ ...entry, keys: formatShortcutKeys(entry.keys) }))
+  })()
 
   // Compute context window usage percentage from active model metadata
   const contextPercent = useMemo(() => {

--- a/packages/dashboard/src/hooks/useGlobalShortcuts-comprehensive.test.ts
+++ b/packages/dashboard/src/hooks/useGlobalShortcuts-comprehensive.test.ts
@@ -1,17 +1,19 @@
 /**
- * Comprehensive keyboard shortcuts test (#1115).
+ * Comprehensive keyboard shortcuts test (#1115, #3852, #4412).
  *
- * Source-level tests verifying the dashboard still covers all required
- * shortcuts from the IDE shortcut map.
+ * Source-of-truth: the shortcut registry. Pre-#4412 a subset of
+ * shortcuts (Cmd+1-9, Cmd+Shift+[/], Cmd+W, Cmd+Shift+P, Cmd+Shift+D,
+ * Cmd+.) were hand-rolled in App.tsx's keydown ladder, so this file
+ * grepped App.tsx text for them. After #4412 every global shortcut is
+ * declared in `shortcuts/defaults.ts`, so every assertion below
+ * inspects the registry definitions instead — declarative, robust to
+ * dispatch-table refactors, and re-uses the registry types directly.
  *
- * #3852 split the source of truth in two:
- *  - User-rebindable shortcuts (palette, sidebar, settings, new
- *    session) now live in the shortcut registry's defaults file. We
- *    import the registry directly so these tests track the binding
- *    declaratively rather than scraping App.tsx text.
- *  - The remaining shortcuts (Cmd+1-9, Cmd+Shift+[/], Cmd+W,
- *    Cmd+Shift+P, Cmd+Shift+D, Cmd+.) are still hand-rolled in
- *    App.tsx's keydown ladder, so we keep the textual grep for them.
+ * Two non-registry assertions remain:
+ *  - `sendInterrupt()` is wired to the `session.interrupt` shortcut
+ *    in App.tsx — we still grep for the call to catch a regression
+ *    where the dispatch arm is dropped.
+ *  - `setViewMode` is wired to `view.toggleChatTerminal`.
  */
 import { describe, it, expect } from 'vitest'
 import * as fs from 'node:fs'
@@ -38,34 +40,56 @@ describe('Comprehensive keyboard shortcuts (#1115)', () => {
     expect(defaultBindingFor('session.new')).toBe('cmd+n')
   })
 
-  it('has Cmd+1-9 for tab switching', () => {
-    expect(appSource).toMatch(/e\.key\s*>=\s*'1'/)
+  it('has Cmd+1-9 for tab switching (via shortcut registry — one entry per digit)', () => {
+    for (let n = 1; n <= 9; n += 1) {
+      expect(defaultBindingFor(`session.switch.${n}`)).toBe(`cmd+${n}`)
+    }
   })
 
-  it('has Cmd+Shift+[/] for prev/next tab', () => {
-    expect(appSource).toMatch(/e\.key\s*===\s*'\['/)
+  it('has Cmd+Shift+[/] for prev/next tab (via shortcut registry)', () => {
+    expect(defaultBindingFor('session.prev')).toBe('cmd+shift+[')
+    expect(defaultBindingFor('session.next')).toBe('cmd+shift+]')
   })
 
-  it('has Cmd+W for close tab', () => {
-    expect(appSource).toMatch(/e\.key\s*===\s*'w'/)
+  it('has Cmd+W for close tab (via shortcut registry)', () => {
+    expect(defaultBindingFor('session.close')).toBe('cmd+w')
   })
 
   it('has Cmd+B for sidebar toggle (via shortcut registry)', () => {
     expect(defaultBindingFor('sidebar.toggle')).toBe('cmd+b')
   })
 
-  it('has Cmd+Shift+P for command palette alias', () => {
-    expect(appSource).toMatch(/e\.key.*'p'/)
-    expect(appSource).toMatch(/e\.shiftKey.*'p'|'p'.*e\.shiftKey/)
+  it('has Cmd+Shift+P for command palette alias (via shortcut registry)', () => {
+    expect(defaultBindingFor('palette.toggle.vscode')).toBe('cmd+shift+p')
   })
 
-  it('has Cmd+Shift+D for toggle view mode', () => {
-    expect(appSource).toMatch(/e\.key.*'d'/)
+  it('has Cmd+Shift+D for toggle view mode (via shortcut registry + App dispatch)', () => {
+    expect(defaultBindingFor('view.toggleChatTerminal')).toBe('cmd+shift+d')
     expect(appSource).toMatch(/setViewMode/)
   })
 
-  it('has Cmd+. for interrupt', () => {
-    expect(appSource).toMatch(/e\.key\s*===\s*'\.'/)
+  it('has Cmd+. for interrupt (via shortcut registry + App dispatch)', () => {
+    expect(defaultBindingFor('session.interrupt')).toBe('cmd+.')
     expect(appSource).toMatch(/sendInterrupt\(\)/)
+  })
+
+  it('has Cmd+\\ for cycle split view (via shortcut registry)', () => {
+    expect(defaultBindingFor('view.cycleSplit')).toBe('cmd+\\')
+  })
+
+  it('has Cmd+Shift+T for copy transcript (via shortcut registry)', () => {
+    expect(defaultBindingFor('session.copyTranscript')).toBe('cmd+shift+t')
+  })
+
+  it('has Shift+Tab for toggle plan mode (via shortcut registry, gated in text inputs)', () => {
+    const entry = DEFAULT_SHORTCUTS.find(d => d.id === 'session.togglePlanMode')
+    expect(entry?.defaultBinding).toBe('shift+tab')
+    expect(entry?.disabledInTextInput).toBe(true)
+  })
+
+  it('has ? for shortcut help (via shortcut registry, gated in text inputs)', () => {
+    const entry = DEFAULT_SHORTCUTS.find(d => d.id === 'help.toggle')
+    expect(entry?.defaultBinding).toBe('?')
+    expect(entry?.disabledInTextInput).toBe(true)
   })
 })

--- a/packages/dashboard/src/hooks/useGlobalShortcuts-integration.test.ts
+++ b/packages/dashboard/src/hooks/useGlobalShortcuts-integration.test.ts
@@ -1,25 +1,37 @@
+/**
+ * Global keyboard-shortcut wiring (#1334, #3852, #4412).
+ *
+ * Pre-#4412 these tests grep'd App.tsx for the raw `shiftKey` / `'p'`
+ * combos because the keydown ladder was hand-rolled. After #4412 the
+ * ladder dispatches by registry id, so the literal combos live in
+ * `shortcuts/defaults.ts` instead. The assertions are now against the
+ * registry contents (still a static check — no React rendering) so a
+ * regression that drops a shortcut entry from defaults.ts still fails
+ * here.
+ */
 import { describe, it, expect } from 'vitest'
 import * as fs from 'fs'
 import * as path from 'path'
-
-const appSource = fs.readFileSync(
-  path.resolve(__dirname, '../App.tsx'),
-  'utf-8',
-)
+import { DEFAULT_SHORTCUTS } from '../shortcuts/defaults'
 
 const commandsSource = fs.readFileSync(
   path.resolve(__dirname, '../store/commands.ts'),
   'utf-8',
 )
 
-describe('Global keyboard shortcuts (#1334)', () => {
-  it('Cmd+Shift+P toggles command palette', () => {
-    // Should handle Cmd+Shift+P alongside Cmd+K
-    expect(appSource).toMatch(/shiftKey[\s\S]{0,100}['"]p['"]|['"]p['"][\s\S]{0,100}shiftKey/)
+function findShortcut(id: string) {
+  return DEFAULT_SHORTCUTS.find(s => s.id === id)
+}
+
+describe('Global keyboard shortcuts (#1334, #3852, #4412)', () => {
+  it('Cmd+Shift+P (VSCode palette alias) is registered', () => {
+    const shortcut = findShortcut('palette.toggle.vscode')
+    expect(shortcut?.defaultBinding).toBe('cmd+shift+p')
   })
 
-  it('Cmd+Shift+D toggles view mode', () => {
-    expect(appSource).toMatch(/shiftKey[\s\S]{0,100}['"]d['"]|['"]d['"][\s\S]{0,100}shiftKey/)
+  it('Cmd+Shift+D (toggle chat/terminal view) is registered', () => {
+    const shortcut = findShortcut('view.toggleChatTerminal')
+    expect(shortcut?.defaultBinding).toBe('cmd+shift+d')
   })
 
   it('toggle-view command has shortcut badge', () => {

--- a/packages/dashboard/src/shortcuts/defaults.ts
+++ b/packages/dashboard/src/shortcuts/defaults.ts
@@ -1,19 +1,52 @@
 /**
- * Default shortcut definitions (#3852).
+ * Default shortcut definitions (#3852, #4412).
  *
- * Scope-reduced for the first cut: the most-commonly-rebound shortcuts
- * — palette, sidebar, settings, new session — are user-customizable
- * through the registry. The remaining (Cmd+1-9 tab switching,
- * Cmd+Shift+[/], Cmd+\, etc.) stay in the keydown ladder for now; once
- * this lands they can be migrated in follow-ups without changing the
- * registry contract.
+ * Full migration of App.tsx's global keydown ladder into the registry
+ * so every shortcut is user-rebindable. The four palette/sidebar/
+ * settings/new-session entries from #3852 stay first for source-diff
+ * readability; everything below was migrated in #4412.
+ *
+ * Variadic shortcuts
+ * ------------------
+ * Cmd+1-9 (tab switching by index) and Cmd+Shift+[/] (prev/next tab)
+ * could be modelled as either a single parameterised action or as N
+ * separate entries. We picked N entries because the registry only
+ * needs combo->id matching to stay simple, and per-digit entries let
+ * users rebind individual slots in Settings independently (e.g. wire
+ * Cmd+1 to a different action without losing Cmd+2-9). The trade-off
+ * is nine rows in the Settings panel — acceptable, and they group
+ * cleanly under the "Session" category. The cheat sheet collapses
+ * them back into a single "Cmd+1-9" row for readability.
+ *
+ * Edge cases / gates
+ * ------------------
+ * - Cmd+W (close tab): Tauri-only. Uses `enabled: () => isTauri()`.
+ * - Shift+Tab (toggle plan mode): must NOT fire inside text inputs so
+ *   the user can still reverse-tab between form fields. Uses
+ *   `disabledInTextInput: true`.
+ * - `?` (open cheat sheet): same text-input gate, plus an overlay
+ *   stack check that the App.tsx call site still enforces (the
+ *   registry has no notion of modal stacks).
  *
  * The id namespace is `<area>.<action>` so future shortcuts slot in
  * predictably (e.g. `composer.history.prev` for #3854).
  */
 import type { ShortcutDef } from './registry'
+import { isTauri } from '../utils/tauri'
+
+// 1-indexed digit list for the variadic Cmd+<n> tab-switch entries.
+const TAB_DIGITS = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
+
+const tabSwitchShortcuts: ShortcutDef[] = TAB_DIGITS.map(n => ({
+  id: `session.switch.${n}`,
+  defaultBinding: `cmd+${n}`,
+  description: `Switch to tab ${n}`,
+  category: 'session',
+  scope: 'global',
+}))
 
 export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
+  // -- #3852: original migration -----------------------------------
   {
     id: 'palette.toggle',
     defaultBinding: 'cmd+k',
@@ -42,4 +75,86 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
     category: 'session',
     scope: 'global',
   },
+  // -- #4412: remaining ladder entries -----------------------------
+  {
+    id: 'palette.toggle.vscode',
+    defaultBinding: 'cmd+shift+p',
+    description: 'Toggle command palette (VSCode alias)',
+    category: 'navigation',
+    scope: 'global',
+  },
+  {
+    id: 'view.toggleChatTerminal',
+    defaultBinding: 'cmd+shift+d',
+    description: 'Toggle chat / terminal view',
+    category: 'view',
+    scope: 'global',
+  },
+  {
+    id: 'view.cycleSplit',
+    defaultBinding: 'cmd+\\',
+    description: 'Cycle split view',
+    category: 'view',
+    scope: 'global',
+  },
+  {
+    id: 'session.copyTranscript',
+    defaultBinding: 'cmd+shift+t',
+    description: 'Copy chat transcript',
+    category: 'session',
+    scope: 'global',
+  },
+  {
+    id: 'session.interrupt',
+    defaultBinding: 'cmd+.',
+    description: 'Interrupt session',
+    category: 'session',
+    scope: 'global',
+  },
+  {
+    id: 'session.togglePlanMode',
+    defaultBinding: 'shift+tab',
+    description: 'Toggle plan mode',
+    category: 'session',
+    scope: 'global',
+    disabledInTextInput: true,
+  },
+  {
+    id: 'help.toggle',
+    defaultBinding: '?',
+    description: 'Show keyboard shortcuts',
+    category: 'other',
+    scope: 'global',
+    disabledInTextInput: true,
+  },
+  // Variadic-ish: prev / next tab. Two entries (one per arm) so users
+  // can rebind them independently and the registry stays a plain
+  // combo->id map. Both dispatch to a single nav action in App.tsx.
+  {
+    id: 'session.prev',
+    defaultBinding: 'cmd+shift+[',
+    description: 'Previous tab',
+    category: 'session',
+    scope: 'global',
+  },
+  {
+    id: 'session.next',
+    defaultBinding: 'cmd+shift+]',
+    description: 'Next tab',
+    category: 'session',
+    scope: 'global',
+  },
+  // Cmd+W close tab — Tauri only. In the browser Cmd+W is reserved by
+  // the OS for closing the tab/window itself, so the `enabled`
+  // predicate keeps the shortcut quiescent there.
+  {
+    id: 'session.close',
+    defaultBinding: 'cmd+w',
+    description: 'Close tab (desktop)',
+    category: 'session',
+    scope: 'global',
+    enabled: () => isTauri(),
+  },
+  // Cmd+1 .. Cmd+9 tab-switch entries — one per digit.
+  ...tabSwitchShortcuts,
 ]

--- a/packages/dashboard/src/shortcuts/registry.test.ts
+++ b/packages/dashboard/src/shortcuts/registry.test.ts
@@ -218,4 +218,76 @@ describe('createShortcutRegistry', () => {
     }, 'global')
     expect(match).toBeNull()
   })
+
+  describe('matchEvent gates (#4412)', () => {
+    it('respects the `enabled` predicate — false skips the match', () => {
+      let enabled = false
+      const gated: ShortcutDef[] = [
+        { id: 'session.close', defaultBinding: 'Cmd+W', description: 'Close tab', category: 'session', scope: 'global', enabled: () => enabled },
+      ]
+      const registry = createShortcutRegistry(gated)
+      // Disabled: no match.
+      expect(registry.matchEvent({
+        key: 'w', metaKey: true, ctrlKey: false, shiftKey: false, altKey: false,
+      }, 'global')).toBeNull()
+      // Flip the predicate, same event matches.
+      enabled = true
+      expect(registry.matchEvent({
+        key: 'w', metaKey: true, ctrlKey: false, shiftKey: false, altKey: false,
+      }, 'global')).toBe('session.close')
+    })
+
+    it('respects `disabledInTextInput` — suppresses match inside INPUT/TEXTAREA/contenteditable', () => {
+      const gated: ShortcutDef[] = [
+        { id: 'help.toggle', defaultBinding: '?', description: 'Help', category: 'other', scope: 'global', disabledInTextInput: true },
+      ]
+      const registry = createShortcutRegistry(gated)
+      // No target — fires.
+      expect(registry.matchEvent({
+        key: '?', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false,
+      }, 'global')).toBe('help.toggle')
+      // INPUT target — suppressed.
+      const input = document.createElement('input')
+      expect(registry.matchEvent({
+        key: '?', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, target: input,
+      }, 'global')).toBeNull()
+      // TEXTAREA target — suppressed.
+      const textarea = document.createElement('textarea')
+      expect(registry.matchEvent({
+        key: '?', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, target: textarea,
+      }, 'global')).toBeNull()
+      // contenteditable target — suppressed. jsdom's
+      // `isContentEditable` derives from `contentEditable === 'true'`
+      // but only when the element is actually attached and the
+      // attribute is reflected; stub the getter so the match-event
+      // gate sees `true` deterministically across jsdom versions.
+      const div = document.createElement('div')
+      Object.defineProperty(div, 'isContentEditable', { value: true, configurable: true })
+      expect(registry.matchEvent({
+        key: '?', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, target: div,
+      }, 'global')).toBeNull()
+      // Non-text element (button) — fires.
+      const button = document.createElement('button')
+      expect(registry.matchEvent({
+        key: '?', metaKey: false, ctrlKey: false, shiftKey: false, altKey: false, target: button,
+      }, 'global')).toBe('help.toggle')
+    })
+
+    it('a disabled shortcut does not block a later (non-gated) match on the same combo', () => {
+      // Realistic: two shortcuts in different scopes can't share a combo
+      // in the same scope by conflict-detection rules, but `enabled` is
+      // evaluated AFTER combo match so a disabled shortcut must not
+      // shadow nothing. This test pins the behaviour: when the disabled
+      // shortcut comes first in the definitions list, matchEvent still
+      // returns null (no later entry to fall back to) rather than
+      // throwing.
+      const gated: ShortcutDef[] = [
+        { id: 'tauri.only', defaultBinding: 'Cmd+W', description: 'Tauri', category: 'session', scope: 'global', enabled: () => false },
+      ]
+      const registry = createShortcutRegistry(gated)
+      expect(registry.matchEvent({
+        key: 'w', metaKey: true, ctrlKey: false, shiftKey: false, altKey: false,
+      }, 'global')).toBeNull()
+    })
+  })
 })

--- a/packages/dashboard/src/shortcuts/registry.ts
+++ b/packages/dashboard/src/shortcuts/registry.ts
@@ -33,6 +33,21 @@ export interface ShortcutDef {
   description: string
   category: ShortcutCategory
   scope: ShortcutScope
+  /**
+   * Optional runtime predicate: shortcut only fires when this returns
+   * true. Used for environment gates that the registry can't know
+   * about (e.g. Tauri-only shortcuts like Cmd+W close-tab). Evaluated
+   * inside `matchEvent` — a false predicate means the shortcut is
+   * skipped even if the combo matches.
+   */
+  enabled?: () => boolean
+  /**
+   * When true, the shortcut does NOT fire while focus is in a text
+   * input (INPUT / TEXTAREA / contenteditable / SELECT). Mirrors the
+   * inline gates the App.tsx ladder used to do per-branch. Evaluated
+   * inside `matchEvent` when the caller passes a target element.
+   */
+  disabledInTextInput?: boolean
 }
 
 export interface ShortcutListEntry extends ShortcutDef {
@@ -140,6 +155,21 @@ interface KeyEventLike {
   ctrlKey: boolean
   shiftKey: boolean
   altKey: boolean
+  /**
+   * Optional event target — when provided, `matchEvent` respects each
+   * shortcut's `disabledInTextInput` flag. KeyboardEvent already
+   * carries `target` so the standard call site needs no extra plumbing.
+   */
+  target?: EventTarget | null
+}
+
+function isTextInputTarget(target: EventTarget | null | undefined): boolean {
+  if (!target || typeof (target as HTMLElement).tagName !== 'string') return false
+  const el = target as HTMLElement
+  const tag = el.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  if (el.isContentEditable) return true
+  return false
 }
 
 export interface ShortcutRegistry {
@@ -297,6 +327,7 @@ export function createShortcutRegistry(defs: readonly ShortcutDef[]): ShortcutRe
   function matchEvent(event: KeyEventLike, scope: ShortcutScope): string | null {
     const eventKey = (event.key || '').toLowerCase()
     const eventMeta = event.metaKey || event.ctrlKey
+    const inTextInput = isTextInputTarget(event.target)
     for (const def of definitions) {
       if (def.scope !== scope) continue
       const binding = getBinding(def.id)
@@ -307,6 +338,11 @@ export function createShortcutRegistry(defs: readonly ShortcutDef[]): ShortcutRe
         parsed.shift === event.shiftKey &&
         parsed.alt === event.altKey
       ) {
+        // Environment / context gates — applied after the combo match
+        // so `enabled` and `disabledInTextInput` short-circuit cleanly
+        // without affecting conflict detection.
+        if (def.disabledInTextInput && inTextInput) continue
+        if (def.enabled && !def.enabled()) continue
         return def.id
       }
     }


### PR DESCRIPTION
Closes #4412

## Summary

Completes the #3852 migration by moving every entry in App.tsx's global keydown ladder into the shortcut registry. All dashboard shortcuts are now user-rebindable through Settings.

### Registry contract additions

- `enabled?: () => boolean` — runtime gate (used by `session.close` for Tauri-only)
- `disabledInTextInput?: boolean` — text-input gate (used by `session.togglePlanMode` and `help.toggle`)

Both are evaluated inside `matchEvent` so the dispatch site stays clean.

### Migrated shortcuts

| Shortcut | Registry id | Notes |
|---|---|---|
| Cmd+Shift+P | `palette.toggle.vscode` | VSCode-style palette alias |
| Cmd+Shift+D | `view.toggleChatTerminal` | |
| Cmd+\\ | `view.cycleSplit` | |
| Cmd+Shift+T | `session.copyTranscript` | |
| Cmd+. | `session.interrupt` | |
| Shift+Tab | `session.togglePlanMode` | `disabledInTextInput` |
| ? | `help.toggle` | `disabledInTextInput` |
| Cmd+Shift+[ / ] | `session.prev` / `session.next` | |
| Cmd+W | `session.close` | `enabled: isTauri()` |
| Cmd+1-9 | `session.switch.1` .. `session.switch.9` | 9 separate entries |

### Variadic shortcuts

Cmd+1-9 modelled as 9 separate registry entries (one per digit) rather than a single parameterised action. Per-digit entries let users rebind individual slots in Settings, and the registry stays a plain combo->id map. The cheat sheet collapses them into a single "Cmd+1-9" row driven by the `session.switch.1` binding so a rebind still surfaces correctly.

Cmd+Shift+[ / Cmd+Shift+] modelled similarly as two entries.

### Cheat sheet

Now derives rows from `registry.list()` instead of a parallel hardcoded array, so the cheat sheet, settings panel, and keydown dispatch all read from one source of truth.

## Test plan

- [x] `npm test -- --run` (123 files, 2194 tests pass)
- [x] `npm run typecheck` clean
- [x] `registry.test.ts`: new `matchEvent gates (#4412)` block covers `enabled` predicate (false skips, true matches), `disabledInTextInput` for INPUT / TEXTAREA / contenteditable / no-target / non-text-element targets
- [x] `App.test.tsx`: new `registry-driven shortcut dispatch (#4412)` block covers 10 end-to-end paths — Cmd+. interrupt, Cmd+Shift+D view toggle, Cmd+2 switch, Cmd+1 no-op when no sessions, Cmd+Shift+] wrap-around, Cmd+Shift+[ wrap-back, Shift+Tab plan mode toggle outside text input, Shift+Tab suppressed in textarea, Cmd+Shift+P palette open, Cmd+W single-tab safeguard
- [x] `useGlobalShortcuts-comprehensive.test.ts` / `useGlobalShortcuts-integration.test.ts`: rewritten to assert against `DEFAULT_SHORTCUTS` rather than grepping App.tsx text (the dispatch arms no longer contain the raw combos)