### PR TITLE
chore(release): cut v0.9.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.27] - 2026-05-31
+
+Short-term fix for the v0.9.26 multi-question AskUserQuestion wedge (#4668). When claude TUI retried as N "separate" single-question calls after the #4648 multi-question deny, it issued them as parallel `tool_use` blocks in one assistant turn — and chroxy's `_pendingUserAnswer` is a single field, so the user's answer to question 1 routed to question 4's slot and the 5-minute stream-stall watchdog fired. The hook now refuses sibling AskUserQuestion calls while one is already pending, forcing true serialization until the long-term Map-keyed refactor lands.
+
+### Fixed
+
+- **Sibling AskUserQuestion deny at the permission-hook layer (#4669):** `permission-hook.sh` now claims an `askuserquestion-active` lock in the session sink dir (`CHROXY_SINK_DIR`) on first AskUserQuestion and denies subsequent siblings while the lock is fresh (<60s). PostToolUse cleanup releases the lock via a `tee | grep | rm -rf` chain wired through `claude-tui-session.js`. Atomic via `mkdir` (TOCTOU-safe), portable across macOS and Linux (`uname -s`-switched `stat`), and stale-lock-resilient (auto-reclaims after 60s). Deny copy steers the model to wait for each `tool_result` before issuing the next `tool_use` instead of the ambiguous "answer each in turn" phrasing that the model previously read as "fire in parallel."
+
 ## [0.9.26] - 2026-05-31
 
 Adds a per-session, user-authored **preamble** that the server prepends to the system prompt every turn so you can pre-load context once instead of retyping it in every message ("always respond in bullet points", "this is a Godot 4 project — prefer GDScript over C#"). New text area lives in the dashboard's Active session section, persists across server restarts, and applies to every provider (Claude TUI/SDK/CLI, BYOK, DeepSeek, Codex, Gemini).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.26",
+      "version": "0.9.27",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.26",
+      "version": "0.9.27",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.26",
+      "version": "0.9.27",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.26"
+      "version": "0.9.27"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.26",
+      "version": "0.9.27",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.26",
+      "version": "0.9.27",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.26",
+      "version": "0.9.27",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.26",
+    "version": "0.9.27",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.26</string>
+    <string>0.9.27</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.26"
+version = "0.9.27"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.26",
+      "version": "0.9.27",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Cuts v0.9.27 with the short-term sibling-deny fix for the multi-question wedge.

- #4669 — `permission-hook.sh` claims a sibling lock via atomic `mkdir`, denies subsequent AskUserQuestion calls while one is pending, PostToolUse cleanup releases the lock. Forces true serialization in the post-#4648 retry-as-singles path so all 4 user answers don't route to the wrong slot via the single `_pendingUserAnswer` field.
- Long-term fix (`_pendingUserAnswer` → Map keyed by `toolUseId`) tracked at #4668.

## Test plan
- [x] CI passing on parent branch (#4669 merged: 13/13 green)
- [ ] CI green on this release branch
- [ ] Release workflow produces notarized DMG
- [ ] Local Tauri rebuild and smoke-test multi-question wedge against the fix