### PR TITLE
chore(release): cut v0.9.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.14] - 2026-05-29
+
+Wave 2 of the from-review marathon — three follow-ups plus the foundation slice of the v0.9.13 #4349 user-notification-settings decomposition. The K8sBackend gains a multi-node-cluster path via a PVC workspace strategy (#3385), the dashboard's SidebarTokenView popover gains the same Escape focus-restore #4525 added to ActivityIndicator (#4539), and `PushManager` grows a user-prefs surface backed by `~/.chroxy/notification-prefs.json` + `notification_prefs_get/set` WS messages (#4541) — the substrate that the per-category UI (#4542), per-device UI (#4543), and quiet-hours (#4544) sub-issues will consume in a future marathon.
+
+### Added
+
+- **K8sBackend PVC workspace strategy (#3385 / #4547):** `opts.workspacePVC = { claimName, mountPath? }` translates to a `persistentVolumeClaim` volume + `volumeMount` in the Pod spec, giving multi-node-cluster operators a working alternative to the single-node-only `hostPath` workspace. Passing both `cwd` (hostPath) and `workspacePVC` throws early — operators pick one strategy. Existing `hostPath` path is unchanged. Follow-up [#4548](https://github.com/blamechris/chroxy/issues/4548) tracks plumbing `workspacePVC` through EnvironmentManager so high-level callers can reach it without bypassing the manager.
+- **Notification preferences foundation (#4541 / #4549):** `~/.chroxy/notification-prefs.json` (mode 0600, atomic temp+rename writes) holds global per-category defaults + per-device override map keyed by Expo push token. `PushManager` grows `getPrefs()`, `setPrefs(patch)`, `isCategoryEnabled(category, pushToken)`, and `isInQuietHours(now, pushToken)` (stub — quiet-hours logic ships with #4544). WS protocol adds `notification_prefs_get` / `notification_prefs_set` messages with Zod schemas in `@chroxy/protocol`. Server-side `RATE_LIMITS` remain as the defensive lower bound — user prefs can mute but never enable more spam.
+
+### Fixed
+
+- **SidebarTokenView popover focus restore on Escape (#4539 / #4545):** Escape dismiss now calls `triggerRef.current?.focus()` so keyboard users return to the disclosure trigger instead of being parked on `document.body` (WAI-ARIA APG). Outside-click path deliberately does NOT restore focus — preserves pointer intent. Mirrors v0.9.13's #4525 ActivityIndicator fix. Follow-up [#4546](https://github.com/blamechris/chroxy/issues/4546) tracks a TUI-untracked-trigger regression test variant.
+
+### Internal
+
+- **#4349 decomposed:** the multi-package user-notification-settings parent closed in favour of four sub-issues — #4541 (foundation, landed here), #4542 (per-category UI), #4543 (per-device UI), #4544 (quiet hours).
+
 ## [0.9.13] - 2026-05-29
 
 Wave 1 of the from-review marathon: 20 follow-ups across BYOK MCP (config, client, trust), dashboard ActivityIndicator polish, session-manager test helpers, and a timeout-ceiling consolidation. Theme is "harden the BYOK surface": the MCP trust store now serialises concurrent writes (#4526), uses JSON-encoded tuple keys that resist collision and tamper (#4529), denies bypass-mode auto-trust (#4531), and cleans up `.tmp` leakage on rename failure (#4534). The MCP client gets exponential restart backoff (#4530), a tunable handshake timeout (#4533), debug-level orphan-response logging (#4536), and a wall-clock fast-fail on broken MCP configs (#4537). Plus dashboard a11y/i18n polish (#4523, #4525) and the `mcpToolCallTimeoutMs` ceiling (#4538) closing the v0.9.12 #4517 follow-up.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.13"
+      "version": "0.9.14"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.13",
+    "version": "0.9.14",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.13</string>
+    <string>0.9.14</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.13"
+version = "0.9.14"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Wave 2 of the from-review marathon — 3 follow-ups merged plus the foundation slice of v0.9.13's #4349 user-notification-settings decomposition.

- **#3385 / #4547** — K8sBackend PVC workspace strategy (multi-node-cluster path)
- **#4539 / #4545** — SidebarTokenView Escape focus restore (mirrors v0.9.13's #4525)
- **#4541 / #4549** — Notification-prefs store + WS protocol (foundation for deferred #4542/#4543/#4544)

Version cascaded via `scripts/bump-version.sh 0.9.14` to root + 6 package.jsons + app.json + Tauri Cargo.toml + tauri.conf.json + iOS Info.plist + lockfiles. No native deps changed → no EAS rebuild required.

## Test plan

- [x] All 3 wave-2 PRs reviewed Approve, 13/13 CI green at merge
- [x] No cluster-internal rebases needed (different packages: dashboard / server k8s / server push)
- [ ] Smoke-test dashboard load on `0.9.14`
- [ ] Smoke-test server boot + `notification_prefs_get` WS round-trip