### PR TITLE
feat(server): configurable MCP tools/call timeout (#4482)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -244,6 +244,17 @@ export class ClaudeByokSession extends BaseSession {
     // #4077: MCPFleet is lazy — created in start() only if servers exist.
     // Held here so destroy() can tear down even if start() never ran.
     this._mcpFleet = null
+    // #4482: per-call MCP tools/call timeout (ms). null = use byok-mcp-client's
+    // DEFAULT_TOOL_CALL_TIMEOUT_MS (30s) via the destructured default in
+    // MCPFleet.callTool. Forwarded from session-manager via providerOpts →
+    // opts.mcpToolCallTimeoutMs. Same defensive guard as resultTimeoutMs:
+    // non-finite / non-positive (NaN, Infinity, 0, -1, strings) falls back
+    // to null because setTimeout coerces those to 0 ms and every MCP tool
+    // would look broken.
+    this._mcpToolCallTimeoutMs =
+      Number.isFinite(opts.mcpToolCallTimeoutMs) && opts.mcpToolCallTimeoutMs > 0
+        ? opts.mcpToolCallTimeoutMs
+        : null
   }
 
   async start() {
@@ -961,7 +972,11 @@ export class ClaudeByokSession extends BaseSession {
    */
   async _dispatchMcpTool(toolName, input) {
     try {
-      const result = await this._mcpFleet.callTool(toolName, input)
+      // #4482: pass undefined when the operator didn't set a timeout so
+      // MCPFleet.callTool's destructured default (DEFAULT_TOOL_CALL_TIMEOUT_MS)
+      // fires — duplicating the constant here would silently desync if
+      // MCPClient ever retunes its 30s default.
+      const result = await this._mcpFleet.callTool(toolName, input, this._mcpToolCallTimeoutMs ?? undefined)
       const blocks = Array.isArray(result?.content) ? result.content : []
       const text = blocks
         .map((b) => (typeof b?.text === 'string' ? b.text : JSON.stringify(b)))

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -161,6 +161,13 @@ const CONFIG_SCHEMA = {
   // and the dashboard can offer a retry. Default 300000 (5 min). Set to
   // 0 to disable (operators with legitimately long event gaps).
   streamStallTimeoutMs: 'number',
+  // #4482: per-call MCP tools/call timeout (ms). Forwarded to
+  // byok-mcp-client.callTool's setTimeout via byok-session →
+  // MCPFleet.callTool → MCPClient.callTool. Default 30000 (30s) at the
+  // client layer matches DEFAULT_TOOL_CALL_TIMEOUT_MS. Range 1s-10min —
+  // below 1s every realistic MCP server times out, above 10min the
+  // model conversation is already lost.
+  mcpToolCallTimeoutMs: 'number',
 }
 
 /**
@@ -273,6 +280,19 @@ export function validateConfig(config, verbose = false) {
       warnings.push(`Invalid value for 'streamStallTimeoutMs': ${config.streamStallTimeoutMs} (minimum 5000 / 5s; set 0 to disable)`)
     } else if (config.streamStallTimeoutMs > 24 * 60 * 60 * 1000) {
       warnings.push(`Invalid value for 'streamStallTimeoutMs': ${config.streamStallTimeoutMs} (maximum 86400000 / 24h)`)
+    }
+  }
+
+  // #4482: per-MCP-call timeout. 1s-10min. Unlike streamStallTimeoutMs,
+  // 0 isn't meaningful here — a 0-ms callTool timeout fires immediately
+  // and makes every MCP tool look broken — so any non-finite / non-
+  // positive value gets a warning and the runtime falls back to the
+  // client default (30s) instead of accepting it.
+  if (Number.isFinite(config.mcpToolCallTimeoutMs)) {
+    if (config.mcpToolCallTimeoutMs < 1_000) {
+      warnings.push(`Invalid value for 'mcpToolCallTimeoutMs': ${config.mcpToolCallTimeoutMs} (minimum 1000 / 1s)`)
+    } else if (config.mcpToolCallTimeoutMs > 10 * 60 * 1000) {
+      warnings.push(`Invalid value for 'mcpToolCallTimeoutMs': ${config.mcpToolCallTimeoutMs} (maximum 600000 / 10min)`)
     }
   }
 
@@ -414,6 +434,7 @@ function envKeyForConfig(key) {
     resultTimeoutMs: 'CHROXY_RESULT_TIMEOUT_MS',
     hardTimeoutMs: 'CHROXY_HARD_TIMEOUT_MS',
     streamStallTimeoutMs: 'CHROXY_STREAM_STALL_TIMEOUT_MS',
+    mcpToolCallTimeoutMs: 'CHROXY_MCP_TOOL_CALL_TIMEOUT_MS',
     // #4384 — canonical env var for the #4246 rename. Without this entry
     // the fallback was `key.toUpperCase()` (DANGEROUSLYSKIPPERMISSIONS,
     // no underscores) which is not what we document or what operators

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -386,6 +386,13 @@ export async function startCliServer(config) {
       Number.isFinite(config.streamStallTimeoutMs) && config.streamStallTimeoutMs >= 0
         ? config.streamStallTimeoutMs
         : null,
+    // #4482: per-MCP-call timeout (ms). null = byok-mcp-client default (30s).
+    // Unlike streamStallTimeoutMs, 0 is not a meaningful disable — every
+    // MCP tool would look broken — so non-positive falls back to null.
+    mcpToolCallTimeoutMs:
+      Number.isFinite(config.mcpToolCallTimeoutMs) && config.mcpToolCallTimeoutMs > 0
+        ? config.mcpToolCallTimeoutMs
+        : null,
     // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
     maxSkillBytes: Number.isFinite(config.maxSkillBytes) ? config.maxSkillBytes : null,
     maxTotalSkillBytes: Number.isFinite(config.maxTotalSkillBytes) ? config.maxTotalSkillBytes : null,

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -214,6 +214,10 @@ export class SessionManager extends EventEmitter {
     // #4467: stream-stall recovery timeout (ms). Forwarded via providerOpts.
     // null = use BaseSession's DEFAULT_STREAM_STALL_TIMEOUT_MS (5min).
     streamStallTimeoutMs,
+    // #4482: per-MCP-call timeout (ms). Forwarded via providerOpts to
+    // byok-session, which threads it into MCPFleet.callTool. null = use
+    // byok-mcp-client's DEFAULT_TOOL_CALL_TIMEOUT_MS (30s).
+    mcpToolCallTimeoutMs,
 
     // State persistence
     stateFilePath,
@@ -268,6 +272,14 @@ export class SessionManager extends EventEmitter {
     this._streamStallTimeoutMs =
       Number.isFinite(streamStallTimeoutMs) && streamStallTimeoutMs >= 0
         ? streamStallTimeoutMs
+        : null
+    // #4482: per-MCP-call timeout. Unlike streamStallTimeoutMs, 0 is not a
+    // valid disable here — a 0-ms callTool timeout fires immediately. Only
+    // positive finite values are accepted; null falls through to byok-mcp-
+    // client's 30s default.
+    this._mcpToolCallTimeoutMs =
+      Number.isFinite(mcpToolCallTimeoutMs) && mcpToolCallTimeoutMs > 0
+        ? mcpToolCallTimeoutMs
         : null
     this._costBudget = new CostBudgetManager({ budget: costBudget })
     // #4075: per-session crossing threshold. Stored as a runtime-mutable
@@ -584,6 +596,7 @@ export class SessionManager extends EventEmitter {
     if (this._resultTimeoutMs != null) providerOpts.resultTimeoutMs = this._resultTimeoutMs
     if (this._hardTimeoutMs != null) providerOpts.hardTimeoutMs = this._hardTimeoutMs
     if (this._streamStallTimeoutMs != null) providerOpts.streamStallTimeoutMs = this._streamStallTimeoutMs
+    if (this._mcpToolCallTimeoutMs != null) providerOpts.mcpToolCallTimeoutMs = this._mcpToolCallTimeoutMs
     // Skills size budgets — pass through if configured. BaseSession forwards
     // these to loadActiveSkillsLayered. (#3202)
     if (this._maxSkillBytes !== null) providerOpts.maxSkillBytes = this._maxSkillBytes

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3279,4 +3279,63 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
   })
+
+  // #4482: per-MCP-call timeout knob — operators can stretch the 30s
+  // DEFAULT_TOOL_CALL_TIMEOUT_MS for slow MCP servers (filesystem grep
+  // across large repos, container exec, remote API wrappers) without
+  // patching byok-mcp-client. The session reads opts.mcpToolCallTimeoutMs
+  // (forwarded by session-manager → providerOpts) and passes it as the
+  // third arg to fleet.callTool, which propagates to MCPClient.callTool's
+  // setTimeout. Unset / non-positive falls back to the fleet/client
+  // default — same defensive guard pattern as resultTimeoutMs.
+  describe('MCP tools/call timeout configuration (#4482)', () => {
+    function buildSessionWithMockFleet(opts = {}) {
+      const session = new ClaudeByokSession({ cwd: '/tmp', ...opts })
+      const captured = []
+      session._mcpFleet = {
+        callTool: async (prefixedName, args, timeoutMs) => {
+          captured.push({ prefixedName, args, timeoutMs })
+          return { content: [{ type: 'text', text: 'ok' }] }
+        },
+      }
+      return { session, captured }
+    }
+
+    it('forwards configured mcpToolCallTimeoutMs to fleet.callTool', async () => {
+      const { session, captured } = buildSessionWithMockFleet({ mcpToolCallTimeoutMs: 90_000 })
+      await session._dispatchMcpTool('mcp__stub__echo', { x: 1 })
+      assert.equal(captured.length, 1)
+      assert.equal(captured[0].timeoutMs, 90_000,
+        '_dispatchMcpTool must propagate the configured timeout so MCPClient.callTool can arm setTimeout against it')
+    })
+
+    it('passes undefined (fleet default) when mcpToolCallTimeoutMs is omitted', async () => {
+      // Default behaviour: callers that never set the knob get the
+      // existing 30s DEFAULT_TOOL_CALL_TIMEOUT_MS via the fleet/client
+      // chain — passing `undefined` lets the destructured default in
+      // MCPFleet.callTool fire (rather than forcing 30s here too, which
+      // would duplicate the constant).
+      const { session, captured } = buildSessionWithMockFleet()
+      await session._dispatchMcpTool('mcp__stub__echo', {})
+      assert.equal(captured.length, 1)
+      assert.equal(captured[0].timeoutMs, undefined,
+        'omitted opt must leave fleet/client to apply DEFAULT_TOOL_CALL_TIMEOUT_MS — duplicating the constant here would silently desync if MCPClient later retunes its default')
+    })
+
+    it('falls back to undefined when mcpToolCallTimeoutMs is non-positive or non-finite', async () => {
+      // Same defensive guard as resultTimeoutMs — a config typo
+      // (CHROXY_MCP_TOOL_CALL_TIMEOUT_MS=oops → NaN, or -1, or 0) must
+      // NOT silently pass through to setTimeout, where:
+      //   setTimeout(fn, NaN)      → fires immediately (0ms coercion)
+      //   setTimeout(fn, -1)       → fires immediately (clamped to 0)
+      //   setTimeout(fn, Infinity) → fires immediately (also clamped)
+      // Falling back to undefined lets the fleet's default fire — same
+      // safe behaviour as omitting the opt entirely.
+      for (const bad of [0, -1, NaN, Infinity, '60000']) {
+        const { session, captured } = buildSessionWithMockFleet({ mcpToolCallTimeoutMs: bad })
+        await session._dispatchMcpTool('mcp__stub__echo', {})
+        assert.equal(captured[0].timeoutMs, undefined, `bad input ${String(bad)} must fall back`)
+      }
+    })
+  })
 })

--- a/packages/server/tests/config.test.js
+++ b/packages/server/tests/config.test.js
@@ -191,6 +191,35 @@ describe('validateConfig', () => {
       assert.ok(result.warnings.some(w => w.includes('streamStallTimeoutMs') && w.includes('number')))
     })
   })
+
+  // #4482: per-call MCP tools/call timeout. Defaults to 30s (matches
+  // byok-mcp-client's DEFAULT_TOOL_CALL_TIMEOUT_MS). Allowed range
+  // 1s-10min — below 1s every realistic MCP server times out, above
+  // 10min the model conversation is already lost.
+  describe('mcpToolCallTimeoutMs (#4482)', () => {
+    it('accepts a value within the allowed range', () => {
+      const result = validateConfig({ mcpToolCallTimeoutMs: 60_000 })
+      assert.equal(result.valid, true)
+    })
+
+    it('rejects values below the 1s minimum', () => {
+      const result = validateConfig({ mcpToolCallTimeoutMs: 500 })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('mcpToolCallTimeoutMs') && w.includes('minimum')))
+    })
+
+    it('rejects values above the 10min maximum', () => {
+      const result = validateConfig({ mcpToolCallTimeoutMs: 11 * 60 * 1000 })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('mcpToolCallTimeoutMs') && w.includes('maximum')))
+    })
+
+    it('warns when value is not a number', () => {
+      const result = validateConfig({ mcpToolCallTimeoutMs: '60s' })
+      assert.equal(result.valid, false)
+      assert.ok(result.warnings.some(w => w.includes('mcpToolCallTimeoutMs') && w.includes('number')))
+    })
+  })
 })
 
 describe('mergeConfig', () => {
@@ -414,6 +443,13 @@ describe('mergeConfig', () => {
     const merged = mergeConfig({})
     assert.equal(merged.streamStallTimeoutMs, 0)
     delete process.env.CHROXY_STREAM_STALL_TIMEOUT_MS
+  })
+
+  it('reads mcpToolCallTimeoutMs from CHROXY_MCP_TOOL_CALL_TIMEOUT_MS env var as number (#4482)', () => {
+    process.env.CHROXY_MCP_TOOL_CALL_TIMEOUT_MS = '90000'
+    const merged = mergeConfig({})
+    assert.equal(merged.mcpToolCallTimeoutMs, 90_000)
+    delete process.env.CHROXY_MCP_TOOL_CALL_TIMEOUT_MS
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #4482 — adds `CHROXY_MCP_TOOL_CALL_TIMEOUT_MS` env knob (also accepted via the config file as `mcpToolCallTimeoutMs`) so operators can stretch the hardcoded 30s `DEFAULT_TOOL_CALL_TIMEOUT_MS` for slow MCP servers.

Real-world cases the 30s default doesn't fit:
- Filesystem grep / find across large repositories
- Slow remote-API wrappers (60–120s)
- Docker / container exec through an MCP wrapper
- Build / test runners dispatched via MCP

Default stays 30s — this is purely an escape hatch.

## Changes

- **`packages/server/src/config.js`**: Schema entry `mcpToolCallTimeoutMs: 'number'` + env mapping `CHROXY_MCP_TOOL_CALL_TIMEOUT_MS`. Range validation 1s–10min. Unlike `streamStallTimeoutMs`, `0` is not a meaningful disable here — a 0-ms `setTimeout` fires immediately and every MCP tool would look broken.
- **`packages/server/src/session-manager.js`**: Constructor accepts `mcpToolCallTimeoutMs`, stores as `_mcpToolCallTimeoutMs` (positive int or `null`), forwards via `providerOpts.mcpToolCallTimeoutMs` only when set (consistent with the `resultTimeoutMs` / `hardTimeoutMs` / `streamStallTimeoutMs` pattern).
- **`packages/server/src/byok-session.js`**: Constructor reads `opts.mcpToolCallTimeoutMs` with same defensive guard. `_dispatchMcpTool` passes `this._mcpToolCallTimeoutMs ?? undefined` as the third arg to `fleet.callTool`, letting the fleet's destructured default fire when unset — avoids duplicating the 30s constant.
- **`packages/server/src/server-cli.js`**: Plumbs `config.mcpToolCallTimeoutMs` to SessionManager.

## Why option 1 (env knob), not option 2 (per-server config)

The issue suggested two paths. Option 1 (env knob) is simpler, ships with the daemon, and matches every other timeout pattern in chroxy (`CHROXY_RESULT_TIMEOUT_MS`, `CHROXY_HARD_TIMEOUT_MS`, `CHROXY_STREAM_STALL_TIMEOUT_MS`). Option 2 (per-server config in `mcpServers[name]`) is more flexible but requires changes to the config parser and the trust prompt UI. Worth its own issue if operators end up needing it — the env knob is the 80% solution.

## Test plan

- [x] 4 `validateConfig` tests covering the new field — valid range, < 1s rejected, > 10min rejected, non-number warned
- [x] 1 `mergeConfig` test — reads `CHROXY_MCP_TOOL_CALL_TIMEOUT_MS=90000` as number
- [x] 3 `byok-session` tests — forwards configured value to `fleet.callTool`, omitted opt passes `undefined` (fleet default), bad inputs (0/-1/NaN/Infinity/string) fall back to `undefined`
- [x] Full `packages/server/tests/config.test.js` passes (72/72)
- [x] Full `packages/server/tests/session-manager.test.js` passes (160/160)
- [x] `packages/server/tests/byok-session.test.js` — new tests pass (3/3); file hits the pre-existing 120s file-level timeout cap that's shared with `main` (this PR adds 3 fast unit tests, not slow integration tests)