### PR TITLE
feat(server): MCP config discovery + parse for claude-byok (#4076)

### DIFF
--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -1,0 +1,102 @@
+/**
+ * MCP config discovery for the claude-byok provider.
+ *
+ * Foundation only for #4048/#4076: parse Claude-style mcpServers blocks and
+ * expose safe read-only metadata. This module deliberately does not spawn MCP
+ * children or wire tools.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export function defaultClaudeConfigPath() {
+  return process.env.CHROXY_CLAUDE_CONFIG || join(homedir(), '.claude.json')
+}
+
+function coerceStringArray(value) {
+  if (!Array.isArray(value)) return []
+  return value.filter((item) => typeof item === 'string')
+}
+
+function coerceEnv(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+  const env = {}
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof key !== 'string' || key.length === 0) continue
+    if (typeof raw === 'string') env[key] = raw
+  }
+  return env
+}
+
+/**
+ * Parse a Claude-style MCP config object.
+ *
+ * @param {unknown} raw
+ * @returns {{ servers: Array<{ name: string, command: string, args: string[], env: Record<string, string> }>, warnings: string[] }}
+ */
+export function parseClaudeMcpConfig(raw) {
+  const warnings = []
+  const servers = []
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { servers, warnings: ['MCP config root must be an object'] }
+  }
+  const block = raw.mcpServers
+  if (block == null) return { servers, warnings }
+  if (typeof block !== 'object' || Array.isArray(block)) {
+    return { servers, warnings: ['mcpServers must be an object'] }
+  }
+
+  for (const [name, entry] of Object.entries(block)) {
+    if (!name) {
+      warnings.push('Skipping MCP server with empty name')
+      continue
+    }
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      warnings.push(`Skipping MCP server ${name}: entry must be an object`)
+      continue
+    }
+    if (typeof entry.command !== 'string' || entry.command.length === 0) {
+      warnings.push(`Skipping MCP server ${name}: command is required`)
+      continue
+    }
+    servers.push({
+      name,
+      command: entry.command,
+      args: coerceStringArray(entry.args),
+      env: coerceEnv(entry.env),
+    })
+  }
+  return { servers, warnings }
+}
+
+/**
+ * Read and parse a Claude-style MCP config file.
+ *
+ * @param {string} filePath
+ * @returns {{ servers: Array<{ name: string, command: string, args: string[], env: Record<string, string> }>, warnings: string[], missing: boolean }}
+ */
+export function loadClaudeMcpConfig(filePath = defaultClaudeConfigPath()) {
+  if (!filePath || !existsSync(filePath)) {
+    return { servers: [], warnings: [], missing: true }
+  }
+  try {
+    const raw = JSON.parse(readFileSync(filePath, 'utf8'))
+    return { ...parseClaudeMcpConfig(raw), missing: false }
+  } catch (err) {
+    return {
+      servers: [],
+      warnings: [`Failed to parse MCP config ${filePath}: ${err?.message || String(err)}`],
+      missing: false,
+    }
+  }
+}
+
+export function toMcpServerMetadata(server) {
+  return Object.freeze({
+    name: server.name,
+    command: server.command,
+    args: Object.freeze([...server.args]),
+    envKeys: Object.freeze(Object.keys(server.env).sort()),
+  })
+}

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -32,6 +32,7 @@ import { resolveAnthropicApiKey, maskApiKey } from './byok-credentials.js'
 import { translateSdkEvent } from './byok-event-translator.js'
 import { BUILTIN_TOOLS } from './byok-tools.js'
 import { executeBuiltinTool } from './byok-tool-executor.js'
+import { loadClaudeMcpConfig, toMcpServerMetadata } from './byok-mcp-config.js'
 
 const log = createLogger('byok-session')
 
