### PR TITLE
feat(app): stream-stalled chip with retry (#4496)

### DIFF
--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -20,6 +20,7 @@ import { ActivityGroup } from './chat/ActivityGroup';
 import { ToolDetailModal } from './chat/ToolDetailModal';
 import { MessageBubble } from './chat/MessageBubble';
 import { groupMessages, applyStreamingOverlay } from '@chroxy/store-core';
+import { useConnectionStore } from '../store/connection';
 
 // -- Props --
 
@@ -200,6 +201,23 @@ export function ChatView({
     [baseGroups, streamingMessageId, messages],
   );
 
+  // #4496: tail message id + last user input — used to gate the
+  // stream-stall chip's Retry button. Mirrors the dashboard's `isTail`
+  // check (only the most recent stall retry-button-wires; historical
+  // replayed stalls render chip text only). Walking messages once here
+  // is cheaper than recomputing per bubble.
+  const sendInput = useConnectionStore((s) => s.sendInput);
+  const chatTailMessageId = useMemo(
+    () => (messages.length > 0 ? messages[messages.length - 1].id : null),
+    [messages],
+  );
+  const lastUserInputContent = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].type === 'user_input') return messages[i].content;
+    }
+    return null;
+  }, [messages]);
+
   const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
     const threshold = 100;
