### PR TITLE
fix(dashboard): add outside-click + Escape dismiss to ActivityIndicator popover

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
@@ -414,3 +414,119 @@ describe('ActivityIndicator — pending-shell disclosure for multiple shells (#4
     expect(screen.queryByTestId('activity-indicator-disclosure')).toBeNull()
   })
 })
+
+describe('ActivityIndicator — popover dismiss paths (#4427)', () => {
+  // Shared fixture for the dismiss-path tests: two pending shells means the
+  // disclosure button + overflow popover render, which is the precondition
+  // for outside-click / Escape dismissal to matter.
+  const seedTwoPendingShells = () => {
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'old01', command: 'sleep 60', startedAt: now - 30_000 },
+            { shellId: 'new02', command: 'npm test', startedAt: now - 5_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+  }
+
+  it('closes the popover when the user clicks outside of it', () => {
+    seedTwoPendingShells()
+    render(<ActivityIndicator />)
+    fireEvent.click(screen.getByTestId('activity-indicator-disclosure'))
+    expect(screen.getByTestId('activity-indicator-popover')).toBeTruthy()
+    // mousedown is the listener the component subscribes to (matches the
+    // pre-click moment so the popover dismisses before focus moves).
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeNull()
+  })
+
+  it('keeps the popover open when the user mousedowns inside it', () => {
+    // Sanity check: outside-click dismiss must not fire on clicks that hit
+    // popover children (e.g. selecting text in a <code> entry).
+    seedTwoPendingShells()
+    render(<ActivityIndicator />)
+    fireEvent.click(screen.getByTestId('activity-indicator-disclosure'))
+    const popover = screen.getByTestId('activity-indicator-popover')
+    fireEvent.mouseDown(popover)
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeTruthy()
+  })
+
+  it('keeps the popover open when the user mousedowns the disclosure button itself', () => {
+    // The disclosure button owns the toggle; a mousedown there must not race
+    // the click handler and pre-close, otherwise the click would re-open the
+    // popover instead of closing it (and vice versa).
+    seedTwoPendingShells()
+    render(<ActivityIndicator />)
+    const disclosure = screen.getByTestId('activity-indicator-disclosure')
+    fireEvent.click(disclosure)
+    expect(screen.getByTestId('activity-indicator-popover')).toBeTruthy()
+    fireEvent.mouseDown(disclosure)
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeTruthy()
+  })
+
+  it('closes the popover when Escape is pressed', () => {
+    seedTwoPendingShells()
+    render(<ActivityIndicator />)
+    fireEvent.click(screen.getByTestId('activity-indicator-disclosure'))
+    expect(screen.getByTestId('activity-indicator-popover')).toBeTruthy()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeNull()
+  })
+
+  it('ignores non-Escape keys', () => {
+    // Regression guard: the keydown listener must filter by `event.key` so
+    // typing in another input doesn't dismiss the popover.
+    seedTwoPendingShells()
+    render(<ActivityIndicator />)
+    fireEvent.click(screen.getByTestId('activity-indicator-disclosure'))
+    fireEvent.keyDown(document, { key: 'a' })
+    fireEvent.keyDown(document, { key: 'Enter' })
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeTruthy()
+  })
+
+  it('does not attach document listeners while the popover is closed', () => {
+    // Idle chip: no perf hit. Spy on document.addEventListener and assert no
+    // mousedown/keydown listeners are attached for the lifetime of the render.
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    seedTwoPendingShells()
+    render(<ActivityIndicator />)
+    // Popover starts closed — no document listener subscriptions yet.
+    const calls = addSpy.mock.calls.map((c) => c[0])
+    expect(calls).not.toContain('mousedown')
+    expect(calls).not.toContain('keydown')
+    // Cross-check: simulating the dismiss events with the popover closed has
+    // no effect on the chip's contents (we'd assert "popover not visible"
+    // either way; this just confirms no stray state mutation).
+    fireEvent.mouseDown(document.body)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeNull()
+    addSpy.mockRestore()
+  })
+
+  it('detaches both document listeners when the popover closes', () => {
+    // After Escape closes the popover, a subsequent mousedown / keydown must
+    // not hit a stale handler (closure on prior state, or repeated
+    // setPopoverOpen(false) on an already-closed popover).
+    seedTwoPendingShells()
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+    render(<ActivityIndicator />)
+    fireEvent.click(screen.getByTestId('activity-indicator-disclosure'))
+    fireEvent.keyDown(document, { key: 'Escape' })
+    const removed = removeSpy.mock.calls.map((c) => c[0])
+    expect(removed).toContain('mousedown')
+    expect(removed).toContain('keydown')
+    removeSpy.mockRestore()
+  })
+})

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -21,7 +21,7 @@
  * payload (#3760), falling back to BaseSession.DEFAULT_RESULT_TIMEOUT_MS
  * (30 min) when connected to an older server that doesn't broadcast it.
  */
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { formatToolName } from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
@@ -227,6 +227,40 @@ export function ActivityIndicator() {
   useEffect(() => {
     if (overflowShells.length === 0 && popoverOpen) setPopoverOpen(false)
   }, [overflowShells.length, popoverOpen])
+
+  // #4427 — refs let the dismiss handlers below decide whether an event
+  // originated inside the popover/disclosure (ignored) or outside (close).
+  // Typed as the concrete element so consumers don't need null guards beyond
+  // the ref-not-yet-attached case.
+  const popoverRef = useRef<HTMLDivElement | null>(null)
+  const disclosureRef = useRef<HTMLButtonElement | null>(null)
+
+  // #4427 — outside-click + Escape dismiss for the overflow popover. Without
+  // these the popover only closes by re-toggling the same disclosure button or
+  // waiting for every shell to drain, which traps focus and surprises users
+  // who click anywhere else expecting the menu to dismiss.
+  //
+  // Listeners are mounted lazily — only while `popoverOpen` is true — so the
+  // idle chip pays no document-event cost when the popover is closed.
+  useEffect(() => {
+    if (!popoverOpen) return
+    const onMouseDown = (event: MouseEvent) => {
+      const target = event.target as Node | null
+      if (!target) return
+      if (popoverRef.current && popoverRef.current.contains(target)) return
+      if (disclosureRef.current && disclosureRef.current.contains(target)) return
+      setPopoverOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setPopoverOpen(false)
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [popoverOpen])
   const referenceTimeoutMs = useConnectionStore(
     (s) => s.serverResultTimeoutMs ?? FALLBACK_TIMEOUT_MS,
   )
@@ -289,6 +323,7 @@ export function ActivityIndicator() {
           </span>
           {overflowCount > 0 && (
             <button
+              ref={disclosureRef}
               type="button"
               className="activity-indicator__disclosure"
               data-testid="activity-indicator-disclosure"
@@ -305,6 +340,7 @@ export function ActivityIndicator() {
           {popoverOpen && overflowCount > 0 && (
             <div
               id={popoverId}
+              ref={popoverRef}
               className="activity-indicator__popover"
               data-testid="activity-indicator-popover"
               role="dialog"


### PR DESCRIPTION
## Summary

The pending-shell overflow popover in `ActivityIndicator` only closed when the user re-clicked the disclosure button or every overflow shell finished. Standard popover affordances were missing: clicking elsewhere or pressing Escape both left the menu stuck open.

This PR wires both dismissal paths through a single lazy `useEffect` keyed on `popoverOpen`, so listeners only attach while the popover is visible.

## Changes

- Add `popoverRef` (HTMLDivElement) and `disclosureRef` (HTMLButtonElement) and attach them to the popover container and disclosure button.
- Add a `useEffect([popoverOpen])` that, while open, subscribes to:
  - `document.mousedown` — close when the target is outside both refs.
  - `document.keydown` — close on `Escape`.
- Cleanup detaches both listeners when the popover closes or the component unmounts.
- When `popoverOpen` is `false` the effect returns early, so the idle chip incurs zero document-event cost.

## Tests

New describe block in `ActivityIndicator.pendingShells.test.tsx`:

- Outside mousedown closes the popover.
- Inside mousedown keeps it open.
- Mousedown on the disclosure button itself does not pre-close.
- Escape closes the popover.
- Non-Escape keys are ignored.
- `document.addEventListener` is not called with `mousedown`/`keydown` while the popover is closed (no idle perf hit).
- Both listeners are removed via `document.removeEventListener` when the popover closes.

All 19 tests in the file pass; the wider ActivityIndicator suite (52 tests) and `tsc --noEmit` are green.

## Test plan

- [x] `npm --prefix packages/dashboard run test -- ActivityIndicator.pendingShells`
- [x] `npm --prefix packages/dashboard run test -- ActivityIndicator`
- [x] `npm --prefix packages/dashboard run typecheck`

## Notes

Parallel to #4428 (aria-label); whichever lands second will need a small rebase.

Closes #4427