### PR TITLE
chore(release): cut v0.9.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.12] - 2026-05-28
+
+Small follow-up sweep closing seven leftovers from the v0.9.10–v0.9.11 marathons. Theme is "finish what we started": the keyboard-shortcut registry now owns every dashboard binding (the tail #4412 deferred from v0.9.10's #3852), the context-window learn-loop now persists and runs on both Codex and Gemini (the two #4413/#4414 follow-ups from v0.9.10's #3857), and the pending-background-shells feature lights up the mobile app + handles overflow and multi-shell expansion (the three #4420/#4421/#4422 follow-ups from v0.9.11's #4307). No new user-facing features — every change is making an existing v0.9.x feature work the way it was advertised.
+
+### Added
+
+- **Mobile-app surface for pending background shells (#4422 / #4425):** `ActivityIndicator.tsx` (mobile) now shows "Waiting on background work" with the most-recently-started shell's command text, matching the dashboard's #4418 surface from v0.9.11. Uses the same `pendingBackgroundShells` store-core field that already flows through the WS event + snapshot — no protocol changes, just renderer parity.
+- **ActivityIndicator chip handles overflow + multi-shell expand (#4420 + #4421 / #4426):** the chip text now tail-truncates long shell commands with `title=""` fallback so the full command is reachable on hover. Tapping a multi-shell chip expands to the full list of pending shells with start time. Bundled into one PR because both touch `ActivityIndicator.tsx` heavily.
+- **Keyboard-shortcut migration tail — Cmd+1-9, Cmd+Shift+[/], Cmd+W (#4412 / #4429):** the remaining hand-rolled shortcuts deferred from v0.9.10's #3852 are now registered in the shortcut registry, so they show up in the cheat sheet and are rebindable. Three follow-ups left for the operator-visible polish: [#4427](https://github.com/blamechris/chroxy/issues/4427) (outside-click / Escape dismissal), [#4428](https://github.com/blamechris/chroxy/issues/4428) (aria-label off-by-one), [#4431](https://github.com/blamechris/chroxy/issues/4431) (registry-aware conflict-detection predicate), [#4432](https://github.com/blamechris/chroxy/issues/4432) (cheat-sheet collapsed-state mislabel).
+
+### Fixed
+
+- **Codex context-window ratchets survive server restart (#4413 / #4433):** v0.9.10 ratcheted the in-memory registry on every Codex turn but lost the result on restart. Now the bumped value is written through to the provider-scoped cache file (`~/.chroxy/models-cache.codex.json`) via `registry.saveCache()`. `saveCache()` is idempotent (snapshot-deduped) and logs a warn on disk failure rather than throwing, so the in-memory ratchet always succeeds even when the disk path is unwritable. The existing learn-loop test was caught writing to the operator's real cache file mid-run; the fix isolated it to a temp `CHROXY_CONFIG_DIR` per the long-standing `feedback_test_state_contamination.md` rule.
+- **Context-window learn-loop extended to Gemini (#4414 / #4430):** the Codex-specific ratchet from v0.9.10 + #4413's persistence are now factored into a shared `maybeRatchetContextWindow` helper in `packages/server/src/utils/context-window-learn.js` and used by both Codex and Gemini. `Object.hasOwn` guard on the per-provider cap lookup so `getRatchetCap('constructor')` no longer returns `Object` from the prototype chain. `_processGeminiEvent`'s legacy path now has an explanatory comment for why the duplicate emit is intentional. Follow-up [#4431](https://github.com/blamechris/chroxy/issues/4431) tracks tightening the registry-enabled predicate for sessions that haven't reported usage yet.
+
+### Changed
+
+- **`_pendingBackgroundShells` documented as transient by design (#4417 / #4424):** v0.9.11 deferred the question of persistence across restart; this release makes it explicit. The Map is rebuilt from `Bash`/`BashOutput` events on the next foreground turn, so restart loses pending tracking only for the brief window between the shell launching and its first `BashOutput` — a tradeoff worth keeping for the operational simplicity of not writing transient state to disk. Docstring on `background-shells.js` now states this so the next reader doesn't re-relitigate it.
+
 ## [0.9.11] - 2026-05-28
 
 Focused release shipping the long-standing dogfood pain point: TUI / SDK sessions waiting on a backgrounded shell no longer look idle/dead and can no longer be reaped by `CHROXY_SESSION_TIMEOUT`. Closes #4307 (the `priority:high` server bug) plus its dashboard renderer follow-up #4418, completing the user-visible feature in a single version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.11"
+      "version": "0.9.12"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.11",
+    "version": "0.9.12",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.11</string>
+    <string>0.9.12</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.11"
+version = "0.9.12"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.11",
+      "version": "0.9.12",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## v0.9.12 — Follow-up sweep

Small follow-up sweep closing seven leftovers from the v0.9.10–v0.9.11 marathons. No new user-facing features — every change is making an existing v0.9.x feature work the way it was advertised.

### Ships
- **Mobile pending-shells surface (#4422)** — `ActivityIndicator.tsx` mobile parity with dashboard's #4418
- **ActivityIndicator overflow + multi-shell expand (#4420 + #4421)** — tail-truncate + tap-to-expand
- **Shortcut-registry migration tail (#4412)** — Cmd+1-9, Cmd+Shift+[/], Cmd+W now registered
- **Codex ratchet persistence (#4413)** — writes through to `models-cache.codex.json`
- **Gemini context-window learn-loop (#4414)** — shared helper, both providers persist
- **Pending-shells documented as transient (#4417)** — design boundary pinned in docstring

### Test plan
- [x] All 6 feature PRs landed clean on main (`1618acbc5`)
- [x] `scripts/bump-version.sh 0.9.12` updates 15 files atomically
- [x] CHANGELOG entry follows Keep a Changelog format
- [ ] CI green
- [ ] Tag pushed + GH release created post-merge
- [ ] Tauri app rebuilt with `--bundles app` + installed to /Applications