### PR TITLE
fix(dashboard): desktop Copy transcript silently fails in Tauri WKWebView (#4673)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -6,10 +6,18 @@
  * avoiding real WebSocket connections.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { render, screen, cleanup, fireEvent, within } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, within, waitFor } from '@testing-library/react'
 
 vi.mock('./hooks/usePathAutocomplete', () => ({
   usePathAutocomplete: () => ({ suggestions: [] }),
+}))
+
+// #4673 — control the clipboard helper per-test so we can assert that the
+// "Copied!" check mark only fires when the helper actually wrote. Default
+// to a successful write so the unrelated render-smoke tests stay green.
+const clipboardWriteTextMock = vi.fn<(text: string) => Promise<boolean>>(() => Promise.resolve(true))
+vi.mock('./utils/clipboard', () => ({
+  writeText: (text: string) => clipboardWriteTextMock(text),
 }))
 
 // #3608: capture the `onRestart` prop the App passes into StdinDisabledBanner
@@ -151,6 +159,10 @@ vi.mock('zustand/react/shallow', () => ({
 beforeEach(() => {
   stateOverrides = {}
   capturedOnRestart = null
+  // #4673 — reset the clipboard mock between tests so per-case rejection
+  // overrides don't bleed through.
+  clipboardWriteTextMock.mockReset()
+  clipboardWriteTextMock.mockResolvedValue(true)
   // #4432 — reset the shared shortcut registry so per-test rebinds
   // don't bleed between cases. The registry persists overrides to
   // localStorage; clearing the key keeps loadOverrides() returning {}.
@@ -1477,6 +1489,67 @@ describe('App', () => {
 
       expect(screen.queryByRole('menu')).not.toBeInTheDocument()
       expect(document.activeElement).toBe(treeitem)
+    })
+  })
+
+  // #4673 — Tauri WKWebView's `navigator.clipboard.writeText` silently
+  // resolves without writing to the OS clipboard, which made the "Copied!"
+  // check mark flash on a transcript that was never actually copied. The
+  // copy callback now routes through the `writeText` helper and only marks
+  // the button as copied when the helper reports success.
+  describe('handleCopyTranscript copy indicator (#4673)', () => {
+    const connectedWithMessages = {
+      connectionPhase: 'connected' as const,
+      sessions: [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }],
+      activeSessionId: 's1',
+      getActiveSessionState: () => ({
+        messages: [
+          { id: 'msg-1', type: 'user_input', content: 'hello', timestamp: 1 },
+          { id: 'msg-2', type: 'response', content: 'hi back', timestamp: 2 },
+        ],
+        streamingMessageId: null,
+        activeModel: null,
+        permissionMode: null,
+        contextUsage: null,
+        sessionCost: null,
+        isIdle: true,
+        activeAgents: [],
+        isPlanPending: false,
+      }),
+    }
+
+    it('does NOT flash the check mark when the clipboard helper returns false', async () => {
+      clipboardWriteTextMock.mockResolvedValue(false)
+      stateOverrides = connectedWithMessages
+      render(<App />)
+
+      const btn = screen.getByTestId('btn-copy-transcript')
+      // Title before click reflects the not-copied state (no "Copied!").
+      expect(btn.getAttribute('title')).not.toContain('Copied!')
+
+      fireEvent.click(btn)
+      await waitFor(() => {
+        expect(clipboardWriteTextMock).toHaveBeenCalledTimes(1)
+      })
+
+      // Indicator must NOT flip — the OS clipboard was never written.
+      expect(btn.textContent).not.toContain('✓')
+      expect(btn.getAttribute('title')).not.toContain('Copied!')
+    })
+
+    it('DOES flash the check mark when the clipboard helper returns true', async () => {
+      clipboardWriteTextMock.mockResolvedValue(true)
+      stateOverrides = connectedWithMessages
+      render(<App />)
+
+      const btn = screen.getByTestId('btn-copy-transcript')
+      fireEvent.click(btn)
+
+      await waitFor(() => {
+        expect(btn.textContent).toContain('✓')
+      })
+      expect(clipboardWriteTextMock).toHaveBeenCalledTimes(1)
+      expect(btn.getAttribute('title')).toContain('Copied!')
     })
   })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -63,6 +63,7 @@ import { formatShortcutKeys, isMacPlatform } from './utils/platform'
 import { useShortcutRegistry } from './shortcuts/useShortcutRegistry'
 import { formatBindingForDisplay, parseBinding } from './shortcuts/registry'
 import { readClipboardImage } from './utils/clipboard-image'
+import { writeText as clipboardWriteText } from './utils/clipboard'
 import { useTauriEvents } from './hooks/useTauriEvents'
 import { isTauri } from './utils/tauri'
 import { startServer, revealInFinder } from './hooks/useTauriIPC'
@@ -503,19 +504,15 @@ export function App() {
   const handleCopyTranscript = useCallback(() => {
     const text = formatTranscript(storeMessages)
     if (!text) return
-    // navigator.clipboard is undefined in non-secure contexts (and some
-    // embedded webviews). Accessing .writeText on undefined would throw
-    // synchronously — bypass the .catch() and surface as a runtime error
-    // in the keyboard handler. Guard with the same pattern as the other
-    // dashboard copy paths.
-    if (!navigator.clipboard) return
-    void navigator.clipboard.writeText(text).then(() => {
+    // #4673: route through the clipboard helper so Tauri builds use the
+    // native plugin (navigator.clipboard.writeText silently no-ops in
+    // WKWebView). Only flash the "Copied!" check mark if the helper actually
+    // wrote — otherwise the indicator lies about an empty OS clipboard.
+    void clipboardWriteText(text).then((ok) => {
+      if (!ok) return
       setTranscriptCopied(true)
       if (transcriptResetTimerRef.current) clearTimeout(transcriptResetTimerRef.current)
       transcriptResetTimerRef.current = setTimeout(() => setTranscriptCopied(false), 1500)
-    }).catch(() => {
-      // Clipboard rejected (e.g. user denied permissions). Surface the
-      // failure quietly — the user can copy manually from the chat view.
     })
   }, [storeMessages])
   useEffect(() => () => {
@@ -621,16 +618,12 @@ export function App() {
         useConnectionStore.getState().addServerError(message)
       },
       copyToClipboard: (text) => {
-        // navigator.clipboard is undefined in non-secure contexts and some
-        // embedded webviews; mirror the same guard handleCopyTranscript
-        // uses (see the comment block on that callback) so this menu item
-        // doesn't throw out of the synchronous click handler.
-        if (!navigator.clipboard) return
-        void navigator.clipboard.writeText(text).catch(() => {
-          // Clipboard rejected (user denied permission) — fail quietly.
-          // The user can still see the conversation id by hovering or
-          // re-running the search.
-        })
+        // #4673: route through the clipboard helper so Tauri builds use the
+        // native plugin instead of navigator.clipboard (which silently
+        // no-ops in WKWebView). Failures fall through quietly — the user
+        // can still see the conversation id by hovering or re-running the
+        // search.
+        void clipboardWriteText(text)
       },
       openCreateSessionAt: (cwd) => {
         setPendingCwd(cwd)

--- a/packages/dashboard/src/utils/clipboard.test.ts
+++ b/packages/dashboard/src/utils/clipboard.test.ts
@@ -32,7 +32,9 @@ function clearNavigatorClipboard() {
       configurable: true,
     })
   } catch {
-    // ignore — afterEach resets via setNavigatorClipboard in each test
+    // ignore — if jsdom locks `clipboard` non-configurable, the next test
+    // that needs a specific value calls setNavigatorClipboard() before
+    // exercising the helper, which overrides the stale value.
   }
 }
 
@@ -62,6 +64,24 @@ describe('writeText() clipboard helper (#4673)', () => {
 
     expect(result).toBe(false)
     expect(tauriWrite).toHaveBeenCalledWith('hello')
+  })
+
+  // #4676 — Copilot review: when the Tauri plugin is reachable but rejects,
+  // we must NOT fall through to navigator.clipboard. Under WKWebView the
+  // navigator path is exactly the broken one #4673 was filed for (resolves
+  // without writing), so a fallback would re-introduce the lying "Copied!"
+  // indicator. Hard-fail returns false and leaves navigator untouched.
+  it('returns false (and does NOT call navigator.clipboard) when the Tauri plugin write rejects even if navigator.clipboard is present', async () => {
+    const tauriWrite = vi.fn().mockRejectedValue(new Error('plugin denied'))
+    const navWrite = vi.fn().mockResolvedValue(undefined)
+    setTauri({ writeText: tauriWrite })
+    setNavigatorClipboard({ writeText: navWrite })
+
+    const result = await writeText('hello')
+
+    expect(result).toBe(false)
+    expect(tauriWrite).toHaveBeenCalledWith('hello')
+    expect(navWrite).not.toHaveBeenCalled()
   })
 
   it('falls back to navigator.clipboard.writeText when not in Tauri', async () => {

--- a/packages/dashboard/src/utils/clipboard.test.ts
+++ b/packages/dashboard/src/utils/clipboard.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { writeText } from './clipboard'
+
+function setTauri(clipboardManager: unknown) {
+  Object.defineProperty(window, '__TAURI__', {
+    value: { clipboardManager },
+    writable: true,
+    configurable: true,
+  })
+}
+
+function clearTauri() {
+  delete (window as unknown as Record<string, unknown>).__TAURI__
+  delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+}
+
+function setNavigatorClipboard(clipboard: unknown) {
+  Object.defineProperty(window.navigator, 'clipboard', {
+    value: clipboard,
+    writable: true,
+    configurable: true,
+  })
+}
+
+function clearNavigatorClipboard() {
+  // Some jsdom builds make `clipboard` non-configurable once defined; setting
+  // to undefined gets us the same observable "not present" branch.
+  try {
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    })
+  } catch {
+    // ignore — afterEach resets via setNavigatorClipboard in each test
+  }
+}
+
+describe('writeText() clipboard helper (#4673)', () => {
+  afterEach(() => {
+    clearTauri()
+    clearNavigatorClipboard()
+    vi.restoreAllMocks()
+  })
+
+  it('returns true when the Tauri plugin write succeeds', async () => {
+    const tauriWrite = vi.fn().mockResolvedValue(undefined)
+    setTauri({ writeText: tauriWrite })
+
+    const result = await writeText('hello')
+
+    expect(result).toBe(true)
+    expect(tauriWrite).toHaveBeenCalledWith('hello')
+  })
+
+  it('returns false when the Tauri plugin write rejects and no navigator clipboard fallback exists', async () => {
+    const tauriWrite = vi.fn().mockRejectedValue(new Error('plugin denied'))
+    setTauri({ writeText: tauriWrite })
+    clearNavigatorClipboard()
+
+    const result = await writeText('hello')
+
+    expect(result).toBe(false)
+    expect(tauriWrite).toHaveBeenCalledWith('hello')
+  })
+
+  it('falls back to navigator.clipboard.writeText when not in Tauri', async () => {
+    clearTauri()
+    const navWrite = vi.fn().mockResolvedValue(undefined)
+    setNavigatorClipboard({ writeText: navWrite })
+
+    const result = await writeText('hello')
+
+    expect(result).toBe(true)
+    expect(navWrite).toHaveBeenCalledWith('hello')
+  })
+
+  it('returns false when navigator.clipboard is undefined (non-secure context)', async () => {
+    clearTauri()
+    setNavigatorClipboard(undefined)
+
+    const result = await writeText('hello')
+
+    expect(result).toBe(false)
+  })
+
+  it('returns false when navigator.clipboard.writeText rejects', async () => {
+    clearTauri()
+    const navWrite = vi.fn().mockRejectedValue(new DOMException('NotAllowedError'))
+    setNavigatorClipboard({ writeText: navWrite })
+
+    const result = await writeText('hello')
+
+    expect(result).toBe(false)
+    expect(navWrite).toHaveBeenCalledWith('hello')
+  })
+
+  it('prefers the Tauri plugin path even when navigator.clipboard is present', async () => {
+    const tauriWrite = vi.fn().mockResolvedValue(undefined)
+    const navWrite = vi.fn().mockResolvedValue(undefined)
+    setTauri({ writeText: tauriWrite })
+    setNavigatorClipboard({ writeText: navWrite })
+
+    const result = await writeText('hello')
+
+    expect(result).toBe(true)
+    expect(tauriWrite).toHaveBeenCalledWith('hello')
+    expect(navWrite).not.toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/utils/clipboard.ts
+++ b/packages/dashboard/src/utils/clipboard.ts
@@ -1,0 +1,61 @@
+/**
+ * Clipboard helper (#4673).
+ *
+ * In Tauri 2 / WKWebView, `navigator.clipboard.writeText()` resolves
+ * successfully but the OS clipboard is never actually written — so the
+ * dashboard's "Copied!" check mark fires while the user's clipboard stays
+ * empty. The Tauri shell exposes a real clipboard plugin via
+ * `window.__TAURI__.clipboardManager.writeText` (enabled by
+ * `withGlobalTauri: true` + `clipboard-manager:allow-write-text` capability),
+ * which writes through to the native clipboard.
+ *
+ * This helper routes writes through the Tauri plugin first when running
+ * under the desktop shell, and falls back to `navigator.clipboard` for the
+ * browser-dashboard path. Returns `true` only when the write actually
+ * succeeded, so callers can avoid flashing a false success indicator.
+ */
+import { isTauri } from './tauri'
+
+type TauriClipboardManager = {
+  writeText?: (text: string) => Promise<void>
+}
+
+function getTauriClipboardManager(): TauriClipboardManager | null {
+  if (typeof window === 'undefined') return null
+  const w = window as unknown as Record<string, unknown>
+  const tauri = w.__TAURI__ as Record<string, unknown> | undefined
+  const cm = tauri?.clipboardManager as TauriClipboardManager | undefined
+  return cm ?? null
+}
+
+/**
+ * Writes `text` to the OS clipboard. Returns `true` on success, `false` when
+ * the write failed (rejection, missing API, non-secure context, etc.).
+ * Never throws.
+ */
+export async function writeText(text: string): Promise<boolean> {
+  if (isTauri()) {
+    const cm = getTauriClipboardManager()
+    if (cm?.writeText) {
+      try {
+        await cm.writeText(text)
+        return true
+      } catch {
+        // Tauri plugin rejected — fall through to navigator.clipboard so the
+        // user still gets a chance to copy if the JS API happens to work in
+        // this build.
+      }
+    }
+  }
+
+  // Browser-dashboard path (also the Tauri fallback if the plugin isn't
+  // reachable for some reason). navigator.clipboard is undefined in
+  // non-secure contexts and some embedded webviews — guard before .writeText.
+  if (typeof navigator === 'undefined' || !navigator.clipboard) return false
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/dashboard/src/utils/clipboard.ts
+++ b/packages/dashboard/src/utils/clipboard.ts
@@ -37,15 +37,25 @@ export async function writeText(text: string): Promise<boolean> {
   if (isTauri()) {
     const cm = getTauriClipboardManager()
     if (cm?.writeText) {
+      // The Tauri plugin is the authoritative clipboard path under the
+      // desktop shell. If it rejects, do NOT fall through to
+      // navigator.clipboard — under WKWebView that path resolves without
+      // actually writing (the original #4673 bug), so a fallback would
+      // silently re-introduce the lying success indicator. Treat the
+      // rejection as a hard failure and return false so callers skip the
+      // "Copied!" affordance.
       try {
         await cm.writeText(text)
         return true
       } catch {
-        // Tauri plugin rejected — fall through to navigator.clipboard so the
-        // user still gets a chance to copy if the JS API happens to work in
-        // this build.
+        return false
       }
     }
+    // Plugin entry missing under Tauri (e.g. withGlobalTauri changed, or
+    // capability removed). Fall through to the navigator path below — same
+    // false-positive risk applies, but at that point the Tauri side is
+    // misconfigured and there is no better option than letting the JS API
+    // try.
   }
 
   // Browser-dashboard path (also the Tauri fallback if the plugin isn't


### PR DESCRIPTION
Closes #4673

## Root cause

In Tauri 2's WKWebView, `navigator.clipboard.writeText()` resolves successfully but never actually writes to the OS clipboard. The dashboard's `Copy transcript` button (plus sidebar `Copy path` / `Copy Conversation ID` actions) all called `navigator.clipboard.writeText(text).then(...)` — so the `.then()` callback fired (flashing the `Copied!` check mark / changing `transcriptCopied` to `true`) while the user's actual clipboard stayed empty. Reproduced live on v0.9.27.

The Tauri side was already wired correctly (`tauri-plugin-clipboard-manager = 2`, `clipboard-manager:allow-write-text` capability granted, `withGlobalTauri: true`), so `window.__TAURI__.clipboardManager.writeText` was reachable but unused.

## Fix

- New helper `packages/dashboard/src/utils/clipboard.ts` exposing `writeText(text): Promise<boolean>`. Routes through `window.__TAURI__.clipboardManager.writeText` first when `isTauri()`, falls back to `navigator.clipboard.writeText` for the browser dashboard. Returns `true` only when the write actually succeeded; never throws.
- `App.tsx#handleCopyTranscript` now only sets `transcriptCopied = true` when the helper returns `true` — fixing the lying check mark.
- `App.tsx` sidebar `copyToClipboard` injection now also routes through the helper (covers `Copy path` and `Copy Conversation ID` from `sidebarContextMenuItems.ts`, which already takes the callback by injection).

## Files changed

- `packages/dashboard/src/utils/clipboard.ts` (new)
- `packages/dashboard/src/utils/clipboard.test.ts` (new — 6 tests covering Tauri success/reject, browser fallback, no-clipboard, reject, Tauri-preferred-over-navigator)
- `packages/dashboard/src/App.tsx` — `handleCopyTranscript` and sidebar `copyToClipboard` now use the helper
- `packages/dashboard/src/App.test.tsx` — new `handleCopyTranscript copy indicator (#4673)` describe block: asserts the check mark does NOT fire when the helper returns `false`, and DOES fire when it returns `true`

## Browser dashboard path

Unchanged. When `isTauri()` is false the helper goes straight to `navigator.clipboard.writeText` and returns true/false on the same conditions the old guarded path did.

## Test Plan

- [x] `npm test` from `packages/dashboard/` — 2389/2389 passing including the 6 new clipboard unit tests + 2 new App-level tests
- [x] `npm run typecheck` from `packages/dashboard/` — clean
- [ ] Manual verification on the desktop build:
  - [ ] Launch desktop app, open a chat with some messages
  - [ ] Click `Copy transcript` (or hit `Cmd+Shift+T`) — confirm check mark flashes AND that pasting elsewhere yields the transcript
  - [ ] Right-click a sidebar session row with a `cwd` → `Copy path` — confirm pasting yields the path
  - [ ] Right-click a resumable conversation → `Copy Conversation ID` — confirm pasting yields the id
- [ ] Manual verification on browser dashboard:
  - [ ] Open the dashboard in Chrome/Safari over HTTPS or localhost, repeat the three Copy actions, confirm pasting still works (i.e. no regression on the `navigator.clipboard` path)