### PR TITLE
chore(release): cut v0.9.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.13] - 2026-05-29
+
+Wave 1 of the from-review marathon: 20 follow-ups across BYOK MCP (config, client, trust), dashboard ActivityIndicator polish, session-manager test helpers, and a timeout-ceiling consolidation. Theme is "harden the BYOK surface": the MCP trust store now serialises concurrent writes (#4526), uses JSON-encoded tuple keys that resist collision and tamper (#4529), denies bypass-mode auto-trust (#4531), and cleans up `.tmp` leakage on rename failure (#4534). The MCP client gets exponential restart backoff (#4530), a tunable handshake timeout (#4533), debug-level orphan-response logging (#4536), and a wall-clock fast-fail on broken MCP configs (#4537). Plus dashboard a11y/i18n polish (#4523, #4525) and the `mcpToolCallTimeoutMs` ceiling (#4538) closing the v0.9.12 #4517 follow-up.
+
+### Added
+
+- **Exponential restart backoff in byok-mcp-client (#4453 / #4530):** restart delays now ramp 1s → 2s → 4s (was fixed 1s/1s/1s), giving wedged dependencies — port conflicts, transient FS hiccups — time to recover before DEAD. Also fixed an off-by-one in the attempt-cap (`>=` → `>`) so the third attempt actually runs.
+- **Per-instance handshake timeout in byok-mcp-client (#4454 / #4533):** new `opts.handshakeTimeoutMs` (and per-config `handshakeTimeoutMs`) overrides `DEFAULT_HANDSHAKE_TIMEOUT_MS` so slow MCP servers can have wider timeouts and tests can have tighter ones. Defensive guard against non-finite / non-positive values falls back to the default.
+- **MCP wall-clock fast-fail (#4456 / #4537):** `MCPFleet.start()` now caps total wait at `DEFAULT_FLEET_START_CAP_MS` (1500ms) so a single broken MCP config can't hang session startup indefinitely. Operators can opt in to legacy convergence behaviour via `opts.startCapMs = Infinity`.
+
+### Fixed
+
+- **Trust-store serialization (#4460 / #4526):** two MCPFleet clients started in parallel could both pass through their trustGate (load → prompt → recordTrust) interleaved, with the last write clobbering the first. Added `withTrustStoreLock(filePath, critical)` — a per-path async mutex — and serialised the whole gate sequence inside it. Prompts now surface one at a time; concurrent recordTrust calls all persist.
+- **Trust-store tuple key hardened against collision + tamper (#4461 / #4529):** replaced the NUL-byte separator with `JSON.stringify([name, command, arg0])` so values containing spaces, NUL, quotes, or brackets cannot collide. `loadTrustStore()` now recomputes each entry's canonical key from its stored components and drops any entry whose stored key doesn't match — catches "hand-edit command, keep stored key intact" tamper attempts.
+- **Bypass-mode no longer silently persists MCP trust (#4462 / #4531):** `autoAllowPending()` now tags pending entries with `mcpTrust: true` and denies them explicitly with the reason "MCP trust not persisted via auto-mode bypass" — prevents auto-mode from quietly accumulating trust entries the user never approved.
+- **Trust-store cleans up `.tmp` on renameSync failure (#4463 / #4534):** when `renameSync` threw (cross-device link, FS quota, ACL) the temp file was left behind in `~/.chroxy/`. Wrap in try/catch that `unlinkSync`-es the temp on failure and re-throws the original error.
+- **MCP config-file 10MB read cap (#4447 / #4524):** `byok-mcp-config.js` now caps the JSON read at 10MB so a malformed or hostile config can't exhaust memory. Over-cap reads warn and fall back to empty config.
+- **MCP config coerces and warns on non-string values (#4448 / #4528):** non-string values for `command`/`args` items now warn and are dropped instead of producing a broken MCPClient config.
+- **Unified `mcpConfigPath` opt naming (#4449 / #4532):** `byok-session.js` now uses `opts.mcpConfigPath` consistently; the unused `claudeConfigPath` alias was dropped.
+- **MCP client logs orphan JSON-RPC responses at debug (#4455 / #4536):** unsolicited responses (id the client never sent) now log at debug level instead of warn, since they're benign noise from buggy MCP servers. Notifications (id == null) are silently dropped.
+- **`mcpToolCallTimeoutMs` clamped to MAX_SANE_DURATION_MS (#4517 / #4538):** the operator-facing knob now respects the 24h ceiling enforced for other timeout fields (extends v0.9.12's #4516 to the three byok-session sites + config validation).
+- **1M-variant model label uses providerMeta (#4441 / #4518):** `humanizeModelId` now applies provider-supplied labels to the 1M variants instead of dropping back to the raw model ID.
+- **ActivityIndicator popover focus-restore (#4445 / #4525):** Escape now restores focus to the disclosure trigger instead of dropping focus to the document body. Follow-up [#4539](https://github.com/blamechris/chroxy/issues/4539) tracks the SidebarTokenView parallel.
+
+### Changed
+
+- **`useId()` for ActivityIndicator popover id (#4444 / #4523):** replaced the manual `useRef(`indicator-${Math.random()}`)` hack with React 19's `useId()` so popover ids are stable across re-renders and SSR-safe.
+- **Shared session-manager forwarding test helper (#4511 / #4519):** extracted `CapturingProvider` + `assertForwardingPattern` from session-manager tests into `packages/server/tests/helpers/provider-forwarding.js` so future timeout-forwarding tests don't duplicate the harness. Includes follow-up #4522 covering the `streamStallTimeoutMs=0` edge case.
+
+### Internal
+
+- **Dashboard registry conflict-scan coverage (#4442 / #4520):** added the both-defs-disabled case to `findConflict` tests.
+- **Dashboard registry interface doc (#4443 / #4521):** documented enabled-aware conflict semantics on the registry interface JSDoc.
+- **byok-mcp-client constants parameterized (#4452 / #4527):** `MCP_PROTOCOL_VERSION` and `MCP_CLIENT_VERSION` are now exported module constants — `MCP_CLIENT_VERSION` derives from `package.json` instead of the legacy `'1'` placeholder, so MCP server logs see a real chroxy version.
+
 ## [0.9.12] - 2026-05-28
 
 Small follow-up sweep closing seven leftovers from the v0.9.10–v0.9.11 marathons. Theme is "finish what we started": the keyboard-shortcut registry now owns every dashboard binding (the tail #4412 deferred from v0.9.10's #3852), the context-window learn-loop now persists and runs on both Codex and Gemini (the two #4413/#4414 follow-ups from v0.9.10's #3857), and the pending-background-shells feature lights up the mobile app + handles overflow and multi-shell expansion (the three #4420/#4421/#4422 follow-ups from v0.9.11's #4307). No new user-facing features — every change is making an existing v0.9.x feature work the way it was advertised.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.12"
+      "version": "0.9.13"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.12",
+    "version": "0.9.13",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.12</string>
+    <string>0.9.13</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.12"
+version = "0.9.13"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.12",
+      "version": "0.9.13",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Wave 1 of the from-review marathon — 20 follow-ups landed across BYOK MCP (config/client/trust), dashboard ActivityIndicator polish, session-manager test helpers, and a timeout-ceiling consolidation. Theme: harden the BYOK surface.

Highlights:
- **Trust store hardening:** serialised concurrent writes (#4526), JSON-encoded tuple keys with tamper detection (#4529), denied bypass-mode auto-trust (#4531), `.tmp` cleanup on rename failure (#4534)
- **MCP client robustness:** exponential restart backoff (#4530), tunable handshake timeout (#4533), orphan-response debug logging (#4536), wall-clock fast-fail (#4537)
- **`mcpToolCallTimeoutMs` ceiling (#4538)** closes the v0.9.12 #4517 follow-up
- **Dashboard polish:** `useId()` for popover ids (#4523), focus-restore on Escape (#4525)

Version cascaded via `scripts/bump-version.sh`: root + 6 package.jsons + app.json + Tauri Cargo.toml + tauri.conf.json + iOS Info.plist + lockfiles.

## Test plan

- [x] All 20 wave-1 PRs reviewed Approve, CI green at time of merge
- [x] Trust-store tests: 32/32 pass after cluster-D rebase merge
- [x] MCP client tests: 31/31 pass after cluster-C rebase merge
- [ ] Smoke-test dashboard load on `0.9.13`
- [ ] Smoke-test mobile-app connect on `0.9.13`