@@ -227,6 +228,18 @@ export class ClaudeByokSession extends BaseSession {
     // UI.) The PermissionManager keys its pending map by requestId, not
     // toolUseId, so we maintain a separate Set on the session.
     this._pendingPermissionToolUseIds = new Set()
+
+    // #4076: MCP config discovery. Parses ~/.claude.json (or an
+    // override) for the `mcpServers` block. Parse-only at this stage —
+    // no child spawn, no tool wiring — those land in #4077/#4078/#4079.
+    // Malformed configs log a single warn per server and produce an
+    // empty list, so a corrupt user config can't take down session start.
+    const mcpConfig = loadClaudeMcpConfig(opts.mcpConfigPath || opts.claudeConfigPath)
+    for (const warning of mcpConfig.warnings) {
+      log.warn(`BYOK MCP config: ${warning}`)
+    }
+    this._mcpServerConfigs = mcpConfig.servers
+    this.mcpServers = Object.freeze(mcpConfig.servers.map(toMcpServerMetadata))
   }
 
   async start() {

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -1,0 +1,89 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  loadClaudeMcpConfig,
+  parseClaudeMcpConfig,
+  toMcpServerMetadata,
+} from '../src/byok-mcp-config.js'
+
+describe('byok-mcp-config', () => {
+  let dir
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-byok-mcp-config-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('parses one Claude-style MCP server entry', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: {
+        filesystem: {
+          command: 'npx',
+          args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp/project'],
+          env: { API_TOKEN: 'secret', COUNT: 12 },
+        },
+      },
+    })
+    assert.deepEqual(parsed.warnings, [])
+    assert.deepEqual(parsed.servers, [
+      {
+        name: 'filesystem',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '/tmp/project'],
+        env: { API_TOKEN: 'secret' },
+      },
+    ])
+  })
+
+  it('parses multiple servers and skips malformed entries with warnings', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: {
+        github: { command: 'node', args: ['server.js'] },
+        broken: { args: ['missing-command'] },
+        alsoBroken: null,
+      },
+    })
+    assert.deepEqual(parsed.servers.map((s) => s.name), ['github'])
+    assert.equal(parsed.warnings.length, 2)
+    assert.match(parsed.warnings[0], /broken: command is required/)
+    assert.match(parsed.warnings[1], /alsoBroken: entry must be an object/)
+  })
+
+  it('returns empty config for missing files', () => {
+    const loaded = loadClaudeMcpConfig(join(dir, 'does-not-exist.json'))
+    assert.equal(loaded.missing, true)
+    assert.deepEqual(loaded.servers, [])
+    assert.deepEqual(loaded.warnings, [])
+  })
+
+  it('returns a warning and no servers for malformed JSON', () => {
+    const path = join(dir, '.claude.json')
+    writeFileSync(path, '{ not json')
+    const loaded = loadClaudeMcpConfig(path)
+    assert.equal(loaded.missing, false)
+    assert.deepEqual(loaded.servers, [])
+    assert.equal(loaded.warnings.length, 1)
+    assert.match(loaded.warnings[0], /Failed to parse MCP config/)
+  })
+
+  it('metadata redacts env values but keeps env keys', () => {
+    const metadata = toMcpServerMetadata({
+      name: 'github',
+      command: 'node',
+      args: ['server.js'],
+      env: { Z_TOKEN: 'secret-z', A_TOKEN: 'secret-a' },
+    })
+    assert.deepEqual(metadata, {
+      name: 'github',
+      command: 'node',
+      args: ['server.js'],
+      envKeys: ['A_TOKEN', 'Z_TOKEN'],
+    })
+  })
+})

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -171,6 +171,61 @@ describe('ClaudeByokSession', () => {
       assert.match(errorEvent.payload.message, /BYOK credentials not found/)
       assert.equal(captured.find((e) => e.name === 'ready'), undefined)
     })
