### PR TITLE
fix(ui): unify mobile not-supported notification copy

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -479,6 +479,29 @@ describe('SettingsScreen — notification-prefs capability gate (#4560)', () => 
     expect(settingsSource).toMatch(/testID="quiet-hours-not-supported"/);
   });
 
+  it('uses one shared copy constant for both not-supported hints (#4585)', () => {
+    // Pre-#4585 the categories section showed the long upgrade explanation
+    // and the quiet-hours section showed a terser "Requires chroxy
+    // v0.9.14 or newer." — visible to any user testing on a pre-#4541
+    // server, and the disparity made it unclear whether quiet hours needed
+    // a different upgrade path. The constant declaration AND its use at
+    // both render sites must all be present.
+    expect(settingsSource).toMatch(/const NOTIFICATION_PREFS_UNSUPPORTED_MESSAGE\s*=/);
+    expect(settingsSource).toMatch(
+      /testID="notification-prefs-not-supported"[\s\S]{0,200}\{NOTIFICATION_PREFS_UNSUPPORTED_MESSAGE\}/,
+    );
+    expect(settingsSource).toMatch(
+      /testID="quiet-hours-not-supported"[\s\S]{0,200}\{NOTIFICATION_PREFS_UNSUPPORTED_MESSAGE\}/,
+    );
+  });
+
+  it('drops the terse "Requires chroxy v0.9.14 or newer." copy (#4585)', () => {
+    // Regression guard: if a future refactor reintroduces the terser
+    // string, the two not-supported sections will diverge again. Asserting
+    // the literal string is GONE locks the unification in.
+    expect(settingsSource).not.toMatch(/Requires chroxy v0\.9\.14 or newer\./);
+  });
+
   it('declares serverCapabilities on the lifecycle store with a fail-closed default', () => {
     // Empty `{}` is the fail-closed default: an absent flag reads as
     // `false`, so feature-gated UI hides itself rather than silently

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -110,6 +110,17 @@ const SPEECH_LANGUAGES = [
 const WS_CLOSED_MESSAGE =
   'Settings save failed — server disconnected. Reconnect and try again.';
 
+// #4585: shared copy for the capability-gated "not supported" hint. Both the
+// Categories and Quiet-hours sections render this when the server lacks the
+// `notificationPrefs` capability. Previously the quiet-hours section showed
+// a terser one-liner that made it ambiguous whether quiet hours needed a
+// different upgrade than the rest of notifications — the dashboard avoids
+// this by colocating both controls under a single capability-gated hint,
+// but the mobile layout keeps them as separate sections so the fix is to
+// echo the same long copy in both.
+const NOTIFICATION_PREFS_UNSUPPORTED_MESSAGE =
+  'Your server does not support notification preferences. Upgrade to chroxy v0.9.14 or newer to manage per-category opt-in, per-device mutes, and quiet hours from here.';
+
 export function SettingsScreen() {
   const insets = useSafeAreaInsets();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
@@ -549,7 +560,7 @@ export function SettingsScreen() {
           // section sat on "Loading preferences…" forever.
           <View style={styles.row}>
             <Text style={styles.rowHint} testID="notification-prefs-not-supported">
-              Your server does not support notification preferences. Upgrade to chroxy v0.9.14 or newer to manage per-category opt-in, per-device mutes, and quiet hours from here.
+              {NOTIFICATION_PREFS_UNSUPPORTED_MESSAGE}
             </Text>
           </View>
         ) : notificationPrefs == null ? (
@@ -625,7 +636,7 @@ export function SettingsScreen() {
           // editor would put it in a permanent loading state.
           <View style={styles.row}>
             <Text style={styles.rowHint} testID="quiet-hours-not-supported">
-              Requires chroxy v0.9.14 or newer.
+              {NOTIFICATION_PREFS_UNSUPPORTED_MESSAGE}
             </Text>
           </View>
         ) : notificationPrefs == null ? (


### PR DESCRIPTION
## Summary

Closes #4585 (wave-5 follow-up to #4584 capability-gate).

Pre-#4585 the mobile `SettingsScreen` rendered two different "not supported" hints when the server lacked the `notificationPrefs` capability:

- **Categories section**: long upgrade explanation mentioning per-category opt-in, per-device mutes, and quiet hours.
- **Quiet-hours section**: terser `Requires chroxy v0.9.14 or newer.`

Both reference the same upgrade target but the disparity made it unclear whether quiet hours needed a different upgrade path. The dashboard already avoids this by colocating both controls under a single capability-gated hint; the mobile layout keeps them as separate sections so the simplest fix is **Option A** from the issue — echo the long copy in both.

Centralised the message into a `NOTIFICATION_PREFS_UNSUPPORTED_MESSAGE` constant so any future version bump touches one site.

## Test plan

- [x] New static-source case asserts both render sites use the shared constant
- [x] Regression guard: the terse "Requires chroxy v0.9.14 or newer." literal must NOT appear in JSX
- [x] Full mobile suite: 1430/1430 pass