### PR TITLE
feat(dashboard,app): per-device notification opt-in/out UI

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsDevice.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsDevice.test.ts
@@ -1,0 +1,129 @@
+/**
+ * SettingsScreen — per-device notification opt-in/out UI tests (#4543)
+ *
+ * Mirrors the per-category test file (#4542): static source analysis is the
+ * dominant mobile-app test style for screens that compose Zustand selectors
+ * + RN primitives. This file covers ONLY the per-device additions; the
+ * per-category surface stays under SettingsScreenNotificationPrefs.test.ts.
+ *
+ * The per-device key on mobile is the registered Expo push token (stored in
+ * `pushToken` on the connection store once `register_push_token` succeeds).
+ * On the dashboard the equivalent is a localStorage `device-id`; both flow
+ * through the same `notification_prefs.devices` map keyed by an opaque
+ * string of the client's choosing.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const settingsSource = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/SettingsScreen.tsx'),
+  'utf-8',
+);
+
+const typesSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/types.ts'),
+  'utf-8',
+);
+
+const connectionSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/connection.ts'),
+  'utf-8',
+);
+
+const messageHandlerSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/message-handler.ts'),
+  'utf-8',
+);
+
+describe('SettingsScreen — per-device opt-in/out section (#4543)', () => {
+  it('selects pushToken from the connection store as the per-device key source', () => {
+    // The Expo push token is the addressing key for THIS device's entry
+    // in `notification_prefs.devices`. Without selecting it, the UI can't
+    // patch a device-specific override.
+    expect(settingsSource).toMatch(/pushToken\s*=\s*useConnectionStore/);
+  });
+
+  it('selects setNotificationPrefsDevice from the store', () => {
+    expect(settingsSource).toMatch(/setNotificationPrefsDevice\s*=\s*useConnectionStore/);
+  });
+
+  it('renders a "Mute on this device" label for each category', () => {
+    expect(settingsSource).toMatch(/Mute on this device/);
+  });
+
+  it('emits a testID per per-device toggle for E2E discovery', () => {
+    expect(settingsSource).toMatch(/testID=\{`notification-prefs-device-toggle-\$\{cat\}`\}/);
+  });
+
+  it('passes (pushToken, cat, !value) so a checked "mute" maps to enabled=false on the wire', () => {
+    // The per-device Switch onValueChange MUST invert the boolean because
+    // the user-facing affordance is "mute" (true = muted) while the wire
+    // patch carries `enabled` (true = on). Without the negation a tap-to-mute
+    // would actually un-mute the category.
+    expect(settingsSource).toMatch(
+      /onValueChange=\{\(value\) => setNotificationPrefsDevice\(pushToken, cat, !value\)\}/,
+    );
+  });
+
+  it('suppresses the per-device toggle when no pushToken is available yet', () => {
+    // If push registration hasn't completed (permission denied, simulator,
+    // etc.), pushToken is null. Rendering a per-device toggle in that state
+    // would silently ship a `devices[null]` patch — guard at render time.
+    expect(settingsSource).toMatch(/pushToken\s*&&/);
+  });
+});
+
+describe('ConnectionState — per-device push token surface (#4543)', () => {
+  it('declares pushToken on the connection state', () => {
+    // The token is sourced once at register_push_token time and persists
+    // across the connection's lifetime so per-device toggles always
+    // address the same `devices` entry.
+    expect(typesSource).toMatch(/pushToken:\s*string\s*\|\s*null/);
+  });
+
+  it('declares setNotificationPrefsDevice with (deviceKey, category, enabled) signature', () => {
+    expect(typesSource).toMatch(
+      /setNotificationPrefsDevice:\s*\(deviceKey:\s*string,\s*category:\s*string,\s*enabled:\s*boolean\)\s*=>\s*void/,
+    );
+  });
+});
+
+describe('connection.ts — per-device action wiring (#4543)', () => {
+  it('initializes pushToken to null', () => {
+    expect(connectionSource).toMatch(/pushToken:\s*null/);
+  });
+
+  it('clears pushToken on disconnect so a reconnect cycle re-registers', () => {
+    // Two assignments: initial + the disconnect/reset block. If the reset
+    // ever drops, a stale token would survive across reconnects to a
+    // different host — addressing the wrong device's override map.
+    const matches = connectionSource.match(/pushToken:\s*null/g);
+    expect(matches?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it('setNotificationPrefsDevice sends a single-device notification_prefs_set patch', () => {
+    expect(connectionSource).toMatch(
+      /setNotificationPrefsDevice[\s\S]{0,400}notification_prefs_set[\s\S]{0,300}devices:\s*\{[\s\S]{0,200}\[deviceKey\]:[\s\S]{0,200}categories:[\s\S]{0,80}\[category\]:\s*enabled/,
+    );
+  });
+
+  it('short-circuits the per-device action when deviceKey is empty', () => {
+    // Defensive: even if the UI rail ever drops, the action MUST refuse to
+    // ship a `devices[""]` patch which would pollute the map indefinitely.
+    expect(connectionSource).toMatch(/setNotificationPrefsDevice[\s\S]{0,300}if\s*\(!deviceKey\)\s*return/);
+  });
+});
+
+describe('message-handler.ts — push token round-trip (#4543)', () => {
+  it('mirrors the registered push token into the connection store', () => {
+    // The token returned from registerForPushNotifications() MUST be
+    // assigned to the store so the SettingsScreen can address THIS device's
+    // override entry; without the mirror the screen never knows which key
+    // it's patching. We anchor on the resolved `token` variable being
+    // forwarded into setState so a refactor that decouples the await from
+    // the setState (separate fn, hook etc.) still trips this guard.
+    expect(messageHandlerSource).toMatch(
+      /await\s+registerForPushNotifications\(\)[\s\S]{0,800}setState\(\s*\{\s*pushToken:\s*token\s*\}\s*\)/,
+    );
+  });
+});

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -150,6 +150,13 @@ export function SettingsScreen() {
   const notificationPrefs = useConnectionStore((s) => s.notificationPrefs);
   const refreshNotificationPrefs = useConnectionStore((s) => s.refreshNotificationPrefs);
   const setNotificationPrefsCategory = useConnectionStore((s) => s.setNotificationPrefsCategory);
+  // #4543: per-device override. `pushToken` is the registered Expo token
+  // for THIS device, used as the key into `notificationPrefs.devices`. Null
+  // when push registration hasn't completed (simulator, permission denied,
+  // pre-`register_push_token`); the per-device toggle row is suppressed in
+  // that state so we never ship a `devices[null]` patch.
+  const pushToken = useConnectionStore((s) => s.pushToken);
+  const setNotificationPrefsDevice = useConnectionStore((s) => s.setNotificationPrefsDevice);
 
   useEffect(() => {
     refreshNotificationPrefs();
@@ -419,7 +426,7 @@ export function SettingsScreen() {
         </TouchableOpacity>
       </View>
 
-      {/* NOTIFICATIONS — Categories (#4542) */}
+      {/* NOTIFICATIONS — Categories (#4542) + per-device opt-in/out (#4543) */}
       <Text style={styles.sectionHeader}>NOTIFICATION CATEGORIES</Text>
       <View style={styles.section} testID="notification-prefs-section">
         {notificationPrefs == null ? (
@@ -434,6 +441,18 @@ export function SettingsScreen() {
             const label = meta?.label ?? cat;
             const hint = meta?.hint;
             const checked = notificationPrefs.categories[cat] !== false;
+            // #4543: per-device override resolution for THIS device.
+            //   - explicit `false` → muted on this device.
+            //   - explicit `true`  → unmuted on this device (overrides a
+            //                        `false` global default).
+            //   - missing entry    → falls through to global default; mute
+            //                        toggle shows unchecked.
+            // The mute Switch carries the inverse boolean: a tap to enable
+            // mute === sending `enabled: false` on the wire.
+            const deviceOverride = pushToken
+              ? notificationPrefs.devices?.[pushToken]?.categories?.[cat]
+              : undefined;
+            const mutedOnThisDevice = deviceOverride === false;
             return (
               <React.Fragment key={cat}>
                 {idx > 0 && <View style={styles.separator} />}
@@ -451,6 +470,22 @@ export function SettingsScreen() {
                     testID={`notification-prefs-toggle-${cat}`}
                   />
                 </View>
+                {pushToken && (
+                  <View
+                    style={[styles.row, styles.deviceOverrideRow]}
+                    testID={`notification-prefs-device-row-${cat}`}
+                  >
+                    <View style={{ flex: 1, paddingRight: 12 }}>
+                      <Text style={styles.rowHint}>Mute on this device</Text>
+                    </View>
+                    <Switch
+                      value={mutedOnThisDevice}
+                      onValueChange={(value) => setNotificationPrefsDevice(pushToken, cat, !value)}
+                      trackColor={{ false: COLORS.backgroundCard, true: COLORS.accentBlue }}
+                      testID={`notification-prefs-device-toggle-${cat}`}
+                    />
+                  </View>
+                )}
               </React.Fragment>
             );
           })
@@ -689,6 +724,16 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 16,
     minHeight: 44,
+  },
+  // #4543: subordinate per-device row sits flush under the parent category
+  // row with a slight indent so the visual hierarchy makes it clear that
+  // "Mute on this device" is layered on top of the global toggle, not a
+  // peer of it.
+  deviceOverrideRow: {
+    paddingLeft: 32,
+    paddingTop: 4,
+    paddingBottom: 8,
+    minHeight: 36,
   },
   separator: {
     height: StyleSheet.hairlineWidth,

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -324,6 +324,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #4542: per-category notification prefs snapshot. Populated by the
   // `notification_prefs` WS message; null until the first snapshot arrives.
   notificationPrefs: null,
+  // #4543: registered Expo push token for THIS device. Filled by
+  // registerPushToken (message-handler.ts) after register_push_token. Used
+  // as the key into notificationPrefs.devices when patching per-device
+  // overrides; null until registration succeeds (or forever on simulators
+  // without push capability).
+  pushToken: null,
   slashCommands: [],
   customAgents: [],
   checkpoints: [],
@@ -414,6 +420,28 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: { categories: { [category]: enabled } },
+      });
+    }
+  },
+
+  // #4543: patch a per-device category override. Server's setPrefs
+  // (push.js) shallow-merges per device key, so a single-category patch
+  // leaves other categories under THIS device — and every OTHER device's
+  // entry — untouched. Defensive guards:
+  // - empty deviceKey → no-op (refuse to ship a `devices[""]` patch).
+  // - socket closed   → no-op (the snapshot is the source of truth; we
+  //   don't queue, matching setNotificationPrefsCategory).
+  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => {
+    if (!deviceKey) return;
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: {
+          devices: {
+            [deviceKey]: { categories: { [category]: enabled } },
+          },
+        },
       });
     }
   },
