### PR TITLE
fix(server): clamp internal timeout guards to MAX_SANE_DURATION_MS (#4509)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -18,6 +18,10 @@ import {
   SKILLS_PROMPT_HEADER,
 } from './skills-loader.js'
 import { SkillsTrustStore } from './skills-trust.js'
+import { isOperatorTimeoutInRange } from './duration.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('base-session')
 
 const VALID_PERMISSION_MODES = ['approve', 'auto', 'plan', 'acceptEdits']
 
@@ -285,8 +289,15 @@ export class BaseSession extends EventEmitter {
     // SessionManager(resultTimeoutMs:…) which itself reads
     // ~/.chroxy/config.json#resultTimeoutMs or
     // CHROXY_RESULT_TIMEOUT_MS.
+    //
+    // #4509: `isOperatorTimeoutInRange` mirrors the ceiling check #4503
+    // added to `ws-history.js sendPostAuthInfo`. BaseSession is the final
+    // destination — it arms the actual setTimeout against this value — so
+    // even when an over-ceiling number sneaks past SessionManager (e.g. a
+    // provider that hand-builds providerOpts) we still clamp it here so the
+    // inactivity-warning path can't effectively never fire.
     this._resultTimeoutMs =
-      Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
+      isOperatorTimeoutInRange(resultTimeoutMs, { name: 'resultTimeoutMs', log })
         ? resultTimeoutMs
         : DEFAULT_RESULT_TIMEOUT_MS
     // #3899: effective HARD-cap timeout in ms. Defaults to 2 hours.
@@ -294,14 +305,14 @@ export class BaseSession extends EventEmitter {
     // / CHROXY_HARD_TIMEOUT_MS. Operators wanting tight kill-on-stuck
     // semantics can drop this; the soft warning fires first regardless.
     this._hardTimeoutMs =
-      Number.isFinite(hardTimeoutMs) && hardTimeoutMs > 0
+      isOperatorTimeoutInRange(hardTimeoutMs, { name: 'hardTimeoutMs', log })
         ? hardTimeoutMs
         : DEFAULT_HARD_TIMEOUT_MS
     // #4467: stream-stall recovery timer. 0 disables the active recovery
-    // path (the soft warning + hard cap still apply). Non-finite or
-    // negative falls back to the default.
+    // path (the soft warning + hard cap still apply). Non-finite, negative,
+    // or above the 24h ceiling falls back to the default.
     this._streamStallTimeoutMs =
-      Number.isFinite(streamStallTimeoutMs) && streamStallTimeoutMs >= 0
+      isOperatorTimeoutInRange(streamStallTimeoutMs, { allowZero: true, name: 'streamStallTimeoutMs', log })
         ? streamStallTimeoutMs
         : DEFAULT_STREAM_STALL_TIMEOUT_MS
 

--- a/packages/server/src/duration.js
+++ b/packages/server/src/duration.js
@@ -1,3 +1,47 @@
+import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
+
+/**
+ * Validate an operator-supplied inactivity-timeout value (in ms) against the
+ * shared `MAX_SANE_DURATION_MS` (24h) ceiling that the protocol schemas apply
+ * via `.max(MAX_SANE_DURATION_MS)`.
+ *
+ * Returns `true` when the value is a finite number, within the ceiling, and
+ * positive (or non-negative when `allowZero` is set). Returns `false`
+ * otherwise so the caller can fall back to its own default (`null` /
+ * `DEFAULT_*_TIMEOUT_MS`). When the value falls back specifically because it
+ * exceeds the ceiling, a single warning log line is emitted so operators can
+ * spot a typoed `CHROXY_*` env var.
+ *
+ * Mirrors the ceiling check #4484 added to `ws-history.js sendPostAuthInfo`,
+ * extending the same guardrail to the three internal sites listed in #4509
+ * (session-manager, server-cli, base-session).
+ *
+ * @param {*} value - The candidate timeout in ms.
+ * @param {object} opts
+ * @param {boolean} [opts.allowZero=false] - `streamStallTimeoutMs` accepts 0
+ *   as "explicitly disabled"; the two soft/hard timeouts treat 0 as invalid.
+ * @param {string} opts.name - Operator-facing name used in the warn log
+ *   (e.g. `resultTimeoutMs`). Should match the `CHROXY_*`/config-file key
+ *   the operator would have set.
+ * @param {{ warn: Function }} opts.log - Logger to emit the over-ceiling
+ *   warning through. Tests can stub this.
+ * @returns {boolean} `true` if the value is in-range and should be used as-is.
+ */
+export function isOperatorTimeoutInRange(value, { allowZero = false, name, log }) {
+  if (!Number.isFinite(value)) return false
+  const lowerOk = allowZero ? value >= 0 : value > 0
+  if (!lowerOk) return false
+  if (value <= MAX_SANE_DURATION_MS) return true
+  // Over-ceiling: warn once so operators can spot a typoed CHROXY_* env var
+  // (e.g. `CHROXY_HARD_TIMEOUT_MS=99999999999` accidentally typed with an
+  // extra digit) instead of silently producing a >24h internal inactivity
+  // timer.
+  if (log && typeof log.warn === 'function') {
+    log.warn(`${name} ${value} exceeds MAX_SANE_DURATION_MS (${MAX_SANE_DURATION_MS}ms / 24h); falling back to default`)
+  }
+  return false
+}
+
 /**
  * Parse a human-readable duration string into milliseconds.
  *

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1,6 +1,7 @@
 import { SessionManager } from './session-manager.js'
 import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS, DEFAULT_STREAM_STALL_TIMEOUT_MS } from './base-session.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
+import { isOperatorTimeoutInRange } from './duration.js'
 import { WsServer, TUNNEL_STATUS_MIN_PROTOCOL_VERSION } from './ws-server.js'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 import { QUICK_TUNNEL_DNS_SETTLE_MS, waitForTunnel } from './tunnel-check.js'
@@ -224,6 +225,51 @@ function isWithinHome(dir) {
  * @param {{ logLevel?: string, logDir?: string }} config
  * @returns {{ enabled: boolean, level: string, logDir: string|null, error?: string }}
  */
+/**
+ * #4509: resolve the three operator-facing inactivity timeouts
+ * (resultTimeoutMs / hardTimeoutMs / streamStallTimeoutMs) from a startup
+ * config object into BOTH shapes `startCliServer` needs:
+ *
+ *   - SessionManager constructor args (`*TimeoutMs`): null = let BaseSession
+ *     apply its default. The provider opts forwarding path treats null as
+ *     "omit", which is exactly the behaviour we want for fallback.
+ *   - Startup log line (`effective*TimeoutMs`): the resolved DEFAULT_*
+ *     constant so operators see the actual wall-clock value that will fire
+ *     instead of a misleading `null`.
+ *
+ * Previously these two sites hand-rolled the same
+ * `Number.isFinite(x) && x [>|>=] 0` check independently, with no
+ * MAX_SANE_DURATION_MS ceiling. Consolidating into one helper closes the
+ * #4509 gap and makes the two sites impossible to drift apart.
+ *
+ * @param {object} config - The merged startup config (from `~/.chroxy/config.json`
+ *   + CLI flags + env vars).
+ * @param {{ warn: Function }} log - Logger to emit the over-ceiling
+ *   warning through. Defaults to a no-op so callers can omit it in tests.
+ * @returns {{
+ *   resultTimeoutMs: number|null,
+ *   hardTimeoutMs: number|null,
+ *   streamStallTimeoutMs: number|null,
+ *   effectiveResultTimeoutMs: number,
+ *   effectiveHardTimeoutMs: number,
+ *   effectiveStreamStallTimeoutMs: number,
+ * }}
+ */
+export function resolveStartupTimeouts(config = {}, log = { warn: () => {} }) {
+  const resultOk = isOperatorTimeoutInRange(config.resultTimeoutMs, { name: 'resultTimeoutMs', log })
+  const hardOk = isOperatorTimeoutInRange(config.hardTimeoutMs, { name: 'hardTimeoutMs', log })
+  const stallOk = isOperatorTimeoutInRange(config.streamStallTimeoutMs, { allowZero: true, name: 'streamStallTimeoutMs', log })
+
+  return {
+    resultTimeoutMs: resultOk ? config.resultTimeoutMs : null,
+    hardTimeoutMs: hardOk ? config.hardTimeoutMs : null,
+    streamStallTimeoutMs: stallOk ? config.streamStallTimeoutMs : null,
+    effectiveResultTimeoutMs: resultOk ? config.resultTimeoutMs : DEFAULT_RESULT_TIMEOUT_MS,
+    effectiveHardTimeoutMs: hardOk ? config.hardTimeoutMs : DEFAULT_HARD_TIMEOUT_MS,
+    effectiveStreamStallTimeoutMs: stallOk ? config.streamStallTimeoutMs : DEFAULT_STREAM_STALL_TIMEOUT_MS,
+  }
+}
+
 export function initFileLoggingFromConfig(config = {}) {
   if (process.env.CHROXY_NO_FILE_LOGGING === '1') {
     return { enabled: false, level: 'info', logDir: null }
@@ -346,6 +392,11 @@ export async function startCliServer(config) {
     await logEnvironmentManagerReconnectResult(environmentManager, log)
   }
 
+  // #4509: resolve once so the SessionManager arg side and the startup log
+  // line below can't drift apart, and any over-ceiling operator value emits
+  // a single warning here at boot (not three on each tunable).
+  const startupTimeouts = resolveStartupTimeouts(config, log)
+
   // 1. Create session manager
   const sessionManager = new SessionManager({
     maxSessions: config.maxSessions || 5,
@@ -370,22 +421,16 @@ export async function startCliServer(config) {
     costBudget: config.costBudget || null,
     maxMessages: config.maxMessages || config.maxHistory || null,
     // #3749 / #3884 / #3899: SOFT-warning inactivity timeout (ms). null = BaseSession default (30 min).
-    resultTimeoutMs:
-      Number.isFinite(config.resultTimeoutMs) && config.resultTimeoutMs > 0
-        ? config.resultTimeoutMs
-        : null,
     // #3899: HARD-cap inactivity timeout (ms). null = BaseSession default (2h).
-    hardTimeoutMs:
-      Number.isFinite(config.hardTimeoutMs) && config.hardTimeoutMs > 0
-        ? config.hardTimeoutMs
-        : null,
     // #4467: stream-stall recovery (ms). null = BaseSession default (5min).
-    // 0 explicitly disables (operators with workloads that have legitimate
-    // long event gaps can opt out).
-    streamStallTimeoutMs:
-      Number.isFinite(config.streamStallTimeoutMs) && config.streamStallTimeoutMs >= 0
-        ? config.streamStallTimeoutMs
-        : null,
+    //   0 explicitly disables (operators with workloads that have legitimate
+    //   long event gaps can opt out).
+    // #4509: ceiling-clamped via `resolveStartupTimeouts()` above; an
+    // over-24h operator value falls back to null here so BaseSession applies
+    // its default (and the operator gets a warn log identifying the bad key).
+    resultTimeoutMs: startupTimeouts.resultTimeoutMs,
+    hardTimeoutMs: startupTimeouts.hardTimeoutMs,
+    streamStallTimeoutMs: startupTimeouts.streamStallTimeoutMs,
     // #4482: per-MCP-call timeout (ms). null = byok-mcp-client default (30s).
     // Unlike streamStallTimeoutMs, 0 is not a meaningful disable — every
     // MCP tool would look broken — so non-positive falls back to null.
@@ -400,18 +445,11 @@ export async function startCliServer(config) {
 
   // #3749 / #3899: surface the effective inactivity timeouts at startup so
   // operators can verify their config overrides took effect.
-  const effectiveResultTimeoutMs =
-    Number.isFinite(config.resultTimeoutMs) && config.resultTimeoutMs > 0
-      ? config.resultTimeoutMs
-      : DEFAULT_RESULT_TIMEOUT_MS
-  const effectiveHardTimeoutMs =
-    Number.isFinite(config.hardTimeoutMs) && config.hardTimeoutMs > 0
-      ? config.hardTimeoutMs
-      : DEFAULT_HARD_TIMEOUT_MS
-  const effectiveStreamStallTimeoutMs =
-    Number.isFinite(config.streamStallTimeoutMs) && config.streamStallTimeoutMs >= 0
-      ? config.streamStallTimeoutMs
-      : DEFAULT_STREAM_STALL_TIMEOUT_MS
+  // #4509: re-use the already-clamped values from `resolveStartupTimeouts()`
+  // so the log line can't drift away from the SessionManager constructor
+  // args (e.g. log "12h hard-cap" while passing `null` because only one of
+  // the two sites caught a typo).
+  const { effectiveResultTimeoutMs, effectiveHardTimeoutMs, effectiveStreamStallTimeoutMs } = startupTimeouts
   const stallLabel = effectiveStreamStallTimeoutMs === 0
     ? 'disabled'
     : `${formatIdleDuration(effectiveStreamStallTimeoutMs)} (${effectiveStreamStallTimeoutMs}ms)`

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -10,7 +10,7 @@ import { runProviderPreflight, ProviderBinaryNotFoundError, ProviderCredentialMi
 import { GIT } from './git.js'
 import { resolveJsonlPath, readConversationHistoryAsync } from './jsonl-reader.js'
 import { readSessionContext } from './session-context.js'
-import { parseDuration } from './duration.js'
+import { parseDuration, isOperatorTimeoutInRange } from './duration.js'
 import { SessionLockManager } from './session-lock.js'
 import { CostBudgetManager } from './cost-budget-manager.js'
 import { SessionStatePersistence } from './session-state-persistence.js'
@@ -256,21 +256,30 @@ export class SessionManager extends EventEmitter {
     this._sandbox = sandbox || null
     // #3749: per-server inactivity timeout (ms) forwarded to providers
     // via providerOpts. null = use BaseSession's DEFAULT_RESULT_TIMEOUT_MS.
+    //
+    // #4509: the ceiling check inside `isOperatorTimeoutInRange` mirrors the
+    // wire-side guard #4503 added to `ws-history.js sendPostAuthInfo`. An
+    // operator typo (`CHROXY_RESULT_TIMEOUT_MS=99999999999`, extra digit)
+    // would otherwise pass `Number.isFinite > 0` here and silently produce a
+    // >24h internal inactivity timer; the helper instead falls back to null
+    // (→ BaseSession default) and warns once.
     this._resultTimeoutMs =
-      Number.isFinite(resultTimeoutMs) && resultTimeoutMs > 0
+      isOperatorTimeoutInRange(resultTimeoutMs, { name: 'resultTimeoutMs', log })
         ? resultTimeoutMs
         : null
     // #3899: same shape as resultTimeoutMs — null means "let BaseSession
-    // use DEFAULT_HARD_TIMEOUT_MS (2h)"; a positive finite value flows
-    // through providerOpts to each session subclass.
+    // use DEFAULT_HARD_TIMEOUT_MS (2h)"; a positive finite value (≤ ceiling)
+    // flows through providerOpts to each session subclass.
     this._hardTimeoutMs =
-      Number.isFinite(hardTimeoutMs) && hardTimeoutMs > 0
+      isOperatorTimeoutInRange(hardTimeoutMs, { name: 'hardTimeoutMs', log })
         ? hardTimeoutMs
         : null
     // #4467: 0 explicitly disables stream-stall recovery; null = use default;
-    // positive finite value sets the recovery window.
+    // positive finite value sets the recovery window. `allowZero: true` keeps
+    // the explicit-disable behaviour intact while #4509's ceiling gate clamps
+    // pathological over-24h values back to the default.
     this._streamStallTimeoutMs =
-      Number.isFinite(streamStallTimeoutMs) && streamStallTimeoutMs >= 0
+      isOperatorTimeoutInRange(streamStallTimeoutMs, { allowZero: true, name: 'streamStallTimeoutMs', log })
         ? streamStallTimeoutMs
         : null
     // #4482: per-MCP-call timeout. Unlike streamStallTimeoutMs, 0 is not a

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1,9 +1,14 @@
-import { describe, it, beforeEach, afterEach } from 'node:test'
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, utimesSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { BaseSession } from '../src/base-session.js'
+import {
+  BaseSession,
+  DEFAULT_RESULT_TIMEOUT_MS,
+  DEFAULT_HARD_TIMEOUT_MS,
+  DEFAULT_STREAM_STALL_TIMEOUT_MS,
+} from '../src/base-session.js'
 import { SkillsTrustStore, sha256Hex } from '../src/skills-trust.js'
 
 describe('BaseSession', () => {
@@ -1320,4 +1325,78 @@ describe('BaseSession', () => {
       assert.equal(s._getSkills().length, 1, 'malformed trust file must not break loading')
     })
   })
+})
+
+// #4509: BaseSession's three per-session inactivity timeouts must also clamp
+// to the shared MAX_SANE_DURATION_MS (24h) ceiling. Even when an operator
+// over-ceiling value somehow gets past session-manager (e.g. a provider
+// that hand-builds providerOpts), BaseSession is the final destination — it
+// arms the actual setTimeout against the value and a >24h timer would
+// silently make the inactivity-warning / hard-cap / stream-stall paths
+// effectively never fire.
+describe('BaseSession operator-timeout MAX_SANE_DURATION_MS ceiling (#4509)', () => {
+  const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
+
+  // Each row: ctor key, internal slot the value lands in, BaseSession default
+  // it falls back to, display name in the warn log.
+  const TIMEOUT_SPECS = [
+    {
+      ctorKey: 'resultTimeoutMs',
+      internalField: '_resultTimeoutMs',
+      fallback: DEFAULT_RESULT_TIMEOUT_MS,
+      displayName: 'resultTimeoutMs',
+    },
+    {
+      ctorKey: 'hardTimeoutMs',
+      internalField: '_hardTimeoutMs',
+      fallback: DEFAULT_HARD_TIMEOUT_MS,
+      displayName: 'hardTimeoutMs',
+    },
+    {
+      ctorKey: 'streamStallTimeoutMs',
+      internalField: '_streamStallTimeoutMs',
+      fallback: DEFAULT_STREAM_STALL_TIMEOUT_MS,
+      displayName: 'streamStallTimeoutMs',
+    },
+  ]
+
+  let skillsDirLocal
+
+  beforeEach(() => {
+    skillsDirLocal = mkdtempSync(join(tmpdir(), 'chroxy-base-ceiling-'))
+  })
+
+  afterEach(() => {
+    if (skillsDirLocal) rmSync(skillsDirLocal, { recursive: true, force: true })
+    skillsDirLocal = null
+    mock.restoreAll()
+  })
+
+  for (const { ctorKey, internalField, fallback, displayName } of TIMEOUT_SPECS) {
+    it(`clamps ${ctorKey} above MAX_SANE_DURATION_MS back to the default and warns`, () => {
+      const warnings = []
+      mock.method(console, 'warn', (msg) => warnings.push(msg))
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir: skillsDirLocal,
+        repoSkillsDir: null,
+        [ctorKey]: MAX_SANE_DURATION_MS + 1,
+      })
+      assert.equal(s[internalField], fallback,
+        `${internalField} must fall back to its BaseSession default when ${ctorKey} exceeds the 24h ceiling`)
+      const hit = warnings.find((w) => w.includes(displayName) && w.includes('MAX_SANE_DURATION_MS'))
+      assert.ok(hit, `expected a single warn log mentioning ${displayName} + MAX_SANE_DURATION_MS, got: ${warnings.join(' | ')}`)
+    })
+
+    it(`accepts the exact MAX_SANE_DURATION_MS boundary for ${ctorKey}`, () => {
+      const s = new BaseSession({
+        cwd: '/tmp',
+        skillsDir: skillsDirLocal,
+        repoSkillsDir: null,
+        [ctorKey]: MAX_SANE_DURATION_MS,
+      })
+      assert.equal(s[internalField], MAX_SANE_DURATION_MS,
+        `the boundary must be INCLUSIVE — clamping it would surprise operators who tuned the dial to exactly 24h`)
+    })
+  }
 })

--- a/packages/server/tests/server-cli-startup-timeouts.test.js
+++ b/packages/server/tests/server-cli-startup-timeouts.test.js
@@ -1,0 +1,151 @@
+import { describe, it, mock, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveStartupTimeouts } from '../src/server-cli.js'
+import {
+  DEFAULT_RESULT_TIMEOUT_MS,
+  DEFAULT_HARD_TIMEOUT_MS,
+  DEFAULT_STREAM_STALL_TIMEOUT_MS,
+} from '../src/base-session.js'
+
+/**
+ * #4509: `startCliServer` previously hand-rolled the same
+ * `Number.isFinite(x) && x [>|>=] 0` check at two adjacent sites — once when
+ * building SessionManager constructor args (which take null = use BaseSession
+ * default) and once when building the startup log line (which takes the
+ * resolved DEFAULT_* constant). Neither site enforced the shared
+ * MAX_SANE_DURATION_MS (24h) ceiling, so an operator typo like
+ * `CHROXY_HARD_TIMEOUT_MS=99999999999` would silently pass through to
+ * BaseSession and arm a >24h internal inactivity timer.
+ *
+ * `resolveStartupTimeouts(config, log)` consolidates the predicate, applies
+ * the ceiling, and returns both shapes so the two sites can't drift apart.
+ * These tests exercise the helper directly — the SessionManager / BaseSession
+ * sites have their own coverage in their respective `*.test.js`.
+ */
+describe('resolveStartupTimeouts (#4509)', () => {
+  const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
+
+  // Shape of the return value the helper produces. The constructor arg side
+  // (`*TimeoutMs`) takes `null` for invalid/over-ceiling so BaseSession can
+  // apply its default; the log-line side (`effective*`) takes the resolved
+  // default so the operator sees the actual wall-clock value that will fire.
+  function expectShape(out) {
+    assert.ok(out && typeof out === 'object', 'helper must return an object')
+    for (const k of [
+      'resultTimeoutMs', 'hardTimeoutMs', 'streamStallTimeoutMs',
+      'effectiveResultTimeoutMs', 'effectiveHardTimeoutMs', 'effectiveStreamStallTimeoutMs',
+    ]) {
+      assert.ok(Object.prototype.hasOwnProperty.call(out, k), `missing key: ${k}`)
+    }
+  }
+
+  afterEach(() => {
+    mock.restoreAll()
+  })
+
+  it('passes in-range positive values through verbatim on both sides', () => {
+    const out = resolveStartupTimeouts({
+      resultTimeoutMs: 90_000,
+      hardTimeoutMs: 3_600_000,
+      streamStallTimeoutMs: 120_000,
+    }, { warn: () => {} })
+    expectShape(out)
+    assert.equal(out.resultTimeoutMs, 90_000)
+    assert.equal(out.effectiveResultTimeoutMs, 90_000)
+    assert.equal(out.hardTimeoutMs, 3_600_000)
+    assert.equal(out.effectiveHardTimeoutMs, 3_600_000)
+    assert.equal(out.streamStallTimeoutMs, 120_000)
+    assert.equal(out.effectiveStreamStallTimeoutMs, 120_000)
+  })
+
+  it('accepts streamStallTimeoutMs=0 as an explicit disable (does NOT fall back)', () => {
+    // 0 is the documented opt-out for stream-stall recovery (#4467); the soft
+    // warning + hard cap still fire regardless. The other two timeouts treat
+    // 0 as invalid (see next test).
+    const out = resolveStartupTimeouts({ streamStallTimeoutMs: 0 }, { warn: () => {} })
+    assert.equal(out.streamStallTimeoutMs, 0)
+    assert.equal(out.effectiveStreamStallTimeoutMs, 0)
+  })
+
+  it('falls back to null / DEFAULT_* when config values are non-positive or non-finite', () => {
+    for (const bad of [NaN, Infinity, -1, undefined, '60000']) {
+      const out = resolveStartupTimeouts({
+        resultTimeoutMs: bad,
+        hardTimeoutMs: bad,
+        // For streamStall, only Infinity / NaN / strings are invalid — 0 and
+        // -1 paths are tested separately because 0 is intentional and -1 is
+        // just "out of range" without a special-case meaning.
+        streamStallTimeoutMs: bad === 0 ? -1 : bad,
+      }, { warn: () => {} })
+      assert.equal(out.resultTimeoutMs, null, `resultTimeoutMs null for ${String(bad)}`)
+      assert.equal(out.effectiveResultTimeoutMs, DEFAULT_RESULT_TIMEOUT_MS)
+      assert.equal(out.hardTimeoutMs, null, `hardTimeoutMs null for ${String(bad)}`)
+      assert.equal(out.effectiveHardTimeoutMs, DEFAULT_HARD_TIMEOUT_MS)
+      assert.equal(out.streamStallTimeoutMs, null, `streamStallTimeoutMs null for ${String(bad)}`)
+      assert.equal(out.effectiveStreamStallTimeoutMs, DEFAULT_STREAM_STALL_TIMEOUT_MS)
+    }
+  })
+
+  it('clamps resultTimeoutMs above MAX_SANE_DURATION_MS back to null + DEFAULT and warns', () => {
+    const warnings = []
+    const out = resolveStartupTimeouts(
+      { resultTimeoutMs: MAX_SANE_DURATION_MS + 1 },
+      { warn: (msg) => warnings.push(msg) },
+    )
+    assert.equal(out.resultTimeoutMs, null,
+      'SessionManager arg side must fall back to null so BaseSession applies its default')
+    assert.equal(out.effectiveResultTimeoutMs, DEFAULT_RESULT_TIMEOUT_MS,
+      'log-line side must resolve to DEFAULT_RESULT_TIMEOUT_MS so operators see the actual effective value')
+    const hit = warnings.find((w) => w.includes('resultTimeoutMs') && w.includes('MAX_SANE_DURATION_MS'))
+    assert.ok(hit, `expected warn log mentioning resultTimeoutMs + MAX_SANE_DURATION_MS, got: ${warnings.join(' | ')}`)
+  })
+
+  it('clamps hardTimeoutMs above MAX_SANE_DURATION_MS back to null + DEFAULT and warns', () => {
+    const warnings = []
+    const out = resolveStartupTimeouts(
+      { hardTimeoutMs: MAX_SANE_DURATION_MS + 1 },
+      { warn: (msg) => warnings.push(msg) },
+    )
+    assert.equal(out.hardTimeoutMs, null)
+    assert.equal(out.effectiveHardTimeoutMs, DEFAULT_HARD_TIMEOUT_MS)
+    const hit = warnings.find((w) => w.includes('hardTimeoutMs') && w.includes('MAX_SANE_DURATION_MS'))
+    assert.ok(hit, `expected warn log mentioning hardTimeoutMs + MAX_SANE_DURATION_MS, got: ${warnings.join(' | ')}`)
+  })
+
+  it('clamps streamStallTimeoutMs above MAX_SANE_DURATION_MS back to null + DEFAULT and warns', () => {
+    const warnings = []
+    const out = resolveStartupTimeouts(
+      { streamStallTimeoutMs: MAX_SANE_DURATION_MS + 1 },
+      { warn: (msg) => warnings.push(msg) },
+    )
+    assert.equal(out.streamStallTimeoutMs, null)
+    assert.equal(out.effectiveStreamStallTimeoutMs, DEFAULT_STREAM_STALL_TIMEOUT_MS)
+    const hit = warnings.find((w) => w.includes('streamStallTimeoutMs') && w.includes('MAX_SANE_DURATION_MS'))
+    assert.ok(hit, `expected warn log mentioning streamStallTimeoutMs + MAX_SANE_DURATION_MS, got: ${warnings.join(' | ')}`)
+  })
+
+  it('accepts the exact MAX_SANE_DURATION_MS boundary on all three timeouts', () => {
+    const out = resolveStartupTimeouts({
+      resultTimeoutMs: MAX_SANE_DURATION_MS,
+      hardTimeoutMs: MAX_SANE_DURATION_MS,
+      streamStallTimeoutMs: MAX_SANE_DURATION_MS,
+    }, { warn: () => {} })
+    assert.equal(out.resultTimeoutMs, MAX_SANE_DURATION_MS)
+    assert.equal(out.effectiveResultTimeoutMs, MAX_SANE_DURATION_MS)
+    assert.equal(out.hardTimeoutMs, MAX_SANE_DURATION_MS)
+    assert.equal(out.effectiveHardTimeoutMs, MAX_SANE_DURATION_MS)
+    assert.equal(out.streamStallTimeoutMs, MAX_SANE_DURATION_MS)
+    assert.equal(out.effectiveStreamStallTimeoutMs, MAX_SANE_DURATION_MS)
+  })
+
+  it('returns the same shape with no config (all defaults)', () => {
+    const out = resolveStartupTimeouts({}, { warn: () => {} })
+    expectShape(out)
+    assert.equal(out.resultTimeoutMs, null)
+    assert.equal(out.effectiveResultTimeoutMs, DEFAULT_RESULT_TIMEOUT_MS)
+    assert.equal(out.hardTimeoutMs, null)
+    assert.equal(out.effectiveHardTimeoutMs, DEFAULT_HARD_TIMEOUT_MS)
+    assert.equal(out.streamStallTimeoutMs, null)
+    assert.equal(out.effectiveStreamStallTimeoutMs, DEFAULT_STREAM_STALL_TIMEOUT_MS)
+  })
+})

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -3326,3 +3326,57 @@ describe('SessionManager providerOpts timeout forwarding (#4487)', () => {
     })
   })
 })
+
+// #4509: SessionManager's three operator-facing inactivity timeouts
+// (resultTimeoutMs / hardTimeoutMs / streamStallTimeoutMs) are clamped to
+// the shared MAX_SANE_DURATION_MS (24h) ceiling that the protocol schemas
+// apply via `.max(MAX_SANE_DURATION_MS)`. Mirrors the wire-side guard #4503
+// added to `ws-history.js sendPostAuthInfo`. A typoed CHROXY_* env var
+// (extra digit, accidental exponent) is the realistic source of an
+// over-ceiling value; without this guard the operator silently gets a >24h
+// internal inactivity timer instead of the BaseSession default.
+describe('SessionManager operator-timeout MAX_SANE_DURATION_MS ceiling (#4509)', () => {
+  const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
+
+  // Spec table — each row is one operator-tunable timeout we expect to be
+  // clamped. `internalField` is the underscore-prefixed slot the constructor
+  // sets; `displayName` is the warn-log token the helper uses (matches the
+  // CHROXY_* env-var stem so an operator scanning logs can correlate).
+  const TIMEOUT_SPECS = [
+    { configKey: 'resultTimeoutMs', internalField: '_resultTimeoutMs', displayName: 'resultTimeoutMs' },
+    { configKey: 'hardTimeoutMs', internalField: '_hardTimeoutMs', displayName: 'hardTimeoutMs' },
+    { configKey: 'streamStallTimeoutMs', internalField: '_streamStallTimeoutMs', displayName: 'streamStallTimeoutMs' },
+  ]
+
+  afterEach(() => {
+    mock.restoreAll()
+  })
+
+  for (const { configKey, internalField, displayName } of TIMEOUT_SPECS) {
+    it(`clamps ${configKey} above MAX_SANE_DURATION_MS back to null and warns`, () => {
+      const warnings = []
+      mock.method(console, 'warn', (msg) => warnings.push(msg))
+      const mgr = new SessionManager({
+        skipPreflight: true,
+        maxSessions: 5,
+        stateFilePath: tmpStateFile(),
+        [configKey]: MAX_SANE_DURATION_MS + 1,
+      })
+      assert.equal(mgr[internalField], null,
+        `${internalField} must fall back to null when ${configKey} exceeds the 24h ceiling (operator typo guardrail)`)
+      const hit = warnings.find((w) => w.includes(displayName) && w.includes('MAX_SANE_DURATION_MS'))
+      assert.ok(hit, `expected a single warn log mentioning ${displayName} + MAX_SANE_DURATION_MS, got: ${warnings.join(' | ')}`)
+    })
+
+    it(`accepts the exact MAX_SANE_DURATION_MS boundary for ${configKey}`, () => {
+      const mgr = new SessionManager({
+        skipPreflight: true,
+        maxSessions: 5,
+        stateFilePath: tmpStateFile(),
+        [configKey]: MAX_SANE_DURATION_MS,
+      })
+      assert.equal(mgr[internalField], MAX_SANE_DURATION_MS,
+        `the exact boundary is INCLUSIVE — clamping it would surprise operators who tuned the dial to exactly 24h`)
+    })
+  }
+})


### PR DESCRIPTION
## Summary

PR #4503 added the `<= MAX_SANE_DURATION_MS` (24h) ceiling to the wire-side
guards in `ws-history.js sendPostAuthInfo`. The same
`Number.isFinite(x) && x [>|>=] 0` pattern existed unfenced at three internal
sites — `session-manager.js`, `server-cli.js`, and `base-session.js`. A typoed
`CHROXY_*` env var (e.g. `CHROXY_HARD_TIMEOUT_MS=99999999999` with an extra
digit) would silently arm a >24h internal inactivity timer instead of falling
back to the BaseSession default.

This PR closes the gap by adding a shared `isOperatorTimeoutInRange()` helper
to `duration.js` that mirrors the #4503 predicate (finite + lower bound +
`<= MAX_SANE_DURATION_MS`) and emits a single warn log when the ceiling
fallback fires. Applied at the three call sites:

- **`session-manager.js`** — `_resultTimeoutMs`, `_hardTimeoutMs`,
  `_streamStallTimeoutMs` constructor assignments. Over-ceiling falls back to
  `null`, so the BaseSession default propagates through `providerOpts`.
- **`base-session.js`** — same three slots at the final-destination
  per-session assignment. Over-ceiling falls back to the appropriate
  `DEFAULT_*_TIMEOUT_MS` constant; needed even though session-manager already
  clamps, because providers can hand-build `providerOpts` and bypass it.
- **`server-cli.js`** — extracted `resolveStartupTimeouts(config, log)` so the
  `SessionManager` constructor args and the startup `effective*` log block
  share one predicate; the two sites previously duplicated the check and
  could drift apart on future changes.

The protocol schema (`MAX_SANE_DURATION_MS` export, the `remainingMs` /
`idleMs` / `restartEtaMs` schemas) is unchanged — only the three
operator-facing inactivity timeouts share the operator-typo failure mode.

## Test plan

- [x] 18 new test cases — over-ceiling fallback + boundary acceptance per
  timeout per file (`session-manager.test.js`, `base-session.test.js`,
  new `server-cli-startup-timeouts.test.js`).
- [x] Existing tests still pass (the four pre-existing failures in
  `tunnel.integration.test.js` and `web-task-manager.test.js` are
  environmental — missing `cloudflared` and `claude` binaries in the worktree
  — and reproduce on `main`).
- [x] `Number.isFinite` predicate behaviour for in-range values unchanged;
  the existing `#3749` / `#3899` / `#4467` forwarding tests still pass.
- [x] Confirmed `resolveStartupTimeouts` is exported and callable.

Closes #4509