### PR TITLE
fix(server): unify byok-session on opts.mcpConfigPath; drop unused claudeConfigPath alias

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -153,6 +153,20 @@ export class ClaudeByokSession extends BaseSession {
     }
   }
 
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.cwd]            Working directory for tool execution.
+   * @param {string} [opts.model]          Anthropic model id; falls back to `claude-opus-4-7`.
+   * @param {string} [opts.mcpConfigPath]  Path to a Claude-style MCP config (default: `~/.claude.json` or `$CHROXY_CLAUDE_CONFIG`).
+   *   Canonical name (#4449). Only the `mcpServers` block is read — the rest of the
+   *   file is ignored. A previous `opts.claudeConfigPath` alias was removed because
+   *   it was unused at every call site and added no semantics over `mcpConfigPath`:
+   *   only the MCP portion of the file is consumed by this session, so a single
+   *   "where does the MCP config live" knob is sufficient. Wider Claude-config
+   *   overrides (system prompt, settings) can be added as distinct named opts when
+   *   any of them are actually used.
+   * @param {number} [opts.mcpToolCallTimeoutMs]  Per-tools/call timeout; null/undefined = MCPClient default (30s).
+   */
   constructor(opts = {}) {
     super({ ...opts, provider: opts.provider || 'claude-byok' })
     // Anthropic SDK client; lazily instantiated in start() so unit tests
@@ -235,7 +249,13 @@ export class ClaudeByokSession extends BaseSession {
     // no child spawn, no tool wiring — those land in #4077/#4078/#4079.
     // Malformed configs log a single warn per server and produce an
     // empty list, so a corrupt user config can't take down session start.
-    const mcpConfig = loadClaudeMcpConfig(opts.mcpConfigPath || opts.claudeConfigPath)
+    //
+    // #4449: `mcpConfigPath` is the only supported override. The
+    // earlier `opts.claudeConfigPath` alias was redundant — this
+    // session only reads the `mcpServers` block, so a separate
+    // "whole Claude config" knob added no behavior over
+    // `mcpConfigPath` and had no callers. See constructor JSDoc.
+    const mcpConfig = loadClaudeMcpConfig(opts.mcpConfigPath)
     for (const warning of mcpConfig.warnings) {
       log.warn(`BYOK MCP config: ${warning}`)
     }

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -256,6 +256,38 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('#4449: mcpConfigPath is the canonical MCP-config opt; the dead claudeConfigPath alias is ignored', async () => {
+      // The pre-#4449 constructor honored either `opts.mcpConfigPath`
+      // OR `opts.claudeConfigPath` for historical reasons, but every
+      // caller — production and test — only ever set `mcpConfigPath`.
+      // After #4449 only `mcpConfigPath` is read. Passing the dead
+      // alias must not silently load a config, otherwise downstream
+      // callers could come to depend on it and re-create the
+      // two-names-for-one-thing surface.
+      //
+      // We write to a non-default filename (`mcp-custom.json`) so the
+      // default-path fallback (`$HOME/.claude.json` — which is
+      // `tmpHome/.claude.json` for this test thanks to the `HOME`
+      // override in beforeEach) doesn't accidentally satisfy the
+      // ignored alias path and mask the regression.
+      const configPath = join(tmpHome, 'mcp-custom.json')
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          ghost: { command: 'node', args: ['server.js'], env: {} },
+        },
+      }))
+      // mcpConfigPath honored — the canonical path.
+      const honored = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+      assert.equal(honored._mcpServerConfigs.length, 1)
+      assert.equal(honored._mcpServerConfigs[0].name, 'ghost')
+
+      // claudeConfigPath alone is ignored — falls back to the default
+      // location (which doesn't exist in this isolated tmpHome).
+      const ignored = new ClaudeByokSession({ cwd: '/tmp', claudeConfigPath: configPath })
+      assert.deepEqual(ignored._mcpServerConfigs, [],
+        'claudeConfigPath must not be read; mcpConfigPath is the only knob')
+    })
+
     it('#4077: lazy-spawns an MCPFleet for configured servers and reaches READY before emitting ready', async () => {
       preTrustStub()
       const configPath = join(tmpHome, '.claude.json')


### PR DESCRIPTION
## Summary

The `ClaudeByokSession` constructor previously accepted either `opts.mcpConfigPath` or `opts.claudeConfigPath` as the MCP-config override (`loadClaudeMcpConfig(opts.mcpConfigPath || opts.claudeConfigPath)`). Every production and test caller only ever set `mcpConfigPath`; the `claudeConfigPath` name added no behavior — both knobs loaded the same `mcpServers` block from the same file.

Keeping both was strictly worse than picking one: downstream session wrappers (#4077, #4078 etc.) would have to forward both names, and a future divergence (e.g. `claudeConfigPath` overriding the WHOLE Claude config, `mcpConfigPath` only the MCP portion) would be a breaking reinterpretation of a name that already had a meaning.

## Decision

`mcpConfigPath` is canonical and `claudeConfigPath` is dropped.

- `mcpConfigPath` is descriptive: this session only consumes the `mcpServers` block from the file, so a single "where does the MCP config live" knob is sufficient.
- All existing callers already use this name — no migration needed.
- If a wider Claude-config override is ever needed (system prompt, settings, etc.) it can be added as a distinct named opt with documented semantics. Reviving the alias for that would silently change behavior under existing callers.

## Changes

- `byok-session.js`: drop `|| opts.claudeConfigPath` from `loadClaudeMcpConfig(...)`; add a JSDoc block on the constructor documenting the canonical opt and decision rationale; inline the same rationale next to the call site.
- `byok-session.test.js`: add a regression test asserting `claudeConfigPath` alone does NOT load the config. Writes to a non-default filename (`mcp-custom.json`) so the `~/.claude.json` default fallback can't mask the regression.

## Test plan

- [x] New test `#4449: mcpConfigPath is the canonical MCP-config opt; the dead claudeConfigPath alias is ignored` passes.
- [x] Full byok-session.test.js suite: 91 / 91 pass, 0 fail.

Closes #4449