@@ -822,6 +850,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #4542: clear the cached prefs snapshot on disconnect so the next
       // connect refetches from the actual server (snapshots are host-specific).
       notificationPrefs: null,
+      // #4543: clear pushToken on disconnect so a reconnect cycle
+      // re-registers and re-mirrors a fresh token. Stale tokens would
+      // address the wrong device's override map after a token refresh.
+      pushToken: null,
       slashCommands: [],
       customAgents: [],
       checkpoints: [],

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -836,6 +836,12 @@ async function registerPushToken(socket: WebSocket): Promise<void> {
     const token = await registerForPushNotifications();
     if (token && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'register_push_token', token });
+      // #4543: mirror the resolved token into the store so the
+      // SettingsScreen can address THIS device's entry in the
+      // `notification_prefs.devices` map. Without this mirror the
+      // per-device toggle row would never know which key to patch and
+      // would have to render disabled forever.
+      getStore().setState({ pushToken: token });
       console.log('[push] Registered push token with server');
     }
   } catch (err) {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -293,6 +293,14 @@ export interface ServerNotificationData {
     devices: Record<string, { categories?: Record<string, boolean> }>;
     quietHours: { start: string; end: string } | null;
   } | null;
+  // #4543: registered Expo push token for THIS device. Used as the key
+  // into `notificationPrefs.devices` so the SettingsScreen can patch a
+  // per-device override that survives across reconnects. Set once by
+  // `registerPushToken` in message-handler.ts after a successful
+  // `register_push_token` ack, cleared on disconnect so a fresh connect
+  // cycle re-fetches. Null when the device has no push capability (e.g.
+  // simulator) — the per-device UI hides itself in that case.
+  pushToken: string | null;
 }
 
 /**
@@ -493,6 +501,14 @@ export interface ServerNotificationActions {
   // are preserved).
   refreshNotificationPrefs: () => void;
   setNotificationPrefsCategory: (category: string, enabled: boolean) => void;
+  // #4543: patch a per-device category override. Sends a single
+  // `notification_prefs_set` with `{ devices: { [deviceKey]: { categories:
+  // { [category]: enabled } } } }`. Server shallow-merges so other device
+  // entries — and other categories under THIS device — survive. `enabled =
+  // false` mutes the category on this device only; `true` is the
+  // explicit-unmute path that overrides a `false` global default. No-op
+  // when deviceKey is empty or the socket is closed.
+  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => void;
 }
 
 /**

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -73,6 +73,12 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     notificationPrefs: null,
     refreshNotificationPrefs: vi.fn(),
     setNotificationPrefsCategory: vi.fn(),
+    // #4543: per-device opt-in/out. `currentDeviceKey` is the stable browser
+    // localStorage id used as the device key in the per-device override map.
+    // The test default uses a fixed string so toggles assert against a known
+    // key without coupling to localStorage; individual tests can override.
+    currentDeviceKey: 'test-device-key',
+    setNotificationPrefsDevice: vi.fn(),
     ...extra,
   }
 }
@@ -753,6 +759,127 @@ describe('SettingsPanel', () => {
       })
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       expect(screen.getByTestId('notification-prefs-toggle-future_category')).toBeInTheDocument()
+    })
+  })
+
+  describe('Notification preferences — per-device opt-in/out (#4543)', () => {
+    // Same full category set as the per-category block — keep in sync so a
+    // server-side rename trips both groups at once.
+    const categories = {
+      permission: true,
+      result: true,
+      activity_update: true,
+      activity_waiting: true,
+      activity_error: true,
+      inactivity_warning: true,
+      live_activity: true,
+    }
+    const defaultPrefs = { categories, devices: {}, quietHours: null }
+
+    it('renders a "Mute on this device" toggle alongside each global category toggle', () => {
+      setMockState({ notificationPrefs: defaultPrefs })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Every category gets its own per-device toggle, keyed by category name.
+      for (const cat of Object.keys(categories)) {
+        expect(screen.getByTestId(`notification-prefs-device-toggle-${cat}`)).toBeInTheDocument()
+      }
+    })
+
+    it('reflects a device override (false) as a checked "mute" toggle', () => {
+      // Per-device override: result is muted on THIS device only — global stays on.
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: {
+            'test-device-key': { categories: { result: false } },
+          },
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const resultDeviceMute = screen.getByTestId('notification-prefs-device-toggle-result') as HTMLInputElement
+      const permDeviceMute = screen.getByTestId('notification-prefs-device-toggle-permission') as HTMLInputElement
+      // Checked = "muted on this device". The per-device override of `false`
+      // means "explicitly off here", so the mute checkbox is checked.
+      expect(resultDeviceMute.checked).toBe(true)
+      // Permission has no device override — falls through to global default
+      // (true), so it is NOT muted on this device.
+      expect(permDeviceMute.checked).toBe(false)
+    })
+
+    it('reflects a device override (true) as an explicit unmute (mute toggle unchecked)', () => {
+      // Override `true` means "explicitly enabled on this device" even if
+      // global is off. The mute checkbox stays unchecked.
+      setMockState({
+        notificationPrefs: {
+          categories: { ...categories, result: false },
+          devices: {
+            'test-device-key': { categories: { result: true } },
+          },
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const resultDeviceMute = screen.getByTestId('notification-prefs-device-toggle-result') as HTMLInputElement
+      expect(resultDeviceMute.checked).toBe(false)
+    })
+
+    it('calls setNotificationPrefsDevice(deviceKey, cat, false) when the user mutes a category on this device', () => {
+      const setNotificationPrefsDevice = vi.fn()
+      setMockState({ notificationPrefs: defaultPrefs, setNotificationPrefsDevice })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Currently unmuted — clicking the mute toggle should patch
+      // devices[deviceKey].categories[result] = false on the wire.
+      fireEvent.click(screen.getByTestId('notification-prefs-device-toggle-result'))
+      expect(setNotificationPrefsDevice).toHaveBeenCalledWith('test-device-key', 'result', false)
+    })
+
+    it('calls setNotificationPrefsDevice(deviceKey, cat, true) when the user unmutes a muted-here category', () => {
+      const setNotificationPrefsDevice = vi.fn()
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: {
+            'test-device-key': { categories: { result: false } },
+          },
+          quietHours: null,
+        },
+        setNotificationPrefsDevice,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Clicking a checked mute toggle should flip back to enabled (true).
+      // This is the "explicit unmute" path — even after this, the per-device
+      // override row stays in the map (server can't delete via shallow-merge),
+      // but the user-visible state matches expectation.
+      fireEvent.click(screen.getByTestId('notification-prefs-device-toggle-result'))
+      expect(setNotificationPrefsDevice).toHaveBeenCalledWith('test-device-key', 'result', true)
+    })
+
+    it('does not surface per-device toggles when currentDeviceKey is null', () => {
+      // If the client hasn't established a device identity yet (e.g. storage
+      // unavailable), the per-device row should not render — there's no key
+      // to patch against. The global per-category toggles still work.
+      setMockState({ notificationPrefs: defaultPrefs, currentDeviceKey: null })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Global toggles still present.
+      expect(screen.getByTestId('notification-prefs-toggle-result')).toBeInTheDocument()
+      // Per-device row hidden.
+      expect(screen.queryByTestId('notification-prefs-device-toggle-result')).not.toBeInTheDocument()
+    })
+
+    it('does not patch when clicked but currentDeviceKey is null', () => {
+      // Defensive: even if a stale-rendered toggle somehow fires, the action
+      // must short-circuit so we never send a `devices[null]` patch.
+      const setNotificationPrefsDevice = vi.fn()
+      setMockState({
+        notificationPrefs: defaultPrefs,
+        currentDeviceKey: null,
+        setNotificationPrefsDevice,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Toggles aren't rendered, so there's nothing to click — verifies the
+      // contract holds without any synthetic interaction.
+      expect(setNotificationPrefsDevice).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -142,6 +142,13 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const notificationPrefs = useConnectionStore(s => s.notificationPrefs)
   const refreshNotificationPrefs = useConnectionStore(s => s.refreshNotificationPrefs)
   const setNotificationPrefsCategory = useConnectionStore(s => s.setNotificationPrefsCategory)
+  // #4543: per-device opt-in/out. `currentDeviceKey` is the stable
+  // localStorage id used to address THIS browser tab in the per-device
+  // override map. Null means we never minted a key (storage unavailable);
+  // when null, the per-device toggle row is suppressed entirely so we never
+  // ship a `devices[""]` / `devices[null]` patch.
+  const currentDeviceKey = useConnectionStore(s => s.currentDeviceKey)
+  const setNotificationPrefsDevice = useConnectionStore(s => s.setNotificationPrefsDevice)
   const activeSessionPromptEvaluator = sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator
   // #3805: same capability gate pattern as promptEvaluator — only
   // render the toggle when the active session reports the boolean
@@ -589,7 +596,14 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               via `notification_prefs_set` and the server re-broadcasts so
               other clients stay in lockstep. The section renders even
               before the first snapshot lands so the user knows the feature
-              exists (with a loading hint). */}
+              exists (with a loading hint).
+
+              #4543: each row also exposes a "Mute on this device" toggle.
+              The per-device entry is keyed by `currentDeviceKey` (the same
+              stable localStorage id sent in `deviceInfo` on auth), so the
+              dashboard always addresses the same `devices` entry across
+              reconnects. When `currentDeviceKey` is null (storage broken),
+              the per-device toggle row is suppressed entirely. */}
           <section className="settings-section" data-testid="notification-prefs-section">
             <h3>Notifications</h3>
             <p className="settings-hint">
