### PR TITLE
fix(app): gate pre-handler activity bump on receivingHistoryReplay (#4492)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -3175,6 +3175,84 @@ describe('set_permission_mode CAPABILITY_NOT_SUPPORTED rejection', () => {
   });
 });
 
+// #4492: switching tabs sends `switch_session`, which causes the server to
+// dispatch history_replay_start → all past events → history_replay_end.
+// Pre-fix, the mobile pre-handler logic at message-handler.ts ran the
+// lastClientActivityAt bump (#3758) and inactivityWarning dismiss (#3899) for
+// EVERY replayed event. Visible symptoms mirror the dashboard's #4466:
+// "Working… last activity Ns ago" reset to 1s and the "Agent quiet for
+// Nm Ns" chip disappeared. The fix gates the pre-handler bump on the same
+// per-connection `_ctx.receivingHistoryReplay` flag used elsewhere in this
+// handler — mobile's equivalent of the dashboard's module-level
+// `_receivingHistoryReplay`.
+describe('history replay must not reset activity timers (#4492)', () => {
+  function seedSession(extra: Partial<ReturnType<typeof createEmptySessionState>> = {}) {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), ...extra } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    return store;
+  }
+
+  afterEach(() => {
+    resetReplayFlags();
+  });
+
+  it('does not bump lastClientActivityAt for replayed activity events', () => {
+    const store = seedSession({ lastClientActivityAt: 100 });
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
+    // tool_start is in ACTIVITY_EVENT_TYPES — pre-fix this bumped to Date.now().
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'tool-1',
+      tool: 'Bash',
+      toolUseId: 'tu-1',
+      input: { command: 'ls' },
+      sessionId: 's1',
+    });
+    // The pre-seeded "stale" 100ms timestamp must survive — replay is NOT
+    // fresh activity. Without this guard, every tab switch resets the
+    // "last activity Ns ago" pill to "1s ago" no matter how long the
+    // session has actually been idle.
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.lastClientActivityAt).toBe(100);
+  });
+
+  it('does not dismiss inactivityWarning for replayed activity events', () => {
+    // "Agent quiet for 46m 32s · Status update?" chip is mid-display when
+    // the user switches back to this session. Pre-fix, the first replayed
+    // tool_start / message / result wiped it (the activity-bump path also
+    // clears inactivityWarning). User loses the chip with no chance to act.
+    const warning = { idleMs: 2_792_000, prefab: 'Status update?', receivedAt: 200 };
+    const store = seedSession({ inactivityWarning: warning } as any);
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
+    _testMessageHandler.handle({
+      type: 'result', sessionId: 's1', usage: {}, cost: 0, duration: 0,
+    });
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.inactivityWarning).toEqual(warning);
+  });
+
+  it('live activity AFTER history_replay_end still bumps lastClientActivityAt', () => {
+    // Regression guard: the replay flag is cleared on history_replay_end,
+    // so the next genuine live event must resume bumping the timestamp —
+    // otherwise the gate would freeze activity tracking forever after the
+    // first replay.
+    const store = seedSession({ lastClientActivityAt: 100 });
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 's1' });
+    // Live activity event after replay closes — must bump.
+    _testMessageHandler.handle({
+      type: 'tool_start', messageId: 't', tool: 'Bash', toolUseId: 'tu-2', sessionId: 's1',
+    });
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.lastClientActivityAt).toBeGreaterThan(100);
+  });
+});
+
 // #3141: scoped routing for session-tagged server_error messages on the app
 // (dashboard parity).
 describe('server_error session-scoped routing (#3141)', () => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -912,7 +912,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   // by definition the silence has ended, so the chip should disappear
   // without waiting for the user to dismiss it manually. Mirrors the
   // equivalent clear in packages/dashboard/src/store/message-handler.ts.
-  if (isActivityEvent(msg.type)) {
+  //
+  // #4492 — gate on `!_ctx.receivingHistoryReplay` (mobile's per-connection
+  // equivalent of the dashboard's `_receivingHistoryReplay` module flag —
+  // see #4466 / PR #4490). switch_session and reconnect both replay past
+  // events through this handler via history_replay_start → events →
+  // history_replay_end, and replayed tool_start / message / result is NOT
+  // fresh activity. Without this gate, every reconnect or session switch:
+  //   1) bumps lastClientActivityAt to Date.now(), so "Working… last
+  //      activity Ns ago" resets to 1s no matter how idle the session was;
+  //   2) wipes inactivityWarning, so the "Agent quiet for 46m 32s · Status
+  //      update?" chip disappears without the user ever seeing it again.
+  // Live activity events arriving AFTER history_replay_end clears the flag
+  // still bump correctly — verified by the regression-guard test in
+  // message-handler.test.ts.
+  if (isActivityEvent(msg.type) && !_ctx.receivingHistoryReplay) {
     const targetId = (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
     if (targetId && get().sessionStates[targetId]) {
       updateSession(targetId, (ss) => {


### PR DESCRIPTION
## Summary
- Mirrors dashboard fix #4466 / PR #4490 to the mobile app: gates the pre-handler `lastClientActivityAt` bump (#3758) and `inactivityWarning` dismiss (#3899) on `!_ctx.receivingHistoryReplay` so replayed events on reconnect / session switch no longer reset activity timers.
- Adds 3 regression tests in `packages/app/src/__tests__/store/message-handler.test.ts` covering replay-doesn't-bump, replay-doesn't-dismiss, and live-activity-after-replay still bumps.

## Background
Mobile's `_ctx.receivingHistoryReplay` is the per-connection equivalent of the dashboard's module-level `_receivingHistoryReplay` flag, already used elsewhere in this handler. The dashboard's `activeTools`-clear half of #4466 does not apply on mobile because mobile's `history_replay_start` case doesn't clear `activeTools`.

## Test plan
- [x] RED → GREEN: 3 new tests at `packages/app/src/__tests__/store/message-handler.test.ts` failed before the gate change, pass after.
- [x] Full `packages/app` message-handler suite (125 tests) passes.
- [x] No regressions across the broader app jest suite (1156 tests pass; 3 pre-existing suite failures are missing `xterm-bundle.generated.ts` postinstall artifact, unrelated).

Closes #4492