### PR TITLE
fix(server): enforce MAX_SANE_DURATION_MS ceiling on ws-history timeout guards (#4484)

### DIFF
--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -9,6 +9,7 @@ import { PERMISSION_MODES } from './handler-utils.js'
 import { listProviders } from './providers.js'
 import { createLogger } from './logger.js'
 import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS, DEFAULT_STREAM_STALL_TIMEOUT_MS } from './base-session.js'
+import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 
 const log = createLogger('ws')
 
@@ -95,12 +96,20 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   // value (e.g. `CHROXY_HARD_TIMEOUT_MS=7200000.5` via `parseFloat`)
   // would silently fail client-side schema validation on the auth_ok
   // payload. Falling back to the default lets the wire stay valid.
+  //
+  // #4484: also enforce the `<= MAX_SANE_DURATION_MS` (24h) ceiling that the
+  // protocol schemas apply via `.max(MAX_SANE_DURATION_MS)`. Without this
+  // check an operator value like `CHROXY_HARD_TIMEOUT_MS=99999999999`
+  // (>24h) would pass isSafeInteger here, hit the wire, and fail the
+  // client-side schema's `.max()` gate — silently breaking the auth_ok
+  // parse for every connecting client. Mirroring the ceiling here lets
+  // the server degrade gracefully to the default instead.
   const effectiveResultTimeoutMs =
-    Number.isSafeInteger(resultTimeoutMs) && resultTimeoutMs > 0
+    Number.isSafeInteger(resultTimeoutMs) && resultTimeoutMs > 0 && resultTimeoutMs <= MAX_SANE_DURATION_MS
       ? resultTimeoutMs
       : DEFAULT_RESULT_TIMEOUT_MS
   const effectiveHardTimeoutMs =
-    Number.isSafeInteger(hardTimeoutMs) && hardTimeoutMs > 0
+    Number.isSafeInteger(hardTimeoutMs) && hardTimeoutMs > 0 && hardTimeoutMs <= MAX_SANE_DURATION_MS
       ? hardTimeoutMs
       : DEFAULT_HARD_TIMEOUT_MS
   // #4477: stream-stall window. Semantics differ from the two timeouts above —
@@ -111,8 +120,10 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
   // isSafeInteger and fall back to the default — they'd otherwise fail the
   // protocol schema's int().nonnegative().max(MAX_SANE_DURATION_MS) gate at
   // the client and silently break dashboard message handling.
+  // #4484: ceiling check mirrors the protocol schema's `.max()` gate; see
+  // resultTimeoutMs above for the asymmetry rationale.
   const effectiveStreamStallTimeoutMs =
-    Number.isSafeInteger(streamStallTimeoutMs) && streamStallTimeoutMs >= 0
+    Number.isSafeInteger(streamStallTimeoutMs) && streamStallTimeoutMs >= 0 && streamStallTimeoutMs <= MAX_SANE_DURATION_MS
       ? streamStallTimeoutMs
       : DEFAULT_STREAM_STALL_TIMEOUT_MS
 

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -8,6 +8,7 @@ import {
   flushPostAuthQueue,
 } from '../src/ws-history.js'
 import { PERMISSION_MODES } from '../src/handler-utils.js'
+import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 // Importing providers.js triggers built-in provider registration, which in turn
 // calls registerProviderRegistry() so getRegistryForProvider('codex'/'gemini')
 // resolves to the correct provider class in per-provider tests below.
@@ -173,6 +174,82 @@ describe('sendPostAuthInfo — resultTimeoutMs (#3760)', () => {
       assert.equal(authOk.resultTimeoutMs, 30 * 60 * 1000, `bad input: ${bad}`)
     }
   })
