### PR TITLE
feat(server): plumb workspacePVC through EnvironmentManager

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -83,9 +83,15 @@ export class EnvironmentManager extends EventEmitter {
    * @param {string} [opts.memoryLimit] - Memory limit (default: 2g)
    * @param {string} [opts.cpuLimit] - CPU limit (default: 2)
    * @param {string} [opts.containerUser] - Non-root user (default: chroxy)
+   * @param {Object} [opts.workspacePVC] - K8s-only: mount a pre-provisioned
+   *   PersistentVolumeClaim as the workspace instead of the host `cwd` directory.
+   *   See `K8sBackend.createEnvironment` (#3385) for the full shape and semantics
+   *   (`{ claimName, mountPath?, readOnly? }`). Forwarded verbatim to the backend;
+   *   DockerBackend and other non-K8s backends ignore it. Mutually exclusive with
+   *   `opts.cwd`-as-hostPath on K8sBackend — the backend validates and throws.
    * @returns {Promise<Object>} The created environment object
    */
-  async create({ name, cwd, image, memoryLimit, cpuLimit, containerUser, compose, primaryService, devcontainer } = {}) {
+  async create({ name, cwd, image, memoryLimit, cpuLimit, containerUser, compose, primaryService, devcontainer, workspacePVC } = {}) {
     if (!name?.trim()) throw new Error('Environment name is required')
     if (!cwd?.trim()) throw new Error('Environment cwd is required')
 
@@ -128,6 +134,9 @@ export class EnvironmentManager extends EventEmitter {
       forwardPorts: dcConfig.forwardPorts,
       mounts: validatedMounts,
       postCreateCommand: dcConfig.postCreateCommand,
+      // #4548: forward verbatim — only K8sBackend acts on this. Manager does no
+      // shape validation; that lives in K8sBackend.validateWorkspacePVC().
+      workspacePVC,
     })
 
     const env = {

--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -58,6 +58,15 @@
  *   Honoured only by K8sBackend — Docker and other backends silently ignore this field.
  *   When absent, K8sBackend omits the field from the Pod spec and the K8s cluster default applies
  *   (typically `IfNotPresent` for tagged images, `Always` for `latest`).
+ * @param {Object} [opts.workspacePVC] - PersistentVolumeClaim-based workspace strategy for
+ *   multi-node K8s clusters where `hostPath` cannot reach the operator's source tree (#3385).
+ *   Honoured only by K8sBackend — Docker and other backends silently ignore this field.
+ *   Mutually exclusive with `opts.cwd` on K8sBackend (passing both throws so the operator picks
+ *   exactly one strategy — see `K8sBackend.validateWorkspacePVC`).
+ * @param {string}  opts.workspacePVC.claimName   - Name of a pre-provisioned PVC in the
+ *   target namespace. Required when `workspacePVC` is set; must be a non-empty string.
+ * @param {string}  [opts.workspacePVC.mountPath] - Pod-side mount path (default: `/workspace`).
+ * @param {boolean} [opts.workspacePVC.readOnly]  - Mount the PVC read-only (default: false).
  * @returns {Promise<{ containerId: string, containerCliPath: string }>}
  *   containerId — the full container ID string returned by the runtime
  *   containerCliPath — absolute path inside the container where the CLI binary was installed

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -245,6 +245,83 @@ describe('EnvironmentManager.create()', () => {
   })
 })
 
+/**
+ * #4548 — EnvironmentManager.create() must forward opts.workspacePVC through to
+ * the backend's createEnvironment() so callers of the high-level manager API can
+ * reach K8sBackend's PVC workspace strategy (added in #4547 for #3385) without
+ * bypassing the manager.
+ *
+ * The manager itself does not validate the shape of workspacePVC — that lives in
+ * K8sBackend.validateWorkspacePVC(). The manager is a pure passthrough: it must
+ * not strip, mutate, or default the option. Other backends (e.g. DockerBackend)
+ * simply ignore the field.
+ */
+describe('EnvironmentManager.create() — workspacePVC passthrough (#4548)', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-env-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  /**
+   * Build a stub backend that records every opts payload it receives. The
+   * minimal Backend surface we touch in create() is createEnvironment — we don't
+   * need to implement the rest of the interface for these tests.
+   */
+  function createRecordingBackend() {
+    const calls = []
+    return {
+      calls,
+      async createEnvironment(opts) {
+        calls.push(opts)
+        return {
+          containerId: 'stub-container-id',
+          containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+        }
+      },
+    }
+  }
+
+  it('forwards opts.workspacePVC verbatim to the backend', async () => {
+    const backend = createRecordingBackend()
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    const workspacePVC = { claimName: 'shared-workspace-pvc', mountPath: '/work', readOnly: true }
+
+    await manager.create({
+      name: 'pvc-env',
+      cwd: '/tmp',
+      workspacePVC,
+    })
+
+    assert.equal(backend.calls.length, 1, 'backend.createEnvironment must be invoked exactly once')
+    assert.deepEqual(
+      backend.calls[0].workspacePVC,
+      workspacePVC,
+      'workspacePVC must be forwarded verbatim — manager is a pure passthrough'
+    )
+  })
+
+  it('omits workspacePVC from the backend call when the caller does not pass it', async () => {
+    const backend = createRecordingBackend()
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    await manager.create({ name: 'no-pvc-env', cwd: '/tmp' })
+
+    assert.equal(backend.calls.length, 1)
+    assert.equal(
+      backend.calls[0].workspacePVC,
+      undefined,
+      'workspacePVC must be undefined when the caller does not pass it (no synthetic defaults)'
+    )
+  })
+})
+
 describe('EnvironmentManager.destroy()', () => {
   let tmpDir, statePath
 


### PR DESCRIPTION
## Summary

PR #4547 (now merged) added `opts.workspacePVC = { claimName, mountPath?, readOnly? }` to `K8sBackend.createEnvironment` so multi-node operators can mount a pre-provisioned PVC at the workspace path. But `EnvironmentManager.create()` only forwarded a fixed set of opts to `this._backend.createEnvironment` — so anyone using the high-level manager API (the dashboard, session creation flow, devcontainer entry points) couldn't reach the new strategy without bypassing the manager.

This PR is purely the **plumbing**: forward the opt verbatim, document it on the Backend interface, and lock the behaviour in with a passthrough test.

## Changes

- **`packages/server/src/environment-manager.js`**
  - Destructure `workspacePVC` from `create()` opts and forward it inside the `this._backend.createEnvironment(...)` payload.
  - Add a JSDoc entry on `create()` for the new option.
  - The manager does **no** shape validation — that lives in `K8sBackend.validateWorkspacePVC()`. Non-K8s backends ignore the field. This keeps validation in exactly one place and matches how `imagePullPolicy` is handled.
- **`packages/server/src/environments/backends/types.js`**
  - Document `workspacePVC` shape and semantics on the Backend interface `createEnvironment` JSDoc, alongside the existing `imagePullPolicy` entry.
- **`packages/server/tests/environment-manager.test.js`**
  - New describe block `EnvironmentManager.create() — workspacePVC passthrough (#4548)` with two tests using a recording stub backend:
    - forwards `opts.workspacePVC` verbatim (no mutation, no stripping)
    - omits `workspacePVC` from the backend call when the caller doesn't pass it (no synthetic defaults)

Naming note: the issue references `EnvironmentManager.createEnvironment` but the method is actually named `create()`. The `createEnvironment` call site at line 120 is the **backend** method being invoked — which is exactly where the new opt needs to land.

## Design choice — where does the operator configure the PVC?

Out of the three candidates raised in #4548 (chroxy config / devcontainer.json / dashboard input), the leaning is **chroxy config** for the next sub-issue. Rationale:

- **chroxy config (preferred)** — Keeps the choice operator-side, where it belongs. The PVC is a *cluster operations* concern (the operator has provisioned the PVC, knows its claimName, and decides whether environments should share it or pin to it). It does not vary per project, per session, or per user — so per-project / per-call surfaces are the wrong level. A single `[k8s.workspace]` block in chroxy config (e.g. `claimName`, `mountPath`, `readOnly`) lets the operator set it once and have every environment created on that backend pick it up automatically.
- **devcontainer.json (rejected)** — This is a per-project file checked into the user's repo. Polluting it with a deployment-specific PVC claim name would couple project repos to a specific cluster's operations, which is exactly the kind of leak devcontainer.json is meant to avoid. Different operators running the same project would each need to fork.
- **dashboard input (rejected for the default; possibly useful as an override)** — Asking the operator to type a claim name into a form every time they create an environment is friction without payoff — the value is stable across environments on a given backend. A dashboard field could later be added as a per-create override on top of the config default, but it shouldn't be the only surface.

**This PR does NOT implement the config surface** — that's the next sub-issue. Scope here is purely the plumbing so the option can reach the backend at all.

## Test plan

- [x] New passthrough tests (2) pass: `node --test --test-name-pattern="workspacePVC passthrough" packages/server/tests/environment-manager.test.js`
- [x] Full `environment-manager.test.js` suite green: 91/91
- [x] K8sBackend suite still green (no behaviour changes there): 200/200 in `packages/server/tests/environments/backends/k8s.test.js`
- [x] No regressions in the wider server suite from this change (pre-existing failures in `service.test.js` are caused by a local chroxy daemon on port 8765 and reproduce on main without this PR)

Closes #4548