### PR TITLE
feat(dashboard,app): per-category notification opt-in/out UI

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,7 +26,8 @@
     ],
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/src/$1",
-      "^@chroxy/protocol$": "<rootDir>/../protocol/dist/index.js"
+      "^@chroxy/protocol$": "<rootDir>/../protocol/dist/index.js",
+      "^@chroxy/protocol/schemas$": "<rootDir>/../protocol/dist/schemas/index.js"
     },
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}",

--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -1,0 +1,138 @@
+/**
+ * SettingsScreen — per-category notification preferences UI tests (#4542)
+ *
+ * Mirrors the existing SettingsScreenSessionRules pattern (#2434): static
+ * source analysis is the dominant mobile-app test style for screens that
+ * compose Zustand selectors + RN primitives.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const settingsSource = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/SettingsScreen.tsx'),
+  'utf-8',
+);
+
+const typesSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/types.ts'),
+  'utf-8',
+);
+
+const connectionSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/connection.ts'),
+  'utf-8',
+);
+
+const messageHandlerSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/message-handler.ts'),
+  'utf-8',
+);
+
+describe('SettingsScreen — Notification categories section (#4542)', () => {
+  it('renders a NOTIFICATION CATEGORIES section header', () => {
+    expect(settingsSource).toMatch(/NOTIFICATION CATEGORIES/);
+  });
+
+  it('reads notificationPrefs from the connection store', () => {
+    expect(settingsSource).toMatch(/notificationPrefs\s*=\s*useConnectionStore/);
+  });
+
+  it('selects refreshNotificationPrefs from the store', () => {
+    expect(settingsSource).toMatch(/refreshNotificationPrefs\s*=\s*useConnectionStore/);
+  });
+
+  it('selects setNotificationPrefsCategory from the store', () => {
+    expect(settingsSource).toMatch(/setNotificationPrefsCategory\s*=\s*useConnectionStore/);
+  });
+
+  it('calls refreshNotificationPrefs on mount via useEffect', () => {
+    // The useEffect body must invoke refreshNotificationPrefs(); the
+    // dependency array must include the action so React doesn't warn.
+    expect(settingsSource).toMatch(/useEffect\([\s\S]{0,200}refreshNotificationPrefs\(\)/);
+  });
+
+  it('shows a loading hint until the first snapshot lands', () => {
+    expect(settingsSource).toMatch(/notification-prefs-loading/);
+    expect(settingsSource).toMatch(/Loading preferences/);
+  });
+
+  it('labels every category from the server-side RATE_LIMITS enum', () => {
+    // These labels MUST exist so the mobile-side stays in sync with
+    // packages/server/src/notification-prefs.js ALL_CATEGORIES.
+    expect(settingsSource).toMatch(/permission:.*Permission requests/);
+    expect(settingsSource).toMatch(/result:.*Task completion/);
+    expect(settingsSource).toMatch(/activity_update:.*Activity updates/);
+    expect(settingsSource).toMatch(/activity_waiting:.*Waiting for input/);
+    expect(settingsSource).toMatch(/activity_error:.*Session errors/);
+    expect(settingsSource).toMatch(/inactivity_warning:.*Inactivity warnings/);
+    expect(settingsSource).toMatch(/live_activity:.*Live Activity/);
+  });
+
+  it('passes the toggled value through Switch.onValueChange to setNotificationPrefsCategory', () => {
+    // The Switch component MUST forward the new boolean — not the
+    // category name — as the second arg.
+    expect(settingsSource).toMatch(/onValueChange=\{\(value\) => setNotificationPrefsCategory\(cat, value\)\}/);
+  });
+
+  it('emits a testID per category toggle for E2E + a11y discovery', () => {
+    expect(settingsSource).toMatch(/testID=\{`notification-prefs-toggle-\$\{cat\}`\}/);
+  });
+
+  it('orders categories deterministically so the UI does not jitter on every snapshot', () => {
+    expect(settingsSource).toMatch(/NOTIFICATION_CATEGORY_ORDER/);
+  });
+});
+
+describe('ConnectionState — notification prefs surface (#4542)', () => {
+  it('declares notificationPrefs in ServerNotificationData', () => {
+    expect(typesSource).toMatch(/notificationPrefs:\s*\{[\s\S]{0,400}categories:\s*Record<string,\s*boolean>/);
+  });
+
+  it('declares refreshNotificationPrefs in ServerNotificationActions', () => {
+    expect(typesSource).toMatch(/refreshNotificationPrefs:\s*\(\)\s*=>\s*void/);
+  });
+
+  it('declares setNotificationPrefsCategory with (category, enabled) signature', () => {
+    expect(typesSource).toMatch(/setNotificationPrefsCategory:\s*\(category:\s*string,\s*enabled:\s*boolean\)\s*=>\s*void/);
+  });
+});
+
+describe('connection.ts — notification prefs actions (#4542)', () => {
+  it('initializes notificationPrefs to null', () => {
+    expect(connectionSource).toMatch(/notificationPrefs:\s*null/);
+  });
+
+  it('clears notificationPrefs on disconnect so the next connect refetches', () => {
+    // Two assignments: initial + the disconnect/reset block. If the reset
+    // ever drops, a stale snapshot would survive across reconnects to a
+    // different host.
+    const matches = connectionSource.match(/notificationPrefs:\s*null/g);
+    expect(matches?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it('refreshNotificationPrefs sends notification_prefs_get over the socket', () => {
+    expect(connectionSource).toMatch(/refreshNotificationPrefs[\s\S]{0,300}notification_prefs_get/);
+  });
+
+  it('setNotificationPrefsCategory sends a single-category notification_prefs_set patch', () => {
+    expect(connectionSource).toMatch(
+      /setNotificationPrefsCategory[\s\S]{0,400}notification_prefs_set[\s\S]{0,200}\[category\]:\s*enabled/,
+    );
+  });
+});
+
+describe('message-handler.ts — notification_prefs WS message (#4542)', () => {
+  it('imports ServerNotificationPrefsSchema from @chroxy/protocol/schemas', () => {
+    expect(messageHandlerSource).toMatch(/import\s*\{\s*ServerNotificationPrefsSchema\s*\}\s*from\s*'@chroxy\/protocol\/schemas'/);
+  });
+
+  it('handles the notification_prefs case and stores the parsed snapshot', () => {
+    expect(messageHandlerSource).toMatch(/case 'notification_prefs'[\s\S]{0,800}ServerNotificationPrefsSchema\.safeParse[\s\S]{0,300}notificationPrefs:/);
+  });
+
+  it('logs and skips when the payload fails schema validation', () => {
+    expect(messageHandlerSource).toMatch(
+      /case 'notification_prefs'[\s\S]{0,600}!parsed\.success[\s\S]{0,200}console\.warn\(\s*'notification_prefs:/,
+    );
+  });
+});

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -35,6 +35,33 @@ const APP_VERSION = Constants.expoConfig?.version ?? 'unknown';
 // returning a new [] on every render (which causes infinite re-render loops).
 const EMPTY_RULES: PermissionRule[] = [];
 
+/**
+ * #4542: friendly labels for per-category notification toggles. Keys MUST
+ * match the server-side `ALL_CATEGORIES` enum from notification-prefs.js
+ * (mirrors RATE_LIMITS in push.js). Unknown keys fall back to the raw key
+ * so a future server-side category is never silently hidden.
+ */
+const NOTIFICATION_CATEGORY_LABELS: Record<string, { label: string; hint?: string }> = {
+  permission: { label: 'Permission requests', hint: 'Tool-use prompts awaiting allow / deny.' },
+  result: { label: 'Task completion', hint: 'Sent when a Claude turn finishes unattended.' },
+  activity_update: { label: 'Activity updates', hint: 'Foreground task progress when you are away.' },
+  activity_waiting: { label: 'Waiting for input', hint: 'Claude paused on a question or prompt.' },
+  activity_error: { label: 'Session errors', hint: 'Crashes, tunnel drops, fatal session failures.' },
+  inactivity_warning: { label: 'Inactivity warnings', hint: 'Heads-up before a long-idle session is paused.' },
+  live_activity: { label: 'Live Activity (iOS)', hint: 'iOS Dynamic Island / lock-screen updates.' },
+};
+
+/** Render order for known categories. Unknown keys append in snapshot order. */
+const NOTIFICATION_CATEGORY_ORDER = [
+  'permission',
+  'activity_waiting',
+  'activity_error',
+  'activity_update',
+  'inactivity_warning',
+  'result',
+  'live_activity',
+];
+
 const SPEECH_LANGUAGES = [
   { tag: 'en-US', label: 'English (US)' },
   { tag: 'en-GB', label: 'English (UK)' },
@@ -115,6 +142,26 @@ export function SettingsScreen() {
   const dismissSessionNotification = useConnectionStore((s) => s.dismissSessionNotification);
   const dismissServerError = useConnectionStore((s) => s.dismissServerError);
   const totalActiveNotifications = sessionNotifications.length + serverErrors.length;
+
+  // #4542: per-category notification preferences. Snapshot arrives via the
+  // WS `notification_prefs` message; we request it on mount and toggle a
+  // single category at a time via `notification_prefs_set` (server shallow-
+  // merges so untouched categories are preserved).
+  const notificationPrefs = useConnectionStore((s) => s.notificationPrefs);
+  const refreshNotificationPrefs = useConnectionStore((s) => s.refreshNotificationPrefs);
+  const setNotificationPrefsCategory = useConnectionStore((s) => s.setNotificationPrefsCategory);
+
+  useEffect(() => {
+    refreshNotificationPrefs();
+  }, [refreshNotificationPrefs]);
+
+  const orderedNotificationCategories = useMemo(() => {
+    if (!notificationPrefs) return [];
+    const cats = notificationPrefs.categories;
+    const known = NOTIFICATION_CATEGORY_ORDER.filter((k) => k in cats);
+    const unknown = Object.keys(cats).filter((k) => !NOTIFICATION_CATEGORY_ORDER.includes(k));
+    return [...known, ...unknown];
+  }, [notificationPrefs]);
 
   const serverVersion = useConnectionLifecycleStore((s) => s.serverVersion);
   const latestVersion = useConnectionLifecycleStore((s) => s.latestVersion);
@@ -370,6 +417,44 @@ export function SettingsScreen() {
           <Text style={styles.rowLabel}>Activity History</Text>
           <Text style={styles.rowValue}>View all</Text>
         </TouchableOpacity>
+      </View>
+
+      {/* NOTIFICATIONS — Categories (#4542) */}
+      <Text style={styles.sectionHeader}>NOTIFICATION CATEGORIES</Text>
+      <View style={styles.section} testID="notification-prefs-section">
+        {notificationPrefs == null ? (
+          <View style={styles.row}>
+            <Text style={styles.rowHint} testID="notification-prefs-loading">
+              Loading preferences&hellip;
+            </Text>
+          </View>
+        ) : (
+          orderedNotificationCategories.map((cat, idx) => {
+            const meta = NOTIFICATION_CATEGORY_LABELS[cat];
+            const label = meta?.label ?? cat;
+            const hint = meta?.hint;
+            const checked = notificationPrefs.categories[cat] !== false;
+            return (
+              <React.Fragment key={cat}>
+                {idx > 0 && <View style={styles.separator} />}
+                <View style={styles.row}>
+                  <View style={{ flex: 1, paddingRight: 12 }}>
+                    <Text style={styles.rowLabel}>{label}</Text>
+                    {hint && (
+                      <Text style={[styles.rowHint, { marginTop: 2 }]}>{hint}</Text>
+                    )}
+                  </View>
+                  <Switch
+                    value={checked}
+                    onValueChange={(value) => setNotificationPrefsCategory(cat, value)}
+                    trackColor={{ false: COLORS.backgroundCard, true: COLORS.accentBlue }}
+                    testID={`notification-prefs-toggle-${cat}`}
+                  />
+                </View>
+              </React.Fragment>
+            );
+          })
+        )}
       </View>
 
       {/* PORTABILITY */}

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -321,6 +321,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   restartingSince: null,
   pendingPermissionConfirm: null,
   timeoutWarning: null,
+  // #4542: per-category notification prefs snapshot. Populated by the
+  // `notification_prefs` WS message; null until the first snapshot arrives.
+  notificationPrefs: null,
   slashCommands: [],
   customAgents: [],
   checkpoints: [],
@@ -391,6 +394,28 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   dismissTimeoutWarning: () => {
     set({ timeoutWarning: null });
+  },
+
+  // #4542: notification-prefs round-trip. Mirrors the dashboard's pattern —
+  // `refresh` sends `notification_prefs_get`; `setCategory` sends a single
+  // shallow-merge patch via `notification_prefs_set`. The server broadcasts
+  // the merged snapshot so other clients (dashboard + mobile) stay in sync
+  // without polling.
+  refreshNotificationPrefs: () => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'notification_prefs_get' });
+    }
+  },
+
+  setNotificationPrefsCategory: (category: string, enabled: boolean) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { categories: { [category]: enabled } },
+      });
+    }
   },
 
   setFollowMode: (enabled: boolean) => {
@@ -794,6 +819,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       restartingSince: null,
       pendingPermissionConfirm: null,
       timeoutWarning: null,
+      // #4542: clear the cached prefs snapshot on disconnect so the next
+      // connect refetches from the actual server (snapshots are host-specific).
+      notificationPrefs: null,
       slashCommands: [],
       customAgents: [],
       checkpoints: [],

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -110,6 +110,7 @@ import {
   isActivityEvent,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
+import { ServerNotificationPrefsSchema } from '@chroxy/protocol/schemas';
 import { hapticSuccess } from '../utils/haptics';
 import type {
   ChatMessage,
@@ -2670,6 +2671,28 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // results is already typed as SearchResult[] from store-core (#3146).
       set({ searchResults: results, searchLoading: false, searchError: null });
       useConversationStore.getState().setSearchResults(results, currentQuery);
+      break;
+    }
+
+    case 'notification_prefs': {
+      // #4542: notification-prefs snapshot. Emitted in response to
+      // `notification_prefs_get` and broadcast after every
+      // `notification_prefs_set` so multiple connected clients stay in
+      // lockstep. Validated against the protocol Zod schema before storing.
+      const parsed = ServerNotificationPrefsSchema.safeParse(msg);
+      if (!parsed.success) {
+        // eslint-disable-next-line no-console
+        console.warn('notification_prefs: invalid payload from server', parsed.error.issues);
+        break;
+      }
+      const prefs = parsed.data.prefs;
+      set({
+        notificationPrefs: {
+          categories: prefs.categories,
+          devices: prefs.devices,
+          quietHours: prefs.quietHours,
+        },
+      });
       break;
     }
 

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -284,6 +284,15 @@ export interface ServerNotificationData {
   restartingSince: number | null;
   // Session timeout warning (from server session_warning event)
   timeoutWarning: { sessionId: string; sessionName: string; remainingMs: number; receivedAt: number } | null;
+  // #4542: per-category notification preferences. Mirrors the latest
+  // `notification_prefs` snapshot received from the server. `null` until
+  // the first snapshot arrives. Server is the single source of truth —
+  // ~/.chroxy/notification-prefs.json on the host.
+  notificationPrefs: {
+    categories: Record<string, boolean>;
+    devices: Record<string, { categories?: Record<string, boolean> }>;
+    quietHours: { start: string; end: string } | null;
+  } | null;
 }
 
 /**
@@ -478,6 +487,12 @@ export interface ServerNotificationActions {
   dismissServerError: (id: string) => void;
   dismissSessionNotification: (id: string) => void;
   dismissTimeoutWarning: () => void;
+  // #4542: notification-prefs round-trip. `refresh` sends
+  // `notification_prefs_get`; `setCategory` sends `notification_prefs_set`
+  // with a single-category patch (server shallow-merges so other toggles
+  // are preserved).
+  refreshNotificationPrefs: () => void;
+  setNotificationPrefsCategory: (category: string, enabled: boolean) => void;
 }
 
 /**

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -67,6 +67,12 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     refreshByokCredentialsStatus: vi.fn(),
     setByokCredentials: vi.fn(),
     clearByokCredentials: vi.fn(),
+    // #4542: per-category notification toggles. `notificationPrefs` mirrors
+    // the latest snapshot received over the WS connection (null until the
+    // first `notification_prefs` arrives).
+    notificationPrefs: null,
+    refreshNotificationPrefs: vi.fn(),
+    setNotificationPrefsCategory: vi.fn(),
     ...extra,
   }
 }
@@ -645,6 +651,108 @@ describe('SettingsPanel', () => {
       const input = screen.getByTestId('byok-key-input')
       expect(input.getAttribute('type')).toBe('password')
       expect(input.getAttribute('autocomplete')).toBe('off')
+    })
+  })
+
+  describe('Notification preferences — per-category toggles (#4542)', () => {
+    // The full RATE_LIMITS-derived category set from packages/server/src/push.js.
+    // Kept verbatim so a server-side rename is caught by these tests.
+    const categories = {
+      permission: true,
+      result: true,
+      activity_update: true,
+      activity_waiting: true,
+      activity_error: true,
+      inactivity_warning: true,
+      live_activity: true,
+    }
+    const defaultPrefs = { categories, devices: {}, quietHours: null }
+
+    it('renders the Notifications section when prefs are loaded', () => {
+      setMockState({ notificationPrefs: defaultPrefs })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('notification-prefs-section')).toBeInTheDocument()
+    })
+
+    it('renders the section even before the first snapshot lands (loading state)', () => {
+      setMockState({ notificationPrefs: null })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Section is always present so users see the loading hint instead of
+      // wondering whether the feature exists.
+      expect(screen.getByTestId('notification-prefs-section')).toBeInTheDocument()
+      expect(screen.getByTestId('notification-prefs-loading')).toBeInTheDocument()
+    })
+
+    it('renders one toggle per known server category', () => {
+      setMockState({ notificationPrefs: defaultPrefs })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // The set MUST cover everything in RATE_LIMITS (push.js). If the server
+      // adds a new category, this test fails so the UI can label it.
+      for (const cat of Object.keys(categories)) {
+        expect(screen.getByTestId(`notification-prefs-toggle-${cat}`)).toBeInTheDocument()
+      }
+    })
+
+    it('reflects a category disabled state as an unchecked checkbox', () => {
+      setMockState({
+        notificationPrefs: {
+          categories: { ...categories, result: false },
+          devices: {},
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const resultToggle = screen.getByTestId('notification-prefs-toggle-result') as HTMLInputElement
+      const permToggle = screen.getByTestId('notification-prefs-toggle-permission') as HTMLInputElement
+      expect(resultToggle.checked).toBe(false)
+      expect(permToggle.checked).toBe(true)
+    })
+
+    it('calls setNotificationPrefsCategory(cat, next) when a toggle is clicked', () => {
+      const setNotificationPrefsCategory = vi.fn()
+      setMockState({ notificationPrefs: defaultPrefs, setNotificationPrefsCategory })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('notification-prefs-toggle-result'))
+      // Toggling an enabled category sends `false`.
+      expect(setNotificationPrefsCategory).toHaveBeenCalledWith('result', false)
+    })
+
+    it('emits true when toggling a disabled category back on', () => {
+      const setNotificationPrefsCategory = vi.fn()
+      setMockState({
+        notificationPrefs: {
+          categories: { ...categories, inactivity_warning: false },
+          devices: {},
+          quietHours: null,
+        },
+        setNotificationPrefsCategory,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('notification-prefs-toggle-inactivity_warning'))
+      expect(setNotificationPrefsCategory).toHaveBeenCalledWith('inactivity_warning', true)
+    })
+
+    it('calls refreshNotificationPrefs when the panel opens', () => {
+      const refreshNotificationPrefs = vi.fn()
+      setMockState({ refreshNotificationPrefs })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(refreshNotificationPrefs).toHaveBeenCalled()
+    })
+
+    it('renders only categories present in the snapshot — unknown server keys are surfaced too', () => {
+      // The wire schema is permissive (z.record(string, boolean)) — if a
+      // future server adds a category the UI doesn't know about, render it
+      // with the raw key so the user can still toggle it. Better than
+      // silently hiding a notification source.
+      setMockState({
+        notificationPrefs: {
+          categories: { ...categories, future_category: true },
+          devices: {},
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('notification-prefs-toggle-future_category')).toBeInTheDocument()
     })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -25,6 +25,55 @@ import {
 const AUTO_PERMISSION_CONFIRM_MESSAGE =
   'Auto-permission mode disables all per-tool prompts for non-paired clients. Continue?'
 
+/**
+ * #4542: friendly labels + ordering for the per-category notification
+ * toggles. Keys MUST match the server-side `ALL_CATEGORIES` enum from
+ * packages/server/src/notification-prefs.js (mirrors RATE_LIMITS in
+ * push.js). Unknown keys from the snapshot fall back to the raw key name
+ * so a future server-side category isn't silently hidden.
+ */
+const NOTIFICATION_CATEGORY_LABELS: Record<string, { label: string; hint?: string }> = {
+  permission: {
+    label: 'Permission requests',
+    hint: 'Tool-use prompts that need an allow / deny decision.',
+  },
+  result: {
+    label: 'Task completion',
+    hint: 'Sent when a Claude turn finishes and no one is watching.',
+  },
+  activity_update: {
+    label: 'Activity updates',
+    hint: 'Foreground task progress while you are away.',
+  },
+  activity_waiting: {
+    label: 'Waiting for input',
+    hint: 'Claude asked a question or is paused on a prompt.',
+  },
+  activity_error: {
+    label: 'Session errors',
+    hint: 'Crashes, tunnel drops, and unrecoverable session failures.',
+  },
+  inactivity_warning: {
+    label: 'Inactivity warnings',
+    hint: 'Heads-up before a long-idle session is auto-paused.',
+  },
+  live_activity: {
+    label: 'Live Activity (iOS)',
+    hint: 'iOS Dynamic Island / lock-screen Live Activity updates.',
+  },
+}
+
+/** Render order for known categories. Unknown keys append at the end in snapshot order. */
+const NOTIFICATION_CATEGORY_ORDER = [
+  'permission',
+  'activity_waiting',
+  'activity_error',
+  'activity_update',
+  'inactivity_warning',
+  'result',
+  'live_activity',
+]
+
 export interface SettingsPanelProps {
   isOpen: boolean
   onClose: () => void
@@ -86,6 +135,13 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const refreshByokCredentialsStatus = useConnectionStore(s => s.refreshByokCredentialsStatus)
   const setByokCredentials = useConnectionStore(s => s.setByokCredentials)
   const clearByokCredentials = useConnectionStore(s => s.clearByokCredentials)
+  // #4542: per-category notification preferences. Snapshot arrives via the
+  // WS `notification_prefs` message; the panel sends `notification_prefs_get`
+  // on open and `notification_prefs_set` on every toggle. Server broadcasts
+  // the merged snapshot so other clients stay in lockstep.
+  const notificationPrefs = useConnectionStore(s => s.notificationPrefs)
+  const refreshNotificationPrefs = useConnectionStore(s => s.refreshNotificationPrefs)
+  const setNotificationPrefsCategory = useConnectionStore(s => s.setNotificationPrefsCategory)
   const activeSessionPromptEvaluator = sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator
   // #3805: same capability gate pattern as promptEvaluator — only
   // render the toggle when the active session reports the boolean
@@ -138,6 +194,15 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
     if (!isOpen) return
     refreshByokCredentialsStatus()
   }, [isOpen, refreshByokCredentialsStatus])
+
+  // #4542: Pull the latest notification prefs on open. Out-of-band changes
+  // (other dashboard / mobile client setting a category) are pushed via the
+  // server's broadcast after every `notification_prefs_set`, so once
+  // connected we stay in sync without polling.
+  useEffect(() => {
+    if (!isOpen) return
+    refreshNotificationPrefs()
+  }, [isOpen, refreshNotificationPrefs])
 
   const handleSaveByokKey = useCallback(() => {
     setByokError(null)
@@ -517,6 +582,62 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 </button>
               )}
             </div>
+          </section>
+
+          {/* #4542: per-category notification opt-in/out. Snapshot lands via
+              `notification_prefs`; toggling a checkbox patches one category
+              via `notification_prefs_set` and the server re-broadcasts so
+              other clients stay in lockstep. The section renders even
+              before the first snapshot lands so the user knows the feature
+              exists (with a loading hint). */}
+          <section className="settings-section" data-testid="notification-prefs-section">
+            <h3>Notifications</h3>
+            <p className="settings-hint">
+              Choose which push categories reach your devices. Server-side rate
+              limits still apply as a defensive floor — these toggles can only
+              mute further, never amplify.
+            </p>
+            {notificationPrefs == null ? (
+              <p
+                className="settings-hint"
+                data-testid="notification-prefs-loading"
+              >
+                Loading preferences&hellip;
+              </p>
+            ) : (
+              (() => {
+                const cats = notificationPrefs.categories
+                const knownKeys = NOTIFICATION_CATEGORY_ORDER.filter(k => k in cats)
+                const unknownKeys = Object.keys(cats).filter(k => !NOTIFICATION_CATEGORY_ORDER.includes(k))
+                const ordered = [...knownKeys, ...unknownKeys]
+                return (
+                  <ul className="notification-prefs-list">
+                    {ordered.map(cat => {
+                      const meta = NOTIFICATION_CATEGORY_LABELS[cat]
+                      const label = meta?.label ?? cat
+                      const hint = meta?.hint
+                      const checked = cats[cat] !== false
+                      const toggleId = `notification-prefs-${cat}`
+                      return (
+                        <li key={cat} className="settings-field settings-field-checkbox">
+                          <label htmlFor={toggleId}>
+                            <input
+                              id={toggleId}
+                              type="checkbox"
+                              checked={checked}
+                              onChange={(e) => setNotificationPrefsCategory(cat, e.target.checked)}
+                              data-testid={`notification-prefs-toggle-${cat}`}
+                            />
+                            {label}
+                          </label>
+                          {hint && <p className="settings-hint">{hint}</p>}
+                        </li>
+                      )
+                    })}
+                  </ul>
+                )
+              })()
+            )}
           </section>
 
           {onToggleConsoleTab && (

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -336,6 +336,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // mirrors the resolved status (set/missing) + a masked preview. Updates
   // arrive via byok_credentials_status WS messages.
   byokCredentialsStatus: null,
+  // #4542: per-category notification prefs. Server-of-truth lives in
+  // ~/.chroxy/notification-prefs.json; the dashboard mirrors the latest
+  // `notification_prefs` snapshot. The Settings panel sends
+  // `notification_prefs_get` on open and `notification_prefs_set` on each
+  // toggle — the server broadcasts the merged snapshot so other dashboards
+  // / mobile clients stay in lockstep.
+  notificationPrefs: null,
   connectionError: null,
   connectionRetryCount: 0,
   serverStartupLogs: null,
@@ -473,6 +480,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'byok_clear_credentials' });
+    }
+  },
+
+  // #4542: notification-prefs round-trip. Requests the current snapshot
+  // (on Settings panel open) or patches a single category. The server
+  // shallow-merges over the categories map, so a single-key patch never
+  // wipes the others.
+  refreshNotificationPrefs: () => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, { type: 'notification_prefs_get' });
+    }
+  },
+
+  setNotificationPrefsCategory: (category: string, enabled: boolean) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { categories: { [category]: enabled } },
+      });
     }
   },
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -96,7 +96,7 @@ import {
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerNotificationPrefsSchema } from '@chroxy/protocol/schemas'
 import {
   createKeyPair,
   deriveSharedKey,
@@ -2914,6 +2914,29 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           masked: payload.masked,
           reason: payload.reason,
           fileExists: payload.fileExists,
+        },
+      });
+      break;
+    }
+
+    case 'notification_prefs': {
+      // #4542: notification-prefs snapshot. Emitted in response to
+      // `notification_prefs_get` and broadcast after every
+      // `notification_prefs_set`. The wire schema is permissive
+      // (z.record(string, boolean) for categories) — adding a category
+      // server-side does not require a client rebuild.
+      const parsed = ServerNotificationPrefsSchema.safeParse(msg);
+      if (!parsed.success) {
+        // eslint-disable-next-line no-console
+        console.warn('notification_prefs: invalid payload from server', parsed.error.issues);
+        break;
+      }
+      const prefs = parsed.data.prefs;
+      set({
+        notificationPrefs: {
+          categories: prefs.categories,
+          devices: prefs.devices,
+          quietHours: prefs.quietHours,
         },
       });
       break;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -786,6 +786,24 @@ export interface ConnectionState {
   setByokCredentials: (anthropicApiKey: string) => void;
   clearByokCredentials: () => void;
 
+  // #4542: per-category notification preferences. Mirrors the server
+  // snapshot received over WS (`notification_prefs`). `null` until the
+  // first snapshot lands. Categories is open-ended (server-side keys
+  // come from RATE_LIMITS in push.js — adding a new category there does
+  // not require a protocol bump).
+  notificationPrefs: {
+    categories: Record<string, boolean>;
+    devices: Record<string, { categories?: Record<string, boolean> }>;
+    quietHours: { start: string; end: string } | null;
+  } | null;
+  refreshNotificationPrefs: () => void;
+  /**
+   * Patch a single category's enabled flag. Sends a `notification_prefs_set`
+   * with a minimal shallow-merge patch (server merges over the existing
+   * categories map, so other toggles are preserved).
+   */
+  setNotificationPrefsCategory: (category: string, enabled: boolean) => void;
+
   // Multi-server registry actions
   addServer: (name: string, wsUrl: string, token: string) => ServerEntry;
   removeServer: (serverId: string) => void;

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -360,6 +360,7 @@ function _isSecureRequest(req) {
  *   { type: 'background_work_changed', sessionId, pending } — pending background shells snapshot changed (#4307, transient; `pending: [{ shellId, command, startedAt }, …]`)
  *   { type: 'provider_list', providers }                — available providers
  *   { type: 'byok_credentials_status', requestId?, status, source, masked?, reason? } — BYOK credentials state for the dashboard (#4052)
+ *   { type: 'notification_prefs', requestId?, prefs: { categories, devices, quietHours } } — current notification preferences snapshot (#4541/#4542); echoed back on `notification_prefs_get` and broadcast after every `notification_prefs_set`
  *   { type: 'skills_list', skills }                     — active skills (name, description, activation, active per entry)
  *   { type: 'skill_changed', skillName, sessionId, oldHashPrefix, newHashPrefix, mode } — skill content-hash mismatch (#3234, transient)
  *   { type: 'skill_activated', sessionId, skillName }   — manual skill toggled on at runtime (#3209)


### PR DESCRIPTION
## Summary

Adds per-category notification toggles in both the dashboard `SettingsPanel` and the mobile-app `SettingsScreen`, consuming the WS protocol surface that landed with the #4541 foundation (#4549).

- **Dashboard** — new Notifications section: one checkbox per server-emitted category, sourced from the latest `notification_prefs` snapshot. Refreshes on open via `notification_prefs_get`; each toggle patches a single category via `notification_prefs_set` (server shallow-merges so untouched categories survive).
- **Mobile app** — equivalent `NOTIFICATION CATEGORIES` section in `SettingsScreen` with the same store actions and the same loading-then-snapshot wire. Snapshot is cleared on disconnect so reconnecting to a different host refetches.
- **Friendly labels + deterministic render order** live next to each UI; unknown server keys fall back to the raw key so a future server-side category is never silently hidden.
- **Store surface** (both packages): `notificationPrefs` state + `refreshNotificationPrefs` / `setNotificationPrefsCategory` actions. The mobile app gets the same `@chroxy/protocol/schemas` import path the dashboard already uses (added the matching `moduleNameMapper` entry in `package.json`).
- **WS doc** in `ws-server.js` extended to list the `notification_prefs` server message so the protocol handler-coverage contract passes.

## Scope notes

- Server-side `RATE_LIMITS` (`packages/server/src/push.js`) are unchanged — toggles only mute further; the defensive lower-bound floor stays in place per the foundation.
- The wire schema is permissive (`z.record(string, boolean)` for categories), so adding a category server-side does not require a client rebuild.
- A single shallow-merge patch is sent per toggle, so two clients toggling different categories cannot race-overwrite each other.

## Out of scope (separate sub-issues, intentionally NOT touched in this PR)

- Per-device routing UI — #4543
- Quiet-hours UI — #4544

## Test plan

- [x] Dashboard: 8 new tests in `SettingsPanel.test.tsx` covering loading state, toggle-per-known-category, disabled-state reflection, click round-trip (both directions), refresh-on-open, and unknown-key fallback. Full dashboard suite: **2262/2262** pass.
- [x] Mobile: 20 new static-analysis tests in `SettingsScreenNotificationPrefs.test.ts` mirroring the existing `SettingsScreenSessionRules` pattern — assert section header, store selectors, useEffect-on-mount, every category label, Switch `onValueChange` shape, `testID` per toggle, deterministic ordering, the `ConnectionState` type surface, the `connection.ts` action shape, and the message-handler dispatch. Full mobile suite: **1348/1348** pass across 101 suites.
- [x] Protocol handler-coverage contract passes (**143/143**) after adding `notification_prefs` to the `Server -> Client:` doc in `ws-server.js`.
- [x] Server foundation tests still pass (`notification-prefs.test.js`, `notification-prefs-handlers.test.js`, `ws-schemas.test.js`).
- [x] `tsc --noEmit` clean for both `packages/dashboard` and `packages/app`.

Closes #4542
Related to #4541 (foundation), #4549 (foundation PR), and parent #4349.