### PR TITLE
refactor(dashboard): use useId() for ActivityIndicator popover id

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -21,7 +21,7 @@
  * payload (#3760), falling back to BaseSession.DEFAULT_RESULT_TIMEOUT_MS
  * (30 min) when connected to an older server that doesn't broadcast it.
  */
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { formatToolName } from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
@@ -235,6 +235,12 @@ export function ActivityIndicator() {
   const popoverRef = useRef<HTMLDivElement | null>(null)
   const disclosureRef = useRef<HTMLButtonElement | null>(null)
 
+  // #4444 — useId() keeps the disclosure↔popover aria-controls relationship
+  // unique even if <ActivityIndicator /> is ever rendered twice (e.g. a
+  // future split-pane sidebar), and stays stable across SSR/hydration.
+  // Matches the pattern SidebarTokenView and ToolBubble already use.
+  const popoverId = useId()
+
   // #4427 — outside-click + Escape dismiss for the overflow popover. Without
   // these the popover only closes by re-toggling the same disclosure button or
   // waiting for every shell to drain, which traps focus and surprises users
@@ -307,7 +313,6 @@ export function ActivityIndicator() {
       // The previous "Show N additional…" wording understated the dialog by
       // one and left assistive tech expecting fewer items than rendered.
       const totalShellCount = overflowCount + 1
-      const popoverId = 'activity-indicator-popover'
       return (
         <div
           className="activity-indicator activity-indicator--green"


### PR DESCRIPTION
## Summary

- The hard-coded `'activity-indicator-popover'` literal works today because the component only mounts once, but the rest of the dashboard's disclosure pattern (`SidebarTokenView`, `ToolBubble`) uses `useId()`.
- Switching to `useId()` keeps the `aria-controls` relationship unique if the component is ever rendered twice (future split-pane sidebar) and stable across SSR/hydration.

## Changes

- `packages/dashboard/src/components/ActivityIndicator.tsx` — import `useId`, hoist `popoverId = useId()` to component scope, drop the literal const inside the render branch.

## Test plan

- [x] `cd packages/dashboard && npx vitest run src/components/ActivityIndicator` — 53 pass (inflight, pendingShells, stack all green; the #4428 regression test reads the id off the popover and compares against the disclosure's `aria-controls` rather than the literal, so it kept passing unchanged)

Closes #4444