### PR TITLE
test(server): cover byok-mcp-client handshake timeout + tunable HANDSHAKE_TIMEOUT_MS

### DIFF
--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -22,7 +22,16 @@ import { createLogger } from './logger.js'
 const MAX_RESTART_ATTEMPTS = 3
 const RESTART_DELAY_MS = 1000
 const KILL_GRACE_MS = 1000
-const HANDSHAKE_TIMEOUT_MS = 5000
+// #4454: handshake-request timeout. Some MCP servers (sandboxed containers,
+// servers that download packages on startup) legitimately take >5s to reply
+// to initialize / tools/list. Override per-config via `handshakeTimeoutMs`
+// (preferred — sourced from ~/.claude.json → byok-mcp-config) or per-
+// MCPClient via `opts.handshakeTimeoutMs` (used by tests). The export
+// makes #4078 / future tooling able to read the default without
+// re-deriving it. Both export and the override remain on the same
+// "absolute upper bound for ONE handshake request" semantics — total
+// handshake budget is up to 2× this (initialize + tools/list).
+export const DEFAULT_HANDSHAKE_TIMEOUT_MS = 5000
 export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30_000
 
 export const MCP_STATES = Object.freeze({
@@ -45,6 +54,18 @@ export class MCPClient extends EventEmitter {
     // tuple, which doesn't change between restart attempts). Returns true →
     // proceed; false → state=DEAD permanently, no child is ever spawned.
     this._trustGate = opts.trustGate || null
+    // #4454: per-instance handshake timeout. Precedence (high → low):
+    //   1. opts.handshakeTimeoutMs (constructor; tests / fleet pass-through)
+    //   2. config.handshakeTimeoutMs (per-MCP-server, sourced from ~/.claude.json)
+    //   3. DEFAULT_HANDSHAKE_TIMEOUT_MS module constant
+    // Same defensive guard as resultTimeoutMs in byok-session: non-finite
+    // / non-positive (NaN, Infinity, 0, -1, '5s') falls through to the next
+    // tier because setTimeout coerces those to 0ms and would make every
+    // handshake look broken.
+    this._handshakeTimeoutMs =
+      (Number.isFinite(opts.handshakeTimeoutMs) && opts.handshakeTimeoutMs > 0 && opts.handshakeTimeoutMs) ||
+      (Number.isFinite(config?.handshakeTimeoutMs) && config.handshakeTimeoutMs > 0 && config.handshakeTimeoutMs) ||
+      DEFAULT_HANDSHAKE_TIMEOUT_MS
     this._state = MCP_STATES.IDLE
     this._tools = []
     this._child = null
@@ -132,12 +153,12 @@ export class MCPClient extends EventEmitter {
       protocolVersion: '2024-11-05',
       capabilities: {},
       clientInfo: { name: 'chroxy-byok', version: '1' },
-    }, HANDSHAKE_TIMEOUT_MS)
+    }, this._handshakeTimeoutMs)
     if (!initResult || typeof initResult !== 'object') {
       throw new Error('initialize returned non-object result')
     }
     this._notify('notifications/initialized')
-    const toolsResult = await this._request('tools/list', {}, HANDSHAKE_TIMEOUT_MS)
+    const toolsResult = await this._request('tools/list', {}, this._handshakeTimeoutMs)
     const tools = Array.isArray(toolsResult?.tools) ? toolsResult.tools : []
     this._tools = Object.freeze(tools.map((t) => Object.freeze({ ...t })))
     this._restartAttempts = 0

