### PR TITLE
fix(dashboard): tab switch resets all activity timers (#4466)

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3290,5 +3290,48 @@ describe('dashboard message-handler dispatch', () => {
       const ss = (store.getState() as any).sessionStates.s1
       expect(ss.inactivityWarning).toBeNull()
     })
+
+    // Regression for the agent-review critical finding (#4491): `result`
+    // events are recorded in the per-session history ring buffer
+    // (session-message-history.js) and replayed via PROXIED_EVENTS
+    // (session-manager.js). The `case 'result'` handler also clears
+    // activeTools — without a replay gate on THAT clear, every tab switch
+    // on a session with at least one completed prior turn fires a replayed
+    // result mid-replay, wiping the activeTools that history_replay_start
+    // had intentionally preserved. Tested explicitly: a replayed result
+    // must NOT touch activeTools, but a live result still must (#4308
+    // turn-boundary sweep stays intact for the legitimate "missed
+    // tool_result" case after a server crash / dropped broadcast).
+    it('replayed result events do NOT clear activeTools (regression #4491)', () => {
+      const startedAt = 100
+      const inFlightTool = { toolUseId: 'tu-1', tool: 'Bash', input: { command: 'sleep' }, startedAt }
+      seedSession({ activeTools: [inFlightTool] })
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      // result fires during the replay window — pre-fix this wiped activeTools.
+      handleMessage(
+        { type: 'result', sessionId: 's1', usage: {}, cost: 0, duration: 0 },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.activeTools).toHaveLength(1)
+      expect(ss.activeTools[0].toolUseId).toBe('tu-1')
+      expect(ss.activeTools[0].startedAt).toBe(startedAt)
+    })
+
+    it('live result events still clear activeTools (#4308 turn-boundary sweep preserved)', () => {
+      // After history_replay_end clears the flag, a live result must still
+      // sweep stale in-flight tools — that was the original #4308 behaviour
+      // for missed tool_results from server crashes / dropped broadcasts.
+      const inFlightTool = { toolUseId: 'tu-1', tool: 'Bash', input: { command: 'sleep' }, startedAt: 100 }
+      seedSession({ activeTools: [inFlightTool] })
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        { type: 'result', sessionId: 's1', usage: {}, cost: 0, duration: 0 },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.activeTools).toEqual([])
+    })
   })
 })

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3182,4 +3182,113 @@ describe('dashboard message-handler dispatch', () => {
       expect((store.getState() as any).sessionStates.s1.inactivityWarning).toBeNull()
     })
   })
