### PR TITLE
refactor(app,dashboard): share quiet-hours timezone choices across mobile + dashboard

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -180,10 +180,14 @@ describe('SettingsScreen — Quiet hours editor section (#4544)', () => {
     expect(settingsSource).toMatch(/Invalid time[\s\S]{0,100}HH:MM/);
   });
 
-  it('declares a sensible curated timezone list', () => {
-    expect(settingsSource).toMatch(/QUIET_HOURS_TIMEZONE_CHOICES/);
-    expect(settingsSource).toMatch(/America\/Los_Angeles/);
-    expect(settingsSource).toMatch(/Europe\/London/);
+  it('consumes the shared curated timezone list from @chroxy/store-core (#4569)', () => {
+    // The list itself lives in store-core (see store-core/src/timezones.ts);
+    // SettingsScreen must import the shared helper rather than redeclare a
+    // duplicate array. Verify both the import and the call-site.
+    expect(settingsSource).toMatch(/import\s+\{\s*buildQuietHoursTimezoneList\s*\}\s+from\s+['"]@chroxy\/store-core['"]/);
+    expect(settingsSource).toMatch(/buildQuietHoursTimezoneList\(/);
+    // The duplicate local constant from PR #4565 must be gone.
+    expect(settingsSource).not.toMatch(/const\s+QUIET_HOURS_TIMEZONE_CHOICES\s*=/);
   });
 
   it('falls back to DEFAULT_BYPASS_CATEGORIES when the snapshot omits the list', () => {

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -29,6 +29,7 @@ import {
   setBiometricEnabled,
   authenticate,
 } from '../hooks/useBiometricLock';
+import { buildQuietHoursTimezoneList } from '@chroxy/store-core';
 
 const APP_VERSION = Constants.expoConfig?.version ?? 'unknown';
 
@@ -70,32 +71,6 @@ const NOTIFICATION_CATEGORY_ORDER = [
  * the UI shows the right initial checkboxes.
  */
 const DEFAULT_BYPASS_CATEGORIES = ['permission', 'activity_error'];
-
-/**
- * #4544: curated timezone short-list. Same set as the dashboard's
- * `getQuietHoursTimezoneOptions` so mobile + desktop pickers agree on
- * the most-likely picks. The device's resolved zone is prepended so the
- * user can pick "this device" without scrolling.
- */
-const QUIET_HOURS_TIMEZONE_CHOICES = [
-  'UTC',
-  'America/Los_Angeles',
-  'America/Denver',
-  'America/Chicago',
-  'America/New_York',
-  'America/Sao_Paulo',
-  'Europe/London',
-  'Europe/Berlin',
-  'Europe/Paris',
-  'Europe/Moscow',
-  'Asia/Dubai',
-  'Asia/Kolkata',
-  'Asia/Shanghai',
-  'Asia/Tokyo',
-  'Asia/Singapore',
-  'Australia/Sydney',
-  'Pacific/Auckland',
-];
 
 /**
  * #4544: HH:MM validation predicate. Mirrors the server-side regex in
@@ -791,11 +766,7 @@ function QuietHoursEditor(props: {
   const browserTz = useMemo(() => {
     try { return Intl.DateTimeFormat().resolvedOptions().timeZone; } catch { return 'UTC'; }
   }, []);
-  const tzOptions = useMemo(() => {
-    const list = [...QUIET_HOURS_TIMEZONE_CHOICES];
-    if (browserTz && !list.includes(browserTz)) list.unshift(browserTz);
-    return list;
-  }, [browserTz]);
+  const tzOptions = useMemo(() => buildQuietHoursTimezoneList(browserTz), [browserTz]);
 
   const [enabled, setEnabled] = useState<boolean>(win != null);
   const [start, setStart] = useState<string>(win?.start ?? '22:00');

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -11,6 +11,7 @@ import { getAvailableThemes, applyTheme } from '../theme/theme-engine'
 import { getThemeById } from '../theme/themes'
 import type { ThemeDefinition } from '../theme/themes'
 import { PROVIDER_LABELS } from '../lib/provider-labels'
+import { buildQuietHoursTimezoneList } from '@chroxy/store-core'
 import { isTauri } from '../utils/tauri'
 import {
   getTunnelMode,
@@ -83,41 +84,20 @@ const NOTIFICATION_CATEGORY_ORDER = [
 const DEFAULT_BYPASS_CATEGORIES = ['permission', 'activity_error']
 
 /**
- * #4544: timezone picker options. The full IANA database is hundreds of
- * entries; we surface a curated short list plus a "browser default" sentinel
- * so the user can pick the most common cases without scrolling. The actual
- * wire value is the IANA name (e.g. `America/Los_Angeles`).
+ * #4544: timezone picker options. The curated short-list lives in
+ * `@chroxy/store-core` (#4569) so the dashboard and mobile pickers share a
+ * single source of truth. We prepend the browser-resolved zone here so the
+ * user can pick "this device" without scrolling, and tag the matching entry
+ * with the trailing label.
  *
  * `Intl.supportedValuesOf('timeZone')` returns the full set on modern
- * browsers — listed here in case a future iteration switches to a
- * searchable combobox.
+ * browsers — kept in mind for a future searchable combobox.
  */
 function getQuietHoursTimezoneOptions(): { value: string; label: string }[] {
   const browser = (() => {
     try { return Intl.DateTimeFormat().resolvedOptions().timeZone } catch { return 'UTC' }
   })()
-  const curated = [
-    'UTC',
-    'America/Los_Angeles',
-    'America/Denver',
-    'America/Chicago',
-    'America/New_York',
-    'America/Sao_Paulo',
-    'Europe/London',
-    'Europe/Berlin',
-    'Europe/Paris',
-    'Europe/Moscow',
-    'Asia/Dubai',
-    'Asia/Kolkata',
-    'Asia/Shanghai',
-    'Asia/Tokyo',
-    'Asia/Singapore',
-    'Australia/Sydney',
-    'Pacific/Auckland',
-  ]
-  const set = new Set(curated)
-  if (browser && !set.has(browser)) curated.unshift(browser)
-  return curated.map((tz) => ({
+  return buildQuietHoursTimezoneList(browser).map((tz) => ({
     value: tz,
     label: tz === browser ? `${tz} (this device)` : tz,
   }))

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -221,6 +221,15 @@ export type {
   ProviderDisplayInfo,
 } from './provider-labels'
 
+// #4569: curated IANA timezone short-list for the notification
+// quiet-hours editor. Single source of truth shared by the dashboard's
+// SettingsPanel and the mobile SettingsScreen so the two pickers can't
+// drift apart when one is extended.
+export {
+  QUIET_HOURS_TIMEZONE_CHOICES,
+  buildQuietHoursTimezoneList,
+} from './timezones'
+
 export type {
   SessionPatch,
   PermissionMode,

--- a/packages/store-core/src/timezones.test.ts
+++ b/packages/store-core/src/timezones.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import {
+  QUIET_HOURS_TIMEZONE_CHOICES,
+  buildQuietHoursTimezoneList,
+} from './timezones'
+
+describe('QUIET_HOURS_TIMEZONE_CHOICES', () => {
+  it('is a non-empty readonly array of IANA timezone strings', () => {
+    expect(Array.isArray(QUIET_HOURS_TIMEZONE_CHOICES)).toBe(true)
+    expect(QUIET_HOURS_TIMEZONE_CHOICES.length).toBeGreaterThan(0)
+    for (const tz of QUIET_HOURS_TIMEZONE_CHOICES) {
+      expect(typeof tz).toBe('string')
+      expect(tz.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('contains no duplicates', () => {
+    const set = new Set(QUIET_HOURS_TIMEZONE_CHOICES)
+    expect(set.size).toBe(QUIET_HOURS_TIMEZONE_CHOICES.length)
+  })
+
+  it('includes UTC and at least one entry per major continent', () => {
+    expect(QUIET_HOURS_TIMEZONE_CHOICES).toContain('UTC')
+    // sanity: the curated list covers the regions both clients have historically shown
+    expect(QUIET_HOURS_TIMEZONE_CHOICES.some((tz) => tz.startsWith('America/'))).toBe(true)
+    expect(QUIET_HOURS_TIMEZONE_CHOICES.some((tz) => tz.startsWith('Europe/'))).toBe(true)
+    expect(QUIET_HOURS_TIMEZONE_CHOICES.some((tz) => tz.startsWith('Asia/'))).toBe(true)
+    expect(QUIET_HOURS_TIMEZONE_CHOICES.some((tz) => tz.startsWith('Australia/') || tz.startsWith('Pacific/'))).toBe(true)
+  })
+
+  it('uses IANA `Region/City` form (one slash) for every non-UTC entry', () => {
+    for (const tz of QUIET_HOURS_TIMEZONE_CHOICES) {
+      if (tz === 'UTC') continue
+      expect(tz.split('/').length).toBeGreaterThanOrEqual(2)
+    }
+  })
+
+  it('is validated by Intl.DateTimeFormat (no malformed zone names slip in)', () => {
+    for (const tz of QUIET_HOURS_TIMEZONE_CHOICES) {
+      expect(() => new Intl.DateTimeFormat('en-US', { timeZone: tz })).not.toThrow()
+    }
+  })
+})
+
+describe('buildQuietHoursTimezoneList', () => {
+  it('returns the curated list as-is when the device timezone is already present', () => {
+    const list = buildQuietHoursTimezoneList('UTC')
+    expect(list).toEqual([...QUIET_HOURS_TIMEZONE_CHOICES])
+    // identity preserved (no surprise mutation of the source array)
+    expect(list).not.toBe(QUIET_HOURS_TIMEZONE_CHOICES)
+  })
+
+  it('prepends the device timezone when it is not in the curated list', () => {
+    const exotic = 'Antarctica/Vostok'
+    expect(QUIET_HOURS_TIMEZONE_CHOICES).not.toContain(exotic)
+    const list = buildQuietHoursTimezoneList(exotic)
+    expect(list[0]).toBe(exotic)
+    expect(list.slice(1)).toEqual([...QUIET_HOURS_TIMEZONE_CHOICES])
+  })
+
+  it('does not mutate the source constant when prepending', () => {
+    const before = [...QUIET_HOURS_TIMEZONE_CHOICES]
+    buildQuietHoursTimezoneList('Antarctica/Vostok')
+    expect([...QUIET_HOURS_TIMEZONE_CHOICES]).toEqual(before)
+  })
+
+  it('falls back to the curated list when given an empty / nullish device timezone', () => {
+    expect(buildQuietHoursTimezoneList('')).toEqual([...QUIET_HOURS_TIMEZONE_CHOICES])
+    expect(buildQuietHoursTimezoneList(null)).toEqual([...QUIET_HOURS_TIMEZONE_CHOICES])
+    expect(buildQuietHoursTimezoneList(undefined)).toEqual([...QUIET_HOURS_TIMEZONE_CHOICES])
+  })
+})

--- a/packages/store-core/src/timezones.ts
+++ b/packages/store-core/src/timezones.ts
@@ -1,0 +1,52 @@
+/**
+ * #4569: shared curated IANA timezone short-list for the notification
+ * quiet-hours editor. Both the dashboard `SettingsPanel` and the mobile
+ * `SettingsScreen` import this list so they cannot drift when one
+ * platform extends the picker without the other.
+ *
+ * The full IANA database has hundreds of entries; we surface a curated
+ * subset that covers the most common operator timezones. UI code is
+ * expected to prepend the device's resolved zone (see
+ * `buildQuietHoursTimezoneList`) so the user can always pick "this
+ * device" without scrolling.
+ *
+ * The wire value sent to the server is the raw IANA name
+ * (e.g. `America/Los_Angeles`); labels are derived by the UI.
+ */
+export const QUIET_HOURS_TIMEZONE_CHOICES = [
+  'UTC',
+  'America/Los_Angeles',
+  'America/Denver',
+  'America/Chicago',
+  'America/New_York',
+  'America/Sao_Paulo',
+  'Europe/London',
+  'Europe/Berlin',
+  'Europe/Paris',
+  'Europe/Moscow',
+  'Asia/Dubai',
+  'Asia/Kolkata',
+  'Asia/Shanghai',
+  'Asia/Tokyo',
+  'Asia/Singapore',
+  'Australia/Sydney',
+  'Pacific/Auckland',
+] as const
+
+/**
+ * Compose the picker list for the quiet-hours timezone control.
+ *
+ * Returns a fresh array (never the source constant) so callers can
+ * safely mutate it. When `deviceTimezone` is missing or already in the
+ * curated list, the list is returned unchanged; otherwise the device
+ * zone is prepended so it appears first in the picker.
+ */
+export function buildQuietHoursTimezoneList(
+  deviceTimezone: string | null | undefined,
+): string[] {
+  const list: string[] = [...QUIET_HOURS_TIMEZONE_CHOICES]
+  if (deviceTimezone && !list.includes(deviceTimezone)) {
+    list.unshift(deviceTimezone)
+  }
+  return list
+}


### PR DESCRIPTION
## Summary

PR #4565 (notification quiet-hours window) landed the curated IANA
timezone short-list in **two** places:

- Dashboard: `getQuietHoursTimezoneOptions` in `packages/dashboard/src/components/SettingsPanel.tsx`
- Mobile: `QUIET_HOURS_TIMEZONE_CHOICES` in `packages/app/src/screens/SettingsScreen.tsx`

The lists were byte-identical and would drift the next time either platform
extended its picker. This PR extracts the array + the "prepend device
timezone" helper into a single shared module so the two pickers stay in
lock-step by construction.

## Design

`@chroxy/store-core` already runs in both the mobile bundle and the
dashboard bundle, has zero React Native / DOM dependencies, and is where
PR #4565's `getProviderLabel` / `formatCostBadge` / etc. live for the
same reason (UI-side choices shared by two clients). The wire schema in
`@chroxy/protocol` is unchanged — these are UI-side picker choices, not
protocol-defined values, so they belong in store-core, not protocol.

New module: `packages/store-core/src/timezones.ts`

- `QUIET_HOURS_TIMEZONE_CHOICES` — the curated array, `as const` so
  consumers can pick up the literal tuple type if useful.
- `buildQuietHoursTimezoneList(deviceTimezone)` — returns a fresh
  `string[]` with the device zone prepended when it isn't already
  present. Never mutates the source constant.

Both consumers (`SettingsPanel.tsx`, `SettingsScreen.tsx`) now defer to
the shared helper. The dashboard still owns its own "(this device)"
label decoration; the mobile screen still owns its modal picker chrome.
Pure refactor — zero behavior change to the rendered quiet-hours UI on
either platform.

## Test plan

- [x] **Store-core new tests** (9 in `timezones.test.ts`):
  - shape: non-empty, all strings, no duplicates
  - covers every major continent (`America/`, `Europe/`, `Asia/`,
    `Australia/` or `Pacific/`)
  - every entry validates under `Intl.DateTimeFormat` (no malformed
    IANA names)
  - `buildQuietHoursTimezoneList` returns the curated list when the
    device zone is already in it; prepends when it isn't; never mutates
    the source array; tolerates `''` / `null` / `undefined`.
- [x] **Store-core full suite**: 877/877 pass (16 test files).
- [x] **Dashboard `SettingsPanel.test`**: 73/73 pass.
- [x] **Dashboard `tsc --noEmit`**: clean.
- [x] **Mobile `SettingsScreen*` suites**: 62/62 pass. The existing
  `SettingsScreenNotificationPrefs.test.ts` source-grep test was
  updated to assert (a) the `@chroxy/store-core` import path, (b) the
  `buildQuietHoursTimezoneList` call-site, and (c) the duplicate
  `QUIET_HOURS_TIMEZONE_CHOICES` const is *gone* — so future drift gets
  caught at test time, not at review time.
- [x] **Mobile `tsc --noEmit`**: clean.

Closes #4569
Related to #4544 (parent quiet-hours brief), #4565 (introduced the
duplicated lists).