### PR TITLE
fix(dashboard): style MultiQuestionForm — Submit visible, questions separated, softer radio dot (#4634)

### DIFF
--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2218,6 +2218,60 @@
   opacity: 1;
 }
 
+/* #4634: multi-question AskUserQuestion form (#4604 Chunk B / #4620).
+   The component renders these class names but they previously had no
+   CSS rules — Submit fell back to the native browser button (gray-on-
+   dark, unreadable) and questions had no visual separation. */
+.question-prompt--multi {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.question-prompt-multi-row {
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.question-prompt-multi-row:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.question-multi-submit {
+  align-self: flex-start;
+  padding: 8px 24px;
+  border-radius: 6px;
+  border: 1px solid var(--accent-purple);
+  background: var(--accent-purple);
+  color: #fff;
+  font-size: var(--text-base);
+  font-weight: 500;
+  cursor: pointer;
+  margin-top: 8px;
+}
+
+.question-multi-submit:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.question-multi-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.question-multi-submit:focus-visible {
+  outline: 2px solid var(--accent-purple);
+  outline-offset: 2px;
+}
+
+/* Soften the native radio/checkbox dot — pure white reads as foreign
+   inside the purple-outlined option pills on the dark theme. */
+.question-option input[type="radio"],
+.question-option input[type="checkbox"] {
+  accent-color: var(--accent-purple);
+}
+
 .question-freetext {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary

CSS-only fix for #4634. The multi-question AskUserQuestion form (#4604 Chunk B / #4620) renders with `question-prompt--multi`, `question-prompt-multi-row`, and `question-multi-submit` class names that previously had **no CSS rules**. Submit fell back to the native browser button (gray-on-dark, unreadable per the user's screenshot), questions flowed into each other with no separator, and native radio dots rendered pure white against the dark theme.

Added rules (in `packages/dashboard/src/theme/components.css` near the existing `.question-prompt` block):

- `.question-prompt--multi` — flex column with 16px gap
- `.question-prompt-multi-row` — 12px bottom padding + subtle bottom border; last row clears the border to avoid a dangling line
- `.question-multi-submit` — matches `.question-freetext-send` style (filled accent-purple background, white text, hover/disabled/focus-visible states)
- `input[type='radio'/'checkbox']` inside `.question-option` — `accent-color: var(--accent-purple)` so the dot reads as part of the design rather than as a foreign white circle

## Test plan

- [x] All 2375 dashboard tests pass
- [ ] Manual visual verification on next desktop build — Submit button readable, questions visually distinct, radio dot blends with the purple outline

Closes #4634

## Related (not in this PR)

- **#4635** filed for the *separate* multi-question Submit failure on pure all-single-select forms — that needs an empirical byte-sequence re-record via `scripts/tui-form-recorder.mjs` and is unrelated to styling.