### PR TITLE
fix(server): emit result on CLI child close so dashboard recovers from Stop

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -308,26 +308,7 @@ export class CliSession extends BaseSession {
       this._scheduleRespawn()
     })
 
-    child.on('close', (code) => {
-      this._cleanupReadlines()
-      this._processReady = false
-      this._child = null
-
-      if (this._destroying) return
-      if (this._respawning) return
-
-      // Safety net: if we were mid-message, close the stream
-      if (this._isBusy && this._currentMessageId) {
-        if (this._currentCtx?.hasStreamStarted) {
-          this.emit('stream_end', { messageId: this._currentMessageId })
-        }
-        this._clearMessageState()
-      }
-
-      log.info(`Process exited (code ${code}), scheduling respawn`)
-      this.emit('error', { message: 'Claude process exited unexpectedly, restarting...' })
-      this._scheduleRespawn()
-    })
+    child.on('close', (code) => this._handleChildClose(code))
 
     // stdin is writable immediately — process is ready for NDJSON messages.
     // system.init arrives with the first response, not at startup.
@@ -1067,6 +1048,33 @@ export class CliSession extends BaseSession {
     } catch (err) {
       log.error(`stdin.write failed (respondToQuestion): ${err.message}`)
     }
+  }
+
+  // `result` emit is load-bearing: event-normalizer fans it to `agent_idle`,
+  // which clears the dashboard's streamingMessageId/isIdle. Without it, an
+  // interrupted CLI turn leaves Stop stuck visible and "Thinking…" permanent.
+  // Mirrors TUI #4010 (claude-tui-session.js:1328). cost:null skips billing.
+  _handleChildClose(code) {
+    this._cleanupReadlines()
+    this._processReady = false
+    this._child = null
+
+    if (this._destroying) return
+    if (this._respawning) return
+
+    if (this._isBusy && this._currentMessageId) {
+      const messageId = this._currentMessageId
+      const sessionId = this._sessionId
+      if (this._currentCtx?.hasStreamStarted) {
+        this.emit('stream_end', { messageId })
+      }
+      this._clearMessageState()
+      this.emit('result', { cost: null, duration: 0, usage: null, sessionId })
+    }
+
+    log.info(`Process exited (code ${code}), scheduling respawn`)
+    this.emit('error', { message: 'Claude process exited unexpectedly, restarting...' })
+    this._scheduleRespawn()
   }
 
   /** Interrupt the current message (send SIGINT to child process) */

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -256,6 +256,91 @@ describe('CliSession.interrupt', () => {
   })
 })
 
