### PR TITLE
feat(server,dashboard,app): notification quiet-hours window

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -127,12 +127,102 @@ describe('message-handler.ts — notification_prefs WS message (#4542)', () => {
   });
 
   it('handles the notification_prefs case and stores the parsed snapshot', () => {
-    expect(messageHandlerSource).toMatch(/case 'notification_prefs'[\s\S]{0,800}ServerNotificationPrefsSchema\.safeParse[\s\S]{0,300}notificationPrefs:/);
+    expect(messageHandlerSource).toMatch(/case 'notification_prefs'[\s\S]{0,1500}ServerNotificationPrefsSchema\.safeParse[\s\S]{0,800}notificationPrefs:/);
   });
 
   it('logs and skips when the payload fails schema validation', () => {
     expect(messageHandlerSource).toMatch(
       /case 'notification_prefs'[\s\S]{0,600}!parsed\.success[\s\S]{0,200}console\.warn\(\s*'notification_prefs:/,
+    );
+  });
+
+  // #4544: the wire snapshot now carries an optional bypassCategories
+  // array. The handler must forward it when present so the UI sees the
+  // current gate state; absent means "use documented defaults".
+  it('forwards bypassCategories from the parsed snapshot when present (#4544)', () => {
+    expect(messageHandlerSource).toMatch(/bypassCategories\s*=\s*\(prefs\s*as[\s\S]{0,150}\.bypassCategories/);
+    expect(messageHandlerSource).toMatch(/Array\.isArray\(bypassCategories\)/);
+  });
+});
+
+describe('SettingsScreen — Quiet hours editor section (#4544)', () => {
+  it('renders a QUIET HOURS section header', () => {
+    expect(settingsSource).toMatch(/QUIET HOURS/);
+  });
+
+  it('imports the quiet-hours store actions from the connection store', () => {
+    expect(settingsSource).toMatch(/setNotificationPrefsQuietHours\s*=\s*useConnectionStore/);
+    expect(settingsSource).toMatch(/setNotificationPrefsBypassCategories\s*=\s*useConnectionStore/);
+  });
+
+  it('renders the QuietHoursEditor sub-component inside the QUIET HOURS section', () => {
+    expect(settingsSource).toMatch(/<QuietHoursEditor[\s\S]{0,800}window=\{notificationPrefs\.quietHours\}/);
+  });
+
+  it('defines the QuietHoursEditor component with the documented props shape', () => {
+    expect(settingsSource).toMatch(/function QuietHoursEditor\(props:\s*\{[\s\S]{0,400}window:\s*\{\s*start:\s*string;\s*end:\s*string;\s*timezone:\s*string\s*\}\s*\|\s*null/);
+    expect(settingsSource).toMatch(/onWindowChange:\s*\(w:[\s\S]{0,150}timezone:\s*string\s*\}\s*\|\s*null\)\s*=>\s*void/);
+    expect(settingsSource).toMatch(/onBypassChange:\s*\(categories:\s*string\[\]\)\s*=>\s*void/);
+  });
+
+  it('emits the documented quiet-hours testIDs', () => {
+    expect(settingsSource).toMatch(/testID="quiet-hours-editor"/);
+    expect(settingsSource).toMatch(/testID="quiet-hours-enabled-toggle"/);
+    expect(settingsSource).toMatch(/testID="quiet-hours-start-input"/);
+    expect(settingsSource).toMatch(/testID="quiet-hours-end-input"/);
+    expect(settingsSource).toMatch(/testID="quiet-hours-timezone-picker"/);
+    expect(settingsSource).toMatch(/testID="quiet-hours-save-button"/);
+    expect(settingsSource).toMatch(/testID=\{`quiet-hours-bypass-toggle-\$\{cat\}`\}/);
+  });
+
+  it('validates HH:MM before round-tripping', () => {
+    expect(settingsSource).toMatch(/function isValidHHMM/);
+    expect(settingsSource).toMatch(/Invalid time[\s\S]{0,100}HH:MM/);
+  });
+
+  it('declares a sensible curated timezone list', () => {
+    expect(settingsSource).toMatch(/QUIET_HOURS_TIMEZONE_CHOICES/);
+    expect(settingsSource).toMatch(/America\/Los_Angeles/);
+    expect(settingsSource).toMatch(/Europe\/London/);
+  });
+
+  it('falls back to DEFAULT_BYPASS_CATEGORIES when the snapshot omits the list', () => {
+    expect(settingsSource).toMatch(/bypassCategories=\{notificationPrefs\.bypassCategories\s*\?\?\s*DEFAULT_BYPASS_CATEGORIES\}/);
+  });
+});
+
+describe('ConnectionState — quiet-hours actions (#4544)', () => {
+  it('declares setNotificationPrefsQuietHours with the documented signature', () => {
+    expect(typesSource).toMatch(
+      /setNotificationPrefsQuietHours:\s*\(window:\s*\{\s*start:\s*string;\s*end:\s*string;\s*timezone:\s*string\s*\}\s*\|\s*null\)\s*=>\s*void/,
+    );
+  });
+
+  it('declares setNotificationPrefsBypassCategories with the documented signature', () => {
+    expect(typesSource).toMatch(
+      /setNotificationPrefsBypassCategories:\s*\(categories:\s*string\[\]\)\s*=>\s*void/,
+    );
+  });
+
+  it('extends notificationPrefs.quietHours with a timezone field', () => {
+    expect(typesSource).toMatch(/quietHours:\s*\{\s*start:\s*string;\s*end:\s*string;\s*timezone:\s*string\s*\}\s*\|\s*null/);
+  });
+
+  it('declares optional bypassCategories on notificationPrefs', () => {
+    expect(typesSource).toMatch(/bypassCategories\?:\s*string\[\]/);
+  });
+});
+
+describe('connection.ts — quiet-hours actions (#4544)', () => {
+  it('setNotificationPrefsQuietHours sends a notification_prefs_set patch with quietHours', () => {
+    expect(connectionSource).toMatch(
+      /setNotificationPrefsQuietHours[\s\S]{0,400}notification_prefs_set[\s\S]{0,200}quietHours:\s*window/,
+    );
+  });
+
+  it('setNotificationPrefsBypassCategories sends a notification_prefs_set patch with bypassCategories', () => {
+    expect(connectionSource).toMatch(
+      /setNotificationPrefsBypassCategories[\s\S]{0,400}notification_prefs_set[\s\S]{0,200}bypassCategories:\s*categories/,
     );
   });
 });

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   View,
   Text,
   ScrollView,
   Switch,
   TouchableOpacity,
+  TextInput,
   StyleSheet,
   Alert,
   Modal,
@@ -61,6 +62,52 @@ const NOTIFICATION_CATEGORY_ORDER = [
   'result',
   'live_activity',
 ];
+
+/**
+ * #4544: documented defaults for the quiet-hours bypass list. Mirrors
+ * `DEFAULT_BYPASS_CATEGORIES` from packages/server/src/notification-prefs.js.
+ * Used when a snapshot omits the field (older server, fresh install) so
+ * the UI shows the right initial checkboxes.
+ */
+const DEFAULT_BYPASS_CATEGORIES = ['permission', 'activity_error'];
+
+/**
+ * #4544: curated timezone short-list. Same set as the dashboard's
+ * `getQuietHoursTimezoneOptions` so mobile + desktop pickers agree on
+ * the most-likely picks. The device's resolved zone is prepended so the
+ * user can pick "this device" without scrolling.
+ */
+const QUIET_HOURS_TIMEZONE_CHOICES = [
+  'UTC',
+  'America/Los_Angeles',
+  'America/Denver',
+  'America/Chicago',
+  'America/New_York',
+  'America/Sao_Paulo',
+  'Europe/London',
+  'Europe/Berlin',
+  'Europe/Paris',
+  'Europe/Moscow',
+  'Asia/Dubai',
+  'Asia/Kolkata',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Asia/Singapore',
+  'Australia/Sydney',
+  'Pacific/Auckland',
+];
+
+/**
+ * #4544: HH:MM validation predicate. Mirrors the server-side regex in
+ * `notification-prefs.js` so the mobile UI rejects malformed times before
+ * round-tripping them.
+ */
+const HHMM_RE = /^\d{2}:\d{2}$/;
+function isValidHHMM(s: string): boolean {
+  if (!HHMM_RE.test(s)) return false;
+  const [h, m] = s.split(':').map(Number);
+  return h <= 23 && m <= 59;
+}
 
 const SPEECH_LANGUAGES = [
   { tag: 'en-US', label: 'English (US)' },
@@ -150,6 +197,11 @@ export function SettingsScreen() {
   const notificationPrefs = useConnectionStore((s) => s.notificationPrefs);
   const refreshNotificationPrefs = useConnectionStore((s) => s.refreshNotificationPrefs);
   const setNotificationPrefsCategory = useConnectionStore((s) => s.setNotificationPrefsCategory);
+  // #4544: quiet-hours editor actions. The window is global; per-device
+  // overrides are owned by a future iteration. `bypassCategories` is the
+  // list of categories that fire even during quiet hours.
+  const setNotificationPrefsQuietHours = useConnectionStore((s) => s.setNotificationPrefsQuietHours);
+  const setNotificationPrefsBypassCategories = useConnectionStore((s) => s.setNotificationPrefsBypassCategories);
 
   useEffect(() => {
     refreshNotificationPrefs();
@@ -457,6 +509,24 @@ export function SettingsScreen() {
         )}
       </View>
 
+      {/* NOTIFICATIONS — Quiet hours (#4544) */}
+      <Text style={styles.sectionHeader}>QUIET HOURS</Text>
+      <View style={styles.section} testID="quiet-hours-section">
+        {notificationPrefs == null ? (
+          <View style={styles.row}>
+            <Text style={styles.rowHint}>Loading preferences&hellip;</Text>
+          </View>
+        ) : (
+          <QuietHoursEditor
+            window={notificationPrefs.quietHours}
+            categories={notificationPrefs.categories}
+            bypassCategories={notificationPrefs.bypassCategories ?? DEFAULT_BYPASS_CATEGORIES}
+            onWindowChange={setNotificationPrefsQuietHours}
+            onBypassChange={setNotificationPrefsBypassCategories}
+          />
+        )}
+      </View>
+
       {/* PORTABILITY */}
       {conversationId != null && (
         <>
@@ -662,6 +732,220 @@ export function SettingsScreen() {
   );
 }
 
+/**
+ * #4544: mobile quiet-hours editor.
+ *
+ * Mirrors the dashboard `QuietHoursEditor` shape: enable toggle, HH:MM
+ * inputs for start/end, timezone picker (modal), and a per-category bypass
+ * list. Owns draft state so partial edits don't round-trip every keystroke;
+ * `Save` commits the window in one WS message. Bypass toggles patch
+ * immediately because they're booleans without an intermediate form
+ * stage.
+ */
+function QuietHoursEditor(props: {
+  window: { start: string; end: string; timezone: string } | null;
+  categories: Record<string, boolean>;
+  bypassCategories: string[];
+  onWindowChange: (w: { start: string; end: string; timezone: string } | null) => void;
+  onBypassChange: (categories: string[]) => void;
+}) {
+  const { window: win, categories, bypassCategories, onWindowChange, onBypassChange } = props;
+  // Resolve the device's IANA timezone once. `Intl.DateTimeFormat` is
+  // available in modern Hermes / JSC — the try/catch covers an extremely
+  // old runtime gracefully.
+  const browserTz = useMemo(() => {
+    try { return Intl.DateTimeFormat().resolvedOptions().timeZone; } catch { return 'UTC'; }
+  }, []);
+  const tzOptions = useMemo(() => {
+    const list = [...QUIET_HOURS_TIMEZONE_CHOICES];
+    if (browserTz && !list.includes(browserTz)) list.unshift(browserTz);
+    return list;
+  }, [browserTz]);
+
+  const [enabled, setEnabled] = useState<boolean>(win != null);
+  const [start, setStart] = useState<string>(win?.start ?? '22:00');
+  const [end, setEnd] = useState<string>(win?.end ?? '07:00');
+  const [timezone, setTimezone] = useState<string>(win?.timezone ?? browserTz);
+  const [showTzPicker, setShowTzPicker] = useState(false);
+
+  // Re-sync draft when the snapshot changes (remote save, broadcast).
+  useEffect(() => {
+    setEnabled(win != null);
+    if (win) {
+      setStart(win.start);
+      setEnd(win.end);
+      setTimezone(win.timezone);
+    }
+  }, [win]);
+
+  const handleToggleEnable = useCallback((next: boolean) => {
+    setEnabled(next);
+    if (!next) {
+      onWindowChange(null);
+    } else if (win == null) {
+      onWindowChange({ start, end, timezone });
+    }
+  }, [win, start, end, timezone, onWindowChange]);
+
+  const handleSaveWindow = useCallback(() => {
+    if (!isValidHHMM(start) || !isValidHHMM(end)) {
+      Alert.alert('Invalid time', 'Use HH:MM (24-hour). Example: 22:00');
+      return;
+    }
+    onWindowChange({ start, end, timezone });
+  }, [start, end, timezone, onWindowChange]);
+
+  const handleToggleBypass = useCallback((cat: string, next: boolean) => {
+    const set = new Set(bypassCategories);
+    if (next) set.add(cat); else set.delete(cat);
+    onBypassChange([...set]);
+  }, [bypassCategories, onBypassChange]);
+
+  const bypassCandidates = useMemo(() => {
+    const known = NOTIFICATION_CATEGORY_ORDER.filter((k) => k in categories || bypassCategories.includes(k));
+    const extras = bypassCategories.filter((k) => !NOTIFICATION_CATEGORY_ORDER.includes(k) && !(k in categories));
+    return [...known, ...extras];
+  }, [categories, bypassCategories]);
+
+  const dirty = enabled && (start !== (win?.start ?? '') || end !== (win?.end ?? '') || timezone !== (win?.timezone ?? ''));
+
+  return (
+    <View testID="quiet-hours-editor">
+      <View style={styles.row}>
+        <View style={{ flex: 1, paddingRight: 12 }}>
+          <Text style={styles.rowLabel}>Enable quiet hours</Text>
+          <Text style={[styles.rowHint, { marginTop: 2 }]}>
+            Mute pushes during a fixed window. Operator-blocking categories
+            still fire by default — uncheck them below to silence too.
+          </Text>
+        </View>
+        <Switch
+          value={enabled}
+          onValueChange={handleToggleEnable}
+          trackColor={{ false: COLORS.backgroundCard, true: COLORS.accentBlue }}
+          testID="quiet-hours-enabled-toggle"
+        />
+      </View>
+      {enabled && (
+        <>
+          <View style={styles.separator} />
+          <View style={styles.row}>
+            <Text style={styles.rowLabel}>From</Text>
+            <TextInput
+              value={start}
+              onChangeText={setStart}
+              placeholder="22:00"
+              placeholderTextColor={COLORS.textMuted}
+              keyboardType="numbers-and-punctuation"
+              maxLength={5}
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={styles.timeInput}
+              testID="quiet-hours-start-input"
+            />
+          </View>
+          <View style={styles.separator} />
+          <View style={styles.row}>
+            <Text style={styles.rowLabel}>To</Text>
+            <TextInput
+              value={end}
+              onChangeText={setEnd}
+              placeholder="07:00"
+              placeholderTextColor={COLORS.textMuted}
+              keyboardType="numbers-and-punctuation"
+              maxLength={5}
+              autoCapitalize="none"
+              autoCorrect={false}
+              style={styles.timeInput}
+              testID="quiet-hours-end-input"
+            />
+          </View>
+          <View style={styles.separator} />
+          <TouchableOpacity
+            style={styles.row}
+            onPress={() => setShowTzPicker(true)}
+            testID="quiet-hours-timezone-picker"
+          >
+            <Text style={styles.rowLabel}>Timezone</Text>
+            <Text style={styles.rowValue}>{timezone}</Text>
+          </TouchableOpacity>
+          {dirty && (
+            <>
+              <View style={styles.separator} />
+              <TouchableOpacity
+                style={styles.row}
+                onPress={handleSaveWindow}
+                testID="quiet-hours-save-button"
+              >
+                <Text style={styles.actionText}>Save Quiet Hours</Text>
+              </TouchableOpacity>
+            </>
+          )}
+          <View style={styles.separator} />
+          <View style={styles.row}>
+            <Text style={styles.rowLabel}>Bypass during quiet hours</Text>
+          </View>
+          {bypassCandidates.map((cat, idx) => {
+            const meta = NOTIFICATION_CATEGORY_LABELS[cat];
+            const label = meta?.label ?? cat;
+            const checked = bypassCategories.includes(cat);
+            return (
+              <React.Fragment key={cat}>
+                {idx === 0 ? null : <View style={styles.separator} />}
+                <View style={styles.row}>
+                  <View style={{ flex: 1, paddingRight: 12 }}>
+                    <Text style={styles.rowLabel}>{label}</Text>
+                  </View>
+                  <Switch
+                    value={checked}
+                    onValueChange={(value) => handleToggleBypass(cat, value)}
+                    trackColor={{ false: COLORS.backgroundCard, true: COLORS.accentBlue }}
+                    testID={`quiet-hours-bypass-toggle-${cat}`}
+                  />
+                </View>
+              </React.Fragment>
+            );
+          })}
+        </>
+      )}
+      <Modal
+        visible={showTzPicker}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowTzPicker(false)}
+      >
+        <Pressable style={styles.sheetOverlay} onPress={() => setShowTzPicker(false)}>
+          <Pressable
+            style={[styles.sheetContent, { paddingBottom: 16 }]}
+            onPress={(e) => e.stopPropagation()}
+          >
+            <Text style={styles.sheetTitle}>Timezone</Text>
+            <ScrollView style={styles.sheetList} bounces={false}>
+              {tzOptions.map((tz) => (
+                <TouchableOpacity
+                  key={tz}
+                  style={[styles.sheetOption, tz === timezone && styles.sheetOptionActive]}
+                  onPress={() => { setTimezone(tz); setShowTzPicker(false); }}
+                >
+                  <Text style={[styles.sheetOptionText, tz === timezone && styles.sheetOptionTextActive]}>
+                    {tz === browserTz ? `${tz} (this device)` : tz}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
+            <TouchableOpacity
+              style={[styles.sheetOption, styles.sheetCancel]}
+              onPress={() => setShowTzPicker(false)}
+            >
+              <Text style={[styles.sheetOptionText, styles.sheetCancelText]}>Cancel</Text>
+            </TouchableOpacity>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -706,6 +990,16 @@ const styles = StyleSheet.create({
   rowValueSmall: {
     fontSize: 13,
     maxWidth: 200,
+  },
+  // #4544: HH:MM picker field — small fixed width so the keyboard slots
+  // straight into the row layout without pushing the label.
+  timeInput: {
+    color: COLORS.textPrimary,
+    fontSize: 15,
+    minWidth: 64,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    textAlign: 'right',
   },
   rowHint: {
     color: COLORS.textMuted,

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -418,6 +418,31 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #4544: global quiet-hours window patch. `null` clears; a window
+  // object (with `timezone`) sets it. Server shallow-merges at the top
+  // level so other fields (categories, bypassCategories, devices) survive.
+  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { quietHours: window },
+      });
+    }
+  },
+
+  // #4544: global bypass-category list. Sent as a replacement (not a
+  // delta) — empty array maps to "nothing bypasses, not even errors".
+  setNotificationPrefsBypassCategories: (categories: string[]) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { bypassCategories: categories },
+      });
+    }
+  },
+
   setFollowMode: (enabled: boolean) => {
     useMultiClientStore.getState().setFollowMode(enabled);
     set({ followMode: enabled });

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -2686,11 +2686,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         break;
       }
       const prefs = parsed.data.prefs;
+      // #4544: wire snapshot now carries an optional `bypassCategories`
+      // (categories that fire even during quiet hours). Older servers
+      // omit it — clients fall back to the documented defaults
+      // (permission + activity_error). The quiet-hours window's
+      // `timezone` field is required by the schema when the window is
+      // present, so we forward it verbatim.
+      const bypassCategories = (prefs as { bypassCategories?: string[] }).bypassCategories;
       set({
         notificationPrefs: {
           categories: prefs.categories,
           devices: prefs.devices,
           quietHours: prefs.quietHours,
+          ...(Array.isArray(bypassCategories) ? { bypassCategories } : {}),
         },
       });
       break;

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -288,10 +288,23 @@ export interface ServerNotificationData {
   // `notification_prefs` snapshot received from the server. `null` until
   // the first snapshot arrives. Server is the single source of truth —
   // ~/.chroxy/notification-prefs.json on the host.
+  //
+  // #4544 extends the shape with `timezone` on the quiet-hours window, a
+  // globally-applied `bypassCategories` list (defaults to
+  // permission + activity_error — categories that fire even at 3am), and
+  // optional per-device overrides for quietHours / bypassCategories.
+  // Per-device REPLACES the global value entirely (see
+  // packages/server/src/notification-prefs.js for the precedence
+  // rationale).
   notificationPrefs: {
     categories: Record<string, boolean>;
-    devices: Record<string, { categories?: Record<string, boolean> }>;
-    quietHours: { start: string; end: string } | null;
+    devices: Record<string, {
+      categories?: Record<string, boolean>;
+      quietHours?: { start: string; end: string; timezone: string } | null;
+      bypassCategories?: string[];
+    }>;
+    quietHours: { start: string; end: string; timezone: string } | null;
+    bypassCategories?: string[];
   } | null;
 }
 
@@ -493,6 +506,14 @@ export interface ServerNotificationActions {
   // are preserved).
   refreshNotificationPrefs: () => void;
   setNotificationPrefsCategory: (category: string, enabled: boolean) => void;
+  // #4544: patch the global quiet-hours window. `null` clears the window;
+  // a window object (with `timezone`) sets it. Server broadcasts the
+  // merged snapshot so all clients update in lockstep.
+  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => void;
+  // #4544: replace the global bypass-category list wholesale. An empty
+  // array means "nothing bypasses, not even errors" — the UI should
+  // always send the desired final list.
+  setNotificationPrefsBypassCategories: (categories: string[]) => void;
 }
 
 /**

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -73,6 +73,10 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     notificationPrefs: null,
     refreshNotificationPrefs: vi.fn(),
     setNotificationPrefsCategory: vi.fn(),
+    // #4544: quiet-hours editor actions. Default no-op spies; individual
+    // tests override.
+    setNotificationPrefsQuietHours: vi.fn(),
+    setNotificationPrefsBypassCategories: vi.fn(),
     ...extra,
   }
 }
@@ -753,6 +757,147 @@ describe('SettingsPanel', () => {
       })
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       expect(screen.getByTestId('notification-prefs-toggle-future_category')).toBeInTheDocument()
+    })
+  })
+
+  describe('Notification preferences — quiet-hours editor (#4544)', () => {
+    const categories = {
+      permission: true,
+      result: true,
+      activity_update: true,
+      activity_waiting: true,
+      activity_error: true,
+      inactivity_warning: true,
+      live_activity: true,
+    }
+    const baseSnapshot = { categories, devices: {}, quietHours: null }
+
+    it('renders the quiet-hours toggle inside the Notifications section', () => {
+      setMockState({ notificationPrefs: baseSnapshot })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('quiet-hours-editor')).toBeInTheDocument()
+      expect(screen.getByTestId('quiet-hours-enabled-toggle')).toBeInTheDocument()
+    })
+
+    it('hides the start/end/timezone inputs when quiet hours are disabled', () => {
+      setMockState({ notificationPrefs: baseSnapshot })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.queryByTestId('quiet-hours-start-input')).toBeNull()
+      expect(screen.queryByTestId('quiet-hours-end-input')).toBeNull()
+      expect(screen.queryByTestId('quiet-hours-timezone-select')).toBeNull()
+    })
+
+    it('shows start/end/timezone inputs when quiet hours are enabled', () => {
+      setMockState({
+        notificationPrefs: {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const startInput = screen.getByTestId('quiet-hours-start-input') as HTMLInputElement
+      const endInput = screen.getByTestId('quiet-hours-end-input') as HTMLInputElement
+      const tzSelect = screen.getByTestId('quiet-hours-timezone-select') as HTMLSelectElement
+      expect(startInput.value).toBe('22:00')
+      expect(endInput.value).toBe('07:00')
+      expect(tzSelect.value).toBe('America/Los_Angeles')
+    })
+
+    it('calls setNotificationPrefsQuietHours(null) when disabling', () => {
+      const setNotificationPrefsQuietHours = vi.fn()
+      setMockState({
+        notificationPrefs: {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        },
+        setNotificationPrefsQuietHours,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('quiet-hours-enabled-toggle'))
+      expect(setNotificationPrefsQuietHours).toHaveBeenCalledWith(null)
+    })
+
+    it('calls setNotificationPrefsQuietHours with a default window when enabling for the first time', () => {
+      const setNotificationPrefsQuietHours = vi.fn()
+      setMockState({ notificationPrefs: baseSnapshot, setNotificationPrefsQuietHours })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('quiet-hours-enabled-toggle'))
+      const called = setNotificationPrefsQuietHours.mock.calls[0]?.[0]
+      // Default: 22:00-07:00 in the browser timezone.
+      expect(called).toMatchObject({ start: '22:00', end: '07:00' })
+      expect(typeof called.timezone).toBe('string')
+      expect(called.timezone.length).toBeGreaterThan(0)
+    })
+
+    it('Save button sends the edited window', () => {
+      const setNotificationPrefsQuietHours = vi.fn()
+      setMockState({
+        notificationPrefs: {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        },
+        setNotificationPrefsQuietHours,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Change the start time, then click Save.
+      fireEvent.change(screen.getByTestId('quiet-hours-start-input'), { target: { value: '23:30' } })
+      fireEvent.click(screen.getByTestId('quiet-hours-save-button'))
+      expect(setNotificationPrefsQuietHours).toHaveBeenCalledWith({
+        start: '23:30',
+        end: '07:00',
+        timezone: 'America/Los_Angeles',
+      })
+    })
+
+    it('renders the bypass fieldset with permission + activity_error checked by default', () => {
+      setMockState({
+        notificationPrefs: {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+          bypassCategories: ['permission', 'activity_error'],
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const permCheck = screen.getByTestId('quiet-hours-bypass-toggle-permission') as HTMLInputElement
+      const errCheck = screen.getByTestId('quiet-hours-bypass-toggle-activity_error') as HTMLInputElement
+      const resultCheck = screen.getByTestId('quiet-hours-bypass-toggle-result') as HTMLInputElement
+      expect(permCheck.checked).toBe(true)
+      expect(errCheck.checked).toBe(true)
+      expect(resultCheck.checked).toBe(false)
+    })
+
+    it('toggling a bypass checkbox sends the full updated list', () => {
+      const setNotificationPrefsBypassCategories = vi.fn()
+      setMockState({
+        notificationPrefs: {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+          bypassCategories: ['permission', 'activity_error'],
+        },
+        setNotificationPrefsBypassCategories,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Uncheck activity_error — replacement wire sends just ['permission'].
+      fireEvent.click(screen.getByTestId('quiet-hours-bypass-toggle-activity_error'))
+      const called = setNotificationPrefsBypassCategories.mock.calls[0]?.[0]
+      expect(Array.isArray(called)).toBe(true)
+      expect(called.sort()).toEqual(['permission'])
+    })
+
+    it('falls back to documented bypass defaults when the snapshot omits bypassCategories', () => {
+      // Older server omits the field. The UI must still show permission +
+      // activity_error checked so the user sees the active gate state.
+      setMockState({
+        notificationPrefs: {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const permCheck = screen.getByTestId('quiet-hours-bypass-toggle-permission') as HTMLInputElement
+      const errCheck = screen.getByTestId('quiet-hours-bypass-toggle-activity_error') as HTMLInputElement
+      expect(permCheck.checked).toBe(true)
+      expect(errCheck.checked).toBe(true)
     })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -74,11 +74,236 @@ const NOTIFICATION_CATEGORY_ORDER = [
   'live_activity',
 ]
 
+/**
+ * #4544: documented defaults for the quiet-hours bypass list. Mirrors
+ * `DEFAULT_BYPASS_CATEGORIES` from packages/server/src/notification-prefs.js.
+ * Used when a snapshot omits the field (older server, fresh install) so
+ * the UI shows the right initial checkboxes.
+ */
+const DEFAULT_BYPASS_CATEGORIES = ['permission', 'activity_error']
+
+/**
+ * #4544: timezone picker options. The full IANA database is hundreds of
+ * entries; we surface a curated short list plus a "browser default" sentinel
+ * so the user can pick the most common cases without scrolling. The actual
+ * wire value is the IANA name (e.g. `America/Los_Angeles`).
+ *
+ * `Intl.supportedValuesOf('timeZone')` returns the full set on modern
+ * browsers — listed here in case a future iteration switches to a
+ * searchable combobox.
+ */
+function getQuietHoursTimezoneOptions(): { value: string; label: string }[] {
+  const browser = (() => {
+    try { return Intl.DateTimeFormat().resolvedOptions().timeZone } catch { return 'UTC' }
+  })()
+  const curated = [
+    'UTC',
+    'America/Los_Angeles',
+    'America/Denver',
+    'America/Chicago',
+    'America/New_York',
+    'America/Sao_Paulo',
+    'Europe/London',
+    'Europe/Berlin',
+    'Europe/Paris',
+    'Europe/Moscow',
+    'Asia/Dubai',
+    'Asia/Kolkata',
+    'Asia/Shanghai',
+    'Asia/Tokyo',
+    'Asia/Singapore',
+    'Australia/Sydney',
+    'Pacific/Auckland',
+  ]
+  const set = new Set(curated)
+  if (browser && !set.has(browser)) curated.unshift(browser)
+  return curated.map((tz) => ({
+    value: tz,
+    label: tz === browser ? `${tz} (this device)` : tz,
+  }))
+}
+
 export interface SettingsPanelProps {
   isOpen: boolean
   onClose: () => void
   showConsoleTab?: boolean
   onToggleConsoleTab?: (show: boolean) => void
+}
+
+/**
+ * #4544: quiet-hours editor — start/end/timezone + per-category bypass list.
+ *
+ * Owns its own form state so partial edits (e.g. typing into start before
+ * committing) don't round-trip every keystroke through the WS. On `Save` we
+ * fire `onWindowChange` once; on `Disable` we send `null`. The bypass
+ * checkboxes patch immediately because they're individual booleans that
+ * don't benefit from a Save buffer.
+ */
+function QuietHoursEditor(props: {
+  window: { start: string; end: string; timezone: string } | null
+  categories: Record<string, boolean>
+  bypassCategories: string[]
+  onWindowChange: (w: { start: string; end: string; timezone: string } | null) => void
+  onBypassChange: (categories: string[]) => void
+}) {
+  const { window: win, categories, bypassCategories, onWindowChange, onBypassChange } = props
+  const tzOptions = useMemo(() => getQuietHoursTimezoneOptions(), [])
+  const browserTz = useMemo(() => {
+    try { return Intl.DateTimeFormat().resolvedOptions().timeZone } catch { return 'UTC' }
+  }, [])
+
+  // Draft state. Seeded from the snapshot so reopening the panel after a
+  // remote change reflects the broadcast snapshot, not stale edits.
+  const [enabled, setEnabled] = useState<boolean>(win != null)
+  const [start, setStart] = useState<string>(win?.start ?? '22:00')
+  const [end, setEnd] = useState<string>(win?.end ?? '07:00')
+  const [timezone, setTimezone] = useState<string>(win?.timezone ?? browserTz)
+
+  // Re-sync draft when the snapshot changes (e.g. another client saved a
+  // window or the user just hit Save and the broadcast came back). The
+  // dependency array intentionally captures the inner fields; comparing
+  // object identity wouldn't help since the message-handler always builds
+  // a fresh object.
+  useEffect(() => {
+    setEnabled(win != null)
+    if (win) {
+      setStart(win.start)
+      setEnd(win.end)
+      setTimezone(win.timezone)
+    }
+  }, [win])
+
+  const handleToggleEnable = useCallback((next: boolean) => {
+    setEnabled(next)
+    if (!next) {
+      // Sending null on disable wipes the persisted window so the server
+      // gate short-circuits. Draft fields stay in form state so the user
+      // can re-enable without re-typing.
+      onWindowChange(null)
+    } else if (win == null) {
+      // First-time enable: persist the current draft (defaults
+      // 22:00-07:00 in browser TZ) so the user sees something
+      // immediately rather than an empty muted toggle.
+      onWindowChange({ start, end, timezone })
+    }
+  }, [win, start, end, timezone, onWindowChange])
+
+  const handleSaveWindow = useCallback(() => {
+    onWindowChange({ start, end, timezone })
+  }, [start, end, timezone, onWindowChange])
+
+  const handleToggleBypass = useCallback((cat: string, next: boolean) => {
+    const set = new Set(bypassCategories)
+    if (next) set.add(cat)
+    else set.delete(cat)
+    onBypassChange([...set])
+  }, [bypassCategories, onBypassChange])
+
+  // Surface every known + currently-bypassing category — the user can
+  // re-enable a bypass even if it's not in the active categories map.
+  const bypassCandidates = useMemo(() => {
+    const known = NOTIFICATION_CATEGORY_ORDER.filter((k) => k in categories || bypassCategories.includes(k))
+    const extras = bypassCategories.filter((k) => !NOTIFICATION_CATEGORY_ORDER.includes(k) && !(k in categories))
+    return [...known, ...extras]
+  }, [categories, bypassCategories])
+
+  return (
+    <div className="quiet-hours-editor" data-testid="quiet-hours-editor">
+      <div className="settings-field settings-field-checkbox">
+        <label htmlFor="quiet-hours-enabled">
+          <input
+            id="quiet-hours-enabled"
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => handleToggleEnable(e.target.checked)}
+            data-testid="quiet-hours-enabled-toggle"
+          />
+          Quiet hours
+        </label>
+        <p className="settings-hint">
+          Mute pushes during a fixed window each day. Operator-blocking
+          categories (permission prompts, session errors) still fire by
+          default — uncheck them below to silence them too.
+        </p>
+      </div>
+      {enabled && (
+        <>
+          <div className="settings-field">
+            <label htmlFor="quiet-hours-start">From</label>
+            <input
+              id="quiet-hours-start"
+              type="time"
+              value={start}
+              onChange={(e) => setStart(e.target.value)}
+              data-testid="quiet-hours-start-input"
+            />
+          </div>
+          <div className="settings-field">
+            <label htmlFor="quiet-hours-end">To</label>
+            <input
+              id="quiet-hours-end"
+              type="time"
+              value={end}
+              onChange={(e) => setEnd(e.target.value)}
+              data-testid="quiet-hours-end-input"
+            />
+          </div>
+          <div className="settings-field">
+            <label htmlFor="quiet-hours-timezone">Timezone</label>
+            <select
+              id="quiet-hours-timezone"
+              value={timezone}
+              onChange={(e) => setTimezone(e.target.value)}
+              data-testid="quiet-hours-timezone-select"
+            >
+              {tzOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+          <div className="settings-field">
+            <button
+              type="button"
+              onClick={handleSaveWindow}
+              data-testid="quiet-hours-save-button"
+              disabled={start === (win?.start ?? '') && end === (win?.end ?? '') && timezone === (win?.timezone ?? '')}
+            >
+              Save quiet hours
+            </button>
+          </div>
+          <fieldset className="quiet-hours-bypass" data-testid="quiet-hours-bypass-fieldset">
+            <legend>Bypass during quiet hours</legend>
+            <p className="settings-hint">
+              Categories checked here still fire even at 3am. Uncheck to
+              silence them.
+            </p>
+            <ul className="notification-prefs-list">
+              {bypassCandidates.map((cat) => {
+                const meta = NOTIFICATION_CATEGORY_LABELS[cat]
+                const label = meta?.label ?? cat
+                const checked = bypassCategories.includes(cat)
+                const toggleId = `quiet-hours-bypass-${cat}`
+                return (
+                  <li key={cat} className="settings-field settings-field-checkbox">
+                    <label htmlFor={toggleId}>
+                      <input
+                        id={toggleId}
+                        type="checkbox"
+                        checked={checked}
+                        onChange={(e) => handleToggleBypass(cat, e.target.checked)}
+                        data-testid={`quiet-hours-bypass-toggle-${cat}`}
+                      />
+                      {label}
+                    </label>
+                  </li>
+                )
+              })}
+            </ul>
+          </fieldset>
+        </>
+      )}
+    </div>
+  )
 }
 
 /** Preview swatches for a theme */
@@ -142,6 +367,11 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const notificationPrefs = useConnectionStore(s => s.notificationPrefs)
   const refreshNotificationPrefs = useConnectionStore(s => s.refreshNotificationPrefs)
   const setNotificationPrefsCategory = useConnectionStore(s => s.setNotificationPrefsCategory)
+  // #4544: quiet-hours editor actions. The window is global (per-device
+  // overrides are a future iteration owned by #4543); `bypassCategories`
+  // is the list of categories that fire even during quiet hours.
+  const setNotificationPrefsQuietHours = useConnectionStore(s => s.setNotificationPrefsQuietHours)
+  const setNotificationPrefsBypassCategories = useConnectionStore(s => s.setNotificationPrefsBypassCategories)
   const activeSessionPromptEvaluator = sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator
   // #3805: same capability gate pattern as promptEvaluator — only
   // render the toggle when the active session reports the boolean
@@ -605,38 +835,53 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 Loading preferences&hellip;
               </p>
             ) : (
-              (() => {
-                const cats = notificationPrefs.categories
-                const knownKeys = NOTIFICATION_CATEGORY_ORDER.filter(k => k in cats)
-                const unknownKeys = Object.keys(cats).filter(k => !NOTIFICATION_CATEGORY_ORDER.includes(k))
-                const ordered = [...knownKeys, ...unknownKeys]
-                return (
-                  <ul className="notification-prefs-list">
-                    {ordered.map(cat => {
-                      const meta = NOTIFICATION_CATEGORY_LABELS[cat]
-                      const label = meta?.label ?? cat
-                      const hint = meta?.hint
-                      const checked = cats[cat] !== false
-                      const toggleId = `notification-prefs-${cat}`
-                      return (
-                        <li key={cat} className="settings-field settings-field-checkbox">
-                          <label htmlFor={toggleId}>
-                            <input
-                              id={toggleId}
-                              type="checkbox"
-                              checked={checked}
-                              onChange={(e) => setNotificationPrefsCategory(cat, e.target.checked)}
-                              data-testid={`notification-prefs-toggle-${cat}`}
-                            />
-                            {label}
-                          </label>
-                          {hint && <p className="settings-hint">{hint}</p>}
-                        </li>
-                      )
-                    })}
-                  </ul>
-                )
-              })()
+              <>
+                {(() => {
+                  const cats = notificationPrefs.categories
+                  const knownKeys = NOTIFICATION_CATEGORY_ORDER.filter(k => k in cats)
+                  const unknownKeys = Object.keys(cats).filter(k => !NOTIFICATION_CATEGORY_ORDER.includes(k))
+                  const ordered = [...knownKeys, ...unknownKeys]
+                  return (
+                    <ul className="notification-prefs-list">
+                      {ordered.map(cat => {
+                        const meta = NOTIFICATION_CATEGORY_LABELS[cat]
+                        const label = meta?.label ?? cat
+                        const hint = meta?.hint
+                        const checked = cats[cat] !== false
+                        const toggleId = `notification-prefs-${cat}`
+                        return (
+                          <li key={cat} className="settings-field settings-field-checkbox">
+                            <label htmlFor={toggleId}>
+                              <input
+                                id={toggleId}
+                                type="checkbox"
+                                checked={checked}
+                                onChange={(e) => setNotificationPrefsCategory(cat, e.target.checked)}
+                                data-testid={`notification-prefs-toggle-${cat}`}
+                              />
+                              {label}
+                            </label>
+                            {hint && <p className="settings-hint">{hint}</p>}
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  )
+                })()}
+
+                {/* #4544: quiet-hours editor. The window is global (per-device
+                    overrides are owned by a future iteration). Toggling the
+                    enabled checkbox seeds a sensible default (22:00-07:00 in
+                    the browser timezone) so the user doesn't see an empty
+                    form; clearing it sends `null` to wipe persistence. */}
+                <QuietHoursEditor
+                  window={notificationPrefs.quietHours}
+                  categories={notificationPrefs.categories}
+                  bypassCategories={notificationPrefs.bypassCategories ?? DEFAULT_BYPASS_CATEGORIES}
+                  onWindowChange={setNotificationPrefsQuietHours}
+                  onBypassChange={setNotificationPrefsBypassCategories}
+                />
+              </>
             )}
           </section>
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -504,6 +504,35 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #4544: global quiet-hours window patch. `null` clears the window;
+  // a full window object (start/end/timezone) sets it. The server
+  // shallow-merges at the top level, so other fields (categories,
+  // bypassCategories, devices) are preserved.
+  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { quietHours: window },
+      });
+    }
+  },
+
+  // #4544: global bypass-category list. The wire sends the full list as a
+  // replacement (not a delta), so an empty array maps to "nothing
+  // bypasses, not even errors". UI callers should always send the desired
+  // final list — toggling one bypass on/off means re-sending the resulting
+  // array.
+  setNotificationPrefsBypassCategories: (categories: string[]) => {
+    const { socket } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { bypassCategories: categories },
+      });
+    }
+  },
+
   getActiveSessionState: () => {
     const { activeSessionId, sessionStates } = get();
     if (activeSessionId && sessionStates[activeSessionId]) {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2932,11 +2932,20 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         break;
       }
       const prefs = parsed.data.prefs;
+      // #4544: the wire snapshot now carries an optional `bypassCategories`
+      // array (categories that fire even during quiet hours). Older servers
+      // omit it — clients fall back to the documented defaults
+      // (permission + activity_error). The quiet-hours window's
+      // `timezone` field is also new in #4544; the schema requires it
+      // when present, so per-device timezone-less windows from an
+      // intermediate state simply won't validate.
+      const bypassCategories = (prefs as { bypassCategories?: string[] }).bypassCategories;
       set({
         notificationPrefs: {
           categories: prefs.categories,
           devices: prefs.devices,
           quietHours: prefs.quietHours,
+          ...(Array.isArray(bypassCategories) ? { bypassCategories } : {}),
         },
       });
       break;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -791,10 +791,22 @@ export interface ConnectionState {
   // first snapshot lands. Categories is open-ended (server-side keys
   // come from RATE_LIMITS in push.js — adding a new category there does
   // not require a protocol bump).
+  //
+  // #4544 extends the shape with `timezone` on the quiet-hours window,
+  // a globally-applied `bypassCategories` list (defaults to
+  // permission + activity_error — categories that fire even at 3am), and
+  // optional per-device overrides for quietHours / bypassCategories.
+  // Per-device REPLACES the global value entirely (see notification-prefs.js
+  // for the precedence rationale).
   notificationPrefs: {
     categories: Record<string, boolean>;
-    devices: Record<string, { categories?: Record<string, boolean> }>;
-    quietHours: { start: string; end: string } | null;
+    devices: Record<string, {
+      categories?: Record<string, boolean>;
+      quietHours?: { start: string; end: string; timezone: string } | null;
+      bypassCategories?: string[];
+    }>;
+    quietHours: { start: string; end: string; timezone: string } | null;
+    bypassCategories?: string[];
   } | null;
   refreshNotificationPrefs: () => void;
   /**
@@ -803,6 +815,18 @@ export interface ConnectionState {
    * categories map, so other toggles are preserved).
    */
   setNotificationPrefsCategory: (category: string, enabled: boolean) => void;
+  /**
+   * #4544: patch the global quiet-hours window. `null` clears the window;
+   * a window object (with `timezone`) sets it. The server broadcasts the
+   * merged snapshot so all clients update in lockstep.
+   */
+  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => void;
+  /**
+   * #4544: patch the global bypass-category list. Sends the full list
+   * (replacement, not delta) so an empty array maps to "nothing bypasses,
+   * not even errors".
+   */
+  setNotificationPrefsBypassCategories: (categories: string[]) => void;
 
   // Multi-server registry actions
   addServer: (name: string, wsUrl: string, token: string) => ServerEntry;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -273,11 +273,19 @@ export declare const NotificationPrefsPatchSchema: z.ZodObject<{
     categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
     devices: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
         categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
+        quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
+            start: z.ZodString;
+            end: z.ZodString;
+            timezone: z.ZodString;
+        }, z.core.$strip>]>>;
+        bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
     }, z.core.$loose>>>;
     quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
         start: z.ZodString;
         end: z.ZodString;