@@ -610,6 +624,12 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 const knownKeys = NOTIFICATION_CATEGORY_ORDER.filter(k => k in cats)
                 const unknownKeys = Object.keys(cats).filter(k => !NOTIFICATION_CATEGORY_ORDER.includes(k))
                 const ordered = [...knownKeys, ...unknownKeys]
+                // #4543: look up THIS device's override map once per render
+                // so each row can determine its per-device state without
+                // re-reading the snapshot.
+                const deviceCategories = currentDeviceKey
+                  ? notificationPrefs.devices?.[currentDeviceKey]?.categories ?? {}
+                  : {}
                 return (
                   <ul className="notification-prefs-list">
                     {ordered.map(cat => {
@@ -618,6 +638,18 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                       const hint = meta?.hint
                       const checked = cats[cat] !== false
                       const toggleId = `notification-prefs-${cat}`
+                      // #4543: per-device override resolution.
+                      //   - explicit `false` → muted on this device.
+                      //   - explicit `true`  → unmuted on this device
+                      //                        (overrides a `false` global).
+                      //   - missing entry    → falls through to global default;
+                      //                        UI shows the row as NOT muted
+                      //                        (mute checkbox unchecked).
+                      // Toggling sends the inverse boolean so a checked
+                      // "mute" checkbox === `enabled: false` on the wire.
+                      const deviceOverride = deviceCategories[cat]
+                      const mutedOnThisDevice = deviceOverride === false
+                      const deviceToggleId = `notification-prefs-device-${cat}`
                       return (
                         <li key={cat} className="settings-field settings-field-checkbox">
                           <label htmlFor={toggleId}>
@@ -631,6 +663,24 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                             {label}
                           </label>
                           {hint && <p className="settings-hint">{hint}</p>}
+                          {currentDeviceKey && (
+                            <label
+                              htmlFor={deviceToggleId}
+                              className="notification-prefs-device-row"
+                              data-testid={`notification-prefs-device-row-${cat}`}
+                            >
+                              <input
+                                id={deviceToggleId}
+                                type="checkbox"
+                                checked={mutedOnThisDevice}
+                                onChange={(e) =>
+                                  setNotificationPrefsDevice(currentDeviceKey, cat, !e.target.checked)
+                                }
+                                data-testid={`notification-prefs-device-toggle-${cat}`}
+                              />
+                              <span>Mute on this device</span>
+                            </label>
+                          )}
                         </li>
                       )
                     })}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -287,6 +287,27 @@ function getDeviceInfo(): { deviceName: string | null; deviceType: 'phone' | 'ta
   };
 }
 