+describe('CliSession._handleChildClose (interrupt-recovery)', () => {
+  it('emits stream_end + result + error in order when interrupted mid-turn, so dashboard clears Stop button', () => {
+    const session = createReadySession()
+    session._isBusy = true
+    session._currentMessageId = 'msg_42'
+    session._currentCtx = { hasStreamStarted: true }
+    session._sessionId = 'sess_abc'
+
+    const events = []
+    session.on('stream_end', (p) => events.push({ name: 'stream_end', payload: p }))
+    session.on('result', (p) => events.push({ name: 'result', payload: p }))
+    session.on('error', (p) => events.push({ name: 'error', payload: p }))
+
+    session._handleChildClose(130)
+
+    // Cleanup respawn timer scheduled by _handleChildClose
+    clearTimeout(session._respawnTimer)
+    session._respawnTimer = null
+
+    assert.deepEqual(events.map((e) => e.name), ['stream_end', 'result', 'error'])
+    assert.equal(events[0].payload.messageId, 'msg_42')
+    // The `result` emit is the load-bearing change: event-normalizer fans it
+    // out to `agent_idle`, which is what the dashboard listens for to clear
+    // `streamingMessageId` / `isIdle`. Without it, Stop stays visible and
+    // "Thinking…" never goes away.
+    assert.equal(events[1].payload.sessionId, 'sess_abc')
+    assert.equal(events[1].payload.cost, null, 'cost: null skips session-manager cost accounting')
+    assert.equal(events[1].payload.usage, null)
+    assert.match(events[2].payload.message, /exited unexpectedly/)
+  })
+
+  it('does NOT emit result when not busy (no turn to terminate)', () => {
+    const session = createReadySession()
+    session._isBusy = false
+
+    const events = []
+    session.on('stream_end', () => events.push('stream_end'))
+    session.on('result', () => events.push('result'))
+    session.on('error', () => events.push('error'))
+
+    session._handleChildClose(0)
+    clearTimeout(session._respawnTimer)
+    session._respawnTimer = null
+
+    assert.deepEqual(events, ['error'], 'only the supervisor-restart error fires when no turn is in flight')
+  })
+
+  it('does NOT emit stream_end if the stream had not started yet (tool ran before any text)', () => {
+    const session = createReadySession()
+    session._isBusy = true
+    session._currentMessageId = 'msg_x'
+    session._currentCtx = { hasStreamStarted: false }
+    session._sessionId = 'sess_x'
+
+    const events = []
+    session.on('stream_end', () => events.push('stream_end'))
+    session.on('result', () => events.push('result'))
+    session.on('error', () => events.push('error'))
+
+    session._handleChildClose(0)
+    clearTimeout(session._respawnTimer)
+    session._respawnTimer = null
+
+    // Still emits result — that's the key — so the dashboard's Stop clears
+    // even when the stream never started.
+    assert.deepEqual(events, ['result', 'error'])
+  })
+
+  it('skips all emits when _destroying (session being torn down — no respawn, no result)', () => {
+    const session = createReadySession()
+    session._isBusy = true
+    session._currentMessageId = 'msg_x'
+    session._destroying = true
+
+    const events = []
+    session.on('stream_end', () => events.push('stream_end'))
+    session.on('result', () => events.push('result'))
+    session.on('error', () => events.push('error'))
+
+    session._handleChildClose(0)
+
+    assert.deepEqual(events, [], 'destroy path is silent — caller owns the teardown UX')
+  })
+})
+
 describe('CliSession.destroy', () => {
   it('sets destroying flag and nulls child', () => {
     const session = createReadySession()


### PR DESCRIPTION
## Summary

When the CLI child process exits mid-turn (Stop button pressed, crash, OOM, etc.), the close handler emitted `stream_end` + `error` but never `result`. The event-normalizer fans `result` out to `agent_idle`, which is what the dashboard listens for to clear `streamingMessageId` / `isIdle`.

Without it, **Stop stayed visible and "Thinking…" persisted forever** — the session became effectively unkillable from the dashboard. I hit this myself with my no-it-all session ([screenshot from #4467](https://github.com/blamechris/chroxy/issues/4467)).

This is the load-bearing fix for one of the symptoms in #4467. It mirrors the TUI session's fix at `claude-tui-session.js:1328` (#4010) — that path had the same bug a year ago; the CLI path never got the same treatment.

## Changes

- Extracted `child.on('close', ...)` body into `_handleChildClose(code)` so the recovery logic is unit-testable without spawning a real child.
- Added `this.emit('result', { cost: null, duration: 0, usage: null, sessionId })` after `_clearMessageState()` when interrupted mid-turn. `cost: null` skips session-manager's cost accounting (`typeof === 'number'` gate) so the synthetic emit doesn't bill a non-turn.
- 4 unit tests covering the four behavior matrices:
  - Busy mid-stream → stream_end + result + error in order
  - Not busy → error only
  - Busy but stream hadn't started → result + error (no stream_end)
  - `_destroying` → silent (caller owns teardown UX)

## Test plan

- [x] New unit tests: `node --test --test-name-pattern "_handleChildClose"` — 4/4 pass
- [x] Full `cli-session.test.js` suite: 63 pass (baseline 59; +4 new). File-level timeout is pre-existing and reproduces on `main`.
- [ ] Smoke test: open a CLI session, hit Stop mid-stream, confirm Stop button clears and Thinking indicator goes away

## Related

- Caller of #4467 (silent stream stall + unkillable session)
- Mirrors TUI #4010 architecturally