+        timezone: z.ZodString;
     }, z.core.$strip>]>>;
+    bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
 }, z.core.$strip>;
 /**
  * Request the current notification preferences. Server replies with a
@@ -299,11 +307,19 @@ export declare const NotificationPrefsSetSchema: z.ZodObject<{
         categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
         devices: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
             categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
+            quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
+                start: z.ZodString;
+                end: z.ZodString;
+                timezone: z.ZodString;
+            }, z.core.$strip>]>>;
+            bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
         }, z.core.$loose>>>;
         quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
             start: z.ZodString;
             end: z.ZodString;
+            timezone: z.ZodString;
         }, z.core.$strip>]>>;
+        bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
     }, z.core.$strip>;
 }, z.core.$loose>;
 export declare const UserQuestionResponseSchema: z.ZodObject<{
@@ -645,11 +661,19 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
         categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
         devices: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
             categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
+            quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
+                start: z.ZodString;
+                end: z.ZodString;
+                timezone: z.ZodString;
+            }, z.core.$strip>]>>;
+            bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
         }, z.core.$loose>>>;
         quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
             start: z.ZodString;
             end: z.ZodString;
+            timezone: z.ZodString;
         }, z.core.$strip>]>>;
+        bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
     }, z.core.$strip>;
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"user_question_response">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -260,17 +260,50 @@ export const RegisterPushTokenSchema = z.object({
 // keys at the storage boundary — see notification-prefs.js.
 /** Inner shape of a global / per-device category toggle map. */
 const NotificationCategoryMapSchema = z.record(z.string().min(1).max(64), z.boolean());
