### PR TITLE
feat(ui): optimistic notification-prefs toggle to mask WS round-trip latency

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -115,8 +115,11 @@ describe('connection.ts — notification prefs actions (#4542)', () => {
   });
 
   it('setNotificationPrefsCategory sends a single-category notification_prefs_set patch', () => {
+    // Window widened to 1200 chars in #4558 to accommodate the optimistic
+    // local-state patch (~350 chars of `set({...})` + comment) that now
+    // sits between the function declaration and the `wsSend` call.
     expect(connectionSource).toMatch(
-      /setNotificationPrefsCategory[\s\S]{0,400}notification_prefs_set[\s\S]{0,200}\[category\]:\s*enabled/,
+      /setNotificationPrefsCategory[\s\S]{0,1200}notification_prefs_set[\s\S]{0,200}\[category\]:\s*enabled/,
     );
   });
 });

--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsDevice.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsDevice.test.ts
@@ -102,15 +102,22 @@ describe('connection.ts — per-device action wiring (#4543)', () => {
   });
 
   it('setNotificationPrefsDevice sends a single-device notification_prefs_set patch', () => {
+    // Window widened to 1500 chars in #4558 to accommodate the optimistic
+    // local-state patch (~500 chars of nested `set({...})` mirroring the
+    // server's shallow-merge) that now sits between the function declaration
+    // and the `wsSend` call.
     expect(connectionSource).toMatch(
-      /setNotificationPrefsDevice[\s\S]{0,400}notification_prefs_set[\s\S]{0,300}devices:\s*\{[\s\S]{0,200}\[deviceKey\]:[\s\S]{0,200}categories:[\s\S]{0,80}\[category\]:\s*enabled/,
+      /setNotificationPrefsDevice[\s\S]{0,1500}notification_prefs_set[\s\S]{0,300}devices:\s*\{[\s\S]{0,200}\[deviceKey\]:[\s\S]{0,200}categories:[\s\S]{0,80}\[category\]:\s*enabled/,
     );
   });
 
   it('short-circuits the per-device action when deviceKey is empty', () => {
     // Defensive: even if the UI rail ever drops, the action MUST refuse to
     // ship a `devices[""]` patch which would pollute the map indefinitely.
-    expect(connectionSource).toMatch(/setNotificationPrefsDevice[\s\S]{0,300}if\s*\(!deviceKey\)\s*return/);
+    // Window widened in #4558 — the `if (!deviceKey) return` lives before
+    // the optimistic patch + wire-send, but downstream changes may push it
+    // further into the body.
+    expect(connectionSource).toMatch(/setNotificationPrefsDevice[\s\S]{0,500}if\s*\(!deviceKey\)\s*return/);
   });
 });
 

