### PR TITLE
fix(server): emit synthetic tool_result on stall watchdog (#4616)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1532,6 +1532,19 @@ export class ClaudeTuiSession extends BaseSession {
 
     this._pendingUserAnswer = null
     this._isBusy = false
+    // #4616: emit a synthetic tool_result FIRST so the dashboard's
+    // activeTools entry for this AskUserQuestion is cleared. Without it
+    // the footer "Running AskUserQuestion · Ns" pill keeps ticking
+    // forever even though _isBusy is clear and the user sees the
+    // ASK_USER_QUESTION_STALL error toast. The handler ignores any
+    // fields beyond {toolUseId, result, truncated, images} (see
+    // store-core handleToolResult); pairing-by-toolUseId is what drives
+    // the activeTools removal in store-core handlers.
+    this.emit('tool_result', {
+      toolUseId,
+      result: 'AskUserQuestion stalled — no response from claude TUI within 30s. Likely a multi-question form (#4604).',
+      truncated: false,
+    })
     this.emit('error', {
       code: 'ASK_USER_QUESTION_STALL',
       message: 'The agent\'s question response could not be delivered — likely a multi-question form. Please retry from your last message.',

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1335,7 +1335,18 @@ export class SdkSession extends BaseSession {
     // Attempt to abort the SDK query generator so no further events land
     // into a cleared message context. Best-effort — matches _handleHardTimeout.
     this._abortActiveQuery()
+    // #4616: snapshot sessionId BEFORE _clearMessageState wipes it so the
+    // synthetic `result` event below carries the correct identifier.
+    const sessionId = this._sdkSessionId || this._sessionId
     this._clearMessageState()
+    // #4616: emit a synthetic `result` so event-normalizer fans it to
+    // `agent_idle`. Per #4308 handleAgentIdle clears `activeTools: []`
+    // as a safety net, which is what stops the dashboard's footer pill
+    // from ticking after the stall. CLI does the equivalent via
+    // _emitInterruptedTurnResult (stream_end + result); the SDK was
+    // previously missing the `result` half of the pair. cost:null skips
+    // session-manager billing accumulation (mirrors CLI).
+    this.emit('result', { cost: null, duration: this._streamStallTimeoutMs, usage: null, sessionId })
     this.emit('error', {
       code: 'stream_stall',
       message: `Stream stalled — no response for ${friendly}. Try sending again.`,

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2570,6 +2570,62 @@ describe('ClaudeTuiSession', () => {
       }
     })
 
+    it('watchdog also emits synthetic tool_result so dashboard activeTools clears (#4616)', () => {
+      // #4616 — without the synthetic tool_result the dashboard's
+      // activeTools entry for this AskUserQuestion is never paired/cleared
+      // (handlers.handleToolResult.applyToActiveTools removes by toolUseId).
+      // Result: footer pill "Running AskUserQuestion · Ns" keeps ticking
+      // forever even though _isBusy is clear and the user sees the toast.
+      // Both events MUST emit, and tool_result MUST precede error so the
+      // dashboard's tool-pairing path resolves before the error toast lands.
+      mock.timers.enable({ apis: ['setTimeout'] })
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        const events = []
+        session.on('tool_result', (e) => events.push({ name: 'tool_result', payload: e }))
+        session.on('error', (e) => events.push({ name: 'error', payload: e }))
+
+        session._term = { write: () => {}, kill: () => {} }
+        session._isBusy = true
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_pair',
+          options: [{ label: 'a' }],
+        }
+
+        session.respondToQuestion('a')
+        // Reinstate the stuck-form condition as in the original watchdog test.
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_pair',
+          options: [{ label: 'a' }],
+        }
+
+        mock.timers.tick(31_000)
+
+        assert.equal(events.length, 2,
+          `expected exactly tool_result + error, got ${events.map(e => e.name).join(',')}`)
+        assert.deepEqual(events.map((e) => e.name), ['tool_result', 'error'],
+          'tool_result MUST precede error so activeTools clears before the toast lands')
+
+        const trEvent = events[0].payload
+        assert.equal(trEvent.toolUseId, 'toolu_aq_pair',
+          'tool_result.toolUseId must match the armed toolUseId so store-core applyToActiveTools removes the entry')
+        assert.equal(typeof trEvent.result, 'string',
+          'tool_result.result must be a string (store-core handleToolResult coerces non-strings to "")')
+        assert.equal(trEvent.truncated, false,
+          'tool_result.truncated must be boolean (store-core handleToolResult coerces non-booleans to false)')
+        assert.match(trEvent.result, /stalled/i,
+          'tool_result.result text references the stall so the bubble shows context')
+
+        const errEvent = events[1].payload
+        assert.equal(errEvent.code, 'ASK_USER_QUESTION_STALL',
+          'error event still carries the structured code so the dashboard toast renders correctly')
+        assert.equal(errEvent.toolUseId, 'toolu_aq_pair',
+          'error event still carries toolUseId for triage')
+      } finally {
+        mock.timers.reset()
+      }
+    })
+
     it('watchdog is cleared on interrupt() so a user-interrupted answer does not fire ASK_USER_QUESTION_STALL', () => {
       // #4604 review follow-up: interrupt() does NOT clear _isBusy directly
       // (Ctrl-C resolves via _finishTurn* async). Without clearing the

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -2621,5 +2621,45 @@ describe('SdkSession', () => {
       assert.deepEqual(events, [])
       s.destroy()
     })
+
+    it('emits synthetic `result` so event-normalizer fans to agent_idle → activeTools clear (#4616)', () => {
+      // #4616 — without the synthetic `result` event, the dashboard's
+      // activeTools entries linger after a stream stall: the event-
+      // normalizer only synthesizes `agent_idle` from `result` (see
+      // event-normalizer.js:253), and store-core handleAgentIdle clears
+      // `activeTools: []` as the #4308 safety net. CLI does the same via
+      // _emitInterruptedTurnResult (stream_end + result). Pre-#4616 the
+      // SDK was missing the `result` half of the pair, so its footer
+      // pill never cleared after a stall.
+      const s = createSession({ streamStallTimeoutMs: 60_000 })
+      s._isBusy = true
+      s._currentMessageId = 'msg_ss'
+      s._sessionId = 'sess_ss'
+      s._sdkSessionId = 'sess_ss'
+
+      const events = []
+      s.on('stream_end', (p) => events.push({ name: 'stream_end', payload: p }))
+      s.on('result', (p) => events.push({ name: 'result', payload: p }))
+      s.on('error', (p) => events.push({ name: 'error', payload: p }))
+
+      s._handleStreamStall('msg_ss', true)
+
+      assert.deepEqual(events.map((e) => e.name), ['stream_end', 'result', 'error'],
+        'order is stream_end → result → error so agent_idle lands before the toast')
+
+      const resultEvent = events[1].payload
+      assert.equal(resultEvent.cost, null,
+        'cost MUST be null so session-manager skips billing accumulation on a stalled turn')
+      assert.equal(resultEvent.usage, null,
+        'usage MUST be null on a stalled turn — no real assistant response was produced')
+      assert.equal(resultEvent.sessionId, 'sess_ss',
+        'sessionId snapshotted before _clearMessageState so the synthetic result is correctly identified')
+      assert.equal(typeof resultEvent.duration, 'number',
+        'duration carries the stall timeout so the dashboard can render an approximate turn time')
+
+      assert.equal(events[2].payload.code, 'stream_stall',
+        'error still carries the structured code for the dashboard stall chip')
+      s.destroy()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- AskUserQuestion stall watchdog (#4604 chunk C, shipped in #4614) correctly cleared server `_isBusy` but the dashboard's `activeTools` entry stayed because `_onAskUserQuestionStall` only emitted `error` — there was no paired `tool_result` to clear the entry. Footer pill `Running AskUserQuestion · Nh Mm` kept ticking forever on v0.9.18.
- Now emits `tool_result{toolUseId}` BEFORE the existing `error` event. store-core `handleToolResult.applyToActiveTools` removes the matching activeTools entry by toolUseId (#4308 wiring).
- Symmetric fix in `SdkSession._handleStreamStall` (#4467) flagged in the #4608 review: it emitted `stream_end + error` only, missing the `result` half of the pair. `event-normalizer` fans `result → agent_idle`, and per #4308 `handleAgentIdle` clears `activeTools: []` as the safety net. Adds a synthetic `result{cost:null}` matching CLI's `_emitInterruptedTurnResult`. `cost:null` skips session-manager billing accumulation.
- `CliSession._handleStreamStall` verified to already do this correctly: calls `_emitInterruptedTurnResult` which emits `stream_end` then `result`. No change needed (per #4608 review).

## Test plan
- [x] `claude-tui-session.test.js`: new test in `AskUserQuestion stall watchdog (#4604)` describe block asserts both `tool_result` and `error` emit, in that order, with matching `toolUseId`.
- [x] `sdk-session.test.js`: new test in `SdkSession._handleStreamStall (#4467: stream-stall recovery)` describe block asserts `stream_end → result → error` ordering, `cost:null`, `usage:null`, correct `sessionId`.
- [x] Full server suite: 6156 pass, 9 fail — all pre-existing/environmental (src/test-client.js is a CLI helper not a test; service.test.js + WebTaskManager flakes; smoke-test.mjs needs Playwright browser; TunnelManager needs cloudflared; WsServer drain is cross-test state contamination that passes when run alone). Confirmed baseline behaviour matches.
- [ ] Live verification will land when v0.9.19 is built and the next multi-question wedge fires.

Closes #4616