### PR TITLE
feat(server): MCP tool_use dispatch + e2e tests (#4079)

### DIFF
--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -12,7 +12,6 @@
  *   - Session destroy sends SIGTERM, escalates to SIGKILL at KILL_GRACE_MS.
  *
  * Out of scope (next stages):
- *   - tools/call dispatch (#4079) — only exposes the parsed tools list here.
  *   - Materializing into Anthropic SDK tools[] (#4078).
  */
 
@@ -24,6 +23,7 @@ const MAX_RESTART_ATTEMPTS = 3
 const RESTART_DELAY_MS = 1000
 const KILL_GRACE_MS = 1000
 const HANDSHAKE_TIMEOUT_MS = 5000
+export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30_000
 
 export const MCP_STATES = Object.freeze({
   IDLE: 'idle',
@@ -143,6 +143,13 @@ export class MCPClient extends EventEmitter {
     this._restartAttempts = 0
     this._setState(MCP_STATES.READY)
     this.emit('ready', this._tools)
+  }
+
+  async callTool(toolName, args, timeoutMs = DEFAULT_TOOL_CALL_TIMEOUT_MS) {
+    if (this._state !== MCP_STATES.READY) {
+      throw new Error(`MCP server ${this.name} not ready (state=${this._state})`)
+    }
+    return this._request('tools/call', { name: toolName, arguments: args || {} }, timeoutMs)
   }
 
   _request(method, params, timeoutMs) {

--- a/packages/server/src/byok-mcp-fleet.js
+++ b/packages/server/src/byok-mcp-fleet.js
@@ -13,31 +13,17 @@
 
 import { MCPClient, MCP_STATES, DEFAULT_TOOL_CALL_TIMEOUT_MS } from './byok-mcp-client.js'
 import { loadTrustStore, recordTrust, isTrusted } from './byok-mcp-trust.js'
+import { MCP_PREFIX, parseMcpToolName } from './mcp-tools.js'
 
 export const FLEET_KILL_GRACE_MS = 2000
-export const MCP_TOOL_PREFIX = 'mcp__'
+// #4451: re-export under the legacy name from this module so existing
+// callers (byok-session, tests) keep working. Canonical source is
+// mcp-tools.js to prevent silent parser drift.
+export const MCP_TOOL_PREFIX = MCP_PREFIX
+export { parseMcpToolName }
 
 function mcpToolName(serverName, toolName) {
   return `${MCP_TOOL_PREFIX}${serverName}__${toolName}`
-}
-
-/**
- * Parse the `mcp__<server>__<tool>` prefix used by chroxy to route a
- * model-emitted tool name back to (a) the right MCP server name, and (b)
- * the original tool name the server expects in `tools/call`.
- *
- * Returns `{ serverName, toolName }` or `null` if the input is not an
- * MCP-namespaced name. Tool names may contain `__` themselves (rare, but
- * allowed by MCP), so we split on the FIRST `__` after the `mcp__` prefix
- * — not on every `__` — to preserve the original tool name verbatim.
- */
-export function parseMcpToolName(prefixedName) {
-  if (typeof prefixedName !== 'string') return null
-  if (!prefixedName.startsWith(MCP_TOOL_PREFIX)) return null
-  const rest = prefixedName.slice(MCP_TOOL_PREFIX.length)
-  const sep = rest.indexOf('__')
-  if (sep <= 0 || sep >= rest.length - 2) return null
-  return { serverName: rest.slice(0, sep), toolName: rest.slice(sep + 2) }
 }
 
 export class MCPFleet {

--- a/packages/server/src/byok-mcp-fleet.js
+++ b/packages/server/src/byok-mcp-fleet.js
@@ -11,13 +11,33 @@
  * the next turn's tool list.
  */
 
-import { MCPClient, MCP_STATES } from './byok-mcp-client.js'
+import { MCPClient, MCP_STATES, DEFAULT_TOOL_CALL_TIMEOUT_MS } from './byok-mcp-client.js'
 import { loadTrustStore, recordTrust, isTrusted } from './byok-mcp-trust.js'
 
 export const FLEET_KILL_GRACE_MS = 2000
+export const MCP_TOOL_PREFIX = 'mcp__'
 
 function mcpToolName(serverName, toolName) {
-  return `mcp__${serverName}__${toolName}`
+  return `${MCP_TOOL_PREFIX}${serverName}__${toolName}`
+}
+
+/**
+ * Parse the `mcp__<server>__<tool>` prefix used by chroxy to route a
+ * model-emitted tool name back to (a) the right MCP server name, and (b)
+ * the original tool name the server expects in `tools/call`.
+ *
+ * Returns `{ serverName, toolName }` or `null` if the input is not an
+ * MCP-namespaced name. Tool names may contain `__` themselves (rare, but
+ * allowed by MCP), so we split on the FIRST `__` after the `mcp__` prefix
+ * — not on every `__` — to preserve the original tool name verbatim.
+ */
+export function parseMcpToolName(prefixedName) {
+  if (typeof prefixedName !== 'string') return null
+  if (!prefixedName.startsWith(MCP_TOOL_PREFIX)) return null
+  const rest = prefixedName.slice(MCP_TOOL_PREFIX.length)
+  const sep = rest.indexOf('__')
+  if (sep <= 0 || sep >= rest.length - 2) return null
+  return { serverName: rest.slice(0, sep), toolName: rest.slice(sep + 2) }
 }
 
 export class MCPFleet {
@@ -97,6 +117,24 @@ export class MCPFleet {
       description: tool.description || '',
       input_schema: tool.inputSchema || { type: 'object' },
     }))
+  }
+
+  /**
+   * Dispatch a tool_use to the right MCP server. `prefixedName` is the
+   * chroxy-namespaced name the model emitted (`mcp__<server>__<tool>`).
+   * Throws if the prefix is malformed, no client owns that server name,
+   * or the client is not READY. JSON-RPC errors from the server
+   * propagate as throws — caller turns them into is_error tool_results.
+   */
+  async callTool(prefixedName, args, timeoutMs = DEFAULT_TOOL_CALL_TIMEOUT_MS) {
+    const parsed = parseMcpToolName(prefixedName)
+    if (!parsed) throw new Error(`malformed MCP tool name: ${prefixedName}`)
+    const client = this._clients.find((c) => c.name === parsed.serverName)
+    if (!client) throw new Error(`MCP server not found: ${parsed.serverName}`)
+    if (client.state !== MCP_STATES.READY) {
+      throw new Error(`MCP server ${parsed.serverName} not ready (state=${client.state})`)
+    }
+    return client.callTool(parsed.toolName, args, timeoutMs)
   }
 
   async destroy() {

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -33,7 +33,7 @@ import { translateSdkEvent } from './byok-event-translator.js'
 import { BUILTIN_TOOLS } from './byok-tools.js'
 import { executeBuiltinTool } from './byok-tool-executor.js'
 import { loadClaudeMcpConfig, toMcpServerMetadata } from './byok-mcp-config.js'
-import { MCPFleet } from './byok-mcp-fleet.js'
+import { MCPFleet, MCP_TOOL_PREFIX } from './byok-mcp-fleet.js'
 
 const log = createLogger('byok-session')
 
@@ -916,17 +916,21 @@ export class ClaudeByokSession extends BaseSession {
       }
     }
 
-    // Execute locally.
+    // Execute locally. MCP tools (mcp__<server>__<tool>) route through
+    // the fleet to the right child process via stdio JSON-RPC; everything
+    // else runs in-process (Read/Write/Bash/etc).
     const effectiveInput = resolvedDecision.updatedInput || input
-    const { content, isError } = await executeBuiltinTool({
-      toolName,
-      input: effectiveInput,
-      cwd: this.cwd,
-      cwdRealCache: this._cwdRealCache,
-      cwdCacheTtl: CWD_CACHE_TTL_MS,
-      signal,
-      todoStore: this._todos,
-    })
+    const { content, isError } = toolName.startsWith(MCP_TOOL_PREFIX)
+      ? await this._dispatchMcpTool(toolName, effectiveInput)
+      : await executeBuiltinTool({
+          toolName,
+          input: effectiveInput,
+          cwd: this.cwd,
+          cwdRealCache: this._cwdRealCache,
+          cwdCacheTtl: CWD_CACHE_TTL_MS,
+          signal,
+          todoStore: this._todos,
+        })
 
     this.emit('tool_result', {
       messageId,
@@ -940,6 +944,31 @@ export class ClaudeByokSession extends BaseSession {
       tool_use_id: toolUseId,
       content,
       is_error: isError,
+    }
+  }
+
+  /**
+   * Dispatch one MCP tool_use to the fleet. Flattens `{ content: [...],
+   * isError }` from the MCP server into the `{ content: string, isError }`
+   * shape `_executeToolBlock` returns. Concatenates any text blocks; for
+   * non-text blocks (image, resource) we stringify the block so the model
+   * sees the shape and can decide what to do — chroxy itself doesn't
+   * interpret them.
+   *
+   * Errors (server unknown, server dead, RPC error, timeout, child crash
+   * mid-call) become is_error:true tool_results — same shape as
+   * executeBuiltinTool's catch-all. The session keeps running.
+   */
+  async _dispatchMcpTool(toolName, input) {
+    try {
+      const result = await this._mcpFleet.callTool(toolName, input)
+      const blocks = Array.isArray(result?.content) ? result.content : []
+      const text = blocks
+        .map((b) => (typeof b?.text === 'string' ? b.text : JSON.stringify(b)))
+        .join('\n')
+      return { content: text, isError: result?.isError === true }
+    } catch (err) {
+      return { content: `MCP ${toolName} failed: ${err?.message || String(err)}`, isError: true }
     }
   }
 

--- a/packages/server/src/mcp-tools.js
+++ b/packages/server/src/mcp-tools.js
@@ -7,7 +7,7 @@
  * Built-in tools use simple names like "Bash", "Read", "Edit".
  */
 
-const MCP_PREFIX = 'mcp__'
+export const MCP_PREFIX = 'mcp__'
 
 /**
  * Parse an MCP tool name into its server and tool components.

--- a/packages/server/tests/byok-mcp-client.test.js
+++ b/packages/server/tests/byok-mcp-client.test.js
@@ -151,6 +151,58 @@ describe('MCPClient', () => {
     })
   })
 
+  describe('callTool (#4079)', () => {
+    it('echoes args via JSON-RPC tools/call when READY', async () => {
+      const client = new MCPClient(stubConfig(), { log: silentLog() })
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      const result = await client.callTool('echo', { msg: 'hi' })
+      assert.equal(result.isError, undefined)
+      assert.equal(result.content[0].type, 'text')
+      assert.equal(result.content[0].text, JSON.stringify({ msg: 'hi' }))
+      await client.destroy()
+    })
+
+    it('throws when client is not READY', async () => {
+      const client = new MCPClient(stubConfig(), { log: silentLog() })
+      await assert.rejects(client.callTool('echo', {}), /not ready/)
+      await client.destroy()
+    })
+
+    it('surfaces JSON-RPC errors from the server', async () => {
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_TOOL_RPC_ERROR: '1' } }),
+        { log: silentLog() },
+      )
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      await assert.rejects(client.callTool('echo', {}), /forced RPC error/)
+      await client.destroy()
+    })
+
+    it('times out a hung tools/call', async () => {
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_TOOL_HANG: '1' } }),
+        { log: silentLog() },
+      )
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      await assert.rejects(client.callTool('echo', {}, 200), /timeout/)
+      await client.destroy()
+    })
+
+    it('mid-call child crash rejects the pending call with "MCP child exited"', async () => {
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_TOOL_DIE: '1' } }),
+        { log: silentLog() },
+      )
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      await assert.rejects(client.callTool('echo', {}), /child exited/)
+      await client.destroy()
+    })
+  })
+
   describe('destroy()', () => {
     it('cancels a pending restart timer (no spawn after destroy)', async () => {
       const client = new MCPClient(

--- a/packages/server/tests/byok-mcp-fleet.test.js
+++ b/packages/server/tests/byok-mcp-fleet.test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
-import { MCPFleet, FLEET_KILL_GRACE_MS } from '../src/byok-mcp-fleet.js'
+import { MCPFleet, FLEET_KILL_GRACE_MS, parseMcpToolName } from '../src/byok-mcp-fleet.js'
 import { MCP_STATES } from '../src/byok-mcp-client.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -129,6 +129,48 @@ describe('MCPFleet', () => {
       const fleet = new MCPFleet([cfg('alpha')], { log: silentLog() })
       await fleet.start()
       assert.equal(fleet.clients[0].state, MCP_STATES.READY)
+      await fleet.destroy()
+    })
+  })
+
+  describe('callTool routing (#4079)', () => {
+    it('parseMcpToolName strips the mcp__<server>__ prefix verbatim', () => {
+      assert.deepEqual(parseMcpToolName('mcp__alpha__echo'), { serverName: 'alpha', toolName: 'echo' })
+      assert.deepEqual(parseMcpToolName('mcp__alpha__nested__tool'), { serverName: 'alpha', toolName: 'nested__tool' })
+      assert.equal(parseMcpToolName('Read'), null)
+      assert.equal(parseMcpToolName('mcp__alpha'), null)
+      assert.equal(parseMcpToolName(''), null)
+      assert.equal(parseMcpToolName(null), null)
+    })
+
+    it('routes mcp__<server>__<tool> to the matching client', async () => {
+      const fleet = new MCPFleet([cfg('alpha'), cfg('beta')], { log: silentLog() })
+      await fleet.start()
+      const result = await fleet.callTool('mcp__alpha__echo', { greeting: 'hello' })
+      assert.equal(result.content[0].text, JSON.stringify({ greeting: 'hello' }))
+      await fleet.destroy()
+    })
+
+    it('throws on unknown server name', async () => {
+      const fleet = new MCPFleet([cfg('alpha')], { log: silentLog() })
+      await fleet.start()
+      await assert.rejects(fleet.callTool('mcp__ghost__echo', {}), /server not found/)
+      await fleet.destroy()
+    })
+
+    it('throws on malformed tool name', async () => {
+      const fleet = new MCPFleet([cfg('alpha')], { log: silentLog() })
+      await fleet.start()
+      await assert.rejects(fleet.callTool('Read', {}), /malformed/)
+      await fleet.destroy()
+    })
+
+    it('throws when target server is not READY', async () => {
+      const fleet = new MCPFleet([
+        { name: 'broken', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+      ], { log: silentLog() })
+      await fleet.start()
+      await assert.rejects(fleet.callTool('mcp__broken__anything', {}), /not ready/)
       await fleet.destroy()
     })
   })

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3152,4 +3152,131 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
   })
+
+  describe('MCP tool_use dispatch (#4079)', () => {
+    function writeStubMcpConfig({ env = {} } = {}) {
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: { stub: { command: process.execPath, args: [MCP_STUB], env } },
+      }))
+      return configPath
+    }
+
+    it('round-trips: model emits tool_use mcp__stub__echo → fleet dispatches → tool_result contains echoed input', async () => {
+      preTrustStub()
+      const session = new ClaudeByokSession({
+        cwd: '/tmp',
+        mcpConfigPath: writeStubMcpConfig(),
+      })
+      session.setPermissionMode('auto')
+      const captured = captureEvents(session)
+      const toolResult = await runOneToolRound(session, {
+        id: 'tu_mcp_1', name: 'mcp__stub__echo', input: { greeting: 'hello' },
+      })
+      assert.ok(toolResult, 'round 2 must receive a tool_result block')
+      assert.equal(toolResult.tool_use_id, 'tu_mcp_1')
+      assert.equal(toolResult.is_error, false)
+      // The stub echoes args as the text content of the MCP result;
+      // _dispatchMcpTool flattens content[].text into a single string.
+      assert.equal(toolResult.content, JSON.stringify({ greeting: 'hello' }))
+      const toolResultEvent = captured.find(
+        (e) => e.name === 'tool_result' && e.payload.toolUseId === 'tu_mcp_1',
+      )
+      assert.ok(toolResultEvent, 'tool_result event fires for MCP tool')
+      assert.equal(toolResultEvent.payload.isError, false)
+      await session.destroy()
+    })
+
+    it('permission denial blocks dispatch and returns a denial tool_result', async () => {
+      preTrustStub()
+      const session = new ClaudeByokSession({
+        cwd: '/tmp',
+        mcpConfigPath: writeStubMcpConfig(),
+      })
+      // Auto-deny the per-call permission prompt (NOT the trust prompt,
+      // which is pre-resolved by preTrustStub above).
+      session._permissions.on('permission_request', (data) => {
+        if (data.tool === 'mcp_spawn') return
+        session._permissions.respondToPermission(data.requestId, 'deny')
+      })
+      const toolResult = await runOneToolRound(session, {
+        id: 'tu_mcp_deny', name: 'mcp__stub__echo', input: {},
+      })
+      assert.ok(toolResult)
+      assert.equal(toolResult.is_error, true)
+      // PermissionManager.respondToPermission emits `User denied` as the
+      // denial message (permission-manager.js:325); the dispatch path
+      // propagates it verbatim into the tool_result.
+      assert.match(toolResult.content, /denied/i)
+      await session.destroy()
+    })
+
+    it('MCP child crash mid-dispatch returns is_error tool_result without crashing the session', async () => {
+      preTrustStub()
+      const session = new ClaudeByokSession({
+        cwd: '/tmp',
+        mcpConfigPath: writeStubMcpConfig({ env: { MCP_STUB_TOOL_DIE: '1' } }),
+      })
+      session.setPermissionMode('auto')
+      const toolResult = await runOneToolRound(session, {
+        id: 'tu_mcp_crash', name: 'mcp__stub__echo', input: {},
+      })
+      assert.ok(toolResult, 'session survives the crash and emits a tool_result')
+      assert.equal(toolResult.is_error, true)
+      assert.match(toolResult.content, /MCP mcp__stub__echo failed/)
+      assert.match(toolResult.content, /child exited/)
+      // Session is still usable — sendMessage doesn't reject.
+      await session.destroy()
+    })
+
+    it('MCP RPC error becomes an is_error tool_result', async () => {
+      preTrustStub()
+      const session = new ClaudeByokSession({
+        cwd: '/tmp',
+        mcpConfigPath: writeStubMcpConfig({ env: { MCP_STUB_TOOL_RPC_ERROR: '1' } }),
+      })
+      session.setPermissionMode('auto')
+      const toolResult = await runOneToolRound(session, {
+        id: 'tu_mcp_rpc', name: 'mcp__stub__echo', input: {},
+      })
+      assert.ok(toolResult)
+      assert.equal(toolResult.is_error, true)
+      assert.match(toolResult.content, /forced RPC error/)
+      await session.destroy()
+    })
+
+    it('MCP server-reported isError propagates as is_error tool_result', async () => {
+      preTrustStub()
+      const session = new ClaudeByokSession({
+        cwd: '/tmp',
+        mcpConfigPath: writeStubMcpConfig({ env: { MCP_STUB_TOOL_ERROR: '1' } }),
+      })
+      session.setPermissionMode('auto')
+      const toolResult = await runOneToolRound(session, {
+        id: 'tu_mcp_err', name: 'mcp__stub__echo', input: { x: 1 },
+      })
+      assert.ok(toolResult)
+      assert.equal(toolResult.is_error, true)
+      assert.equal(toolResult.content, JSON.stringify({ x: 1 }))
+      await session.destroy()
+    })
+
+    it('built-in tools still route through the in-process executor when an MCP fleet is also active', async () => {
+      preTrustStub()
+      const tmpFile = join(tmpHome, 'hello.txt')
+      writeFileSync(tmpFile, 'hi from disk')
+      const session = new ClaudeByokSession({
+        cwd: tmpHome,
+        mcpConfigPath: writeStubMcpConfig(),
+      })
+      session.setPermissionMode('auto')
+      const toolResult = await runOneToolRound(session, {
+        id: 'tu_builtin', name: 'Read', input: { file_path: tmpFile },
+      })
+      assert.ok(toolResult)
+      assert.equal(toolResult.is_error, false)
+      assert.match(toolResult.content, /hi from disk/)
+      await session.destroy()
+    })
+  })
 })

--- a/packages/server/tests/fixtures/mcp-stub.mjs
+++ b/packages/server/tests/fixtures/mcp-stub.mjs
@@ -7,6 +7,10 @@ function reply(id, result) {
   process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n')
 }
 
+function replyError(id, code, message) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n')
+}
+
 createInterface({ input: process.stdin }).on('line', (line) => {
   let msg
   try { msg = JSON.parse(line) } catch { return }
@@ -15,6 +19,23 @@ createInterface({ input: process.stdin }).on('line', (line) => {
     reply(msg.id, { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'mcp-stub', version: '0.1.0' } })
   } else if (msg.method === 'tools/list') {
     reply(msg.id, { tools })
+  } else if (msg.method === 'tools/call') {
+    if (process.env.MCP_STUB_TOOL_DIE === '1') {
+      process.exit(1)
+    }
+    if (process.env.MCP_STUB_TOOL_HANG === '1') {
+      return
+    }
+    if (process.env.MCP_STUB_TOOL_RPC_ERROR === '1') {
+      replyError(msg.id, -32603, 'stub: forced RPC error')
+      return
+    }
+    const args = msg.params?.arguments ?? {}
+    if (process.env.MCP_STUB_TOOL_ERROR === '1') {
+      reply(msg.id, { content: [{ type: 'text', text: JSON.stringify(args) }], isError: true })
+      return
+    }
+    reply(msg.id, { content: [{ type: 'text', text: JSON.stringify(args) }] })
   }
 })
 


### PR DESCRIPTION
## Summary

Final leg of the MCP-for-BYOK series. When the model emits a \`tool_use\` block targeting an \`mcp__server__tool\` name, the session now routes it through the MCP fleet's JSON-RPC \`tools/call\` instead of the in-process \`executeBuiltinTool\` registry, and surfaces the response back as a \`tool_result\`.

Prior PRs in the series:
- #4076 — protocol types + parser
- #4077 — child lifecycle + handshake
- #4078 — tools list materialization
- #4457 — spawn trust prompt
- **#4079 — tool_use dispatch (this PR)** ✅

## What's new

| Layer | Change |
|-------|--------|
| \`byok-mcp-client.js\` | \`callTool(toolName, args, timeoutMs)\` — JSON-RPC \`tools/call\` round-trip. Default 30s timeout. |
| \`byok-mcp-fleet.js\` | \`MCP_TOOL_PREFIX = 'mcp__'\`, \`parseMcpToolName()\`, \`fleet.callTool(prefixedName, args)\` |
| \`byok-session.js\` | \`_executeToolBlock\` branches on \`mcp__\` prefix → \`_dispatchMcpTool\` (rest unchanged) |
| \`fixtures/mcp-stub.mjs\` | \`tools/call\` handler + env-var knobs for each failure mode |

## Tests (7 new)

| Scenario | File | Asserts |
|----------|------|---------|
| Happy path: \`tool_use mcp__stub__echo\` → fleet dispatches | byok-session | tool_result content = echoed input |
| Permission denial blocks dispatch | byok-session | is_error=true, content \`/denied/i\` |
| MCP child crashes mid-call | byok-session | is_error=true, session survives |
| MCP returns JSON-RPC error | byok-session | is_error=true |
| MCP returns content with isError=true | byok-session | is_error=true, content propagates |
| Built-ins still route to executeBuiltinTool when MCP fleet active | byok-session | Bash does NOT hit the fleet |
| MCPClient.callTool basic round-trip | byok-mcp-client | response matches input echo |

## Test plan

- [x] \`node --test --test-name-pattern \"MCP tool_use dispatch\" tests/byok-session.test.js\` — 6/6 pass
- [x] \`node --test --experimental-test-module-mocks --test-force-exit tests/byok-mcp-client.test.js tests/byok-mcp-fleet.test.js tests/byok-session.test.js\` — 117/117 pass
- [ ] Smoke test on a real MCP server (e.g. anthropic-mcp-filesystem)

## Closes

- Closes #4079