### PR TITLE
feat(dashboard): humanise StreamStallChip copy via streamStallTimeoutMs (#4497)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -287,6 +287,12 @@ export function App() {
   const inputSettings = useConnectionStore(s => s.inputSettings)
   const connectedClients = useConnectionStore(s => s.connectedClients)
   const pairingRefreshedCount = useConnectionStore(s => s.pairingRefreshedCount)
+  // #4497: server-advertised stream-stall window — threaded into the
+  // StreamStallChip render path so the headline humanises to e.g.
+  // "No response for 5 minutes — retry?" instead of a static phrase.
+  // Null for older servers (server PR #4483 / #4477); chip falls back
+  // to the static copy in that case.
+  const streamStallTimeoutMs = useConnectionStore(s => s.streamStallTimeoutMs)
 
   // Listen for Tauri desktop events (no-op in browser context)
   useTauriEvents()
@@ -1552,13 +1558,14 @@ export function App() {
         <StreamStallChip
           errorText={storeMsg.content}
           onRetry={lastUserInput ? () => sendInput(lastUserInput.content) : undefined}
+          timeoutMs={streamStallTimeoutMs ?? undefined}
         />
       )
     }
 
     // Default rendering
     return null
-  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput])
+  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs])
 
   // #4412: registry-driven cheat sheet. Recomputed on every render —
   // not memoised, by design. The shortcut registry hook re-renders

--- a/packages/dashboard/src/components/StreamStallChip.test.tsx
+++ b/packages/dashboard/src/components/StreamStallChip.test.tsx
@@ -60,4 +60,60 @@ describe('StreamStallChip (#4476)', () => {
     const chip = screen.getByTestId('stream-stall-chip')
     expect(chip.getAttribute('role')).toBe('status')
   })
+
+  // #4497 — humanised headline. When the server advertises
+  // `streamStallTimeoutMs` on auth_ok, the chip swaps the generic phrase
+  // for the more informative "No response for ${humanize(ms)} — retry?"
+  // so the user knows the actual configured inactivity window. The raw
+  // server text on the tooltip must NOT change.
+  describe('humanised headline (#4497)', () => {
+    it('renders the static phrase when timeoutMs is undefined', () => {
+      render(<StreamStallChip errorText="raw server text" />)
+      const chip = screen.getByTestId('stream-stall-chip')
+      expect(chip.textContent).toMatch(/Stream stalled — retry\?/)
+    })
+
+    it('renders "No response for 5 minutes — retry?" for 300_000 ms', () => {
+      render(<StreamStallChip errorText="raw server text" timeoutMs={300_000} />)
+      const chip = screen.getByTestId('stream-stall-chip')
+      expect(chip.textContent).toMatch(/No response for 5 minutes — retry\?/)
+      expect(chip.textContent).not.toMatch(/Stream stalled —/)
+    })
+
+    it('renders "30 seconds" for sub-minute timeouts', () => {
+      render(<StreamStallChip errorText="raw" timeoutMs={30_000} />)
+      const chip = screen.getByTestId('stream-stall-chip')
+      expect(chip.textContent).toMatch(/No response for 30 seconds — retry\?/)
+    })
+
+    it('renders singular "1 minute" for 60_000 ms', () => {
+      render(<StreamStallChip errorText="raw" timeoutMs={60_000} />)
+      const chip = screen.getByTestId('stream-stall-chip')
+      expect(chip.textContent).toMatch(/No response for 1 minute — retry\?/)
+    })
+
+    it('renders hours for >= 1h timeouts', () => {
+      render(<StreamStallChip errorText="raw" timeoutMs={2 * 60 * 60 * 1000} />)
+      const chip = screen.getByTestId('stream-stall-chip')
+      expect(chip.textContent).toMatch(/No response for 2 hours — retry\?/)
+    })
+
+    it('leaves the tooltip (raw server text) untouched when timeoutMs is provided', () => {
+      const raw = 'Stream stalled — no response for 5 minutes (provider=claude-sdk session=abc)'
+      render(<StreamStallChip errorText={raw} timeoutMs={300_000} />)
+      const chip = screen.getByTestId('stream-stall-chip')
+      expect(chip.getAttribute('title')).toBe(raw)
+    })
+
+    it('falls back to the static phrase for non-finite or non-positive timeoutMs', () => {
+      // Defensive: a malformed prop should never produce
+      // "No response for NaN minutes" garbage in the UI.
+      for (const bad of [0, -1, NaN, Infinity, -Infinity]) {
+        cleanup()
+        render(<StreamStallChip errorText="raw" timeoutMs={bad} />)
+        const chip = screen.getByTestId('stream-stall-chip')
+        expect(chip.textContent).toMatch(/Stream stalled — retry\?/)
+      }
+    })
+  })
 })

