### PR TITLE
feat(server,protocol): surface streamStallTimeoutMs in auth_ok (#4477)

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -58,6 +58,7 @@ export declare const ServerAuthOkSchema: z.ZodObject<{
     capabilities: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
     resultTimeoutMs: z.ZodOptional<z.ZodNumber>;
     hardTimeoutMs: z.ZodOptional<z.ZodNumber>;
+    streamStallTimeoutMs: z.ZodOptional<z.ZodNumber>;
 }, z.core.$loose>;
 export declare const ServerAuthFailSchema: z.ZodObject<{
     type: z.ZodLiteral<"auth_fail">;
@@ -199,6 +200,53 @@ export declare const ServerAgentCompletedSchema: z.ZodObject<{
     type: z.ZodLiteral<"agent_completed">;
     toolUseId: z.ZodString;
 }, z.core.$strip>;
+/**
+ * #4307 — one entry per backgrounded `Bash` shell the session is still
+ * waiting on. Pushed when the agent dispatches a `Bash` tool call with
+ * `run_in_background: true` (the matching tool_result carries the
+ * canonical `Command running in background with ID: <id>` text); cleared
+ * when the agent calls `BashOutput` (acknowledged) or the session is
+ * destroyed.
+ *
+ * `shellId` is the short alphanumeric token Claude prints (e.g.
+ * `brk57kt6pm`). `command` is the original Bash command text the agent
+ * dispatched, stashed at tool_use time so the dashboard can render
+ * "waiting on `<command>`" without a separate roundtrip. `startedAt` is
+ * the server-side wall-clock at the moment the tool_result was parsed —
+ * lets the dashboard surface elapsed wait time without trusting the
+ * client clock.
+ */
+export declare const ServerPendingBackgroundShellSchema: z.ZodObject<{
+    shellId: z.ZodString;
+    command: z.ZodString;
+    startedAt: z.ZodNumber;
+}, z.core.$strip>;
+/**
+ * #4307 — transient event: the pending-background-shells snapshot for a
+ * session changed. Emitted both on push (a new `run_in_background` shell
+ * was registered) and on clear (`BashOutput` acknowledged or the session
+ * was destroyed). The full snapshot is on the wire (not a delta) so a
+ * late-joining client sees canonical state.
+ *
+ * Why a full snapshot instead of an event per delta: pending work is a
+ * tiny set (typically 0 or 1 entries) and the event fires rarely, so
+ * the wire cost is negligible. A delta protocol would force every
+ * client to also reconcile against `pendingBackgroundShells` on the
+ * `session_list` snapshot — the full-snapshot shape avoids that.
+ *
+ * Late joiners: `session_list` carries the same `pendingBackgroundShells`
+ * field on each entry, so a client that connects between
+ * `background_work_changed` events catches up via the next snapshot.
+ */
+export declare const ServerBackgroundWorkChangedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"background_work_changed">;
+    sessionId: z.ZodString;
+    pending: z.ZodArray<z.ZodObject<{
+        shellId: z.ZodString;
+        command: z.ZodString;
+        startedAt: z.ZodNumber;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
 export declare const ServerClientFocusChangedSchema: z.ZodObject<{
     type: z.ZodLiteral<"client_focus_changed">;
     clientId: z.ZodString;
@@ -284,6 +332,11 @@ export declare const ServerSessionListEntrySchema: z.ZodObject<{
         costUsd: z.ZodNumber;
         turnsBilled: z.ZodNumber;
     }, z.core.$strip>>;
+    pendingBackgroundShells: z.ZodOptional<z.ZodArray<z.ZodObject<{
+        shellId: z.ZodString;
+        command: z.ZodString;
+        startedAt: z.ZodNumber;
+    }, z.core.$strip>>>;
 }, z.core.$loose>;
 export declare const ServerSessionListSchema: z.ZodObject<{
     type: z.ZodLiteral<"session_list">;
@@ -316,6 +369,11 @@ export declare const ServerSessionListSchema: z.ZodObject<{
             costUsd: z.ZodNumber;
             turnsBilled: z.ZodNumber;
         }, z.core.$strip>>;
+        pendingBackgroundShells: z.ZodOptional<z.ZodArray<z.ZodObject<{
+            shellId: z.ZodString;
+            command: z.ZodString;
+            startedAt: z.ZodNumber;
+        }, z.core.$strip>>>;
     }, z.core.$loose>>;
 }, z.core.$strip>;
 /**

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -73,6 +73,24 @@ export const ServerAuthOkSchema = z.object({
     // `DEFAULT_HARD_TIMEOUT_MS` exported from `base-session.js` but is
     // not re-exported from this package.)
     hardTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
+    // #4477: stream-stall recovery window in ms surfaced in auth_ok so the
+    // dashboard chip (#4476) can render "Stream stalled — no response for
+    // ${humanize(streamStallTimeoutMs)}" with the real configured value
+    // instead of hardcoding the 5-min default.
+    //
+    // Semantics differ from resultTimeoutMs / hardTimeoutMs: 0 is a valid
+    // emission meaning the operator explicitly disabled stream-stall
+    // recovery (CHROXY_STREAM_STALL_TIMEOUT_MS=0). BaseSession's
+    // `_armResultTimeout` skips arming the stall timer when
+    // `_streamStallTimeoutMs === 0`, so the wire must be able to communicate
+    // that state distinctly from "older server" (field absent). Hence
+    // `.nonnegative()` not `.positive()`.
+    //
+    // Optional because servers from before #4477 don't emit it — clients
+    // fall back to the 5-min default when absent. The matching server-side
+    // constant is `DEFAULT_STREAM_STALL_TIMEOUT_MS` exported from
+    // `base-session.js` but is not re-exported from this package.
+    streamStallTimeoutMs: z.number().int().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
 }).passthrough();
 export const ServerAuthFailSchema = z.object({
     type: z.literal('auth_fail'),
@@ -241,6 +259,49 @@ export const ServerAgentCompletedSchema = z.object({
     type: z.literal('agent_completed'),
     toolUseId: z.string(),
 });
+/**
+ * #4307 — one entry per backgrounded `Bash` shell the session is still
+ * waiting on. Pushed when the agent dispatches a `Bash` tool call with
+ * `run_in_background: true` (the matching tool_result carries the
+ * canonical `Command running in background with ID: <id>` text); cleared
+ * when the agent calls `BashOutput` (acknowledged) or the session is
+ * destroyed.
+ *
+ * `shellId` is the short alphanumeric token Claude prints (e.g.
+ * `brk57kt6pm`). `command` is the original Bash command text the agent
+ * dispatched, stashed at tool_use time so the dashboard can render
+ * "waiting on `<command>`" without a separate roundtrip. `startedAt` is
+ * the server-side wall-clock at the moment the tool_result was parsed —
+ * lets the dashboard surface elapsed wait time without trusting the
+ * client clock.
+ */
+export const ServerPendingBackgroundShellSchema = z.object({
+    shellId: z.string(),
+    command: z.string(),
+    startedAt: z.number().int().nonnegative(),
+});
+/**
+ * #4307 — transient event: the pending-background-shells snapshot for a
+ * session changed. Emitted both on push (a new `run_in_background` shell
+ * was registered) and on clear (`BashOutput` acknowledged or the session
+ * was destroyed). The full snapshot is on the wire (not a delta) so a
+ * late-joining client sees canonical state.
+ *
+ * Why a full snapshot instead of an event per delta: pending work is a
+ * tiny set (typically 0 or 1 entries) and the event fires rarely, so
+ * the wire cost is negligible. A delta protocol would force every
+ * client to also reconcile against `pendingBackgroundShells` on the
+ * `session_list` snapshot — the full-snapshot shape avoids that.
+ *
+ * Late joiners: `session_list` carries the same `pendingBackgroundShells`
+ * field on each entry, so a client that connects between
+ * `background_work_changed` events catches up via the next snapshot.
+ */
+export const ServerBackgroundWorkChangedSchema = z.object({
+    type: z.literal('background_work_changed'),
+    sessionId: z.string(),
+    pending: z.array(ServerPendingBackgroundShellSchema),
+});
 export const ServerClientFocusChangedSchema = z.object({
     type: z.literal('client_focus_changed'),
     clientId: z.string(),
@@ -376,6 +437,12 @@ export const ServerSessionListEntrySchema = z.object({
     // running total, and a session that received only refunds could
     // legitimately end up with a negative cumulative.
     cumulativeUsage: CumulativeUsageSchema.optional(),
+    // #4307: pending backgrounded shells. Empty array when no work is
+    // pending — never `undefined` from a #4307-aware server (mirrors the
+    // `cumulativeUsage` shape, which always carries a zero block once
+    // present). Optional in the schema so pre-#4307 servers that omit
+    // the field still parse; consumers should treat `undefined` as `[]`.
+    pendingBackgroundShells: z.array(ServerPendingBackgroundShellSchema).optional(),
 }).passthrough();
 export const ServerSessionListSchema = z.object({
     type: z.literal('session_list'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -76,6 +76,24 @@ export const ServerAuthOkSchema = z.object({
   // `DEFAULT_HARD_TIMEOUT_MS` exported from `base-session.js` but is
   // not re-exported from this package.)
   hardTimeoutMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS).optional(),
+  // #4477: stream-stall recovery window in ms surfaced in auth_ok so the
+  // dashboard chip (#4476) can render "Stream stalled — no response for
+  // ${humanize(streamStallTimeoutMs)}" with the real configured value
+  // instead of hardcoding the 5-min default.
+  //
+  // Semantics differ from resultTimeoutMs / hardTimeoutMs: 0 is a valid
+  // emission meaning the operator explicitly disabled stream-stall
+  // recovery (CHROXY_STREAM_STALL_TIMEOUT_MS=0). BaseSession's
+  // `_armResultTimeout` skips arming the stall timer when
+  // `_streamStallTimeoutMs === 0`, so the wire must be able to communicate
+  // that state distinctly from "older server" (field absent). Hence
+  // `.nonnegative()` not `.positive()`.
+  //
+  // Optional because servers from before #4477 don't emit it — clients
+  // fall back to the 5-min default when absent. The matching server-side
+  // constant is `DEFAULT_STREAM_STALL_TIMEOUT_MS` exported from
+  // `base-session.js` but is not re-exported from this package.
+  streamStallTimeoutMs: z.number().int().nonnegative().finite().max(MAX_SANE_DURATION_MS).optional(),
 }).passthrough()
 
 export const ServerAuthFailSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -214,6 +214,97 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(ServerAuthOkSchema.safeParse({ ...base, hardTimeoutMs: MAX }).success, 'exactly 24h should pass')
   })
 
+  // #4477: streamStallTimeoutMs is the server's stream-stall recovery window,
+  // surfaced so the dashboard chip (#4476) can render copy with the real
+  // configured value instead of hardcoding the 5-min default. Unlike
+  // result/hardTimeoutMs, 0 is a meaningful value here — it means the
+  // operator explicitly disabled stream-stall recovery, so the schema must
+  // accept nonnegative ints (not just positive).
+  it('validates auth_ok with streamStallTimeoutMs (#4477)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const result = ServerAuthOkSchema.safeParse({
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.9.13',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+      streamStallTimeoutMs: 5 * 60 * 1000,
+    })
+    assert.ok(result.success, 'Should validate auth_ok with streamStallTimeoutMs')
+    assert.equal(result.data.streamStallTimeoutMs, 300_000)
+  })
+
+  it('accepts auth_ok with streamStallTimeoutMs=0 (explicitly disabled)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const result = ServerAuthOkSchema.safeParse({
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.9.13',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+      streamStallTimeoutMs: 0,
+    })
+    assert.ok(result.success, 'Should accept 0 as the "disabled" sentinel — base-session armResultTimeout skips the stall timer when _streamStallTimeoutMs === 0')
+    assert.equal(result.data.streamStallTimeoutMs, 0)
+  })
+
+  it('accepts auth_ok without streamStallTimeoutMs (older servers, pre-#4477)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const result = ServerAuthOkSchema.safeParse({
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.9.12',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+    })
+    assert.ok(result.success, 'Should accept auth_ok without streamStallTimeoutMs')
+    assert.equal(result.data.streamStallTimeoutMs, undefined)
+  })
+
+  it('rejects auth_ok with invalid streamStallTimeoutMs (#4477)', async () => {
+    const { ServerAuthOkSchema, MAX_SANE_DURATION_MS: MAX } = await import('../src/schemas/server.ts')
+    const base = {
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.9.13',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+    }
+    for (const bad of [-1, 1.5, Infinity, NaN, '300000', MAX + 1]) {
+      const result = ServerAuthOkSchema.safeParse({ ...base, streamStallTimeoutMs: bad })
+      assert.ok(!result.success, `Should reject bad streamStallTimeoutMs: ${String(bad)}`)
+    }
+    assert.ok(ServerAuthOkSchema.safeParse({ ...base, streamStallTimeoutMs: MAX }).success, 'exactly 24h should pass')
+  })
+
   // #3768: same ceiling applied to other ms-typed fields.
   it('rejects permission_request with remainingMs above 24h ceiling (#3768)', async () => {
     const { ServerPermissionRequestSchema, MAX_SANE_DURATION_MS: MAX } = await import('../src/schemas/server.ts')

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -8,7 +8,7 @@ import { toShortModelId, getModels, getDefaultModelId, getRegistryForProvider } 
 import { PERMISSION_MODES } from './handler-utils.js'
 import { listProviders } from './providers.js'
 import { createLogger } from './logger.js'
-import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS } from './base-session.js'
+import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS, DEFAULT_STREAM_STALL_TIMEOUT_MS } from './base-session.js'
 
 const log = createLogger('ws')
 
@@ -27,7 +27,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     encryptionEnabled, localhostBypass, keyExchangeTimeoutMs,
     protocolVersion, minProtocolVersion, webTaskManager,
     send, broadcast, getConnectedClientList, permissions,
-    resultTimeoutMs, hardTimeoutMs,
+    resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs,
   } = ctx
   const client = clients.get(ws)
 