-/** Quiet-hours window. `null` clears the window; otherwise both times are HH:MM. */
+/**
+ * Quiet-hours window (#4541 shape, extended in #4544).
+ *
+ * `null` clears the window; otherwise `start`/`end` are HH:MM and
+ * `timezone` is an IANA zone string (e.g. `America/Los_Angeles`).
+ *
+ * The timezone is REQUIRED at the wire layer because the server-side
+ * enforcer (`isInQuietHoursIn` in `notification-prefs.js`) refuses to
+ * evaluate a window without one — a half-shape would silently fail-open
+ * every notification, which is the worst possible failure mode for a
+ * notification system. Clients should always pick a sensible default
+ * (e.g. `Intl.DateTimeFormat().resolvedOptions().timeZone`).
+ *
+ * 64 chars is a generous ceiling for IANA zones — `America/Argentina/ComodRivadavia`
+ * is the longest registered name at 33 chars.
+ */
 const NotificationQuietHoursSchema = z.union([
     z.null(),
     z.object({
         start: z.string().regex(/^\d{2}:\d{2}$/),
         end: z.string().regex(/^\d{2}:\d{2}$/),
+        timezone: z.string().min(1).max(64),
     }),
 ]);
-/** Per-device override entry. Today only `categories` is configurable. */
+/**
+ * Per-category bypass list (#4544). Categories named here fire even
+ * during quiet hours. Defaults to `permission` + `activity_error` so
+ * operator-blocking events don't get muted; the user can extend or
+ * shrink the list (empty array = "nothing bypasses, not even errors").
+ */
+const NotificationBypassListSchema = z.array(z.string().min(1).max(64)).max(64);
+/**
+ * Per-device override entry (#4544 extended).
+ *
+ * Per-device fields REPLACE the corresponding global value entirely:
+ *   - `quietHours: null` opts the device out of muting even if global is set.
+ *   - `bypassCategories: []` opts the device out of all bypasses even if
+ *     global lists them.
+ * See `notification-prefs.js` for the precedence rationale.
+ */
 const NotificationDeviceEntrySchema = z.object({
     categories: NotificationCategoryMapSchema.optional(),
+    quietHours: NotificationQuietHoursSchema.optional(),
+    bypassCategories: NotificationBypassListSchema.optional(),
 }).passthrough();
 /**
  * Patch shape accepted by `notification_prefs_set`. Every top-level field
@@ -287,6 +320,7 @@ export const NotificationPrefsPatchSchema = z.object({
         .refine((obj) => Object.keys(obj).length <= 1000, { message: 'Too many device entries (max 1000)' })
         .optional(),
     quietHours: NotificationQuietHoursSchema.optional(),
+    bypassCategories: NotificationBypassListSchema.optional(),
 });
 /**
  * Request the current notification preferences. Server replies with a

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -562,11 +562,19 @@ export declare const ServerNotificationPrefsSchema: z.ZodObject<{
         categories: z.ZodRecord<z.ZodString, z.ZodBoolean>;
         devices: z.ZodRecord<z.ZodString, z.ZodObject<{
             categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
+            quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
+                start: z.ZodString;
+                end: z.ZodString;
+                timezone: z.ZodString;
+            }, z.core.$strip>]>>;
+            bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
         }, z.core.$loose>>;
         quietHours: z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
             start: z.ZodString;
             end: z.ZodString;
+            timezone: z.ZodString;
         }, z.core.$strip>]>;
+        bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
     }, z.core.$loose>;
 }, z.core.$loose>;
 export declare const ServerShutdownSchema: z.ZodObject<{

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -715,14 +715,23 @@ export const ServerPushTokenErrorSchema = z.object({
 // broadcast variant emitted after a set carries no requestId so all
 // connected clients update in lockstep.
 const NotificationPrefsCategoriesSchema = z.record(z.string().min(1).max(64), z.boolean());
-const NotificationPrefsDevicesSchema = z.record(z.string().min(1).max(512), z.object({ categories: NotificationPrefsCategoriesSchema.optional() }).passthrough());
+// #4544: quiet-hours window carries an IANA timezone; per-device entries
+// may also carry their own `quietHours` and `bypassCategories` (the
+// device-level fields REPLACE the global value, see `notification-prefs.js`).
 const NotificationPrefsQuietHoursSchema = z.union([
     z.null(),
     z.object({
         start: z.string().regex(/^\d{2}:\d{2}$/),
         end: z.string().regex(/^\d{2}:\d{2}$/),
+        timezone: z.string().min(1).max(64),
     }),
 ]);
+const NotificationPrefsBypassListSchema = z.array(z.string().min(1).max(64)).max(64);
+const NotificationPrefsDevicesSchema = z.record(z.string().min(1).max(512), z.object({
+    categories: NotificationPrefsCategoriesSchema.optional(),
+    quietHours: NotificationPrefsQuietHoursSchema.optional(),
+    bypassCategories: NotificationPrefsBypassListSchema.optional(),
+}).passthrough());
 export const ServerNotificationPrefsSchema = z.object({
     type: z.literal('notification_prefs'),
     requestId: z.string().nullable().optional(),
@@ -730,6 +739,10 @@ export const ServerNotificationPrefsSchema = z.object({
         categories: NotificationPrefsCategoriesSchema,
         devices: NotificationPrefsDevicesSchema,
         quietHours: NotificationPrefsQuietHoursSchema,
+        // #4544: globally-applied bypass list. Optional in the wire schema so
+        // older servers that omit the field still parse — clients should treat
+        // `undefined` as "use the documented defaults" (permission + activity_error).
+        bypassCategories: NotificationPrefsBypassListSchema.optional(),
     }).passthrough(),
 }).passthrough();
 export const ServerShutdownSchema = z.object({

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -297,18 +297,52 @@ export const RegisterPushTokenSchema = z.object({
 /** Inner shape of a global / per-device category toggle map. */
 const NotificationCategoryMapSchema = z.record(z.string().min(1).max(64), z.boolean())
 
