### PR TITLE
fix(server): drop opts.claudeConfigPath synonym in ClaudeByokSession

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -153,6 +153,20 @@ export class ClaudeByokSession extends BaseSession {
     }
   }
 
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.mcpConfigPath] Override path for MCP config discovery.
+   *   This is the canonical option name and matches the loader's purpose
+   *   (`loadClaudeMcpConfig`). Today the loader reads the whole `~/.claude.json`
+   *   file and parses only the `mcpServers` block, but the override exists
+   *   strictly to point at an alternate MCP config (e.g. a test fixture, an
+   *   env override). See #4449 for the rationale on picking one name.
+   *
+   *   `claudeConfigPath` was briefly accepted as a synonym in #4446 but is
+   *   intentionally not supported — passing it logs a single deprecation warn
+   *   and is otherwise ignored, so downstream session wrappers should forward
+   *   `mcpConfigPath` only.
+   */
   constructor(opts = {}) {
     super({ ...opts, provider: opts.provider || 'claude-byok' })
     // Anthropic SDK client; lazily instantiated in start() so unit tests
@@ -235,7 +249,16 @@ export class ClaudeByokSession extends BaseSession {
     // no child spawn, no tool wiring — those land in #4077/#4078/#4079.
     // Malformed configs log a single warn per server and produce an
     // empty list, so a corrupt user config can't take down session start.
-    const mcpConfig = loadClaudeMcpConfig(opts.mcpConfigPath || opts.claudeConfigPath)
+    //
+    // #4449: `mcpConfigPath` is the canonical override; `claudeConfigPath`
+    // was a synonym added in #4446 and is intentionally not honored. Warn
+    // once if a caller still forwards it so the deprecation is loud.
+    if (opts.claudeConfigPath != null && opts.mcpConfigPath == null) {
+      log.warn(
+        'BYOK MCP config: opts.claudeConfigPath is not supported — pass opts.mcpConfigPath instead (see #4449)',
+      )
+    }
+    const mcpConfig = loadClaudeMcpConfig(opts.mcpConfigPath)
     for (const warning of mcpConfig.warnings) {
       log.warn(`BYOK MCP config: ${warning}`)
     }

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -8,6 +8,7 @@ import { APIUserAbortError } from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from '../src/byok-session.js'
 import { MCP_STATES } from '../src/byok-mcp-client.js'
 import { recordTrust } from '../src/byok-mcp-trust.js'
+import { addLogListener, removeLogListener } from '../src/logger.js'
 
 function preTrustStub() {
   recordTrust(
@@ -254,6 +255,64 @@ describe('ClaudeByokSession', () => {
       assert.deepEqual(session._mcpServerConfigs, [])
       assert.ok(captured.find((e) => e.name === 'ready'), 'malformed MCP config must not block startup')
       await session.destroy()
+    })
+
+    it('#4449: ignores opts.claudeConfigPath and warns once when it is supplied alone', async () => {
+      // The constructor briefly accepted `claudeConfigPath` as a synonym for
+      // `mcpConfigPath`. #4449 picks `mcpConfigPath` as the single canonical
+      // name. Passing `claudeConfigPath` alone must NOT load that file (so
+      // downstream wrappers cannot rely on it) and must emit a deprecation
+      // warn so the dropped path is debuggable.
+      //
+      // The override file is written outside HOME so the HOME-default loader
+      // path (which is still active because `mcpConfigPath` is null) does
+      // not accidentally pick it up.
+      const overrideDir = mkdtempSync(join(tmpdir(), 'chroxy-byok-4449-override-'))
+      try {
+        const configPath = join(overrideDir, 'override.json')
+        writeFileSync(configPath, JSON.stringify({
+          mcpServers: { github: { command: 'node', args: ['server.js'] } },
+        }))
+        const warnings = []
+        const listener = (entry) => {
+          if (entry.level === 'warn') warnings.push(entry.message)
+        }
+        addLogListener(listener)
+        try {
+          const session = new ClaudeByokSession({ cwd: '/tmp', claudeConfigPath: configPath })
+          assert.deepEqual(session.mcpServers, [], 'claudeConfigPath must not feed the loader')
+          const deprecationWarns = warnings.filter((w) => /claudeConfigPath/.test(w))
+          assert.equal(deprecationWarns.length, 1, 'exactly one deprecation warn')
+          assert.match(deprecationWarns[0], /mcpConfigPath/)
+          assert.match(deprecationWarns[0], /#4449/)
+          await session.destroy()
+        } finally {
+          removeLogListener(listener)
+        }
+      } finally {
+        rmSync(overrideDir, { recursive: true, force: true })
+      }
+    })
+
+    it('#4449: does NOT warn when only mcpConfigPath is supplied', async () => {
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: { github: { command: 'node', args: ['server.js'] } },
+      }))
+      const warnings = []
+      const listener = (entry) => {
+        if (entry.level === 'warn') warnings.push(entry.message)
+      }
+      addLogListener(listener)
+      try {
+        const session = new ClaudeByokSession({ cwd: '/tmp', mcpConfigPath: configPath })
+        assert.equal(session.mcpServers.length, 1, 'mcpConfigPath still loads')
+        const deprecationWarns = warnings.filter((w) => /claudeConfigPath/.test(w))
+        assert.equal(deprecationWarns.length, 0)
+        await session.destroy()
+      } finally {
+        removeLogListener(listener)
+      }
     })
 
     it('#4077: lazy-spawns an MCPFleet for configured servers and reaches READY before emitting ready', async () => {


### PR DESCRIPTION
## Summary

PR #4446 added `claudeConfigPath` as a synonym for `mcpConfigPath` in the `ClaudeByokSession` constructor, but only `mcpConfigPath` was ever exercised by tests or any caller. Two distinct option names for the same purpose forces every downstream session wrapper to forward both.

**Decision recorded:** pick `mcpConfigPath` as the single canonical name — it matches the loader's purpose (`loadClaudeMcpConfig`) and is the name already used by every test and call site. Documented on the constructor's JSDoc + via an inline `#4449` comment. Passing `claudeConfigPath` alone now emits one deprecation warn and is ignored, so a stray caller surfaces in logs instead of silently working.

This satisfies AC option (a): one option removed, other tests/docs unchanged, plus a regression test asserting deprecation + ignore behavior.

## Test plan

- [x] New test asserts `claudeConfigPath` alone yields empty `mcpServers` + one deprecation warn
- [x] New test asserts `mcpConfigPath` alone still loads and emits zero deprecation warns
- [x] Full 92-test `byok-session.test.js` suite passes

Closes #4449