--- a/packages/dashboard/src/components/StreamStallChip.tsx
+++ b/packages/dashboard/src/components/StreamStallChip.tsx
@@ -24,12 +24,53 @@ export interface StreamStallChipProps {
    * user input is no longer the obvious target).
    */
   onRetry?: () => void
+  /**
+   * #4497 — the server's configured stream-stall inactivity window in ms,
+   * as advertised on `auth_ok` (server PR #4483 / #4477). When provided,
+   * the chip swaps the generic "Stream stalled — retry?" phrase for the
+   * more informative "No response for ${humanize(ms)} — retry?" so the
+   * user knows the actual timeout that elapsed.
+   *
+   * Falls back to the static phrase when omitted, zero, or non-finite —
+   * older servers omit the field, and a malformed value should never
+   * produce "No response for NaN minutes" garbage in the UI.
+   *
+   * The tooltip (raw server text) is unaffected; humanising is a headline
+   * concern only.
+   */
+  timeoutMs?: number
 }
 
-export function StreamStallChip({ errorText, onRetry }: StreamStallChipProps) {
+/**
+ * #4497 — verbose duration humaniser tailored for the stall headline copy.
+ *
+ * Returns "30 seconds", "1 minute", "5 minutes", "2 hours", etc. The terser
+ * "5m" / "30s" form used by ActivityIndicator's `formatDuration` is wrong
+ * for prose — we want the chip text to read naturally. Thresholds at 1s /
+ * 1min / 1h keep the helper simple; rounding (Math.round) avoids "4 minutes"
+ * for a 299_999ms window.
+ */
+function humanizeDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000)
+  if (seconds < 60) return `${seconds} ${seconds === 1 ? 'second' : 'seconds'}`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
+  const hours = Math.round(minutes / 60)
+  return `${hours} ${hours === 1 ? 'hour' : 'hours'}`
+}
+
+export function StreamStallChip({ errorText, onRetry, timeoutMs }: StreamStallChipProps) {
   const handleClick = useCallback(() => {
     onRetry?.()
   }, [onRetry])
+
+  // #4497: humanise only when the server actually advertised a usable
+  // window. Guard against 0 (explicitly disabled, per protocol) and
+  // non-finite values so a malformed auth_ok can't degrade the UI.
+  const headline =
+    typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0
+      ? `No response for ${humanizeDuration(timeoutMs)} — retry?`
+      : 'Stream stalled — retry?'
 
   return (
     <div
@@ -38,7 +79,7 @@ export function StreamStallChip({ errorText, onRetry }: StreamStallChipProps) {
       role="status"
       title={errorText}
     >
-      <span className="stream-stall-chip-text">Stream stalled — retry?</span>
+      <span className="stream-stall-chip-text">{headline}</span>
       {onRetry && (
         <button
           type="button"

--- a/packages/dashboard/src/store/auth-ok-handler.test.ts
+++ b/packages/dashboard/src/store/auth-ok-handler.test.ts
@@ -181,6 +181,34 @@ describe('auth_ok handler', () => {
       }
     })
 
+    // #4497 / #4477 — server advertises its configured stream-stall
+    // inactivity window so the chip can humanise the headline copy
+    // ("No response for 5 minutes — retry?") instead of a generic phrase.
+    it('stores streamStallTimeoutMs when present', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage({ streamStallTimeoutMs: 5 * 60 * 1000 }), ctx as any)
+
+      expect(store.getState().streamStallTimeoutMs).toBe(5 * 60 * 1000)
+    })
+
+    it('leaves streamStallTimeoutMs null when older server omits the field', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage(), ctx as any)
+
+      expect(store.getState().streamStallTimeoutMs).toBeNull()
+    })
+
+    it('ignores malformed streamStallTimeoutMs values (incl. 0 "disabled" sentinel)', () => {
+      // 0 is the protocol's explicit "stall timer disabled" sentinel —
+      // treat it the same as absent so the chip falls back to the static
+      // phrase rather than rendering "No response for 0 seconds".
+      for (const bad of [0, -1, NaN, Infinity, -Infinity, '5m', null]) {
+        const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+        handleMessage(createAuthOkMessage({ streamStallTimeoutMs: bad }), ctx as any)
+        expect(store.getState().streamStallTimeoutMs).toBeNull()
+      }
+    })
+
     it('clears connection error and retry count', () => {
       const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
       handleMessage(createAuthOkMessage(), ctx as any)

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -306,6 +306,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   serverCommit: null,
   serverProtocolVersion: null,
   serverResultTimeoutMs: null,
+  // #4497: server-advertised stream-stall inactivity window, threaded to
+  // StreamStallChip for the humanised headline.
+  streamStallTimeoutMs: null,
   sessions: [],
   activeSessionId: null,
   sessionStates: {},
@@ -920,6 +923,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       serverCommit: null,
       serverProtocolVersion: null,
       serverResultTimeoutMs: null,
+      streamStallTimeoutMs: null,
       claudeReady: false,
       streamingMessageId: null,
       activeModel: null,
@@ -996,6 +1000,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       serverCommit: null,
       serverProtocolVersion: null,
       serverResultTimeoutMs: null,
+      streamStallTimeoutMs: null,
       viewingCachedSession: false,
     });
   },
