### PR TITLE
fix(server): refuse multi-question AskUserQuestion at permission hook (#4648)

### DIFF
--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -53,6 +53,44 @@ case "$PERM_MODE" in
   *) PERM_MODE="approve" ;;
 esac
 
+# #4648 (v0.9.24): refuse multi-question AskUserQuestion forms before any
+# mode-specific routing. Chroxy's PTY-keystroke driver for multi-question
+# forms has a 0% production success rate (per chroxy.log forensic, 2026-05-31
+# /swarm-audit consensus). Denying here forces the model to re-emit as N
+# sequential single-question calls, each driven by the empirically-validated
+# single-question happy path that has worked since v0.9.4. Defense in depth:
+# the v0.9.23 _onAskUserQuestionStall teardown still catches anything that
+# slips through. See docs/audit-results/tui-form-delivery-rethink/ for the
+# full audit (6 agents, unanimous on this path).
+#
+# Reads stdin once at the top because the deny check must apply regardless
+# of permission mode — auto/plan modes previously exited early without
+# touching the payload. Modes below that need the payload reuse $REQUEST.
+REQUEST=$(cat -)
+TOOL_NAME=$(echo "$REQUEST" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4)
+if [ "$TOOL_NAME" = "AskUserQuestion" ]; then
+  # Count `questions[]` length via python3 (stock macOS has it at /usr/bin/python3
+  # 3.9.6; Homebrew at /opt/homebrew/bin). On parse failure or python3 absence
+  # we get empty output → fall through to normal handling rather than
+  # crash/deny-everything. Worst case: same as today (the v0.9.23 watchdog
+  # catches the wedge), so this defaults safe.
+  QUESTION_COUNT=$(printf '%s' "$REQUEST" | python3 -c '
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    q = d.get("tool_input", {}).get("questions", [])
+    print(len(q) if isinstance(q, list) else 0)
+except Exception:
+    pass
+' 2>/dev/null)
+  if [ -n "$QUESTION_COUNT" ] && [ "$QUESTION_COUNT" -gt 1 ]; then
+    cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Chroxy currently delivers AskUserQuestion forms one question at a time. Please re-issue this call as separate AskUserQuestion tool calls, one per question, and the user will answer each in turn."}}
+EOF
+    exit 0
+  fi
+fi
+
 # ---- Shared: route a permission request to the phone via HTTP ----
 # Expects $REQUEST to contain the JSON body to POST.
 # Outputs the appropriate hookSpecificOutput JSON and exits.
@@ -104,8 +142,7 @@ fi
 
 # Accept Edits mode — auto-approve file operations, route everything else to phone
 if [ "$PERM_MODE" = "acceptEdits" ]; then
-  REQUEST=$(cat -)
-  TOOL_NAME=$(echo "$REQUEST" | grep -o '"tool_name":"[^"]*"' | head -1 | cut -d'"' -f4)
+  # $REQUEST and $TOOL_NAME already populated at top of script (#4648).
   case "$TOOL_NAME" in
     Read|Write|Edit|NotebookEdit|Glob|Grep)
       cat <<'EOF'
@@ -126,5 +163,5 @@ EOF
 fi
 
 # Approve mode (default) — route to phone via HTTP
-REQUEST=$(cat -)
+# $REQUEST already populated at top of script (#4648).
 route_to_phone

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1888,7 +1888,12 @@ export class ClaudeTuiSession extends BaseSession {
     )
     this.emit('error', {
       code: 'ASK_USER_QUESTION_STALL',
-      message: 'The agent\'s question response could not be delivered — likely a multi-question form. Please retry from your last message.',
+      // #4648: dropped the "likely a multi-question form" jargon. The
+      // permission-hook deny path (also #4648) prevents most multi-question
+      // forms from reaching this code path at all, and for the cases that
+      // slip through, the user doesn't care about chroxy internals — they
+      // care about how to recover. The new copy is action-oriented.
+      message: 'Couldn\'t deliver your answers. Tap Retry to resend your original request.',
       toolUseId,
     })
   }

