### PR TITLE
chore(release): cut v0.9.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.24] - 2026-05-31
+
+Rethinks chroxy's multi-question `AskUserQuestion` form handling end-to-end after a 6-agent `/swarm-audit` unanimously concluded the existing PTY-keystroke driver cannot work in production (0/7 success rate per `chroxy.log` forensic, 24h sample). Replaces the driver path with a permission-hook deny that forces the model to re-issue as N sequential single-question calls — each driven by the empirically-validated single-question happy path that has worked since v0.9.4. Also a cosmetic dashboard fix for the Read-tool collapsed preview.
+
+### Fixed
+
+- **Refuse multi-question AskUserQuestion at the permission hook** (#4648, #4649) — `packages/server/hooks/permission-hook.sh` now detects PreToolUse where `tool_name == "AskUserQuestion"` AND `questions[].length > 1`, returns `permissionDecision: "deny"` with a `permissionDecisionReason` instructing the model to re-issue as separate AskUserQuestion calls, one per question. Runs BEFORE permission-mode dispatch so `auto`/`approve`/`acceptEdits`/`plan` all behave consistently. Uses `python3` stdin JSON parse with safe fallthrough — malformed payload or `python3` absence falls through to existing behavior rather than denying broadly. Defense in depth: the v0.9.23 `_onAskUserQuestionStall` teardown still catches anything that slips through. The old multi-question driver code stays in place for one release cycle as defense-in-depth; deletion planned for a future release once refuse is proven stable in dogfood.
+- **Action-oriented error toast on `ASK_USER_QUESTION_STALL`** (#4648, #4649) — was `"The agent's question response could not be delivered — likely a multi-question form. Please retry from your last message."` (chroxy jargon); now `"Couldn't deliver your answers. Tap Retry to resend your original request."` (action-oriented). Most multi-question forms never reach this toast now because the permission hook denies them upstream; the toast is reserved for the rarer cases that slip past the hook.
+- **Raw `tool_input` JSON leaking into Read tool's collapsed preview** (#4648, #4649) — `packages/store-core/src/tool-summary.ts` adds `filePath` to the priority field list and a one-level nested-object walk so the Read tool input shape `{type:'text', file:{filePath:'/foo'}}` summarizes as `/foo` instead of falling through to `ToolBubble`'s raw-JSON-head fallback. Walk stops at depth one so bounded preview cost on the hot `ToolBubble` render path.
+
 ## [0.9.23] - 2026-05-31
 
 Two follow-ups from v0.9.22 dogfooding. The `ASK_USER_QUESTION_STALL` watchdog from #4604 was firing the user-facing error correctly but leaving the session looking busy — the dashboard kept the "Working…" banner and Stop button up for the next 4.5 min (until v0.9.22's new 5-min stream-stall watchdog kicked in), so the toast's "retry from your last message" instruction had no Send affordance to retry from. And the multi-question form's option labels rendered with the radio/checkbox dot jammed against the text.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.23"
+      "version": "0.9.24"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.23",
+    "version": "0.9.24",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.23</string>
+    <string>0.9.24</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.23"
+version = "0.9.24"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.23"
+version = "0.9.24"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.23",
+      "version": "0.9.24",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Release cut for v0.9.24. One PR merged since v0.9.23:

- **#4649** (closes #4648) — refuse multi-question AskUserQuestion at permission hook + error copy rewrite + raw tool_input JSON nested walk

Rooted in a 6-agent `/swarm-audit` that unanimously concluded the existing PTY-keystroke driver cannot work in production (0/7 success rate per chroxy.log forensic).

## Test plan

- [x] `bump-version.sh 0.9.24` ran clean
- [x] CHANGELOG entry written
- [x] Local diff sanity-checked (15 files: package.json × 6, lockfiles × 2, app.json, Info.plist, tauri.conf.json, Cargo.toml, Cargo.lock, CHANGELOG)