### PR TITLE
feat(server): instrument prompt-delivery wedge stages

### DIFF
--- a/docs/investigations/prompt-delivery-wedge.md
+++ b/docs/investigations/prompt-delivery-wedge.md
@@ -1,0 +1,140 @@
+# Prompt Delivery Wedge — Investigation Tracker
+
+**Status:** Active investigation — last live repro 2026-06-01 03:52 UTC on v0.9.29
+**Owner:** @blamechris
+**Related open issues:** #4668 (post-deny single-Q retry wedge), #4654 (long-term multi-Q support), #4635 (pure all-single-select keystroke validation), #4651 (Other / freeform answers)
+**Related closed (but incomplete) issues:** #4678 (multi-line manifestation fixed by #4679; multi-session-restore manifestation still active)
+
+## Why this doc exists
+
+Chroxy's "prompt sent → no response" wedge has been chased across 20+ PRs over ~10 days. Each fix addressed a real manifestation but the symptom keeps recurring under new conditions, and several "shipped fixes" turned out to address adjacent bugs rather than the underlying mechanism. This doc captures what we actually know, what we're guessing, what's been tried, and what NOT to do — so the next fix is targeted instead of speculative.
+
+## Current symptom (live repro 2026-06-01 03:52 UTC)
+
+1. Chroxy starts with N≥2 sessions in `session-state.json` (from a prior run)
+2. Sessions restore successfully; WS backpressure warning fires immediately at client auth (`bufferedAmount 65737 exceeds warning threshold (65536 bytes)`)
+3. User creates a NEW (3rd+) TUI session via the `+` button
+4. User sends a single-line prompt (string of ~250 chars, no embedded newlines)
+5. Chroxy log shows `[ws-forwarding] Broadcasting stream_start: <id> (session ...)` within ~4 seconds
+6. **Then nothing.** No further log entries for that session for minutes.
+7. claude TUI process for the new session: ~0.3% CPU (sleeping), <3 seconds accumulated CPU time
+8. Sink dir (`/var/folders/.../chroxy-claude-tui/s-<uuid>/`) contains only `permission-mode` and `settings.json` — no hook artifacts
+9. Dashboard shows "Working… last activity Xs ago" — but this is chroxy's heartbeat, NOT actual TUI activity. Misleading.
+10. The 5-min stream-stall watchdog (#4467) eventually fires and surfaces an error chip, but by then the user has retried 3 times.
+
+## What we VERIFIED in the code path (not guessing)
+
+From a code trace of `packages/server/src/claude-tui-session.js` (lines 747–944):
+
+1. **`stream_start` is emitted at line 818, BEFORE the PTY write.** Its presence in the log proves the turn was initiated; it proves NOTHING about whether the prompt actually reached the PTY. (Per the `#4010` comment block.)
+2. **`_writePtyTextThrottled` writes to `this._term`** — per-session, not a shared queue. The original #4678 "shared throttle starvation" hypothesis is **wrong**.
+3. **`_waitForPrompt` polls the TUI's session file for `status=idle`** with 100ms sleeps and a `TURN_PROMPT_WAIT_MAX_MS` (5000ms) deadline. On timeout it logs a warning and **proceeds anyway** (line 835) — it cannot silently hang forever.
+4. **Per-char throttle loop uses `setTimeout(..., PROMPT_CHAR_DELAY_MS)`** (~1ms per char). A 250-char prompt should complete in ~250ms.
+5. **`this._term.write(ch)` is synchronous** into node-pty's xterm.js wrapper. node-pty does NOT block on drain — bytes queue into an internal buffer. There is no drain callback wired.
+6. **Sink dir is per-session** with random UUID — cross-session reuse is astronomically unlikely.
+7. **`_consumedFiles` Set is per-session** — no cross-session contamination of hook-file tracking.
+8. **Hook poll loop has `HOOK_TIMEOUT_MS` deadline** (~30s default) — also cannot hang forever.
+
+## What we DON'T have (observability gaps — the actual problem)
+
+From a cross-cut of memory notes and prior issue triage:
+
+1. **No per-stage timing in `sendMessage`.** We cannot tell whether the wedge sits in `_waitForPrompt`, in `_writePtyTextThrottled`, in the hook poll loop, or after the write completed.
+2. **No log confirming the PTY write completed.** `_writePtyTextThrottled` returns `true` but doesn't log byte count or elapsed ms.
+3. **No drain signal on `this._term.write()`.** node-pty buffers bytes silently if claude TUI's read end is back-pressured. No warning, no metric.
+4. **No WS bufferedAmount correlation at sendMessage entry.** We see backpressure at auth time, but don't know whether subsequent broadcasts (incl. `stream_start`) were silently dropped per `ws-broadcaster.js:64-73`.
+5. **No "prompt delivered to PTY" event.** Only `stream_start` (which fires pre-write at line 818) and `stream_end` (after Stop hook). The gap between them is invisible.
+6. **No `_lastProbeSawStatus` log when degraded.** The "degraded probe" branch exists in `_waitForPrompt` but only fires its message on the timeout warning — not on routine timeouts.
+
+## Wedge-point candidates (ranked by code-trace audit)
+
+| Rank | Location | Plausibility | Evidence needed to confirm/refute |
+|------|----------|--------------|-----------------------------------|
+| 1 | `claude-tui-session.js:829` — `_waitForPrompt` degraded probe | **HIGH** | Log `_lastProbeSawStatus` on every call; check session file readability for 3rd+ session |
+| 2 | `claude-tui-session.js:936-943` — hook poll loop never sees stop-file | **HIGH** | Log sink dir state at HOOK_TIMEOUT; check if claude PTY exited or hook process crashed |
+| 3 | `ws-broadcaster.js:64-73` — backpressure drops post-restore broadcasts | **MEDIUM** | Log per-broadcast `bufferedAmount` + drop counter for first 5s after auth |
+| 4 | `_writePtyTextThrottled` per-char buffer stall in node-pty | **MEDIUM** | Wrap `this._term.write()` with byte-count + elapsed-ms logging |
+| 5 | Sink dir cross-contamination | **LOW** | UUID-named — astronomically unlikely but verifiable |
+
+**Critical:** ranks 1 and 2 are roughly equal-plausibility. We cannot pick between them without instrumentation. The wedge symptom (`stream_start` then silence) is consistent with EITHER stage stalling.
+
+## Historical waves — what's been tried
+
+### Wave 1: paste-detector throttle (v0.9.2)
+**PRs:** #4270, #4327, #4359
+**Fix:** Wrap PTY writes in `\x1b[?2004l ... \x1b[?2004h` + per-char throttle to defeat claude TUI v2.1.x's byte-arrival-rate paste detector.
+**Status:** Working; do not regress.
+
+### Wave 2: stream-stall watchdog (v0.9.23–v0.9.25)
+**PRs:** #4475, #4504, #4608, #4614, #4618, #4640, #4646
+**Fix:** 5-min recovery watchdog on silence post-`stream_start`; emit synthetic `tool_result` to clear dashboard footer pill; full turn teardown on AskUserQuestion stall.
+**Status:** Working — recovers from wedge but does NOT prevent it. By the time it fires the user has retried 3 times.
+
+### Wave 3: AskUserQuestion permission-hook hardening (v0.9.26–v0.9.28)
+**PRs:** #4649, #4669, #4675, #4666
+**Fix:** Permission-hook denies multi-question forms (forces retry as singles); sibling-deny serializes parallel AskUserQuestion tool_uses in one turn; dashboard suppresses dead multi-question form UI.
+**Status:** Mitigates multi-question parallel concurrency. #4668 still open — post-deny single-Q retry wedges anyway.
+
+### Wave 4: multi-line bracketed paste (v0.9.29)
+**PR:** #4679
+**Fix:** Multi-line prompts (embedded `\n` from Shift+Enter) delivered as single bracketed-paste write.
+**Status:** Fixes multi-line manifestation. **Does NOT fix the multi-session-restore single-line wedge** observed 2026-06-01.
+
+## Why the proposed "option 3" fix would have been wrong
+
+The proposed v0.9.30 fix was "bypass the per-char throttle for new-session first-prompt." From the audit:
+
+- **Throttle is per-session.** It cannot be starved by other sessions. Bypassing for "first prompt" doesn't address a real mechanism.
+- **Most plausible wedge points are rank 1 (`_waitForPrompt`) and rank 2 (hook poll loop) — not the throttle itself** (rank 4).
+- **Bypassing the throttle would re-trigger paste-detector wedge** (Wave 1) — regression risk for a fix that doesn't address the actual cause.
+- **Guess-fix without instrumentation** leaves us in the same situation next time the symptom recurs under different conditions: ship something plausible, watch it fail, ship something else.
+
+## Recommended approach (phased)
+
+### Phase 1 — Ship instrumentation as v0.9.30 (zero behavior change)
+Goal: make the next repro diagnostic instead of opaque. Concrete adds:
+1. `_waitForPrompt` — log entry/exit, elapsed ms, `_lastProbeSawStatus`, return value
+2. `_writePtyTextThrottled` — log entry, byte count, code-point count, elapsed ms, completion
+3. Hook poll loop — log iterations, sink dir entry count, files consumed per iteration
+4. `ws-broadcaster.js` — log per-broadcast `bufferedAmount` and drop decisions during first 10s after each client auth
+5. `sendMessage` — log a single summary line at completion: `sendMessage done sessionId=... messageId=... waitForPromptMs=... writeMs=... pollMs=... hookCount=...`
+
+All new logs gated behind existing `[claude-tui-session]` / `[ws]` / `[ws-forwarding]` log levels — no new env vars, no debug flag. Verbose enough to diagnose, terse enough to live in prod.
+
+### Phase 2 — Capture next live repro on v0.9.30
+With instrumentation, a single repro tells us exactly which stage stalled. Reopen #4678 with the new evidence and the timing log.
+
+### Phase 3 — Targeted fix for the confirmed cause
+Only after Phase 2 evidence. Likely candidates depending on confirmed cause:
+- If `_waitForPrompt` stalls on a degraded probe: surface degraded state earlier and fall back faster
+- If hook poll loop never sees stop-file: check sink dir lifecycle on session create
+- If WS backpressure drops broadcasts: queue critical broadcasts (incl. `stream_start`) through a drain-aware sender
+- If node-pty buffer stalls: add drain callback + write timeout
+
+## What NOT to do (footguns)
+
+- **Don't bypass the per-char throttle.** Wave 1 history shows this re-triggers paste-detector wedge. The throttle is load-bearing.
+- **Don't add "if N sessions restored, do X" heuristics.** Symptom-driven, not root-cause.
+- **Don't touch the multi-line bracketed-paste path (#4679).** It's working; the current wedge is single-line.
+- **Don't merge any behavioral fix without instrumentation logs proving it landed.** We've shipped 4 "fixes" that addressed adjacent bugs.
+- **Don't trust the dashboard's "Working… last activity Xs ago" pill.** It's chroxy's heartbeat, not TUI activity. Use chroxy log + claude TUI CPU + sink dir state as the ground truth.
+
+## Decision log
+
+| Date | Decision | Reason |
+|------|----------|--------|
+| 2026-06-01 | Cut v0.9.29 with multi-line bracketed-paste fix (#4679) | Addressed multi-line manifestation only. Did NOT address multi-session-restore wedge. |
+| 2026-06-01 | Pause; full audit before option 3 | User requested investigation rather than another guess-fix. |
+| 2026-06-01 | Plan v0.9.30 as instrumentation-only release | Audit showed proposed "bypass throttle for first prompt" fix aimed at wrong layer (rank 4); rank 1 and 2 are higher-plausibility but require evidence to discriminate. |
+
+## How to add evidence to this doc
+
+When new repro evidence lands:
+1. Append a dated entry under "Decision log"
+2. Update "Wedge-point candidates" plausibility ratings if confirmed/refuted
+3. Move resolved candidates to a "Ruled out" section
+4. Update "Current symptom" if the symptom shifts
+
+When a wave ships:
+1. Add a new section under "Historical waves"
+2. List PRs, fix description, and current status (working / superseded / regression risk)

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -989,7 +989,7 @@ export class ClaudeTuiSession extends BaseSession {
         lastHeartbeatMs = now
         let sinkFileCount = 0
         try { sinkFileCount = readdirSync(this._sinkDir).length } catch {}
-        log.info(`hookPoll heartbeat (msg=${messageId} iters=${pollIters} elapsedMs=${now - pollStart} sinkFiles=${sinkFileCount} consumed=${this._consumedFiles.size - consumedAtStart} stopFound=false)`)
+        log.info(`hookPoll heartbeat (msg=${messageId} iters=${pollIters} elapsedMs=${now - pollStart} sinkFiles=${sinkFileCount} consumed=${this._consumedFiles.size - consumedAtStart} stopFound=${stopPayload ? 'yes' : 'no'})`)
       }
       if (stopPayload) break
       await new Promise((r) => setTimeout(r, 150))

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -433,6 +433,11 @@ export class ClaudeTuiSession extends BaseSession {
   // transitions are sub-second once the session is up.
   static get SPAWN_WARMUP_MAX_MS() { return 15_000 }
   static get TURN_PROMPT_WAIT_MAX_MS() { return 5_000 }
+  // Wedge instrumentation (#4678 follow-up): hook-poll loop emits a
+  // heartbeat log line every HOOK_HEARTBEAT_MS of silent waiting (no
+  // stop-hook yet). Sized so healthy short turns (<5s end-to-end) emit
+  // zero heartbeats but wedges produce a 5s-cadence trail of state.
+  static get HOOK_HEARTBEAT_MS() { return 5_000 }
 
   get sessionId() {
     return this._sessionId
@@ -692,10 +697,30 @@ export class ClaudeTuiSession extends BaseSession {
     // doesn't populate `pid` (Copilot review on #4040). Tests that
     // explicitly want to skip the probe stub `_waitForPrompt` directly
     // rather than rely on this guard.
+    //
+    // Wedge instrumentation (#4678 follow-up): record elapsedMs +
+    // sawStatus + result on every exit path. The wedge symptom is
+    // `stream_start` then silence — without this log we cannot tell
+    // whether the call returned promptly (write stage stalled) or
+    // burned its 5s timeout (probe degraded). Routes via `_activeTurn`
+    // so the line is sourced from the same turn the caller is logging.
+    const startMs = Date.now()
+    const finish = (ready) => {
+      const elapsedMs = Date.now() - startMs
+      if (this._activeTurn) {
+        this._activeTurn.waitForPromptMs = elapsedMs
+        this._activeTurn.waitForPromptReady = ready
+        this._activeTurn.waitForPromptSawStatus = this._lastProbeSawStatus
+      }
+      log.info(`waitForPrompt (msg=${this._activeTurn?.messageId ?? 'none'} elapsedMs=${elapsedMs} sawStatus=${this._lastProbeSawStatus} ready=${ready})`)
+      return ready
+    }
     const pid = this._term && this._term.pid
-    if (!Number.isInteger(pid) || pid <= 0) return false
+    if (!Number.isInteger(pid) || pid <= 0) {
+      this._lastProbeSawStatus = false
+      return finish(false)
+    }
     const sessFile = ClaudeTuiSession.sessionFilePath(pid)
-    const start = Date.now()
     // Track whether we ever read a non-null status. Distinguishes
     // "claude wrote status but never reached idle" (real busy/stuck)
     // from "status field never appeared" (probe degraded — see the
@@ -707,20 +732,20 @@ export class ClaudeTuiSession extends BaseSession {
       if (status !== null) sawStatus = true
       return status !== null && status !== 'busy'
     }
-    while (Date.now() - start < timeoutMs) {
+    while (Date.now() - startMs < timeoutMs) {
       if (this._ptyExited) {
         this._lastProbeSawStatus = sawStatus
-        return false
+        return finish(false)
       }
       if (checkReady()) {
         this._lastProbeSawStatus = sawStatus
-        return true
+        return finish(true)
       }
       await new Promise((r) => setTimeout(r, 100))
     }
     const ready = checkReady()
     this._lastProbeSawStatus = sawStatus
-    return ready
+    return finish(ready)
   }
 
   /**
@@ -760,6 +785,12 @@ export class ClaudeTuiSession extends BaseSession {
     this._currentMessageId = messageId
     const startedAt = Date.now()
     this._activeTurn = { messageId, startedAt, aborted: false, synthSeq: 0 }
+    // Wedge instrumentation (#4678 follow-up): entry log for grep'ing
+    // every turn from chroxy.log. Per-stage timings + completion get
+    // accumulated on _activeTurn and emitted in the summary line at
+    // turn finish (success or error). Together they let us reconstruct
+    // where the wedge actually sits without re-instrumenting the file.
+    log.info(`sendMessage start (msg=${messageId} sessionId=${this._sessionId} bytes=${Buffer.byteLength(prompt || '', 'utf8')} attachments=${attachments?.length || 0})`)
 
     // #4012: TUI can't accept inline multimodal blocks the way SDK/CLI
     // do, but it CAN read files via the Read tool. Materialize each
@@ -887,6 +918,14 @@ export class ClaudeTuiSession extends BaseSession {
     const HOOK_TIMEOUT_MS = this._hardTimeoutMs
     const pollStart = Date.now()
     let stopPayload = null
+    // Wedge instrumentation (#4678 follow-up): track loop progress so
+    // a wedge that manifests as "stuck waiting for stop-hook" produces
+    // a heartbeat log every HOOK_HEARTBEAT_MS — without this we cannot
+    // tell whether the loop is iterating but the sink dir stays empty,
+    // or whether the loop itself has stopped iterating.
+    let pollIters = 0
+    let lastHeartbeatMs = pollStart
+    const consumedAtStart = this._consumedFiles.size
 
     const drainHookFiles = () => {
       let entries
@@ -939,9 +978,27 @@ export class ClaudeTuiSession extends BaseSession {
       // _handleHardTimeout clears _isBusy; bail out cleanly if it fired.
       if (!this._isBusy) break
       drainHookFiles()
+      pollIters++
+      // Wedge instrumentation (#4678 follow-up): if the loop has been
+      // running >= HOOK_HEARTBEAT_MS since the last heartbeat with no
+      // stop-hook, emit a progress line. Sized at 5s so a healthy
+      // ~2-5s tool turn emits zero heartbeats while a wedge gets
+      // logged every 5s with sink-dir state.
+      const now = Date.now()
+      if (now - lastHeartbeatMs >= ClaudeTuiSession.HOOK_HEARTBEAT_MS) {
+        lastHeartbeatMs = now
+        let sinkFileCount = 0
+        try { sinkFileCount = readdirSync(this._sinkDir).length } catch {}
+        log.info(`hookPoll heartbeat (msg=${messageId} iters=${pollIters} elapsedMs=${now - pollStart} sinkFiles=${sinkFileCount} consumed=${this._consumedFiles.size - consumedAtStart} stopFound=false)`)
+      }
       if (stopPayload) break
       await new Promise((r) => setTimeout(r, 150))
     }
+    // Wedge instrumentation (#4678 follow-up): always log the loop's
+    // exit shape — whether it broke on stopPayload, abort, ptyExited,
+    // !isBusy, or timeout. Pair with sendMessage's final summary to
+    // reconstruct the wedge stage post-hoc.
+    log.info(`hookPoll exit (msg=${messageId} iters=${pollIters} elapsedMs=${Date.now() - pollStart} consumed=${this._consumedFiles.size - consumedAtStart} stopFound=${stopPayload ? 'yes' : 'no'} aborted=${this._activeTurn?.aborted ? 'yes' : 'no'} ptyExited=${this._ptyExited ? 'yes' : 'no'} stillBusy=${this._isBusy ? 'yes' : 'no'})`)
 
     if (!stopPayload) {
       let reason
@@ -991,6 +1048,10 @@ export class ClaudeTuiSession extends BaseSession {
       sessionId: this._sessionId,
     }, 'stop_hook_fired_without_post_hook')
 
+    // Wedge instrumentation (#4678 follow-up): summary log on success
+    // path, matching the one _finishTurnError emits on error paths so
+    // every turn lands one grep-able line regardless of outcome.
+    this._logSendMessageSummary('success')
     // Clear inactivity timers — turn done, nothing to backstop (#3920, #4638).
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
@@ -1054,6 +1115,28 @@ export class ClaudeTuiSession extends BaseSession {
    * @returns {Promise<boolean>} true if completed, false if aborted.
    */
   async _writePtyTextThrottled(text, { onAbort } = {}) {
+    // Wedge instrumentation (#4678 follow-up): track which path the
+    // write took, the byte/code-point count, and elapsed ms. The wedge
+    // symptom (`stream_start` then silence) is consistent with this
+    // function never returning OR returning but the bytes never being
+    // consumed by claude TUI. The log line at finish() distinguishes
+    // the two — if the line never appears in the log, the wedge is in
+    // here; if it appears with completed=true, the wedge is downstream
+    // (hook poll loop, or claude TUI itself).
+    const writeStartMs = Date.now()
+    const codePointCount = [...text].length
+    const byteLength = Buffer.byteLength(text, 'utf8')
+    const finish = (path, completed) => {
+      const elapsedMs = Date.now() - writeStartMs
+      if (this._activeTurn) {
+        this._activeTurn.writePath = path
+        this._activeTurn.writeMs = elapsedMs
+        this._activeTurn.writeBytes = byteLength
+        this._activeTurn.writeCompleted = completed
+      }
+      log.info(`writePtyText (msg=${this._activeTurn?.messageId ?? 'none'} path=${path} codePoints=${codePointCount} bytes=${byteLength} elapsedMs=${elapsedMs} completed=${completed})`)
+      return completed
+    }
     // #4678: multi-line prompts (from Shift+Enter in the dashboard
     // composer) need to be delivered as a single bracketed paste —
     // claude TUI v2.1.x treats raw \n in the input box as "insert
@@ -1093,7 +1176,7 @@ export class ClaudeTuiSession extends BaseSession {
         .replace(/\n+$/, '')
       if (this._activeTurn?.aborted || this._ptyExited) {
         onAbort?.()
-        return false
+        return finish('paste-abort', false)
       }
       // After stripping, an all-whitespace or all-control-bytes prompt
       // can collapse to an empty body. Sending the degenerate
@@ -1104,19 +1187,18 @@ export class ClaudeTuiSession extends BaseSession {
       // claiming to have sent and then waiting forever for a reply.
       if (body.length === 0) {
         onAbort?.()
-        return false
+        return finish('paste-empty', false)
       }
       this._term.write('\x1b[200~' + body + '\x1b[201~\r')
-      return true
+      return finish('paste', true)
     }
 
     this._term.write('\x1b[?2004l')
     try {
-      // #4276: huge prompts bypass the throttle. Counting code-points
-      // (not UTF-16 units) keeps the threshold consistent with how the
-      // loop iterates — an emoji-only 5000-char string [...].length is
-      // 5000, not 10000.
-      const codePointCount = [...text].length
+      // #4276: huge prompts bypass the throttle. Code-point count
+      // (counted once at function entry) keeps the threshold
+      // consistent with how the loop iterates — an emoji-only 5000-
+      // char string [...].length is 5000, not 10000.
       if (codePointCount > ClaudeTuiSession.MAX_THROTTLED_CHARS) {
         // Re-check the turn lifecycle exactly once before the bulk
         // write — same shape as the loop's per-iter guards, so a
@@ -1124,11 +1206,11 @@ export class ClaudeTuiSession extends BaseSession {
         // flood a torn-down PTY with a huge payload.
         if (this._activeTurn?.aborted || this._ptyExited) {
           onAbort?.()
-          return false
+          return finish('bulk-abort', false)
         }
         this._term.write(text)
         this._term.write('\r')
-        return true
+        return finish('bulk', true)
       }
       for (const ch of text) {
         // #4275: re-check _ptyExited inside the loop, mirroring the
@@ -1138,7 +1220,7 @@ export class ClaudeTuiSession extends BaseSession {
         // pattern the rest of this file uses.
         if (this._activeTurn?.aborted || this._ptyExited) {
           onAbort?.()
-          return false
+          return finish('throttled-abort', false)
         }
         this._term.write(ch)
         if (ClaudeTuiSession.PROMPT_CHAR_DELAY_MS > 0) {
@@ -1146,7 +1228,7 @@ export class ClaudeTuiSession extends BaseSession {
         }
       }
       this._term.write('\r')
-      return true
+      return finish('throttled', true)
     } finally {
       // Always restore bracketed-paste mode, even on abort/throw. Write may
       // throw if PTY has exited mid-loop (#4287) — swallow so we don't mask
@@ -1330,7 +1412,27 @@ export class ClaudeTuiSession extends BaseSession {
     }
   }
 
+  /**
+   * Wedge instrumentation (#4678 follow-up): one-line per-turn summary
+   * with all the per-stage timings accumulated on _activeTurn during
+   * sendMessage. Called from both the success path and _finishTurnError
+   * so every turn ends with the same grep-able shape regardless of
+   * outcome. Reads from _activeTurn; safe to call when it is null.
+   */
+  _logSendMessageSummary(reason) {
+    const turn = this._activeTurn
+    if (!turn) {
+      log.info(`sendMessage done (msg=none reason=${reason})`)
+      return
+    }
+    const duration = Date.now() - turn.startedAt
+    log.info(`sendMessage done (msg=${turn.messageId} reason=${reason} duration=${duration}` +
+      ` waitForPromptMs=${turn.waitForPromptMs ?? 'n/a'} ready=${turn.waitForPromptReady ?? 'n/a'} sawStatus=${turn.waitForPromptSawStatus ?? 'n/a'}` +
+      ` writePath=${turn.writePath ?? 'n/a'} writeMs=${turn.writeMs ?? 'n/a'} writeBytes=${turn.writeBytes ?? 'n/a'} writeCompleted=${turn.writeCompleted ?? 'n/a'})`)
+  }
+
   _finishTurnError(message, callerMessageId) {
+    this._logSendMessageSummary('error')
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
     // #4638: clear the stream-stall watchdog so a turn that fails or

--- a/packages/server/src/ws-client-sender.js
+++ b/packages/server/src/ws-client-sender.js
@@ -62,7 +62,12 @@ export function createClientSender(log, opts = {}) {
         const lastWarn = client._lastBackpressureWarn || 0
         if (now - lastWarn >= warnThrottleMs) {
           client._lastBackpressureWarn = now
-          log.warn(`Backpressure: client ${client.id} bufferedAmount ${buffered} exceeds warning threshold (${warnThreshold} bytes)`)
+          // Wedge instrumentation (#4678 follow-up): include the message
+          // type so we can correlate a warn at restore-time with which
+          // broadcast tipped the buffer. Without the type we cannot tell
+          // whether the restore session_list broadcast or a subsequent
+          // stream_start broadcast pushed past the threshold.
+          log.warn(`Backpressure: client ${client.id} bufferedAmount ${buffered} exceeds warning threshold (${warnThreshold} bytes) type=${message?.type || 'unknown'}`)
         }
       }
     } catch (err) {


### PR DESCRIPTION
Phase 1 of [docs/investigations/prompt-delivery-wedge.md](docs/investigations/prompt-delivery-wedge.md) — pure-instrumentation patch so the next live repro of the multi-session-restore wedge tells us which stage actually stalled, instead of producing the same opaque \`stream_start\` → silence symptom we've been chasing across 4 fix waves.

## Why instrumentation and not a behavioral fix

The audit in the investigation doc (which this PR also adds) found:

- The wedge symptom is consistent with at least 4 different stages stalling. \`stream_start\` is emitted at \`claude-tui-session.js:818\` **before** the actual PTY write — its presence in the log proves nothing.
- The most recent attempt (option 3: bypass throttle for first-prompt) was aimed at the lowest-ranked wedge candidate, and would have risked re-triggering the v0.9.2 paste-detector wedge.
- The pattern across waves has been: ship a plausible fix, watch the symptom recur under new conditions, repeat. The blocker is observability, not behavior.

This PR ships timing logs so the next repro is diagnostic. v0.9.31 can then make a targeted fix with evidence.

## What changed

**Pure additive logs at INFO level. Zero behaviour change.**

- \`_waitForPrompt\`: \`elapsedMs\` + \`sawStatus\` + \`ready\` on every exit path
- \`_writePtyTextThrottled\`: \`path\` (paste / paste-empty / bulk / throttled) + \`bytes\` + \`elapsedMs\` + \`completed\`
- Hook poll loop: 5s heartbeat with sink-file count, and a final exit log capturing iters/consumed/stopFound/abort/ptyExited
- \`sendMessage\`: entry log + per-turn summary via \`_logSendMessageSummary\` called from both success and \`_finishTurnError\` paths
- \`ws-client-sender.js\`: include \`message?.type\` in the backpressure warn so we can tell which broadcast pushed past the threshold

## What this lets us see in the next repro

\`\`\`
[claude-tui-session] sendMessage start (msg=ebda-1 sessionId=fbb6... bytes=247 attachments=0)
[claude-tui-session] waitForPrompt (msg=ebda-1 elapsedMs=42 sawStatus=true ready=true)
[claude-tui-session] writePtyText (msg=ebda-1 path=throttled codePoints=247 bytes=247 elapsedMs=215 completed=true)
[claude-tui-session] hookPoll heartbeat (msg=ebda-1 iters=33 elapsedMs=5000 sinkFiles=0 consumed=0 stopFound=false)
...
[claude-tui-session] hookPoll exit (msg=ebda-1 iters=200 elapsedMs=30015 consumed=0 stopFound=no aborted=no ptyExited=no stillBusy=yes)
[claude-tui-session] sendMessage done (msg=ebda-1 reason=error duration=30020 waitForPromptMs=42 ready=true sawStatus=true writePath=throttled writeMs=215 writeBytes=247 writeCompleted=true)
\`\`\`

That single sequence would tell us the wedge is **post-write** (in claude TUI itself, not in chroxy) — and rule out 4 hypotheses we've been guessing between.

## What this PR does NOT touch

- The multi-line bracketed-paste path (#4679) — working as intended
- Any throttle behaviour, paste-detector defence, or hook-chain logic
- Public/protocol surfaces — no WS message types added or changed

## Test plan
- [x] All 157 tests in \`claude-tui-session.test.js\`, \`claude-tui-session-paste-heuristic.test.js\`, and \`ws-client-sender.test.js\` pass locally
- [x] CI green (will be verified after push)
- [ ] After merge: cut v0.9.30, rebuild Tauri, reproduce the wedge, capture the log trail