--- a/packages/server/tests/permission-hook-multi-question.test.js
+++ b/packages/server/tests/permission-hook-multi-question.test.js
@@ -1,0 +1,142 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import { spawn } from 'child_process'
+
+/**
+ * #4648 (v0.9.24): permission-hook.sh refuses multi-question AskUserQuestion
+ * forms with a structured `deny + permissionDecisionReason` so the model
+ * re-issues the call as N sequential single-question forms (the empirically-
+ * validated happy path that has worked since v0.9.4).
+ *
+ * Why this is its own test file: the existing permission-hook-sanitization
+ * tests focus on PORT/PERM_MODE input validation; the sidecar-integration
+ * tests cover mid-session permission-mode flips. The multi-question deny is
+ * a third orthogonal axis (payload-shape inspection) and gets its own file
+ * so a future refactor of either of the other two areas doesn't grow them
+ * by reading-stdin scaffolding.
+ *
+ * See docs/audit-results/tui-form-delivery-rethink/ for the full audit that
+ * established this approach (6 agents, unanimous).
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const hookPath = join(__dirname, '../hooks/permission-hook.sh')
+
+function runHook(input, env = {}) {
+  return new Promise((resolve) => {
+    const child = spawn('/bin/bash', [hookPath], {
+      env: { CHROXY_PORT: '12345', CHROXY_PERMISSION_MODE: 'approve', ...env },
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (c) => { stdout += c.toString() })
+    child.stderr.on('data', (c) => { stderr += c.toString() })
+    child.on('close', (status) => resolve({ status, stdout, stderr }))
+    if (input != null) child.stdin.write(input)
+    child.stdin.end()
+  })
+}
+
+describe('permission-hook.sh — multi-question AskUserQuestion deny (#4648)', () => {
+  it('denies a multi-question AskUserQuestion with the canonical reason text', async () => {
+    const payload = {
+      tool_name: 'AskUserQuestion',
+      tool_input: {
+        questions: [
+          { question: 'Which provider?', header: 'Provider', options: [{ label: 'A', value: 'a' }] },
+          { question: 'Which transport?', header: 'Transport', options: [{ label: 'B', value: 'b' }] },
+        ],
+      },
+    }
+    const { stdout, status } = await runHook(JSON.stringify(payload))
+    assert.equal(status, 0, 'exits cleanly')
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.hookEventName, 'PreToolUse')
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'deny')
+    // The reason text steers the model toward the right retry behavior.
+    // Don't pin the exact string (a future copy edit shouldn't break tests)
+    // but DO pin the load-bearing semantics: must say "one question at a
+    // time" or equivalent so the model knows how to recover, and must
+    // mention "separate AskUserQuestion" so the model knows it can retry.
+    assert.match(decision.hookSpecificOutput.permissionDecisionReason, /one question at a time/i)
+    assert.match(decision.hookSpecificOutput.permissionDecisionReason, /separate AskUserQuestion/i)
+  })
+
+  it('denies a multi-question form REGARDLESS of permission mode (auto must still deny)', async () => {
+    // Auto mode normally short-circuits to "allow" without reading the
+    // payload. The deny check must run BEFORE the mode dispatch so a user
+    // in auto mode (the most common dogfood mode per [[feedback_app_means_desktop]])
+    // still gets the deny — otherwise auto-mode users would hit the wedge
+    // every time the model emits a multi-q form.
+    const payload = {
+      tool_name: 'AskUserQuestion',
+      tool_input: { questions: [{ q: 1 }, { q: 2 }] },
+    }
+    for (const mode of ['auto', 'approve', 'acceptEdits', 'plan']) {
+      const { stdout } = await runHook(JSON.stringify(payload), { CHROXY_PERMISSION_MODE: mode })
+      const decision = JSON.parse(stdout.trim())
+      assert.equal(
+        decision.hookSpecificOutput.permissionDecision,
+        'deny',
+        `mode=${mode} must deny multi-q form regardless`,
+      )
+    }
+  })
+
+  it('allows a single-question AskUserQuestion in auto mode (only multi-q is denied)', async () => {
+    const payload = {
+      tool_name: 'AskUserQuestion',
+      tool_input: { questions: [{ question: 'one?', header: 'One', options: [{ label: 'A', value: 'a' }] }] },
+    }
+    const { stdout } = await runHook(JSON.stringify(payload), { CHROXY_PERMISSION_MODE: 'auto' })
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'single-q AskUserQuestion in auto mode still allows (no regression of v0.9.4 happy path)')
+  })
+
+  it('lets non-AskUserQuestion tools pass through (Bash in auto mode allows as before)', async () => {
+    const { stdout } = await runHook(
+      JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } }),
+      { CHROXY_PERMISSION_MODE: 'auto' },
+    )
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'Bash in auto mode still allows — multi-q check is AskUserQuestion-only')
+  })
+
+  it('does NOT deny on malformed payload (no tool_input) — falls through safely', async () => {
+    // python3 parse failure → empty QUESTION_COUNT → no deny → normal handling
+    // resumes (which in approve mode tries to route to phone and falls back to
+    // "ask" since no real server is reachable on the test port). This is the
+    // safe default: a broken hook payload must NOT cause us to deny every
+    // tool call across the board.
+    const { stdout } = await runHook(JSON.stringify({ tool_name: 'AskUserQuestion' }))
+    const decision = JSON.parse(stdout.trim())
+    assert.notEqual(decision.hookSpecificOutput.permissionDecision, 'deny',
+      'malformed payload must not deny — fall through to normal handling')
+  })
+
+  it('does NOT deny on empty questions array — only count > 1 triggers deny', async () => {
+    const { stdout } = await runHook(
+      JSON.stringify({ tool_name: 'AskUserQuestion', tool_input: { questions: [] } }),
+    )
+    const decision = JSON.parse(stdout.trim())
+    assert.notEqual(decision.hookSpecificOutput.permissionDecision, 'deny',
+      'empty questions array must not deny — > 1 is the gate, not >= 1')
+  })
+
+  it('does NOT deny on non-array questions value (defensive against shape drift)', async () => {
+    // If Anthropic ever ships a payload where `questions` is an object map or
+    // a string, the python3 check returns 0 (not isinstance(list)), so we
+    // don't deny. Better to attempt the wedge (v0.9.23 watchdog catches it)
+    // than to deny something that wasn't actually multi-question.
+    const { stdout } = await runHook(
+      JSON.stringify({ tool_name: 'AskUserQuestion', tool_input: { questions: 'not-a-list' } }),
+    )
+    const decision = JSON.parse(stdout.trim())
+    assert.notEqual(decision.hookSpecificOutput.permissionDecision, 'deny',
+      'non-array questions value must not deny — defensive against shape drift')
+  })
+})

--- a/packages/store-core/src/tool-summary.test.ts
+++ b/packages/store-core/src/tool-summary.test.ts
@@ -94,3 +94,50 @@ describe('getInputSummary (#4243)', () => {
     expect(getInputSummary({ command: long })).toHaveLength(100)
   })
 })
+
+// #4648 — Read tool input shape from claude TUI is
+// `{type:'text', file:{filePath:'/path'}}`. Pre-fix, none of the priority
+// fields matched at the top level (filePath is camelCase + nested), so the
+// summary was '' and ToolBubble fell through to raw JSON head, leaking
+// `{"type":"text","file":{"filePath":...` as the collapsed preview. Fix
+// adds `filePath` to PRIORITY_FIELDS and one-level walk into nested
+// objects.
+describe('nested priority-field walk (#4648 — Read tool input)', () => {
+  it('getInputSummary extracts filePath from Read tool nested shape', () => {
+    expect(getInputSummary({ type: 'text', file: { filePath: '/Users/foo/x.md' } })).toBe('/Users/foo/x.md')
+  })
+
+  it('getPartialSummary extracts filePath from Read tool nested shape', () => {
+    const json = JSON.stringify({ type: 'text', file: { filePath: '/Users/foo/x.md' } })
+    expect(getPartialSummary(json)).toBe('/Users/foo/x.md')
+  })
+
+  it('top-level filePath also works (not just nested)', () => {
+    // Some tools may emit camelCase at the top level too — make sure adding
+    // filePath to PRIORITY_FIELDS doesn't regress that path.
+    expect(getInputSummary({ filePath: '/etc/hosts' })).toBe('/etc/hosts')
+  })
+
+  it('nested walk stops at one level (no recursion)', () => {
+    // Pathological deep nesting must NOT be walked — bounded preview cost
+    // is load-bearing on hot ToolBubble render path.
+    const deep = { a: { b: { c: { filePath: '/should/not/match' } } } }
+    expect(getInputSummary(deep)).toBe('')
+  })
+
+  it('nested walk does not descend into arrays', () => {
+    const arr = { items: [{ filePath: '/should/not/match' }] }
+    expect(getInputSummary(arr)).toBe('')
+  })
+
+  it('top-level priority wins over nested priority', () => {
+    // `command` at top level beats `filePath` nested — preserve documented
+    // priority order (top-level pass runs first).
+    expect(getInputSummary({ command: 'ls', file: { filePath: '/other' } })).toBe('ls')
+  })
+
+  it('nested walk caps at PREVIEW_MAX_LEN like top-level', () => {
+    const long = 'z'.repeat(500)
+    expect(getInputSummary({ file: { filePath: long } })).toHaveLength(100)
+  })
+})

--- a/packages/store-core/src/tool-summary.ts
+++ b/packages/store-core/src/tool-summary.ts
@@ -17,14 +17,35 @@
 
 import { tryParseCompleteJson } from './partial-json'
 
-const PRIORITY_FIELDS = ['command', 'file_path', 'path', 'description'] as const
+// #4243 set the original priority order. #4648 added `filePath` for the
+// nested-Read-tool input shape `{type:'text', file:{filePath:'/foo'}}` that
+// claude TUI emits — without the camelCase variant, the summary was empty
+// and ToolBubble fell through to rendering raw JSON head (`{"type":"text",
+// "file":{"filePath":...`) directly in the collapsed bubble. Keep snake_case
+// `file_path` first since it's the documented top-level shape across more
+// tools (Edit, Write, NotebookEdit); camelCase nested is the Read-only case.
+const PRIORITY_FIELDS = ['command', 'file_path', 'filePath', 'path', 'description'] as const
 
 const PREVIEW_MAX_LEN = 100
 
 function pickPriorityString(obj: Record<string, unknown>): string | null {
+  // Top-level pass first — the common case for documented tool input shapes.
   for (const field of PRIORITY_FIELDS) {
     const value = obj[field]
     if (typeof value === 'string' && value.length > 0) return value
+  }
+  // #4648: one-level walk into nested objects to find priority fields. Read
+  // tool input is `{type:'text', file:{filePath:'/foo'}}` — the priority
+  // string lives one level down. Stop after one level (no recursion) so a
+  // pathological nesting can't blow up the dashboard preview path. Skip
+  // arrays — `Record<string, unknown>` typing already excludes them at the
+  // entry, but a nested array value could still exist.
+  for (const value of Object.values(obj)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue
+    for (const field of PRIORITY_FIELDS) {
+      const nested = (value as Record<string, unknown>)[field]
+      if (typeof nested === 'string' && nested.length > 0) return nested
+    }
   }
   return null
 }
@@ -80,6 +101,16 @@ export function getInputSummary(input: Record<string, unknown> | string | null |
     if (!value) continue
     if (typeof value === 'string') return value.slice(0, PREVIEW_MAX_LEN)
     return JSON.stringify(value).slice(0, PREVIEW_MAX_LEN)
+  }
+  // #4648: same one-level walk as pickPriorityString for the Read tool
+  // shape `{type:'text', file:{filePath:'/foo'}}` — without this the
+  // summary is '' and ToolBubble falls through to raw JSON head.
+  for (const value of Object.values(inputObj)) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) continue
+    for (const field of PRIORITY_FIELDS) {
+      const nested = (value as Record<string, unknown>)[field]
+      if (typeof nested === 'string' && nested.length > 0) return nested.slice(0, PREVIEW_MAX_LEN)
+    }
   }
   return ''
 }


### PR DESCRIPTION
## Summary

Rethinks chroxy's multi-question AskUserQuestion form interaction model end-to-end after a 6-agent `/swarm-audit` unanimously concluded the PTY-keystroke driver cannot work in production (**0/7 success rate per chroxy.log, 24h sample**).

Closes #4648.

## What ships

### P1 — Permission-hook deny for multi-question AskUserQuestion (critical)

`packages/server/hooks/permission-hook.sh` now detects PreToolUse where `tool_name == "AskUserQuestion"` AND `questions[].length > 1`, returns `permissionDecision: "deny"` with a reason that instructs the model to re-emit as N sequential single-question calls (the empirically-validated v0.9.4 happy path that has worked since v0.9.4).

Key design choices:
- **Runs BEFORE permission-mode dispatch** — auto/approve/acceptEdits/plan all deny consistently. Auto mode would otherwise allow the form to render and hit the wedge.
- **python3 stdin JSON parse** for robust array-length detection (regex on JSON arrays is brittle). Stock macOS has `/usr/bin/python3` 3.9.6 + Homebrew at `/opt/homebrew/bin/python3`. On parse failure / python3 absence the check yields empty count → no deny → existing behavior. Worst case = today's behavior (the v0.9.23 watchdog catches the wedge).
- **Defense in depth retained** — the v0.9.23 `_onAskUserQuestionStall` teardown still catches anything that slips through. Old multi-q driver code kept in place for one release cycle as backstop.

7-test file (`tests/permission-hook-multi-question.test.js`) pins: multi-q deny with structured reason, deny regardless of permission mode, single-q passthrough in auto mode, non-AskUserQuestion tools unaffected, malformed-payload safe fallthrough, empty-array safe fallthrough, non-array shape drift safe fallthrough.

### P2 — Error toast copy rewrite

`claude-tui-session.js` `_onAskUserQuestionStall` error message went from chroxy jargon ("likely a multi-question form") to action-oriented:

> Before: \`The agent's question response could not be delivered — likely a multi-question form. Please retry from your last message.\`
> After: \`Couldn't deliver your answers. Tap Retry to resend your original request.\`

Existing test's \`/retry/i\` pattern still matches. No test changes needed.

### P3 — Raw tool_input JSON exposure

`packages/store-core/src/tool-summary.ts` adds `filePath` to PRIORITY_FIELDS and a one-level nested-object walk for the Read tool input shape `{type:'text', file:{filePath:'/foo'}}`. Pre-fix, none of the priority fields matched and the dashboard's `ToolBubble` fell through to rendering raw JSON head as the collapsed preview. Stops at one level — no recursion — so bounded preview cost on the hot ToolBubble render path. 7 new tests cover nested extraction, depth limit, no-array-descent, top-level priority winning, and length cap.

## What gets deferred to v0.9.25+

- Deleting the ~742 LOC multi-question driver stack (once refuse proves stable in dogfood)
- Skeptic's answersMap text-keying / Submit-screen driver fixes (dead-code path now; textbook YAGNI)
- 4 of 5 Operator UX improvements (separate UX-pass PR)
- Mobile MultiQuestionForm parity (moot — refuse-at-hook fixes mobile for free)
- MCP elicitation evaluation (defer indefinitely)

## Test plan

- [x] `packages/server` — 161/161 pass (claude-tui + permission-hook suites)
- [x] `packages/store-core` — 24/24 pass (tool-summary)
- [x] Manual hook script invocations confirm: multi-q deny, single-q passthrough, edge cases (auto mode + multi-q, Bash + auto, malformed, empty array, acceptEdits + Read)
- [ ] Dogfood v0.9.24: trigger a multi-q form, confirm model receives deny + re-emits as N single-q forms, each succeeds. Confirm Read tool input collapsed preview shows `/path/to/file` not JSON.

## Related

- #4604 — original AskUserQuestion stall watchdog
- #4638 — sibling stream-stall watchdog (v0.9.22)
- #4641 — extract `_teardownTurn()` (even more motivated; deferred)
- #4642 — observability for `_isBusy && !_currentMessageId` invariant
- #4645 — full turn teardown on `ASK_USER_QUESTION_STALL` (v0.9.23)