### PR TITLE
fix(server): clamp mcpToolCallTimeoutMs to MAX_SANE_DURATION_MS (#4517)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -20,6 +20,7 @@ import { homedir } from 'os'
 import { BaseSession } from './base-session.js'
 import { PermissionManager } from './permission-manager.js'
 import { createLogger } from './logger.js'
+import { isOperatorTimeoutInRange } from './duration.js'
 import {
   FALLBACK_MODELS,
   ALLOWED_MODEL_IDS,
@@ -251,8 +252,12 @@ export class ClaudeByokSession extends BaseSession {
     // non-finite / non-positive (NaN, Infinity, 0, -1, strings) falls back
     // to null because setTimeout coerces those to 0 ms and every MCP tool
     // would look broken.
+    // #4517: ceiling check via `isOperatorTimeoutInRange` (same as the three
+    // sibling timeouts in #4509) — defends per-session BYOK assignment
+    // against an over-24h value that would survive session-manager (e.g.
+    // an embedder constructing ClaudeByokSession directly with a typoed opt).
     this._mcpToolCallTimeoutMs =
-      Number.isFinite(opts.mcpToolCallTimeoutMs) && opts.mcpToolCallTimeoutMs > 0
+      isOperatorTimeoutInRange(opts.mcpToolCallTimeoutMs, { name: 'mcpToolCallTimeoutMs', log })
         ? opts.mcpToolCallTimeoutMs
         : null
   }

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1,5 +1,6 @@
 import { SessionManager } from './session-manager.js'
 import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS, DEFAULT_STREAM_STALL_TIMEOUT_MS } from './base-session.js'
+import { DEFAULT_TOOL_CALL_TIMEOUT_MS } from './byok-mcp-client.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { WsServer, TUNNEL_STATUS_MIN_PROTOCOL_VERSION } from './ws-server.js'
@@ -250,23 +251,35 @@ function isWithinHome(dir) {
  *   resultTimeoutMs: number|null,
  *   hardTimeoutMs: number|null,
  *   streamStallTimeoutMs: number|null,
+ *   mcpToolCallTimeoutMs: number|null,
  *   effectiveResultTimeoutMs: number,
  *   effectiveHardTimeoutMs: number,
  *   effectiveStreamStallTimeoutMs: number,
+ *   effectiveMcpToolCallTimeoutMs: number,
  * }}
  */
 export function resolveStartupTimeouts(config = {}, log = { warn: () => {} }) {
   const resultOk = isOperatorTimeoutInRange(config.resultTimeoutMs, { name: 'resultTimeoutMs', log })
   const hardOk = isOperatorTimeoutInRange(config.hardTimeoutMs, { name: 'hardTimeoutMs', log })
   const stallOk = isOperatorTimeoutInRange(config.streamStallTimeoutMs, { allowZero: true, name: 'streamStallTimeoutMs', log })
+  // #4517: mcpToolCallTimeoutMs joined the ceiling-clamped family. Same
+  // `> 0` gate as the soft/hard timeouts (0 fires the callTool deadline
+  // immediately and would make every MCP tool look broken); same fall-back-
+  // to-null contract so byok-mcp-client's DEFAULT_TOOL_CALL_TIMEOUT_MS (30s)
+  // applies. The config.js validator already gates file-loaded values to
+  // 1s-10min — this guardrail catches programmatic instantiation and acts
+  // as defense-in-depth for any future config path that bypasses validation.
+  const mcpOk = isOperatorTimeoutInRange(config.mcpToolCallTimeoutMs, { name: 'mcpToolCallTimeoutMs', log })
 
   return {
     resultTimeoutMs: resultOk ? config.resultTimeoutMs : null,
     hardTimeoutMs: hardOk ? config.hardTimeoutMs : null,
     streamStallTimeoutMs: stallOk ? config.streamStallTimeoutMs : null,
+    mcpToolCallTimeoutMs: mcpOk ? config.mcpToolCallTimeoutMs : null,
     effectiveResultTimeoutMs: resultOk ? config.resultTimeoutMs : DEFAULT_RESULT_TIMEOUT_MS,
     effectiveHardTimeoutMs: hardOk ? config.hardTimeoutMs : DEFAULT_HARD_TIMEOUT_MS,
     effectiveStreamStallTimeoutMs: stallOk ? config.streamStallTimeoutMs : DEFAULT_STREAM_STALL_TIMEOUT_MS,
+    effectiveMcpToolCallTimeoutMs: mcpOk ? config.mcpToolCallTimeoutMs : DEFAULT_TOOL_CALL_TIMEOUT_MS,
   }
 }
 
