### PR TITLE
feat(app): add accessibility roles to quiet-hours conflict banner

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -428,6 +428,30 @@ describe('SettingsScreen — Quiet-hours editor: snapshot-vs-draft (#4570)', () 
       /handleDiscardDraft[\s\S]{0,800}setStart\(snap\.start\)[\s\S]{0,200}setDirty\(false\)[\s\S]{0,200}setPendingSnapshot\(undefined\)/,
     );
   });
+
+  it('announces the conflict banner via accessibilityLiveRegion (#4581)', () => {
+    // The dashboard uses role="alert" which screen readers announce
+    // automatically on mount. The RN equivalent for that "polite" announce
+    // is accessibilityLiveRegion="polite" on the banner View. Without it,
+    // TalkBack / VoiceOver users editing the field would never know a
+    // divergent snapshot arrived.
+    expect(settingsSource).toMatch(
+      /testID="quiet-hours-conflict-banner"[\s\S]{0,400}accessibilityLiveRegion="polite"/,
+    );
+  });
+
+  it('marks both conflict-banner buttons with accessibilityRole + label (#4581)', () => {
+    // Without accessibilityRole="button" the TouchableOpacity exposes as a
+    // generic touchable; the screen reader doesn't announce "button" before
+    // the label. accessibilityLabel echoes the visible text so the
+    // announcement is unambiguous even if the visual changes later.
+    expect(settingsSource).toMatch(
+      /testID="quiet-hours-conflict-accept"[\s\S]{0,300}accessibilityRole="button"[\s\S]{0,200}accessibilityLabel="Keep my edits"/,
+    );
+    expect(settingsSource).toMatch(
+      /testID="quiet-hours-conflict-discard"[\s\S]{0,300}accessibilityRole="button"[\s\S]{0,200}accessibilityLabel="Discard and load latest"/,
+    );
+  });
 });
 
 // #4560: capability gate for the Notifications sections. Pre-#4541 servers

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -1024,7 +1024,20 @@ function QuietHoursEditor(props: {
           {pendingSnapshot !== undefined && (
             <>
               <View style={styles.separator} />
-              <View style={styles.row} testID="quiet-hours-conflict-banner">
+              {/* #4581: accessibilityLiveRegion="polite" lets TalkBack /
+                  VoiceOver announce the divergence the moment the banner
+                  mounts — a screen-reader user editing the field would
+                  otherwise miss the conflict entirely. Matches the
+                  dashboard's role="alert" semantic without using `assertive`,
+                  which would interrupt mid-typing speech. The two action
+                  TouchableOpacity children get accessibilityRole="button"
+                  + accessibilityLabel below for the same reason. */}
+              <View
+                style={styles.row}
+                testID="quiet-hours-conflict-banner"
+                accessibilityLiveRegion="polite"
+                accessible={true}
+              >
                 <View style={{ flex: 1, paddingRight: 12 }}>
                   <Text style={styles.rowLabel}>Another client updated quiet hours</Text>
                   <Text style={[styles.rowHint, { marginTop: 2 }]}>
@@ -1038,6 +1051,8 @@ function QuietHoursEditor(props: {
                 style={styles.row}
                 onPress={handleAcceptDraft}
                 testID="quiet-hours-conflict-accept"
+                accessibilityRole="button"
+                accessibilityLabel="Keep my edits"
               >
                 <Text style={styles.actionText}>Keep my edits</Text>
               </TouchableOpacity>
@@ -1046,6 +1061,8 @@ function QuietHoursEditor(props: {
                 style={styles.row}
                 onPress={handleDiscardDraft}
                 testID="quiet-hours-conflict-discard"
+                accessibilityRole="button"
+                accessibilityLabel="Discard and load latest"
               >
                 <Text style={styles.actionText}>Discard and load latest</Text>
               </TouchableOpacity>


### PR DESCRIPTION
## Summary

Closes #4581 (wave-5 follow-up to #4580).

The mobile quiet-hours conflict banner introduced in PR #4580 (the #4570 fix) rendered as a plain `View` + two `TouchableOpacity` actions with no accessibility roles or live-region hints. A screen-reader user editing the field was never notified when the divergent-snapshot banner appeared. The dashboard equivalent already uses `role="alert"` so the announcement happens automatically.

- **Banner View**: `accessibilityLiveRegion="polite"` so TalkBack / VoiceOver announce the divergence the moment the banner mounts. "Polite" (rather than "assertive") avoids interrupting mid-typing speech — same UX the dashboard's `role="alert"` yields by default.
- **Both TouchableOpacity actions**: `accessibilityRole="button"` + `accessibilityLabel` echoing the visible text so the screen reader announces "button" before the label.

## Test plan

- [x] Static-source assertions verify both attributes appear on the banner + both buttons, with the documented labels
- [x] Full mobile suite: 1430/1430 pass
- [ ] TalkBack / VoiceOver sanity check (manual — needs the dev build on a phone with a screen reader enabled)