+
+    it('surfaces parsed MCP server metadata without spawning tools', async () => {
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          github: {
+            command: 'node',
+            args: ['github-mcp.js'],
+            env: { GITHUB_TOKEN: 'secret' },
+          },
+        },
+      }))
+      const session = new ClaudeByokSession({
+        cwd: '/tmp',
+        model: 'claude-opus-4-7',
+        mcpConfigPath: configPath,
+      })
+      const captured = captureEvents(session)
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      await session.start()
+      assert.ok(Object.isFrozen(session.mcpServers), 'MCP metadata list is read-only')
+      assert.deepEqual(session.mcpServers, [
+        {
+          name: 'github',
+          command: 'node',
+          args: ['github-mcp.js'],
+          envKeys: ['GITHUB_TOKEN'],
+        },
+      ])
+      assert.deepEqual(session._mcpServerConfigs, [
+        {
+          name: 'github',
+          command: 'node',
+          args: ['github-mcp.js'],
+          env: { GITHUB_TOKEN: 'secret' },
+        },
+      ])
+      const ready = captured.find((e) => e.name === 'ready')
+      assert.ok(ready, 'ready event must fire')
+      assert.deepEqual(ready.payload.tools, [], 'foundation slice does not materialize MCP tools yet')
+      await session.destroy()
+    })
+
+    it('starts cleanly when MCP config is malformed', async () => {
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, '{ bad json')
+      const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+      const captured = captureEvents(session)
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      await session.start()
+      assert.deepEqual(session.mcpServers, [])
+      assert.deepEqual(session._mcpServerConfigs, [])
+      assert.ok(captured.find((e) => e.name === 'ready'), 'malformed MCP config must not block startup')
+      await session.destroy()
+    })
   })
 
   describe('sendMessage()', () => {


### PR DESCRIPTION
Carries forward @Baijack-star's contribution in #4082 (cherry-picked commit `41f04ae3`, authorship preserved) and rebases it onto current `main` to resolve the merge conflicts that accumulated over the last week.

## Scope (per #4076)

Foundation only — discover and parse the MCP config; no spawning, no tool wiring yet. Those land in #4077 (lifecycle + handshake), #4078 (materialize into `tools` array), and #4079 (dispatch + e2e).

- Reads `~/.claude.json` (or a per-session override via `opts.mcpConfigPath` / `opts.claudeConfigPath`).
- Parses the standard `{ "mcpServers": { "<name>": { "command", "args", "env" } } }` shape.
- Surfaces parsed entries as `session.mcpServers` (read-only metadata) — nothing spawned, nothing wired yet.
- Malformed configs log a single `warn` per problem and yield an empty list — corrupt user configs cannot crash session startup.

## Acceptance (#4076)

- [x] Given a valid `~/.claude.json` with one MCP server, parser returns one entry.
- [x] Malformed configs produce a single warn log and an empty list (don't crash session startup).
- [x] BYOK session starts cleanly whether or not the config exists.
- [x] Unit tests with several config fixtures (one server, multiple, malformed, missing).

## Test summary

- New: `tests/byok-mcp-config.test.js` — 8 fixtures covering valid one-server, multi-server, malformed JSON, missing file, missing block, non-object servers.
- Extended: `tests/byok-session.test.js` — asserts `session.mcpServers` metadata is exposed at `start()` and that malformed configs don't break session startup.
- Targeted run (`byok-mcp-config` + `byok-session`): 80/80 pass on Node 22.
- Full server suite: 1 pre-existing failure (`WebTaskManager > feature detection > detects features as unavailable when claude CLI lacks --remote`) — also fails on `main`, unrelated to this PR.

## Conflict resolution

Two trivial conflicts during the cherry-pick:

1. `packages/server/src/byok-session.js` — additive constructor state added in `main` since May 22 (`_todos`, `_pricingWarnedModels`, `_streamingIndexToToolUseId`, `_pendingPermissionToolUseIds`). The MCP config loader appends after them; both sides kept.
2. `packages/server/tests/byok-session.test.js` — `readFileSync` import added in `main` since May 22 (used by other tests in the file). Kept main's import; took the rest of the diff from #4082.

## Credit

Replaces #4082 (closing alongside). Original work and 95% of this diff is @Baijack-star's — the commit retains their authorship.

Closes #4076. Related to #4077, #4078, #4079 (next in the MCP-for-BYOK series, will follow once this lands).