### PR TITLE
chore(release): cut v0.9.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.30] - 2026-05-31
+
+Phase 1 of `docs/investigations/prompt-delivery-wedge.md` — the multi-session-restore wedge (chroxy logs `stream_start` then nothing for minutes) has been chased across 20+ PRs without isolating which stage of `sendMessage` actually stalls. This release adds pure-instrumentation timing logs at every stage so the next live repro produces a single grep-able trail pinpointing the wedge stage. Zero behaviour change; v0.9.31 will ship a targeted fix once the next repro is captured.
+
+### Added
+
+- **Per-stage timing logs for prompt delivery (#4681):** `claude-tui-session.js` now logs (a) `sendMessage start` on entry with sessionId/byte-count, (b) `waitForPrompt` exit with elapsedMs + `sawStatus` + `ready`, (c) `writePtyText` exit with path (paste/bulk/throttled) + bytes + elapsedMs + completed, (d) `hookPoll heartbeat` every 5s of silent waiting with sink-file count + actual `stopFound` state, (e) `hookPoll exit` capturing iters/consumed/abort/ptyExited/stillBusy, (f) `sendMessage done` summary via `_logSendMessageSummary` called from both the success path and `_finishTurnError` so every turn ends with the same shape regardless of outcome. New `HOOK_HEARTBEAT_MS=5000` static. ws-client-sender backpressure warn now includes the `message?.type` so we can correlate a warn at restore-time with which broadcast tipped the buffer. The companion investigation tracker doc (`docs/investigations/prompt-delivery-wedge.md`) captures the 4-wave lineage of prior PRs, the ranked wedge-point candidates from the code-trace audit, and the three-phase plan this release opens. Follow-up #4682 will extend the per-turn summary to the `_handleStreamStall` / `_handleHardTimeout` / spawn-onExit teardown paths.
+
 ## [0.9.29] - 2026-05-31
 
 Hot-fix for the v0.9.28 dogfood: multi-line dashboard prompts (anything with an embedded newline from Shift+Enter in the composer) silently wedged claude TUI's input box. The TUI v2.1.x composer treats raw `\n` as "insert newline in multi-line composition" with no way to break out via a subsequent `\r` — the prompt appeared in the input but never submitted, leaving the dashboard's "Working…" indicator running against a TUI doing nothing. This blocked end-to-end testing of the v0.9.28 multi-question fixes because the test prompts themselves were multi-line.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.29",
+      "version": "0.9.30",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.29",
+      "version": "0.9.30",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.29",
+      "version": "0.9.30",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.29"
+      "version": "0.9.30"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.29",
+      "version": "0.9.30",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.29",
+      "version": "0.9.30",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.29",
+      "version": "0.9.30",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.29",
+    "version": "0.9.30",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.29</string>
+    <string>0.9.30</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.29"
+version = "0.9.30"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.29"
+version = "0.9.30"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.29",
+      "version": "0.9.30",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.29",
+  "version": "0.9.30",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
Phase 1 of [docs/investigations/prompt-delivery-wedge.md](https://github.com/blamechris/chroxy/blob/main/docs/investigations/prompt-delivery-wedge.md) — pure-instrumentation release. Adds per-stage timing logs to \`sendMessage\` so the next live repro of the multi-session-restore wedge produces a single grep-able trail that pinpoints the stalled stage instead of the opaque \`stream_start\` → silence symptom we've been chasing across 4 fix waves.

## Added (#4681)
- \`_waitForPrompt\` exit log: elapsedMs + sawStatus + ready
- \`_writePtyTextThrottled\` exit log: path (paste / bulk / throttled) + bytes + elapsedMs + completed
- Hook poll loop: 5s heartbeat with sink-file count + actual stopFound state; final exit log with iters/consumed/abort/ptyExited
- \`sendMessage\` start log + per-turn summary on both success and \`_finishTurnError\` paths via \`_logSendMessageSummary\`
- ws-client-sender backpressure warn now includes \`message?.type\` for correlation

## Out of scope
- Behaviour change to fix the wedge — that's Phase 3, after Phase 2 (capture repro on v0.9.30)
- Wiring \`_logSendMessageSummary\` into stream-stall / hard-timeout / spawn-onExit teardowns — deferred to #4682
- Multi-line bracketed-paste path (#4679) — working, untouched

## Test plan
- [x] CI green on #4681 (13/13)
- [x] 157/157 tests pass locally on affected files
- [ ] After merge: rebuild Tauri, reproduce wedge, capture the log trail, file the evidence under \`docs/investigations/prompt-delivery-wedge.md\`'s "Decision log" → ship v0.9.31 with the targeted fix