### PR TITLE
docs(server): clarify EnvironmentManager workspacePVC passthrough test invariant

### DIFF
--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -293,6 +293,11 @@ describe('EnvironmentManager.create() — workspacePVC passthrough (#4548)', () 
 
     const workspacePVC = { claimName: 'shared-workspace-pvc', mountPath: '/work', readOnly: true }
 
+    // NOTE: cwd: '/tmp' and workspacePVC are passed together here only because
+    // the recording stub does no validation — the manager's only requirement is
+    // that cwd is a non-empty string. A real K8sBackend would reject this
+    // combination via validateWorkspacePVC() (mutual-exclusion). The manager
+    // itself has no opinion on coexistence; enforcement lives in the backend.
     await manager.create({
       name: 'pvc-env',
       cwd: '/tmp',


### PR DESCRIPTION
## Summary

Doc-only follow-up to PR #4554. Adds a 5-line inline comment to the new `forwards opts.workspacePVC verbatim to the backend` passthrough test in `packages/server/tests/environment-manager.test.js` explaining why the test fixture is allowed to pass both `cwd: '/tmp'` and `workspacePVC` to `manager.create()`.

## Why

The passthrough test legally combines `cwd` and `workspacePVC` because the recording stub backend does not validate that combination. A real `K8sBackend` would reject it via `validateWorkspacePVC()` (mutual-exclusion). Without the comment, a future reader extending this test (or copy-pasting the fixture into an integration test against a real backend) might assume the manager has opinions about the combination — it does not. Enforcement lives in the backend.

## Changes

- `packages/server/tests/environment-manager.test.js` — 5 lines of comments inside the existing passthrough test body. No test logic, fixture, or behaviour change.

## Test plan

- [x] `node --test --experimental-test-module-mocks packages/server/tests/environment-manager.test.js` — 91/91 pass

Closes #4555