### PR TITLE
fix(app): scope receivingHistoryReplay per-session (#4512)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -3253,6 +3253,180 @@ describe('history replay must not reset activity timers (#4492)', () => {
   });
 });
 
+// #4512 — the replay flag must be scoped per-session (mirror of dashboard
+// #4493). Pre-fix it was a per-connection boolean (`_ctx.receivingHistoryReplay`):
+// once `history_replay_start` fired for session A, every interleaved live event
+// from session B was treated as replay and dropped its activity bump. The
+// server's `replayHistory()` chunks over `setImmediate`, so live broadcasts
+// from other sessions land between chunks of A's replay.
+describe('replay flag is per-session (#4512)', () => {
+  function seedTwoSessions(
+    sA: Partial<ReturnType<typeof createEmptySessionState>> = {},
+    sB: Partial<ReturnType<typeof createEmptySessionState>> = {},
+  ) {
+    const store = createMockStore({
+      activeSessionId: 'sA',
+      sessions: [
+        { sessionId: 'sA', name: 'A' } as any,
+        { sessionId: 'sB', name: 'B' } as any,
+      ],
+      sessionStates: {
+        sA: { ...createEmptySessionState(), ...sA },
+        sB: { ...createEmptySessionState(), ...sB },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    return store;
+  }
+
+  afterEach(() => {
+    resetReplayFlags();
+  });
+
+  it('live tool_start for session B bumps B during session A replay', () => {
+    // Session A is mid-replay; an interleaved live tool_start for B must
+    // still bump B.lastClientActivityAt. Pre-fix the per-connection flag was
+    // true (for A) so B's bump was suppressed.
+    const store = seedTwoSessions({ lastClientActivityAt: 100 }, { lastClientActivityAt: 100 });
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sA' });
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'tool-b-1',
+      tool: 'Bash',
+      toolUseId: 'tu-b-1',
+      input: { command: 'echo hi' },
+      sessionId: 'sB',
+    });
+    const ssB = store.getState().sessionStates.sB;
+    expect(ssB.lastClientActivityAt).toBeGreaterThan(100);
+  });
+
+  it('history_replay_end for A clears only A from the replaying set', () => {
+    // With two sessions concurrently replaying, ending one must not
+    // un-gate the other — B's replayed tool_start must still NOT bump.
+    const store = seedTwoSessions({ lastClientActivityAt: 100 }, { lastClientActivityAt: 100 });
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sA' });
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sB' });
+    _testMessageHandler.handle({ type: 'history_replay_end', sessionId: 'sA' });
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'tool-b-1',
+      tool: 'Bash',
+      toolUseId: 'tu-b-1',
+      input: { command: 'sleep' },
+      sessionId: 'sB',
+    });
+    const ssB = store.getState().sessionStates.sB;
+    expect(ssB.lastClientActivityAt).toBe(100);
+  });
+
+  it('auth_ok clears all session-replay flags (reconnect scenario)', () => {
+    // After a reconnect, fresh auth means clean slate — any stale entries
+    // in the replaying set must be wiped so future live events aren't
+    // wrongly gated against a session that no longer thinks it's replaying.
+    const store = seedTwoSessions({ lastClientActivityAt: 100 }, { lastClientActivityAt: 100 });
+    // Reconnect context preserves session state through auth_ok.
+    _testMessageHandler.setContext({ ...createMockContext(), isReconnect: true } as any);
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sA' });
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sB' });
+    // Reconnect: auth_ok must drop both entries.
+    _testMessageHandler.handle({
+      type: 'auth_ok',
+      sessionToken: 'tok',
+      clientId: 'client-1',
+      connectedClients: [],
+    });
+    // A subsequent live tool_start for either session must bump.
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'tool-a-1',
+      tool: 'Bash',
+      toolUseId: 'tu-a-1',
+      input: { command: 'ls' },
+      sessionId: 'sA',
+    });
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'tool-b-1',
+      tool: 'Bash',
+      toolUseId: 'tu-b-1',
+      input: { command: 'ls' },
+      sessionId: 'sB',
+    });
+    const stateAfter = store.getState();
+    expect(stateAfter.sessionStates.sA.lastClientActivityAt).toBeGreaterThan(100);
+    expect(stateAfter.sessionStates.sB.lastClientActivityAt).toBeGreaterThan(100);
+  });
+
+  it('tool_start dedup gate uses target session flag, not any session flag', () => {
+    // Per-session dedup gate. Pre-fix: a single per-connection boolean meant
+    // that whenever ANY session was replaying, every interleaved tool_start
+    // (regardless of which session it belongs to) was treated as replay.
+    // Symptom: session B's pre-existing cached tool_use message at the same
+    // id would cause B's live tool_start to be dropped — even though B is
+    // not the one replaying.
+    const sharedToolId = 'tool-shared-id';
+    const store = createMockStore({
+      activeSessionId: 'sA',
+      sessions: [
+        { sessionId: 'sA', name: 'A' } as any,
+        { sessionId: 'sB', name: 'B' } as any,
+      ],
+      sessionStates: {
+        sA: createEmptySessionState(),
+        sB: {
+          ...createEmptySessionState(),
+          // B already has a cached tool message at this id. A live duplicate
+          // tool_start arriving for B would normally append (no replay), but
+          // with a per-connection boolean it gets wrongly dedup-suppressed
+          // while A is replaying.
+          messages: [
+            { id: sharedToolId, type: 'tool_use', content: 'cached', tool: 'Bash', timestamp: 1 } as any,
+          ],
+        },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Session A starts replay. Session B is NOT replaying.
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'sA' });
+
+    // Live tool_start for B at the cached id — B is NOT replaying, so the
+    // dedup gate must not fire and the new message must be appended.
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: sharedToolId,
+      tool: 'Bash',
+      toolUseId: 'tu-b-live',
+      input: { command: 'live' },
+      sessionId: 'sB',
+    });
+    const msgsB = store.getState().sessionStates.sB.messages;
+    expect(msgsB.length).toBeGreaterThanOrEqual(2);
+
+    // And a replayed tool_start for A still dedups against A's cache (sanity:
+    // the per-session gate must still suppress replay duplicates).
+    // Pre-seed an A message at a new id and replay it.
+    const aId = 'tool-a-cached';
+    store.getState().sessionStates.sA.messages.push(
+      { id: aId, type: 'tool_use', content: 'cached', tool: 'Bash', timestamp: 1 } as any,
+    );
+    const lenBefore = store.getState().sessionStates.sA.messages.length;
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: aId,
+      tool: 'Bash',
+      toolUseId: 'tu-a-replay',
+      input: { command: 'replay' },
+      sessionId: 'sA',
+    });
+    const lenAfter = store.getState().sessionStates.sA.messages.length;
+    expect(lenAfter).toBe(lenBefore);
+  });
+});
+
 // #3141: scoped routing for session-tagged server_error messages on the app
 // (dashboard parity).
 describe('server_error session-scoped routing (#3141)', () => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -205,7 +205,15 @@ const INITIAL_ENCRYPTION_CONTEXT: EncryptionContext = {
 
 interface MessageHandlerContext extends EncryptionContext {
   // History replay
-  receivingHistoryReplay: boolean;
+  //
+  // #4512 — per-session replay tracking (mirror of dashboard #4493). The
+  // server's `replayHistory()` chunks over `setImmediate` (ws-history.js),
+  // which yields the event loop between chunks, so live broadcasts from
+  // OTHER sessions can interleave with session A's replay. A per-connection
+  // boolean would gate all sessions on A's replay state and drop legitimate
+  // live activity for sessions B/C/etc. Scope the flag per-session id and
+  // gate per-target.
+  replayingSessions: Set<string>;
   isSessionSwitchReplay: boolean;
   pendingSwitchSessionId: string | null;
 
@@ -234,7 +242,7 @@ interface MessageHandlerContext extends EncryptionContext {
 function createDefaultContext(): MessageHandlerContext {
   return {
     ...INITIAL_ENCRYPTION_CONTEXT,
-    receivingHistoryReplay: false,
+    replayingSessions: new Set<string>(),
     isSessionSwitchReplay: false,
     pendingSwitchSessionId: null,
     postPermissionSplits: new Set<string>(),
@@ -488,7 +496,7 @@ export function setPendingSwitchSessionId(id: string | null): void {
 }
 
 export function resetReplayFlags(): void {
-  _ctx.receivingHistoryReplay = false;
+  _ctx.replayingSessions.clear();
   _ctx.isSessionSwitchReplay = false;
   _ctx.pendingSwitchSessionId = null;
 }
@@ -913,12 +921,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   // without waiting for the user to dismiss it manually. Mirrors the
   // equivalent clear in packages/dashboard/src/store/message-handler.ts.
   //
-  // #4492 — gate on `!_ctx.receivingHistoryReplay` (mobile's per-connection
-  // equivalent of the dashboard's `_receivingHistoryReplay` module flag —
-  // see #4466 / PR #4490). switch_session and reconnect both replay past
-  // events through this handler via history_replay_start → events →
-  // history_replay_end, and replayed tool_start / message / result is NOT
-  // fresh activity. Without this gate, every reconnect or session switch:
+  // #4492 — gate on the replay set (mobile's per-connection equivalent of
+  // the dashboard's `_receivingHistoryReplay` module flag — see #4466 /
+  // PR #4490). switch_session and reconnect both replay past events through
+  // this handler via history_replay_start → events → history_replay_end,
+  // and replayed tool_start / message / result is NOT fresh activity.
+  // Without this gate, every reconnect or session switch:
   //   1) bumps lastClientActivityAt to Date.now(), so "Working… last
   //      activity Ns ago" resets to 1s no matter how idle the session was;
   //   2) wipes inactivityWarning, so the "Agent quiet for 46m 32s · Status
@@ -926,9 +934,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
   // Live activity events arriving AFTER history_replay_end clears the flag
   // still bump correctly — verified by the regression-guard test in
   // message-handler.test.ts.
-  if (isActivityEvent(msg.type) && !_ctx.receivingHistoryReplay) {
+  //
+  // #4512 — gate per target session id (Set membership), not a connection
+  // flag. `replayHistory()` chunks over setImmediate, so live broadcasts
+  // from session B can interleave with A's replay. A per-connection boolean
+  // would wrongly suppress B's live activity bump for the duration of A's
+  // replay.
+  if (isActivityEvent(msg.type)) {
     const targetId = (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
-    if (targetId && get().sessionStates[targetId]) {
+    if (targetId && get().sessionStates[targetId] && !_ctx.replayingSessions.has(targetId)) {
       updateSession(targetId, (ss) => {
         const patch: Partial<SessionState> = { lastClientActivityAt: Date.now() };
         if (ss.inactivityWarning) patch.inactivityWarning = null;
@@ -943,8 +957,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       return;
 
     case 'auth_ok': {
-      // Reset replay flags — fresh auth means clean slate
-      _ctx.receivingHistoryReplay = false;
+      // Reset replay flags — fresh auth means clean slate (#4512: clear the
+      // per-session replaying set so a reconnect doesn't leave stale ids
+      // gating future activity bumps).
+      _ctx.replayingSessions.clear();
       _ctx.isSessionSwitchReplay = false;
       _ctx.pendingSwitchSessionId = null;
       if (!ctx.isReconnect) hapticSuccess();
@@ -1391,7 +1407,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         msg,
         get().activeSessionId,
       );
-      _ctx.receivingHistoryReplay = true;
+      // #4512 — track per-session. Falls back to activeSessionId via
+      // sharedHistoryReplayStart, matching the gate's targetId resolution.
+      if (replayTargetId) _ctx.replayingSessions.add(replayTargetId);
       // Full history replay (from request_full_history): clear messages before replay
       if (fullHistory) {
         _ctx.isSessionSwitchReplay = true;
@@ -1415,7 +1433,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
 
     case 'history_replay_end':
       // Parser is shared via store-core; flag mutation stays here.
-      _ctx.receivingHistoryReplay = sharedHistoryReplayEnd().receivingHistoryReplay;
+      // #4512 — remove this session id from the replaying set. Falls back
+      // to activeSessionId to mirror sharedHistoryReplayStart's resolution.
+      sharedHistoryReplayEnd();
+      {
+        const endTargetId =
+          (typeof msg.sessionId === 'string' && msg.sessionId) || get().activeSessionId;
+        if (endTargetId) _ctx.replayingSessions.delete(endTargetId);
+      }
       _ctx.isSessionSwitchReplay = false;
       // Mark all replayed prompts as answered — any prompt in history
       // has already been resolved by the server.
@@ -1452,7 +1477,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // consistent with sharedMessageHandler and the rest of store-core.
       const targetId = resolveSessionId(msg, get().activeSessionId);
       const cached = getSessionMessages(targetId);
-      const result = sharedMessageHandler(msg, get().activeSessionId, _ctx.receivingHistoryReplay, cached);
+      // #4512 — dedup against history only when THIS message's session is
+      // currently replaying. A per-connection boolean would suppress live
+      // messages for session B while A replays.
+      const messageIsReplay = targetId ? _ctx.replayingSessions.has(targetId) : false;
+      const result = sharedMessageHandler(msg, get().activeSessionId, messageIsReplay, cached);
       if (!result.shouldDispatch) break;
       const newMsg = result.chatMessage;
       const effectiveId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
@@ -1588,10 +1617,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'tool_start': {
       const targetId = (msg.sessionId as string) || get().activeSessionId;
       const cached = getSessionMessages(targetId);
+      // #4512 — dedup against the cached history only when THIS message's
+      // session is currently replaying. A per-connection boolean would
+      // wrongly suppress live tool_start broadcasts for session B while A
+      // is replaying.
+      const toolStartIsReplay = targetId ? _ctx.replayingSessions.has(targetId) : false;
       const result = sharedToolStart(
         msg,
         get().activeSessionId,
-        _ctx.receivingHistoryReplay,
+        toolStartIsReplay,
         cached,
       );
       if (!result.shouldDispatch || !result.chatMessage) break;


### PR DESCRIPTION
## Summary

Mirror of the dashboard fix in #4502 (PR for issue #4493) at the per-connection-context scope. The server's `replayHistory()` chunks via `setImmediate`, so live broadcasts for session B can interleave between chunks of session A's replay. Mobile's `_ctx.receivingHistoryReplay` boolean gated all sessions on A's replay state and dropped legitimate live activity for B/C/etc.

PR #4501 (issue #4492) already added the `!_ctx.receivingHistoryReplay` gate to the pre-handler activity bump — that fixed the single-session case but the multi-session interleave bug remained at the per-connection scope.

## Changes

- `MessageHandlerContext` — replaced `receivingHistoryReplay: boolean` with `replayingSessions: Set<string>`
- `history_replay_start` — `replayingSessions.add(targetId)`
- `history_replay_end` — `replayingSessions.delete(targetId)`
- `auth_ok` — `replayingSessions.clear()` (fresh auth = clean slate)
- Pre-handler activity bump — gated on `!_ctx.replayingSessions.has(targetId)`
- `case 'message'` dedup — per-target `messageIsReplay` flag passed to `sharedMessageHandler`
- `case 'tool_start'` dedup — per-target `toolStartIsReplay` flag passed to `sharedToolStart`
- `resetReplayFlags()` — clears the set

## Test plan

- [x] 4 regression tests added in `packages/app/src/__tests__/store/message-handler.test.ts`:
  - Live `tool_start` for B bumps B during A replay
  - `history_replay_end` for A clears only A from the replaying set
  - `auth_ok` clears all session-replay flags (reconnect scenario)
  - `tool_start` dedup gate uses target session flag, not any session flag
- [x] All 129 message-handler tests pass
- [x] All 1172 app tests pass (3 pre-existing unrelated suite-load failures for missing `xterm-bundle.generated`)
- [x] `tsc --noEmit` clean (only pre-existing `xterm-bundle.generated` error)

Closes #4512