### PR TITLE
fix(ui): surface inline error when notification-prefs / BYOK writes fire while WS is closed

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -48,7 +48,10 @@ describe('SettingsScreen — Notification categories section (#4542)', () => {
   it('calls refreshNotificationPrefs on mount via useEffect', () => {
     // The useEffect body must invoke refreshNotificationPrefs(); the
     // dependency array must include the action so React doesn't warn.
-    expect(settingsSource).toMatch(/useEffect\([\s\S]{0,200}refreshNotificationPrefs\(\)/);
+    // #4559 widened the inner gap to 600 chars to accommodate the
+    // ignore-the-boolean-return docblock that explains why the boolean
+    // is unused on the initial mount refresh.
+    expect(settingsSource).toMatch(/useEffect\([\s\S]{0,600}refreshNotificationPrefs\(\)/);
   });
 
   it('shows a loading hint until the first snapshot lands', () => {
@@ -70,8 +73,13 @@ describe('SettingsScreen — Notification categories section (#4542)', () => {
 
   it('passes the toggled value through Switch.onValueChange to setNotificationPrefsCategory', () => {
     // The Switch component MUST forward the new boolean — not the
-    // category name — as the second arg.
-    expect(settingsSource).toMatch(/onValueChange=\{\(value\) => setNotificationPrefsCategory\(cat, value\)\}/);
+    // category name — as the second arg. #4559 routed the call through
+    // a thin handler wrapper (`handleSetCategory`) so the WS-closed
+    // boolean return can drive the inline error banner; the handler
+    // forwards `(cat, value)` to `setNotificationPrefsCategory` so the
+    // wire payload is unchanged.
+    expect(settingsSource).toMatch(/onValueChange=\{\(value\) => handleSetCategory\(cat, value\)\}/);
+    expect(settingsSource).toMatch(/handleSetCategory\s*=\s*useCallback[\s\S]{0,300}setNotificationPrefsCategory\(cat, value\)/);
   });
 
   it('emits a testID per category toggle for E2E + a11y discovery', () => {
@@ -89,11 +97,15 @@ describe('ConnectionState — notification prefs surface (#4542)', () => {
   });
 
   it('declares refreshNotificationPrefs in ServerNotificationActions', () => {
-    expect(typesSource).toMatch(/refreshNotificationPrefs:\s*\(\)\s*=>\s*void/);
+    // #4559: returns boolean (true = sent, false = WS-closed no-op) so
+    // SettingsScreen can surface an inline "server disconnected" warning
+    // instead of silently dropping the user's tap.
+    expect(typesSource).toMatch(/refreshNotificationPrefs:\s*\(\)\s*=>\s*boolean/);
   });
 
   it('declares setNotificationPrefsCategory with (category, enabled) signature', () => {
-    expect(typesSource).toMatch(/setNotificationPrefsCategory:\s*\(category:\s*string,\s*enabled:\s*boolean\)\s*=>\s*void/);
+    // #4559: returns boolean — see refreshNotificationPrefs comment above.
+    expect(typesSource).toMatch(/setNotificationPrefsCategory:\s*\(category:\s*string,\s*enabled:\s*boolean\)\s*=>\s*boolean/);
   });
 });
 
@@ -200,14 +212,16 @@ describe('SettingsScreen — Quiet hours editor section (#4544)', () => {
 
 describe('ConnectionState — quiet-hours actions (#4544)', () => {
   it('declares setNotificationPrefsQuietHours with the documented signature', () => {
+    // #4559: returns boolean — see refreshNotificationPrefs comment above.
     expect(typesSource).toMatch(
-      /setNotificationPrefsQuietHours:\s*\(window:\s*\{\s*start:\s*string;\s*end:\s*string;\s*timezone:\s*string\s*\}\s*\|\s*null\)\s*=>\s*void/,
+      /setNotificationPrefsQuietHours:\s*\(window:\s*\{\s*start:\s*string;\s*end:\s*string;\s*timezone:\s*string\s*\}\s*\|\s*null\)\s*=>\s*boolean/,
     );
   });
 
   it('declares setNotificationPrefsBypassCategories with the documented signature', () => {
+    // #4559: returns boolean — see refreshNotificationPrefs comment above.
     expect(typesSource).toMatch(
-      /setNotificationPrefsBypassCategories:\s*\(categories:\s*string\[\]\)\s*=>\s*void/,
+      /setNotificationPrefsBypassCategories:\s*\(categories:\s*string\[\]\)\s*=>\s*boolean/,
     );
   });
 
@@ -231,5 +245,113 @@ describe('connection.ts — quiet-hours actions (#4544)', () => {
     expect(connectionSource).toMatch(
       /setNotificationPrefsBypassCategories[\s\S]{0,400}notification_prefs_set[\s\S]{0,200}bypassCategories:\s*categories/,
     );
+  });
+});
+
+// #4559: fail-loud inline error when a notification-prefs WS write fires
+// while the socket is closed. Pre-#4559 the action silently no-op'd; the
+// Switch revert was the only signal and looked like a misfire. Both the
+// store action and the SettingsScreen banner are covered here.
+describe('connection.ts — notification-prefs WS-closed return values (#4559)', () => {
+  it('setNotificationPrefsCategory returns true after sending and false on the no-op path', () => {
+    // The action body must return `true` once `wsSend(...)` has shipped
+    // the patch and `false` from the fall-through (closed socket).
+    expect(connectionSource).toMatch(
+      /setNotificationPrefsCategory[\s\S]{0,1400}wsSend\(socket,[\s\S]{0,200}notification_prefs_set[\s\S]{0,300}return true[\s\S]{0,80}return false/,
+    );
+  });
+
+  it('setNotificationPrefsDevice returns false for empty deviceKey AND closed socket', () => {
+    // Defensive: the empty-deviceKey guard must short-circuit with
+    // `return false` (so the UI can still surface "save failed" should
+    // a stale render somehow fire), and the closed-socket fall-through
+    // must also return `false`.
+    expect(connectionSource).toMatch(
+      /setNotificationPrefsDevice[\s\S]{0,300}if\s*\(!deviceKey\)\s*return false[\s\S]{0,1600}return false/,
+    );
+  });
+
+  it('refreshNotificationPrefs returns true on send and false on closed socket', () => {
+    expect(connectionSource).toMatch(
+      /refreshNotificationPrefs[\s\S]{0,400}wsSend\(socket,[\s\S]{0,150}notification_prefs_get[\s\S]{0,80}return true[\s\S]{0,80}return false/,
+    );
+  });
+
+  it('setNotificationPrefsQuietHours returns true on send and false on closed socket', () => {
+    expect(connectionSource).toMatch(
+      /setNotificationPrefsQuietHours[\s\S]{0,800}return true[\s\S]{0,80}return false/,
+    );
+  });
+
+  it('setNotificationPrefsBypassCategories returns true on send and false on closed socket', () => {
+    expect(connectionSource).toMatch(
+      /setNotificationPrefsBypassCategories[\s\S]{0,800}return true[\s\S]{0,80}return false/,
+    );
+  });
+});
+
+describe('SettingsScreen — fail-loud inline error on WS-closed write (#4559)', () => {
+  it('declares a notifWsClosedError useState slot for the inline banner', () => {
+    // The error is component-local rather than store-state because each
+    // SettingsScreen mount is the only consumer; surfacing it via the
+    // store would risk a banner appearing on screens that don't expose
+    // the failing toggle.
+    expect(settingsSource).toMatch(
+      /\[notifWsClosedError,\s*setNotifWsClosedError\]\s*=\s*useState<string\s*\|\s*null>\(null\)/,
+    );
+  });
+
+  it('declares a shared WS_CLOSED_MESSAGE constant with the documented copy', () => {
+    // The exact copy mirrors the dashboard banner so users see the same
+    // instruction on both clients. Capture the substring so a rename
+    // / soften / typo breaks here intentionally.
+    expect(settingsSource).toMatch(/WS_CLOSED_MESSAGE\s*=/);
+    expect(settingsSource).toMatch(/Settings save failed/);
+    expect(settingsSource).toMatch(/server disconnected/);
+    expect(settingsSource).toMatch(/Reconnect and try again/);
+  });
+
+  it('renders the banner with testID notification-prefs-ws-closed-error when the error is set', () => {
+    expect(settingsSource).toMatch(/testID="notification-prefs-ws-closed-error"/);
+    // The banner is a conditional render keyed on notifWsClosedError.
+    expect(settingsSource).toMatch(/\{notifWsClosedError\s*&&/);
+  });
+
+  it('exposes the banner as an accessibility alert for screen readers', () => {
+    // Without role="alert" VoiceOver / TalkBack just announces the
+    // banner like any other Text — easy to miss for the same reason
+    // the original toggle revert was invisible.
+    expect(settingsSource).toMatch(/accessibilityRole="alert"/);
+  });
+
+  it('handleSetCategory delegates to setNotificationPrefsCategory and sets/clears the banner from the boolean', () => {
+    expect(settingsSource).toMatch(
+      /handleSetCategory\s*=\s*useCallback[\s\S]{0,300}setNotificationPrefsCategory\(cat, value\)[\s\S]{0,200}setNotifWsClosedError\(sent\s*\?\s*null\s*:\s*WS_CLOSED_MESSAGE\)/,
+    );
+  });
+
+  it('handleSetDevice delegates to setNotificationPrefsDevice and sets/clears the banner from the boolean', () => {
+    expect(settingsSource).toMatch(
+      /handleSetDevice\s*=\s*useCallback[\s\S]{0,300}setNotificationPrefsDevice\(deviceKey, cat, value\)[\s\S]{0,200}setNotifWsClosedError\(sent\s*\?\s*null\s*:\s*WS_CLOSED_MESSAGE\)/,
+    );
+  });
+
+  it('handleSetQuietHours delegates to setNotificationPrefsQuietHours and sets/clears the banner', () => {
+    expect(settingsSource).toMatch(
+      /handleSetQuietHours\s*=\s*useCallback[\s\S]{0,300}setNotificationPrefsQuietHours\(win\)[\s\S]{0,200}setNotifWsClosedError\(sent\s*\?\s*null\s*:\s*WS_CLOSED_MESSAGE\)/,
+    );
+  });
+
+  it('handleSetBypassCategories delegates to setNotificationPrefsBypassCategories and sets/clears the banner', () => {
+    expect(settingsSource).toMatch(
+      /handleSetBypassCategories\s*=\s*useCallback[\s\S]{0,300}setNotificationPrefsBypassCategories\(cats\)[\s\S]{0,200}setNotifWsClosedError\(sent\s*\?\s*null\s*:\s*WS_CLOSED_MESSAGE\)/,
+    );
+  });
+
+  it('QuietHoursEditor receives the handler wrappers — not the raw store actions', () => {
+    // Without this routing the editor would silently no-op on a closed
+    // socket and the user would never see the banner.
+    expect(settingsSource).toMatch(/onWindowChange=\{handleSetQuietHours\}/);
+    expect(settingsSource).toMatch(/onBypassChange=\{handleSetBypassCategories\}/);
   });
 });

--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsDevice.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsDevice.test.ts
@@ -59,9 +59,16 @@ describe('SettingsScreen — per-device opt-in/out section (#4543)', () => {
     // The per-device Switch onValueChange MUST invert the boolean because
     // the user-facing affordance is "mute" (true = muted) while the wire
     // patch carries `enabled` (true = on). Without the negation a tap-to-mute
-    // would actually un-mute the category.
+    // would actually un-mute the category. #4559 routed the call through
+    // a thin handler wrapper (`handleSetDevice`) so the WS-closed boolean
+    // return can drive the inline error banner — the handler still
+    // forwards `(pushToken, cat, !value)` to `setNotificationPrefsDevice`
+    // so the wire payload is unchanged.
     expect(settingsSource).toMatch(
-      /onValueChange=\{\(value\) => setNotificationPrefsDevice\(pushToken, cat, !value\)\}/,
+      /onValueChange=\{\(value\) => handleSetDevice\(pushToken, cat, !value\)\}/,
+    );
+    expect(settingsSource).toMatch(
+      /handleSetDevice\s*=\s*useCallback[\s\S]{0,300}setNotificationPrefsDevice\(deviceKey, cat, value\)/,
     );
   });
 
@@ -82,8 +89,10 @@ describe('ConnectionState — per-device push token surface (#4543)', () => {
   });
 
   it('declares setNotificationPrefsDevice with (deviceKey, category, enabled) signature', () => {
+    // #4559: returns boolean (true = sent, false = WS-closed/empty-key
+    // no-op) so SettingsScreen can surface an inline error.
     expect(typesSource).toMatch(
-      /setNotificationPrefsDevice:\s*\(deviceKey:\s*string,\s*category:\s*string,\s*enabled:\s*boolean\)\s*=>\s*void/,
+      /setNotificationPrefsDevice:\s*\(deviceKey:\s*string,\s*category:\s*string,\s*enabled:\s*boolean\)\s*=>\s*boolean/,
     );
   });
 });

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -103,6 +103,13 @@ const SPEECH_LANGUAGES = [
   { tag: 'ar-SA', label: 'Arabic' },
 ];
 
+// #4559: shared inline-error copy for notification-prefs writes that fired
+// while the WS was closed. Pre-#4559 the action silently no-op'd and the
+// Switch revert looked like a misfire. The mobile copy mirrors the
+// dashboard's banner so users see the same instruction on both clients.
+const WS_CLOSED_MESSAGE =
+  'Settings save failed — server disconnected. Reconnect and try again.';
+
 export function SettingsScreen() {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -110,6 +117,10 @@ export function SettingsScreen() {
   const [showLangPicker, setShowLangPicker] = useState(false);
   const [biometricAvail, setBiometricAvail] = useState(false);
   const [biometricOn, setBiometricOn] = useState(false);
+  // #4559: surfaces "server disconnected" when a notification-prefs Switch
+  // tap fires while the WS is closed. Cleared on a subsequent successful
+  // write (post-reconnect) so a stale banner can't persist after recovery.
+  const [notifWsClosedError, setNotifWsClosedError] = useState<string | null>(null);
 
   useEffect(() => {
     getSpeechLang()
@@ -186,8 +197,38 @@ export function SettingsScreen() {
   const setNotificationPrefsBypassCategories = useConnectionStore((s) => s.setNotificationPrefsBypassCategories);
 
   useEffect(() => {
+    // #4559: ignore the boolean return on initial refresh — a closed
+    // socket on mount is the common case (mobile re-opens the app while
+    // the tunnel is still recovering). The inline banner only fires for
+    // user-initiated writes; the snapshot will arrive once the connection
+    // settles.
     refreshNotificationPrefs();
   }, [refreshNotificationPrefs]);
+
+  // #4559: thin wrappers around the four notification-prefs setters. Each
+  // delegates to the store action (which returns `true` when sent, `false`
+  // when the WS is closed) and updates the inline banner accordingly.
+  // Sharing the wrappers keeps the success → clear / failure → set
+  // behaviour uniform so we can't forget to clear on a later success.
+  const handleSetCategory = useCallback((cat: string, value: boolean) => {
+    const sent = setNotificationPrefsCategory(cat, value);
+    setNotifWsClosedError(sent ? null : WS_CLOSED_MESSAGE);
+  }, [setNotificationPrefsCategory]);
+
+  const handleSetDevice = useCallback((deviceKey: string, cat: string, value: boolean) => {
+    const sent = setNotificationPrefsDevice(deviceKey, cat, value);
+    setNotifWsClosedError(sent ? null : WS_CLOSED_MESSAGE);
+  }, [setNotificationPrefsDevice]);
+
+  const handleSetQuietHours = useCallback((win: { start: string; end: string; timezone: string } | null) => {
+    const sent = setNotificationPrefsQuietHours(win);
+    setNotifWsClosedError(sent ? null : WS_CLOSED_MESSAGE);
+  }, [setNotificationPrefsQuietHours]);
+
+  const handleSetBypassCategories = useCallback((cats: string[]) => {
+    const sent = setNotificationPrefsBypassCategories(cats);
+    setNotifWsClosedError(sent ? null : WS_CLOSED_MESSAGE);
+  }, [setNotificationPrefsBypassCategories]);
 
   const orderedNotificationCategories = useMemo(() => {
     if (!notificationPrefs) return [];
@@ -455,6 +496,21 @@ export function SettingsScreen() {
 
       {/* NOTIFICATIONS — Categories (#4542) + per-device opt-in/out (#4543) */}
       <Text style={styles.sectionHeader}>NOTIFICATION CATEGORIES</Text>
+      {/* #4559: inline "server disconnected" warning. Surfaces when any
+          notification-prefs Switch tap fires while the WS is closed so the
+          revert is no longer a silent no-op. accessibilityRole='alert' so
+          VoiceOver / TalkBack announce the failure rather than letting the
+          Switch revert pass without explanation. */}
+      {notifWsClosedError && (
+        <View style={styles.wsClosedBanner} testID="notification-prefs-ws-closed-error">
+          <Text
+            style={styles.wsClosedBannerText}
+            accessibilityRole="alert"
+          >
+            {notifWsClosedError}
+          </Text>
+        </View>
+      )}
       <View style={styles.section} testID="notification-prefs-section">
         {notificationPrefs == null ? (
           <View style={styles.row}>
@@ -492,7 +548,7 @@ export function SettingsScreen() {
                   </View>
                   <Switch
                     value={checked}
-                    onValueChange={(value) => setNotificationPrefsCategory(cat, value)}
+                    onValueChange={(value) => handleSetCategory(cat, value)}
                     trackColor={{ false: COLORS.backgroundCard, true: COLORS.accentBlue }}
                     testID={`notification-prefs-toggle-${cat}`}
                   />
@@ -507,7 +563,7 @@ export function SettingsScreen() {
                     </View>
                     <Switch
                       value={mutedOnThisDevice}
-                      onValueChange={(value) => setNotificationPrefsDevice(pushToken, cat, !value)}
+                      onValueChange={(value) => handleSetDevice(pushToken, cat, !value)}
                       trackColor={{ false: COLORS.backgroundCard, true: COLORS.accentBlue }}
                       testID={`notification-prefs-device-toggle-${cat}`}
                     />
@@ -531,8 +587,8 @@ export function SettingsScreen() {
             window={notificationPrefs.quietHours}
             categories={notificationPrefs.categories}
             bypassCategories={notificationPrefs.bypassCategories ?? DEFAULT_BYPASS_CATEGORIES}
-            onWindowChange={setNotificationPrefsQuietHours}
-            onBypassChange={setNotificationPrefsBypassCategories}
+            onWindowChange={handleSetQuietHours}
+            onBypassChange={handleSetBypassCategories}
           />
         )}
       </View>
@@ -1025,6 +1081,26 @@ const styles = StyleSheet.create({
   destructiveText: {
     color: COLORS.accentRed,
     fontSize: 15,
+  },
+  // #4559: inline banner shown above the NOTIFICATION CATEGORIES section
+  // when a notification-prefs Switch tap fires while the WS is closed.
+  // Matches the section header indent (marginHorizontal: 16) so the
+  // banner aligns with the section it describes; tinted with the
+  // destructive red used by Clear actions so the failure tone reads
+  // immediately.
+  wsClosedBanner: {
+    marginHorizontal: 16,
+    marginBottom: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    backgroundColor: COLORS.backgroundCard,
+    borderLeftWidth: 3,
+    borderLeftColor: COLORS.accentRed,
+  },
+  wsClosedBannerText: {
+    color: COLORS.accentRed,
+    fontSize: 13,
   },
   actionText: {
     color: COLORS.accentBlue,

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -407,11 +407,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // shallow-merge patch via `notification_prefs_set`. The server broadcasts
   // the merged snapshot so other clients (dashboard + mobile) stay in sync
   // without polling.
-  refreshNotificationPrefs: () => {
+  // #4559: action returns `true` when the WS message was sent, `false`
+  // when the socket was closed (no-op). SettingsScreen surfaces an inline
+  // error on `false` so the user knows their change did not reach the
+  // server — pre-#4559 the silent-drop made the Switch look unresponsive.
+  refreshNotificationPrefs: (): boolean => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'notification_prefs_get' });
+      return true;
     }
+    return false;
   },
 
   // #4558: optimistic update. The Switch should flip the moment the user
@@ -429,7 +435,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   //   - socket closed              → no optimistic patch either. A
   //     local-only flip would never reconcile and would drift on the next
   //     reconnect snapshot.
-  setNotificationPrefsCategory: (category: string, enabled: boolean) => {
+  // #4559: returns `true` when sent, `false` when the WS is closed.
+  setNotificationPrefsCategory: (category: string, enabled: boolean): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       if (notificationPrefs) {
@@ -444,7 +451,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         type: 'notification_prefs_set',
         prefs: { categories: { [category]: enabled } },
       });
+      return true;
     }
+    return false;
   },
 
   // #4543: patch a per-device category override. Server's setPrefs
@@ -458,8 +467,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #4558: optimistic update — the per-device mute Switch flips before the
   // broadcast lands. Mirrors the server's shallow-merge so other devices
   // and other categories under THIS device survive.
-  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => {
-    if (!deviceKey) return;
+  // #4559: returns `true` when sent, `false` for both no-op branches
+  // (empty deviceKey OR closed socket).
+  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean): boolean => {
+    if (!deviceKey) return false;
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       if (notificationPrefs) {
@@ -486,7 +497,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           },
         },
       });
+      return true;
     }
+    return false;
   },
 
   // #4544: global quiet-hours window patch. `null` clears; a window
@@ -495,7 +508,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   //
   // #4558: optimistic update — local `quietHours` flips before the
   // broadcast lands so the editor's Save button doesn't visibly lag.
-  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => {
+  // #4559: returns `false` when the socket is closed.
+  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       if (notificationPrefs) {
@@ -507,7 +521,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         type: 'notification_prefs_set',
         prefs: { quietHours: window },
       });
+      return true;
     }
+    return false;
   },
 
   // #4544: global bypass-category list. Sent as a replacement (not a
@@ -515,7 +531,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   //
   // #4558: optimistic update — local `bypassCategories` flips before the
   // broadcast lands so the bypass Switch row feels snappy.
-  setNotificationPrefsBypassCategories: (categories: string[]) => {
+  // #4559: returns `false` when the socket is closed.
+  setNotificationPrefsBypassCategories: (categories: string[]): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       if (notificationPrefs) {
@@ -527,7 +544,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         type: 'notification_prefs_set',
         prefs: { bypassCategories: categories },
       });
+      return true;
     }
+    return false;
   },
 
   setFollowMode: (enabled: boolean) => {

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -512,8 +512,14 @@ export interface ServerNotificationActions {
   // `notification_prefs_get`; `setCategory` sends `notification_prefs_set`
   // with a single-category patch (server shallow-merges so other toggles
   // are preserved).
-  refreshNotificationPrefs: () => void;
-  setNotificationPrefsCategory: (category: string, enabled: boolean) => void;
+  //
+  // #4559: each action returns a boolean indicating whether the WS message
+  // actually went on the wire. `true` = sent; `false` = socket was closed
+  // and the write was a no-op. Pre-#4559 the silent-drop made the toggle
+  // look unresponsive; SettingsScreen now surfaces an inline error so the
+  // user knows to retry after reconnect.
+  refreshNotificationPrefs: () => boolean;
+  setNotificationPrefsCategory: (category: string, enabled: boolean) => boolean;
   // #4543: patch a per-device category override. Sends a single
   // `notification_prefs_set` with `{ devices: { [deviceKey]: { categories:
   // { [category]: enabled } } } }`. Server shallow-merges so other device
@@ -521,15 +527,22 @@ export interface ServerNotificationActions {
   // false` mutes the category on this device only; `true` is the
   // explicit-unmute path that overrides a `false` global default. No-op
   // when deviceKey is empty or the socket is closed.
-  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => void;
+  //
+  // #4559: returns `true` when sent, `false` for both no-op branches
+  // (empty deviceKey OR closed socket).
+  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => boolean;
   // #4544: patch the global quiet-hours window. `null` clears the window;
   // a window object (with `timezone`) sets it. Server broadcasts the
   // merged snapshot so all clients update in lockstep.
-  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => void;
+  //
+  // #4559: returns `false` when the socket is closed.
+  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => boolean;
   // #4544: replace the global bypass-category list wholesale. An empty
   // array means "nothing bypasses, not even errors" — the UI should
   // always send the desired final list.
-  setNotificationPrefsBypassCategories: (categories: string[]) => void;
+  //
+  // #4559: returns `false` when the socket is closed.
+  setNotificationPrefsBypassCategories: (categories: string[]) => boolean;
 }
 
 /**

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -63,26 +63,32 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     setChroxyContextHint: vi.fn(),
     // #4052: BYOK credentials defaults — refresh is a no-op spy by
     // default; individual tests override status / actions as needed.
+    //
+    // #4559: each action returns `true` by default (mirrors the
+    // store's "WS open → patch sent" path) so existing assertions that
+    // rely on success-side effects (e.g. input clearing after Save) keep
+    // passing. Tests covering the WS-closed branch override with
+    // `vi.fn().mockReturnValue(false)`.
     byokCredentialsStatus: null,
-    refreshByokCredentialsStatus: vi.fn(),
-    setByokCredentials: vi.fn(),
-    clearByokCredentials: vi.fn(),
+    refreshByokCredentialsStatus: vi.fn().mockReturnValue(true),
+    setByokCredentials: vi.fn().mockReturnValue(true),
+    clearByokCredentials: vi.fn().mockReturnValue(true),
     // #4542: per-category notification toggles. `notificationPrefs` mirrors
     // the latest snapshot received over the WS connection (null until the
     // first `notification_prefs` arrives).
     notificationPrefs: null,
-    refreshNotificationPrefs: vi.fn(),
-    setNotificationPrefsCategory: vi.fn(),
+    refreshNotificationPrefs: vi.fn().mockReturnValue(true),
+    setNotificationPrefsCategory: vi.fn().mockReturnValue(true),
     // #4543: per-device opt-in/out. `currentDeviceKey` is the stable browser
     // localStorage id used as the device key in the per-device override map.
     // The test default uses a fixed string so toggles assert against a known
     // key without coupling to localStorage; individual tests can override.
     currentDeviceKey: 'test-device-key',
-    setNotificationPrefsDevice: vi.fn(),
+    setNotificationPrefsDevice: vi.fn().mockReturnValue(true),
     // #4544: quiet-hours editor actions. Default no-op spies; individual
     // tests override.
-    setNotificationPrefsQuietHours: vi.fn(),
-    setNotificationPrefsBypassCategories: vi.fn(),
+    setNotificationPrefsQuietHours: vi.fn().mockReturnValue(true),
+    setNotificationPrefsBypassCategories: vi.fn().mockReturnValue(true),
     ...extra,
   }
 }
@@ -615,7 +621,10 @@ describe('SettingsPanel', () => {
     })
 
     it('calls setByokCredentials with the trimmed key and clears the input on Save', () => {
-      const setByokCredentials = vi.fn()
+      // #4559: the input only clears on a successful send — mirror the
+      // OPEN-socket store path by returning `true`. The failure path is
+      // covered separately in the WS-closed describe block.
+      const setByokCredentials = vi.fn().mockReturnValue(true)
       setMockState({ setByokCredentials })
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       const input = screen.getByTestId('byok-key-input') as HTMLInputElement
@@ -1061,6 +1070,226 @@ describe('SettingsPanel', () => {
       const errCheck = screen.getByTestId('quiet-hours-bypass-toggle-activity_error') as HTMLInputElement
       expect(permCheck.checked).toBe(true)
       expect(errCheck.checked).toBe(true)
+    })
+  })
+
+  // #4559: fail-loud inline error when a notification-prefs / BYOK write
+  // fires while the WS is closed. Pre-#4559 these actions silently no-op'd
+  // (the action read `socket.readyState !== OPEN` and returned without
+  // sending), so the user saw a switch refuse to stay flipped with no
+  // feedback. The store actions now return a boolean; SettingsPanel
+  // surfaces a banner per section when the action reports `false`.
+  describe('Fail-loud inline error on WS-closed write (#4559)', () => {
+    // Same RATE_LIMITS-derived category set used elsewhere in the file —
+    // kept inline so a server-side rename trips here too.
+    const categories = {
+      permission: true,
+      result: true,
+      activity_update: true,
+      activity_waiting: true,
+      activity_error: true,
+      inactivity_warning: true,
+      live_activity: true,
+    }
+    const defaultPrefs = { categories, devices: {}, quietHours: null }
+
+    describe('Notification prefs', () => {
+      it('renders no error banner on initial render (WS open path)', () => {
+        // Defensive: ensure the banner only appears after a failed write,
+        // never on first paint.
+        setMockState({ notificationPrefs: defaultPrefs })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        expect(screen.queryByTestId('notification-prefs-ws-closed-error')).toBeNull()
+      })
+
+      it('surfaces an inline error and still calls the action when a category toggle fires while WS is closed', () => {
+        // Action returns false to mimic the closed-socket path. The
+        // toggle handler still calls the action (the store decides
+        // whether to send) but the banner makes the failure visible
+        // instead of leaving the user staring at a reverted checkbox.
+        const setNotificationPrefsCategory = vi.fn().mockReturnValue(false)
+        setMockState({
+          notificationPrefs: defaultPrefs,
+          setNotificationPrefsCategory,
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('notification-prefs-toggle-result'))
+        // The action ran — the store is responsible for the no-op gate.
+        expect(setNotificationPrefsCategory).toHaveBeenCalledWith('result', false)
+        // Banner is visible and tagged role=alert so a screen reader
+        // announces the failure.
+        const banner = screen.getByTestId('notification-prefs-ws-closed-error')
+        expect(banner).toBeInTheDocument()
+        expect(banner).toHaveAttribute('role', 'alert')
+        // Copy mentions the recovery path so the user knows what to do.
+        expect(banner.textContent).toMatch(/server disconnected/i)
+        expect(banner.textContent).toMatch(/Reconnect/i)
+      })
+
+      it('does NOT render the WS-closed banner when the toggle succeeds', () => {
+        // Sanity: the success path leaves no banner behind. Pre-#4559
+        // there was no banner at all; this test guards against a future
+        // refactor leaving a stale "sent" toast on screen.
+        const setNotificationPrefsCategory = vi.fn().mockReturnValue(true)
+        setMockState({
+          notificationPrefs: defaultPrefs,
+          setNotificationPrefsCategory,
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('notification-prefs-toggle-result'))
+        expect(setNotificationPrefsCategory).toHaveBeenCalledWith('result', false)
+        expect(screen.queryByTestId('notification-prefs-ws-closed-error')).toBeNull()
+      })
+
+      it('clears the banner after a subsequent successful toggle', () => {
+        // First toggle fails (WS closed → banner appears). Then the
+        // user reconnects, toggles again, and the banner clears.
+        // Modeling the action returning false then true mirrors the
+        // ConnectionPhase transition without needing to drive the
+        // socket itself.
+        const setNotificationPrefsCategory = vi
+          .fn<(cat: string, enabled: boolean) => boolean>()
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(true)
+        setMockState({
+          notificationPrefs: defaultPrefs,
+          setNotificationPrefsCategory,
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('notification-prefs-toggle-result'))
+        expect(screen.getByTestId('notification-prefs-ws-closed-error')).toBeInTheDocument()
+        fireEvent.click(screen.getByTestId('notification-prefs-toggle-result'))
+        expect(screen.queryByTestId('notification-prefs-ws-closed-error')).toBeNull()
+      })
+
+      it('surfaces the banner when a per-device mute toggle fires while WS is closed', () => {
+        // Per-device mute toggle shares the banner with the global
+        // category toggle — both flow through the same section.
+        const setNotificationPrefsDevice = vi.fn().mockReturnValue(false)
+        setMockState({
+          notificationPrefs: defaultPrefs,
+          setNotificationPrefsDevice,
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('notification-prefs-device-toggle-result'))
+        expect(setNotificationPrefsDevice).toHaveBeenCalledWith('test-device-key', 'result', false)
+        expect(screen.getByTestId('notification-prefs-ws-closed-error')).toBeInTheDocument()
+      })
+
+      it('surfaces the banner when the quiet-hours Save fires while WS is closed', () => {
+        // Quiet-hours editor uses the same banner because it sits inside
+        // the Notifications section.
+        const setNotificationPrefsQuietHours = vi.fn().mockReturnValue(false)
+        setMockState({
+          notificationPrefs: {
+            ...defaultPrefs,
+            quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+          },
+          setNotificationPrefsQuietHours,
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.change(screen.getByTestId('quiet-hours-start-input'), { target: { value: '23:30' } })
+        fireEvent.click(screen.getByTestId('quiet-hours-save-button'))
+        expect(setNotificationPrefsQuietHours).toHaveBeenCalled()
+        expect(screen.getByTestId('notification-prefs-ws-closed-error')).toBeInTheDocument()
+      })
+
+      it('surfaces the banner when a bypass-category toggle fires while WS is closed', () => {
+        // Bypass-category toggles share the same banner. The user just
+        // unchecks one of the documented defaults to trigger the action.
+        const setNotificationPrefsBypassCategories = vi.fn().mockReturnValue(false)
+        setMockState({
+          notificationPrefs: {
+            ...defaultPrefs,
+            quietHours: { start: '22:00', end: '07:00', timezone: 'America/Los_Angeles' },
+            bypassCategories: ['permission', 'activity_error'],
+          },
+          setNotificationPrefsBypassCategories,
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('quiet-hours-bypass-toggle-activity_error'))
+        expect(setNotificationPrefsBypassCategories).toHaveBeenCalled()
+        expect(screen.getByTestId('notification-prefs-ws-closed-error')).toBeInTheDocument()
+      })
+    })
+
+    describe('BYOK credentials', () => {
+      it('surfaces an inline error and preserves the input when Save fires while WS is closed', () => {
+        // Pre-#4559 the input was cleared regardless of whether the
+        // write actually went out — the user would re-type the key
+        // after reconnecting. Now the input survives the failed save
+        // so retry is a single click after the reconnect lands.
+        const setByokCredentials = vi.fn().mockReturnValue(false)
+        setMockState({ setByokCredentials })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const input = screen.getByTestId('byok-key-input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'sk-ant-from-user' } })
+        fireEvent.click(screen.getByTestId('byok-save-button'))
+        expect(setByokCredentials).toHaveBeenCalledWith('sk-ant-from-user')
+        // Banner visible + role=alert.
+        const banner = screen.getByTestId('byok-ws-closed-error')
+        expect(banner).toBeInTheDocument()
+        expect(banner).toHaveAttribute('role', 'alert')
+        // Input preserved on failure — user retries with one click.
+        expect(input.value).toBe('sk-ant-from-user')
+      })
+
+      it('does NOT render the BYOK WS-closed banner when Save succeeds', () => {
+        // Sanity: the success path clears the input and leaves no banner.
+        const setByokCredentials = vi.fn().mockReturnValue(true)
+        setMockState({ setByokCredentials })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const input = screen.getByTestId('byok-key-input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'sk-ant-from-user' } })
+        fireEvent.click(screen.getByTestId('byok-save-button'))
+        expect(setByokCredentials).toHaveBeenCalledWith('sk-ant-from-user')
+        expect(screen.queryByTestId('byok-ws-closed-error')).toBeNull()
+        // Input still clears on success.
+        expect(input.value).toBe('')
+      })
+
+      it('surfaces an inline error when Remove fires while WS is closed', () => {
+        const clearByokCredentials = vi.fn().mockReturnValue(false)
+        setMockState({
+          byokCredentialsStatus: {
+            status: 'set', source: 'file', masked: 'sk-ant-api03...[95 chars redacted]',
+            fileExists: true,
+          },
+          clearByokCredentials,
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('byok-clear-button'))
+        expect(clearByokCredentials).toHaveBeenCalled()
+        expect(screen.getByTestId('byok-ws-closed-error')).toBeInTheDocument()
+      })
+
+      it('does not surface the notif banner when only BYOK fails (sections are independent)', () => {
+        // Defensive: each section owns its own banner so a stale BYOK
+        // error doesn't bleed into the Notifications section.
+        const setByokCredentials = vi.fn().mockReturnValue(false)
+        setMockState({ setByokCredentials, notificationPrefs: defaultPrefs })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.change(screen.getByTestId('byok-key-input'), { target: { value: 'sk-ant-from-user' } })
+        fireEvent.click(screen.getByTestId('byok-save-button'))
+        expect(screen.getByTestId('byok-ws-closed-error')).toBeInTheDocument()
+        expect(screen.queryByTestId('notification-prefs-ws-closed-error')).toBeNull()
+      })
+
+      it('clears the BYOK banner after a subsequent successful Save', () => {
+        const setByokCredentials = vi
+          .fn<(key: string) => boolean>()
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(true)
+        setMockState({ setByokCredentials })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const input = screen.getByTestId('byok-key-input') as HTMLInputElement
+        fireEvent.change(input, { target: { value: 'sk-ant-from-user' } })
+        fireEvent.click(screen.getByTestId('byok-save-button'))
+        expect(screen.getByTestId('byok-ws-closed-error')).toBeInTheDocument()
+        // Reconnect lands; user retries — banner clears.
+        fireEvent.click(screen.getByTestId('byok-save-button'))
+        expect(screen.queryByTestId('byok-ws-closed-error')).toBeNull()
+      })
     })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -375,10 +375,26 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   // store) so the raw key is never observable beyond this one render.
   const [byokKeyInput, setByokKeyInput] = useState('')
   const [byokError, setByokError] = useState<string | null>(null)
+  // #4559: inline "server disconnected" warning surfaced when a BYOK or
+  // notification-prefs WS write fires while `socket.readyState !== OPEN`.
+  // Pre-#4559 these actions silently no-op'd and the toggle reverted, so
+  // the user saw nothing to explain why their change didn't stick. Split
+  // into two state vars so a stale BYOK error doesn't bleed into the
+  // notifications section (and vice versa) — each section owns its own
+  // banner that clears the next time a successful write goes out.
+  const [byokWsClosedError, setByokWsClosedError] = useState<string | null>(null)
+  const [notifWsClosedError, setNotifWsClosedError] = useState<string | null>(null)
   const [allowAutoPerm, setAllowAutoPerm] = useState<boolean>(false)
   const [autoPermError, setAutoPermError] = useState<string | null>(null)
   const [autoPermDirty, setAutoPermDirty] = useState<boolean>(false)
   const [autoPermSaving, setAutoPermSaving] = useState<boolean>(false)
+
+  // #4559: shared copy for the inline "server disconnected" banner so the
+  // BYOK and notifications sections stay in lockstep on phrasing. Mentions
+  // the exact recovery path (wait for reconnect, then retry) so the user
+  // doesn't need to dig through docs to know what to do next.
+  const WS_CLOSED_MESSAGE =
+    'Settings save failed — server disconnected. Reconnect and try again.'
 
   // Load tunnel mode from Tauri settings and running server on open
   useEffect(() => {
@@ -407,6 +423,12 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   // #4052: Pull the latest credentials status whenever the panel opens so
   // it's accurate even after an out-of-band change (e.g. the user edited
   // ~/.chroxy/credentials.json directly in another terminal).
+  //
+  // #4559: ignore the boolean return here intentionally — a closed socket
+  // on panel open is the common case (Settings can be opened while the
+  // ConnectionPhase is still 'reconnecting'). The banner only fires for
+  // user-initiated writes; the refresh path quietly retries on the next
+  // open or when notificationPrefs/byokCredentialsStatus actually need it.
   useEffect(() => {
     if (!isOpen) return
     refreshByokCredentialsStatus()
@@ -421,6 +443,17 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
     refreshNotificationPrefs()
   }, [isOpen, refreshNotificationPrefs])
 
+  // #4559: clear the inline "server disconnected" banners when the panel
+  // closes so re-opening Settings starts from a clean slate. A stale
+  // banner from a prior open would confuse the user if the connection has
+  // since recovered — the next interaction will surface a fresh banner if
+  // the socket is still closed.
+  useEffect(() => {
+    if (isOpen) return
+    setByokWsClosedError(null)
+    setNotifWsClosedError(null)
+  }, [isOpen])
+
   const handleSaveByokKey = useCallback(() => {
     setByokError(null)
     const trimmed = byokKeyInput.trim()
@@ -428,14 +461,55 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
       setByokError('Anthropic API keys start with "sk-ant-".')
       return
     }
-    setByokCredentials(trimmed)
-    setByokKeyInput('')
+    // #4559: surface inline error when the WS is closed instead of the
+    // pre-existing silent no-op. Clear the input only on a successful
+    // send so the user can retry without re-pasting.
+    const sent = setByokCredentials(trimmed)
+    if (sent) {
+      setByokWsClosedError(null)
+      setByokKeyInput('')
+    } else {
+      setByokWsClosedError(WS_CLOSED_MESSAGE)
+    }
   }, [byokKeyInput, setByokCredentials])
 
   const handleClearByokKey = useCallback(() => {
     setByokError(null)
-    clearByokCredentials()
+    // #4559: same fail-loud contract as Save.
+    const sent = clearByokCredentials()
+    if (sent) setByokWsClosedError(null)
+    else setByokWsClosedError(WS_CLOSED_MESSAGE)
   }, [clearByokCredentials])
+
+  // #4559: notification-prefs wrappers. Each handler delegates to the
+  // store action (which returns `true` when sent, `false` when the WS is
+  // closed) and updates the inline banner accordingly. Sharing the
+  // wrappers across all four prefs setters keeps the success → clear /
+  // failure → set pattern uniform — no chance of forgetting to clear on a
+  // subsequent successful save.
+  const handleSetNotificationCategory = useCallback((cat: string, enabled: boolean) => {
+    const sent = setNotificationPrefsCategory(cat, enabled)
+    if (sent) setNotifWsClosedError(null)
+    else setNotifWsClosedError(WS_CLOSED_MESSAGE)
+  }, [setNotificationPrefsCategory])
+
+  const handleSetNotificationDevice = useCallback((deviceKey: string, cat: string, enabled: boolean) => {
+    const sent = setNotificationPrefsDevice(deviceKey, cat, enabled)
+    if (sent) setNotifWsClosedError(null)
+    else setNotifWsClosedError(WS_CLOSED_MESSAGE)
+  }, [setNotificationPrefsDevice])
+
+  const handleSetNotificationQuietHours = useCallback((window: { start: string; end: string; timezone: string } | null) => {
+    const sent = setNotificationPrefsQuietHours(window)
+    if (sent) setNotifWsClosedError(null)
+    else setNotifWsClosedError(WS_CLOSED_MESSAGE)
+  }, [setNotificationPrefsQuietHours])
+
+  const handleSetNotificationBypassCategories = useCallback((categories: string[]) => {
+    const sent = setNotificationPrefsBypassCategories(categories)
+    if (sent) setNotifWsClosedError(null)
+    else setNotifWsClosedError(WS_CLOSED_MESSAGE)
+  }, [setNotificationPrefsBypassCategories])
 
   const handleToggleAutoPerm = useCallback(async (next: boolean) => {
     setAutoPermError(null)
@@ -777,6 +851,21 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 {byokError}
               </p>
             )}
+            {/* #4559: inline "server disconnected" warning. Same
+                .settings-hint + error color as `byokError` so the BYOK
+                section has a single error treatment. role=alert so
+                screen readers announce the failure rather than letting
+                the toggle revert silently. */}
+            {byokWsClosedError && (
+              <p
+                className="settings-hint"
+                role="alert"
+                data-testid="byok-ws-closed-error"
+                style={{ color: 'var(--error, #f00)' }}
+              >
+                {byokWsClosedError}
+              </p>
+            )}
             <div className="settings-field">
               <button
                 type="button"
@@ -821,6 +910,19 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               limits still apply as a defensive floor — these toggles can only
               mute further, never amplify.
             </p>
+            {/* #4559: inline "server disconnected" warning. role=alert so
+                screen readers announce the failure rather than letting
+                a reverted toggle pass without explanation. */}
+            {notifWsClosedError && (
+              <p
+                className="settings-hint"
+                role="alert"
+                data-testid="notification-prefs-ws-closed-error"
+                style={{ color: 'var(--error, #f00)' }}
+              >
+                {notifWsClosedError}
+              </p>
+            )}
             {notificationPrefs == null ? (
               <p
                 className="settings-hint"
@@ -868,7 +970,7 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                                 id={toggleId}
                                 type="checkbox"
                                 checked={checked}
-                                onChange={(e) => setNotificationPrefsCategory(cat, e.target.checked)}
+                                onChange={(e) => handleSetNotificationCategory(cat, e.target.checked)}
                                 data-testid={`notification-prefs-toggle-${cat}`}
                               />
                               {label}
@@ -894,7 +996,7 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                                   type="checkbox"
                                   checked={mutedOnThisDevice}
                                   onChange={(e) =>
-                                    setNotificationPrefsDevice(currentDeviceKey, cat, !e.target.checked)
+                                    handleSetNotificationDevice(currentDeviceKey, cat, !e.target.checked)
                                   }
                                   data-testid={`notification-prefs-device-toggle-${cat}`}
                                 />
@@ -917,8 +1019,8 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                   window={notificationPrefs.quietHours}
                   categories={notificationPrefs.categories}
                   bypassCategories={notificationPrefs.bypassCategories ?? DEFAULT_BYPASS_CATEGORIES}
-                  onWindowChange={setNotificationPrefsQuietHours}
-                  onBypassChange={setNotificationPrefsBypassCategories}
+                  onWindowChange={handleSetNotificationQuietHours}
+                  onBypassChange={handleSetNotificationBypassCategories}
                 />
               </>
             )}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -488,36 +488,54 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #4052: BYOK credentials actions. The full key is never stored in the
   // store — only the masked preview from the server's reply. We never
   // round-trip the raw value back to the UI.
-  refreshByokCredentialsStatus: () => {
+  //
+  // #4559: each action returns a boolean indicating whether the WS message
+  // actually went on the wire. `false` means the socket was closed and the
+  // change was silently dropped before this PR — SettingsPanel now surfaces
+  // an inline error so the user knows to retry after reconnect.
+  refreshByokCredentialsStatus: (): boolean => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'byok_get_credentials_status' });
+      return true;
     }
+    return false;
   },
 
-  setByokCredentials: (anthropicApiKey: string) => {
+  setByokCredentials: (anthropicApiKey: string): boolean => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'byok_set_credentials', anthropicApiKey });
+      return true;
     }
+    return false;
   },
 
-  clearByokCredentials: () => {
+  clearByokCredentials: (): boolean => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'byok_clear_credentials' });
+      return true;
     }
+    return false;
   },
 
   // #4542: notification-prefs round-trip. Requests the current snapshot
   // (on Settings panel open) or patches a single category. The server
   // shallow-merges over the categories map, so a single-key patch never
   // wipes the others.
-  refreshNotificationPrefs: () => {
+  //
+  // #4559: returns `true` when the WS message was sent, `false` when the
+  // socket was closed (no-op). Callers MUST surface an inline error on
+  // `false` — pre-#4559, a closed socket silently dropped the patch and
+  // the user had no idea why the checkbox refused to stay flipped.
+  refreshNotificationPrefs: (): boolean => {
     const { socket } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, { type: 'notification_prefs_get' });
+      return true;
     }
+    return false;
   },
 
   // #4558: optimistic update. The user's toggle has to feel instant — on
@@ -536,8 +554,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   //   - socket closed              → no optimistic patch either. Same
   //     server-of-truth contract as before — without a server to confirm,
   //     a local-only flip would never reconcile and would drift on the
-  //     next reconnect snapshot.
-  setNotificationPrefsCategory: (category: string, enabled: boolean) => {
+  //     next reconnect snapshot. Return `false` so SettingsPanel can
+  //     surface an inline error (#4559).
+  setNotificationPrefsCategory: (category: string, enabled: boolean): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       if (notificationPrefs) {
@@ -552,7 +571,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         type: 'notification_prefs_set',
         prefs: { categories: { [category]: enabled } },
       });
+      return true;
     }
+    return false;
   },
 
   // #4543: patch a per-device category override. The server's
@@ -568,8 +589,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // broadcast reconciles. We mirror the server's shallow-merge semantics
   // in the local patch so other devices and other categories under THIS
   // device survive.
-  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => {
-    if (!deviceKey) return;
+  //
+  // #4559: returns `true` when sent, `false` for both no-op branches
+  // (empty deviceKey OR closed socket). UI surfaces an inline error on
+  // `false` for the closed-socket case (the empty-deviceKey branch only
+  // fires from defensive paths that already gate on currentDeviceKey).
+  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean): boolean => {
+    if (!deviceKey) return false;
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       if (notificationPrefs) {
@@ -596,7 +622,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           },
         },
       });
