### PR TITLE
chore(release): cut v0.9.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.20] - 2026-05-30
+
+Patches the last remaining zombie-chip path in v0.9.19. Forensic on a live wedged session showed claude TUI sometimes drops a PostToolUse hook (1 of 35 observed in a clean turn — likely an upstream race between turn-end and post-hook fire). When that happens, chroxy persists an unpaired `tool_start` to `session-state.json`, and the dashboard's `activeTools` chip ticks forever — `result` is broadcast live so `handleAgentIdle` clears it, but `replayHistory` on dashboard reconnect sent the raw `result` event verbatim and the dashboard has no `result` handler, so the chip survived every reload until the next chroxy restart. Two-layer defense: prevent new orphans at turn-end (sweep), heal existing wedged sessions on reconnect (replay fan-out).
+
+### Fixed
+
+- **Zombie tool_start chip via emit-result sweep + replay agent_idle fan-out (#4628 / #4631):**
+  - **Layer 3 (BaseSession `_emitResult` sweep):** new `_inFlightToolStarts` Map tracks every emitted `tool_start` until matching `tool_result` fires. `_sweepUnresolvedToolStarts(reason)` emits a synthetic `tool_result` per orphan (carries `synthetic`, `interrupted`, `isError`, `reason` diagnostic fields + the original `toolUseId` — dashboard's `applyToActiveTools` pairs by `toolUseId` alone, so the chip clears). `_emitResult(payload, reason)` wraps sweep + result emit so the synthetic fires BEFORE the result. `_clearMessageState` also sweeps as belt-and-braces for paths that emit result via a different route (e.g. SDK `_handleStreamStall` clears state BEFORE emitting result). Wired into all three providers (`claude-tui-session.js` — all 3 result paths + hook pair tracking + AskUserQuestion stall path; `sdk-session.js` — tool_start track + turn-end via `_emitResult`; `cli-session.js` — tool_start track) and into the shared `tool-result.js` helper (untracks when emitting `tool_result` via `emitToolResults`).
+  - **Layer 2 (replay-time `result → agent_idle` fan-out in `ws-history.js`):** `replayHistory` now mirrors the live `event-normalizer.js` fan-out — any `result` entry in the replay stream is followed by a synthetic `agent_idle`. Without this, the dashboard's handler dispatch table (no `result` handler, only `agent_idle`) silently drops replayed results, so `handleAgentIdle` (the #4308 `activeTools` safety net) never fires. Heals existing wedged sessions on dashboard reconnect — no chroxy restart required.
+  - Pairs with the existing layers: #4308 (live `handleAgentIdle`), #4619 (restart-time sweep on persisted history), #4618 (stall watchdog `tool_result` emit), #4614 (AskUserQuestion stall watchdog). Together they cover every known path from `tool_start` to chip-not-clearing.
+
 ## [0.9.19] - 2026-05-30
 
 Coordinated attack on the "Running X · Nh Mm" zombie chip plus the stall paths that produced it — #4604 (multi-question AskUserQuestion) lands its full A→B→C arc: observability + 30s watchdog (#4614), root-cause multi-question form driver (#4620), and two fallbacks so the footer pill clears even when the driver can't help (#4618, #4619). Stream-stall watchdog extends to SDK sessions (#4608, closes #4467). Plus notification-prefs durability hardening (#4605, #4606) and a wire-timestamp respect for `tool_start` (#4612, closes #4607).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.19"
+      "version": "0.9.20"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.19",
+    "version": "0.9.20",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.19</string>
+    <string>0.9.20</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.19"
+version = "0.9.20"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.19"
+version = "0.9.20"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.19",
+      "version": "0.9.20",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Cuts **v0.9.20** — ships #4631 (#4628 fix). The last remaining zombie-chip path uncovered by live forensic on a wedged session: claude TUI occasionally drops a PostToolUse hook (1/35 observed), and the resulting orphan `tool_start` survived dashboard reconnects because `replayHistory` sent raw `result` events the dashboard had no handler for.

**Layer 3** — BaseSession `_emitResult` sweeps in-flight tool_starts at turn-end (broadcasts synthetic `tool_result`s before `result`). Wired into all 3 providers.

**Layer 2** — `ws-history.js` `replayHistory` mirrors live `event-normalizer` fan-out: any `result` in the replay stream is followed by synthetic `agent_idle`. Heals existing wedged sessions on reconnect.

## Test plan

- [x] All package files bumped to 0.9.20 via `scripts/bump-version.sh`
- [x] CHANGELOG.md covers #4631 with the full Layer 2/3 architecture
- [x] #4631 already merged to main with CI green
- [ ] Post-release: rebuild Tauri app, confirm the still-wedged No-it-all session's chip clears on reconnect (Layer 2 healing path — no chroxy restart needed)