### PR TITLE
feat(ui): capability-gate Notifications settings section

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -51,7 +51,13 @@ describe('SettingsScreen — Notification categories section (#4542)', () => {
     // #4559 widened the inner gap to 600 chars to accommodate the
     // ignore-the-boolean-return docblock that explains why the boolean
     // is unused on the initial mount refresh.
-    expect(settingsSource).toMatch(/useEffect\([\s\S]{0,600}refreshNotificationPrefs\(\)/);
+    // #4560 widened further to 1000 chars to fit the capability-gate
+    // docblock (`notificationPrefsSupported` early-return) that explains
+    // why we skip the WS write when the server doesn't advertise the
+    // notification-prefs handler — pre-#4541 servers would otherwise see
+    // an `unknown_message` error and the client would sit on "Loading
+    // preferences…" forever waiting for a snapshot that will never arrive.
+    expect(settingsSource).toMatch(/useEffect\([\s\S]{0,1000}refreshNotificationPrefs\(\)/);
   });
 
   it('shows a loading hint until the first snapshot lands', () => {
@@ -421,5 +427,77 @@ describe('SettingsScreen — Quiet-hours editor: snapshot-vs-draft (#4570)', () 
     expect(settingsSource).toMatch(
       /handleDiscardDraft[\s\S]{0,800}setStart\(snap\.start\)[\s\S]{0,200}setDirty\(false\)[\s\S]{0,200}setPendingSnapshot\(undefined\)/,
     );
+  });
+});
+
+// #4560: capability gate for the Notifications sections. Pre-#4541 servers
+// (no `notification_prefs_get` handler) used to leave the sections stuck on
+// "Loading preferences…" forever waiting for a snapshot that would never
+// arrive. The gate reads `serverCapabilities.notificationPrefs` from the
+// lifecycle store, swaps the section body for an explicit "not supported"
+// hint when the capability is missing, and skips the WS refresh write so
+// pre-#4541 servers don't log `unknown_message` noise on every Settings open.
+describe('SettingsScreen — notification-prefs capability gate (#4560)', () => {
+  const lifecycleSource = fs.readFileSync(
+    path.resolve(__dirname, '../../store/connection-lifecycle.ts'),
+    'utf-8',
+  );
+
+  it('reads notificationPrefsSupported from the lifecycle store', () => {
+    expect(settingsSource).toMatch(
+      /notificationPrefsSupported\s*=\s*useConnectionLifecycleStore\([\s\S]{0,200}serverCapabilities\?\.notificationPrefs/,
+    );
+  });
+
+  it('skips the refresh when capability is missing (early-return in useEffect)', () => {
+    // The early-return must short-circuit BEFORE the wsSend so pre-#4541
+    // servers don't log `unknown_message` noise on every mount.
+    expect(settingsSource).toMatch(
+      /if\s*\(!notificationPrefsSupported\)\s*return;\s*\n\s*refreshNotificationPrefs\(\);/,
+    );
+  });
+
+  it('keys the refresh useEffect on notificationPrefsSupported (so reconnects retry)', () => {
+    // The dep array must include the capability flag so a reconnect that
+    // flips the flag from false → true triggers the deferred refresh.
+    expect(settingsSource).toMatch(
+      /\}, \[notificationPrefsSupported,\s*refreshNotificationPrefs\]\);/,
+    );
+  });
+
+  it('renders the not-supported hint with the documented testID + copy', () => {
+    expect(settingsSource).toMatch(/testID="notification-prefs-not-supported"/);
+    expect(settingsSource).toMatch(/Your server does not support notification preferences/);
+    expect(settingsSource).toMatch(/v0\.9\.14/);
+  });
+
+  it('gates both the categories AND the quiet-hours sections', () => {
+    // Quiet-hours uses the same QuietHoursEditor which reads from
+    // `notificationPrefs.quietHours` — that field never arrives on a
+    // pre-#4541 server, so the editor would also be stuck. The fix is to
+    // gate both sections on the same capability flag.
+    expect(settingsSource).toMatch(/testID="quiet-hours-not-supported"/);
+  });
+
+  it('declares serverCapabilities on the lifecycle store with a fail-closed default', () => {
+    // Empty `{}` is the fail-closed default: an absent flag reads as
+    // `false`, so feature-gated UI hides itself rather than silently
+    // no-oping clicks against a missing server handler.
+    expect(lifecycleSource).toMatch(/serverCapabilities:\s*Record<string,\s*boolean>/);
+    expect(lifecycleSource).toMatch(/serverCapabilities:\s*\{\}\s*as\s*Record<string,\s*boolean>/);
+  });
+
+  it('parses the auth_ok capability map in the message-handler (coerces non-true to false)', () => {
+    // Mirror of the dashboard's parser: malformed entries (string "true",
+    // numeric 1, null, etc.) must be coerced to `false` so a buggy server
+    // can't accidentally enable a UI gate.
+    expect(messageHandlerSource).toMatch(/capabilitiesRaw\s*=\s*msg\.capabilities/);
+    expect(messageHandlerSource).toMatch(
+      /serverCapabilities\s*:\s*Record<string,\s*boolean>\s*=\s*\{\}/,
+    );
+    expect(messageHandlerSource).toMatch(/serverCapabilities\[k\]\s*=\s*v\s*===\s*true/);
+    // Forwarded to the lifecycle store on auth_ok so the gate flips
+    // immediately on (re)connect.
+    expect(messageHandlerSource).toMatch(/setServerInfo\([\s\S]{0,800}serverCapabilities,/);
   });
 });

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -195,6 +195,17 @@ export function SettingsScreen() {
   // list of categories that fire even during quiet hours.
   const setNotificationPrefsQuietHours = useConnectionStore((s) => s.setNotificationPrefsQuietHours);
   const setNotificationPrefsBypassCategories = useConnectionStore((s) => s.setNotificationPrefsBypassCategories);
+  // #4560: capability gate for the Notifications sections. Pre-#4541 servers
+  // have no `notification_prefs_get` handler — without this gate the
+  // category list + quiet-hours editor sat on "Loading preferences…" forever
+  // waiting for a snapshot that would never arrive. Empty map = fail-closed
+  // so an older server (or a still-connecting one) surfaces the explicit
+  // "not supported" message instead of dead UI. Declared above the refresh
+  // useEffect so it can be referenced from both the dep array and the
+  // early-return guard.
+  const notificationPrefsSupported = useConnectionLifecycleStore(
+    (s) => !!s.serverCapabilities?.notificationPrefs,
+  );
 
   useEffect(() => {
     // #4559: ignore the boolean return on initial refresh — a closed
@@ -202,8 +213,16 @@ export function SettingsScreen() {
     // the tunnel is still recovering). The inline banner only fires for
     // user-initiated writes; the snapshot will arrive once the connection
     // settles.
+    //
+    // #4560: skip the refresh entirely when the server doesn't advertise
+    // the `notificationPrefs` capability. Pre-#4541 servers have no handler
+    // for `notification_prefs_get`, so the request would either get
+    // rejected as an `unknown_message` error or silently dropped — either
+    // way no snapshot lands and the loading hint sits forever. Skipping
+    // the WS write also keeps the gated render decisions self-consistent.
+    if (!notificationPrefsSupported) return;
     refreshNotificationPrefs();
-  }, [refreshNotificationPrefs]);
+  }, [notificationPrefsSupported, refreshNotificationPrefs]);
 
   // #4559: thin wrappers around the four notification-prefs setters. Each
   // delegates to the store action (which returns `true` when sent, `false`
@@ -512,7 +531,17 @@ export function SettingsScreen() {
         </View>
       )}
       <View style={styles.section} testID="notification-prefs-section">
