### PR TITLE
fix(server): consult provider metadata before humanizing fallback label

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -699,14 +699,27 @@ export function createModelsRegistry(hooks = {}) {
             if (minor === null) return true
             return fallbackByFamily.get(family).has(minor)
           })
-          .map(m => ({
-            id: m.id,
-            fullId: m.fullId,
-            label: typeof m.label === 'string' && m.label.length > 0 ? m.label : humanizeModelId(m.id),
-            contextWindow: typeof m.contextWindow === 'number' && m.contextWindow > 0
-              ? m.contextWindow
-              : resolveContextWindowFn(m.fullId),
-          }))
+          .map(m => {
+            // #4434: when the cached label is missing/empty (older cache
+            // files, or operators hand-editing the on-disk cache that
+            // landed in #4413), prefer the provider's own metadata label
+            // before falling back to `humanizeModelId`. The humanize
+            // helper assumes Claude-style ids ("opus-4-7" → "Opus 4.7")
+            // and mangles non-Claude ids ("gpt-5-codex" → "Gpt 5.codex").
+            // Mirrors the post-filter merge step below which already
+            // consults `getModelMetadataFn` for the same reason.
+            const providerMeta = getModelMetadataFn ? getModelMetadataFn(m.fullId) : null
+            return {
+              id: m.id,
+              fullId: m.fullId,
+              label: typeof m.label === 'string' && m.label.length > 0
+                ? m.label
+                : (providerMeta?.label || humanizeModelId(m.id)),
+              contextWindow: typeof m.contextWindow === 'number' && m.contextWindow > 0
+                ? m.contextWindow
+                : resolveContextWindowFn(m.fullId),
+            }
+          })
 
         const droppedStaleCount = valid.length - models.length
         if (droppedStaleCount > 0) {

--- a/packages/server/tests/models-per-provider.test.js
+++ b/packages/server/tests/models-per-provider.test.js
@@ -1,11 +1,18 @@
-import { describe, it } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 // Importing providers.js triggers built-in provider registration, which
 // in turn calls registerProviderRegistry() on models.js so that
 // getRegistryForProvider('codex'|'gemini') can resolve to the correct
 // provider class in this test suite.
 import '../src/providers.js'
-import { createModelsRegistry, getRegistryForProvider } from '../src/models.js'
+import {
+  createModelsRegistry,
+  getRegistryForProvider,
+  _resetProviderRegistryCacheForTests,
+} from '../src/models.js'
 import { CodexSession } from '../src/codex-session.js'
 import { GeminiSession } from '../src/gemini-session.js'
 import { SdkSession } from '../src/sdk-session.js'
@@ -188,5 +195,54 @@ describe('getRegistryForProvider(providerName)', () => {
     // Must return something functional — default to Claude for backward compat
     assert.ok(typeof r.getModels === 'function')
     assert.ok(r.getModels().length > 0)
+  })
+})
+
+describe('loadCache() label fill (#4434)', () => {
+  // #4434: loadCache() previously fell back to humanizeModelId() when a
+  // cached entry's `label` was empty, which mangles non-Claude ids
+  // ("gpt-5-codex" → "Gpt 5.codex"). After #4413 cache files live on
+  // disk and operators may hand-edit them, so the empty-label path is
+  // reachable in practice. The fix consults the provider's
+  // getModelMetadata(fullId)?.label before falling back.
+  let tmpConfigDir
+  let origConfigDir
+  beforeEach(() => {
+    tmpConfigDir = mkdtempSync(join(tmpdir(), 'chroxy-models-loadcache-'))
+    origConfigDir = process.env.CHROXY_CONFIG_DIR
+    process.env.CHROXY_CONFIG_DIR = tmpConfigDir
+    _resetProviderRegistryCacheForTests()
+  })
+  afterEach(() => {
+    _resetProviderRegistryCacheForTests()
+    if (origConfigDir === undefined) {
+      delete process.env.CHROXY_CONFIG_DIR
+    } else {
+      process.env.CHROXY_CONFIG_DIR = origConfigDir
+    }
+    try { rmSync(tmpConfigDir, { recursive: true, force: true }) } catch {}
+  })
+
+  it('uses provider getModelMetadata().label, not humanizeModelId, when cached label is empty', () => {
+    // Hand-rolled codex cache file with an empty label — simulates an
+    // operator editing the file or an older save before the label was
+    // persisted. The on-disk cache path matches what
+    // getProviderCachePath('codex') produces.
+    const cachePath = join(tmpConfigDir, 'models-cache.codex.json')
+    writeFileSync(cachePath, JSON.stringify({
+      models: [
+        { id: 'gpt-5-codex', fullId: 'gpt-5-codex', label: '', contextWindow: 400_000 },
+      ],
+      defaultModelId: null,
+      savedAt: Date.now(),
+    }))
+
+    // Rebuild the codex registry so loadCache() runs against our temp dir.
+    const r = getRegistryForProvider('codex')
+    const entry = r.getModels().find(m => m.fullId === 'gpt-5-codex')
+    assert.ok(entry, 'codex registry should expose the gpt-5-codex entry from cache')
+    // The provider's metadata label, NOT the humanizeModelId mangling.
+    assert.equal(entry.label, 'GPT-5 Codex',
+      `expected provider-supplied 'GPT-5 Codex' label, got '${entry.label}' — humanizeModelId would have produced 'Gpt 5.codex'`)
   })
 })


### PR DESCRIPTION
`loadCache()` in `packages/server/src/models.js` fell back to `humanizeModelId(m.id)` when a cached entry's `label` field was missing or empty. That helper assumes Claude-style ids ("opus-4-7" → "Opus 4.7") and mangles non-Claude ids — `gpt-5-codex` rendered as `Gpt 5.codex`. After #4413 per-provider caches live on disk, so operators can hand-edit them and an empty-label entry is reachable in practice.

## Fix

In the `loadCache()` label-fill `.map()`, consult `getModelMetadataFn(m.fullId)?.label` before falling back to `humanizeModelId(m.id)`. Mirrors how the post-filter fallback-merge step (a few lines down) already prefers provider metadata for the same reason.

## Test

Added `loadCache() label fill (#4434)` in `packages/server/tests/models-per-provider.test.js`. It writes a codex cache file with an empty `label` for `gpt-5-codex` into a temp `CHROXY_CONFIG_DIR`, rebuilds the codex registry, and asserts the resulting entry label is `GPT-5 Codex` (the provider value), not `Gpt 5.codex`.

Closes #4434