### PR TITLE
fix(dashboard): restore focus to disclosure on SidebarTokenView Escape dismiss

### DIFF
--- a/packages/dashboard/src/components/SidebarTokenView.test.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.test.tsx
@@ -342,6 +342,26 @@ describe('SidebarTokenView (#4303 v0)', () => {
         expect(trigger.getAttribute('aria-expanded')).toBe('false')
       })
 
+      it('restores focus to the disclosure button when Escape dismisses the popover (#4539)', () => {
+        // WAI-ARIA APG: a disclosure-triggered popover dismissed via Escape
+        // should return focus to the invoker so keyboard users don't get
+        // parked on document.body and lose their place in the tab order.
+        // Mirrors PR #4525 which fixed the same omission for ActivityIndicator.
+        render(<SidebarTokenView sessions={sessions} />)
+        const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+        fireEvent.click(trigger)
+        expect(screen.getByTestId('sidebar-token-view-cost-info-popover')).toBeInTheDocument()
+        // Move focus into the popover to simulate a keyboard user who has
+        // tabbed into the disclosure content. The Escape dismiss must yank
+        // focus back to the trigger regardless of which element currently
+        // holds it.
+        const popover = screen.getByTestId('sidebar-token-view-cost-info-popover')
+        ;(popover as HTMLElement).focus()
+        fireEvent.keyDown(document, { key: 'Escape' })
+        expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+        expect(document.activeElement).toBe(trigger)
+      })
+
       it('dismisses the popover when clicking outside', () => {
         render(
           <div>
@@ -356,6 +376,30 @@ describe('SidebarTokenView (#4303 v0)', () => {
         // mousedown is the typical click-outside trigger (fires before focus).
         fireEvent.mouseDown(screen.getByTestId('outside-button'))
         expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+      })
+
+      it('does NOT restore focus to the disclosure button on outside-click dismiss (#4539)', () => {
+        // Outside-click dismiss intentionally leaves focus where the user
+        // clicked — stealing it back would fight their pointer intent. Only
+        // the keyboard-only Escape path restores focus per APG guidance.
+        // Mirrors PR #4525 which made the same deliberate distinction for
+        // ActivityIndicator.
+        render(
+          <div>
+            <SidebarTokenView sessions={sessions} />
+            <button type="button" data-testid="outside-button">outside</button>
+          </div>,
+        )
+        const trigger = screen.getByTestId('sidebar-token-view-cost-info')
+        fireEvent.click(trigger)
+        expect(screen.getByTestId('sidebar-token-view-cost-info-popover')).toBeInTheDocument()
+        // Move focus elsewhere first so we can assert focus is NOT pulled
+        // back to the disclosure after the outside-click dismiss.
+        document.body.focus()
+        expect(document.activeElement).not.toBe(trigger)
+        fireEvent.mouseDown(document.body)
+        expect(screen.queryByTestId('sidebar-token-view-cost-info-popover')).toBeNull()
+        expect(document.activeElement).not.toBe(trigger)
       })
 
       it('does not dismiss when clicking inside the popover', () => {

--- a/packages/dashboard/src/components/SidebarTokenView.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.tsx
@@ -188,6 +188,10 @@ function InfoDisclosure({
   const [open, setOpen] = useState(false)
   const popoverId = useId()
   const containerRef = useRef<HTMLSpanElement | null>(null)
+  // #4539 — keep a handle on the disclosure button so Escape dismiss can
+  // return focus to the invoker per WAI-ARIA APG disclosure guidance.
+  // Mirrors the ActivityIndicator fix from PR #4525.
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
   // Track whether the popover was opened via hover (mouse) so a subsequent
   // mouseleave can close it. Click-opened popovers stay until explicit
   // dismissal (Escape, click-outside, or second click).
@@ -206,12 +210,23 @@ function InfoDisclosure({
     function onKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') {
         setOpen(false)
+        // #4539 — WAI-ARIA APG: a disclosure-triggered popover dismissed
+        // via Escape should return focus to the invoker so keyboard users
+        // don't get parked on document.body and lose their place in the
+        // tab order. Mirrors PR #4525 which did the same for
+        // ActivityIndicator.
+        triggerRef.current?.focus()
       }
     }
     function onPointerDown(e: PointerEvent) {
       const target = e.target as Node | null
       if (!target) return
       if (containerRef.current && containerRef.current.contains(target)) return
+      // #4539 — outside-click dismiss intentionally does NOT restore focus
+      // to the disclosure trigger: the user explicitly clicked elsewhere,
+      // so stealing focus back would fight their pointer intent. Escape
+      // (above) is the keyboard-only path that needs focus restoration
+      // per WAI-ARIA APG disclosure guidance.
       setOpen(false)
     }
     document.addEventListener('keydown', onKeyDown)
@@ -232,6 +247,7 @@ function InfoDisclosure({
     <span className="sidebar-token-view-disclosure" ref={containerRef}>
       <button
         type="button"
+        ref={triggerRef}
         className={triggerClassName}
         data-testid={testIdBase}
         aria-label={ariaLabel}


### PR DESCRIPTION
## Summary

The `InfoDisclosure` popovers inside `SidebarTokenView` (cost-info marker and TUI-untracked marker) dismissed on Escape with a plain `setOpen(false)` and never restored focus to the disclosure trigger. Keyboard users were parked on `document.body` and lost their place in the tab order — the same WAI-ARIA APG violation `ActivityIndicator` had before #4445 / #4525.

Fix mirrors PR #4525 exactly:

- Add a `triggerRef` and attach it to the disclosure button.
- In the Escape branch of the `keydown` listener, call `triggerRef.current?.focus()` after `setOpen(false)`.
- Outside-click path deliberately does NOT restore focus — stealing it back from where the user clicked would fight their pointer intent. This is the same intentional asymmetry adopted in #4525.

## Tests

Two regression tests added to `SidebarTokenView.test.tsx` mirroring the ones in PR #4525:

- `restores focus to the disclosure button when Escape dismisses the popover (#4539)` — clicks the cost-info trigger, moves focus into the popover, dispatches Escape, then asserts `document.activeElement === trigger`.
- `does NOT restore focus to the disclosure button on outside-click dismiss (#4539)` — moves focus to `document.body`, fires `mouseDown` outside, then asserts focus is NOT pulled back to the trigger.

## Test plan

- [x] `cd packages/dashboard && npx vitest run src/components/SidebarTokenView` — 33 passed
- [x] `cd packages/dashboard && npx vitest run` — 2254 passed across 124 files
- [x] New Escape-restore test fails on the pre-fix code (verified by running it before applying the implementation)

Closes #4539