### PR TITLE
chore: add stale-PR policy for external contributions (#4394)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           # PRs only — issues are not affected by this policy
           days-before-issue-stale: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,40 @@
+name: Stale PRs
+
+on:
+  schedule:
+    # Daily at 01:30 UTC
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # PRs only — issues are not affected by this policy
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # 7 days idle -> mark stale; 7 more days idle -> close (14 days total)
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+
+          # Never stale the repo owner's own PRs
+          exempt-pr-authors: blamechris
+
+          stale-pr-label: stale
+
+          stale-pr-message: >
+            Hey, thanks for your contribution! This PR hasn't had any activity
+            in the last 7 days, so it's been marked `stale`. If you're still
+            working on it, just leave a comment (anything works) or push a
+            new commit to reset the timer. Otherwise it'll be closed in
+            another 7 days — no hard feelings, you can always reopen later.
+
+          close-pr-message: >
+            Closing this out due to inactivity. Thanks again for the
+            contribution — feel free to reopen if you come back to this!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,3 +84,20 @@ Thanks for your interest in contributing! This document covers how to get starte
 ## Questions?
 
 Open an issue or start a discussion. We're friendly!
+
+## Stale PR policy
+
+To keep the PR queue manageable, external contributions follow an automated stale policy:
+
+- **7 days** without contributor activity (commits, comments, or pushes) — a friendly reminder comment is posted and the PR is labeled `stale`.
+- **14 days** without contributor activity (7 days after the reminder) — the PR is closed with a "feel free to reopen" message.
+
+PRs from the repo owner are exempt. Issues are not affected by this policy.
+
+### How to keep your PR open
+
+Just comment on the PR (anything works — a status update, a question, or a "still working on this") to reset the timer. Pushing new commits also counts as activity.
+
+If your PR is closed and you come back to it later, you can reopen it directly on GitHub — no need to file a new one.
+
+The policy is automated via [`.github/workflows/stale.yml`](.github/workflows/stale.yml).


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` with documented stale-PR thresholds (7-day reminder, 14-day close)
- Add `.github/workflows/stale.yml` using `actions/stale@v9`, exempts repo owner, PR-only

## Test plan
- [x] Workflow YAML loads on push (gh validates schema)
- [x] Verify schedule + exempt-authors config in `.github/workflows/stale.yml`
- [x] CONTRIBUTING.md renders cleanly on github.com

Closes #4394