### PR TITLE
feat(server,ui): track lastSeen + platform per notification-prefs device

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsDeviceMeta.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsDeviceMeta.test.ts
@@ -1,0 +1,86 @@
+/**
+ * SettingsScreen — per-device lastSeenAt + platform metadata tests (#4587).
+ *
+ * Mirrors the dashboard surface in
+ * `packages/dashboard/src/components/SettingsPanel.test.tsx` which renders
+ * the same per-device list. Mobile sticks with static-source assertions
+ * because RN primitives are impractical to render under Jest without a
+ * heavy harness (same pattern as `SettingsScreenNotificationPrefsClearDevice`
+ * and `SettingsScreenNotificationPrefsDevice`).
+ *
+ * The metadata is non-critical: operators with multiple orphan device
+ * entries need a way to tell them apart before clicking Clear, but
+ * pre-#4587 servers omit both fields and the row must degrade to the
+ * legacy token-only render. The tests below pin both branches so a
+ * regression that always renders the meta (or drops it entirely) trips
+ * before any UI ships.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const settingsSource = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/SettingsScreen.tsx'),
+  'utf-8',
+);
+
+describe('SettingsScreen — per-device meta surface (#4587)', () => {
+  it('declares the optional lastSeenAt + platform fields on the KnownDevicesList devices prop', () => {
+    // The prop type MUST carry the optional fields or the render branch
+    // below trips a TS error. We anchor on the literal field names rather
+    // than the full prop shape so the assertion stays small.
+    expect(settingsSource).toMatch(/lastSeenAt\?:\s*number/);
+    expect(settingsSource).toMatch(/platform\?:\s*string/);
+  });
+
+  it('renders a platform badge with the canonical testID when entry.platform is set', () => {
+    // testID matches the dashboard naming
+    // (`notification-prefs-device-platform-${key}`) so cross-surface tests
+    // can share fixtures and Maestro can reach both screens uniformly.
+    expect(settingsSource).toMatch(
+      /testID=\{`notification-prefs-device-platform-\$\{key\}`\}/,
+    );
+  });
+
+  it('renders a last-seen badge with the canonical testID when entry.lastSeenAt is set', () => {
+    expect(settingsSource).toMatch(
+      /testID=\{`notification-prefs-device-last-seen-\$\{key\}`\}/,
+    );
+  });
+
+  it('guards both meta renders behind a truthiness check so pre-#4587 entries degrade cleanly', () => {
+    // Without the guard, a pre-#4587 server snapshot (where neither field
+    // is set) would render an empty `· ` separator inside the row.
+    // Truthy-string + truthy-number check on each branch keeps the legacy
+    // row identical to before. RN doesn't accept short-circuit `&& null`
+    // gracefully inside parents that expect children, so the implementation
+    // uses the ternary `entry.platform ? <Text/> : null` shape.
+    expect(settingsSource).toMatch(/entry\.platform\s*\?\s*[\s\S]{0,400}notification-prefs-device-platform/);
+    expect(settingsSource).toMatch(/entry\.lastSeenAt\s*\?\s*[\s\S]{0,400}notification-prefs-device-last-seen/);
+  });
+
+  it('rewrites the canonical platform values through formatPlatform()', () => {
+    // `ios` -> `iOS`, `android` -> `Android`, etc. — without the rewrite
+    // operators see lowercase tags that read as a debug string. Anchor on
+    // the function definition + a representative case so a future addition
+    // (web/desktop already present) doesn't accidentally drop the iOS case.
+    expect(settingsSource).toMatch(/function formatPlatform\(p: string\)/);
+    expect(settingsSource).toMatch(/case 'ios':\s*return 'iOS'/);
+    expect(settingsSource).toMatch(/case 'android':\s*return 'Android'/);
+  });
+
+  it('declares formatRelativeTime with minute-granularity output and forward-skew fallback', () => {
+    // Two anchors: (1) the function exists and rounds down to minutes,
+    // (2) future timestamps (clock skew) render "just now" rather than a
+    // negative duration. Both fail-safes were spelled out in #4587.
+    expect(settingsSource).toMatch(/function formatRelativeTime\(epochMs: number\)/);
+    expect(settingsSource).toMatch(/if \(diffMs < 0\) return 'just now'/);
+    expect(settingsSource).toMatch(/Math\.floor\(diffMs \/ 60_000\)/);
+  });
+
+  it('uses a muted style for the meta text so it reads as secondary content', () => {
+    // The deviceMetaText style maps to COLORS.textMuted (same hue as
+    // section headers + hints elsewhere) — without it the meta would be
+    // primary-coloured and visually compete with the token + Clear button.
+    expect(settingsSource).toMatch(/deviceMetaText:\s*\{[\s\S]{0,200}color:\s*COLORS\.textMuted/);
+  });
+});

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -1182,6 +1182,45 @@ function truncateDeviceLabel(key: string): string {
 }
 
 /**
+ * #4587: friendly label for the canonical `deviceInfo.platform` values
+ * persisted with per-device entries. Mirrors the dashboard copy in
+ * `packages/dashboard/src/components/SettingsPanel.tsx` rather than
+ * importing a shared util — pulling a shared dep into the RN bundle for
+ * a 6-line switch isn't worth the indirection.
+ */
+function formatPlatform(p: string): string {
+  switch (p) {
+    case 'ios': return 'iOS';
+    case 'android': return 'Android';
+    case 'web': return 'Web';
+    case 'desktop': return 'Desktop';
+    default: return p;
+  }
+}
+
+/**
+ * #4587: minute-granularity "X ago" renderer for the per-device list.
+ * See dashboard sibling for the rationale on local-only formatting.
+ * Future timestamps (clock skew between server and phone) fall through
+ * to "just now" so we never render negative durations.
+ */
+function formatRelativeTime(epochMs: number): string {
+  const diffMs = Date.now() - epochMs;
+  if (diffMs < 0) return 'just now';
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hr ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days} day${days === 1 ? '' : 's'} ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months} mo ago`;
+  const years = Math.floor(months / 12);
+  return `${years} yr ago`;
+}
+
+/**
  * #4564: list of per-device override entries with a "Clear" button per
  * row. The map can accumulate orphans when Expo refreshes the push token
  * or the app is reinstalled — without this list the only way to drain
@@ -1193,6 +1232,11 @@ function KnownDevicesList(props: {
     categories?: Record<string, boolean>;
     quietHours?: { start: string; end: string; timezone: string } | null;
     bypassCategories?: string[];
+    // #4587: optional last-seen + platform metadata stamped by the server.
+    // Pre-#4587 servers omit both fields, in which case the row renders
+    // exactly as before (truncated token + optional "this device" tag).
+    lastSeenAt?: number;
+    platform?: string;
   }>;
   currentDeviceKey: string | null;
   onClear: (deviceKey: string) => void;
@@ -1221,6 +1265,7 @@ function KnownDevicesList(props: {
     <View testID="notification-prefs-devices-list">
       {sorted.map((key, idx) => {
         const isCurrent = key === currentDeviceKey;
+        const entry = devices[key];
         return (
           <React.Fragment key={key}>
             {idx > 0 && <View style={styles.separator} />}
@@ -1239,6 +1284,25 @@ function KnownDevicesList(props: {
                 {isCurrent && (
                   <Text style={styles.deviceSelfTag}> (this device)</Text>
                 )}
+                {/* #4587: optional platform + last-seen metadata. Both
+                    hidden when absent (pre-#4587 server snapshot) so the
+                    row degrades to the original token-only render. */}
+                {entry.platform ? (
+                  <Text
+                    style={styles.deviceMetaText}
+                    testID={`notification-prefs-device-platform-${key}`}
+                  >
+                    {' · '}{formatPlatform(entry.platform)}
+                  </Text>
+                ) : null}
+                {entry.lastSeenAt ? (
+                  <Text
+                    style={styles.deviceMetaText}
+                    testID={`notification-prefs-device-last-seen-${key}`}
+                  >
+                    {' · Last seen '}{formatRelativeTime(entry.lastSeenAt)}
+                  </Text>
+                ) : null}
               </View>
               <TouchableOpacity
                 onPress={() => onClear(key)}
@@ -1371,6 +1435,13 @@ const styles = StyleSheet.create({
   },
   deviceSelfTag: {
     color: COLORS.accentBlue,
+    fontSize: 12,
+  },
+  // #4587: subdued meta text for the platform + last-seen badges. Borrows
+  // the same `textMuted` accent already used for hints and section
+  // headers so the badges read as secondary content next to the token.
+  deviceMetaText: {
+    color: COLORS.textMuted,
     fontSize: 12,
   },
   deviceClearButton: {

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -1075,6 +1075,91 @@ describe('SettingsPanel', () => {
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       expect(screen.queryByTestId('notification-prefs-devices-list')).toBeNull()
     })
+
+    // #4587: per-device metadata (lastSeenAt + platform). The dashboard
+    // surfaces these as a muted "{platform} · Last seen {relative}" suffix
+    // next to the truncated token so operators can tell orphan entries
+    // apart. Both fields are optional — pre-#4587 servers omit them and
+    // the row renders exactly as before.
+    describe('lastSeen + platform metadata (#4587)', () => {
+      it('renders a platform badge when entry.platform is set', () => {
+        setMockState({
+          notificationPrefs: {
+            categories,
+            devices: {
+              'tok-ios': { categories: { result: false }, platform: 'ios' },
+            },
+            quietHours: null,
+          },
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const badge = screen.getByTestId('notification-prefs-device-platform-tok-ios')
+        // Friendly label rewrite — `ios` -> `iOS` — so the row reads
+        // correctly for non-technical operators.
+        expect(badge.textContent).toMatch(/iOS/)
+      })
+
+      it('renders a last-seen badge when entry.lastSeenAt is set', () => {
+        setMockState({
+          notificationPrefs: {
+            categories,
+            devices: {
+              'tok-seen': {
+                categories: { result: false },
+                // 1 minute ago — should render as "1 min ago"
+                lastSeenAt: Date.now() - 60_000,
+              },
+            },
+            quietHours: null,
+          },
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const badge = screen.getByTestId('notification-prefs-device-last-seen-tok-seen')
+        // Match the minute-granularity render. Allow `1 min` or `2 min`
+        // depending on which side of the floor we land on.
+        expect(badge.textContent).toMatch(/Last seen \d+ min ago/)
+      })
+
+      it('renders both meta spans when both fields are set', () => {
+        setMockState({
+          notificationPrefs: {
+            categories,
+            devices: {
+              'tok-both': {
+                categories: { result: false },
+                platform: 'android',
+                lastSeenAt: Date.now() - 3_600_000, // 1 hr ago
+              },
+            },
+            quietHours: null,
+          },
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        expect(screen.getByTestId('notification-prefs-device-platform-tok-both').textContent).toMatch(/Android/)
+        expect(screen.getByTestId('notification-prefs-device-last-seen-tok-both').textContent).toMatch(/hr ago/)
+      })
+
+      it('omits both meta spans when fields are absent (pre-#4587 server)', () => {
+        // Graceful fallback — a snapshot from an older server still
+        // renders, just without the new affordances. The truncated token
+        // and Clear button are still present.
+        setMockState({
+          notificationPrefs: {
+            categories,
+            devices: {
+              'tok-legacy': { categories: { result: false } },
+            },
+            quietHours: null,
+          },
+        })
+        render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        expect(screen.queryByTestId('notification-prefs-device-platform-tok-legacy')).toBeNull()
+        expect(screen.queryByTestId('notification-prefs-device-last-seen-tok-legacy')).toBeNull()
+        // Sanity — the row itself still renders.
+        expect(screen.getByTestId('notification-prefs-device-entry-tok-legacy')).toBeInTheDocument()
+        expect(screen.getByTestId('notification-prefs-device-clear-tok-legacy')).toBeInTheDocument()
+      })
+    })
   })
 
   describe('Notification preferences — quiet-hours editor (#4544)', () => {

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -515,6 +515,13 @@ function KnownDevicesList(props: {
           {sorted.map(key => {
             const isCurrent = key === currentDeviceKey
             const entry = devices[key]
+            // Index access on Record<string, T> returns `T | undefined`
+            // under noUncheckedIndexedAccess. `key` came from
+            // Object.keys(devices) so `entry` is always present in
+            // practice, but the type narrowing keeps strict TS happy
+            // and guards against a race where `devices` mutates
+            // between the keys() snapshot and the render.
+            if (!entry) return null
             return (
               <li
                 key={key}

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -528,23 +528,26 @@ function KnownDevicesList(props: {
                   )}
                   {/* #4587: optional platform + last-seen metadata. Both
                       hidden when absent (pre-#4587 server snapshot) so the
-                      row degrades to the original token-only render. */}
-                  {entry.platform && (
+                      row degrades to the original token-only render.
+                      Ternary (not `&&`) so a stray 0 in lastSeenAt — or
+                      empty-string platform that bypassed the sanitizer —
+                      can never render as a raw literal text node. */}
+                  {entry.platform ? (
                     <span
                       className="notification-prefs-device-meta"
                       data-testid={`notification-prefs-device-platform-${key}`}
                     >
                       {' · '}{formatPlatform(entry.platform)}
                     </span>
-                  )}
-                  {entry.lastSeenAt && (
+                  ) : null}
+                  {entry.lastSeenAt ? (
                     <span
                       className="notification-prefs-device-meta"
                       data-testid={`notification-prefs-device-last-seen-${key}`}
                     >
                       {' · Last seen '}{formatRelativeTime(entry.lastSeenAt)}
                     </span>
-                  )}
+                  ) : null}
                 </span>
                 <button
                   type="button"

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -403,6 +403,51 @@ function truncateDeviceLabel(key: string): string {
 }
 
 /**
+ * #4587: friendly label for the canonical platform values shipped by
+ * `deviceInfo.platform` on auth (`ios`/`android`/`web`/`desktop` plus
+ * `unknown` and any future values). Falls back to the raw string so a
+ * forward-compatible client carrying a new value still renders, just
+ * without the title-cased rewrite.
+ */
+function formatPlatform(p: string): string {
+  switch (p) {
+    case 'ios': return 'iOS'
+    case 'android': return 'Android'
+    case 'web': return 'Web'
+    case 'desktop': return 'Desktop'
+    default: return p
+  }
+}
+
+/**
+ * #4587: cheap human-readable "X ago" for the per-device list. Renders at
+ * minute granularity (rounds down) so the smallest unit the operator sees
+ * is "just now" or "N min ago" — nothing as precise as seconds. Future
+ * timestamps (clock skew, server stamping ahead of dashboard read) fall
+ * through to "just now" rather than rendering nonsense like "-1 min ago".
+ *
+ * Kept module-local instead of imported from a shared utility because the
+ * dashboard already has a few tiny ad-hoc formatters in this file; the
+ * mobile copy is a parallel implementation in `SettingsScreen.tsx` to
+ * avoid pulling a shared dep into the RN bundle for a 12-line helper.
+ */
+function formatRelativeTime(epochMs: number): string {
+  const diffMs = Date.now() - epochMs
+  if (diffMs < 0) return 'just now'
+  const minutes = Math.floor(diffMs / 60_000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes} min ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} hr ago`
+  const days = Math.floor(hours / 24)
+  if (days < 30) return `${days} day${days === 1 ? '' : 's'} ago`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `${months} mo ago`
+  const years = Math.floor(months / 12)
+  return `${years} yr ago`
+}
+
+/**
  * #4564: list of currently-known per-device override entries with a
  * per-row "Clear" button. Lets the user drain orphans accumulated when a
  * push token refreshes, an app reinstalls, or a browser tab loses its
@@ -424,6 +469,12 @@ function KnownDevicesList(props: {
     categories?: Record<string, boolean>
     quietHours?: { start: string; end: string; timezone: string } | null
     bypassCategories?: string[]
+    // #4587: optional last-seen + platform metadata stamped by the server
+    // on each device patch + register_push_token. Pre-#4587 servers omit
+    // both fields, in which case the row renders exactly as before
+    // (truncated token + optional "this device" tag, no meta spans).
+    lastSeenAt?: number
+    platform?: string
   }>
   currentDeviceKey: string | null
   onClear: (deviceKey: string) => void
@@ -463,6 +514,7 @@ function KnownDevicesList(props: {
         <ul className="notification-prefs-devices-list">
           {sorted.map(key => {
             const isCurrent = key === currentDeviceKey
+            const entry = devices[key]
             return (
               <li
                 key={key}
@@ -473,6 +525,25 @@ function KnownDevicesList(props: {
                   <code>{truncateDeviceLabel(key)}</code>
                   {isCurrent && (
                     <span className="notification-prefs-device-self-tag"> (this device)</span>
+                  )}
+                  {/* #4587: optional platform + last-seen metadata. Both
+                      hidden when absent (pre-#4587 server snapshot) so the
+                      row degrades to the original token-only render. */}
+                  {entry.platform && (
+                    <span
+                      className="notification-prefs-device-meta"
+                      data-testid={`notification-prefs-device-platform-${key}`}
+                    >
+                      {' · '}{formatPlatform(entry.platform)}
+                    </span>
+                  )}
+                  {entry.lastSeenAt && (
+                    <span
+                      className="notification-prefs-device-meta"
+                      data-testid={`notification-prefs-device-last-seen-${key}`}
+                    >
+                      {' · Last seen '}{formatRelativeTime(entry.lastSeenAt)}
+                    </span>
                   )}
                 </span>
                 <button

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4994,6 +4994,14 @@
   color: var(--accent-blue);
 }
 
