### PR TITLE
feat(server): add DeepSeek as a first-class provider

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -289,20 +289,44 @@ export class ClaudeByokSession extends BaseSession {
         : null
   }
 
+  // Subclass seams (#4656 — DeepSeek). Overriding these four lets a
+  // sibling provider (DeepSeek's Anthropic-compatible endpoint, any
+  // other future Anthropic-compatible service) reuse this entire agent
+  // loop by swapping credentials, base URL, default model, and pricing
+  // table — no fork, no re-implementation of the streaming + tool +
+  // permission + MCP machinery.
+  get _defaultModel() {
+    return 'claude-opus-4-7'
+  }
+
+  _resolveCredentials() {
+    return resolveAnthropicApiKey()
+  }
+
+  _buildClient(apiKey) {
+    return new Anthropic({ apiKey })
+  }
+
+  _getPricing(model) {
+    return getModelPricing(model)
+  }
+
   async start() {
     if (this._client === null) {
       // Spike (BYOK direct) confirmed the SDK's standard constructor
       // works fine; baseURL defaults to api.anthropic.com.
-      const resolved = resolveAnthropicApiKey()
+      const resolved = this._resolveCredentials()
       if (!resolved.key) {
         this.emit('error', { message: `BYOK credentials not found — ${resolved.reason}` })
         return
       }
       this._apiKeySource = resolved.source
       // Mask in logs — full key never appears on disk. logger.js redactor
-      // catches Bearer / sk-ant patterns as a defense in depth.
-      log.info(`BYOK session ready — key source=${this._apiKeySource} key=${maskApiKey(resolved.key)} model=${this.model || 'default'}`)
-      this._client = new Anthropic({ apiKey: resolved.key })
+      // catches Bearer / sk-ant patterns as a defense in depth. The
+      // `this._provider` label keeps the line accurate when a subclass
+      // (#4656 — DeepSeek) reuses this start() through the four seams.
+      log.info(`${this._provider || 'BYOK'} session ready — key source=${this._apiKeySource} key=${maskApiKey(resolved.key)} model=${this.model || 'default'}`)
+      this._client = this._buildClient(resolved.key)
     }
 
     // #4077: spawn MCP children lazily on first start(). Errors during
@@ -397,8 +421,8 @@ export class ClaudeByokSession extends BaseSession {
     // tool-use turn reports only 1/5th of the actual cost (#4056).
     const turnUsage = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
     let turnCost = 0
-    const pricingModel = this.model || 'claude-opus-4-7'
-    const pricing = getModelPricing(pricingModel)
+    const pricingModel = this.model || this._defaultModel
+    const pricing = this._getPricing(pricingModel)
     if (!pricing && !this._pricingWarnedModels.has(pricingModel)) {
       // #4085: warn at most once per (session, model) — not once per turn.
       this._pricingWarnedModels.add(pricingModel)
@@ -422,7 +446,7 @@ export class ClaudeByokSession extends BaseSession {
         try {
           stream = this._client.messages.stream(
             {
-              model: this.model || 'claude-opus-4-7',
+              model: this.model || this._defaultModel,
               max_tokens: DEFAULT_MAX_TOKENS,
               ...(systemPrompt ? { system: systemPrompt } : {}),
               // #4078: merge BUILTIN_TOOLS with live MCP tools at turn time.
@@ -666,7 +690,7 @@ export class ClaudeByokSession extends BaseSession {
           try {
             summaryStream = this._client.messages.stream(
               {
-                model: this.model || 'claude-opus-4-7',
+                model: this.model || this._defaultModel,
                 max_tokens: DEFAULT_MAX_TOKENS,
                 ...(systemPrompt ? { system: systemPrompt } : {}),
                 // No tools — force a text-only summary. Even if the model

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -317,7 +317,14 @@ export class ClaudeByokSession extends BaseSession {
       // works fine; baseURL defaults to api.anthropic.com.
       const resolved = this._resolveCredentials()
       if (!resolved.key) {
-        this.emit('error', { message: `BYOK credentials not found — ${resolved.reason}` })
+        // Use the subclass's preflight label (or provider id) so the
+        // toast / error feed names the right provider. Pre-#4656 this
+        // was hardcoded "BYOK" — DeepSeek would inherit the misleading
+        // "BYOK credentials not found" string. Keep "BYOK" as the last
+        // resort in case a subclass declares neither preflight nor
+        // provider.
+        const label = this.constructor.preflight?.label || this._provider || 'BYOK'
+        this.emit('error', { message: `${label} credentials not found — ${resolved.reason}` })
         return
       }
       this._apiKeySource = resolved.source

--- a/packages/server/src/deepseek-credentials.js
+++ b/packages/server/src/deepseek-credentials.js
@@ -1,0 +1,99 @@
+/**
+ * Credential sourcing for the deepseek provider (#4656).
+ *
+ * Mirrors byok-credentials.js — the priority order, the 0600 mode
+ * enforcement, the lazy path resolution, the masking helper — but
+ * reads `DEEPSEEK_API_KEY` from the env and `deepseekApiKey` from
+ * `~/.chroxy/credentials.json`. Kept as a separate module (rather than
+ * a generic "any provider's API key" helper) so a credentials.json with
+ * both `anthropicApiKey` and `deepseekApiKey` populated routes to the
+ * right provider without either path having to know about the other.
+ *
+ * Priority order:
+ *   1. process.env.DEEPSEEK_API_KEY
+ *   2. ~/.chroxy/credentials.json — { deepseekApiKey: "sk-..." }
+ *      File MUST be mode 0600. We refuse to read it otherwise (security
+ *      boundary: API keys are user-pasted secrets).
+ *
+ * Never logged. The redactor at logger.js scrubs `Bearer` patterns; the
+ * DeepSeek `sk-` prefix overlaps with many other key formats so it isn't
+ * special-cased there — masking at the use site is the defense.
+ */
+import { readFileSync, statSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import { maskApiKey } from './byok-credentials.js'
+
+// Lazy-resolved per call so tests that mutate process.env.HOME between
+// cases pick up the new home (same rationale as byok-credentials.js).
+function credentialsFilePath() {
+  return join(homedir(), '.chroxy', 'credentials.json')
+}
+
+/**
+ * Resolve the DeepSeek API key for a DeepSeek session.
+ *
+ * @returns {{ key: string, source: 'env' | 'file' } | { key: null, source: 'none', reason: string }}
+ */
+export function resolveDeepSeekApiKey() {
+  const envKey = process.env.DEEPSEEK_API_KEY
+  if (typeof envKey === 'string' && envKey.length > 0) {
+    return { key: envKey, source: 'env' }
+  }
+
+  const CREDENTIALS_FILE = credentialsFilePath()
+  let stat
+  try {
+    stat = statSync(CREDENTIALS_FILE)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return {
+        key: null,
+        source: 'none',
+        reason: `DEEPSEEK_API_KEY not set and ${CREDENTIALS_FILE} does not exist`,
+      }
+    }
+    return {
+      key: null,
+      source: 'none',
+      reason: `unable to stat ${CREDENTIALS_FILE}: ${err.message}`,
+    }
+  }
+
+  // Refuse anything more permissive than 0600 — same security boundary
+  // as the BYOK resolver. A pasted-in credentials.json defaulting to 0644
+  // on macOS would otherwise leak the key to every local user.
+  const perms = stat.mode & 0o777
+  if (perms !== 0o600) {
+    return {
+      key: null,
+      source: 'none',
+      reason: `${CREDENTIALS_FILE} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600 — run: chmod 600 ${CREDENTIALS_FILE})`,
+    }
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(CREDENTIALS_FILE, 'utf8'))
+  } catch (err) {
+    return {
+      key: null,
+      source: 'none',
+      reason: `${CREDENTIALS_FILE} unreadable or not valid JSON: ${err.message}`,
+    }
+  }
+
+  if (typeof parsed?.deepseekApiKey !== 'string' || parsed.deepseekApiKey.length === 0) {
+    return {
+      key: null,
+      source: 'none',
+      reason: `${CREDENTIALS_FILE} missing or empty "deepseekApiKey" field`,
+    }
+  }
+
+  return { key: parsed.deepseekApiKey, source: 'file' }
+}
+
+// Re-export the masking helper so callers don't have to import from two
+// modules to log a redacted DeepSeek key.
+export { maskApiKey }

--- a/packages/server/src/deepseek-session.js
+++ b/packages/server/src/deepseek-session.js
@@ -1,0 +1,122 @@
+/**
+ * DeepSeek provider (#4656) — talks to DeepSeek's Anthropic-compatible
+ * endpoint at `https://api.deepseek.com/anthropic` using the existing
+ * `@anthropic-ai/sdk` client. Reuses ClaudeByokSession's entire agent
+ * loop (streaming, tools, permissions, MCP, history, cost) by swapping
+ * the four seams (`_defaultModel`, `_resolveCredentials`, `_buildClient`,
+ * `_getPricing`) plus the static-side metadata.
+ *
+ * Why subclass instead of fork: every fix that lands in byok-session
+ * (history rollback semantics, parallel-tool execution, MAX_TOOL_ROUNDS
+ * summary, `tool_input_delta` flicker suppression, MCP fleet teardown)
+ * is correctness work that DeepSeek users want too. A fork would have
+ * to be hand-merged on every byok change; subclassing keeps the
+ * tracking automatic.
+ *
+ * Onboarding: the user gets a key at platform.deepseek.com, exports
+ * `DEEPSEEK_API_KEY` OR drops `{"deepseekApiKey":"sk-..."}` into
+ * `~/.chroxy/credentials.json` (chmod 600), then picks the "deepseek"
+ * provider in the dashboard / mobile app. See the issue tracker for the
+ * full onboarding doc.
+ */
+
+import Anthropic from '@anthropic-ai/sdk'
+import { ClaudeByokSession } from './byok-session.js'
+import { resolveDeepSeekApiKey } from './deepseek-credentials.js'
+import { getDeepSeekPricing } from './models.js'
+
+// Override point for self-hosted or pinned-version endpoints. Defaults
+// to DeepSeek's Anthropic-compatible endpoint, which they explicitly
+// publish so Claude Code clients can point at it without translation.
+const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/anthropic'
+
+// DeepSeek's published context window for both `deepseek-chat` (V3) and
+// `deepseek-reasoner` (R1). If they ever ship a larger-context variant,
+// extend the metadata map below and the chip will surface automatically.
+const DEEPSEEK_CONTEXT_WINDOW = 128_000
+
+// Static model registry. `id` matches `fullId` because DeepSeek doesn't
+// use a `claude-` style prefix — the registry's deriveId hook for
+// non-Claude providers defaults to identity, so this stays consistent
+// with what providers.js installs.
+const DEEPSEEK_MODELS = Object.freeze([
+  Object.freeze({
+    id: 'deepseek-chat',
+    label: 'DeepSeek V3 (Chat)',
+    fullId: 'deepseek-chat',
+    contextWindow: DEEPSEEK_CONTEXT_WINDOW,
+  }),
+  Object.freeze({
+    id: 'deepseek-reasoner',
+    label: 'DeepSeek R1 (Reasoner)',
+    fullId: 'deepseek-reasoner',
+    contextWindow: DEEPSEEK_CONTEXT_WINDOW,
+  }),
+])
+
+const DEEPSEEK_MODEL_IDS = Object.freeze(DEEPSEEK_MODELS.map((m) => m.id))
+
+export class DeepSeekSession extends ClaudeByokSession {
+  static get displayLabel() {
+    return 'DeepSeek (API key)'
+  }
+
+  static get dataDir() {
+    // No `~/.claude` dependency — pure HTTPS to api.deepseek.com.
+    // getProviderDataDirs() skips providers that return null (#2965).
+    return null
+  }
+
+  static get preflight() {
+    return {
+      label: 'DeepSeek',
+      credentials: {
+        envVars: ['DEEPSEEK_API_KEY'],
+        hint: 'set DEEPSEEK_API_KEY or save it as "deepseekApiKey" in ~/.chroxy/credentials.json (mode 0600)',
+        optional: false,
+      },
+    }
+  }
+
+  static getFallbackModels() {
+    return DEEPSEEK_MODELS
+  }
+
+  static getAllowedModels() {
+    return [...DEEPSEEK_MODEL_IDS]
+  }
+
+  static getModelMetadata(modelId) {
+    if (typeof modelId !== 'string' || modelId.length === 0) return null
+    const hit = DEEPSEEK_MODELS.find((m) => m.id === modelId || m.fullId === modelId)
+    if (!hit) return null
+    return { id: hit.id, label: hit.label, fullId: hit.fullId, contextWindow: hit.contextWindow }
+  }
+
+  constructor(opts = {}) {
+    // Force the registry name so the provider id on this session is
+    // always 'deepseek' — independent of whatever the embedder passed.
+    super({ ...opts, provider: 'deepseek' })
+  }
+
+  // --- Seam overrides (see byok-session.js for the contract) ---
+
+  get _defaultModel() {
+    return 'deepseek-chat'
+  }
+
+  _resolveCredentials() {
+    return resolveDeepSeekApiKey()
+  }
+
+  _buildClient(apiKey) {
+    return new Anthropic({
+      apiKey,
+      baseURL: process.env.DEEPSEEK_BASE_URL || DEFAULT_DEEPSEEK_BASE_URL,
+    })
+  }
+
+  _getPricing(model) {
+    return getDeepSeekPricing(model)
+  }
+}

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -162,6 +162,40 @@ export function getModelPricing(modelId) {
   return key ? CLAUDE_PRICING_USD_PER_MTOK[key] : null
 }
 
+// Public DeepSeek pricing in USD per million tokens (#4656). Source:
+// https://api-docs.deepseek.com/quick_start/pricing — keep in sync.
+// DeepSeek bills cache hits separately from cache misses but does NOT
+// charge a separate cache-write fee, so `cacheWrite` is 0; the field is
+// kept so the same `computePromptCostUsd` helper consumes both tables
+// without a shape branch.
+//
+// DeepSeek hits chroxy through their Anthropic-compatible endpoint
+// (https://api.deepseek.com/anthropic), so usage objects arrive in the
+// Anthropic shape (`input_tokens` / `output_tokens` /
+// `cache_read_input_tokens` / `cache_creation_input_tokens`). DeepSeek's
+// own docs note that they map their internal cache-hit metric onto the
+// Anthropic `cache_read_input_tokens` slot, and they never report cache
+// writes — so the zero rate is correct, not a placeholder.
+const DEEPSEEK_PRICING_USD_PER_MTOK = Object.freeze({
+  // V3 chat — general-purpose model.
+  'deepseek-chat':     Object.freeze({ input: 0.27, output: 1.10, cacheRead: 0.07, cacheWrite: 0 }),
+  // R1 reasoning — emits a reasoning trace before the final answer.
+  'deepseek-reasoner': Object.freeze({ input: 0.55, output: 2.19, cacheRead: 0.14, cacheWrite: 0 }),
+})
+
+/**
+ * Returns the DeepSeek pricing rates for a model (USD per million tokens),
+ * or null if pricing is unknown (#4656).
+ *
+ * Verbatim-only lookup. DeepSeek doesn't ship date-suffixed model ids the
+ * way Anthropic does, so the strip-and-retry dance from `resolvePricingKey`
+ * isn't warranted here. If they ever do, extend along the same shape.
+ */
+export function getDeepSeekPricing(modelId) {
+  if (typeof modelId !== 'string' || modelId.length === 0) return null
+  return DEEPSEEK_PRICING_USD_PER_MTOK[modelId] || null
+}
+
 /**
  * Compute USD cost for a single turn's usage object as returned by the
  * Anthropic SDK (`{ input_tokens, output_tokens, cache_creation_input_tokens,

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -20,16 +20,19 @@ import { CliSession } from './cli-session.js'
 import { SdkSession } from './sdk-session.js'
 import { ClaudeTuiSession } from './claude-tui-session.js'
 import { ClaudeByokSession } from './byok-session.js'
+import { DeepSeekSession } from './deepseek-session.js'
 import { GeminiSession } from './gemini-session.js'
 import { CodexSession } from './codex-session.js'
 import { registerProviderRegistry } from './models.js'
 import { resolveAnthropicApiKey } from './byok-credentials.js'
+import { resolveDeepSeekApiKey } from './deepseek-credentials.js'
 
 const PROVIDERS = {
   'claude-cli': CliSession,
   'claude-sdk': SdkSession,
   'claude-tui': ClaudeTuiSession,
   'claude-byok': ClaudeByokSession,
+  'deepseek': DeepSeekSession,
   'gemini': GeminiSession,
   'codex': CodexSession,
 }
@@ -289,6 +292,35 @@ function getProviderAuthInfo(name, ProviderClass) {
       envVars,
       hint,
       detail: `Anthropic API (${resolved.reason})`,
+    }
+  }
+
+  // DeepSeek mirrors the BYOK branch (#4656): env-var OR
+  // ~/.chroxy/credentials.json `deepseekApiKey` field. Both surface as
+  // source: 'env' so SettingsPanel's tone legend maps cleanly; the
+  // `detail` string disambiguates which path supplied the key. Without
+  // this dedicated branch the generic env-var match below would return
+  // ready:false whenever the user stored the key in credentials.json
+  // rather than exporting DEEPSEEK_API_KEY.
+  if (name === 'deepseek') {
+    const resolved = resolveDeepSeekApiKey()
+    if (resolved.key) {
+      return {
+        ready: true,
+        source: 'env',
+        envVar: resolved.source === 'env' ? 'DEEPSEEK_API_KEY' : null,
+        envVars,
+        hint: '',
+        detail: `DeepSeek API (${resolved.source === 'env' ? 'DEEPSEEK_API_KEY set' : '~/.chroxy/credentials.json'} — per-token billing)`,
+      }
+    }
+    return {
+      ready: false,
+      source: 'none',
+      envVar: null,
+      envVars,
+      hint,
+      detail: `DeepSeek API (${resolved.reason})`,
     }
   }
 
@@ -596,6 +628,7 @@ function describeBillingIdentity(name, envVar) {
   }
   if (name === 'codex') return 'OpenAI API'
   if (name === 'gemini') return 'Google API'
+  if (name === 'deepseek') return 'DeepSeek API'
   return 'External provider'
 }
 

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -189,7 +189,13 @@ describe('ClaudeByokSession', () => {
       await session.start()
       const errorEvent = captured.find((e) => e.name === 'error')
       assert.ok(errorEvent, 'error event must fire')
-      assert.match(errorEvent.payload.message, /BYOK credentials not found/)
+      // After #4656 the prefix uses the preflight label ('Claude (BYOK)')
+      // so the legacy contiguous "BYOK credentials not found" no longer
+      // matches verbatim. Pin both the BYOK marker and the credentials
+      // phrase independently so a future label change doesn't silently
+      // pass an unrelated error string.
+      assert.match(errorEvent.payload.message, /BYOK/)
+      assert.match(errorEvent.payload.message, /credentials not found/)
       assert.equal(captured.find((e) => e.name === 'ready'), undefined)
     })
 

--- a/packages/server/tests/deepseek-credentials.test.js
+++ b/packages/server/tests/deepseek-credentials.test.js
@@ -1,0 +1,156 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveDeepSeekApiKey, maskApiKey } from '../src/deepseek-credentials.js'
+
+/**
+ * Tests for deepseek-credentials.js (#4656) — env-var precedence,
+ * file-fallback, 0600 permission enforcement, key masking re-export.
+ *
+ * Run with HOME pointed at a tmpdir so we never touch the real
+ * ~/.chroxy/credentials.json on the dev machine.
+ */
+
+describe('deepseek-credentials', () => {
+  let tmpHome
+  let originalHome
+  let originalApiKey
+  let originalAnthropicKey
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-deepseek-cred-test-'))
+    originalHome = process.env.HOME
+    originalApiKey = process.env.DEEPSEEK_API_KEY
+    originalAnthropicKey = process.env.ANTHROPIC_API_KEY
+    process.env.HOME = tmpHome
+    delete process.env.DEEPSEEK_API_KEY
+    // Defensive: a bleed-through ANTHROPIC_API_KEY must not poison this
+    // resolver — the two paths are independent. Confirms isolation.
+    delete process.env.ANTHROPIC_API_KEY
+  })
+
+  afterEach(() => {
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    if (originalApiKey) process.env.DEEPSEEK_API_KEY = originalApiKey
+    else delete process.env.DEEPSEEK_API_KEY
+    if (originalAnthropicKey) process.env.ANTHROPIC_API_KEY = originalAnthropicKey
+    else delete process.env.ANTHROPIC_API_KEY
+    rmSync(tmpHome, { recursive: true, force: true })
+  })
+
+  describe('resolveDeepSeekApiKey', () => {
+    it('returns env-var key when DEEPSEEK_API_KEY is set', () => {
+      process.env.DEEPSEEK_API_KEY = 'sk-deepseek-from-env'
+      const result = resolveDeepSeekApiKey()
+      assert.equal(result.key, 'sk-deepseek-from-env')
+      assert.equal(result.source, 'env')
+    })
+
+    it('returns "none" with helpful reason when neither env nor file present', () => {
+      const result = resolveDeepSeekApiKey()
+      assert.equal(result.key, null)
+      assert.equal(result.source, 'none')
+      assert.match(result.reason, /DEEPSEEK_API_KEY not set/)
+      assert.match(result.reason, /does not exist/)
+    })
+
+    it('reads file when env not set and file is mode 0600', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, JSON.stringify({ deepseekApiKey: 'sk-deepseek-from-file' }))
+      chmodSync(credPath, 0o600)
+      const result = resolveDeepSeekApiKey()
+      assert.equal(result.key, 'sk-deepseek-from-file')
+      assert.equal(result.source, 'file')
+    })
+
+    it('refuses to read a 0644 credentials file (security boundary)', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, JSON.stringify({ deepseekApiKey: 'sk-should-not-load' }))
+      chmodSync(credPath, 0o644)
+      const result = resolveDeepSeekApiKey()
+      assert.equal(result.key, null)
+      assert.match(result.reason, /mode 644/)
+      assert.match(result.reason, /must be 0600/)
+    })
+
+    it('returns "none" when credentials.json is unparseable', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, 'not valid json {')
+      chmodSync(credPath, 0o600)
+      const result = resolveDeepSeekApiKey()
+      assert.equal(result.key, null)
+      assert.match(result.reason, /unreadable or not valid JSON/)
+    })
+
+    it('returns "none" when credentials.json lacks deepseekApiKey field', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, JSON.stringify({ anthropicApiKey: 'sk-ant-only' }))
+      chmodSync(credPath, 0o600)
+      const result = resolveDeepSeekApiKey()
+      assert.equal(result.key, null)
+      assert.match(result.reason, /missing or empty "deepseekApiKey"/)
+    })
+
+    it('ignores anthropicApiKey siblings — only deepseekApiKey is consulted', () => {
+      // A user with both Anthropic and DeepSeek keys in the same
+      // credentials.json must have each provider read its own field.
+      // Without this isolation the wrong key would silently bind to the
+      // wrong provider on every session.
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, JSON.stringify({
+        anthropicApiKey: 'sk-ant-not-mine',
+        deepseekApiKey: 'sk-deepseek-mine',
+      }))
+      chmodSync(credPath, 0o600)
+      const result = resolveDeepSeekApiKey()
+      assert.equal(result.key, 'sk-deepseek-mine')
+      assert.equal(result.source, 'file')
+    })
+
+    it('prefers env var over file when both are present', () => {
+      const chroxyDir = join(tmpHome, '.chroxy')
+      const credPath = join(chroxyDir, 'credentials.json')
+      mkdirSync(chroxyDir, { recursive: true })
+      writeFileSync(credPath, JSON.stringify({ deepseekApiKey: 'sk-deepseek-from-file' }))
+      chmodSync(credPath, 0o600)
+      process.env.DEEPSEEK_API_KEY = 'sk-deepseek-from-env'
+      const result = resolveDeepSeekApiKey()
+      assert.equal(result.key, 'sk-deepseek-from-env')
+      assert.equal(result.source, 'env')
+    })
+
+    it('does not interpret ANTHROPIC_API_KEY as a DeepSeek key', () => {
+      // The two env vars are independent identity surfaces; setting one
+      // must NOT make the other provider claim ready.
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-not-mine'
+      const result = resolveDeepSeekApiKey()
+      assert.equal(result.key, null)
+      assert.equal(result.source, 'none')
+    })
+  })
+
+  describe('maskApiKey re-export', () => {
+    it('exports the same masking helper as byok-credentials', () => {
+      // The re-export exists so callers don't have to import from two
+      // modules to log a redacted DeepSeek key. Use a long input so the
+      // visible prefix isn't capped to floor(len/3); maskApiKey hits the
+      // 12-char ceiling for any input >= 36 chars.
+      const masked = maskApiKey('sk-test-deepseek-' + 'x'.repeat(60))
+      assert.match(masked, /^sk-test-deep/)
+      assert.match(masked, /\[\d+ chars redacted\]$/)
+    })
+  })
+})