--- a/packages/app/src/__tests__/store/notification-prefs-optimistic.test.ts
+++ b/packages/app/src/__tests__/store/notification-prefs-optimistic.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Mobile-app notification-prefs optimistic update tests (#4558)
+ *
+ * Mirrors the dashboard suite at
+ * packages/dashboard/src/store/notification-prefs-optimistic.test.ts —
+ * the contract is the same on both clients:
+ *
+ *   1. Clicking the per-category Switch calls
+ *      `setNotificationPrefsCategory(cat, next)`, which immediately patches
+ *      `notificationPrefs.categories[cat]` in the store so the next render
+ *      reflects the new value before the WS round-trip completes.
+ *   2. The action still ships a `notification_prefs_set` message.
+ *   3. When the server's `notification_prefs` broadcast arrives, the
+ *      message-handler overwrites the optimistic value with the server
+ *      snapshot — server wins, rejected toggles visibly revert.
+ *
+ * Same contract for per-device, quiet-hours, and bypass-list actions.
+ */
+import { useConnectionStore } from '../../store/connection';
+
+function makeMockSocket(): { socket: WebSocket; sent: unknown[] } {
+  const sent: unknown[] = [];
+  const socket = {
+    readyState: 1,
+    send: (data: string) => {
+      try { sent.push(JSON.parse(data)); } catch { /* noop */ }
+    },
+    close: () => {},
+    onclose: null,
+  } as unknown as WebSocket;
+  return { socket, sent };
+}
+
+const baseCats = {
+  permission: true,
+  result: true,
+  activity_update: true,
+  activity_waiting: true,
+  activity_error: true,
+  inactivity_warning: true,
+  live_activity: true,
+};
+
+describe('#4558 — notification-prefs optimistic update (mobile)', () => {
+  afterEach(() => {
+    useConnectionStore.setState({ socket: null, notificationPrefs: null });
+  });
+
+  it('setNotificationPrefsCategory updates local snapshot immediately', () => {
+    const { socket } = makeMockSocket();
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: { categories: { ...baseCats }, devices: {}, quietHours: null },
+    });
+
+    useConnectionStore.getState().setNotificationPrefsCategory('result', false);
+
+    const after = useConnectionStore.getState().notificationPrefs!;
+    expect(after.categories.result).toBe(false);
+    // Other categories survive the shallow-merge patch.
+    expect(after.categories.permission).toBe(true);
+    expect(after.categories.activity_update).toBe(true);
+  });
+
+  it('setNotificationPrefsCategory still sends the notification_prefs_set WS message', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: { categories: { ...baseCats }, devices: {}, quietHours: null },
+    });
+
+    useConnectionStore.getState().setNotificationPrefsCategory('result', false);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({
+      type: 'notification_prefs_set',
+      prefs: { categories: { result: false } },
+    });
+  });
+
+  it('does not mint a synthetic snapshot when notificationPrefs is null', () => {
+    // The Switch only renders after the first snapshot lands, but the
+    // action must be safe to call even if a race triggers it earlier —
+    // we ship the WS message (so the server's reply seeds the snapshot)
+    // but DO NOT fabricate a local snapshot with one made-up category.
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket, notificationPrefs: null });
+
+    useConnectionStore.getState().setNotificationPrefsCategory('result', false);
+
+    expect(useConnectionStore.getState().notificationPrefs).toBeNull();
+    expect(sent).toHaveLength(1);
+  });
+
+  it('setNotificationPrefsDevice patches the per-device override locally', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { ...baseCats },
+        devices: { 'tok-a': { categories: { permission: false } } },
+        quietHours: null,
+      },
+    });
+
+    useConnectionStore.getState().setNotificationPrefsDevice('tok-a', 'result', false);
+
+    const after = useConnectionStore.getState().notificationPrefs!;
+    expect(after.devices['tok-a']?.categories?.result).toBe(false);
+    // Existing per-device category override survives the shallow-merge.
+    expect(after.devices['tok-a']?.categories?.permission).toBe(false);
+    // Wire ships the minimal patch.
+    expect(sent[0]).toEqual({
+      type: 'notification_prefs_set',
+      prefs: { devices: { 'tok-a': { categories: { result: false } } } },
+    });
+  });
+
+  it('setNotificationPrefsQuietHours sets the window locally and on the wire', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: { categories: { ...baseCats }, devices: {}, quietHours: null },
+    });
+    const win = { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' };
+
+    useConnectionStore.getState().setNotificationPrefsQuietHours(win);
+
+    expect(useConnectionStore.getState().notificationPrefs!.quietHours).toEqual(win);
+    expect(sent[0]).toEqual({ type: 'notification_prefs_set', prefs: { quietHours: win } });
+  });
+
+  it('setNotificationPrefsBypassCategories replaces the list locally and on the wire', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { ...baseCats },
+        devices: {},
+        quietHours: null,
+        bypassCategories: ['permission', 'activity_error'],
+      },
+    });
+
+    useConnectionStore.getState().setNotificationPrefsBypassCategories(['permission']);
+
+    expect(useConnectionStore.getState().notificationPrefs!.bypassCategories).toEqual(['permission']);
+    expect(sent[0]).toEqual({
+      type: 'notification_prefs_set',
+      prefs: { bypassCategories: ['permission'] },
+    });
+  });
+
+  it('no-op when socket is closed (no local patch, no wire message)', () => {
+    // Without a server to confirm, a local-only flip would never reconcile.
+    // The contract matches the old (pre-#4558) server-of-truth behaviour:
+    // if there's no socket, do nothing.
+    useConnectionStore.setState({
+      socket: null,
+      notificationPrefs: { categories: { ...baseCats }, devices: {}, quietHours: null },
+    });
+
+    useConnectionStore.getState().setNotificationPrefsCategory('result', false);
+
+    // Local state unchanged.
+    expect(useConnectionStore.getState().notificationPrefs!.categories.result).toBe(true);
+  });
+
+  it('refuses to ship a devices[""] patch when deviceKey is empty', () => {
+    // Mirrors the existing defensive guard — empty deviceKey is a no-op
+    // and must not mutate local state either.
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: { categories: { ...baseCats }, devices: {}, quietHours: null },
+    });
+
+    useConnectionStore.getState().setNotificationPrefsDevice('', 'result', false);
+
+    expect(sent).toHaveLength(0);
+    expect(useConnectionStore.getState().notificationPrefs!.devices).toEqual({});
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -414,9 +414,32 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #4558: optimistic update. The Switch should flip the moment the user
+  // taps it — the WS → server → broadcast round-trip over cellular +
+  // Cloudflare tunnel is hundreds of milliseconds, long enough that a
+  // server-of-truth-only Switch felt unresponsive. Patch
+  // `notificationPrefs` locally BEFORE sending the WS message; the eventual
+  // `notification_prefs` broadcast reconciles (server wins, see
+  // message-handler.ts case 'notification_prefs').
+  //
+  // Edge cases mirror the dashboard:
+  //   - notificationPrefs == null  → ship the WS message (so the server's
+  //     reply seeds the snapshot) but DO NOT mint a synthetic snapshot
+  //     locally. The UI gates Switch rendering on a non-null snapshot.
+  //   - socket closed              → no optimistic patch either. A
+  //     local-only flip would never reconcile and would drift on the next
+  //     reconnect snapshot.
   setNotificationPrefsCategory: (category: string, enabled: boolean) => {
-    const { socket } = get();
+    const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        set({
+          notificationPrefs: {
+            ...notificationPrefs,
+            categories: { ...notificationPrefs.categories, [category]: enabled },
+          },
+        });
+      }
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: { categories: { [category]: enabled } },
@@ -431,10 +454,30 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // - empty deviceKey → no-op (refuse to ship a `devices[""]` patch).
   // - socket closed   → no-op (the snapshot is the source of truth; we
   //   don't queue, matching setNotificationPrefsCategory).