--- a/packages/server/tests/byok-mcp-client.test.js
+++ b/packages/server/tests/byok-mcp-client.test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
-import { MCPClient, MCP_STATES } from '../src/byok-mcp-client.js'
+import { MCPClient, MCP_STATES, DEFAULT_HANDSHAKE_TIMEOUT_MS } from '../src/byok-mcp-client.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const STUB = join(__dirname, 'fixtures', 'mcp-stub.mjs')
@@ -45,6 +45,109 @@ describe('MCPClient', () => {
       assert.equal(client.state, MCP_STATES.READY)
       assert.equal(client.tools.length, 1)
       assert.equal(client.tools[0].name, 'echo')
+      await client.destroy()
+    })
+
+    it('exposes DEFAULT_HANDSHAKE_TIMEOUT_MS for downstream tuning (#4454)', () => {
+      assert.equal(typeof DEFAULT_HANDSHAKE_TIMEOUT_MS, 'number')
+      assert.ok(DEFAULT_HANDSHAKE_TIMEOUT_MS > 0, 'default must be a positive ms count')
+    })
+
+    it('per-instance opts.handshakeTimeoutMs overrides the default (#4454)', async () => {
+      // The stub never replies to tools/list. A 200ms override on the
+      // client should expire well before the 5s default, surfacing the
+      // restart loop quickly. End-to-end success: client reaches DEAD via
+      // the timeout → kill → restart → repeat path.
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_TOOLS_LIST_HANG: '1' } }),
+        { log: silentLog(), handshakeTimeoutMs: 200 },
+      )
+      const t0 = Date.now()
+      await client.start()
+      // start() resolves on DEAD. Three handshakes × 200ms timeout + 3
+      // restart backoffs + spawn overhead → comfortably under 12s for the
+      // test deadline. The point is just that we DID hit DEAD via timeouts,
+      // not via spawn-failure.
+      assert.equal(client.state, MCP_STATES.DEAD)
+      const elapsed = Date.now() - t0
+      assert.ok(elapsed < 12_000, `DEAD took ${elapsed}ms, expected <12s`)
+      await client.destroy()
+    })
+
+    it('per-config handshakeTimeoutMs overrides the default (#4454)', async () => {
+      // Same shape as above but the override lives on `config` (the path
+      // ~/.claude.json → byok-mcp-config will use).
+      const cfg = { ...stubConfig({ env: { MCP_STUB_TOOLS_LIST_HANG: '1' } }), handshakeTimeoutMs: 200 }
+      const client = new MCPClient(cfg, { log: silentLog() })
+      const t0 = Date.now()
+      await client.start()
+      assert.equal(client.state, MCP_STATES.DEAD)
+      const elapsed = Date.now() - t0
+      assert.ok(elapsed < 12_000, `DEAD took ${elapsed}ms via config override, expected <12s`)
+      await client.destroy()
+    })
+
+    it('opts.handshakeTimeoutMs takes precedence over config.handshakeTimeoutMs (#4454)', async () => {
+      // opts=200, config=60_000 — if precedence is reversed we'd hang for
+      // a minute. A successful 12s-bounded DEAD asserts opts won.
+      const cfg = { ...stubConfig({ env: { MCP_STUB_TOOLS_LIST_HANG: '1' } }), handshakeTimeoutMs: 60_000 }
+      const client = new MCPClient(cfg, { log: silentLog(), handshakeTimeoutMs: 200 })
+      const t0 = Date.now()
+      await client.start()
+      assert.equal(client.state, MCP_STATES.DEAD)
+      const elapsed = Date.now() - t0
+      assert.ok(elapsed < 12_000, `DEAD took ${elapsed}ms, expected <12s — opts override should have won`)
+      await client.destroy()
+    })
+
+    it('non-finite / non-positive timeouts fall back to the default (#4454)', () => {
+      // Defensive guard: NaN, Infinity, 0, -1, strings — setTimeout coerces
+      // those to 0ms and would make every handshake look broken. Verified
+      // by reading the resolved field rather than running a handshake.
+      for (const bogus of [NaN, Infinity, 0, -1, '5s', null, undefined]) {
+        const client = new MCPClient(stubConfig(), { log: silentLog(), handshakeTimeoutMs: bogus })
+        assert.equal(
+          client._handshakeTimeoutMs,
+          DEFAULT_HANDSHAKE_TIMEOUT_MS,
+          `opts=${String(bogus)} should fall back to DEFAULT_HANDSHAKE_TIMEOUT_MS`,
+        )
+      }
+    })
+
+    it('handshake-timeout path: initialize hang → DEAD with no leaked timers (#4454)', async () => {
+      // Stub accepts the spawn but never replies to initialize. The client
+      // must hit its handshake timeout, kill the child, restart, eventually
+      // declare DEAD. Verifies the negative branch of _handshake() that the
+      // existing tests never exercised. Use a short override so the test
+      // doesn't add ~15s to the suite (3 × default 5s).
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_INITIALIZE_HANG: '1' } }),
+        { log: silentLog(), handshakeTimeoutMs: 200 },
+      )
+      await client.start()
+      assert.equal(client.state, MCP_STATES.DEAD)
+      assert.equal(client.tools.length, 0)
+      // The restart timer should have been cleared (DEAD path never schedules
+      // a follow-up). _pending must be empty (every request settled). Verify
+      // no internal handles linger before destroy.
+      assert.equal(client._restartTimer, null, 'restart timer should be cleared on DEAD')
+      assert.equal(client._pending.size, 0, '_pending should be drained when child exits')
+      await client.destroy()
+    })
+
+    it('handshake-timeout path: tools/list hang → DEAD (#4454)', async () => {
+      // Same flow as initialize-hang but the timeout fires on the SECOND
+      // handshake request (tools/list). Asserts the catch-around-handshake
+      // path correctly kills the child after the partially-completed
+      // initialize.
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_TOOLS_LIST_HANG: '1' } }),
+        { log: silentLog(), handshakeTimeoutMs: 200 },
+      )
+      await client.start()
+      assert.equal(client.state, MCP_STATES.DEAD)
+      assert.equal(client._restartTimer, null)
+      assert.equal(client._pending.size, 0)
       await client.destroy()
     })
 