+      return true;
     }
+    return false;
   },
 
   // #4544: global quiet-hours window patch. `null` clears the window;
@@ -607,7 +635,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #4558: optimistic update — local `quietHours` flips before the
   // broadcast lands so the editor's Save button doesn't visibly lag
   // behind the click.
-  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => {
+  //
+  // #4559: returns `false` when the socket is closed.
+  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       if (notificationPrefs) {
@@ -619,7 +649,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         type: 'notification_prefs_set',
         prefs: { quietHours: window },
       });
+      return true;
     }
+    return false;
   },
 
   // #4544: global bypass-category list. The wire sends the full list as a
@@ -630,7 +662,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   //
   // #4558: optimistic update — local `bypassCategories` flips before the
   // broadcast lands so the bypass checkboxes feel snappy.
-  setNotificationPrefsBypassCategories: (categories: string[]) => {
+  //
+  // #4559: returns `false` when the socket is closed.
+  setNotificationPrefsBypassCategories: (categories: string[]): boolean => {
     const { socket, notificationPrefs } = get();
     if (socket && socket.readyState === WebSocket.OPEN) {
       if (notificationPrefs) {
@@ -642,7 +676,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         type: 'notification_prefs_set',
         prefs: { bypassCategories: categories },
       });
+      return true;
     }
+    return false;
   },
 
   getActiveSessionState: () => {

--- a/packages/dashboard/src/store/notification-prefs-ws-closed.test.ts
+++ b/packages/dashboard/src/store/notification-prefs-ws-closed.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Notification-prefs / BYOK fail-loud contract tests (#4559)
+ *
+ * Pre-#4559 the BYOK and notification-prefs store actions silently no-op'd
+ * when `socket.readyState !== OPEN`. The user toggled a checkbox, the WS
+ * write was dropped, the optimistic patch never fired, and the toggle
+ * snapped back to its prior state with no feedback. This file pins the
+ * post-#4559 contract:
+ *
+ *   1. WS OPEN  → action sends the message and returns `true`.
+ *   2. WS CLOSED → action does NOT send the message and returns `false`.
+ *   3. The boolean is the SettingsPanel's signal to render an inline
+ *      "server disconnected" banner (covered in SettingsPanel.test.tsx).
+ *
+ * Same contract covers `setNotificationPrefsCategory`,
+ * `setNotificationPrefsDevice`, `setNotificationPrefsQuietHours`,
+ * `setNotificationPrefsBypassCategories`, `refreshNotificationPrefs`,
+ * `setByokCredentials`, `clearByokCredentials`, and
+ * `refreshByokCredentialsStatus`.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+interface SentPayload {
+  type: string
+  prefs?: Record<string, unknown>
+  [k: string]: unknown
+}
+
+function createMockSocket(sent: SentPayload[], readyState: number = WebSocket.OPEN): WebSocket {
+  return {
+    send: vi.fn((raw: string) => {
+      try { sent.push(JSON.parse(raw) as SentPayload) } catch { /* noop */ }
+    }),
+    close: vi.fn(),
+    readyState,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+describe('#4559 — notification-prefs WS-closed fail-loud contract', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  describe('setNotificationPrefsCategory', () => {
+    it('returns true and sends a notification_prefs_set when WS is OPEN', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.OPEN)
+      useConnectionStore.setState({
+        socket,
+        notificationPrefs: {
+          categories: { result: true },
+          devices: {},
+          quietHours: null,
+        },
+      })
+
+      const result = useConnectionStore.getState().setNotificationPrefsCategory('result', false)
+
+      expect(result).toBe(true)
+      expect(sent).toHaveLength(1)
+      expect(sent[0]).toEqual({
+        type: 'notification_prefs_set',
+        prefs: { categories: { result: false } },
+      })
+    })
+
+    it('returns false and sends NO message when WS is CLOSED', async () => {
+      // The whole point of #4559: the silent no-op is now visible.
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.CLOSED)
+      useConnectionStore.setState({
+        socket,
+        notificationPrefs: {
+          categories: { result: true },
+          devices: {},
+          quietHours: null,
+        },
+      })
+
+      const result = useConnectionStore.getState().setNotificationPrefsCategory('result', false)
+
+      expect(result).toBe(false)
+      expect(sent).toHaveLength(0)
+      // Optimistic patch must NOT fire either — a local-only flip would
+      // drift on the next reconnect snapshot.
+      expect(useConnectionStore.getState().notificationPrefs!.categories.result).toBe(true)
+    })
+
+    it('returns false when there is no socket at all', async () => {
+      // Mirror the "never connected" path — no socket object, not even a
+      // CLOSED one. Same contract: no send, false return.
+      const { useConnectionStore } = await import('./connection')
+      useConnectionStore.setState({
+        socket: null,
+        notificationPrefs: {
+          categories: { result: true },
+          devices: {},
+          quietHours: null,
+        },
+      })
+
+      const result = useConnectionStore.getState().setNotificationPrefsCategory('result', false)
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('setNotificationPrefsDevice', () => {
+    it('returns true and sends a device patch when WS is OPEN', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.OPEN)
+      useConnectionStore.setState({
+        socket,
+        notificationPrefs: {
+          categories: { result: true },
+          devices: {},
+          quietHours: null,
+        },
+      })
+
+      const result = useConnectionStore.getState().setNotificationPrefsDevice('dev-a', 'result', false)
+      expect(result).toBe(true)
+      expect(sent).toHaveLength(1)
+    })
+
+    it('returns false when WS is CLOSED', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.CLOSED)
+      useConnectionStore.setState({
+        socket,
+        notificationPrefs: {
+          categories: { result: true },
+          devices: {},
+          quietHours: null,
+        },
+      })
+
+      const result = useConnectionStore.getState().setNotificationPrefsDevice('dev-a', 'result', false)
+      expect(result).toBe(false)
+      expect(sent).toHaveLength(0)
+    })
+
+    it('returns false for empty deviceKey regardless of socket state', async () => {
+      // Defensive no-op: never ship a `devices[""]` patch even if a stale
+      // render somehow fires the action. SettingsPanel already gates on
+      // currentDeviceKey, but the store guards both paths.
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.OPEN)
+      useConnectionStore.setState({ socket, notificationPrefs: null })
+
+      const result = useConnectionStore.getState().setNotificationPrefsDevice('', 'result', false)
+      expect(result).toBe(false)
+      expect(sent).toHaveLength(0)
+    })
+  })
+
+  describe('setNotificationPrefsQuietHours', () => {
+    it('returns true and sends a quietHours patch when WS is OPEN', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.OPEN)
+      useConnectionStore.setState({
+        socket,
+        notificationPrefs: {
+          categories: {},
+          devices: {},
+          quietHours: null,
+        },
+      })
+
+      const result = useConnectionStore.getState().setNotificationPrefsQuietHours({
+        start: '22:00', end: '07:00', timezone: 'America/Los_Angeles',
+      })
+      expect(result).toBe(true)
+      expect(sent).toHaveLength(1)
+    })
+
+    it('returns false when WS is CLOSED', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.CLOSED)
+      useConnectionStore.setState({
+        socket,
+        notificationPrefs: {
+          categories: {},
+          devices: {},
+          quietHours: null,
+        },
+      })
+
+      const result = useConnectionStore.getState().setNotificationPrefsQuietHours({
+        start: '22:00', end: '07:00', timezone: 'America/Los_Angeles',
+      })
+      expect(result).toBe(false)
+      expect(sent).toHaveLength(0)
+    })
+  })
+
+  describe('setNotificationPrefsBypassCategories', () => {
+    it('returns true and sends a bypassCategories patch when WS is OPEN', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.OPEN)
+      useConnectionStore.setState({
+        socket,
+        notificationPrefs: {
+          categories: {},
+          devices: {},
+          quietHours: null,
+          bypassCategories: ['permission', 'activity_error'],
+        },
+      })
+
+      const result = useConnectionStore.getState().setNotificationPrefsBypassCategories(['permission'])
+      expect(result).toBe(true)
+      expect(sent).toHaveLength(1)
+    })
+
+    it('returns false when WS is CLOSED', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.CLOSED)
+      useConnectionStore.setState({
+        socket,
+        notificationPrefs: {
+          categories: {},
+          devices: {},
+          quietHours: null,
+          bypassCategories: ['permission', 'activity_error'],
+        },
+      })
+
+      const result = useConnectionStore.getState().setNotificationPrefsBypassCategories(['permission'])
+      expect(result).toBe(false)
+      expect(sent).toHaveLength(0)
+    })
+  })
+
+  describe('refreshNotificationPrefs', () => {
+    it('returns true and sends notification_prefs_get when WS is OPEN', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.OPEN)
+      useConnectionStore.setState({ socket })
+
+      const result = useConnectionStore.getState().refreshNotificationPrefs()
+      expect(result).toBe(true)
+      expect(sent).toHaveLength(1)
+      expect(sent[0]?.type).toBe('notification_prefs_get')
+    })
+
+    it('returns false when WS is CLOSED', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.CLOSED)
+      useConnectionStore.setState({ socket })
+
+      const result = useConnectionStore.getState().refreshNotificationPrefs()
+      expect(result).toBe(false)
+      expect(sent).toHaveLength(0)
+    })
+  })
+
+  describe('BYOK actions', () => {
+    it('setByokCredentials returns true + sends when WS is OPEN', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.OPEN)
+      useConnectionStore.setState({ socket })
+
+      const result = useConnectionStore.getState().setByokCredentials('sk-ant-abc')
+      expect(result).toBe(true)
+      expect(sent).toHaveLength(1)
+      expect(sent[0]?.type).toBe('byok_set_credentials')
+    })
+
+    it('setByokCredentials returns false + sends nothing when WS is CLOSED', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.CLOSED)
+      useConnectionStore.setState({ socket })
+
+      const result = useConnectionStore.getState().setByokCredentials('sk-ant-abc')
+      expect(result).toBe(false)
+      expect(sent).toHaveLength(0)
+    })
+
+    it('clearByokCredentials returns true + sends when WS is OPEN', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.OPEN)
+      useConnectionStore.setState({ socket })
+
+      const result = useConnectionStore.getState().clearByokCredentials()
+      expect(result).toBe(true)
+      expect(sent[0]?.type).toBe('byok_clear_credentials')
+    })
+
+    it('clearByokCredentials returns false when WS is CLOSED', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.CLOSED)
+      useConnectionStore.setState({ socket })
+
+      const result = useConnectionStore.getState().clearByokCredentials()
+      expect(result).toBe(false)
+      expect(sent).toHaveLength(0)
+    })
+
+    it('refreshByokCredentialsStatus returns true when WS is OPEN', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.OPEN)
+      useConnectionStore.setState({ socket })
+
+      const result = useConnectionStore.getState().refreshByokCredentialsStatus()
+      expect(result).toBe(true)
+      expect(sent[0]?.type).toBe('byok_get_credentials_status')
+    })
+
+    it('refreshByokCredentialsStatus returns false when WS is CLOSED', async () => {
+      const { useConnectionStore } = await import('./connection')
+      const sent: SentPayload[] = []
+      const socket = createMockSocket(sent, WebSocket.CLOSED)
+      useConnectionStore.setState({ socket })
+
+      const result = useConnectionStore.getState().refreshByokCredentialsStatus()
+      expect(result).toBe(false)
+      expect(sent).toHaveLength(0)
+    })
+  })
+})

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -782,9 +782,16 @@ export interface ConnectionState {
     // shadowed but the user can still want it cleared).
     fileExists?: boolean;
   } | null;
