### PR TITLE
feat(server): persist Codex learn-loop ratchets across restart (#4413)

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -319,6 +319,14 @@ export function _maybeRatchetContextWindow(session, modelId, inputTokens) {
   const changed = registry.updateContextWindow(modelId, bumped)
   if (!changed) return false
 
+  // #4413 — persist the bumped registry to the codex-scoped cache file
+  // (`~/.chroxy/models-cache.codex.json`) so a server restart doesn't lose
+  // the learned window. `saveCache()` is idempotent (snapshot-deduped) and
+  // logs a warn on disk failure rather than throwing, so the in-memory
+  // ratchet always succeeds even when the disk path is unwritable. The
+  // default Claude cache is unaffected — non-Claude providers use their
+  // own path via `getRegistryForProvider`'s `cachePath` hook.
+  registry.saveCache()
   // Mirror sdk-session.js:763 — broadcast the corrected registry so the
   // dashboard's `availableModels` (and therefore the footer meter) picks
   // up the new window without waiting for the next refresh.

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -207,6 +207,24 @@ function getDefaultCachePath() {
 }
 
 /**
+ * Per-provider cache path resolver (#4413). Non-Claude providers
+ * (codex, gemini, …) persist learned context-window ratchets to their own
+ * disk file so a server restart doesn't lose state and the default Claude
+ * cache (`models-cache.json`) stays untouched.
+ *
+ * The provider name is sanitised to a filename-safe slug so an unexpected
+ * `providerName` value can't escape the config dir via path metacharacters.
+ *
+ * @param {string} providerName
+ * @returns {string}
+ */
+function getProviderCachePath(providerName) {
+  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  const safe = String(providerName).replace(/[^a-zA-Z0-9_-]/g, '_')
+  return join(configDir, `models-cache.${safe}.json`)
+}
+
+/**
  * Canonical JSON stringifier — sorts object keys recursively so equivalent
  * data produces an identical string regardless of construction order.
  *
@@ -340,6 +358,13 @@ function humanizeModelId(id) {
  *   Optional provider lookup that can return `{id,label,fullId,contextWindow}`
  *   for a known model fullId. When present it is consulted first during
  *   `updateModels()` to reuse provider-authoritative metadata.
+ * @param {() => string} [hooks.cachePath] - Resolver for the disk cache path
+ *   used by `loadCache()` / `saveCache()` when no explicit path is passed.
+ *   Lazy so the path is re-read from `CHROXY_CONFIG_DIR` after env edits in
+ *   tests. Defaults to the shared Claude cache at
+ *   `~/.chroxy/models-cache.json`. Non-Claude providers should supply a
+ *   provider-scoped path (e.g. `~/.chroxy/models-cache.codex.json`) so the
+ *   default Claude cache stays untouched by per-provider learn-loops (#4413).
  */
 export function createModelsRegistry(hooks = {}) {
   const fallbackModels = hooks.fallbackModels ?? FALLBACK_MODELS
@@ -347,6 +372,7 @@ export function createModelsRegistry(hooks = {}) {
   const resolveContextWindowFn = typeof hooks.resolveContextWindow === 'function'
     ? hooks.resolveContextWindow
     : resolveClaudeContextWindow
+  const cachePathFn = typeof hooks.cachePath === 'function' ? hooks.cachePath : getDefaultCachePath
   const getModelMetadataFn = typeof hooks.getModelMetadata === 'function' ? hooks.getModelMetadata : null
 
   let activeModels = fallbackModels
@@ -639,7 +665,7 @@ export function createModelsRegistry(hooks = {}) {
      * older or hand-edited cache files don't leave the picker with empty
      * labels or a default context window.
      */
-    loadCache(path = getDefaultCachePath()) {
+    loadCache(path = cachePathFn()) {
       try {
         const raw = readFileSync(path, 'utf-8')
         const parsed = JSON.parse(raw)
@@ -754,7 +780,7 @@ export function createModelsRegistry(hooks = {}) {
      * leave a truncated cache, and permissions are locked down via
      * writeFileRestricted (0600).
      */
-    saveCache(path = getDefaultCachePath()) {
+    saveCache(path = cachePathFn()) {
       return saveCacheImpl(path)
     },
   }
@@ -838,6 +864,26 @@ export function registerProviderRegistry(providerName, ProviderClass) {
 }
 
 /**
+ * Test helper (#4413). Drops the cached provider registries so the next
+ * `getRegistryForProvider()` call rebuilds — and re-runs `loadCache()` —
+ * from disk. Used by the persistence test suite to simulate "server
+ * restart": save → wipe in-memory state → re-read.
+ *
+ * Not exported via the public API surface beyond tests; the name leads
+ * with an underscore to signal that.
+ *
+ * @param {string} [providerName] - When provided, drop only that provider's
+ *   cached registry; when omitted, drop all of them.
+ */
+export function _resetProviderRegistryCacheForTests(providerName) {
+  if (typeof providerName === 'string' && providerName.length > 0) {
+    providerRegistryCache.delete(providerName)
+    return
+  }
+  providerRegistryCache.clear()
+}
+
+/**
  * Lazily create and cache a provider-scoped registry.
  *
  * Claude providers (including docker-based variants) share the module-level
@@ -879,7 +925,21 @@ export function getRegistryForProvider(providerName) {
         : null
       return meta?.contextWindow ?? DEFAULT_CONTEXT_WINDOW
     },
+    // #4413: provider-scoped cache path. Lazy resolver so tests that mutate
+    // `CHROXY_CONFIG_DIR` after registry creation still hit the temp dir.
+    cachePath: () => getProviderCachePath(providerName),
   })
+  // #4413: hydrate the registry from its own cache file before serving the
+  // first getModels() call. A miss (no file, malformed, all-stale) is a
+  // silent no-op so cold-boot semantics are unchanged. This restores any
+  // previously-learned context-window ratchet (gpt-5/gpt-5-codex 400k →
+  // 550k after a series of large turns) so the dashboard meter is honest
+  // immediately, not only after the next over-budget turn.
+  try {
+    registry.loadCache()
+  } catch (err) {
+    log.warn(`getRegistryForProvider(${providerName}): loadCache threw unexpectedly: ${err?.message || err}`)
+  }
   providerRegistryCache.set(providerName, registry)
   return registry
 }

--- a/packages/server/tests/codex-ratchet-persistence.test.js
+++ b/packages/server/tests/codex-ratchet-persistence.test.js
@@ -1,0 +1,179 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+// Importing providers.js triggers built-in provider registration so
+// getRegistryForProvider('codex') resolves to the CodexSession class.
+import '../src/providers.js'
+import {
+  getRegistryForProvider,
+  _resetProviderRegistryCacheForTests,
+} from '../src/models.js'
+import {
+  _maybeRatchetContextWindow,
+  CODEX_CONTEXT_WINDOW_HEADROOM,
+  CODEX_CONTEXT_WINDOW_RATCHET_CAP,
+} from '../src/codex-session.js'
+
+// ---------------------------------------------------------------------------
+// #4413 — persist Codex learn-loop ratchets across server restart.
+//
+// Every test uses an isolated `CHROXY_CONFIG_DIR` (the per-provider cache
+// path is derived from this env var via `getProviderCachePath`). The
+// provider-registry cache is purged before AND after each test so the
+// codex registry rebuilds against the temp dir and never leaks into other
+// suites (memory: feedback_test_state_contamination.md).
+// ---------------------------------------------------------------------------
+
+describe('#4413 Codex ratchet persistence (cross-restart)', () => {
+  let tmpDir
+  let origConfigDir
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-codex-ratchet-'))
+    origConfigDir = process.env.CHROXY_CONFIG_DIR
+    process.env.CHROXY_CONFIG_DIR = tmpDir
+    // Force a fresh codex registry so the first getRegistryForProvider()
+    // call inside each test re-runs loadCache() against the temp dir.
+    _resetProviderRegistryCacheForTests('codex')
+  })
+
+  afterEach(() => {
+    if (origConfigDir === undefined) {
+      delete process.env.CHROXY_CONFIG_DIR
+    } else {
+      process.env.CHROXY_CONFIG_DIR = origConfigDir
+    }
+    _resetProviderRegistryCacheForTests('codex')
+    try { rmSync(tmpDir, { recursive: true, force: true }) } catch {}
+  })
+
+  it('writes the per-provider cache file after a successful ratchet', () => {
+    const codexPath = join(tmpDir, 'models-cache.codex.json')
+    assert.equal(existsSync(codexPath), false, 'sanity: no cache file before ratchet')
+
+    const fakeSession = { model: 'gpt-5-codex', emit: () => {} }
+    // 500k input on a 400k registered window → ratchets up.
+    const changed = _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 500_000)
+    assert.equal(changed, true, 'ratchet should fire for an over-budget turn')
+
+    assert.equal(existsSync(codexPath), true,
+      `expected codex-scoped cache file at ${codexPath}`)
+    const parsed = JSON.parse(readFileSync(codexPath, 'utf-8'))
+    assert.ok(Array.isArray(parsed.models), 'cache file should carry a models array')
+    const persisted = parsed.models.find(m => m.fullId === 'gpt-5-codex')
+    assert.ok(persisted, 'gpt-5-codex must be persisted')
+    assert.ok(persisted.contextWindow >= 500_000 * CODEX_CONTEXT_WINDOW_HEADROOM,
+      `expected persisted window >= ${500_000 * CODEX_CONTEXT_WINDOW_HEADROOM}, got ${persisted.contextWindow}`)
+  })
+
+  it('does NOT touch the default Claude cache file (models-cache.json)', () => {
+    const claudePath = join(tmpDir, 'models-cache.json')
+    const codexPath = join(tmpDir, 'models-cache.codex.json')
+
+    const fakeSession = { model: 'gpt-5-codex', emit: () => {} }
+    _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 600_000)
+
+    assert.equal(existsSync(codexPath), true, 'codex cache should exist')
+    assert.equal(existsSync(claudePath), false,
+      'codex ratchet must not write to the Claude registry cache (#4413 acceptance criterion)')
+  })
+
+  it('on simulated restart, the ratcheted window is restored before getModels() serves traffic', () => {
+    // --- "Pre-restart" session: ratchet up to ~550k.
+    const fakeSession = { model: 'gpt-5-codex', emit: () => {} }
+    _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 500_000)
+    const beforeRestart = getRegistryForProvider('codex')
+      .getModels().find(m => m.fullId === 'gpt-5-codex')
+    assert.ok(beforeRestart.contextWindow >= 500_000 * CODEX_CONTEXT_WINDOW_HEADROOM)
+    const expectedWindow = beforeRestart.contextWindow
+
+    // --- Simulated restart: drop the cached registry. Next
+    //     getRegistryForProvider('codex') call must rebuild from fallback
+    //     metadata and then immediately hydrate from the on-disk cache.
+    _resetProviderRegistryCacheForTests('codex')
+
+    const restored = getRegistryForProvider('codex')
+      .getModels().find(m => m.fullId === 'gpt-5-codex')
+    assert.ok(restored, 'gpt-5-codex must survive the simulated restart')
+    assert.equal(restored.contextWindow, expectedWindow,
+      `post-restart window should match pre-restart ratcheted value (was ${beforeRestart.contextWindow}, got ${restored.contextWindow})`)
+  })
+
+  it('restored ratchet is also honored by a subsequent ratchet call (no double-bump)', () => {
+    // First "session" ratchets to ~550k.
+    const fakeSession = { model: 'gpt-5-codex', emit: () => {} }
+    _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 500_000)
+
+    // Restart: drop in-memory state.
+    _resetProviderRegistryCacheForTests('codex')
+
+    // After restart, a turn that fits inside the restored window must NOT
+    // re-trigger the ratchet. If persistence is broken, the registry would
+    // reset to the 400k static value and 450k would look over-budget again.
+    const changed = _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 450_000)
+    assert.equal(changed, false,
+      'a turn inside the restored window must be a no-op — persistence not honored?')
+  })
+
+  it('persistence respects CODEX_CONTEXT_WINDOW_RATCHET_CAP', () => {
+    // A wildly high observed value triggers the cap; the persisted file
+    // must reflect the capped value, not the uncapped raw multiplication.
+    const fakeSession = { model: 'gpt-5-codex', emit: () => {} }
+    _maybeRatchetContextWindow(fakeSession, 'gpt-5-codex', 10_000_000)
+
+    const codexPath = join(tmpDir, 'models-cache.codex.json')
+    const parsed = JSON.parse(readFileSync(codexPath, 'utf-8'))
+    const persisted = parsed.models.find(m => m.fullId === 'gpt-5-codex')
+    assert.ok(persisted.contextWindow <= CODEX_CONTEXT_WINDOW_RATCHET_CAP,
+      `persisted ratchet must respect cap of ${CODEX_CONTEXT_WINDOW_RATCHET_CAP}, got ${persisted.contextWindow}`)
+  })
+
+  it('cold boot with no cache file is a silent no-op (returns the fallback list)', () => {
+    // No file written, no ratchet performed: the registry must still serve
+    // the static fallback metadata so first-boot semantics are unchanged.
+    const codexPath = join(tmpDir, 'models-cache.codex.json')
+    assert.equal(existsSync(codexPath), false)
+
+    const models = getRegistryForProvider('codex').getModels()
+    assert.ok(models.length > 0, 'codex registry should serve fallback even with no cache')
+    const gpt5 = models.find(m => m.fullId === 'gpt-5-codex')
+    assert.ok(gpt5, 'gpt-5-codex fallback must be present')
+    assert.equal(gpt5.contextWindow, 400_000,
+      'cold boot should serve the static 400k fallback when no cache exists')
+  })
+
+  it('malformed cache file falls through to fallback list without throwing', () => {
+    const codexPath = join(tmpDir, 'models-cache.codex.json')
+    writeFileSync(codexPath, 'not valid json {{{')
+    _resetProviderRegistryCacheForTests('codex')
+
+    // Should not throw — loadCache returns false silently and the registry
+    // serves fallback. This matches the existing Claude path's failure mode.
+    const models = getRegistryForProvider('codex').getModels()
+    const gpt5 = models.find(m => m.fullId === 'gpt-5-codex')
+    assert.ok(gpt5)
+    assert.equal(gpt5.contextWindow, 400_000,
+      'malformed cache should fall through to fallback, not corrupt state')
+  })
+
+  it('Claude default registry continues to use the shared models-cache.json path', async () => {
+    // Sanity: changing how non-Claude providers persist must NOT redirect
+    // the Claude default registry to a per-provider path. Verifies the
+    // saveCache default for the default registry still resolves to
+    // `<configDir>/models-cache.json`.
+    const claudePath = join(tmpDir, 'models-cache.json')
+    // Use the legacy module-level Claude entry point.
+    const { saveModelsCache, getRegistryForProvider: gp } = await import('../src/models.js')
+    // Bump the default registry's snapshot to force a write.
+    const claudeRegistry = gp('claude-sdk')
+    claudeRegistry.updateContextWindow('claude-opus-4-7', 1_500_000)
+    saveModelsCache()
+    assert.equal(existsSync(claudePath), true,
+      `default Claude cache should still land at ${claudePath}`)
+    // Reset so we don't leak this contextWindow override into other suites.
+    claudeRegistry.resetModels()
+  })
+})

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -1611,11 +1611,29 @@ describe('CodexSession', () => {
   })
 
   describe('#3857 learn-loop — _maybeRatchetContextWindow()', () => {
-    // The codex provider registry is module-cached; reset before each test
-    // so the pollution from a previous ratchet doesn't bleed in.
+    // #4413: the ratchet now persists to disk via the codex-scoped cache
+    // file (`~/.chroxy/models-cache.codex.json`). Without an isolated
+    // CHROXY_CONFIG_DIR these tests would write to the operator's real
+    // chroxy state directory and contaminate it with the test cap value
+    // (see memory: feedback_test_state_contamination.md). Each test gets
+    // its own temp dir, and the registry cache is purged so the next
+    // `getRegistryForProvider('codex')` rebuilds against that dir.
+    let _ratchetTmpDir
+    let _ratchetOrigConfigDir
     beforeEach(() => {
+      _ratchetTmpDir = mkdtempSync(join(tmpdir(), 'chroxy-codex-ratchet-block-'))
+      _ratchetOrigConfigDir = process.env.CHROXY_CONFIG_DIR
+      process.env.CHROXY_CONFIG_DIR = _ratchetTmpDir
       const r = getRegistryForProvider('codex')
       r.resetModels()
+    })
+    afterEach(() => {
+      if (_ratchetOrigConfigDir === undefined) {
+        delete process.env.CHROXY_CONFIG_DIR
+      } else {
+        process.env.CHROXY_CONFIG_DIR = _ratchetOrigConfigDir
+      }
+      try { rmSync(_ratchetTmpDir, { recursive: true, force: true }) } catch {}
     })
 
     it('no-op when input_tokens is at or below the registered window', () => {


### PR DESCRIPTION
Closes #4413

## Summary

- Adds a `cachePath` hook to `createModelsRegistry` so non-Claude providers can persist their registry to a provider-scoped file (`~/.chroxy/models-cache.codex.json`) instead of sharing `models-cache.json` with the Claude registry.
- `getRegistryForProvider('codex')` (and any other non-Claude provider) now autoloads its cache on first construction, restoring any previously-learned context window before the first `getModels()` call.
- The Codex `_maybeRatchetContextWindow` helper persists the bumped registry via `registry.saveCache()` after a successful `updateContextWindow()`. The save is idempotent (snapshot-deduped) and degrades to in-memory only on disk failure via the existing warn-and-continue path in `saveCacheImpl`.
- The default Claude registry continues to use `~/.chroxy/models-cache.json` — no change to that code path.

## Acceptance criteria (from #4413)

- [x] After a successful `_maybeRatchetContextWindow` ratchet, the new contextWindow is persisted to disk.
- [x] On boot, the codex registry loads any persisted overrides before serving its first `getModels()` call.
- [x] Persisted overrides survive a server restart (full round-trip test).
- [x] The default Claude registry's cache is not affected by codex persistence.
- [x] Persistence failures (disk full, permission denied) log at warn-level and degrade to in-memory only — same failure mode as the Claude `saveCacheImpl()` path.

## Tests

- New `tests/codex-ratchet-persistence.test.js` (8 cases) covers: write-after-ratchet, default Claude cache untouched, restart round-trip via `_resetProviderRegistryCacheForTests`, no double-bump after restart, cap is preserved on disk, cold-boot no-op, malformed-file fallthrough, Claude default registry path unchanged.
- All tests use `mkdtempSync` + `CHROXY_CONFIG_DIR` for isolated state (no real `~/.chroxy` pollution).
- Full server suite: 5739 pass; the 2 pre-existing failures (`TunnelManager Integration`, `WebTaskManager` feature-detection) reproduce on plain main and are unrelated.

## Test plan

- [ ] CI green on the new suite + `tests/models*.test.js` + `tests/codex-session.test.js`
- [ ] Manual: ratchet `gpt-5-codex` past 400k, restart server, confirm dashboard meter shows the bumped window without waiting for the next over-budget turn