### PR TITLE
fix(server): full turn teardown when AskUserQuestion stall fires (#4645)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1797,8 +1797,29 @@ export class ClaudeTuiSession extends BaseSession {
    * Watchdog handler for an AskUserQuestion answer that claude TUI never
    * acknowledged via PostToolUse (#4604). Multi-question forms render a
    * per-question form needing more than the single digit chroxy writes,
-   * leaving _isBusy=true forever. We force-clear the busy state and
-   * surface a structured error so the dashboard can render a retry prompt.
+   * leaving _isBusy=true forever. We tear the turn down end-to-end and
+   * surface a structured error so the dashboard renders a retry prompt
+   * AND the Working banner / Stop button clear immediately.
+   *
+   * Pre-#4645 this only cleared `_isBusy` + emitted the stall error,
+   * leaving `stream_start` orphaned (no matching `stream_end`) and no
+   * `result` for the event-normalizer to fan into `agent_idle`. The
+   * dashboard kept showing "Working… Ns ago" + Stop forever (until the
+   * 5-min #4638 stream-stall watchdog or the 2h hard cap eventually
+   * cleaned up) even though the agent had already given up. Worse: the
+   * red error toast told the user to retry, but the Stop button was up
+   * and the input box read "Type to send follow-up…" — there was no
+   * Send affordance to retry FROM.
+   *
+   * Now: best-effort Ctrl-C into the TUI (so `claude` itself unsticks
+   * from the form screen for the next turn) → emit `stream_end` →
+   * `_emitResult` (sweeps orphan tool_starts and fans `result` →
+   * `agent_idle` via the event-normalizer, clearing both Working banner
+   * and Stop) → emit `error{code:'ASK_USER_QUESTION_STALL'}` last so the
+   * dashboard surfaces the user-facing toast AFTER state has settled.
+   *
+   * Shape mirrors `_handleStreamStall` and `_handleHardTimeout` —
+   * extracting a shared `_teardownTurn` helper is tracked in #4641.
    *
    * No-ops on destroyed sessions and on sessions where PostToolUse
    * already arrived (would have cleared _pendingUserAnswer + busy state
@@ -1808,10 +1829,12 @@ export class ClaudeTuiSession extends BaseSession {
     if (this._destroying) return
     if (!this._pendingUserAnswer && !this._isBusy) return
 
-    log.warn(`AskUserQuestion stall: tool=${toolUseId} — claude TUI never emitted PostToolUse after answer write (${ASK_USER_QUESTION_WATCHDOG_MS}ms). Likely a multi-question form (#4604). Clearing busy state so the session is recoverable.`)
+    log.warn(`AskUserQuestion stall: tool=${toolUseId} — claude TUI never emitted PostToolUse after answer write (${ASK_USER_QUESTION_WATCHDOG_MS}ms). Likely a multi-question form (#4604). Tearing down turn so the session is recoverable.`)
+
+    const messageId = this._currentMessageId
+    const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : 0
 
     this._pendingUserAnswer = null
-    this._isBusy = false
     // #4616: emit a synthetic tool_result FIRST so the dashboard's
     // activeTools entry for this AskUserQuestion is cleared. Without it
     // the footer "Running AskUserQuestion · Ns" pill keeps ticking
@@ -1827,6 +1850,42 @@ export class ClaudeTuiSession extends BaseSession {
     })
     // #4628: matching tool_start resolved — drop from the in-flight map.
     this._trackToolResult(toolUseId)
+
+    // #4645: best-effort Ctrl-C so claude TUI itself unsticks from the
+    // form screen. Without this the next sendMessage's prompt write
+    // would queue behind the still-displayed form and silently desync.
+    // Mirrors _handleStreamStall / _handleHardTimeout.
+    if (this._term) {
+      try { this._term.write('\x03') } catch { /* ignore */ }
+    }
+
+    // Clear all three inactivity timers — turn is over, nothing to
+    // backstop, leaving them armed would fire stale callbacks on a
+    // session that's already idle.
+    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
+    if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
+    if (this._streamStallTimeout) { clearTimeout(this._streamStallTimeout); this._streamStallTimeout = null }
+
+    // #4022: drop per-turn attachment dir on stall (same as the other
+    // teardown paths) so a stalled turn doesn't leak materialized files
+    // until destroy().
+    this._cleanupTurnAttachments(this._activeTurn)
+    this._activeTurn = null
+    this._isBusy = false
+    this._currentMessageId = null
+
+    // #4645: pair the stream_start fired at turn-start with stream_end +
+    // result so the dashboard's streamingMessageId + Working banner +
+    // Stop button all clear immediately (event-normalizer turns result
+    // into result + agent_idle). The if-guard mirrors _handleStreamStall
+    // — silent skip is acceptable here because the only way messageId
+    // is null is a contract violation (_isBusy=true without an active
+    // turn), tracked in #4642.
+    if (messageId) this.emit('stream_end', { messageId })
+    this._emitResult(
+      { cost: null, duration, usage: null, sessionId: this._sessionId },
+      'ask_user_question_stall',
+    )
     this.emit('error', {
       code: 'ASK_USER_QUESTION_STALL',
       message: 'The agent\'s question response could not be delivered — likely a multi-question form. Please retry from your last message.',

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2628,6 +2628,72 @@ describe('ClaudeTuiSession', () => {
       }
     })
 
+    // #4645 — pre-fix the stall handler only cleared _isBusy + emitted the
+    // ASK_USER_QUESTION_STALL error, leaving stream_start orphaned (no
+    // matching stream_end, no result, no agent_idle fan-out). The dashboard
+    // kept showing "Working… Ns ago" + Stop button forever even though the
+    // turn had been given up on — and the input was still in
+    // "Type to send follow-up…" mode so the user had no Send affordance to
+    // retry from. Pin the full teardown so a regression can't re-introduce
+    // the misleading UI state.
+    it('stall fires full teardown (stream_end + result + error) so dashboard banner + Stop button clear (#4645)', () => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        const events = []
+        session.on('tool_result', (e) => events.push({ type: 'tool_result', ...e }))
+        session.on('stream_end', (e) => events.push({ type: 'stream_end', ...e }))
+        session.on('result', (e) => events.push({ type: 'result', ...e }))
+        session.on('error', (e) => events.push({ type: 'error', ...e }))
+
+        const ptyWrites = []
+        session._term = { write: (b) => ptyWrites.push(b), kill: () => {} }
+        session._isBusy = true
+        session._currentMessageId = 'msg-stall'
+        session._activeTurn = { startedAt: Date.now() - 50, aborted: false, uuid: 't', synthSeq: 0 }
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_stall',
+          options: [{ label: 'a' }, { label: 'b' }],
+        }
+
+        session.respondToQuestion('a')
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_stall',
+          options: [{ label: 'a' }, { label: 'b' }],
+        }
+
+        mock.timers.tick(31_000)
+
+        // Full teardown: synthetic tool_result → stream_end → result → error.
+        // tool_result first so the activeTools pill clears before the result
+        // fan-out; error last so the toast surfaces after busy state settles.
+        const types = events.map((e) => e.type)
+        assert.deepEqual(types, ['tool_result', 'stream_end', 'result', 'error'],
+          'fan-out order: tool_result → stream_end → result → error')
+
+        const streamEnd = events.find((e) => e.type === 'stream_end')
+        assert.equal(streamEnd.messageId, 'msg-stall', 'stream_end carries the current messageId')
+
+        const result = events.find((e) => e.type === 'result')
+        assert.equal(result.cost, null, 'cost=null skips billing accumulation')
+        assert.ok(Number.isFinite(result.duration), 'duration is finite')
+
+        const err = events.find((e) => e.type === 'error')
+        assert.equal(err.code, 'ASK_USER_QUESTION_STALL', 'error code preserved for dashboard chip')
+        assert.equal(err.toolUseId, 'toolu_aq_stall')
+
+        // Best-effort Ctrl-C so claude TUI itself unsticks for the next turn.
+        assert.ok(ptyWrites.includes('\x03'), 'Ctrl-C written to PTY')
+
+        assert.equal(session._isBusy, false, 'busy cleared')
+        assert.equal(session._currentMessageId, null, 'messageId nulled')
+        assert.equal(session._activeTurn, null, 'active turn nulled')
+        assert.equal(session._pendingUserAnswer, null, 'pending answer slot cleared')
+      } finally {
+        mock.timers.reset()
+      }
+    })
+
     it('watchdog does NOT fire when PostToolUse arrives in time (happy path)', () => {
       mock.timers.enable({ apis: ['setTimeout'] })
       try {


### PR DESCRIPTION
## Summary

When the 30s `ASK_USER_QUESTION_STALL` watchdog (#4604) fires after a multi-question form delivery failure, the dashboard surfaces the red error toast — but the "Working… Ns ago" banner and Stop button stay visible for the next 4.5 minutes (until #4638's stream-stall watchdog kicks in) or up to 2 hours. The toast says "Please retry from your last message", but the input still shows "Type to send follow-up…" with Stop visible, so there's no Send affordance to actually retry from.

Live reproduction during v0.9.22 dogfood (the No-it-all session hit the exact #4635 case).

## Root cause

`_onAskUserQuestionStall` only cleared `_isBusy` and emitted the error — it never emitted `stream_end` or `result`. The `stream_start` fired at turn-start stayed orphaned, the event-normalizer never fanned out `agent_idle`, and the dashboard's `streamingMessageId` / `activeTools` / Stop button state stuck.

`_handleStreamStall` (#4638) and `_handleHardTimeout` both do full teardown; `_onAskUserQuestionStall` was the outlier.

## Fix

Mirror the teardown shape used by `_handleStreamStall` / `_handleHardTimeout`:

1. Synthetic `tool_result` (unchanged — clears the activeTools pill)
2. Best-effort Ctrl-C into the PTY so `claude` TUI itself unsticks from the form screen for the next turn
3. Clear all three inactivity timers (soft + hard + stream-stall)
4. Drop per-turn attachment dir
5. Null `_activeTurn` / `_isBusy` / `_currentMessageId` / pending answer slot
6. `stream_end` → `_emitResult` (sweeps orphan tool_starts and fans `result` → `agent_idle`) → `error{code:'ASK_USER_QUESTION_STALL'}` in that order so state settles BEFORE the toast surfaces

`ASK_USER_QUESTION_STALL` error code preserved so the user-facing toast stays specific to this failure mode.

## Test plan

- [x] `node --test tests/claude-tui-session.test.js` — 130/130 pass, includes new test pinning the full `tool_result → stream_end → result → error` event sequence + post-teardown state (`_isBusy=false`, `_currentMessageId=null`, `_activeTurn=null`, `_pendingUserAnswer=null`, Ctrl-C written to PTY)
- [x] Existing `#4604` stall watchdog tests still pass — the error code, message, and `_isBusy` clear semantics they pin are unchanged
- [ ] Dogfood (v0.9.23): trigger the multi-question form stall again, confirm Working banner clears immediately and Send button returns

## Follow-up

A shared `_teardownTurn()` helper across `_handleStreamStall`, `_handleHardTimeout`, and `_onAskUserQuestionStall` is tracked in #4641 — this PR is the third site that follows the same pattern almost-but-not-quite identically. Strong motivation for #4641 now.

Closes #4645