### PR TITLE
chore(release): cut v0.9.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.21] - 2026-05-30
+
+CSS polish for the multi-question AskUserQuestion form shipped in v0.9.19 — the component rendered with class names that had no rules at all, so Submit fell back to the native browser button (gray-on-dark, unreadable), questions ran together with no separator, and the native radio dot was harsh-white against the dark theme. No functional changes.
+
+### Fixed
+
+- **MultiQuestionForm styling (#4634 / #4636):** added rules in `packages/dashboard/src/theme/components.css` for `.question-prompt--multi` (flex column with 16px gap between questions), `.question-prompt-multi-row` (12px bottom padding + subtle bottom divider; last row clears its border so there's no dangling line above Submit), and `.question-multi-submit` (matches the existing `.question-freetext-send` shape — filled accent-purple background, white text, hover/disabled/focus-visible states). Plus `accent-color: var(--accent-purple)` on the per-option radio/checkbox inputs so the selection dot blends with the purple option-pill outline instead of standing out as pure white. `accent-color` is Baseline since 2022, safe for Tauri WKWebView.
+
+### Known issues (filed)
+
+- **#4635** — multi-question Submit fails on **pure all-single-select** forms. The driver shipped in v0.9.19 was empirically validated only against a MIXED form (with at least one multi-select question, captured via `scripts/tui-form-recorder.mjs`); the all-single-select case wasn't pinned and the same byte sequence doesn't make claude TUI emit PostToolUse. Stall watchdog still correctly recovers (chip clears, error toast shown, session re-promptable). Needs a fresh recorder pass against an all-single-select prompt before the right fix can be written.
+
 ## [0.9.20] - 2026-05-30
 
 Patches the last remaining zombie-chip path in v0.9.19. Forensic on a live wedged session showed claude TUI sometimes drops a PostToolUse hook (1 of 35 observed in a clean turn — likely an upstream race between turn-end and post-hook fire). When that happens, chroxy persists an unpaired `tool_start` to `session-state.json`, and the dashboard's `activeTools` chip ticks forever — `result` is broadcast live so `handleAgentIdle` clears it, but `replayHistory` on dashboard reconnect sent the raw `result` event verbatim and the dashboard has no `result` handler, so the chip survived every reload until the next chroxy restart. Two-layer defense: prevent new orphans at turn-end (sweep), heal existing wedged sessions on reconnect (replay fan-out).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.20",
+      "version": "0.9.21",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.20",
+      "version": "0.9.21",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.20",
+      "version": "0.9.21",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.20"
+      "version": "0.9.21"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.20",
+      "version": "0.9.21",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.20",
+      "version": "0.9.21",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.20",
+      "version": "0.9.21",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.20",
+    "version": "0.9.21",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.20</string>
+    <string>0.9.21</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.20"
+version = "0.9.21"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.20",
+      "version": "0.9.21",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Cuts **v0.9.21** — ships #4636 (#4634 fix). CSS-only polish for the multi-question AskUserQuestion form: Submit button now readable (was native browser gray default), questions visually separated, radio dot blends with the option pill outline.

## Test plan

- [x] All package files bumped to 0.9.21 via `scripts/bump-version.sh`
- [x] CHANGELOG.md covers #4636 + flags #4635 as known issue
- [x] #4636 merged to main with CI green + 2375 dashboard tests pass
- [ ] Post-release: rebuild Tauri app, confirm Submit visible + radio dot soft