### PR TITLE
fix(server): cap MCPFleet.start() wall-clock to fast-fail broken MCP configs

### DIFF
--- a/packages/server/src/byok-mcp-fleet.js
+++ b/packages/server/src/byok-mcp-fleet.js
@@ -16,6 +16,19 @@ import { loadTrustStore, recordTrust, isTrusted } from './byok-mcp-trust.js'
 import { MCP_PREFIX, parseMcpToolName } from './mcp-tools.js'
 
 export const FLEET_KILL_GRACE_MS = 2000
+
+// #4456: wall-clock cap on fleet.start() to bound the worst-case session-
+// start latency on a misconfigured MCP server. The fleet awaits each
+// client's first stable state (READY or DEAD); with the post-#4453 1/2/4s
+// restart backoff a single broken server adds up to ~7s to session-start.
+// At the cap, clients still in STARTING/RESTARTING contribute zero tools
+// to the first turn but remain alive and will surface on subsequent turns
+// (the fleet re-queries .tools per turn, so a late-arriving client lands
+// naturally). 1500 ms is enough for a fast happy path (the common case
+// completes in ~50–200 ms) without making the user feel the bad-config
+// tax. Operators can override via the `startCapMs` constructor opt.
+export const DEFAULT_FLEET_START_CAP_MS = 1500
+
 // #4451: re-export under the legacy name from this module so existing
 // callers (byok-session, tests) keep working. Canonical source is
 // mcp-tools.js to prevent silent parser drift.
