### PR TITLE
feat(app): announce quiet-hours conflict banner on iOS via AccessibilityInfo

### DIFF
--- a/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
+++ b/packages/app/src/__tests__/components/SettingsScreenNotificationPrefs.test.ts
@@ -452,6 +452,43 @@ describe('SettingsScreen — Quiet-hours editor: snapshot-vs-draft (#4570)', () 
       /testID="quiet-hours-conflict-discard"[\s\S]{0,300}accessibilityRole="button"[\s\S]{0,200}accessibilityLabel="Discard and load latest"/,
     );
   });
+
+  it('imports AccessibilityInfo for the iOS VoiceOver fallback (#4595)', () => {
+    // accessibilityLiveRegion is Android-only — iOS needs an explicit
+    // AccessibilityInfo.announceForAccessibility call to speak when the
+    // banner appears. The import has to be present for the call to typecheck.
+    expect(settingsSource).toMatch(
+      /import\s*\{[\s\S]{0,400}AccessibilityInfo[\s\S]{0,400}\}\s*from\s*'react-native'/,
+    );
+  });
+
+  it('fires AccessibilityInfo.announceForAccessibility on pendingSnapshot mount, iOS only (#4595)', () => {
+    // The useEffect must (1) key on pendingSnapshot so it fires on banner
+    // mount, (2) gate on Platform.OS === 'ios' so Android (which already
+    // gets a live-region announce) doesn't double-speak, (3) actually call
+    // announceForAccessibility with the conflict copy.
+    expect(settingsSource).toMatch(
+      /useEffect\(\(\)\s*=>\s*\{[\s\S]{0,600}pendingSnapshot !== undefined[\s\S]{0,200}Platform\.OS === 'ios'[\s\S]{0,400}AccessibilityInfo\.announceForAccessibility/,
+    );
+  });
+
+  it('passes a sensible iOS announce string (#4595)', () => {
+    // The spoken sentence must convey "another client updated quiet hours"
+    // and offer the two recovery actions ("keep" / "discard"). Exact
+    // wording is documented in the issue.
+    expect(settingsSource).toMatch(
+      /announceForAccessibility\([\s\S]{0,100}Another client updated quiet hours/,
+    );
+  });
+
+  it('depends on pendingSnapshot in the useEffect dep array (#4595 — re-announce on new conflicts)', () => {
+    // If the dep array omits pendingSnapshot the effect fires once on mount
+    // and never re-announces — a second mid-edit conflict would silently
+    // surface without VoiceOver. Anchor the dep array specifically.
+    expect(settingsSource).toMatch(
+      /AccessibilityInfo\.announceForAccessibility[\s\S]{0,400}\},\s*\[pendingSnapshot\]\);/,
+    );
+  });
 });
 
 // #4560: capability gate for the Notifications sections. Pre-#4541 servers

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -11,6 +11,7 @@ import {
   Modal,
   Pressable,
   Platform,
+  AccessibilityInfo,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -946,6 +947,26 @@ function QuietHoursEditor(props: {
     | null
     | undefined
   >(undefined);
+
+  // #4595: VoiceOver fallback for the conflict banner on iOS.
+  // #4594 (the original a11y wiring) set `accessibilityLiveRegion="polite"`
+  // on the banner View, which is what Android TalkBack uses to auto-announce
+  // a region as it mounts. The prop is Android-only — iOS VoiceOver does
+  // NOT auto-announce live regions; it only speaks when focus moves to the
+  // View. A user editing the field via VoiceOver would never hear about the
+  // divergent snapshot. AccessibilityInfo.announceForAccessibility is the
+  // iOS equivalent of the live-region announce. We gate on Platform.OS so
+  // Android (which already gets the announcement via the live-region prop)
+  // doesn't double-speak the same line. The effect fires on every mount of
+  // a new pending conflict (`pendingSnapshot !== undefined` transition);
+  // resolving the conflict (banner unmounts) does not re-announce.
+  useEffect(() => {
+    if (pendingSnapshot !== undefined && Platform.OS === 'ios') {
+      AccessibilityInfo.announceForAccessibility(
+        'Another client updated quiet hours. Keep your edits, or discard and load the latest values.',
+      );
+    }
+  }, [pendingSnapshot]);
 
   // Re-sync draft when the snapshot changes (remote save, broadcast).
   //


### PR DESCRIPTION
## Summary

Closes #4595 (wave-6 follow-up to #4594).

#4594 added `accessibilityLiveRegion="polite"` to the quiet-hours conflict banner in mobile `SettingsScreen`. That prop is **Android-only** — Android TalkBack auto-announces the region on mount, but iOS VoiceOver does not. On iOS the banner only spoke when focus moved to the View, so a user editing the field via VoiceOver would never hear about the divergent snapshot.

- Imports `AccessibilityInfo` from react-native.
- Adds a `useEffect` inside `QuietHoursEditor` keyed on `pendingSnapshot`. When `pendingSnapshot` transitions from `undefined` to a parked snapshot AND `Platform.OS === 'ios'`, fires `AccessibilityInfo.announceForAccessibility` with the documented conflict copy.
- Gated on `Platform.OS` so Android (which already gets the live-region announce) doesn't double-speak. Pattern matches `ThinkingIndicator` and `CheckInChip` — existing `AccessibilityInfo` precedents in this codebase.

## Test plan

- [x] 4 new static-source cases assert the import, useEffect gating, sentence content, and dep-array entry (so re-mounts re-announce)
- [x] Full mobile suite: 1446/1446 pass
- [ ] iOS VoiceOver sanity check (manual — needs the dev build on an iOS device with VoiceOver enabled, exercise the quiet-hours editor while a second client edits the window to force a snapshot-vs-draft race)