### PR TITLE
fix(server): cap byok mcp config reads at 10MB

### DIFF
--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -6,9 +6,18 @@
  * children or wire tools.
  */
 
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+
+/**
+ * Defensive upper bound on the size of `~/.claude.json`. Today the file is
+ * small (a few KB), but it is owned by Claude Code, not by us — a future
+ * schema change that starts persisting conversation history into it could
+ * grow it substantially. Reading hundreds of MB synchronously at session-start
+ * would block the server, so we bail with a single warning above this cap.
+ */
+export const CLAUDE_CONFIG_MAX_BYTES = 10 * 1024 * 1024
 
 export function defaultClaudeConfigPath() {
   return process.env.CHROXY_CLAUDE_CONFIG || join(homedir(), '.claude.json')
@@ -81,6 +90,14 @@ export function loadClaudeMcpConfig(filePath = defaultClaudeConfigPath()) {
     return { servers: [], warnings: [], missing: true }
   }
   try {
+    // statSync is cheap; do it before readFileSync so a pathologically large
+    // file (see CLAUDE_CONFIG_MAX_BYTES) does not block startup.
+    const stat = statSync(filePath)
+    if (stat.size > CLAUDE_CONFIG_MAX_BYTES) {
+      const warning = `MCP config ${filePath} exceeds size cap (${stat.size} bytes > ${CLAUDE_CONFIG_MAX_BYTES} bytes); skipping load`
+      console.warn(`[byok-mcp-config] ${warning}`)
+      return { servers: [], warnings: [warning], missing: false }
+    }
     const raw = JSON.parse(readFileSync(filePath, 'utf8'))
     return { ...parseClaudeMcpConfig(raw), missing: false }
   } catch (err) {

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
+  CLAUDE_CONFIG_MAX_BYTES,
   loadClaudeMcpConfig,
   parseClaudeMcpConfig,
   toMcpServerMetadata,
@@ -70,6 +71,20 @@ describe('byok-mcp-config', () => {
     assert.deepEqual(loaded.servers, [])
     assert.equal(loaded.warnings.length, 1)
     assert.match(loaded.warnings[0], /Failed to parse MCP config/)
+  })
+
+  it('bails out with a warning when the config file exceeds the size cap', () => {
+    const path = join(dir, '.claude.json')
+    // Write a JSON-shaped payload just over the size cap; content shape does not
+    // matter because the loader must bail before parsing.
+    const padding = ' '.repeat(CLAUDE_CONFIG_MAX_BYTES + 1)
+    writeFileSync(path, `{"mcpServers":{}}${padding}`)
+    const loaded = loadClaudeMcpConfig(path)
+    assert.equal(loaded.missing, false)
+    assert.deepEqual(loaded.servers, [])
+    assert.equal(loaded.warnings.length, 1)
+    assert.match(loaded.warnings[0], /exceeds size cap/)
+    assert.match(loaded.warnings[0], new RegExp(path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
   })
 
   it('metadata redacts env values but keeps env keys', () => {


### PR DESCRIPTION
## Summary

`loadClaudeMcpConfig` reads `~/.claude.json` synchronously at session-start. The file is owned by Claude Code, not us, so a future schema change that starts persisting conversation history could grow it to hundreds of MB and block server startup.

Adds a cheap `statSync` upfront and bails out with a single warn above `CLAUDE_CONFIG_MAX_BYTES` (10MB). Returns the standard `{ servers: [], warnings: [...], missing: false }` shape so callers don't need a new code path.

## Test plan

- [x] New test covers the over-threshold path
- [x] Existing 6 tests in `byok-mcp-config.test.js` still pass
- [x] All 90 `byok-session.test.js` tests still pass

Closes #4447