### PR TITLE
feat(app,server): allow clearing orphaned per-device notification overrides

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsClearDevice.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsClearDevice.test.ts
@@ -1,0 +1,135 @@
+/**
+ * SettingsScreen — per-device "Clear" UI tests (#4564)
+ *
+ * Mirrors the static-source style used by SettingsScreenNotificationPrefsDevice
+ * (#4543). Verifies the new known-devices list surfaces a Clear button per
+ * row, wires it through the connection store's `deleteNotificationPrefsDevice`
+ * action, and threads the WS-closed banner the same way the rest of the
+ * notification-prefs handlers do.
+ *
+ * The same orphan-clearing semantics apply on dashboard (`SettingsPanel.tsx`)
+ * — that surface gets fuller render-time coverage in
+ * `SettingsPanel.test.tsx`. Mobile sticks with static-source assertions
+ * because the SettingsScreen pulls in React Native primitives that are
+ * impractical to render under Jest without a heavy harness.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const settingsSource = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/SettingsScreen.tsx'),
+  'utf-8',
+);
+
+const typesSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/types.ts'),
+  'utf-8',
+);
+
+const connectionSource = fs.readFileSync(
+  path.resolve(__dirname, '../../store/connection.ts'),
+  'utf-8',
+);
+
+describe('SettingsScreen — per-device Clear surface (#4564)', () => {
+  it('selects deleteNotificationPrefsDevice from the connection store', () => {
+    // Without selecting the action, the row's onPress can't reach the
+    // wire — guard so a refactor that drops the selector trips this test
+    // before any UI ships.
+    expect(settingsSource).toMatch(
+      /deleteNotificationPrefsDevice\s*=\s*useConnectionStore/,
+    );
+  });
+
+  it('renders a per-row Clear button under the known-devices list', () => {
+    // testID anchors the per-row affordance for both Maestro E2E and the
+    // dashboard's matching `notification-prefs-device-clear-${key}` pattern.
+    expect(settingsSource).toMatch(
+      /testID=\{`notification-prefs-device-clear-\$\{key\}`\}/,
+    );
+  });
+
+  it('wires the Clear button onPress through a thin handler that hits the store action', () => {
+    // The handler must call `deleteNotificationPrefsDevice(deviceKey)` AND
+    // funnel through `handleClearDevice` so the WS-closed boolean return can
+    // drive `setNotifWsClosedError`. A direct call would skip the banner —
+    // identical pattern to handleSetDevice (#4559).
+    expect(settingsSource).toMatch(
+      /handleClearDevice\s*=\s*useCallback[\s\S]{0,400}deleteNotificationPrefsDevice\(deviceKey\)/,
+    );
+    expect(settingsSource).toMatch(
+      /onPress=\{\(\) => onClear\(key\)\}/,
+    );
+  });
+
+  it('threads the WS-closed banner from the Clear handler', () => {
+    // Same banner contract as the other notification-prefs handlers
+    // (#4559): on `false`, set the inline message so the user knows the
+    // delete did not reach the server.
+    expect(settingsSource).toMatch(
+      /handleClearDevice[\s\S]{0,400}setNotifWsClosedError\(sent \? null : WS_CLOSED_MESSAGE\)/,
+    );
+  });
+
+  it('renders an empty-state hint when no per-device entries exist', () => {
+    // Always-rendered list (even when empty) so users find the surface
+    // for later. The testID makes the empty branch addressable.
+    expect(settingsSource).toMatch(/testID="notification-prefs-devices-empty"/);
+  });
+
+  it('tags the row matching the current device with a "(this device)" marker', () => {
+    // A misclick on the wrong row would mute the device the operator is
+    // currently using — the marker is the cheap defensive cue. The
+    // implementation flips `isCurrent` against `currentDeviceKey` and
+    // appends the tag inline.
+    expect(settingsSource).toMatch(/\(this device\)/);
+  });
+
+  it('emits a testID per device row keyed by the raw device key', () => {
+    // E2E discovery for a specific row. Matches the dashboard naming
+    // (notification-prefs-device-entry-${key}) so cross-surface tests can
+    // share fixtures.
+    expect(settingsSource).toMatch(
+      /testID=\{`notification-prefs-device-entry-\$\{key\}`\}/,
+    );
+  });
+});
+
+describe('ConnectionState — deleteNotificationPrefsDevice surface (#4564)', () => {
+  it('declares deleteNotificationPrefsDevice with (deviceKey) => boolean signature', () => {
+    // Same fail-loud `boolean` return as the other notification-prefs
+    // setters (#4559) so UI can branch on socket-closed.
+    expect(typesSource).toMatch(
+      /deleteNotificationPrefsDevice:\s*\(deviceKey:\s*string\)\s*=>\s*boolean/,
+    );
+  });
+});
+
+describe('connection.ts — delete action wiring (#4564)', () => {
+  it('sends a notification_prefs_set with `devices: { [deviceKey]: null }` as the patch', () => {
+    // The null sentinel is the on-wire convention the server interprets
+    // as delete. Without it the server's shallow-merge would just set the
+    // entry to null and keep the key — exactly the bug #4564 is fixing.
+    expect(connectionSource).toMatch(
+      /deleteNotificationPrefsDevice[\s\S]{0,1500}notification_prefs_set[\s\S]{0,400}devices:\s*\{[\s\S]{0,200}\[deviceKey\]:\s*null/,
+    );
+  });
+
+  it('short-circuits when deviceKey is empty', () => {
+    // Defensive: never ship a `devices[""]` patch. Mirrors the
+    // setNotificationPrefsDevice guard.
+    expect(connectionSource).toMatch(
+      /deleteNotificationPrefsDevice[\s\S]{0,400}if\s*\(!deviceKey\)\s*return/,
+    );
+  });
+
+  it('drops the local snapshot entry optimistically before the broadcast lands', () => {
+    // The Settings row should disappear the moment the user taps Clear —
+    // waiting for the WS round-trip + broadcast over a cellular Cloudflare
+    // tunnel leaves the user wondering if the tap registered. The store
+    // mutates `notificationPrefs.devices` to drop the key before sending.
+    expect(connectionSource).toMatch(
+      /deleteNotificationPrefsDevice[\s\S]{0,1500}set\(\s*\{\s*notificationPrefs:[\s\S]{0,500}devices:\s*rest/,
+    );
+  });
+});

--- a/packages/app/src/__tests__/store/notification-prefs-optimistic.test.ts
+++ b/packages/app/src/__tests__/store/notification-prefs-optimistic.test.ts
@@ -180,4 +180,72 @@ describe('#4558 — notification-prefs optimistic update (mobile)', () => {
     expect(sent).toHaveLength(0);
     expect(useConnectionStore.getState().notificationPrefs!.devices).toEqual({});
   });
+
+  // #4564: per-device delete via the null sentinel. Mirrors the
+  // dashboard-side optimistic suite — drop the key locally, ship a null
+  // patch on the wire, server confirms via broadcast.
+  it('deleteNotificationPrefsDevice drops the entry locally and ships a null sentinel patch', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { ...baseCats },
+        devices: {
+          'dev-a': { categories: { result: false } },
+          'dev-b': { categories: { result: false } },
+        },
+        quietHours: null,
+      },
+    });
+
+    const result = useConnectionStore.getState().deleteNotificationPrefsDevice('dev-a');
+
+    expect(result).toBe(true);
+    const after = useConnectionStore.getState().notificationPrefs!;
+    expect(after.devices['dev-a']).toBeUndefined();
+    // Sibling entries survive the targeted delete.
+    expect(after.devices['dev-b']).toBeDefined();
+    expect(sent[0]).toEqual({
+      type: 'notification_prefs_set',
+      prefs: { devices: { 'dev-a': null } },
+    });
+  });
+
+  it('deleteNotificationPrefsDevice is a no-op when deviceKey is empty', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { ...baseCats },
+        devices: { 'dev-a': { categories: { result: false } } },
+        quietHours: null,
+      },
+    });
+
+    const result = useConnectionStore.getState().deleteNotificationPrefsDevice('');
+
+    expect(result).toBe(false);
+    expect(sent).toHaveLength(0);
+    expect(useConnectionStore.getState().notificationPrefs!.devices['dev-a']).toBeDefined();
+  });
+
+  it('deleteNotificationPrefsDevice returns false on a closed socket without mutating state', () => {
+    // The optimistic delete would never reconcile on a closed socket, so
+    // the action MUST refuse to flip local state on the closed-socket
+    // branch — otherwise a reconnect snapshot would resurrect the entry
+    // and the UI would have lied to the user.
+    useConnectionStore.setState({
+      socket: null,
+      notificationPrefs: {
+        categories: { ...baseCats },
+        devices: { 'dev-a': { categories: { result: false } } },
+        quietHours: null,
+      },
+    });
+
+    const result = useConnectionStore.getState().deleteNotificationPrefsDevice('dev-a');
+
+    expect(result).toBe(false);
+    expect(useConnectionStore.getState().notificationPrefs!.devices['dev-a']).toBeDefined();
+  });
 });

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -190,6 +190,10 @@ export function SettingsScreen() {
   // that state so we never ship a `devices[null]` patch.
   const pushToken = useConnectionStore((s) => s.pushToken);
   const setNotificationPrefsDevice = useConnectionStore((s) => s.setNotificationPrefsDevice);
+  // #4564: drop an entire per-device entry — the per-row "Clear" button in
+  // the known-devices list calls this to drain orphans from the prefs
+  // file (token refresh / app reinstall / browser-id wipe).
+  const deleteNotificationPrefsDevice = useConnectionStore((s) => s.deleteNotificationPrefsDevice);
   // #4544: quiet-hours editor actions. The window is global; per-device
   // overrides are owned by a future iteration. `bypassCategories` is the
   // list of categories that fire even during quiet hours.
@@ -238,6 +242,13 @@ export function SettingsScreen() {
     const sent = setNotificationPrefsDevice(deviceKey, cat, value);
     setNotifWsClosedError(sent ? null : WS_CLOSED_MESSAGE);
   }, [setNotificationPrefsDevice]);
+
+  // #4564: per-row "Clear" handler. Same WS-closed banner contract as the
+  // other notification-prefs setters so a botched clear isn't silent.
+  const handleClearDevice = useCallback((deviceKey: string) => {
+    const sent = deleteNotificationPrefsDevice(deviceKey);
+    setNotifWsClosedError(sent ? null : WS_CLOSED_MESSAGE);
+  }, [deleteNotificationPrefsDevice]);
 
   const handleSetQuietHours = useCallback((win: { start: string; end: string; timezone: string } | null) => {
     const sent = setNotificationPrefsQuietHours(win);
@@ -631,6 +642,23 @@ export function SettingsScreen() {
           />
         )}
       </View>
+
+      {/* NOTIFICATIONS — Known devices (#4564). Renders even when empty
+          so users find the affordance once orphans accumulate. Gated on
+          the notificationPrefs capability + a loaded snapshot, mirroring
+          the categories/quiet-hours sections. */}
+      {notificationPrefsSupported && notificationPrefs != null && (
+        <>
+          <Text style={styles.sectionHeader}>PER-DEVICE OVERRIDES</Text>
+          <View style={styles.section}>
+            <KnownDevicesList
+              devices={notificationPrefs.devices}
+              currentDeviceKey={pushToken}
+              onClear={handleClearDevice}
+            />
+          </View>
+        </>
+      )}
 
       {/* PORTABILITY */}
       {conversationId != null && (
@@ -1141,6 +1169,92 @@ function QuietHoursEditor(props: {
   );
 }
 
+/**
+ * #4564: token label truncation. Expo push tokens look like
+ * `ExponentPushToken[~40-base64-chars]` — too wide for a list row. Trim
+ * to a stable first-N prefix plus an ellipsis so the operator can match
+ * the row to a clear action without exposing the full token.
+ */
+function truncateDeviceLabel(key: string): string {
+  const MAX = 24;
+  if (key.length <= MAX) return key;
+  return `${key.slice(0, MAX)}…`;
+}
+
+/**
+ * #4564: list of per-device override entries with a "Clear" button per
+ * row. The map can accumulate orphans when Expo refreshes the push token
+ * or the app is reinstalled — without this list the only way to drain
+ * them is hand-editing `~/.chroxy/notification-prefs.json`. The list
+ * always renders (even when empty) so users find the affordance.
+ */
+function KnownDevicesList(props: {
+  devices: Record<string, {
+    categories?: Record<string, boolean>;
+    quietHours?: { start: string; end: string; timezone: string } | null;
+    bypassCategories?: string[];
+  }>;
+  currentDeviceKey: string | null;
+  onClear: (deviceKey: string) => void;
+}) {
+  const { devices, currentDeviceKey, onClear } = props;
+  // Stable order: current device first, then lexicographic.
+  const keys = Object.keys(devices);
+  const sorted = keys.slice().sort((a, b) => {
+    if (a === currentDeviceKey) return -1;
+    if (b === currentDeviceKey) return 1;
+    return a.localeCompare(b);
+  });
+
+  if (sorted.length === 0) {
+    return (
+      <View style={styles.row} testID="notification-prefs-devices-empty">
+        <Text style={styles.rowHint}>
+          No per-device overrides yet. Mute a category on this device above to
+          create one.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View testID="notification-prefs-devices-list">
+      {sorted.map((key, idx) => {
+        const isCurrent = key === currentDeviceKey;
+        return (
+          <React.Fragment key={key}>
+            {idx > 0 && <View style={styles.separator} />}
+            <View
+              style={styles.row}
+              testID={`notification-prefs-device-entry-${key}`}
+            >
+              <View style={styles.deviceLabelGroup}>
+                <Text
+                  style={styles.deviceLabelText}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {truncateDeviceLabel(key)}
+                </Text>
+                {isCurrent && (
+                  <Text style={styles.deviceSelfTag}> (this device)</Text>
+                )}
+              </View>
+              <TouchableOpacity
+                onPress={() => onClear(key)}
+                testID={`notification-prefs-device-clear-${key}`}
+                style={styles.deviceClearButton}
+              >
+                <Text style={styles.deviceClearText}>Clear</Text>
+              </TouchableOpacity>
+            </View>
+          </React.Fragment>
+        );
+      })}
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -1238,6 +1352,37 @@ const styles = StyleSheet.create({
   actionText: {
     color: COLORS.accentBlue,
     fontSize: 15,
+  },
+  // #4564: known-devices list styles. The label group flexes so a long
+  // truncated token still leaves the Clear button room; the self-tag
+  // borrows the accent blue used elsewhere for "this device" markers
+  // (LAN scan, etc.) so cross-screen styling stays consistent.
+  deviceLabelGroup: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    marginRight: 12,
+  },
+  deviceLabelText: {
+    color: COLORS.textPrimary,
+    fontSize: 13,
+    fontFamily: 'Courier',
+    flexShrink: 1,
+  },
+  deviceSelfTag: {
+    color: COLORS.accentBlue,
+    fontSize: 12,
+  },
+  deviceClearButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    backgroundColor: COLORS.backgroundCard,
+  },
+  deviceClearText: {
+    color: COLORS.accentRed,
+    fontSize: 13,
+    fontWeight: '600',
   },
   versionRow: {
     flexDirection: 'row',

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -502,6 +502,42 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return false;
   },
 
+  // #4564: drop a per-device entry entirely by sending the null sentinel
+  // (`devices: { [deviceKey]: null }`). The server's setPrefs interprets
+  // null as "remove this token from the persisted devices map" — the only
+  // way to drain orphan entries left behind when an Expo push token
+  // refreshes, the app is reinstalled, or a browser device id is cleared.
+  //
+  // Mirrors setNotificationPrefsDevice's guards:
+  // - empty deviceKey → no-op (never ship `devices[""]`).
+  // - socket closed   → no-op AND no local mutation (an optimistic delete
+  //   on a closed socket would never reconcile, leaving the UI lying).
+  //
+  // Optimistic local update: drop the key from the snapshot immediately
+  // so the Settings list row disappears without waiting for the broadcast.
+  deleteNotificationPrefsDevice: (deviceKey: string): boolean => {
+    if (!deviceKey) return false;
+    const { socket, notificationPrefs } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        const { [deviceKey]: _removed, ...rest } = notificationPrefs.devices;
+        void _removed;
+        set({
+          notificationPrefs: {
+            ...notificationPrefs,
+            devices: rest,
+          },
+        });
+      }
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { devices: { [deviceKey]: null } },
+      });
+      return true;
+    }
+    return false;
+  },
+
   // #4544: global quiet-hours window patch. `null` clears; a window
   // object (with `timezone`) sets it. Server shallow-merges at the top
   // level so other fields (categories, bypassCategories, devices) survive.

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -531,6 +531,18 @@ export interface ServerNotificationActions {
   // #4559: returns `true` when sent, `false` for both no-op branches
   // (empty deviceKey OR closed socket).
   setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => boolean;
+  // #4564: drop an entire per-device override entry. Sends
+  // `notification_prefs_set` with `{ devices: { [deviceKey]: null } }`, the
+  // server interprets the null sentinel as "remove this token from the
+  // persisted devices map". Used by the per-row "Clear" button in the
+  // known-devices section to drain orphans left when an Expo push token
+  // refreshes, an app is reinstalled, or a browser tab loses its
+  // localStorage device id — without this surface the on-disk file
+  // accumulates dead entries forever.
+  //
+  // Returns `true` when the WS message was sent, `false` for both no-op
+  // branches (empty deviceKey OR closed socket).
+  deleteNotificationPrefsDevice: (deviceKey: string) => boolean;
   // #4544: patch the global quiet-hours window. `null` clears the window;
   // a window object (with `timezone`) sets it. Server broadcasts the
   // merged snapshot so all clients update in lockstep.

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -85,6 +85,8 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     // key without coupling to localStorage; individual tests can override.
     currentDeviceKey: 'test-device-key',
     setNotificationPrefsDevice: vi.fn().mockReturnValue(true),
+    // #4564: per-device delete (the "Clear" buttons in the device list).
+    deleteNotificationPrefsDevice: vi.fn().mockReturnValue(true),
     // #4544: quiet-hours editor actions. Default no-op spies; individual
     // tests override.
     setNotificationPrefsQuietHours: vi.fn().mockReturnValue(true),
@@ -934,6 +936,144 @@ describe('SettingsPanel', () => {
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       const row = screen.getByTestId('notification-prefs-device-row-result')
       expect(row.classList.contains('notification-prefs-device-row')).toBe(true)
+    })
+  })
+
+  // #4564: per-device-list orphan-clearing UI. The per-device map can
+  // accumulate dead entries when Expo refreshes a push token, an app is
+  // reinstalled, or a browser tab loses its `chroxy_device_id`. The list
+  // surface lets the user drain those orphans one at a time without
+  // hand-editing the prefs file. The list always renders when prefs are
+  // loaded — even when empty — so the operator knows the surface exists.
+  describe('Notification preferences — known-devices list (#4564)', () => {
+    const categories = {
+      permission: true,
+      result: true,
+      activity_update: true,
+      activity_waiting: true,
+      activity_error: true,
+      inactivity_warning: true,
+      live_activity: true,
+    }
+
+    it('renders an empty-state hint when no per-device entries exist', () => {
+      // No `devices` keys at all — the list should still render the header
+      // (so users find the affordance for next time) plus a quiet hint.
+      setMockState({
+        notificationPrefs: { categories, devices: {}, quietHours: null },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('notification-prefs-devices-list')).toBeInTheDocument()
+      expect(screen.getByTestId('notification-prefs-devices-empty')).toBeInTheDocument()
+    })
+
+    it('renders one row per device entry', () => {
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: {
+            'test-device-key': { categories: { result: false } },
+            'other-device-key': { categories: { result: false } },
+            'ExponentPushToken[orphan-12345]': { categories: { permission: false } },
+          },
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('notification-prefs-device-entry-test-device-key')).toBeInTheDocument()
+      expect(screen.getByTestId('notification-prefs-device-entry-other-device-key')).toBeInTheDocument()
+      expect(
+        screen.getByTestId('notification-prefs-device-entry-ExponentPushToken[orphan-12345]'),
+      ).toBeInTheDocument()
+    })
+
+    it('tags the row matching currentDeviceKey as "this device"', () => {
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: {
+            'test-device-key': { categories: { result: false } },
+            'other-device-key': { categories: { result: false } },
+          },
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const thisDeviceRow = screen.getByTestId('notification-prefs-device-entry-test-device-key')
+      // The current-device row carries an explicit marker the user can see
+      // before clicking Clear (a missed click on the wrong row reads as a
+      // surprise self-mute on the device they're currently using).
+      expect(thisDeviceRow.textContent).toMatch(/this device/i)
+      // Sibling row does NOT carry the marker.
+      const otherRow = screen.getByTestId('notification-prefs-device-entry-other-device-key')
+      expect(otherRow.textContent).not.toMatch(/this device/i)
+    })
+
+    it('shows a truncated token label so long Expo tokens stay readable', () => {
+      // The full Expo token is `ExponentPushToken[~40 base64 chars]` — too
+      // long to read in a settings row. The label trims to a stable
+      // first-N prefix so the user can still match it against a per-row
+      // action and so visually-similar tokens stay distinguishable.
+      const longToken = 'ExponentPushToken[abcdefghijklmnopqrstuvwxyz0123456789]'
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: { [longToken]: { categories: { result: false } } },
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const row = screen.getByTestId(`notification-prefs-device-entry-${longToken}`)
+      // The truncated label appears AND the full token does not (otherwise
+      // truncation isn't actually happening).
+      expect(row.textContent).not.toContain(longToken)
+      expect(row.textContent?.includes('…') || row.textContent?.includes('...')).toBe(true)
+    })
+
+    it('renders a Clear button per row', () => {
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: {
+            'test-device-key': { categories: { result: false } },
+            'other-device-key': { categories: { result: false } },
+          },
+          quietHours: null,
+        },
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('notification-prefs-device-clear-test-device-key')).toBeInTheDocument()
+      expect(screen.getByTestId('notification-prefs-device-clear-other-device-key')).toBeInTheDocument()
+    })
+
+    it('calls deleteNotificationPrefsDevice(deviceKey) when Clear is clicked', () => {
+      const deleteNotificationPrefsDevice = vi.fn().mockReturnValue(true)
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: {
+            'orphan-device-key': { categories: { result: false } },
+          },
+          quietHours: null,
+        },
+        deleteNotificationPrefsDevice,
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('notification-prefs-device-clear-orphan-device-key'))
+      expect(deleteNotificationPrefsDevice).toHaveBeenCalledWith('orphan-device-key')
+    })
+
+    it('does not render the list when the server lacks the notificationPrefs capability', () => {
+      // The capability gate (#4560) replaces the body of the Notifications
+      // section with an upgrade hint. The device list shares that gate so
+      // we never render Clear buttons against a pre-#4541 server that
+      // would silently ignore the `notification_prefs_set` patch.
+      setMockState({
+        notificationPrefs: null,
+        serverCapabilities: {},
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.queryByTestId('notification-prefs-devices-list')).toBeNull()
     })
   })
 

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -386,6 +386,112 @@ function QuietHoursEditor(props: {
   )
 }
 
