### PR TITLE
chore(ci): fail CI on packages/protocol dist drift (#4485)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,14 @@ jobs:
       - name: Build @chroxy/protocol
         run: npm run build
 
+      - name: Check protocol dist is in sync with src
+        working-directory: .
+        run: |
+          git diff --exit-code packages/protocol/dist || {
+            echo "::error::packages/protocol/dist drift detected. Run 'npm run build -w packages/protocol' and commit the changes."
+            exit 1
+          }
+
       - name: Run tests
         run: npm test
 


### PR DESCRIPTION
## Summary

Adds a CI drift-check step to the `protocol-tests` job that fails when `packages/protocol/dist/` diverges from what `packages/protocol/src/` compiles to. Catches PRs that touch protocol src without regenerating dist (or vice versa) — the exact failure mode that surfaced as unrelated dist churn during PR #4483 review.

## Changes

- `.github/workflows/ci.yml`: add `Check protocol dist is in sync with src` step to `protocol-tests`, right after the existing `Build @chroxy/protocol` step. Uses `git diff --exit-code packages/protocol/dist` with a clear error message pointing at the fix command.

## Why Option B (not gitignore + prepare)

The issue offers two options. Chose B (CI drift check) over A (gitignore dist + build via `prepare`):

- Option A would remove tracked files from history — destructive, risks breaking downstream `dist/` consumers (server, app, dashboard, store-core all import from `@chroxy/protocol` which resolves to `dist/`).
- Option B is purely additive: one workflow step, no file deletions, no consumer impact.
- Aligns with the marathon "minimal scope, no over-engineering" convention.

## Test plan

- [x] Local build is clean on `main`: `npm run build -w packages/protocol && git diff packages/protocol/dist` produces no output.
- [x] Workflow YAML is structurally valid (job + step parsed correctly).
- [ ] CI green on this PR.
- [ ] Sanity-check the failure path on a follow-up PR that intentionally edits `src/` without rebuilding (optional — failure path is straightforward).

Closes #4485