### PR TITLE
feat(server): MCP child-process lifecycle + JSON-RPC handshake (#4077)

### DIFF
--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -1,0 +1,241 @@
+/**
+ * MCP child-process lifecycle for the claude-byok provider (#4077).
+ *
+ * One MCPClient owns one MCP server child. Handles spawn, JSON-RPC handshake
+ * (initialize → initialized → tools/list), crash detection with a constant 1s
+ * backoff up to MAX_RESTART_ATTEMPTS, and SIGTERM/SIGKILL grace on destroy.
+ *
+ * Per #4077 scope:
+ *   - Lazy spawn: caller decides when to call start().
+ *   - Crash detection on child exit / spawn error → schedule restart at 1s.
+ *   - After MAX_RESTART_ATTEMPTS failures, state=dead and tools=[].
+ *   - Session destroy sends SIGTERM, escalates to SIGKILL at KILL_GRACE_MS.
+ *
+ * Out of scope (next stages):
+ *   - tools/call dispatch (#4079) — only exposes the parsed tools list here.
+ *   - Materializing into Anthropic SDK tools[] (#4078).
+ */
+
+import { spawn } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { createLogger } from './logger.js'
+
+const MAX_RESTART_ATTEMPTS = 3
+const RESTART_DELAY_MS = 1000
+const KILL_GRACE_MS = 1000
+const HANDSHAKE_TIMEOUT_MS = 5000
+
+export const MCP_STATES = Object.freeze({
+  IDLE: 'idle',
+  STARTING: 'starting',
+  READY: 'ready',
+  RESTARTING: 'restarting',
+  DEAD: 'dead',
+  DESTROYED: 'destroyed',
+})
+
+export class MCPClient extends EventEmitter {
+  constructor(config, opts = {}) {
+    super()
+    this.name = config.name
+    this._config = config
+    this._log = opts.log || createLogger('byok-mcp')
+    this._state = MCP_STATES.IDLE
+    this._tools = []
+    this._child = null
+    this._stdoutBuf = ''
+    this._nextId = 1
+    this._pending = new Map()
+    this._restartTimer = null
+    this._restartAttempts = 0
+    this._destroyed = false
+  }
+
+  get state() { return this._state }
+  get tools() { return this._tools }
+
+  async start() {
+    if (this._destroyed) throw new Error('MCPClient destroyed')
+    if (this._state === MCP_STATES.READY) return
+    if (this._state === MCP_STATES.DEAD) return
+    this._spawnAndHandshake()
+    // Resolve when state stabilises — first READY (handshake success) or
+    // DEAD (max restart attempts exhausted). RESTARTING intermediate states
+    // are transparent to the caller; what they want is "is this thing
+    // usable or not", and that's the steady-state answer.
+    if (this._state !== MCP_STATES.READY && this._state !== MCP_STATES.DEAD) {
+      await new Promise((resolve) => {
+        const onState = ({ next }) => {
+          if (next === MCP_STATES.READY || next === MCP_STATES.DEAD) {
+            this.off('state', onState)
+            resolve()
+          }
+        }
+        this.on('state', onState)
+      })
+    }
+  }
+
+  _spawnAndHandshake() {
+    this._setState(MCP_STATES.STARTING)
+    let child
+    try {
+      child = spawn(this._config.command, this._config.args, {
+        env: { ...process.env, ...this._config.env },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      })
+    } catch (err) {
+      this._log.warn(`MCP server ${this.name}: spawn threw: ${err?.message || err}`)
+      this._onExit(null, null)
+      return
+    }
+    this._child = child
+    child.on('error', (err) => {
+      this._log.warn(`MCP server ${this.name}: child error: ${err?.message || err}`)
+    })
+    child.stderr.on('data', (chunk) => {
+      this._log.debug(`MCP server ${this.name} stderr: ${chunk.toString().trimEnd()}`)
+    })
+    child.stdout.on('data', (chunk) => this._onStdoutChunk(chunk))
+    child.on('exit', (code, signal) => this._onExit(code, signal))
+
+    this._handshake().catch((err) => {
+      this._log.warn(`MCP server ${this.name}: handshake failed: ${err?.message || err}`)
+      this._killChild()
+    })
+  }
+
+  async _handshake() {
+    const initResult = await this._request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'chroxy-byok', version: '1' },
+    }, HANDSHAKE_TIMEOUT_MS)
+    if (!initResult || typeof initResult !== 'object') {
+      throw new Error('initialize returned non-object result')
+    }
+    this._notify('notifications/initialized')
+    const toolsResult = await this._request('tools/list', {}, HANDSHAKE_TIMEOUT_MS)
+    const tools = Array.isArray(toolsResult?.tools) ? toolsResult.tools : []
+    this._tools = Object.freeze(tools.map((t) => Object.freeze({ ...t })))
+    this._restartAttempts = 0
+    this._setState(MCP_STATES.READY)
+    this.emit('ready', this._tools)
+  }
+
+  _request(method, params, timeoutMs) {
+    return new Promise((resolve, reject) => {
+      const id = this._nextId++
+      const payload = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n'
+      let timer = null
+      const settle = (err, val) => {
+        if (timer) clearTimeout(timer)
+        this._pending.delete(id)
+        if (err) reject(err); else resolve(val)
+      }
+      this._pending.set(id, settle)
+      timer = setTimeout(() => settle(new Error(`MCP ${method} timeout`)), timeoutMs)
+      if (!this._child?.stdin?.writable) {
+        settle(new Error('MCP child stdin not writable'))
+        return
+      }
+      this._child.stdin.write(payload, (err) => {
+        if (err) settle(err)
+      })
+    })
+  }
+
+  _notify(method, params) {
+    if (!this._child?.stdin?.writable) return
+    this._child.stdin.write(JSON.stringify({ jsonrpc: '2.0', method, params }) + '\n')
+  }
+
+  _onStdoutChunk(chunk) {
+    this._stdoutBuf += chunk.toString('utf8')
+    const lines = this._stdoutBuf.split('\n')
+    this._stdoutBuf = lines.pop() ?? ''
+    for (const line of lines) {
+      if (!line) continue
+      let msg
+      try {
+        msg = JSON.parse(line)
+      } catch (err) {
+        this._log.warn(`MCP server ${this.name}: non-JSON line: ${line.slice(0, 80)}`)
+        continue
+      }
+      if (msg.id != null && this._pending.has(msg.id)) {
+        const settle = this._pending.get(msg.id)
+        if (msg.error) settle(new Error(msg.error.message || 'MCP RPC error'))
+        else settle(null, msg.result)
+      }
+    }
+  }
+
+  _onExit(code, signal) {
+    const wasStartingOrReady = this._state === MCP_STATES.STARTING || this._state === MCP_STATES.READY
+    for (const settle of this._pending.values()) settle(new Error('MCP child exited'))
+    this._pending.clear()
+    this._stdoutBuf = ''
+    this._child = null
+
+    if (this._destroyed) {
+      this._setState(MCP_STATES.DESTROYED)
+      return
+    }
+    if (!wasStartingOrReady) return
+
+    this._tools = []
+    this._restartAttempts += 1
+    if (this._restartAttempts >= MAX_RESTART_ATTEMPTS) {
+      this._log.warn(`MCP server ${this.name}: dead after ${this._restartAttempts} failed attempts (last exit code=${code} signal=${signal})`)
+      this._setState(MCP_STATES.DEAD)
+      this.emit('dead')
+      return
+    }
+
+    this._setState(MCP_STATES.RESTARTING)
+    this.emit('restart', { attempt: this._restartAttempts, code, signal })
+    this._restartTimer = setTimeout(() => {
+      this._restartTimer = null
+      if (this._destroyed) return
+      this._spawnAndHandshake()
+    }, RESTART_DELAY_MS)
+  }
+
+  _killChild() {
+    if (!this._child) return
+    try { this._child.kill('SIGTERM') } catch {}
+  }
+
+  destroy() {
+    if (this._destroyed) return Promise.resolve()
+    this._destroyed = true
+    if (this._restartTimer) {
+      clearTimeout(this._restartTimer)
+      this._restartTimer = null
+    }
+    const child = this._child
+    if (!child) {
+      this._setState(MCP_STATES.DESTROYED)
+      return Promise.resolve()
+    }
+    return new Promise((resolve) => {
+      const onExit = () => {
+        clearTimeout(killTimer)
+        resolve()
+      }
+      child.once('exit', onExit)
+      try { child.kill('SIGTERM') } catch {}
+      const killTimer = setTimeout(() => {
+        try { child.kill('SIGKILL') } catch {}
+      }, KILL_GRACE_MS)
+    })
+  }
+
+  _setState(next) {
+    if (this._state === next) return
+    const prev = this._state
+    this._state = next
+    this.emit('state', { prev, next })
+  }
+}