-  refreshByokCredentialsStatus: () => void;
-  setByokCredentials: (anthropicApiKey: string) => void;
-  clearByokCredentials: () => void;
+  /**
+   * #4559: actions return a boolean indicating whether the WS message was
+   * sent. `true` = the socket was OPEN and the patch went on the wire;
+   * `false` = the socket was closed and the action was a silent no-op.
+   * Callers MUST surface an inline error when `false` is returned so the
+   * user knows their change did not reach the server.
+   */
+  refreshByokCredentialsStatus: () => boolean;
+  setByokCredentials: (anthropicApiKey: string) => boolean;
+  clearByokCredentials: () => boolean;
 
   // #4542: per-category notification preferences. Mirrors the server
   // snapshot received over WS (`notification_prefs`). `null` until the
@@ -808,13 +815,21 @@ export interface ConnectionState {
     quietHours: { start: string; end: string; timezone: string } | null;
     bypassCategories?: string[];
   } | null;
-  refreshNotificationPrefs: () => void;
+  /**
+   * #4559: same fail-loud contract as the BYOK actions. Returns `true` when
+   * the WS message was sent, `false` when the socket was closed and the
+   * action no-op'd. UI must surface inline error feedback on `false`.
+   */
+  refreshNotificationPrefs: () => boolean;
   /**
    * Patch a single category's enabled flag. Sends a `notification_prefs_set`
    * with a minimal shallow-merge patch (server merges over the existing
    * categories map, so other toggles are preserved).
+   *
+   * #4559: returns `false` when the socket is closed (silent-drop is gone —
+   * SettingsPanel surfaces an inline error to keep the user honest).
    */
