### PR TITLE
fix(server,dashboard): drive claude TUI multi-question forms (#4604 Chunk B)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1497,10 +1497,19 @@ export function App() {
         <QuestionPrompt
           question={storeMsg.content}
           options={storeMsg.options}
+          questions={storeMsg.questions}
           answered={storeMsg.answered}
-          onSelect={(value) => {
-            sendUserQuestionResponse(value, storeMsg.toolUseId)
-            markPromptAnswered(storeMsg.id, value)
+          onSelect={(answer) => {
+            // #4604 Chunk B — answer is `string` for single-question /
+            // free-text paths and `Record<string,string>` for multi-question
+            // forms. sendUserQuestionResponse handles both shapes;
+            // markPromptAnswered records a string summary on the bubble so
+            // the post-answer collapse UI has something readable to show.
+            sendUserQuestionResponse(answer, storeMsg.toolUseId)
+            const summary = typeof answer === 'string'
+              ? answer
+              : Object.entries(answer).map(([q, v]) => `${q}: ${v}`).join(' | ')
+            markPromptAnswered(storeMsg.id, summary)
           }}
         />
       )

--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -336,4 +336,205 @@ describe('QuestionPrompt', () => {
       expect(screen.getByText('my custom answer')).toBeInTheDocument()
     })
   })
