### PR TITLE
fix(dashboard): suppress multi-question AskUserQuestion form (#4666)

### DIFF
--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { OTHER_OPTION_VALUE } from '@chroxy/store-core'
-import { QuestionPrompt } from './QuestionPrompt'
+import { QuestionPrompt, MultiQuestionForm } from './QuestionPrompt'
 
 afterEach(cleanup)
 
@@ -337,13 +337,14 @@ describe('QuestionPrompt', () => {
     })
   })
 
-  // #4604 Chunk B — multi-question form UI. Renders one selection control
-  // per question (radio for single-select, checkboxes for multi-select)
-  // with a single Submit button that fires onSelect(answersMap).
-  describe('multi-question form (#4604 Chunk B)', () => {
-    // Using `as const` so the tuple types index without
-    // noUncheckedIndexedAccess complaints. Each question is consumed as
-    // a top-level fixture below.
+  // #4666: multi-question AskUserQuestion tool_uses are denied at the
+  // permission-hook (#4648 / v0.9.24) because the keystroke driver can't
+  // reliably answer combined forms, and the broadcast layer emits the
+  // tool_use independently of the deny decision. The dashboard must render
+  // a non-interactive notice instead of the MultiQuestionForm so the user
+  // can't submit answers that misroute through `_pendingUserAnswer` to the
+  // wrong question slot (the long-term refactor lives on #4668).
+  describe('multi-question deferred notice (#4666)', () => {
     const q1 = {
       question: 'Which release strategy?',
       options: [{ label: 'Patch', value: 'Patch' }, { label: 'Minor', value: 'Minor' }],
@@ -363,97 +364,7 @@ describe('QuestionPrompt', () => {
     }
     const multiQuestions = [q1, q2, q3]
 
-    it('renders every question with its label', () => {
-      render(
-        <QuestionPrompt
-          question={q1.question}
-          options={q1.options}
-          questions={multiQuestions}
-          onSelect={vi.fn()}
-        />
-      )
-      expect(screen.getByTestId('question-prompt-multi')).toBeInTheDocument()
-      expect(screen.getByText('Which release strategy?')).toBeInTheDocument()
-      expect(screen.getByText('Which targets?')).toBeInTheDocument()
-      expect(screen.getByText('Confirm?')).toBeInTheDocument()
-    })
-
-    it('single-select questions render as radio buttons', () => {
-      render(
-        <QuestionPrompt
-          question={q1.question}
-          options={q1.options}
-          questions={multiQuestions}
-          onSelect={vi.fn()}
-        />
-      )
-      // Q1 single-select renders radios; the two option inputs belong to
-      // the same radio group so only one is selectable at a time.
-      const patch = screen.getByTestId('question-multi-option-0-Patch').querySelector('input')!
-      const minor = screen.getByTestId('question-multi-option-0-Minor').querySelector('input')!
-      expect(patch.getAttribute('type')).toBe('radio')
-      expect(minor.getAttribute('type')).toBe('radio')
-      expect(patch.getAttribute('name')).toBe(minor.getAttribute('name'))
-    })
-
-    it('multi-select questions render as checkboxes', () => {
-      render(
-        <QuestionPrompt
-          question={q1.question}
-          options={q1.options}
-          questions={multiQuestions}
-          onSelect={vi.fn()}
-        />
-      )
-      const app = screen.getByTestId('question-multi-option-1-App').querySelector('input')!
-      const docs = screen.getByTestId('question-multi-option-1-Docs').querySelector('input')!
-      expect(app.getAttribute('type')).toBe('checkbox')
-      expect(docs.getAttribute('type')).toBe('checkbox')
-    })
-
-    it('Submit is disabled until every single-select question has a choice', () => {
-      render(
-        <QuestionPrompt
-          question={q1.question}
-          options={q1.options}
-          questions={multiQuestions}
-          onSelect={vi.fn()}
-        />
-      )
-      const submit = screen.getByTestId('question-multi-submit') as HTMLButtonElement
-      expect(submit).toBeDisabled()
-
-      // Answer Q1 only — still disabled, Q3 unanswered.
-      fireEvent.click(screen.getByTestId('question-multi-option-0-Patch').querySelector('input')!)
-      expect(submit).toBeDisabled()
-
-      // Answer Q3 (Q2 is multi-select, allowed empty) — enables Submit.
-      fireEvent.click(screen.getByTestId('question-multi-option-2-Yes').querySelector('input')!)
-      expect(submit).not.toBeDisabled()
-    })
-
-    it('multi-select toggles let the user pick multiple options', () => {
-      render(
-        <QuestionPrompt
-          question={q1.question}
-          options={q1.options}
-          questions={multiQuestions}
-          onSelect={vi.fn()}
-        />
-      )
-      const app = screen.getByTestId('question-multi-option-1-App').querySelector<HTMLInputElement>('input')!
-      const docs = screen.getByTestId('question-multi-option-1-Docs').querySelector<HTMLInputElement>('input')!
-      fireEvent.click(app)
-      fireEvent.click(docs)
-      expect(app.checked).toBe(true)
-      expect(docs.checked).toBe(true)
-      // Toggling off works too.
-      fireEvent.click(app)
-      expect(app.checked).toBe(false)
-      expect(docs.checked).toBe(true)
-    })
-
-    it('Submit fires onSelect with the full answersMap, multi-select JSON-encoded', () => {
+    it('renders the deferred notice instead of the multi-question form when questions.length > 1', () => {
       const onSelect = vi.fn()
       render(
         <QuestionPrompt
@@ -463,24 +374,18 @@ describe('QuestionPrompt', () => {
           onSelect={onSelect}
         />
       )
-      fireEvent.click(screen.getByTestId('question-multi-option-0-Minor').querySelector('input')!)
-      fireEvent.click(screen.getByTestId('question-multi-option-1-App').querySelector('input')!)
-      fireEvent.click(screen.getByTestId('question-multi-option-1-Tests').querySelector('input')!)
-      fireEvent.click(screen.getByTestId('question-multi-option-2-No').querySelector('input')!)
-      fireEvent.click(screen.getByTestId('question-multi-submit'))
-
-      expect(onSelect).toHaveBeenCalledTimes(1)
-      const arg = onSelect.mock.calls[0]?.[0] as Record<string, string> | undefined
-      expect(arg).toBeDefined()
-      expect(typeof arg).toBe('object')
-      expect(arg!['Which release strategy?']).toBe('Minor')
-      // Multi-select wire shape: JSON-stringified array (Record<string,string>
-      // wire constraint — server's respondToQuestion JSON.parse splits it back).
-      expect(arg!['Which targets?']).toBe(JSON.stringify(['App', 'Tests']))
-      expect(arg!['Confirm?']).toBe('No')
+      expect(screen.getByTestId('multi-question-deferred-notice')).toBeInTheDocument()
+      // The interactive multi-question form is NOT rendered — no Submit,
+      // no per-question radios/checkboxes, no per-question rows.
+      expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('question-multi-submit')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('question-multi-row-0')).not.toBeInTheDocument()
+      // No input elements (radios/checkboxes) rendered for any question.
+      expect(screen.queryAllByRole('radio')).toHaveLength(0)
+      expect(screen.queryAllByRole('checkbox')).toHaveLength(0)
     })
 
-    it('Submit guards against double-fire (only first click registers)', () => {
+    it('the deferred notice is non-interactive (no buttons, never invokes onSelect)', () => {
       const onSelect = vi.fn()
       render(
         <QuestionPrompt
@@ -490,18 +395,30 @@ describe('QuestionPrompt', () => {
           onSelect={onSelect}
         />
       )
-      fireEvent.click(screen.getByTestId('question-multi-option-0-Patch').querySelector('input')!)
-      fireEvent.click(screen.getByTestId('question-multi-option-2-Yes').querySelector('input')!)
-      const submit = screen.getByTestId('question-multi-submit')
-      fireEvent.click(submit)
-      fireEvent.click(submit)
-      fireEvent.click(submit)
-      expect(onSelect).toHaveBeenCalledTimes(1)
+      // No buttons rendered at all in the deferred-notice variant.
+      expect(screen.queryAllByRole('button')).toHaveLength(0)
+      // Clicking the notice itself does nothing.
+      fireEvent.click(screen.getByTestId('multi-question-deferred-notice'))
+      expect(onSelect).not.toHaveBeenCalled()
     })
 
-    it('falls back to single-question UI when questions has length <= 1', () => {
-      // N=1 multi-question payload — should render the legacy
-      // single-question UI (button list), not the multi-question form.
+    it('mentions the question count in the notice copy so the user knows what was suppressed', () => {
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          onSelect={vi.fn()}
+        />
+      )
+      const notice = screen.getByTestId('multi-question-deferred-notice')
+      // 3 questions in `multiQuestions`.
+      expect(notice.textContent).toContain('3')
+    })
+
+    it('falls back to single-question UI when questions has length 1', () => {
+      // N=1 payload — single-question UI must render the interactive
+      // button list as before, NOT the deferred notice.
       render(
         <QuestionPrompt
           question="Just one?"
@@ -510,16 +427,47 @@ describe('QuestionPrompt', () => {
           onSelect={vi.fn()}
         />
       )
-      // Legacy single-q UI uses `question-prompt`, not `question-prompt-multi`.
       expect(screen.getByTestId('question-prompt')).toBeInTheDocument()
-      expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('multi-question-deferred-notice')).not.toBeInTheDocument()
+      // Interactive option buttons remain present.
+      expect(screen.getByText('Yes')).toBeInTheDocument()
+      expect(screen.getByText('No')).toBeInTheDocument()
+    })
+
+    it('falls back to single-question UI when questions is an empty array', () => {
+      // questions.length === 0 — the multi-question branch should not
+      // fire. Single-question UI renders normally.
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={[{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }]}
+          questions={[]}
+          onSelect={vi.fn()}
+        />
+      )
+      expect(screen.getByTestId('question-prompt')).toBeInTheDocument()
+      expect(screen.queryByTestId('multi-question-deferred-notice')).not.toBeInTheDocument()
+      expect(screen.getByText('A')).toBeInTheDocument()
+    })
+
+    it('falls back to single-question UI when questions is undefined', () => {
+      // No questions prop at all — the legacy single-question path is
+      // the regression-guard happy path for the v0.9.4 majority case.
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={[{ label: 'A', value: 'a' }, { label: 'B', value: 'b' }]}
+          onSelect={vi.fn()}
+        />
+      )
+      expect(screen.getByTestId('question-prompt')).toBeInTheDocument()
+      expect(screen.queryByTestId('multi-question-deferred-notice')).not.toBeInTheDocument()
     })
 
     it('falls back to single-question UI when answered is already set (multi-question post-answer summary path)', () => {
-      // The post-answer collapse/summary path is single-question UI only;
-      // once the user has submitted a multi-question form, render the
-      // legacy collapse UI with the answer summary string. Multi-question
-      // mode is only entered when answered is null/undefined.
+      // Once an answer is recorded, render the single-question collapse
+      // UI — even for a multi-question payload. The deferred notice is
+      // strictly the pre-answer state.
       render(
         <QuestionPrompt
           question="Q1?"
@@ -532,9 +480,44 @@ describe('QuestionPrompt', () => {
           onSelect={vi.fn()}
         />
       )
-      expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
-      // Single-q UI renders the answered summary
+      expect(screen.queryByTestId('multi-question-deferred-notice')).not.toBeInTheDocument()
+      // Single-q UI renders the answered summary (free-text variant).
       expect(screen.getByTestId('question-answered-summary')).toBeInTheDocument()
+    })
+  })
+
+  // #4666: MultiQuestionForm stays exported but unused by QuestionPrompt.
+  // When the #4668 long-term refactor lands (Map-keyed _pendingUserAnswer),
+  // native multi-question support can be re-enabled by flipping the gate
+  // in QuestionPrompt back to rendering this component. Keep a smoke test
+  // so the dormant component doesn't bit-rot in the meantime.
+  describe('MultiQuestionForm (#4604 Chunk B, dormant per #4666)', () => {
+    const q1 = {
+      question: 'Which release strategy?',
+      options: [{ label: 'Patch', value: 'Patch' }, { label: 'Minor', value: 'Minor' }],
+    }
+    const q2 = {
+      question: 'Confirm?',
+      options: [{ label: 'Yes', value: 'Yes' }, { label: 'No', value: 'No' }],
+    }
+
+    it('renders the interactive form when invoked directly', () => {
+      const onSelect = vi.fn()
+      render(<MultiQuestionForm questions={[q1, q2]} onSelect={onSelect} />)
+      expect(screen.getByTestId('question-prompt-multi')).toBeInTheDocument()
+      expect(screen.getByTestId('question-multi-submit')).toBeInTheDocument()
+    })
+
+    it('Submit fires onSelect with the answersMap', () => {
+      const onSelect = vi.fn()
+      render(<MultiQuestionForm questions={[q1, q2]} onSelect={onSelect} />)
+      fireEvent.click(screen.getByTestId('question-multi-option-0-Minor').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-option-1-Yes').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-submit'))
+      expect(onSelect).toHaveBeenCalledTimes(1)
+      const arg = onSelect.mock.calls[0]?.[0] as Record<string, string> | undefined
+      expect(arg!['Which release strategy?']).toBe('Minor')
+      expect(arg!['Confirm?']).toBe('Yes')
     })
   })
 })

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -46,8 +46,18 @@ export interface QuestionPromptProps {
 export function QuestionPrompt({ question, options, answered, questions, onSelect }: QuestionPromptProps) {
   const isMultiQuestion = Array.isArray(questions) && questions.length > 1
 
+  // #4666: the permission-hook (`packages/server/hooks/permission-hook.sh`,
+  // shipped in #4648 / v0.9.24) unconditionally denies any AskUserQuestion
+  // whose `questions[]` has length > 1 because the TUI keystroke driver
+  // can't reliably answer combined multi-question forms. The dashboard
+  // still receives the tool_use event though (broadcast is independent of
+  // the permission decision), so rendering the interactive MultiQuestionForm
+  // here would let the user submit answers that route through
+  // `_pendingUserAnswer` to the wrong question slot — see the live trace in
+  // #4666 / #4668. Render a non-interactive placeholder instead so the user
+  // understands chroxy is waiting for Claude to retry one-at-a-time.
   if (isMultiQuestion && answered == null) {
-    return <MultiQuestionForm questions={questions} onSelect={onSelect} />
+    return <MultiQuestionDeferredNotice count={questions.length} />
   }
 
   return (
@@ -61,19 +71,48 @@ export function QuestionPrompt({ question, options, answered, questions, onSelec
 }
 
 /**
+ * #4666 — non-interactive placeholder shown when the TUI emitted a
+ * multi-question AskUserQuestion. The permission-hook will deny the
+ * combined form and force Claude to re-emit one question at a time;
+ * those single-question retries render with the normal interactive UI.
+ */
+function MultiQuestionDeferredNotice({ count }: { count: number }) {
+  return (
+    <div
+      className="question-prompt question-prompt--deferred"
+      data-testid="multi-question-deferred-notice"
+      role="status"
+    >
+      <div className="question-text">
+        Claude tried to ask {count} questions at once. Waiting for it to retry one at a time…
+      </div>
+    </div>
+  )
+}
+
+/**
  * #4604 Chunk B — N-question form. Each question gets its own selection
  * control (radio for single-select, checkboxes for multiSelect); the
  * single Submit button at the bottom fires `onSelect(answersMap)` with
  * one entry per question (multi-select values are JSON-stringified
  * arrays so the wire shape `Record<string,string>` is preserved — the
  * server's respondToQuestion JSON.parse handles the round trip).
+ *
+ * #4666 — intentionally retained but not currently rendered by
+ * `QuestionPrompt`. The permission-hook denies multi-question
+ * AskUserQuestion tool_uses, so showing the interactive form would let
+ * the user submit answers that misroute via the single `_pendingUserAnswer`
+ * field. Once #4668's `Map<toolUseId, ...>` refactor lands, native
+ * multi-question support can be re-enabled by flipping the gate in
+ * `QuestionPrompt` back to rendering this component. Exported so that
+ * `noUnusedLocals` doesn't strip it while it sits dormant.
  */
-interface MultiQuestionFormProps {
+export interface MultiQuestionFormProps {
   questions: ChatMessageQuestion[]
   onSelect: (answersMap: Record<string, string>) => void
 }
 
-function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProps) {
+export function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProps) {
   // State per question: single-select holds the chosen value string,
   // multi-select holds an array of chosen value strings. Indexed by
   // question position so duplicate question texts don't collide.

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2218,6 +2218,21 @@
   opacity: 1;
 }
 
+/* #4666: deferred-notice variant shown when the TUI emits a multi-question
+   AskUserQuestion. The permission-hook denies the combined form (#4648);
+   chroxy waits for Claude to re-emit one question at a time, and this
+   placeholder explains the gap so the user doesn't try to interact. Muted
+   tone — visually distinct from the active question-prompt card. */
+.question-prompt--deferred {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.question-prompt--deferred .question-text {
+  margin-bottom: 0;
+  color: var(--text-muted);
+}
+
 /* #4634: multi-question AskUserQuestion form (#4604 Chunk B / #4620).
    The component renders these class names but they previously had no
    CSS rules — Submit fell back to the native browser button (gray-on-


### PR DESCRIPTION
## Summary

Closes #4666. Related to #4668 (long-term `_pendingUserAnswer` Map refactor).

The permission-hook at `packages/server/hooks/permission-hook.sh` (shipped in #4648 / v0.9.24) unconditionally denies any `AskUserQuestion` whose `questions[]` array has length > 1, because the TUI keystroke driver can't reliably answer combined multi-question forms. That deny is correct, but the dashboard still **rendered** the interactive `MultiQuestionForm` because the WS broadcast layer emits `tool_use` events independently of the permission decision.

The result on v0.9.27 (live screenshots, 2026-05-31):

1. Dashboard shows the combined multi-question form (4 questions, single Submit button)
2. A few seconds later one of the single-question retries also renders (#4669's sibling-deny blocks parallel siblings, so the rest are denied as siblings)
3. User submits the combined form → answer text routes to whatever's in `_pendingUserAnswer` → typed into the wrong question slot in the claude TUI
4. Claude responds with "All four answers came back bundled in that one response"
5. Stream-stall watchdog (#4467) fires 5 minutes later on the denied parallel tool_uses

## Why dashboard-layer suppression

The combined form should never have been clickable in the first place. Three places could enforce that:

1. **TUI parser** (`packages/server/src/claude-tui-session.js`) — suggested in #4666. Riskier: would need to swallow the tool_use altogether and the existing per-toolUseId bubble tracking would have nothing to thread the eventual `tool_result` through.
2. **WS broadcast layer** (`packages/server/src/ws-server.js`) — cleanest at the protocol seam but requires plumbing the permission decision into the broadcast path. Viable as a follow-up.
3. **Dashboard component** (this PR) — cheapest, smallest blast radius, ships the user-facing fix now. The tool_use bubble in the tool-group still renders verbatim (no regression on the audit trail in #4278); only the interactive form is replaced by a non-interactive notice.

Server-side filtering remains a viable alternative for a follow-up if we want to stop the wasted broadcast entirely. This PR is the short-term mitigation; the long-term proper fix is #4668's `Map<toolUseId, ...>` refactor that would make multi-question delivery actually work end-to-end.

## Changes

- `packages/dashboard/src/components/QuestionPrompt.tsx` — gate the multi-question render path. When `questions.length > 1` and `answered == null`, render the new `MultiQuestionDeferredNotice` (`testID: multi-question-deferred-notice`) instead of `MultiQuestionForm`. The notice has no buttons, no inputs, and cannot fire `onSelect`. Copy: "Claude tried to ask {count} questions at once. Waiting for it to retry one at a time…"
- `MultiQuestionForm` is **intentionally retained** (now exported so `noUnusedLocals` doesn't strip it) for when #4668's long-term refactor lands and native multi-question support can be re-enabled by flipping the gate back.
- `packages/dashboard/src/theme/components.css` — add `.question-prompt--deferred` muted/italic variant on the existing question-prompt card.
- `packages/dashboard/src/components/QuestionPrompt.test.tsx` — replace the old multi-question form test block with deferred-notice assertions:
  - `questions.length > 1` renders the deferred notice, NOT the form (no `question-prompt-multi`, no `question-multi-submit`, no radios/checkboxes)
  - Deferred notice is non-interactive (no buttons, click does not fire `onSelect`)
  - Notice copy mentions the question count
  - Regression guards: `length === 0`, `length === 1`, `questions === undefined` all fall back to the single-question UI (the v0.9.4 happy path stays intact)
  - `answered` already set falls back to the single-question summary (post-answer collapse)
  - Dormant smoke test for `MultiQuestionForm` (called directly) so it doesn't bit-rot before #4668 re-enables it

## Test Plan

- [x] `cd packages/dashboard && npm test` — 127/127 files, 2381/2381 tests pass
- [x] `cd packages/dashboard && npm run typecheck` — clean
- [ ] Manual dogfood with the multi-question prompt:
  > I want to scaffold a new full-stack web app. Before you write any code, ask me about my preferences for: (1) frontend framework, (2) backend language, (3) database, and (4) testing library. Use AskUserQuestion for each.
  - Verify the combined form does NOT render in the dashboard
  - Verify the deferred notice ("Claude tried to ask 4 questions at once. Waiting for it to retry one at a time…") renders in its place
  - Verify the single-question retries (one at a time, per #4669's sibling-deny) still render with the interactive button UI and submit correctly
- [ ] Single-question AskUserQuestion regression check (any normal "would you like X?" prompt) — interactive form still works exactly as before

## Out of scope

- Server-side TUI-parser / WS-broadcast suppression (alternatives 1+2 above)
- Long-term `_pendingUserAnswer` → `Map<toolUseId, ...>` refactor — stays on #4668