### PR TITLE
chore(release): cut v0.9.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.28] - 2026-05-31
+
+Three follow-up fixes from the v0.9.27 dogfood: the multi-question dashboard form no longer renders for tool_uses that the permission hook will deny, the desktop Copy transcript actually puts text on the OS clipboard, and the require-review-before-merge hook resolves regardless of the bash cwd. The two dashboard fixes together stop the misroute path where users would submit the dead multi-question form and have all four answers typed into Q1's slot in claude TUI.
+
+### Fixed
+
+- **Suppress multi-question AskUserQuestion form in dashboard (#4666, #4675):** `QuestionPrompt.tsx` now renders a non-interactive `MultiQuestionDeferredNotice` ("Claude tried to ask N questions at once. Waiting for it to retry one at a time…") when `questions.length > 1`, instead of the combined form whose Submit button was dead under the #4648 hook deny. Removes the misroute path that fed all four answers into the first question's slot via `_pendingUserAnswer`. `MultiQuestionForm` is retained (exported, with re-enable comment) for #4668's long-term Map-keyed refactor.
+- **Desktop Copy transcript actually writes to the OS clipboard (#4673, #4676):** new `packages/dashboard/src/utils/clipboard.ts` helper prefers the Tauri clipboard-manager plugin (already wired in `Cargo.toml` and `capabilities/default.json`) when running under `isTauri()`, falls back to `navigator.clipboard.writeText` for the browser dashboard. The previous `navigator.clipboard.writeText` path resolved successfully on Tauri 2's WKWebView without actually writing — the check-mark fired but the OS clipboard was empty. `handleCopyTranscript` and the sidebar Copy-path / Copy-Conversation-ID actions now only flip success state when the helper returns `true`, and the Tauri-reject path no longer falls through to the broken `navigator` call.
+- **Require-review-before-merge hook resolves from any cwd (#4674):** `.claude/settings.json` switched the PreToolUse Bash hook from `bash scripts/require-review-before-merge.sh` (cwd-relative — silently broken when agents ran tests from `packages/dashboard/`) to `bash "$CLAUDE_PROJECT_DIR/scripts/require-review-before-merge.sh"`. Before this fix, the merge gate was silently bypassed on any `gh pr merge` invoked from a subdirectory.
+
 ## [0.9.27] - 2026-05-31
 
 Short-term fix for the v0.9.26 multi-question AskUserQuestion wedge (#4668). When claude TUI retried as N "separate" single-question calls after the #4648 multi-question deny, it issued them as parallel `tool_use` blocks in one assistant turn — and chroxy's `_pendingUserAnswer` is a single field, so the user's answer to question 1 routed to question 4's slot and the 5-minute stream-stall watchdog fired. The hook now refuses sibling AskUserQuestion calls while one is already pending, forcing true serialization until the long-term Map-keyed refactor lands.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.27"
+      "version": "0.9.28"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.27",
+    "version": "0.9.28",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.27</string>
+    <string>0.9.28</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.27"
+version = "0.9.28"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.27"
+version = "0.9.28"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.27",
+      "version": "0.9.28",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.27",
+  "version": "0.9.28",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Three follow-up fixes from the v0.9.27 dogfood:

- **#4675** (closes #4666) — dashboard suppresses the multi-question combined form, renders a non-interactive deferred-notice instead. Stops the misroute path where submitting the dead form fed all four answers into Q1's slot.
- **#4676** (closes #4673) — desktop Copy transcript routes through the Tauri clipboard plugin and actually writes to the OS clipboard. Previous `navigator.clipboard.writeText` resolved without writing on Tauri 2 WKWebView.
- **#4674** — `$CLAUDE_PROJECT_DIR`-anchored require-review-before-merge hook so the merge gate works from any cwd (was silently bypassed when agents ran from subdirectories).

## Test plan

- [x] All three PRs reviewed via /full-review (1 critical in #4676 caught & fixed in `693bf7530`)
- [x] CI green on each parent branch before merge
- [ ] CI green on this release branch
- [ ] Release workflow produces notarized DMG
- [ ] Local Tauri rebuild and smoke-test: multi-question prompt should render the deferred notice (not the combined form), and Copy transcript should put text on the OS clipboard