### PR TITLE
fix(server): emit result on all Stop-stuck CLI/Docker paths (#4469, #4470, #4471)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -523,10 +523,6 @@ export class CliSession extends BaseSession {
     if (!this._isBusy) return
     const friendly = formatIdleDuration(this._hardTimeoutMs)
     log.warn(`Hard-cap timeout (${friendly}) — force-clearing busy state`)
-    const messageId = this._currentMessageId
-    if (this._currentCtx?.hasStreamStarted) {
-      this.emit('stream_end', { messageId })
-    }
     // Fire permission_expired for every pending permission we know about
     // so the client clears the stale prompt.
     for (const requestId of this._pendingPermissionIds) {
@@ -536,7 +532,7 @@ export class CliSession extends BaseSession {
       })
     }
     this._pendingPermissionIds.clear()
-    this._clearMessageState()
+    this._emitInterruptedTurnResult(this._hardTimeoutMs)
     this.emit('error', { message: `Response timed out after ${friendly}` })
   }
 
@@ -913,6 +909,12 @@ export class CliSession extends BaseSession {
    * Suppresses auto-respawn during the kill, clears timers, and starts fresh.
    */
   _killAndRespawn() {
+    // #4471: emit synthetic terminating events BEFORE setting _respawning,
+    // otherwise the _handleChildClose guard short-circuits and the dashboard
+    // never receives `agent_idle` — Stop stays stuck on panic-button +
+    // mid-turn setModel paths.
+    this._emitInterruptedTurnResult()
+
     this._respawning = true
     this._processReady = false
     this._sessionId = null
@@ -1050,10 +1052,22 @@ export class CliSession extends BaseSession {
     }
   }
 
-  // `result` emit is load-bearing: event-normalizer fans it to `agent_idle`,
-  // which clears the dashboard's streamingMessageId/isIdle. Without it, an
-  // interrupted CLI turn leaves Stop stuck visible and "Thinking…" permanent.
-  // Mirrors TUI #4010 (claude-tui-session.js:1328). cost:null skips billing.
+  // Synthetic terminating events for an interrupted turn. The `result` emit
+  // is load-bearing: event-normalizer fans it to `agent_idle`, which clears
+  // the dashboard's streamingMessageId/isIdle. Without it, an interrupted
+  // turn leaves Stop stuck visible and "Thinking…" permanent.
+  // Mirrors TUI #4010. cost:null skips session-manager billing.
+  _emitInterruptedTurnResult(duration = 0) {
+    if (!this._isBusy || !this._currentMessageId) return
+    const messageId = this._currentMessageId
+    const sessionId = this._sessionId
+    if (this._currentCtx?.hasStreamStarted) {
+      this.emit('stream_end', { messageId })
+    }
+    this._clearMessageState()
+    this.emit('result', { cost: null, duration, usage: null, sessionId })
+  }
+
   _handleChildClose(code) {
     this._cleanupReadlines()
     this._processReady = false
@@ -1062,15 +1076,7 @@ export class CliSession extends BaseSession {
     if (this._destroying) return
     if (this._respawning) return
 
-    if (this._isBusy && this._currentMessageId) {
-      const messageId = this._currentMessageId
-      const sessionId = this._sessionId
-      if (this._currentCtx?.hasStreamStarted) {
-        this.emit('stream_end', { messageId })
-      }
-      this._clearMessageState()
-      this.emit('result', { cost: null, duration: 0, usage: null, sessionId })
-    }
+    this._emitInterruptedTurnResult()
 
     log.info(`Process exited (code ${code}), scheduling respawn`)
     this.emit('error', { message: 'Claude process exited unexpectedly, restarting...' })
@@ -1095,11 +1101,7 @@ export class CliSession extends BaseSession {
       this._interruptTimer = null
       if (this._isBusy) {
         log.warn('Interrupt safety timeout — force-clearing busy state')
-        const messageId = this._currentMessageId
-        if (this._currentCtx?.hasStreamStarted) {
-          this.emit('stream_end', { messageId })
-        }
-        this._clearMessageState()
+        this._emitInterruptedTurnResult()
       }
     }, 5000)
   }

--- a/packages/server/src/docker-session.js
+++ b/packages/server/src/docker-session.js
@@ -264,25 +264,7 @@ export class DockerSession extends CliSession {
       this._scheduleRespawn()
     })
 
-    child.on('close', (code) => {
-      this._cleanupReadlines()
-      this._processReady = false
-      this._child = null
-
-      if (this._destroying) return
-      if (this._respawning) return
-
-      if (this._isBusy && this._currentMessageId) {
-        if (this._currentCtx?.hasStreamStarted) {
-          this.emit('stream_end', { messageId: this._currentMessageId })
-        }
-        this._clearMessageState()
-      }
-
-      log.info(`Container exec exited (code ${code}), scheduling respawn`)
-      this.emit('error', { message: 'Claude process exited unexpectedly, restarting...' })
-      this._scheduleRespawn()
-    })
+    child.on('close', (code) => this._handleChildClose(code))
 
     this._processReady = true
     log.info('Container exec started, ready for messages')

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -341,6 +341,108 @@ describe('CliSession._handleChildClose (interrupt-recovery)', () => {
   })
 })
 