@@ -434,10 +447,10 @@ export async function startCliServer(config) {
     // #4482: per-MCP-call timeout (ms). null = byok-mcp-client default (30s).
     // Unlike streamStallTimeoutMs, 0 is not a meaningful disable — every
     // MCP tool would look broken — so non-positive falls back to null.
-    mcpToolCallTimeoutMs:
-      Number.isFinite(config.mcpToolCallTimeoutMs) && config.mcpToolCallTimeoutMs > 0
-        ? config.mcpToolCallTimeoutMs
-        : null,
+    // #4517: ceiling-clamped via `resolveStartupTimeouts()` above; an
+    // over-24h operator value falls back to null here so byok-mcp-client
+    // applies its default (and the operator gets a warn log).
+    mcpToolCallTimeoutMs: startupTimeouts.mcpToolCallTimeoutMs,
     // Skills size budgets (#3202). null = use loader defaults (32KB / 256KB).
     maxSkillBytes: Number.isFinite(config.maxSkillBytes) ? config.maxSkillBytes : null,
     maxTotalSkillBytes: Number.isFinite(config.maxTotalSkillBytes) ? config.maxTotalSkillBytes : null,

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -286,8 +286,11 @@ export class SessionManager extends EventEmitter {
     // valid disable here — a 0-ms callTool timeout fires immediately. Only
     // positive finite values are accepted; null falls through to byok-mcp-
     // client's 30s default.
+    // #4517: ceiling check via `isOperatorTimeoutInRange` (same as the three
+    // sibling timeouts in #4509) — a typoed CHROXY_MCP_TOOL_CALL_TIMEOUT_MS
+    // (extra digit / accidental exponent) falls back to null and warns.
     this._mcpToolCallTimeoutMs =
-      Number.isFinite(mcpToolCallTimeoutMs) && mcpToolCallTimeoutMs > 0
+      isOperatorTimeoutInRange(mcpToolCallTimeoutMs, { name: 'mcpToolCallTimeoutMs', log })
         ? mcpToolCallTimeoutMs
         : null
     this._costBudget = new CostBudgetManager({ budget: costBudget })

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3337,5 +3337,34 @@ describe('ClaudeByokSession', () => {
         assert.equal(captured[0].timeoutMs, undefined, `bad input ${String(bad)} must fall back`)
       }
     })
+
+    it('clamps mcpToolCallTimeoutMs above MAX_SANE_DURATION_MS back to undefined (#4517)', async () => {
+      // #4517: a typoed CHROXY_MCP_TOOL_CALL_TIMEOUT_MS (extra digit,
+      // accidental exponent) must NOT arm a >24h MCP setTimeout. Mirrors
+      // the ceiling check the three sibling timeouts got via #4509 —
+      // byok-session uses `isOperatorTimeoutInRange` so the over-ceiling
+      // value falls back to the fleet/client default exactly like the
+      // bad-input cases above.
+      const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
+      const { session, captured } = buildSessionWithMockFleet({
+        mcpToolCallTimeoutMs: MAX_SANE_DURATION_MS + 1,
+      })
+      await session._dispatchMcpTool('mcp__stub__echo', {})
+      assert.equal(captured[0].timeoutMs, undefined,
+        'over-ceiling input must fall back to fleet/client default')
+    })
+
+    it('accepts the exact MAX_SANE_DURATION_MS boundary (#4517)', async () => {
+      // The boundary is INCLUSIVE — clamping it would surprise operators who
+      // tuned the dial to exactly 24h (unlikely for a per-call MCP timeout,
+      // but consistency with the soft/hard inactivity timeouts matters).
+      const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
+      const { session, captured } = buildSessionWithMockFleet({
+        mcpToolCallTimeoutMs: MAX_SANE_DURATION_MS,
+      })
+      await session._dispatchMcpTool('mcp__stub__echo', {})
+      assert.equal(captured[0].timeoutMs, MAX_SANE_DURATION_MS,
+        'exact boundary must pass through verbatim')
+    })
   })
 })

--- a/packages/server/tests/server-cli-startup-timeouts.test.js
+++ b/packages/server/tests/server-cli-startup-timeouts.test.js
@@ -6,6 +6,7 @@ import {
   DEFAULT_HARD_TIMEOUT_MS,
   DEFAULT_STREAM_STALL_TIMEOUT_MS,
 } from '../src/base-session.js'
