### PR TITLE
test(dashboard): cover SidebarTokenView TUI-untracked Escape focus-restore

### DIFF
--- a/packages/dashboard/src/components/SidebarTokenView.test.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.test.tsx
@@ -224,6 +224,23 @@ describe('SidebarTokenView (#4303 v0)', () => {
       expect(popover.textContent ?? '').toContain('claude TUI')
     })
 
+    // #4546: the Escape focus-restore wiring lives on the shared
+    // `InfoDisclosure` component, so it benefits both the cost-info trigger
+    // (covered above) AND the TUI-untracked trigger. Cover the TUI path
+    // explicitly so a future refactor that splits `InfoDisclosure` into two
+    // components — or introduces a per-trigger override — can't silently
+    // lose focus-restoration coverage for the TUI-untracked popover.
+    it('restores focus to the TUI-untracked disclosure on Escape (#4539)', () => {
+      const sessions = [makeSession('tui', 'claude-tui', makeUsage(0, 0, 0))]
+      render(<SidebarTokenView sessions={sessions} />)
+      const trigger = screen.getByTestId('sidebar-token-view-provider-claude-tui-untracked')
+      fireEvent.click(trigger)
+      const popover = screen.getByTestId('sidebar-token-view-provider-claude-tui-untracked-popover')
+      ;(popover as HTMLElement).focus()
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(document.activeElement).toBe(trigger)
+    })
+
     it('renders aggregate total and cost when present', () => {
       const sessions = [
         makeSession('byok', 'claude-byok', makeUsage(1000, 500, 0.10)),


### PR DESCRIPTION
## Summary

PR #4545 added the Escape focus-restore fix (#4539) to the shared `InfoDisclosure` component inside `SidebarTokenView`, but the regression tests only exercised the **cost-info** trigger. Both the cost-info and TUI-untracked popovers go through the same `InfoDisclosure`, so the fix already benefits both — but a future refactor that splits `InfoDisclosure` into per-trigger components (or introduces a per-trigger override) could silently drop focus-restoration coverage for the TUI-untracked path.

This PR adds a third regression test that exercises the TUI-untracked trigger specifically.

## Changes

- `packages/dashboard/src/components/SidebarTokenView.test.tsx` — new test `restores focus to the TUI-untracked disclosure on Escape (#4539)` placed next to the existing TUI-untracked render test, mirroring the cost-info Escape-restore test pattern.

## Test plan

- [x] `cd packages/dashboard && npx vitest run src/components/SidebarTokenView` — 34 passed (was 33)
- [x] `cd packages/dashboard && npx vitest run` — 2255 passed across 124 files (no regressions)
- [x] Verified the new test fails when the `triggerRef.current?.focus()` line is temporarily removed from the Escape branch of `InfoDisclosure` — both the existing cost-info test and the new TUI-untracked test fail, confirming the new test correctly locks the shared-component wiring in place. Source reverted before commit.

Closes #4546