### PR TITLE
fix(claude-hook): use $CLAUDE_PROJECT_DIR for require-review hook path

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/require-review-before-merge.sh"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/require-review-before-merge.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary

The PreToolUse Bash hook at `.claude/settings.json:9` was registered with a **relative path**:

```json
"command": "bash scripts/require-review-before-merge.sh"
```

That only resolves when the Bash invocation's cwd is the chroxy project root. Any time an agent or workflow ran a command from a subdirectory (e.g. `cd packages/dashboard && npm test`), the hook fired against `packages/dashboard/scripts/require-review-before-merge.sh` → script not found → non-blocking error spam in the Claude Code output AND the merge gate silently disabled for that invocation.

## Fix

Switch to `$CLAUDE_PROJECT_DIR` — Claude Code injects this env var on every hook invocation and it's always the project root regardless of the Bash command's cwd. One-line change:

```diff
- "command": "bash scripts/require-review-before-merge.sh"
+ "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/require-review-before-merge.sh\""
```

The quoting protects against path components with spaces (no current risk, but cheap belt-and-braces).

## Test plan

- [ ] In a fresh Claude Code session, `cd packages/dashboard && ls` should no longer produce the `PreToolUse:Bash hook error` line
- [ ] Attempting `gh pr merge <unreviewed-PR>` from any cwd still blocks (hook still gates)
- [ ] Attempting `gh pr merge <reviewed-PR>` from `packages/dashboard/` still succeeds