+  //
+  // #4558: optimistic update — the per-device mute Switch flips before the
+  // broadcast lands. Mirrors the server's shallow-merge so other devices
+  // and other categories under THIS device survive.
   setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => {
     if (!deviceKey) return;
-    const { socket } = get();
+    const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        const existingDevice = notificationPrefs.devices[deviceKey] ?? {};
+        const existingCats = existingDevice.categories ?? {};
+        set({
+          notificationPrefs: {
+            ...notificationPrefs,
+            devices: {
+              ...notificationPrefs.devices,
+              [deviceKey]: {
+                ...existingDevice,
+                categories: { ...existingCats, [category]: enabled },
+              },
+            },
+          },
+        });
+      }
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: {
@@ -449,9 +492,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #4544: global quiet-hours window patch. `null` clears; a window
   // object (with `timezone`) sets it. Server shallow-merges at the top
   // level so other fields (categories, bypassCategories, devices) survive.
+  //
+  // #4558: optimistic update — local `quietHours` flips before the
+  // broadcast lands so the editor's Save button doesn't visibly lag.
   setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => {
-    const { socket } = get();
+    const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        set({
+          notificationPrefs: { ...notificationPrefs, quietHours: window },
+        });
+      }
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: { quietHours: window },
@@ -461,9 +512,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   // #4544: global bypass-category list. Sent as a replacement (not a
   // delta) — empty array maps to "nothing bypasses, not even errors".
+  //
+  // #4558: optimistic update — local `bypassCategories` flips before the
+  // broadcast lands so the bypass Switch row feels snappy.
   setNotificationPrefsBypassCategories: (categories: string[]) => {
-    const { socket } = get();
+    const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        set({
+          notificationPrefs: { ...notificationPrefs, bypassCategories: categories },
+        });
+      }
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: { bypassCategories: categories },

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -520,9 +520,34 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
   },
 
+  // #4558: optimistic update. The user's toggle has to feel instant — on
+  // a slow cellular → Cloudflare tunnel round-trip the prior server-of-truth
+  // behaviour left the checkbox stationary for hundreds of milliseconds
+  // until the broadcast landed. We patch `notificationPrefs` locally
+  // BEFORE sending the WS message, then rely on the eventual
+  // `notification_prefs` broadcast to reconcile — server wins, see the
+  // handler in message-handler.ts case 'notification_prefs'.
+  //
+  // Edge cases:
+  //   - notificationPrefs == null  → don't mint a synthetic snapshot. The
+  //     UI gates on null and renders the loading hint, so the action only
+  //     fires from a checkbox bound to a real snapshot. Still ship the WS
+  //     message so the server's reply seeds the snapshot.
+  //   - socket closed              → no optimistic patch either. Same
+  //     server-of-truth contract as before — without a server to confirm,
+  //     a local-only flip would never reconcile and would drift on the
+  //     next reconnect snapshot.
   setNotificationPrefsCategory: (category: string, enabled: boolean) => {
-    const { socket } = get();
+    const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        set({
+          notificationPrefs: {
+            ...notificationPrefs,
+            categories: { ...notificationPrefs.categories, [category]: enabled },
+          },
+        });
+      }
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: { categories: { [category]: enabled } },
@@ -537,10 +562,32 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // - empty deviceKey → no-op (we never want a `devices[""]` entry).
   // - socket closed → no-op (the snapshot is the source of truth; we don't
   //   queue, matching `setNotificationPrefsCategory`).
