### PR TITLE
feat(server): add chroxy-config surface for K8s workspacePVC

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -268,6 +268,52 @@ The `provider` key picks which AI CLI backs a session by default:
 
 Clients can override the default per-session by passing `provider` in a `create_session` WebSocket message. See [../../docs/providers.md](../../docs/providers.md) for capability differences (plan mode, permission handling, resume, attachments) and troubleshooting.
 
+### Kubernetes workspace PVC (`environments.k8s.workspace`)
+
+When the K8s environment backend is active on a **multi-node** cluster, the
+default `hostPath` workspace mount only works for Pods scheduled on the node
+that owns the host directory — on every other node the Pod silently mounts an
+empty `DirectoryOrCreate` and the workload sees no workspace. To make the
+workspace cluster-wide, K8sBackend supports mounting a pre-provisioned
+`PersistentVolumeClaim` instead (`#3385` / `#4547`).
+
+The PVC strategy is **operator-side configuration**: the claim, mount path, and
+read-only flag are cluster-ops concerns that don't vary per project, per
+session, or per user. Set the block once in `~/.chroxy/config.json` and every
+environment created on the K8s backend picks it up automatically (`#4556`).
+
+```json
+{
+  "environments": {
+    "enabled": true,
+    "k8s": {
+      "workspace": {
+        "claimName": "chroxy-workspace-pvc",
+        "mountPath": "/workspace",
+        "readOnly": false
+      }
+    }
+  }
+}
+```
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `claimName` | string | yes | — | Name of a pre-provisioned PVC in the target namespace. Must be a non-empty string. |
+| `mountPath` | string | no | `/workspace` | Pod-side mount path. |
+| `readOnly` | boolean | no | `false` | Mount the PVC read-only. |
+
+The block shape is validated at config-load time — a typo (missing `claimName`,
+wrong type) surfaces at startup, not at the first environment-creation call.
+Docker and other non-K8s backends silently ignore the block, so it's safe to
+leave in config when switching backends.
+
+Per-create callers (a future dashboard or CLI flag) can pass an explicit
+`workspacePVC` opt to override the configured default for a single environment;
+the per-call value always wins. With no caller override and no config block,
+the manager omits the field entirely and the K8s backend falls back to the
+`hostPath` strategy (single-node clusters).
+
 ## Examples
 
 ### Using Config File Only

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -296,6 +296,54 @@ export function validateConfig(config, verbose = false) {
     }
   }
 
