### PR TITLE
feat(dashboard): read-only model badge for TUI sessions (#4464)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -335,10 +335,15 @@ export function App() {
       availableModelsProvider === activeProvider
     return {
       showModelPicker: caps?.modelSwitch !== false && modelsMatchProvider,
+      // #4464: render a non-interactive badge in the picker's slot when the
+      // active provider permanently lacks mid-session model switching (TUI).
+      // null on transient "models not matching provider" (provider just
+      // switched) so we don't flash a stale-label badge during reconnect.
+      readOnlyModel: caps?.modelSwitch === false ? activeModel : null,
       showPermissionMode: caps?.permissionModeSwitch !== false,
       showThinkingLevel: !!caps?.thinkingLevel,
     }
-  }, [sessions, activeSessionId, availableProviders, availableModelsProvider])
+  }, [sessions, activeSessionId, availableProviders, availableModelsProvider, activeModel])
 
   // Fire native notifications for permission requests when window is not focused
   const permissionPrompts = useMemo<PermissionPromptInfo[]>(() =>
@@ -1755,6 +1760,7 @@ export function App() {
             activeModel={activeModel}
             defaultModelId={defaultModelId}
             onModelChange={setModel}
+            readOnlyModel={dropdownFlags.readOnlyModel}
             availablePermissionModes={availablePermissionModes}
             permissionMode={permissionMode}
             onPermissionModeChange={setPermissionMode}

--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -207,6 +207,79 @@ describe('ChatSettingsDropdown', () => {
     })
   })
 
+  // #4464 — TUI provider declares `modelSwitch: false` because the claude
+  // TUI binary doesn't expose mid-session model switching. Today the
+  // dashboard hides the picker entirely by passing availableModels=[], so
+  // users running a long TUI session have no UI surface telling them which
+  // model is active. The fix is a non-interactive read-only badge that
+  // shows in the same slot when a read-only model label is passed AND the
+  // picker is hidden (availableModels is empty).
+  describe('read-only model badge (#4464)', () => {
+    it('renders a non-interactive badge when availableModels is empty and readOnlyModel is set', () => {
+      renderDropdown({ availableModels: [], readOnlyModel: 'opus' })
+      // No <select> for model — the picker remains hidden.
+      expect(screen.queryByTestId('chat-settings-trigger')).toBeNull()
+      // The badge IS rendered with a stable testid the Maestro flows can
+      // anchor on.
+      const badge = screen.getByTestId('active-model-badge')
+      expect(badge).toBeInTheDocument()
+      // Crucially NOT a <select> — must be a static span/div so screen
+      // readers + click handlers treat it as read-only.
+      expect(badge.tagName.toLowerCase()).not.toBe('select')
+    })
+
+    it('badge text surfaces the active model id', () => {
+      renderDropdown({ availableModels: [], readOnlyModel: 'opus' })
+      const badge = screen.getByTestId('active-model-badge')
+      expect(badge.textContent).toContain('opus')
+    })
+
+    it('badge falls back to "Default" when readOnlyModel is an empty string', () => {
+      // Per #4464 acceptance: "if `activeModel` is empty/unknown, fall back
+      // to 'default' (whatever ~/.claude/settings.json resolves to)
+      // rather than hiding entirely." Hiding leaves the user blind to which
+      // model the TUI is actually running.
+      renderDropdown({ availableModels: [], readOnlyModel: '' })
+      const badge = screen.getByTestId('active-model-badge')
+      expect(badge.textContent).toMatch(/default/i)
+    })
+
+    it('does NOT render the badge when the picker is shown (availableModels non-empty)', () => {
+      // The picker already displays the active model — a badge alongside
+      // would duplicate the surface.
+      renderDropdown({ availableModels: MODELS, activeModel: 'opus', readOnlyModel: 'opus' })
+      expect(screen.queryByTestId('active-model-badge')).toBeNull()
+      expect(screen.getByTestId('chat-settings-trigger')).toBeInTheDocument()
+    })
+
+    it('does NOT render the badge when readOnlyModel is null', () => {
+      // Transient state where availableModels is empty for some non-TUI
+      // reason (e.g. provider just switched, models not yet broadcast)
+      // — we don't want to flash a "Default" badge during that window.
+      renderDropdown({ availableModels: [], readOnlyModel: null })
+      expect(screen.queryByTestId('active-model-badge')).toBeNull()
+    })
+
+    it('badge surfaces buildActiveModelTooltip output via title and aria-label', () => {
+      // The badge MUST reuse the same tooltip helper as the picker so the
+      // hover text stays in sync (#4464 acceptance: "Hover tooltip matches
+      // existing model picker tooltip").
+      renderDropdown({
+        availableModels: [],
+        activeModel: 'opus',
+        readOnlyModel: 'opus',
+      })
+      const badge = screen.getByTestId('active-model-badge')
+      // When availableModels is empty (the TUI case), the helper still
+      // returns a meaningful "Active model: <id>" line — we don't have
+      // contextWindow metadata, but the headline survives.
+      expect(badge.getAttribute('title')).toMatch(/active model/i)
+      expect(badge.getAttribute('title')).toContain('opus')
+      // Screen reader parity with the picker.
+      expect(badge.getAttribute('aria-label')).toBe(badge.getAttribute('title'))
+    })
+  })
+
   // #4019 / #4211 Copilot review: the description from
   // availablePermissionModes flows onto the permission <select>'s title
   // attribute so the user gets the mid-session trade-off hint on hover.

