### PR TITLE
fix(ui): confirm before clearing current-device notification override

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsClearDevice.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefsClearDevice.test.ts
@@ -105,6 +105,35 @@ describe('ConnectionState — deleteNotificationPrefsDevice surface (#4564)', ()
   });
 });
 
+describe('SettingsScreen — current-device clear confirmation (#4588)', () => {
+  it('prompts via Alert.alert before clearing when deviceKey matches the current pushToken', () => {
+    // The (this device) row silently wipes the operator's own mutes /
+    // quiet-hours overrides if cleared by accident — the prompt is a
+    // second cue after the (this device) tag.
+    expect(settingsSource).toMatch(
+      /handleClearDevice\s*=\s*useCallback[\s\S]{0,800}deviceKey === pushToken[\s\S]{0,400}Alert\.alert/,
+    );
+  });
+
+  it('uses a destructive Clear button alongside Cancel in the alert (#4588)', () => {
+    // Matches the existing pattern for handleClearSessionHistory /
+    // handleClearSavedConnection — destructive styles the action red on
+    // both platforms so the operator reads the affordance as risky.
+    expect(settingsSource).toMatch(
+      /handleClearDevice[\s\S]{0,800}style: 'cancel'[\s\S]{0,200}style: 'destructive'/,
+    );
+  });
+
+  it('falls through to the dispatch when deviceKey !== pushToken (orphan rows stay one-tap)', () => {
+    // Without the early-return inside the `if (deviceKey === pushToken)`
+    // branch, orphan-row clears would also be gated behind Alert.alert —
+    // exactly the behaviour the issue text rules out.
+    expect(settingsSource).toMatch(
+      /if\s*\(deviceKey === pushToken\)[\s\S]{0,600}return;[\s\S]{0,200}dispatch\(\);/,
+    );
+  });
+});
+
 describe('connection.ts — delete action wiring (#4564)', () => {
   it('sends a notification_prefs_set with `devices: { [deviceKey]: null }` as the patch', () => {
     // The null sentinel is the on-wire convention the server interprets

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -245,10 +245,31 @@ export function SettingsScreen() {
 
   // #4564: per-row "Clear" handler. Same WS-closed banner contract as the
   // other notification-prefs setters so a botched clear isn't silent.
+  //
+  // #4588: clearing the row matching `pushToken` (the operator's own
+  // device) silently wipes whatever per-category mutes / quiet-hours
+  // overrides they had set up; the next push will fire under global
+  // defaults with no other warning. Prompt with a destructive Clear
+  // button only for that row — orphan rows (key !== pushToken) flow
+  // straight through so the orphan-cleanup affordance stays one-tap.
   const handleClearDevice = useCallback((deviceKey: string) => {
-    const sent = deleteNotificationPrefsDevice(deviceKey);
-    setNotifWsClosedError(sent ? null : WS_CLOSED_MESSAGE);
-  }, [deleteNotificationPrefsDevice]);
+    const dispatch = () => {
+      const sent = deleteNotificationPrefsDevice(deviceKey);
+      setNotifWsClosedError(sent ? null : WS_CLOSED_MESSAGE);
+    };
+    if (deviceKey === pushToken) {
+      Alert.alert(
+        'Clear this device?',
+        'Notifications on this device will fall back to global defaults.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Clear', style: 'destructive', onPress: dispatch },
+        ],
+      );
+      return;
+    }
+    dispatch();
+  }, [deleteNotificationPrefsDevice, pushToken]);
 
   const handleSetQuietHours = useCallback((win: { start: string; end: string; timezone: string } | null) => {
     const sent = setNotificationPrefsQuietHours(win);

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -1063,6 +1063,71 @@ describe('SettingsPanel', () => {
       expect(deleteNotificationPrefsDevice).toHaveBeenCalledWith('orphan-device-key')
     })
 
+    it('prompts before clearing when the row matches currentDeviceKey (#4588)', () => {
+      // The (this device) row silently wipes the operator's own mutes /
+      // quiet-hours overrides if cleared by accident — the prompt is a
+      // second cue after the (this device) tag.
+      const deleteNotificationPrefsDevice = vi.fn().mockReturnValue(true)
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: { 'test-device-key': { categories: { result: false } } },
+          quietHours: null,
+        },
+        deleteNotificationPrefsDevice,
+        currentDeviceKey: 'test-device-key',
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('notification-prefs-device-clear-test-device-key'))
+      expect(confirmSpy).toHaveBeenCalledOnce()
+      expect(confirmSpy.mock.calls[0][0]).toMatch(/fall back to global defaults/i)
+      expect(deleteNotificationPrefsDevice).toHaveBeenCalledWith('test-device-key')
+      confirmSpy.mockRestore()
+    })
+
+    it('does NOT dispatch the delete when the current-device confirm is dismissed (#4588)', () => {
+      // Cancel path — the dispatch must NOT fire. This is the whole point
+      // of the prompt: a misclick on your own row should be recoverable.
+      const deleteNotificationPrefsDevice = vi.fn().mockReturnValue(true)
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: { 'test-device-key': { categories: { result: false } } },
+          quietHours: null,
+        },
+        deleteNotificationPrefsDevice,
+        currentDeviceKey: 'test-device-key',
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('notification-prefs-device-clear-test-device-key'))
+      expect(confirmSpy).toHaveBeenCalledOnce()
+      expect(deleteNotificationPrefsDevice).not.toHaveBeenCalled()
+      confirmSpy.mockRestore()
+    })
+
+    it('skips the confirm prompt for orphan rows (#4588)', () => {
+      // Orphan-row clears stay one-click — the whole point of the orphan
+      // list is fast cleanup. Only the current-device row gates the dispatch.
+      const deleteNotificationPrefsDevice = vi.fn().mockReturnValue(true)
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+      setMockState({
+        notificationPrefs: {
+          categories,
+          devices: { 'orphan-device-key': { categories: { result: false } } },
+          quietHours: null,
+        },
+        deleteNotificationPrefsDevice,
+        currentDeviceKey: 'test-device-key',
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('notification-prefs-device-clear-orphan-device-key'))
+      expect(confirmSpy).not.toHaveBeenCalled()
+      expect(deleteNotificationPrefsDevice).toHaveBeenCalledWith('orphan-device-key')
+      confirmSpy.mockRestore()
+    })
+
     it('does not render the list when the server lacks the notificationPrefs capability', () => {
       // The capability gate (#4560) replaces the body of the Notifications
       // section with an upgrade hint. The device list shares that gate so

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -1081,7 +1081,7 @@ describe('SettingsPanel', () => {
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       fireEvent.click(screen.getByTestId('notification-prefs-device-clear-test-device-key'))
       expect(confirmSpy).toHaveBeenCalledOnce()
-      expect(confirmSpy.mock.calls[0][0]).toMatch(/fall back to global defaults/i)
+      expect(confirmSpy.mock.calls[0]![0]).toMatch(/fall back to global defaults/i)
       expect(deleteNotificationPrefsDevice).toHaveBeenCalledWith('test-device-key')
       confirmSpy.mockRestore()
     })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -27,6 +27,17 @@ const AUTO_PERMISSION_CONFIRM_MESSAGE =
   'Auto-permission mode disables all per-tool prompts for non-paired clients. Continue?'
 
 /**
+ * #4588: confirmation copy for clearing the current device's per-device
+ * overrides. Only fires when the user clicks Clear on the row tagged
+ * `(this device)` — orphan-row clears stay one-click because the whole
+ * point of the orphan list is fast cleanup. A misclick on your own row,
+ * though, silently wipes whatever mutes / quiet-hours overrides you set
+ * up; the prompt is the second cue (after the `(this device)` tag).
+ */
+const CURRENT_DEVICE_CLEAR_CONFIRM_MESSAGE =
+  'Clear your per-device overrides? Notifications on this device will fall back to global defaults.'
+
+/**
  * #4542: friendly labels + ordering for the per-category notification
  * toggles. Keys MUST match the server-side `ALL_CATEGORIES` enum from
  * packages/server/src/notification-prefs.js (mirrors RATE_LIMITS in
@@ -731,11 +742,22 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   // #4564: clear an entire per-device entry. Same WS-closed banner contract
   // as the rest of the notification-prefs handlers — a closed-socket clear
   // would silently fail and the orphan would stay on disk.
+  //
+  // #4588: clearing the row tagged `(this device)` silently wipes the
+  // operator's own mute/quiet-hours overrides — surface a confirm prompt
+  // for that case only. Orphan-row clears stay one-click; the whole point
+  // of the orphan list is fast cleanup.
   const handleClearNotificationDevice = useCallback((deviceKey: string) => {
+    if (deviceKey === currentDeviceKey) {
+      const ok = typeof window !== 'undefined' && typeof window.confirm === 'function'
+        ? window.confirm(CURRENT_DEVICE_CLEAR_CONFIRM_MESSAGE)
+        : true
+      if (!ok) return
+    }
     const sent = deleteNotificationPrefsDevice(deviceKey)
     if (sent) setNotifWsClosedError(null)
     else setNotifWsClosedError(WS_CLOSED_MESSAGE)
-  }, [deleteNotificationPrefsDevice])
+  }, [deleteNotificationPrefsDevice, currentDeviceKey])
 
   const handleSetNotificationQuietHours = useCallback((window: { start: string; end: string; timezone: string } | null) => {
     const sent = setNotificationPrefsQuietHours(window)


### PR DESCRIPTION
## Summary

Closes #4588 (wave-5 follow-up to #4564 orphan-clearing UI).

The new per-device **Clear** button (#4564) fires immediately on click — no confirm. For an **orphan row** that is the right call (low-risk, easy to re-create by toggling a mute). But clicking Clear on the row tagged `(this device)` silently wipes whatever per-category mutes / quiet-hours overrides the operator set up for the device they are currently using. The next push fires under the global defaults with no other warning that the previous overrides are gone.

- **Dashboard** `KnownDevicesList`: `window.confirm` with a verbatim message only when `deviceKey === currentDeviceKey`. Orphan rows skip the prompt.
- **Mobile** `KnownDevicesList`: `Alert.alert` with Cancel + destructive Clear button only when `deviceKey === pushToken`. Orphan rows flow straight through.

The `(this device)` tag is still the first cue — the prompt is the second cue for the destructive case only.

## Test plan

- [x] Dashboard: 3 new vitest cases confirm the prompt fires on the current-device row, that dismissing does NOT dispatch the delete, and that orphan-row clears never prompt
- [x] Mobile: 3 new static-source jest cases assert the Alert.alert branch, destructive button style, and orphan-row fall-through
- [x] Full dashboard suite: 2344/2344 pass
- [x] Full mobile suite: 1431/1431 pass