### PR TITLE
fix(server): observability + watchdog for AskUserQuestion stalls (#4604 chunks A+C)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -90,6 +90,17 @@ const CLAUDE = resolveBinary('claude', [
   join(homedir(), '.npm-global/bin/claude'),
 ])
 
+// #4604 — watchdog window for the AskUserQuestion answer round-trip.
+// respondToQuestion() writes ONE keystroke (the chosen option's digit)
+// and assumes claude TUI emits PostToolUse shortly after. Multi-question
+// AskUserQuestion forms violate that assumption: claude TUI renders a
+// per-question form that needs additional keystrokes + a Submit, and
+// PostToolUse never fires. Without this watchdog the session wedges at
+// _isBusy=true forever (the 8m+ symptom in #4604). On expiry we clear
+// _isBusy + _pendingUserAnswer and emit ASK_USER_QUESTION_STALL so the
+// dashboard can prompt the user to retry. Root cause is fixed in Chunk B.
+const ASK_USER_QUESTION_WATCHDOG_MS = 30 * 1000
+
 // Pre-trust the cwd in ~/.claude.json so the workspace-trust dialog doesn't
 // block headless spawn. The dialog is interactive-only — without this, the
 // PTY would render "Is this a project you trust?" and wait for Enter.
@@ -329,6 +340,11 @@ export class ClaudeTuiSession extends BaseSession {
     // on PostToolUse (claude resolved the prompt some other way), or
     // on session destroy.
     this._pendingUserAnswer = null
+    // #4604: watchdog timer armed in respondToQuestion(). If PostToolUse
+    // never arrives after we write the answer (multi-question form wedge),
+    // _onAskUserQuestionStall clears busy state + emits an error so the
+    // session is recoverable. Cleared on PostToolUse + destroy().
+    this._askUserQuestionWatchdog = null
   }
 
   // Tail length to keep + length to include in error diagnostics.
@@ -1147,6 +1163,14 @@ export class ClaudeTuiSession extends BaseSession {
           ? questions[0].options
           : []
         this._pendingUserAnswer = { toolUseId, options }
+        // #4604: surface the AskUserQuestion shape in chroxy.log so the
+        // multi-question wedge condition is greppable. The bug was
+        // diagnosed via /tmp/.../pre-*.json spelunking — never again.
+        const questionCount = questions.length
+        log.info(`AskUserQuestion pending: tool=${toolUseId} questions=${questionCount} options.q1=${options.length}`)
+        if (questionCount > 1) {
+          log.warn(`AskUserQuestion has ${questionCount} questions — multi-question forms are not yet supported (see #4604). Only question 1 will be answered.`)
+        }
         this.emit('user_question', { toolUseId, questions })
       }
       return
