### PR TITLE
chore(release): cut v0.9.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.17] - 2026-05-30
+
+Waves 5 + 6 of the from-review marathon — 6 follow-ups polishing what v0.9.16 shipped. Per-device notification overrides become operator-friendly: server now stamps `lastSeenAt` + `platform` on each entry (#4587), the UI renders "iOS · Last seen 15 min ago" next to the truncated token, and clearing your own row prompts before wiping local mutes (#4588). Mobile a11y catches up to the dashboard's `role="alert"` semantic on both Android (live-region prop, #4581) and iOS (`AccessibilityInfo.announceForAccessibility`, #4595). Plus a shared-helper refactor (#4591) and a copy unification (#4585) cleaning up the marathon's wake.
+
+### Added
+
+- **Per-device notification metadata (#4587 / #4590):** server stamps `lastSeenAt` (epoch ms) and `platform` (from `client.deviceInfo`) on every per-device notification-prefs entry it touches. `register_push_token` bumps `lastSeenAt` on existing entries without creating empty ones. Protocol's `NotificationDeviceEntrySchema` gets two optional fields; older clients/servers unaffected. Dashboard + mobile `KnownDevicesList` render `{Platform} · Last seen {rel}` next to the truncated token when fields are present; missing fields render exactly as before. Operators with multiple orphan tokens can now tell which one is which.
+- **iOS VoiceOver announce for quiet-hours conflict banner (#4595 / #4597):** mobile `QuietHoursEditor` now calls `AccessibilityInfo.announceForAccessibility` on `pendingSnapshot` mount, gated on `Platform.OS === 'ios'` so Android (which already gets the announcement via the `accessibilityLiveRegion="polite"` prop from #4581) doesn't double-speak. Closes the iOS gap left by #4594 — `accessibilityLiveRegion` is Android-only, iOS needs an explicit announce call.
+- **Android TalkBack roles on quiet-hours conflict banner (#4581 / #4594):** banner View carries `accessibilityLiveRegion="polite"` so TalkBack announces the divergence the moment it mounts; both action buttons carry `accessibilityRole="button"` + `accessibilityLabel` echoing the visible text. Closes the a11y gap reported on the #4570 fix.
+
+### Fixed
+
+- **Confirm before clearing current-device notification override (#4588 / #4592):** dashboard `window.confirm` and mobile `Alert.alert` now prompt when the user clicks Clear on the row tagged `(this device)`. Orphan rows skip the prompt — the whole point of the orphan list is fast cleanup. Catches the misclick that would silently wipe the operator's own mutes / quiet-hours overrides.
+- **Unify mobile "not supported" notification copy (#4585 / #4593):** mobile `SettingsScreen` previously showed a long upgrade explanation in the Categories section and a terser `Requires chroxy v0.9.14 or newer.` in the Quiet-hours section — visible to any user testing against a pre-#4541 server. Both sites now share a single `NOTIFICATION_PREFS_UNSUPPORTED_MESSAGE` constant. Dashboard already colocated both under one capability-gated hint, so no change there.
+
+### Internal
+
+- **Extract `formatRelativeTime` + `formatPlatform` to `@chroxy/store-core` (#4591 / #4596):** the two helpers shipped duplicated in dashboard `SettingsPanel` and mobile `SettingsScreen` as part of #4587. Moved to a new `packages/store-core/src/device-format.ts` with 11 vitest cases covering all branches (minutes / hours / days / months / years / clock-skew fall-through). Both consumers now import from `@chroxy/store-core` — no new dependency on either side, since the package already ships to both. 24 lines deduplicated; mobile static-source tests pivoted to import + regression-guard.
+
 ## [0.9.16] - 2026-05-30
 
 Wave 4 of the from-review marathon — 13 follow-ups polishing what v0.9.13–0.9.15 shipped. Notification preferences round out with optimistic toggles (#4558), WS-closed error surfacing (#4559), capability gating for pre-v0.9.14 servers (#4560), quiet-hours editor draft preservation (#4570), and per-device override cleanup (#4564). Quiet-hours validation and perf hardened (#4566, #4567, #4568). K8s `workspacePVC` finally gets an operator-facing config surface (#4556). Plus a refactor (#4569), accessibility (#4562), styling (#4563), test coverage (#4555), and v0.9.15 SidebarTokenView coverage extension (#4546 — which actually shipped in v0.9.15, but the polish chain continues here).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.16"
+      "version": "0.9.17"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.16",
+    "version": "0.9.17",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.16</string>
+    <string>0.9.17</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.16",
+      "version": "0.9.17",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Mechanical release PR cascading the version bump from v0.9.16 → v0.9.17.

Waves 5 + 6 of the from-review marathon (6 PRs total):

**Wave 5** — polish on v0.9.16's notification preferences:
- #4590 — feat(server,ui): track lastSeen + platform per notification-prefs device entry
- #4592 — fix(ui): confirm before clearing current-device notification override
- #4593 — fix(ui): unify mobile not-supported notification copy
- #4594 — feat(app): add accessibility roles to quiet-hours conflict banner

**Wave 6** — polish on wave 5's polish:
- #4596 — refactor: extract formatRelativeTime + formatPlatform to @chroxy/store-core
- #4597 — feat(app): announce quiet-hours conflict banner on iOS via AccessibilityInfo

Each wave was fully /full-reviewed. No outstanding follow-ups beyond the natural next-batch fodder.

See CHANGELOG.md for the user-facing notes.

## Test plan

- [x] All workspace test suites green on each individual PR
- [x] `scripts/bump-version.sh 0.9.17` cascaded version cleanly to 15 files (root + 6 package.jsons + app.json + Tauri Cargo.toml/Cargo.lock/tauri.conf.json + iOS Info.plist + 2 lockfiles)
- [ ] CI passes on this branch (waiting for workflow run)