+/**
+ * #4543: stable per-device key used as the `notification_prefs.devices` map
+ * key for THIS browser tab. Wraps `getDeviceId()` so the per-device UI can
+ * read the key safely without panicking when storage is broken (private mode
+ * + cookies disabled etc.). Returns `null` only when minting failed entirely
+ * — UI gates on null to suppress a `devices[null]` patch. In practice we
+ * always have a key (in-memory cache mints one even when localStorage write
+ * fails), so null is a defensive belt-and-braces branch rather than a hot
+ * path.
+ *
+ * Exported for tests so spec mocks can pin the key without poking localStorage.
+ */
+export function getCurrentDeviceKey(): string | null {
+  try {
+    const id = getDeviceId();
+    return id.length > 0 ? id : null;
+  } catch {
+    return null;
+  }
+}
+
 // Set server scope before store init so loadPersistedState reads scoped keys
 const _initialServerId = loadPersistedActiveServer();
 if (_initialServerId) setServerScope(_initialServerId);
@@ -343,6 +364,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // toggle — the server broadcasts the merged snapshot so other dashboards
   // / mobile clients stay in lockstep.
   notificationPrefs: null,
+  // #4543: stable per-device key for THIS browser tab. Resolved once at
+  // store init from the same localStorage id used in auth's `deviceInfo`,
+  // so the dashboard always addresses the same `devices` map entry across
+  // reconnects, tab refreshes, and process restarts.
+  currentDeviceKey: getCurrentDeviceKey(),
   connectionError: null,
   connectionRetryCount: 0,
   serverStartupLogs: null,
