### PR TITLE
fix(server): tighten quiet-hours HH:MM range validation in sanitizeQuietHours

### DIFF
--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -105,7 +105,11 @@ export const CATEGORY_DEFAULTS = Object.freeze(
 export const DEFAULT_BYPASS_CATEGORIES = Object.freeze(['permission', 'activity_error'])
 
 const _ALL_CATEGORIES_SET = new Set(ALL_CATEGORIES)
-const _HHMM_RE = /^\d{2}:\d{2}$/
+// Two-digit zero-padded HH:MM with HH in 00-23 and MM in 00-59 (#4566).
+// The narrower regex replaces the older `/^\d{2}:\d{2}$/`, which accepted
+// out-of-range values like `25:99` and let a hand-edited typo land in the
+// in-memory prefs before fail-opening at gate-eval time.
+const _HHMM_RE = /^(?:[01]\d|2[0-3]):[0-5]\d$/
 
 export function defaultNotificationPrefsPath() {
   return process.env.CHROXY_NOTIFICATION_PREFS_PATH || join(homedir(), '.chroxy', 'notification-prefs.json')
@@ -155,7 +159,7 @@ function sanitizeCategoryMap(raw) {
  * of muting on this device, `{ start, end, timezone }` = device-specific
  * window.
  */
-function sanitizeDevices(raw) {
+function sanitizeDevices(raw, { log } = {}) {
   if (!raw || typeof raw !== 'object') return {}
   const out = {}
   for (const [token, entry] of Object.entries(raw)) {
@@ -167,6 +171,14 @@ function sanitizeDevices(raw) {
     // "fall back to global". hasOwnProperty distinguishes absent from null.
     if (Object.prototype.hasOwnProperty.call(entry, 'quietHours')) {
       cleaned.quietHours = sanitizeQuietHours(entry.quietHours)
+      // #4566: surface a typo on a per-device window — the original block
+      // existed on disk but failed range/shape validation, so the device
+      // silently inherits "no muting" (null). Warn so the operator notices
+      // rather than discovering it the next time a notification fires
+      // outside their expected window.
+      if (cleaned.quietHours === null && entry.quietHours !== null) {
+        log?.warn?.(`notification-prefs: device ${token} quietHours rejected (invalid shape or out-of-range HH:MM)`)
+      }
     }
     if (Object.prototype.hasOwnProperty.call(entry, 'bypassCategories')) {
       const bypass = sanitizeBypassList(entry.bypassCategories)
@@ -178,12 +190,19 @@ function sanitizeDevices(raw) {
 }
 
 /**
- * Sanitize the quiet-hours window (#4544).
+ * Sanitize the quiet-hours window (#4544, tightened #4566).
  *
  * Requires `start`, `end`, AND `timezone` to all be present and well-formed
  * — a window without a timezone cannot be evaluated at the gate (see
  * `isInQuietHoursIn`'s fail-open behaviour), so we refuse to load a
  * half-shape that would silently mis-mute later.
+ *
+ * `start`/`end` must match the two-digit zero-padded `HH:MM` form with
+ * `HH` in 00-23 and `MM` in 00-59 (#4566). The previous regex
+ * (`/^\d{2}:\d{2}$/`) accepted out-of-range values like `25:99`, which
+ * survived the loader and silently fail-opened at gate-eval time; the
+ * stricter pattern in `_HHMM_RE` rejects those at load. Returning `null`
+ * here triggers a `log.warn` in `loadPrefs` so the typo surfaces.
  *
  * The IANA timezone is validated by constructing a `DateTimeFormat` with
  * the requested zone — Node throws `RangeError` for unknown zones, which
@@ -247,10 +266,24 @@ export function loadPrefs(filePath = defaultNotificationPrefsPath(), { log } = {
       const cleaned = sanitizeBypassList(raw.bypassCategories)
       bypass = cleaned ?? [...DEFAULT_BYPASS_CATEGORIES]
     }
+    const cleanedQuietHours = sanitizeQuietHours(raw?.quietHours)
+    // #4566: warn when the on-disk file carried a quietHours block but it
+    // failed validation. The pre-#4566 behaviour silently dropped the bad
+    // window and the operator believed quiet-hours were active. We skip
+    // the warn for `null` (explicit "no quiet hours") and for "key absent"
+    // — only a present, non-null, rejected block deserves the signal.
+    const rawQuietHours = raw?.quietHours
+    if (
+      cleanedQuietHours === null &&
+      rawQuietHours !== null &&
+      rawQuietHours !== undefined
+    ) {
+      log?.warn?.(`notification-prefs ${filePath} quietHours rejected (invalid shape or out-of-range HH:MM)`)
+    }
     return {
       categories: { ...base.categories, ...sanitizeCategoryMap(raw?.categories) },
-      devices: sanitizeDevices(raw?.devices),
-      quietHours: sanitizeQuietHours(raw?.quietHours),
+      devices: sanitizeDevices(raw?.devices, { log }),
+      quietHours: cleanedQuietHours,
       bypassCategories: bypass,
     }
   } catch (err) {

--- a/packages/server/tests/notification-prefs-quiet-hours.test.js
+++ b/packages/server/tests/notification-prefs-quiet-hours.test.js
@@ -470,6 +470,161 @@ describe('loadPrefs — extended quiet-hours schema (#4544)', () => {
   })
 })
 
+describe('loadPrefs — strict HH:MM range validation (#4566)', () => {
+  // The regex `/^\d{2}:\d{2}$/` alone accepts out-of-range values like
+  // `25:99`. A hand-edited prefs file with `start: '25:99'` previously
+  // survived the loader and landed in memory — `_parseHHMM` then returned
+  // null at gate time and `isInQuietHoursIn` fail-opened, so the bad
+  // window was silently disabled. These tests pin the stricter contract:
+  // sanitizeQuietHours rejects the window AND loadPrefs warns so the
+  // operator notices the typo.
+  it('drops a quietHours window with hour > 23 (25:00)', () => {
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '25:00', end: '07:00', timezone: 'America/Los_Angeles' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours, null)
+  })
+
+  it('drops a quietHours window with minute > 59 (12:99)', () => {
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '12:99', end: '07:00', timezone: 'America/Los_Angeles' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours, null)
+  })
+
+  it('drops a quietHours window with hour and minute both out of range (25:99)', () => {
+    // The headline issue example. `25:99` matches the loose regex but
+    // describes no valid wall-clock instant.
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '25:99', end: '07:00', timezone: 'America/Los_Angeles' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours, null)
+  })
+
+  it('drops a quietHours window with non-numeric components (ab:cd)', () => {
+    // Defensive: even though the existing regex catches this, pin it so a
+    // refactor of `_HHMM_RE` cannot silently weaken the contract.
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: 'ab:cd', end: '07:00', timezone: 'America/Los_Angeles' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours, null)
+  })
+
+  it('drops a quietHours window with unpadded single-digit hour (9:00)', () => {
+    // Spec is two-digit zero-padded HH:MM. `9:00` is rejected — same as
+    // pre-#4566 behaviour from the regex, pinned to prevent regression.
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '9:00', end: '07:00', timezone: 'America/Los_Angeles' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours, null)
+  })
+
+  it('drops a quietHours window with empty string start', () => {
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '', end: '07:00', timezone: 'America/Los_Angeles' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours, null)
+  })
+
+  it('accepts boundary values 00:00 and 23:59', () => {
+    // The narrowest legal range — pin both ends so a regex tweak that
+    // accidentally clamps the boundary is caught.
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '00:00', end: '23:59', timezone: 'America/Los_Angeles' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours.start, '00:00')
+    assert.equal(prefs.quietHours.end, '23:59')
+  })
+
+  it('accepts typical wall-clock values 09:00 and 23:59', () => {
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '09:00', end: '23:59', timezone: 'America/Los_Angeles' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.quietHours.start, '09:00')
+    assert.equal(prefs.quietHours.end, '23:59')
+  })
+
+  it('logs a warn when an on-disk quietHours block is rejected', () => {
+    // Acceptance criterion: the operator must see a signal in logs when a
+    // hand-edited typo survives JSON.parse but fails range validation.
+    // Without this warn the bad window is silently dropped and the
+    // operator believes their quiet-hours are active.
+    const onDisk = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '25:99', end: '07:00', timezone: 'America/Los_Angeles' },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const warnings = []
+    const log = { warn: (msg) => warnings.push(msg) }
+    const prefs = loadPrefs(prefsPath, { log })
+    assert.equal(prefs.quietHours, null)
+    assert.equal(warnings.length, 1, 'exactly one warn fires for the rejected global window')
+    assert.match(warnings[0], /quietHours/i, 'warn mentions quietHours')
+  })
+
+  it('does NOT log a warn when on-disk quietHours is absent (default state)', () => {
+    // First-run / clean prefs files have no quietHours key — that's not a
+    // typo, so silence is correct.
+    const onDisk = { categories: {}, devices: {} }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const warnings = []
+    const log = { warn: (msg) => warnings.push(msg) }
+    loadPrefs(prefsPath, { log })
+    assert.equal(warnings.length, 0)
+  })
+
+  it('logs a warn when a per-device quietHours block is rejected', () => {
+    const onDisk = {
+      categories: {},
+      devices: {
+        'phone-1': {
+          quietHours: { start: '99:99', end: '07:00', timezone: 'America/Los_Angeles' },
+        },
+      },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const warnings = []
+    const log = { warn: (msg) => warnings.push(msg) }
+    const prefs = loadPrefs(prefsPath, { log })
+    assert.equal(prefs.devices['phone-1'].quietHours, null)
+    assert.equal(warnings.length, 1)
+    assert.match(warnings[0], /phone-1/, 'warn identifies the device token')
+  })
+})
+
 describe('savePrefs — round-trip extended schema (#4544)', () => {
   it('round-trips timezone and bypassCategories', () => {
     const written = {


### PR DESCRIPTION
## Summary

Closes #4566.

`sanitizeQuietHours` in `packages/server/src/notification-prefs.js` previously used the regex `/^\d{2}:\d{2}$/` to validate `start`/`end`, which accepted out-of-range values like `25:99`. A hand-edited prefs file with `start: '25:99'` survived the loader and landed in the in-memory prefs. At gate-eval time `_parseHHMM` returned `null` and `isInQuietHoursIn` fail-opened, so the bad window was silently disabled rather than mis-muting — but the operator had no signal that their config was wrong.

## Changes

- Tighten `_HHMM_RE` to `^(?:[01]\d|2[0-3]):[0-5]\d$` so HH must be 00-23 and MM must be 00-59. Two-digit zero-padded form unchanged.
- `loadPrefs` warns via `log.warn` when an on-disk `quietHours` block was present but rejected by `sanitizeQuietHours`. Silent for the "absent" and "explicit null" cases — only a present, non-null, rejected block fires the warn.
- `sanitizeDevices` threads the same `log` down so per-device rejections also warn, naming the offending token.
- Doc-comments on `_HHMM_RE` and `sanitizeQuietHours` updated to call out the #4566 contract.

## Tests

Added `#4566` block in `notification-prefs-quiet-hours.test.js` covering:
- Rejected: `25:00`, `12:99`, `25:99`, `ab:cd`, `9:00`, empty string
- Accepted: `00:00`, `23:59` boundaries plus typical `09:00` / `23:59`
- Warn fires for rejected global block, stays silent when block is absent
- Per-device rejection warns and identifies the token

All 94 notification-prefs tests pass; the one unrelated full-suite failure (`WebTaskManager > feature detection`) requires the `claude` CLI binary and is pre-existing.

## Test plan

- [x] `cd packages/server && PATH="/opt/homebrew/opt/node@22/bin:\$PATH" node --experimental-test-module-mocks --test tests/notification-prefs-quiet-hours.test.js` — 57/57 pass
- [x] All notification-prefs test files — 94/94 pass
- [ ] CI green