### PR TITLE
fix(dashboard): split cheat-sheet tab-switch row when bindings diverge

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -59,6 +59,9 @@ vi.mock('./components/StdinDisabledBanner', () => ({
 }))
 
 import { App } from './App'
+import { createShortcutRegistry } from './shortcuts/registry'
+import { DEFAULT_SHORTCUTS } from './shortcuts/defaults'
+import { __setSharedRegistryForTesting } from './shortcuts/useShortcutRegistry'
 
 // Mutable state override — tests can change this before rendering
 let stateOverrides: Record<string, unknown> = {}
@@ -148,6 +151,11 @@ vi.mock('zustand/react/shallow', () => ({
 beforeEach(() => {
   stateOverrides = {}
   capturedOnRestart = null
+  // #4432 — reset the shared shortcut registry so per-test rebinds
+  // don't bleed between cases. The registry persists overrides to
+  // localStorage; clearing the key keeps loadOverrides() returning {}.
+  try { localStorage.removeItem('chroxy_persist_shortcut_overrides_v1') } catch { /* jsdom always provides localStorage */ }
+  __setSharedRegistryForTesting(createShortcutRegistry(DEFAULT_SHORTCUTS))
 })
 
 afterEach(cleanup)
@@ -225,6 +233,62 @@ describe('App', () => {
     expect(screen.getByText('Ctrl+Shift+D')).toBeInTheDocument()
     expect(screen.queryByText('Cmd+K')).not.toBeInTheDocument()
     expect(screen.queryByText('Cmd+Enter')).not.toBeInTheDocument()
+  })
+
+  // #4432 — the cheat sheet's tab-switch row used to be derived from
+  // session.switch.1's binding alone, then string-replaced "1$" with
+  // "1-9". When the other eight bindings still pointed at their
+  // defaults, a rebind of just session.switch.1 to "Cmd+Q" produced a
+  // misleading "Ctrl+Q-9" / "Cmd+Q-9" row that didn't describe any
+  // real binding. The fix detects divergence and falls back to nine
+  // individual rows when the bindings aren't aligned.
+  describe('cheat sheet tab-switch divergence (#4432)', () => {
+    it('renders a single collapsed Ctrl+1-9 row when all nine bindings are at their defaults', () => {
+      render(<App />)
+      fireEvent.keyDown(window, { key: '?' })
+
+      // Default case: single collapsed row, no per-digit rows.
+      expect(screen.getByText('Ctrl+1-9')).toBeInTheDocument()
+      expect(screen.getByText('Switch to tab by number')).toBeInTheDocument()
+      // None of the individual per-digit labels or descriptions
+      // should appear — they're folded into the collapsed row.
+      expect(screen.queryByText('Ctrl+1')).not.toBeInTheDocument()
+      expect(screen.queryByText('Ctrl+2')).not.toBeInTheDocument()
+      expect(screen.queryByText('Ctrl+9')).not.toBeInTheDocument()
+      expect(screen.queryByText('Switch to tab 1')).not.toBeInTheDocument()
+      expect(screen.queryByText('Switch to tab 9')).not.toBeInTheDocument()
+    })
+
+    it('splits into nine individual rows when only session.switch.1 is rebound to Cmd+Q', () => {
+      // Install a fresh registry, then rebind session.switch.1 to
+      // something that diverges from the digit pattern. The other
+      // eight entries stay at their cmd+N defaults, so the cheat
+      // sheet must NOT collapse into a single misleading row.
+      const registry = createShortcutRegistry(DEFAULT_SHORTCUTS)
+      registry.setBinding('session.switch.1', 'cmd+q')
+      __setSharedRegistryForTesting(registry)
+
+      render(<App />)
+      fireEvent.keyDown(window, { key: '?' })
+
+      // No collapsed row — the misleading "Ctrl+Q-9" label must NOT
+      // appear, and neither should "Switch to tab by number".
+      expect(screen.queryByText('Ctrl+Q-9')).not.toBeInTheDocument()
+      expect(screen.queryByText('Switch to tab by number')).not.toBeInTheDocument()
+      // Also guard against the original buggy "Ctrl+1-9" label
+      // appearing alongside a rebound entry 1.
+      expect(screen.queryByText('Ctrl+1-9')).not.toBeInTheDocument()
+
+      // The nine entries each render with their own keys and
+      // description. Entry 1 reflects the rebind; 2..9 reflect the
+      // defaults.
+      expect(screen.getByText('Ctrl+Q')).toBeInTheDocument()
+      expect(screen.getByText('Switch to tab 1')).toBeInTheDocument()
+      for (let n = 2; n <= 9; n += 1) {
+        expect(screen.getByText(`Ctrl+${n}`)).toBeInTheDocument()
+        expect(screen.getByText(`Switch to tab ${n}`)).toBeInTheDocument()
+      }
+    })
   })
 
   it('does not open shortcut help when ? is typed in an input', () => {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -60,7 +60,7 @@ import { SettingsPanel } from './components/SettingsPanel'
 import { ShortcutHelp, type ShortcutEntry } from './components/ShortcutHelp'
 import { formatShortcutKeys, isMacPlatform } from './utils/platform'
 import { useShortcutRegistry } from './shortcuts/useShortcutRegistry'
-import { formatBindingForDisplay } from './shortcuts/registry'
+import { formatBindingForDisplay, parseBinding } from './shortcuts/registry'
 import { readClipboardImage } from './utils/clipboard-image'
 import { useTauriEvents } from './hooks/useTauriEvents'
 import { isTauri } from './utils/tauri'
@@ -1551,22 +1551,66 @@ export function App() {
     // sheet without adding signal. Emit a single "Cmd+1-9" row whose
     // keys reflect the registry's current first-digit binding so a
     // rebind (e.g. moving them to Alt+1-9) is still visible.
-    const tabSwitch1 = shortcutRegistry.get('session.switch.1')
+    //
+    // #4432 — only collapse when all nine bindings share the same
+    // modifier set AND each `session.switch.N` has key `N`. If any
+    // entry diverges (e.g. user rebinds only session.switch.1 to
+    // Cmd+Q) the cheat sheet would otherwise show a misleading
+    // "Cmd+Q-9" label, so we fall back to nine individual rows.
+    const tabSwitchEntries = Array.from({ length: 9 }, (_, i) =>
+      shortcutRegistry.get(`session.switch.${i + 1}`),
+    )
+    const tabSwitchAligned = (() => {
+      const first = tabSwitchEntries[0]
+      if (!first) return false
+      const firstParsed = parseBinding(first.binding)
+      if (firstParsed.key !== '1') return false
+      for (let i = 0; i < tabSwitchEntries.length; i += 1) {
+        const entry = tabSwitchEntries[i]
+        if (!entry) return false
+        const parsed = parseBinding(entry.binding)
+        if (parsed.key !== String(i + 1)) return false
+        if (
+          parsed.meta !== firstParsed.meta ||
+          parsed.shift !== firstParsed.shift ||
+          parsed.alt !== firstParsed.alt
+        ) return false
+      }
+      return true
+    })()
+    const tabSwitch1 = tabSwitchEntries[0]
     const tabSwitchKeys = tabSwitch1
       ? formatBindingForDisplay(tabSwitch1.binding, isMacForCheatsheet).replace(/1$/, '1-9')
       : 'Cmd+1-9'
     const registryRows: ShortcutEntry[] = []
     for (const entry of shortcutRegistry.list()) {
-      // Skip the 2..9 tab-switch entries — collapsed into one row
-      // below. Keep session.switch.1 as the canonical source so its
-      // override drives the collapsed row's display string.
-      if (/^session\.switch\.[2-9]$/.test(entry.id)) continue
-      if (entry.id === 'session.switch.1') {
+      // When aligned: skip the 2..9 tab-switch entries — they're
+      // collapsed into one row driven by session.switch.1 below.
+      // When diverged: render all nine individually so each rebind is
+      // visible.
+      if (/^session\.switch\.[2-9]$/.test(entry.id)) {
+        if (tabSwitchAligned) continue
         registryRows.push({
-          keys: tabSwitchKeys,
-          description: 'Switch to tab by number',
+          keys: formatBindingForDisplay(entry.binding, isMacForCheatsheet),
+          description: entry.description,
           section: CATEGORY_TO_SECTION[entry.category] || 'Global',
         })
+        continue
+      }
+      if (entry.id === 'session.switch.1') {
+        if (tabSwitchAligned) {
+          registryRows.push({
+            keys: tabSwitchKeys,
+            description: 'Switch to tab by number',
+            section: CATEGORY_TO_SECTION[entry.category] || 'Global',
+          })
+        } else {
+          registryRows.push({
+            keys: formatBindingForDisplay(entry.binding, isMacForCheatsheet),
+            description: entry.description,
+            section: CATEGORY_TO_SECTION[entry.category] || 'Global',
+          })
+        }
         continue
       }
       registryRows.push({


### PR DESCRIPTION
## Summary

The dashboard cheat sheet collapses `session.switch.1`..`session.switch.9` into a single "Cmd+1-9" row driven only by `session.switch.1`'s binding. If a user rebinds only `session.switch.1` (e.g. to `Cmd+Q`), the row label becomes a misleading "Cmd+Q-9" — the other eight entries are still on their defaults but never get their own row.

## Fix

Implements option (1) from #4432: detect divergence and split into nine individual rows when the bindings aren't aligned.

A helper gathers all nine effective bindings via `shortcutRegistry.get('session.switch.N')`, parses each with `parseBinding`, and checks two conditions:

1. Each entry's key equals its digit (`session.switch.1` → key `1`, ..., `session.switch.9` → key `9`).
2. All nine share the same modifier set (`meta` / `shift` / `alt`) as `session.switch.1`.

If both hold, the cheat sheet keeps the single collapsed row driven by `session.switch.1`'s display string. Otherwise it emits nine individual rows (one per registry entry), each with its own keys and "Switch to tab N" description, so every rebind is accurately reflected.

## Test plan

- [x] New unit test (`cheat sheet tab-switch divergence (#4432)`):
  - Default bindings render a single `Ctrl+1-9` row plus the "Switch to tab by number" description; no per-digit rows leak through.
  - Rebinding only `session.switch.1` to `cmd+q` splits the row into nine entries: `Ctrl+Q` / "Switch to tab 1" plus `Ctrl+2`..`Ctrl+9` with their individual descriptions. The buggy `Ctrl+Q-9` label is asserted absent.
- [x] `npm test` in `packages/dashboard` — 2202 tests pass (123 files).
- [x] `npm run typecheck` clean.

## Notes

Parallel work in #4431 touches the same shortcut registry area (`findConflict` / `setBinding`); this PR only changes the cheat-sheet renderer in `App.tsx` and should not conflict at the code level.

Closes #4432