### PR TITLE
fix(server): roll back in-memory notification prefs when persist fails (#4550)

### DIFF
--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -300,17 +300,27 @@ export class PushManager {
         next.bypassCategories = [...defaultNotificationPrefs().bypassCategories]
       }
     }
-    this._prefs = next
+    // #4550: persist FIRST, swap in-memory state only after the save
+    // succeeds. Pre-#4550 we assigned `this._prefs = next` unconditionally
+    // and then tried to save; a failed rename (EACCES / EXDEV / quota)
+    // re-threw out to the WS handler but left `_prefs` already mutated,
+    // so `isCategoryEnabled` answered based on a value the user thought
+    // failed to save — and the next process restart silently reverted
+    // the change because disk never received it.
     if (this._prefsPath) {
       try {
-        saveNotificationPrefs(this._prefs, this._prefsPath)
+        saveNotificationPrefs(next, this._prefsPath)
       } catch (err) {
         log.error(`Failed to persist notification prefs: ${err?.message || err}`)
         // Re-throw so the WS handler can surface a CREDENTIALS_WRITE_FAILED-
-        // style error rather than silently lying about persistence.
+        // style error rather than silently lying about persistence. The
+        // in-memory `_prefs` is intentionally left untouched here so the
+        // next isCategoryEnabled / getPrefs call reflects the pre-patch
+        // state, matching what's actually on disk.
         throw err
       }
     }
+    this._prefs = next
     return this.getPrefs()
   }
 

--- a/packages/server/tests/push.test.js
+++ b/packages/server/tests/push.test.js
@@ -1,5 +1,8 @@
-import { describe, it, before, afterEach, mock } from 'node:test'
+import { describe, it, before, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { PushManager } from '../src/push.js'
 
 /**
@@ -387,5 +390,65 @@ describe('PushManager', () => {
       await manager.send('custom', 'T', 'B')
       assert.equal(fetchMock.mock.calls.length, 2)
     })
+  })
+})
+
+// #4550 — setPrefs must persist BEFORE mutating in-memory state, so a
+// failed rename doesn't leave _prefs reporting a value the user thinks
+// failed to save. Without the rollback, isCategoryEnabled answers based
+// on the unsaved patch until the next server restart reloads from disk.
+describe('PushManager.setPrefs rollback on persist failure (#4550)', () => {
+  let tmpDir
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-push-rollback-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('rolls back in-memory prefs when persist fails', () => {
+    // Force the on-disk persist to fail by pointing prefsPath into a
+    // location whose "directory" is actually a regular file. savePrefs
+    // calls mkdirSync(dirname(prefsPath), { recursive: true }) which
+    // throws ENOTDIR / EEXIST in this layout, propagating out of
+    // setPrefs exactly the way a real EACCES / EXDEV / quota failure
+    // would. This avoids module-mocking the fs surface (and the ESM
+    // cache headaches that come with it) while still exercising the
+    // production write path.
+    const blocker = join(tmpDir, 'blocker-file')
+    writeFileSync(blocker, 'not-a-directory')
+    const blockedPrefsPath = join(blocker, 'notification-prefs.json')
+
+    const pm = new PushManager({ prefsPath: blockedPrefsPath })
+
+    // Sanity check: `result` defaults to enabled. The whole point of
+    // the test is that after a failed setPrefs trying to mute it,
+    // isCategoryEnabled('result') must STILL return true.
+    assert.equal(pm.isCategoryEnabled('result'), true, 'precondition: result starts enabled')
+
+    let threw = null
+    try {
+      pm.setPrefs({ categories: { result: false } })
+    } catch (err) {
+      threw = err
+    }
+    assert.ok(threw, 'setPrefs must re-throw the rename failure so the WS handler can surface it')
+
+    // The actual regression assertion: in-memory state must match the
+    // pre-patch decision because the persist failed.
+    assert.equal(
+      pm.isCategoryEnabled('result'),
+      true,
+      'isCategoryEnabled must return the pre-patch value when persist fails',
+    )
+    // Belt-and-braces: getPrefs() snapshot must also show the
+    // unchanged category, not the attempted patch.
+    assert.equal(
+      pm.getPrefs().categories.result,
+      true,
+      'getPrefs snapshot must reflect the rolled-back in-memory state',
+    )
   })
 })


### PR DESCRIPTION
## Summary
- \`PushManager.setPrefs\` now persists to disk first, mutates \`this._prefs\` only on success
- Failed saves no longer leave the in-memory state inconsistent with disk
- Added regression test that forces a rename failure and asserts \`isCategoryEnabled\` still returns the pre-patch value

## Test plan
- [x] \`cd packages/server && PATH=\"/opt/homebrew/opt/node@22/bin:\$PATH\" npx vitest run test/push.test.js\`
- [x] Full server suite stays green

Closes #4550