### PR TITLE
feat(dashboard,store-core): Stream stalled chip with retry (#4476)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -45,6 +45,7 @@ import { ToolBubble } from './components/ToolBubble'
 import { ToolGroup } from './components/ToolGroup'
 import { PastedTextModal } from './components/PastedTextModal'
 import { EvaluatorRewriteBanner, EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
+import { StreamStallChip } from './components/StreamStallChip'
 import { PlanApproval } from './components/PlanApproval'
 import { ReconnectBanner } from './components/ReconnectBanner'
 import { StdinDisabledBanner } from './components/StdinDisabledBanner'
@@ -121,6 +122,10 @@ function toChatViewMessage(msg: ChatMessage): ChatViewMessage {
     type: msg.type === 'prompt' ? 'response' : msg.type,
     content: msg.content,
     timestamp: msg.timestamp,
+    // #4476: propagate the structured error code so the chat-view
+    // renderMessage path can switch error bubbles into the
+    // StreamStallChip variant.
+    ...(msg.code ? { code: msg.code } : {}),
   }
 }
 
@@ -1525,9 +1530,30 @@ export function App() {
       return <EvaluatorRewriteBanner meta={storeMsg.evaluator} />
     }
 
+    // #4476: distinct chip for stream-stall errors (server PR #4475 emits
+    // `error{code: 'stream_stall'}` after the configured inactivity window).
+    // Generic red bubble reads as "broken"; this affordance signals
+    // "recoverable, just retry" and offers a one-tap resend of the last
+    // user message. Only render the retry button when the stall is the
+    // most recent bubble (chatTailMessageId) — replayed historical stalls
+    // surface the chip text + tooltip for diagnostics, but resending an
+    // ancient user_input from a long-finished turn would be misleading.
+    if (storeMsg.type === 'error' && storeMsg.code === 'stream_stall') {
+      const isTail = msg.id === chatTailMessageId
+      const lastUserInput = isTail
+        ? [...storeMessages].reverse().find(m => m.type === 'user_input')
+        : undefined
+      return (
+        <StreamStallChip
+          errorText={storeMsg.content}
+          onRetry={lastUserInput ? () => sendInput(lastUserInput.content) : undefined}
+        />
+      )
+    }
+
     // Default rendering
     return null
-  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered])
+  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput])
 
   // #4412: registry-driven cheat sheet. Recomputed on every render —
   // not memoised, by design. The shortcut registry hook re-renders

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -90,6 +90,13 @@ export interface ChatViewMessage {
   content: string
   timestamp: number
   isStreaming?: boolean
+  /**
+   * #4476: structured error code mirrored from the store ChatMessage.
+   * Renderers may switch on this to surface a distinct variant for known
+   * error categories (e.g. `'stream_stall'` → chip + retry). Undefined
+   * for legacy errors without a structured code.
+   */
+  code?: string
 }
 
 export interface ChatViewProps {

--- a/packages/dashboard/src/components/StreamStallChip.test.tsx
+++ b/packages/dashboard/src/components/StreamStallChip.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * StreamStallChip tests — #4476
+ *
+ * Asserts the distinct affordance (chip, not generic red bubble) renders,
+ * the retry button surfaces and fires onRetry, the raw error text is
+ * preserved via the title attribute for diagnostics, and the retry button
+ * stays hidden when onRetry is omitted (historical / replayed entries).
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { StreamStallChip } from './StreamStallChip'
+
+afterEach(cleanup)
+
+describe('StreamStallChip (#4476)', () => {
+  it('renders the chip text', () => {
+    render(<StreamStallChip errorText="Stream stalled — no response for 5 minutes" />)
+    const chip = screen.getByTestId('stream-stall-chip')
+    expect(chip).toBeInTheDocument()
+    expect(chip.textContent).toMatch(/Stream stalled/i)
+    expect(chip.textContent).toMatch(/retry/i)
+  })
+
+  it('preserves the raw server error text via the title attribute', () => {
+    // Operators investigating a stall pattern need the underlying server
+    // message — the chip's prose is friendly, but the diagnostic detail
+    // must remain accessible without losing it.
+    const raw = 'Stream stalled — no response for 5 minutes (provider=claude-sdk session=abc)'
+    render(<StreamStallChip errorText={raw} />)
+    const chip = screen.getByTestId('stream-stall-chip')
+    expect(chip.getAttribute('title')).toBe(raw)
+  })
+
+  it('shows a Retry button when onRetry is provided', () => {
+    const onRetry = vi.fn()
+    render(<StreamStallChip errorText="x" onRetry={onRetry} />)
+    expect(screen.getByTestId('stream-stall-chip-retry')).toBeInTheDocument()
+  })
+
+  it('hides the Retry button when onRetry is omitted', () => {
+    // For historical/replayed entries the original user input is no longer
+    // the obvious target to resend — render the chip without the button
+    // rather than wire it to a misleading action.
+    render(<StreamStallChip errorText="x" />)
+    expect(screen.queryByTestId('stream-stall-chip-retry')).toBeNull()
+  })
+
+  it('invokes onRetry when the Retry button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<StreamStallChip errorText="x" onRetry={onRetry} />)
+    fireEvent.click(screen.getByTestId('stream-stall-chip-retry'))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses role="status" so assistive tech announces the stall', () => {
+    // The chip's purpose is to make a recoverable failure visible — give
+    // screen readers a live-region announcement so users not watching the
+    // chat aren't stuck guessing why the assistant went silent.
+    render(<StreamStallChip errorText="x" />)
+    const chip = screen.getByTestId('stream-stall-chip')
+    expect(chip.getAttribute('role')).toBe('status')
+  })
+})