-        {notificationPrefs == null ? (
+        {!notificationPrefsSupported ? (
+          // #4560: capability-gated branch. Pre-#4541 servers don't have a
+          // `notification_prefs_get` handler — the user must upgrade to
+          // chroxy v0.9.14+ to manage these. Without this branch the
+          // section sat on "Loading preferences…" forever.
+          <View style={styles.row}>
+            <Text style={styles.rowHint} testID="notification-prefs-not-supported">
+              Your server does not support notification preferences. Upgrade to chroxy v0.9.14 or newer to manage per-category opt-in, per-device mutes, and quiet hours from here.
+            </Text>
+          </View>
+        ) : notificationPrefs == null ? (
           <View style={styles.row}>
             <Text style={styles.rowHint} testID="notification-prefs-loading">
               Loading preferences&hellip;
@@ -578,7 +607,17 @@ export function SettingsScreen() {
       {/* NOTIFICATIONS — Quiet hours (#4544) */}
       <Text style={styles.sectionHeader}>QUIET HOURS</Text>
       <View style={styles.section} testID="quiet-hours-section">
-        {notificationPrefs == null ? (
+        {!notificationPrefsSupported ? (
+          // #4560: same capability gate as the categories section above.
+          // The QuietHoursEditor reads from `notificationPrefs.quietHours`
+          // which never lands on a pre-#4541 server, so rendering the
+          // editor would put it in a permanent loading state.
+          <View style={styles.row}>
+            <Text style={styles.rowHint} testID="quiet-hours-not-supported">
+              Requires chroxy v0.9.14 or newer.
+            </Text>
+          </View>
+        ) : notificationPrefs == null ? (
           <View style={styles.row}>
             <Text style={styles.rowHint}>Loading preferences&hellip;</Text>
           </View>

--- a/packages/app/src/store/connection-lifecycle.ts
+++ b/packages/app/src/store/connection-lifecycle.ts
@@ -39,6 +39,9 @@ interface ServerInfo {
   serverResultTimeoutMs?: number | null;
   sessionCwd?: string | null;
   isEncrypted?: boolean;
+  // #4560 — server-advertised capability map from auth_ok. See the
+  // doc comment on ConnectionLifecycleState.serverCapabilities below.
+  serverCapabilities?: Record<string, boolean>;
 }
 
 interface ConnectionLifecycleState {
@@ -64,6 +67,18 @@ interface ConnectionLifecycleState {
    */
   serverResultTimeoutMs: number | null;
   isEncrypted: boolean;
+
+  /**
+   * #4560 — server-advertised capability map from auth_ok. Keyed by feature
+   * name (e.g. `notificationPrefs`), value=boolean. Lets the app gate UI
+   * affordances on the server actually supporting the matching WS message —
+   * pre-#4541 servers omit `notificationPrefs` so the Notifications section
+   * in SettingsScreen renders an explicit "not supported" message instead
+   * of sitting on "Loading preferences…" forever. Empty `{}` on fresh
+   * connect, repopulated on every auth_ok; cleared on disconnect so a
+   * reconnect against an older server can't have stale flags left set.
+   */
+  serverCapabilities: Record<string, boolean>;
 
   // Connection quality
   latencyMs: number | null;
@@ -99,6 +114,10 @@ const initialState = {
   serverProtocolVersion: null as number | null,
   serverResultTimeoutMs: null as number | null,
   isEncrypted: false,
+  // #4560 — empty map until auth_ok lands; cleared on every disconnect via
+  // reset() so a reconnect against a different (or older) server can't have
+  // its UI gates left enabled by stale state. Empty = fail-closed.
+  serverCapabilities: {} as Record<string, boolean>,
   latencyMs: null as number | null,
   connectionQuality: null as 'good' | 'fair' | 'poor' | null,
   connectionError: null as string | null,

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1015,6 +1015,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         teleport: !!webFeaturesRaw.teleport,
       } : { available: false, remote: false, teleport: false };
 
+      // #4560: parse server-advertised capability map. Older servers omit the
+      // field; treat absence as "no advertised capabilities" so feature-gated
+      // UI hides itself fail-closed (rather than silently no-oping clicks
+      // against unimplemented WS handlers). Coerce values to boolean so a
+      // malformed entry can't accidentally enable a gate.
+      const capabilitiesRaw = msg.capabilities as Record<string, unknown> | undefined;
+      const serverCapabilities: Record<string, boolean> = {};
+      if (capabilitiesRaw && typeof capabilitiesRaw === 'object' && !Array.isArray(capabilitiesRaw)) {
+        for (const [k, v] of Object.entries(capabilitiesRaw)) {
+          serverCapabilities[k] = v === true;
+        }
+      }
+
 
       // On reconnect, preserve messages and terminal buffer
       // If server provided a sessionToken (via pairing), use it for future auth
@@ -1059,6 +1072,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         serverProtocolVersion: authProtocolVersion,
         serverResultTimeoutMs: authResultTimeoutMs,
         sessionCwd: authSessionCwd,
+        // #4560: overwrite stale capabilities from a previous connection on
+        // every auth_ok so a reconnect against a different (or older) server
+        // can't have UI gates left enabled by previously-advertised flags.
+        serverCapabilities,
       });
       useConnectionLifecycleStore.getState().setConnectionError(null, 0);
       useConnectionLifecycleStore.getState().setUserDisconnected(false);

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -89,6 +89,11 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     // tests override.
     setNotificationPrefsQuietHours: vi.fn().mockReturnValue(true),
     setNotificationPrefsBypassCategories: vi.fn().mockReturnValue(true),
+    // #4560: server-advertised capabilities. Default to the modern shape
+    // (notificationPrefs supported) so existing tests covering the
+    // Notifications section keep exercising the rendered path. Tests
+    // covering the older-server gate override with `{}`.
+    serverCapabilities: { notificationPrefs: true },
     ...extra,
   }
 }
@@ -1468,6 +1473,94 @@ describe('SettingsPanel', () => {
         fireEvent.click(screen.getByTestId('byok-save-button'))
         expect(screen.queryByTestId('byok-ws-closed-error')).toBeNull()
       })
+    })
+  })
+
+  // #4560: gate the Notifications section on the server advertising the
+  // `notificationPrefs` capability in auth_ok. Pre-#4541 servers have no
+  // `notification_prefs_get` handler — without this gate the section sat on
+  // "Loading preferences…" forever waiting for a snapshot that would never
+  // arrive. Capability-true keeps the existing render path; capability-false
+  // swaps in a "not supported" message that names the requirement.
+  describe('Notification preferences — capability gate (#4560)', () => {
+    const categories = {
+      permission: true,
+      result: true,
+      activity_update: true,
+      activity_waiting: true,
+      activity_error: true,
+      inactivity_warning: true,
+      live_activity: true,
+    }
+    const defaultPrefs = { categories, devices: {}, quietHours: null }
+
+    it('renders the Notifications section when the server advertises notificationPrefs', () => {
+      setMockState({
+        notificationPrefs: defaultPrefs,
+        serverCapabilities: { notificationPrefs: true },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('notification-prefs-section')).toBeInTheDocument()
+      // Loading hint is absent because prefs already landed.
+      expect(screen.queryByTestId('notification-prefs-not-supported')).toBeNull()
+    })
+
+    it('renders the loading hint when capability is on but the snapshot has not arrived yet', () => {
+      // Pre-snapshot state on a supported server still flows through the
+      // existing "Loading preferences…" affordance — the gate only changes
+      // behaviour for unsupported servers.
+      setMockState({
+        notificationPrefs: null,
+        serverCapabilities: { notificationPrefs: true },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('notification-prefs-section')).toBeInTheDocument()
+      expect(screen.getByTestId('notification-prefs-loading')).toBeInTheDocument()
+      expect(screen.queryByTestId('notification-prefs-not-supported')).toBeNull()
+    })
+
+    it('renders the "not supported" message when the server omits the capability', () => {
+      setMockState({
+        notificationPrefs: null,
+        serverCapabilities: {},
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      // Section header still rendered so users can see the feature exists
+      // (and what they would need to upgrade to in order to use it), but
+      // the loading hint is replaced with an explicit explanation.
+      expect(screen.getByTestId('notification-prefs-section')).toBeInTheDocument()
+      const notSupported = screen.getByTestId('notification-prefs-not-supported')
+      expect(notSupported).toBeInTheDocument()
+      // Loading hint must NOT appear — the pre-#4560 bug was leaving it
+      // there forever; that's the behaviour this gate fixes.
+      expect(screen.queryByTestId('notification-prefs-loading')).toBeNull()
+      // No category toggles should be rendered against an unsupported
+      // server — the buttons would no-op against a missing handler.
+      expect(screen.queryByTestId('notification-prefs-toggle-result')).toBeNull()
+    })
+
+    it('does not call refreshNotificationPrefs when capability is missing', () => {
+      // Pre-#4541 servers don't recognise `notification_prefs_get`. Firing
+      // it against them produces an `unknown_message` error in the server
+      // logs and accomplishes nothing — gate the call out entirely.
+      const refreshNotificationPrefs = vi.fn()
+      setMockState({
+        notificationPrefs: null,
+        serverCapabilities: {},
+        refreshNotificationPrefs,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(refreshNotificationPrefs).not.toHaveBeenCalled()
+    })
+
+    it('treats serverCapabilities defaulting to {} as unsupported (fail-closed)', () => {
+      // Mirrors the auth_ok-handler default — older servers omit the field
+      // entirely and the store seeds an empty map. The UI must read absence
+      // as "feature off" so a stale connection (or a buggy server that
+      // omits the flag) doesn't accidentally re-enable the broken section.
+      setMockState({ notificationPrefs: null, serverCapabilities: {} })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('notification-prefs-not-supported')).toBeInTheDocument()
     })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -459,6 +459,15 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   // is the list of categories that fire even during quiet hours.
   const setNotificationPrefsQuietHours = useConnectionStore(s => s.setNotificationPrefsQuietHours)
   const setNotificationPrefsBypassCategories = useConnectionStore(s => s.setNotificationPrefsBypassCategories)
+  // #4560: capability gate for the Notifications section. Pre-#4541 servers
+  // have no `notification_prefs_get` handler; firing the request was a
+  // fire-and-forget no-op that left the section stuck on "Loading
+  // preferences…" forever. Mirrors the per-capability pattern already used
+  // by skillTrustAccept / skillTrustGrant (App.tsx), gated server-wide
+  // rather than per-session. Default to fail-closed: an empty map (older
+  // server, or pre-connect) reads as "feature not supported" so the user
+  // sees an explicit "needs a newer server" message instead of dead UI.
+  const notificationPrefsSupported = useConnectionStore(s => !!s.serverCapabilities?.notificationPrefs)
   const activeSessionPromptEvaluator = sessions.find(s => s.sessionId === activeSessionId)?.promptEvaluator
   // #3805: same capability gate pattern as promptEvaluator — only
   // render the toggle when the active session reports the boolean
@@ -538,10 +547,19 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   // (other dashboard / mobile client setting a category) are pushed via the
   // server's broadcast after every `notification_prefs_set`, so once
   // connected we stay in sync without polling.
+  //
+  // #4560: skip the refresh entirely when the server doesn't advertise the
+  // `notificationPrefs` capability — pre-#4541 servers have no handler for
+  // `notification_prefs_get`, so the request would either get rejected as
+  // an `unknown_message` error or be silently dropped. Either way the
+  // section never receives a snapshot and the loading hint sits forever.
+  // Skipping the WS write keeps the server logs clean and makes the gated
+  // render decisions self-consistent.
   useEffect(() => {
     if (!isOpen) return
+    if (!notificationPrefsSupported) return
     refreshNotificationPrefs()
-  }, [isOpen, refreshNotificationPrefs])
+  }, [isOpen, notificationPrefsSupported, refreshNotificationPrefs])
 
   // #4559: clear the inline "server disconnected" banners when the panel
   // closes so re-opening Settings starts from a clean slate. A stale
@@ -1002,7 +1020,14 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               stable localStorage id sent in `deviceInfo` on auth), so the
               dashboard always addresses the same `devices` entry across
               reconnects. When `currentDeviceKey` is null (storage broken),
-              the per-device toggle row is suppressed entirely. */}
+              the per-device toggle row is suppressed entirely.
+
+              #4560: the section header is always rendered so the user knows
+              the feature exists. When the server doesn't advertise the
+              `notificationPrefs` capability (pre-#4541), the body is
+              replaced with an explicit "needs a newer server" message —
+              the prior behaviour left "Loading preferences…" up forever
+              because pre-#4541 servers never reply to `notification_prefs_get`. */}
           <section className="settings-section" data-testid="notification-prefs-section">
             <h3>Notifications</h3>
             <p className="settings-hint">
@@ -1023,7 +1048,16 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 {notifWsClosedError}
               </p>
             )}
-            {notificationPrefs == null ? (
+            {!notificationPrefsSupported ? (
+              <p
+                className="settings-hint"
+                data-testid="notification-prefs-not-supported"
+              >
+                Your server does not support notification preferences. Upgrade
+                to chroxy v0.9.14 or newer to manage per-category opt-in,
+                per-device mutes, and quiet hours from here.
+              </p>
+            ) : notificationPrefs == null ? (
               <p
                 className="settings-hint"
                 data-testid="notification-prefs-loading"

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -282,6 +282,56 @@ describe('@chroxy/protocol schemas', () => {
     assert.equal(result.data.streamStallTimeoutMs, undefined)
   })
 
+  // #4560 — `notificationPrefs` capability surfaced in auth_ok so dashboard /
+  // mobile can gate the Notifications settings section on the server having a
+  // `notification_prefs_get` handler (added in #4541). Older servers omit the
+  // flag and clients fall through to the "not supported" branch.
+  it('accepts auth_ok with notificationPrefs capability (#4560)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const result = ServerAuthOkSchema.safeParse({
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.9.13',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+      capabilities: {
+        skillTrustAccept: true,
+        skillTrustGrant: true,
+        notificationPrefs: true,
+      },
+    })
+    assert.ok(result.success, 'Should validate auth_ok with notificationPrefs capability')
+    assert.equal(result.data.capabilities.notificationPrefs, true)
+  })
+
+  it('accepts auth_ok without notificationPrefs capability (older servers, pre-#4541)', async () => {
+    const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
+    const result = ServerAuthOkSchema.safeParse({
+      type: 'auth_ok',
+      clientId: 'c',
+      serverMode: 'cli',
+      serverVersion: '0.9.0',
+      latestVersion: null,
+      serverCommit: 'abc',
+      cwd: null,
+      connectedClients: [],
+      encryption: 'disabled',
+      protocolVersion: 1,
+      minProtocolVersion: 1,
+      maxProtocolVersion: 1,
+      capabilities: { skillTrustAccept: true },
+    })
+    assert.ok(result.success, 'Should accept auth_ok without notificationPrefs capability')
+    assert.equal(result.data.capabilities.notificationPrefs, undefined)
+  })
+
   it('rejects auth_ok with invalid streamStallTimeoutMs (#4477)', async () => {
     const { ServerAuthOkSchema, MAX_SANE_DURATION_MS: MAX } = await import('../src/schemas/server.ts')
     const base = {

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -82,6 +82,14 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     // #3297 — `skill_trust_grant` handler + `skill_trust_granted` broadcast.
     // Gates the community-skill first-activation trust-grant UI.
     skillTrustGrant: true,
+    // #4560 — `notification_prefs_get` / `notification_prefs_set` handlers
+    // + `notification_prefs` snapshot broadcast (added in #4541). Gates the
+    // Notifications section in SettingsPanel / SettingsScreen so a client
+    // connecting to a pre-#4541 server doesn't sit on "Loading
+    // preferences…" indefinitely waiting for a snapshot that will never
+    // arrive — instead the section either hides itself or surfaces a
+    // "not supported on this server" message.
+    notificationPrefs: true,
   }
 
   // #3760, #3905: surface the effective inactivity timeouts so clients

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -465,6 +465,32 @@ describe('multi-client awareness', () => {
     ws.close()
   })
 
+  // #4560 — the Notifications settings section sits on "Loading preferences…"
+  // forever when connecting to a pre-#4541 server (no `notification_prefs_get`
+  // handler). Advertising `notificationPrefs: true` in the auth_ok capability
+  // map lets clients gate the section render so older servers either hide it
+  // or show a "not supported on this server" message instead of dead UI.
+  it('advertises notificationPrefs capability in auth_ok (#4560)', async () => {
+    const mockSession = createMockSession()
+    server = new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      cliSession: mockSession,
+      authRequired: true,
+    })
+    const port = await startServerAndGetPort(server)
+
+    const { ws, messages } = await createClient(port, false)
+    send(ws, { type: 'auth', token: 'test-token' })
+
+    const authOk = await waitForMessage(messages, 'auth_ok', 2000)
+    assert.ok(authOk, 'Should receive auth_ok')
+    assert.ok(authOk.capabilities, 'auth_ok should include capabilities map')
+    assert.equal(authOk.capabilities.notificationPrefs, true, 'capabilities.notificationPrefs should be true')
+
+    ws.close()
+  })
+
   it('stores deviceInfo from auth message', async () => {
     const mockSession = createMockSession()
     server = new WsServer({


### PR DESCRIPTION
## Summary

Closes #4560.

The Notifications section in both the dashboard SettingsPanel and the mobile SettingsScreen rendered unconditionally and sat on "Loading preferences…" forever when connecting to a pre-#4541 server (no `notification_prefs_get` handler). This PR gates the section on a new `notificationPrefs` capability advertised in `auth_ok`, mirroring the existing `skillTrustAccept` / `skillTrustGrant` pattern.

### Behaviour

- Modern server (advertises `notificationPrefs: true`) → unchanged.
- Older server (omits the flag) → section header still renders so users know the feature exists, body is replaced with "Your server does not support notification preferences. Upgrade to chroxy v0.9.14 or newer." The `notification_prefs_get` WS write is also skipped so older servers don't log `unknown_message` noise on every Settings open.
- Pre-connect / capability not yet known → fail-closed (treated as unsupported) until `auth_ok` flips the flag.

### Files

- `packages/server/src/ws-history.js` — add `notificationPrefs: true` to the auth_ok capability map.
- `packages/dashboard/src/components/SettingsPanel.tsx` — read `serverCapabilities.notificationPrefs`, gate the section render + the refresh useEffect.
- `packages/app/src/store/connection-lifecycle.ts` + `packages/app/src/store/message-handler.ts` — mirror the dashboard's `serverCapabilities` parser + plumb it through the mobile lifecycle store.
- `packages/app/src/screens/SettingsScreen.tsx` — gate categories AND quiet-hours sections on the same flag.
- Tests in `packages/dashboard`, `packages/app`, `packages/protocol`, `packages/server` cover supported / loading / unsupported / no-refresh-when-missing branches.

## Test plan

- [x] Dashboard: `cd packages/dashboard && npx vitest run` — 2331/2331 pass (includes new #4560 capability-gate block).
- [x] Protocol: `cd packages/protocol && npm test` — 145/145 pass (new round-trip + back-compat tests for the capability key).
- [x] Mobile: `cd packages/app && npx jest` — 1414/1414 pass (new #4560 static-source block in SettingsScreenNotificationPrefs.test.ts).
- [x] Store-core: `cd packages/store-core && npm test` — 877/877 pass.
- [x] Server: focused `ws-server.test.js` + `ws-history.test.js` — 189/189 pass (new "advertises notificationPrefs capability in auth_ok" assertion green). Pre-existing tunnel.integration + webtask failures are environment-dependent and unrelated.
- [x] TypeScript: `tsc --noEmit` clean on both `packages/dashboard` and `packages/app`.