### PR TITLE
refactor(dashboard): consolidate duration helpers (#4510)

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.tsx
@@ -25,6 +25,7 @@ import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { formatToolName } from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
+import { formatDurationTerse } from '../utils/duration'
 
 /**
  * #4420 — Tail-ellipsis truncation for the pending-shell command label. User-
@@ -104,17 +105,11 @@ function formatElapsed(ms: number): string {
 }
 
 // #4308 — duration without the "ago" suffix, used for the "Running X · 12s"
-// label (the named tool is current, not past, so "ago" is wrong).
-function formatDuration(ms: number): string {
-  const s = Math.max(0, Math.floor(ms / 1000))
-  if (s < 60) return `${s}s`
-  const m = Math.floor(s / 60)
-  const remS = s % 60
-  if (m < 60) return remS === 0 ? `${m}m` : `${m}m ${remS}s`
-  const h = Math.floor(m / 60)
-  return `${h}h ${m % 60}m`
-}
-
+// label (the named tool is current, not past, so "ago" is wrong). #4510 — the
+// implementation lives in `utils/duration.ts` (`formatDurationTerse`) so the
+// terse register is shared with any future consumer; ActivityIndicator
+// continues to consume the terse form because the chip's compact pill layout
+// can't accommodate "5 minutes 12 seconds".
 function statusClass(elapsedMs: number, timeoutMs: number): string {
   if (elapsedMs >= timeoutMs - 60_000) return 'activity-indicator--red'
   if (elapsedMs >= 60_000) return 'activity-indicator--orange'
@@ -369,7 +364,7 @@ export function ActivityIndicator() {
                   const cmd = shell.command && shell.command.length > 0
                     ? shell.command
                     : shell.shellId
-                  const elapsed = formatDuration(Math.max(0, now - shell.startedAt))
+                  const elapsed = formatDurationTerse(Math.max(0, now - shell.startedAt))
                   return (
                     <li
                       key={shell.shellId}
@@ -438,9 +433,9 @@ export function ActivityIndicator() {
   // criteria and intentionally do not enter the preference order here.
   let label: string
   if (agentDescription != null && agentStartedAt != null) {
-    label = `Running ${agentDescription} · ${formatDuration(now - agentStartedAt)}`
+    label = `Running ${agentDescription} · ${formatDurationTerse(now - agentStartedAt)}`
   } else if (inFlightTool != null && inFlightStartedAt != null) {
-    label = `Running ${formatToolName(inFlightTool, inFlightServerName ?? undefined)} · ${formatDuration(now - inFlightStartedAt)}`
+    label = `Running ${formatToolName(inFlightTool, inFlightServerName ?? undefined)} · ${formatDurationTerse(now - inFlightStartedAt)}`
   } else {
     label = `Working… last activity ${formatElapsed(elapsed)}`
   }

--- a/packages/dashboard/src/components/StreamStallChip.tsx
+++ b/packages/dashboard/src/components/StreamStallChip.tsx
@@ -12,6 +12,7 @@
  * hover for the underlying server message.
  */
 import { useCallback } from 'react'
+import { formatDurationVerbose } from '../utils/duration'
 
 export interface StreamStallChipProps {
   /** The raw error text from the server (e.g. "Stream stalled — no response for 5 minutes"). */
@@ -41,23 +42,10 @@ export interface StreamStallChipProps {
   timeoutMs?: number
 }
 
-/**
- * #4497 — verbose duration humaniser tailored for the stall headline copy.
- *
- * Returns "30 seconds", "1 minute", "5 minutes", "2 hours", etc. The terser
- * "5m" / "30s" form used by ActivityIndicator's `formatDuration` is wrong
- * for prose — we want the chip text to read naturally. Thresholds at 1s /
- * 1min / 1h keep the helper simple; rounding (Math.round) avoids "4 minutes"
- * for a 299_999ms window.
- */
-function humanizeDuration(ms: number): string {
-  const seconds = Math.round(ms / 1000)
-  if (seconds < 60) return `${seconds} ${seconds === 1 ? 'second' : 'seconds'}`
-  const minutes = Math.round(seconds / 60)
-  if (minutes < 60) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
-  const hours = Math.round(minutes / 60)
-  return `${hours} ${hours === 1 ? 'hour' : 'hours'}`
-}
+// #4497 — verbose duration humaniser tailored for the stall headline copy.
+// #4510 — implementation now lives in `utils/duration.ts`
+// (`formatDurationVerbose`), shared with any other prose-register consumer.
+// Headline copy still reads "No response for ${verbose(ms)} — retry?".
 
 export function StreamStallChip({ errorText, onRetry, timeoutMs }: StreamStallChipProps) {
   const handleClick = useCallback(() => {
@@ -69,7 +57,7 @@ export function StreamStallChip({ errorText, onRetry, timeoutMs }: StreamStallCh
   // non-finite values so a malformed auth_ok can't degrade the UI.
   const headline =
     typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0
-      ? `No response for ${humanizeDuration(timeoutMs)} — retry?`
+      ? `No response for ${formatDurationVerbose(timeoutMs)} — retry?`
       : 'Stream stalled — retry?'
 
   return (

--- a/packages/dashboard/src/utils/duration.test.ts
+++ b/packages/dashboard/src/utils/duration.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Duration helper tests — #4510.
+ *
+ * Locks in the behaviour of the two registers consolidated from
+ * `ActivityIndicator.formatDuration` (terse) and
+ * `StreamStallChip.humanizeDuration` (verbose). Sub-500ms input on the verbose
+ * path is hardened with `Math.max(1, …)` so the helper never produces
+ * "0 seconds" — call sites currently gate with `> 0` but the helper should be
+ * safe to reuse without that guard.
+ */
+import { describe, it, expect } from 'vitest'
+import { formatDurationTerse, formatDurationVerbose } from './duration'
+
+describe('formatDurationTerse', () => {
+  it('returns 0s for sub-second input', () => {
+    expect(formatDurationTerse(0)).toBe('0s')
+    expect(formatDurationTerse(499)).toBe('0s')
+    expect(formatDurationTerse(999)).toBe('0s')
+  })
+
+  it('returns Ns for inputs under 60s', () => {
+    expect(formatDurationTerse(1000)).toBe('1s')
+    expect(formatDurationTerse(30_000)).toBe('30s')
+    expect(formatDurationTerse(59_999)).toBe('59s')
+  })
+
+  it('returns Nm exactly at 60s and integer minute boundaries', () => {
+    expect(formatDurationTerse(60_000)).toBe('1m')
+    expect(formatDurationTerse(120_000)).toBe('2m')
+  })
+
+  it('returns Nm Ns for non-exact minutes under 60m', () => {
+    expect(formatDurationTerse(65_000)).toBe('1m 5s')
+    expect(formatDurationTerse(5 * 60_000 + 7_000)).toBe('5m 7s')
+  })
+
+  it('returns Nh Nm at and above one hour', () => {
+    expect(formatDurationTerse(60 * 60_000)).toBe('1h 0m')
+    expect(formatDurationTerse(60 * 60_000 + 2 * 60_000)).toBe('1h 2m')
+    expect(formatDurationTerse(2 * 60 * 60_000 + 30 * 60_000)).toBe('2h 30m')
+  })
+
+  it('clamps negative input to 0s', () => {
+    expect(formatDurationTerse(-1000)).toBe('0s')
+  })
+})
+
+describe('formatDurationVerbose', () => {
+  it('floors sub-500ms inputs to "1 second" (Math.max(1, …) guard)', () => {
+    expect(formatDurationVerbose(0)).toBe('1 second')
+    expect(formatDurationVerbose(1)).toBe('1 second')
+    expect(formatDurationVerbose(250)).toBe('1 second')
+    expect(formatDurationVerbose(499)).toBe('1 second')
+  })
+
+  it('returns "1 second" singular for exactly 1s', () => {
+    expect(formatDurationVerbose(1000)).toBe('1 second')
+  })
+
+  it('returns "N seconds" plural for inputs under 60s', () => {
+    expect(formatDurationVerbose(2000)).toBe('2 seconds')
+    expect(formatDurationVerbose(30_000)).toBe('30 seconds')
+    expect(formatDurationVerbose(59_000)).toBe('59 seconds')
+  })
+
+  it('returns "1 minute" singular at exactly 60s', () => {
+    expect(formatDurationVerbose(60_000)).toBe('1 minute')
+  })
+
+  it('returns "N minutes" plural between 60s and 59m', () => {
+    expect(formatDurationVerbose(2 * 60_000)).toBe('2 minutes')
+    expect(formatDurationVerbose(5 * 60_000)).toBe('5 minutes')
+    expect(formatDurationVerbose(59 * 60_000)).toBe('59 minutes')
+  })
+
+  it('returns "1 hour" singular at exactly one hour', () => {
+    expect(formatDurationVerbose(60 * 60_000)).toBe('1 hour')
+  })
+
+  it('returns "N hours" plural above one hour', () => {
+    expect(formatDurationVerbose(2 * 60 * 60_000)).toBe('2 hours')
+    expect(formatDurationVerbose(5 * 60 * 60_000)).toBe('5 hours')
+  })
+
+  it('handles 0 input without producing "0 seconds"', () => {
+    // Critical hardening: previously the helper produced "0 seconds" for
+    // sub-500ms input, which is meaningless prose. Math.max(1, …) keeps the
+    // floor at "1 second".
+    expect(formatDurationVerbose(0)).toBe('1 second')
+  })
+
+  it('handles NaN input without crashing or returning NaN-containing string', () => {
+    // The helper guards non-finite inputs and falls back to "1 second" so a
+    // malformed value from upstream never bleeds a literal "NaN" into the UI.
+    const out = formatDurationVerbose(NaN)
+    expect(typeof out).toBe('string')
+    expect(out).not.toContain('NaN')
+  })
+
+  it('handles Infinity input without crashing', () => {
+    const out = formatDurationVerbose(Infinity)
+    expect(typeof out).toBe('string')
+    expect(out).not.toContain('Infinity')
+  })
+})

--- a/packages/dashboard/src/utils/duration.ts
+++ b/packages/dashboard/src/utils/duration.ts
@@ -1,0 +1,52 @@
+/**
+ * Duration formatting utilities — #4510.
+ *
+ * Two named exports cover the two display registers used across the
+ * dashboard:
+ *   - `formatDurationTerse`   — "30s" / "5m" / "1h 2m"  (chip / inline labels)
+ *   - `formatDurationVerbose` — "30 seconds" / "5 minutes" / "2 hours" (prose)
+ *
+ * Consolidated from two private helpers previously inlined in
+ * `ActivityIndicator.tsx` (#4308) and `StreamStallChip.tsx` (#4497, PR #4505).
+ * The terse form is wrong for natural-language sentences ("No response for
+ * 5m") and the verbose form is wrong for compact chips ("Running Bash · 30
+ * seconds"); we keep both registers but ship them from one place so future
+ * consumers don't reinvent either.
+ */
+
+/**
+ * Terse "Ns" / "Nm" / "Nh Nm" form, suitable for inline chip labels where
+ * vertical space and reading speed both matter more than grammar. Mirrors the
+ * original ActivityIndicator helper byte-for-byte.
+ */
+export function formatDurationTerse(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const remS = s % 60
+  if (m < 60) return remS === 0 ? `${m}m` : `${m}m ${remS}s`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
+
+/**
+ * Verbose "N seconds / N minutes / N hours" form, suitable for prose copy
+ * ("No response for 5 minutes — retry?"). Pluralisation is decided per unit.
+ *
+ * Hardening notes:
+ *   - Non-finite inputs (NaN, ±Infinity) collapse to "1 second" so a malformed
+ *     value from upstream never bleeds a literal "NaN" or "Infinity" into the
+ *     UI. Real call sites (StreamStallChip) gate with `Number.isFinite`, but
+ *     the helper owns its own contract.
+ *   - `Math.max(1, seconds)` floors sub-500ms inputs to "1 second" rather than
+ *     the meaningless "0 seconds" the original helper produced.
+ */
+export function formatDurationVerbose(ms: number): string {
+  if (!Number.isFinite(ms)) return '1 second'
+  const seconds = Math.max(1, Math.round(ms / 1000))
+  if (seconds < 60) return `${seconds} ${seconds === 1 ? 'second' : 'seconds'}`
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
+  const hours = Math.round(minutes / 60)
+  return `${hours} ${hours === 1 ? 'hour' : 'hours'}`
+}


### PR DESCRIPTION
## Summary
- Extract `formatDurationTerse` and `formatDurationVerbose` to `packages/dashboard/src/utils/duration.ts`
- Replace inlined helpers in `ActivityIndicator.tsx` and `StreamStallChip.tsx`
- Add `Math.max(1, seconds)` guard on verbose path

## Test plan
- [x] `cd packages/dashboard && npx vitest run src/utils/duration.test.ts` (unit coverage)
- [x] `cd packages/dashboard && npx vitest run` (full dashboard suite stays green)

Closes #4510