### PR TITLE
fix(server): apply providerMeta label to 1M variant synthesis

### DIFF
--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -578,9 +578,15 @@ export function createModelsRegistry(hooks = {}) {
         const variantFullId = `${m.fullId}${ONE_M_SUFFIX}`
         if (seenFullIds.has(variantFullId)) continue
         const variantId = `${m.id}${ONE_M_SUFFIX}`
+        // Consult the provider's metadata hook first so non-Claude registries
+        // that eventually ship a >=1M model get their authoritative label
+        // instead of the humanizeModelId mangling (#4441 follow-up to #4438).
+        // Currently unreachable for codex/gemini (no 1M models today) but
+        // keeps the synthesis path consistent with the five other call sites.
+        const providerMeta = getModelMetadataFn ? getModelMetadataFn(variantFullId) : null
         variants.push({
           id: variantId,
-          label: humanizeModelId(variantId),
+          label: providerMeta?.label || humanizeModelId(variantId),
           fullId: variantFullId,
           contextWindow: 1_000_000,
         })

--- a/packages/server/tests/models-per-provider.test.js
+++ b/packages/server/tests/models-per-provider.test.js
@@ -134,6 +134,41 @@ describe('createModelsRegistry(providerHooks)', () => {
     assert.equal(converted[0].fullId, 'gpt-5')
   })
 
+  it('1M variant synthesis consults provider getModelMetadata().label (#4441)', () => {
+    // Forward-compat: if a non-Claude provider ever ships a >=1M-context
+    // model, the variant-synthesis branch in updateModels() must defer to
+    // the provider's metadata label instead of humanizeModelId — same
+    // rule that #4438 applied to the cache-load + fallback-merge paths.
+    const r = createModelsRegistry({
+      fallbackModels: [],
+      getModelMetadata: (id) => {
+        if (id === 'mega-model-9') return { id: 'mega-model-9', label: 'Mega Model 9', fullId: 'mega-model-9', contextWindow: 1_000_000 }
+        if (id === 'mega-model-9[1m]') return { id: 'mega-model-9[1m]', label: 'Mega Model 9 (1M)', fullId: 'mega-model-9[1m]', contextWindow: 1_000_000 }
+        return { id, label: id, fullId: id, contextWindow: 1_000_000 }
+      },
+    })
+    const converted = r.updateModels([
+      { value: 'mega-model-9', displayName: 'Mega Model 9', description: '' },
+    ])
+    const variant = converted.find(m => m.fullId === 'mega-model-9[1m]')
+    assert.ok(variant, 'synthesized 1M variant must be present')
+    assert.equal(variant.label, 'Mega Model 9 (1M)',
+      `expected provider-supplied 'Mega Model 9 (1M)' label, got '${variant.label}' — humanizeModelId would have produced 'Mega Model 9[1m]'`)
+  })
+
+  it('1M variant synthesis still uses humanizeModelId when provider metadata returns no label (Claude path)', () => {
+    // Default Claude registry has no getModelMetadata().label override for
+    // synthesized [1m] variants (the hook returns id/contextWindow only),
+    // so humanizeModelId remains the source of truth — unchanged behaviour.
+    const r = createModelsRegistry()
+    const converted = r.updateModels([
+      { value: 'claude-opus-4-7', displayName: 'Opus 4.7', description: '' },
+    ])
+    const variant = converted.find(m => m.fullId === 'claude-opus-4-7[1m]')
+    assert.ok(variant, 'synthesized 1M variant must be present')
+    assert.equal(variant.label, 'Opus 4.7 (1M)', 'Claude path label unchanged')
+  })
+
   it('backward compat: no args => Claude-style defaults (FALLBACK_MODELS, claude- stripping)', () => {
     const r = createModelsRegistry()
     const ids = r.getModels().map(m => m.id).sort()


### PR DESCRIPTION
## Summary

- Variant synthesis in `updateModels()` was the last `humanizeModelId()` call site that didn't consult `getModelMetadataFn()` first; fix brings it in line with the other five call sites.
- Today only Claude crosses the >=1M context threshold so the divergence is unreachable, but the moment a non-Claude provider ships a >=1M model (or an operator hand-edits a provider cache), the synthesized `[1m]` chip would get a mangled label in the same way #4434 described.

## Changes

- `packages/server/src/models.js` — consult `getModelMetadataFn(variantFullId)?.label` before falling back to `humanizeModelId(variantId)` in the variant-synthesis branch.
- `packages/server/tests/models-per-provider.test.js` — registry-level regression test for both a hypothetical non-Claude 1M model (uses provider label) and the default Claude path (unchanged: `humanizeModelId` fallback).

## Test plan

- [x] `node --test packages/server/tests/models-per-provider.test.js` — 20 pass
- [x] `node --test packages/server/tests/models.test.js` — 76 pass (no regressions)

Closes #4441