--- a/packages/server/src/byok-mcp-fleet.js
+++ b/packages/server/src/byok-mcp-fleet.js
@@ -1,0 +1,55 @@
+/**
+ * MCPFleet orchestrates one MCPClient per configured MCP server (#4077).
+ *
+ * One fleet per BYOK session. Lazy: start() spawns all clients in parallel;
+ * destroy() kills all children, waiting up to KILL_GRACE_MS for SIGTERM then
+ * escalating to SIGKILL.
+ *
+ * Tools are surfaced flat with the chroxy mcp__<server>__<tool> namespace
+ * convention (matches `mcp-tools.js` parser). Dead servers contribute zero
+ * tools, so a crashed-then-restart-exhausted server cleanly disappears from
+ * the next turn's tool list.
+ */
+
+import { MCPClient, MCP_STATES } from './byok-mcp-client.js'
+
+export const FLEET_KILL_GRACE_MS = 2000
+
+function mcpToolName(serverName, toolName) {
+  return `mcp__${serverName}__${toolName}`
+}
+
+export class MCPFleet {
+  constructor(configs, opts = {}) {
+    this._clients = configs.map((cfg) => new MCPClient(cfg, opts))
+  }
+
+  get clients() { return this._clients }
+
+  async start() {
+    await Promise.all(this._clients.map((c) => c.start().catch(() => {})))
+  }
+
+  get tools() {
+    const out = []
+    for (const client of this._clients) {
+      if (client.state !== MCP_STATES.READY) continue
+      for (const tool of client.tools) {
+        out.push({
+          ...tool,
+          name: mcpToolName(client.name, tool.name),
+          _mcpServer: client.name,
+          _mcpOriginalName: tool.name,
+        })
+      }
+    }
+    return out
+  }
+
+  async destroy() {
+    await Promise.race([
+      Promise.all(this._clients.map((c) => c.destroy())),
+      new Promise((resolve) => setTimeout(resolve, FLEET_KILL_GRACE_MS + 500)),
+    ])
+  }
+}

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -33,6 +33,7 @@ import { translateSdkEvent } from './byok-event-translator.js'
 import { BUILTIN_TOOLS } from './byok-tools.js'
 import { executeBuiltinTool } from './byok-tool-executor.js'
 import { loadClaudeMcpConfig, toMcpServerMetadata } from './byok-mcp-config.js'
