### PR TITLE
feat(server): stream-stall recovery timer for CLI sessions (#4467)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -62,6 +62,23 @@ export const DEFAULT_RESULT_TIMEOUT_MS = 30 * 60 * 1000
 // CHROXY_HARD_TIMEOUT_MS.
 export const DEFAULT_HARD_TIMEOUT_MS = 2 * 60 * 60 * 1000
 
+// #4467: stream-stall recovery timeout (ms). Resets on ANY stream event from
+// the child (stdout line, stream_delta, tool_start, etc.). When no event has
+// arrived for this long while busy, emit a recoverable error (code:
+// `stream_stall`) and clear busy state so the user can retry. Distinct from
+// the soft inactivity warning — the warning is passive (just a chip); this
+// is active recovery.
+//
+// Default 5 minutes: a stalled HTTPS connection to the Anthropic API
+// (half-open TCP, mobile NAT idle, Cloudflare timeout) typically would have
+// recovered by then if it was going to; longer-than-5min legitimate gaps
+// between events are rare (interactive tools poll faster than that).
+//
+// Operators with workloads that have long compile-then-edit gaps can raise
+// via config.streamStallTimeoutMs or CHROXY_STREAM_STALL_TIMEOUT_MS, or set
+// to 0 to disable.
+export const DEFAULT_STREAM_STALL_TIMEOUT_MS = 5 * 60 * 1000
+
 // Default per-provider injection mode (#3200). Subprocess providers without
 // a system-prompt flag (Codex, Gemini) prepend skills to the first user
 // message; Claude (SDK or CLI) appends to the system prompt. Maps the
@@ -148,6 +165,8 @@ export class BaseSession extends EventEmitter {
     // 2h. Override via ~/.chroxy/config.json#hardTimeoutMs or
     // CHROXY_HARD_TIMEOUT_MS.
     hardTimeoutMs,
+    // #4467: stream-stall recovery timeout. See DEFAULT_STREAM_STALL_TIMEOUT_MS.
+    streamStallTimeoutMs,
   } = {}) {
     super()
     this.cwd = cwd || process.cwd()
@@ -258,6 +277,9 @@ export class BaseSession extends EventEmitter {
     // Fires `_handleHardTimeout` when silence reaches `_hardTimeoutMs`
     // even if the user never engages with the soft check-in prompt.
     this._hardTimeout = null
+    // #4467: stream-stall recovery timer. See _streamStallTimeoutMs and
+    // CliSession._handleStreamStall for the active-recovery path.
+    this._streamStallTimeout = null
     // #3749 / #3884 / #3899: effective SOFT-warning timeout in ms.
     // Defaults to 30 minutes; overrides come from
     // SessionManager(resultTimeoutMs:…) which itself reads
@@ -275,6 +297,13 @@ export class BaseSession extends EventEmitter {
       Number.isFinite(hardTimeoutMs) && hardTimeoutMs > 0
         ? hardTimeoutMs
         : DEFAULT_HARD_TIMEOUT_MS
+    // #4467: stream-stall recovery timer. 0 disables the active recovery
+    // path (the soft warning + hard cap still apply). Non-finite or
+    // negative falls back to the default.
+    this._streamStallTimeoutMs =
+      Number.isFinite(streamStallTimeoutMs) && streamStallTimeoutMs >= 0
+        ? streamStallTimeoutMs
+        : DEFAULT_STREAM_STALL_TIMEOUT_MS
 
     // Provider id (registry key from providers.js — `claude-sdk`, `codex`,
     // etc.). Stored so frontmatter `providers:` filtering (#3198) and
@@ -966,6 +995,11 @@ export class BaseSession extends EventEmitter {
     if (this._hardTimeout) {
       clearTimeout(this._hardTimeout)
       this._hardTimeout = null
+    }
+    // #4467: clear the stream-stall recovery timer too.
+    if (this._streamStallTimeout) {
+      clearTimeout(this._streamStallTimeout)
+      this._streamStallTimeout = null
     }
   }
 }

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -457,15 +457,18 @@ export class CliSession extends BaseSession {
   }
 
   /**
-   * Arm the SOFT-warning + HARD-cap timers in parallel. No-op when paused
-   * because of a pending permission prompt (#2831). Windows are
-   * configurable per server via config.resultTimeoutMs / hardTimeoutMs
-   * (#3749 / #3899).
+   * Arm the SOFT-warning + HARD-cap + STREAM-STALL timers in parallel.
+   * No-op when paused because of a pending permission prompt (#2831).
+   * Windows are configurable per server via config.resultTimeoutMs /
+   * hardTimeoutMs / streamStallTimeoutMs (#3749 / #3899 / #4467).
    *
-   * Both timers are cleared at the top of every call, so any activity-
-   * triggered reset (`_handleStdoutLine`) restarts the silence window
-   * from zero — including the hard cap. That's by design: the hard cap
-   * bounds *silent* stretches, not the wall-clock session duration.
+   * Stall timer is only armed when `_streamStallTimeoutMs > 0` —
+   * operators can disable the active-recovery path via config 0.
+   *
+   * All timers are cleared at the top of every call, so any activity-
+   * triggered reset (`_handleStdoutLine`) restarts the silence windows
+   * from zero. That's by design: every cap bounds *silent* stretches,
+   * not the wall-clock session duration.
    */
   _armResultTimeout() {
     if (this._resultTimeout) clearTimeout(this._resultTimeout)

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -161,8 +161,8 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, resultTimeoutMs, hardTimeoutMs } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, resultTimeoutMs, hardTimeoutMs })
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs })
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null
@@ -470,8 +470,10 @@ export class CliSession extends BaseSession {
   _armResultTimeout() {
     if (this._resultTimeout) clearTimeout(this._resultTimeout)
     if (this._hardTimeout) clearTimeout(this._hardTimeout)
+    if (this._streamStallTimeout) clearTimeout(this._streamStallTimeout)
     this._resultTimeout = null
     this._hardTimeout = null
+    this._streamStallTimeout = null
     if (this._resultTimeoutPaused) return
     this._resultTimeout = setTimeout(() => {
       this._resultTimeout = null
@@ -481,6 +483,13 @@ export class CliSession extends BaseSession {
       this._hardTimeout = null
       this._handleHardTimeout()
     }, this._hardTimeoutMs)
+    // #4467: only arm if configured > 0 (operators can disable).
+    if (this._streamStallTimeoutMs > 0) {
+      this._streamStallTimeout = setTimeout(() => {
+        this._streamStallTimeout = null
+        this._handleStreamStall()
+      }, this._streamStallTimeoutMs)
+    }
   }
 
   /**
@@ -536,6 +545,25 @@ export class CliSession extends BaseSession {
     this.emit('error', { message: `Response timed out after ${friendly}` })
   }
 
+  // #4467: stream-stall recovery. Fires when the child has been silent
+  // for `_streamStallTimeoutMs` despite the session being busy — typically
+  // a half-open TCP to the Anthropic API that the OS hasn't surfaced yet.
+  // Logs with context, emits `error` with `code: 'stream_stall'` so the
+  // dashboard can show a distinct "Stream stalled — retry?" affordance,
+  // then clears busy state so the user CAN actually retry.
+  _handleStreamStall() {
+    if (!this._isBusy) return
+    const friendly = formatIdleDuration(this._streamStallTimeoutMs)
+    log.warn(
+      `Stream stalled (${friendly}, messageId=${this._currentMessageId}) — clearing busy state for retry`,
+    )
+    this._emitInterruptedTurnResult(this._streamStallTimeoutMs)
+    this.emit('error', {
+      code: 'stream_stall',
+      message: `Stream stalled — no response for ${friendly}. Try sending again.`,
+    })
+  }
+
   /**
    * Notify the session that a permission request belonging to it is
    * outstanding — pauses the inactivity timer so the session doesn't
@@ -558,6 +586,11 @@ export class CliSession extends BaseSession {
       if (this._hardTimeout) {
         clearTimeout(this._hardTimeout)
         this._hardTimeout = null
+      }
+      // #4467: clear the stall timer too — waiting on the user is not a stall.
+      if (this._streamStallTimeout) {
+        clearTimeout(this._streamStallTimeout)
+        this._streamStallTimeout = null
       }
     }
   }
@@ -951,6 +984,11 @@ export class CliSession extends BaseSession {
       clearTimeout(this._hardTimeout)
       this._hardTimeout = null
     }
+    // #4467: release the stream-stall timer too for the same reason.
+    if (this._streamStallTimeout) {
+      clearTimeout(this._streamStallTimeout)
+      this._streamStallTimeout = null
+    }
     this._resultTimeoutPaused = false
 
     this._cleanupReadlines()
@@ -1131,6 +1169,10 @@ export class CliSession extends BaseSession {
     if (this._hardTimeout) {
       clearTimeout(this._hardTimeout)
       this._hardTimeout = null
+    }
+    if (this._streamStallTimeout) {
+      clearTimeout(this._streamStallTimeout)
+      this._streamStallTimeout = null
     }
 
     if (this._interruptTimer) {

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -155,6 +155,12 @@ const CONFIG_SCHEMA = {
   // they want tighter runaway-session protection, but it should always
   // be >= resultTimeoutMs (the soft warning fires first).
   hardTimeoutMs: 'number',
+  // #4467: stream-stall recovery (ms). Resets on any stream activity from
+  // the child; when silence reaches this window while busy, the session
+  // emits a recoverable error (code: stream_stall), clears busy state,
+  // and the dashboard can offer a retry. Default 300000 (5 min). Set to
+  // 0 to disable (operators with legitimately long event gaps).
+  streamStallTimeoutMs: 'number',
 }
 
 /**
@@ -258,6 +264,15 @@ export function validateConfig(config, verbose = false) {
       warnings.push(`Invalid value for 'hardTimeoutMs': ${config.hardTimeoutMs} (maximum 86400000 / 24h)`)
     } else if (Number.isFinite(config.resultTimeoutMs) && config.hardTimeoutMs < config.resultTimeoutMs) {
       warnings.push(`'hardTimeoutMs' (${config.hardTimeoutMs}) is less than 'resultTimeoutMs' (${config.resultTimeoutMs}) — the soft warning will never fire before the hard kill`)
+    }
+  }
+
+  // #4467: stream-stall range. 0 is valid (disable). Otherwise 5s-24h.
+  if (Number.isFinite(config.streamStallTimeoutMs) && config.streamStallTimeoutMs !== 0) {
+    if (config.streamStallTimeoutMs < 5_000) {
+      warnings.push(`Invalid value for 'streamStallTimeoutMs': ${config.streamStallTimeoutMs} (minimum 5000 / 5s; set 0 to disable)`)
+    } else if (config.streamStallTimeoutMs > 24 * 60 * 60 * 1000) {
+      warnings.push(`Invalid value for 'streamStallTimeoutMs': ${config.streamStallTimeoutMs} (maximum 86400000 / 24h)`)
     }
   }
 
@@ -398,6 +413,7 @@ function envKeyForConfig(key) {
     sandbox: 'CHROXY_SANDBOX',
     resultTimeoutMs: 'CHROXY_RESULT_TIMEOUT_MS',
     hardTimeoutMs: 'CHROXY_HARD_TIMEOUT_MS',
+    streamStallTimeoutMs: 'CHROXY_STREAM_STALL_TIMEOUT_MS',
     // #4384 — canonical env var for the #4246 rename. Without this entry
     // the fallback was `key.toUpperCase()` (DANGEROUSLYSKIPPERMISSIONS,
     // no underscores) which is not what we document or what operators

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1,5 +1,5 @@
 import { SessionManager } from './session-manager.js'
-import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS } from './base-session.js'
+import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS, DEFAULT_STREAM_STALL_TIMEOUT_MS } from './base-session.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { WsServer, TUNNEL_STATUS_MIN_PROTOCOL_VERSION } from './ws-server.js'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
@@ -379,6 +379,13 @@ export async function startCliServer(config) {
       Number.isFinite(config.hardTimeoutMs) && config.hardTimeoutMs > 0
         ? config.hardTimeoutMs
         : null,
+    // #4467: stream-stall recovery (ms). null = BaseSession default (5min).
+    // 0 explicitly disables (operators with workloads that have legitimate
+    // long event gaps can opt out).
+    streamStallTimeoutMs:
+      Number.isFinite(config.streamStallTimeoutMs) && config.streamStallTimeoutMs >= 0
+        ? config.streamStallTimeoutMs
+        : null,
     // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
     maxSkillBytes: Number.isFinite(config.maxSkillBytes) ? config.maxSkillBytes : null,
     maxTotalSkillBytes: Number.isFinite(config.maxTotalSkillBytes) ? config.maxTotalSkillBytes : null,
@@ -394,7 +401,14 @@ export async function startCliServer(config) {
     Number.isFinite(config.hardTimeoutMs) && config.hardTimeoutMs > 0
       ? config.hardTimeoutMs
       : DEFAULT_HARD_TIMEOUT_MS
-  log.info(`Inactivity soft-warning: ${formatIdleDuration(effectiveResultTimeoutMs)} (${effectiveResultTimeoutMs}ms); hard-cap: ${formatIdleDuration(effectiveHardTimeoutMs)} (${effectiveHardTimeoutMs}ms)`)
+  const effectiveStreamStallTimeoutMs =
+    Number.isFinite(config.streamStallTimeoutMs) && config.streamStallTimeoutMs >= 0
+      ? config.streamStallTimeoutMs
+      : DEFAULT_STREAM_STALL_TIMEOUT_MS
+  const stallLabel = effectiveStreamStallTimeoutMs === 0
+    ? 'disabled'
+    : `${formatIdleDuration(effectiveStreamStallTimeoutMs)} (${effectiveStreamStallTimeoutMs}ms)`
+  log.info(`Inactivity soft-warning: ${formatIdleDuration(effectiveResultTimeoutMs)} (${effectiveResultTimeoutMs}ms); hard-cap: ${formatIdleDuration(effectiveHardTimeoutMs)} (${effectiveHardTimeoutMs}ms); stream-stall: ${stallLabel}`)
 
   // 2. Try restoring session state from a previous instance
   let defaultSessionId

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -211,6 +211,9 @@ export class SessionManager extends EventEmitter {
     // #3899: HARD-cap inactivity timeout (ms). Forwarded to providers via
     // providerOpts. null = use BaseSession's DEFAULT_HARD_TIMEOUT_MS (2h).
     hardTimeoutMs,
+    // #4467: stream-stall recovery timeout (ms). Forwarded via providerOpts.
+    // null = use BaseSession's DEFAULT_STREAM_STALL_TIMEOUT_MS (5min).
+    streamStallTimeoutMs,
 
     // State persistence
     stateFilePath,
@@ -259,6 +262,12 @@ export class SessionManager extends EventEmitter {
     this._hardTimeoutMs =
       Number.isFinite(hardTimeoutMs) && hardTimeoutMs > 0
         ? hardTimeoutMs
+        : null
+    // #4467: 0 explicitly disables stream-stall recovery; null = use default;
+    // positive finite value sets the recovery window.
+    this._streamStallTimeoutMs =
+      Number.isFinite(streamStallTimeoutMs) && streamStallTimeoutMs >= 0
+        ? streamStallTimeoutMs
         : null
     this._costBudget = new CostBudgetManager({ budget: costBudget })
     // #4075: per-session crossing threshold. Stored as a runtime-mutable
@@ -574,6 +583,7 @@ export class SessionManager extends EventEmitter {
     if (this._maxToolInput) providerOpts.maxToolInput = this._maxToolInput
     if (this._resultTimeoutMs != null) providerOpts.resultTimeoutMs = this._resultTimeoutMs
     if (this._hardTimeoutMs != null) providerOpts.hardTimeoutMs = this._hardTimeoutMs
+    if (this._streamStallTimeoutMs != null) providerOpts.streamStallTimeoutMs = this._streamStallTimeoutMs
     // Skills size budgets — pass through if configured. BaseSession forwards
     // these to loadActiveSkillsLayered. (#3202)
     if (this._maxSkillBytes !== null) providerOpts.maxSkillBytes = this._maxSkillBytes

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -443,6 +443,83 @@ describe('CliSession._killAndRespawn (#4471: panic-button drops dashboard recove
   })
 })
 
+describe('CliSession._handleStreamStall (#4467: stream-stall recovery)', () => {
+  it('emits stream_end + result + error{code:stream_stall} so dashboard can offer retry', () => {
+    const session = createReadySession({ streamStallTimeoutMs: 60_000 })
+    session._isBusy = true
+    session._currentMessageId = 'msg_ss'
+    session._currentCtx = { hasStreamStarted: true }
+    session._sessionId = 'sess_ss'
+
+    const events = []
+    session.on('stream_end', (p) => events.push({ name: 'stream_end', payload: p }))
+    session.on('result', (p) => events.push({ name: 'result', payload: p }))
+    session.on('error', (p) => events.push({ name: 'error', payload: p }))
+
+    session._handleStreamStall()
+
+    assert.deepEqual(events.map((e) => e.name), ['stream_end', 'result', 'error'])
+    assert.equal(events[1].payload.sessionId, 'sess_ss')
+    assert.equal(events[1].payload.duration, session._streamStallTimeoutMs)
+    assert.equal(events[2].payload.code, 'stream_stall', 'error MUST carry code:stream_stall so dashboard can distinguish from generic errors')
+    assert.match(events[2].payload.message, /stalled/i)
+  })
+
+  it('no-ops when not busy (timer fired against an idle session)', () => {
+    const session = createReadySession()
+    session._isBusy = false
+
+    const events = []
+    session.on('stream_end', () => events.push('stream_end'))
+    session.on('result', () => events.push('result'))
+    session.on('error', () => events.push('error'))
+
+    session._handleStreamStall()
+    assert.deepEqual(events, [])
+  })
+
+  it('_armResultTimeout arms the stall timer when streamStallTimeoutMs > 0', () => {
+    const session = createReadySession({ streamStallTimeoutMs: 60_000 })
+    session._armResultTimeout()
+    assert.ok(session._streamStallTimeout, 'stall timer must be armed')
+    // Cleanup all three timers
+    clearTimeout(session._resultTimeout)
+    clearTimeout(session._hardTimeout)
+    clearTimeout(session._streamStallTimeout)
+  })
+
+  it('_armResultTimeout does NOT arm the stall timer when streamStallTimeoutMs is 0 (disabled)', () => {
+    const session = createReadySession({ streamStallTimeoutMs: 0 })
+    session._armResultTimeout()
+    assert.equal(session._streamStallTimeout, null, 'stall timer must remain disarmed when configured to 0')
+    clearTimeout(session._resultTimeout)
+    clearTimeout(session._hardTimeout)
+  })
+
+  it('_armResultTimeout resets the stall timer on subsequent activity (timer reference changes)', () => {
+    const session = createReadySession({ streamStallTimeoutMs: 60_000 })
+    session._armResultTimeout()
+    const firstTimer = session._streamStallTimeout
+    session._armResultTimeout()
+    const secondTimer = session._streamStallTimeout
+    assert.notStrictEqual(firstTimer, secondTimer, 'arming again must replace the timer handle, proving the silence window restarts')
+    clearTimeout(session._resultTimeout)
+    clearTimeout(session._hardTimeout)
+    clearTimeout(session._streamStallTimeout)
+  })
+
+  it('notifyPermissionPending clears the stall timer (waiting on the user is not a stall)', () => {
+    const session = createReadySession({ streamStallTimeoutMs: 60_000 })
+    session._isBusy = true
+    session._armResultTimeout()
+    assert.ok(session._streamStallTimeout)
+
+    session.notifyPermissionPending('req-stall-1')
+    assert.equal(session._streamStallTimeout, null, 'stall timer must clear when a permission prompt is outstanding')
+    assert.equal(session._resultTimeoutPaused, true)
+  })
+})
+
 describe('CliSession.destroy', () => {
   it('sets destroying flag and nulls child', () => {
     const session = createReadySession()

--- a/packages/server/tests/config.test.js
+++ b/packages/server/tests/config.test.js
@@ -161,6 +161,36 @@ describe('validateConfig', () => {
       assert.ok(result.warnings.some(w => w.includes('resultTimeoutMs') && w.includes('number')))
     })
   })
+
+  describe('streamStallTimeoutMs (#4467)', () => {
+    it('accepts a value within the allowed range', () => {
+      const result = validateConfig({ streamStallTimeoutMs: 300_000 })
+      assert.equal(result.valid, true)
+    })
+
+    it('accepts 0 as an explicit disable', () => {
+      const result = validateConfig({ streamStallTimeoutMs: 0 })
+      assert.equal(result.valid, true)
+    })
+
+    it('rejects values below the 5s minimum', () => {
+      const result = validateConfig({ streamStallTimeoutMs: 1000 })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('streamStallTimeoutMs') && w.includes('minimum')))
+    })
+
+    it('rejects values above the 24h maximum', () => {
+      const result = validateConfig({ streamStallTimeoutMs: 25 * 60 * 60 * 1000 })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('streamStallTimeoutMs') && w.includes('maximum')))
+    })
+
+    it('warns when value is not a number', () => {
+      const result = validateConfig({ streamStallTimeoutMs: '5m' })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('streamStallTimeoutMs') && w.includes('number')))
+    })
+  })
 })
 
 describe('mergeConfig', () => {
@@ -370,6 +400,20 @@ describe('mergeConfig', () => {
     process.env.CHROXY_RESULT_TIMEOUT_MS = '600000'
     const merged = mergeConfig({})
     assert.equal(merged.resultTimeoutMs, 600_000)
+  })
+
+  it('reads streamStallTimeoutMs from CHROXY_STREAM_STALL_TIMEOUT_MS env var as number (#4467)', () => {
+    process.env.CHROXY_STREAM_STALL_TIMEOUT_MS = '300000'
+    const merged = mergeConfig({})
+    assert.equal(merged.streamStallTimeoutMs, 300_000)
+    delete process.env.CHROXY_STREAM_STALL_TIMEOUT_MS
+  })
+
+  it('reads streamStallTimeoutMs=0 from env var as explicit disable (#4467)', () => {
+    process.env.CHROXY_STREAM_STALL_TIMEOUT_MS = '0'
+    const merged = mergeConfig({})
+    assert.equal(merged.streamStallTimeoutMs, 0)
+    delete process.env.CHROXY_STREAM_STALL_TIMEOUT_MS
   })
 })
 


### PR DESCRIPTION
## Summary

When a CLI session's HTTPS connection to the Anthropic API hits a half-open TCP state (mobile NAT idle, Cloudflare timeout, API-side hang), the socket goes silent — no error, no event. Pre-fix: no upstream timeout meant sessions sat at \"Thinking…\" indefinitely, and \`_isBusy\` bounced every retry with **\"Already processing a message\"** until the user clicked Stop. I hit this myself with my no-it-all session (the reported case in #4467).

## Fix

Adds a third timer alongside the soft warning (30min) and the hard cap (2h) — **stream-stall recovery at 5min by default**. Fires whenever the child has been silent that long while the session is busy.

| Timer | Default | On fire |
|-------|---------|---------|
| Soft warning (#3899) | 30 min | Emits \`inactivity_warning\` chip, session stays busy |
| **Stream stall (this PR)** | **5 min** | **Emits \`error{code:'stream_stall'}\` + clears busy state for retry** |
| Hard cap (#3899) | 2 h | Emits \`error\` + clears busy state — absolute backstop |

The stall timer is the active-recovery path. Soft warning stays as the passive \"Status update?\" chip. Hard cap stays as the absolute backstop.

## Acceptance from #4467

- [x] Configurable per-provider stream-silence timeout (default 5min)
- [x] Server emits error, clears \`_isBusy\`, surfaces recoverable state (via \`code: 'stream_stall'\`)
- [x] No regression for long legitimate turns — timer resets on **ANY** child activity
- [x] Server-side error log with last event context (messageId, elapsed)
- [ ] Dashboard \"Stream stalled — retry?\" chip — deferred to follow-up (the \`code:'stream_stall'\` is on the wire; UI work is separate)
- [ ] Surface \`streamStallTimeoutMs\` in \`auth_ok\` — deferred (protocol schema change is its own PR)

## Config

| Knob | Default | Notes |
|------|---------|-------|
| \`config.streamStallTimeoutMs\` | 300000 (5 min) | 0 = disable; range 5s–24h |
| \`CHROXY_STREAM_STALL_TIMEOUT_MS\` | env override | same semantics |

Server startup log now shows: \`Inactivity soft-warning: 30m (1800000ms); hard-cap: 2h (7200000ms); stream-stall: 5m (300000ms)\`.

## Test plan

- [x] 6 new unit tests in \`cli-session.test.js\` covering: fires on silence, no-op when idle, arm based on config, no-arm when 0, reset on activity, permission-prompt pause
- [x] \`node --test tests/cli-session.test.js tests/docker-session.test.js tests/session-manager.test.js tests/config.test.js tests/ws-history.test.js\` — 390 pass, 1 pre-existing file-level cancel
- [ ] Smoke test on a real stalled session: trigger silence, confirm error+code arrives at 5min, Stop button clears, retry works

## Scope

- **In:** CLI session + DockerSession (inherits via CliSession). The original reported case.
- **Out:** SDK, TUI, Codex, Gemini sessions. They keep current 30min/2h defaults. Same pattern can be ported in follow-ups if those provider classes hit the same symptom.

## Related

- Partial fix for #4467
- Builds on #4468, #4472 (the Stop-stuck recovery fixes) — without those, the stall would clear busy state but the dashboard wouldn't know