### PR TITLE
fix(server): extend stream-stall watchdog to SDK sessions (#4467)

### DIFF
--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -244,8 +244,8 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, stdinForwardingDisabled, resultTimeoutMs, hardTimeoutMs } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, resultTimeoutMs, hardTimeoutMs })
+  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, stdinForwardingDisabled, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs })
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null
@@ -552,20 +552,26 @@ export class SdkSession extends BaseSession {
       options.resume = this._sdkSessionId
     }
 
-    // Safety timeouts: SOFT warning + HARD cap, both armed on every SDK
-    // event. Soft fires `inactivity_warning` (session stays alive);
-    // hard fires the existing kill path (force-clear, auto-deny
-    // pending perms, emit error). Both paused while a permission
-    // prompt is outstanding (#2831) — awaiting user input is not
-    // inactivity. Both windows configurable per server (#3749 / #3899)
-    // — see BaseSession.
+    // Safety timeouts: SOFT warning + HARD cap + STREAM-STALL recovery,
+    // all armed on every SDK event. Soft fires `inactivity_warning`
+    // (session stays alive); hard fires the existing kill path (force-
+    // clear, auto-deny pending perms, emit error); stall (#4467) fires
+    // the active-recovery path — clears busy state and emits
+    // `error{code:'stream_stall'}` so the dashboard's StreamStallChip
+    // can offer a retry without the user having to click Stop. All
+    // three paused while a permission prompt is outstanding (#2831) —
+    // awaiting user input is not inactivity / not a stall. Windows
+    // configurable per server (#3749 / #3899 / #4467) — see BaseSession.
     const SOFT_TIMEOUT_MS = this._resultTimeoutMs
     const HARD_TIMEOUT_MS = this._hardTimeoutMs