+/**
+ * #4564: token label truncation. Expo push tokens look like
+ * `ExponentPushToken[~40-base64-chars]` — too wide to read in a settings
+ * row. Trim to a stable first-N prefix plus an ellipsis so the user can
+ * still match the row against a clear action without exposing the full
+ * token. The displayed prefix length (24 chars) keeps `ExponentPushToken[`
+ * (18 chars) plus a few discriminating characters of the inner token —
+ * enough to distinguish two simultaneously-registered devices from the
+ * same vendor.
+ */
+function truncateDeviceLabel(key: string): string {
+  const MAX = 24
+  if (key.length <= MAX) return key
+  return `${key.slice(0, MAX)}…`
+}
+
+/**
+ * #4564: list of currently-known per-device override entries with a
+ * per-row "Clear" button. Lets the user drain orphans accumulated when a
+ * push token refreshes, an app reinstalls, or a browser tab loses its
+ * `chroxy_device_id` — without those there's no way to remove a stale
+ * entry short of hand-editing `~/.chroxy/notification-prefs.json`.
+ *
+ * Render contract:
+ *   - Always renders (even when empty) so users can find the affordance
+ *     once they DO accumulate orphans.
+ *   - Tags the row matching `currentDeviceKey` as "this device" so a
+ *     misclick on the wrong row doesn't surprise the operator by muting
+ *     the device they're currently using.
+ *   - Truncates long tokens via `truncateDeviceLabel` so the list stays
+ *     readable; the full token is intentionally not shown — operators
+ *     who want to verify before clearing can read the prefs file.
+ */
+function KnownDevicesList(props: {
+  devices: Record<string, {
+    categories?: Record<string, boolean>
+    quietHours?: { start: string; end: string; timezone: string } | null
+    bypassCategories?: string[]
+  }>
+  currentDeviceKey: string | null
+  onClear: (deviceKey: string) => void
+}) {
+  const { devices, currentDeviceKey, onClear } = props
+  // Stable order: render the current device first (so the user reaches
+  // their own row without scrolling), then other tokens lexicographically
+  // for a deterministic ordering across reloads.
+  const keys = Object.keys(devices)
+  const sorted = keys.slice().sort((a, b) => {
+    if (a === currentDeviceKey) return -1
+    if (b === currentDeviceKey) return 1
+    return a.localeCompare(b)
+  })
+
+  return (
+    <fieldset
+      className="settings-fieldset notification-prefs-devices"
+      data-testid="notification-prefs-devices-list"
+    >
+      <legend>Per-device overrides</legend>
+      <p className="settings-hint">
+        Each entry is a device (browser tab or mobile app) that has set its
+        own notification preferences. Clear an entry to drop its overrides —
+        useful when a push token refreshes or an app is reinstalled and the
+        old entry becomes orphaned.
+      </p>
+      {sorted.length === 0 ? (
+        <p
+          className="settings-hint"
+          data-testid="notification-prefs-devices-empty"
+        >
+          No per-device overrides yet. Mute a category on this device above to
+          create one.
+        </p>
+      ) : (
+        <ul className="notification-prefs-devices-list">
+          {sorted.map(key => {
+            const isCurrent = key === currentDeviceKey
+            return (
+              <li
+                key={key}
+                className="notification-prefs-device-entry"
+                data-testid={`notification-prefs-device-entry-${key}`}
+              >
+                <span className="notification-prefs-device-label">
+                  <code>{truncateDeviceLabel(key)}</code>
+                  {isCurrent && (
+                    <span className="notification-prefs-device-self-tag"> (this device)</span>
+                  )}
+                </span>
+                <button
+                  type="button"
+                  className="notification-prefs-device-clear"
+                  onClick={() => onClear(key)}
+                  data-testid={`notification-prefs-device-clear-${key}`}
+                >
+                  Clear
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </fieldset>
+  )
+}
+
 /** Preview swatches for a theme */
 function ThemeSwatches({ theme }: { theme: ThemeDefinition }) {
   const bg = theme.colors['bg-primary'] || '#0f0f1a'
@@ -454,6 +560,11 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   // ship a `devices[""]` / `devices[null]` patch.
   const currentDeviceKey = useConnectionStore(s => s.currentDeviceKey)
   const setNotificationPrefsDevice = useConnectionStore(s => s.setNotificationPrefsDevice)
+  // #4564: drop an entire per-device entry — the "Clear" buttons in the
+  // known-devices list call this to drain orphans left by token refresh,
+  // app reinstall, or browser storage wipe. Sends the null sentinel
+  // (`devices: { [token]: null }`) which the server interprets as delete.
+  const deleteNotificationPrefsDevice = useConnectionStore(s => s.deleteNotificationPrefsDevice)
   // #4544: quiet-hours editor actions. The window is global (per-device
   // overrides are a future iteration owned by #4543); `bypassCategories`
   // is the list of categories that fire even during quiet hours.
@@ -616,6 +727,15 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
     if (sent) setNotifWsClosedError(null)
     else setNotifWsClosedError(WS_CLOSED_MESSAGE)
   }, [setNotificationPrefsDevice])
+
+  // #4564: clear an entire per-device entry. Same WS-closed banner contract
+  // as the rest of the notification-prefs handlers — a closed-socket clear
+  // would silently fail and the orphan would stay on disk.
+  const handleClearNotificationDevice = useCallback((deviceKey: string) => {
+    const sent = deleteNotificationPrefsDevice(deviceKey)
+    if (sent) setNotifWsClosedError(null)
+    else setNotifWsClosedError(WS_CLOSED_MESSAGE)
+  }, [deleteNotificationPrefsDevice])
 
   const handleSetNotificationQuietHours = useCallback((window: { start: string; end: string; timezone: string } | null) => {
     const sent = setNotificationPrefsQuietHours(window)
@@ -1155,6 +1275,17 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                   bypassCategories={notificationPrefs.bypassCategories ?? DEFAULT_BYPASS_CATEGORIES}
                   onWindowChange={handleSetNotificationQuietHours}
                   onBypassChange={handleSetNotificationBypassCategories}
+                />
+
+                {/* #4564: per-device override list — lets the user drain
+                    orphan entries left behind when Expo refreshes a push
+                    token, an app is reinstalled, or a browser tab loses
+                    its localStorage device id. Rendered even when the map
+                    is empty so users find the surface for later. */}
+                <KnownDevicesList
+                  devices={notificationPrefs.devices}
+                  currentDeviceKey={currentDeviceKey}
+                  onClear={handleClearNotificationDevice}
                 />
               </>
             )}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -627,6 +627,45 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return false;
   },
 
+  // #4564: drop an entire per-device entry by sending the null sentinel
+  // (`devices: { [deviceKey]: null }`). The server's setPrefs interprets
+  // null as "remove this token from the persisted devices map". This is the
+  // only way to drain orphan entries left behind when an Expo push token
+  // refreshes, the app reinstalls, or a browser tab loses its
+  // localStorage device id — without it, the on-disk file grows forever.
+  //
+  // Defensive guards mirror setNotificationPrefsDevice:
+  // - empty deviceKey → no-op (we refuse to ship a `devices[""]` patch).
+  // - socket closed   → no-op AND no local mutation. An optimistic delete
+  //   on a closed socket would never reconcile and would resurrect on the
+  //   next reconnect snapshot, leaving the UI lying to the user.
+  //
+  // Optimistic local update mirrors setNotificationPrefsDevice: drop the
+  // key from the local snapshot immediately so the Settings list row
+  // disappears without waiting for the broadcast.
+  deleteNotificationPrefsDevice: (deviceKey: string): boolean => {
+    if (!deviceKey) return false;
+    const { socket, notificationPrefs } = get();
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      if (notificationPrefs) {
+        const { [deviceKey]: _removed, ...rest } = notificationPrefs.devices;
+        void _removed;
+        set({
+          notificationPrefs: {
+            ...notificationPrefs,
+            devices: rest,
+          },
+        });
+      }
+      wsSend(socket, {
+        type: 'notification_prefs_set',
+        prefs: { devices: { [deviceKey]: null } },
+      });
+      return true;
+    }
+    return false;
+  },
+
   // #4544: global quiet-hours window patch. `null` clears the window;
   // a full window object (start/end/timezone) sets it. The server
   // shallow-merges at the top level, so other fields (categories,

--- a/packages/dashboard/src/store/notification-prefs-optimistic.test.ts
+++ b/packages/dashboard/src/store/notification-prefs-optimistic.test.ts
@@ -272,4 +272,87 @@ describe('#4558 — notification-prefs optimistic update', () => {
       prefs: { bypassCategories: ['permission'] },
     })
   })
+
+  // #4564: per-device delete semantics. The dashboard mirrors the server
+  // convention — sending `devices: { [token]: null }` drains an orphan
+  // entry. The local snapshot drops the key immediately (optimistic) and
+  // the server's broadcast confirms after the round-trip.
+  it('deleteNotificationPrefsDevice removes the device entry locally and ships a null sentinel patch', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { result: true },
+        devices: {
+          'dev-a': { categories: { result: false } },
+          'dev-b': { categories: { result: false } },
+        },
+        quietHours: null,
+      },
+    })
+
+    const sentResult = useConnectionStore.getState().deleteNotificationPrefsDevice('dev-a')
+
+    expect(sentResult).toBe(true)
+    const after = useConnectionStore.getState().notificationPrefs!
+    expect(after.devices['dev-a']).toBeUndefined()
+    // Sibling entries survive.
+    expect(after.devices['dev-b']).toBeDefined()
+    expect(sent[0]).toEqual({
+      type: 'notification_prefs_set',
+      prefs: { devices: { 'dev-a': null } },
+    })
+  })
+
+  it('deleteNotificationPrefsDevice is a no-op when deviceKey is empty', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = createMockSocket(sent)
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { result: true },
+        devices: { 'dev-a': { categories: { result: false } } },
+        quietHours: null,
+      },
+    })
+
+    const sentResult = useConnectionStore.getState().deleteNotificationPrefsDevice('')
+
+    expect(sentResult).toBe(false)
+    expect(sent).toHaveLength(0)
+    expect(useConnectionStore.getState().notificationPrefs!.devices['dev-a']).toBeDefined()
+  })
+
+  it('deleteNotificationPrefsDevice returns false when the socket is closed and does not mutate state', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const sent: SentPayload[] = []
+    const socket = {
+      send: vi.fn((raw: string) => {
+        try { sent.push(JSON.parse(raw) as SentPayload) } catch { /* noop */ }
+      }),
+      close: vi.fn(),
+      readyState: WebSocket.CLOSED,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as WebSocket
+    useConnectionStore.setState({
+      socket,
+      notificationPrefs: {
+        categories: { result: true },
+        devices: { 'dev-a': { categories: { result: false } } },
+        quietHours: null,
+      },
+    })
+
+    const sentResult = useConnectionStore.getState().deleteNotificationPrefsDevice('dev-a')
+
+    expect(sentResult).toBe(false)
+    // The optimistic deletion would never reconcile if the socket is closed,
+    // so the action must not mutate local state on the closed-socket branch.
+    expect(useConnectionStore.getState().notificationPrefs!.devices['dev-a']).toBeDefined()
+    expect(sent).toHaveLength(0)
+  })
 })

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -855,6 +855,20 @@ export interface ConnectionState {
    */
   setNotificationPrefsDevice: (deviceKey: string, category: string, enabled: boolean) => boolean;
   /**
+   * #4564: drop a per-device override entry entirely. Sends
+   * `notification_prefs_set` with `{ devices: { [deviceKey]: null } }`,
+   * which the server interprets as "remove this device from the persisted
+   * map". Used by the "Clear" buttons in the Notifications settings list
+   * to drain orphan entries left behind by push-token refresh, app
+   * reinstall, or browser-storage wipe.
+   *
+   * Returns `true` when the WS message was sent, `false` when the socket
+   * was closed OR the deviceKey was empty (both yield a no-op so we never
+   * ship a `devices[""]` / `devices[null]` patch). UI surfaces an inline
+   * error on `false` so a botched clear isn't silent.
+   */
+  deleteNotificationPrefsDevice: (deviceKey: string) => boolean;
+  /**
    * #4544: patch the global quiet-hours window. `null` clears the window;
    * a window object (with `timezone`) sets it. The server broadcasts the
    * merged snapshot so all clients update in lockstep.

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4937,6 +4937,79 @@
   cursor: pointer;
 }
 
+/* #4564: known-devices list (drain-orphans surface). A subordinate
+   fieldset under the per-category toggles — borrows the same compact
+   font as `.notification-prefs-device-row` so the two read as part of
+   one section. The list itself is flat (no indent) because each row is
+   already a top-level device, not a child of another control. */
+.notification-prefs-devices {
+  margin-top: 16px;
+  padding: 12px;
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+}
+
+.notification-prefs-devices legend {
+  padding: 0 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.notification-prefs-devices-list {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.notification-prefs-device-entry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  background: var(--bg-input);
+}
+
+.notification-prefs-device-label {
+  font-size: 12px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.notification-prefs-device-label code {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.notification-prefs-device-self-tag {
+  margin-left: 4px;
+  font-size: 11px;
+  color: var(--accent-blue);
+}
+
+.notification-prefs-device-clear {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 4px;
+  border: 1px solid var(--border-primary);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.notification-prefs-device-clear:hover {
+  background: var(--bg-hover, var(--bg-input));
+  border-color: var(--accent-blue);
+}
+
 /* #3404 audit F1: per-provider auth/billing status panel */
 .settings-hint {
   margin: 0 0 12px;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -268,10 +268,17 @@ export declare const RegisterPushTokenSchema: z.ZodObject<{
  * The device map is bounded at 1000 entries to keep a malicious client
  * from bloating the on-disk file; in practice users have at most a
  * handful of devices.
+ *
+ * #4564: per-device entries also accept `null` as a sentinel meaning
+ * "delete this device entry". The "Clear" buttons in Settings emit
+ * `devices: { [token]: null }` to drain orphan entries left behind by
+ * push-token refresh, app reinstall, or browser-storage wipe. Server-side
+ * `setPrefs` interprets the null sentinel and removes the key from the
+ * persisted devices map.
  */
 export declare const NotificationPrefsPatchSchema: z.ZodObject<{
     categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
-    devices: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
+    devices: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodObject<{
         categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
         quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
             start: z.ZodString;
@@ -279,7 +286,7 @@ export declare const NotificationPrefsPatchSchema: z.ZodObject<{
             timezone: z.ZodString;
         }, z.core.$strip>]>>;
         bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
-    }, z.core.$loose>>>;
+    }, z.core.$loose>, z.ZodNull]>>>;
     quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
         start: z.ZodString;
         end: z.ZodString;
@@ -305,7 +312,7 @@ export declare const NotificationPrefsSetSchema: z.ZodObject<{
     requestId: z.ZodOptional<z.ZodString>;
     prefs: z.ZodObject<{
         categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
-        devices: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
+        devices: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodObject<{
             categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
             quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
                 start: z.ZodString;
@@ -313,7 +320,7 @@ export declare const NotificationPrefsSetSchema: z.ZodObject<{
                 timezone: z.ZodString;
             }, z.core.$strip>]>>;
             bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
-        }, z.core.$loose>>>;
+        }, z.core.$loose>, z.ZodNull]>>>;
         quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
             start: z.ZodString;
             end: z.ZodString;
@@ -659,7 +666,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     requestId: z.ZodOptional<z.ZodString>;
     prefs: z.ZodObject<{
         categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
-        devices: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodObject<{
+        devices: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodObject<{
             categories: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodBoolean>>;
             quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
                 start: z.ZodString;
@@ -667,7 +674,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
                 timezone: z.ZodString;
             }, z.core.$strip>]>>;
             bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
-        }, z.core.$loose>>>;
+        }, z.core.$loose>, z.ZodNull]>>>;
         quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
             start: z.ZodString;
             end: z.ZodString;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -313,10 +313,17 @@ const NotificationDeviceEntrySchema = z.object({
  * The device map is bounded at 1000 entries to keep a malicious client
  * from bloating the on-disk file; in practice users have at most a
  * handful of devices.
+ *
+ * #4564: per-device entries also accept `null` as a sentinel meaning
+ * "delete this device entry". The "Clear" buttons in Settings emit
+ * `devices: { [token]: null }` to drain orphan entries left behind by
+ * push-token refresh, app reinstall, or browser-storage wipe. Server-side
+ * `setPrefs` interprets the null sentinel and removes the key from the
+ * persisted devices map.
  */
 export const NotificationPrefsPatchSchema = z.object({
     categories: NotificationCategoryMapSchema.optional(),
-    devices: z.record(z.string().min(1).max(512), NotificationDeviceEntrySchema)
+    devices: z.record(z.string().min(1).max(512), z.union([NotificationDeviceEntrySchema, z.null()]))
         .refine((obj) => Object.keys(obj).length <= 1000, { message: 'Too many device entries (max 1000)' })
         .optional(),
     quietHours: NotificationQuietHoursSchema.optional(),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -353,10 +353,20 @@ const NotificationDeviceEntrySchema = z.object({
  * The device map is bounded at 1000 entries to keep a malicious client
  * from bloating the on-disk file; in practice users have at most a
  * handful of devices.
+ *
+ * #4564: per-device entries also accept `null` as a sentinel meaning
+ * "delete this device entry". The "Clear" buttons in Settings emit
+ * `devices: { [token]: null }` to drain orphan entries left behind by
+ * push-token refresh, app reinstall, or browser-storage wipe. Server-side
+ * `setPrefs` interprets the null sentinel and removes the key from the
+ * persisted devices map.
  */
 export const NotificationPrefsPatchSchema = z.object({
   categories: NotificationCategoryMapSchema.optional(),
-  devices: z.record(z.string().min(1).max(512), NotificationDeviceEntrySchema)
+  devices: z.record(
+    z.string().min(1).max(512),
+    z.union([NotificationDeviceEntrySchema, z.null()]),
+  )
     .refine((obj) => Object.keys(obj).length <= 1000, { message: 'Too many device entries (max 1000)' })
     .optional(),
   quietHours: NotificationQuietHoursSchema.optional(),

--- a/packages/server/tests/notification-prefs.test.js
+++ b/packages/server/tests/notification-prefs.test.js
@@ -333,3 +333,93 @@ describe('PushManager prefs surface (#4541)', () => {
     assert.equal(pm.isCategoryEnabled('result', 'tok'), false)
   })
 })
+
+/**
+ * #4564: per-device delete semantics.
+ *
+ * The shallow-merge in setPrefs cannot REMOVE a device entry without an
+ * explicit signal — adding/modifying a category under a token is the
+ * common path. Convention introduced here: `devices: { [token]: null }`
+ * in a patch deletes the entry entirely.
+ *
+ * Why: per-device entries are keyed by Expo push token (mobile) or
+ * `chroxy_device_id` (browser). When Expo refreshes a token, an app is
+ * reinstalled, or a browser tab loses its localStorage id, the OLD entry
+ * lingers on disk forever with no UI affordance to clear it. The null
+ * sentinel pairs with the new "Clear device" buttons in Settings to give
+ * the operator a way to drain orphans without hand-editing the prefs file.
+ */
+describe('PushManager prefs surface — per-device delete (#4564)', () => {
+  it('deletes a device entry when patch sets `devices[token] = null`', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    // Seed two device entries so we can verify the delete is targeted.
+    pm.setPrefs({ devices: { 'tok-a': { categories: { result: false } } } })
+    pm.setPrefs({ devices: { 'tok-b': { categories: { result: true } } } })
+    let snapshot = pm.getPrefs()
+    assert.ok(snapshot.devices['tok-a'], 'tok-a seeded')
+    assert.ok(snapshot.devices['tok-b'], 'tok-b seeded')
+
+    // Null sentinel deletes only the named device.
+    pm.setPrefs({ devices: { 'tok-a': null } })
+    snapshot = pm.getPrefs()
+    assert.equal(snapshot.devices['tok-a'], undefined, 'tok-a entry removed')
+    assert.ok(snapshot.devices['tok-b'], 'tok-b entry untouched')
+  })
+
+  it('persists the deletion to disk so the orphan does not resurrect on reload', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs({ devices: { 'orphan-tok': { categories: { result: false } } } })
+    pm.setPrefs({ devices: { 'orphan-tok': null } })
+
+    // Round-trip the on-disk file through a fresh loader — if the null
+    // sentinel were misinterpreted as a literal value, the loader would
+    // either crash or resurrect the entry with an empty body.
+    const reloaded = loadPrefs(prefsPath)
+    assert.equal(reloaded.devices['orphan-tok'], undefined, 'deletion survives reload')
+  })
+
+  it('tolerates deleting a token that was never registered (idempotent)', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    // No-op delete on an empty map must not throw or write malformed state.
+    pm.setPrefs({ devices: { 'never-seen': null } })
+    const snapshot = pm.getPrefs()
+    assert.deepEqual(snapshot.devices, {}, 'delete-of-nothing is a no-op')
+  })
+
+  it('falls back to global decision after a per-device entry is deleted', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    // Global says muted; per-device override unmutes for `tok-a`.
+    pm.setPrefs({ categories: { result: false } })
+    pm.setPrefs({ devices: { 'tok-a': { categories: { result: true } } } })
+    assert.equal(pm.isCategoryEnabled('result', 'tok-a'), true, 'override active')
+    // Drop the override — `tok-a` now falls back to the global mute.
+    pm.setPrefs({ devices: { 'tok-a': null } })
+    assert.equal(
+      pm.isCategoryEnabled('result', 'tok-a'),
+      false,
+      'after delete, the device follows the global default',
+    )
+  })
+
+  it('allows mixed add + delete in a single devices patch', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs({ devices: { 'old-tok': { categories: { result: false } } } })
+    // One patch drops the orphan and registers the fresh token. This is
+    // the shape a UI clicking "Clear old, register new" would emit if the
+    // two actions ever batched.
+    pm.setPrefs({
+      devices: {
+        'old-tok': null,
+        'new-tok': { categories: { result: true } },
+      },
+    })
+    const snapshot = pm.getPrefs()
+    assert.equal(snapshot.devices['old-tok'], undefined)
+    assert.deepEqual(snapshot.devices['new-tok'].categories, { result: true })
+  })
+})

--- a/packages/server/tests/ws-schemas.test.js
+++ b/packages/server/tests/ws-schemas.test.js
@@ -776,6 +776,29 @@ describe('NotificationPrefsSetSchema (#4541)', () => {
     }).success)
   })
 