@@ -500,6 +526,28 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: { categories: { [category]: enabled } },
+      });
+    }
+  },
+
+  // #4543: patch a per-device category override. The server's
+  // setPrefs (push.js) shallow-merges the inner categories map per device
+  // key, so a single-category patch leaves other categories under THIS
+  // device — and every OTHER device's entry — untouched. Defensive guards:
+  // - empty deviceKey → no-op (we never want a `devices[""]` entry).
+  // - socket closed → no-op (the snapshot is the source of truth; we don't
+  //   queue, matching `setNotificationPrefsCategory`).
+  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => {
+    if (!deviceKey) return;
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: {
+          devices: {
+            [deviceKey]: { categories: { [category]: enabled } },
+          },
+        },
       });
     }
   },

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -803,6 +803,27 @@ export interface ConnectionState {
    * categories map, so other toggles are preserved).
    */
   setNotificationPrefsCategory: (category: string, enabled: boolean) => void;
+  /**
+   * #4543: stable per-device key used to address THIS client in the
+   * `notification_prefs.devices` map. Sourced once at store init from
+   * localStorage (`chroxy_device_id` — the same id sent in `deviceInfo` on
+   * auth). `null` only when storage was completely unavailable AND we never
+   * minted a key — in practice a long-lived browser tab always has one, but
+   * UI code MUST tolerate null so a missing key can't ship a `devices[null]`
+   * patch.
+   */
+  currentDeviceKey: string | null;
+  /**
+   * #4543: patch a per-device category override. Sends a single
+   * `notification_prefs_set` with `{ devices: { [deviceKey]: { categories:
+   * { [category]: enabled } } } }`. Server shallow-merges so other device
+   * entries — and other categories under THIS device — survive untouched.
+   * `enabled = false` mutes the category on this device only; `true` is the
+   * explicit-unmute path (overrides a `false` global default). No-op when
+   * the socket is closed; the action does not surface errors back to the
+   * UI — the broadcast snapshot is the source of truth.
+   */
+  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => void;
 
   // Multi-server registry actions
   addServer: (name: string, wsUrl: string, token: string) => ServerEntry;