+/* #4587: per-device metadata badges (platform + last-seen). Subdued
+   styling so the token + Clear button still read as primary content;
+   the meta is just an aid for telling orphans apart. */
+.notification-prefs-device-meta {
+  font-size: 11px;
+  color: var(--text-muted, #888);
+}
+
 .notification-prefs-device-clear {
   flex-shrink: 0;
   padding: 4px 10px;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -286,6 +286,8 @@ export declare const NotificationPrefsPatchSchema: z.ZodObject<{
             timezone: z.ZodString;
         }, z.core.$strip>]>>;
         bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
+        lastSeenAt: z.ZodOptional<z.ZodNumber>;
+        platform: z.ZodOptional<z.ZodString>;
     }, z.core.$loose>, z.ZodNull]>>>;
     quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
         start: z.ZodString;
@@ -320,6 +322,8 @@ export declare const NotificationPrefsSetSchema: z.ZodObject<{
                 timezone: z.ZodString;
             }, z.core.$strip>]>>;
             bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
+            lastSeenAt: z.ZodOptional<z.ZodNumber>;
+            platform: z.ZodOptional<z.ZodString>;
         }, z.core.$loose>, z.ZodNull]>>>;
         quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
             start: z.ZodString;
@@ -674,6 +678,8 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
                 timezone: z.ZodString;
             }, z.core.$strip>]>>;
             bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