@@ -1159,6 +1183,13 @@ export class ClaudeTuiSession extends BaseSession {
     // user_question_response doesn't write into a stale context.
     if (toolName === 'AskUserQuestion' && this._pendingUserAnswer) {
       this._pendingUserAnswer = null
+    }
+    // #4604: PostToolUse means claude accepted the answer (single-question
+    // happy path). Cancel the stall watchdog so it doesn't fire a spurious
+    // ASK_USER_QUESTION_STALL error 30s later.
+    if (toolName === 'AskUserQuestion' && this._askUserQuestionWatchdog) {
+      clearTimeout(this._askUserQuestionWatchdog)
+      this._askUserQuestionWatchdog = null
     }
 
     // PostToolUse — extract a string-ish result for the dashboard.
@@ -1407,6 +1438,11 @@ export class ClaudeTuiSession extends BaseSession {
    * @param {object} [_answersMap] — reserved; unused in TUI mode
    */
   respondToQuestion(text, _answersMap) {
+    // #4604: capture toolUseId BEFORE clearing _pendingUserAnswer so the
+    // observability log + watchdog arm have something to correlate on
+    // when the response fails or stalls.
+    const prevToolUseId = this._pendingUserAnswer?.toolUseId || null
+    log.info(`respondToQuestion: tool=${prevToolUseId || '?'} text.length=${(text || '').length} answersMap.keys=${_answersMap ? Object.keys(_answersMap).length : 0} options=${this._pendingUserAnswer?.options?.length || 0}`)
     if (!this._pendingUserAnswer) return
     if (typeof text !== 'string' || text.length === 0) return
     const { options } = this._pendingUserAnswer
@@ -1441,7 +1477,44 @@ export class ClaudeTuiSession extends BaseSession {
     // but the caller (handleUserQuestionResponse) is sync. Errors here
     // are non-fatal; worst case the user re-sends the answer.
     this._writePtyTextThrottled(writeText).catch((err) => {
-      log.warn(`respondToQuestion PTY write failed: ${err.message}`)
+      log.warn(`respondToQuestion PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
+    })
+    // #4604: arm a stall watchdog. If claude TUI never emits PostToolUse
+    // for this AskUserQuestion (multi-question form wedge), the watchdog
+    // clears _isBusy + _pendingUserAnswer and emits ASK_USER_QUESTION_STALL
+    // so the dashboard prompts the user to retry. Cancelled on PostToolUse
+    // (happy path) and on destroy().
+    const armedToolUseId = prevToolUseId
+    if (this._askUserQuestionWatchdog) clearTimeout(this._askUserQuestionWatchdog)
+    this._askUserQuestionWatchdog = setTimeout(() => {
+      this._askUserQuestionWatchdog = null
+      this._onAskUserQuestionStall(armedToolUseId)
+    }, ASK_USER_QUESTION_WATCHDOG_MS)
+  }
+
+  /**
+   * Watchdog handler for an AskUserQuestion answer that claude TUI never
+   * acknowledged via PostToolUse (#4604). Multi-question forms render a
+   * per-question form needing more than the single digit chroxy writes,
+   * leaving _isBusy=true forever. We force-clear the busy state and
+   * surface a structured error so the dashboard can render a retry prompt.
+   *
+   * No-ops on destroyed sessions and on sessions where PostToolUse
+   * already arrived (would have cleared _pendingUserAnswer + busy state
+   * in the normal flow before the watchdog timer fired).
+   */
+  _onAskUserQuestionStall(toolUseId) {
+    if (this._destroying) return
+    if (!this._pendingUserAnswer && !this._isBusy) return
+
+    log.warn(`AskUserQuestion stall: tool=${toolUseId} — claude TUI never emitted PostToolUse after answer write (${ASK_USER_QUESTION_WATCHDOG_MS}ms). Likely a multi-question form (#4604). Clearing busy state so the session is recoverable.`)
+
+    this._pendingUserAnswer = null
+    this._isBusy = false
+    this.emit('error', {
+      code: 'ASK_USER_QUESTION_STALL',
+      message: 'The agent\'s question response could not be delivered — likely a multi-question form. Please retry from your last message.',
+      toolUseId,
     })
   }
 
@@ -1455,6 +1528,12 @@ export class ClaudeTuiSession extends BaseSession {
     this._pendingUserAnswer = null
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
+    // #4604: cancel the AskUserQuestion stall watchdog so it can't fire
+    // a stale ASK_USER_QUESTION_STALL event into a torn-down listener.
+    if (this._askUserQuestionWatchdog) {
+      clearTimeout(this._askUserQuestionWatchdog)
+      this._askUserQuestionWatchdog = null
+    }
     if (this._term) {
       try { this._term.kill('SIGTERM') } catch { /* already dead */ }
       this._term = null

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1269,6 +1269,14 @@ export class ClaudeTuiSession extends BaseSession {
     // clicked the QuestionPrompt right as the hard timeout fired) would
     // attempt a PTY write that no longer matches a live turn.
     this._pendingUserAnswer = null
+    // #4604: same symmetry for the stall watchdog. The guard in
+    // _onAskUserQuestionStall (`!_pendingUserAnswer && !_isBusy`) would
+    // currently no-op the late fire (both are falsy here), but leaving
+    // the setTimeout handle live wastes a callback invocation 30s later.
+    if (this._askUserQuestionWatchdog) {
+      clearTimeout(this._askUserQuestionWatchdog)
+      this._askUserQuestionWatchdog = null
+    }
   }
 
   /**
@@ -1352,6 +1360,11 @@ export class ClaudeTuiSession extends BaseSession {
     // after we've already fired Ctrl-C and emitted error/result has
     // nowhere meaningful to go.
     this._pendingUserAnswer = null
+    // #4604: same symmetry for the stall watchdog — see _finishTurnError.
+    if (this._askUserQuestionWatchdog) {
+      clearTimeout(this._askUserQuestionWatchdog)
+      this._askUserQuestionWatchdog = null
+    }
     this.emit('error', { message: `Response timed out after ${friendly}` })
     // #4010: emit result so the dashboard receives agent_idle and clears
     // the Stop button. stream_end on its own only clears streamingMessageId.
@@ -1417,6 +1430,14 @@ export class ClaudeTuiSession extends BaseSession {
     // #4278: also drop any pending AskUserQuestion so a subsequent
     // user_question_response can't write into a torn-down context.
     this._pendingUserAnswer = null
+    // #4604: cancel the stall watchdog too. interrupt() does NOT clear
+    // _isBusy directly (Ctrl-C surfaces async via _finishTurn*), so without
+    // this the watchdog could fire ~30s later and emit a spurious
+    // ASK_USER_QUESTION_STALL for a session the user already interrupted.
+    if (this._askUserQuestionWatchdog) {
+      clearTimeout(this._askUserQuestionWatchdog)
+      this._askUserQuestionWatchdog = null
+    }
   }
 
   /**

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -538,6 +538,11 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
 
   const entry = ctx.sessionManager.getSession(questionSessionId)
   if (entry && typeof entry.session.respondToQuestion === 'function' && typeof msg.answer === 'string') {
+    // #4604: log the incoming response shape so a multi-question form
+    // wedge is correlatable from chroxy.log alone (toolUseId + map-key
+    // count distinguishes the SDK's per-question form from the TUI's
+    // single-answer string).
+    log.info(`user_question_response received: toolUseId=${msg.toolUseId || '?'} answer.length=${(msg.answer || '').length} answers.keys=${msg.answers ? Object.keys(msg.answers).length : 0}`)
     entry.session.respondToQuestion(msg.answer, msg.answers)
   }
 }

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach } from 'node:test'
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
@@ -2381,6 +2381,193 @@ describe('ClaudeTuiSession', () => {
       session._hardTimeoutMs = 1000
       session._handleHardTimeout()
       assert.equal(session._pendingUserAnswer, null, 'hard timeout clears pending answer')
+    })
+  })
+
+  // #4604 — observability + watchdog around AskUserQuestion. The root
+  // cause (claude TUI multi-question forms render a per-question form
+  // that needs more than one keystroke) is fixed in a separate refactor
+  // (Chunk B). These tests pin the defensive layers:
+  //   - A WARN log fires when a PreToolUse arrives with >1 question so
+  //     the wedge condition is visible in chroxy.log.
+  //   - A 30s watchdog clears the busy state + emits ASK_USER_QUESTION_STALL
+  //     when claude TUI never emits PostToolUse after chroxy writes the
+  //     answer (i.e. the keystroke didn't satisfy the form).
+  //   - The watchdog is cancelled on PostToolUse arrival (happy path) and
+  //     on destroy() (clean teardown).
+  describe('AskUserQuestion stall watchdog (#4604)', () => {
+    let warnLines
+    let infoLines
+    let logSpy
+
+    beforeEach(() => {
+      warnLines = []
+      infoLines = []
+      logSpy = (entry) => {
+        if (entry.component !== 'claude-tui-session') return
+        if (entry.level === 'warn') warnLines.push(entry.message)
+        if (entry.level === 'info') infoLines.push(entry.message)
+      }
+      addLogListener(logSpy)
+    })
+
+    afterEach(() => {
+      if (logSpy) removeLogListener(logSpy)
+      logSpy = null
+      warnLines = null
+      infoLines = null
+    })
+
+    it('PreToolUse with >1 question fires a multi-question warn (#4604 chunk A)', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { uuid: 'test', synthSeq: 0 }
+
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', multiSelect: true, options: [{ label: 'x' }, { label: 'y' }] },
+        { question: 'Q3?', options: [{ label: 'p' }] },
+        { question: 'Q4?', options: [{ label: 'q' }] },
+      ]
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_aq_multi',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions },
+      }, 'msg-aq-multi')
+
+      const multiWarn = warnLines.find((m) => /multi-question forms are not yet supported/.test(m))
+      assert.ok(multiWarn, `expected multi-question warn, got warnLines=${JSON.stringify(warnLines)}`)
+      assert.match(multiWarn, /4 questions/, 'warn includes the question count')
+      assert.match(multiWarn, /#4604/, 'warn references the tracking issue')
+
+      const pendingInfo = infoLines.find((m) => /AskUserQuestion pending/.test(m))
+      assert.ok(pendingInfo, 'PreToolUse also fires an info log with the toolUseId + counts')
+      assert.match(pendingInfo, /questions=4/)
+    })
+
+    it('does NOT fire the multi-question warn for a single-question prompt (happy path)', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { uuid: 'test', synthSeq: 0 }
+
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_aq_single',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'Q1?', options: [{ label: 'a' }] }] },
+      }, 'msg-aq-single')
+
+      const multiWarn = warnLines.find((m) => /multi-question forms are not yet supported/.test(m))
+      assert.equal(multiWarn, undefined, 'single-question must not trigger the multi-question warn')
+    })
+
+    it('watchdog fires after 30s when PostToolUse never arrives — clears busy + emits ASK_USER_QUESTION_STALL', () => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        session._term = { write: () => {}, kill: () => {} }
+        session._isBusy = true
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_stall',
+          options: [{ label: 'a' }, { label: 'b' }],
+        }
+
+        session.respondToQuestion('a')
+        // respondToQuestion clears _pendingUserAnswer synchronously at the
+        // top — simulate the stuck-form condition by reinstating it (this
+        // is what would happen if PostToolUse never arrived: chroxy wrote
+        // one digit but claude TUI is sitting on question 2).
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_stall',
+          options: [{ label: 'a' }, { label: 'b' }],
+        }
+
+        // Just under the watchdog window — nothing should fire yet.
+        mock.timers.tick(29_000)
+        assert.equal(errors.length, 0, 'no error before the 30s watchdog window')
+        assert.equal(session._isBusy, true, 'still busy before fire')
+
+        // Cross the threshold.
+        mock.timers.tick(2_000)
+
+        assert.equal(errors.length, 1, 'exactly one error after the watchdog fires')
+        assert.equal(errors[0].code, 'ASK_USER_QUESTION_STALL', 'error carries the structured code')
+        assert.equal(errors[0].toolUseId, 'toolu_aq_stall', 'error carries the toolUseId we armed with')
+        assert.match(errors[0].message, /retry/i, 'message tells the user to retry')
+
+        assert.equal(session._isBusy, false, 'busy cleared so the session is recoverable')
+        assert.equal(session._pendingUserAnswer, null, 'pending answer slot cleared')
+
+        const stallWarn = warnLines.find((m) => /AskUserQuestion stall/.test(m))
+        assert.ok(stallWarn, 'watchdog fire also logs a warn for triage')
+        assert.match(stallWarn, /toolu_aq_stall/, 'warn includes toolUseId')
+      } finally {
+        mock.timers.reset()
+      }
+    })
+
+    it('watchdog does NOT fire when PostToolUse arrives in time (happy path)', () => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._activeTurn = { uuid: 'test', synthSeq: 0 }
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        session._term = { write: () => {}, kill: () => {} }
+        session._isBusy = true
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_ok',
+          options: [{ label: 'a' }, { label: 'b' }],
+        }
+
+        session.respondToQuestion('a')
+
+        // Halfway through the watchdog window — claude TUI emits PostToolUse.
+        mock.timers.tick(15_000)
+        assert.equal(errors.length, 0, 'no error before PostToolUse')
+
+        session._emitToolHookEvent('PostToolUse', {
+          tool_use_id: 'toolu_aq_ok',
+          tool_name: 'AskUserQuestion',
+          tool_response: { selectedLabel: 'a' },
+        }, 'msg-aq-ok')
+
+        // Push well past the original 30s window — watchdog must have been
+        // cleared by PostToolUse, so no late fire.
+        mock.timers.tick(60_000)
+        assert.equal(errors.length, 0, 'watchdog cancelled by PostToolUse, no late stall error')
+      } finally {
+        mock.timers.reset()
+      }
+    })
+
+    it('watchdog is cleared on destroy() (clean teardown)', async () => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        session._term = { write: () => {}, kill: () => {} }
+        session._isBusy = true
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_destroy',
+          options: [{ label: 'a' }],
+        }
+
+        session.respondToQuestion('a')
+
+        // Tear down before the watchdog fires.
+        await session.destroy()
+        session = null  // afterEach should not double-destroy
+
+        // Push well past the watchdog window.
+        mock.timers.tick(60_000)
+        assert.equal(errors.length, 0, 'destroy() must cancel the watchdog — no late stall error')
+      } finally {
+        mock.timers.reset()
+      }
     })
   })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2569,6 +2569,40 @@ describe('ClaudeTuiSession', () => {
         mock.timers.reset()
       }
     })
+
+    it('watchdog is cleared on interrupt() so a user-interrupted answer does not fire ASK_USER_QUESTION_STALL', () => {
+      // #4604 review follow-up: interrupt() does NOT clear _isBusy directly
+      // (Ctrl-C resolves via _finishTurn* async). Without clearing the
+      // watchdog in interrupt(), the guard in _onAskUserQuestionStall
+      // (_pendingUserAnswer=null + _isBusy=true → does not bail) would
+      // emit a spurious ASK_USER_QUESTION_STALL ~30s after the user
+      // already interrupted the session.
+      mock.timers.enable({ apis: ['setTimeout'] })
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        session._term = { write: () => {}, kill: () => {} }
+        session._isBusy = true
+        session._activeTurn = { uuid: 'test', synthSeq: 0, aborted: false, startedAt: Date.now() }
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_interrupt',
+          options: [{ label: 'a' }],
+        }
+
+        session.respondToQuestion('a')
+        // User interrupts before claude TUI emits PostToolUse.
+        session.interrupt()
+
+        // Push well past the watchdog window — interrupt() must have
+        // cancelled the watchdog so no spurious stall error fires.
+        mock.timers.tick(60_000)
+        assert.equal(errors.length, 0, 'interrupt() must cancel the watchdog — no late stall error')
+      } finally {
+        mock.timers.reset()
+      }
+    })
   })
 
   // #4044: per-session option that spawns claude TUI with the literal


### PR DESCRIPTION
## Summary
Chunks A and C of #4604 — defensive additions that ship value independent of the root-cause Chunk B (which needs empirical claude TUI key-sequence testing). After this PR:
- Multi-question AskUserQuestion still hangs internally in claude TUI BUT chroxy now logs the condition (WARN) and recovers the session after 30s (`ASK_USER_QUESTION_STALL` error).
- Single-question AskUserQuestion (the happy path) behaves exactly as before.

### Chunk A — observability
- `[INFO]` log in `handleUserQuestionResponse` (input-handlers.js): toolUseId, answer length, answers-map key count
- `[INFO]` log on PreToolUse PendingUserAnswer set (claude-tui-session.js): toolUseId, question count, q1 option count
- `[WARN]` when questions.length > 1: surfaces the multi-question wedge condition for triage
- `[INFO]` at top of `respondToQuestion`: toolUseId, text length, answersMap keys, options count

### Chunk C — watchdog
- 30s timer armed after `respondToQuestion` dispatches PTY write
- On fire: WARN + clear `_isBusy` + clear `_pendingUserAnswer` + emit `ASK_USER_QUESTION_STALL` error so the dashboard can show "retry your message"
- Cleared on PostToolUse arrival (happy path) and on `destroy()`

### Out of scope (deferred to other chunks)
- Chunk B: real multi-question fix (server + dashboard rewrite) — needs empirical TUI key-sequence pinning
- Chunk D: full test coverage including Maestro

## Test plan
- [x] `cd packages/server && PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --experimental-test-module-mocks --test --test-force-exit tests/claude-tui-session.test.js`
- [x] Full server suite (pre-existing flakes confirmed unrelated)

Closes #4604 chunks A+C