+import { MCPFleet } from './byok-mcp-fleet.js'
 
 const log = createLogger('byok-session')
 
@@ -240,6 +241,9 @@ export class ClaudeByokSession extends BaseSession {
     }
     this._mcpServerConfigs = mcpConfig.servers
     this.mcpServers = Object.freeze(mcpConfig.servers.map(toMcpServerMetadata))
+    // #4077: MCPFleet is lazy — created in start() only if servers exist.
+    // Held here so destroy() can tear down even if start() never ran.
+    this._mcpFleet = null
   }
 
   async start() {
@@ -256,6 +260,16 @@ export class ClaudeByokSession extends BaseSession {
       // catches Bearer / sk-ant patterns as a defense in depth.
       log.info(`BYOK session ready — key source=${this._apiKeySource} key=${maskApiKey(resolved.key)} model=${this.model || 'default'}`)
       this._client = new Anthropic({ apiKey: resolved.key })
+    }
+
+    // #4077: spawn MCP children lazily on first start(). Errors during
+    // handshake are non-fatal — the dead client just contributes zero
+    // tools, identical to a server missing from config. We deliberately
+    // wait for fleet.start() so this.mcpServers + tools list are stable
+    // by the time we emit 'ready'.
+    if (this._mcpServerConfigs.length > 0 && this._mcpFleet === null) {
+      this._mcpFleet = new MCPFleet(this._mcpServerConfigs, { log })
+      await this._mcpFleet.start()
     }
 
     this._processReady = true
@@ -1031,6 +1045,16 @@ export class ClaudeByokSession extends BaseSession {
     this._streamingIndexToToolUseId.clear()
     this._pendingPermissionToolUseIds.clear()
     this._client = null
+    // #4077: tear down MCP children with SIGTERM → SIGKILL grace.
+    // Awaits up to FLEET_KILL_GRACE_MS (2s) + 500ms safety margin so a
+    // hung child cannot stall destroy() indefinitely.
+    if (this._mcpFleet) {
+      const fleet = this._mcpFleet
+      this._mcpFleet = null
+      try { await fleet.destroy() } catch (err) {
+        log.warn(`MCP fleet teardown failed: ${err?.message || err}`)
+      }
+    }
     this.removeAllListeners()
   }
 }