-  setNotificationPrefsCategory: (category: string, enabled: boolean) => void;
+  setNotificationPrefsCategory: (category: string, enabled: boolean) => boolean;
   /**
    * #4543: stable per-device key used to address THIS client in the
    * `notification_prefs.devices` map. Sourced once at store init from
@@ -831,23 +846,30 @@ export interface ConnectionState {
    * { [category]: enabled } } } }`. Server shallow-merges so other device
    * entries — and other categories under THIS device — survive untouched.
    * `enabled = false` mutes the category on this device only; `true` is the
-   * explicit-unmute path (overrides a `false` global default). No-op when
-   * the socket is closed; the action does not surface errors back to the
-   * UI — the broadcast snapshot is the source of truth.
+   * explicit-unmute path (overrides a `false` global default).
+   *
+   * #4559: returns `true` when the WS message was sent, `false` when the
+   * socket was closed OR the deviceKey was empty (both cases yield a
+   * no-op). UI surfaces an inline error on `false` so the toggle revert
+   * isn't mistaken for the user mis-clicking.
    */
-  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => void;
+  setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => boolean;
   /**
    * #4544: patch the global quiet-hours window. `null` clears the window;
    * a window object (with `timezone`) sets it. The server broadcasts the
    * merged snapshot so all clients update in lockstep.
+   *
+   * #4559: returns `false` when the socket is closed.
    */