+
+  // #4484: operator-set value over the MAX_SANE_DURATION_MS (24h) ceiling must
+  // fall back to the default. Without this guard the server would emit the
+  // literal over-ceiling value and the protocol schema's `.max()` would reject
+  // the entire auth_ok payload on every client, silently breaking the
+  // handshake.
+  it('falls back to the default when ctx.resultTimeoutMs exceeds MAX_SANE_DURATION_MS', () => {
+    const ctx = makeCtx({ resultTimeoutMs: MAX_SANE_DURATION_MS + 1 })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.resultTimeoutMs, 30 * 60 * 1000)
+  })
+
+  it('accepts the exact MAX_SANE_DURATION_MS boundary for resultTimeoutMs', () => {
+    const ctx = makeCtx({ resultTimeoutMs: MAX_SANE_DURATION_MS })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.resultTimeoutMs, MAX_SANE_DURATION_MS)
+  })
+})
+
+// #3905: surface the effective hard-kill inactivity timeout in auth_ok so the
+// dashboard check-in chip can render a "kill in Xh" countdown against the
+// real configured value instead of assuming the 2-hour default.
+describe('sendPostAuthInfo — hardTimeoutMs (#3905)', () => {
+  it('uses the configured hardTimeoutMs when set', () => {
+    const ctx = makeCtx({ hardTimeoutMs: 3 * 60 * 60 * 1000 })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.hardTimeoutMs, 3 * 60 * 60 * 1000)
+  })
+
+  it('falls back to BaseSession default (2h) when ctx.hardTimeoutMs is null', () => {
+    const ctx = makeCtx({ hardTimeoutMs: null })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.hardTimeoutMs, 2 * 60 * 60 * 1000)
+  })
+
+  it('falls back to the default when ctx.hardTimeoutMs is non-positive or non-finite', () => {
+    for (const bad of [0, -1, NaN, Infinity]) {
+      const ctx = makeCtx({ hardTimeoutMs: bad })
+      const ws = makeFakeWs()
+      registerClient(ctx, ws)
+      sendPostAuthInfo(ctx, ws)
+      const authOk = ctx._sends[0]
+      assert.equal(authOk.hardTimeoutMs, 2 * 60 * 60 * 1000, `bad input: ${bad}`)
+    }
+  })
+
+  // #4484: see resultTimeoutMs sibling test for the asymmetry rationale.
+  it('falls back to the default when ctx.hardTimeoutMs exceeds MAX_SANE_DURATION_MS', () => {
+    const ctx = makeCtx({ hardTimeoutMs: MAX_SANE_DURATION_MS + 1 })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.hardTimeoutMs, 2 * 60 * 60 * 1000)
+  })
+
+  it('accepts the exact MAX_SANE_DURATION_MS boundary for hardTimeoutMs', () => {
+    const ctx = makeCtx({ hardTimeoutMs: MAX_SANE_DURATION_MS })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.hardTimeoutMs, MAX_SANE_DURATION_MS)
+  })
 })
 
 // #4477: surface the effective stream-stall recovery window in auth_ok so the
@@ -226,6 +303,27 @@ describe('sendPostAuthInfo — streamStallTimeoutMs (#4477)', () => {
       const authOk = ctx._sends[0]
       assert.equal(authOk.streamStallTimeoutMs, 5 * 60 * 1000, `bad input: ${String(bad)}`)
     }
+  })
+
+  // #4484: see resultTimeoutMs sibling test for the asymmetry rationale —
+  // applies the same way to streamStallTimeoutMs (which the protocol schema
+  // also gates with `.max(MAX_SANE_DURATION_MS)`).
+  it('falls back to the default when ctx.streamStallTimeoutMs exceeds MAX_SANE_DURATION_MS', () => {
+    const ctx = makeCtx({ streamStallTimeoutMs: MAX_SANE_DURATION_MS + 1 })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.streamStallTimeoutMs, 5 * 60 * 1000)
+  })
+
+  it('accepts the exact MAX_SANE_DURATION_MS boundary for streamStallTimeoutMs', () => {
+    const ctx = makeCtx({ streamStallTimeoutMs: MAX_SANE_DURATION_MS })
+    const ws = makeFakeWs()
+    registerClient(ctx, ws)
+    sendPostAuthInfo(ctx, ws)
+    const authOk = ctx._sends[0]
+    assert.equal(authOk.streamStallTimeoutMs, MAX_SANE_DURATION_MS)
   })
 })
 


### PR DESCRIPTION
## Summary

- `sendPostAuthInfo` in `packages/server/src/ws-history.js` guarded `resultTimeoutMs`, `hardTimeoutMs`, and `streamStallTimeoutMs` with `Number.isSafeInteger(x) && x >= 0` but did not enforce the `MAX_SANE_DURATION_MS` (24h) ceiling that the protocol schemas apply via `.max(MAX_SANE_DURATION_MS)`.
- An operator setting e.g. `CHROXY_STREAM_STALL_TIMEOUT_MS=99999999999` (>24h) passed the server guard, hit the wire, and then failed the client-side schema's `.max()` rule — silently breaking the entire `auth_ok` parse for every connecting client.
- Each guard now additionally checks `x <= MAX_SANE_DURATION_MS` (imported from `@chroxy/protocol`) and falls back to the BaseSession default when exceeded. No behavior change for in-range values.

## Test plan

- [x] RED: added 3 tests passing `MAX_SANE_DURATION_MS + 1` per timeout — they assert the default is emitted in `auth_ok`. Failed on `main`.
- [x] GREEN: implementation now satisfies all 3 over-ceiling cases plus exact-boundary acceptance.
- [x] `npm test -w packages/server` ws-history.test.js: 74/74 pass
- [x] `npm test -w packages/protocol`: 143/143 pass
- [x] Full server suite: 5888 pass / 1 pre-existing flake (perf-threshold test in base-session.test.js, unrelated)

Closes #4484