### PR TITLE
fix(server): sweep unresolved tool_starts on session restore (#4617)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1334,9 +1334,16 @@ export class SessionManager extends EventEmitter {
             if (n > this._sessionCounter) this._sessionCounter = n
           }
         }
-        // Restore message history if present (v1+)
+        // Restore message history if present (v1+).
+        // Sweep any `tool_start` that lacks a matching `tool_result` and
+        // splice in a synthetic interrupted result (#4617) BEFORE seeding
+        // history so the subsequent dashboard history replay never sees a
+        // dangling tool_start. Without this, an unresolved tool_use from
+        // before shutdown re-enters `activeTools` on replay and never gets
+        // cleared — the footer shows "Running X · Nh Mm" forever.
         if (hasVersion && Array.isArray(saved.history) && saved.history.length > 0) {
-          this._history.setHistory(sessionId, saved.history)
+          const swept = SessionMessageHistory.sweepUnresolvedToolStarts(saved.history)
+          this._history.setHistory(sessionId, swept)
         }
         if (typeof saved.lastActivityAt === 'number' && Number.isFinite(saved.lastActivityAt) && saved.lastActivityAt > 0) {
           this._sessionLastActivityAt.set(sessionId, saved.lastActivityAt)

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -152,6 +152,15 @@ export class SessionMessageHistory extends EventEmitter {
         const baseTs = typeof entry.timestamp === 'number' && Number.isFinite(entry.timestamp)
           ? entry.timestamp
           : Date.now()
+        // `synthetic` / `interrupted` / `isError` / `reason` are diagnostic
+        // hints only — no client code branches on them today, and the wire
+        // schema (`ServerToolResultSchema` in packages/protocol) strips
+        // unknown fields on parse. The behaviour that clears the dashboard's
+        // activeTools entry is driven purely by the `tool_result` type +
+        // matching `toolUseId` going through `handleToolResult.applyToActiveTools`
+        // (store-core/handlers/index.ts). Keep these fields anyway so the
+        // synthetic stays grep-able on disk and a future renderer can show
+        // a distinct "interrupted" badge without a protocol change.
         out.push({
           type: 'tool_result',
           toolUseId: entry.toolUseId,

--- a/packages/server/src/session-message-history.js
+++ b/packages/server/src/session-message-history.js
@@ -110,6 +110,67 @@ export class SessionMessageHistory extends EventEmitter {
   }
 
   /**
+   * Sweep an in-memory history array for `tool_start` entries that lack a
+   * matching `tool_result` and splice in a synthetic `tool_result` right
+   * after each one. Used during session restore (#4617) so that a session
+   * which was wedged on a tool when chroxy shut down does not zombify the
+   * dashboard's `activeTools` pill on the next history replay — the
+   * synthetic result rides the same handler path that normally clears
+   * activeTools (`handleToolResult.applyToActiveTools`).
+   *
+   * Returns a NEW array; the input is not mutated. The original ordering
+   * is preserved and the synthetic result is inserted immediately after
+   * its matching `tool_start`, with a timestamp one millisecond later so
+   * downstream consumers that sort by timestamp stay monotonic without
+   * pretending the tool completed "now".
+   *
+   * Safe to call on:
+   *   - empty / non-array input (returns the input unchanged)
+   *   - history with no tool_start entries (returns a shallow copy)
+   *   - history with all tool_starts already matched (returns a shallow copy)
+   *
+   * @param {Array} history
+   * @returns {Array}
+   */
+  static sweepUnresolvedToolStarts(history) {
+    if (!Array.isArray(history) || history.length === 0) return history
+    const resolved = new Set()
+    for (const entry of history) {
+      if (entry && entry.type === 'tool_result' && typeof entry.toolUseId === 'string') {
+        resolved.add(entry.toolUseId)
+      }
+    }
+    const out = []
+    for (const entry of history) {
+      out.push(entry)
+      if (
+        entry
+        && entry.type === 'tool_start'
+        && typeof entry.toolUseId === 'string'
+        && !resolved.has(entry.toolUseId)
+      ) {
+        const baseTs = typeof entry.timestamp === 'number' && Number.isFinite(entry.timestamp)
+          ? entry.timestamp
+          : Date.now()
+        out.push({
+          type: 'tool_result',
+          toolUseId: entry.toolUseId,
+          result: 'Tool was in flight when chroxy was last shut down. Tool may have continued or been cancelled — no record of outcome.',
+          interrupted: true,
+          isError: true,
+          synthetic: true,
+          reason: 'session_restored',
+          timestamp: baseTs + 1,
+        })
+        // Mark this toolUseId resolved so a malformed history with two
+        // tool_starts for the same id does not get two synthetic results.
+        resolved.add(entry.toolUseId)
+      }
+    }
+    return out
+  }
+
+  /**
    * Record a user input message in the session's history ring buffer.
    * On the first non-empty input, emits auto_label if the session qualifies.
    *

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -902,6 +902,58 @@ describe('SessionManager.restoreState', () => {
     mgr.destroyAll()
   })
 
+  // #4617 — a session wedged on a tool at shutdown persists a tool_start
+  // without a matching tool_result. Restore must splice in a synthetic
+  // interrupted tool_result so history replay clears the dashboard's
+  // activeTools entry instead of zombifying ("Running X · 4h+ forever").
+  it('sweeps unresolved tool_starts on restore so activeTools cannot zombify (#4617)', () => {
+    const wedgedHistory = [
+      { type: 'message', messageType: 'user_input', content: 'do something', timestamp: 1000 },
+      { type: 'tool_start', toolUseId: 'wedged-tool', tool: 'AskUserQuestion', timestamp: 1100 },
+      // No tool_result here — process died before it could complete.
+    ]
+    const completedHistory = [
+      { type: 'tool_start', toolUseId: 'completed', tool: 'Bash', timestamp: 2000 },
+      { type: 'tool_result', toolUseId: 'completed', result: 'done', timestamp: 2100 },
+    ]
+    writeFileSync(stateFile, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        { name: 'Wedged', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, history: wedgedHistory },
+        { name: 'Healthy', cwd: '/tmp', model: null, permissionMode: 'approve', sdkSessionId: null, history: completedHistory },
+      ],
+    }))
+
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile })
+    mgr.restoreState()
+
+    const sessions = mgr.listSessions()
+    const wedged = sessions.find(s => s.name === 'Wedged')
+    const healthy = sessions.find(s => s.name === 'Healthy')
+    assert.ok(wedged && healthy)
+
+    const wedgedAfter = mgr.getHistory(wedged.sessionId)
+    assert.equal(wedgedAfter.length, 3, 'synthetic tool_result spliced after the orphan tool_start')
+    assert.equal(wedgedAfter[1].type, 'tool_start')
+    assert.equal(wedgedAfter[1].toolUseId, 'wedged-tool')
+    assert.equal(wedgedAfter[2].type, 'tool_result')
+    assert.equal(wedgedAfter[2].toolUseId, 'wedged-tool')
+    assert.equal(wedgedAfter[2].synthetic, true)
+    assert.equal(wedgedAfter[2].interrupted, true)
+    assert.equal(wedgedAfter[2].isError, true)
+    assert.equal(wedgedAfter[2].reason, 'session_restored')
+    assert.ok(wedgedAfter[2].timestamp > wedgedAfter[1].timestamp, 'synthetic timestamp stays monotonic')
+
+    // The healthy session must NOT pick up any synthetic results — its
+    // tool_start already had a matching tool_result.
+    const healthyAfter = mgr.getHistory(healthy.sessionId)
+    assert.equal(healthyAfter.length, 2)
+    assert.notEqual(healthyAfter[1].synthetic, true)
+
+    mgr.destroyAll()
+  })
+
   // Regression for #2906 / PR #2907 Copilot finding: createSession() flushes
   // synchronously on session-list mutations, but restoreState() calls it in a
   // loop and seeds history/budget AFTER the loop. Without skipPersist, each

--- a/packages/server/tests/session-message-history.test.js
+++ b/packages/server/tests/session-message-history.test.js
@@ -481,8 +481,15 @@ describe('SessionMessageHistory', () => {
       const input = [
         { type: 'tool_start', toolUseId: 'A', tool: 'Bash', timestamp: 1000 },
       ]
+      const originalLength = input.length
       const copy = JSON.parse(JSON.stringify(input))
-      SessionMessageHistory.sweepUnresolvedToolStarts(input)
+      const out = SessionMessageHistory.sweepUnresolvedToolStarts(input)
+      // Belt-and-braces: assert array identity differs AND length/contents are
+      // unchanged. The deep-equal alone would miss a regression where
+      // someone refactors to `history.splice(...)` and the splice happens to
+      // leave the test fixture's values identical by accident.
+      assert.notStrictEqual(out, input, 'sweep must return a new array, not the input')
+      assert.equal(input.length, originalLength, 'input length unchanged')
       assert.deepStrictEqual(input, copy, 'input array left intact for crash-safe re-restore')
     })
 

--- a/packages/server/tests/session-message-history.test.js
+++ b/packages/server/tests/session-message-history.test.js
@@ -409,4 +409,114 @@ describe('SessionMessageHistory', () => {
       assert.equal(history.pendingStreams.size, 0)
     })
   })
+
+  // #4617 — session restore must not zombify the dashboard's activeTools pill.
+  // When a session was wedged on a tool at shutdown, the persisted history has
+  // a tool_start without a matching tool_result. The sweep synthesises the
+  // missing tool_result so history replay → handleToolResult → applyToActiveTools
+  // clears the entry on reconnect.
+  describe('sweepUnresolvedToolStarts (static)', () => {
+    it('injects a synthetic tool_result for an unresolved tool_start', () => {
+      const input = [
+        { type: 'tool_start', toolUseId: 'A', tool: 'AskUserQuestion', timestamp: 1000 },
+        { type: 'tool_start', toolUseId: 'B', tool: 'Bash', timestamp: 2000 },
+        { type: 'tool_result', toolUseId: 'B', result: 'ok', timestamp: 2500 },
+      ]
+      const out = SessionMessageHistory.sweepUnresolvedToolStarts(input)
+
+      assert.equal(out.length, 4, 'one synthetic result spliced after the orphan tool_start')
+      assert.equal(out[0].type, 'tool_start')
+      assert.equal(out[0].toolUseId, 'A')
+      assert.equal(out[1].type, 'tool_result')
+      assert.equal(out[1].toolUseId, 'A')
+      assert.equal(out[1].synthetic, true)
+      assert.equal(out[1].interrupted, true)
+      assert.equal(out[1].isError, true)
+      assert.equal(out[1].reason, 'session_restored')
+      // The matched B pair must remain untouched and in order.
+      assert.equal(out[2].type, 'tool_start')
+      assert.equal(out[2].toolUseId, 'B')
+      assert.equal(out[3].type, 'tool_result')
+      assert.equal(out[3].toolUseId, 'B')
+      assert.notEqual(out[3].synthetic, true)
+    })
+
+    it('is a no-op when every tool_start already has a matching tool_result', () => {
+      const input = [
+        { type: 'tool_start', toolUseId: 'A', tool: 'Read', timestamp: 1000 },
+        { type: 'tool_result', toolUseId: 'A', result: 'ok', timestamp: 1100 },
+        { type: 'tool_start', toolUseId: 'B', tool: 'Bash', timestamp: 2000 },
+        { type: 'tool_result', toolUseId: 'B', result: 'ok', timestamp: 2100 },
+      ]
+      const out = SessionMessageHistory.sweepUnresolvedToolStarts(input)
+      assert.equal(out.length, input.length, 'no synthetic entries when all pairs are matched')
+      for (let i = 0; i < input.length; i++) {
+        assert.deepStrictEqual(out[i], input[i])
+      }
+    })
+
+    it('flags synthetic results with synthetic + interrupted + isError', () => {
+      const input = [{ type: 'tool_start', toolUseId: 'X', tool: 'AskUserQuestion', timestamp: 5000 }]
+      const out = SessionMessageHistory.sweepUnresolvedToolStarts(input)
+      assert.equal(out.length, 2)
+      const synthetic = out[1]
+      assert.equal(synthetic.type, 'tool_result')
+      assert.equal(synthetic.toolUseId, 'X')
+      assert.equal(synthetic.synthetic, true)
+      assert.equal(synthetic.interrupted, true)
+      assert.equal(synthetic.isError, true)
+      assert.equal(synthetic.reason, 'session_restored')
+      assert.equal(typeof synthetic.result, 'string')
+      assert.ok(synthetic.result.length > 0)
+    })
+
+    it('keeps the synthetic timestamp strictly greater than the tool_start timestamp', () => {
+      const input = [{ type: 'tool_start', toolUseId: 'X', tool: 'Read', timestamp: 1700000000000 }]
+      const out = SessionMessageHistory.sweepUnresolvedToolStarts(input)
+      assert.equal(out[1].timestamp, 1700000000001)
+      assert.ok(out[1].timestamp > out[0].timestamp, 'timestamp monotonicity preserved')
+    })
+
+    it('does not mutate the input array', () => {
+      const input = [
+        { type: 'tool_start', toolUseId: 'A', tool: 'Bash', timestamp: 1000 },
+      ]
+      const copy = JSON.parse(JSON.stringify(input))
+      SessionMessageHistory.sweepUnresolvedToolStarts(input)
+      assert.deepStrictEqual(input, copy, 'input array left intact for crash-safe re-restore')
+    })
+
+    it('handles empty / non-array input gracefully', () => {
+      assert.deepStrictEqual(SessionMessageHistory.sweepUnresolvedToolStarts([]), [])
+      assert.equal(SessionMessageHistory.sweepUnresolvedToolStarts(null), null)
+      assert.equal(SessionMessageHistory.sweepUnresolvedToolStarts(undefined), undefined)
+    })
+
+    it('falls back to Date.now() when tool_start has no usable timestamp', () => {
+      // A pre-shutdown bug or older state file could persist a tool_start
+      // without a timestamp. The sweep must still produce a synthetic result;
+      // base on Date.now() so order is at least "recent" rather than negative.
+      const before = Date.now()
+      const out = SessionMessageHistory.sweepUnresolvedToolStarts([
+        { type: 'tool_start', toolUseId: 'A', tool: 'Read' },
+      ])
+      const after = Date.now()
+      assert.equal(out.length, 2)
+      assert.ok(out[1].timestamp >= before + 1)
+      assert.ok(out[1].timestamp <= after + 1)
+    })
+
+    it('only emits one synthetic result per toolUseId even if duplicate tool_starts appear', () => {
+      // Defence-in-depth: a malformed/concatenated history with two
+      // tool_starts sharing a toolUseId would otherwise produce two
+      // synthetics that both target the same activeTools entry.
+      const input = [
+        { type: 'tool_start', toolUseId: 'A', tool: 'Read', timestamp: 1000 },
+        { type: 'tool_start', toolUseId: 'A', tool: 'Read', timestamp: 2000 },
+      ]
+      const out = SessionMessageHistory.sweepUnresolvedToolStarts(input)
+      const synthetics = out.filter(e => e.type === 'tool_result' && e.synthetic === true)
+      assert.equal(synthetics.length, 1)
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Before this PR: if a session was wedged on a tool when chroxy shut down, the unresolved tool_start was persisted to session-state.json. On next restore, history replay re-emitted it to the dashboard and activeTools picked it up — but no path ever cleared it. Footer pill showed "Running X · 4h+" forever.
- After: session restore scans history and synthesizes a tool_result{interrupted:true, synthetic:true, reason:'session_restored'} for any tool_start that doesn't have a matching tool_result. Dashboard's tool-pairing path clears activeTools normally.

## Test plan
- [x] Unit tests cover the sweep logic + edge cases
- [x] Live verification will land when v0.9.19 is built — restart with a wedged session, confirm activeTools is empty on dashboard reconnect

Closes #4617