--- a/packages/server/tests/fixtures/mcp-stub.mjs
+++ b/packages/server/tests/fixtures/mcp-stub.mjs
@@ -16,8 +16,17 @@ createInterface({ input: process.stdin }).on('line', (line) => {
   try { msg = JSON.parse(line) } catch { return }
   if (msg.id == null) return
   if (msg.method === 'initialize') {
+    // #4454: optionally never respond to initialize so the client's handshake
+    // timeout branch can be exercised. The stub stays alive (no exit) — the
+    // client must rely on its own timeout, not on EOF.
+    if (process.env.MCP_STUB_INITIALIZE_HANG === '1') return
     reply(msg.id, { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'mcp-stub', version: '0.1.0' } })
   } else if (msg.method === 'tools/list') {
+    // #4454: optionally accept initialize but never reply to tools/list.
+    // Exercises the *second* handshake-timeout branch which the existing
+    // MCP_STUB_HANG (whole-process hang) couldn't reach because that knob
+    // also blocks initialize.
+    if (process.env.MCP_STUB_TOOLS_LIST_HANG === '1') return
     reply(msg.id, { tools })
   } else if (msg.method === 'tools/call') {
     if (process.env.MCP_STUB_TOOL_DIE === '1') {


### PR DESCRIPTION
## Summary

- Export `DEFAULT_HANDSHAKE_TIMEOUT_MS` so downstream tooling (#4078) can read the default without duplicating it.
- Accept `handshakeTimeoutMs` via constructor opts AND per-server `config.handshakeTimeoutMs` (the path `~/.claude.json` → `byok-mcp-config` will use). Precedence: **opts > config > module default**. Same defensive guard as `resultTimeoutMs` so NaN / Infinity / 0 / negative / non-number values fall back instead of silently coercing to 0 ms.
- Add stub fixture knobs `MCP_STUB_INITIALIZE_HANG` and `MCP_STUB_TOOLS_LIST_HANG` so the two distinct handshake-timeout branches can be exercised. The existing `MCP_STUB_HANG` couldn't drive these — it also blocks `initialize`, leaving the `tools/list` branch unreachable.
- Add tests covering: the constant export, opts/config precedence (including override-wins), defensive-fallback for bogus values, and the timeout-then-restart-then-DEAD path with no leaked timers or `_pending` entries.

Closes #4454

## Test plan

- [x] `node --test packages/server/tests/byok-mcp-client.test.js` — 22/22 pass (was 15, added 7)
- [x] `node --test packages/server/tests/byok-mcp-fleet.test.js` — 15/15 still pass