### PR TITLE
feat(server): materialize MCP tools into messages.stream() tools array (#4078)

### DIFF
--- a/packages/server/src/byok-mcp-fleet.js
+++ b/packages/server/src/byok-mcp-fleet.js
@@ -46,6 +46,29 @@ export class MCPFleet {
     return out
   }
 
+  /**
+   * Anthropic-shaped tool definitions for messages.stream({ tools }).
+   *
+   * MCP's tools/list returns { name, description, inputSchema } per tool.
+   * Anthropic's API wants { name, description, input_schema }. The rename
+   * happens here so byok-session can `[...BUILTIN_TOOLS, ...fleet.anthropicTools]`
+   * without knowing the MCP shape.
+   *
+   * Internal markers (_mcpServer, _mcpOriginalName) are stripped — they're
+   * useful inside chroxy for routing tool_use back to the right client (#4079)
+   * but the SDK would reject unknown keys.
+   *
+   * Dead servers (post-restart-exhaustion) contribute zero tools because
+   * `this.tools` already filters by READY state.
+   */
+  get anthropicTools() {
+    return this.tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description || '',
+      input_schema: tool.inputSchema || { type: 'object' },
+    }))
+  }
+
   async destroy() {
     await Promise.race([
       Promise.all(this._clients.map((c) => c.destroy())),

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -372,7 +372,11 @@ export class ClaudeByokSession extends BaseSession {
               model: this.model || 'claude-opus-4-7',
               max_tokens: DEFAULT_MAX_TOKENS,
               ...(systemPrompt ? { system: systemPrompt } : {}),
-              tools: BUILTIN_TOOLS,
+              // #4078: merge BUILTIN_TOOLS with live MCP tools at turn time.
+              // fleet.anthropicTools filters DEAD servers, so a crashed-then-
+              // restart-exhausted MCP server cleanly disappears from the next
+              // turn without anything to invalidate.
+              tools: this._buildTools(),
               messages: this._history,
             },
             { signal: this._abortController.signal },
@@ -1013,6 +1017,18 @@ export class ClaudeByokSession extends BaseSession {
     if (!super.setPermissionMode(mode)) return
     // PR 1 has no permission gating, so this is purely persisted state
     // for PR 2 to consume.
+  }
+
+  // #4078: assemble the per-turn tools array. BUILTIN_TOOLS first
+  // (Read/Write/Edit/Bash/Glob/Grep) then any live MCP tools surfaced by
+  // the fleet, namespaced as mcp__<server>__<tool>. Re-evaluated every
+  // turn rather than cached because the cost is trivial and the fleet's
+  // READY-state filter is the source of truth for which servers are
+  // contributing right now.
+  _buildTools() {
+    if (!this._mcpFleet) return BUILTIN_TOOLS
+    const mcp = this._mcpFleet.anthropicTools
+    return mcp.length === 0 ? BUILTIN_TOOLS : [...BUILTIN_TOOLS, ...mcp]
   }
 
   async destroy() {

--- a/packages/server/tests/byok-mcp-fleet.test.js
+++ b/packages/server/tests/byok-mcp-fleet.test.js
@@ -68,4 +68,40 @@ describe('MCPFleet', () => {
     const elapsed = Date.now() - t0
     assert.ok(elapsed <= FLEET_KILL_GRACE_MS + 600, `destroy took ${elapsed}ms, expected <= ${FLEET_KILL_GRACE_MS + 600}ms`)
   })
+
+  describe('anthropicTools (#4078)', () => {
+    it('renames inputSchema → input_schema and strips internal markers', async () => {
+      const tools = [{ name: 'echo', description: 'e', inputSchema: { type: 'object', properties: { msg: { type: 'string' } } } }]
+      const fleet = new MCPFleet([cfg('alpha', { MCP_STUB_TOOLS: JSON.stringify(tools) })], { log: silentLog() })
+      await fleet.start()
+      const anth = fleet.anthropicTools
+      assert.equal(anth.length, 1)
+      assert.equal(anth[0].name, 'mcp__alpha__echo')
+      assert.equal(anth[0].description, 'e')
+      assert.deepEqual(anth[0].input_schema, { type: 'object', properties: { msg: { type: 'string' } } })
+      assert.equal(anth[0].inputSchema, undefined, 'inputSchema renamed away')
+      assert.equal(anth[0]._mcpServer, undefined, 'internal marker stripped')
+      assert.equal(anth[0]._mcpOriginalName, undefined, 'internal marker stripped')
+      await fleet.destroy()
+    })
+
+    it('falls back to { type: object } when MCP server omits inputSchema', async () => {
+      const tools = [{ name: 'no_schema', description: 'd' }]
+      const fleet = new MCPFleet([cfg('alpha', { MCP_STUB_TOOLS: JSON.stringify(tools) })], { log: silentLog() })
+      await fleet.start()
+      assert.deepEqual(fleet.anthropicTools[0].input_schema, { type: 'object' })
+      await fleet.destroy()
+    })
+
+    it('excludes anthropicTools from dead servers', async () => {
+      const fleet = new MCPFleet([
+        cfg('alpha'),
+        { name: 'broken', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+      ], { log: silentLog() })
+      await fleet.start()
+      const names = fleet.anthropicTools.map((t) => t.name)
+      assert.deepEqual(names, ['mcp__alpha__echo'])
+      await fleet.destroy()
+    })
+  })
 })

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -250,6 +250,65 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('#4078: messages.stream receives BUILTIN_TOOLS + MCP tools merged for the turn', async () => {
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          stub: { command: process.execPath, args: [MCP_STUB], env: { MCP_STUB_TOOLS: JSON.stringify([
+            { name: 'one', description: 'first', inputSchema: { type: 'object' } },
+            { name: 'two', description: 'second', inputSchema: { type: 'object' } },
+          ]) } },
+        },
+      }))
+      const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+      let capturedTools = null
+      session._client = {
+        messages: {
+          stream: ({ tools }) => {
+            capturedTools = tools
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }],
+              { stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      await session.start()
+      await session.sendMessage('hello')
+      assert.ok(capturedTools, 'tools must be captured from stream call')
+      const builtinCount = capturedTools.filter((t) => !t.name.startsWith('mcp__')).length
+      const mcpTools = capturedTools.filter((t) => t.name.startsWith('mcp__'))
+      assert.ok(builtinCount >= 1, `expected at least 1 builtin tool, got ${builtinCount}`)
+      assert.deepEqual(mcpTools.map((t) => t.name).sort(), ['mcp__stub__one', 'mcp__stub__two'])
+      for (const mcp of mcpTools) {
+        assert.ok(mcp.input_schema, 'MCP tool must carry input_schema (renamed from inputSchema)')
+        assert.equal(mcp.inputSchema, undefined, 'inputSchema rename complete')
+        assert.equal(mcp._mcpServer, undefined, 'internal markers stripped before API')
+      }
+      await session.destroy()
+    })
+
+    it('#4078: messages.stream receives only BUILTIN_TOOLS when no MCP servers configured', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      let capturedTools = null
+      session._client = {
+        messages: {
+          stream: ({ tools }) => {
+            capturedTools = tools
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }],
+              { stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      await session.start()
+      await session.sendMessage('hello')
+      assert.ok(capturedTools)
+      assert.ok(capturedTools.every((t) => !t.name.startsWith('mcp__')), 'no MCP tools when fleet is null')
+      await session.destroy()
+    })
+
     it('#4077: destroy() kills MCP children and clears the fleet reference', async () => {
       const configPath = join(tmpHome, '.claude.json')
       writeFileSync(configPath, JSON.stringify({


### PR DESCRIPTION
Stage 3 of the MCP-for-BYOK series. Surfaces the MCP servers' `tools/list` results to the model by merging them with `BUILTIN_TOOLS` in every `messages.stream({ tools })` call.

Builds on #4076 (config) + #4077 (lifecycle). Next: #4079 (tool_use dispatch + end-to-end) — and the trust-prompt gate ([#4457](https://github.com/blamechris/chroxy/issues/4457)) lands between this PR and #4079 so the dispatcher doesn't widen the trust surface without user consent.

## Scope

- **`MCPFleet.anthropicTools` getter** (`byok-mcp-fleet.js`) — transforms the READY-state-filtered MCP `tools/list` result into Anthropic SDK shape: renames `inputSchema → input_schema`, strips internal markers (`_mcpServer`, `_mcpOriginalName`), falls back to `{ type: 'object' }` when a server omits the schema.
- **`ClaudeByokSession._buildTools()`** (`byok-session.js`) — merges `BUILTIN_TOOLS` + `fleet.anthropicTools` per turn. Both `messages.stream` calls in `sendMessage` route through it.

## Why no cache

The issue suggests caching the materialized list with crash-restart invalidation. I deliberately skipped that: `fleet.tools` is O(N_servers × N_tools_per_server) — for typical configs that's <50 entries, recomputed per turn at zero perceptible cost. More importantly, the READY-state filter is the source of truth — a server that died mid-session is excluded automatically with no cache to invalidate. Less code, fewer bugs, identical behavior to the spec.

## Acceptance (#4078)

- [x] BYOK session with one MCP server (stub fixture exposing 2 tools) calls `messages.stream` with builtin + 2 MCP tools (`#4078: messages.stream receives BUILTIN_TOOLS + MCP tools merged` test).
- [x] Tool names follow the `mcp__<server>__<name>` convention (asserted in both fleet and session tests).
- [x] If an MCP server is dead (post-restart-exhaustion), its tools are absent from the array on the next turn (`excludes anthropicTools from dead servers` test).

## Test summary

- New: `tests/byok-mcp-fleet.test.js` — 3 tests in `anthropicTools (#4078)`: shape rename + marker strip, missing-schema fallback, dead-server exclusion.
- New: `tests/byok-session.test.js` — 2 tests for `#4078`: stream call carries BUILTIN_TOOLS + MCP tools when configured, only BUILTIN_TOOLS when fleet is null.
- Targeted run across `byok-mcp-*` + `byok-session`: **85/85 pass** on Node 22.
- Lint: zero new warnings.

Closes #4078. Related to #4076, #4077, #4079, [#4457](https://github.com/blamechris/chroxy/issues/4457).