### PR TITLE
fix(dashboard): clear TUI AskUserQuestion footer pill on user answer (#4465)

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1333,13 +1333,40 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // didn't carry a tool pairing) so the server stays authoritative for
     // any in-flight tools.
     if (activeSessionId && sessionStates[activeSessionId]) {
-      updateActiveSession((ss) => ({
-        isIdle: false,
-        lastClientActivityAt: Date.now(),
-        ...(toolUseId
-          ? { activeTools: ss.activeTools.filter(t => t.toolUseId !== toolUseId) }
-          : {}),
-      }));
+      updateActiveSession((ss) => {
+        const patch: Partial<typeof ss> = {
+          isIdle: false,
+          lastClientActivityAt: Date.now(),
+        };
+        if (toolUseId) {
+          patch.activeTools = ss.activeTools.filter(t => t.toolUseId !== toolUseId);
+          // #4499: also patch the matching `tool_use` ChatMessage in
+          // messages[] so the messages-walk fallback
+          // (ActivityIndicator.findInFlightToolUse) stops surfacing the
+          // unresolved AskUserQuestion the moment activeTools is empty.
+          // Without this patch the walk picks it back up (toolResult is
+          // undefined because PostToolUse never fired in the TUI case) and
+          // the "Running AskUserQuestion · Ns" pill re-appears via the
+          // fallback path immediately after the activeTools clear.
+          //
+          // Sentinel `'(resolved by user)'` mirrors the answered-bubble
+          // semantic and is not interpreted as content by any renderer —
+          // only the existence-check in findInFlightToolUse matters.
+          // sharedToolResult will OVERWRITE this if the server eventually
+          // does emit tool_result for the same toolUseId; we never lose
+          // server data, only fill in the gap.
+          let patched = false;
+          const nextMessages = ss.messages.map(m => {
+            if (m.id === toolUseId && m.type === 'tool_use' && m.toolResult === undefined) {
+              patched = true;
+              return { ...m, toolResult: '(resolved by user)' };
+            }
+            return m;
+          });
+          if (patched) patch.messages = nextMessages;
+        }
+        return patch;
+      });
     }
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, payload);

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1319,10 +1319,26 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // server-emitted stream/tool event, making the answer look dropped.
     // Once a server event arrives, the bump is a no-op (server is
     // authoritative); the timestamp is overwritten in dispatch-activity.