--- a/packages/dashboard/src/components/ChatSettingsDropdown.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.tsx
@@ -42,6 +42,14 @@ export interface ChatSettingsDropdownProps {
   activeModel: string | null
   defaultModelId: string | null
   onModelChange: (id: string) => void
+  // #4464: render a non-interactive pill instead of the model <select>
+  // when the active provider doesn't expose a mid-session model switch
+  // (today: claude TUI — see claude-tui-session.js capability.modelSwitch=false).
+  // Passing a string here causes the badge to render in the picker's slot
+  // showing that id (or "Default" when empty). Null hides any model UI —
+  // same as today's "availableModels=[]" behaviour for the transient
+  // provider-switch case where we don't want a flash of a stale label.
+  readOnlyModel?: string | null
   // #4019: PermissionMode carries an optional `description` field server-side
   // (PERMISSION_MODES exports it for every mode). Use the typed import from
   // store-core so the title-attribute hint stays in lockstep with the wire shape.
@@ -74,6 +82,7 @@ export function ChatSettingsDropdown({
   showThinkingLevel,
   thinkingLevel,
   onThinkingLevelChange,
+  readOnlyModel = null,
 }: ChatSettingsDropdownProps) {
   const handleModelChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     const v = e.target.value
@@ -117,6 +126,23 @@ export function ChatSettingsDropdown({
               <option key={m.id} value={m.id}>{m.label}</option>
             ))}
         </select>
+      )}
+
+      {/* #4464: read-only badge for providers without modelSwitch (claude TUI).
+          Renders ONLY when the picker is hidden (availableModels empty) AND a
+          read-only label was explicitly passed — never on the transient
+          "models not yet broadcast" window where readOnlyModel stays null. */}
+      {availableModels.length === 0 && readOnlyModel !== null && (
+        <span
+          data-testid="active-model-badge"
+          data-kind="model-readonly"
+          className="chat-settings-readonly-badge"
+          title={modelTitle}
+          aria-label={modelTitle}
+          role="status"
+        >
+          {readOnlyModel || 'Default'}
+        </span>
       )}
 
       {/* Permission Mode */}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -153,6 +153,27 @@
   border-color: var(--accent-blue);
 }
 
+/* #4464: read-only model badge for TUI sessions (claude TUI declares
+   modelSwitch: false). Mirrors the model <select>'s size + chrome so the
+   pill sits cleanly in the same slot; the muted text/border + cursor:default
+   communicates "not interactive" — no click handlers, no focus ring. */
+.chat-settings-readonly-badge {
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border: 1px solid var(--scrollbar-thumb);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: var(--text-base);
+  cursor: default;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  min-width: 180px;
+  max-width: 240px;
+  display: inline-block;
+}
+
 /* (#3185 prompt-evaluator-toggle CSS removed — toggle moved from the
    header dropdown into SettingsPanel which uses .settings-field-checkbox
    for inline-checkbox layout.) */

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4160,6 +4160,15 @@
   .header-center select[data-kind="model"] { min-width: 120px; max-width: 160px; }
   .header-center select[data-kind="permission"] { min-width: 80px; max-width: 110px; }
   .header-center select[data-kind="thinking"] { min-width: 60px; max-width: 80px; }
+  /* #4464: match the model <select>'s narrow-viewport floors. Without
+     this rule the read-only badge keeps the 180–240px desktop floor and
+     overflows the header center column on phone widths. */
+  .header-center .chat-settings-readonly-badge {
+    min-width: 120px;
+    max-width: 160px;
+    font-size: var(--text-sm);
+    padding: 3px 6px;
+  }
   .header-center { gap: 4px; }
   .header-right { gap: 4px; }
   .status-bar { gap: 6px; padding: 4px 6px; }


### PR DESCRIPTION
## Summary

Closes #4464 — adds a non-interactive model badge for sessions whose provider declares `modelSwitch: false` (today: claude TUI). Replaces the current "hide the picker entirely" behaviour with a read-only pill in the same header slot, so users running long TUI sessions can see which model the session is actually on.

The motivation in the issue body holds: for context-window-sensitive work (especially with the v0.9.12 learn-loop ratchets), a user can't tell whether their TUI session is on Opus or Sonnet without leaving chroxy. The badge fixes that.

## Changes

- **`packages/dashboard/src/components/ChatSettingsDropdown.tsx`**: New optional `readOnlyModel?: string | null` prop. When `availableModels.length === 0` AND `readOnlyModel !== null`, renders a `<span role="status" data-testid="active-model-badge">` showing the model id (or `"Default"` when empty). NOT a `<select>` — no click handler, no focus ring. Reuses the existing `buildActiveModelTooltip` helper so the hover/aria-label text matches the picker's tooltip elsewhere in the UI.
- **`packages/dashboard/src/App.tsx`**: Computes `readOnlyModel: caps?.modelSwitch === false ? activeModel : null` alongside the existing `showModelPicker` flag. Stays `null` during the transient "provider just switched, models not yet broadcast" window so we don't flash a stale-label badge during reconnect.
- **`packages/dashboard/src/theme/components.css`**: New `.chat-settings-readonly-badge` rule. Mirrors the model `<select>`'s dimensions and chrome (border, radius, padding, width clamp) but uses `var(--text-secondary)` + `cursor: default` so the read-only nature is obvious at a glance.

## Test plan

- [x] 6 new tests in `ChatSettingsDropdown.test.tsx` — badge renders, badge text, "Default" fallback, picker takes precedence, null hides, tooltip parity
- [x] All 31 tests in the file pass (25 pre-existing + 6 new)
- [x] `tsc --noEmit` clean
- [ ] Manual smoke (will verify against the dashboard once the marathon finishes): start a TUI session, confirm the badge appears in the header where the picker used to be hidden

## Out of scope

- The matching mobile-app surface in `packages/app` — the issue acceptance specifies the dashboard, and the mobile app's session header doesn't currently render a model picker at all. Can follow up if/when the mobile header gets a model surface.