### PR TITLE
fix(dashboard): space radio/checkbox dot from label in multi-question form

### DIFF
--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2272,6 +2272,17 @@
   accent-color: var(--accent-purple);
 }
 
+/* Multi-question form options wrap an input + span inside a label. The
+   default inline layout jammed the radio/checkbox dot against the text
+   with no gap. Use flex + gap on the radio/checkbox variants only so the
+   single-select QuestionPrompt path (no input element) is untouched. */
+.question-option--radio,
+.question-option--checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .question-freetext {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary

Tiny CSS follow-up to #4634 / v0.9.21. The multi-question form renders each option as a `<label>` wrapping an `<input>` + `<span>`. Default inline layout jammed the radio/checkbox dot directly against the text with no horizontal gap, reading as cramped — especially on the unselected purple-outlined pills.

## Change

Add `display: inline-flex` + `gap: 10px` to `.question-option--radio` and `.question-option--checkbox` only. The single-select QuestionPrompt path (no input element) is intentionally untouched.

## Before / After

Before: `(○)Anthropic only (Claude)`
After: `(○) Anthropic only (Claude)`

Reported live during v0.9.22 dogfooding ("Wish the selection buttons text and the circle to indicate it was selected were spaced a bit better").