### PR TITLE
test(server): cover session-manager providerOpts timeout forwarding (#4487)

### DIFF
--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -3200,3 +3200,129 @@ describe('SessionManager cost-threshold soft warning (#4075)', () => {
     assert.equal(crossings.length, 2)
   })
 })
+
+// SessionManager forwards four operator-tunable timeout knobs via providerOpts
+// using a "forward only when set" pattern: a configured positive value is
+// passed through verbatim, while a null/unset value is OMITTED from
+// providerOpts (rather than set to null) so each provider's BaseSession-level
+// default applies. The consumer side (byok-session / base-session) has direct
+// coverage for each knob; these tests close the forwarding-side gap (#4487).
+describe('SessionManager providerOpts timeout forwarding (#4487)', () => {
+  // Each captured opts snapshot from a test provider constructor is appended
+  // to this array via the shared helper below.
+  let captured
+
+  // Bare-bones provider that records the providerOpts handed to its
+  // constructor. Mirrors the FailingProvider/TestProvider shapes used
+  // elsewhere in this file so registerProvider's validateProviderClass
+  // contract is satisfied.
+  class CapturingProvider extends EventEmitter {
+    constructor(opts) {
+      super()
+      captured.push(opts)
+      this.cwd = opts.cwd
+      this.model = opts.model || null
+      this.permissionMode = opts.permissionMode || 'approve'
+      this.isRunning = false
+      this.resumeSessionId = null
+    }
+    static get capabilities() { return {} }
+    start() {}
+    destroy() {}
+    interrupt() {}
+    sendMessage() {}
+    setModel() {}
+    setPermissionMode() {}
+  }
+
+  // Register the capturing provider once and reuse it across every assertion.
+  // The provider registry is process-global so re-registering under the same
+  // name is a no-op after the first import.
+  let providerRegistered = false
+  async function ensureProvider() {
+    if (providerRegistered) return
+    const { registerProvider } = await import('../src/providers.js')
+    registerProvider('test-timeout-capture', CapturingProvider)
+    providerRegistered = true
+  }
+
+  beforeEach(() => {
+    captured = []
+  })
+
+  /**
+   * Build a SessionManager with `configKey` set to `configValue`, drive
+   * createSession() through the capturing provider, and return the captured
+   * providerOpts so the caller can assert on a single key. Resets the
+   * shared `captured` buffer per call so back-to-back invocations within
+   * one test (set + null) read clean.
+   */
+  async function captureProviderOpts(configKey, configValue) {
+    await ensureProvider()
+    captured.length = 0
+    const mgr = new SessionManager({
+      skipPreflight: true,
+      maxSessions: 5,
+      stateFilePath: tmpStateFile(),
+      [configKey]: configValue,
+    })
+    mgr.createSession({ cwd: '/tmp', provider: 'test-timeout-capture' })
+    assert.equal(captured.length, 1, 'CapturingProvider should be instantiated exactly once per captureProviderOpts call')
+    return captured[0]
+  }
+
+  /**
+   * Shared helper: assert that `configKey` flows through as
+   * `providerOpts[providerOptsKey]` when configured to a positive value, and
+   * is OMITTED (key absent — not set to null/undefined) when configured to
+   * null. The 4 knobs use identical forwarding semantics, so this collapses
+   * the per-knob noise to a single line each.
+   */
+  async function assertForwardingPattern({ configKey, providerOptsKey, setValue }) {
+    const setOpts = await captureProviderOpts(configKey, setValue)
+    assert.equal(
+      setOpts[providerOptsKey],
+      setValue,
+      `${providerOptsKey} should be forwarded verbatim when ${configKey}=${setValue}`,
+    )
+
+    const nullOpts = await captureProviderOpts(configKey, null)
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(nullOpts, providerOptsKey),
+      false,
+      `${providerOptsKey} should be OMITTED from providerOpts when ${configKey} is null (got ${nullOpts[providerOptsKey]})`,
+    )
+  }
+
+  it('forwards resultTimeoutMs when set; omits when null (#3749)', async () => {
+    await assertForwardingPattern({
+      configKey: 'resultTimeoutMs',
+      providerOptsKey: 'resultTimeoutMs',
+      setValue: 90_000,
+    })
+  })
+
+  it('forwards hardTimeoutMs when set; omits when null (#3899)', async () => {
+    await assertForwardingPattern({
+      configKey: 'hardTimeoutMs',
+      providerOptsKey: 'hardTimeoutMs',
+      setValue: 3_600_000,
+    })
+  })
+
+  it('forwards streamStallTimeoutMs when set; omits when null (#4467)', async () => {
+    await assertForwardingPattern({
+      configKey: 'streamStallTimeoutMs',
+      providerOptsKey: 'streamStallTimeoutMs',
+      setValue: 120_000,
+    })
+  })
+
+  it('forwards mcpToolCallTimeoutMs when set; omits when null (#4482)', async () => {
+    await assertForwardingPattern({
+      configKey: 'mcpToolCallTimeoutMs',
+      providerOptsKey: 'mcpToolCallTimeoutMs',
+      setValue: 45_000,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Adds session-manager-level tests for the four operator-tunable timeout knobs that `SessionManager` forwards through `providerOpts` to the provider constructor:

- `resultTimeoutMs` (#3749)
- `hardTimeoutMs` (#3899)
- `streamStallTimeoutMs` (#4467)
- `mcpToolCallTimeoutMs` (#4482)

For each knob, the new tests assert:

1. A configured positive value flows through verbatim as `providerOpts.<key>`.
2. A `null` value is OMITTED from `providerOpts` (key absent — not set to `null`) so each provider's BaseSession-level default applies.

Consumer-side coverage already existed in `byok-session` / `base-session`; this PR closes the forwarding-side gap noted during review of #4486.

## Implementation notes

- Registers a single `CapturingProvider` that records its constructor `opts` into a shared buffer.
- A `captureProviderOpts(configKey, configValue)` helper spins up a `SessionManager` with the knob configured, drives `createSession()` through the capturing provider, and returns the captured opts.
- An `assertForwardingPattern({ configKey, providerOptsKey, setValue })` helper collapses each knob to a single assertion, satisfying the issue's "reasonable shared helper" criterion.
- Tests-only — no behaviour changes.

## Test plan

- [x] `node --test packages/server/tests/session-manager.test.js` — 164/164 pass (added 4)
- [x] Full server suite via `npm test -w packages/server` — only pre-existing flakes in `tunnel-manager.integration.test.js` and `web-task-manager.test.js` fail (confirmed present on `main` without this change)

Closes #4487