### PR TITLE
fix(server): deny sibling AskUserQuestion at permission-hook (short-term #4668)

### DIFF
--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -102,27 +102,58 @@ EOF
   # (claude-tui-session.js) clears this lock when the active AskUserQuestion
   # completes, so sequential AskUserQuestions are unaffected.
   #
-  # Lock dir + mkdir is atomic enough — first parallel hook wins the mkdir
-  # race; subsequent hooks see the existing dir and deny. The age fallback
-  # (60s) catches truly stale locks left by crashes / killed sessions.
+  # mkdir IS the atomic claim — not a follow-up to a separate existence
+  # check. POSIX guarantees mkdir is atomic across concurrent processes: at
+  # most one caller per parent directory wins; the rest see EEXIST. Pre-v1
+  # of this fix used `if [ -d "$LOCK" ]; then deny; else mkdir; fi` which
+  # is TOCTOU-broken: parallel hooks (chroxy's exact case — 4 AskUserQuestion
+  # hooks firing within milliseconds) can all observe "not exists" before
+  # any of them mkdir. The mkdir-first structure here eliminates that
+  # window: the race-winner gets through, every other caller sees the dir
+  # already there and falls into the stale-check / deny branch.
   if [ -n "$CHROXY_SINK_DIR" ] && [ -d "$CHROXY_SINK_DIR" ]; then
     SIBLING_LOCK="${CHROXY_SINK_DIR}/askuserquestion-active"
-    if [ -d "$SIBLING_LOCK" ]; then
-      LOCK_AGE=$(($(date +%s) - $(stat -f %m "$SIBLING_LOCK" 2>/dev/null || stat -c %Y "$SIBLING_LOCK" 2>/dev/null || echo 0)))
+    if ! mkdir "$SIBLING_LOCK" 2>/dev/null; then
+      # mkdir failed because the dir already exists (EEXIST — the only
+      # plausible cause once CHROXY_SINK_DIR is verified writable above).
+      # Inspect the existing lock's age to decide: fresh sibling (deny) or
+      # stale leftover (reclaim).
+      #
+      # stat flag portability: macOS uses BSD stat (-f %m, mtime as epoch
+      # seconds); Linux uses GNU stat (-c %Y). The platform branch keeps
+      # the wrong invocation from succeeding accidentally — GNU stat -f
+      # silently switches to filesystem-info mode and returns a mount-point
+      # string, which then breaks the arithmetic below (assigns LOCK_AGE
+      # to empty → the [ -lt 60 ] check evaluates falsy → would skip the
+      # deny path and bypass the fix entirely on Linux CI).
+      case "$(uname -s)" in
+        Darwin) LOCK_MTIME=$(stat -f %m "$SIBLING_LOCK" 2>/dev/null) ;;
+        *)      LOCK_MTIME=$(stat -c %Y "$SIBLING_LOCK" 2>/dev/null) ;;
+      esac
+      LOCK_AGE=$(($(date +%s) - ${LOCK_MTIME:-0}))
       if [ "$LOCK_AGE" -ge 0 ] && [ "$LOCK_AGE" -lt 60 ]; then
         cat <<'EOF'
 {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Another AskUserQuestion is already pending in this session. Wait for the user's answer (tool_result) before issuing the next AskUserQuestion. Do NOT issue multiple AskUserQuestion tool_use blocks in parallel within the same assistant turn — chroxy delivers them serially."}}
 EOF
         exit 0
       fi
-      # Stale lock (>60s, prior session likely crashed) — wipe and reclaim.
+      # Stale lock (>60s old OR mtime unreadable — LOCK_MTIME defaulted to
+      # 0 so LOCK_AGE ≈ epoch seconds, well past 60 → treated as stale and
+      # reclaimed; explicit "fall back to reclaim" semantics for the
+      # belt-and-suspenders case where stat fails for an unexpected reason).
+      # Reclaim by removing + recreating so mtime resets and our new claim
+      # is the active sibling. If a concurrent hook also detected staleness
+      # and reclaimed first, our mkdir fails — deny ourselves so we don't
+      # bypass the single-pending invariant the recovery is trying to
+      # preserve.
       rm -rf "$SIBLING_LOCK" 2>/dev/null
+      if ! mkdir "$SIBLING_LOCK" 2>/dev/null; then
+        cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Another AskUserQuestion is already pending in this session. Wait for the user's answer (tool_result) before issuing the next AskUserQuestion. Do NOT issue multiple AskUserQuestion tool_use blocks in parallel within the same assistant turn — chroxy delivers them serially."}}
+EOF
+        exit 0
+      fi
     fi
-    # Claim the lock. mkdir is atomic across parallel hook invocations —
-    # exactly one will succeed; the losers fall into the `if [ -d "$SIBLING_LOCK" ]`
-    # branch above when re-checked. We don't re-check here because the
-    # parallel-race window is microseconds vs the 300s curl timeout below.
-    mkdir "$SIBLING_LOCK" 2>/dev/null || true
   fi
 fi
 

--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -85,9 +85,44 @@ except Exception:
 ' 2>/dev/null)
   if [ -n "$QUESTION_COUNT" ] && [ "$QUESTION_COUNT" -gt 1 ]; then
     cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Chroxy currently delivers AskUserQuestion forms one question at a time. Please re-issue this call as separate AskUserQuestion tool calls, one per question, and the user will answer each in turn."}}
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Chroxy currently delivers AskUserQuestion forms one question at a time. Please re-issue this call as separate AskUserQuestion tool calls, ONE AT A TIME — issue the next one only after the previous one's tool_result has been returned. Do NOT issue multiple AskUserQuestion tool_use blocks in parallel within the same assistant turn."}}
 EOF
     exit 0
+  fi
+
+  # #4668 (short-term): deny when another AskUserQuestion is already pending
+  # in this session. The model interprets #4648's "separate AskUserQuestion
+  # tool calls" as "parallel within the same turn" — empirically, claude TUI
+  # was emitting 4 parallel AskUserQuestion tool_use blocks in one turn,
+  # which overwrote chroxy's single `_pendingUserAnswer` field and routed all
+  # user answers to the wrong question (chroxy.log forensic 2026-05-31 on
+  # v0.9.26 session 9ea82aed). Forcing true serialization at the hook layer
+  # restores the single-pending invariant that the existing keystroke driver
+  # was built around. The PostToolUse hook in writeHookSettings()
+  # (claude-tui-session.js) clears this lock when the active AskUserQuestion
+  # completes, so sequential AskUserQuestions are unaffected.
+  #
+  # Lock dir + mkdir is atomic enough — first parallel hook wins the mkdir
+  # race; subsequent hooks see the existing dir and deny. The age fallback
+  # (60s) catches truly stale locks left by crashes / killed sessions.
+  if [ -n "$CHROXY_SINK_DIR" ] && [ -d "$CHROXY_SINK_DIR" ]; then
+    SIBLING_LOCK="${CHROXY_SINK_DIR}/askuserquestion-active"
+    if [ -d "$SIBLING_LOCK" ]; then
+      LOCK_AGE=$(($(date +%s) - $(stat -f %m "$SIBLING_LOCK" 2>/dev/null || stat -c %Y "$SIBLING_LOCK" 2>/dev/null || echo 0)))
+      if [ "$LOCK_AGE" -ge 0 ] && [ "$LOCK_AGE" -lt 60 ]; then
+        cat <<'EOF'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Another AskUserQuestion is already pending in this session. Wait for the user's answer (tool_result) before issuing the next AskUserQuestion. Do NOT issue multiple AskUserQuestion tool_use blocks in parallel within the same assistant turn — chroxy delivers them serially."}}
+EOF
+        exit 0
+      fi
+      # Stale lock (>60s, prior session likely crashed) — wipe and reclaim.
+      rm -rf "$SIBLING_LOCK" 2>/dev/null
+    fi
+    # Claim the lock. mkdir is atomic across parallel hook invocations —
+    # exactly one will succeed; the losers fall into the `if [ -d "$SIBLING_LOCK" ]`
+    # branch above when re-checked. We don't re-check here because the
+    # parallel-race window is microseconds vs the 300s curl timeout below.
+    mkdir "$SIBLING_LOCK" 2>/dev/null || true
   fi
 fi
 

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -188,7 +188,13 @@ function writeHookSettings(sinkDir, { permissionsEnabled }) {
         { hooks: preToolUseHooks },
       ],
       PostToolUse: [
-        { hooks: [{ type: 'command', command: `cat > ${sinkDirEsc}/post-$(uuidgen).json` }] },
+        // First hook: forensic sink — tee preserves stdin for the
+        // sibling-cleanup hook below. Replaces the pre-#4668 cat-to-file
+        // because cat would consume stdin entirely, leaving the cleanup
+        // hook with an empty payload.
+        { hooks: [
+          { type: 'command', command: `tee ${sinkDirEsc}/post-$(uuidgen).json | grep -q '"tool_name":"AskUserQuestion"' && rm -rf ${sinkDirEsc}/askuserquestion-active || true` },
+        ] },
       ],
     },
   }
