### PR TITLE
fix(server): defensive Number.isFinite guard in isInQuietHoursIn

### DIFF
--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -416,6 +416,14 @@ function _parseHHMM(s) {
  * `RATE_LIMITS`) provide layered protection regardless.
  */
 export function isInQuietHoursIn(prefs, now, pushToken) {
+  // Defensive: `now` must be a finite epoch-ms. Without this guard a caller
+  // passing `null`/`undefined`/`NaN` would coerce through `new Date(now)`
+  // (e.g. `new Date(null)` → 1970-01-01T00:00:00Z) and silently activate
+  // quiet hours for every push that happens to fall inside a window
+  // overlapping 00:00 UTC. Fail-open (return false) matches the rest of
+  // the function's posture — better to deliver a push than to silently
+  // suppress all of them on a caller bug. (#4567)
+  if (!Number.isFinite(now)) return false
   const window = resolveQuietHoursWindow(prefs, pushToken)
   if (!window) return false
   if (typeof window.timezone !== 'string' || window.timezone.length === 0) return false

--- a/packages/server/tests/notification-prefs-quiet-hours.test.js
+++ b/packages/server/tests/notification-prefs-quiet-hours.test.js
@@ -394,6 +394,27 @@ describe('isInQuietHoursIn — defensive cases (#4544)', () => {
     const prefs = { categories: {}, devices: {}, quietHours: { start: '22:00', end: '07:00', timezone: 'Not/Real_Zone' } }
     assert.equal(isInQuietHoursIn(prefs, Date.now(), 'tok'), false)
   })
+
+  it('returns false when `now` is not a finite number (#4567)', () => {
+    // Defensive guard: a future caller passing null/undefined/NaN/Infinity
+    // must NOT silently activate quiet hours. Without the guard,
+    // `new Date(null)` coerces to the unix epoch (1970-01-01T00:00:00Z),
+    // which falls inside a 22:00-07:00 UTC window and would suppress every
+    // push for the affected token. Fail-open (return false) matches the
+    // rest of the function's defensive posture.
+    const prefs = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '22:00', end: '07:00', timezone: 'UTC' },
+    }
+    assert.equal(isInQuietHoursIn(prefs, null, 'tok'), false)
+    assert.equal(isInQuietHoursIn(prefs, undefined, 'tok'), false)
+    assert.equal(isInQuietHoursIn(prefs, NaN, 'tok'), false)
+    assert.equal(isInQuietHoursIn(prefs, Infinity, 'tok'), false)
+    assert.equal(isInQuietHoursIn(prefs, -Infinity, 'tok'), false)
+    assert.equal(isInQuietHoursIn(prefs, '1700000000000', 'tok'), false)
+    assert.equal(isInQuietHoursIn(prefs, {}, 'tok'), false)
+  })
 })
 
 describe('loadPrefs — extended quiet-hours schema (#4544)', () => {


### PR DESCRIPTION
## Summary

`isInQuietHoursIn(prefs, now, pushToken)` in `packages/server/src/notification-prefs.js` trusts `now` to be a finite epoch-ms. If a future caller passes `null`/`undefined`/`NaN`/`Infinity`, the value flows through `new Date(now)` in `_wallClockMinutes`. `new Date(null)` becomes `1970-01-01T00:00:00Z`, which falls inside any window overlapping 00:00 UTC (e.g. `22:00-07:00 UTC`) and the function silently returns `true` — suppressing every push for that token.

This PR adds a `Number.isFinite(now)` guard at the entry of `isInQuietHoursIn`. Fail-open (return `false`) matches the rest of the function's defensive posture: it is strictly better to deliver a push than to silently swallow all of them on a caller bug.

All in-tree callers pass `Date.now()` today, so this is a hardening patch with no behavioural change for valid input.

## Changes

- `packages/server/src/notification-prefs.js` — early-return `false` when `!Number.isFinite(now)` (with comment explaining the failure mode and fail-open rationale).
- `packages/server/tests/notification-prefs-quiet-hours.test.js` — new defensive test case covering `null`, `undefined`, `NaN`, `Infinity`, `-Infinity`, string-numeric, and object inputs against a `22:00-07:00 UTC` window (the case where the pre-fix bug returns `true`).

## Test Plan

- [x] TDD: added test fails on `main` with `true !== false` for `now=null`
- [x] After fix: `notification-prefs-quiet-hours.test.js` — 47/47 pass
- [x] `notification-prefs.test.js` + `push.test.js` — 61/61 pass
- [x] No semicolons, single quotes, ES modules (server style)
- [x] Scope is narrow to the `Number.isFinite` guard inside `isInQuietHoursIn` (no overlap with parallel #4566 `sanitizeQuietHours` work)

Closes #4567