--- a/packages/server/tests/byok-mcp-client.test.js
+++ b/packages/server/tests/byok-mcp-client.test.js
@@ -1,0 +1,144 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { MCPClient, MCP_STATES } from '../src/byok-mcp-client.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const STUB = join(__dirname, 'fixtures', 'mcp-stub.mjs')
+
+function silentLog() {
+  return { info: () => {}, warn: () => {}, debug: () => {}, error: () => {} }
+}
+
+function stubConfig({ name = 'stub', env = {} } = {}) {
+  return { name, command: process.execPath, args: [STUB], env }
+}
+
+async function waitForState(client, target, timeoutMs = 4000) {
+  if (client.state === target) return
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => {
+      cleanup()
+      reject(new Error(`timeout waiting for state=${target}, got=${client.state}`))
+    }, timeoutMs)
+    const onState = ({ next }) => {
+      if (next === target) {
+        cleanup()
+        resolve()
+      }
+    }
+    function cleanup() {
+      clearTimeout(t)
+      client.off('state', onState)
+    }
+    client.on('state', onState)
+  })
+}
+
+describe('MCPClient', () => {
+  describe('handshake', () => {
+    it('initializes, fetches tools/list, and reaches READY', async () => {
+      const client = new MCPClient(stubConfig(), { log: silentLog() })
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      assert.equal(client.state, MCP_STATES.READY)
+      assert.equal(client.tools.length, 1)
+      assert.equal(client.tools[0].name, 'echo')
+      await client.destroy()
+    })
+
+    it('exposes server-supplied tools verbatim (test fixture override)', async () => {
+      const customTools = [
+        { name: 'one', description: 'first', inputSchema: { type: 'object' } },
+        { name: 'two', description: 'second', inputSchema: { type: 'object' } },
+      ]
+      const client = new MCPClient(stubConfig({ env: { MCP_STUB_TOOLS: JSON.stringify(customTools) } }), { log: silentLog() })
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      assert.deepEqual(client.tools.map((t) => t.name), ['one', 'two'])
+      await client.destroy()
+    })
+  })
+
+  describe('crash + restart', () => {
+    it('triggers exactly 1 restart attempt within 1s after child exit (acceptance criterion)', async () => {
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_DIE_AFTER_MS: '100' } }),
+        { log: silentLog() },
+      )
+      await client.start()
+      // First life: spawns, handshakes, reaches READY, then exits at ~100ms.
+      // The client schedules a restart for ~1s later.  Acceptance criterion:
+      // the *actual* restart attempt (second spawn → STARTING) happens within
+      // ~1s of the death.  Measure between the death (RESTARTING entry) and
+      // the next spawn (next STARTING entry).
+      await waitForState(client, MCP_STATES.READY)
+      await waitForState(client, MCP_STATES.RESTARTING, 2000)
+      const t0 = Date.now()
+      await waitForState(client, MCP_STATES.STARTING, 2000)
+      const elapsed = Date.now() - t0
+      assert.ok(elapsed >= 800 && elapsed <= 1500, `2nd spawn fired at ${elapsed}ms after RESTARTING, expected ~1000ms`)
+      await client.destroy()
+    })
+
+    it('declares dead after MAX_RESTART_ATTEMPTS (3) consecutive failed restarts', async () => {
+      // Use a bad command so spawn succeeds at exec(2) layer but child exits
+      // immediately. Three rapid failures should trip the dead state.
+      const client = new MCPClient(
+        { name: 'bad', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+        { log: silentLog() },
+      )
+      await client.start()
+      await waitForState(client, MCP_STATES.DEAD, 8000)
+      assert.equal(client.state, MCP_STATES.DEAD)
+      assert.equal(client.tools.length, 0)
+      await client.destroy()
+    })
+
+    it('clears tools when entering DEAD state', async () => {
+      const client = new MCPClient(stubConfig(), { log: silentLog() })
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      assert.equal(client.tools.length, 1)
+      // Force three exits in rapid succession by replacing the child with
+      // an immediately-exiting child after each restart.
+      client._config = { name: 'stub', command: process.execPath, args: ['-e', 'process.exit(1)'], env: {} }
+      // Kill the live child to trigger the first restart on the new (bad) config.
+      client._child.kill('SIGKILL')
+      await waitForState(client, MCP_STATES.DEAD, 8000)
+      assert.equal(client.tools.length, 0)
+      await client.destroy()
+    })
+  })
+
+  describe('destroy()', () => {
+    it('cancels a pending restart timer (no spawn after destroy)', async () => {
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_DIE_AFTER_MS: '50' } }),
+        { log: silentLog() },
+      )
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      await waitForState(client, MCP_STATES.RESTARTING, 2000)
+      await client.destroy()
+      // Wait past the restart timer; state should remain DESTROYED.
+      await new Promise((r) => setTimeout(r, 1500))
+      assert.equal(client.state, MCP_STATES.DESTROYED)
+    })
+
+    it('SIGTERM then SIGKILL grace — escalates within KILL_GRACE_MS for a hung child', async () => {
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_HANG: '1' } }),
+        { log: silentLog() },
+      )
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      const t0 = Date.now()
+      await client.destroy()
+      const elapsed = Date.now() - t0
+      // SIGTERM is swallowed; SIGKILL fires at 1000ms; child exits ~immediately.
+      assert.ok(elapsed >= 900 && elapsed <= 2000, `destroy took ${elapsed}ms, expected ~1000ms (SIGTERM grace before SIGKILL)`)
+    })
+  })
+})

