### PR TITLE
fix(dashboard): hoist per-device notification label outside parent label

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -885,6 +885,30 @@ describe('SettingsPanel', () => {
       // contract holds without any synthetic interaction.
       expect(setNotificationPrefsDevice).not.toHaveBeenCalled()
     })
+
+    it('does not wrap the per-device input inside a <label> element (#4562)', () => {
+      // Regression for #4562: the per-device row originally used a wrapping
+      // <label> that shared its <li> ancestor with the global category's
+      // <label>. Two labels in the same row confuses screen readers and can
+      // bubble click events to the wrong input. Hoisted: the per-device input
+      // sits alongside an explicit <label htmlFor={deviceToggleId}> sibling
+      // inside a plain <div>, with no <label> ancestor at all.
+      setMockState({ notificationPrefs: defaultPrefs })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const deviceToggle = screen.getByTestId('notification-prefs-device-toggle-result')
+      // No ancestor <label> for the per-device input.
+      expect(deviceToggle.closest('label')).toBeNull()
+      // The per-device row wrapper is a <div>, not a <label>.
+      const row = screen.getByTestId('notification-prefs-device-row-result')
+      expect(row.tagName).toBe('DIV')
+      // And the explicit "Mute on this device" label still associates via htmlFor
+      // so clicking the text toggles only the device input (scoped to the
+      // `result` row — every category renders its own copy of the text).
+      const muteLabel = row.querySelector('label')
+      expect(muteLabel).not.toBeNull()
+      expect(muteLabel!.getAttribute('for')).toBe('notification-prefs-device-result')
+      expect(muteLabel!.textContent).toBe('Mute on this device')
+    })
   })
 
   describe('Notification preferences — quiet-hours editor (#4544)', () => {

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -895,8 +895,17 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                             </label>
                             {hint && <p className="settings-hint">{hint}</p>}
                             {currentDeviceKey && (
-                              <label
-                                htmlFor={deviceToggleId}
+                              // #4562: per-device row uses a <div> wrapper +
+                              // explicit `htmlFor` <label> sibling rather than
+                              // a wrapping <label>. The parent category row
+                              // already lives inside its own <label> on the
+                              // same <li>, and screen readers / click bubbling
+                              // get confused when two label elements share an
+                              // ancestor `<li>` — hoisting the per-device
+                              // label out of a wrapper element keeps the input
+                              // and its text label as flat siblings with a
+                              // single explicit association.
+                              <div
                                 className="notification-prefs-device-row"
                                 data-testid={`notification-prefs-device-row-${cat}`}
                               >
@@ -909,8 +918,8 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                                   }
                                   data-testid={`notification-prefs-device-toggle-${cat}`}
                                 />
-                                <span>Mute on this device</span>
-                              </label>
+                                <label htmlFor={deviceToggleId}>Mute on this device</label>
+                              </div>
                             )}
                           </li>
                         )


### PR DESCRIPTION
## Summary

Restructures the per-device "Mute on this device" row in the dashboard's `SettingsPanel` so it no longer wraps an `<input>` in a `<label>` that shares its `<li>` ancestor with the global category's `<label>`. Two `<label>` elements in the same row can confuse screen readers and bubble click events to the wrong input.

The per-device row now uses a plain `<div>` wrapper with an explicit `<label htmlFor={deviceToggleId}>` sibling — the input and its text label are flat siblings with a single explicit `htmlFor` association, and the row has no `<label>` ancestor at all.

## Changes

- `packages/dashboard/src/components/SettingsPanel.tsx`: per-device row wrapper changed from `<label>` to `<div>` (same className and testid so CSS + existing tests continue to apply); inner `<span>Mute on this device</span>` becomes `<label htmlFor>Mute on this device</label>` sibling.
- `packages/dashboard/src/components/SettingsPanel.test.tsx`: new regression test in the per-device describe block asserts the per-device input has no `<label>` ancestor, the row wrapper is a `<div>`, and the new explicit label still associates via `htmlFor`.

## Test plan

- [x] `npx vitest run src/components/SettingsPanel` from `packages/dashboard/` — 74 tests pass (73 prior + 1 regression)
- [x] Full dashboard suite: `npx vitest run` from `packages/dashboard/` — 2280 tests pass
- [x] Acceptance criteria from the issue:
  - Per-device input no longer nested inside parent category's `<label>` (now no `<label>` ancestor at all)
  - Clicking "Mute on this device" text only toggles the per-device input (single explicit `htmlFor` association)
  - Existing 7 per-device + 8 per-category tests still pass
  - No visual regression — DOM shape unchanged modulo outer tag swap

Closes #4562