### PR TITLE
feat(server): exponential restart backoff in byok-mcp-client

### DIFF
--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -2,12 +2,14 @@
  * MCP child-process lifecycle for the claude-byok provider (#4077).
  *
  * One MCPClient owns one MCP server child. Handles spawn, JSON-RPC handshake
- * (initialize → initialized → tools/list), crash detection with a constant 1s
- * backoff up to MAX_RESTART_ATTEMPTS, and SIGTERM/SIGKILL grace on destroy.
+ * (initialize → initialized → tools/list), crash detection with exponential
+ * backoff between restart attempts (1s/2s/4s, #4453), and SIGTERM/SIGKILL
+ * grace on destroy.
  *
  * Per #4077 scope:
  *   - Lazy spawn: caller decides when to call start().
- *   - Crash detection on child exit / spawn error → schedule restart at 1s.
+ *   - Crash detection on child exit / spawn error → schedule restart per the
+ *     RESTART_BACKOFF_MS schedule (1s/2s/4s).
  *   - After MAX_RESTART_ATTEMPTS failures, state=dead and tools=[].
  *   - Session destroy sends SIGTERM, escalates to SIGKILL at KILL_GRACE_MS.
  *
@@ -19,8 +21,19 @@ import { spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { createLogger } from './logger.js'
 
-const MAX_RESTART_ATTEMPTS = 3
-const RESTART_DELAY_MS = 1000
+// #4453: exponential restart backoff. The first restart still fires at ~1s
+// after the death (no regression on the existing acceptance test); the
+// second waits ~2s after that failure; the third waits ~4s. Total budget
+// before DEAD is ~7s, up from the previous fixed 3s. This better matches
+// "wedged dependency that needs a moment to recover" failure modes (e.g.
+// a transient port conflict that resolves in ~5s would have been blown
+// past by the previous 1/1/1 schedule).
+//
+// The array length is the authoritative max-attempt count — derive
+// MAX_RESTART_ATTEMPTS from it so an operator who edits the schedule
+// can't accidentally desync the two.
+const RESTART_BACKOFF_MS = [1000, 2000, 4000]
+const MAX_RESTART_ATTEMPTS = RESTART_BACKOFF_MS.length
 const KILL_GRACE_MS = 1000
 const HANDSHAKE_TIMEOUT_MS = 5000
 export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30_000
@@ -215,8 +228,16 @@ export class MCPClient extends EventEmitter {
 
     this._tools = []
     this._restartAttempts += 1
-    if (this._restartAttempts >= MAX_RESTART_ATTEMPTS) {
-      this._log.warn(`MCP server ${this.name}: dead after ${this._restartAttempts} failed attempts (last exit code=${code} signal=${signal})`)
+    // #4453: gate on `>` (not `>=`) so the FULL RESTART_BACKOFF_MS schedule
+    // is consumed before declaring DEAD. Pre-#4453 the gate fired on `>=`
+    // and MAX_RESTART_ATTEMPTS=3 — meaning only 2 restart delays were
+    // actually applied (the 3rd post-spawn-death went straight to DEAD with
+    // the 3rd entry of the schedule unused). Under `>`, MAX=3 yields 3
+    // applied delays (1s/2s/4s), and DEAD fires after the 4th post-death
+    // count crosses the bound. Issue framing: "max 3 attempts before
+    // declaring dead" means 3 restarts actually happen, then DEAD.
+    if (this._restartAttempts > MAX_RESTART_ATTEMPTS) {
+      this._log.warn(`MCP server ${this.name}: dead after ${this._restartAttempts - 1} failed attempts (last exit code=${code} signal=${signal})`)
       this._setState(MCP_STATES.DEAD)
       this.emit('dead')
       return
@@ -224,11 +245,17 @@ export class MCPClient extends EventEmitter {
 
     this._setState(MCP_STATES.RESTARTING)
     this.emit('restart', { attempt: this._restartAttempts, code, signal })
+    // #4453: pick the delay for this attempt from the backoff schedule.
+    // _restartAttempts was bumped above; subtract 1 to index. Defensive
+    // fallback to the last entry guards against a future refactor that
+    // diverges MAX_RESTART_ATTEMPTS from the array length.
+    const delayIdx = Math.min(this._restartAttempts - 1, RESTART_BACKOFF_MS.length - 1)
+    const delay = RESTART_BACKOFF_MS[delayIdx]
     this._restartTimer = setTimeout(() => {
       this._restartTimer = null
       if (this._destroyed) return
       this._spawnAndHandshake()
-    }, RESTART_DELAY_MS)
+    }, delay)
   }
 
   _killChild() {

--- a/packages/server/tests/byok-mcp-client.test.js
+++ b/packages/server/tests/byok-mcp-client.test.js
@@ -62,7 +62,7 @@ describe('MCPClient', () => {
   })
 
   describe('crash + restart', () => {
-    it('triggers exactly 1 restart attempt within 1s after child exit (acceptance criterion)', async () => {
+    it('triggers the 1st restart attempt ~1s after child exit (#4453 — first-attempt timing unchanged)', async () => {
       const client = new MCPClient(
         stubConfig({ env: { MCP_STUB_DIE_AFTER_MS: '100' } }),
         { log: silentLog() },
@@ -72,25 +72,87 @@ describe('MCPClient', () => {
       // The client schedules a restart for ~1s later.  Acceptance criterion:
       // the *actual* restart attempt (second spawn → STARTING) happens within
       // ~1s of the death.  Measure between the death (RESTARTING entry) and
-      // the next spawn (next STARTING entry).
+      // the next spawn (next STARTING entry). #4453 added exponential backoff
+      // but the FIRST attempt's timing is intentionally preserved at 1s so a
+      // fast-recovery flake doesn't regress; subsequent attempts back off.
       await waitForState(client, MCP_STATES.READY)
       await waitForState(client, MCP_STATES.RESTARTING, 2000)
       const t0 = Date.now()
       await waitForState(client, MCP_STATES.STARTING, 2000)
       const elapsed = Date.now() - t0
-      assert.ok(elapsed >= 800 && elapsed <= 1500, `2nd spawn fired at ${elapsed}ms after RESTARTING, expected ~1000ms`)
+      assert.ok(elapsed >= 800 && elapsed <= 1500, `1st restart fired at ${elapsed}ms after RESTARTING, expected ~1000ms`)
+      await client.destroy()
+    })
+
+    it('triggers the 2nd restart attempt ~2s after the 2nd failure (#4453 exponential backoff)', async () => {
+      // Bad command so each spawn immediately exits — drives the restart loop
+      // without depending on the stub fixture's handshake.
+      const client = new MCPClient(
+        { name: 'bad', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+        { log: silentLog() },
+      )
+      // Capture every state transition with a timestamp BEFORE start() so we
+      // don't miss the first STARTING/RESTARTING (start() resolves only when
+      // the client reaches a terminal state — READY or DEAD — so by the time
+      // it returns the early transitions are already over).
+      const events = []
+      client.on('state', ({ next }) => events.push({ state: next, t: Date.now() }))
+      await client.start()
+      // start() resolves on DEAD. By then we should have observed:
+      //   STARTING(1) → RESTARTING(1) → STARTING(2) → RESTARTING(2) →
+      //   STARTING(3) → RESTARTING(3) ... → DEAD
+      // Pick the 2nd RESTARTING and the 3rd STARTING — the gap is the
+      // 2nd backoff delay under the 1/2/4 schedule.
+      const restarts = events.filter((e) => e.state === MCP_STATES.RESTARTING)
+      const starts = events.filter((e) => e.state === MCP_STATES.STARTING)
+      assert.ok(restarts.length >= 2, `expected ≥2 RESTARTINGs, got ${restarts.length} — events=${JSON.stringify(events)}`)
+      assert.ok(starts.length >= 3, `expected ≥3 STARTINGs, got ${starts.length} — events=${JSON.stringify(events)}`)
+      const secondGap = starts[2].t - restarts[1].t
+      assert.ok(
+        secondGap >= 1700 && secondGap <= 2500,
+        `2nd backoff fired at ${secondGap}ms after RESTARTING#2, expected ~2000ms`,
+      )
+      await client.destroy()
+    })
+
+    it('triggers the 3rd restart attempt ~4s after the 3rd failure (#4453 exponential backoff)', async () => {
+      // Same fixture as the 2nd-backoff test, but assert the 3rd gap to lock
+      // in the full 1/2/4 schedule. Two tests rather than one combined check
+      // so a regression in just one of the steps surfaces clearly.
+      const client = new MCPClient(
+        { name: 'bad', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+        { log: silentLog() },
+      )
+      const events = []
+      client.on('state', ({ next }) => events.push({ state: next, t: Date.now() }))
+      await client.start()
+      const restarts = events.filter((e) => e.state === MCP_STATES.RESTARTING)
+      assert.ok(restarts.length >= 3, `expected ≥3 RESTARTINGs, got ${restarts.length}`)
+      // After the 3rd RESTARTING, the client schedules a 4s timer then DEAD
+      // fires on the next exit. We can't observe a 4th STARTING (the loop
+      // stops there), so measure RESTARTING(3) → DEAD instead, which is
+      // backoff(3) + spawn(~50ms exit) ≈ ~4050ms.
+      const deadEvent = events.find((e) => e.state === MCP_STATES.DEAD)
+      assert.ok(deadEvent, `expected DEAD transition, got events=${JSON.stringify(events)}`)
+      const thirdGap = deadEvent.t - restarts[2].t
+      assert.ok(
+        thirdGap >= 3700 && thirdGap <= 4800,
+        `3rd backoff + final exit took ${thirdGap}ms after RESTARTING#3, expected ~4050ms`,
+      )
       await client.destroy()
     })
 
     it('declares dead after MAX_RESTART_ATTEMPTS (3) consecutive failed restarts', async () => {
       // Use a bad command so spawn succeeds at exec(2) layer but child exits
-      // immediately. Three rapid failures should trip the dead state.
+      // immediately. Three failures + the new 1/2/4s backoff schedule tip
+      // the total budget to ~7s, so the deadline is bumped from 8s to 10s
+      // to give CI a comfortable margin (#4453).
       const client = new MCPClient(
         { name: 'bad', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
         { log: silentLog() },
       )
       await client.start()
-      await waitForState(client, MCP_STATES.DEAD, 8000)
+      await waitForState(client, MCP_STATES.DEAD, 10_000)
       assert.equal(client.state, MCP_STATES.DEAD)
       assert.equal(client.tools.length, 0)
       await client.destroy()
@@ -102,11 +164,12 @@ describe('MCPClient', () => {
       await waitForState(client, MCP_STATES.READY)
       assert.equal(client.tools.length, 1)
       // Force three exits in rapid succession by replacing the child with
-      // an immediately-exiting child after each restart.
+      // an immediately-exiting child after each restart. #4453's 1/2/4s
+      // backoff makes this take up to ~7s — bump deadline to 10s.
       client._config = { name: 'stub', command: process.execPath, args: ['-e', 'process.exit(1)'], env: {} }
       // Kill the live child to trigger the first restart on the new (bad) config.
       client._child.kill('SIGKILL')
-      await waitForState(client, MCP_STATES.DEAD, 8000)
+      await waitForState(client, MCP_STATES.DEAD, 10_000)
       assert.equal(client.tools.length, 0)
       await client.destroy()
     })


### PR DESCRIPTION
## Summary

- Replace `RESTART_DELAY_MS = 1000` with `RESTART_BACKOFF_MS = [1000, 2000, 4000]` so the restart loop can ride out "wedged dependency that needs a moment to recover" failure modes that the fixed 1s schedule couldn't cover.
- Derive `MAX_RESTART_ATTEMPTS` from `RESTART_BACKOFF_MS.length` so a future tune of one can't silently desync the two.
- Switch the death-counter gate from `>=` to `>` so the **full** schedule actually fires. Pre-fix the 3rd backoff entry was unused — only 2 delays were applied (1s + 1s = ~2s budget). Now 3 delays apply (1s + 2s + 4s = ~7s budget).
- Total budget before DEAD is now ~7s, up from ~2s. First restart still fires at ~1s (no regression on the existing acceptance test).
- Add tests asserting the 2nd attempt fires ~2s after the 2nd failure and the 3rd attempt ~4s after the 3rd failure.

Closes #4453

## Test plan

- [x] `node --test packages/server/tests/byok-mcp-client.test.js` — 17/17 pass (was 15, added 2)
- [x] `node --test packages/server/tests/byok-mcp-fleet.test.js` — 15/15 still pass
- [x] `node --test packages/server/tests/byok-session.test.js` — 90/90 still pass