@@ -526,6 +532,12 @@ export class ClaudeTuiSession extends BaseSession {
       if (this._permissionModeFile) {
         env.CHROXY_PERMISSION_MODE_FILE = this._permissionModeFile
       }
+      // #4668 (short-term): per-session sink directory so the hook can
+      // place its sibling-AskUserQuestion lockfile somewhere that's
+      // automatically cleaned up by destroy()'s rmSync of this._sinkDir.
+      // The hook silently no-ops the sibling-deny check when this env
+      // var is absent, so removing it again later is safe.
+      env.CHROXY_SINK_DIR = this._sinkDir
     }
 
     const args = [

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -536,7 +536,10 @@ export class ClaudeTuiSession extends BaseSession {
       // place its sibling-AskUserQuestion lockfile somewhere that's
       // automatically cleaned up by destroy()'s rmSync of this._sinkDir.
       // The hook silently no-ops the sibling-deny check when this env
-      // var is absent, so removing it again later is safe.
+      // var is absent, so removing it again later is safe. Set under
+      // permissionsEnabled because the hook itself only runs in that
+      // mode — outside it, claude TUI takes its own permission path and
+      // none of CHROXY_* env vars are read.
       env.CHROXY_SINK_DIR = this._sinkDir
     }
 

--- a/packages/server/tests/permission-hook-sibling-deny.test.js
+++ b/packages/server/tests/permission-hook-sibling-deny.test.js
@@ -81,9 +81,13 @@ describe('permission-hook.sh — sibling AskUserQuestion deny (#4668)', () => {
     assert.equal(decision.hookSpecificOutput.permissionDecision, 'deny',
       'second sibling must deny while the first is pending')
     // The reason text must steer the model toward true serialization — pin
-    // the load-bearing phrases without locking the exact copy.
+    // the load-bearing phrases without locking the exact copy. tool_result
+    // is the explicit signal the model has been observed responding to;
+    // pre-#4668 "answer each in turn" was the ambiguous phrasing the model
+    // mis-read as "parallel within one turn".
     assert.match(decision.hookSpecificOutput.permissionDecisionReason, /pending/i)
     assert.match(decision.hookSpecificOutput.permissionDecisionReason, /parallel/i)
+    assert.match(decision.hookSpecificOutput.permissionDecisionReason, /tool_result/i)
   })
 
   it('allows the next AskUserQuestion after the lock is removed (PostToolUse cleanup path)', async () => {

--- a/packages/server/tests/permission-hook-sibling-deny.test.js
+++ b/packages/server/tests/permission-hook-sibling-deny.test.js
@@ -1,0 +1,175 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import { spawn } from 'child_process'
+import { mkdirSync, rmSync, mkdtempSync, existsSync, statSync, utimesSync } from 'fs'
+import { tmpdir } from 'os'
+
+/**
+ * #4668 (short-term): permission-hook.sh refuses an AskUserQuestion when a
+ * sibling AskUserQuestion is already pending in the session sink directory.
+ *
+ * Why this is its own test file: parallel-tool-use is an orthogonal axis from
+ * the multi-question payload-shape check (`permission-hook-multi-question.test.js`)
+ * — same hook script, different lifetime semantics (filesystem state vs.
+ * stdin payload). Splitting keeps each file focused on one invariant.
+ *
+ * Wedge that motivated this fix (chroxy.log 2026-05-31, v0.9.26 session
+ * 9ea82aed): #4648's deny pushed claude TUI to re-emit as N "separate"
+ * AskUserQuestion calls, but the model interpreted "separate" as parallel
+ * within the same turn. Chroxy's `_pendingUserAnswer` is a single field that
+ * gets overwritten by each new tool_use → all 4 user answers routed to the
+ * wrong question, 5-minute stall watchdog fires. Forcing true serialization
+ * at the hook layer restores the single-pending invariant that the existing
+ * keystroke driver was built around — until the long-term Map-keyed refactor
+ * lands.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const hookPath = join(__dirname, '../hooks/permission-hook.sh')
+
+function runHook(input, env = {}) {
+  return new Promise((resolve) => {
+    const child = spawn('/bin/bash', [hookPath], {
+      env: { CHROXY_PORT: '12345', CHROXY_PERMISSION_MODE: 'auto', ...env },
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (c) => { stdout += c.toString() })
+    child.stderr.on('data', (c) => { stderr += c.toString() })
+    child.on('close', (status) => resolve({ status, stdout, stderr }))
+    if (input != null) child.stdin.write(input)
+    child.stdin.end()
+  })
+}
+
+const singleQuestion = (label = 'A') => ({
+  tool_name: 'AskUserQuestion',
+  tool_input: {
+    questions: [{ question: 'one?', header: 'One', options: [{ label, value: label.toLowerCase() }] }],
+  },
+})
+
+describe('permission-hook.sh — sibling AskUserQuestion deny (#4668)', () => {
+  let sinkDir
+
+  beforeEach(() => {
+    sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-hook-sibling-'))
+  })
+
+  afterEach(() => {
+    rmSync(sinkDir, { recursive: true, force: true })
+  })
+
+  it('allows the first AskUserQuestion and claims the sibling lock', async () => {
+    const { stdout, status } = await runHook(JSON.stringify(singleQuestion('Vite')), { CHROXY_SINK_DIR: sinkDir })
+    assert.equal(status, 0)
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'first AskUserQuestion must allow — no sibling pending yet')
+    assert.ok(existsSync(join(sinkDir, 'askuserquestion-active')),
+      'first call must claim the lock so subsequent siblings can see it')
+  })
+
+  it('denies a second AskUserQuestion while the sibling lock is fresh', async () => {
+    // First call claims the lock.
+    await runHook(JSON.stringify(singleQuestion('Vite')), { CHROXY_SINK_DIR: sinkDir })
+    // Second call (no PostToolUse cleanup in between — simulates the parallel-burst case).
+    const { stdout } = await runHook(JSON.stringify(singleQuestion('Webpack')), { CHROXY_SINK_DIR: sinkDir })
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'deny',
+      'second sibling must deny while the first is pending')
+    // The reason text must steer the model toward true serialization — pin
+    // the load-bearing phrases without locking the exact copy.
+    assert.match(decision.hookSpecificOutput.permissionDecisionReason, /pending/i)
+    assert.match(decision.hookSpecificOutput.permissionDecisionReason, /parallel/i)
+  })
+
+  it('allows the next AskUserQuestion after the lock is removed (PostToolUse cleanup path)', async () => {
+    // First call claims the lock.
+    await runHook(JSON.stringify(singleQuestion('Vite')), { CHROXY_SINK_DIR: sinkDir })
+    // Simulate the PostToolUse cleanup hook removing the lock when the user
+    // answered the first question and the TUI emitted PostToolUse. The
+    // production cleanup runs via the `tee | grep | rm -rf` chain wired in
+    // claude-tui-session.js writeHookSettings(); here we just remove it
+    // directly so this test doesn't depend on that wiring.
+    rmSync(join(sinkDir, 'askuserquestion-active'), { recursive: true, force: true })
+    // Second call should now allow — the sequential happy path.
+    const { stdout } = await runHook(JSON.stringify(singleQuestion('Webpack')), { CHROXY_SINK_DIR: sinkDir })
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'sequential AskUserQuestion after cleanup must allow')
+  })
+
+  it('reclaims a stale lock older than 60s (crash recovery)', async () => {
+    // Manually create a stale lock with mtime 5 minutes ago — simulates a
+    // wedged session that died without cleaning up. The hook must reclaim
+    // the lock rather than wedge the next session permanently.
+    const lockPath = join(sinkDir, 'askuserquestion-active')
+    mkdirSync(lockPath)
+    const fiveMinAgo = (Date.now() - 5 * 60 * 1000) / 1000
+    utimesSync(lockPath, fiveMinAgo, fiveMinAgo)
+    // Sanity check the mtime was applied.
+    assert.ok((Date.now() / 1000) - statSync(lockPath).mtimeMs / 1000 > 60,
+      'precondition: lock is older than 60s')
+
+    const { stdout } = await runHook(JSON.stringify(singleQuestion('React')), { CHROXY_SINK_DIR: sinkDir })
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'stale lock (>60s) must be reclaimed — otherwise a dead session permanently wedges its successors')
+  })
+
+  it('no-ops the sibling check when CHROXY_SINK_DIR is unset (backward compat)', async () => {
+    // Without the env var, the hook can't manage the lock — it must skip
+    // the sibling check entirely and behave like pre-#4668. Otherwise
+    // upgrading the script without upgrading claude-tui-session.js (e.g.,
+    // partial deploy) would block every AskUserQuestion.
+    const { stdout } = await runHook(JSON.stringify(singleQuestion('Vite')))
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'no sink dir → no sibling check → allow (pre-#4668 behavior preserved)')
+  })
+
+  it('no-ops the sibling check when CHROXY_SINK_DIR points to a non-existent dir', async () => {
+    // Defensive: an operator-set sink dir that no longer exists shouldn't
+    // crash or accidentally deny. The hook's `[ -d "$CHROXY_SINK_DIR" ]`
+    // guard handles this; verifies the guard works.
+    const { stdout } = await runHook(JSON.stringify(singleQuestion('Vite')), { CHROXY_SINK_DIR: '/nonexistent/path/xyz123' })
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'missing sink dir → no sibling check → allow')
+  })
+
+  it('does not affect non-AskUserQuestion tools (Bash unblocked even with stale lock)', async () => {
+    // A pending AskUserQuestion lock must not block other tools — only
+    // a sibling AskUserQuestion. Otherwise a stale lock could globally
+    // block Bash / Read / etc, which is much worse than the wedge it's
+    // trying to fix.
+    mkdirSync(join(sinkDir, 'askuserquestion-active'))
+    const { stdout } = await runHook(
+      JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } }),
+      { CHROXY_SINK_DIR: sinkDir, CHROXY_PERMISSION_MODE: 'auto' },
+    )
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'allow',
+      'Bash must not be blocked by a pending AskUserQuestion lock')
+  })
+
+  it('the multi-question deny still runs BEFORE the sibling check (deny-first ordering)', async () => {
+    // If both conditions fire on the same call (multi-question payload AND
+    // a sibling lock exists), the multi-question deny should win — its
+    // reason text is more actionable for the model. Verify by setting up
+    // both conditions and asserting the multi-q phrasing surfaces.
+    mkdirSync(join(sinkDir, 'askuserquestion-active'))
+    const payload = {
+      tool_name: 'AskUserQuestion',
+      tool_input: { questions: [{ q: 1 }, { q: 2 }] },
+    }
+    const { stdout } = await runHook(JSON.stringify(payload), { CHROXY_SINK_DIR: sinkDir })
+    const decision = JSON.parse(stdout.trim())
+    assert.equal(decision.hookSpecificOutput.permissionDecision, 'deny')
+    assert.match(decision.hookSpecificOutput.permissionDecisionReason, /one question at a time/i,
+      'multi-question deny text should win over the sibling-pending text')
+  })
+})


### PR DESCRIPTION
## Summary
- Short-term fix for #4668 — multi-question AskUserQuestion wedge on TUI sessions.
- After #4648 ships the multi-q deny in v0.9.24, claude TUI re-emits as N **parallel** AskUserQuestion tool_uses in one assistant turn (not N sequential turns as the deny message implied). Chroxy's `_pendingUserAnswer` is a single field → only the last tool_use is tracked → user's Q1 answer typed for Q4's question slot → 5-min stall watchdog fires.
- This PR refuses a second AskUserQuestion at the PreToolUse hook when a sibling is already pending in the session sink directory. Lock is per-session, claimed via atomic `mkdir`, released by a new PostToolUse cleanup hook. Stale locks (>60s) auto-reclaim.
- Restores the single-pending invariant the existing keystroke driver was built around. The long-term fix (`_pendingAnswers` Map + `respondToQuestion(toolUseId, ...)` signature) stays open on #4668.

## Diagnosis evidence
Reproduced live on v0.9.26 with session `9ea82aeda9ebce803f1ecd539e3fee6a` — see [#4668 comment](https://github.com/blamechris/chroxy/issues/4668#issuecomment-4588388283) for the full chroxy.log trace.

Smoking gun (timestamps, condensed):
```
21:43:18  AskUserQuestion pending: tool=01ND6t  ← Q1 framework
21:43:21  AskUserQuestion pending: tool=01GUet  ← Q2 build tool (overwrites Q1)
21:43:24  AskUserQuestion pending: tool=01J5tc  ← Q3 styling (overwrites Q2)
21:43:27  AskUserQuestion pending: tool=01Adsf  ← Q4 testing (overwrites Q3)

21:46:02  user_question_response received: toolUseId=01ND6t  (user submitted Q1)
21:46:02  respondToQuestion: tool=01Adsf text.length=5      ← Wrote keystrokes for Q4!
21:46:06  user_question_response received: toolUseId=01GUet  (user submitted Q2)
21:46:06  respondToQuestion: tool=? text.length=4            ← Dropped (pending was cleared)
21:46:09  user_question_response received: toolUseId=01J5tc  (user submitted Q3)
21:46:09  respondToQuestion: tool=? text.length=8            ← Dropped
21:46:13  user_question_response received: toolUseId=01Adsf  (user submitted Q4)
21:46:13  respondToQuestion: tool=? text.length=6            ← Dropped

21:51:02  [WARN] Stream stalled (5 minutes) — clearing busy state
```

## How the fix works
With sibling-deny, in the same scenario:
1. Q1 fires → no sibling lock → allows + claims lock
2. Q2/Q3/Q4 fire → see fresh lock → deny with "wait for the user's answer before issuing the next AskUserQuestion"
3. Claude gets 3 deny tool_results → waits on Q1's result
4. User answers Q1 → only one `_pendingUserAnswer` (Q1) → keystrokes route correctly → TUI emits PostToolUse → cleanup hook releases lock
5. Claude re-emits Q2 (alone) → no sibling → allow → ...continues sequentially

## Files changed
- `packages/server/hooks/permission-hook.sh` — sibling-pending check (atomic `mkdir` lock, 60s stale-recovery, no-op when `CHROXY_SINK_DIR` unset for backward compat with partial deploys). Updated multi-question deny copy to explicitly say "ONE AT A TIME" since "separate" was ambiguous.
- `packages/server/src/claude-tui-session.js` — export `CHROXY_SINK_DIR` env var; PostToolUse cleanup hook (`tee | grep | rm -rf`) that releases the lock when an AskUserQuestion completes.
- `packages/server/tests/permission-hook-sibling-deny.test.js` — 8 new tests.

## Test plan
- [x] `node --test packages/server/tests/permission-hook-sibling-deny.test.js packages/server/tests/permission-hook-multi-question.test.js` — 15/15 pass
- [x] `node --test packages/server/tests/claude-tui-session.test.js packages/server/tests/permission-hook*.test.js` — 183/183 pass
- [ ] Live dogfood — fire a 4-question prompt on a TUI session, confirm the 4 individual retries serialize correctly and each answer routes to the right question
- [ ] Smoke: also exercise a single-question AskUserQuestion to confirm no regression on the v0.9.4 happy path

## Out of scope
The long-term refactor stays on #4668:
- `_pendingUserAnswer` → `Map<toolUseId, ...>`
- `respondToQuestion(toolUseId, text, answersMap)` signature
- Queue answers and feed as TUI advances

Needed regardless because other tools also emit in parallel (Read/Read/Read is common), but the short-term fix unblocks dogfood now.

Refs #4668.
