### PR TITLE
perf(server): memoize Intl.DateTimeFormat per timezone in quiet-hours gate

### DIFF
--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -393,6 +393,55 @@ export function shouldBypassQuietHours(prefs, category, pushToken) {
 }
 
 /**
+ * Memoized `Intl.DateTimeFormat` instances keyed by IANA timezone (#4568).
+ *
+ * The quiet-hours gate runs once per registered push token per
+ * `PushManager.send()` call. Each `Intl.DateTimeFormat` instance carries a
+ * few KB of locale data, so re-allocating on every call wastes work in a hot
+ * path that scales with token count.
+ *
+ * Bounded memory: the set of timezones in real prefs is tiny (one global
+ * window plus at most one per device) and stable for the process lifetime,
+ * so a plain `Map` with no eviction is safe — no LRU bookkeeping needed.
+ * If a future feature lets users construct ad-hoc timezone strings (e.g.
+ * from untrusted input), revisit this; today every timezone arrives via
+ * `sanitizeQuietHours`, which only persists strings the constructor accepts.
+ *
+ * Failure-cache policy: we only cache SUCCESSFUL constructions. A
+ * `RangeError` from an unrecognised IANA zone returns `null` upstream so
+ * the gate fail-opens; never caching the failure means a later prefs reload
+ * that fixes the typo will reconstruct cleanly with the same key.
+ */
+const _dtfCache = new Map()
+
+/**
+ * Test-only escape hatch: clear the cached formatters so a test can
+ * deterministically count constructor invocations (e.g. by spying on
+ * `Intl.DateTimeFormat`). Production code never needs this — the cache is
+ * correct for the process lifetime.
+ */
+export function _resetDateTimeFormatCacheForTests() {
+  _dtfCache.clear()
+}
+
+function _getDateTimeFormat(timezone) {
+  let dtf = _dtfCache.get(timezone)
+  if (dtf) return dtf
+  try {
+    dtf = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    })
+  } catch {
+    return null
+  }
+  _dtfCache.set(timezone, dtf)
+  return dtf
+}
+
+/**
  * Format `now` (epoch ms) in the given IANA timezone and return its
  * minute-of-day (0..1439). Uses `Intl.DateTimeFormat` with a 24-hour
  * `h23` cycle so DST transitions and non-Pacific zones are handled
@@ -400,20 +449,13 @@ export function shouldBypassQuietHours(prefs, category, pushToken) {
  *
  * Returns `null` when the timezone is unrecognised (Node throws
  * `RangeError` from the constructor; we treat that as a malformed window
- * and let the caller fail open).
+ * and let the caller fail open). Formatter instances are memoized in
+ * `_dtfCache` to avoid re-allocating locale data on every call (#4568).
  */
 function _wallClockMinutes(now, timezone) {
-  let parts
-  try {
-    parts = new Intl.DateTimeFormat('en-US', {
-      timeZone: timezone,
-      hour: '2-digit',
-      minute: '2-digit',
-      hourCycle: 'h23',
-    }).formatToParts(new Date(now))
-  } catch {
-    return null
-  }
+  const dtf = _getDateTimeFormat(timezone)
+  if (!dtf) return null
+  const parts = dtf.formatToParts(new Date(now))
   const hour = Number(parts.find((p) => p.type === 'hour')?.value)
   const minute = Number(parts.find((p) => p.type === 'minute')?.value)
   if (!Number.isFinite(hour) || !Number.isFinite(minute)) return null

--- a/packages/server/tests/notification-prefs-quiet-hours.test.js
+++ b/packages/server/tests/notification-prefs-quiet-hours.test.js
@@ -32,6 +32,7 @@ import {
   resolveBypassCategories,
   shouldBypassQuietHours,
   DEFAULT_BYPASS_CATEGORIES,
+  _resetDateTimeFormatCacheForTests,
 } from '../src/notification-prefs.js'
 
 let tmpDir
@@ -666,6 +667,140 @@ describe('savePrefs — round-trip extended schema (#4544)', () => {
     assert.deepEqual([...reread.bypassCategories].sort(), ['activity_error', 'permission'])
     assert.equal(reread.devices['phone-1'].quietHours.timezone, 'America/Los_Angeles')
     assert.deepEqual(reread.devices['phone-1'].bypassCategories, ['permission'])
+  })
+})
+
+describe('isInQuietHoursIn — Intl.DateTimeFormat memoization (#4568)', () => {
+  // The gate runs once per registered push token per `PushManager.send()` call.
+  // Constructing a fresh `Intl.DateTimeFormat` instance for every call wastes
+  // a few KB of locale data on each hit; the set of timezones in real prefs is
+  // tiny (one global + at most one per device) and stable across the process
+  // lifetime, so a module-local Map is the right shape. These tests pin both
+  // the "construct exactly once per timezone" contract and the "still produces
+  // correct results across calls" invariant so a future refactor of the cache
+  // (e.g. swapping in LRU eviction) cannot silently break either.
+  let OriginalDTF
+  let constructionCalls
+
+  beforeEach(() => {
+    // Reset the module-level formatter cache so each test starts from a
+    // known state — earlier suites (DST, midnight-wrap) populated the cache
+    // for common timezones via the real `Intl.DateTimeFormat`, which would
+    // otherwise mask the contract this suite is pinning.
+    _resetDateTimeFormatCacheForTests()
+    OriginalDTF = Intl.DateTimeFormat
+    constructionCalls = []
+    function SpyDTF(...args) {
+      // Record the timezone arg so a regression that keys the cache wrong
+      // (e.g. on locale instead of timezone) shows up as duplicate entries.
+      constructionCalls.push(args?.[1]?.timeZone ?? null)
+      return new OriginalDTF(...args)
+    }
+    // Preserve static methods (supportedLocalesOf etc.) so any caller that
+    // touches them keeps working during the test window.
+    Object.setPrototypeOf(SpyDTF, OriginalDTF)
+    Intl.DateTimeFormat = SpyDTF
+  })
+
+  afterEach(() => {
+    Intl.DateTimeFormat = OriginalDTF
+    // Clear again so any subsequent suite that doesn't expect the spy's
+    // residue in the cache (none today, but defensive) starts clean.
+    _resetDateTimeFormatCacheForTests()
+  })
+
+  it('constructs Intl.DateTimeFormat once per timezone across repeated calls', async () => {
+    // Re-import the module after the spy is installed so the module-level
+    // cache is populated against the spied constructor. (The cache itself
+    // lives across calls within the test process; what we're asserting is
+    // that within one timezone, repeated gate evaluations never re-allocate.)
+    const { isInQuietHoursIn } = await import('../src/notification-prefs.js')
+    const prefs = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+    }
+    // First call may also construct one extra DTF inside the test's
+    // `dateInZone` helper — count only constructions targeting the gate's
+    // timezone to isolate the contract.
+    isInQuietHoursIn(prefs, Date.now(), 'tok')
+    isInQuietHoursIn(prefs, Date.now() + 1000, 'tok')
+    isInQuietHoursIn(prefs, Date.now() + 2000, 'tok')
+    const laConstructions = constructionCalls.filter((tz) => tz === 'America/Los_Angeles')
+    assert.equal(
+      laConstructions.length,
+      1,
+      `expected 1 construction for America/Los_Angeles across 3 gate calls, got ${laConstructions.length}`,
+    )
+  })
+
+  it('constructs a separate Intl.DateTimeFormat for each distinct timezone', async () => {
+    const { isInQuietHoursIn } = await import('../src/notification-prefs.js')
+    const tokyo = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '22:00', end: '07:00', timezone: 'Asia/Tokyo' },
+    }
+    const london = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '22:00', end: '07:00', timezone: 'Europe/London' },
+    }
+    isInQuietHoursIn(tokyo, Date.now(), 'tok-tokyo')
+    isInQuietHoursIn(london, Date.now(), 'tok-london')
+    isInQuietHoursIn(tokyo, Date.now() + 1000, 'tok-tokyo')
+    isInQuietHoursIn(london, Date.now() + 1000, 'tok-london')
+    const tokyoConstructions = constructionCalls.filter((tz) => tz === 'Asia/Tokyo')
+    const londonConstructions = constructionCalls.filter((tz) => tz === 'Europe/London')
+    assert.equal(tokyoConstructions.length, 1, 'Tokyo formatter constructed exactly once')
+    assert.equal(londonConstructions.length, 1, 'London formatter constructed exactly once')
+  })
+
+  it('does NOT cache failed constructions (unrecognised IANA zone)', async () => {
+    // A RangeError from `new Intl.DateTimeFormat(..., { timeZone: <bad> })`
+    // must NOT populate the cache with a sentinel — otherwise a later fix
+    // (e.g. a prefs reload that swaps in a valid zone with the same key)
+    // would never re-attempt construction. The simplest contract is "only
+    // cache successful formatters"; the gate still fail-opens on any error,
+    // and the cache stays correct across hot reloads.
+    const { isInQuietHoursIn } = await import('../src/notification-prefs.js')
+    const prefs = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '22:00', end: '07:00', timezone: 'Not/Real_Zone_4568' },
+    }
+    assert.equal(isInQuietHoursIn(prefs, Date.now(), 'tok'), false, 'fail-open on bad zone')
+    assert.equal(isInQuietHoursIn(prefs, Date.now(), 'tok'), false, 'still fail-open on bad zone')
+    // Both calls SHOULD attempt construction since neither succeeded — pin
+    // this so a future refactor that caches null/undefined breaks the test.
+    const badZoneAttempts = constructionCalls.filter((tz) => tz === 'Not/Real_Zone_4568')
+    assert.equal(
+      badZoneAttempts.length,
+      2,
+      'unsuccessful constructions must NOT be cached — both calls should re-attempt',
+    )
+  })
+
+  it('still produces correct wall-clock results across repeated calls', async () => {
+    // Behavioural regression: confirm the cache returns equivalent results to
+    // a fresh formatter. We re-test the spring-forward DST case from the
+    // existing `isInQuietHoursIn — DST transitions` suite to make sure the
+    // memoized formatter doesn't capture stale offsets across calls.
+    const { isInQuietHoursIn } = await import('../src/notification-prefs.js')
+    const prefs = {
+      categories: {},
+      devices: {},
+      quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+    }
+    // 04:00 PDT on spring-forward Sunday 2026 — inside the window.
+    const insideWindow = dateInZone('America/Los_Angeles', 2026, 3, 8, 4, 0)
+    // 08:00 PDT same day — outside the window.
+    const outsideWindow = dateInZone('America/Los_Angeles', 2026, 3, 8, 8, 0)
+    // Call the gate enough times that any cache miss would be obvious.
+    for (let i = 0; i < 5; i++) {
+      assert.equal(isInQuietHoursIn(prefs, insideWindow.getTime(), 'tok'), true)
+      assert.equal(isInQuietHoursIn(prefs, outsideWindow.getTime(), 'tok'), false)
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

`_wallClockMinutes` in `packages/server/src/notification-prefs.js` allocated a fresh `Intl.DateTimeFormat` on every quiet-hours gate evaluation. Each instance carries a few KB of locale data, and the gate runs once per registered push token per `PushManager.send()` call.

This PR memoizes the formatter in a module-local `Map<timezone, Intl.DateTimeFormat>`, keyed by IANA zone, populated lazily.

## Why this shape

- **Plain `Map`, no eviction.** The set of timezones in real prefs is tiny (one global window + at most one per device) and stable across the process lifetime. LRU bookkeeping would be more code than the cache it protects.
- **Cache only successful constructions.** A `RangeError` from a bad IANA zone returns `null` upstream so the gate fail-opens. We deliberately do NOT cache the failure — a later prefs reload that fixes the typo reconstructs cleanly with the same key.
- **Test-only escape hatch.** `_resetDateTimeFormatCacheForTests` lets spy-on-constructor tests deterministically count invocations. Production code never calls it.

Closes #4568.

## Test plan

- [x] New `isInQuietHoursIn — Intl.DateTimeFormat memoization (#4568)` suite (4 tests):
  - construct exactly once per timezone across repeated gate calls
  - distinct timezones get distinct formatters
  - failed constructions are NOT cached (re-attempts every call)
  - DST spring-forward + boundary results still correct across cache hits
- [x] `npm test` (packages/server): 6094 pass / 5 pre-existing unrelated failures (`TunnelManager Integration (requires cloudflared)`, `WebTaskManager` claude-CLI feature detection, encryption-integration nonce flake — all environmental, unaffected by this change)
- [x] Notification-prefs + push focused run: 123/123 pass