--- a/packages/server/tests/byok-mcp-fleet.test.js
+++ b/packages/server/tests/byok-mcp-fleet.test.js
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { MCPFleet, FLEET_KILL_GRACE_MS } from '../src/byok-mcp-fleet.js'
+import { MCP_STATES } from '../src/byok-mcp-client.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const STUB = join(__dirname, 'fixtures', 'mcp-stub.mjs')
+
+function silentLog() {
+  return { info: () => {}, warn: () => {}, debug: () => {}, error: () => {} }
+}
+
+function cfg(name, env = {}) {
+  return { name, command: process.execPath, args: [STUB], env }
+}
+
+async function waitForReady(client, timeoutMs = 4000) {
+  if (client.state === MCP_STATES.READY) return
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`timeout: ${client.name}`)), timeoutMs)
+    client.on('state', ({ next }) => {
+      if (next === MCP_STATES.READY) { clearTimeout(t); resolve() }
+    })
+  })
+}
+
+describe('MCPFleet', () => {
+  it('aggregates tools from multiple ready servers with mcp__<server>__<tool> namespace', async () => {
+    const tools = [{ name: 'echo', description: 'e', inputSchema: { type: 'object' } }]
+    const fleet = new MCPFleet([
+      cfg('alpha', { MCP_STUB_TOOLS: JSON.stringify(tools) }),
+      cfg('beta', { MCP_STUB_TOOLS: JSON.stringify(tools) }),
+    ], { log: silentLog() })
+    await fleet.start()
+    const names = fleet.tools.map((t) => t.name).sort()
+    assert.deepEqual(names, ['mcp__alpha__echo', 'mcp__beta__echo'])
+    await fleet.destroy()
+  })
+
+  it('excludes tools from dead servers', async () => {
+    // alpha is healthy, broken always exits — broken should die after 3 attempts
+    // and contribute zero tools. fleet.start() awaits each client's first
+    // stable state, so by the time it returns alpha is READY and broken is
+    // DEAD.
+    const fleet = new MCPFleet([
+      cfg('alpha'),
+      { name: 'broken', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+    ], { log: silentLog() })
+    await fleet.start()
+    assert.equal(fleet.clients[0].state, MCP_STATES.READY)
+    assert.equal(fleet.clients[1].state, MCP_STATES.DEAD)
+    const names = fleet.tools.map((t) => t.name)
+    assert.deepEqual(names, ['mcp__alpha__echo'])
+    await fleet.destroy()
+  })
+
+  it('destroy() returns within FLEET_KILL_GRACE_MS + safety margin even with hung children', async () => {
+    const fleet = new MCPFleet([
+      cfg('hung1', { MCP_STUB_HANG: '1' }),
+      cfg('hung2', { MCP_STUB_HANG: '1' }),
+    ], { log: silentLog() })
+    await fleet.start()
+    await Promise.all(fleet.clients.map((c) => waitForReady(c)))
+    const t0 = Date.now()
+    await fleet.destroy()
+    const elapsed = Date.now() - t0
+    assert.ok(elapsed <= FLEET_KILL_GRACE_MS + 600, `destroy took ${elapsed}ms, expected <= ${FLEET_KILL_GRACE_MS + 600}ms`)
+  })
+})

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -2,9 +2,14 @@ import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { APIUserAbortError } from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from '../src/byok-session.js'
+import { MCP_STATES } from '../src/byok-mcp-client.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MCP_STUB = join(__dirname, 'fixtures', 'mcp-stub.mjs')
 
 /**
  * Tests for byok-session.js (PR 1 — chat only, no tool dispatch).
@@ -225,6 +230,43 @@ describe('ClaudeByokSession', () => {
       assert.deepEqual(session._mcpServerConfigs, [])
       assert.ok(captured.find((e) => e.name === 'ready'), 'malformed MCP config must not block startup')
       await session.destroy()
+    })
+
+    it('#4077: lazy-spawns an MCPFleet for configured servers and reaches READY before emitting ready', async () => {
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          stub: { command: process.execPath, args: [MCP_STUB], env: {} },
+        },
+      }))
+      const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      assert.equal(session._mcpFleet, null, 'fleet not created before start()')
+      await session.start()
+      assert.ok(session._mcpFleet, 'fleet created during start()')
+      assert.equal(session._mcpFleet.clients.length, 1)
+      assert.equal(session._mcpFleet.clients[0].state, MCP_STATES.READY)
+      assert.equal(session._mcpFleet.clients[0].tools.length, 1)
+      await session.destroy()
+    })
+
+    it('#4077: destroy() kills MCP children and clears the fleet reference', async () => {
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          stub: { command: process.execPath, args: [MCP_STUB], env: {} },
+        },
+      }))
+      const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      await session.start()
+      const client = session._mcpFleet.clients[0]
+      assert.equal(client.state, MCP_STATES.READY)
+      const t0 = Date.now()
+      await session.destroy()
+      const elapsed = Date.now() - t0
+      assert.ok(elapsed <= 2500, `destroy took ${elapsed}ms, expected <= 2500ms (FLEET_KILL_GRACE_MS + safety)`)
+      assert.equal(session._mcpFleet, null, 'fleet reference cleared after destroy')
     })
   })
 

--- a/packages/server/tests/fixtures/mcp-stub.mjs
+++ b/packages/server/tests/fixtures/mcp-stub.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { createInterface } from 'node:readline'
+
+const tools = JSON.parse(process.env.MCP_STUB_TOOLS || '[{"name":"echo","description":"echo input","inputSchema":{"type":"object"}}]')
+
+function reply(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n')
+}
+
+createInterface({ input: process.stdin }).on('line', (line) => {
+  let msg
+  try { msg = JSON.parse(line) } catch { return }
+  if (msg.id == null) return
+  if (msg.method === 'initialize') {
+    reply(msg.id, { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'mcp-stub', version: '0.1.0' } })
+  } else if (msg.method === 'tools/list') {
+    reply(msg.id, { tools })
+  }
+})
+
+if (process.env.MCP_STUB_DIE_AFTER_MS) {
+  setTimeout(() => process.exit(1), Number(process.env.MCP_STUB_DIE_AFTER_MS))
+}
+
+if (process.env.MCP_STUB_HANG === '1') {
+  process.on('SIGTERM', () => {})
+  setInterval(() => {}, 60_000)
+}


### PR DESCRIPTION
Stage 2 of the MCP-for-BYOK series. Spawns each MCP server configured via `byok-mcp-config` as a child process, runs the JSON-RPC handshake, surfaces tool metadata, and handles crashes / teardown.

Builds on #4076 (config discovery), unblocks #4078 (materialize tools into `messages.stream({ tools })`) and #4079 (tool_use dispatch + end-to-end).

## Scope

- **Per-server `MCPClient`** (`byok-mcp-client.js`): owns one child via `spawn`, newline-delimited JSON-RPC framing on stdio, handshake `initialize` → `notifications/initialized` → `tools/list`, EventEmitter for `state`/`ready`/`dead`/`restart`.
- **Per-session `MCPFleet`** (`byok-mcp-fleet.js`): orchestrates clients in parallel, aggregates tools with the chroxy `mcp__<server>__<tool>` namespace, kills children with grace on destroy.
- **Lazy spawn**: `byok-session.start()` creates the fleet only if `_mcpServerConfigs.length > 0`; `client.start()` resolves on first stable state (`READY` or `DEAD`) so callers know whether a server is usable.
- **Crash detection**: `child.exit` / `child.error` → tools cleared, 1s constant backoff, restart up to `MAX_RESTART_ATTEMPTS = 3` then `DEAD`.
- **Destroy grace**: SIGTERM → 1s wait → SIGKILL, mirroring the bash-exec teardown pattern referenced in the issue.

## Acceptance (#4077)

- [x] Stub MCP server fixture (`tests/fixtures/mcp-stub.mjs`, 25 lines) starts, handshakes, and surfaces its tools.
- [x] Killing the child mid-session triggers exactly 1 restart attempt within ~1s (measured between `RESTARTING` and the next `STARTING`).
- [x] After 3 failed restarts, the server is marked `DEAD` and excluded from the tools list.
- [x] Session destroy kills all MCP children within ~2s (SIGTERM → SIGKILL grace).

## What's *not* in this PR

- No `tools/call` dispatch — that's #4079.
- No materialization into the Anthropic SDK `messages.stream({ tools })` array — that's #4078. The fleet exposes the tools shape; the next PR wires it.
- No allowlist / trust prompt for `command` / `args`. Today's risk is bounded — only operators who edit `~/.claude.json` get child processes spawned. The same surface area exists in upstream Claude Code. Worth a follow-up issue if we want to add a trust prompt before #4079 lands an executor that runs arbitrary MCP tool calls.

## Test summary

- New `tests/byok-mcp-client.test.js` — 7/7 pass (handshake, crash + 1-restart-within-1s, 3-fail→DEAD, tools-cleared-on-DEAD, restart-timer-cancellation-on-destroy, SIGTERM→SIGKILL grace).
- New `tests/byok-mcp-fleet.test.js` — 3/3 pass (namespace aggregation, dead-server exclusion, destroy grace).
- Extended `tests/byok-session.test.js` — 2 new tests for `#4077` (lazy fleet creation in `start()`, destroy kills children + clears fleet reference).
- Targeted run across `byok-mcp-{config,client,fleet}` + `byok-session`: **92/92 pass** on Node 22.
- Lint: zero new warnings (4 pre-existing warnings on unrelated files).

Closes #4077. Related to #4076, #4078, #4079.