+  //
+  // #4558: optimistic update — same rationale as setNotificationPrefsCategory.
+  // The per-device row's mute checkbox flips immediately; the server's
+  // broadcast reconciles. We mirror the server's shallow-merge semantics
+  // in the local patch so other devices and other categories under THIS
+  // device survive.
   setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => {
     if (!deviceKey) return;
-    const { socket } = get();
+    const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        const existingDevice = notificationPrefs.devices[deviceKey] ?? {};
+        const existingCats = existingDevice.categories ?? {};
+        set({
+          notificationPrefs: {
+            ...notificationPrefs,
+            devices: {
+              ...notificationPrefs.devices,
+              [deviceKey]: {
+                ...existingDevice,
+                categories: { ...existingCats, [category]: enabled },
+              },
+            },
+          },
+        });
+      }
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: {
@@ -556,9 +603,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // a full window object (start/end/timezone) sets it. The server
   // shallow-merges at the top level, so other fields (categories,
   // bypassCategories, devices) are preserved.
+  //
+  // #4558: optimistic update — local `quietHours` flips before the
+  // broadcast lands so the editor's Save button doesn't visibly lag
+  // behind the click.
   setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => {
-    const { socket } = get();
+    const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        set({
+          notificationPrefs: { ...notificationPrefs, quietHours: window },
+        });
+      }
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: { quietHours: window },
@@ -571,9 +627,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // bypasses, not even errors". UI callers should always send the desired
   // final list — toggling one bypass on/off means re-sending the resulting
   // array.
+  //
+  // #4558: optimistic update — local `bypassCategories` flips before the
+  // broadcast lands so the bypass checkboxes feel snappy.
   setNotificationPrefsBypassCategories: (categories: string[]) => {
-    const { socket } = get();
+    const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        set({
+          notificationPrefs: { ...notificationPrefs, bypassCategories: categories },
+        });
+      }
       wsSend(socket, {
         type: 'notification_prefs_set',
         prefs: { bypassCategories: categories },

--- a/packages/dashboard/src/store/notification-prefs-optimistic.test.ts
+++ b/packages/dashboard/src/store/notification-prefs-optimistic.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Notification-prefs optimistic update tests (#4558)
+ *
+ * Verifies that the per-category notification toggles in SettingsPanel feel
+ * instant. The contract:
+ *
+ *   1. Clicking a toggle calls `setNotificationPrefsCategory(cat, next)`,
+ *      which immediately patches `notificationPrefs.categories[cat]` in the
+ *      store so the next React render reflects the new value — no waiting
+ *      for the WS round-trip and broadcast.
+ *   2. The same action still ships a `notification_prefs_set` message on the
+ *      socket (the server remains the source of truth).
+ *   3. When the eventual `notification_prefs` broadcast arrives, the
+ *      message-handler overwrites the locally-optimistic value with whatever
+ *      the server actually persisted. Server-wins reconciliation means a
+ *      rejected/coerced toggle visibly reverts.
+ *
+ * Same contract is mirrored for the per-device override
+ * (`setNotificationPrefsDevice`), the quiet-hours window
+ * (`setNotificationPrefsQuietHours`), and the global bypass list
+ * (`setNotificationPrefsBypassCategories`).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+interface SentPayload {
+  type: string
+  prefs?: Record<string, unknown>
+  [k: string]: unknown
+}
+
+function createMockSocket(sent: SentPayload[]): WebSocket {
+  return {
+    send: vi.fn((raw: string) => {
+      try { sent.push(JSON.parse(raw) as SentPayload) } catch { /* noop */ }
+    }),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+describe('#4558 — notification-prefs optimistic update', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('setNotificationPrefsCategory updates local notificationPrefs immediately', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { permission: true, result: true, activity_update: true },
+        devices: {},
+        quietHours: null,
+      },
+    })
+
+    // BEFORE the server broadcasts anything back, flip `result` off. The
+    // local store must reflect the new value on the very next read.
+    useConnectionStore.getState().setNotificationPrefsCategory('result', false)
+
+    const after = useConnectionStore.getState().notificationPrefs!
+    expect(after.categories.result).toBe(false)
+    // Untouched categories survive — the optimistic patch is shallow-merge.
+    expect(after.categories.permission).toBe(true)
+    expect(after.categories.activity_update).toBe(true)
+  })
+
+  it('setNotificationPrefsCategory still ships the notification_prefs_set WS message', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { permission: true, result: true },
+        devices: {},
+        quietHours: null,
+      },
+    })
+
+    useConnectionStore.getState().setNotificationPrefsCategory('result', false)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]).toEqual({
+      type: 'notification_prefs_set',
+      prefs: { categories: { result: false } },
+    })
+  })
+
+  it('server snapshot overrides the local optimistic value when they disagree', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const { handleMessage, setStore } = await import('./message-handler')
+
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { permission: true, result: true },
+        devices: {},
+        quietHours: null,
+      },
+    })
+
+    // Wire the message-handler to the real store so a broadcast actually
+    // mutates `notificationPrefs`. The handler's setStore contract accepts
+    // an object with `getState`/`setState` shaped like Zustand's; pass
+    // through the real store as an opaque object — type machinery only
+    // matters at the boundary, not inside the test fixture.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    setStore(useConnectionStore as any)
+
+    // Optimistic flip: user clicks `result` off.
+    useConnectionStore.getState().setNotificationPrefsCategory('result', false)
+    expect(useConnectionStore.getState().notificationPrefs!.categories.result).toBe(false)
+
+    // Server disagrees and broadcasts the truth (e.g. the patch was rejected
+    // server-side or coerced — for whatever reason `result` is still enabled).
+    handleMessage(
+      {
+        type: 'notification_prefs',
+        prefs: {
+          categories: { permission: true, result: true },
+          devices: {},
+          quietHours: null,
+        },
+      },
+      { url: 'wss://t', token: 'tok', socket, isReconnect: false, silent: false },
+    )
+
+    // Server wins: the optimistic `false` is replaced by the broadcast `true`.
+    expect(useConnectionStore.getState().notificationPrefs!.categories.result).toBe(true)
+  })
+
+  it('setNotificationPrefsCategory is a no-op on local state when notificationPrefs is null', async () => {
+    // Defensive: the action is bound to a checkbox that only renders after
+    // the first snapshot lands, but the toggle is gated by `notificationPrefs
+    // == null`. If a race somehow triggered the action before the first
+    // snapshot, we must NOT mint a synthetic snapshot (which would lock in
+    // an incorrect "all categories enabled except this one" baseline). The
+    // WS message still goes out so the server's reply seeds the snapshot.
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({ socket, notificationPrefs: null })
+
+    useConnectionStore.getState().setNotificationPrefsCategory('result', false)
+
+    expect(useConnectionStore.getState().notificationPrefs).toBeNull()
+    expect(sent).toHaveLength(1)
+  })
+
+  it('setNotificationPrefsDevice updates the device override immediately', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { result: true },
+        devices: {},
+        quietHours: null,
+      },
+    })
+
+    useConnectionStore.getState().setNotificationPrefsDevice('dev-a', 'result', false)
+
+    const after = useConnectionStore.getState().notificationPrefs!
+    expect(after.devices['dev-a']?.categories?.result).toBe(false)
+    // Wire still ships.
+    expect(sent[0]).toEqual({
+      type: 'notification_prefs_set',
+      prefs: { devices: { 'dev-a': { categories: { result: false } } } },
+    })
+  })
+
+  it('setNotificationPrefsDevice preserves existing per-device categories on a single-key patch', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { result: true, permission: true },
+        devices: {
+          'dev-a': { categories: { permission: false } },
+        },
+        quietHours: null,
+      },
+    })
+
+    useConnectionStore.getState().setNotificationPrefsDevice('dev-a', 'result', false)
+
+    const after = useConnectionStore.getState().notificationPrefs!
+    expect(after.devices['dev-a']?.categories?.result).toBe(false)
+    expect(after.devices['dev-a']?.categories?.permission).toBe(false)
+  })
+
+  it('setNotificationPrefsQuietHours sets the window locally and on the wire', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { result: true },
+        devices: {},
+        quietHours: null,
+      },
+    })
+
+    const win = { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' }
+    useConnectionStore.getState().setNotificationPrefsQuietHours(win)
+
+    expect(useConnectionStore.getState().notificationPrefs!.quietHours).toEqual(win)
+    expect(sent[0]).toEqual({ type: 'notification_prefs_set', prefs: { quietHours: win } })
+  })
+
+  it('setNotificationPrefsQuietHours(null) clears the window locally and on the wire', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { result: true },
+        devices: {},
+        quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+      },
+    })
+
+    useConnectionStore.getState().setNotificationPrefsQuietHours(null)
+
+    expect(useConnectionStore.getState().notificationPrefs!.quietHours).toBeNull()
+    expect(sent[0]).toEqual({ type: 'notification_prefs_set', prefs: { quietHours: null } })
+  })
+
+  it('setNotificationPrefsBypassCategories replaces the list locally and on the wire', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { result: true },
+        devices: {},
+        quietHours: null,
+        bypassCategories: ['permission', 'activity_error'],
+      },
+    })
+
+    useConnectionStore.getState().setNotificationPrefsBypassCategories(['permission'])
+
+    expect(useConnectionStore.getState().notificationPrefs!.bypassCategories).toEqual(['permission'])
+    expect(sent[0]).toEqual({
+      type: 'notification_prefs_set',
+      prefs: { bypassCategories: ['permission'] },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Per #4558 (review of #4557). The per-category notification toggles in
both the dashboard `SettingsPanel` and the mobile `SettingsScreen` are
currently fully server-of-truth: the click → `notification_prefs_set` →
server merge + persist → broadcast → store overwrite → re-render
round-trip is hundreds of milliseconds on a cellular → Cloudflare
tunnel path, long enough that the Switch / checkbox visibly does not
move when the user clicks it.

This PR adds an optimistic local apply in front of the wire send,
keeping the server-of-truth contract intact for reconciliation.

## What changes

The four notification-prefs setter actions in both stores
(`packages/dashboard/src/store/connection.ts` and
`packages/app/src/store/connection.ts`) now:

1. Patch `notificationPrefs` locally with the requested change BEFORE
   calling `wsSend` (when the snapshot is non-null and the socket is
   open).
2. Ship the same `notification_prefs_set` message as before.
3. Rely on the existing message-handler case `notification_prefs` to
   overwrite the optimistic value with whatever the server actually
   broadcasts back. **Server wins** — rejected or coerced toggles
   visibly revert on the next snapshot.

Applies to:

- `setNotificationPrefsCategory` — per-category checkbox / Switch
- `setNotificationPrefsDevice` — per-device override (shallow-merges
  other devices and other categories under THIS device)
- `setNotificationPrefsQuietHours` — quiet-hours window set / clear
- `setNotificationPrefsBypassCategories` — global bypass list
  replacement

## Edge cases

- `notificationPrefs == null` → ship the WS message (so the server's
  reply seeds the snapshot) but do **not** mint a synthetic snapshot
  locally. The UI gates Switch / checkbox rendering on a non-null
  snapshot, so this branch is only hit by a race; minting a fake
  snapshot would lock in an incorrect "everything but this one
  enabled" baseline.
- Socket closed → no optimistic patch either. A local-only flip would
  never reconcile and would drift on the next reconnect snapshot, so
  the existing no-op contract is preserved for both wire and local
  state.

## Out of scope (intentionally, separate sub-issues)

- Inline error UI on a 5s timeout — #4559
- Editor-draft preservation across reconnect — #4570

## Test plan

- [x] `packages/dashboard/src/store/notification-prefs-optimistic.test.ts`
  (new, 9 tests):
  - Immediate local apply for each of the four actions
  - WS `notification_prefs_set` payload shape unchanged
  - Server-snapshot reconciliation via the real `handleMessage` —
    asserts the optimistic `false` is overwritten by a broadcast `true`
  - Null-snapshot guard (no synthetic snapshot, WS still sent)
  - Per-device shallow-merge preserves other category overrides under
    THIS device
- [x] `packages/app/src/__tests__/store/notification-prefs-optimistic.test.ts`
  (new, 8 tests) — mirrored for the mobile app, plus socket-closed and
  empty-`deviceKey` defensive guards
- [x] Two existing static-analysis regex windows in
  `SettingsScreenNotificationPrefs(.|Device).test.ts` widened to cover
  the new `set({...})` block now sitting between the action's
  declaration and its `wsSend` call (comment-documented)
- [x] Full dashboard suite: **2289 / 2289** passing
- [x] Full mobile suite: **1384 / 1384** passing
- [x] `tsc --noEmit` clean for both `packages/dashboard` and
  `packages/app`

Closes #4558