### PR TITLE
fix(server): emit-result sweep + replay agent_idle fan-out for zombie tool_start (#4628)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -259,6 +259,17 @@ export class BaseSession extends EventEmitter {
     // result this turn are stranded; the agent's next turn re-emits a
     // fresh `tool_use` if it cares to wait again.
     this._pendingBackgroundCommands = new Map()
+    // #4628: in-flight tool_start tracking. Each entry is the toolUseId
+    // of a tool_start the session has emitted but for which no matching
+    // tool_result has fired yet. On `result` (turn end), `_emitResult`
+    // sweeps any remaining entries and emits synthetic tool_results so
+    // the dashboard's activeTools chip clears. Without this, claude TUI
+    // sessions that drop a PostToolUse hook (rare but observed — one
+    // Bash out of 35 per the #4628 forensic) leave the chip ticking
+    // forever AND persist the orphan to session-state.json. Companion
+    // path: SessionMessageHistory.sweepUnresolvedToolStarts (#4617/#4619)
+    // catches stragglers at restore-time as a backstop.
+    this._inFlightToolStarts = new Map()
     this._messageCounter = 0
     // Boot-unique prefix mixed into every emitted messageId (#3700).
     // The dashboard caches up to 100 messages per session in localStorage
@@ -974,6 +985,80 @@ export class BaseSession extends EventEmitter {
     return `${SKILLS_PROMPT_HEADER}${parts.join('\n\n---\n\n')}`
   }
 
+  /**
+   * #4628: track that a tool_start event was emitted. Pair with
+   * `_trackToolResult(toolUseId)` once the matching tool_result fires.
+   * Idempotent on duplicate ids (overwrites tool/startedAt). Safe to
+   * call before/after the actual emit — the tracking is decoupled.
+   */
+  _trackToolStart(toolUseId, tool) {
+    if (typeof toolUseId !== 'string' || toolUseId.length === 0) return
+    this._inFlightToolStarts.set(toolUseId, {
+      tool: typeof tool === 'string' && tool.length > 0 ? tool : 'unknown',
+      startedAt: Date.now(),
+    })
+  }
+
+  /**
+   * #4628: mark a tool_start resolved (matching tool_result fired).
+   * Idempotent — calling for an unknown id is a no-op.
+   */
+  _trackToolResult(toolUseId) {
+    if (typeof toolUseId !== 'string' || toolUseId.length === 0) return
+    this._inFlightToolStarts.delete(toolUseId)
+  }
+
+  /**
+   * #4628: sweep any tool_starts that never got their matching
+   * tool_result and emit synthetic tool_result events for each.
+   * Companion to SessionMessageHistory.sweepUnresolvedToolStarts (#4619)
+   * — that one runs at restore-time on persisted history; this one runs
+   * at turn-end on live in-memory tracking so the orphan never gets
+   * persisted in the first place.
+   *
+   * The synthetic tool_result carries the same shape as a real one (the
+   * dashboard's `handleToolResult.applyToActiveTools` only matches on
+   * `toolUseId`). Extra fields (`synthetic`, `interrupted`, `reason`)
+   * are diagnostic hints — the wire schema strips them on parse but
+   * they stay grep-able on disk in the persisted history.
+   *
+   * @param {string} reason — short identifier for the sweep cause
+   * @returns {number} count of sweeps emitted
+   */
+  _sweepUnresolvedToolStarts(reason = 'stream_completed_without_result') {
+    if (this._inFlightToolStarts.size === 0) return 0
+    const count = this._inFlightToolStarts.size
+    for (const [toolUseId, entry] of this._inFlightToolStarts) {
+      this.emit('tool_result', {
+        toolUseId,
+        result: `Tool ${entry.tool} did not emit a result before the turn ended (reason: ${reason}). Chroxy synthesized this result to clear the stale activeTools entry.`,
+        truncated: false,
+        synthetic: true,
+        interrupted: true,
+        isError: true,
+        reason,
+      })
+    }
+    this._inFlightToolStarts.clear()
+    return count
+  }
+
+  /**
+   * #4628: emit `result` after sweeping any in-flight tool_starts. All
+   * provider sessions should route through this rather than calling
+   * `this.emit('result', ...)` directly, so orphan tool_starts get
+   * paired with a synthetic tool_result BEFORE the result fires (and
+   * BEFORE state is persisted, since session-message-history listens
+   * for both events).
+   *
+   * @param {object} payload — the result event payload ({cost, duration, usage, sessionId})
+   * @param {string} [sweepReason] — optional override for the sweep reason
+   */
+  _emitResult(payload, sweepReason = 'stream_completed_without_result') {
+    this._sweepUnresolvedToolStarts(sweepReason)
+    this.emit('result', payload)
+  }
+
   _clearMessageState() {
     this._isBusy = false
     this._currentMessageId = null
@@ -986,6 +1071,16 @@ export class BaseSession extends EventEmitter {
     // turn — once the turn ends, any unmatched entries are stranded
     // and a fresh tool_use would re-populate.
     this._pendingBackgroundCommands.clear()
+    // #4628: sweep any orphan tool_starts that didn't get their
+    // matching tool_result this turn. Most providers route through
+    // _emitResult which sweeps before broadcasting result; this is the
+    // belt-and-braces for paths that call _clearMessageState directly
+    // (e.g. SDK stream-stall recovery clears state BEFORE emitting the
+    // synthetic result). Sweeping here ensures the orphan is paired
+    // with a synthetic tool_result rather than silently dropped — so
+    // the dashboard's activeTools clears whether result fires next or
+    // never fires at all.
+    this._sweepUnresolvedToolStarts('message_state_cleared')
 
     // Emit completions for any tracked agents so the app clears badges
     if (this._activeAgents.size > 0) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -958,7 +958,12 @@ export class ClaudeTuiSession extends BaseSession {
     if (text) this.emit('stream_delta', { messageId, delta: text })
     this.emit('stream_end', { messageId })
 
-    this.emit('result', {
+    // #4628: sweep any tool_starts whose PostToolUse hook never fired
+    // BEFORE emitting result. _emitResult does this in one step. The
+    // sweep ensures the synthetic tool_result is broadcast first, so
+    // the dashboard's activeTools clears as part of the same turn-end
+    // burst rather than zombifying until next chroxy restart.
+    this._emitResult({
       // #4072: `cost: null` (not 0) is the chroxy convention for
       // "subscription-billed provider, cost not measured". The session-
       // manager `_trackCost`/`_trackUsage` gate is
@@ -969,7 +974,7 @@ export class ClaudeTuiSession extends BaseSession {
       duration,
       usage: null,                   // not exposed by Stop hook in MVP
       sessionId: this._sessionId,
-    })
+    }, 'stop_hook_fired_without_post_hook')
 
     // Clear inactivity timers — turn done, nothing to backstop (#3920).
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
@@ -1134,6 +1139,10 @@ export class ClaudeTuiSession extends BaseSession {
         tool: toolName,
         input: payload.tool_input ?? null,
       })
+      // #4628: track this tool_start so _emitResult can sweep it on
+      // turn-end if the matching PostToolUse hook is never written
+      // (the upstream failure mode observed in #4628).
+      this._trackToolStart(toolUseId, toolName)
       // #4278: AskUserQuestion in TUI sessions previously had no special
       // path — the tool_use bubble appeared in the chat with no
       // interactive way to answer, and claude sat on its own TTY-style
@@ -1220,6 +1229,9 @@ export class ClaudeTuiSession extends BaseSession {
       result,
       truncated,
     })
+    // #4628: matching tool_start resolved — drop from the in-flight map
+    // so _emitResult's sweep doesn't double-emit a synthetic for it.
+    this._trackToolResult(toolUseId)
 
     // #4307: scan PostToolUse output for the canonical "Command running
     // in background with ID: <id>" pattern. The PostToolUse hook
@@ -1261,7 +1273,12 @@ export class ClaudeTuiSession extends BaseSession {
     this.emit('error', { message })
     // #4072: subscription-billed → cost: null so SessionManager skips
     // accumulation. See companion sites above.
-    this.emit('result', { cost: null, duration, usage: null, sessionId: this._sessionId })
+    // #4628: sweep orphan tool_starts before result so the dashboard's
+    // activeTools clears as part of the same error burst.
+    this._emitResult(
+      { cost: null, duration, usage: null, sessionId: this._sessionId },
+      'turn_finished_with_error',
+    )
     // #4022: drop the per-turn attachment dir on every failure path so
     // a stalled/aborted/PTY-exited turn doesn't leak the materialized
     // files until destroy(). No-op when the turn had no attachments.
@@ -1375,7 +1392,11 @@ export class ClaudeTuiSession extends BaseSession {
     // #4010: emit result so the dashboard receives agent_idle and clears
     // the Stop button. stream_end on its own only clears streamingMessageId.
     // #4072: subscription-billed → cost: null. See companion sites above.
-    this.emit('result', { cost: null, duration, usage: null, sessionId: this._sessionId })
+    // #4628: sweep orphan tool_starts before the timeout-driven result.
+    this._emitResult(
+      { cost: null, duration, usage: null, sessionId: this._sessionId },
+      'hard_timeout',
+    )
   }
 
   /**
@@ -1718,6 +1739,8 @@ export class ClaudeTuiSession extends BaseSession {
       result: 'AskUserQuestion stalled — no response from claude TUI within 30s. Likely a multi-question form (#4604).',
       truncated: false,
     })
+    // #4628: matching tool_start resolved — drop from the in-flight map.
+    this._trackToolResult(toolUseId)
     this.emit('error', {
       code: 'ASK_USER_QUESTION_STALL',
       message: 'The agent\'s question response could not be delivered — likely a multi-question form. Please retry from your last message.',

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -728,6 +728,9 @@ export class CliSession extends BaseSession {
               const mcp = parseMcpToolName(event.content_block.name)
               if (mcp) toolStartData.serverName = mcp.serverName
               this.emit('tool_start', toolStartData)
+              // #4628: track so _clearMessageState (or _emitResult) can
+              // sweep on turn-end if the API ever drops a tool_result.
+              this._trackToolStart(toolId, event.content_block.name)
             }
             break
           }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -691,6 +691,9 @@ export class SdkSession extends BaseSession {
                   const mcp = parseMcpToolName(event.content_block.name)
                   if (mcp) toolStartData.serverName = mcp.serverName
                   this.emit('tool_start', toolStartData)
+                  // #4628: defense-in-depth — track so _emitResult sweep
+                  // catches any orphan if the API ever drops a tool_result.
+                  this._trackToolStart(toolId, event.content_block.name)
                 }
                 break
               }
@@ -795,12 +798,17 @@ export class SdkSession extends BaseSession {
               this.emit('models_updated', { models: getModels() })
             }
 
-            this.emit('result', {
+            // #4628: sweep any orphan tool_starts before emitting result
+            // so the dashboard's activeTools clears as part of the same
+            // turn-end burst. _clearMessageState (called next) would also
+            // clear the in-flight map but without broadcasting synthetic
+            // tool_results to the dashboard.
+            this._emitResult({
               sessionId: msg.session_id || this._sdkSessionId,
               cost: msg.total_cost_usd,
               duration: msg.duration_ms,
               usage: msg.usage,
-            })
+            }, 'turn_ended_with_orphan_tool_start')
 
             this._clearMessageState()
             break

--- a/packages/server/src/tool-result.js
+++ b/packages/server/src/tool-result.js
@@ -75,5 +75,13 @@ export function emitToolResults(content, emitter, maxSize = MAX_TOOL_RESULT_SIZE
     }
 
     emitter.emit('tool_result', event)
+    // #4628: drop the in-flight tracker entry so _emitResult's sweep
+    // (BaseSession) doesn't double-emit a synthetic for an already-
+    // resolved tool. Only the BaseSession-derived emitter exposes
+    // _trackToolResult; ignore for any other emitter shape (e.g. tests
+    // that pass a bare EventEmitter).
+    if (typeof emitter._trackToolResult === 'function') {
+      emitter._trackToolResult(block.tool_use_id)
+    }
   }
 }

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -376,7 +376,23 @@ export function replayHistory(ctx, ws, sessionId) {
     if (ws.readyState !== 1) return
     const end = Math.min(offset + CHUNK_SIZE, history.length)
     for (let i = offset; i < end; i++) {
-      send(ws, { ...history[i], sessionId })
+      const entry = history[i]
+      send(ws, { ...entry, sessionId })
+      // #4628: mirror the live `result → agent_idle` fan-out from
+      // event-normalizer.js. The dashboard's handler dispatch table has
+      // no `result` entry — only `agent_idle` — so a raw `result` in
+      // history-replay is silently dropped, and `handleAgentIdle`
+      // (which clears activeTools as the #4308 safety net) never fires.
+      // Without this, a session that completed cleanly but had an
+      // orphan tool_start in history (e.g. dropped PostToolUse hook,
+      // #4628 root cause) shows a zombie "Running X" chip every time
+      // the dashboard reconnects, until the next chroxy restart. The
+      // companion `_emitResult` sweep in BaseSession prevents new
+      // orphans from being persisted; this heals the existing wedged
+      // sessions on reconnect without requiring a restart.
+      if (entry && entry.type === 'result') {
+        send(ws, { type: 'agent_idle', sessionId })
+      }
     }
     if (end < history.length) {
       setImmediate(() => sendChunk(end))

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -1325,6 +1325,86 @@ describe('BaseSession', () => {
       assert.equal(s._getSkills().length, 1, 'malformed trust file must not break loading')
     })
   })
+
+  // #4628: in-flight tool_start tracking + sweep at turn-end
+  describe('in-flight tool_start sweep (#4628)', () => {
+    let s, sweepSkillsDir
+    beforeEach(() => {
+      sweepSkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bs-4628-'))
+      s = new BaseSession({ cwd: '/tmp', skillsDir: sweepSkillsDir, repoSkillsDir: null })
+    })
+    afterEach(() => { rmSync(sweepSkillsDir, { recursive: true, force: true }) })
+
+    it('_trackToolStart adds to in-flight map; _trackToolResult removes', () => {
+      s._trackToolStart('toolu_1', 'Bash')
+      s._trackToolStart('toolu_2', 'Read')
+      assert.equal(s._inFlightToolStarts.size, 2)
+      s._trackToolResult('toolu_1')
+      assert.equal(s._inFlightToolStarts.size, 1)
+      assert.ok(s._inFlightToolStarts.has('toolu_2'))
+    })
+
+    it('_trackToolStart ignores empty / non-string ids (defensive)', () => {
+      s._trackToolStart('', 'Bash')
+      s._trackToolStart(null, 'Bash')
+      s._trackToolStart(undefined, 'Bash')
+      s._trackToolStart(42, 'Bash')
+      assert.equal(s._inFlightToolStarts.size, 0)
+    })
+
+    it('_sweepUnresolvedToolStarts emits one synthetic tool_result per orphan and clears the map', () => {
+      s._trackToolStart('toolu_A', 'Bash')
+      s._trackToolStart('toolu_B', 'Read')
+      const events = []
+      s.on('tool_result', (ev) => events.push(ev))
+      const swept = s._sweepUnresolvedToolStarts('test_reason')
+      assert.equal(swept, 2)
+      assert.equal(events.length, 2)
+      const ids = events.map((e) => e.toolUseId).sort()
+      assert.deepEqual(ids, ['toolu_A', 'toolu_B'])
+      for (const ev of events) {
+        assert.equal(ev.synthetic, true, 'synthetic flag for grep-ability')
+        assert.equal(ev.interrupted, true)
+        assert.equal(ev.isError, true)
+        assert.equal(ev.reason, 'test_reason')
+        assert.equal(ev.truncated, false)
+        assert.ok(typeof ev.result === 'string' && ev.result.length > 0)
+      }
+      assert.equal(s._inFlightToolStarts.size, 0, 'map cleared after sweep')
+    })
+
+    it('_sweepUnresolvedToolStarts is a no-op when no orphans (returns 0, emits nothing)', () => {
+      const events = []
+      s.on('tool_result', (ev) => events.push(ev))
+      const swept = s._sweepUnresolvedToolStarts('test_reason')
+      assert.equal(swept, 0)
+      assert.equal(events.length, 0)
+    })
+
+    it('_emitResult sweeps orphans BEFORE emitting result (ordering matters for dashboard activeTools clear)', () => {
+      s._trackToolStart('toolu_orphan', 'Bash')
+      const events = []
+      s.on('tool_result', (ev) => events.push({ type: 'tool_result', toolUseId: ev.toolUseId, synthetic: ev.synthetic }))
+      s.on('result', (ev) => events.push({ type: 'result', cost: ev.cost }))
+      s._emitResult({ cost: null, duration: 100, usage: null, sessionId: 'sess_1' }, 'turn_end')
+      assert.equal(events.length, 2)
+      assert.equal(events[0].type, 'tool_result', 'synthetic tool_result fires FIRST')
+      assert.equal(events[0].toolUseId, 'toolu_orphan')
+      assert.equal(events[0].synthetic, true)
+      assert.equal(events[1].type, 'result', 'result fires SECOND')
+    })
+
+    it('_clearMessageState sweeps orphans (belt-and-braces for paths that bypass _emitResult)', () => {
+      s._trackToolStart('toolu_orphan', 'Bash')
+      const events = []
+      s.on('tool_result', (ev) => events.push(ev))
+      s._clearMessageState()
+      assert.equal(events.length, 1, 'sweep ran from within _clearMessageState')
+      assert.equal(events[0].toolUseId, 'toolu_orphan')
+      assert.equal(events[0].synthetic, true)
+      assert.equal(s._inFlightToolStarts.size, 0)
+    })
+  })
 })
 
 // #4509: BaseSession's three per-session inactivity timeouts must also clamp

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -1033,6 +1033,62 @@ describe('replayHistory', () => {
     const endMsg = ctx._sends.find(m => m.type === 'history_replay_end')
     assert.ok(endMsg)
   })
+
+  // #4628: replay must mirror the live event-normalizer fan-out so the
+  // dashboard's `handleAgentIdle` (the #4308 safety net that clears
+  // activeTools) actually fires for replayed sessions. Without this,
+  // a session with an orphan tool_start in history (e.g. dropped
+  // PostToolUse hook) shows a zombie chip on every dashboard
+  // reconnect until the next chroxy restart.
+  it('emits synthetic agent_idle after each `result` entry to mirror live event-normalizer fan-out (#4628)', async () => {
+    const history = [
+      { type: 'tool_start', tool: 'Bash', toolUseId: 'toolu_orphan' },
+      { type: 'result', cost: null, duration: 100 },
+    ]
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    manager.getHistory = () => history
+    manager.isHistoryTruncated = () => false
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    registerClient(ctx, ws)
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const types = ctx._sends.map(m => m.type)
+    assert.deepEqual(types, [
+      'history_replay_start',
+      'tool_start',
+      'result',
+      'agent_idle',
+      'history_replay_end',
+    ], 'agent_idle must follow result in the replay stream')
+    const agentIdle = ctx._sends.find(m => m.type === 'agent_idle')
+    assert.equal(agentIdle.sessionId, 'sess-1', 'agent_idle carries the session id')
+  })
+
+  it('does not emit agent_idle for histories without a result entry (#4628)', async () => {
+    const history = [
+      { type: 'user_message', content: 'hi' },
+      { type: 'response', content: 'hello' },
+    ]
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    manager.getHistory = () => history
+    manager.isHistoryTruncated = () => false
+    const ws = makeFakeWs()
+    const ctx = makeCtx({ sessionManager: manager })
+    registerClient(ctx, ws)
+
+    replayHistory(ctx, ws, 'sess-1')
+    await new Promise(r => setImmediate(r))
+
+    const types = ctx._sends.map(m => m.type)
+    assert.ok(!types.includes('agent_idle'), 'no result → no synthetic agent_idle')
+  })
 })
 
 // ── flushPostAuthQueue ─────────────────────────────────────────────────────

--- a/packages/server/tests/ws-server.test.js
+++ b/packages/server/tests/ws-server.test.js
@@ -1297,8 +1297,12 @@ describe('_replayHistory()', () => {
     const endIdx = messages.indexOf(replayEnd)
     assert.ok(startIdx < endIdx, 'history_replay_start should come before history_replay_end')
 
-    // Full ring buffer is replayed — all 5 messages including user_input
-    const replayed = messages.slice(startIdx + 1, endIdx)
+    // #4628: replay also emits synthetic `agent_idle` after each `result`
+    // to mirror the live event-normalizer fan-out (so dashboard handleAgentIdle
+    // fires for replayed sessions). Filter those out — this test is about the
+    // original history entries, not the fan-out (which has its own test in
+    // ws-history.test.js).
+    const replayed = messages.slice(startIdx + 1, endIdx).filter(m => m.type !== 'agent_idle')
     assert.equal(replayed.length, 5, 'Should replay full ring buffer (all 5 entries)')
     assert.equal(replayed[0].type, 'message')
     assert.equal(replayed[0].messageType, 'user_input')
@@ -1340,7 +1344,9 @@ describe('_replayHistory()', () => {
     const replayStart = messages.find(m => m.type === 'history_replay_start')
     const startIdx = messages.indexOf(replayStart)
     const endIdx = messages.indexOf(replayEnd)
-    const replayed = messages.slice(startIdx + 1, endIdx)
+    // #4628: filter out synthetic agent_idle (fan-out after each `result`)
+    // — this test asserts on original history entries.
+    const replayed = messages.slice(startIdx + 1, endIdx).filter(m => m.type !== 'agent_idle')
 
     assert.equal(replayed.length, 3, 'Should replay all 3 entries')
     for (const entry of replayed) {
@@ -1378,7 +1384,9 @@ describe('_replayHistory()', () => {
     const replayStart = messages.find(m => m.type === 'history_replay_start')
     const startIdx = messages.indexOf(replayStart)
     const endIdx = messages.indexOf(replayEnd)
-    const replayed = messages.slice(startIdx + 1, endIdx)
+    // #4628: filter out synthetic agent_idle (fan-out after each `result`)
+    // — this test asserts on original history entries.
+    const replayed = messages.slice(startIdx + 1, endIdx).filter(m => m.type !== 'agent_idle')
 
     // Full ring buffer replayed — all 5 messages across both turns
     assert.equal(replayed.length, 5, 'Should replay all turns (5 entries)')
@@ -1445,7 +1453,9 @@ describe('_replayHistory()', () => {
     const replayStart = messages.find(m => m.type === 'history_replay_start')
     const startIdx = messages.indexOf(replayStart)
     const endIdx = messages.indexOf(replayEnd)
-    const replayed = messages.slice(startIdx + 1, endIdx)
+    // #4628: filter out synthetic agent_idle (fan-out after each `result`)
+    // — this test asserts on original history entries.
+    const replayed = messages.slice(startIdx + 1, endIdx).filter(m => m.type !== 'agent_idle')
 
     assert.equal(replayed.length, 4)
 


### PR DESCRIPTION
## Summary

Two-layer defense against the zombie "Running X · Nh Mm" footer chip from #4628. Hits the same class of bug as #4616/#4617/#4619 but covers the case where a TUI session completes cleanly while leaving an orphan tool_start in history (root cause: claude TUI sometimes drops a PostToolUse hook — 1 of 35 observed in the #4628 forensic).

### Layer 3 — emit-result sweep (BaseSession)
- New `_inFlightToolStarts` Map tracks every emitted `tool_start` until the matching `tool_result` fires
- `_sweepUnresolvedToolStarts(reason)` emits synthetic `tool_result` per orphan + clears the map
- `_emitResult(payload, reason)` wraps sweep + result so the synthetic fires BEFORE the result (dashboard's `applyToActiveTools` matches on `toolUseId` only — synthetic clears the chip)
- `_clearMessageState` also sweeps as belt-and-braces for paths that emit result via a different route (e.g. SDK stall recovery)
- Wired into all 3 providers: claude-tui-session (3 result sites + hook tracking + AskUserQuestion stall path), sdk-session (tool_start track + turn-end via _emitResult), cli-session (tool_start track — result sites already pair with `_clearMessageState`), `tool-result.js` helper (untracks on tool_result emit)

### Layer 2 — replay-time `result → agent_idle` fan-out (ws-history.js)
- `replayHistory` now emits synthetic `agent_idle` after each `result` entry, mirroring the live `event-normalizer.js` fan-out
- Without this, the dashboard's handler dispatch table (no `result` handler, only `agent_idle`) silently drops replayed results, so `handleAgentIdle` (the #4308 `activeTools` safety net) never fires
- Heals existing wedged sessions on dashboard reconnect — no chroxy restart required

## Test plan

- [x] 6 new BaseSession tests: `_trackToolStart`, `_trackToolResult`, sweep emission shape, `_emitResult` ordering, `_clearMessageState` belt-and-braces
- [x] 2 new ws-history tests: `agent_idle` fan-out after `result` (with and without)
- [x] Full server suite across all touched files: **540 pass / 0 fail**
- [ ] Live verification post v0.9.20 build: confirm the still-wedged No-it-all session chip clears on reconnect (Layer 2 healing path)
- [ ] Live verification: run a new TUI prompt that triggers many tools, confirm no zombie chip even if a PostToolUse drops

Closes #4628