### PR TITLE
fix(dashboard): preserve timer startedAt across tab-switch history replay (#4607)

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3333,6 +3333,124 @@ describe('dashboard message-handler dispatch', () => {
       const ss = (store.getState() as any).sessionStates.s1
       expect(ss.activeTools).toEqual([])
     })
+
+    // #4607 — full tab-switch flow: server's `replayHistory()` always sends
+    // `fullHistory: true`, which the dashboard treats as "clear messages
+    // before applying replayed events" (ws-history.js:372, message-handler
+    // case 'history_replay_start'). With messages wiped, the dedup check
+    // inside `sharedToolStart` (`cachedMessages.some(m => m.id === toolId)`)
+    // can no longer find the prior tool_use bubble, so it falls through and
+    // builds a fresh chatMessage with `timestamp: Date.now()` PLUS a fresh
+    // ActiveTool whose `startedAt` is also Date.now(). The toolUseId-dedup
+    // inside `applyToActiveTools` preserves the original ActiveTool entry
+    // (so the structured `activeTools` slot keeps its original startedAt) —
+    // BUT the new tool_use bubble pushed onto `messages` carries the fresh
+    // timestamp. The ActivityIndicator's `findInFlightToolUse` fallback
+    // would read THAT timestamp if `activeTools` were ever empty (e.g. a
+    // server that didn't broadcast tool_start, or pre-bootstrap), so any
+    // future regression that empties `activeTools` mid-replay would silently
+    // reset the timer to ~0s. Pin both invariants in one place.
+    it('full tab-switch (history_replay_start fullHistory:true + replayed tool_start) preserves startedAt (#4607)', () => {
+      const originalStartedAt = 100
+      const originalToolMsg = {
+        id: 'tool-1',
+        type: 'tool_use' as const,
+        content: '{"command":"sleep 999"}',
+        tool: 'Bash',
+        toolUseId: 'tu-1',
+        timestamp: originalStartedAt,
+      }
+      const inFlightTool = {
+        toolUseId: 'tu-1',
+        tool: 'Bash',
+        input: { command: 'sleep 999' },
+        startedAt: originalStartedAt,
+      }
+      seedSession({
+        activeTools: [inFlightTool],
+        messages: [originalToolMsg as any],
+      })
+      // Step 1: tab switch → server sends history_replay_start with
+      // fullHistory:true. The dashboard clears the messages array — this
+      // is what makes the cached-message dedup miss on the replayed
+      // tool_start that follows.
+      handleMessage(
+        { type: 'history_replay_start', sessionId: 's1', fullHistory: true },
+        ctx() as any,
+      )
+      // After history_replay_start: messages is [] but activeTools must still
+      // hold the original entry with its original startedAt.
+      let ss = (store.getState() as any).sessionStates.s1
+      expect(ss.messages).toEqual([])
+      expect(ss.activeTools).toHaveLength(1)
+      expect(ss.activeTools[0].startedAt).toBe(originalStartedAt)
+      // Step 2: server replays the original tool_start (same messageId and
+      // toolUseId). Pre-fix path would have rebuilt the activeTools entry
+      // with startedAt: Date.now(); the toolUseId dedup in
+      // applyToActiveTools is what saves us, but the test pins it.
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          input: { command: 'sleep 999' },
+          sessionId: 's1',
+        },
+        ctx() as any,
+      )
+      ss = (store.getState() as any).sessionStates.s1
+      // Critical invariant: activeTools entry's startedAt is preserved.
+      // This is what the ActivityIndicator reads for "Running Bash · Ns".
+      expect(ss.activeTools).toHaveLength(1)
+      expect(ss.activeTools[0].toolUseId).toBe('tu-1')
+      expect(ss.activeTools[0].startedAt).toBe(originalStartedAt)
+      // Step 3: history_replay_end — flag clears, normal operation resumes.
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      ss = (store.getState() as any).sessionStates.s1
+      expect(ss.activeTools[0].startedAt).toBe(originalStartedAt)
+    })
+
+    // #4607 — fallback-path coverage. ActivityIndicator prefers `activeTools`
+    // but falls back to `findInFlightToolUse(messages)` when activeTools is
+    // empty. That fallback reads `m.timestamp` from the tool_use ChatMessage.
+    // After a replayed tool_start the messages array contains a freshly
+    // pushed tool_use bubble with `timestamp: Date.now()` — so if the
+    // fallback ever fires post-replay the timer would jump to ~0s. Pin that
+    // the replayed bubble carries the ORIGINAL server-side timestamp when
+    // the server includes one in the tool_start payload (history entries
+    // do — session-message-history.js:208-216 stamps `timestamp: Date.now()`
+    // at append time and forwards it on replay). Without this, the
+    // "Running X · 1s" symptom resurfaces the moment activeTools is empty
+    // for any reason (handleAgentIdle, future refactor, missing toolUseId).
+    it('replayed tool_use bubble inherits the wire timestamp, not Date.now() (#4607)', () => {
+      const wireTimestamp = 200
+      seedSession({ activeTools: [] })
+      handleMessage(
+        { type: 'history_replay_start', sessionId: 's1', fullHistory: true },
+        ctx() as any,
+      )
+      handleMessage(
+        {
+          type: 'tool_start',
+          messageId: 'tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          input: { command: 'sleep 999' },
+          sessionId: 's1',
+          timestamp: wireTimestamp,
+        },
+        ctx() as any,
+      )
+      handleMessage({ type: 'history_replay_end', sessionId: 's1' }, ctx() as any)
+      const ss = (store.getState() as any).sessionStates.s1
+      const toolMsg = ss.messages.find((m: any) => m.id === 'tool-1')
+      expect(toolMsg).toBeDefined()
+      expect(toolMsg.timestamp).toBe(wireTimestamp)
+      // And the rebuilt activeTools entry must also use the wire timestamp.
+      expect(ss.activeTools).toHaveLength(1)
+      expect(ss.activeTools[0].startedAt).toBe(wireTimestamp)
+    })
   })
 
   // #4493 — the replay flag must be scoped per-session. Pre-fix it was a

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -5401,6 +5401,68 @@ describe('handleToolStart', () => {
       expect(out.activeTool).toBeNull()
     })
 