+    //
+    // #4465: also drop the matching activeTools entry. In TUI sessions,
+    // claude TUI may not emit PostToolUse for some AskUserQuestion shapes
+    // (v0.9.12 empirical), so the server never sends tool_result and the
+    // dashboard's footer pill ticks `Running AskUserQuestion · Nm Ns`
+    // indefinitely. Drop the entry optimistically when the user answers
+    // so the pill clears within ~1s of the answer landing. If the server
+    // does later emit tool_result for the same toolUseId, sharedToolResult
+    // is idempotent on missing entries — no double-clear, no re-append.
+    //
+    // Skipped when toolUseId is absent (free-text question prompts that
+    // didn't carry a tool pairing) so the server stays authoritative for
+    // any in-flight tools.
     if (activeSessionId && sessionStates[activeSessionId]) {
-      updateActiveSession(() => ({
+      updateActiveSession((ss) => ({
         isIdle: false,
         lastClientActivityAt: Date.now(),
+        ...(toolUseId
+          ? { activeTools: ss.activeTools.filter(t => t.toolUseId !== toolUseId) }
+          : {}),
       }));
     }
     if (socket && socket.readyState === WebSocket.OPEN) {

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1555,6 +1555,89 @@ describe('sendUserQuestionResponse clears in-flight tool slot (#4465)', () => {
     useConnectionStore.setState({ activeSessionId: null, sessionStates: {} });
   });
 
+  // Regression for agent-review critical finding (#4499): the
+  // ActivityIndicator messages-walk fallback re-surfaces the AskUserQuestion
+  // tool_use the moment activeTools empties. Optimistically clearing
+  // activeTools alone is insufficient — we must ALSO patch the tool_use
+  // ChatMessage in messages[] so findInFlightToolUse no longer treats it
+  // as in-flight.
+  it('patches the tool_use ChatMessage in messages[] so the walk fallback no longer surfaces it (#4499)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const { findInFlightToolUse } = await import('../components/ActivityIndicator');
+    const mockSocket = { readyState: 1, send: () => {} };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          activeTools: [
+            { toolUseId: 'tu-ask-walk', tool: 'AskUserQuestion', input: {}, startedAt: 100 },
+          ],
+          // tool_use ChatMessage pushed by handleToolStart — same id as the
+          // toolUseId per claude-tui-session.js:1115. toolResult undefined
+          // because PostToolUse never fired (the #4465 scenario).
+          messages: [
+            { id: 'tu-ask-walk', type: 'tool_use', tool: 'AskUserQuestion', content: '', timestamp: 100 },
+          ],
+        },
+      },
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    // Sanity: before the answer, the walk fallback finds the in-flight tool.
+    const before = findInFlightToolUse(
+      useConnectionStore.getState().sessionStates.s1!.messages,
+    );
+    expect(before).not.toBeNull();
+    expect(before!.tool).toBe('AskUserQuestion');
+
+    useConnectionStore.getState().sendUserQuestionResponse('A', 'tu-ask-walk');
+
+    const after = useConnectionStore.getState().sessionStates.s1!;
+    expect(after.activeTools).toEqual([]);
+    // The walk fallback no longer surfaces the AskUserQuestion because the
+    // tool_use now carries a synthetic toolResult.
+    const post = findInFlightToolUse(after.messages);
+    expect(post).toBeNull();
+
+    useConnectionStore.setState({ activeSessionId: null, sessionStates: {} });
+  });
+
+  it('leaves an already-resolved tool_use intact (no double-patch)', async () => {
+    // Defense: if the server's tool_result already landed for the AskUserQuestion
+    // and patched toolResult on the message, the answer-send must NOT overwrite
+    // the real result with our sentinel.
+    const { useConnectionStore } = await import('./connection');
+    const mockSocket = { readyState: 1, send: () => {} };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          activeTools: [],
+          messages: [
+            { id: 'tu-already-resolved', type: 'tool_use', tool: 'AskUserQuestion', content: '', toolResult: 'server answer', timestamp: 100 },
+          ],
+        },
+      },
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse('A', 'tu-already-resolved');
+
+    const ss = useConnectionStore.getState().sessionStates.s1!;
+    const m = ss.messages.find(x => x.id === 'tu-already-resolved');
+    expect(m?.toolResult).toBe('server answer');
+
+    useConnectionStore.setState({ activeSessionId: null, sessionStates: {} });
+  });
+
   it('a subsequent server-emitted tool_result for the same toolUseId is a no-op (idempotent)', async () => {
     // After the optimistic clear, if claude TUI does eventually emit
     // PostToolUse, the resulting tool_result hits sharedToolResult which

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1483,6 +1483,115 @@ describe('sendUserQuestionResponse optimistic activity bump (#4312)', () => {
   });
 });
 