+  // #4564: per-device entries accept `null` as a delete sentinel so the UI
+  // can drain orphan tokens left behind by Expo refresh, app reinstall, or
+  // browser-storage wipe. The server-side `setPrefs` interprets the sentinel
+  // and removes the matching device key from the persisted map.
+  it('accepts a null device entry to signal deletion (#4564)', () => {
+    assert.ok(NotificationPrefsSetSchema.safeParse({
+      type: 'notification_prefs_set',
+      prefs: { devices: { 'ExponentPushToken[old]': null } },
+    }).success)
+  })
+
+  it('accepts a mixed add + delete devices patch (#4564)', () => {
+    assert.ok(NotificationPrefsSetSchema.safeParse({
+      type: 'notification_prefs_set',
+      prefs: {
+        devices: {
+          'old-tok': null,
+          'new-tok': { categories: { result: false } },
+        },
+      },
+    }).success)
+  })
+
   it('routes through ClientMessageSchema', () => {
     assert.ok(ClientMessageSchema.safeParse({
       type: 'notification_prefs_set',


### PR DESCRIPTION
## Summary

Closes #4564.

- Server already interpreted `devices: { [token]: null }` as a delete sentinel in `push.js setPrefs`; documents the contract, loosens the protocol schema so the wire accepts null, and adds a server round-trip test that the deletion survives reload.
- Adds `deleteNotificationPrefsDevice(deviceKey)` on both connection stores (dashboard + mobile). Same optimistic + WS-closed-banner contract as the other notification-prefs setters: drop the key locally before sending, no-op on closed socket or empty deviceKey.
- Adds a "Per-device overrides" list in both Settings surfaces with a truncated token label, a "(this device)" marker on the row matching the current device key, and a per-row Clear button. Always renders (even when empty) so users find the affordance before the first orphan accumulates.

## Why

Without a delete affordance, the per-device map grew indefinitely:
- Expo refreshes a push token on the mobile app → old entry orphaned.
- App is reinstalled → fresh token registers, old one lingers forever.
- Browser tab loses its `chroxy_device_id` (storage cleared) → same.

Operators had no way to drain these short of hand-editing `~/.chroxy/notification-prefs.json`. This PR exposes the existing server-side delete capability through the UI.

## Design notes

- "Friendly label" for v1 is the truncated token (24-char prefix + ellipsis). Per the issue scope, we deferred richer metadata (last-seen time, platform hint) — the truncated token plus the "(this device)" marker is enough for the user to identify their own row vs orphans.
- Current device row sorts first; siblings sort lexicographically for deterministic ordering across reloads.
- The Settings section is capability-gated the same way as the existing notification UI (#4560) — pre-#4541 servers see nothing.

## Test plan

- [x] Server: `cd packages/server && PATH="/opt/homebrew/opt/node@22/bin:\$PATH" node --test --experimental-test-module-mocks tests/notification-prefs.test.js tests/ws-schemas.test.js tests/handlers/notification-prefs-handlers.test.js` (206 pass)
- [x] Dashboard: `cd packages/dashboard && PATH="/opt/homebrew/opt/node@22/bin:\$PATH" npx vitest run` (2341 pass)
- [x] Mobile: `cd packages/app && PATH="/opt/homebrew/opt/node@22/bin:\$PATH" npx jest` (1428 pass)
- [x] TypeScript: dashboard + app `npx tsc --noEmit` (clean)
- [x] Dashboard build: `npm run build` (succeeds)
- [ ] Manual: open Settings on dashboard with a per-device override seeded, click Clear, verify entry disappears and reload doesn't resurrect it.