--- a/packages/dashboard/src/components/StreamStallChip.tsx
+++ b/packages/dashboard/src/components/StreamStallChip.tsx
@@ -1,0 +1,54 @@
+/**
+ * StreamStallChip — #4476
+ *
+ * Replaces the generic red error bubble when the server emits
+ * `error{code: 'stream_stall'}` (server PR #4475). Signals "recoverable,
+ * just retry" rather than "something is broken" via a distinct chip
+ * affordance, and provides a one-tap retry button that re-sends the last
+ * user message.
+ *
+ * The full error text remains accessible via the title attribute so
+ * diagnostics aren't lost — operators investigating a stall pattern can
+ * hover for the underlying server message.
+ */
+import { useCallback } from 'react'
+
+export interface StreamStallChipProps {
+  /** The raw error text from the server (e.g. "Stream stalled — no response for 5 minutes"). */
+  errorText: string
+  /**
+   * Invoked when the user taps Retry. Caller is responsible for resending
+   * the last user message — the chip itself doesn't know which message to
+   * resend. Setting this to undefined hides the retry button (e.g. for
+   * historical entries replayed from session_messages where the original
+   * user input is no longer the obvious target).
+   */
+  onRetry?: () => void
+}
+
+export function StreamStallChip({ errorText, onRetry }: StreamStallChipProps) {
+  const handleClick = useCallback(() => {
+    onRetry?.()
+  }, [onRetry])
+
+  return (
+    <div
+      className="stream-stall-chip"
+      data-testid="stream-stall-chip"
+      role="status"
+      title={errorText}
+    >
+      <span className="stream-stall-chip-text">Stream stalled — retry?</span>
+      {onRetry && (
+        <button
+          type="button"
+          className="stream-stall-chip-retry"
+          data-testid="stream-stall-chip-retry"
+          onClick={handleClick}
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1600,18 +1600,21 @@
 
 /* #4476: stream-stall chip — replaces the generic red error bubble for
    recoverable stalls (server PR #4475 error{code: 'stream_stall'}).
-   Yellow/amber palette communicates "recoverable" vs the red "broken"
-   bubble; inline Retry button surfaces the most common follow-up so the
-   user doesn't have to retype their last message. */
+   Amber palette communicates "recoverable" vs the red "broken" bubble;
+   inline Retry button surfaces the most common follow-up so the user
+   doesn't have to retype their last message. Uses --warning-fg /
+   --warning-bg-subtle (the canonical chroxy warning surface, theme.css
+   line ~99) so the chip themes correctly across light/dark mode and
+   doesn't introduce a new ad-hoc palette. */
 .stream-stall-chip {
   display: inline-flex;
   align-items: center;
   gap: 12px;
   padding: 6px 12px;
   border-radius: 16px;
-  background: var(--accent-yellow-subtle, rgba(250, 204, 21, 0.12));
-  color: var(--accent-yellow, #facc15);
-  border: 1px solid var(--accent-yellow, #facc15);
+  background: var(--warning-bg-subtle);
+  color: var(--warning-fg);
+  border: 1px solid var(--warning-fg);
   align-self: center;
   font-size: var(--text-base);
 }
@@ -1629,7 +1632,7 @@
 }
 .stream-stall-chip-retry:hover,
 .stream-stall-chip-retry:focus {
-  background: var(--accent-yellow, #facc15);
+  background: var(--warning-fg);
   color: var(--bg-primary);
   outline: none;
 }

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1598,6 +1598,42 @@
   font-size: var(--text-base);
 }
 
+/* #4476: stream-stall chip — replaces the generic red error bubble for
+   recoverable stalls (server PR #4475 error{code: 'stream_stall'}).
+   Yellow/amber palette communicates "recoverable" vs the red "broken"
+   bubble; inline Retry button surfaces the most common follow-up so the
+   user doesn't have to retype their last message. */
+.stream-stall-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  border-radius: 16px;
+  background: var(--accent-yellow-subtle, rgba(250, 204, 21, 0.12));
+  color: var(--accent-yellow, #facc15);
+  border: 1px solid var(--accent-yellow, #facc15);
+  align-self: center;
+  font-size: var(--text-base);
+}
+.stream-stall-chip-text {
+  white-space: nowrap;
+}
+.stream-stall-chip-retry {
+  background: transparent;
+  border: 1px solid currentColor;
+  color: inherit;
+  border-radius: 12px;
+  padding: 2px 10px;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+.stream-stall-chip-retry:hover,
+.stream-stall-chip-retry:focus {
+  background: var(--accent-yellow, #facc15);
+  color: var(--bg-primary);
+  outline: none;
+}
+
 .msg.thinking {
   background: transparent;
   align-self: flex-start;

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -4784,6 +4784,75 @@ describe('handleMessage', () => {
     }
   })
 
+  // #4476: server PR #4475 emits `error{code: 'stream_stall'}` when the CLI
+  // child has been silent for the configured stall window (default 5min).
+  // The discriminator field flows through event-normalizer.js (#4467) and
+  // lands here as a top-level `message` with `messageType: 'error'` and a
+  // populated `code`. The dashboard chip needs that `code` on the
+  // ChatMessage so it can render the distinct 'Stream stalled — retry?'
+  // affordance instead of the generic red error bubble.
+  it('preserves the structured error code on the ChatMessage (#4476)', () => {
+    const out = handleMessage(
+      {
+        messageType: 'error',
+        content: 'Stream stalled — no response for 5 minutes',
+        code: 'stream_stall',
+        timestamp: 100,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(true)
+    if (out.shouldDispatch) {
+      expect(out.chatMessage.type).toBe('error')
+      expect(out.chatMessage.code).toBe('stream_stall')
+    }
+  })
+
+  it('leaves chatMessage.code undefined when the wire message omits code', () => {
+    // Existing generic errors (no structured code) must continue to render
+    // as the plain red bubble — the chip variant only kicks in when the
+    // server explicitly tags the error.
+    const out = handleMessage(
+      {
+        messageType: 'error',
+        content: 'something exploded',
+        timestamp: 100,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(true)
+    if (out.shouldDispatch) {
+      expect(out.chatMessage.code).toBeUndefined()
+    }
+  })
+
+  it('coerces a non-string code to undefined rather than passing junk through', () => {
+    // Defense in depth — the protocol schema already constrains `code` to
+    // a string at the wire boundary, but the runtime type of `msg` is
+    // `Record<string, unknown>` and a malformed payload could land here
+    // with `code: 42`. Drop it instead of storing the wrong type on
+    // ChatMessage.
+    const out = handleMessage(
+      {
+        messageType: 'error',
+        content: 'something exploded',
+        code: 42,
+        timestamp: 100,
+      },
+      'sess-active',
+      false,
+      [],
+    )
+    expect(out.shouldDispatch).toBe(true)
+    if (out.shouldDispatch) {
+      expect(out.chatMessage.code).toBeUndefined()
+    }
+  })
+
   it('skips user_input outside replay (live echo handled elsewhere)', () => {
     const out = handleMessage(
       { messageType: 'user_input', content: 'hi', timestamp: 1 },

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3276,6 +3276,12 @@ export function handleMessage(
     tool: typeof msg.tool === 'string' ? msg.tool : undefined,
     options: msg.options as ChatMessage['options'],
     timestamp: msg.timestamp,
+    // #4476: preserve the structured error code so renderers can switch
+    // on it (e.g. `stream_stall` → chip + retry, default → generic
+    // bubble). Only forwarded when typed string; non-string `msg.code`
+    // (defensive against malformed payloads) is dropped to keep junk off
+    // the store.
+    ...(typeof msg.code === 'string' ? { code: msg.code } : {}),
   }
 
   // Surface rate-limit / usage-limit / quota / overloaded errors prominently (#616).

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -52,6 +52,15 @@ export interface ChatMessage {
   toolUseId?: string;
   toolResult?: string;
   toolResultTruncated?: boolean;
+  /**
+   * #4476: structured error code for `type: 'error'` bubbles. Mirrors the
+   * `code` field on `ServerMessageSchema` — populated when the server tags
+   * an error with a known machine-readable identifier (e.g. `'stream_stall'`
+   * from #4475). Renderers can switch on this to surface a distinct
+   * affordance (chip + retry button) instead of the generic red bubble.
+   * Undefined for legacy errors that carry no code.
+   */
+  code?: string;
   /** Base64 images from tool results (e.g. computer use screenshots) */
   toolResultImages?: ToolResultImage[];
   /**


### PR DESCRIPTION
## Summary

Closes #4476. Server PR #4475 emits `error{code: 'stream_stall'}` after the configured inactivity window. Pre-fix the dashboard rendered this as the generic red error bubble — reading as "broken" rather than the actual "recoverable, just retry" semantic. This adds a distinct yellow/amber chip with a one-tap Retry button.

## What's in this PR

- **Wire → ChatMessage code propagation** (store-core)
  - `ChatMessage` type gains optional `code?: string`
  - `handleMessage` copies `msg.code` when string-typed, dropping non-string defensively
- **Chip component** (`packages/dashboard/src/components/StreamStallChip.tsx`)
  - "Stream stalled — retry?" headline + Retry button + raw error text in `title`
  - `role="status"` so AT users get a live-region announcement
  - Retry button suppressed when `onRetry` is omitted (used for historical/replayed entries)
- **App.tsx wiring**
  - `renderMessage` adds a `code === 'stream_stall'` case
  - `onRetry` resends the most recent user_input — but ONLY when the chip is the tail message (chatTailMessageId)
  - Historical stalls render the chip text + tooltip for diagnostics, without a retry button
- **CSS** (`packages/dashboard/src/theme/components.css`)
  - Yellow/amber palette to distinguish from the red `.msg.error` bubble
  - Inline chip layout with rounded Retry button

## Why retry-on-tail-only

Resending an ancient user_input from a long-finished turn would be misleading. The chip text + diagnostic tooltip still surface on historical stalls; just the retry action is hidden.

## Test plan

- [x] 3 new `handleMessage` tests in store-core — `code` propagated, `code` undefined when absent, non-string `code` dropped
- [x] 6 new tests for `StreamStallChip` — text, tooltip, retry button visibility (with/without onRetry), click invokes onRetry, role="status"
- [x] Full `packages/store-core` suite passes (868/868)
- [x] Full `packages/dashboard` suite passes (2217/2217)
- [x] `tsc --noEmit` clean

## Out of scope (deferred)

- **Mobile app rendering** — the wire field flows to `packages/app` via the same `code` propagation in store-core. Adopting the chip pattern there is a follow-up — the issue acceptance prioritised dashboard.
- **`streamStallTimeoutMs` consumer** — PR #4483 (#4477) lands the value on `auth_ok`. The chip currently shows the generic "Stream stalled — retry?" text; humanised "no response for ${humanize(streamStallTimeoutMs)}" copy that consumes the auth_ok field can land once both PRs are merged.