+import { DEFAULT_TOOL_CALL_TIMEOUT_MS } from '../src/byok-mcp-client.js'
 
 /**
  * #4509: `startCliServer` previously hand-rolled the same
@@ -29,11 +30,13 @@ describe('resolveStartupTimeouts (#4509)', () => {
   // (`*TimeoutMs`) takes `null` for invalid/over-ceiling so BaseSession can
   // apply its default; the log-line side (`effective*`) takes the resolved
   // default so the operator sees the actual wall-clock value that will fire.
+  // #4517: mcpToolCallTimeoutMs joined the helper family — its "effective"
+  // side resolves to DEFAULT_TOOL_CALL_TIMEOUT_MS (byok-mcp-client default).
   function expectShape(out) {
     assert.ok(out && typeof out === 'object', 'helper must return an object')
     for (const k of [
-      'resultTimeoutMs', 'hardTimeoutMs', 'streamStallTimeoutMs',
-      'effectiveResultTimeoutMs', 'effectiveHardTimeoutMs', 'effectiveStreamStallTimeoutMs',
+      'resultTimeoutMs', 'hardTimeoutMs', 'streamStallTimeoutMs', 'mcpToolCallTimeoutMs',
+      'effectiveResultTimeoutMs', 'effectiveHardTimeoutMs', 'effectiveStreamStallTimeoutMs', 'effectiveMcpToolCallTimeoutMs',
     ]) {
       assert.ok(Object.prototype.hasOwnProperty.call(out, k), `missing key: ${k}`)
     }
@@ -48,6 +51,7 @@ describe('resolveStartupTimeouts (#4509)', () => {
       resultTimeoutMs: 90_000,
       hardTimeoutMs: 3_600_000,
       streamStallTimeoutMs: 120_000,
+      mcpToolCallTimeoutMs: 45_000,
     }, { warn: () => {} })
     expectShape(out)
     assert.equal(out.resultTimeoutMs, 90_000)
@@ -56,6 +60,8 @@ describe('resolveStartupTimeouts (#4509)', () => {
     assert.equal(out.effectiveHardTimeoutMs, 3_600_000)
     assert.equal(out.streamStallTimeoutMs, 120_000)
     assert.equal(out.effectiveStreamStallTimeoutMs, 120_000)
+    assert.equal(out.mcpToolCallTimeoutMs, 45_000)
+    assert.equal(out.effectiveMcpToolCallTimeoutMs, 45_000)
   })
 
   it('accepts streamStallTimeoutMs=0 as an explicit disable (does NOT fall back)', () => {
@@ -76,6 +82,10 @@ describe('resolveStartupTimeouts (#4509)', () => {
         // -1 paths are tested separately because 0 is intentional and -1 is
         // just "out of range" without a special-case meaning.
         streamStallTimeoutMs: bad === 0 ? -1 : bad,
+        // #4517: mcpToolCallTimeoutMs follows the same `> 0` gate as the soft/
+        // hard inactivity timeouts — 0 fires immediately and makes every MCP
+        // tool look broken — so it joins the bad-input loop directly.
+        mcpToolCallTimeoutMs: bad,
       }, { warn: () => {} })
       assert.equal(out.resultTimeoutMs, null, `resultTimeoutMs null for ${String(bad)}`)
       assert.equal(out.effectiveResultTimeoutMs, DEFAULT_RESULT_TIMEOUT_MS)
@@ -83,6 +93,8 @@ describe('resolveStartupTimeouts (#4509)', () => {
       assert.equal(out.effectiveHardTimeoutMs, DEFAULT_HARD_TIMEOUT_MS)
       assert.equal(out.streamStallTimeoutMs, null, `streamStallTimeoutMs null for ${String(bad)}`)
       assert.equal(out.effectiveStreamStallTimeoutMs, DEFAULT_STREAM_STALL_TIMEOUT_MS)
+      assert.equal(out.mcpToolCallTimeoutMs, null, `mcpToolCallTimeoutMs null for ${String(bad)}`)
+      assert.equal(out.effectiveMcpToolCallTimeoutMs, DEFAULT_TOOL_CALL_TIMEOUT_MS)
     }
   })
 
@@ -124,11 +136,31 @@ describe('resolveStartupTimeouts (#4509)', () => {
     assert.ok(hit, `expected warn log mentioning streamStallTimeoutMs + MAX_SANE_DURATION_MS, got: ${warnings.join(' | ')}`)
   })
 
-  it('accepts the exact MAX_SANE_DURATION_MS boundary on all three timeouts', () => {
+  it('clamps mcpToolCallTimeoutMs above MAX_SANE_DURATION_MS back to null + DEFAULT and warns (#4517)', () => {
+    // #4517: mcpToolCallTimeoutMs joined the three sibling timeouts in the
+    // ceiling-clamp guardrail. config.js has a tighter 1s-10min validator
+    // applied to file-loaded values (left in place — see PR notes for the
+    // site-4 decision), but defense-in-depth at the resolution layer keeps
+    // programmatic instantiation (tests, embedders) honest.
+    const warnings = []
+    const out = resolveStartupTimeouts(
+      { mcpToolCallTimeoutMs: MAX_SANE_DURATION_MS + 1 },
+      { warn: (msg) => warnings.push(msg) },
+    )
+    assert.equal(out.mcpToolCallTimeoutMs, null,
+      'SessionManager arg side must fall back to null so byok-mcp-client applies its default')
+    assert.equal(out.effectiveMcpToolCallTimeoutMs, DEFAULT_TOOL_CALL_TIMEOUT_MS,
+      'log-line side must resolve to DEFAULT_TOOL_CALL_TIMEOUT_MS so operators see the actual effective value')
+    const hit = warnings.find((w) => w.includes('mcpToolCallTimeoutMs') && w.includes('MAX_SANE_DURATION_MS'))
+    assert.ok(hit, `expected warn log mentioning mcpToolCallTimeoutMs + MAX_SANE_DURATION_MS, got: ${warnings.join(' | ')}`)
+  })
+
+  it('accepts the exact MAX_SANE_DURATION_MS boundary on all four timeouts', () => {
     const out = resolveStartupTimeouts({
       resultTimeoutMs: MAX_SANE_DURATION_MS,
       hardTimeoutMs: MAX_SANE_DURATION_MS,
       streamStallTimeoutMs: MAX_SANE_DURATION_MS,
+      mcpToolCallTimeoutMs: MAX_SANE_DURATION_MS,
     }, { warn: () => {} })
     assert.equal(out.resultTimeoutMs, MAX_SANE_DURATION_MS)
     assert.equal(out.effectiveResultTimeoutMs, MAX_SANE_DURATION_MS)
@@ -136,6 +168,8 @@ describe('resolveStartupTimeouts (#4509)', () => {
     assert.equal(out.effectiveHardTimeoutMs, MAX_SANE_DURATION_MS)
     assert.equal(out.streamStallTimeoutMs, MAX_SANE_DURATION_MS)
     assert.equal(out.effectiveStreamStallTimeoutMs, MAX_SANE_DURATION_MS)
+    assert.equal(out.mcpToolCallTimeoutMs, MAX_SANE_DURATION_MS)
+    assert.equal(out.effectiveMcpToolCallTimeoutMs, MAX_SANE_DURATION_MS)
   })
 
   it('returns the same shape with no config (all defaults)', () => {
@@ -147,5 +181,7 @@ describe('resolveStartupTimeouts (#4509)', () => {
     assert.equal(out.effectiveHardTimeoutMs, DEFAULT_HARD_TIMEOUT_MS)
     assert.equal(out.streamStallTimeoutMs, null)
     assert.equal(out.effectiveStreamStallTimeoutMs, DEFAULT_STREAM_STALL_TIMEOUT_MS)
+    assert.equal(out.mcpToolCallTimeoutMs, null)
+    assert.equal(out.effectiveMcpToolCallTimeoutMs, DEFAULT_TOOL_CALL_TIMEOUT_MS)
   })
 })

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -3327,14 +3327,15 @@ describe('SessionManager providerOpts timeout forwarding (#4487)', () => {
   })
 })
 
-// #4509: SessionManager's three operator-facing inactivity timeouts
-// (resultTimeoutMs / hardTimeoutMs / streamStallTimeoutMs) are clamped to
-// the shared MAX_SANE_DURATION_MS (24h) ceiling that the protocol schemas
-// apply via `.max(MAX_SANE_DURATION_MS)`. Mirrors the wire-side guard #4503
-// added to `ws-history.js sendPostAuthInfo`. A typoed CHROXY_* env var
-// (extra digit, accidental exponent) is the realistic source of an
-// over-ceiling value; without this guard the operator silently gets a >24h
-// internal inactivity timer instead of the BaseSession default.
+// #4509 + #4517: SessionManager's four operator-facing timeouts
+// (resultTimeoutMs / hardTimeoutMs / streamStallTimeoutMs /
+// mcpToolCallTimeoutMs) are clamped to the shared MAX_SANE_DURATION_MS (24h)
+// ceiling that the protocol schemas apply via `.max(MAX_SANE_DURATION_MS)`.
+// Mirrors the wire-side guard #4503 added to `ws-history.js sendPostAuthInfo`.
+// A typoed CHROXY_* env var (extra digit, accidental exponent) is the
+// realistic source of an over-ceiling value; without this guard the operator
+// silently gets a >24h internal timer instead of the BaseSession / MCP
+// client default.
 describe('SessionManager operator-timeout MAX_SANE_DURATION_MS ceiling (#4509)', () => {
   const MAX_SANE_DURATION_MS = 24 * 60 * 60 * 1000
 
@@ -3346,6 +3347,10 @@ describe('SessionManager operator-timeout MAX_SANE_DURATION_MS ceiling (#4509)',
     { configKey: 'resultTimeoutMs', internalField: '_resultTimeoutMs', displayName: 'resultTimeoutMs' },
     { configKey: 'hardTimeoutMs', internalField: '_hardTimeoutMs', displayName: 'hardTimeoutMs' },
     { configKey: 'streamStallTimeoutMs', internalField: '_streamStallTimeoutMs', displayName: 'streamStallTimeoutMs' },
+    // #4517: mcpToolCallTimeoutMs joined the ceiling-clamped family — same
+    // operator-typo class as the other three. The internal `_mcpToolCallTimeoutMs`
+    // slot follows the identical fall-back-to-null contract.
+    { configKey: 'mcpToolCallTimeoutMs', internalField: '_mcpToolCallTimeoutMs', displayName: 'mcpToolCallTimeoutMs' },
   ]
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

PR #4516 added the 24h `MAX_SANE_DURATION_MS` ceiling guard to the three sibling internal timeouts (`resultTimeoutMs` / `hardTimeoutMs` / `streamStallTimeoutMs`); `mcpToolCallTimeoutMs` was explicitly out of scope at the time. This PR closes the audit by applying the same `isOperatorTimeoutInRange()` gate to the three internal sites where the knob lives.

## Sites fixed

1. **`packages/server/src/session-manager.js`** — providerOpts forwarding guard now uses the shared helper; `_mcpToolCallTimeoutMs` falls back to `null` (BaseSession default) on over-ceiling values.
2. **`packages/server/src/server-cli.js`** — `resolveStartupTimeouts()` gains a fourth knob. The companion `effectiveMcpToolCallTimeoutMs` resolves to `DEFAULT_TOOL_CALL_TIMEOUT_MS` (30s) so the existing pattern (`*TimeoutMs` for SessionManager arg side, `effective*` for log line) extends cleanly.
3. **`packages/server/src/byok-session.js`** — per-session BYOK assignment uses the helper; defends against an over-ceiling value reaching here via an embedder that constructs `ClaudeByokSession` directly.

## Site 4 decision (config.js)

Per the issue, two options:
- (a) Leave the existing 10-min validator (1s-10min) in place — it's **strictly tighter** than the 24h ceiling, so tightening to 24h would *loosen* it, not strengthen it.
- (b) Tighten validator to `MAX_SANE_DURATION_MS`.

Chose **(a)** — `config.js` is unchanged. The 10-min validator catches file-loaded values; the three sites above act as defense-in-depth for programmatic instantiation paths that bypass config validation (embedders, direct `SessionManager` construction, future env-var paths that route differently).

## Tests

- `session-manager.test.js` — extends the `#4509` `TIMEOUT_SPECS` table to cover the 4th knob with the existing spec-driven pattern (clamps + exact boundary).
- `server-cli-startup-timeouts.test.js` — shape, in-range, bad-input, over-ceiling, and exact-boundary cases for `mcpToolCallTimeoutMs`.
- `byok-session.test.js` — over-ceiling falls back to fleet default; exact boundary passes through.

All 273 tests across the three affected files pass; full server suite has 4 unrelated pre-existing flakes (cloudflared/encryption/web-task-manager/feature-detection) that fail identically on `main`.

## Test plan

- [x] `node --test packages/server/tests/session-manager.test.js packages/server/tests/server-cli-startup-timeouts.test.js packages/server/tests/byok-session.test.js` — 273 pass, 0 fail
- [x] RED → GREEN proven per site (test added, ran, confirmed fail, then implemented)

Closes #4517