### PR TITLE
fix(dashboard): restore focus to disclosure on ActivityIndicator Escape dismiss

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
@@ -485,6 +485,43 @@ describe('ActivityIndicator — popover dismiss paths (#4427)', () => {
     expect(screen.queryByTestId('activity-indicator-popover')).toBeNull()
   })
 
+  it('restores focus to the disclosure button when Escape dismisses the popover (#4445)', () => {
+    // WAI-ARIA APG: a disclosure-triggered dialog dismissed via Escape
+    // should return focus to the invoker so keyboard users don't get
+    // parked on document.body and lose their place in the tab order.
+    seedTwoPendingShells()
+    render(<ActivityIndicator />)
+    const disclosure = screen.getByTestId('activity-indicator-disclosure')
+    fireEvent.click(disclosure)
+    expect(screen.getByTestId('activity-indicator-popover')).toBeTruthy()
+    // Move focus into the popover to simulate a keyboard user who has
+    // tabbed into the dialog. The Escape dismiss must yank focus back
+    // to the disclosure regardless of which element currently holds it.
+    const popover = screen.getByTestId('activity-indicator-popover')
+    ;(popover as HTMLElement).focus()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeNull()
+    expect(document.activeElement).toBe(disclosure)
+  })
+
+  it('does NOT restore focus to the disclosure button on outside-click dismiss (#4445)', () => {
+    // Outside-click dismiss intentionally leaves focus where the user
+    // clicked — stealing it back would fight their pointer intent. Only
+    // the keyboard-only Escape path restores focus per APG guidance.
+    seedTwoPendingShells()
+    render(<ActivityIndicator />)
+    const disclosure = screen.getByTestId('activity-indicator-disclosure')
+    fireEvent.click(disclosure)
+    expect(screen.getByTestId('activity-indicator-popover')).toBeTruthy()
+    // Move focus elsewhere first so we can assert focus is NOT pulled
+    // back to the disclosure after the outside-click dismiss.
+    document.body.focus()
+    expect(document.activeElement).not.toBe(disclosure)
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByTestId('activity-indicator-popover')).toBeNull()
+    expect(document.activeElement).not.toBe(disclosure)
+  })
+
   it('ignores non-Escape keys', () => {
     // Regression guard: the keydown listener must filter by `event.key` so
     // typing in another input doesn't dismiss the popover.

--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -249,10 +249,23 @@ export function ActivityIndicator() {
       if (!target) return
       if (popoverRef.current && popoverRef.current.contains(target)) return
       if (disclosureRef.current && disclosureRef.current.contains(target)) return
+      // #4445 — outside-click dismiss intentionally does NOT restore focus
+      // to the disclosure button: the user explicitly clicked elsewhere,
+      // so stealing focus back would fight their pointer intent. Escape
+      // dismiss (below) is the keyboard-only path that needs focus
+      // restoration per WAI-ARIA APG disclosure guidance.
       setPopoverOpen(false)
     }
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setPopoverOpen(false)
+      if (event.key === 'Escape') {
+        setPopoverOpen(false)
+        // #4445 — WAI-ARIA APG: a disclosure-triggered dialog dismissed
+        // via Escape should return focus to the invoker so keyboard users
+        // don't get parked on document.body and lose their place in the
+        // tab order. The popover has role="dialog" which reinforces the
+        // expectation.
+        disclosureRef.current?.focus()
+      }
     }
     document.addEventListener('mousedown', onMouseDown)
     document.addEventListener('keydown', onKeyDown)


### PR DESCRIPTION
## Summary

- WAI-ARIA APG: a disclosure-triggered dialog dismissed via Escape should return focus to the invoker so keyboard users don't get parked on `document.body`. The popover has `role='dialog'` which reinforces the expectation.
- After `setPopoverOpen(false)` on Escape, focus `disclosureRef`. Outside-click path intentionally does NOT restore focus — stealing it back would fight the user's pointer intent.

## Changes

- `packages/dashboard/src/components/ActivityIndicator.tsx` — call `disclosureRef.current?.focus()` after Escape dismiss; document the outside-click decision in the `mousedown` handler comment.
- `packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx` — two regression tests: Escape pulls focus back even when focus is inside the popover; outside-click does NOT yank focus.

## Notes

The sibling `SidebarTokenView` popover has the same omission. Deferring that to a paired issue to keep this PR scoped to the #4427 follow-up the issue called out — happy to extend the pattern in a separate PR.

## Test plan

- [x] `cd packages/dashboard && npx vitest run src/components/ActivityIndicator` — 55 pass (53 existing + 2 new)

Closes #4445