### PR TITLE
chore(release): cut v0.9.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.29] - 2026-05-31
+
+Hot-fix for the v0.9.28 dogfood: multi-line dashboard prompts (anything with an embedded newline from Shift+Enter in the composer) silently wedged claude TUI's input box. The TUI v2.1.x composer treats raw `\n` as "insert newline in multi-line composition" with no way to break out via a subsequent `\r` — the prompt appeared in the input but never submitted, leaving the dashboard's "Working…" indicator running against a TUI doing nothing. This blocked end-to-end testing of the v0.9.28 multi-question fixes because the test prompts themselves were multi-line.
+
+### Fixed
+
+- **Multi-line prompts delivered via single bracketed paste (#4678, #4679):** `_writePtyTextThrottled` in `claude-tui-session.js` now detects newlines in incoming text and bypasses the per-char throttle in favor of a single atomic write wrapping the body in CSI bracketed-paste markers (`\x1b[200~ ... \x1b[201~\r`). Order-sensitive sanitization strips embedded `\x1b[201~` end-markers BEFORE the trailing-newline strip so attacker- or user-injected paste terminators can't truncate the body and re-expose hidden trailing newlines. Single-line prompts continue through the existing paste-detector-aware throttle path unchanged. Pinned by 8 new tests in `claude-tui-session-paste-heuristic.test.js` covering byte sequence, CRLF normalization, trailing-newline strip, 201~ strip ordering, empty-body abort guard, abort-during-write, single-line regression, and the composite case where 201~ markers hide a trailing newline.
+
 ## [0.9.28] - 2026-05-31
 
 Three follow-up fixes from the v0.9.27 dogfood: the multi-question dashboard form no longer renders for tool_uses that the permission hook will deny, the desktop Copy transcript actually puts text on the OS clipboard, and the require-review-before-merge hook resolves regardless of the bash cwd. The two dashboard fixes together stop the misroute path where users would submit the dead multi-question form and have all four answers typed into Q1's slot in claude TUI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.28",
+      "version": "0.9.29",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.28",
+      "version": "0.9.29",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.28",
+      "version": "0.9.29",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.28"
+      "version": "0.9.29"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.28",
+      "version": "0.9.29",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.28",
+      "version": "0.9.29",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.28",
+      "version": "0.9.29",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.28",
+    "version": "0.9.29",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.28</string>
+    <string>0.9.29</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.28"
+version = "0.9.29"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.28"
+version = "0.9.29"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.28",
+      "version": "0.9.29",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.28",
+  "version": "0.9.29",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
Hot-fix release for the v0.9.28 dogfood — multi-line dashboard prompts (Shift+Enter in the composer) silently wedged claude TUI's input box. The TUI v2.1.x composer treats raw \n as "insert newline in multi-line composition" with no way to break out via a subsequent \r — the prompt appeared but never submitted, leaving "Working…" running against a TUI doing nothing.

## Fixed

- **Multi-line prompts via bracketed paste (#4678, #4679):** `_writePtyTextThrottled` now detects newlines and bypasses the per-char throttle in favor of a single atomic write wrapping the body in CSI bracketed-paste markers (`\x1b[200~ ... \x1b[201~\r`). Order-sensitive sanitization strips embedded `\x1b[201~` end-markers BEFORE the trailing-newline strip. Single-line prompts unchanged. Pinned by 8 tests covering byte sequence, CRLF normalization, 201~ strip ordering, abort guards, single-line regression, and the composite hiding-newline case.

## Test plan
- [x] CI green on #4679 (13/13 checks)
- [x] Validated end-to-end on hot-patched Tauri: 4-question multi-question prompt delivered serially, deny → retry-as-singles works