### PR TITLE
fix(server): clean up leaked .tmp on renameSync failure

### DIFF
--- a/packages/server/src/byok-mcp-trust.js
+++ b/packages/server/src/byok-mcp-trust.js
@@ -24,7 +24,7 @@
  * iteration can add expiry timestamps without breaking the file format.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, chmodSync } from 'node:fs'
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync, chmodSync, unlinkSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, dirname } from 'node:path'
 
@@ -154,7 +154,18 @@ export function recordTrust(server, filePath = defaultTrustStorePath()) {
   const tmp = `${filePath}.tmp`
   writeFileSync(tmp, JSON.stringify({ trustedTuples: entries }, null, 2), { mode: 0o600 })
   try { chmodSync(tmp, 0o600) } catch {}
-  renameSync(tmp, filePath)
+  // #4463: when renameSync throws (cross-device link, FS quota, ACL) the
+  // temp file would otherwise be left behind. Unlink it on the failure
+  // path and re-throw the ORIGINAL rename error so the caller sees the
+  // real failure rather than a cleanup-side ENOENT. The cleanup unlink
+  // swallows its own errors (the temp may already be gone if the rename
+  // partially succeeded or the FS removed it).
+  try {
+    renameSync(tmp, filePath)
+  } catch (err) {
+    try { unlinkSync(tmp) } catch {}
+    throw err
+  }
   return loadTrustStore(filePath)
 }
 

--- a/packages/server/tests/byok-mcp-trust.test.js
+++ b/packages/server/tests/byok-mcp-trust.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from 'node:test'
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync, statSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -337,4 +337,71 @@ describe('byok-mcp-trust', () => {
       }
     })
   })
+
+  describe('recordTrust rename failure cleanup (#4463)', () => {
+    // #4463: when renameSync fails (cross-device link, FS quota, ACL)
+    // the .tmp file is left behind. recordTrust now wraps rename in a
+    // try/catch that unlinks .tmp on failure and re-throws the original
+    // error. Module mocks are required because the bug is in the
+    // failure path of a sync fs operation — there's no portable way to
+    // force a real rename failure that's deterministic across tmpfs /
+    // ext4 / APFS.
+    if (typeof mock.module !== 'function') {
+      it('skipped — mock.module requires --experimental-test-module-mocks', (t) => {
+        t.skip('re-run with --experimental-test-module-mocks to exercise these tests')
+      })
+    } else {
+      it('unlinks the leaked .tmp file when renameSync fails', async () => {
+        const realFs = await import('node:fs')
+        let renameError = new Error('EXDEV cross-device link')
+        let unlinkCalls = []
+        const mockFs = {
+          ...realFs,
+          renameSync: () => { throw renameError },
+          unlinkSync: (p) => { unlinkCalls.push(p) },
+        }
+        mock.module('node:fs', { defaultExport: mockFs, namedExports: mockFs })
+        try {
+          const { recordTrust: rt } = await import(`../src/byok-mcp-trust.js?cacheBust=4463-${Date.now()}`)
+          let threw = null
+          try {
+            rt({ name: 'leak', command: 'node', args: ['leak.js'] }, storePath)
+          } catch (err) {
+            threw = err
+          }
+          assert.ok(threw, 'recordTrust must re-throw the rename failure')
+          assert.match(threw.message, /EXDEV/, 'original error is surfaced')
+          assert.equal(unlinkCalls.length, 1, '.tmp must be unlinked exactly once')
+          assert.ok(unlinkCalls[0].endsWith('.tmp'), 'cleanup targets the .tmp file')
+        } finally {
+          mock.restoreAll()
+        }
+      })
+
+      it('tolerates the .tmp already being absent during cleanup', async () => {
+        const realFs = await import('node:fs')
+        const renameError = new Error('original rename failure')
+        const mockFs = {
+          ...realFs,
+          renameSync: () => { throw renameError },
+          unlinkSync: () => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) },
+        }
+        mock.module('node:fs', { defaultExport: mockFs, namedExports: mockFs })
+        try {
+          const { recordTrust: rt } = await import(`../src/byok-mcp-trust.js?cacheBust=4463b-${Date.now()}`)
+          let threw = null
+          try {
+            rt({ name: 'gone', command: 'node', args: ['gone.js'] }, storePath)
+          } catch (err) {
+            threw = err
+          }
+          assert.ok(threw)
+          assert.match(threw.message, /original rename failure/, 'original error surfaces, not the cleanup ENOENT')
+        } finally {
+          mock.restoreAll()
+        }
+      })
+    }
+  })
+
 })


### PR DESCRIPTION
Closes #4463.

## Summary

`recordTrust` wrote the new trust store to a `.tmp` file then `renameSync`-ed it into place. If `renameSync` threw (cross-device link, FS quota, ACL) the `.tmp` was left behind in `~/.chroxy/` — lingering state until the next write overwrote it.

Wrap `renameSync` in a try/catch that `unlinkSync`-es the temp on failure and re-throws the original error. Cleanup itself swallows errors so the caller always sees the real rename failure (cross-device, quota, etc.) rather than a misleading `ENOENT` from the cleanup unlink.

## Tests

- `cleans up the .tmp file when renameSync fails`: mocks `node:fs` to throw `EXDEV`; asserts `unlinkSync` was called exactly once on the `.tmp` path and the original error surfaces.
- `tolerates the .tmp already being absent during cleanup`: mocks both `renameSync` and `unlinkSync` to throw; asserts the original rename error is what surfaces (not the cleanup ENOENT).

Uses `--experimental-test-module-mocks` (already in the test script). All 124 trust/fleet/session tests pass.