### PR TITLE
fix(dashboard): align ActivityIndicator disclosure aria-label with popover content

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
@@ -340,6 +340,57 @@ describe('ActivityIndicator — pending-shell disclosure for multiple shells (#4
     expect(screen.queryByTestId('activity-indicator-popover')).toBeNull()
   })
 
+  it('announces the total shell count and wires aria-controls when the popover is open (#4428)', () => {
+    // The disclosure button's aria-label previously said "Show N additional
+    // pending background shells" where N = overflowShells.length. But when
+    // opened, the popover lists the headline shell + every overflow shell,
+    // so the announcement understated the dialog by one. Pin the new wording
+    // (total count) and the aria-controls relationship to the popover id.
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'old01', command: 'sleep 60', startedAt: now - 30_000 },
+            { shellId: 'mid02', command: 'tail -f /var/log/system.log', startedAt: now - 20_000 },
+            { shellId: 'new03', command: 'npm test', startedAt: now - 5_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    render(<ActivityIndicator />)
+    const toggle = screen.getByTestId('activity-indicator-disclosure')
+    // Closed state: aria-label uses total count (headline + overflow), and
+    // aria-controls is absent because nothing is exposed yet.
+    expect(toggle.getAttribute('aria-label')).toBe('Show all 3 pending background shells')
+    expect(toggle.getAttribute('aria-controls')).toBeNull()
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(toggle)
+    const popover = screen.getByTestId('activity-indicator-popover')
+    // aria-controls now points at the popover's id so AT can follow the link.
+    const popoverId = popover.getAttribute('id')
+    expect(popoverId).toBeTruthy()
+    expect(toggle.getAttribute('aria-controls')).toBe(popoverId)
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+
+    // Announcement count must match the number of <li> entries the dialog
+    // actually renders — this is the core "off-by-one" guard.
+    const items = popover.querySelectorAll('li')
+    const announced = toggle.getAttribute('aria-label') ?? ''
+    const match = /Show all (\d+) pending background shells/.exec(announced)
+    expect(match).not.toBeNull()
+    expect(Number(match![1])).toBe(items.length)
+  })
+
   it('does not render the disclosure button when only one shell is pending', () => {
     const now = Date.now()
     storeState = {

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -267,6 +267,13 @@ export function ActivityIndicator() {
         : headlineShell.shellId
       const detail = truncatePendingShellCommand(rawDetail)
       const overflowCount = overflowShells.length
+      // #4428 — the popover lists the headline shell + every overflow shell,
+      // so the screen-reader announcement on the disclosure button must
+      // describe the TOTAL count (overflowCount + 1), not just the overflow.
+      // The previous "Show N additional…" wording understated the dialog by
+      // one and left assistive tech expecting fewer items than rendered.
+      const totalShellCount = overflowCount + 1
+      const popoverId = 'activity-indicator-popover'
       return (
         <div
           className="activity-indicator activity-indicator--green"
@@ -286,7 +293,8 @@ export function ActivityIndicator() {
               className="activity-indicator__disclosure"
               data-testid="activity-indicator-disclosure"
               aria-expanded={popoverOpen}
-              aria-label={`Show ${overflowCount} additional pending background shell${overflowCount === 1 ? '' : 's'}`}
+              aria-controls={popoverOpen ? popoverId : undefined}
+              aria-label={`Show all ${totalShellCount} pending background shells`}
               onClick={() => setPopoverOpen((v) => !v)}
             >
               <span data-testid="activity-indicator-more-badge">
@@ -296,6 +304,7 @@ export function ActivityIndicator() {
           )}
           {popoverOpen && overflowCount > 0 && (
             <div
+              id={popoverId}
               className="activity-indicator__popover"
               data-testid="activity-indicator-popover"
               role="dialog"


### PR DESCRIPTION
## Summary

The disclosure button's `aria-label` understated the popover by one. It said `Show N additional pending background shells` where `N = overflowShells.length`, but the popover renders the headline shell + every overflow shell (`[headlineShell, ...overflowShells]`), so the dialog actually contains `N + 1` items. Screen-reader users were primed to expect fewer rows than the dialog renders.

This PR adopts option (a) from the issue:

- Rewords the disclosure button to `Show all <total> pending background shells` where `total = overflowShells.length + 1`, matching the list the popover renders.
- Adds an `id` to the popover (`activity-indicator-popover`) and wires `aria-controls` on the disclosure button only while the popover is open, so assistive tech can follow the relationship from the trigger to the dialog.
- Adds a regression test that opens the popover and asserts the count announced in the `aria-label` equals the number of `<li>` entries actually rendered, plus the `aria-expanded` / `aria-controls` transitions on open and close.

Parallel to #4427 (popover dismiss handlers); whichever lands second will need a small rebase — both touch `ActivityIndicator.tsx` and `ActivityIndicator.pendingShells.test.tsx`, but on different surfaces (aria vs dismiss handlers), so the conflict should be mechanical.

## Test plan

- [x] `npm test -- ActivityIndicator` in `packages/dashboard` (46 passing, includes new test)
- [x] `npm run typecheck` in `packages/dashboard`
- [ ] Manual: open the dashboard with >1 pending background shell, inspect the disclosure button — announcement reads `Show all 3 pending background shells` (matches popover row count), and `aria-controls="activity-indicator-popover"` appears only when expanded

Closes #4428