+// #4465: when the user answers a TUI AskUserQuestion, claude TUI may or may
+// not emit PostToolUse for it (v0.9.12 — empirical: the prompt resolves but
+// the hook never fires for some question shapes). Without server-side
+// tool_result the dashboard's activeTools entry sits forever, so the footer
+// pill keeps ticking `Running AskUserQuestion · Nm Ns` indefinitely.
+//
+// Fix: when the user answers via the QuestionPrompt UI, optimistically drop
+// the matching activeTools entry. If the server later does fire tool_result,
+// sharedToolResult is idempotent on missing entries. If it doesn't (#4465's
+// stall case), the pill clears anyway.
+describe('sendUserQuestionResponse clears in-flight tool slot (#4465)', () => {
+  it('drops the matching activeTools entry when called with toolUseId', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const mockSocket = { readyState: 1, send: () => {} };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          activeTools: [
+            { toolUseId: 'tu-ask-1', tool: 'AskUserQuestion', input: {}, startedAt: 100 },
+            // Sibling in-flight tool that must NOT be cleared.
+            { toolUseId: 'tu-bash-1', tool: 'Bash', input: { command: 'ls' }, startedAt: 150 },
+          ],
+        },
+      },
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse('Option A', 'tu-ask-1');
+
+    const ss = useConnectionStore.getState().sessionStates.s1!;
+    expect(ss.activeTools.map(t => t.toolUseId)).toEqual(['tu-bash-1']);
+
+    useConnectionStore.setState({ activeSessionId: null, sessionStates: {} });
+  });
+
+  it('is a no-op on activeTools when called without toolUseId (free-text fallback)', async () => {
+    // Some legacy callsites send the answer without a toolUseId (free-text
+    // question prompts where the dashboard can't pair to a specific tool).
+    // Those must NOT clear any in-flight tool — the server stays
+    // authoritative.
+    const { useConnectionStore } = await import('./connection');
+    const mockSocket = { readyState: 1, send: () => {} };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          activeTools: [
+            { toolUseId: 'tu-ask-1', tool: 'AskUserQuestion', input: {}, startedAt: 100 },
+          ],
+        },
+      },
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse('A');
+
+    const ss = useConnectionStore.getState().sessionStates.s1!;
+    expect(ss.activeTools).toHaveLength(1)
+    expect(ss.activeTools[0]!.toolUseId).toBe('tu-ask-1')
+
+    useConnectionStore.setState({ activeSessionId: null, sessionStates: {} });
+  });
+
+  it('a subsequent server-emitted tool_result for the same toolUseId is a no-op (idempotent)', async () => {
+    // After the optimistic clear, if claude TUI does eventually emit
+    // PostToolUse, the resulting tool_result hits sharedToolResult which
+    // looks up by toolUseId and finds nothing — no double-clear, no
+    // re-append. Verifies the cross-PR contract isn't broken.
+    const { useConnectionStore } = await import('./connection');
+    const { handleMessage } = await import('./message-handler');
+
+    const mockSocket = { readyState: 1, send: () => {} };
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: {
+          ...createEmptySessionState(),
+          activeTools: [
+            { toolUseId: 'tu-ask-2', tool: 'AskUserQuestion', input: {}, startedAt: 100 },
+          ],
+        },
+      },
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse('B', 'tu-ask-2');
+    // Late tool_result arrives.
+    handleMessage(
+      { type: 'tool_result', toolUseId: 'tu-ask-2', result: 'B', sessionId: 's1' },
+      { url: 'wss://t' } as any,
+    );
+    const ss = useConnectionStore.getState().sessionStates.s1!;
+    expect(ss.activeTools).toEqual([]);
+
+    useConnectionStore.setState({ activeSessionId: null, sessionStates: {} });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // PTY dead code removal (#1759)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #4465 (the pill-never-clears half). In TUI sessions, claude TUI may not emit `PostToolUse` for some `AskUserQuestion` shapes (v0.9.12 empirical), so the server never sends `tool_result` for them. The dashboard's `activeTools[]` entry sits forever and the footer pill keeps ticking `Running AskUserQuestion · Nm Ns` indefinitely — long after the QuestionPrompt bubble has flipped to `(resolved) ✓`.

## Fix

`sendUserQuestionResponse` now optimistically drops the matching `activeTools` entry when a `toolUseId` is paired. The pill clears within ~1s of the answer landing, regardless of whether the server's `PostToolUse` round-trips.

```ts
updateActiveSession((ss) => ({
  isIdle: false,
  lastClientActivityAt: Date.now(),
  ...(toolUseId
    ? { activeTools: ss.activeTools.filter(t => t.toolUseId !== toolUseId) }
    : {}),
}));
```

**Idempotency:** if the server later does emit `tool_result` for the same `toolUseId`, `sharedToolResult` looks up by id and finds nothing — no double-clear, no re-append.

**Free-text safe:** skipped when `toolUseId` is absent (legacy question prompts without a tool pairing) so the server stays authoritative there.

## Out of scope (issue tail)

The issue body also describes the TUI **session-side stall** (no `PostToolUse` ever fires for some shapes, so claude TUI never resumes producing assistant turns). That's a separate problem — either a claude TUI binary issue or a chroxy-side PTY-write divergence — and probably needs its own investigation + follow-up. This PR fixes the dashboard symptom that anyone hitting that stall is staring at; the underlying TUI behavior question stays open.

## Test plan

- [x] 3 new tests in `store.test.ts` — drops matching entry while preserving sibling activeTools, no-op without toolUseId, late server tool_result stays idempotent
- [x] Full `store.test.ts` regression (109/109)
- [x] `tsc --noEmit` clean