-/** Quiet-hours window. `null` clears the window; otherwise both times are HH:MM. */
+/**
+ * Quiet-hours window (#4541 shape, extended in #4544).
+ *
+ * `null` clears the window; otherwise `start`/`end` are HH:MM and
+ * `timezone` is an IANA zone string (e.g. `America/Los_Angeles`).
+ *
+ * The timezone is REQUIRED at the wire layer because the server-side
+ * enforcer (`isInQuietHoursIn` in `notification-prefs.js`) refuses to
+ * evaluate a window without one — a half-shape would silently fail-open
+ * every notification, which is the worst possible failure mode for a
+ * notification system. Clients should always pick a sensible default
+ * (e.g. `Intl.DateTimeFormat().resolvedOptions().timeZone`).
+ *
+ * 64 chars is a generous ceiling for IANA zones — `America/Argentina/ComodRivadavia`
+ * is the longest registered name at 33 chars.
+ */
 const NotificationQuietHoursSchema = z.union([
   z.null(),
   z.object({
     start: z.string().regex(/^\d{2}:\d{2}$/),
     end: z.string().regex(/^\d{2}:\d{2}$/),
+    timezone: z.string().min(1).max(64),
   }),
 ])
 
-/** Per-device override entry. Today only `categories` is configurable. */
+/**
+ * Per-category bypass list (#4544). Categories named here fire even
+ * during quiet hours. Defaults to `permission` + `activity_error` so
+ * operator-blocking events don't get muted; the user can extend or
+ * shrink the list (empty array = "nothing bypasses, not even errors").
+ */
+const NotificationBypassListSchema = z.array(z.string().min(1).max(64)).max(64)
+
+/**
+ * Per-device override entry (#4544 extended).
+ *
+ * Per-device fields REPLACE the corresponding global value entirely:
+ *   - `quietHours: null` opts the device out of muting even if global is set.
+ *   - `bypassCategories: []` opts the device out of all bypasses even if
+ *     global lists them.
+ * See `notification-prefs.js` for the precedence rationale.
+ */
 const NotificationDeviceEntrySchema = z.object({
   categories: NotificationCategoryMapSchema.optional(),
+  quietHours: NotificationQuietHoursSchema.optional(),
+  bypassCategories: NotificationBypassListSchema.optional(),
 }).passthrough()
 
 /**
@@ -326,6 +360,7 @@ export const NotificationPrefsPatchSchema = z.object({
     .refine((obj) => Object.keys(obj).length <= 1000, { message: 'Too many device entries (max 1000)' })
     .optional(),
   quietHours: NotificationQuietHoursSchema.optional(),
+  bypassCategories: NotificationBypassListSchema.optional(),
 })
 
 /**

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -770,17 +770,26 @@ export const ServerPushTokenErrorSchema = z.object({
 // broadcast variant emitted after a set carries no requestId so all
 // connected clients update in lockstep.
 const NotificationPrefsCategoriesSchema = z.record(z.string().min(1).max(64), z.boolean())
-const NotificationPrefsDevicesSchema = z.record(
-  z.string().min(1).max(512),
-  z.object({ categories: NotificationPrefsCategoriesSchema.optional() }).passthrough(),
-)
+// #4544: quiet-hours window carries an IANA timezone; per-device entries
+// may also carry their own `quietHours` and `bypassCategories` (the
+// device-level fields REPLACE the global value, see `notification-prefs.js`).
 const NotificationPrefsQuietHoursSchema = z.union([
   z.null(),
   z.object({
     start: z.string().regex(/^\d{2}:\d{2}$/),
     end: z.string().regex(/^\d{2}:\d{2}$/),
+    timezone: z.string().min(1).max(64),
   }),
 ])
+const NotificationPrefsBypassListSchema = z.array(z.string().min(1).max(64)).max(64)
+const NotificationPrefsDevicesSchema = z.record(
+  z.string().min(1).max(512),
+  z.object({
+    categories: NotificationPrefsCategoriesSchema.optional(),
+    quietHours: NotificationPrefsQuietHoursSchema.optional(),
+    bypassCategories: NotificationPrefsBypassListSchema.optional(),
+  }).passthrough(),
+)
 
 export const ServerNotificationPrefsSchema = z.object({
   type: z.literal('notification_prefs'),
@@ -789,6 +798,10 @@ export const ServerNotificationPrefsSchema = z.object({
     categories: NotificationPrefsCategoriesSchema,
     devices: NotificationPrefsDevicesSchema,
     quietHours: NotificationPrefsQuietHoursSchema,
+    // #4544: globally-applied bypass list. Optional in the wire schema so
+    // older servers that omit the field still parse — clients should treat
+    // `undefined` as "use the documented defaults" (permission + activity_error).
+    bypassCategories: NotificationPrefsBypassListSchema.optional(),
   }).passthrough(),
 }).passthrough()
 

--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -1,10 +1,10 @@
 /**
- * Notification preferences store (#4541).
+ * Notification preferences store (#4541, extended in #4544).
  *
  * Foundation for user-controllable notification settings (parent #4349).
  * Persists per-category and per-device toggles, plus a quiet-hours window
- * (the window structure is wired through but the time-of-day enforcement
- * is deferred to sub-issue #4544 — `isInQuietHoursIn` is a stub today).
+ * with timezone enforcement and a bypass-category list (#4544 — the actual
+ * time-of-day check; #4541 only persisted the window).
  *
  * On-disk shape (~/.chroxy/notification-prefs.json, mode 0600):
  *
@@ -20,10 +20,13 @@
  *     },
  *     "devices": {                     // per-device overrides keyed by push token
  *       "ExponentPushToken[abc]": {
- *         "categories": { "result": false }
+ *         "categories": { "result": false },
+ *         "quietHours": { "start": "23:00", "end": "06:00", "timezone": "America/Los_Angeles" },
+ *         "bypassCategories": ["permission"]
  *       }
  *     },
- *     "quietHours": { "start": "22:00", "end": "07:00" } | null
+ *     "quietHours": { "start": "22:00", "end": "07:00", "timezone": "America/Los_Angeles" } | null,
+ *     "bypassCategories": ["permission", "activity_error"]   // categories that fire even during quiet hours
  *   }
  *
  * Decision precedence (resolveCategoryDecision):
@@ -31,6 +34,16 @@
  *   2. global default (categories.<name>)
  *   3. fail-open `true` (unknown category — defensive lower-bound rate limits
  *      in push.js still apply)
+ *
+ * Quiet-hours precedence (resolveQuietHoursWindow / resolveBypassCategories):
+ *   - Per-device REPLACES the global value entirely. A device with
+ *     `quietHours: null` opts out of muting even if the global window is set;
+ *     a device with `bypassCategories: []` opts out of every bypass even if
+ *     the global list includes them.
+ *   - Rationale (per #4544 design notes): replace is simpler than shadow
+ *     because the user can express "this phone is special — here is its
+ *     entire policy" without having to mentally diff against the global
+ *     window.
  *
  * The defensive RATE_LIMITS gate in push.js stays in place — user prefs can
  * only further mute notifications, never override the spam ceiling.
@@ -76,7 +89,23 @@ export const CATEGORY_DEFAULTS = Object.freeze(
   Object.fromEntries(ALL_CATEGORIES.map((c) => [c, true]))
 )
 
+/**
+ * Categories that bypass quiet hours when no explicit override is set (#4544).
+ *
+ * Rationale: `permission` blocks the agent until the operator decides — if it
+ * gets muted by quiet hours the agent stalls indefinitely. `activity_error`
+ * surfaces crashes/tunnel drops/fatal session failures and demands operator
+ * attention in the same way. Anything else (completion pings, activity
+ * updates, inactivity warnings) is exactly what quiet hours is for, so it
+ * stays muted by default.
+ *
+ * Users can opt out per-device (`bypassCategories: []`) or extend the
+ * global list to silence even errors if they want.
+ */
+export const DEFAULT_BYPASS_CATEGORIES = Object.freeze(['permission', 'activity_error'])
+
 const _ALL_CATEGORIES_SET = new Set(ALL_CATEGORIES)