@@ -103,6 +103,18 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     Number.isSafeInteger(hardTimeoutMs) && hardTimeoutMs > 0
       ? hardTimeoutMs
       : DEFAULT_HARD_TIMEOUT_MS
+  // #4477: stream-stall window. Semantics differ from the two timeouts above —
+  // 0 is a meaningful operator-set value ("explicitly disabled") that must
+  // survive intact to the dashboard so the chip (#4476) can hide instead of
+  // rendering against a disabled timer. Use `>= 0` here, not `> 0`.
+  // Negative / fractional / NaN / Infinity / string inputs fail
+  // isSafeInteger and fall back to the default — they'd otherwise fail the
+  // protocol schema's int().nonnegative().max(MAX_SANE_DURATION_MS) gate at
+  // the client and silently break dashboard message handling.
+  const effectiveStreamStallTimeoutMs =
+    Number.isSafeInteger(streamStallTimeoutMs) && streamStallTimeoutMs >= 0
+      ? streamStallTimeoutMs
+      : DEFAULT_STREAM_STALL_TIMEOUT_MS
 
   send(ws, {
     type: 'auth_ok',
@@ -123,6 +135,7 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     capabilities,
     resultTimeoutMs: effectiveResultTimeoutMs,
     hardTimeoutMs: effectiveHardTimeoutMs,
+    streamStallTimeoutMs: effectiveStreamStallTimeoutMs,
     ...extra,
   })
 

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -271,7 +271,7 @@ function _isSecureRequest(req) {
  *
  * Server -> Client:
  *   All session-scoped messages include a `sessionId` field for background sync.
- *   { type: 'auth_ok', clientId, serverMode, serverVersion, latestVersion, serverCommit, cwd, defaultCwd, connectedClients, encryption, resultTimeoutMs, hardTimeoutMs } — auth succeeded (encryption: 'required'|'disabled'; resultTimeoutMs = soft-warning window in ms, hardTimeoutMs = hard-kill window in ms — #3760, #3905)
+ *   { type: 'auth_ok', clientId, serverMode, serverVersion, latestVersion, serverCommit, cwd, defaultCwd, connectedClients, encryption, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs } — auth succeeded (encryption: 'required'|'disabled'; resultTimeoutMs = soft-warning window in ms, hardTimeoutMs = hard-kill window in ms, streamStallTimeoutMs = stream-stall recovery window in ms (0 = disabled) — #3760, #3905, #4477)
  *   { type: 'key_exchange_ok', publicKey }               — server's ephemeral X25519 public key (E2E encryption)
  *   { type: 'auth_fail',    reason: '...' }           — auth failed
  *   { type: 'server_mode',  mode: 'cli' }             — which backend mode is active
@@ -588,6 +588,12 @@ export class WsServer {
       // after construction are reflected. #3905 adds the parallel hard-cap.
       get resultTimeoutMs() { return self.config?.resultTimeoutMs ?? null },
       get hardTimeoutMs() { return self.config?.hardTimeoutMs ?? null },
+      // #4477: effective stream-stall recovery window in ms. null = use
+      // BaseSession's DEFAULT_STREAM_STALL_TIMEOUT_MS (5min); 0 = operator
+      // explicitly disabled stall recovery (preserved as-is on the wire so
+      // the dashboard chip can hide instead of rendering against a
+      // disabled timer).
+      get streamStallTimeoutMs() { return self.config?.streamStallTimeoutMs ?? null },
     }
     this._authCtx = {
       get clients() { return self.clients },

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -175,6 +175,60 @@ describe('sendPostAuthInfo — resultTimeoutMs (#3760)', () => {
   })
 })
 
+// #4477: surface the effective stream-stall recovery window in auth_ok so the
+// dashboard chip (#4476) can render its humanized copy with the real configured
+// value instead of hardcoding the 5-min default. Unlike resultTimeoutMs, 0 is
+// a meaningful emission (operator explicitly disabled stream-stall recovery) —
+// the wire must communicate that state distinctly from "field absent / older
+// server", so the fallback must NOT fire on a 0 input.
+describe('sendPostAuthInfo — streamStallTimeoutMs (#4477)', () => {
+  it('uses the configured streamStallTimeoutMs when set', () => {
+    const ctx = makeCtx({ streamStallTimeoutMs: 90_000 })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.streamStallTimeoutMs, 90_000)
+  })
+
+  it('emits 0 when ctx.streamStallTimeoutMs is 0 (operator explicitly disabled)', () => {
+    // The operator set CHROXY_STREAM_STALL_TIMEOUT_MS=0 to opt out of the
+    // 5-min stall timer (workloads with legitimate long event gaps). The wire
+    // must propagate 0 distinctly so the dashboard hides the chip entirely
+    // rather than rendering "no response for 5min" against a disabled timer.
+    const ctx = makeCtx({ streamStallTimeoutMs: 0 })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.streamStallTimeoutMs, 0)
+  })
+
+  it('falls back to BaseSession default (5 min) when ctx.streamStallTimeoutMs is null', () => {
+    const ctx = makeCtx({ streamStallTimeoutMs: null })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.streamStallTimeoutMs, 5 * 60 * 1000)
+  })
+
+  it('falls back to the default when ctx.streamStallTimeoutMs is negative, fractional, or non-finite', () => {
+    // Note: 0 is NOT in this list — see the "emits 0 when ctx is 0" test
+    // above. Negative / NaN / Infinity / non-integers fall back to default
+    // because they'd fail the protocol schema's int().nonnegative().max(MAX)
+    // gate and silently break clients.
+    for (const bad of [-1, 1.5, NaN, Infinity, 'oops']) {
+      const ctx = makeCtx({ streamStallTimeoutMs: bad })
+      const ws = makeFakeWs()
+      registerClient(ctx, ws)
+      sendPostAuthInfo(ctx, ws)
+      const authOk = ctx._sends[0]
+      assert.equal(authOk.streamStallTimeoutMs, 5 * 60 * 1000, `bad input: ${String(bad)}`)
+    }
+  })
+})
+
 describe('sendPostAuthInfo — cwd from sessionManager', () => {
   it('uses cwd from defaultSessionId when available', () => {
     const { manager } = createMockSessionManager([


### PR DESCRIPTION
## Summary

Closes #4477 — surfaces the effective stream-stall recovery window in the `auth_ok` handshake so the dashboard chip (#4476) can render humanized copy with the real configured value instead of hardcoding the 5-min default.

## Changes

- **`packages/protocol`**: Add optional `streamStallTimeoutMs?: number` to `ServerAuthOkSchema`, validated as `int().nonnegative().finite().max(MAX_SANE_DURATION_MS)`. Unlike the sibling `resultTimeoutMs` / `hardTimeoutMs` (which use `.positive()`), this field accepts `0` because it's a meaningful operator-set value ("explicitly disabled" — `CHROXY_STREAM_STALL_TIMEOUT_MS=0`) that must survive intact to the dashboard so the chip can hide instead of rendering against a disabled timer.
- **`packages/server/src/ws-server.js`**: Add `streamStallTimeoutMs` getter to the post-auth ctx, late-bound on `self.config?.streamStallTimeoutMs`. Mirrors the existing `resultTimeoutMs` / `hardTimeoutMs` pattern (#3760, #3905). Updates the `auth_ok` docblock at the top of the file.
- **`packages/server/src/ws-history.js`**: `sendPostAuthInfo` destructures `streamStallTimeoutMs` from ctx, applies the same `Number.isSafeInteger` guard as the existing timeouts but with `>= 0` (not `> 0`) to preserve the explicit-disabled 0. Negative / fractional / non-finite inputs fall back to `DEFAULT_STREAM_STALL_TIMEOUT_MS` because they'd fail the protocol schema's gate at the client and silently break dashboard message handling.

## Why no protocol version bump

The field is optional and backwards-compatible. Older clients ignore unknown fields. Newer clients fall back to a hardcoded 5-min default when the field is absent. The issue mentions bumping `minProtocolVersion`, but that pattern (e.g. `TUNNEL_STATUS_MIN_PROTOCOL_VERSION`) is reserved for cases where clients depend on a new feature — here the dashboard chip degrades gracefully without it. Same approach we took for `resultTimeoutMs` (#3760) and `hardTimeoutMs` (#3905).

## Out of scope (deferred)

- Dashboard / app consumers reading `streamStallTimeoutMs` from `auth_ok` — that's #4476's scope (the chip itself).

## Test plan

- [x] `packages/protocol` — 4 new schema tests covering: positive int validates, 0 validates (explicit-disabled), absent validates (older servers), invalid (negative/fractional/Infinity/NaN/string/>24h) rejects
- [x] `packages/server` — 4 new `sendPostAuthInfo` tests covering: configured value flows through, 0 preserved, null falls back to default, bad inputs fall back to default
- [x] Full `packages/protocol` suite passes (143/143)
- [x] Full `packages/server/tests/ws-history.test.js` suite passes (65/65)