+
+  // #4466: switching tabs sends `switch_session`, which causes the server to
+  // dispatch history_replay_start → all past events → history_replay_end.
+  // Pre-fix, the dashboard's pre-handler logic ran the lastClientActivityAt
+  // bump (#3758) and inactivityWarning dismiss (#3899) for EVERY replayed
+  // event, plus the activeTools rebuild restarted the in-flight tool clock.
+  // Visible symptoms: "Working… last activity Ns ago" reset to 1s, "Agent
+  // quiet for Nm Ns" disappeared entirely, and the green "Running <tool> ·
+  // Ns" pill restarted at 1s. The fix gates all three on the existing
+  // `_receivingHistoryReplay` flag.
+  describe('history replay must not reset activity timers (#4466)', () => {
+    function seedSession(extra: Partial<ReturnType<typeof createEmptySessionState>> = {}) {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), ...extra } },
+      }))
+      setStore(store)
+    }
+
+    it('does not bump lastClientActivityAt for replayed activity events', () => {
+      seedSession({ lastClientActivityAt: 100 })
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      // tool_start is in ACTIVITY_EVENT_TYPES — pre-fix this bumped to Date.now().
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          input: { command: 'ls' },
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      // The pre-seeded "stale" 100ms timestamp must survive — replay is NOT
+      // fresh activity. Without this guard, every tab switch resets the
+      // "last activity Ns ago" pill to "1s ago" no matter how long the
+      // session has actually been idle.
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.lastClientActivityAt).toBe(100)
+    })
+
+    it('does not dismiss inactivityWarning for replayed activity events', () => {
+      // "Agent quiet for 46m 32s · Status update?" chip is mid-display when
+      // the user clicks back to this tab. Pre-fix, the first replayed
+      // tool_start / message / result wiped it (because the activity-bump
+      // path also clears inactivityWarning). User loses the chip and has
+      // no idea anything is waiting on them.
+      const warning = { idleMs: 2_792_000, prefab: 'Status update?', receivedAt: 200 }
+      seedSession({ inactivityWarning: warning })
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        { type: 'result', sessionId: 's1', usage: {}, cost: 0, duration: 0 },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.inactivityWarning).toEqual(warning)
+    })
+
+    it('preserves activeTools across history_replay_start (no clock reset)', () => {
+      // Pre-fix: history_replay_start cleared activeTools, then the replayed
+      // tool_start rebuilt the entry with startedAt = Date.now(). The "Running
+      // <tool> · Ns" pill restarted at 1s. Preserving the in-flight set
+      // through the replay boundary keeps the elapsed clock intact — the
+      // tool_result events that follow will still correctly drop resolved
+      // entries.
+      const startedAt = 100
+      const inFlightTool = { toolUseId: 'tu-1', tool: 'Bash', input: { command: 'sleep 999' }, startedAt }
+      seedSession({ activeTools: [inFlightTool] })
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.activeTools).toHaveLength(1)
+      expect(ss.activeTools[0].toolUseId).toBe('tu-1')
+      // Specifically the original startedAt must be preserved — that's what
+      // drives the elapsed-time display.
+      expect(ss.activeTools[0].startedAt).toBe(startedAt)
+    })
+
+    it('live activity AFTER history_replay_end still bumps lastClientActivityAt', () => {
+      // Regression guard: the replay flag is cleared on history_replay_end,
+      // so the next genuine live event must resume bumping the timestamp —
+      // otherwise the gate would freeze activity tracking forever after the
+      // first replay.
+      seedSession({ lastClientActivityAt: 100 })
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      // Live activity event after replay closes — must bump.
+      handleMessage(
+        { type: 'tool_start', messageId: 't', tool: 'Bash', toolUseId: 'tu-2', sessionId: 's1' },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.lastClientActivityAt).toBeGreaterThan(100)
+    })
+
+    it('live activity AFTER history_replay_end still dismisses inactivityWarning', () => {
+      const warning = { idleMs: 2_792_000, prefab: 'Status update?', receivedAt: 200 }
+      seedSession({ inactivityWarning: warning })
+      handleMessage({ type: 'history_replay_start', sessionId: 's1' }, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      handleMessage(
+        { type: 'result', sessionId: 's1', usage: {}, cost: 0, duration: 0 },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.inactivityWarning).toBeNull()
+    })
+  })
 })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2456,11 +2456,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // activeTools are a missed tool_result (server crash, dropped
           // broadcast) and must be dropped so the activity indicator can't
           // get stuck on a phantom "Running X". Mirror in agent_idle.
+          //
+          // #4466 — but ONLY for live result events. `result` events are
+          // recorded in the server's per-session history ring buffer
+          // (session-message-history.js) and replayed on switch_session via
+          // PROXIED_EVENTS (session-manager.js). Without this gate, every
+          // tab switch on a session that's completed at least one prior
+          // turn fires a replayed `result` that wipes the activeTools the
+          // history_replay_start guard is trying to preserve — the
+          // replayed in-flight tool_start then re-adds the entry with a
+          // fresh Date.now() startedAt, restoring the exact "Running X · 1s"
+          // clock-reset symptom #4466 set out to fix.
           const patch: Partial<SessionState> = {
             ...resultPatch,
             messages: [...ss.messages],
           };