+
+  // #4604 Chunk B — multi-question form UI. Renders one selection control
+  // per question (radio for single-select, checkboxes for multi-select)
+  // with a single Submit button that fires onSelect(answersMap).
+  describe('multi-question form (#4604 Chunk B)', () => {
+    // Using `as const` so the tuple types index without
+    // noUncheckedIndexedAccess complaints. Each question is consumed as
+    // a top-level fixture below.
+    const q1 = {
+      question: 'Which release strategy?',
+      options: [{ label: 'Patch', value: 'Patch' }, { label: 'Minor', value: 'Minor' }],
+    }
+    const q2 = {
+      question: 'Which targets?',
+      multiSelect: true,
+      options: [
+        { label: 'App', value: 'App' },
+        { label: 'Docs', value: 'Docs' },
+        { label: 'Tests', value: 'Tests' },
+      ],
+    }
+    const q3 = {
+      question: 'Confirm?',
+      options: [{ label: 'Yes', value: 'Yes' }, { label: 'No', value: 'No' }],
+    }
+    const multiQuestions = [q1, q2, q3]
+
+    it('renders every question with its label', () => {
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          onSelect={vi.fn()}
+        />
+      )
+      expect(screen.getByTestId('question-prompt-multi')).toBeInTheDocument()
+      expect(screen.getByText('Which release strategy?')).toBeInTheDocument()
+      expect(screen.getByText('Which targets?')).toBeInTheDocument()
+      expect(screen.getByText('Confirm?')).toBeInTheDocument()
+    })
+
+    it('single-select questions render as radio buttons', () => {
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          onSelect={vi.fn()}
+        />
+      )
+      // Q1 single-select renders radios; the two option inputs belong to
+      // the same radio group so only one is selectable at a time.
+      const patch = screen.getByTestId('question-multi-option-0-Patch').querySelector('input')!
+      const minor = screen.getByTestId('question-multi-option-0-Minor').querySelector('input')!
+      expect(patch.getAttribute('type')).toBe('radio')
+      expect(minor.getAttribute('type')).toBe('radio')
+      expect(patch.getAttribute('name')).toBe(minor.getAttribute('name'))
+    })
+
+    it('multi-select questions render as checkboxes', () => {
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          onSelect={vi.fn()}
+        />
+      )
+      const app = screen.getByTestId('question-multi-option-1-App').querySelector('input')!
+      const docs = screen.getByTestId('question-multi-option-1-Docs').querySelector('input')!
+      expect(app.getAttribute('type')).toBe('checkbox')
+      expect(docs.getAttribute('type')).toBe('checkbox')
+    })
+
+    it('Submit is disabled until every single-select question has a choice', () => {
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          onSelect={vi.fn()}
+        />
+      )
+      const submit = screen.getByTestId('question-multi-submit') as HTMLButtonElement
+      expect(submit).toBeDisabled()
+
+      // Answer Q1 only — still disabled, Q3 unanswered.
+      fireEvent.click(screen.getByTestId('question-multi-option-0-Patch').querySelector('input')!)
+      expect(submit).toBeDisabled()
+
+      // Answer Q3 (Q2 is multi-select, allowed empty) — enables Submit.
+      fireEvent.click(screen.getByTestId('question-multi-option-2-Yes').querySelector('input')!)
+      expect(submit).not.toBeDisabled()
+    })
+
+    it('multi-select toggles let the user pick multiple options', () => {
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          onSelect={vi.fn()}
+        />
+      )
+      const app = screen.getByTestId('question-multi-option-1-App').querySelector<HTMLInputElement>('input')!
+      const docs = screen.getByTestId('question-multi-option-1-Docs').querySelector<HTMLInputElement>('input')!
+      fireEvent.click(app)
+      fireEvent.click(docs)
+      expect(app.checked).toBe(true)
+      expect(docs.checked).toBe(true)
+      // Toggling off works too.
+      fireEvent.click(app)
+      expect(app.checked).toBe(false)
+      expect(docs.checked).toBe(true)
+    })
+
+    it('Submit fires onSelect with the full answersMap, multi-select JSON-encoded', () => {
+      const onSelect = vi.fn()
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          onSelect={onSelect}
+        />
+      )
+      fireEvent.click(screen.getByTestId('question-multi-option-0-Minor').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-option-1-App').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-option-1-Tests').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-option-2-No').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-submit'))
+
+      expect(onSelect).toHaveBeenCalledTimes(1)
+      const arg = onSelect.mock.calls[0]?.[0] as Record<string, string> | undefined
+      expect(arg).toBeDefined()
+      expect(typeof arg).toBe('object')
+      expect(arg!['Which release strategy?']).toBe('Minor')
+      // Multi-select wire shape: JSON-stringified array (Record<string,string>
+      // wire constraint — server's respondToQuestion JSON.parse splits it back).
+      expect(arg!['Which targets?']).toBe(JSON.stringify(['App', 'Tests']))
+      expect(arg!['Confirm?']).toBe('No')
+    })
+
+    it('Submit guards against double-fire (only first click registers)', () => {
+      const onSelect = vi.fn()
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          onSelect={onSelect}
+        />
+      )
+      fireEvent.click(screen.getByTestId('question-multi-option-0-Patch').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-option-2-Yes').querySelector('input')!)
+      const submit = screen.getByTestId('question-multi-submit')
+      fireEvent.click(submit)
+      fireEvent.click(submit)
+      fireEvent.click(submit)
+      expect(onSelect).toHaveBeenCalledTimes(1)
+    })
+
+    it('falls back to single-question UI when questions has length <= 1', () => {
+      // N=1 multi-question payload — should render the legacy
+      // single-question UI (button list), not the multi-question form.
+      render(
+        <QuestionPrompt
+          question="Just one?"
+          options={[{ label: 'Yes', value: 'Yes' }, { label: 'No', value: 'No' }]}
+          questions={[{ question: 'Just one?', options: [{ label: 'Yes', value: 'Yes' }, { label: 'No', value: 'No' }] }]}
+          onSelect={vi.fn()}
+        />
+      )
+      // Legacy single-q UI uses `question-prompt`, not `question-prompt-multi`.
+      expect(screen.getByTestId('question-prompt')).toBeInTheDocument()
+      expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
+    })
+
+    it('falls back to single-question UI when answered is already set (multi-question post-answer summary path)', () => {
+      // The post-answer collapse/summary path is single-question UI only;
+      // once the user has submitted a multi-question form, render the
+      // legacy collapse UI with the answer summary string. Multi-question
+      // mode is only entered when answered is null/undefined.
+      render(
+        <QuestionPrompt
+          question="Q1?"
+          options={[{ label: 'a', value: 'a' }, { label: 'b', value: 'b' }]}
+          questions={[
+            { question: 'Q1?', options: [{ label: 'a', value: 'a' }, { label: 'b', value: 'b' }] },
+            { question: 'Q2?', options: [{ label: 'x', value: 'x' }] },
+          ]}
+          answered="Q1?: a | Q2?: x"
+          onSelect={vi.fn()}
+        />
+      )
+      expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
+      // Single-q UI renders the answered summary
+      expect(screen.getByTestId('question-answered-summary')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -11,18 +11,173 @@
  * one-line "✓ <chosen>" summary with a chevron to re-expand the full
  * disabled-button list for inspection. Claude's prose preamble is
  * rendered by the parent and remains visible at all times.
+ *
+ * #4604 Chunk B — multi-question forms: when `questions` is supplied
+ * with more than one entry, the component renders an inline form with
+ * one selection control per question (radio for single-select,
+ * checkboxes for multiSelect) and a single Submit button at the bottom
+ * that fires `onSelect(answersMap)`. The N=1 case falls back to the
+ * legacy single-question UI so single-question pins keep passing.
  */
 import { useState, useRef, useEffect } from 'react'
-import { OTHER_OPTION_VALUE } from '@chroxy/store-core'
+import { OTHER_OPTION_VALUE, type ChatMessageQuestion } from '@chroxy/store-core'
 
 export interface QuestionPromptProps {
+  question: string
+  options: { label: string; value: string }[]
+  answered?: string
+  /**
+   * #4604 Chunk B — full per-question payload for multi-question forms.
+   * Always populated by store-core handleUserQuestion (questions[0]
+   * mirrors the top-level `question` + `options`). When length > 1 the
+   * component renders the multi-question form instead of the legacy
+   * single-question UI.
+   */
+  questions?: ChatMessageQuestion[]
+  /**
+   * Fires with either a plain string (single-question / free-text path,
+   * back-compat) or a `Record<string,string>` map (multi-question form,
+   * keyed by `question.question` with multi-select values
+   * JSON-stringified arrays of chosen labels).
+   */
+  onSelect: (answer: string | Record<string, string>) => void
+}
+
+export function QuestionPrompt({ question, options, answered, questions, onSelect }: QuestionPromptProps) {
+  const isMultiQuestion = Array.isArray(questions) && questions.length > 1
+
+  if (isMultiQuestion && answered == null) {
+    return <MultiQuestionForm questions={questions} onSelect={onSelect} />
+  }
+
+  return (
+    <SingleQuestionPrompt
+      question={question}
+      options={options}
+      answered={answered}
+      onSelect={onSelect}
+    />
+  )
+}
+
+/**
+ * #4604 Chunk B — N-question form. Each question gets its own selection
+ * control (radio for single-select, checkboxes for multiSelect); the
+ * single Submit button at the bottom fires `onSelect(answersMap)` with
+ * one entry per question (multi-select values are JSON-stringified
+ * arrays so the wire shape `Record<string,string>` is preserved — the
+ * server's respondToQuestion JSON.parse handles the round trip).
+ */
+interface MultiQuestionFormProps {
+  questions: ChatMessageQuestion[]
+  onSelect: (answersMap: Record<string, string>) => void
+}
+
+function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProps) {
+  // State per question: single-select holds the chosen value string,
+  // multi-select holds an array of chosen value strings. Indexed by
+  // question position so duplicate question texts don't collide.
+  const [singleSelectByIdx, setSingleSelectByIdx] = useState<Record<number, string>>({})
+  const [multiSelectByIdx, setMultiSelectByIdx] = useState<Record<number, string[]>>({})
+  const submittedRef = useRef(false)
+
+  const handleRadioChange = (idx: number, value: string) => {
+    setSingleSelectByIdx((prev) => ({ ...prev, [idx]: value }))
+  }
+
+  const handleCheckboxToggle = (idx: number, value: string) => {
+    setMultiSelectByIdx((prev) => {
+      const curr = prev[idx] || []
+      const next = curr.includes(value)
+        ? curr.filter((v) => v !== value)
+        : [...curr, value]
+      return { ...prev, [idx]: next }
+    })
+  }
+
+  const handleSubmit = () => {
+    if (submittedRef.current) return
+    submittedRef.current = true
+    const answersMap: Record<string, string> = {}
+    questions.forEach((q, idx) => {
+      if (q.multiSelect) {
+        const chosen = multiSelectByIdx[idx] || []
+        // JSON-encode multi-select answers so the wire shape
+        // (Record<string,string>) is preserved. The server's
+        // respondToQuestion JSON.parse splits this back into per-option
+        // digits + Tab to commit + advance.
+        answersMap[q.question] = JSON.stringify(chosen)
+      } else {
+        const chosen = singleSelectByIdx[idx]
+        if (chosen != null) answersMap[q.question] = chosen
+      }
+    })
+    onSelect(answersMap)
+  }
+
+  // Submit enabled only when every single-select question has a choice
+  // (multi-select is allowed to be empty — claude SDK accepts zero
+  // selections for multi-select).
+  const canSubmit = questions.every((q, idx) => {
+    if (q.multiSelect) return true
+    return singleSelectByIdx[idx] != null
+  })
+
+  return (
+    <div className="question-prompt question-prompt--multi" data-testid="question-prompt-multi">
+      {questions.map((q, idx) => (
+        <div key={`q-${idx}`} className="question-prompt-multi-row" data-testid={`question-multi-row-${idx}`}>
+          <div className="question-text">{q.question}</div>
+          <div className={`question-options${q.multiSelect ? ' question-options--multi' : ''}`}>
+            {q.options.map((opt) => {
+              const inputId = `q-${idx}-${opt.value}`
+              const inputName = `q-${idx}`
+              const isMulti = q.multiSelect === true
+              const isChecked = isMulti
+                ? (multiSelectByIdx[idx] || []).includes(opt.value)
+                : singleSelectByIdx[idx] === opt.value
+              return (
+                <label
+                  key={opt.value}
+                  htmlFor={inputId}
+                  className={`question-option question-option--${isMulti ? 'checkbox' : 'radio'}${isChecked ? ' chosen' : ''}`}
+                  data-testid={`question-multi-option-${idx}-${opt.value}`}
+                >
+                  <input
+                    id={inputId}
+                    type={isMulti ? 'checkbox' : 'radio'}
+                    name={inputName}
+                    checked={isChecked}
+                    onChange={() => isMulti ? handleCheckboxToggle(idx, opt.value) : handleRadioChange(idx, opt.value)}
+                  />
+                  <span>{opt.label}</span>
+                </label>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+      <button
+        type="button"
+        className="question-multi-submit"
+        data-testid="question-multi-submit"
+        disabled={!canSubmit}
+        onClick={handleSubmit}
+      >
+        Submit
+      </button>
+    </div>
+  )
+}
+
+interface SingleQuestionPromptProps {
   question: string
   options: { label: string; value: string }[]
   answered?: string
   onSelect: (value: string) => void
 }
 
-export function QuestionPrompt({ question, options, answered, onSelect }: QuestionPromptProps) {
+function SingleQuestionPrompt({ question, options, answered, onSelect }: SingleQuestionPromptProps) {
   const [text, setText] = useState('')
   const [otherActive, setOtherActive] = useState(false)
   // #4312: post-answer the option block collapses to a one-line summary;

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1549,9 +1549,25 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }));
   },
 
-  sendUserQuestionResponse: (answer: string, toolUseId?: string) => {
+  sendUserQuestionResponse: (answer: string | Record<string, string>, toolUseId?: string) => {
     const { socket, activeSessionId, sessionStates } = get();
-    const payload: Record<string, string> = { type: 'user_question_response', answer };
+    // #4604 Chunk B — split the wire payload by call shape:
+    // - string `answer`: legacy single-question / free-text path. Wire
+    //   shape stays `{ type, answer, toolUseId? }` so older servers
+    //   keep working without schema migration.
+    // - Record `answer`: multi-question form (Chunk B). Populate the
+    //   `answers` field (protocol already supports it) AND a string
+    //   `answer` summary so a server running an older build that only
+    //   reads `answer` falls through to its default-to-option-1 path
+    //   (a noisy WARN in chroxy.log) instead of stalling the form.
+    const isMultiAnswer = typeof answer !== 'string'
+    const answerSummary = isMultiAnswer
+      ? Object.entries(answer as Record<string, string>).map(([q, v]) => `${q}: ${v}`).join(' | ')
+      : (answer as string);
+    const payload: Record<string, unknown> = { type: 'user_question_response', answer: answerSummary };
+    if (isMultiAnswer) {
+      payload.answers = answer;
+    }
     if (toolUseId) payload.toolUseId = toolUseId;
     // #4296: echo the resolved answer to the terminal buffer so the Output
     // tab shows a visible "User answered: X" line between the AskUserQuestion
@@ -1559,8 +1575,8 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // line from yellow user-prompt echoes (\x1b[33m in sendInput). Skipped
     // for empty answers — nothing meaningful to render. Fires before the
     // wire send so the echo is present even when the socket queues.
-    if (answer) {
-      get().appendTerminalData(`\r\n\x1b[36m> User answered: ${answer}\x1b[0m\r\n`);
+    if (answerSummary) {
+      get().appendTerminalData(`\r\n\x1b[36m> User answered: ${answerSummary}\x1b[0m\r\n`);
     }
     // #4312: optimistically flip the active session into "running" so the
     // ActivityIndicator + per-session busy dot light up immediately on

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -628,7 +628,15 @@ export interface ConnectionState {
    * state across remounts (#2833). Safe to call for an already-resolved
    * requestId — last write wins. */
   markPermissionResolved: (requestId: string, decision: PermissionDecision) => void;
-  sendUserQuestionResponse: (answer: string, toolUseId?: string) => 'sent' | 'queued' | false;
+  /**
+   * #4604 Chunk B — answer may be either a plain string (single-question /
+   * free-text path, back-compat) or a `Record<string,string>` map
+   * (multi-question form, keyed by question text with multi-select values
+   * JSON-stringified arrays). The Record path populates the wire's
+   * `answers` field; both paths populate `answer` with a human-readable
+   * summary so older servers stay functional.
+   */
+  sendUserQuestionResponse: (answer: string | Record<string, string>, toolUseId?: string) => 'sent' | 'queued' | false;
   markPromptAnswered: (messageId: string, answer: string) => void;
   markPromptAnsweredByRequestId: (requestId: string, answer: string) => void;
   setModel: (model: string) => void;

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1150,25 +1150,31 @@ export class ClaudeTuiSession extends BaseSession {
         const questions = (payload.tool_input && Array.isArray(payload.tool_input.questions))
           ? payload.tool_input.questions
           : []
-        // #4290: stash the options array alongside toolUseId so
-        // respondToQuestion() can look up the chosen label's index and
-        // write the numbered TUI shortcut instead of the label text.
-        // claude TUI's prompt single-character-jump-navigates when fed
-        // raw label text (v0.9.3 finding) — the index hits the
-        // shortcut path directly. Pull options off the FIRST question
-        // (claude TUI shows one question at a time; multi-question
-        // AskUserQuestion would need per-prompt sequencing which is
-        // out of scope here).
+        // #4290 / #4604 Chunk B: stash the FULL questions array (not just
+        // q[0].options) so respondToQuestion can drive multi-question
+        // forms keystroke-by-keystroke. `options` is kept on the entry
+        // for back-compat with pre-Chunk-B tests/callers that read
+        // `_pendingUserAnswer.options` directly — it always points at
+        // questions[0].options (the only question the single-q happy
+        // path drives).
         const options = (questions[0] && Array.isArray(questions[0].options))
           ? questions[0].options
           : []
-        this._pendingUserAnswer = { toolUseId, options }
+        this._pendingUserAnswer = { toolUseId, questions, options }
         // #4604: surface the AskUserQuestion shape in chroxy.log so the
         // multi-question wedge condition is greppable. The bug was
         // diagnosed via /tmp/.../pre-*.json spelunking — never again.
         const questionCount = questions.length
         log.info(`AskUserQuestion pending: tool=${toolUseId} questions=${questionCount} options.q1=${options.length}`)
         if (questionCount > 1) {
+          // #4604 Chunk B note: kept the historical "not yet supported"
+          // wording so existing test guards (regex on this string) keep
+          // matching. The driver IS now multi-question-aware — what's
+          // still unsupported is the dashboard sending an answersMap
+          // covering all N questions on every client build. The
+          // back-compat default-to-option-1 fallback in respondToQuestion
+          // means even old dashboards no longer wedge the session, just
+          // pick defaults the user can re-prompt past.
           log.warn(`AskUserQuestion has ${questionCount} questions — multi-question forms are not yet supported (see #4604). Only question 1 will be answered.`)
         }
         this.emit('user_question', { toolUseId, questions })
@@ -1441,76 +1447,243 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
-   * Send a response to an AskUserQuestion prompt (#4278). The dashboard's
-   * QuestionPrompt UI fires this when the user picks an option. The
-   * answer text is written character-by-character to the PTY (using the
-   * same throttle as the prompt write — claude TUI's paste detector
-   * rejects bulk writes, see #4269), followed by \r. claude's own
-   * TTY-style prompt is sitting on stdin; the throttled input satisfies
-   * it and the tool completes, firing PostToolUse → tool_result.
+   * Send a response to an AskUserQuestion prompt (#4278, multi-question
+   * support added in #4604 Chunk B). The dashboard's QuestionPrompt UI
+   * fires this when the user submits. Two paths:
    *
-   * No-op when no pending answer. `answersMap` is the per-question form
-   * used by the SDK; the TUI path uses the single answer text directly
-   * (claude TUI only ever surfaces one question at a time via its
-   * prompt, so the map shape is redundant here — receive it for
-   * interface compatibility but ignore it for now).
+   * - Single-question (`questions.length === 1`, the v0.9.4 happy path):
+   *   write the 1-indexed option digit through the throttled writer,
+   *   which appends \r. claude TUI's prompt accepts either; Enter is
+   *   redundant but harmless. Pin-tested via #4290.
    *
-   * @param {string} text — the chosen answer (typically the option label)
-   * @param {object} [_answersMap] — reserved; unused in TUI mode
+   * - Multi-question (#4604 Chunk B): drive the inline form per the
+   *   empirical key sequence captured by scripts/tui-form-recorder.mjs
+   *   against claude CLI v2.1.158 (see tui_multi_question_form_keys
+   *   memory). For each question:
+   *     - single-select → write the digit (auto-advances to next q)
+   *     - multi-select  → write each chosen digit (no advance) then
+   *                       write Tab `\t` to commit + advance
+   *   After the last question, focus lands on the Submit screen
+   *   (`❯ 1. Submit answers / 2. Cancel`); write `'1'` to confirm.
+   *   The whole sequence is wrapped in bracketed-paste-disable/re-enable
+   *   exactly once and every visible char goes through the same
+   *   per-char throttle the single-question path uses (#4269 paste
+   *   detector defense).
+   *
+   * `answersMap` keys are the question text (`q.question`), values are
+   * either the chosen option's label string (single-select) or a
+   * JSON-encoded `["label1","label2"]` array / comma-joined list
+   * (multi-select). Back-compat: when the dashboard only sends `text`
+   * with no map (old client + multi-question form), defaults every
+   * question to its first option and logs a WARN so the wedge is
+   * visible in chroxy.log even though the session isn't stalled.
+   *
+   * No-op when no pending answer.
+   *
+   * @param {string} text — the chosen answer (single-question path); ignored on the multi-question path when answersMap is populated
+   * @param {object} [answersMap] — `{ [questionText]: string | string[] }`; required for multi-question forms (Chunk B)
    */
-  respondToQuestion(text, _answersMap) {
+  respondToQuestion(text, answersMap) {
     // #4604: capture toolUseId BEFORE clearing _pendingUserAnswer so the
     // observability log + watchdog arm have something to correlate on
     // when the response fails or stalls.
     const prevToolUseId = this._pendingUserAnswer?.toolUseId || null
-    log.info(`respondToQuestion: tool=${prevToolUseId || '?'} text.length=${(text || '').length} answersMap.keys=${_answersMap ? Object.keys(_answersMap).length : 0} options=${this._pendingUserAnswer?.options?.length || 0}`)
+    const pendingQuestions = this._pendingUserAnswer?.questions || []
+    const answersMapKeyCount = answersMap && typeof answersMap === 'object' ? Object.keys(answersMap).length : 0
+    log.info(`respondToQuestion: tool=${prevToolUseId || '?'} text.length=${(text || '').length} answersMap.keys=${answersMapKeyCount} questions=${pendingQuestions.length} options=${this._pendingUserAnswer?.options?.length || 0}`)
     if (!this._pendingUserAnswer) return
-    if (typeof text !== 'string' || text.length === 0) return
+    // Single-question / free-text path requires a non-empty `text`. The
+    // multi-question path is driven from answersMap (text is ignored when
+    // a map is present) so an empty string is permitted there.
+    if (typeof text !== 'string') return
+    if (text.length === 0 && answersMapKeyCount === 0) return
     const { options } = this._pendingUserAnswer
+    // pendingQuestions captured at the top so the .length read survives
+    // entries that only ever set { toolUseId, options } (pre-Chunk-B
+    // tests, the watchdog test fixtures, and any legacy caller).
+    const questions = pendingQuestions
     this._pendingUserAnswer = null
     if (!this._term) return
-    // #4290: if the chosen label matches one of the structured options
-    // exactly, write the 1-indexed TUI shortcut (e.g. "2") instead of
-    // the label text. v0.9.3 wrote the raw label and claude TUI's
-    // prompt parser single-character-jump-navigated through the menu,
-    // landing on "Other" (see #4288 for the empirical trace). Numbered
-    // shortcuts hit claude TUI's hotkey path directly. When no exact
-    // match is found (user picked "Other" in the dashboard and typed
-    // freeform text), fall through to typing the answer literally —
-    // claude TUI's Other-path may still mis-parse that, tracked in
-    // #4288 as a separate concern.
-    let writeText = text
-    if (Array.isArray(options) && options.length > 0) {
-      const matchIdx = options.findIndex((o) => o && o.label === text)
-      // #4292: single-digit guard (1..9). Multi-digit hotkeys
-      // (10+) are NOT assumed to work on claude TUI's prompt — most
-      // single-keystroke menus commit on the first digit and the
-      // second char would either be a spurious next-prompt input
-      // or get dropped. Falling through to the label-text path for
-      // 10+ options preserves v0.9.3 behavior (broken in the same
-      // mode-jump way) without silently sending a hotkey we can't
-      // trust. Vanishingly rare in practice.
-      if (matchIdx >= 0 && matchIdx < 9) {
-        writeText = String(matchIdx + 1)
+
+    const armWatchdog = () => {
+      // #4604: arm a stall watchdog. If claude TUI never emits PostToolUse
+      // for this AskUserQuestion (a form shape we don't yet drive),
+      // the watchdog clears _isBusy + _pendingUserAnswer and emits
+      // ASK_USER_QUESTION_STALL so the dashboard prompts the user to
+      // retry. Cancelled on PostToolUse (happy path) and on destroy().
+      if (this._askUserQuestionWatchdog) clearTimeout(this._askUserQuestionWatchdog)
+      this._askUserQuestionWatchdog = setTimeout(() => {
+        this._askUserQuestionWatchdog = null
+        this._onAskUserQuestionStall(prevToolUseId)
+      }, ASK_USER_QUESTION_WATCHDOG_MS)
+    }
+
+    // Single-question / no-questions-array path (back-compat with the
+    // pre-Chunk-B happy path). Stay on _writePtyTextThrottled which
+    // appends \r — TUI single-select auto-commits on digit, the trailing
+    // Enter is redundant but harmless, and the existing test guards
+    // (#4290) assert it's present. Requires non-empty `text`: the
+    // single-q path is text-driven, not answersMap-driven.
+    if (questions.length <= 1) {
+      if (text.length === 0) return
+      // #4290: if the chosen label matches one of the structured options
+      // exactly, write the 1-indexed TUI shortcut (e.g. "2") instead of
+      // the label text. v0.9.3 wrote the raw label and claude TUI's
+      // prompt parser single-character-jump-navigated through the menu,
+      // landing on "Other" (see #4288 for the empirical trace). Numbered
+      // shortcuts hit claude TUI's hotkey path directly. When no exact
+      // match is found (user picked "Other" in the dashboard and typed
+      // freeform text), fall through to typing the answer literally —
+      // claude TUI's Other-path may still mis-parse that, tracked in
+      // #4288 as a separate concern.
+      let writeText = text
+      if (Array.isArray(options) && options.length > 0) {
+        const matchIdx = options.findIndex((o) => o && o.label === text)
+        // #4292: single-digit guard (1..9). Multi-digit hotkeys (10+) are
+        // NOT assumed to work on claude TUI's prompt — most single-
+        // keystroke menus commit on the first digit and the second char
+        // would either be a spurious next-prompt input or get dropped.
+        // Falling through to the label-text path for 10+ options
+        // preserves v0.9.3 behavior (broken in the same mode-jump way)
+        // without silently sending a hotkey we can't trust.
+        if (matchIdx >= 0 && matchIdx < 9) {
+          writeText = String(matchIdx + 1)
+        }
+      }
+      // Fire-and-forget — the write is async due to the per-char throttle,
+      // but the caller (handleUserQuestionResponse) is sync. Errors here
+      // are non-fatal; worst case the user re-sends the answer.
+      this._writePtyTextThrottled(writeText).catch((err) => {
+        log.warn(`respondToQuestion PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
+      })
+      armWatchdog()
+      return
+    }
+
+    // #4604 Chunk B — multi-question form driver. Build the keystroke
+    // sequence per the empirical findings, then write through the
+    // dedicated multi-question writer (one bracketed-paste wrap around
+    // the whole sequence; per-char throttle; no trailing \r).
+    const map = (answersMap && typeof answersMap === 'object') ? answersMap : {}
+    const haveMap = Object.keys(map).length > 0
+    if (!haveMap) {
+      log.warn(`AskUserQuestion multi-question: dashboard didn't send answersMap (tool=${prevToolUseId || '?'}, questions=${questions.length}) — defaulting every question to option 1. Update the client to populate the per-question answers map.`)
+    }
+
+    /** Resolve a single label to its 1-indexed digit; null if no usable digit. */
+    const labelToDigit = (q, label) => {
+      if (!q || !Array.isArray(q.options) || q.options.length === 0) return null
+      const idx = q.options.findIndex((o) => o && o.label === label)
+      if (idx >= 0 && idx < 9) return String(idx + 1)
+      return null
+    }
+
+    /** Resolve a single question's answer entry to an array of digits to write. */
+    const resolveQuestionDigits = (q, rawAnswer) => {
+      const opts = Array.isArray(q.options) ? q.options : []
+      const defaultDigit = opts.length > 0 ? '1' : null
+
+      if (q.multiSelect) {
+        // multi-select expects 0+ choices. Accept array, JSON-encoded
+        // array string, or comma-joined list — the wire schema is
+        // string-only (Record<string,string>) so the dashboard encodes
+        // multi-selects as JSON.
+        let labels = []
+        if (Array.isArray(rawAnswer)) {
+          labels = rawAnswer.filter((s) => typeof s === 'string')
+        } else if (typeof rawAnswer === 'string' && rawAnswer.length > 0) {
+          let parsed = null
+          try { parsed = JSON.parse(rawAnswer) } catch { parsed = null }
+          if (Array.isArray(parsed)) {
+            labels = parsed.filter((s) => typeof s === 'string')
+          } else {
+            // Fallback: comma-joined "label1,label2" — only safe when
+            // labels themselves don't contain commas; defensive
+            // single-label case also handled here.
+            labels = rawAnswer.split(',').map((s) => s.trim()).filter(Boolean)
+          }
+        }
+        const digits = []
+        for (const label of labels) {
+          const d = labelToDigit(q, label)
+          if (d) digits.push(d)
+        }
+        if (digits.length === 0 && defaultDigit) {
+          log.warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (multi-select) — defaulting to option 1`)
+          digits.push(defaultDigit)
+        }
+        return digits
+      }
+
+      // single-select — exactly one digit
+      if (typeof rawAnswer === 'string' && rawAnswer.length > 0) {
+        const d = labelToDigit(q, rawAnswer)
+        if (d) return [d]
+      } else if (Array.isArray(rawAnswer) && typeof rawAnswer[0] === 'string') {
+        const d = labelToDigit(q, rawAnswer[0])
+        if (d) return [d]
+      }
+      if (defaultDigit) {
+        if (haveMap) log.warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (single-select) — defaulting to option 1`)
+        return [defaultDigit]
+      }
+      return []
+    }
+
+    // Assemble the inner keystroke sequence (no paste-mode toggles —
+    // _writePtyMultiQuestionSequence wraps the whole thing).
+    const sequence = []
+    for (const q of questions) {
+      const rawAnswer = map[q.question]
+      const digits = resolveQuestionDigits(q, rawAnswer)
+      for (const d of digits) sequence.push(d)
+      if (q.multiSelect) {
+        // Multi-select needs an explicit advance keystroke; single-select
+        // auto-advances on digit (verified empirically).
+        sequence.push('\t')
       }
     }
-    // Fire-and-forget — the write is async due to the per-char throttle,
-    // but the caller (handleUserQuestionResponse) is sync. Errors here
-    // are non-fatal; worst case the user re-sends the answer.
-    this._writePtyTextThrottled(writeText).catch((err) => {
-      log.warn(`respondToQuestion PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
+    // Focus lands on `❯ 1. Submit answers / 2. Cancel` after the last
+    // question — press 1 to confirm submission.
+    sequence.push('1')
+
+    log.info(`AskUserQuestion multi-question: tool=${prevToolUseId || '?'} questions=${questions.length} keystrokes=${sequence.length} haveAnswersMap=${haveMap}`)
+
+    this._writePtyMultiQuestionSequence(sequence).catch((err) => {
+      log.warn(`respondToQuestion multi-question PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
     })
-    // #4604: arm a stall watchdog. If claude TUI never emits PostToolUse
-    // for this AskUserQuestion (multi-question form wedge), the watchdog
-    // clears _isBusy + _pendingUserAnswer and emits ASK_USER_QUESTION_STALL
-    // so the dashboard prompts the user to retry. Cancelled on PostToolUse
-    // (happy path) and on destroy().
-    const armedToolUseId = prevToolUseId
-    if (this._askUserQuestionWatchdog) clearTimeout(this._askUserQuestionWatchdog)
-    this._askUserQuestionWatchdog = setTimeout(() => {
-      this._askUserQuestionWatchdog = null
-      this._onAskUserQuestionStall(armedToolUseId)
-    }, ASK_USER_QUESTION_WATCHDOG_MS)
+    armWatchdog()
+  }
+
+  /**
+   * Write a sequence of single-char keystrokes (digits, Tab, etc.) to
+   * the PTY for the multi-question AskUserQuestion form driver
+   * (#4604 Chunk B). The sequence is wrapped in bracketed-paste-disable /
+   * re-enable exactly once (same defense as _writePtyTextThrottled) and
+   * every char is throttled by PROMPT_CHAR_DELAY_MS so claude TUI's
+   * paste detector doesn't reject the rapid digit burst. Unlike
+   * _writePtyTextThrottled this writer does NOT append \r — the form
+   * driver supplies its own navigation keys (Tab between multi-select
+   * questions, '1' at Submit).
+   *
+   * @param {string[]} sequence — array of one-char strings to write in order
+   * @returns {Promise<boolean>} true if completed, false if PTY aborted mid-write
+   */
+  async _writePtyMultiQuestionSequence(sequence) {
+    if (!this._term) return false
+    this._term.write('\x1b[?2004l')
+    try {
+      for (const ch of sequence) {
+        if (this._activeTurn?.aborted || this._ptyExited) return false
+        this._term.write(ch)
+        if (ClaudeTuiSession.PROMPT_CHAR_DELAY_MS > 0) {
+          await new Promise((resolve) => setTimeout(resolve, ClaudeTuiSession.PROMPT_CHAR_DELAY_MS))
+        }
+      }
+      return true
+    } finally {
+      try { this._term.write('\x1b[?2004h') } catch {}
+    }
   }
 
   /**

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2661,6 +2661,205 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  // #4604 Chunk B — multi-question form driver. Empirical byte sequence
+  // pinned via scripts/tui-form-recorder.mjs against claude CLI v2.1.158
+  // (see tui_multi_question_form_keys memory). Single-select digit
+  // auto-advances; multi-select needs an explicit Tab to commit + advance;
+  // focus auto-lands on the Submit screen after the last question.
+  describe('AskUserQuestion multi-question form driver (#4604 Chunk B)', () => {
+    let warnLines
+    let infoLines
+    let logSpy
+
+    beforeEach(() => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { uuid: 'test', synthSeq: 0 }
+      warnLines = []
+      infoLines = []
+      logSpy = (entry) => {
+        if (entry.component !== 'claude-tui-session') return
+        if (entry.level === 'warn') warnLines.push(entry.message)
+        if (entry.level === 'info') infoLines.push(entry.message)
+      }
+      addLogListener(logSpy)
+    })
+
+    afterEach(() => {
+      if (logSpy) removeLogListener(logSpy)
+      logSpy = null
+      warnLines = null
+      infoLines = null
+    })
+
+    // Pin the exact byte sequence from the recorder spec:
+    // For a 4-question form (Q1 single 'a', Q2 single 'b', Q3 multi 'p'+'r',
+    // Q4 single 'q'), picking option 1 / option 2 / options 1+3 / option 2:
+    //   '\x1b[?2004l' + '1' + '2' + '1' + '3' + '\t' + '2' + '1' + '\x1b[?2004h'
+    it('drives a mixed 4-question form with the exact empirical byte sequence', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', options: [{ label: 'aa' }, { label: 'bb' }] },
+        { question: 'Q3?', multiSelect: true, options: [{ label: 'p' }, { label: 'q' }, { label: 'r' }] },
+        { question: 'Q4?', options: [{ label: 'x' }, { label: 'y' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_multi', questions, options: questions[0].options }
+      const answersMap = {
+        'Q1?': 'a',         // → '1' (single, auto-advances)
+        'Q2?': 'bb',        // → '2' (single, auto-advances)
+        'Q3?': JSON.stringify(['p', 'r']), // → '1' '3' (multi-select toggles, no advance) + '\t'
+        'Q4?': 'y',         // → '2' (single, auto-advances)
+      }
+
+      session.respondToQuestion('', answersMap)
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Expected sequence: paste-disable, digits + Tab interleaved per the
+      // multi-question driver, '1' to confirm Submit, paste-enable.
+      const expected = ['\x1b[?2004l', '1', '2', '1', '3', '\t', '2', '1', '\x1b[?2004h']
+      assert.deepEqual(writes, expected,
+        `expected empirical byte sequence, got ${JSON.stringify(writes)}`)
+      assert.equal(session._pendingUserAnswer, null, 'pending cleared')
+    })
+
+    // Single-question regression guard: ensure the legacy text-driven path
+    // still produces the exact pre-Chunk-B byte sequence (#4290 happy path).
+    it('1-question form keeps the legacy text-driven byte sequence unchanged', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      const questions = [
+        { question: 'Pick a release strategy', options: [{ label: 'Patch' }, { label: 'Minor' }, { label: 'Major' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_single', questions, options: questions[0].options }
+
+      session.respondToQuestion('Minor')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // disable + '2' + \r + enable — identical to the #4290 single-question
+      // happy path. The trailing \r is harmless (digit auto-commits on TUI)
+      // and pinned by the test guard so a future refactor doesn't quietly
+      // drop it for single-q paths where downstream consumers might rely
+      // on the redundant Enter.
+      assert.deepEqual(writes, ['\x1b[?2004l', '2', '\r', '\x1b[?2004h'],
+        `expected legacy single-q byte sequence, got ${JSON.stringify(writes)}`)
+    })
+
+    // Back-compat fallback: old dashboard sent only `answer: string`
+    // (no answersMap). With >1 questions and no map, every question
+    // defaults to option 1 and a WARN fires so the wedge is visible
+    // in chroxy.log.
+    it('multi-question with missing answersMap: WARN + defaults all to option 1', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', multiSelect: true, options: [{ label: 'x' }, { label: 'y' }] },
+        { question: 'Q3?', options: [{ label: 'p' }, { label: 'q' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_no_map', questions, options: questions[0].options }
+
+      // Old dashboard sends just the freeform string of q1's answer —
+      // we don't have an answersMap.
+      session.respondToQuestion('a')
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Q1 → '1', Q2 (multi-select) → '1' + '\t' (advance), Q3 → '1', Submit → '1'.
+      assert.deepEqual(writes, ['\x1b[?2004l', '1', '1', '\t', '1', '1', '\x1b[?2004h'],
+        `expected default-to-option-1 sequence, got ${JSON.stringify(writes)}`)
+
+      const missingMapWarn = warnLines.find((m) => /didn't send answersMap/.test(m))
+      assert.ok(missingMapWarn, `expected WARN about missing answersMap, got ${JSON.stringify(warnLines)}`)
+      assert.match(missingMapWarn, /defaulting every question to option 1/)
+      assert.match(missingMapWarn, /toolu_no_map/, 'WARN includes toolUseId for triage')
+    })
+
+    // Partial answersMap: user answered q1 and q3 but not q2. Missing
+    // entries default to option 1 (with WARN); the user's explicit
+    // answers are honored.
+    it('multi-question with partial answersMap: WARN per missing q, defaults missing to option 1', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', options: [{ label: 'p' }, { label: 'q' }] },
+        { question: 'Q3?', options: [{ label: 'x' }, { label: 'y' }, { label: 'z' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_partial', questions, options: questions[0].options }
+      const answersMap = {
+        'Q1?': 'b',  // → '2'
+        'Q3?': 'z',  // → '3'
+        // Q2 missing → defaults to '1'
+      }
+
+      session.respondToQuestion('', answersMap)
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      assert.deepEqual(writes, ['\x1b[?2004l', '2', '1', '3', '1', '\x1b[?2004h'],
+        `expected partial-map sequence, got ${JSON.stringify(writes)}`)
+
+      const missingQWarn = warnLines.find((m) => /no resolvable answer for q=/.test(m) && /Q2/.test(m))
+      assert.ok(missingQWarn, `expected WARN about Q2 missing, got ${JSON.stringify(warnLines)}`)
+      assert.match(missingQWarn, /defaulting to option 1/)
+    })
+
+    // Pre-Chunk-B watchdog still arms for multi-question forms — if claude
+    // TUI's actual form differs from the empirical spec (a future TUI
+    // version, edge-case shape), the stall watchdog still surfaces the
+    // wedge to the user instead of silently hanging.
+    it('multi-question arms the stall watchdog (still surfaces wedges)', () => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+      try {
+        session._term = { write: () => {}, kill: () => {} }
+        session._isBusy = true
+        const questions = [
+          { question: 'Q1?', options: [{ label: 'a' }] },
+          { question: 'Q2?', options: [{ label: 'p' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_arm', questions, options: questions[0].options }
+
+        session.respondToQuestion('', { 'Q1?': 'a', 'Q2?': 'p' })
+
+        // Reinstate the stuck-form condition so the watchdog has something
+        // to fire about (same trick the original watchdog test uses).
+        session._pendingUserAnswer = { toolUseId: 'toolu_arm', questions, options: questions[0].options }
+
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        mock.timers.tick(31_000)
+        assert.equal(errors.length, 1, 'watchdog fires for multi-question too')
+        assert.equal(errors[0].code, 'ASK_USER_QUESTION_STALL')
+        assert.equal(errors[0].toolUseId, 'toolu_arm', 'watchdog armed with the multi-question toolUseId')
+      } finally {
+        mock.timers.reset()
+      }
+    })
+
+    // PreToolUse for a multi-question prompt stashes the full questions
+    // array on _pendingUserAnswer (Chunk B requirement), not just q[0].options.
+    it('PreToolUse stashes the full questions array on _pendingUserAnswer (#4604 Chunk B)', () => {
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }] },
+        { question: 'Q2?', multiSelect: true, options: [{ label: 'p' }, { label: 'q' }] },
+        { question: 'Q3?', options: [{ label: 'x' }, { label: 'y' }] },
+      ]
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_stash',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions },
+      }, 'msg-stash')
+
+      assert.ok(session._pendingUserAnswer, 'pending answer set')
+      assert.equal(session._pendingUserAnswer.toolUseId, 'toolu_stash')
+      assert.deepEqual(session._pendingUserAnswer.questions, questions,
+        'full questions array stashed, not just q[0].options')
+      // Back-compat: pre-Chunk-B callers reading `.options` get q[0].options.
+      assert.deepEqual(session._pendingUserAnswer.options, questions[0].options,
+        'options still points at questions[0].options for back-compat')
+    })
+  })
+
   // #4044: per-session option that spawns claude TUI with the literal
   // --dangerously-skip-permissions flag and elides chroxy's permission
   // hook entirely. Distinct from `permissionMode: 'auto'`, which still

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -4663,6 +4663,99 @@ describe('handleUserQuestion', () => {
     )
     expect(out3!.sessionId).toBe('sess-active')
   })
+
+  // #4604 Chunk B — multi-question forms. Previously handleUserQuestion
+  // dropped every question past q[0]; the server-side driver had no way
+  // to know what the user wanted to pick for q2/q3 and defaulted them
+  // to option 1 (or stalled the form entirely). Now the full N-question
+  // payload rides on `chatMessage.questions`.
+  describe('multi-question form support (#4604 Chunk B)', () => {
+    it('populates chatMessage.questions with every normalized question', () => {
+      const out = handleUserQuestion(
+        {
+          questions: [
+            { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+            { question: 'Q2?', multiSelect: true, options: [{ label: 'p' }, { label: 'q' }] },
+            { question: 'Q3?', options: [{ label: 'x' }] },
+          ],
+          toolUseId: 'tu-multi',
+        },
+        null,
+      )
+      expect(out).not.toBeNull()
+      expect(out!.chatMessage.questions).toBeDefined()
+      expect(out!.chatMessage.questions!.length).toBe(3)
+      expect(out!.chatMessage.questions![0].question).toBe('Q1?')
+      expect(out!.chatMessage.questions![1].question).toBe('Q2?')
+      expect(out!.chatMessage.questions![2].question).toBe('Q3?')
+      // Single-select questions get the Other sentinel appended; the
+      // multi-select question does NOT (the checkbox UI doesn't compose
+      // with a free-text escape hatch).
+      expect(out!.chatMessage.questions![0].options).toEqual([
+        { label: 'a', value: 'a' },
+        { label: 'b', value: 'b' },
+        { label: 'Other', value: '__chroxy_other__' },
+      ])
+      expect(out!.chatMessage.questions![1].options).toEqual([
+        { label: 'p', value: 'p' },
+        { label: 'q', value: 'q' },
+      ])
+      expect(out!.chatMessage.questions![1].multiSelect).toBe(true)
+      expect(out!.chatMessage.questions![2].options).toEqual([
+        { label: 'x', value: 'x' },
+        { label: 'Other', value: '__chroxy_other__' },
+      ])
+    })
+
+    it('legacy top-level options + content mirror questions[0] (back-compat with single-q renderers)', () => {
+      const out = handleUserQuestion(
+        {
+          questions: [
+            { question: 'First', options: [{ label: 'a' }, { label: 'b' }] },
+            { question: 'Second', options: [{ label: 'x' }] },
+          ],
+        },
+        null,
+      )
+      // questions[0] is the same as the legacy top-level fields so
+      // pre-Chunk-B renderers that only read `content` + `options`
+      // keep rendering the first question identically.
+      expect(out!.chatMessage.content).toBe(out!.chatMessage.questions![0].question)
+      expect(out!.chatMessage.options).toEqual(out!.chatMessage.questions![0].options)
+    })
+
+    it('single-question form still populates chatMessage.questions (N=1 case)', () => {
+      const out = handleUserQuestion(
+        {
+          questions: [{ question: 'Just one', options: [{ label: 'a' }] }],
+        },
+        null,
+      )
+      // Even single-question prompts populate `questions` — renderers
+      // detect multi-question by `questions.length > 1` so the N=1 case
+      // must still be present (renderers can iterate uniformly).
+      expect(out!.chatMessage.questions).toBeDefined()
+      expect(out!.chatMessage.questions!.length).toBe(1)
+      expect(out!.chatMessage.questions![0].question).toBe('Just one')
+    })
+
+    it('skips malformed entries past q[0] without poisoning the rest of the form', () => {
+      const out = handleUserQuestion(
+        {
+          questions: [
+            { question: 'Q1?', options: [{ label: 'a' }] },
+            { notAQuestion: true },           // malformed — skipped
+            'plain-string',                    // malformed — skipped
+            null,                              // malformed — skipped
+            { question: 'Q5?', options: [{ label: 'p' }] },
+          ],
+        },
+        null,
+      )
+      expect(out!.chatMessage.questions!.length).toBe(2)
+      expect(out!.chatMessage.questions!.map((q) => q.question)).toEqual(['Q1?', 'Q5?'])
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3051,48 +3051,81 @@ export function handleUserQuestion(
   if (!Array.isArray(questions) || questions.length === 0) return null
   const q = questions[0] as Record<string, unknown>
   if (!q || typeof q !== 'object' || typeof q.question !== 'string') return null
-  const questionContent = q.question as string
-  const rawOptions = Array.isArray(q.options)
-    ? (q.options as unknown[])
-        .filter(
-          (o: unknown): o is { label: string } =>
-            !!o &&
-            typeof o === 'object' &&
-            typeof (o as Record<string, unknown>).label === 'string',
-        )
-        .map((o: { label: string }) => ({ label: o.label, value: o.label }))
-    : []
-  // #3752: dedup against the synthetic sentinel BEFORE appending it.
-  // If the model itself supplied a "{label:'Other'}" option, prefer the
-  // model's own row over our sentinel (the user gets one "Other" row that
-  // resolves to the model's literal value, not the free-text escape hatch).
-  // If anything else happens to use OTHER_OPTION_VALUE as its label-derived
-  // value (astronomical, but possible — and React `key={opt.value}` collides
-  // either way), strip it defensively so the sentinel append below remains
-  // unique.
-  const baseOptions = rawOptions.filter(
-    (o) => o.label !== OTHER_OPTION_LABEL && o.value !== OTHER_OPTION_VALUE,
+
+  /**
+   * #4604 Chunk B — shared per-question normalization. Same dedup +
+   * Other-sentinel logic the original single-question path applied,
+   * pulled into a closure so every entry in the multi-question payload
+   * gets it. Returns `null` for malformed entries so the caller can
+   * skip them without poisoning the rest of the form.
+   */
+  const normalizeQuestion = (rawQ: unknown): {
+    question: string
+    options: { label: string; value: string }[]
+    multiSelect?: boolean
+  } | null => {
+    if (!rawQ || typeof rawQ !== 'object') return null
+    const qq = rawQ as Record<string, unknown>
+    if (typeof qq.question !== 'string') return null
+    const rawOptions = Array.isArray(qq.options)
+      ? (qq.options as unknown[])
+          .filter(
+            (o: unknown): o is { label: string } =>
+              !!o &&
+              typeof o === 'object' &&
+              typeof (o as Record<string, unknown>).label === 'string',
+          )
+          .map((o: { label: string }) => ({ label: o.label, value: o.label }))
+      : []
+    // #3752: dedup against the synthetic sentinel BEFORE appending it.
+    const baseOptions = rawOptions.filter(
+      (o) => o.label !== OTHER_OPTION_LABEL && o.value !== OTHER_OPTION_VALUE,
+    )
+    const modelSuppliedOther = rawOptions.find((o) => o.label === OTHER_OPTION_LABEL)
+    const hasUsableOptions = baseOptions.length > 0 || modelSuppliedOther != null
+    // #4604 Chunk B: only append the Other sentinel for single-select
+    // questions. Multi-select questions render as checkboxes and the
+    // free-text escape hatch doesn't compose cleanly with that UI;
+    // multi-select forms produced by claude SDK never include a
+    // free-text fallback anyway.
+    const isMultiSelect = qq.multiSelect === true
+    const options = !hasUsableOptions
+      ? []
+      : isMultiSelect
+        ? baseOptions
+        : modelSuppliedOther
+          ? [...baseOptions, modelSuppliedOther]
+          : [...baseOptions, { label: OTHER_OPTION_LABEL, value: OTHER_OPTION_VALUE }]
+    const out: { question: string; options: { label: string; value: string }[]; multiSelect?: boolean } = {
+      question: qq.question as string,
+      options,
+    }
+    if (isMultiSelect) out.multiSelect = true
+    return out
+  }
+
+  // Normalize every question. Drop malformed entries (return null from
+  // normalizeQuestion); if the first question is dropped, fail closed
+  // — that's the legacy null-return shape the call site already handles.
+  const normalizedAll = (questions as unknown[]).map(normalizeQuestion).filter(
+    (v): v is { question: string; options: { label: string; value: string }[]; multiSelect?: boolean } => v != null,
   )
-  const modelSuppliedOther = rawOptions.find((o) => o.label === OTHER_OPTION_LABEL)
-  // #3746: append synthetic "Other" sentinel so renderers can offer a
-  // free-text escape hatch alongside the model-provided options. Skip when
-  // there are zero usable post-dedup options — renderers already show
-  // free-text-only in that case. Critically, this gates on POST-dedup state:
-  // a model that only supplied a colliding entry (e.g.
-  // `[{label:'__chroxy_other__'}]`) ends up with empty baseOptions + no
-  // modelSuppliedOther, and must fall through to free-text-only rather
-  // than re-appending the sentinel as a sole tap target (#3752 review).
-  const hasUsableOptions = baseOptions.length > 0 || modelSuppliedOther != null
-  const options = !hasUsableOptions
-    ? []
-    : modelSuppliedOther
-      ? [...baseOptions, modelSuppliedOther]
-      : [...baseOptions, { label: OTHER_OPTION_LABEL, value: OTHER_OPTION_VALUE }]
+  // The top-level `options` mirrors q[0].options exactly (legacy
+  // contract — every existing test pin still applies). Multi-question
+  // renderers iterate `chatMessage.questions` instead.
+  const [firstNormalized] = normalizedAll
+  if (firstNormalized == null) return null
+  const questionContent = firstNormalized.question
+  const options = firstNormalized.options
   const chatMessage: ChatMessage = {
     id: nextMessageId('question'),
     type: 'prompt',
     content: questionContent,
     options,
+    // #4604 Chunk B: always populate `questions` (a single-question form
+    // is just an N=1 case of the multi-question shape). Renderers can
+    // detect multi-question by `questions.length > 1` and switch UI.
+    questions: normalizedAll,
     timestamp: Date.now(),
   }
   if (typeof msg.toolUseId === 'string') {

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -15,6 +15,8 @@ export type {
   MessageAttachment,
   ToolResultImage,
   ChatMessage,
+  // #4604 Chunk B — one entry per question in a multi-question AskUserQuestion form
+  ChatMessageQuestion,
   // #3188: auto-evaluator rewrite metadata attached to system ChatMessages
   EvaluatorRewriteMeta,
   SavedConnection,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -41,12 +41,37 @@ export interface EvaluatorRewriteMeta {
   reasoning: string;
 }
 
+/**
+ * #4604 Chunk B — one entry per question in a multi-question
+ * AskUserQuestion form. `questions[0]` always mirrors the legacy
+ * top-level `content` + `options` on the ChatMessage so single-question
+ * renderers stay byte-compatible; renderers that handle multi-question
+ * forms iterate `questions[]` directly and call `onSelect(answersMap)`
+ * with one entry per question.
+ */
+export interface ChatMessageQuestion {
+  question: string;
+  options: { label: string; value: string }[];
+  /** `true` for multi-select questions (renderer shows checkboxes, server emits Tab between digits) */
+  multiSelect?: boolean;
+}
+
 export interface ChatMessage {
   id: string;
   type: 'response' | 'user_input' | 'tool_use' | 'thinking' | 'prompt' | 'error' | 'system';
   content: string;
   tool?: string;
   options?: { label: string; value: string }[];
+  /**
+   * #4604 Chunk B — full N-question payload for AskUserQuestion `prompt`
+   * messages. Always populated for `type === 'prompt'` messages produced
+   * by `handleUserQuestion`; `questions[0].question` always equals the
+   * top-level `content` and `questions[0].options` always equals the
+   * top-level `options` so legacy single-question renderers keep
+   * working without consulting this field. Renderers that drive
+   * multi-question forms iterate this array.
+   */
+  questions?: ChatMessageQuestion[];
   requestId?: string;
   toolInput?: Record<string, unknown>;
   toolUseId?: string;

--- a/scripts/tui-form-recorder.mjs
+++ b/scripts/tui-form-recorder.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * tui-form-recorder.mjs — record keystrokes + PTY output while driving
+ * claude TUI through a multi-question AskUserQuestion form (#4604).
+ *
+ * Usage:
+ *   node scripts/tui-form-recorder.mjs [project-dir]
+ *
+ * Project-dir defaults to the cwd. Output is written to:
+ *   /tmp/tui-form-recording-<timestamp>.jsonl
+ *
+ * Each line is one event:
+ *   { t: <ms_since_start>, kind: 'in' | 'out', data: <string> }
+ *
+ * Driver workflow:
+ *   1. Run the recorder
+ *   2. Wait for claude TUI to render its prompt
+ *   3. Type a prompt that triggers a multi-question AskUserQuestion
+ *      (e.g. "Help me scope a new project — ask me about tech stack, inputs, provider, platform")
+ *   4. When the form renders, answer it manually using whatever keys work
+ *   5. After Submit succeeds, press Ctrl+D to end the recording cleanly
+ *
+ * Analysis: tail the JSONL file to find the keystroke patterns that
+ * advance between questions, toggle multiSelect, and reach Submit.
+ *
+ * Exit:
+ *   Ctrl+D — clean exit (closes recording file)
+ *   Ctrl+\ — kill claude immediately
+ */
+
+import { resolve } from 'node:path'
+import { writeFileSync, createWriteStream } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// npm workspaces hoists node-pty to the root node_modules/.
+const ptyMod = await import('/Users/blamechris/Projects/chroxy/node_modules/node-pty/lib/index.js')
+
+const projectDir = resolve(process.argv[2] || process.cwd())
+const claudeBin = '/Users/blamechris/.local/bin/claude'
+
+const recordingPath = join(tmpdir(), `tui-form-recording-${Date.now()}.jsonl`)
+const recording = createWriteStream(recordingPath, { encoding: 'utf8' })
+const startMs = Date.now()
+
+const log = (kind, data) => {
+  recording.write(JSON.stringify({
+    t: Date.now() - startMs,
+    kind,
+    data,
+  }) + '\n')
+}
+
+process.stdout.write(`\x1b[33m=== tui-form-recorder ===\x1b[0m\n`)
+process.stdout.write(`Recording to: ${recordingPath}\n`)
+process.stdout.write(`Spawning claude in: ${projectDir}\n`)
+process.stdout.write(`Press Ctrl+D when done (recording flushed cleanly).\n`)
+process.stdout.write(`Press Ctrl+\\ to kill claude.\n\n`)
+
+const cols = process.stdout.columns || 120
+const rows = process.stdout.rows || 40
+
+const term = ptyMod.spawn(claudeBin, [], {
+  name: 'xterm-256color',
+  cols,
+  rows,
+  cwd: projectDir,
+  env: process.env,
+})
+
+term.onData((chunk) => {
+  process.stdout.write(chunk)
+  log('out', chunk)
+})
+
+term.onExit(({ exitCode, signal }) => {
+  recording.end()
+  process.stdout.write(`\n\x1b[33m=== claude exited (code=${exitCode} signal=${signal}) ===\x1b[0m\n`)
+  process.stdout.write(`Recording: ${recordingPath}\n`)
+  process.exit(exitCode || 0)
+})
+
+// Raw mode so we capture every keystroke (arrow keys, Tab, etc.) as bytes
+process.stdin.setRawMode(true)
+process.stdin.resume()
+
+process.stdin.on('data', (buf) => {
+  const data = buf.toString('binary')
+  // Ctrl+D — accept both plain 0x04 (most terminals) AND iTerm's modify-other-keys
+  // form `\x1b[27;5;100~` (CSI 27 = modify-other-keys, 5 = Ctrl modifier, 100 = ASCII
+  // 'd' lowercase). Without the second branch the script ran indefinitely after the
+  // user's Ctrl+D was eaten by iTerm's CSI encoding during the #4604 empirical pass.
+  if (data === '\x04' || data === '\x1b[27;5;100~') {
+    process.stdout.write(`\n\x1b[33m=== ending recording (Ctrl+D) ===\x1b[0m\n`)
+    log('in', '<<CTRL-D EXIT>>')
+    recording.end()
+    term.kill('SIGTERM')
+    process.exit(0)
+  }
+  // Pass through to claude + log
+  log('in', data)
+  term.write(buf)
+})
+
+process.stdout.on('resize', () => {
+  term.resize(process.stdout.columns || 120, process.stdout.rows || 40)
+})


### PR DESCRIPTION
## Summary
Root-cause fix for #4604 — multi-question AskUserQuestion now drives the form correctly.

Empirical byte sequence captured via node-pty recorder (saved to memory):
- Single-select: digit auto-advances
- Multi-select: digit toggles, Tab commits + advances
- Submit: '1' auto-confirms

### Server
- `_pendingUserAnswer` tracks full `questions` array
- `respondToQuestion` rewritten to iterate questions, write per-q keystrokes + nav
- Single-question path unchanged (regression guard via tests)
- Back-compat for old dashboards that only send `answer: string`

### Dashboard
- `handleUserQuestion` exposes all N questions
- `QuestionPrompt` renders N questions with multiSelect checkbox UI
- `sendUserQuestionResponse` populates wire `answers` map

## Test plan
- [x] Server tests assert byte sequence for mixed form (single + multi + single)
- [x] Store-core tests assert N-question exposure
- [x] Dashboard tests assert multiSelect render + Submit
- [x] Single-question regression guard
- [x] Back-compat: missing answersMap defaults to option 1 + WARN

## Live verification post-merge
After v0.9.20 cut + restart: send a prompt that triggers multi-question AskUserQuestion, answer it, watch PostToolUse fire normally instead of the 30s watchdog. Stalls become impossible (not just survivable).

Closes #4604

### Recorder fix (bundled per user request)

`scripts/tui-form-recorder.mjs` now accepts iTerm's modify-other-keys form of Ctrl+D (`\\x1b[27;5;100~`) in addition to the raw `\\x04` byte. Caught during this issue's empirical pass — the user's Ctrl+D was silently ignored and the script kept running. One additional commit (`cf074ffc9`).