@@ -40,6 +53,15 @@ export class MCPFleet {
     // (session passes its _permissions in) is wired in byok-session.
     const permissionManager = opts.permissionManager || null
     const trustStorePath = opts.trustStorePath  // tests override; undefined falls through to default
+    // #4456: per-fleet wall-clock cap on start(). Same defensive guard
+    // pattern as resultTimeoutMs in byok-session: non-finite / non-positive
+    // values fall back to the module default. Setting opts.startCapMs to
+    // Infinity (legacy behavior — wait for full convergence) requires
+    // explicitly opting in below.
+    this._startCapMs =
+      Number.isFinite(opts.startCapMs) && opts.startCapMs > 0
+        ? opts.startCapMs
+        : DEFAULT_FLEET_START_CAP_MS
     this._clients = configs.map((cfg) => {
       const clientOpts = { ...opts }
       if (permissionManager) {
@@ -62,8 +84,46 @@ export class MCPFleet {
 
   get clients() { return this._clients }
 
+  /**
+   * Spawn every client and resolve when either (a) every client has reached
+   * a stable state (READY or DEAD), or (b) the wall-clock cap fires —
+   * whichever is first (#4456).
+   *
+   * Trade-off: a session with one broken MCP server (e.g. command-not-found
+   * from a deleted binary) used to wait the FULL ~7s restart budget on
+   * session start. With the cap, the user gets a ready session in ≤
+   * `startCapMs` ms even on broken configs; clients still in STARTING /
+   * RESTARTING at the cap contribute zero tools to the first turn but get
+   * picked up automatically on the next turn (byok-session re-queries
+   * `fleet.tools` per turn). A transiently-flaky server that would have
+   * recovered on attempt 2 also loses its first-turn contribution under
+   * the cap — that's the cost of bounding the worst case.
+   *
+   * The per-client `start()` promises are *not* dropped at the cap — they
+   * continue running in the background and update `client.state` as they
+   * settle. We just stop *awaiting* them so the caller can move on.
+   */
   async start() {
-    await Promise.all(this._clients.map((c) => c.start().catch(() => {})))
+    const startPromises = this._clients.map((c) => c.start().catch(() => {}))
+    if (!Number.isFinite(this._startCapMs) || this._startCapMs <= 0) {
+      // Defensive — should be unreachable given the constructor guard, but
+      // an explicit Infinity opt-in would land here and we just wait.
+      await Promise.all(startPromises)
+      return
+    }
+    let capTimer = null
+    const capPromise = new Promise((resolve) => {
+      capTimer = setTimeout(resolve, this._startCapMs)
+      // Don't keep the event loop alive solely for this timer — if every
+      // client settles before the cap, the timer's still pending and would
+      // otherwise hold the process open.
+      if (typeof capTimer.unref === 'function') capTimer.unref()
+    })
+    try {
+      await Promise.race([Promise.all(startPromises), capPromise])
+    } finally {
+      if (capTimer) clearTimeout(capTimer)
+    }
   }
 
   get tools() {

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -255,6 +255,13 @@ export class ClaudeByokSession extends BaseSession {
       Number.isFinite(opts.mcpToolCallTimeoutMs) && opts.mcpToolCallTimeoutMs > 0
         ? opts.mcpToolCallTimeoutMs
         : null
+    // #4456: wall-clock cap on fleet.start(). null = use the fleet's
+    // DEFAULT_FLEET_START_CAP_MS (1500ms). Same defensive guard pattern
+    // as _mcpToolCallTimeoutMs.
+    this._mcpStartCapMs =
+      Number.isFinite(opts.mcpStartCapMs) && opts.mcpStartCapMs > 0
+        ? opts.mcpStartCapMs
+        : null
   }
 
   async start() {
@@ -283,7 +290,13 @@ export class ClaudeByokSession extends BaseSession {
       // emit a trust prompt for new (name, command, args[0]) tuples.
       // Tuples already trusted in ~/.chroxy/mcp-trust.json spawn directly
       // with no prompt; denied tuples set state=DEAD without spawning.
-      this._mcpFleet = new MCPFleet(this._mcpServerConfigs, { log, permissionManager: this._permissions })
+      // #4456: forward startCapMs override so operators can tune the
+      // session-start wall-clock cap. Passing undefined lets the fleet's
+      // constructor default (DEFAULT_FLEET_START_CAP_MS) win — exactly
+      // what we want when no override is in play.
+      const fleetOpts = { log, permissionManager: this._permissions }
+      if (this._mcpStartCapMs !== null) fleetOpts.startCapMs = this._mcpStartCapMs
+      this._mcpFleet = new MCPFleet(this._mcpServerConfigs, fleetOpts)
       await this._mcpFleet.start()
     }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -218,6 +218,12 @@ export class SessionManager extends EventEmitter {
     // byok-session, which threads it into MCPFleet.callTool. null = use
     // byok-mcp-client's DEFAULT_TOOL_CALL_TIMEOUT_MS (30s).
     mcpToolCallTimeoutMs,
+    // #4456: wall-clock cap on MCPFleet.start() (ms). Forwarded via
+    // providerOpts to byok-session, which threads it into the MCPFleet
+    // constructor. null = use byok-mcp-fleet's DEFAULT_FLEET_START_CAP_MS
+    // (1500ms). Bounds the worst-case session-start latency on a broken
+    // MCP config — see byok-mcp-fleet.MCPFleet.start() for the trade-off.
+    mcpStartCapMs,
 
     // State persistence
     stateFilePath,
@@ -289,6 +295,14 @@ export class SessionManager extends EventEmitter {
     this._mcpToolCallTimeoutMs =
       Number.isFinite(mcpToolCallTimeoutMs) && mcpToolCallTimeoutMs > 0
         ? mcpToolCallTimeoutMs
+        : null
+    // #4456: same defensive shape as mcpToolCallTimeoutMs — only positive
+    // finite values are forwarded; bogus values fall back to the fleet's
+    // default cap. 0 is rejected (a 0 ms cap would fire before any
+    // handshake could complete).
+    this._mcpStartCapMs =
+      Number.isFinite(mcpStartCapMs) && mcpStartCapMs > 0
+        ? mcpStartCapMs
         : null
     this._costBudget = new CostBudgetManager({ budget: costBudget })
     // #4075: per-session crossing threshold. Stored as a runtime-mutable
@@ -606,6 +620,7 @@ export class SessionManager extends EventEmitter {
     if (this._hardTimeoutMs != null) providerOpts.hardTimeoutMs = this._hardTimeoutMs
     if (this._streamStallTimeoutMs != null) providerOpts.streamStallTimeoutMs = this._streamStallTimeoutMs
     if (this._mcpToolCallTimeoutMs != null) providerOpts.mcpToolCallTimeoutMs = this._mcpToolCallTimeoutMs
+    if (this._mcpStartCapMs != null) providerOpts.mcpStartCapMs = this._mcpStartCapMs
     // Skills size budgets — pass through if configured. BaseSession forwards
     // these to loadActiveSkillsLayered. (#3202)
     if (this._maxSkillBytes !== null) providerOpts.maxSkillBytes = this._maxSkillBytes

--- a/packages/server/tests/byok-mcp-fleet.test.js
+++ b/packages/server/tests/byok-mcp-fleet.test.js
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
-import { MCPFleet, FLEET_KILL_GRACE_MS, parseMcpToolName } from '../src/byok-mcp-fleet.js'
+import { MCPFleet, FLEET_KILL_GRACE_MS, DEFAULT_FLEET_START_CAP_MS, parseMcpToolName } from '../src/byok-mcp-fleet.js'
 import { MCP_STATES } from '../src/byok-mcp-client.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -41,19 +41,89 @@ describe('MCPFleet', () => {
 
   it('excludes tools from dead servers', async () => {
     // alpha is healthy, broken always exits — broken should die after 3 attempts
-    // and contribute zero tools. fleet.start() awaits each client's first
-    // stable state, so by the time it returns alpha is READY and broken is
-    // DEAD.
+    // and contribute zero tools. Use a large startCapMs override (#4456) so
+    // fleet.start() waits the full restart budget — keeps this test asserting
+    // the "DEAD by start()" invariant without depending on the new wall-clock
+    // cap (which would return early and leave broken in RESTARTING).
     const fleet = new MCPFleet([
       cfg('alpha'),
       { name: 'broken', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
-    ], { log: silentLog() })
+    ], { log: silentLog(), startCapMs: 60_000 })
     await fleet.start()
     assert.equal(fleet.clients[0].state, MCP_STATES.READY)
     assert.equal(fleet.clients[1].state, MCP_STATES.DEAD)
     const names = fleet.tools.map((t) => t.name)
     assert.deepEqual(names, ['mcp__alpha__echo'])
     await fleet.destroy()
+  })
+
+  describe('start() wall-clock cap (#4456)', () => {
+    it('exposes DEFAULT_FLEET_START_CAP_MS as a module export', () => {
+      assert.equal(typeof DEFAULT_FLEET_START_CAP_MS, 'number')
+      assert.ok(DEFAULT_FLEET_START_CAP_MS > 0)
+    })
+
+    it('returns within ~startCapMs even when one server is permanently broken', async () => {
+      // One healthy + one perpetually-failing server. Without the cap,
+      // start() would wait the full ~7s restart budget on the broken one.
+      // With a 300ms cap, we expect start() to return promptly — the broken
+      // server is still in STARTING/RESTARTING (not DEAD).
+      const fleet = new MCPFleet([
+        cfg('alpha'),
+        { name: 'broken', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+      ], { log: silentLog(), startCapMs: 300 })
+      const t0 = Date.now()
+      await fleet.start()
+      const elapsed = Date.now() - t0
+      assert.ok(elapsed < 800, `start() took ${elapsed}ms, expected <800ms under 300ms cap`)
+      // alpha should have stabilized inside the cap (handshake ~50-200ms).
+      assert.equal(fleet.clients[0].state, MCP_STATES.READY)
+      // broken should NOT be DEAD yet — the restart loop is still running
+      // in the background. State will be STARTING or RESTARTING.
+      assert.notEqual(fleet.clients[1].state, MCP_STATES.DEAD, 'cap fired before broken server exhausted its restart budget')
+      await fleet.destroy()
+    })
+
+    it('returns immediately on the happy path (no cap-induced latency)', async () => {
+      // All servers healthy — start() should resolve as soon as every
+      // handshake completes, well under the default cap.
+      const fleet = new MCPFleet([cfg('alpha'), cfg('beta')], { log: silentLog() })
+      const t0 = Date.now()
+      await fleet.start()
+      const elapsed = Date.now() - t0
+      // Generous bound — healthy handshakes typically complete in <300ms.
+      assert.ok(elapsed < 1200, `happy-path start() took ${elapsed}ms, expected <1200ms`)
+      assert.equal(fleet.clients[0].state, MCP_STATES.READY)
+      assert.equal(fleet.clients[1].state, MCP_STATES.READY)
+      await fleet.destroy()
+    })
+
+    it('uses DEFAULT_FLEET_START_CAP_MS when no override is supplied', async () => {
+      // The cap default itself bounds the wait — verify the broken-server
+      // worst case stays under the default + a generous margin.
+      const fleet = new MCPFleet([
+        cfg('alpha'),
+        { name: 'broken', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+      ], { log: silentLog() })
+      const t0 = Date.now()
+      await fleet.start()
+      const elapsed = Date.now() - t0
+      assert.ok(
+        elapsed < DEFAULT_FLEET_START_CAP_MS + 500,
+        `start() took ${elapsed}ms, expected <${DEFAULT_FLEET_START_CAP_MS + 500}ms under default cap`,
+      )
+      await fleet.destroy()
+    })
+
+    it('bogus startCapMs (NaN, 0, negative) falls back to the default', async () => {
+      // Defensive guard — non-positive setTimeout values would otherwise
+      // coerce to 0 and break the cap entirely.
+      for (const bogus of [NaN, 0, -1, '500', null, undefined]) {
+        const fleet = new MCPFleet([cfg('alpha')], { log: silentLog(), startCapMs: bogus })
+        assert.equal(fleet._startCapMs, DEFAULT_FLEET_START_CAP_MS, `startCapMs=${String(bogus)} should fall back`)
+        await fleet.destroy()
+      }
+    })
   })
 
   it('destroy() returns within FLEET_KILL_GRACE_MS + safety margin even with hung children', async () => {
@@ -200,10 +270,13 @@ describe('MCPFleet', () => {
     })
 
     it('excludes anthropicTools from dead servers', async () => {
+      // Same DEAD-by-start invariant as the earlier "excludes tools from dead
+      // servers" test — bypass the #4456 wall-clock cap with a large override
+      // so the broken server has time to walk through its full restart budget.
       const fleet = new MCPFleet([
         cfg('alpha'),
         { name: 'broken', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
-      ], { log: silentLog() })
+      ], { log: silentLog(), startCapMs: 60_000 })
       await fleet.start()
       const names = fleet.anthropicTools.map((t) => t.name)
       assert.deepEqual(names, ['mcp__alpha__echo'])

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -382,6 +382,45 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('#4456: session-ready emits within the cap even when one MCP server is permanently broken', async () => {
+      preTrustStub()
+      // Pre-trust the broken server too so the trust prompt doesn't sit in
+      // the way — we're isolating the start-cap behavior, not the trust gate.
+      recordTrust(
+        { name: 'broken', command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+        process.env.CHROXY_MCP_TRUST_PATH,
+      )
+      const configPath = join(tmpHome, '.claude.json')
+      writeFileSync(configPath, JSON.stringify({
+        mcpServers: {
+          stub: { command: process.execPath, args: [MCP_STUB], env: {} },
+          broken: { command: process.execPath, args: ['-e', 'process.exit(2)'], env: {} },
+        },
+      }))
+      const session = new ClaudeByokSession({
+        cwd: '/tmp',
+        mcpConfigPath: configPath,
+        mcpStartCapMs: 400,
+      })
+      session._client = { messages: { stream: () => fakeStream([]) } }
+      const t0 = Date.now()
+      let readyAt = null
+      session.on('ready', () => { readyAt = Date.now() })
+      await session.start()
+      const elapsed = (readyAt ?? Date.now()) - t0
+      // Under the cap the session emits ready promptly; without it, start()
+      // would block ~7s for the broken server's full restart budget.
+      assert.ok(elapsed < 1000, `session 'ready' fired at ${elapsed}ms, expected <1000ms under 400ms cap`)
+      assert.equal(session._mcpFleet.clients.find((c) => c.name === 'stub').state, MCP_STATES.READY)
+      // Broken still in mid-restart loop, not DEAD yet.
+      assert.notEqual(
+        session._mcpFleet.clients.find((c) => c.name === 'broken').state,
+        MCP_STATES.DEAD,
+        'cap should fire before broken server exhausts its restart budget',
+      )
+      await session.destroy()
+    })
+
     it('#4077: destroy() kills MCP children and clears the fleet reference', async () => {
       preTrustStub()
       const configPath = join(tmpHome, '.claude.json')


### PR DESCRIPTION
## Summary

Pre-fix: `byok-session.start()` awaited `MCPFleet.start()`, which awaited each `MCPClient.start()`, which only resolved on the first stable state (READY or DEAD). A single broken MCP server in `~/.claude.json` added the full restart budget (~7 s after #4453's exponential backoff) to every session-start — with no UI signal that anything was pending. `Promise.all` in `fleet.start()` meant a single bad server delayed *all* multi-server sessions too.

This PR implements the issue's **Option 2** (wall-clock cap on `fleet.start()`):

- Add `DEFAULT_FLEET_START_CAP_MS = 1500` and a `startCapMs` constructor opt on `MCPFleet`. `start()` now resolves on whichever happens first: every client reaches a stable state, OR the wall-clock cap fires.
- Clients still in `STARTING` / `RESTARTING` at the cap remain alive in the background. `byok-session._buildTools()` already re-queries `fleet.tools` per turn, so a late-arriving client lands naturally on the next turn — no manual re-trigger needed.
- Forward the cap end-to-end: `session-manager` → `providerOpts` → `byok-session` → `MCPFleet`. Same defensive-guard shape as `mcpToolCallTimeoutMs` (only positive finite values; bogus values fall back to the fleet's default).
- Two existing fleet tests asserted "broken server is DEAD by the time `start()` returns" — kept those invariants by passing `startCapMs: 60_000` (legacy wait-for-full-convergence behavior).

Closes #4456

## Test plan

- [x] `node --test packages/server/tests/byok-mcp-fleet.test.js` — 20/20 pass (was 15, added 5)
- [x] `node --test packages/server/tests/byok-session.test.js` — 91/91 pass (was 90, added 1 end-to-end test)
- [x] `node --test packages/server/tests/byok-mcp-client.test.js` — 15/15 still pass