### PR TITLE
fix(dashboard): skip enabled:false defs in shortcut conflict scan

### DIFF
--- a/packages/dashboard/src/shortcuts/registry.test.ts
+++ b/packages/dashboard/src/shortcuts/registry.test.ts
@@ -166,6 +166,38 @@ describe('createShortcutRegistry', () => {
       // bound to Cmd+K — no conflict.
       expect(registry.findConflict('palette.toggle', 'Cmd+K')).toBeNull()
     })
+
+    it('skips runtime-disabled defs when scanning for conflicts (#4431)', () => {
+      // Two shortcuts that can never both be live at once — e.g. a
+      // Tauri-only desktop binding and a browser-only web binding —
+      // sharing the same combo must NOT be flagged as a conflict.
+      // matchEvent already respects `enabled`, so the registry must
+      // mirror that during the conflict scan and during setBinding.
+      let isTauri = true
+      const gated: ShortcutDef[] = [
+        { id: 'tauri.close', defaultBinding: 'Cmd+W', description: 'Tauri close', category: 'session', scope: 'global', enabled: () => isTauri },
+        { id: 'browser.close', defaultBinding: 'Cmd+W', description: 'Browser close', category: 'session', scope: 'global', enabled: () => !isTauri },
+      ]
+      const registry = createShortcutRegistry(gated)
+      // Tauri side live, browser side disabled — no conflict either way.
+      expect(registry.findConflict('tauri.close', 'Cmd+W')).toBeNull()
+      expect(registry.findConflict('browser.close', 'Cmd+W')).toBeNull()
+      // Flip the environment — same expectation, conflict still
+      // suppressed because exactly one side is live.
+      isTauri = false
+      expect(registry.findConflict('tauri.close', 'Cmd+W')).toBeNull()
+      expect(registry.findConflict('browser.close', 'Cmd+W')).toBeNull()
+
+      // setBinding must agree with findConflict — rebinding either side
+      // to a fresh shared combo must succeed when the counterpart is
+      // gated off. Use Cmd+T (not in `defs` because this registry only
+      // has the two gated entries) to exercise the conflict path.
+      isTauri = true
+      registry.setBinding('tauri.close', 'Cmd+T')
+      expect(registry.getBinding('tauri.close')).toBe('cmd+t')
+      registry.setBinding('browser.close', 'Cmd+T')
+      expect(registry.getBinding('browser.close')).toBe('cmd+t')
+    })
   })
 
   it('notifies subscribers when a binding changes', () => {

--- a/packages/dashboard/src/shortcuts/registry.ts
+++ b/packages/dashboard/src/shortcuts/registry.ts
@@ -269,9 +269,18 @@ export function createShortcutRegistry(defs: readonly ShortcutDef[]): ShortcutRe
     if (!target) return null
     const canonical = normalizeBinding(binding)
     if (!canonical) return null
+    // If the shortcut being bound is itself runtime-disabled, it can't
+    // collide with anything — its combo will never fire. Symmetrically,
+    // disabled defs below are skipped so two mutually-exclusive
+    // environment gates (e.g. Tauri-only vs browser-only) can share a
+    // combo without false conflicts (#4431).
+    if (target.enabled && !target.enabled()) return null
     for (const def of definitions) {
       if (def.id === id) continue
       if (def.scope !== target.scope) continue
+      // Skip runtime-disabled defs — they don't fire on this combo, so
+      // they can't collide with the binding we're checking.
+      if (def.enabled && !def.enabled()) continue
       if (getBinding(def.id) === canonical) {
         return { ...def, binding: canonical, isCustomized: getBinding(def.id) !== def.defaultBinding }
       }


### PR DESCRIPTION
## Summary

`createShortcutRegistry.findConflict` iterated every def in scope to detect a binding collision but did not consult each def's `enabled?: () => boolean` predicate. Two runtime-mutually-exclusive shortcuts (e.g. one Tauri-only, one browser-only) that share a combo were falsely flagged as a conflict, and `setBinding` would throw.

Today this is latent: only one gated shortcut exists (`session.close`, gated on `isTauri()`). It would have bitten as soon as a second environment-gated shortcut landed.

## Fix

`findConflict` now skips defs whose `enabled()` returns `false` during the scan. For symmetry, if the shortcut being bound is itself runtime-disabled the scan short-circuits to `null` (its combo can't fire, so it can't collide). `enabled === undefined` is treated as enabled, matching existing `matchEvent` semantics.

This is option (1) from the issue.

## Tests

- New registry test `skips runtime-disabled defs when scanning for conflicts (#4431)`: two `enabled`-gated shortcuts share `Cmd+W`, asserts both directions return `null`, flips the environment and re-asserts, then exercises `setBinding` end-to-end to confirm the conflict path also lets them coexist.
- All 55 existing `registry.test.ts` / `ShortcutsSection.test.tsx` tests still pass.

## Test plan

- [x] `vitest run registry.test.ts` — 55/55 pass
- [ ] No regressions in the cheat-sheet renderer (#4432 touches the same area but a different file)

Closes #4431