+            lastSeenAt: z.ZodOptional<z.ZodNumber>;
+            platform: z.ZodOptional<z.ZodString>;
         }, z.core.$loose>, z.ZodNull]>>>;
         quietHours: z.ZodOptional<z.ZodUnion<readonly [z.ZodNull, z.ZodObject<{
             start: z.ZodString;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -292,18 +292,28 @@ const NotificationQuietHoursSchema = z.union([
  */
 const NotificationBypassListSchema = z.array(z.string().min(1).max(64)).max(64);
 /**
- * Per-device override entry (#4544 extended).
+ * Per-device override entry (#4544 extended, #4587 added metadata).
  *
  * Per-device fields REPLACE the corresponding global value entirely:
  *   - `quietHours: null` opts the device out of muting even if global is set.
  *   - `bypassCategories: []` opts the device out of all bypasses even if
  *     global lists them.
  * See `notification-prefs.js` for the precedence rationale.
+ *
+ * #4587: `lastSeenAt` (epoch ms) is stamped by the server every time the
+ * entry is patched or its push token re-registers. `platform`
+ * (`ios`/`android`/`web`/`desktop`/`unknown` or a future value) is read
+ * from the connecting client's `deviceInfo` during auth and persisted with
+ * the entry. Both are optional on the wire so a pre-#4587 server snapshot
+ * still validates cleanly; the dashboard + mobile per-device lists hide
+ * the meta when absent.
  */
 const NotificationDeviceEntrySchema = z.object({
     categories: NotificationCategoryMapSchema.optional(),
     quietHours: NotificationQuietHoursSchema.optional(),
     bypassCategories: NotificationBypassListSchema.optional(),
+    lastSeenAt: z.number().int().positive().optional(),
+    platform: z.string().min(1).max(32).optional(),
 }).passthrough();
 /**
  * Patch shape accepted by `notification_prefs_set`. Every top-level field

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -331,18 +331,28 @@ const NotificationQuietHoursSchema = z.union([
 const NotificationBypassListSchema = z.array(z.string().min(1).max(64)).max(64)
 
 /**
- * Per-device override entry (#4544 extended).
+ * Per-device override entry (#4544 extended, #4587 added metadata).
  *
  * Per-device fields REPLACE the corresponding global value entirely:
  *   - `quietHours: null` opts the device out of muting even if global is set.
  *   - `bypassCategories: []` opts the device out of all bypasses even if
  *     global lists them.
  * See `notification-prefs.js` for the precedence rationale.
+ *
+ * #4587: `lastSeenAt` (epoch ms) is stamped by the server every time the
+ * entry is patched or its push token re-registers. `platform`
+ * (`ios`/`android`/`web`/`desktop`/`unknown` or a future value) is read
+ * from the connecting client's `deviceInfo` during auth and persisted with
+ * the entry. Both are optional on the wire so a pre-#4587 server snapshot
+ * still validates cleanly; the dashboard + mobile per-device lists hide
+ * the meta when absent.
  */
 const NotificationDeviceEntrySchema = z.object({
   categories: NotificationCategoryMapSchema.optional(),
   quietHours: NotificationQuietHoursSchema.optional(),
   bypassCategories: NotificationBypassListSchema.optional(),
+  lastSeenAt: z.number().int().positive().optional(),
+  platform: z.string().min(1).max(32).optional(),
 }).passthrough()
 
 /**

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -439,6 +439,12 @@ function handleRegisterPushToken(ws, client, msg, ctx) {
     client._ownedPushTokens = new Set()
   }
   client._ownedPushTokens.add(msg.token)
+
+  // #4587: bump lastSeenAt + platform on the matching per-device entry
+  // (if one exists) so the per-device list UI reflects last-connect time
+  // rather than last-pref-change time. NO-OPs on devices that have never
+  // muted anything — touchDevice deliberately won't create empty entries.
+  ctx.pushManager.touchDevice(msg.token, client.deviceInfo?.platform || null)
 }
 
 /**
@@ -481,7 +487,11 @@ function handleNotificationPrefsSet(ws, client, msg, ctx) {
   }
   let next
   try {
-    next = ctx.pushManager.setPrefs(patch)
+    // #4587: pass the auth-derived platform so new per-device entries get
+    // tagged with ios/android/desktop/web without the client having to
+    // include it in every patch. A patch-supplied `platform` (future
+    // client carrying richer info) still wins inside setPrefs.
+    next = ctx.pushManager.setPrefs(patch, { platform: client.deviceInfo?.platform || null })
   } catch (err) {
     log.warn(`notification_prefs_set persist failed: ${err?.message}`)
     sendError(ws, msg?.requestId, 'NOTIFICATION_PREFS_WRITE_FAILED', err?.message || 'write failed')

--- a/packages/server/src/notification-prefs.js
+++ b/packages/server/src/notification-prefs.js
@@ -184,6 +184,17 @@ function sanitizeDevices(raw, { log } = {}) {
       const bypass = sanitizeBypassList(entry.bypassCategories)
       if (bypass !== null) cleaned.bypassCategories = bypass
     }
+    // #4587: non-critical metadata for the per-device list UI. Operators
+    // need to tell orphan entries apart before clicking Clear — the truncated
+    // token alone is opaque. Strict type/range guards; no log warns
+    // because a malformed metadata field should never affect notification
+    // delivery (it just degrades the UI hint).
+    if (typeof entry.lastSeenAt === 'number' && Number.isFinite(entry.lastSeenAt) && entry.lastSeenAt > 0) {
+      cleaned.lastSeenAt = entry.lastSeenAt
+    }
+    if (typeof entry.platform === 'string' && entry.platform.length > 0 && entry.platform.length <= 32) {
+      cleaned.platform = entry.platform
+    }
     out[token] = cleaned
   }
   return out

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -194,9 +194,21 @@ export class PushManager {
    * (defaults to permission + activity_error). Both fields accept the
    * same per-device override shape as the existing `categories` map.
    *
+   * #4587: per-device entries are stamped with `lastSeenAt = Date.now()`
+   * on every touch (create + modify; not on `null` delete). When the
+   * caller supplies a `platform` (e.g. WS handler passing
+   * `client.deviceInfo?.platform`) it's persisted with the entry — a
+   * patch-supplied `platform` wins over the caller-supplied default so a
+   * future client carrying richer info can still override the
+   * auth-derived value.
+   *
    * @param {object} patch - Partial prefs ({ categories?, devices?, quietHours?, bypassCategories? })
+   * @param {object} [opts]
+   * @param {string|null} [opts.platform] - Caller-supplied platform hint
+   *   (from `client.deviceInfo.platform` in the WS auth context) used to
+   *   stamp NEW per-device entries when the patch itself doesn't carry one.
    */
-  setPrefs(patch) {
+  setPrefs(patch, { platform = null } = {}) {
     if (!patch || typeof patch !== 'object') return this.getPrefs()
     const next = {
       categories: { ...this._prefs.categories },
@@ -253,6 +265,21 @@ export class PushManager {
             merged.bypassCategories = entry.bypassCategories.filter((c) => typeof c === 'string' && c.length > 0)
           }
         }
+        // #4587: stamp lastSeenAt on every touch. The per-device list UI
+        // uses this to render "Last seen X ago" so operators can tell
+        // recently-active devices apart from stale orphans without having
+        // to hand-read the prefs file.
+        merged.lastSeenAt = Date.now()
+        // Allow the caller to inject the canonical platform (from auth
+        // deviceInfo). Patch-supplied platform wins over caller-supplied
+        // (forward-compat: a future client could send a more specific value
+        // than auth carries). Both paths clamp to 32 chars to match the
+        // wire schema bound.
+        if (typeof entry.platform === 'string' && entry.platform.length > 0) {
+          merged.platform = entry.platform.slice(0, 32)
+        } else if (typeof platform === 'string' && platform.length > 0) {
+          merged.platform = platform.slice(0, 32)
+        }
         next.devices[token] = merged
       }
     }
@@ -285,6 +312,43 @@ export class PushManager {
       }
     }
     return this.getPrefs()
+  }
+
+  /**
+   * Stamp `lastSeenAt` (and optionally `platform`) on an EXISTING device
+   * entry without otherwise modifying it (#4587).
+   *
+   * No-op when the device has no entry — `register_push_token` calls this
+   * on every reconnect, but we don't want to create empty per-device
+   * entries for devices that have never muted anything. Empty entries
+   * would clutter the per-device list with rows that have no overrides to
+   * clear, defeating the purpose of the orphan-clearing UI in #4564.
+   *
+   * Called from `handleRegisterPushToken` so the per-device list reflects
+   * the last CONNECT time of each device, not just the last time its
+   * prefs were patched — without this, a device that registers but never
+   * mutes a category would show a `lastSeenAt` from the first mute
+   * forever.
+   */
+  touchDevice(token, platform = null) {
+    if (typeof token !== 'string' || token.length === 0) return
+    const existing = this._prefs.devices?.[token]
+    if (!existing) return
+    existing.lastSeenAt = Date.now()
+    if (typeof platform === 'string' && platform.length > 0) {
+      existing.platform = platform.slice(0, 32)
+    }
+    if (this._prefsPath) {
+      try {
+        saveNotificationPrefs(this._prefs, this._prefsPath)
+      } catch (err) {
+        // Metadata write failure is non-critical (push delivery still
+        // works), so log and continue rather than throwing — unlike
+        // setPrefs, which surfaces a write failure to the WS handler so
+        // the client knows their patch didn't persist.
+        log.error(`Failed to persist notification prefs: ${err?.message || err}`)
+      }
+    }
   }
 
   /**

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -263,7 +263,7 @@ describe('input-handlers', () => {
   describe('register_push_token', () => {
     it('calls pushManager.registerToken when present', () => {
       const ctx = makeCtx()
-      ctx.pushManager = { registerToken: createSpy(() => true) }
+      ctx.pushManager = { registerToken: createSpy(() => true), touchDevice: createSpy() }
 
       inputHandlers.register_push_token(makeWs(), makeClient(), { token: 'expo-tok-123' }, ctx)
 
@@ -273,7 +273,7 @@ describe('input-handlers', () => {
 
     it('sends push_token_error when registerToken returns false', () => {
       const ctx = makeCtx()
-      ctx.pushManager = { registerToken: createSpy(() => false) }
+      ctx.pushManager = { registerToken: createSpy(() => false), touchDevice: createSpy() }
 
       inputHandlers.register_push_token(makeWs(), makeClient(), { token: 'bad' }, ctx)
 
@@ -285,6 +285,32 @@ describe('input-handlers', () => {
       // Should not throw
       inputHandlers.register_push_token(makeWs(), makeClient(), { token: 'tok' }, ctx)
       assert.equal(ctx._sent.length, 0)
+    })
+
+    // #4587: touchDevice bumps the matching per-device entry's lastSeenAt
+    // + platform from the auth deviceInfo. The handler MUST forward the
+    // platform string so the per-device list shows ios/android/desktop —
+    // a regression that dropped this arg would leave every entry tagged
+    // with `null` and break the dashboard label.
+    it('calls touchDevice with the auth-derived platform from client.deviceInfo (#4587)', () => {
+      const ctx = makeCtx()
+      ctx.pushManager = { registerToken: createSpy(() => true), touchDevice: createSpy() }
+      const client = makeClient({ deviceInfo: { platform: 'ios' } })
+
+      inputHandlers.register_push_token(makeWs(), client, { token: 'expo-tok-xyz' }, ctx)
+
+      assert.equal(ctx.pushManager.touchDevice.callCount, 1)
+      assert.equal(ctx.pushManager.touchDevice.lastCall[0], 'expo-tok-xyz')
+      assert.equal(ctx.pushManager.touchDevice.lastCall[1], 'ios')
+    })
+
+    it('passes null to touchDevice when client lacks deviceInfo.platform (#4587)', () => {
+      const ctx = makeCtx()
+      ctx.pushManager = { registerToken: createSpy(() => true), touchDevice: createSpy() }
+      // Default makeClient() has no deviceInfo — platform falls back to null
+      // so touchDevice still no-ops correctly on the existing-entry check.
+      inputHandlers.register_push_token(makeWs(), makeClient(), { token: 'expo-tok-xyz' }, ctx)
+      assert.equal(ctx.pushManager.touchDevice.lastCall[1], null)
     })
   })
 

--- a/packages/server/tests/notification-prefs.test.js
+++ b/packages/server/tests/notification-prefs.test.js
@@ -423,3 +423,229 @@ describe('PushManager prefs surface — per-device delete (#4564)', () => {
     assert.deepEqual(snapshot.devices['new-tok'].categories, { result: true })
   })
 })
+
+/**
+ * #4587: per-device `lastSeenAt` (epoch ms) + `platform` metadata.
+ *
+ * Operators with multiple orphan entries in the per-device list need a way
+ * to tell which is which before clicking Clear. The truncated token alone
+ * is opaque — augment each entry with the platform (`ios`/`android`/
+ * `web`/`desktop`) and the timestamp of the last patch that touched the
+ * entry. Both fields are optional on the wire; older clients/servers
+ * round-trip without them.
+ */
+describe('sanitizeDevices — lastSeenAt + platform (#4587)', () => {
+  it('passes through a valid lastSeenAt (positive finite number)', () => {
+    const onDisk = {
+      devices: {
+        'tok-a': {
+          categories: { result: false },
+          lastSeenAt: 1_700_000_000_000,
+        },
+      },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.devices['tok-a'].lastSeenAt, 1_700_000_000_000)
+  })
+
+  it('passes through a valid platform (string, 1-32 chars)', () => {
+    const onDisk = {
+      devices: {
+        'tok-a': { categories: { result: false }, platform: 'ios' },
+      },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.devices['tok-a'].platform, 'ios')
+  })
+
+  it('drops a non-finite lastSeenAt (NaN, Infinity)', () => {
+    // NaN/Infinity round-trip through JSON as `null`, which would already
+    // miss `typeof === number`. Cover the in-memory path where the loader
+    // re-sanitises a malformed value (e.g. passed via setPrefs).
+    const onDisk = {
+      devices: {
+        'tok-a': { categories: {}, lastSeenAt: null },
+        'tok-b': { categories: {}, lastSeenAt: 'not-a-number' },
+      },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.devices['tok-a'].lastSeenAt, undefined)
+    assert.equal(prefs.devices['tok-b'].lastSeenAt, undefined)
+  })
+
+  it('drops a zero or negative lastSeenAt (epoch ms must be > 0)', () => {
+    const onDisk = {
+      devices: {
+        'tok-zero': { categories: {}, lastSeenAt: 0 },
+        'tok-neg': { categories: {}, lastSeenAt: -1 },
+      },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.devices['tok-zero'].lastSeenAt, undefined)
+    assert.equal(prefs.devices['tok-neg'].lastSeenAt, undefined)
+  })
+
+  it('drops an empty-string platform', () => {
+    const onDisk = {
+      devices: { 'tok-a': { categories: {}, platform: '' } },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.devices['tok-a'].platform, undefined)
+  })
+
+  it('drops a platform string longer than 32 chars', () => {
+    const tooLong = 'x'.repeat(33)
+    const onDisk = {
+      devices: { 'tok-a': { categories: {}, platform: tooLong } },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.devices['tok-a'].platform, undefined)
+  })
+
+  it('drops a non-string platform', () => {
+    const onDisk = {
+      devices: { 'tok-a': { categories: {}, platform: 123 } },
+    }
+    writeFileSync(prefsPath, JSON.stringify(onDisk))
+    const prefs = loadPrefs(prefsPath)
+    assert.equal(prefs.devices['tok-a'].platform, undefined)
+  })
+
+  it('round-trips lastSeenAt + platform through save+load', () => {
+    const written = {
+      categories: { result: true },
+      devices: {
+        'tok-a': {
+          categories: { result: false },
+          lastSeenAt: 1_700_000_000_000,
+          platform: 'desktop',
+        },
+      },
+    }
+    savePrefs(written, prefsPath)
+    const reread = loadPrefs(prefsPath)
+    assert.equal(reread.devices['tok-a'].lastSeenAt, 1_700_000_000_000)
+    assert.equal(reread.devices['tok-a'].platform, 'desktop')
+  })
+})
+
+/**
+ * #4587: PushManager.setPrefs + touchDevice stamping behaviour.
+ */
+describe('PushManager — lastSeenAt + platform stamping (#4587)', () => {
+  it('stamps lastSeenAt = Date.now() when creating a new device entry', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    const before = Date.now()
+    pm.setPrefs({ devices: { 'tok-a': { categories: { result: false } } } })
+    const after = Date.now()
+    const stamp = pm.getPrefs().devices['tok-a'].lastSeenAt
+    assert.equal(typeof stamp, 'number')
+    assert.ok(stamp >= before && stamp <= after, `expected stamp in [${before}, ${after}], got ${stamp}`)
+  })
+
+  it('stamps lastSeenAt when patching an existing device', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs({ devices: { 'tok-a': { categories: { result: false } } } })
+    const firstStamp = pm.getPrefs().devices['tok-a'].lastSeenAt
+    // Force a measurable gap so the second stamp is strictly newer.
+    await new Promise((r) => setTimeout(r, 5))
+    pm.setPrefs({ devices: { 'tok-a': { categories: { result: true } } } })
+    const secondStamp = pm.getPrefs().devices['tok-a'].lastSeenAt
+    assert.ok(secondStamp > firstStamp, `expected ${secondStamp} > ${firstStamp}`)
+  })
+
+  it('does NOT stamp lastSeenAt on the null-delete case (entry is gone)', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs({ devices: { 'tok-a': { categories: { result: false } } } })
+    pm.setPrefs({ devices: { 'tok-a': null } })
+    const snapshot = pm.getPrefs()
+    assert.equal(snapshot.devices['tok-a'], undefined)
+  })
+
+  it('honours patch-supplied platform over caller-supplied', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs(
+      { devices: { 'tok-a': { categories: { result: false }, platform: 'ios' } } },
+      { platform: 'android' },
+    )
+    assert.equal(pm.getPrefs().devices['tok-a'].platform, 'ios')
+  })
+
+  it('falls back to caller-supplied platform when patch has none', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs(
+      { devices: { 'tok-a': { categories: { result: false } } } },
+      { platform: 'desktop' },
+    )
+    assert.equal(pm.getPrefs().devices['tok-a'].platform, 'desktop')
+  })
+
+  it('clamps platform to 32 chars', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    const longPlatform = 'x'.repeat(50)
+    pm.setPrefs({ devices: { 'tok-a': { categories: {}, platform: longPlatform } } })
+    assert.equal(pm.getPrefs().devices['tok-a'].platform.length, 32)
+  })
+
+  it('touchDevice bumps lastSeenAt on an existing entry', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs({ devices: { 'tok-a': { categories: { result: false } } } })
+    const firstStamp = pm.getPrefs().devices['tok-a'].lastSeenAt
+    await new Promise((r) => setTimeout(r, 5))
+    pm.touchDevice('tok-a')
+    const secondStamp = pm.getPrefs().devices['tok-a'].lastSeenAt
+    assert.ok(secondStamp > firstStamp, `expected ${secondStamp} > ${firstStamp}`)
+  })
+
+  it('touchDevice is a NO-OP on a non-existing entry (no empty entry created)', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.touchDevice('never-seen', 'ios')
+    const snapshot = pm.getPrefs()
+    assert.equal(snapshot.devices['never-seen'], undefined, 'must not create empty entries')
+  })
+
+  it('touchDevice updates platform when supplied', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs({ devices: { 'tok-a': { categories: { result: false } } } })
+    pm.touchDevice('tok-a', 'android')
+    assert.equal(pm.getPrefs().devices['tok-a'].platform, 'android')
+  })
+
+  it('touchDevice ignores invalid token (non-string, empty)', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs({ devices: { 'tok-a': { categories: {} } } })
+    // Should not throw or mutate anything.
+    pm.touchDevice('')
+    pm.touchDevice(null)
+    pm.touchDevice(undefined)
+    const snapshot = pm.getPrefs()
+    assert.deepEqual(Object.keys(snapshot.devices), ['tok-a'])
+  })
+
+  it('touchDevice persists to disk when prefsPath is configured', async () => {
+    const { PushManager } = await import('../src/push.js')
+    const pm = new PushManager({ prefsPath })
+    pm.setPrefs({ devices: { 'tok-a': { categories: { result: false } } } })
+    await new Promise((r) => setTimeout(r, 5))
+    pm.touchDevice('tok-a', 'ios')
+    const reread = loadPrefs(prefsPath)
+    assert.equal(reread.devices['tok-a'].platform, 'ios')
+    assert.ok(typeof reread.devices['tok-a'].lastSeenAt === 'number')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #4587 (wave-5 follow-up to #4564 orphan-clearing UI).

Per-device override rows previously showed only a truncated token — operators with multiple orphans had no way to tell which was which. This adds:

- **Server**: stamps `lastSeenAt = Date.now()` on every per-device patch via `setPrefs`. Reads `platform` from `client.deviceInfo` (already populated on auth) and persists it. New `touchDevice()` method bumps existing entries on `register_push_token` so the orphan list reflects last-connect time, not just last-pref-change time.
- **Protocol**: `NotificationDeviceEntrySchema` gets two new `.optional()` fields. Older clients/servers unaffected.
- **UI**: dashboard `SettingsPanel` and mobile `SettingsScreen` `KnownDevicesList` both render `{Platform} . Last seen {rel}` next to the truncated token when the fields are present. Pre-existing entries from older servers render exactly as before (truncated token + `(this device)` only).

## Test plan

- [x] Server tests cover sanitize pass-through, save/load round-trip, setPrefs stamping, touchDevice upsert semantics (11 new cases in `notification-prefs.test.js` + 2 in `input-handlers.test.js`)
- [x] Dashboard test renders enriched + plain rows (4 new cases in `SettingsPanel.test.tsx`)
- [x] Mobile test mirrors dashboard (new `SettingsScreenNotificationPrefsDeviceMeta.test.ts`, 7 cases)
- [x] All workspace test suites pass (server 6138/6146 - 4 unrelated flakes pre-existing on main; dashboard 2345/2345; mobile 1435/1435; protocol 145/145)