+    // #4607 — the server's history ring buffer stamps `timestamp: Date.now()`
+    // at append time and forwards it on every replay
+    // (session-message-history.js:208-216). When the dashboard rebuilds the
+    // tool_use ChatMessage during history_replay (e.g. because fullHistory
+    // wiped the messages array so the cached-id dedup misses), it must
+    // honour that wire timestamp instead of stamping a new Date.now(). Both
+    // `chatMessage.timestamp` AND the derived `activeTool.startedAt` must
+    // carry it through, otherwise the "Running <tool> · Ns" pill restarts
+    // at ~1s on tab-switch for any session whose activeTools was previously
+    // empty (toolUseId-dedup in applyToActiveTools only protects the case
+    // where the same id is already tracked).
+    it('honours wire `timestamp` field on the tool_start payload (#4607)', () => {
+      const wireTimestamp = 1_700_000_000_000
+      const out = handleToolStart(
+        {
+          messageId: 'srv-tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          timestamp: wireTimestamp,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.chatMessage!.timestamp).toBe(wireTimestamp)
+      expect(out.activeTool!.startedAt).toBe(wireTimestamp)
+    })
+
+    it('falls back to Date.now() when wire `timestamp` is missing (live tool_start, #4607)', () => {
+      const before = Date.now()
+      const out = handleToolStart(
+        { messageId: 'srv-tool-1', tool: 'Bash', toolUseId: 'tu-1' },
+        'sess-active',
+        false,
+        [],
+      )
+      const after = Date.now()
+      expect(out.chatMessage!.timestamp).toBeGreaterThanOrEqual(before)
+      expect(out.chatMessage!.timestamp).toBeLessThanOrEqual(after)
+      expect(out.activeTool!.startedAt).toBe(out.chatMessage!.timestamp)
+    })
+
+    it('ignores non-finite wire `timestamp` and falls back to Date.now() (#4607)', () => {
+      // Defensive: a malformed wire payload (NaN, Infinity, string-coerced)
+      // must not poison the elapsed-time clock with NaN-driven arithmetic.
+      const before = Date.now()
+      const out = handleToolStart(
+        {
+          messageId: 'srv-tool-1',
+          tool: 'Bash',
+          toolUseId: 'tu-1',
+          timestamp: Number.NaN,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      const after = Date.now()
+      expect(out.chatMessage!.timestamp).toBeGreaterThanOrEqual(before)
+      expect(out.chatMessage!.timestamp).toBeLessThanOrEqual(after)
+    })
+
     it('applyToActiveTools pushes the new entry onto the array', () => {
       const out = handleToolStart(
         { messageId: 'srv-tool-1', tool: 'Bash', toolUseId: 'tu-1' },

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3402,6 +3402,27 @@ export function handleToolStart(
     }
   }
 
+  // #4607 — honour the wire `timestamp` field when present (number). The
+  // server's history ring buffer stamps `timestamp: Date.now()` at append
+  // time (session-message-history.js:208-216) and forwards it on every
+  // replay. Pre-#4607 we always overwrote with `Date.now()`, which:
+  //   1) made the rebuilt `chatMessage.timestamp` jump to the replay moment,
+  //      so any UI that reads `tool_use.timestamp` (e.g.
+  //      ActivityIndicator.findInFlightToolUse fallback) sees a fresh time
+  //      instead of when the tool actually started.
+  //   2) made the rebuilt `ActiveTool.startedAt` jump to the replay moment
+  //      whenever `activeTools` was empty at history_replay_start time
+  //      (toolUseId-dedup in applyToActiveTools only preserves the original
+  //      `startedAt` when an entry with the same id already exists). The
+  //      "Running <tool> · Ns" pill restarted at ~1s on tab-switch for any
+  //      session whose activeTools had been swept by a prior handleAgentIdle
+  //      / live `result` / etc.
+  // The fallback to `Date.now()` covers live (non-replay) tool_start
+  // broadcasts, which never carry `msg.timestamp` on the wire.
+  const wireTimestamp =
+    typeof msg.timestamp === 'number' && Number.isFinite(msg.timestamp)
+      ? msg.timestamp
+      : Date.now()
   const chatMessage: ChatMessage = {
     id: toolId,
     type: 'tool_use',
@@ -3409,7 +3430,7 @@ export function handleToolStart(
     tool,
     toolUseId,
     serverName,
-    timestamp: Date.now(),
+    timestamp: wireTimestamp,
   }
 
   // #4308 — build the ActiveTool entry. Skip when `toolUseId` is missing


### PR DESCRIPTION
## Root cause (matched hypothesis: **H2 / H3 hybrid**)

The #4490/#4501 fix for #4466 preserved `activeTools` through the replay boundary, but left the underlying bug in `sharedToolStart` (`packages/store-core/src/handlers/index.ts:3412`) unaddressed — it always stamped both `chatMessage.timestamp` AND the derived `ActiveTool.startedAt` with `Date.now()`, ignoring the wire `timestamp` field.

The `toolUseId` dedup in `applyToActiveTools` (line 3434) masks this when an entry with the same id is already tracked at replay time — so the dashboard suite's `preserves activeTools across history_replay_start` test passed. But the moment `activeTools` is empty when `history_replay_start` arrives (a prior `handleAgentIdle` swept it, the wedged tool predates the activeTools tracking, or first connection), the rebuilt entry's `startedAt` jumps to the replay moment and the "Running &lt;tool&gt; · Ns" pill restarts at ~1s on tab-switch.

This matches the **wedged-AskUserQuestion** scenario from issue #4604 — the AskUserQuestion stays in `activeTools` while the agent runs, but any tab-switch flow where activeTools has been cleared (e.g. by the live `handleAgentIdle` that fired before the user_question was answered, or any session whose activeTools tracking was reset) hits the wire-timestamp path and resets.

Offending lines (pre-fix `packages/store-core/src/handlers/index.ts`):

\`\`\`ts
// line 3412
timestamp: Date.now(),

// line 3425 — derived from chatMessage.timestamp, so also Date.now()
startedAt: chatMessage.timestamp,
\`\`\`

Server-side `session-message-history.js:208-216` already stamps `timestamp: Date.now()` at append time and forwards it on every replay, so the data is on the wire — the handler just wasn't reading it.

## Fix

Honour `msg.timestamp` (typed number, finite) when present; fall back to `Date.now()` for live `tool_start` broadcasts which never carry the field. Both `chatMessage.timestamp` and the derived `ActiveTool.startedAt` then carry the original server-side start time through replay, so the elapsed-time clock is preserved regardless of whether the `activeTools` toolUseId-dedup hits.

## Test plan

- [x] Failing test reproducing the regression added first (`replayed tool_use bubble inherits the wire timestamp, not Date.now() (#4607)` — fails on `Date.now()` overwrite, passes on the fix)
- [x] Full tab-switch flow test added (`full tab-switch (history_replay_start fullHistory:true + replayed tool_start) preserves startedAt (#4607)`)
- [x] Three store-core handler tests pinning wire-timestamp behaviour (live/replay/malformed-NaN)
- [x] `cd packages/dashboard && npm run typecheck` clean
- [x] `cd packages/dashboard && npx vitest run` — 2366 tests pass
- [x] `cd packages/store-core && npx vitest run` — 891 tests pass

Closes #4607
Related: #4466, #4490, #4501, #4604