+const _HHMM_RE = /^\d{2}:\d{2}$/
 
 export function defaultNotificationPrefsPath() {
   return process.env.CHROXY_NOTIFICATION_PREFS_PATH || join(homedir(), '.chroxy', 'notification-prefs.json')
@@ -92,6 +121,10 @@ export function defaultPrefs() {
     categories: { ...CATEGORY_DEFAULTS },
     devices: {},
     quietHours: null,
+    // Default to the documented bypass list. `setPrefs` accepts an empty
+    // array to override (user explicitly says "nothing bypasses, even
+    // errors"), and a missing key keeps the default.
+    bypassCategories: [...DEFAULT_BYPASS_CATEGORIES],
   }
 }
 
@@ -115,6 +148,12 @@ function sanitizeCategoryMap(raw) {
  * Sanitize the on-disk `devices` map. Drops malformed entries silently —
  * a corrupt per-device override should not break notifications for every
  * other device.
+ *
+ * #4544: per-device entries may now carry `quietHours` and
+ * `bypassCategories` in addition to `categories`. `quietHours` retains
+ * its tri-state semantics: `undefined` = inherit global, `null` = opt out
+ * of muting on this device, `{ start, end, timezone }` = device-specific
+ * window.
  */
 function sanitizeDevices(raw) {
   if (!raw || typeof raw !== 'object') return {}
@@ -122,22 +161,71 @@ function sanitizeDevices(raw) {
   for (const [token, entry] of Object.entries(raw)) {
     if (typeof token !== 'string' || token.length === 0) continue
     if (!entry || typeof entry !== 'object') continue
-    out[token] = { categories: sanitizeCategoryMap(entry.categories) }
+    const cleaned = { categories: sanitizeCategoryMap(entry.categories) }
+    // Tri-state: present-as-null means "explicitly disable muting on this
+    // device"; present-as-window means "use this window"; absent means
+    // "fall back to global". hasOwnProperty distinguishes absent from null.
+    if (Object.prototype.hasOwnProperty.call(entry, 'quietHours')) {
+      cleaned.quietHours = sanitizeQuietHours(entry.quietHours)
+    }
+    if (Object.prototype.hasOwnProperty.call(entry, 'bypassCategories')) {
+      const bypass = sanitizeBypassList(entry.bypassCategories)
+      if (bypass !== null) cleaned.bypassCategories = bypass
+    }
+    out[token] = cleaned
   }
   return out
 }
 
 /**
- * Sanitize the quiet-hours window. Foundation only — the deferred sub-issue
- * (#4544) owns the time-of-day enforcement; today this just preserves the
- * shape so the UI can round-trip user input.
+ * Sanitize the quiet-hours window (#4544).
+ *
+ * Requires `start`, `end`, AND `timezone` to all be present and well-formed
+ * — a window without a timezone cannot be evaluated at the gate (see
+ * `isInQuietHoursIn`'s fail-open behaviour), so we refuse to load a
+ * half-shape that would silently mis-mute later.
+ *
+ * The IANA timezone is validated by constructing a `DateTimeFormat` with
+ * the requested zone — Node throws `RangeError` for unknown zones, which
+ * we catch and treat as a malformed window.
  */
 function sanitizeQuietHours(raw) {
+  if (raw === null) return null
   if (!raw || typeof raw !== 'object') return null
   if (typeof raw.start !== 'string' || typeof raw.end !== 'string') return null
-  // Loose HH:MM format check. Tighten in #4544 once UI lands.
-  if (!/^\d{2}:\d{2}$/.test(raw.start) || !/^\d{2}:\d{2}$/.test(raw.end)) return null
-  return { start: raw.start, end: raw.end }
+  if (!_HHMM_RE.test(raw.start) || !_HHMM_RE.test(raw.end)) return null
+  if (typeof raw.timezone !== 'string' || raw.timezone.length === 0) return null
+  try {
+    // Throws if the timezone is unrecognised.
+    new Intl.DateTimeFormat('en-US', { timeZone: raw.timezone })
+  } catch {
+    return null
+  }
+  return { start: raw.start, end: raw.end, timezone: raw.timezone }
+}
+
+/**
+ * Sanitize the bypass-categories list (#4544).
+ *
+ * Returns `null` when the input is missing entirely (caller distinguishes
+ * absent from empty-array via `null`). Returns an array of unique
+ * non-empty strings otherwise — non-string entries are dropped silently
+ * so a corrupted file doesn't break the gate. We intentionally do NOT
+ * whitelist against `ALL_CATEGORIES` here so a forward-compatible install
+ * (older binary, newer prefs file mentioning a category the binary hasn't
+ * shipped yet) preserves the stored value.
+ */
+function sanitizeBypassList(raw) {
+  if (raw == null) return null
+  if (!Array.isArray(raw)) return []
+  const seen = new Set()
+  for (const item of raw) {
+    if (typeof item !== 'string') continue
+    const trimmed = item.trim()
+    if (trimmed.length === 0) continue
+    seen.add(trimmed)
+  }
+  return [...seen]
 }
 
 /**
@@ -151,10 +239,19 @@ export function loadPrefs(filePath = defaultNotificationPrefsPath(), { log } = {
   if (!existsSync(filePath)) return base
   try {
     const raw = JSON.parse(readFileSync(filePath, 'utf8'))
+    // bypassCategories: explicit on-disk array overrides defaults; absent
+    // key keeps defaults. A read-side `null` (corruption / hand-edit) is
+    // coerced to defaults so the gate never misbehaves.
+    let bypass = base.bypassCategories
+    if (Object.prototype.hasOwnProperty.call(raw ?? {}, 'bypassCategories')) {
+      const cleaned = sanitizeBypassList(raw.bypassCategories)
+      bypass = cleaned ?? [...DEFAULT_BYPASS_CATEGORIES]
+    }
     return {
       categories: { ...base.categories, ...sanitizeCategoryMap(raw?.categories) },
       devices: sanitizeDevices(raw?.devices),
       quietHours: sanitizeQuietHours(raw?.quietHours),
+      bypassCategories: bypass,
     }
   } catch (err) {
     log?.warn?.(`notification-prefs ${filePath} unreadable: ${err?.message || err}`)
@@ -215,15 +312,124 @@ export function isCategoryEnabledIn(prefs, category, pushToken) {
 }
 
 /**
- * Stub for the deferred quiet-hours enforcement (#4544). Foundation only —
- * always returns false today. The signature is published so callers
- * (push.js `send`, future tests) can wire to it without churn when #4544
- * implements the real check.
+ * Resolve the effective quiet-hours window for a device (#4544).
+ *
+ * Per-device entry REPLACES the global window when the device entry
+ * carries the `quietHours` key — including the `null` case (which means
+ * "this device is never muted by quiet hours"). When the device entry
+ * does NOT carry the key, the global window applies.
  */
-// eslint-disable-next-line no-unused-vars
+export function resolveQuietHoursWindow(prefs, pushToken) {
+  if (!prefs || typeof prefs !== 'object') return null
+  if (pushToken && prefs.devices) {
+    const entry = prefs.devices[pushToken]
+    if (entry && Object.prototype.hasOwnProperty.call(entry, 'quietHours')) {
+      return entry.quietHours
+    }
+  }
+  return prefs.quietHours || null
+}
+
+/**
+ * Resolve the effective bypass-category list for a device (#4544).
+ *
+ * Same REPLACE semantics as quiet-hours: per-device list (when present,
+ * including empty array) wins entirely. When absent, the global list
+ * (or `DEFAULT_BYPASS_CATEGORIES` when the global is also absent)
+ * applies.
+ */
+export function resolveBypassCategories(prefs, pushToken) {
+  if (!prefs || typeof prefs !== 'object') return [...DEFAULT_BYPASS_CATEGORIES]
+  if (pushToken && prefs.devices) {
+    const entry = prefs.devices[pushToken]
+    if (entry && Array.isArray(entry.bypassCategories)) {
+      return [...entry.bypassCategories]
+    }
+  }
+  if (Array.isArray(prefs.bypassCategories)) return [...prefs.bypassCategories]
+  return [...DEFAULT_BYPASS_CATEGORIES]
+}
+
+/**
+ * Quick predicate: does this category bypass quiet hours for this device?
+ * Pure composition over `resolveBypassCategories`.
+ */
+export function shouldBypassQuietHours(prefs, category, pushToken) {
+  const list = resolveBypassCategories(prefs, pushToken)
+  return list.includes(category)
+}
+
+/**
+ * Format `now` (epoch ms) in the given IANA timezone and return its
+ * minute-of-day (0..1439). Uses `Intl.DateTimeFormat` with a 24-hour
+ * `h23` cycle so DST transitions and non-Pacific zones are handled
+ * correctly without re-implementing zone math.
+ *
+ * Returns `null` when the timezone is unrecognised (Node throws
+ * `RangeError` from the constructor; we treat that as a malformed window
+ * and let the caller fail open).
+ */
+function _wallClockMinutes(now, timezone) {
+  let parts
+  try {
+    parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    }).formatToParts(new Date(now))
+  } catch {
+    return null
+  }
+  const hour = Number(parts.find((p) => p.type === 'hour')?.value)
+  const minute = Number(parts.find((p) => p.type === 'minute')?.value)
+  if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null
+  return hour * 60 + minute
+}
+
+/** Parse "HH:MM" → minutes since midnight, or null on malformed input. */
+function _parseHHMM(s) {
+  if (typeof s !== 'string' || !_HHMM_RE.test(s)) return null
+  const [h, m] = s.split(':').map(Number)
+  if (h > 23 || m > 59) return null
+  return h * 60 + m
+}
+
+/**
+ * Real quiet-hours enforcement (#4544).
+ *
+ * Returns true when `now` falls inside the device's effective quiet-hours
+ * window (per-device override beats global). The window is interpreted
+ * with start INCLUSIVE and end EXCLUSIVE — i.e. [start, end) — so a
+ * window of 22:00-07:00 includes 22:00:00.000 but excludes 07:00:00.000.
+ *
+ * Midnight wrap: when start > end the window spans midnight, so it
+ * matches `minutes >= start OR minutes < end`. When start === end the
+ * window has zero duration and never matches (defensive — a UI that
+ * accidentally writes start=end shouldn't lock out all notifications).
+ *
+ * Defensive fail-open: any structural error (no window, no timezone,
+ * unparseable times, unrecognised IANA zone) returns false. The
+ * alternative — fail-CLOSED — would silently swallow every push for a
+ * misconfigured user, which is the worst possible outcome for a
+ * notification system. The companion checkers (`isCategoryEnabledIn`,
+ * `RATE_LIMITS`) provide layered protection regardless.
+ */
 export function isInQuietHoursIn(prefs, now, pushToken) {
-  // Window is parsed and persisted, but the actual time check lives in
-  // sub-issue #4544 (UI + business logic). Returning false here means
-  // pushes are never blocked by quiet-hours until #4544 lands.
-  return false
+  const window = resolveQuietHoursWindow(prefs, pushToken)
+  if (!window) return false
+  if (typeof window.timezone !== 'string' || window.timezone.length === 0) return false
+  const startMin = _parseHHMM(window.start)
+  const endMin = _parseHHMM(window.end)
+  if (startMin == null || endMin == null) return false
+  // Zero-duration window: never matches (defensive).
+  if (startMin === endMin) return false
+  const nowMin = _wallClockMinutes(now, window.timezone)
+  if (nowMin == null) return false
+  if (startMin < endMin) {
+    // Same-day window.
+    return nowMin >= startMin && nowMin < endMin
+  }
+  // Midnight-wrap window: [start, 24:00) ∪ [00:00, end).
+  return nowMin >= startMin || nowMin < endMin
 }

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -23,6 +23,7 @@ import {
   defaultPrefs as defaultNotificationPrefs,
   isCategoryEnabledIn,
   isInQuietHoursIn,
+  shouldBypassQuietHours,
 } from './notification-prefs.js'
 
 const log = createLogger('push')