+    const STALL_TIMEOUT_MS = this._streamStallTimeoutMs
     const resetResultTimeout = () => {
       if (this._resultTimeout) clearTimeout(this._resultTimeout)
       if (this._hardTimeout) clearTimeout(this._hardTimeout)
+      if (this._streamStallTimeout) clearTimeout(this._streamStallTimeout)
       this._resultTimeout = null
       this._hardTimeout = null
+      this._streamStallTimeout = null
       if (this._resultTimeoutPaused) return
       this._resultTimeout = setTimeout(() => {
         this._resultTimeout = null
@@ -575,6 +581,15 @@ export class SdkSession extends BaseSession {
         this._hardTimeout = null
         this._handleHardTimeout(messageId, streamState.hasStreamStarted)
       }, HARD_TIMEOUT_MS)
+      // #4467: only arm the stall timer when the operator has not
+      // disabled the active-recovery path (value > 0). Soft + hard
+      // still apply regardless. Mirrors CliSession._armResultTimeout.
+      if (STALL_TIMEOUT_MS > 0) {
+        this._streamStallTimeout = setTimeout(() => {
+          this._streamStallTimeout = null
+          this._handleStreamStall(messageId, streamState.hasStreamStarted)
+        }, STALL_TIMEOUT_MS)
+      }
     }
     this._resetResultTimeout = resetResultTimeout
     resetResultTimeout()
@@ -1292,6 +1307,42 @@ export class SdkSession extends BaseSession {
   }
 
   /**
+   * Handle the STREAM-STALL recovery timer (#4467). Fires when the SDK
+   * has been silent for `_streamStallTimeoutMs` despite the session
+   * being busy — typically a half-open HTTPS to the Anthropic API that
+   * the OS hasn't surfaced as an error yet. Distinct from the SOFT
+   * inactivity warning (which is passive — just a chip) and the HARD
+   * cap (which is the absolute backstop at 2h): this is the ACTIVE
+   * recovery path so the user can retry without clicking Stop.
+   *
+   * On fire: log with context (messageId, elapsed) for triage; abort
+   * the in-flight query so further events don't land in a cleared
+   * context; emit `stream_end` (if streaming) then `error` with
+   * `code: 'stream_stall'` so the dashboard's StreamStallChip can
+   * render a dedicated retry affordance distinct from generic errors;
+   * clear message state so `_isBusy` flips false and the next
+   * `sendMessage` is no longer rejected by the busy guard.
+   */
+  _handleStreamStall(messageId, hasStreamStarted) {
+    if (!this._isBusy) return
+    const friendly = formatIdleDuration(this._streamStallTimeoutMs)
+    log.warn(
+      `Stream stalled (${friendly}, messageId=${messageId}) — clearing busy state for retry`,
+    )
+    if (hasStreamStarted) {
+      this.emit('stream_end', { messageId })
+    }
+    // Attempt to abort the SDK query generator so no further events land
+    // into a cleared message context. Best-effort — matches _handleHardTimeout.
+    this._abortActiveQuery()
+    this._clearMessageState()
+    this.emit('error', {
+      code: 'stream_stall',
+      message: `Stream stalled — no response for ${friendly}. Try sending again.`,
+    })
+  }
+
+  /**
    * Best-effort abort of the active SDK query generator. Used when the
    * session times out mid-turn so tool results don't stream into a
    * cleared message context (#2831).
@@ -1332,6 +1383,11 @@ export class SdkSession extends BaseSession {
       if (this._hardTimeout) {
         clearTimeout(this._hardTimeout)
         this._hardTimeout = null
+      }
+      // #4467: clear the stall timer too — waiting on the user is not a stall.
+      if (this._streamStallTimeout) {
+        clearTimeout(this._streamStallTimeout)
+        this._streamStallTimeout = null
       }
     }
   }
@@ -1378,6 +1434,12 @@ export class SdkSession extends BaseSession {
     if (this._hardTimeout) {
       clearTimeout(this._hardTimeout)
       this._hardTimeout = null
+    }
+    // #4467: clear stall timer on destroy so a stale fire can't run
+    // against a torn-down session.
+    if (this._streamStallTimeout) {
+      clearTimeout(this._streamStallTimeout)
+      this._streamStallTimeout = null
     }
 
     // Interrupt active query

--- a/packages/server/tests/sdk-session-timeout-pause.test.js
+++ b/packages/server/tests/sdk-session-timeout-pause.test.js
@@ -434,4 +434,143 @@ describe('SdkSession — inactivity timer pause/resume (#2831)', () => {
       }
     })
   })
+
+  // #4467: stream-stall recovery — third timer armed in parallel with
+  // the soft warning + hard cap. Fires at `streamStallTimeoutMs` (default
+  // 5 min, configurable) when no SDK event has arrived. Distinct from
+  // the soft warning because it ACTIVELY clears busy state + emits
+  // `error{code:'stream_stall'}` so the dashboard's StreamStallChip
+  // (#4476/#4494) can offer a retry affordance instead of the user
+  // having to click Stop. Parity with the CLI stall suite (#4475 in
+  // cli-session.test.js) — the SDK's two-timer closure in
+  // `_iterateSdkQuery` needs the third timer too or SDK-driven sessions
+  // sit at "Thinking…" forever.
+  describe('stream-stall recovery (#4467)', () => {
+    const STALL = 60_000
+    // Pin SOFT + HARD far past the stall window so the stall handler
+    // fires first and we can assert its events in isolation.
+    const SOFT_WIDE = 60 * 60_000
+    const HARD_WIDE = 2 * 60 * 60_000
+
+    function createReadyStallSession(opts = {}) {
+      const s = new SdkSession({
+        cwd: '/tmp',
+        resultTimeoutMs: SOFT_WIDE,
+        hardTimeoutMs: HARD_WIDE,
+        streamStallTimeoutMs: STALL,
+        ...opts,
+      })
+      s._processReady = true
+      s._isBusy = true
+      s._currentMessageId = 'msg-stall'
+      return s
+    }
+
+    it('stall timer fires at exactly streamStallTimeoutMs with code:stream_stall', () => {
+      const s = createReadyStallSession()
+      const errors = []
+      const streamEnds = []
+      s.on('error', (d) => errors.push(d))
+      s.on('stream_end', (d) => streamEnds.push(d))
+      try {
+        armResultTimeoutForTest(s, 'msg-stall', true)
+
+        mock.timers.tick(STALL - 1)
+        assert.equal(errors.length, 0, 'stall must not fire 1ms before configured window')
+
+        mock.timers.tick(1)
+        assert.equal(errors.length, 1, 'stall fires at exactly streamStallTimeoutMs')
+        assert.equal(errors[0].code, 'stream_stall',
+          'error MUST carry code:stream_stall so dashboard can distinguish from generic errors')
+        assert.match(errors[0].message, /stalled/i)
+        assert.equal(streamEnds.length, 1, 'stream_end fires before error because hasStreamStarted=true')
+        assert.equal(s._isBusy, false,
+          'busy state must clear so the user can retry from the same session')
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('activity at 4 min resets the stall window (no fire until 4+5 = 9 min)', () => {
+      const s = createReadyStallSession()
+      const errors = []
+      s.on('error', (d) => errors.push(d))
+      try {
+        armResultTimeoutForTest(s, 'msg-stall', true)
+
+        mock.timers.tick(STALL - 1_000) // 59s — almost stalled
+        assert.equal(errors.length, 0)
+
+        // Simulated SDK event resets the timer trio
+        s._resetResultTimeout()
+
+        mock.timers.tick(STALL - 1)
+        assert.equal(errors.length, 0, 'reset must restart the stall window from zero')
+
+        mock.timers.tick(1)
+        assert.equal(errors.length, 1, 'stall fires at exactly one full window after the reset')
+        assert.equal(errors[0].code, 'stream_stall')
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('streamStallTimeoutMs=0 disables active recovery (soft+hard still apply)', () => {
+      const s = createReadyStallSession({ streamStallTimeoutMs: 0 })
+      const errors = []
+      s.on('error', (d) => errors.push(d))
+      try {
+        armResultTimeoutForTest(s, 'msg-stall', true)
+        // Tick well past what would have been the default stall window.
+        mock.timers.tick(10 * 60_000)
+        assert.equal(errors.length, 0,
+          'disabled stall recovery must not emit stream_stall errors')
+        assert.equal(s._streamStallTimeout, null,
+          'stall timer handle must remain null when disabled')
+        assert.equal(s._isBusy, true,
+          'busy state must NOT be cleared by the disabled stall path')
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('pause during a pending permission clears the stall timer', async () => {
+      const s = createReadyStallSession()
+      try {
+        armResultTimeoutForTest(s, 'msg-stall', true)
+        assert.ok(s._streamStallTimeout, 'stall timer must be armed before pause')
+
+        const p = s._handlePermission('Bash', { command: 'ls' }, null)
+
+        assert.equal(s._streamStallTimeout, null,
+          'stall timer must clear when a permission prompt is outstanding')
+        assert.equal(s._resultTimeoutPaused, true)
+
+        // Resolve to let the awaited promise settle inside the finally block.
+        const reqId = Array.from(s._pendingPermissions.keys())[0]
+        s.respondToPermission(reqId, 'allow')
+        await p
+      } finally {
+        s.destroy()
+      }
+    })
+
+    it('stall fires without stream_end when hasStreamStarted=false', () => {
+      const s = createReadyStallSession()
+      const errors = []
+      const streamEnds = []
+      s.on('error', (d) => errors.push(d))
+      s.on('stream_end', (d) => streamEnds.push(d))
+      try {
+        armResultTimeoutForTest(s, 'msg-stall', false)
+        mock.timers.tick(STALL)
+        assert.equal(errors.length, 1, 'stall still fires')
+        assert.equal(errors[0].code, 'stream_stall')
+        assert.equal(streamEnds.length, 0,
+          'no stream_end when the SDK turn never started streaming')
+      } finally {
+        s.destroy()
+      }
+    })
+  })
 })

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -2562,4 +2562,64 @@ describe('SdkSession', () => {
       assert.equal(totalsEvents[2].count, 3, 'count still increments on unknown payloads')
     })
   })
+
+  // #4467: stream-stall recovery — SDK sibling of the CLI watchdog
+  // (already shipped in cli-session.js via #4475). The SDK path was
+  // missing the third timer, so a half-open HTTPS connection to the
+  // Anthropic API would leave the session at "Thinking…" until the user
+  // clicked Stop. These tests pin the unit behaviour of the handler
+  // itself; the arm/reset/pause integration tests live in
+  // sdk-session-timeout-pause.test.js alongside the soft+hard suite.
+  describe('SdkSession._handleStreamStall (#4467: stream-stall recovery)', () => {
+    it('emits stream_end + error{code:stream_stall} so dashboard can offer retry', () => {
+      const s = createSession({ streamStallTimeoutMs: 60_000 })
+      s._isBusy = true
+      s._currentMessageId = 'msg_ss'
+      s._sessionId = 'sess_ss'
+
+      const events = []
+      s.on('stream_end', (p) => events.push({ name: 'stream_end', payload: p }))
+      s.on('error', (p) => events.push({ name: 'error', payload: p }))
+
+      s._handleStreamStall('msg_ss', true)
+
+      assert.deepEqual(events.map((e) => e.name), ['stream_end', 'error'])
+      assert.equal(events[0].payload.messageId, 'msg_ss')
+      assert.equal(events[1].payload.code, 'stream_stall',
+        'error MUST carry code:stream_stall so dashboard can distinguish from generic errors')
+      assert.match(events[1].payload.message, /stalled/i)
+      assert.equal(s._isBusy, false,
+        'busy state must clear so the user can retry from the same session')
+      s.destroy()
+    })
+
+    it('does NOT emit stream_end when the stream had not yet started', () => {
+      const s = createSession({ streamStallTimeoutMs: 60_000 })
+      s._isBusy = true
+      s._currentMessageId = 'msg_ss'
+
+      const events = []
+      s.on('stream_end', (p) => events.push({ name: 'stream_end', payload: p }))
+      s.on('error', (p) => events.push({ name: 'error', payload: p }))
+
+      s._handleStreamStall('msg_ss', false)
+
+      assert.deepEqual(events.map((e) => e.name), ['error'])
+      assert.equal(events[0].payload.code, 'stream_stall')
+      s.destroy()
+    })
+
+    it('no-ops when not busy (timer fired against an idle session)', () => {
+      const s = createSession()
+      s._isBusy = false
+
+      const events = []
+      s.on('stream_end', () => events.push('stream_end'))
+      s.on('error', () => events.push('error'))
+
+      s._handleStreamStall('msg_x', true)
+      assert.deepEqual(events, [])
+      s.destroy()
+    })
+  })
 })

--- a/packages/server/tests/test-helpers.js
+++ b/packages/server/tests/test-helpers.js
@@ -346,8 +346,10 @@ export function armResultTimeoutForTest(session, messageId, hasStreamStarted = f
   const reset = () => {
     if (session._resultTimeout) clearTimeout(session._resultTimeout)
     if (session._hardTimeout) clearTimeout(session._hardTimeout)
+    if (session._streamStallTimeout) clearTimeout(session._streamStallTimeout)
     session._resultTimeout = null
     session._hardTimeout = null
+    session._streamStallTimeout = null
     if (session._resultTimeoutPaused) return
     session._resultTimeout = setTimeout(() => {
       session._resultTimeout = null
@@ -357,6 +359,15 @@ export function armResultTimeoutForTest(session, messageId, hasStreamStarted = f
       session._hardTimeout = null
       session._handleHardTimeout(messageId, hasStreamStarted)
     }, session._hardTimeoutMs)
+    // #4467: stream-stall recovery — only arm when the operator has not
+    // disabled the active-recovery path (value > 0). Mirrors the
+    // production reset closure in `sdk-session.js`.
+    if (session._streamStallTimeoutMs > 0 && typeof session._handleStreamStall === 'function') {
+      session._streamStallTimeout = setTimeout(() => {
+        session._streamStallTimeout = null
+        session._handleStreamStall(messageId, hasStreamStarted)
+      }, session._streamStallTimeoutMs)
+    }
   }
   session._resetResultTimeout = reset
   reset()


### PR DESCRIPTION
## Summary

Closes #4467 (the original CLI half landed in #4475; this PR is the SDK sibling).

- Adds the stream-silence watchdog (default 5 min, configurable via existing \`streamStallTimeoutMs\` / \`CHROXY_STREAM_STALL_TIMEOUT_MS\` — 0 disables) to \`sdk-session.js\`'s \`_iterateSdkQuery\` reset closure, alongside the existing soft-warning (#3899) and hard-cap (#3899) timers.
- On stall: aborts the in-flight SDK query, emits \`stream_end\` (when streaming had started), clears \`_isBusy\` so the user can retry from the same session, emits \`error{code:'stream_stall'}\` so the existing dashboard StreamStallChip (#4476/#4494) and mobile chip (#4496/#4504) light up the dedicated retry affordance.
- Fixes a quiet bug in \`SdkSession\`'s constructor: it wasn't accepting or forwarding \`streamStallTimeoutMs\` to \`super()\`. SessionManager already passes it through providerOpts since #4475, so prod was using the default 5 min by accident — but operator opt-out (\`streamStallTimeoutMs: 0\`) silently reverted to default until this fix.
- Pause/destroy paths clear the stall timer alongside soft+hard so permission prompts and session teardown don't leave a stale fire pending.
- Test helper \`armResultTimeoutForTest\` extended to arm the stall timer alongside soft+hard so existing SDK pause/resume tests still cover the production reset closure faithfully.

## Test plan

- [x] 3 new unit tests in \`sdk-session.test.js\` covering \`_handleStreamStall\` (stream_end gating on hasStreamStarted, no-op when idle, code/message contract)
- [x] 5 new integration tests in \`sdk-session-timeout-pause.test.js\` with \`node:test\` fake timers covering: arm-at-exact-window, activity-resets-window, opt-out=0 disables, pause-during-permission clears the timer, hasStreamStarted=false path
- [x] All existing \`cli-session\` / \`sdk-session\` / \`base-session\` / \`session-manager\` / \`ws-permissions-pause-integration\` / \`ws-server\` / \`ws-history\` suites stay green (716 / 716 pass in the affected files)
- [x] 6 pre-existing failures in \`service.test.js\` / \`tunnel.integration.test.js\` / \`web-task-manager.test.js\` are env-dependent (cloudflared, claude CLI \`--remote\` probe) and unrelated to this change

## Follow-ups filed during this PR (scope guard)

- #4601 — make \`STREAM_SILENCE_TIMEOUT_MS\` configurable per provider (currently one global value across CLI + SDK; Codex / Gemini / TUI may want longer windows)
- #4602 — \`cli-session.js\` distinguishes intentional SIGINT from child crash (Stop currently shows the misleading "exited unexpectedly" toast and triggers a respawn the user explicitly stopped)
- #4603 — dashboard chip polish placeholder (the chip already exists via #4476/#4494/#4496/#4504; this tracker is for any cross-provider polish that surfaces as the stall watchdog extends to Codex/Gemini/TUI)

## Note on issue spec deviations

- Tests use \`node:test\` + \`node --experimental-test-module-mocks\` + \`mock.timers\` (the project's test runner), not vitest. Same fake-timer semantics, same RED→GREEN cycle.
- The 5-minute default was already enforced + configurable (#4475/#4477/#4483) before this PR — this PR adds the SDK arm site, not the constants or surfacing.
- The dashboard chip distinguishing \`stream_stall\` from generic errors already shipped (#4476/#4494/#4505); this PR makes it actually fire for SDK-driven sessions for the first time.

Closes #4467 (final scope: SDK extension of the watchdog landed in #4475)