### PR TITLE
style(dashboard): add CSS for per-device notification row visual hierarchy

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -909,6 +909,18 @@ describe('SettingsPanel', () => {
       expect(muteLabel!.getAttribute('for')).toBe('notification-prefs-device-result')
       expect(muteLabel!.textContent).toBe('Mute on this device')
     })
+
+    it('applies the .notification-prefs-device-row class for visual hierarchy (#4563)', () => {
+      // Regression for #4563: the per-device row must carry the
+      // `notification-prefs-device-row` className so the matching CSS rule
+      // (indent + muted label) renders it as subordinate to the global
+      // per-category toggle. Without the class the row reads as a sibling
+      // toggle — the original visual-hierarchy bug.
+      setMockState({ notificationPrefs: defaultPrefs })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const row = screen.getByTestId('notification-prefs-device-row-result')
+      expect(row.classList.contains('notification-prefs-device-row')).toBe(true)
+    })
   })
 
   describe('Notification preferences — quiet-hours editor (#4544)', () => {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4911,6 +4911,32 @@
   margin-bottom: 0;
 }
 
+/* #4563: per-device "Mute on this device" row inside each notification
+   category <li>. The row is logically subordinate to the global per-category
+   toggle (which lives on the same <li>), so it needs visible hierarchy:
+   indent to the right of the parent checkbox, plus muted color/smaller font
+   so users don't read it as a sibling toggle. Mirrors the mobile-app
+   `deviceOverrideRow` (paddingLeft: 32) for cross-surface parity. */
+.notification-prefs-device-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+  padding-left: 24px;
+}
+
+.notification-prefs-device-row input[type='checkbox'] {
+  cursor: pointer;
+  accent-color: var(--accent-blue);
+  margin: 0;
+}
+
+.notification-prefs-device-row label {
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
 /* #3404 audit F1: per-provider auth/billing status panel */
 .settings-hint {
   margin: 0 0 12px;


### PR DESCRIPTION
## Summary

PR #4561 (per-device notification opt-in/out UI, #4543) added a per-device "Mute on this device" row inside each notification category `<li>` in `SettingsPanel.tsx`, using `className="notification-prefs-device-row"` — but no matching CSS rule was added. The row inherited default styling and read as a sibling toggle rather than as a subordinate of the global per-category one, blurring the hierarchy.

This PR adds the missing CSS rule so the row reads as visibly subordinate, mirroring the mobile-app `deviceOverrideRow` (`paddingLeft: 32`) for cross-surface parity.

- `packages/dashboard/src/theme/components.css`: new `.notification-prefs-device-row` block with `padding-left: 24px` to indent under the parent checkbox, plus nested rules for the input (`accent-color: var(--accent-blue)`) and the label (`font-size: 12px; color: var(--text-muted)`) so the secondary text reads as muted hint-level affordance.
- `packages/dashboard/src/components/SettingsPanel.test.tsx`: regression test asserting the wrapper carries the className (catches future refactors that drop the class).

All theme values use existing CSS variables (`--text-muted`, `--accent-blue`) so dark/light themes continue to work.

## Acceptance criteria from #4563

- [x] CSS rule for `.notification-prefs-device-row` exists in the dashboard's stylesheet
- [x] Rule includes a left indent (24px) so the row reads as subordinate to the parent category
- [x] Rule includes a subdued color/font-size for the "Mute on this device" label text
- [x] Per-device toggle is clearly distinct from the global one and from the hint paragraph

## Test plan

- [x] `npx vitest run src/components/SettingsPanel` — **75/75 pass** (includes the new regression test)
- [x] `npx tsc --noEmit` — clean
- [ ] Visual check on the dashboard — see indented muted "Mute on this device" sub-row under each category toggle

Closes #4563
Related to #4561 / #4543 (per-device UI foundation)