-  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => void;
+  setNotificationPrefsQuietHours: (window: { start: string; end: string; timezone: string } | null) => boolean;
   /**
    * #4544: patch the global bypass-category list. Sends the full list
    * (replacement, not delta) so an empty array maps to "nothing bypasses,
    * not even errors".
+   *
+   * #4559: returns `false` when the socket is closed.
    */
-  setNotificationPrefsBypassCategories: (categories: string[]) => void;
+  setNotificationPrefsBypassCategories: (categories: string[]) => boolean;
 
   // Multi-server registry actions
   addServer: (name: string, wsUrl: string, token: string) => ServerEntry;


### PR DESCRIPTION
## Summary

Closes #4559.

When `setNotificationPrefsCategory`, `setNotificationPrefsDevice`, `setNotificationPrefsQuietHours`, `setNotificationPrefsBypassCategories`, `setByokCredentials`, `clearByokCredentials`, or `refreshByokCredentialsStatus` fired while `socket.readyState !== OPEN`, the action silently no-op'd. The user toggled a checkbox, saw it refuse to stay flipped, and had no idea why — a soft failure indistinguishable from a misfire.

Implements Option B from the issue: fail-loud inline error. Each affected store action now returns `boolean` (`true` = sent, `false` = WS-closed no-op). SettingsPanel / SettingsScreen surface an inline banner ("Settings save failed — server disconnected. Reconnect and try again.") when the action reports `false`, and clear the banner on the next successful send.

