### PR TITLE
fix(dashboard): scope receivingHistoryReplay per-session (#4493)

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3334,4 +3334,108 @@ describe('dashboard message-handler dispatch', () => {
       expect(ss.activeTools).toEqual([])
     })
   })
+
+  // #4493 — the replay flag must be scoped per-session. Pre-fix it was a
+  // module-level boolean: once `history_replay_start` fired for session A,
+  // every interleaved live event from session B (replayHistory chunks over
+  // setImmediate, so live broadcasts can land between chunks) was treated
+  // as replay and dropped its activity bump / activeTools clear.
+  describe('replay flag is per-session (#4493)', () => {
+    function seedTwoSessions(
+      sA: Partial<ReturnType<typeof createEmptySessionState>> = {},
+      sB: Partial<ReturnType<typeof createEmptySessionState>> = {},
+    ) {
+      store = createMockStore(baseState({
+        activeSessionId: 'sA',
+        sessions: [
+          { sessionId: 'sA', name: 'A' } as any,
+          { sessionId: 'sB', name: 'B' } as any,
+        ],
+        sessionStates: {
+          sA: { ...createEmptySessionState(), ...sA },
+          sB: { ...createEmptySessionState(), ...sB },
+        },
+      }))
+      setStore(store)
+    }
+
+    it('live tool_start for session B bumps B during session A replay', () => {
+      // Session A is mid-replay; an interleaved live tool_start for B must
+      // still bump B.lastClientActivityAt. Pre-fix the module flag was true
+      // (for A) so B's bump was suppressed.
+      seedTwoSessions({ lastClientActivityAt: 100 }, { lastClientActivityAt: 100 })
+      handleMessage({ type: 'history_replay_start', sessionId: 'sA' }, ctx() as any)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-b-1',
+          tool: 'Bash',
+          toolUseId: 'tu-b-1',
+          input: { command: 'echo hi' },
+          sessionId: 'sB',
+        },
+        ctx() as any,
+      )
+      const ssB = (store.getState() as any).sessionStates.sB
+      expect(ssB.lastClientActivityAt).toBeGreaterThan(100)
+    })
+
+    it('replayed tool_start for session A still does NOT bump A', () => {
+      // Sanity: per-session scoping must still suppress replayed events for
+      // the actually-replaying session (the #4466 guarantee).
+      seedTwoSessions({ lastClientActivityAt: 100 }, { lastClientActivityAt: 100 })
+      handleMessage({ type: 'history_replay_start', sessionId: 'sA' }, ctx() as any)
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-a-1',
+          tool: 'Bash',
+          toolUseId: 'tu-a-1',
+          input: { command: 'sleep' },
+          sessionId: 'sA',
+        },
+        ctx() as any,
+      )
+      const ssA = (store.getState() as any).sessionStates.sA
+      expect(ssA.lastClientActivityAt).toBe(100)
+    })
+
+    it('live result for session B still clears B.activeTools during A replay', () => {
+      // Mirror of the #4491 gate, per-session: a live `result` for session
+      // B during A's replay window must still run the #4308 turn-boundary
+      // sweep on B.activeTools.
+      const inFlightToolB = { toolUseId: 'tu-b-1', tool: 'Bash', input: { command: 'sleep' }, startedAt: 100 }
+      seedTwoSessions({}, { activeTools: [inFlightToolB] })
+      handleMessage({ type: 'history_replay_start', sessionId: 'sA' }, ctx() as any)
+      handleMessage(
+        { type: 'result', sessionId: 'sB', usage: {}, cost: 0, duration: 0 },
+        ctx() as any,
+      )
+      const ssB = (store.getState() as any).sessionStates.sB
+      expect(ssB.activeTools).toEqual([])
+    })
+
+    it('history_replay_end for A clears only A from the replaying set', () => {
+      // With two sessions concurrently replaying, ending one must not
+      // un-gate the other.
+      seedTwoSessions({ lastClientActivityAt: 100 }, { lastClientActivityAt: 100 })
+      handleMessage({ type: 'history_replay_start', sessionId: 'sA' }, ctx() as any)
+      handleMessage({ type: 'history_replay_start', sessionId: 'sB' }, ctx() as any)
+      handleMessage({ type: 'history_replay_end', sessionId: 'sA' }, ctx() as any)
+      // sB is still replaying — a replayed tool_start for B must not bump.
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-b-1',
+          tool: 'Bash',
+          toolUseId: 'tu-b-1',
+          input: { command: 'sleep' },
+          sessionId: 'sB',
+        },
+        ctx() as any,
+      )
+      const ssB = (store.getState() as any).sessionStates.sB
+      expect(ssB.lastClientActivityAt).toBe(100)
+    })
+  })
 })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -401,10 +401,16 @@ export function setLastConnectedUrl(url: string | null): void {
 // ---------------------------------------------------------------------------
 // History replay flags
 // ---------------------------------------------------------------------------
-let _receivingHistoryReplay = false;
+// #4493 — per-session replay tracking. `replayHistory()` on the server chunks
+// the replay over `setImmediate` (ws-history.js), which yields the event loop
+// between chunks, so live broadcasts from OTHER sessions can interleave with
+// session A's replay. A module-level boolean would gate all sessions on A's
+// replay state and drop legitimate live activity for sessions B/C/etc.
+// Scope the flag per-session id and gate per-target.
+const _replayingSessions = new Set<string>();
 
 export function resetReplayFlags(): void {
-  _receivingHistoryReplay = false;
+  _replayingSessions.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -1467,12 +1473,15 @@ function handleToolStart(msg: Record<string, unknown>, get: MsgGet, _set: MsgSet
   // terminal preview write — matches the prior inline ordering.
   const toolName = typeof msg.tool === 'string' ? msg.tool : 'tool';
   get().appendTerminalData(`\r\n\x1b[36m⏺ ${toolName}\x1b[0m\r\n`);
+  const toolStartTargetId = typeof msg.sessionId === 'string' ? msg.sessionId : get().activeSessionId;
   const cached = (() => {
-    const targetId = typeof msg.sessionId === 'string' ? msg.sessionId : get().activeSessionId;
-    const targetState = targetId ? get().sessionStates[targetId] : null;
+    const targetState = toolStartTargetId ? get().sessionStates[toolStartTargetId] : null;
     return targetState ? targetState.messages : get().messages;
   })();
-  const result = sharedToolStart(msg, get().activeSessionId, _receivingHistoryReplay, cached);
+  // #4493 — per-session replay scoping. Dedup against the cached history
+  // only when THIS message's session is currently replaying.
+  const toolStartIsReplay = toolStartTargetId ? _replayingSessions.has(toolStartTargetId) : false;
+  const result = sharedToolStart(msg, get().activeSessionId, toolStartIsReplay, cached);
   if (!result.shouldDispatch || !result.chatMessage) return;
   const toolMsg = result.chatMessage;
   const targetId = result.sessionId;
@@ -1868,20 +1877,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   // warning: by definition the silence has ended, so the chip should
   // disappear without waiting for the user to dismiss it manually.
   //
-  // #4466 — gate on `!_receivingHistoryReplay`. switch_session on the
-  // server replays every past event in the target session through this
-  // handler, and a replayed tool_start / message / result is NOT fresh
-  // activity. Without this gate the act of switching tabs:
+  // #4466 — gate on the replay set. switch_session on the server replays
+  // every past event in the target session through this handler, and a
+  // replayed tool_start / message / result is NOT fresh activity. Without
+  // this gate the act of switching tabs:
   //   1) bumps lastClientActivityAt to Date.now(), so "Working… last
   //      activity Ns ago" resets to 1s no matter how idle the session was;
   //   2) wipes inactivityWarning, so the "Agent quiet for 46m 32s · Status
   //      update?" chip disappears without the user ever seeing it again.
-  // The live activity events that arrive AFTER history_replay_end clears
-  // the flag still bump correctly — verified by the regression-guard tests
-  // in message-handler.test.ts.
-  if (isActivityEvent(msg.type) && !_receivingHistoryReplay) {
+  // The live activity events that arrive AFTER history_replay_end removes
+  // the session from the set still bump correctly — verified by the
+  // regression-guard tests in message-handler.test.ts.
+  //
+  // #4493 — gate per target session id (Set membership), not a module flag.
+  // `replayHistory()` chunks over setImmediate, so live broadcasts from
+  // session B can interleave with A's replay. A module-wide boolean would
+  // wrongly suppress B's live activity bump for the duration of A's replay.
+  if (isActivityEvent(msg.type)) {
     const targetId = (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
-    if (targetId && get().sessionStates[targetId]) {
+    if (targetId && get().sessionStates[targetId] && !_replayingSessions.has(targetId)) {
       updateSession(targetId, (ss) => {
         const patch: Partial<SessionState> = { lastClientActivityAt: Date.now() };
         if (ss.inactivityWarning) patch.inactivityWarning = null;
@@ -1900,8 +1914,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   switch (msg.type) {
 
     case 'auth_ok': {
-      // Reset replay flags — fresh auth means clean slate
-      _receivingHistoryReplay = false;
+      // Reset replay flags — fresh auth means clean slate (#4493: clear the
+      // per-session replaying set so a reconnect doesn't leave stale ids
+      // gating future activity bumps).
+      _replayingSessions.clear();
       // Track this URL as successfully connected
       lastConnectedUrl = ctx.url;
       // Extract server context fields via shared handler (#3102)
@@ -2294,7 +2310,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         msg,
         get().activeSessionId,
       );
-      _receivingHistoryReplay = true;
+      // #4493 — track per-session. Falls back to activeSessionId via
+      // sharedHistoryReplayStart, matching the gate's targetId resolution.
+      if (replayTargetId) _replayingSessions.add(replayTargetId);
       // Full history replay (from request_full_history): clear messages before replay
       if (fullHistory) {
         if (replayTargetId && get().sessionStates[replayTargetId]) {
@@ -2327,7 +2345,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'history_replay_end':
       // Parser is shared via store-core; flag mutation stays here.
-      _receivingHistoryReplay = sharedHistoryReplayEnd().receivingHistoryReplay;
+      sharedHistoryReplayEnd();
+      // #4493 — remove this session id from the replaying set. Falls back
+      // to activeSessionId to mirror sharedHistoryReplayStart's resolution.
+      {
+        const endTargetId =
+          (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
+        if (endTargetId) _replayingSessions.delete(endTargetId);
+      }
       // Mark all replayed prompts as answered — any prompt in history
       // has already been resolved by the server.
       updateActiveSession((ss) => {
@@ -2380,7 +2405,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // else the global message log).
       const targetState = targetId ? get().sessionStates[targetId] : null;
       const cached = targetState ? targetState.messages : get().messages;
-      const result = sharedMessageHandler(msg, get().activeSessionId, _receivingHistoryReplay, cached);
+      // #4493 — dedup against history only when THIS message's session is
+      // currently replaying. A module-wide boolean would suppress live
+      // messages for session B while A replays.
+      const messageIsReplay = targetId ? _replayingSessions.has(targetId) : false;
+      const result = sharedMessageHandler(msg, get().activeSessionId, messageIsReplay, cached);
       if (!result.shouldDispatch) break;
       const newMsg = result.chatMessage;
       if (targetId && get().sessionStates[targetId]) {
@@ -2471,7 +2500,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             ...resultPatch,
             messages: [...ss.messages],
           };
-          if (ss.activeTools.length > 0 && !_receivingHistoryReplay) patch.activeTools = [];
+          // #4493 — gate per target session id. A live `result` for
+          // session B during A's replay must still sweep B's activeTools.
+          if (ss.activeTools.length > 0 && !_replayingSessions.has(targetId)) patch.activeTools = [];
           return patch;
         });
       } else {


### PR DESCRIPTION
## Summary

- Convert dashboard's `_receivingHistoryReplay` from module-level boolean to `_replayingSessions: Set<string>`, gated per target session id.
- `replayHistory()` chunks over `setImmediate`, so a live `tool_start` / `message` / `result` for session B could interleave with A's replay and be wrongly suppressed by the module-wide flag (missed activity bump, missed activeTools sweep).
- All four call sites updated: pre-handler activity bump (line 1882), `case 'result'` activeTools clear (line 2474), and the per-session dedup booleans passed to `sharedToolStart` / `sharedMessageHandler`.

## Behavior

- `history_replay_start`: adds the resolved session id to the set.
- `history_replay_end`: removes that session id (server emits `sessionId` on both — confirmed in `packages/server/src/ws-history.js` line 353/365).
- `auth_ok`: `clear()` — reconnect means clean slate.
- Activity gate: `if (isActivityEvent(msg.type)) { ... if (!_replayingSessions.has(targetId)) bump }`.

## Test plan

- [x] RED: 3 of 4 new tests fail against the pre-fix module flag (verified locally).
- [x] GREEN: all 148 message-handler tests pass; all 320 tests across the affected store test files pass (`message-handler`, `message-handler-evaluator`, `auth-ok-handler`, `dispatch-activity`, `store`).
- [x] The existing #4466 + #4491 regression suite still passes — per-session scoping does not regress the single-session case.
- [x] TypeScript: no new errors introduced in `message-handler.ts` / `message-handler.test.ts`.

Closes #4493