### PR TITLE
fix(server): warn when byok-mcp-config drops non-string values

### DIFF
--- a/packages/server/src/byok-mcp-config.js
+++ b/packages/server/src/byok-mcp-config.js
@@ -14,17 +14,57 @@ export function defaultClaudeConfigPath() {
   return process.env.CHROXY_CLAUDE_CONFIG || join(homedir(), '.claude.json')
 }
 
-function coerceStringArray(value) {
-  if (!Array.isArray(value)) return []
-  return value.filter((item) => typeof item === 'string')
+/**
+ * Coerce an args array to strings only. Pushes one warning per dropped entry
+ * naming the server, the offending index (`args[<i>]`), and the value's type
+ * so a user who typoed a number-as-number gets a signal instead of a silent
+ * strip. Non-arrays drop the whole field with a single warning.
+ */
+function coerceStringArray(value, { warnings, serverName }) {
+  if (value == null) return []
+  if (!Array.isArray(value)) {
+    warnings.push(
+      `MCP server ${serverName}: ignoring args (expected array, got ${typeof value})`,
+    )
+    return []
+  }
+  const out = []
+  for (let i = 0; i < value.length; i++) {
+    const item = value[i]
+    if (typeof item === 'string') {
+      out.push(item)
+    } else {
+      warnings.push(
+        `MCP server ${serverName}: dropping args[${i}] (expected string, got ${typeof item})`,
+      )
+    }
+  }
+  return out
 }
 
-function coerceEnv(value) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+/**
+ * Coerce an env object to string→string only. Pushes one warning per dropped
+ * key naming the server, the offending field (`env.<KEY>`), and the value's
+ * type. Non-objects drop the whole field with a single warning.
+ */
+function coerceEnv(value, { warnings, serverName }) {
+  if (value == null) return {}
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    warnings.push(
+      `MCP server ${serverName}: ignoring env (expected object, got ${Array.isArray(value) ? 'array' : typeof value})`,
+    )
+    return {}
+  }
   const env = {}
   for (const [key, raw] of Object.entries(value)) {
     if (typeof key !== 'string' || key.length === 0) continue
-    if (typeof raw === 'string') env[key] = raw
+    if (typeof raw === 'string') {
+      env[key] = raw
+    } else {
+      warnings.push(
+        `MCP server ${serverName}: dropping env.${key} (expected string, got ${typeof raw})`,
+      )
+    }
   }
   return env
 }
@@ -63,8 +103,8 @@ export function parseClaudeMcpConfig(raw) {
     servers.push({
       name,
       command: entry.command,
-      args: coerceStringArray(entry.args),
-      env: coerceEnv(entry.env),
+      args: coerceStringArray(entry.args, { warnings, serverName: name }),
+      env: coerceEnv(entry.env, { warnings, serverName: name }),
     })
   }
   return { servers, warnings }

--- a/packages/server/tests/byok-mcp-config.test.js
+++ b/packages/server/tests/byok-mcp-config.test.js
@@ -30,7 +30,10 @@ describe('byok-mcp-config', () => {
         },
       },
     })
-    assert.deepEqual(parsed.warnings, [])
+    assert.equal(parsed.warnings.length, 1)
+    assert.match(parsed.warnings[0], /filesystem/)
+    assert.match(parsed.warnings[0], /env\.COUNT/)
+    assert.match(parsed.warnings[0], /number/)
     assert.deepEqual(parsed.servers, [
       {
         name: 'filesystem',
@@ -39,6 +42,27 @@ describe('byok-mcp-config', () => {
         env: { API_TOKEN: 'secret' },
       },
     ])
+  })
+
+  it('warns on non-string args entries naming the index and type', () => {
+    const parsed = parseClaudeMcpConfig({
+      mcpServers: {
+        github: {
+          command: 'node',
+          args: ['server.js', 42, null, '--flag'],
+        },
+      },
+    })
+    assert.deepEqual(parsed.servers, [
+      { name: 'github', command: 'node', args: ['server.js', '--flag'], env: {} },
+    ])
+    assert.equal(parsed.warnings.length, 2)
+    assert.match(parsed.warnings[0], /github/)
+    assert.match(parsed.warnings[0], /args\[1\]/)
+    assert.match(parsed.warnings[0], /number/)
+    assert.match(parsed.warnings[1], /github/)
+    assert.match(parsed.warnings[1], /args\[2\]/)
+    assert.match(parsed.warnings[1], /object/)
   })
 
   it('parses multiple servers and skips malformed entries with warnings', () => {


### PR DESCRIPTION
## Summary

`coerceEnv` and `coerceStringArray` in `byok-mcp-config.js` previously discarded non-string env values and non-string args entries silently. A user who typoed a number as a number (e.g. `COUNT: 12` instead of `COUNT: "12"`) had no signal that their config lost a field.

Both helpers now push a warning per dropped entry naming the server, the offending field (`env.<KEY>` or `args[<i>]`), and the value's type. Non-array args / non-object env emit a single warning for the whole field. The set of values kept vs. dropped is unchanged — only the warning surface is new.

## Changes

- `coerceStringArray` / `coerceEnv` now take `{ warnings, serverName }` and push per-entry warnings.
- Non-array args / non-object env get one warning for the field instead of silently becoming `[]`/`{}`.
- Existing "parses one Claude-style MCP server entry" test updated to assert one warning for the dropped `COUNT: 12`.
- New test `warns on non-string args entries naming the index and type` covers the args[i] path with two non-strings of different types.

## Test plan

- [x] `node --test packages/server/tests/byok-mcp-config.test.js` — 6/6 pass.
- [x] No external callers of the renamed helpers (only used inside `parseClaudeMcpConfig`).

Closes #4448