### PR DESCRIPTION
## Summary

Surfaces the per-device override map (foundation #4541/#4549, persisted in `~/.chroxy/notification-prefs.json`) in both the dashboard `SettingsPanel` and the mobile-app `SettingsScreen`, layered on top of the per-category toggles that landed with #4542 (#4557).

- **Dashboard** — each category row in the Notifications section now exposes a "Mute on this device" checkbox. The per-device key is the stable `chroxy_device_id` from localStorage (same id auth's `deviceInfo` already uses), exposed as `currentDeviceKey` on the store and resolved once at init. A null key (storage broken) suppresses the per-device row so we never ship a `devices[null]` patch.
- **Mobile** — same shape: "Mute on this device" row under each category in the NOTIFICATION CATEGORIES section. The per-device key is the registered Expo push token, mirrored into the store from `registerForPushNotifications()` so the screen can address THIS device's entry. The token is cleared on disconnect so a reconnect cycle re-registers and re-addresses the right map entry.
- **Store surface** (both packages) — `setNotificationPrefsDevice(deviceKey, category, enabled)` sends a single-device shallow-merge patch via `notification_prefs_set`. The server's existing `setPrefs` (push.js) shallow-merges per device key, so a single-category patch leaves other categories under THIS device — and every OTHER device's entry — untouched.
- A checked mute toggle === `enabled: false` on the wire; unchecked === `enabled: true`. The explicit-`true` path lets a device override a `false` global default so a user can keep a category on for one device while muting it globally.

## Scope

- **Wire** — no protocol change. `notification_prefs_set` already accepts `devices: Record<string, { categories? }>` (NotificationDeviceEntrySchema, client.ts:309). The dashboard and mobile both consume this existing surface.
- **Server** — untouched. `push.js` `setPrefs` already shallow-merges per device-key + per-category, and `isCategoryEnabled` already resolves per-device override first (see `notification-prefs.js:resolveCategoryDecision`). This PR only consumes that.

## Out of scope (separate sub-issues, intentionally NOT touched)

- Quiet-hours UI and time-of-day enforcement — #4544 (the deferred sub-issue from the #4541 plan).

## Test plan

- [x] Dashboard: 7 new tests in `SettingsPanel.test.tsx` covering per-device toggle presence per known category, reflection of device-override state (muted-here vs explicit-unmute), wire-shape assertions for both directions, and the null-`currentDeviceKey` suppression contract. Full dashboard suite: **2270/2270** pass.
- [x] Mobile: 13 new static-analysis tests in `SettingsScreenNotificationPrefsDevice.test.ts` mirroring the per-category test pattern. Covers selector wiring, testIDs, the inverse-boolean Switch contract, the suppression-when-no-`pushToken` guard, store types, action signature, disconnect-clears-token, and the `registerForPushNotifications` → `setState` mirror. Full mobile suite: **1361/1361** pass across 102 suites.
- [x] Server foundation tests still pass (notification-prefs, notification-prefs-handlers, ws-schemas, ws-handler-coverage): **194/194** + **36/36**.
- [x] `tsc --noEmit` clean for both `packages/dashboard` and `packages/app`.

Closes #4543
Related to #4541 / #4549 (foundation) and #4542 / #4557 (per-category UI).