### PR TITLE
fix(server): deliver multi-line TUI prompts via bracketed paste (#4678)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1049,6 +1049,36 @@ export class ClaudeTuiSession extends BaseSession {
    * @returns {Promise<boolean>} true if completed, false if aborted.
    */
   async _writePtyTextThrottled(text, { onAbort } = {}) {
+    // #4678: multi-line prompts (from Shift+Enter in the dashboard
+    // composer) need to be delivered as a single bracketed paste —
+    // claude TUI v2.1.x treats raw \n in the input box as "insert
+    // newline in multi-line composition" with no way to break out via
+    // a subsequent \r (the bare \r is also interpreted as a newline
+    // when the cursor is in a multi-line composition). Wrapping the
+    // content in CSI bracketed-paste markers (\x1b[200~ ... \x1b[201~)
+    // tells claude TUI the content was pasted; on receipt of the close
+    // marker the input is ready to submit and the trailing \r fires.
+    //
+    // Single-line content keeps the per-char throttled write — the
+    // #4269 throttle exists to defeat claude TUI's heuristic paste
+    // detector when the input is typed input (not a real paste). For
+    // genuine paste we use the explicit markers and rely on claude TUI
+    // honouring DEC mode 2004 for those bytes.
+    const hasNewlines = /\r?\n/.test(text)
+    if (hasNewlines) {
+      // Normalise CRLF → LF so the pasted body contains a single line
+      // break per logical newline. Trailing newlines are dropped so
+      // the close marker lands at the end of the visible content
+      // rather than after an empty trailing line.
+      const body = text.replace(/\r\n/g, '\n').replace(/\n+$/, '')
+      if (this._activeTurn?.aborted || this._ptyExited) {
+        onAbort?.()
+        return false
+      }
+      this._term.write('\x1b[200~' + body + '\x1b[201~\r')
+      return true
+    }
+
     this._term.write('\x1b[?2004l')
     try {
       // #4276: huge prompts bypass the throttle. Counting code-points

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1042,6 +1042,11 @@ export class ClaudeTuiSession extends BaseSession {
    * — the bulk path may trip claude's paste detector but that's
    * preferable to multi-minute silent hangs.
    *
+   * Multi-line input (any embedded `\n`) takes a separate fast-path
+   * (#4678): the body is normalised, wrapped in CSI bracketed-paste
+   * markers, and delivered as a single atomic write — see the inline
+   * comment in the function body for the why.
+   *
    * @param {string} text — the text to write (no trailing CR; \r appended)
    * @param {object} [opts]
    * @param {() => void} [opts.onAbort] — called if abort tripped; caller
@@ -1069,9 +1074,35 @@ export class ClaudeTuiSession extends BaseSession {
       // Normalise CRLF → LF so the pasted body contains a single line
       // break per logical newline. Trailing newlines are dropped so
       // the close marker lands at the end of the visible content
-      // rather than after an empty trailing line.
-      const body = text.replace(/\r\n/g, '\n').replace(/\n+$/, '')
+      // rather than after an empty trailing line. Embedded paste-end
+      // markers (`\x1b[201~`) are stripped from the body — leaving
+      // them intact would let attacker-controlled content (an MCP tool
+      // result echoed into a follow-up prompt, an evaluator rewrite,
+      // any future content-injection path) terminate the bracketed
+      // paste early and land the suffix as typed input in claude TUI.
+      // Defense-in-depth; the typing-user case is zero-risk today.
+      // Order matters: strip embedded \x1b[201~ markers BEFORE the
+      // trailing-newline strip. Removing markers can expose trailing
+      // newlines that were hidden by them — e.g. "\n\x1b[201~\n" needs
+      // to become "" (empty body → abort), not "\n" (a degenerate
+      // one-newline paste). Doing trailing-strip first would keep the
+      // newline that the marker was masking.
+      const body = text
+        .replace(/\r\n/g, '\n')
+        .replace(/\x1b\[201~/g, '')
+        .replace(/\n+$/, '')
       if (this._activeTurn?.aborted || this._ptyExited) {
+        onAbort?.()
+        return false
+      }
+      // After stripping, an all-whitespace or all-control-bytes prompt
+      // can collapse to an empty body. Sending the degenerate
+      // `\x1b[200~\x1b[201~\r` produces a CR-on-empty-input — at best
+      // a no-op, at worst behaviour the TUI doesn't expect. Drop the
+      // turn cleanly via the abort path so the caller sees a finished
+      // turn (no message ever leaves chroxy) rather than chroxy
+      // claiming to have sent and then waiting forever for a reply.
+      if (body.length === 0) {
         onAbort?.()
         return false
       }

--- a/packages/server/tests/claude-tui-session-paste-heuristic.test.js
+++ b/packages/server/tests/claude-tui-session-paste-heuristic.test.js
@@ -177,6 +177,102 @@ describe('ClaudeTuiSession paste-heuristic integration (#4271)', () => {
     )
   })
 
+  // #4678: multi-line prompts (from Shift+Enter in the dashboard composer)
+  // are delivered as a single bracketed paste so claude TUI v2.1.x receives
+  // them as one block and the trailing CR fires as a submit. Without this,
+  // embedded \n chars put the input box into multi-line composition mode
+  // where the trailing \r is interpreted as another newline rather than
+  // submit, and the turn wedges until the 5-minute stream-stall watchdog.
+  describe('multi-line prompt delivery (#4678)', () => {
+    it('multi-line prompt wraps the body in CSI bracketed-paste markers + trailing CR', async () => {
+      const session = makeSession()
+      const pty = new PasteHeuristicPtyStub()
+      session._term = pty
+
+      const prompt = 'first line\nsecond line\nthird line'
+      const completed = await session._writePtyTextThrottled(prompt)
+      assert.equal(completed, true, 'multi-line write completes')
+
+      const writes = pty.allWrites()
+      assert.equal(writes.length, 1, 'multi-line uses a single atomic write — not the per-char throttle')
+      const sent = writes[0]
+      assert.ok(sent.startsWith('\x1b[200~'), `must start with paste-start CSI (got ${JSON.stringify(sent.slice(0, 10))})`)
+      assert.ok(sent.endsWith('\x1b[201~\r'), `must end with paste-end CSI + CR (got ${JSON.stringify(sent.slice(-12))})`)
+      assert.ok(sent.includes('first line\nsecond line\nthird line'), 'body preserves embedded \\n chars verbatim')
+    })
+
+    it('CRLF in multi-line content is normalised to LF before paste', async () => {
+      const session = makeSession()
+      const pty = new PasteHeuristicPtyStub()
+      session._term = pty
+
+      const prompt = 'one\r\ntwo\r\nthree'
+      const completed = await session._writePtyTextThrottled(prompt)
+      assert.equal(completed, true)
+
+      const sent = pty.allWrites()[0]
+      assert.ok(!sent.includes('\r\n'), 'no CRLF survives in the pasted body')
+      assert.ok(sent.includes('one\ntwo\nthree'), 'CRLF collapsed to LF')
+    })
+
+    it('trailing newlines are stripped so the close marker lands flush with content', async () => {
+      const session = makeSession()
+      const pty = new PasteHeuristicPtyStub()
+      session._term = pty
+
+      // Trailing newline (user pressed Shift+Enter at the end of their
+      // prompt) — without stripping, the body would end with \n right
+      // before the paste-close marker, putting the cursor on a blank
+      // line on receipt of \r and either inserting another empty line
+      // or producing inconsistent submit behaviour across TUI versions.
+      const prompt = 'hello\n\n'
+      const completed = await session._writePtyTextThrottled(prompt)
+      assert.equal(completed, true)
+
+      const sent = pty.allWrites()[0]
+      assert.equal(sent, '\x1b[200~hello\x1b[201~\r', 'trailing newlines stripped; body is just "hello"')
+    })
+
+    it('single-line prompts still use the per-char throttle path (regression guard)', async () => {
+      const session = makeSession()
+      const pty = new PasteHeuristicPtyStub()
+      session._term = pty
+
+      const prompt = 'no newlines here just plain text'
+      const completed = await session._writePtyTextThrottled(prompt)
+      assert.equal(completed, true)
+
+      // Single-line should still go through the per-char throttle: one
+      // write per character + the mode-2004 wrap + final \r. If this
+      // ever switched to bracketed paste for single-line too, the #4269
+      // paste-detector defence would regress (the throttle is required
+      // because the detector ignores DEC mode 2004 toggles on real
+      // claude TUI).
+      assert.ok(pty.visibleCharCount() === prompt.length, 'every char written individually')
+      assert.equal(pty.visibleBody(), prompt, 'visible body matches prompt verbatim')
+      // No paste markers anywhere in the byte stream for single-line.
+      const allBytes = pty.allWrites().join('')
+      assert.ok(!allBytes.includes('\x1b[200~'), 'single-line must not emit paste-start CSI')
+      assert.ok(!allBytes.includes('\x1b[201~'), 'single-line must not emit paste-end CSI')
+    })
+
+    it('multi-line write honours abort flag set before the paste fires', async () => {
+      const session = makeSession()
+      const pty = new PasteHeuristicPtyStub()
+      session._term = pty
+      session._activeTurn.aborted = true
+
+      let onAbortCalled = false
+      const completed = await session._writePtyTextThrottled('aborted\nprompt', {
+        onAbort: () => { onAbortCalled = true },
+      })
+
+      assert.equal(completed, false, 'aborted returns false')
+      assert.equal(onAbortCalled, true, 'onAbort fired')
+      assert.equal(pty.allWrites().length, 0, 'no bytes leaked to the PTY after abort')
+    })
+  })
+
   it('abort-mid-loop: partial write does NOT trip the heuristic', async () => {
     const session = makeSession()
     const pty = new PasteHeuristicPtyStub()

--- a/packages/server/tests/claude-tui-session-paste-heuristic.test.js
+++ b/packages/server/tests/claude-tui-session-paste-heuristic.test.js
@@ -256,6 +256,67 @@ describe('ClaudeTuiSession paste-heuristic integration (#4271)', () => {
       assert.ok(!allBytes.includes('\x1b[201~'), 'single-line must not emit paste-end CSI')
     })
 
+    it('strips embedded paste-end markers (\\x1b[201~) from the body so attacker content cannot escape the paste', async () => {
+      const session = makeSession()
+      const pty = new PasteHeuristicPtyStub()
+      session._term = pty
+
+      // Without stripping, the embedded \x1b[201~ would terminate
+      // claude TUI's paste at "legit content" and the suffix
+      // ("rm -rf /") would land as typed input in the input box —
+      // a sandbox-escape primitive if any future code path feeds
+      // attacker-controlled content into _writePtyTextThrottled.
+      const prompt = 'legit content\n\x1b[201~rm -rf /\nmore content'
+      const completed = await session._writePtyTextThrottled(prompt)
+      assert.equal(completed, true)
+
+      const sent = pty.allWrites()[0]
+      // Exactly one start and one end marker — the embedded one is gone.
+      assert.equal((sent.match(/\x1b\[200~/g) || []).length, 1, 'one paste-start marker')
+      assert.equal((sent.match(/\x1b\[201~/g) || []).length, 1, 'one paste-end marker (embedded one stripped)')
+      // Suffix text survives (it's just text, no longer a sandbox-escape).
+      assert.ok(sent.includes('rm -rf /'), 'attacker text passes through as inert content')
+      assert.ok(sent.includes('legit content'), 'legitimate content passes through')
+    })
+
+    it('all-newline prompt collapses to empty body and aborts cleanly (no degenerate empty-paste)', async () => {
+      const session = makeSession()
+      const pty = new PasteHeuristicPtyStub()
+      session._term = pty
+
+      // After CRLF normalise + trailing-newline strip, body == ''. Sending
+      // \x1b[200~\x1b[201~\r is a degenerate empty paste — undocumented
+      // claude TUI behaviour. The guard short-circuits via the abort path
+      // so no bytes leak to the PTY and the caller sees a clean turn end.
+      let onAbortCalled = false
+      const completed = await session._writePtyTextThrottled('\n\n\n', {
+        onAbort: () => { onAbortCalled = true },
+      })
+
+      assert.equal(completed, false, 'empty-body returns false (treated as abort)')
+      assert.equal(onAbortCalled, true, 'onAbort fired so caller can surface turn error')
+      assert.equal(pty.allWrites().length, 0, 'no bytes leaked to the PTY for empty-body input')
+    })
+
+    it('prompt that is entirely embedded paste-end markers also aborts cleanly (defense-in-depth + empty-body interplay)', async () => {
+      const session = makeSession()
+      const pty = new PasteHeuristicPtyStub()
+      session._term = pty
+
+      // After stripping \x1b[201~ from "\n\x1b[201~\x1b[201~\n", body
+      // is "\n\n" which then trims trailing newlines to "". Both guards
+      // run in sequence; verify the abort path fires for the composite
+      // case as well.
+      let onAbortCalled = false
+      const completed = await session._writePtyTextThrottled('\n\x1b[201~\x1b[201~\n', {
+        onAbort: () => { onAbortCalled = true },
+      })
+
+      assert.equal(completed, false)
+      assert.equal(onAbortCalled, true)
+      assert.equal(pty.allWrites().length, 0)
+    })
+
     it('multi-line write honours abort flag set before the paste fires', async () => {
       const session = makeSession()
       const pty = new PasteHeuristicPtyStub()

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -872,13 +872,18 @@ describe('ClaudeTuiSession', () => {
       assert.equal(writes[2 + codePoints.length], '\x1b[?2004h', 'final write is bracketed-paste re-enable')
     })
 
-    it('throttles multi-line prompts too — embedded \\n passes through as a single-char write', async () => {
-      // The original symptom was triggered by multi-line input — claude
-      // sees an embedded \n in a bulk write and shows "+1 lines paste
-      // again to expand". With per-char throttling the \n arrives at
-      // typing speed, the same way a human typing Enter mid-prompt
-      // would. We do not strip or rewrite the prompt — that would
-      // silently mangle the user's text.
+    it('delivers multi-line prompts via a single bracketed-paste write (#4678)', async () => {
+      // #4678 superseded the per-char throttle for multi-line input.
+      // Claude TUI v2.1.x treats embedded \n in the input box as
+      // "insert newline in multi-line composition" and the trailing
+      // bare \r we appended was being interpreted as another newline
+      // rather than submit — the input box stayed in composition mode
+      // forever and the 5-min stream-stall watchdog was the only escape.
+      // Multi-line prompts now wrap the body in CSI bracketed-paste
+      // markers (\x1b[200~ ... \x1b[201~) so claude TUI receives the
+      // block as a paste and the trailing \r fires as submit. The
+      // per-char throttle is still used for single-line input (#4269
+      // paste-detector defence) — see the emoji/CJK test below.
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._processReady = true
       session._sessionId = 'test'
@@ -900,17 +905,16 @@ describe('ClaudeTuiSession', () => {
       const multiline = 'line one\nline two\nline three'
       await session.sendMessage(multiline)
 
-      // #4274: count code-points, not UTF-16 units (no difference for
-      // pure ASCII like this fixture — the emoji/CJK fixture below
-      // covers the divergence).
-      const codePoints = [...multiline]
-      assert.equal(writes.length, codePoints.length + 3)
-      // Char writes must reproduce the multi-line content verbatim,
-      // including the embedded \n bytes as their own single-char writes.
-      const charWrites = writes.slice(1, 1 + codePoints.length)
-      assert.equal(charWrites.join(''), multiline, 'multi-line prompt body reproduced verbatim')
-      const newlineWrites = charWrites.filter((c) => c === '\n')
-      assert.equal(newlineWrites.length, 2, 'each embedded \\n is its own single-char write')
+      // Exactly ONE write for the whole multi-line input — no per-char
+      // throttle for this path. The disable/enable mode-2004 wrap is
+      // also skipped because bracketed paste IS the mode signal.
+      assert.equal(writes.length, 1, 'multi-line prompt sent as one atomic paste, not per-char')
+      const sent = writes[0]
+      assert.ok(sent.startsWith('\x1b[200~'), `must start with paste-start CSI (got ${JSON.stringify(sent.slice(0, 10))})`)
+      assert.ok(sent.endsWith('\x1b[201~\r'), `must end with paste-end CSI + CR (got ${JSON.stringify(sent.slice(-12))})`)
+      assert.ok(sent.includes(multiline), 'body preserves embedded \\n chars verbatim inside the paste')
+      const newlineCount = (sent.match(/\n/g) || []).length
+      assert.equal(newlineCount, 2, 'each embedded \\n survives literally inside the bracketed-paste body')
     })
 
     // #4274: bare String#length counts UTF-16 code units, so a single


### PR DESCRIPTION
## Summary

Fixes the wedge where TUI sessions silently drop **multi-line prompts** (any prompt with Shift+Enter line breaks in the dashboard composer). Reproduced live on v0.9.28 in the multi-question testing thread: the prompt was visibly typed into claude TUI's input box (confirmed via the Output tab) but never submitted; the only escape was the 5-minute stream-stall watchdog.

Closes #4678.

## Root cause

claude TUI v2.1.x treats embedded `\n` in the input box as "insert newline in multi-line composition" and the **trailing bare `\r` we appended** is then interpreted as another newline (you can see this in the Output tab — the cursor lands on a fresh empty line, no submit). The previous fix attempt (translating `\n` → `\x1b\r` = Alt+Return) made the newlines visible as proper line breaks but didn't fix the submit problem — composition mode swallows the `\r`.

## Fix

For multi-line content, deliver the body as a **single bracketed paste**:

```
\x1b[200~ + body + \x1b[201~ + \r
```

claude TUI receives the whole block as one paste (the CSI markers signal "this is a terminal paste"), so on receipt of the close marker the input is positioned to submit and the trailing `\r` fires normally — same submit gesture that works for single-line input today.

Single-line prompts keep the existing per-char throttled path. The #4269 throttle is required there to defeat claude TUI's heuristic paste detector for genuine typed input; we only switch to bracketed paste when there's an actual `\n` in the content.

## Why this didn't surface earlier

This bug has likely existed since the keystroke driver was added in #3916, but it only bites when the user types a multi-line prompt. Most chroxy users today send single-line prompts (and the test prompts in the smoke-test suite are all single-line). The multi-question testing thread today exposed it because the test prompt has Shift+Enter line breaks between the lead-in and the actual ask.

## Validation (live)

After hot-patching the installed Chroxy.app server bundle with this change and restarting chroxy:

- ✅ Multi-line prompt with Shift+Enter line breaks now reaches claude TUI and **submits cleanly**
- ✅ Multi-question deny (#4648) fires
- ✅ Deferred-notice rendered (#4675)
- ✅ All 4 single-question retries delivered **serially one at a time** (#4669 sibling-deny)
- ✅ Each AskUserQuestion approval card rendered (Approve permission mode)
- ✅ User answered each in sequence (PostgreSQL, Vitest, etc.) and claude continued

## Tests

5 new tests in `claude-tui-session-paste-heuristic.test.js` pin the byte sequences:

- Multi-line prompts wrap the body in `\x1b[200~...\x1b[201~\r`
- CRLF in input is normalised to LF
- Trailing newlines stripped so the close marker lands flush with content
- Single-line prompts still use the per-char throttle (regression guard)
- Abort flag honoured before the paste fires

All 11 tests in the file pass.

## Test plan

- [x] Live smoke test on hot-patched build (see Validation above)
- [ ] CI green
- [ ] Live re-test on the v0.9.29 release build to confirm the bundled fix matches the hot-patch