## Scope

- **Dashboard store** (`packages/dashboard/src/store/connection.ts` + `types.ts`): all eight affected actions now return `boolean`. Wire payload + optimistic patch behaviour unchanged.
- **Dashboard UI** (`SettingsPanel.tsx`): wraps each setter in a handler that flips an inline banner per section (BYOK and Notifications get independent banners, so a stale BYOK failure can't bleed into Notifications). `role=alert` for screen readers. BYOK Save preserves the input on failure so retry is one click after reconnect.
- **Mobile store** (`packages/app/src/store/connection.ts` + `types.ts`): same four notification-prefs setters + refresh now return `boolean`. BYOK is dashboard-only.
- **Mobile UI** (`SettingsScreen.tsx`): same handler pattern with a red-tinted banner above the NOTIFICATION CATEGORIES section, `accessibilityRole='alert'` for VoiceOver / TalkBack. Shared copy matches the dashboard.

## Acceptance criteria

- [x] No silent no-op for notification-prefs toggle, BYOK Save, BYOK Remove, BYOK Refresh when WS is closed.
- [x] Inline error appears next to the control (Option B). User retries after reconnect.
- [x] Dashboard + mobile both implement the same pattern.
- [x] Tests cover the disconnected-toggle path for notification-prefs AND BYOK in the dashboard suite; mobile static-source tests pin the same handler routing + banner element.

## Test plan

- [x] `npx vitest run` (dashboard) — 2320/2320 tests pass, including the new `notification-prefs-ws-closed.test.ts` and the `Fail-loud inline error on WS-closed write (#4559)` describe block in `SettingsPanel.test.tsx`.
- [x] `npx jest` (mobile app) — 1398/1398 tests pass, including the new `SettingsScreen — fail-loud inline error on WS-closed write (#4559)` describe block.
- [x] `npx tsc --noEmit` passes on both packages.
- [ ] Manual: toggle a notification category while the dashboard's WS is dropped (kill the tunnel) — banner appears, toggle reverts, banner clears after reconnect + a successful re-toggle.

## Concurrency note

#4570 (preserve editor drafts) is being implemented in parallel on a separate worktree and also touches `SettingsPanel.tsx`. This PR is narrowly scoped to the WS-closed error surface; merge order does not matter, but a small conflict in `SettingsPanel.tsx` is likely.