@@ -180,12 +181,20 @@ export class PushManager {
 
   /**
    * Patch preferences. Shallow-merge at the top level (`categories`,
-   * `devices`, `quietHours`); the categories map itself is shallow-merged
-   * so an inbound patch that only mentions `result` does not wipe the
-   * `permission` toggle the user set earlier. Persists to disk when a
-   * `prefsPath` was configured at construction time.
+   * `devices`, `quietHours`, `bypassCategories`); the categories map
+   * itself is shallow-merged so an inbound patch that only mentions
+   * `result` does not wipe the `permission` toggle the user set earlier.
+   * Per-device entries are field-merged so the caller can patch one
+   * device's quiet-hours window without wiping its category overrides.
+   * Persists to disk when a `prefsPath` was configured at construction
+   * time.
    *
-   * @param {object} patch - Partial prefs ({ categories?, devices?, quietHours? })
+   * #4544: `quietHours` now carries an IANA `timezone`; `bypassCategories`
+   * is a list of category names that fire even during quiet hours
+   * (defaults to permission + activity_error). Both fields accept the
+   * same per-device override shape as the existing `categories` map.
+   *
+   * @param {object} patch - Partial prefs ({ categories?, devices?, quietHours?, bypassCategories? })
    */
   setPrefs(patch) {
     if (!patch || typeof patch !== 'object') return this.getPrefs()
@@ -193,6 +202,9 @@ export class PushManager {
       categories: { ...this._prefs.categories },
       devices: { ...this._prefs.devices },
       quietHours: this._prefs.quietHours,
+      bypassCategories: Array.isArray(this._prefs.bypassCategories)
+        ? [...this._prefs.bypassCategories]
+        : [],
     }
     if (patch.categories && typeof patch.categories === 'object') {
       // Shallow-merge into the existing categories map so unmentioned
@@ -202,25 +214,64 @@ export class PushManager {
       }
     }
     if (patch.devices && typeof patch.devices === 'object') {
-      // Per-device: replace the inner categories block wholesale per
-      // device key — the caller owns its device entry. A device key
-      // not mentioned in the patch survives.
+      // Per-device: shallow-merge the inner fields per device key. The
+      // caller may patch one field (e.g. just `quietHours`) without
+      // wiping the rest (e.g. an existing `categories` mute). A device
+      // key not mentioned in the patch survives.
       for (const [token, entry] of Object.entries(patch.devices)) {
+        if (entry === null) {
+          // Explicit null deletes the entry.
+          delete next.devices[token]
+          continue
+        }
         if (!entry || typeof entry !== 'object') continue
         const existing = next.devices[token] || { categories: {} }
-        const mergedCategories = { ...(existing.categories || {}) }
+        const merged = { ...existing }
         if (entry.categories && typeof entry.categories === 'object') {
+          const mergedCategories = { ...(existing.categories || {}) }
           for (const [k, v] of Object.entries(entry.categories)) {
             if (typeof v === 'boolean') mergedCategories[k] = v
           }
+          merged.categories = mergedCategories
+        } else {
+          merged.categories = existing.categories || {}
         }
-        next.devices[token] = { categories: mergedCategories }
+        // Tri-state: present `quietHours` key (including null) is honoured;
+        // absent key leaves the existing value alone. Matches the loader
+        // semantics — `null` means "this device opts out of muting" while
+        // `undefined` means "inherit global".
+        if (Object.prototype.hasOwnProperty.call(entry, 'quietHours')) {
+          merged.quietHours = entry.quietHours
+        }
+        // Same tri-state for bypassCategories. An explicit `null` resets
+        // the device to inheriting the global list; an array (including
+        // empty) records an override.
+        if (Object.prototype.hasOwnProperty.call(entry, 'bypassCategories')) {
+          if (entry.bypassCategories === null) {
+            delete merged.bypassCategories
+          } else if (Array.isArray(entry.bypassCategories)) {
+            merged.bypassCategories = entry.bypassCategories.filter((c) => typeof c === 'string' && c.length > 0)
+          }
+        }
+        next.devices[token] = merged
       }
     }
     if (Object.prototype.hasOwnProperty.call(patch, 'quietHours')) {
       // Allow explicit null to clear the window; the loader sanitises
       // shape on re-read so we don't need to validate here.
       next.quietHours = patch.quietHours || null
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'bypassCategories')) {
+      // Replace the bypass list wholesale. An empty array is a legitimate
+      // value (user says "nothing bypasses, not even errors") so we
+      // intentionally do NOT default-fill here — that distinction is
+      // preserved by `resolveBypassCategories` on the read path.
+      if (Array.isArray(patch.bypassCategories)) {
+        next.bypassCategories = patch.bypassCategories.filter((c) => typeof c === 'string' && c.length > 0)
+      } else if (patch.bypassCategories === null) {
+        // Explicit null restores defaults.
+        next.bypassCategories = [...defaultNotificationPrefs().bypassCategories]
+      }
     }
     this._prefs = next
     if (this._prefsPath) {
@@ -248,13 +299,25 @@ export class PushManager {
   }
 
   /**
-   * Stub for the deferred quiet-hours enforcement (#4544). Returns false
-   * today — the foundation only persists the configured window so a
-   * future UI iteration can read it back. The signature is published so
-   * push.js can wire the gate without a follow-up API churn.
+   * Resolve "is `now` inside this device's quiet-hours window?" (#4544).
+   *
+   * Honours per-device override precedence and timezone-aware boundary
+   * math (including midnight wrap + DST). See `notification-prefs.js`
+   * `isInQuietHoursIn` for the full evaluation rules and fail-open
+   * defensive cases.
    */
   isInQuietHours(now = Date.now(), pushToken = null) {
     return isInQuietHoursIn(this._prefs, now, pushToken)
+  }
+
+  /**
+   * Resolve "does this category bypass quiet hours for this device?"
+   * (#4544). Operator-blocking categories (`permission`,
+   * `activity_error`) bypass by default; users can extend or override
+   * this list globally and per-device.
+   */
+  shouldBypassQuietHours(category, pushToken = null) {
+    return shouldBypassQuietHours(this._prefs, category, pushToken)
   }
 
   /**
@@ -435,7 +498,10 @@ export class PushManager {
   async send(category, title, body, data = {}, categoryId = undefined) {
     if (this.tokens.size === 0) return true
 
-    // Rate limit check
+    // Rate limit check — the FIRST line of defence. Stays in place
+    // ahead of the #4542 per-category mute and the #4544 quiet-hours
+    // gate so a single shared throttle still applies regardless of
+    // per-device prefs. See RATE_LIMITS history comments above.
     const limit = RATE_LIMITS[category] ?? 30_000
     const lastSent = this._lastSent.get(category) || 0
     if (Date.now() - lastSent < limit) {
@@ -443,7 +509,25 @@ export class PushManager {
     }
     this._lastSent.set(category, Date.now())
 
-    const messages = [...this.tokens].map((token) => ({
+    // #4542 per-category mute + #4544 quiet-hours gate, evaluated PER
+    // TOKEN so a desktop and a phone with different prefs both get the
+    // right behaviour from a single send() call. The quiet-hours gate
+    // is conditional: a category in the device's bypass list (default
+    // permission + activity_error) still fires even at 3am.
+    const now = Date.now()
+    const eligibleTokens = []
+    for (const token of this.tokens) {
+      if (!this.isCategoryEnabled(category, token)) continue
+      if (this.isInQuietHours(now, token) && !this.shouldBypassQuietHours(category, token)) continue
+      eligibleTokens.push(token)
+    }
+    if (eligibleTokens.length === 0) {
+      // Every token filtered — no Expo POST. Returning `true` matches the
+      // existing "nothing to send is not a failure" contract.
+      return true
+    }
+
+    const messages = eligibleTokens.map((token) => ({
       to: token,
       sound: 'default',
       title,

--- a/packages/server/tests/notification-prefs-quiet-hours.test.js
+++ b/packages/server/tests/notification-prefs-quiet-hours.test.js
@@ -1,0 +1,638 @@
+/**
+ * Quiet-hours enforcement tests (#4544).
+ *
+ * Covers `isInQuietHoursIn`, `resolveQuietHoursWindow`,
+ * `resolveBypassCategories`, and `shouldBypassQuietHours` against the
+ * boundary cases called out in the issue: midnight wrap, DST, per-device
+ * override precedence, bypass-category gating, and the load/save sanitisers
+ * for the extended schema (`timezone`, `bypassCategories`, per-device
+ * `quietHours`).
+ *
+ * Design decisions encoded in these tests:
+ *   - Per-device `quietHours` REPLACES the global window (does not shadow).
+ *     A device with `quietHours: null` opts out entirely even if the global
+ *     window is set.
+ *   - `bypassCategories` listed at the device level REPLACES the global
+ *     list; absent (`undefined`) means "fall back to global".
+ *   - Defaults: `permission` and `activity_error` bypass quiet hours.
+ *   - DST transitions are evaluated via the IANA timezone string fed to
+ *     `Intl.DateTimeFormat` — `America/Los_Angeles` is the load-bearing
+ *     fixture because it covers both spring-forward and fall-back.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  loadPrefs,
+  savePrefs,
+  isInQuietHoursIn,
+  resolveQuietHoursWindow,
+  resolveBypassCategories,
+  shouldBypassQuietHours,
+  DEFAULT_BYPASS_CATEGORIES,
+} from '../src/notification-prefs.js'
+
+let tmpDir
+let prefsPath
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-notif-quiet-'))
+  prefsPath = join(tmpDir, 'notification-prefs.json')
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/**
+ * Build a Date for an instant such that `Intl.DateTimeFormat` in the given
+ * timezone reports it as the requested wall-clock (YYYY-MM-DD HH:MM). Uses
+ * a small offset-search loop because the inverse of "format in TZ" doesn't
+ * exist in the standard library — but Date arithmetic + a format check
+ * converges in one or two iterations for any IANA zone.
+ */
+function dateInZone(tz, year, month, day, hour, minute) {
+  // Initial guess: treat input as UTC.
+  let guess = new Date(Date.UTC(year, month - 1, day, hour, minute))
+  for (let i = 0; i < 3; i++) {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      hourCycle: 'h23',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).formatToParts(guess)
+    const get = (t) => parts.find((p) => p.type === t).value
+    const actual = {
+      year: Number(get('year')),
+      month: Number(get('month')),
+      day: Number(get('day')),
+      hour: Number(get('hour')),
+      minute: Number(get('minute')),
+    }
+    const target = { year, month, day, hour, minute }
+    const wantedMs = Date.UTC(target.year, target.month - 1, target.day, target.hour, target.minute)
+    const actualMs = Date.UTC(actual.year, actual.month - 1, actual.day, actual.hour, actual.minute)
+    const drift = wantedMs - actualMs
+    if (drift === 0) return guess
+    guess = new Date(guess.getTime() + drift)
+  }
+  return guess
+}
+
+describe('DEFAULT_BYPASS_CATEGORIES (#4544)', () => {
+  it('includes permission and activity_error by default', () => {
+    // Operator-blocking categories should bypass quiet hours unless the
+    // user explicitly opts out. Anything that demands action right now
+    // (permission prompt, fatal session error) belongs here.
+    assert.ok(DEFAULT_BYPASS_CATEGORIES.includes('permission'), 'permission must default-bypass')
+    assert.ok(DEFAULT_BYPASS_CATEGORIES.includes('activity_error'), 'activity_error must default-bypass')
+  })
+
+  it('does NOT include non-blocking categories like result', () => {
+    // Completion pings are exactly the category quiet-hours exists to mute.
+    assert.equal(DEFAULT_BYPASS_CATEGORIES.includes('result'), false)
+    assert.equal(DEFAULT_BYPASS_CATEGORIES.includes('activity_update'), false)
+    assert.equal(DEFAULT_BYPASS_CATEGORIES.includes('inactivity_warning'), false)
+  })
+})
+
+describe('resolveQuietHoursWindow (#4544)', () => {
+  it('returns null when no global window and no per-device override', () => {
+    const prefs = { categories: {}, devices: {}, quietHours: null }
+    assert.equal(resolveQuietHoursWindow(prefs, 'tok-a'), null)
+  })
+
+  it('returns the global window when no per-device entry exists', () => {
+    const w = { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' }
+    const prefs = { categories: {}, devices: {}, quietHours: w }
+    assert.deepEqual(resolveQuietHoursWindow(prefs, 'tok-a'), w)
+  })
+
+  it('per-device override REPLACES the global window (does not shadow)', () => {
+    // The design decision documented in the PR body: per-device wins
+    // entirely, so a phone can have a NARROWER window than the desktop's
+    // global setting without inheriting unrelated global keys.
+    const global = { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' }
+    const perDevice = { start: '23:30', end: '06:00', timezone: 'America/Los_Angeles' }
+    const prefs = {
+      categories: {},
+      devices: { 'phone-1': { quietHours: perDevice } },
+      quietHours: global,
+    }
+    assert.deepEqual(resolveQuietHoursWindow(prefs, 'phone-1'), perDevice)
+    // Other devices still see the global window.
+    assert.deepEqual(resolveQuietHoursWindow(prefs, 'desk-1'), global)
+  })
+
+  it('per-device quietHours: null opts the device OUT of any quiet hours', () => {
+    // The user explicitly says "this device should never be muted" — even
+    // if the global window is set, this device wakes up.
+    const global = { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' }
+    const prefs = {
+      categories: {},
+      devices: { 'on-call-pager': { quietHours: null } },
+      quietHours: global,
+    }
+    assert.equal(resolveQuietHoursWindow(prefs, 'on-call-pager'), null)
+  })
+})
+
+describe('resolveBypassCategories (#4544)', () => {
+  it('returns the global bypass list when present', () => {
+    const prefs = {
+      categories: {},
+      devices: {},
+      quietHours: null,
+      bypassCategories: ['permission', 'activity_error', 'result'],
+    }
+    const list = resolveBypassCategories(prefs, 'tok')
+    assert.deepEqual(list.sort(), ['activity_error', 'permission', 'result'])
+  })
+
+  it('falls back to DEFAULT_BYPASS_CATEGORIES when prefs.bypassCategories is omitted', () => {
+    const prefs = { categories: {}, devices: {}, quietHours: null }
+    const list = resolveBypassCategories(prefs, 'tok')
+    assert.deepEqual([...list].sort(), [...DEFAULT_BYPASS_CATEGORIES].sort())
+  })
+
+  it('per-device bypass list REPLACES the global list', () => {
+    const prefs = {
+      categories: {},
+      devices: { 'phone-1': { bypassCategories: ['permission'] } },
+      quietHours: null,
+      bypassCategories: ['permission', 'activity_error', 'result'],
+    }
+    // Per-device only allows `permission` through; activity_error is now
+    // muted on this device.
+    assert.deepEqual(resolveBypassCategories(prefs, 'phone-1'), ['permission'])
+    // Other devices still see the global list.
+    assert.deepEqual(
+      resolveBypassCategories(prefs, 'desk-1').sort(),
+      ['activity_error', 'permission', 'result'],
+    )
+  })
+
+  it('per-device empty array opts the device out of ALL bypasses', () => {
+    // Useful for "I really want this phone to be silent during quiet hours,
+    // even for errors — I'll see them in the morning".
+    const prefs = {
+      categories: {},
+      devices: { 'silent-phone': { bypassCategories: [] } },
+      quietHours: null,
+    }
+    assert.deepEqual(resolveBypassCategories(prefs, 'silent-phone'), [])
+  })
+})
+
+describe('shouldBypassQuietHours (#4544)', () => {
+  it('returns true for default-bypass categories with no overrides', () => {
+    const prefs = { categories: {}, devices: {}, quietHours: null }
+    assert.equal(shouldBypassQuietHours(prefs, 'permission', 'tok'), true)
+    assert.equal(shouldBypassQuietHours(prefs, 'activity_error', 'tok'), true)
+  })
+
+  it('returns false for non-bypass categories with no overrides', () => {
+    const prefs = { categories: {}, devices: {}, quietHours: null }
+    assert.equal(shouldBypassQuietHours(prefs, 'result', 'tok'), false)
+    assert.equal(shouldBypassQuietHours(prefs, 'activity_update', 'tok'), false)
+  })
+
+  it('respects per-device empty bypass list', () => {
+    const prefs = {
+      categories: {},
+      devices: { 'silent-phone': { bypassCategories: [] } },
+      quietHours: null,
+    }
+    assert.equal(shouldBypassQuietHours(prefs, 'permission', 'silent-phone'), false)
+    assert.equal(shouldBypassQuietHours(prefs, 'activity_error', 'silent-phone'), false)
+  })
+})
+
+describe('isInQuietHoursIn — same-day window (#4544)', () => {
+  // start < end means the window is on the same calendar day (e.g. 13:00-15:00).
+  const window = { start: '13:00', end: '15:00', timezone: 'America/Los_Angeles' }
+  const prefs = { categories: {}, devices: {}, quietHours: window }
+
+  it('returns true at the midpoint of the window', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 1, 14, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), true)
+  })
+
+  it('returns true exactly at start (inclusive)', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 1, 13, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), true)
+  })
+
+  it('returns false exactly at end (exclusive)', () => {
+    // Half-open interval [start, end) — at exactly 15:00 the user is back.
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 1, 15, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), false)
+  })
+
+  it('returns false outside the window', () => {
+    const before = dateInZone('America/Los_Angeles', 2026, 5, 1, 12, 59)
+    const after = dateInZone('America/Los_Angeles', 2026, 5, 1, 15, 1)
+    assert.equal(isInQuietHoursIn(prefs, before.getTime(), 'tok'), false)
+    assert.equal(isInQuietHoursIn(prefs, after.getTime(), 'tok'), false)
+  })
+})
+
+describe('isInQuietHoursIn — midnight-wrap window (#4544)', () => {
+  // start > end means the window crosses midnight (e.g. 22:00-07:00).
+  // This is the headline UX case: "don't wake me from 10pm to 7am".
+  const window = { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' }
+  const prefs = { categories: {}, devices: {}, quietHours: window }
+
+  it('returns true just after start (22:30 same day)', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 1, 22, 30)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), true)
+  })
+
+  it('returns true around midnight (00:30 next day)', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 2, 0, 30)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), true)
+  })
+
+  it('returns true just before end (06:59 next day)', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 2, 6, 59)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), true)
+  })
+
+  it('returns false exactly at end (07:00 next day, exclusive)', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 2, 7, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), false)
+  })
+
+  it('returns false during the awake band (noon)', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 1, 12, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), false)
+  })
+
+  it('returns false at exactly the awake boundary (21:59)', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 1, 21, 59)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), false)
+  })
+
+  it('returns true exactly at start (22:00, inclusive)', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 5, 1, 22, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), true)
+  })
+})
+
+describe('isInQuietHoursIn — DST transitions (#4544)', () => {
+  // The two DST edges that historically break naive "minutes since
+  // midnight" math: spring-forward (02:00 jumps to 03:00) and fall-back
+  // (02:00 happens twice). Using Intl.DateTimeFormat in the timezone
+  // avoids the trap — we render the instant in the zone and compare
+  // wall-clock minutes-of-day, which match how the user reasons about
+  // "I want quiet hours from 10pm to 7am" regardless of UTC offset
+  // changes.
+  const window = { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' }
+  const prefs = { categories: {}, devices: {}, quietHours: window }
+
+  it('spring-forward Sunday morning: 04:00 PDT is inside the 22:00-07:00 window', () => {
+    // 2026 spring-forward in America/Los_Angeles: March 8, 2026 at 02:00
+    // local time jumps to 03:00 local time.
+    const at = dateInZone('America/Los_Angeles', 2026, 3, 8, 4, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), true)
+  })
+
+  it('spring-forward Sunday morning: 08:00 PDT is OUTSIDE the window', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 3, 8, 8, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), false)
+  })
+
+  it('fall-back Sunday morning: 03:00 PST is inside the window', () => {
+    // 2026 fall-back: November 1, 2026 at 02:00 local time rolls back
+    // to 01:00.
+    const at = dateInZone('America/Los_Angeles', 2026, 11, 1, 3, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), true)
+  })
+
+  it('fall-back Sunday morning: 08:00 PST is OUTSIDE the window', () => {
+    const at = dateInZone('America/Los_Angeles', 2026, 11, 1, 8, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tok'), false)
+  })
+})
+
+describe('isInQuietHoursIn — per-device override (#4544)', () => {
+  const global = { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' }
+
+  it('per-device window REPLACES global', () => {
+    // Global: 22:00-07:00 (asleep at midnight)
+    // Per-device: 14:00-15:00 (only quiet during a one-hour nap)
+    const prefs = {
+      categories: {},
+      devices: { 'napper': { quietHours: { start: '14:00', end: '15:00', timezone: 'America/Los_Angeles' } } },
+      quietHours: global,
+    }
+    const midnight = dateInZone('America/Los_Angeles', 2026, 5, 1, 0, 0)
+    const napTime = dateInZone('America/Los_Angeles', 2026, 5, 1, 14, 30)
+    // Napper is NOT muted at midnight (its window says 14-15).
+    assert.equal(isInQuietHoursIn(prefs, midnight.getTime(), 'napper'), false)
+    // Napper IS muted at 14:30.
+    assert.equal(isInQuietHoursIn(prefs, napTime.getTime(), 'napper'), true)
+    // Other devices follow the global window.
+    assert.equal(isInQuietHoursIn(prefs, midnight.getTime(), 'desk-1'), true)
+    assert.equal(isInQuietHoursIn(prefs, napTime.getTime(), 'desk-1'), false)
+  })
+
+  it('per-device quietHours: null opts the device OUT (never muted)', () => {
+    const prefs = {
+      categories: {},
+      devices: { 'pager': { quietHours: null } },
+      quietHours: global,
+    }
+    const midnight = dateInZone('America/Los_Angeles', 2026, 5, 1, 0, 0)
+    assert.equal(isInQuietHoursIn(prefs, midnight.getTime(), 'pager'), false)
+  })
+
+  it('per-device with different timezone is honoured', () => {
+    // Device in Tokyo with its own 22:00-07:00 window. When it's 11pm
+    // in Tokyo (= 06:00 PT in LA), the Tokyo device should be in quiet
+    // hours while a Pacific device with global 22:00-07:00 should also
+    // be in quiet hours coincidentally — split them apart by checking
+    // at 18:00 Tokyo (= 01:00 PT) where only the Pacific device is
+    // muted.
+    const prefs = {
+      categories: {},
+      devices: { 'tokyo-phone': { quietHours: { start: '22:00', end: '07:00', timezone: 'Asia/Tokyo' } } },
+      quietHours: global,
+    }
+    // 18:00 Tokyo on 2026-05-01.
+    const at = dateInZone('Asia/Tokyo', 2026, 5, 1, 18, 0)
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'tokyo-phone'), false, 'Tokyo phone awake at 18:00 local')
+    assert.equal(isInQuietHoursIn(prefs, at.getTime(), 'desk-1'), true, 'Pacific desktop asleep at the corresponding 02:00 PT')
+  })
+})
+
+describe('isInQuietHoursIn — defensive cases (#4544)', () => {
+  it('returns false when prefs is null/undefined', () => {
+    assert.equal(isInQuietHoursIn(null, Date.now(), 'tok'), false)
+    assert.equal(isInQuietHoursIn(undefined, Date.now(), 'tok'), false)
+  })
+
+  it('returns false when window lacks a timezone', () => {
+    // No timezone → cannot evaluate; defensive fail-open (let the push
+    // through) so a misconfigured prefs file never silently swallows
+    // every notification.
+    const prefs = { categories: {}, devices: {}, quietHours: { start: '22:00', end: '07:00' } }
+    assert.equal(isInQuietHoursIn(prefs, Date.now(), 'tok'), false)
+  })
+
+  it('returns false when window has malformed times', () => {
+    const prefs = { categories: {}, devices: {}, quietHours: { start: 'not-a-time', end: '07:00', timezone: 'UTC' } }
+    assert.equal(isInQuietHoursIn(prefs, Date.now(), 'tok'), false)
+  })
+
+  it('returns false when timezone is unrecognized (fail-open)', () => {
+    const prefs = { categories: {}, devices: {}, quietHours: { start: '22:00', end: '07:00', timezone: 'Not/Real_Zone' } }
+    assert.equal(isInQuietHoursIn(prefs, Date.now(), 'tok'), false)
+  })
+})
+
+describe('loadPrefs — extended quiet-hours schema (#4544)', () => {
+  it('preserves timezone in quietHours', () => {
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '22:00', end: '07:00', timezone: 'America/New_York' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours.timezone, 'America/New_York')
+  })
+
+  it('drops a quietHours block without timezone (defensive)', () => {
+    // A pre-#4544 file with no timezone field — without a zone we can't
+    // evaluate, so refuse to load a half-shape that would silently
+    // fail-open every notification at the gate.
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '22:00', end: '07:00' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours, null)
+  })
+
+  it('preserves bypassCategories', () => {
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: null,
+      bypassCategories: ['permission', 'result'],
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.deepEqual([...prefs.bypassCategories].sort(), ['permission', 'result'])
+  })
+
+  it('preserves per-device quietHours and bypassCategories', () => {
+    const onDisk = {
+      categories: {},
+      devices: {
+        'phone-1': {
+          quietHours: { start: '23:00', end: '06:00', timezone: 'America/Los_Angeles' },
+          bypassCategories: ['permission'],
+        },
+      },
+      quietHours: null,
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.devices['phone-1'].quietHours.start, '23:00')
+    assert.equal(prefs.devices['phone-1'].quietHours.timezone, 'America/Los_Angeles')
+    assert.deepEqual(prefs.devices['phone-1'].bypassCategories, ['permission'])
+  })
+
+  it('drops unknown bypass-category strings (sanitises wire)', () => {
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: null,
+      bypassCategories: ['permission', 12345, null, 'activity_error', '   '],
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    // Strings stay, non-strings drop. We don't whitelist against
+    // ALL_CATEGORIES here because the bypass list is forward-compatible:
+    // a future server-side category appearing in a stored bypass list
+    // would otherwise be dropped silently on the first load with the
+    // older binary.
+    assert.deepEqual([...prefs.bypassCategories].sort(), ['activity_error', 'permission'])
+  })
+})
+
+describe('savePrefs — round-trip extended schema (#4544)', () => {
+  it('round-trips timezone and bypassCategories', () => {
+    const written = {
+      categories: { result: false },
+      devices: {
+        'phone-1': {
+          quietHours: { start: '23:00', end: '06:00', timezone: 'America/Los_Angeles' },
+          bypassCategories: ['permission'],
+        },
+      },
+      quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+      bypassCategories: ['permission', 'activity_error'],
+    }
+    savePrefs(written, prefsPath)
+    const reread = loadPrefs(prefsPath)
+    assert.equal(reread.quietHours.start, '22:00')
+    assert.equal(reread.quietHours.timezone, 'America/Los_Angeles')
+    assert.deepEqual([...reread.bypassCategories].sort(), ['activity_error', 'permission'])
+    assert.equal(reread.devices['phone-1'].quietHours.timezone, 'America/Los_Angeles')
+    assert.deepEqual(reread.devices['phone-1'].bypassCategories, ['permission'])
+  })
+})
+
+describe('PushManager.send — quiet-hours gate (#4544)', () => {
+  it('skips Expo POST when ALL tokens are in quiet hours and category does not bypass', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.registerToken('ExponentPushToken[tok-a]')
+    pm.registerToken('ExponentPushToken[tok-b]')
+    // Set a global window that covers "now" — set start/end such that
+    // wall-clock NOW (any timezone) falls inside [start, end). Easiest:
+    // 00:00-23:59 catches everything.
+    pm.setPrefs({
+      quietHours: { start: '00:00', end: '23:59', timezone: 'UTC' },
+      bypassCategories: ['permission'], // result is NOT in this list
+    })
+    let fetchCalled = false
+    const origFetch = global.fetch
+    global.fetch = async () => {
+      fetchCalled = true
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+    }
+    try {
+      // result is muted — fetch must NOT fire.
+      const ok = await pm.send('result', 'Done', 'task complete')
+      assert.equal(ok, true, 'returns true (no error) when fully muted')
+      assert.equal(fetchCalled, false, 'fetch must not be called when every token is muted')
+    } finally {
+      global.fetch = origFetch
+    }
+  })
+
+  it('STILL fires the Expo POST when category is in bypassCategories', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.registerToken('ExponentPushToken[tok-a]')
+    pm.setPrefs({
+      quietHours: { start: '00:00', end: '23:59', timezone: 'UTC' },
+      bypassCategories: ['permission', 'activity_error'],
+    })
+    let fetchCalled = false
+    const origFetch = global.fetch
+    global.fetch = async () => {
+      fetchCalled = true
+      return new Response(JSON.stringify({ data: [{ status: 'ok' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    try {
+      const ok = await pm.send('permission', 'Permission needed', 'Allow Read?')
+      assert.equal(ok, true)
+      assert.equal(fetchCalled, true, 'permission must bypass quiet hours when listed in bypassCategories')
+    } finally {
+      global.fetch = origFetch
+    }
+  })
+
+  it('sends only to tokens NOT in quiet hours when per-device overrides differ', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.registerToken('ExponentPushToken[tok-asleep]')
+    pm.registerToken('ExponentPushToken[tok-awake]')
+    // Global: always-on quiet hours.
+    // Per-device: tok-awake opts out entirely.
+    pm.setPrefs({
+      quietHours: { start: '00:00', end: '23:59', timezone: 'UTC' },
+      bypassCategories: [], // explicit empty — nothing bypasses globally
+      devices: {
+        'ExponentPushToken[tok-awake]': { quietHours: null },
+      },
+    })
+    let messagesSent = null
+    const origFetch = global.fetch
+    global.fetch = async (_url, opts) => {
+      messagesSent = JSON.parse(opts.body)
+      return new Response(JSON.stringify({ data: [{ status: 'ok' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    try {
+      const ok = await pm.send('result', 'Done', 'task complete')
+      assert.equal(ok, true)
+      assert.ok(Array.isArray(messagesSent), 'fetch should be called when at least one device is awake')
+      assert.equal(messagesSent.length, 1, 'only the awake device is messaged')
+      assert.equal(messagesSent[0].to, 'ExponentPushToken[tok-awake]')
+    } finally {
+      global.fetch = origFetch
+    }
+  })
+
+  it('per-category mute (isCategoryEnabled=false) still filters tokens before quiet-hours check', async () => {
+    // Defensive: the #4542 per-category mute path must still work. A
+    // category muted for a device is dropped even when the device is
+    // awake — quiet-hours is an additional gate, not a replacement.
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.registerToken('ExponentPushToken[tok-a]')
+    pm.setPrefs({
+      categories: { result: false },
+      quietHours: null,
+    })
+    let fetchCalled = false
+    const origFetch = global.fetch
+    global.fetch = async () => {
+      fetchCalled = true
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+    }
+    try {
+      const ok = await pm.send('result', 'Done', 'task complete')
+      assert.equal(ok, true)
+      assert.equal(fetchCalled, false, 'per-category mute should drop the token before fetch')
+    } finally {
+      global.fetch = origFetch
+    }
+  })
+
+  it('existing RATE_LIMITS gate still fires before the quiet-hours check', async () => {
+    // Defensive: rate-limit is the FIRST line of defence. Two consecutive
+    // `result` pushes inside the 30s throttle should drop the second one
+    // regardless of quiet-hours state.
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.registerToken('ExponentPushToken[tok-a]')
+    pm.setPrefs({ quietHours: null })
+    let fetchCount = 0
+    const origFetch = global.fetch
+    global.fetch = async () => {
+      fetchCount++
+      return new Response(JSON.stringify({ data: [{ status: 'ok' }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    try {
+      const a = await pm.send('result', 'Done', 'first')
+      const b = await pm.send('result', 'Done', 'second')
+      assert.equal(a, true)
+      assert.equal(b, true)
+      assert.equal(fetchCount, 1, 'rate limit drops the second fetch even with no quiet-hours muting')
+    } finally {
+      global.fetch = origFetch
+    }
+  })
+})

--- a/packages/server/tests/notification-prefs.test.js
+++ b/packages/server/tests/notification-prefs.test.js
@@ -79,10 +79,14 @@ describe('notification-prefs', () => {
     })
 
     it('parses a well-formed file and merges over defaults', () => {
+      // #4544 tightened the quiet-hours shape to require a timezone — a
+      // window without one is dropped on load. The legacy two-field
+      // shape (start/end only) is exercised separately below to lock in
+      // that defensive behaviour.
       const onDisk = {
         categories: { result: false },
         devices: { 'ExponentPushToken[abc]': { categories: { permission: false } } },
-        quietHours: { start: '22:00', end: '07:00' },
+        quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
       }
       writeFileSync(prefsPath, JSON.stringify(onDisk))
       const prefs = loadPrefs(prefsPath)
@@ -111,10 +115,11 @@ describe('notification-prefs', () => {
     })
 
     it('round-trips through loadPrefs', () => {
+      // #4544: timezone is required for the window to survive the loader.
       const written = {
         categories: { result: false, permission: true },
         devices: { 'tok-1': { categories: { result: true } } },
-        quietHours: { start: '23:00', end: '06:00' },
+        quietHours: { start: '23:00', end: '06:00', timezone: 'America/Los_Angeles' },
       }
       savePrefs(written, prefsPath)
       const reread = loadPrefs(prefsPath)

--- a/packages/server/tests/ws-schemas.test.js
+++ b/packages/server/tests/ws-schemas.test.js
@@ -685,11 +685,52 @@ describe('NotificationPrefsSetSchema (#4541)', () => {
   })
 
   it('accepts a quietHours patch', () => {
+    // #4544 tightened the window shape — `timezone` is now required
+    // when a window is present (an unconfigured zone can't be evaluated
+    // by the gate, so refuse the half-shape at the schema boundary).
     const result = NotificationPrefsSetSchema.safeParse({
       type: 'notification_prefs_set',
-      prefs: { quietHours: { start: '22:00', end: '07:00' } },
+      prefs: { quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' } },
     })
     assert.ok(result.success)
+  })
+
+  it('rejects a quietHours patch missing timezone (#4544)', () => {
+    // The pre-#4544 two-field shape is now refused — the gate can't
+    // evaluate a window without an IANA zone and the loader would drop
+    // it anyway, so the wire schema rejects it up front.
+    assert.ok(!NotificationPrefsSetSchema.safeParse({
+      type: 'notification_prefs_set',
+      prefs: { quietHours: { start: '22:00', end: '07:00' } },
+    }).success)
+  })
+
+  it('accepts a bypassCategories patch (#4544)', () => {
+    assert.ok(NotificationPrefsSetSchema.safeParse({
+      type: 'notification_prefs_set',
+      prefs: { bypassCategories: ['permission', 'activity_error'] },
+    }).success)
+  })
+
+  it('accepts an empty bypassCategories patch (silence everything, even errors)', () => {
+    assert.ok(NotificationPrefsSetSchema.safeParse({
+      type: 'notification_prefs_set',
+      prefs: { bypassCategories: [] },
+    }).success)
+  })
+
+  it('accepts per-device quietHours + bypassCategories (#4544)', () => {
+    assert.ok(NotificationPrefsSetSchema.safeParse({
+      type: 'notification_prefs_set',
+      prefs: {
+        devices: {
+          'ExponentPushToken[abc]': {
+            quietHours: { start: '23:00', end: '06:00', timezone: 'America/Los_Angeles' },
+            bypassCategories: ['permission'],
+          },
+        },
+      },
+    }).success)
   })
 
   it('accepts null quietHours to clear the window', () => {
@@ -745,17 +786,34 @@ describe('NotificationPrefsSetSchema (#4541)', () => {
 
 describe('ServerNotificationPrefsSchema (#4541)', () => {
   it('accepts a fully populated snapshot', () => {
+    // #4544: timezone is required on the wire — see NotificationPrefsSetSchema
+    // companion test for the rationale (gate can't evaluate without it).
     const result = ServerNotificationPrefsSchema.safeParse({
       type: 'notification_prefs',
       requestId: 'r1',
       prefs: {
         categories: { result: true, permission: false },
         devices: { 'token-a': { categories: { result: false } } },
-        quietHours: { start: '22:00', end: '07:00' },
+        quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        bypassCategories: ['permission', 'activity_error'],
       },
     })
     assert.ok(result.success)
     assert.equal(result.data.prefs.categories.permission, false)
+  })
+
+  it('accepts a snapshot that omits bypassCategories (#4544 — older server compat)', () => {
+    // Older servers (pre-#4544) don't emit the field at all — clients
+    // should fall back to documented defaults. The schema must accept
+    // the absence to stay backward-compatible.
+    assert.ok(ServerNotificationPrefsSchema.safeParse({
+      type: 'notification_prefs',
+      prefs: {
+        categories: { result: true },
+        devices: {},
+        quietHours: null,
+      },
+    }).success)
   })
 
   it('accepts a snapshot with null quietHours and empty devices', () => {


### PR DESCRIPTION
## Summary

Server-side gate inside `PushManager.send()` drops Expo pushes that land inside a per-device quiet-hours window. Operator-blocking categories (permission prompts, session errors) bypass the gate by default so the agent never silently stalls overnight.

- **Server logic** — `notification-prefs.js` `isInQuietHoursIn` is now real (replaces the #4541 stub). Timezone-aware via `Intl.DateTimeFormat` so DST + non-Pacific zones work without re-implementing zone math. `PushManager.send` filters tokens through category-mute + quiet-hours + bypass list, with the defensive `RATE_LIMITS` gate untouched as the spam ceiling.
- **Schema** — `quietHours` carries an IANA `timezone` (required when present; loader drops the window otherwise so the gate never mis-mutes). New top-level `bypassCategories` array; per-device entries may carry their own `quietHours` and `bypassCategories` — both REPLACE the global value entirely.
- **Dashboard** — `QuietHoursEditor` sub-component inside the existing Notifications section: enable toggle, HH:MM time inputs, IANA timezone select (browser default + curated short list), per-category bypass checkboxes.
- **Mobile** — equivalent `QUIET HOURS` section in `SettingsScreen`: same fields with a modal timezone picker and TextInput HH:MM validation.

## Design decisions (per #4544 brief)

- **Override resolution** — per-device REPLACES the global window. Simpler mental model than shadowing: one device can express \"my entire policy is X\" without thinking about which global fields it would inherit.
- **Default bypass categories** — `permission` + `activity_error`. Operator-blocking by nature; muting them would stall the agent. User opts every category out by sending `bypassCategories: []`.
- **Failure mode** — defensive fail-OPEN. Any structural error (missing timezone, malformed times, unknown IANA zone, missing window) returns `false` so the push goes through. Silently swallowing every notification on a misconfiguration is the worst failure mode for a notification system; the layered `RATE_LIMITS` gate + per-category mute still throttle the worst-case spam.

## Scope notes

- The dashboard QuietHoursEditor patches the GLOBAL window. Per-device override UI (the wire schema supports it) lands in #4543's per-device notification panel; this PR keeps that scope intentionally separate to avoid colliding with the parallel work.
- Existing `interceptPermissionPrompt` path, per-category mute (#4542), and `RATE_LIMITS` gate all still fire — quiet-hours is layered ON TOP of them, never replaces.
- Older servers that emit a `notification_prefs` snapshot without `bypassCategories` still parse; clients fall back to the documented defaults at the gate.

## Test plan

- [x] **Server quiet-hours unit tests** (12 new suites in `notification-prefs-quiet-hours.test.js`):
  - midnight-wrap window inclusive/exclusive boundaries
  - DST spring-forward + fall-back in `America/Los_Angeles`
  - per-device override REPLACE precedence (including `null` opt-out)
  - per-device different-timezone resolution (Tokyo vs Pacific)
  - bypass-category gating (default list, per-device override, empty opt-out)
  - PushManager.send filters tokens correctly + RATE_LIMITS still fires first
- [x] **Server existing tests** (`notification-prefs.test.js`, `notification-prefs-handlers.test.js`, `ws-schemas.test.js`) updated for the extended schema (timezone required, bypassCategories accepted) — all pass.
- [x] **Server full suite**: 6044/6050 pass; the 6 fails are pre-existing environmental flakes (cloudflared-needs-installed + a Chroxy server happening to be running on the test machine), reproduced on unmodified `main`.
- [x] **Dashboard SettingsPanel tests**: 66/66 pass (8 new quiet-hours editor tests covering loading state, enable toggle defaults, Save round-trip, bypass checkboxes, snapshot fallback when older server omits the field).
- [x] **Dashboard full suite**: 2272/2272 pass; `tsc --noEmit` clean.
- [x] **Mobile suite**: 1363/1363 pass (35 tests in `SettingsScreenNotificationPrefs.test.ts` including 16 new for quiet-hours editor + types + connection actions); `tsc --noEmit` clean.
- [x] **Protocol package**: 143/143 pass after the schema bump.

Closes #4544
Related to #4541 (foundation), #4549 (foundation PR), #4542 (per-category UI), #4557 (per-category UI PR), parent #4349.