@@ -1021,6 +1026,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       serverCommit: null,
       serverProtocolVersion: null,
       serverResultTimeoutMs: null,
+      streamStallTimeoutMs: null,
       viewingCachedSession: false,
     });
   },

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1924,6 +1924,17 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         msg.resultTimeoutMs > 0
           ? msg.resultTimeoutMs
           : null;
+      // #4497 / #4477: server-advertised stream-stall window — threaded to
+      // StreamStallChip so the headline can humanise to "No response for
+      // 5 minutes — retry?". 0 is the protocol's "disabled" sentinel so we
+      // treat it the same as absent: the chip falls back to the static
+      // phrase. Same finite/positive guard as resultTimeoutMs.
+      const authStreamStallTimeoutMs =
+        typeof msg.streamStallTimeoutMs === 'number' &&
+        Number.isFinite(msg.streamStallTimeoutMs) &&
+        msg.streamStallTimeoutMs > 0
+          ? msg.streamStallTimeoutMs
+          : null;
       // Parse connected clients list with self-detection via clientId
       const myClientId = typeof msg.clientId === 'string' ? msg.clientId : null;
       const rawClients = Array.isArray(msg.connectedClients) ? msg.connectedClients : [];
@@ -1975,6 +1986,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         serverCommit: authServerCommit,
         serverProtocolVersion: authProtocolVersion,
         serverResultTimeoutMs: authResultTimeoutMs,
+        streamStallTimeoutMs: authStreamStallTimeoutMs,
         streamingMessageId: null,
         myClientId: myClientId,
         connectedClients: clients,

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -437,6 +437,15 @@ export interface ConnectionState {
    * the field (the indicator falls back to its built-in default).
    */
   serverResultTimeoutMs: number | null;
+  /**
+   * #4497 — effective server stream-stall (no-stream-data) inactivity
+   * window in ms, as advertised on auth_ok (server PR #4483 / #4477).
+   * Threaded to `StreamStallChip` so the headline can humanise to
+   * "No response for 5 minutes — retry?" instead of a static phrase.
+   * Null when the server omits the field (older servers, or explicit 0
+   * "disabled" sentinel — the chip then falls back to the static copy).
+   */
+  streamStallTimeoutMs: number | null;
 
   // Multi-session state
   sessions: SessionInfo[];


### PR DESCRIPTION
## Summary

Replaces the generic `Stream stalled — retry?` headline in `StreamStallChip` with the more informative `No response for ${humanize(ms)} — retry?` when the server advertises its configured stream-stall window on `auth_ok` (server PR #4483 / #4477). Falls back to the static phrase for older servers, the protocol's `0` "disabled" sentinel, or any malformed value. The tooltip (raw server error text) is unchanged so operators investigating a stall pattern still have the full diagnostic detail.

- New `streamStallTimeoutMs: number | null` field on the connection store, parsed from `auth_ok` with the same `Number.isFinite && > 0` guard as `serverResultTimeoutMs`
- `StreamStallChip` accepts an optional `timeoutMs?: number` prop and a small local verbose humaniser (`30 seconds` / `1 minute` / `5 minutes` / `2 hours`)
- `App.tsx` threads the store value into the chip render site

## Implementation notes

- The existing `formatDuration` helper in `ActivityIndicator.tsx` was inspected but is private to that file and returns terse `5m` / `30s` strings — wrong for prose. A small `humanizeDuration` is added inside `StreamStallChip.tsx` returning singular/plural verbose forms, kept simple with thresholds at 1s / 1min / 1h and `Math.round` to avoid `4 minutes` for a `299_999ms` window.

## Test plan

- [x] `cd packages/dashboard && npx vitest run` — **2245 tests pass (124 files)**
- [x] `npx tsc --noEmit` clean
- [x] RED → GREEN verified for the 7 new `StreamStallChip` headline tests + 3 new `auth_ok` handler tests covering present / absent / malformed `streamStallTimeoutMs`
- [x] Tooltip-untouched assertion confirms the raw server text still reaches the `title` attribute in both humanised and fallback paths

Closes #4497