### PR TITLE
fix(server): log orphan JSON-RPC responses in byok-mcp-client at debug level

### DIFF
--- a/packages/server/src/byok-mcp-client.js
+++ b/packages/server/src/byok-mcp-client.js
@@ -192,10 +192,28 @@ export class MCPClient extends EventEmitter {
         this._log.warn(`MCP server ${this.name}: non-JSON line: ${line.slice(0, 80)}`)
         continue
       }
-      if (msg.id != null && this._pending.has(msg.id)) {
+      if (msg.id == null) {
+        // Notification from the server (per JSON-RPC spec: `id` is required
+        // on responses, absent on notifications). Ignored silently — they
+        // are a normal part of the protocol (e.g. `notifications/cancelled`,
+        // server-initiated progress events) and would only add log noise.
+        continue
+      }
+      if (this._pending.has(msg.id)) {
         const settle = this._pending.get(msg.id)
         if (msg.error) settle(new Error(msg.error.message || 'MCP RPC error'))
         else settle(null, msg.result)
+      } else {
+        // #4455: orphan response — server emitted a response with an id we
+        // never sent (or one we already settled). Could be a buggy server
+        // emitting a stale id after restart, a state-machine bug on the
+        // server side, or a duplicate. Not necessarily an error (don't
+        // warn); but without a log we'd have no audit trail when debugging
+        // "why doesn't my MCP tool respond". Capture the unmatched id and
+        // a small shape marker so future investigation has something to
+        // grep for.
+        const shape = msg.error ? 'error' : 'result'
+        this._log.debug(`MCP server ${this.name}: orphan JSON-RPC response id=${msg.id} shape=${shape}`)
       }
     }
   }

--- a/packages/server/tests/byok-mcp-client.test.js
+++ b/packages/server/tests/byok-mcp-client.test.js
@@ -61,6 +61,56 @@ describe('MCPClient', () => {
     })
   })
 
+  describe('orphan responses (#4455)', () => {
+    it('logs orphan JSON-RPC response at debug level', async () => {
+      const debugs = []
+      const log = { info: () => {}, warn: () => {}, debug: (m) => debugs.push(m), error: () => {} }
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_EMIT_ORPHAN: '1' } }),
+        { log },
+      )
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      // The stub emits an orphan response with id=999999 alongside the
+      // real initialize reply. Give the buffer a tick to flush.
+      await new Promise((r) => setTimeout(r, 100))
+      const orphanLog = debugs.find((m) => /orphan JSON-RPC response/i.test(m))
+      assert.ok(orphanLog, `expected an orphan-response debug log, got debugs=${JSON.stringify(debugs)}`)
+      assert.match(orphanLog, /id=999999/, 'orphan log must name the unmatched id')
+      assert.match(orphanLog, /shape=result/, 'orphan log must surface the response shape (result|error)')
+      await client.destroy()
+    })
+
+    it('does NOT log on the happy path — no orphan, no notification', async () => {
+      const debugs = []
+      const log = { info: () => {}, warn: () => {}, debug: (m) => debugs.push(m), error: () => {} }
+      const client = new MCPClient(stubConfig(), { log })
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      await new Promise((r) => setTimeout(r, 100))
+      const orphanLog = debugs.find((m) => /orphan JSON-RPC response/i.test(m))
+      assert.equal(orphanLog, undefined, `unexpected orphan-response log on happy path: ${orphanLog}`)
+      await client.destroy()
+    })
+
+    it('silently drops notifications (id == null) without an orphan log', async () => {
+      const debugs = []
+      const log = { info: () => {}, warn: () => {}, debug: (m) => debugs.push(m), error: () => {} }
+      const client = new MCPClient(
+        stubConfig({ env: { MCP_STUB_EMIT_NOTIFICATION: '1' } }),
+        { log },
+      )
+      await client.start()
+      await waitForState(client, MCP_STATES.READY)
+      await new Promise((r) => setTimeout(r, 100))
+      // Notifications are a normal part of the JSON-RPC protocol — they
+      // must not surface as orphan responses (would be noise).
+      const orphanLog = debugs.find((m) => /orphan JSON-RPC response/i.test(m))
+      assert.equal(orphanLog, undefined, `notifications must not log as orphans, got: ${orphanLog}`)
+      await client.destroy()
+    })
+  })
+
   describe('crash + restart', () => {
     it('triggers exactly 1 restart attempt within 1s after child exit (acceptance criterion)', async () => {
       const client = new MCPClient(

--- a/packages/server/tests/fixtures/mcp-stub.mjs
+++ b/packages/server/tests/fixtures/mcp-stub.mjs
@@ -17,6 +17,24 @@ createInterface({ input: process.stdin }).on('line', (line) => {
   if (msg.id == null) return
   if (msg.method === 'initialize') {
     reply(msg.id, { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'mcp-stub', version: '0.1.0' } })
+    // #4455: optionally emit an orphan response (id the client never sent)
+    // alongside the real initialize reply. The client should silently log
+    // and drop it.
+    if (process.env.MCP_STUB_EMIT_ORPHAN === '1') {
+      // Use a deliberately-high id so it can't collide with anything the
+      // client will ever send during this short-lived test.
+      reply(999_999, { fake: 'orphan' })
+    }
+    // #4455: optionally emit a notification (id == null) alongside the
+    // real reply. Notifications must be silently dropped — no orphan log,
+    // no warn. Used to assert the non-noise contract.
+    if (process.env.MCP_STUB_EMIT_NOTIFICATION === '1') {
+      process.stdout.write(JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'notifications/progress',
+        params: { detail: 'fake notification' },
+      }) + '\n')
+    }
   } else if (msg.method === 'tools/list') {
     reply(msg.id, { tools })
   } else if (msg.method === 'tools/call') {


### PR DESCRIPTION
## Summary

- Split `_onStdoutChunk` message handling into three explicit branches:
  1. **Notification** (`id == null`) — silently dropped (normal protocol).
  2. **Matched response** (`id` in `_pending`) — settle the pending promise.
  3. **Orphan response** (`id` set, no `_pending` entry) — debug log with the unmatched id and shape (`result` | `error`).
- Previously orphan responses were silently dropped alongside notifications. A buggy MCP server emitting a stale id (post-restart) or a duplicate response left no audit trail — debugging started with "why doesn't my MCP tool respond" with nothing to grep for. A single debug-level log fixes that without spamming the happy path.
- Stub fixture knobs `MCP_STUB_EMIT_ORPHAN` and `MCP_STUB_EMIT_NOTIFICATION` drive the two paths from tests. Happy-path test asserts zero log noise.

Closes #4455

## Test plan

- [x] `node --test packages/server/tests/byok-mcp-client.test.js` — 18/18 pass (was 15, added 3)
- [x] `node --test packages/server/tests/byok-mcp-fleet.test.js` — 15/15 still pass