@@ -304,6 +322,17 @@ export function ChatView({
                   onPress={() => onToggleSelection(msg.id)}
                   onOpenDetail={handleOpenDetail}
                   onImagePress={setViewerUri}
+                  onRetryStreamStall={
+                    // #4496: only wire retry when this stall is the tail
+                    // bubble AND there's a user_input to resend. Mirrors
+                    // dashboard App.tsx renderMessage gating.
+                    msg.type === 'error' &&
+                    msg.code === 'stream_stall' &&
+                    msg.id === chatTailMessageId &&
+                    lastUserInputContent != null
+                      ? () => sendInput(lastUserInputContent)
+                      : undefined
+                  }
                 />
               </AnimatedMessage>
             </View>

--- a/packages/app/src/components/StreamStallChip.tsx
+++ b/packages/app/src/components/StreamStallChip.tsx
@@ -1,0 +1,149 @@
+/**
+ * StreamStallChip — #4496
+ *
+ * Mobile companion to packages/dashboard/src/components/StreamStallChip
+ * (#4476). Replaces the generic red error bubble when the server emits
+ * `error{code: 'stream_stall'}` (server PR #4475). The chip signals
+ * "recoverable, just retry" rather than "something is broken" via an
+ * amber/yellow palette and offers a one-tap Retry button that re-sends
+ * the most recent user input (caller is responsible for that lookup —
+ * the chip itself doesn't know which message to resend).
+ *
+ * The raw server error text remains accessible on demand:
+ *  - exposed to assistive tech via `accessibilityHint`
+ *  - revealed inline by long-pressing the chip
+ *
+ * Uses `accentYellow500` from constants/colors to match the rest of the
+ * chroxy amber-yellow warning surfaces (`CheckInChip`, the inactivity
+ * warning chips, etc.).
+ */
+import React, { useCallback, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { COLORS } from '../constants/colors';
+
+export interface StreamStallChipProps {
+  /** Raw error text from the server (e.g. "Stream stalled — no response for 5 minutes"). */
+  errorText: string;
+  /**
+   * Invoked when the user taps Retry. Caller is responsible for
+   * resending the last user message. Setting this to `undefined` hides
+   * the Retry button — used for historical entries replayed from
+   * `session_messages` where resending an ancient user_input would be
+   * misleading.
+   */
+  onRetry?: () => void;
+}
+
+export function StreamStallChip({ errorText, onRetry }: StreamStallChipProps) {
+  const [detailVisible, setDetailVisible] = useState(false);
+
+  const handleRetry = useCallback(() => {
+    onRetry?.();
+  }, [onRetry]);
+
+  const toggleDetail = useCallback(() => {
+    setDetailVisible((v) => !v);
+  }, []);
+
+  return (
+    <Pressable
+      testID="stream-stall-chip"
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel="Stream stalled — retry?"
+      accessibilityHint={errorText}
+      // Long-press reveals the underlying server diagnostic text without
+      // an always-on text wall on the chip — preserves the "raw error
+      // accessible for diagnostics" acceptance criterion compactly.
+      onLongPress={toggleDetail}
+      style={styles.container}
+    >
+      <View style={styles.dot} />
+      <Text style={styles.label}>Stream stalled — retry?</Text>
+      {onRetry && (
+        <Pressable
+          testID="stream-stall-chip-retry"
+          accessibilityRole="button"
+          accessibilityLabel="Retry — resend last message"
+          onPress={handleRetry}
+          // Compact chip button: expand the actionable region via hitSlop
+          // to meet the 44pt accessibility minimum without inflating the
+          // visual chip. Mirrors CheckInChip's slop convention.
+          hitSlop={{ top: 11, bottom: 11, left: 14, right: 14 }}
+          style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+        >
+          <Text style={styles.buttonLabel}>Retry</Text>
+        </Pressable>
+      )}
+      {detailVisible && (
+        <Text
+          testID="stream-stall-chip-detail"
+          style={styles.detail}
+          accessibilityElementsHidden
+          importantForAccessibility="no"
+          selectable
+        >
+          {errorText}
+        </Text>
+      )}
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    marginVertical: 4,
+    gap: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: COLORS.accentYellow500,
+    // Subtle amber-yellow fill — matches the CheckInChip / warning chip
+    // surface convention rather than the red error palette so users read
+    // the bubble as "recoverable" rather than "broken".
+    backgroundColor: 'rgba(217, 165, 12, 0.12)',
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: COLORS.accentYellow500,
+  },
+  label: {
+    fontSize: 13,
+    color: COLORS.textPrimary,
+    fontWeight: '500',
+  },
+  button: {
+    backgroundColor: COLORS.accentYellow500,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    // Visible button area is intentionally compact — the 44pt
+    // accessibility minimum is reached via hitSlop above.
+  },
+  buttonPressed: {
+    opacity: 0.85,
+  },
+  buttonLabel: {
+    color: COLORS.backgroundPrimary,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  detail: {
+    // Full-width row that wraps under the chip header when expanded.
+    width: '100%',
+    marginTop: 6,
+    paddingTop: 6,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: COLORS.accentYellow500,
+    color: COLORS.textSecondary,
+    fontSize: 12,
+    lineHeight: 16,
+  },
+});

--- a/packages/app/src/components/__tests__/MessageBubble.streamStall.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.streamStall.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * MessageBubble stream-stall integration — #4496
+ *
+ * Asserts that MessageBubble special-cases `error{code:'stream_stall'}`
+ * and renders the StreamStallChip in place of the generic red error
+ * bubble. Confirms `onRetryStreamStall` is forwarded to the chip and
+ * the chip's Retry button only surfaces when the prop is wired
+ * (mirrors the dashboard's `isTail` gate handled upstream in ChatView).
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { MessageBubble } from '../chat/MessageBubble';
+import type { ChatMessage } from '../../store/types';
+
+function makeStallMessage(): ChatMessage {
+  return {
+    id: 'err-1',
+    type: 'error',
+    code: 'stream_stall',
+    content: 'Stream stalled — no response for 5 minutes',
+    timestamp: Date.now(),
+  } as ChatMessage;
+}
+
+function makeGenericErrorMessage(): ChatMessage {
+  return {
+    id: 'err-2',
+    type: 'error',
+    content: 'Something exploded',
+    timestamp: Date.now(),
+  } as ChatMessage;
+}
+
+function render(message: ChatMessage, onRetryStreamStall?: () => void) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(
+      <MessageBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onLongPress={() => {}}
+        onPress={() => {}}
+        onOpenDetail={() => {}}
+        onRetryStreamStall={onRetryStreamStall}
+      />,
+    );
+  });
+  return tree;
+}
+
+describe('MessageBubble stream-stall handling (#4496)', () => {
+  it('renders the StreamStallChip for error{code: "stream_stall"}', () => {
+    const tree = render(makeStallMessage());
+    const chip = tree.root.findByProps({ testID: 'stream-stall-chip' });
+    expect(chip).toBeDefined();
+  });
+
+  it('falls through to the generic error bubble when code is missing', () => {
+    // Legacy / non-stall errors must still render through the red
+    // bubble path — the chip is only for the structured stall signal.
+    const tree = render(makeGenericErrorMessage());
+    const chips = tree.root.findAllByProps({ testID: 'stream-stall-chip' });
+    expect(chips).toHaveLength(0);
+  });
+
+  it('shows the Retry button when onRetryStreamStall is wired (tail message)', () => {
+    const onRetry = jest.fn();
+    const tree = render(makeStallMessage(), onRetry);
+    const retry = tree.root.findByProps({ testID: 'stream-stall-chip-retry' });
+    act(() => {
+      retry.props.onPress?.();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the Retry button when onRetryStreamStall is undefined (historical)', () => {
+    // ChatView leaves the prop unwired for any stall that isn't the
+    // tail message — the chip then renders text only.
+    const tree = render(makeStallMessage(), undefined);
+    const retries = tree.root.findAllByProps({ testID: 'stream-stall-chip-retry' });
+    expect(retries).toHaveLength(0);
+  });
+});

--- a/packages/app/src/components/__tests__/StreamStallChip.test.tsx
+++ b/packages/app/src/components/__tests__/StreamStallChip.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * StreamStallChip tests — #4496
+ *
+ * Mobile companion to packages/dashboard/src/components/StreamStallChip
+ * (#4476). Asserts the distinct chip affordance (not the red error bubble)
+ * renders for `error.code === 'stream_stall'`, the Retry button surfaces +
+ * fires onRetry only when provided (historical replays render text only),
+ * and the raw server error text remains accessible to screen readers and
+ * the long-press-for-detail affordance.
+ *
+ * Mirrors CheckInChip.test.tsx — react-test-renderer + act, no
+ * `@testing-library/react-native` dependency required.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { StreamStallChip } from '../StreamStallChip';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root
+    .findAllByType(Text)
+    .map((node) => {
+      const c = node.props.children;
+      if (typeof c === 'string' || typeof c === 'number') return String(c);
+      if (Array.isArray(c)) {
+        return c
+          .map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : ''))
+          .join('');
+      }
+      return '';
+    })
+    .join(' ');
+}
+
+describe('StreamStallChip (#4496)', () => {
+  let activeTree: renderer.ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (activeTree) {
+      act(() => {
+        activeTree!.unmount();
+      });
+      activeTree = null;
+    }
+  });
+
+  function render(node: React.ReactElement): renderer.ReactTestRenderer {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(node);
+    });
+    activeTree = tree;
+    return tree;
+  }
+
+  it('renders the chip headline', () => {
+    const tree = render(
+      <StreamStallChip errorText="Stream stalled — no response for 5 minutes" />,
+    );
+    const text = collectVisibleText(tree.root);
+    expect(text).toMatch(/Stream stalled/i);
+    expect(text).toMatch(/retry/i);
+  });
+
+  it('preserves the raw server error text via the accessibilityHint', () => {
+    // Operators investigating a stall pattern need the underlying server
+    // message — the chip's prose is friendly, but the diagnostic detail
+    // must remain accessible without losing it (mirrors the dashboard's
+    // `title` attribute affordance, which RN exposes via accessibilityHint).
+    const raw = 'Stream stalled — no response for 5 minutes (provider=claude-sdk session=abc)';
+    const tree = render(<StreamStallChip errorText={raw} />);
+    const chip = tree.root.findByProps({ testID: 'stream-stall-chip' });
+    expect(chip.props.accessibilityHint).toBe(raw);
+  });
+
+  it('shows a Retry button when onRetry is provided', () => {
+    const onRetry = jest.fn();
+    const tree = render(<StreamStallChip errorText="x" onRetry={onRetry} />);
+    const retryButton = tree.root.findByProps({ testID: 'stream-stall-chip-retry' });
+    expect(retryButton).toBeDefined();
+  });
+
+  it('hides the Retry button when onRetry is omitted (historical/replayed)', () => {
+    // For replayed historical entries the original user input is no longer
+    // the obvious target to resend — render the chip without the button
+    // rather than wire it to a misleading action.
+    const tree = render(<StreamStallChip errorText="x" />);
+    const retryButtons = tree.root.findAllByProps({ testID: 'stream-stall-chip-retry' });
+    expect(retryButtons).toHaveLength(0);
+  });
+
+  it('invokes onRetry when the Retry button is pressed', () => {
+    const onRetry = jest.fn();
+    const tree = render(<StreamStallChip errorText="x" onRetry={onRetry} />);
+    const retryButton = tree.root.findByProps({ testID: 'stream-stall-chip-retry' });
+    act(() => {
+      retryButton.props.onPress?.();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('reveals the raw error text when the chip is long-pressed', () => {
+    // Long-press exposes the underlying server diagnostic without an
+    // always-on text wall — keeps the chip compact but the detail
+    // reachable on demand (acceptance criterion: raw error remains
+    // accessible for diagnostics).
+    const raw = 'Stream stalled — no response for 5 minutes (provider=claude-sdk)';
+    const tree = render(<StreamStallChip errorText={raw} />);
+    const chip = tree.root.findByProps({ testID: 'stream-stall-chip' });
+    act(() => {
+      chip.props.onLongPress?.();
+    });
+    const detail = tree.root.findByProps({ testID: 'stream-stall-chip-detail' });
+    expect(collectVisibleText(detail)).toContain(raw);
+  });
+
+  it('exposes role="alert" / accessibilityLiveRegion="polite" so screen readers announce the stall', () => {
+    // The chip's purpose is to make a recoverable failure visible — give
+    // assistive tech a live-region announcement so users not watching the
+    // chat aren't stuck guessing why the assistant went silent. RN uses
+    // accessibilityLiveRegion (Android) + accessibilityRole='alert' as the
+    // cross-platform equivalent of the dashboard's role="status".
+    const tree = render(<StreamStallChip errorText="x" />);
+    const chip = tree.root.findByProps({ testID: 'stream-stall-chip' });
+    expect(chip.props.accessibilityRole).toBe('alert');
+    expect(chip.props.accessibilityLiveRegion).toBe('polite');
+  });
+
+  it('meets the 44pt minimum tap target on the Retry button', () => {
+    // Touch target acceptance criterion: hitSlop expands the actionable
+    // region of the compact chip button to the 44pt accessibility minimum.
+    const onRetry = jest.fn();
+    const tree = render(<StreamStallChip errorText="x" onRetry={onRetry} />);
+    const retryButton = tree.root.findByProps({ testID: 'stream-stall-chip-retry' });
+    const hitSlop = retryButton.props.hitSlop;
+    expect(hitSlop).toBeDefined();
+    // Vertical: padded button height + top+bottom slop must reach >= 44.
+    // Horizontal: left+right slop padding is informative; main bar is the
+    // vertical-tap-target axis (compact chip is short).
+    expect((hitSlop?.top ?? 0) + (hitSlop?.bottom ?? 0)).toBeGreaterThanOrEqual(22);
+  });
+});

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -16,8 +16,9 @@ import { FormattedResponse } from '../MarkdownRenderer';
 import { PermissionDetailOrFallback, PermissionCountdown, PermissionPill, permissionStyles } from '../PermissionDetail';
 import { ThinkingIndicator } from './ThinkingIndicator';
 import { ToolBubble } from './ToolBubble';
+import { StreamStallChip } from '../StreamStallChip';
 
-export function MessageBubble({ message, onSelectOption, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress }: {
+export function MessageBubble({ message, onSelectOption, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall }: {
   message: ChatMessage;
   onSelectOption?: (value: string, messageId: string, requestId?: string, toolUseId?: string) => void;
   isSelected: boolean;
@@ -26,6 +27,13 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
   onPress: () => void;
   onOpenDetail: (toolName: string, content: string, toolResult?: string, toolResultTruncated?: boolean, toolResultImages?: ToolResultImage[], serverName?: string) => void;
   onImagePress?: (uri: string) => void;
+  /**
+   * #4496: retry handler for stream-stall error chips. ChatView wires
+   * this only when the stall IS the tail message (mirrors the dashboard's
+   * `isTail` gate) — historical replayed stalls receive `undefined` so
+   * the chip renders text only without a misleading Retry affordance.
+   */
+  onRetryStreamStall?: () => void;
 }) {
   const longPressedRef = useRef(false);
   const [isExpired, setIsExpired] = useState(() =>
@@ -105,6 +113,23 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
         isSelecting={isSelecting}
         onToggleSelection={onPress}
         onOpenDetail={onOpenDetail}
+      />
+    );
+  }
+
+  // #4496: distinct chip for stream-stall errors (server PR #4475 emits
+  // `error{code: 'stream_stall'}` after the configured inactivity window).
+  // Generic red bubble reads as "broken"; this affordance signals
+  // "recoverable, just retry". `onRetryStreamStall` is only wired by
+  // ChatView when this stall is the tail message — historical replayed
+  // stalls render the chip text with the raw error reachable on
+  // long-press, but no retry button (resending an ancient user_input
+  // from a long-finished turn would be misleading).
+  if (isError && message.code === 'stream_stall') {
+    return (
+      <StreamStallChip
+        errorText={message.content?.trim() || ''}
+        onRetry={onRetryStreamStall}
       />
     );
   }


### PR DESCRIPTION
## Summary

Adopts the dashboard stream-stall chip (#4476 / PR #4494) on the mobile chat surface so `error{code:'stream_stall'}` from server PR #4475 renders as a distinct amber/yellow recoverable affordance instead of the generic red error bubble.

- New `StreamStallChip` component (mobile parallel to `packages/dashboard/src/components/StreamStallChip`): yellow palette using `accentYellow500`, "Stream stalled — retry?" headline, one-tap Retry `Pressable` with `hitSlop` reaching the 44pt accessibility minimum.
- Retry is only wired when the stall is the tail message (ChatView walks `messages` once for tail id + last `user_input`, mirrors dashboard `isTail` gate). Historical replayed stalls receive no `onRetry` and render text only.
- Raw server error remains accessible: exposed via `accessibilityHint` for assistive tech and revealed inline by long-pressing the chip body (toggleable detail row).
- `MessageBubble` special-cases `type==='error' && code==='stream_stall'` before the existing red-bubble path; legacy errors without `code` still fall through unchanged.

## Acceptance criteria

- [x] Distinct chip (not red bubble) for `error.code === 'stream_stall'`
- [x] Retry resends most recent `user_input` when stall is the tail message
- [x] Historical/replayed stalls render chip text only (no Retry button)
- [x] Raw error text accessible (long-press + `accessibilityHint`)
- [x] Uses `accentYellow500` from `constants/colors`
- [x] Touch target reaches 44pt via `hitSlop`

## Test plan

- [x] `StreamStallChip.test.tsx` — 8 tests (render, accessibility, retry gating, 44pt target)
- [x] `MessageBubble.streamStall.test.tsx` — 4 tests (chip-vs-bubble routing, retry forwarding)
- [x] Full app test suite: 100 suites / 1321 tests pass
- [x] `tsc --noEmit` clean
- [ ] Visual verification deferred — Expo/Maestro can't run in this sandboxed worktree; type-check + unit tests are the bar.

Closes #4496