+describe('CliSession._handleHardTimeout (#4470: missing result emit)', () => {
+  it('emits stream_end + result + error so dashboard clears Stop on hard-cap timeout', () => {
+    const session = createReadySession({ hardTimeoutMs: 60_000 })
+    session._isBusy = true
+    session._currentMessageId = 'msg_ht'
+    session._currentCtx = { hasStreamStarted: true }
+    session._sessionId = 'sess_ht'
+
+    const events = []
+    session.on('stream_end', (p) => events.push({ name: 'stream_end', payload: p }))
+    session.on('result', (p) => events.push({ name: 'result', payload: p }))
+    session.on('error', (p) => events.push({ name: 'error', payload: p }))
+
+    session._handleHardTimeout()
+
+    assert.deepEqual(events.map((e) => e.name), ['stream_end', 'result', 'error'])
+    assert.equal(events[0].payload.messageId, 'msg_ht')
+    assert.equal(events[1].payload.sessionId, 'sess_ht')
+    assert.equal(events[1].payload.duration, session._hardTimeoutMs, 'duration carries the elapsed cap')
+    assert.equal(events[1].payload.cost, null)
+    assert.match(events[2].payload.message, /timed out/)
+  })
+
+  it('no-ops when not busy (timer fired against an idle session)', () => {
+    const session = createReadySession()
+    session._isBusy = false
+
+    const events = []
+    session.on('stream_end', () => events.push('stream_end'))
+    session.on('result', () => events.push('result'))
+    session.on('error', () => events.push('error'))
+
+    session._handleHardTimeout()
+    assert.deepEqual(events, [])
+  })
+
+  it('fires permission_expired for pending permission ids before clearing state', () => {
+    const session = createReadySession()
+    session._isBusy = true
+    session._currentMessageId = 'msg_pe'
+    session._currentCtx = { hasStreamStarted: false }
+    session._pendingPermissionIds.add('req-1')
+    session._pendingPermissionIds.add('req-2')
+
+    const expired = []
+    session.on('permission_expired', (p) => expired.push(p.requestId))
+    session.on('error', () => {})
+
+    session._handleHardTimeout()
+
+    assert.deepEqual(expired.sort(), ['req-1', 'req-2'])
+    assert.equal(session._pendingPermissionIds.size, 0)
+  })
+})
+
+describe('CliSession._killAndRespawn (#4471: panic-button drops dashboard recovery)', () => {
+  it('emits stream_end + result BEFORE setting _respawning, so dashboard clears Stop', () => {
+    const session = createReadySession()
+    session._isBusy = true
+    session._currentMessageId = 'msg_kr'
+    session._currentCtx = { hasStreamStarted: true }
+    session._sessionId = 'sess_kr'
+    session._destroying = true // suppress respawn (no real spawn in unit test)
+
+    const oldChild = session._child
+    const events = []
+    let respawningAtResult = null
+    session.on('stream_end', (p) => events.push({ name: 'stream_end', payload: p }))
+    session.on('result', (p) => {
+      events.push({ name: 'result', payload: p })
+      respawningAtResult = session._respawning
+    })
+
+    session._killAndRespawn()
+
+    // Drain the closure-scoped forceKillTimer: emitting 'close' on the
+    // mock child invokes the respawn() callback which clears the timer.
+    oldChild.emit('close', 0)
+
+    assert.deepEqual(events.map((e) => e.name), ['stream_end', 'result'])
+    assert.equal(events[0].payload.messageId, 'msg_kr')
+    assert.equal(events[1].payload.sessionId, 'sess_kr')
+    assert.equal(respawningAtResult, false, 'result emit must precede _respawning=true so subsequent close-handler does not duplicate')
+  })
+
+  it('no-ops emit when not busy (setModel called from idle)', () => {
+    const session = createReadySession()
+    session._isBusy = false
+    session._destroying = true // suppress respawn
+
+    const oldChild = session._child
+    const events = []
+    session.on('stream_end', () => events.push('stream_end'))
+    session.on('result', () => events.push('result'))
+
+    session._killAndRespawn()
+    oldChild.emit('close', 0)
+
+    assert.deepEqual(events, [])
+  })
+})
+
 describe('CliSession.destroy', () => {
   it('sets destroying flag and nulls child', () => {
     const session = createReadySession()

--- a/packages/server/tests/docker-session.test.js
+++ b/packages/server/tests/docker-session.test.js
@@ -583,3 +583,44 @@ describe('DockerSession real import (capabilities only)', () => {
     }
   })
 })
+
+describe('DockerSession inherits CliSession close-handler fix (#4469)', () => {
+  it('_handleChildClose is the inherited CliSession method (not overridden)', async () => {
+    const { DockerSession } = await import('../src/docker-session.js')
+    const { CliSession } = await import('../src/cli-session.js')
+    // Docker MUST NOT carry its own override — the inherited helper is what
+    // emits `result` so the dashboard recovers from Stop. If a future change
+    // re-introduces a docker override, this test flags it.
+    assert.equal(
+      DockerSession.prototype._handleChildClose,
+      CliSession.prototype._handleChildClose,
+      'docker-session must inherit _handleChildClose so the synthetic result emit fires (#4469)',
+    )
+  })
+
+  it('emits stream_end + result + error on mid-turn close (via inherited handler)', async () => {
+    const { DockerSession } = await import('../src/docker-session.js')
+    // Construct without spawning anything — we only exercise the close path.
+    const session = new DockerSession({ cwd: '/tmp', image: 'node:22-slim' })
+
+    session._processReady = true
+    session._isBusy = true
+    session._currentMessageId = 'msg_docker'
+    session._currentCtx = { hasStreamStarted: true }
+    session._sessionId = 'sess_docker'
+
+    const events = []
+    session.on('stream_end', (p) => events.push({ name: 'stream_end', payload: p }))
+    session.on('result', (p) => events.push({ name: 'result', payload: p }))
+    session.on('error', (p) => events.push({ name: 'error', payload: p }))
+
+    session._handleChildClose(137)
+    clearTimeout(session._respawnTimer)
+    session._respawnTimer = null
+
+    assert.deepEqual(events.map((e) => e.name), ['stream_end', 'result', 'error'])
+    assert.equal(events[0].payload.messageId, 'msg_docker')
+    assert.equal(events[1].payload.sessionId, 'sess_docker')
+    assert.equal(events[1].payload.cost, null)
+  })
+})


### PR DESCRIPTION
## Summary

Three sibling bugs to #4468. Same shape — an in-flight CLI turn terminates abnormally but never emits \`result\`, so event-normalizer never fans \`agent_idle\`, so the dashboard's Stop button + \"Thinking…\" indicator stay stuck forever.

**The four paths fixed (a fourth one surfaced during the refactor):**

| Path | Trigger | Issue |
|------|---------|-------|
| \`_handleHardTimeout\` | hard-cap inactivity timer fires | [#4470](https://github.com/blamechris/chroxy/issues/4470) |
| \`_killAndRespawn\` | panic-button (mid-turn auto-mode) or mid-turn setModel | [#4471](https://github.com/blamechris/chroxy/issues/4471) |
| \`docker-session\` close handler | container child process exits mid-turn | [#4469](https://github.com/blamechris/chroxy/issues/4469) |
| \`interrupt()\` safety timeout | child didn't exit within 5s of SIGINT | (fixed for free during refactor) |

**#4471 details:** \`_killAndRespawn\` sets \`_respawning=true\` BEFORE the child's close event fires, so #4468's new \`_handleChildClose\` guard (\`if (_respawning) return\`) was short-circuiting the synthetic result emit. Fix is to emit BEFORE setting the flag.

## Refactor

Extracted the emit-sequence into \`_emitInterruptedTurnResult(duration = 0)\` on \`CliSession\`. All four callsites use it. DockerSession's \`child.on('close')\` now delegates to the inherited \`_handleChildClose\`, eliminating the duplicate copy entirely — \`DockerSession.prototype._handleChildClose === CliSession.prototype._handleChildClose\` is now an enforced invariant via a unit test.

## Diff shape

- \`cli-session.js\`: +helper, refactored 4 callsites; net -3 lines
- \`docker-session.js\`: -20 lines (close-handler delete) + 1 line (inherited delegate)
- Tests: 5 new CLI tests + 2 new Docker tests

## Test plan

- [x] \`node --test --test-name-pattern \"_handleChildClose|_handleHardTimeout|_killAndRespawn|inherits CliSession\"\` — all pass (7 new tests)
- [x] Full \`cli-session.test.js\` + \`docker-session.test.js\`: 103 pass + 1 pre-existing file-level timeout (baseline before my changes also had it; not introduced here)
- [x] Full \`npm test\` server suite: 5836 pass, 2 fail (both fail on baseline main too — one depends on local claude binary \`--remote\` flag, one is a ws-server log_entry race; neither touches code in this PR)
- [ ] Smoke test on a real session: trigger each path, confirm Stop button clears

## Closes

- Closes #4469
- Closes #4470
- Closes #4471

## Related

- #4468 — the original CLI close-handler fix this builds on
- #4010 — TUI session, where this pattern originated