### PR TITLE
docs(dashboard): document enabled-aware conflict semantics on registry interface

### DIFF
--- a/packages/dashboard/src/shortcuts/registry.ts
+++ b/packages/dashboard/src/shortcuts/registry.ts
@@ -179,7 +179,15 @@ export interface ShortcutRegistry {
   getBinding(id: string): string
   /** Get a single entry with its effective binding. Returns null if unknown. */
   get(id: string): ShortcutListEntry | null
-  /** Persist a new binding for a shortcut. Throws on scope conflict. */
+  /**
+   * Persist a new binding for a shortcut. Throws on scope conflict.
+   *
+   * Defers to `findConflict` for the collision check, so the same
+   * `enabled()`-aware semantics apply: if `id` itself is currently
+   * runtime-disabled, no conflict can be raised (its combo cannot
+   * fire), and conflicts against other disabled defs are likewise
+   * suppressed. The new binding is still persisted in either case.
+   */
   setBinding(id: string, binding: string): void
   /** Remove the override, restoring the default. */
   resetBinding(id: string): void
@@ -188,6 +196,13 @@ export interface ShortcutRegistry {
   /**
    * Return the shortcut id (if any) that would collide if `id` was
    * bound to `binding`. Null = no conflict.
+   *
+   * Defs whose `enabled()` predicate returns false are skipped during
+   * the scan — they cannot fire at runtime so they cannot collide.
+   * This applies symmetrically to the target (`id`) and to every
+   * other def in scope (#4431, #4442). Two mutually-exclusive
+   * environment gates (e.g. a Tauri-only and a browser-only binding)
+   * can therefore share a combo without a false-positive conflict.
    */
   findConflict(id: string, binding: string): ShortcutListEntry | null
   /**


### PR DESCRIPTION
## Summary

- `findConflict` and `setBinding` both honour each def's runtime `enabled()` predicate, but the public interface JSDoc on `ShortcutRegistry` still read as a naive 'iterate every def in scope' contract.
- Spell out the enabled-aware semantics so consumers discover the behaviour without reading the implementation body.

## Changes

- `packages/dashboard/src/shortcuts/registry.ts` — expand JSDoc on `findConflict` and `setBinding` to call out that disabled defs are skipped (cross-references #4431 + #4442).

## Test plan

- [x] `cd packages/dashboard && npx vitest run src/shortcuts/registry.test.ts` — 28 pass (no test changes; verified docs-only diff doesn't break anything)

Closes #4443