### PR TITLE
fix(ui): preserve quiet-hours editor drafts across snapshot broadcasts

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -233,3 +233,71 @@ describe('connection.ts — quiet-hours actions (#4544)', () => {
     );
   });
 });
+
+// #4570: snapshot broadcasts must not clobber the in-flight quiet-hours
+// draft. The mobile-app test suite is static-source-analysis (mirrors the
+// #4542/#4544 blocks above) — we verify the editor declares a dirty flag,
+// reads it via a ref inside the snapshot effect, parks the divergent
+// snapshot, and surfaces an accept/discard conflict banner. End-to-end
+// behaviour for these guarantees is covered by the dashboard vitest suite.
+describe('SettingsScreen — Quiet-hours editor: snapshot-vs-draft (#4570)', () => {
+  it('declares a dirty flag in the QuietHoursEditor', () => {
+    expect(settingsSource).toMatch(/const\s+\[dirty,\s*setDirty\]\s*=\s*useState\(false\)/);
+  });
+
+  it('mirrors dirty into a ref so the snapshot effect can read it without depending on it', () => {
+    // Adding `dirty` to the snapshot useEffect's dependency array would
+    // re-fire the effect when dirty changes and re-apply the snapshot we
+    // were trying to skip. The ref pattern keeps the effect keyed on `win`
+    // alone, the way #4570 intends.
+    expect(settingsSource).toMatch(/dirtyRef\s*=\s*useRef\(dirty\)/);
+    expect(settingsSource).toMatch(/dirtyRef\.current\s*=\s*dirty/);
+  });
+
+  it('parks the snapshot in pendingSnapshot state when dirty and divergent', () => {
+    expect(settingsSource).toMatch(/pendingSnapshot,\s*setPendingSnapshot/);
+    expect(settingsSource).toMatch(/setPendingSnapshot\(win\)/);
+  });
+
+  it('clears dirty + pendingSnapshot on save', () => {
+    // handleSaveWindow runs setDirty(false) + setPendingSnapshot(undefined)
+    // before forwarding to onWindowChange so the next snapshot echo is
+    // accepted cleanly.
+    expect(settingsSource).toMatch(
+      /handleSaveWindow[\s\S]{0,400}setDirty\(false\)[\s\S]{0,200}setPendingSnapshot\(undefined\)[\s\S]{0,200}onWindowChange\(\{\s*start,\s*end,\s*timezone\s*\}\)/,
+    );
+  });
+
+  it('clears dirty + pendingSnapshot on enable/disable toggle', () => {
+    expect(settingsSource).toMatch(
+      /handleToggleEnable[\s\S]{0,400}setDirty\(false\)[\s\S]{0,200}setPendingSnapshot\(undefined\)/,
+    );
+  });
+
+  it('routes field edits through dirty-flagging setter wrappers', () => {
+    expect(settingsSource).toMatch(/setStartDirty[\s\S]{0,200}setDirty\(true\)/);
+    expect(settingsSource).toMatch(/setEndDirty[\s\S]{0,200}setDirty\(true\)/);
+    expect(settingsSource).toMatch(/setTimezoneDirty[\s\S]{0,200}setDirty\(true\)/);
+    // And the inputs use the dirty-flagging versions, NOT the raw setState.
+    expect(settingsSource).toMatch(/onChangeText=\{setStartDirty\}/);
+    expect(settingsSource).toMatch(/onChangeText=\{setEndDirty\}/);
+  });
+
+  it('renders the conflict banner with accept + discard buttons', () => {
+    expect(settingsSource).toMatch(/testID="quiet-hours-conflict-banner"/);
+    expect(settingsSource).toMatch(/testID="quiet-hours-conflict-accept"/);
+    expect(settingsSource).toMatch(/testID="quiet-hours-conflict-discard"/);
+  });
+
+  it('handleAcceptDraft drops the parked snapshot but keeps the draft', () => {
+    expect(settingsSource).toMatch(
+      /handleAcceptDraft[\s\S]{0,200}setPendingSnapshot\(undefined\)/,
+    );
+  });
+
+  it('handleDiscardDraft applies the parked snapshot and clears dirty', () => {
+    expect(settingsSource).toMatch(
+      /handleDiscardDraft[\s\S]{0,800}setStart\(snap\.start\)[\s\S]{0,200}setDirty\(false\)[\s\S]{0,200}setPendingSnapshot\(undefined\)/,
+    );
+  });
+});

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import {
   View,
   Text,
@@ -774,18 +774,53 @@ function QuietHoursEditor(props: {
   const [timezone, setTimezone] = useState<string>(win?.timezone ?? browserTz);
   const [showTzPicker, setShowTzPicker] = useState(false);
 
+  // #4570: track "user has typed but not saved" so an incoming snapshot
+  // broadcast doesn't clobber the in-flight draft. Cleared on save / disable
+  // / explicit accept. Read via ref inside the snapshot effect so the
+  // dependency array stays minimal (adding `dirty` would re-run the effect
+  // when dirty changes and re-apply the snapshot we just skipped).
+  const [dirty, setDirty] = useState(false);
+  const dirtyRef = useRef(dirty);
+  useEffect(() => { dirtyRef.current = dirty; }, [dirty]);
+
+  // #4570: parked snapshot when a broadcast arrives mid-edit. `undefined`
+  // means no pending conflict; `null` means "remote disabled"; an object
+  // means "remote changed window".
+  const [pendingSnapshot, setPendingSnapshot] = useState<
+    | { start: string; end: string; timezone: string }
+    | null
+    | undefined
+  >(undefined);
+
   // Re-sync draft when the snapshot changes (remote save, broadcast).
+  //
+  // #4570: skip the apply when the editor is dirty AND the incoming
+  // snapshot diverges from the local draft. Park the snapshot so the user
+  // can resolve it via the conflict banner instead of losing their typing.
   useEffect(() => {
+    const isDirty = dirtyRef.current;
+    const matchesDraft = win
+      ? (win.start === start && win.end === end && win.timezone === timezone && enabled)
+      : !enabled;
+    if (isDirty && !matchesDraft) {
+      setPendingSnapshot(win);
+      return;
+    }
     setEnabled(win != null);
     if (win) {
       setStart(win.start);
       setEnd(win.end);
       setTimezone(win.timezone);
     }
+    setPendingSnapshot(undefined);
+    setDirty(false);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [win]);
 
   const handleToggleEnable = useCallback((next: boolean) => {
     setEnabled(next);
+    setDirty(false);
+    setPendingSnapshot(undefined);
     if (!next) {
       onWindowChange(null);
     } else if (win == null) {
@@ -798,8 +833,35 @@ function QuietHoursEditor(props: {
       Alert.alert('Invalid time', 'Use HH:MM (24-hour). Example: 22:00');
       return;
     }
+    setDirty(false);
+    setPendingSnapshot(undefined);
     onWindowChange({ start, end, timezone });
   }, [start, end, timezone, onWindowChange]);
+
+  // #4570: keep the local draft, dismiss the parked snapshot.
+  const handleAcceptDraft = useCallback(() => {
+    setPendingSnapshot(undefined);
+  }, []);
+
+  // #4570: take the remote snapshot, overwrite the draft, clear dirty.
+  const handleDiscardDraft = useCallback(() => {
+    const snap = pendingSnapshot;
+    if (snap === undefined) return;
+    setEnabled(snap != null);
+    if (snap) {
+      setStart(snap.start);
+      setEnd(snap.end);
+      setTimezone(snap.timezone);
+    }
+    setDirty(false);
+    setPendingSnapshot(undefined);
+  }, [pendingSnapshot]);
+
+  // #4570: dirty-tracking wrappers around field setters so every edit path
+  // flips the flag — used by the TextInputs and the timezone picker.
+  const setStartDirty = useCallback((next: string) => { setStart(next); setDirty(true); }, []);
+  const setEndDirty = useCallback((next: string) => { setEnd(next); setDirty(true); }, []);
+  const setTimezoneDirty = useCallback((next: string) => { setTimezone(next); setDirty(true); }, []);
 
   const handleToggleBypass = useCallback((cat: string, next: boolean) => {
     const set = new Set(bypassCategories);
@@ -813,7 +875,9 @@ function QuietHoursEditor(props: {
     return [...known, ...extras];
   }, [categories, bypassCategories]);
 
-  const dirty = enabled && (start !== (win?.start ?? '') || end !== (win?.end ?? '') || timezone !== (win?.timezone ?? ''));
+  // Save button visibility: surface whenever the draft diverges from the
+  // last known snapshot (existing behaviour) OR whenever dirty is set.
+  const saveVisible = enabled && (dirty || start !== (win?.start ?? '') || end !== (win?.end ?? '') || timezone !== (win?.timezone ?? ''));
 
   return (
     <View testID="quiet-hours-editor">
@@ -834,12 +898,42 @@ function QuietHoursEditor(props: {
       </View>
       {enabled && (
         <>
+          {pendingSnapshot !== undefined && (
+            <>
+              <View style={styles.separator} />
+              <View style={styles.row} testID="quiet-hours-conflict-banner">
+                <View style={{ flex: 1, paddingRight: 12 }}>
+                  <Text style={styles.rowLabel}>Another client updated quiet hours</Text>
+                  <Text style={[styles.rowHint, { marginTop: 2 }]}>
+                    Keep your unsaved edits, or discard them and load the
+                    latest values?
+                  </Text>
+                </View>
+              </View>
+              <View style={styles.separator} />
+              <TouchableOpacity
+                style={styles.row}
+                onPress={handleAcceptDraft}
+                testID="quiet-hours-conflict-accept"
+              >
+                <Text style={styles.actionText}>Keep my edits</Text>
+              </TouchableOpacity>
+              <View style={styles.separator} />
+              <TouchableOpacity
+                style={styles.row}
+                onPress={handleDiscardDraft}
+                testID="quiet-hours-conflict-discard"
+              >
+                <Text style={styles.actionText}>Discard and load latest</Text>
+              </TouchableOpacity>
+            </>
+          )}
           <View style={styles.separator} />
           <View style={styles.row}>
             <Text style={styles.rowLabel}>From</Text>
             <TextInput
               value={start}
-              onChangeText={setStart}
+              onChangeText={setStartDirty}
               placeholder="22:00"
               placeholderTextColor={COLORS.textMuted}
               keyboardType="numbers-and-punctuation"
@@ -855,7 +949,7 @@ function QuietHoursEditor(props: {
             <Text style={styles.rowLabel}>To</Text>
             <TextInput
               value={end}
-              onChangeText={setEnd}
+              onChangeText={setEndDirty}
               placeholder="07:00"
               placeholderTextColor={COLORS.textMuted}
               keyboardType="numbers-and-punctuation"
@@ -875,7 +969,7 @@ function QuietHoursEditor(props: {
             <Text style={styles.rowLabel}>Timezone</Text>
             <Text style={styles.rowValue}>{timezone}</Text>
           </TouchableOpacity>
-          {dirty && (
+          {saveVisible && (
             <>
               <View style={styles.separator} />
               <TouchableOpacity
@@ -931,7 +1025,7 @@ function QuietHoursEditor(props: {
                 <TouchableOpacity
                   key={tz}
                   style={[styles.sheetOption, tz === timezone && styles.sheetOptionActive]}
-                  onPress={() => { setTimezone(tz); setShowTzPicker(false); }}
+                  onPress={() => { setTimezoneDirty(tz); setShowTzPicker(false); }}
                 >
                   <Text style={[styles.sheetOptionText, tz === timezone && styles.sheetOptionTextActive]}>
                     {tz === browserTz ? `${tz} (this device)` : tz}

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -1062,5 +1062,183 @@ describe('SettingsPanel', () => {
       expect(permCheck.checked).toBe(true)
       expect(errCheck.checked).toBe(true)
     })
+
+    // #4570: snapshot broadcasts must not clobber unsaved edits.
+    //
+    // Background: PR #4565 wired `useEffect([win])` to re-sync the draft on
+    // every snapshot — which is correct for a remote save with no local
+    // pending changes, but wrong when the user is mid-edit. A broadcast
+    // from another client (or an unrelated notification_prefs_set for a
+    // different field that re-broadcasts the merged snapshot) would
+    // overwrite the user's typed-but-unsaved text. Now: the editor tracks
+    // a `dirty` flag, skips snapshot apply when dirty, and surfaces a
+    // conflict banner with explicit accept/discard.
+    describe('snapshot-vs-draft preservation (#4570)', () => {
+      it('does NOT overwrite the start input when a snapshot arrives mid-edit', () => {
+        const initial = {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        }
+        setMockState({ notificationPrefs: initial })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+        // User starts typing — draft is now dirty.
+        const startInput = screen.getByTestId('quiet-hours-start-input') as HTMLInputElement
+        fireEvent.change(startInput, { target: { value: '23:45' } })
+        expect(startInput.value).toBe('23:45')
+
+        // A new snapshot lands from the server (another client saved a
+        // different end time). Re-render with the new prefs.
+        setMockState({
+          notificationPrefs: {
+            ...baseSnapshot,
+            quietHours: { start: '21:00', end: '06:00', timezone: 'America/Los_Angeles' },
+          },
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+        // The user's in-flight edit is preserved — NOT replaced by the
+        // broadcast value.
+        const startAfter = screen.getByTestId('quiet-hours-start-input') as HTMLInputElement
+        expect(startAfter.value).toBe('23:45')
+      })
+
+      it('surfaces a conflict banner with accept/discard when the snapshot diverges from the dirty draft', () => {
+        const initial = {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        }
+        setMockState({ notificationPrefs: initial })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+        // Make the draft dirty.
+        fireEvent.change(screen.getByTestId('quiet-hours-start-input'), { target: { value: '23:45' } })
+
+        // Snapshot lands from another client with a divergent window.
+        setMockState({
+          notificationPrefs: {
+            ...baseSnapshot,
+            quietHours: { start: '21:00', end: '06:00', timezone: 'America/Los_Angeles' },
+          },
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+        // Banner appears with the explicit accept/discard affordances.
+        expect(screen.getByTestId('quiet-hours-conflict-banner')).toBeInTheDocument()
+        expect(screen.getByTestId('quiet-hours-conflict-accept')).toBeInTheDocument()
+        expect(screen.getByTestId('quiet-hours-conflict-discard')).toBeInTheDocument()
+      })
+
+      it('clicking discard accepts the snapshot, replacing the draft and clearing the banner', () => {
+        const initial = {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        }
+        setMockState({ notificationPrefs: initial })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.change(screen.getByTestId('quiet-hours-start-input'), { target: { value: '23:45' } })
+
+        setMockState({
+          notificationPrefs: {
+            ...baseSnapshot,
+            quietHours: { start: '21:00', end: '06:00', timezone: 'America/Los_Angeles' },
+          },
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('quiet-hours-conflict-discard'))
+
+        // Draft now reflects the snapshot; banner is gone.
+        const startAfter = screen.getByTestId('quiet-hours-start-input') as HTMLInputElement
+        expect(startAfter.value).toBe('21:00')
+        expect(screen.queryByTestId('quiet-hours-conflict-banner')).toBeNull()
+      })
+
+      it('clicking accept keeps the local draft and clears the banner', () => {
+        const initial = {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        }
+        setMockState({ notificationPrefs: initial })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.change(screen.getByTestId('quiet-hours-start-input'), { target: { value: '23:45' } })
+
+        setMockState({
+          notificationPrefs: {
+            ...baseSnapshot,
+            quietHours: { start: '21:00', end: '06:00', timezone: 'America/Los_Angeles' },
+          },
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('quiet-hours-conflict-accept'))
+
+        // Draft preserved; banner dismissed.
+        const startAfter = screen.getByTestId('quiet-hours-start-input') as HTMLInputElement
+        expect(startAfter.value).toBe('23:45')
+        expect(screen.queryByTestId('quiet-hours-conflict-banner')).toBeNull()
+      })
+
+      it('accepts snapshot updates normally when the editor is clean', () => {
+        const initial = {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        }
+        setMockState({ notificationPrefs: initial })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+        // No edits — a fresh snapshot replaces the draft as before.
+        setMockState({
+          notificationPrefs: {
+            ...baseSnapshot,
+            quietHours: { start: '21:00', end: '06:00', timezone: 'America/Los_Angeles' },
+          },
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const startAfter = screen.getByTestId('quiet-hours-start-input') as HTMLInputElement
+        const endAfter = screen.getByTestId('quiet-hours-end-input') as HTMLInputElement
+        expect(startAfter.value).toBe('21:00')
+        expect(endAfter.value).toBe('06:00')
+        expect(screen.queryByTestId('quiet-hours-conflict-banner')).toBeNull()
+      })
+
+      it('accepts the next snapshot after Save (dirty flag clears on save)', () => {
+        const setNotificationPrefsQuietHours = vi.fn()
+        const initial = {
+          ...baseSnapshot,
+          quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+        }
+        setMockState({ notificationPrefs: initial, setNotificationPrefsQuietHours })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+
+        // User edits + saves; dirty clears.
+        fireEvent.change(screen.getByTestId('quiet-hours-start-input'), { target: { value: '23:30' } })
+        fireEvent.click(screen.getByTestId('quiet-hours-save-button'))
+        expect(setNotificationPrefsQuietHours).toHaveBeenCalledWith({
+          start: '23:30', end: '07:00', timezone: 'America/Los_Angeles',
+        })
+
+        // Echo snapshot from server with the saved values arrives — accepted.
+        setMockState({
+          notificationPrefs: {
+            ...baseSnapshot,
+            quietHours: { start: '23:30', end: '07:00', timezone: 'America/Los_Angeles' },
+          },
+          setNotificationPrefsQuietHours,
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        expect(screen.queryByTestId('quiet-hours-conflict-banner')).toBeNull()
+
+        // A subsequent unrelated snapshot still applies normally.
+        setMockState({
+          notificationPrefs: {
+            ...baseSnapshot,
+            quietHours: { start: '00:00', end: '08:00', timezone: 'America/Los_Angeles' },
+          },
+          setNotificationPrefsQuietHours,
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const startAfter = screen.getByTestId('quiet-hours-start-input') as HTMLInputElement
+        expect(startAfter.value).toBe('00:00')
+      })
+    })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -118,6 +118,12 @@ export interface SettingsPanelProps {
  * fire `onWindowChange` once; on `Disable` we send `null`. The bypass
  * checkboxes patch immediately because they're individual booleans that
  * don't benefit from a Save buffer.
+ *
+ * #4570: snapshots arriving mid-edit must not clobber the unsaved draft.
+ * We track a `dirty` flag (true after the user touches any field, false
+ * after Save / Disable / explicit accept). When dirty AND an incoming
+ * snapshot diverges from the user's draft, we hold the draft and surface
+ * a conflict banner with accept (keep mine) / discard (take theirs).
  */
 function QuietHoursEditor(props: {
   window: { start: string; end: string; timezone: string } | null
@@ -139,22 +145,59 @@ function QuietHoursEditor(props: {
   const [end, setEnd] = useState<string>(win?.end ?? '07:00')
   const [timezone, setTimezone] = useState<string>(win?.timezone ?? browserTz)
 
+  // #4570: dirty flips on any edit and clears on save/disable/accept.
+  // The snapshot effect below reads dirty via a ref so we don't add it to
+  // the dependency array (which would re-run the effect when dirty changes
+  // and re-apply the snapshot we were trying to skip).
+  const [dirty, setDirty] = useState(false)
+  const dirtyRef = useRef(dirty)
+  useEffect(() => { dirtyRef.current = dirty }, [dirty])
+
+  // #4570: when a snapshot lands while the draft is dirty AND its values
+  // diverge from the user's draft, we hold the snapshot here and render
+  // the conflict banner. Null = no pending conflict.
+  const [pendingSnapshot, setPendingSnapshot] = useState<
+    | { start: string; end: string; timezone: string }
+    | null
+    | undefined
+  >(undefined)
+
   // Re-sync draft when the snapshot changes (e.g. another client saved a
   // window or the user just hit Save and the broadcast came back). The
   // dependency array intentionally captures the inner fields; comparing
   // object identity wouldn't help since the message-handler always builds
   // a fresh object.
+  //
+  // #4570: skip the apply when the editor is dirty AND the incoming
+  // snapshot diverges from the local draft. Park the snapshot so the user
+  // can resolve via the conflict banner.
   useEffect(() => {
+    const isDirty = dirtyRef.current
+    const matchesDraft = win
+      ? (win.start === start && win.end === end && win.timezone === timezone && enabled)
+      : !enabled
+    if (isDirty && !matchesDraft) {
+      // Hold the snapshot for the user to resolve. We intentionally do NOT
+      // overwrite the draft fields.
+      setPendingSnapshot(win)
+      return
+    }
+    // Clean apply (or snapshot already matches draft — e.g. Save echo).
     setEnabled(win != null)
     if (win) {
       setStart(win.start)
       setEnd(win.end)
       setTimezone(win.timezone)
     }
+    setPendingSnapshot(undefined)
+    setDirty(false)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [win])
 
   const handleToggleEnable = useCallback((next: boolean) => {
     setEnabled(next)
+    setDirty(false)
+    setPendingSnapshot(undefined)
     if (!next) {
       // Sending null on disable wipes the persisted window so the server
       // gate short-circuits. Draft fields stay in form state so the user
@@ -169,8 +212,36 @@ function QuietHoursEditor(props: {
   }, [win, start, end, timezone, onWindowChange])
 
   const handleSaveWindow = useCallback(() => {
+    setDirty(false)
+    setPendingSnapshot(undefined)
     onWindowChange({ start, end, timezone })
   }, [start, end, timezone, onWindowChange])
+
+  // #4570: user keeps their local draft — discard the parked snapshot.
+  // The next divergent snapshot will surface the banner again.
+  const handleAcceptDraft = useCallback(() => {
+    setPendingSnapshot(undefined)
+  }, [])
+
+  // #4570: user takes the remote snapshot — overwrite draft + clear dirty.
+  const handleDiscardDraft = useCallback(() => {
+    const snap = pendingSnapshot
+    if (snap === undefined) return
+    setEnabled(snap != null)
+    if (snap) {
+      setStart(snap.start)
+      setEnd(snap.end)
+      setTimezone(snap.timezone)
+    }
+    setDirty(false)
+    setPendingSnapshot(undefined)
+  }, [pendingSnapshot])
+
+  // #4570: dirty-tracking wrappers around the field setters so every edit
+  // path flips the flag without sprinkling setDirty() through JSX.
+  const setStartDirty = useCallback((next: string) => { setStart(next); setDirty(true) }, [])
+  const setEndDirty = useCallback((next: string) => { setEnd(next); setDirty(true) }, [])
+  const setTimezoneDirty = useCallback((next: string) => { setTimezone(next); setDirty(true) }, [])
 
   const handleToggleBypass = useCallback((cat: string, next: boolean) => {
     const set = new Set(bypassCategories)
@@ -208,13 +279,42 @@ function QuietHoursEditor(props: {
       </div>
       {enabled && (
         <>
+          {pendingSnapshot !== undefined && (
+            <div
+              className="settings-hint quiet-hours-conflict-banner"
+              role="alert"
+              data-testid="quiet-hours-conflict-banner"
+            >
+              <p>
+                Another client updated quiet hours while you were editing.
+                Keep your unsaved changes, or discard them and load the
+                latest values?
+              </p>
+              <div className="settings-field">
+                <button
+                  type="button"
+                  onClick={handleAcceptDraft}
+                  data-testid="quiet-hours-conflict-accept"
+                >
+                  Keep my edits
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDiscardDraft}
+                  data-testid="quiet-hours-conflict-discard"
+                >
+                  Discard and load latest
+                </button>
+              </div>
+            </div>
+          )}
           <div className="settings-field">
             <label htmlFor="quiet-hours-start">From</label>
             <input
               id="quiet-hours-start"
               type="time"
               value={start}
-              onChange={(e) => setStart(e.target.value)}
+              onChange={(e) => setStartDirty(e.target.value)}
               data-testid="quiet-hours-start-input"
             />
           </div>
@@ -224,7 +324,7 @@ function QuietHoursEditor(props: {
               id="quiet-hours-end"
               type="time"
               value={end}
-              onChange={(e) => setEnd(e.target.value)}
+              onChange={(e) => setEndDirty(e.target.value)}
               data-testid="quiet-hours-end-input"
             />
           </div>
@@ -233,7 +333,7 @@ function QuietHoursEditor(props: {
             <select
               id="quiet-hours-timezone"
               value={timezone}
-              onChange={(e) => setTimezone(e.target.value)}
+              onChange={(e) => setTimezoneDirty(e.target.value)}
               data-testid="quiet-hours-timezone-select"
             >
               {tzOptions.map((opt) => (


### PR DESCRIPTION
## Summary

Closes #4570.

PR #4565 wired the quiet-hours editor's `useEffect([win])` to re-sync its draft state on every `notification_prefs` snapshot. That's correct for the "I just hit Save and the broadcast echoed back" case but wrong when the user is mid-edit — an unrelated snapshot from another client (or a re-broadcast triggered by a sibling field) would overwrite the typed-but-unsaved text and the keystrokes would vanish.

## Changes

Both editors (`packages/dashboard/src/components/SettingsPanel.tsx` and `packages/app/src/screens/SettingsScreen.tsx`) gain identical dirty-tracking + conflict-resolution behaviour:

- **Dirty flag.** Every field-edit path (`start`, `end`, `timezone`) routes through a setter wrapper that flips `dirty=true`. Save / Disable / explicit accept clear it.
- **Snapshot effect reads dirty via a ref.** Adding `dirty` to the dep array would re-fire the effect when dirty changes and re-apply the snapshot we were trying to skip. The ref pattern keeps the effect keyed on `win` alone.
- **Park the snapshot.** When dirty AND the incoming snapshot diverges from the local draft, the snapshot is held in `pendingSnapshot` instead of being applied. The user's keystrokes survive.
- **Conflict banner.** A new banner surfaces with explicit affordances:
  - **Keep my edits** — discards the parked snapshot, preserves the draft. The next divergent snapshot will surface the banner again.
  - **Discard and load latest** — overwrites the draft from the parked snapshot, clears dirty, dismisses the banner.
- **Clean editors are unaffected.** When dirty is false (or the snapshot already matches the draft, e.g. Save echo), the existing apply path runs unchanged. No regression to the remote-save sync.

## Test plan

- [x] Dashboard vitest (`packages/dashboard`): 6 new cases in `SettingsPanel.test.tsx` covering mid-edit preservation, banner appearance, accept/discard semantics, clean-editor snapshot acceptance, and post-save acceptance. Full suite green (`2296/2296`).
- [x] Mobile jest (`packages/app`): 9 new static source-analysis cases in `SettingsScreenNotificationPrefs.test.ts` mirroring the established #4542/#4544 pattern — asserts the dirty flag, ref bridge, parked-snapshot state, dirty clears on save/toggle, dirty-flagging setter wrappers, and the conflict banner testIDs. Full suite green (`1393/1393`).
- [x] TypeScript strict (`tsc --noEmit`) passes for both `packages/dashboard` and `packages/app`.

## Notes

- Scoped to the quiet-hours editor only — `#4559` (inline error on WS-closed write) is being implemented in parallel and owns the global error UI.
- The `pendingSnapshot` state distinguishes `undefined` (no conflict) from `null` (remote disabled) so a "remote disabled while I was editing" event surfaces the banner like any other divergence.