+  // #4556: validate the optional environments.k8s.workspace block (operator
+  // surface for the K8sBackend PVC strategy added in #4547 / #4548). Done at
+  // config-load time so a typo (missing claimName, wrong type) surfaces at
+  // startup rather than on the first environment-creation call. Shape mirrors
+  // `K8sBackend.validateWorkspacePVC()` so an operator never sees a different
+  // message at load-time vs runtime for the same malformed value.
+  //
+  // Only fires when the sub-block is present — the common case (Docker
+  // operators without any k8s key, or with other k8s settings but no
+  // workspace block) passes through untouched.
+  if (config.environments && typeof config.environments === 'object' && !Array.isArray(config.environments)) {
+    const k8sBlock = config.environments.k8s
+    if (k8sBlock && typeof k8sBlock === 'object' && !Array.isArray(k8sBlock)) {
+      if (Object.prototype.hasOwnProperty.call(k8sBlock, 'workspace')) {
+        const ws = k8sBlock.workspace
+        if (typeof ws !== 'object' || ws === null || Array.isArray(ws)) {
+          warnings.push(
+            `Invalid 'environments.k8s.workspace': must be an object with a claimName property`,
+          )
+        } else {
+          if (!Object.prototype.hasOwnProperty.call(ws, 'claimName')) {
+            warnings.push(
+              `Missing 'environments.k8s.workspace.claimName': required, non-empty string`,
+            )
+          } else if (typeof ws.claimName !== 'string') {
+            warnings.push(
+              `Invalid type for 'environments.k8s.workspace.claimName': expected string, got ${typeof ws.claimName}`,
+            )
+          } else if (ws.claimName.length === 0) {
+            warnings.push(
+              `Invalid value for 'environments.k8s.workspace.claimName': must be a non-empty string`,
+            )
+          }
+          if (Object.prototype.hasOwnProperty.call(ws, 'mountPath') && typeof ws.mountPath !== 'string') {
+            warnings.push(
+              `Invalid type for 'environments.k8s.workspace.mountPath': expected string, got ${typeof ws.mountPath}`,
+            )
+          }
+          if (Object.prototype.hasOwnProperty.call(ws, 'readOnly') && typeof ws.readOnly !== 'boolean') {
+            warnings.push(
+              `Invalid type for 'environments.k8s.workspace.readOnly': expected boolean, got ${typeof ws.readOnly}`,
+            )
+          }
+        }
+      }
+    }
+  }
+
   // Validate externalUrl format if provided
   if (config.externalUrl && typeof config.externalUrl === 'string') {
     try {

--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -37,7 +37,22 @@ export { UNREACHABLE_STATUSES } from './environment-statuses.js'
  * creating sessions with an environmentId.
  */
 export class EnvironmentManager extends EventEmitter {
-  constructor({ statePath, _execFile, backend } = {}) {
+  /**
+   * @param {Object}  [opts]
+   * @param {string}  [opts.statePath] - On-disk path for environments.json
+   * @param {Function} [opts.\_execFile] - Injected execFile (testing seam)
+   * @param {Object}  [opts.backend]   - Pluggable backend (defaults to DockerBackend)
+   * @param {Object}  [opts.workspacePVCDefault] - #4556: operator-configured
+   *   PVC workspace strategy applied to every `create()` call that doesn't pass
+   *   an explicit `opts.workspacePVC`. Wires the chroxy-config
+   *   `environments.k8s.workspace` block into the manager. Shape mirrors
+   *   `K8sBackend.validateWorkspacePVC()`: `{ claimName, mountPath?, readOnly? }`.
+   *   Forwarded verbatim to the backend; non-K8s backends ignore it. Shape
+   *   validation lives in `validateConfig()` at load-time and (defensively
+   *   again) in `K8sBackend.validateWorkspacePVC()` at create-time — the
+   *   manager performs no validation of its own.
+   */
+  constructor({ statePath, _execFile, backend, workspacePVCDefault } = {}) {
     super()
     this._statePath = statePath || DEFAULT_STATE_PATH
     this._environments = new Map()
@@ -50,6 +65,10 @@ export class EnvironmentManager extends EventEmitter {
     // Pluggable backend — defaults to DockerBackend with the same _execFile
     // so the existing _execFile test seam still reaches Docker shellouts.
     this._backend = backend || new DockerBackend({ _execFile: this._execFile })
+    // #4556: configured PVC workspace default (operator surface). When set,
+    // every create() that doesn't pass workspacePVC falls back to this value.
+    // null when no `environments.k8s.workspace` block is configured.
+    this._workspacePVCDefault = workspacePVCDefault || null
   }
 
   /**
@@ -89,6 +108,12 @@ export class EnvironmentManager extends EventEmitter {
    *   (`{ claimName, mountPath?, readOnly? }`). Forwarded verbatim to the backend;
    *   DockerBackend and other non-K8s backends ignore it. Mutually exclusive with
    *   `opts.cwd`-as-hostPath on K8sBackend — the backend validates and throws.
+   *
+   *   #4556 — when the operator has configured `environments.k8s.workspace` in
+   *   chroxy config (wired via the constructor's `workspacePVCDefault` option),
+   *   a `create()` call that omits this field falls back to the configured
+   *   default. An explicit value here always wins (per-call override surface
+   *   for any future dashboard/CLI input).
    * @returns {Promise<Object>} The created environment object
    */
   async create({ name, cwd, image, memoryLimit, cpuLimit, containerUser, compose, primaryService, devcontainer, workspacePVC } = {}) {
@@ -123,6 +148,12 @@ export class EnvironmentManager extends EventEmitter {
     const validatedMounts = this._validateMounts(dcConfig.mounts, cwd)
     const validatedEnv = this._sanitizeContainerEnv(dcConfig.containerEnv)
 
+    // #4556: caller-supplied workspacePVC wins; otherwise fall back to the
+    // configured default (when the operator has set `environments.k8s.workspace`
+    // in chroxy config). Resolved here so the backend always sees the final
+    // effective value and the manager remains the single wiring point.
+    const effectiveWorkspacePVC = workspacePVC !== undefined ? workspacePVC : this._workspacePVCDefault || undefined
+
     const { containerId, containerCliPath } = await this._backend.createEnvironment({
       envId: id,
       cwd,
@@ -136,7 +167,9 @@ export class EnvironmentManager extends EventEmitter {
       postCreateCommand: dcConfig.postCreateCommand,
       // #4548: forward verbatim — only K8sBackend acts on this. Manager does no
       // shape validation; that lives in K8sBackend.validateWorkspacePVC().
-      workspacePVC,
+      // #4556: `effectiveWorkspacePVC` resolves the caller-vs-config-default
+      // precedence so the backend sees a single value.
+      workspacePVC: effectiveWorkspacePVC,
     })
 
     const env = {

--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -40,7 +40,7 @@ export class EnvironmentManager extends EventEmitter {
   /**
    * @param {Object}  [opts]
    * @param {string}  [opts.statePath] - On-disk path for environments.json
-   * @param {Function} [opts.\_execFile] - Injected execFile (testing seam)
+   * @param {Function} [opts._execFile] - Injected execFile (testing seam)
    * @param {Object}  [opts.backend]   - Pluggable backend (defaults to DockerBackend)
    * @param {Object}  [opts.workspacePVCDefault] - #4556: operator-configured
    *   PVC workspace strategy applied to every `create()` call that doesn't pass
@@ -68,7 +68,7 @@ export class EnvironmentManager extends EventEmitter {
     // #4556: configured PVC workspace default (operator surface). When set,
     // every create() that doesn't pass workspacePVC falls back to this value.
     // null when no `environments.k8s.workspace` block is configured.
-    this._workspacePVCDefault = workspacePVCDefault || null
+    this._workspacePVCDefault = workspacePVCDefault ?? null
   }
 
   /**
@@ -152,7 +152,7 @@ export class EnvironmentManager extends EventEmitter {
     // configured default (when the operator has set `environments.k8s.workspace`
     // in chroxy config). Resolved here so the backend always sees the final
     // effective value and the manager remains the single wiring point.
-    const effectiveWorkspacePVC = workspacePVC !== undefined ? workspacePVC : this._workspacePVCDefault || undefined
+    const effectiveWorkspacePVC = workspacePVC !== undefined ? workspacePVC : (this._workspacePVCDefault ?? undefined)
 
     const { containerId, containerCliPath } = await this._backend.createEnvironment({
       envId: id,

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -412,7 +412,10 @@ export async function startCliServer(config) {
     if (workspacePVCDefault) {
       const mountPath = workspacePVCDefault.mountPath || '/workspace'
       const readOnlyTag = workspacePVCDefault.readOnly ? ' (readOnly)' : ''
-      log.info(`EnvironmentManager: K8s workspace PVC configured (claim: ${workspacePVCDefault.claimName}, mount: ${mountPath})${readOnlyTag}`)
+      // Make the K8s-only scope explicit so an operator who set this block
+      // against a Docker deployment doesn't assume the PVC is being mounted —
+      // Docker / other backends silently ignore the field at runtime.
+      log.info(`EnvironmentManager: K8s workspace PVC configured (claim: ${workspacePVCDefault.claimName}, mount: ${mountPath})${readOnlyTag} — active only on K8sBackend; ignored by Docker and other backends`)
     }
     environmentManager = new EnvironmentManager({ workspacePVCDefault })
     await logEnvironmentManagerReconnectResult(environmentManager, log)

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -401,7 +401,20 @@ export async function startCliServer(config) {
   let environmentManager = null
   if (config?.environments?.enabled) {
     const { EnvironmentManager } = await import('./environment-manager.js')
-    environmentManager = new EnvironmentManager()
+    // #4556: forward the operator-configured K8s workspace PVC default so
+    // every environment created on a K8s backend picks up the strategy
+    // without per-call plumbing. Shape was validated at config-load time
+    // (`validateConfig` in config.js); the manager re-passes it verbatim to
+    // the backend, which is the single enforcement point for runtime checks
+    // (K8sBackend.validateWorkspacePVC). Docker / other backends ignore the
+    // field, so this is safe to pass regardless of the active backend.
+    const workspacePVCDefault = config?.environments?.k8s?.workspace || null
+    if (workspacePVCDefault) {
+      const mountPath = workspacePVCDefault.mountPath || '/workspace'
+      const readOnlyTag = workspacePVCDefault.readOnly ? ' (readOnly)' : ''
+      log.info(`EnvironmentManager: K8s workspace PVC configured (claim: ${workspacePVCDefault.claimName}, mount: ${mountPath})${readOnlyTag}`)
+    }
+    environmentManager = new EnvironmentManager({ workspacePVCDefault })
     await logEnvironmentManagerReconnectResult(environmentManager, log)
   }
 

--- a/packages/server/tests/config-range-validation.test.js
+++ b/packages/server/tests/config-range-validation.test.js
@@ -114,3 +114,111 @@ describe('validateConfig range validation', () => {
     assert.ok(!result.warnings.some(w => w.includes('1-65535')))
   })
 })
+
+/**
+ * #4556 — chroxy-config surface for K8sBackend's workspacePVC strategy.
+ *
+ * Validates `config.environments.k8s.workspace` at load time so the operator
+ * sees errors at startup, not at first environment creation. The block is
+ * optional; when present its shape mirrors `K8sBackend.validateWorkspacePVC()`
+ * so the operator never sees one error message at startup and a different one
+ * at create-time for the same malformed value.
+ *
+ * Schema:
+ *   environments.k8s.workspace = {
+ *     claimName: string (required, non-empty),
+ *     mountPath: string (optional),
+ *     readOnly:  boolean (optional),
+ *   }
+ *
+ * Validation is purely additive — the field is optional, so a config without
+ * the block (the common case for single-node Docker operators) passes
+ * unchanged. The whole `environments` key already accepts arbitrary objects
+ * (`'object'` in CONFIG_SCHEMA); these checks only fire when the workspace
+ * sub-block is actually present.
+ */
+describe('validateConfig environments.k8s.workspace (#4556)', () => {
+  it('accepts a valid workspace block with all fields', () => {
+    const config = {
+      environments: {
+        k8s: {
+          workspace: { claimName: 'shared-pvc', mountPath: '/workspace', readOnly: true },
+        },
+      },
+    }
+    const result = validateConfig(config)
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('accepts a workspace block with only claimName (other fields optional)', () => {
+    const config = { environments: { k8s: { workspace: { claimName: 'minimal-pvc' } } } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('warns when workspace.claimName is missing', () => {
+    const config = { environments: { k8s: { workspace: { mountPath: '/workspace' } } } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, false)
+    assert.ok(
+      result.warnings.some(w => /claimName/.test(w) && /required|non-empty/.test(w)),
+      `expected claimName-required warning, got: ${result.warnings.join('; ')}`
+    )
+  })
+
+  it('warns when workspace.claimName is an empty string', () => {
+    const config = { environments: { k8s: { workspace: { claimName: '' } } } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /claimName/.test(w) && /non-empty/.test(w)))
+  })
+
+  it('warns when workspace.claimName is not a string', () => {
+    const config = { environments: { k8s: { workspace: { claimName: 42 } } } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /claimName/.test(w) && /string/.test(w)))
+  })
+
+  it('warns when workspace.mountPath is not a string', () => {
+    const config = { environments: { k8s: { workspace: { claimName: 'p', mountPath: 123 } } } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /mountPath/.test(w) && /string/.test(w)))
+  })
+
+  it('warns when workspace.readOnly is not a boolean', () => {
+    const config = { environments: { k8s: { workspace: { claimName: 'p', readOnly: 'yes' } } } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /readOnly/.test(w) && /boolean/.test(w)))
+  })
+
+  it('warns when workspace is not an object', () => {
+    const config = { environments: { k8s: { workspace: 'shared-pvc' } } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /workspace/.test(w) && /object/.test(w)))
+  })
+
+  it('warns when workspace is an array (objects only, no array shorthand)', () => {
+    const config = { environments: { k8s: { workspace: ['shared-pvc'] } } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /workspace/.test(w) && /object/.test(w)))
+  })
+
+  it('passes when environments.k8s is present but workspace block is absent', () => {
+    // Only the workspace sub-block is validated; other k8s fields are passed
+    // through untouched (future K8s settings may live there too).
+    const config = { environments: { k8s: { namespace: 'chroxy' } } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('passes when environments.enabled is set without any k8s block (Docker operator)', () => {
+    const config = { environments: { enabled: true } }
+    const result = validateConfig(config)
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+})

--- a/packages/server/tests/environment-manager.test.js
+++ b/packages/server/tests/environment-manager.test.js
@@ -327,6 +327,92 @@ describe('EnvironmentManager.create() — workspacePVC passthrough (#4548)', () 
   })
 })
 
+/**
+ * #4556 — chroxy-config surface for K8sBackend's workspacePVC strategy.
+ *
+ * #4548 plumbed `opts.workspacePVC` through the manager but left no operator-
+ * facing way to configure it: callers (dashboard, session-create flow, CLI) never
+ * pass the option, so the seam was dead. The config block lets operators set the
+ * PVC strategy once per backend; EnvironmentManager wires the configured default
+ * into every `create()` call. An explicit `opts.workspacePVC` from the caller
+ * still wins (per-call override path for any future dashboard/CLI surface).
+ *
+ * The shape validation still lives in K8sBackend.validateWorkspacePVC (and in
+ * `validateConfig` at config-load time). The manager only does the wiring.
+ */
+describe('EnvironmentManager.create() — workspacePVCDefault from config (#4556)', () => {
+  let tmpDir, statePath
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-env-test-'))
+    statePath = join(tmpDir, 'environments.json')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function createRecordingBackend() {
+    const calls = []
+    return {
+      calls,
+      async createEnvironment(opts) {
+        calls.push(opts)
+        return {
+          containerId: 'stub-container-id',
+          containerCliPath: '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js',
+        }
+      },
+    }
+  }
+
+  it('applies workspacePVCDefault when caller omits workspacePVC', async () => {
+    const backend = createRecordingBackend()
+    const workspacePVCDefault = { claimName: 'configured-pvc', mountPath: '/workspace', readOnly: false }
+    const manager = new EnvironmentManager({ statePath, backend, workspacePVCDefault })
+
+    // Caller omits workspacePVC — manager should fill it from the configured default.
+    await manager.create({ name: 'cfg-env', cwd: '/tmp' })
+
+    assert.equal(backend.calls.length, 1)
+    assert.deepEqual(
+      backend.calls[0].workspacePVC,
+      workspacePVCDefault,
+      'manager must forward the configured default verbatim when caller omits the option'
+    )
+  })
+
+  it('caller-supplied workspacePVC wins over workspacePVCDefault', async () => {
+    const backend = createRecordingBackend()
+    const workspacePVCDefault = { claimName: 'cluster-default-pvc' }
+    const manager = new EnvironmentManager({ statePath, backend, workspacePVCDefault })
+
+    const callerPVC = { claimName: 'per-call-override-pvc', mountPath: '/override', readOnly: true }
+    await manager.create({ name: 'override-env', cwd: '/tmp', workspacePVC: callerPVC })
+
+    assert.equal(backend.calls.length, 1)
+    assert.deepEqual(
+      backend.calls[0].workspacePVC,
+      callerPVC,
+      'explicit opts.workspacePVC must override the configured default (per-call surface wins)'
+    )
+  })
+
+  it('omits workspacePVC entirely when neither config nor caller supplies it', async () => {
+    const backend = createRecordingBackend()
+    const manager = new EnvironmentManager({ statePath, backend })
+
+    await manager.create({ name: 'no-config-no-caller', cwd: '/tmp' })
+
+    assert.equal(backend.calls.length, 1)
+    assert.equal(
+      backend.calls[0].workspacePVC,
+      undefined,
+      'workspacePVC must be undefined when no config default and no caller value'
+    )
+  })
+})
+
 describe('EnvironmentManager.destroy()', () => {
   let tmpDir, statePath
 


### PR DESCRIPTION
## Summary

#4548 plumbed `opts.workspacePVC` through `EnvironmentManager.create()` but left no operator-facing way to configure it. Callers (dashboard, session-create, CLI) never pass the option, so the K8s PVC workspace strategy added in #4547 was a dead seam.

Per the design discussion in #4554, the chosen surface is **chroxy config** (operator-side, set once per backend, doesn't pollute per-project `devcontainer.json`, doesn't add per-create dashboard friction). This PR delivers that surface.

```json
{
  "environments": {
    "enabled": true,
    "k8s": {
      "workspace": {
        "claimName": "chroxy-workspace-pvc",
        "mountPath": "/workspace",
        "readOnly": false
      }
    }
  }
}
```

## Changes

- **`packages/server/src/config.js`** — `validateConfig` now checks the optional `environments.k8s.workspace` block at config-load time. Operator sees errors at startup, not on the first `create_environment` call. Shape mirrors `K8sBackend.validateWorkspacePVC()` so messages don't drift between load-time and runtime. Block is optional; the common case (Docker operators without any `k8s` key) passes through unchanged.
- **`packages/server/src/environment-manager.js`** — new constructor opt `workspacePVCDefault`. When `create()` is called without an explicit `opts.workspacePVC`, the manager forwards the configured default to the backend. Explicit caller value always wins (per-call override seam for any future dashboard/CLI surface).
- **`packages/server/src/server-cli.js`** — read `config.environments.k8s.workspace` and forward it as `workspacePVCDefault` when constructing the manager. Logs a one-line summary at startup so operators can verify the configured strategy took effect.
- **`packages/server/CONFIG.md`** — documents the new block with a worked example, field table, and precedence rules.

## Design choices

- **Manager does no shape validation.** Validation lives in `validateConfig` (load-time) and `K8sBackend.validateWorkspacePVC` (defensively, at create-time). The manager is the wiring point, not a third validator.
- **Caller > config > omitted.** Explicit `opts.workspacePVC` always wins (per-call override). With no caller override and no config block, the manager omits the field entirely and the K8s backend falls back to its `hostPath` strategy (single-node clusters).
- **Server-only PR.** No dashboard UI surface here — that's a future sub-issue if needed. Per-call override is already supported on the API; this PR makes the config-only path live.
- **Block lives under `environments.k8s.*`.** Leaves room for future K8s settings (`namespace`, `imagePullPolicy`, …) alongside the workspace sub-block.

## Tests

- `environment-manager.test.js` (3 new): config-only path, caller-override path, neither-supplied path.
- `config-range-validation.test.js` (10 new): valid full / minimal block, missing claimName, empty claimName, non-string claimName, non-string mountPath, non-boolean readOnly, non-object workspace, array workspace, `k8s` block without `workspace` sub-key, `environments.enabled` without any `k8s` block.

## Test plan

- [x] New tests pass: `node --test tests/config-range-validation.test.js tests/environment-manager.test.js` (121/121)
- [x] Related suites pass: `node --test tests/{config-range-validation,environment-manager,config}.test.js tests/environments/backends/{k8s,backend-seam}.test.js tests/server-cli-environment-reconnect.test.js` (416/416)
- [x] Full server suite: 6112/6117. The 3 remaining failures are pre-existing and unrelated: TunnelManager Integration requires `cloudflared`; WebTaskManager feature-detection sees `claude --remote` on the local install. Both reproduce on bare `main` without this PR.

Closes #4556