--- a/packages/server/tests/deepseek-session.test.js
+++ b/packages/server/tests/deepseek-session.test.js
@@ -239,7 +239,10 @@ describe('DeepSeekSession (#4656)', () => {
       await session.start()
       assert.equal(events.length, 1)
       assert.equal(events[0].kind, 'error')
-      assert.match(events[0].payload.message, /BYOK credentials not found|DEEPSEEK_API_KEY/i)
+      // After #4656 the error prefix uses the preflight label so DeepSeek
+      // doesn't inherit a misleading "BYOK credentials not found" string.
+      assert.match(events[0].payload.message, /DeepSeek credentials not found/i)
+      assert.match(events[0].payload.message, /DEEPSEEK_API_KEY/)
     })
 
     it('start() resolves credentials via the file path with 0600 enforcement', async () => {

--- a/packages/server/tests/deepseek-session.test.js
+++ b/packages/server/tests/deepseek-session.test.js
@@ -1,0 +1,266 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DeepSeekSession } from '../src/deepseek-session.js'
+import { ClaudeByokSession } from '../src/byok-session.js'
+
+/**
+ * Tests for DeepSeekSession (#4656).
+ *
+ * The parent ClaudeByokSession is covered by byok-session.test.js — its
+ * agent loop, tool gating, MCP wiring, history rollback, etc. don't get
+ * re-tested here. What this file pins is the subclass contract: the
+ * four seam overrides return the right values, the static-side
+ * metadata advertises the DeepSeek catalogue, and the constructor
+ * stamps `provider: 'deepseek'` so registry-keyed code paths route
+ * correctly.
+ *
+ * Async behaviour goes through `start()` with a stubbed `_buildClient`
+ * so we never call out to DeepSeek's API.
+ */
+
+describe('DeepSeekSession (#4656)', () => {
+  describe('inheritance', () => {
+    it('extends ClaudeByokSession', () => {
+      // Subclass relationship is load-bearing — every fix in byok-session
+      // (history rollback, tool round cap, MCP teardown) flows to
+      // DeepSeek for free. A future refactor that breaks the chain
+      // would silently lose all of that.
+      assert.ok(DeepSeekSession.prototype instanceof ClaudeByokSession)
+    })
+  })
+
+  describe('static metadata', () => {
+    it('exposes a DeepSeek-branded displayLabel', () => {
+      assert.equal(DeepSeekSession.displayLabel, 'DeepSeek (API key)')
+    })
+
+    it('returns null dataDir so getProviderDataDirs() skips it (#2965)', () => {
+      // Same shape as byok — no ~/.claude dependency.
+      assert.equal(DeepSeekSession.dataDir, null)
+    })
+
+    it('preflight declares DEEPSEEK_API_KEY as required (not optional)', () => {
+      const spec = DeepSeekSession.preflight
+      assert.equal(spec.label, 'DeepSeek')
+      assert.deepEqual(spec.credentials.envVars, ['DEEPSEEK_API_KEY'])
+      assert.equal(spec.credentials.optional, false,
+        'DeepSeek has no OAuth fallback — the env var (or file) is required')
+      assert.match(spec.credentials.hint, /DEEPSEEK_API_KEY/)
+      assert.match(spec.credentials.hint, /credentials\.json/)
+    })
+
+    it('getFallbackModels returns deepseek-chat + deepseek-reasoner', () => {
+      const models = DeepSeekSession.getFallbackModels()
+      assert.equal(models.length, 2)
+      const ids = models.map((m) => m.id)
+      assert.ok(ids.includes('deepseek-chat'))
+      assert.ok(ids.includes('deepseek-reasoner'))
+      for (const m of models) {
+        assert.equal(m.contextWindow, 128_000,
+          `${m.id} should have DeepSeek's published 128k context window`)
+        assert.equal(m.id, m.fullId,
+          'DeepSeek does not use a stripped prefix; id == fullId')
+      }
+    })
+
+    it('getAllowedModels mirrors the fallback id set', () => {
+      const allowed = DeepSeekSession.getAllowedModels()
+      assert.deepEqual(allowed.sort(), ['deepseek-chat', 'deepseek-reasoner'].sort())
+    })
+
+    it('getAllowedModels returns a fresh array (mutations cannot leak)', () => {
+      // The static metadata frozen-ness is structural correctness — a
+      // caller mutating the array must not affect the next caller. The
+      // implementation spreads into a new array on each call.
+      const a = DeepSeekSession.getAllowedModels()
+      a.push('mutated')
+      const b = DeepSeekSession.getAllowedModels()
+      assert.equal(b.includes('mutated'), false)
+    })
+
+    it('getModelMetadata returns metadata for known models', () => {
+      const chat = DeepSeekSession.getModelMetadata('deepseek-chat')
+      assert.equal(chat.id, 'deepseek-chat')
+      assert.equal(chat.fullId, 'deepseek-chat')
+      assert.equal(chat.contextWindow, 128_000)
+      assert.equal(chat.label, 'DeepSeek V3 (Chat)')
+
+      const reasoner = DeepSeekSession.getModelMetadata('deepseek-reasoner')
+      assert.equal(reasoner.label, 'DeepSeek R1 (Reasoner)')
+    })
+
+    it('getModelMetadata returns null for unknown models', () => {
+      assert.equal(DeepSeekSession.getModelMetadata('not-a-model'), null)
+      assert.equal(DeepSeekSession.getModelMetadata(''), null)
+      assert.equal(DeepSeekSession.getModelMetadata(null), null)
+      assert.equal(DeepSeekSession.getModelMetadata(undefined), null)
+    })
+  })
+
+  describe('seam overrides', () => {
+    it('_defaultModel is deepseek-chat (the cheaper, more general model)', () => {
+      // Picking the smaller V3 model as default mirrors how byok picks
+      // opus as its default (the workhorse), not the reasoning variant
+      // which costs more per token and is overkill for routine turns.
+      const session = new DeepSeekSession({ cwd: '/tmp' })
+      assert.equal(session._defaultModel, 'deepseek-chat')
+    })
+
+    it('_resolveCredentials reads DEEPSEEK_API_KEY (not ANTHROPIC_API_KEY)', () => {
+      const originalDeepseek = process.env.DEEPSEEK_API_KEY
+      const originalAnthropic = process.env.ANTHROPIC_API_KEY
+      try {
+        delete process.env.DEEPSEEK_API_KEY
+        process.env.ANTHROPIC_API_KEY = 'sk-ant-wrong-provider'
+        const session = new DeepSeekSession({ cwd: '/tmp' })
+        const resolved = session._resolveCredentials()
+        assert.equal(resolved.key, null,
+          'must NOT pick up ANTHROPIC_API_KEY — that is the BYOK path')
+
+        process.env.DEEPSEEK_API_KEY = 'sk-deepseek-from-env'
+        const resolved2 = session._resolveCredentials()
+        assert.equal(resolved2.key, 'sk-deepseek-from-env')
+        assert.equal(resolved2.source, 'env')
+      } finally {
+        if (originalDeepseek === undefined) delete process.env.DEEPSEEK_API_KEY
+        else process.env.DEEPSEEK_API_KEY = originalDeepseek
+        if (originalAnthropic === undefined) delete process.env.ANTHROPIC_API_KEY
+        else process.env.ANTHROPIC_API_KEY = originalAnthropic
+      }
+    })
+
+    it('_buildClient passes the DeepSeek baseURL to the Anthropic SDK', () => {
+      const session = new DeepSeekSession({ cwd: '/tmp' })
+      const client = session._buildClient('sk-test')
+      // The Anthropic SDK stores the base URL on the instance — verify
+      // we routed to api.deepseek.com/anthropic, not api.anthropic.com.
+      // Match either the constructed URL or string form so a future
+      // SDK refactor of property naming doesn't unnecessarily break us.
+      const baseURL = client.baseURL || client._options?.baseURL
+      assert.ok(typeof baseURL === 'string' && baseURL.includes('deepseek.com'),
+        `expected baseURL to include "deepseek.com"; got ${baseURL}`)
+    })
+
+    it('_buildClient honours DEEPSEEK_BASE_URL override for self-hosted endpoints', () => {
+      const original = process.env.DEEPSEEK_BASE_URL
+      try {
+        process.env.DEEPSEEK_BASE_URL = 'http://localhost:9999/anthropic'
+        const session = new DeepSeekSession({ cwd: '/tmp' })
+        const client = session._buildClient('sk-test')
+        const baseURL = client.baseURL || client._options?.baseURL
+        assert.ok(typeof baseURL === 'string' && baseURL.includes('localhost:9999'),
+          `expected DEEPSEEK_BASE_URL override to win; got ${baseURL}`)
+      } finally {
+        if (original === undefined) delete process.env.DEEPSEEK_BASE_URL
+        else process.env.DEEPSEEK_BASE_URL = original
+      }
+    })
+
+    it('_getPricing returns DeepSeek rates, not Claude rates', () => {
+      const session = new DeepSeekSession({ cwd: '/tmp' })
+      const chat = session._getPricing('deepseek-chat')
+      assert.ok(chat, 'deepseek-chat must have pricing')
+      // Sanity-check the order of magnitude — DeepSeek is ~50× cheaper
+      // than Opus per input token. If we accidentally return Claude
+      // pricing here, cost displays would be wildly inflated.
+      assert.ok(chat.input < 1, `deepseek-chat input rate should be << $1/MTok; got ${chat.input}`)
+
+      const reasoner = session._getPricing('deepseek-reasoner')
+      assert.ok(reasoner, 'deepseek-reasoner must have pricing')
+      assert.ok(reasoner.output < 5, `deepseek-reasoner output rate should be << $5/MTok; got ${reasoner.output}`)
+
+      const unknown = session._getPricing('claude-opus-4-7')
+      assert.equal(unknown, null,
+        'a Claude model id passed to the DeepSeek seam must NOT silently bind to Claude pricing')
+    })
+  })
+
+  describe('constructor', () => {
+    it('stamps provider="deepseek" regardless of opts.provider', () => {
+      // BaseSession's `_provider` powers frontmatter-based skill filtering,
+      // session-manager registry routing, and the log-line prefix added
+      // in #4656. The subclass must always claim its identity rather
+      // than inheriting 'claude-byok' through opts default.
+      const session = new DeepSeekSession({ cwd: '/tmp' })
+      assert.equal(session._provider, 'deepseek')
+
+      const overridden = new DeepSeekSession({ cwd: '/tmp', provider: 'someone-else' })
+      assert.equal(overridden._provider, 'deepseek',
+        'subclass must hard-set provider; ignoring opts override is intentional')
+    })
+  })
+
+  describe('end-to-end start() with stubbed seams', () => {
+    let tmpHome
+    let originalHome
+    let originalKey
+
+    beforeEach(() => {
+      tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-deepseek-start-test-'))
+      originalHome = process.env.HOME
+      originalKey = process.env.DEEPSEEK_API_KEY
+      process.env.HOME = tmpHome
+    })
+
+    afterEach(() => {
+      if (originalHome) process.env.HOME = originalHome
+      else delete process.env.HOME
+      if (originalKey) process.env.DEEPSEEK_API_KEY = originalKey
+      else delete process.env.DEEPSEEK_API_KEY
+      rmSync(tmpHome, { recursive: true, force: true })
+    })
+
+    it('start() emits ready when env credentials resolve', async () => {
+      process.env.DEEPSEEK_API_KEY = 'sk-test-from-env'
+      const session = new DeepSeekSession({ cwd: '/tmp' })
+      // Override the client seam so the resolver path runs end-to-end
+      // but we never instantiate a real HTTP client. Stubbing _client
+      // directly would short-circuit the `if (_client === null)` guard
+      // in start() and skip the credential resolution we want to verify.
+      session._buildClient = () => ({ messages: { stream: () => null } })
+      const events = []
+      session.on('ready', (e) => events.push({ kind: 'ready', payload: e }))
+      session.on('error', (e) => events.push({ kind: 'error', payload: e }))
+      await session.start()
+      assert.equal(events.length, 1)
+      assert.equal(events[0].kind, 'ready')
+      assert.equal(session._apiKeySource, 'env')
+    })
+
+    it('start() emits error when no credentials are available', async () => {
+      delete process.env.DEEPSEEK_API_KEY
+      const session = new DeepSeekSession({ cwd: '/tmp' })
+      const events = []
+      session.on('ready', (e) => events.push({ kind: 'ready', payload: e }))
+      session.on('error', (e) => events.push({ kind: 'error', payload: e }))
+      await session.start()
+      assert.equal(events.length, 1)
+      assert.equal(events[0].kind, 'error')
+      assert.match(events[0].payload.message, /BYOK credentials not found|DEEPSEEK_API_KEY/i)
+    })
+
+    it('start() resolves credentials via the file path with 0600 enforcement', async () => {
+      delete process.env.DEEPSEEK_API_KEY
+      const chroxyDir = join(tmpHome, '.chroxy')
+      mkdirSync(chroxyDir, { recursive: true })
+      const credPath = join(chroxyDir, 'credentials.json')
+      writeFileSync(credPath, JSON.stringify({ deepseekApiKey: 'sk-from-file' }))
+      chmodSync(credPath, 0o600)
+
+      const session = new DeepSeekSession({ cwd: '/tmp' })
+      // Override the seam so the resolver runs but no real client gets
+      // built. Same pattern as the env-source test above.
+      session._buildClient = () => ({ messages: { stream: () => null } })
+      const events = []
+      session.on('ready', (e) => events.push({ kind: 'ready', payload: e }))
+      session.on('error', (e) => events.push({ kind: 'error', payload: e }))
+      await session.start()
+      assert.equal(events.length, 1, 'should emit exactly one event')
+      assert.equal(events[0].kind, 'ready')
+      assert.equal(session._apiKeySource, 'file')
+    })
+  })
+})

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { registerProvider, getProvider, listProviders, registerDockerProvider, _resetCredsCacheForTest } from '../src/providers.js'
@@ -106,7 +106,7 @@ describe('Provider Registry', () => {
   // so the dashboard can grey-out unusable providers and show a billing-
   // identity confidence panel without making the user run `chroxy doctor`.
   describe('auth status (#3404 audit)', () => {
-    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME']
+    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'OPENAI_API_KEY', 'GEMINI_API_KEY', 'GOOGLE_API_KEY', 'DEEPSEEK_API_KEY', 'CHROXY_CLAUDE_HOME', 'CHROXY_CLAUDE_CONFIG', 'CHROXY_CODEX_HOME', 'CHROXY_GEMINI_HOME']
     const saved = {}
     let _tmpClaudeHome = null
     let _tmpCodexHome = null
@@ -486,6 +486,82 @@ describe('Provider Registry', () => {
         assert.equal(gemini.auth.source, 'env')
         assert.equal(gemini.auth.envVar, 'GEMINI_API_KEY')
       } finally {
+        restoreKeys()
+      }
+    })
+
+    // #4656: DeepSeek mirrors the BYOK auth flow — DEEPSEEK_API_KEY env
+    // OR a `deepseekApiKey` field in ~/.chroxy/credentials.json (mode 0600).
+    // Both must resolve through the dedicated branch in getProviderAuthInfo;
+    // without it the file path would silently report ready=false.
+    it('deepseek validates and is registered', () => {
+      const list = listProviders()
+      const ds = list.find(p => p.name === 'deepseek')
+      assert.ok(ds, 'deepseek provider should be registered')
+      assert.equal(typeof ds.capabilities, 'object')
+    })
+
+    it('deepseek reports ready=true source=env when DEEPSEEK_API_KEY is set (#4656)', () => {
+      try {
+        clearKeys()
+        process.env.DEEPSEEK_API_KEY = 'sk-deepseek-test'
+        const list = listProviders()
+        const ds = list.find(p => p.name === 'deepseek')
+        assert.ok(ds?.auth)
+        assert.equal(ds.auth.ready, true)
+        assert.equal(ds.auth.source, 'env')
+        assert.equal(ds.auth.envVar, 'DEEPSEEK_API_KEY')
+        assert.match(ds.auth.detail, /DeepSeek API/)
+        assert.match(ds.auth.detail, /DEEPSEEK_API_KEY set/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('deepseek reports ready=false source=none when no credentials are present (#4656)', () => {
+      try {
+        clearKeys()
+        const list = listProviders()
+        const ds = list.find(p => p.name === 'deepseek')
+        assert.ok(ds?.auth)
+        assert.equal(ds.auth.ready, false)
+        assert.equal(ds.auth.source, 'none')
+        assert.match(ds.auth.detail, /DeepSeek API/)
+        // Hint must mention the env var so the user knows the fix.
+        assert.match(ds.auth.hint, /DEEPSEEK_API_KEY/)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('deepseek reports ready=true source=env when key is in credentials.json (#4656)', () => {
+      // Mirrors the claude-byok file-path test. Without the dedicated
+      // DeepSeek branch in getProviderAuthInfo, this would silently
+      // report ready=false because the generic env-var match only
+      // looks at process.env, not the credentials.json file.
+      const tmpFsHome = mkdtempSync(join(tmpdir(), 'chroxy-deepseek-auth-test-'))
+      const savedHome = process.env.HOME
+      try {
+        clearKeys()
+        process.env.HOME = tmpFsHome
+        mkdirSync(join(tmpFsHome, '.chroxy'), { recursive: true })
+        const credPath = join(tmpFsHome, '.chroxy', 'credentials.json')
+        writeFileSync(credPath, JSON.stringify({ deepseekApiKey: 'sk-from-file' }))
+        // Set mode after write because some tmp setups don't honour the
+        // mode arg on writeFileSync. chmod is the authoritative source.
+        chmodSync(credPath, 0o600)
+        const list = listProviders()
+        const ds = list.find(p => p.name === 'deepseek')
+        assert.ok(ds?.auth)
+        assert.equal(ds.auth.ready, true)
+        assert.equal(ds.auth.source, 'env',
+          'file path must surface as source=env so SettingsPanel renders the right tone')
+        assert.equal(ds.auth.envVar, null, 'file source has no env var')
+        assert.match(ds.auth.detail, /credentials\.json/)
+      } finally {
+        if (savedHome) process.env.HOME = savedHome
+        else delete process.env.HOME
+        rmSync(tmpFsHome, { recursive: true, force: true })
         restoreKeys()
       }
     })


### PR DESCRIPTION
## Summary

- Add `deepseek` provider — subclasses `ClaudeByokSession` and points at DeepSeek's Anthropic-compatible endpoint (`api.deepseek.com/anthropic`)
- Reuses the entire BYOK agent loop (streaming, tools, permissions, MCP, history) via four overridable seams on the parent
- Models: `deepseek-chat` (V3, 128k ctx) and `deepseek-reasoner` (R1, 128k ctx); pricing table sourced from DeepSeek's public docs

Closes #4656.

## Setup primer (to share with new users)

```bash
# 1. Install (Node 22+ required)
brew install node@22 cloudflared
npm install -g chroxy

# 2. Get a key at https://platform.deepseek.com → API Keys

# 3. Configure (either path)
export DEEPSEEK_API_KEY=sk-your-key-here
# — OR persist —
mkdir -p ~/.chroxy
echo '{"deepseekApiKey":"sk-your-key-here"}' > ~/.chroxy/credentials.json
chmod 600 ~/.chroxy/credentials.json

# 4. Start the daemon
npx chroxy start

# 5. In the dashboard / app:
#    Settings → Provider → DeepSeek (API key) → Model: deepseek-chat
```

`npx chroxy doctor` should show `deepseek: ready ✓` once configured.

## Implementation notes

Three commits, each independently reviewable:

1. **`56140a7` refactor** — adds four overridable members to `ClaudeByokSession` (`_defaultModel`, `_resolveCredentials`, `_buildClient`, `_getPricing`). Behavior-preserving; all 50 byok tests stay green.
2. **`87dcf55` feat** — DeepSeek provider proper: session class, credentials resolver, pricing table, registry wiring, auth-chip branch, 28 new tests.
3. **`32ee6c6` refactor** — generalises the missing-credentials error message so DeepSeek doesn't surface as "BYOK credentials not found".

## Test plan

- [x] `byok-session.test.js` — 50/50 green (regression check after the seam refactor)
- [x] `deepseek-session.test.js` — inheritance, static metadata, all four seam overrides, base-URL routing + `DEEPSEEK_BASE_URL` override, constructor identity, end-to-end `start()` with stubbed seams
- [x] `deepseek-credentials.test.js` — env, file, 0600 enforcement, malformed JSON, isolation from `anthropicApiKey` siblings
- [x] `providers.test.js` — env-ready, file-ready, missing-creds paths under auth-status section
- [x] Runtime module-load sanity check (importing into a fresh node process resolves all metadata correctly)
- [ ] **Real-key smoke test on `deepseek-chat`** — must trigger a Read or Bash tool call so the full tool_use → tool_result roundtrip through DeepSeek's compat endpoint is verified (audit's Risk #1)

## Out of scope (already tracked in #4656)

- R1 reasoning-trace visualization — Phase 3 follow-up
- Batch API (50% discount endpoint)
- Local/Ollama-hosted DeepSeek (separate provider)