-          if (ss.activeTools.length > 0) patch.activeTools = [];
+          if (ss.activeTools.length > 0 && !_receivingHistoryReplay) patch.activeTools = [];
           return patch;
         });
       } else {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1867,7 +1867,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   // #3899 — any activity event also dismisses an outstanding inactivity
   // warning: by definition the silence has ended, so the chip should
   // disappear without waiting for the user to dismiss it manually.
-  if (isActivityEvent(msg.type)) {
+  //
+  // #4466 — gate on `!_receivingHistoryReplay`. switch_session on the
+  // server replays every past event in the target session through this
+  // handler, and a replayed tool_start / message / result is NOT fresh
+  // activity. Without this gate the act of switching tabs:
+  //   1) bumps lastClientActivityAt to Date.now(), so "Working… last
+  //      activity Ns ago" resets to 1s no matter how idle the session was;
+  //   2) wipes inactivityWarning, so the "Agent quiet for 46m 32s · Status
+  //      update?" chip disappears without the user ever seeing it again.
+  // The live activity events that arrive AFTER history_replay_end clears
+  // the flag still bump correctly — verified by the regression-guard tests
+  // in message-handler.test.ts.
+  if (isActivityEvent(msg.type) && !_receivingHistoryReplay) {
     const targetId = (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
     if (targetId && get().sessionStates[targetId]) {
       updateSession(targetId, (ss) => {
@@ -2294,10 +2306,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       updateActiveSession((ss) => {
         const patch: Partial<SessionState> = {};
         if (ss.activeAgents.length > 0) patch.activeAgents = [];
-        // #4308 — same rationale: in-flight tools never survive a replay
-        // boundary; the live tool_start broadcasts that follow rebuild
-        // activeTools as needed.
-        if (ss.activeTools.length > 0) patch.activeTools = [];
+        // #4466: preserve activeTools through the replay boundary. The
+        // earlier #4308 wipe rebuilt entries from replayed tool_start
+        // events with startedAt = Date.now(), so the "Running <tool> · Ns"
+        // pill restarted at 1s every time the user switched tabs. The
+        // in-flight set is authoritative (carried in-memory, not derivable
+        // from history), so keeping it intact preserves the elapsed-time
+        // clock. tool_result events that fire during replay still
+        // correctly drop resolved entries via sharedToolResult, and the
+        // dedup logic in sharedToolStart prevents replayed tool_start
+        // events from re-adding tools already in activeTools.
         if (ss.isPlanPending) {
           patch.isPlanPending = false;
           patch.planAllowedPrompts = [];


### PR DESCRIPTION
## Summary

Closes #4466. Switching tabs sends `switch_session` to the server, which replays every past event in the target session through `history_replay_start → events → history_replay_end`. The dashboard's pre-handler activity-bump logic (#3758, #3899) and the in-flight tool rebuild (#4308) didn't consult `_receivingHistoryReplay`, so the act of switching tabs:

- Reset `lastClientActivityAt` to `Date.now()` (Working… last activity 1s ago, no matter how idle)
- Wiped any outstanding `inactivityWarning` (the "Agent quiet for 46m 32s · Status update?" chip vanished)
- Restarted the "Running <tool> · Ns" elapsed clock at 1s (activeTools cleared, then rebuilt by replayed tool_start with now-on-rebuild `startedAt`)

## Changes

- **`packages/dashboard/src/store/message-handler.ts`**:
  - Pre-handler activity bump now gates on `!_receivingHistoryReplay`. Same gate covers the `inactivityWarning` dismiss (they share the block).
  - `history_replay_start` no longer clears `activeTools`. The in-flight set is authoritative (carried in-memory, not derivable from history), so preserving it through the replay boundary keeps the elapsed-time clock intact. `tool_result` events during replay still drop resolved entries via `sharedToolResult`; `sharedToolStart`'s dedup prevents replayed `tool_start` from re-adding tools already in `activeTools`.

## Why not also drop the `|| activeSessionId` fallback

The issue mentions as a **Bonus** dropping the `targetId = msg.sessionId || activeSessionId` fallback at the bump site, on the theory that activity events without a `sessionId` are bugs. That's a separate behavior change — handlers elsewhere may rely on the fallback for synthetic events — and isn't listed in the issue's acceptance criteria. Deferred to a follow-up if the assumption turns out true.

## Test plan

- [x] 5 new tests in `message-handler.test.ts` under `history replay must not reset activity timers (#4466)`:
  - replay event doesn't bump `lastClientActivityAt` (asserts the pre-seeded `100` survives)
  - replay event doesn't dismiss `inactivityWarning` (asserts the warning object survives intact)
  - `activeTools` preserved across `history_replay_start` (asserts both length AND the exact original `startedAt`)
  - regression: live activity AFTER `history_replay_end` still bumps `lastClientActivityAt`
  - regression: live activity AFTER `history_replay_end` still dismisses `inactivityWarning`
- [x] Full `message-handler.test.ts` passes (142/142)
- [x] `tsc --noEmit` clean