### PR TITLE
fix(server): route AskUserQuestion answers by toolUseId (#4668)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -342,15 +342,81 @@ export class ClaudeTuiSession extends BaseSession {
     // dashboard's QuestionPrompt UI eventually sends a
     // `user_question_response` which routes to respondToQuestion() —
     // that method writes the chosen answer back to the PTY (claude's
-    // own TTY-style prompt is waiting on stdin). Cleared on response,
-    // on PostToolUse (claude resolved the prompt some other way), or
-    // on session destroy.
-    this._pendingUserAnswer = null
+    // own TTY-style prompt is waiting on stdin).
+    //
+    // #4668 (Map refactor): when claude TUI emits parallel AskUserQuestion
+    // tool_use blocks in one assistant turn (which it has been observed to
+    // do post-#4648 deny), the single-field `_pendingUserAnswer` was
+    // overwritten by each new tool_use — so the user's answer to question
+    // 1 got routed to question 4's slot. Map keyed by toolUseId preserves
+    // every pending answer independently; respondToQuestion(toolUseId, …)
+    // routes the dashboard's answer to the right entry. Back-compat getter
+    // `_pendingUserAnswer` returns the most-recently-set entry so legacy
+    // tests + callers that read the single field keep working.
+    this._pendingUserAnswers = new Map()
+    this._lastPendingAnswerToolUseId = null
     // #4604: watchdog timer armed in respondToQuestion(). If PostToolUse
     // never arrives after we write the answer (multi-question form wedge),
     // _onAskUserQuestionStall clears busy state + emits an error so the
     // session is recoverable. Cleared on PostToolUse + destroy().
     this._askUserQuestionWatchdog = null
+  }
+
+  /**
+   * Back-compat getter for the pre-#4668 single-field `_pendingUserAnswer`.
+   * Returns the most-recently-set pending answer entry, or null when none
+   * are pending. New code should iterate / look up `_pendingUserAnswers`
+   * directly by toolUseId.
+   */
+  get _pendingUserAnswer() {
+    if (!this._lastPendingAnswerToolUseId) return null
+    return this._pendingUserAnswers.get(this._lastPendingAnswerToolUseId) || null
+  }
+
+  /**
+   * Back-compat setter: writing `_pendingUserAnswer = null` (the pattern
+   * used at every turn-teardown site) clears the entire Map. Writing an
+   * entry sets it in the Map keyed by its toolUseId AND updates the
+   * "most recent" pointer. Pre-#4668 callers don't need to change.
+   */
+  set _pendingUserAnswer(entry) {
+    if (entry === null || entry === undefined) {
+      this._pendingUserAnswers.clear()
+      this._lastPendingAnswerToolUseId = null
+      return
+    }
+    const toolUseId = entry.toolUseId
+    if (toolUseId) {
+      this._pendingUserAnswers.set(toolUseId, entry)
+      this._lastPendingAnswerToolUseId = toolUseId
+    }
+  }
+
+  /** Internal: drop a specific pending answer entry (PostToolUse cleanup). */
+  _clearPendingAnswerByToolUseId(toolUseId) {
+    if (!toolUseId) return
+    this._pendingUserAnswers.delete(toolUseId)
+    if (this._lastPendingAnswerToolUseId === toolUseId) {
+      // Advance the "most recent" pointer to whichever entry was set most
+      // recently after the one we just removed (insertion-order via Map
+      // iteration). null when the Map is empty.
+      const keys = [...this._pendingUserAnswers.keys()]
+      this._lastPendingAnswerToolUseId = keys.length > 0 ? keys[keys.length - 1] : null
+    }
+  }
+
+  /**
+   * #4668 cleanup: drop the askuserquestion-active sibling lock the
+   * permission-hook.sh leaves under our sink dir. The hook script's
+   * PostToolUse cleanup (tee | grep | rm) handles the happy path, but
+   * when a turn tears down for ANY other reason (watchdog fire, stream
+   * stall, hard timeout, PTY exit mid-turn, destroy()) the lock leaks
+   * and blocks the next turn's AskUserQuestion at the sibling-deny
+   * check. Cheap idempotent rm — call from every teardown path.
+   */
+  _clearAskUserQuestionLock() {
+    if (!this._sinkDir) return
+    try { rmSync(join(this._sinkDir, 'askuserquestion-active'), { recursive: true, force: true }) } catch {}
   }
 
   // Tail length to keep + length to include in error diagnostics.
@@ -1355,8 +1421,23 @@ export class ClaudeTuiSession extends BaseSession {
     // or via the underlying terminal multiplexer if a human typed into
     // the same PTY. Either way, clear the pending state so the next
     // user_question_response doesn't write into a stale context.
-    if (toolName === 'AskUserQuestion' && this._pendingUserAnswer) {
-      this._pendingUserAnswer = null
+    //
+    // #4668: clear only THIS specific tool_use's entry from the pending
+    // Map, not every entry. Pre-#4668 chroxy used a single field so
+    // clearing was all-or-nothing; with the Map there may be sibling
+    // pending answers from other tool_uses in the same turn that
+    // shouldn't be wiped when this one completes.
+    if (toolName === 'AskUserQuestion' && payload.tool_use_id) {
+      this._clearPendingAnswerByToolUseId(payload.tool_use_id)
+    }
+    // #4669 cleanup: drop the askuserquestion-active sibling lock for THIS
+    // tool_use's PostToolUse (the original PostToolUse hook in
+    // writeHookSettings() does this via tee/grep/rm — duplicated here for
+    // the defensive path where the hook script's cleanup didn't run, e.g.
+    // when claude TUI emitted PostToolUse but the hook chain raced with
+    // turn teardown). Cheap idempotent rm.
+    if (toolName === 'AskUserQuestion' && this._sinkDir) {
+      try { rmSync(join(this._sinkDir, 'askuserquestion-active'), { recursive: true, force: true }) } catch {}
     }
     // #4604: PostToolUse means claude accepted the answer (single-question
     // happy path). Cancel the stall watchdog so it doesn't fire a spurious
@@ -1475,6 +1556,7 @@ export class ClaudeTuiSession extends BaseSession {
     // clicked the QuestionPrompt right as the hard timeout fired) would
     // attempt a PTY write that no longer matches a live turn.
     this._pendingUserAnswer = null
+    this._clearAskUserQuestionLock()
     // #4604: same symmetry for the stall watchdog. The guard in
     // _onAskUserQuestionStall (`!_pendingUserAnswer && !_isBusy`) would
     // currently no-op the late fire (both are falsy here), but leaving
@@ -1584,6 +1666,7 @@ export class ClaudeTuiSession extends BaseSession {
     // after we've already fired Ctrl-C and emitted error/result has
     // nowhere meaningful to go.
     this._pendingUserAnswer = null
+    this._clearAskUserQuestionLock()
     // #4604: same symmetry for the stall watchdog — see _finishTurnError.
     if (this._askUserQuestionWatchdog) {
       clearTimeout(this._askUserQuestionWatchdog)
@@ -1646,6 +1729,7 @@ export class ClaudeTuiSession extends BaseSession {
     // #4286/#4604 symmetry — clear pending AskUserQuestion slot + watchdog
     // so a late answer / late stall fire can't write to a torn-down turn.
     this._pendingUserAnswer = null
+    this._clearAskUserQuestionLock()
     if (this._askUserQuestionWatchdog) {
       clearTimeout(this._askUserQuestionWatchdog)
       this._askUserQuestionWatchdog = null
@@ -1721,6 +1805,7 @@ export class ClaudeTuiSession extends BaseSession {
     // #4278: also drop any pending AskUserQuestion so a subsequent
     // user_question_response can't write into a torn-down context.
     this._pendingUserAnswer = null
+    this._clearAskUserQuestionLock()
     // #4604: cancel the stall watchdog too. interrupt() does NOT clear
     // _isBusy directly (Ctrl-C surfaces async via _finishTurn*), so without
     // this the watchdog could fire ~30s later and emit a spurious
@@ -1768,27 +1853,59 @@ export class ClaudeTuiSession extends BaseSession {
    * @param {string} text — the chosen answer (single-question path); ignored on the multi-question path when answersMap is populated
    * @param {object} [answersMap] — `{ [questionText]: string | string[] }`; required for multi-question forms (Chunk B)
    */
-  respondToQuestion(text, answersMap) {
-    // #4604: capture toolUseId BEFORE clearing _pendingUserAnswer so the
-    // observability log + watchdog arm have something to correlate on
-    // when the response fails or stalls.
-    const prevToolUseId = this._pendingUserAnswer?.toolUseId || null
-    const pendingQuestions = this._pendingUserAnswer?.questions || []
+  respondToQuestion(text, answersMap, toolUseId) {
+    // #4668: route to the specific pending entry the dashboard answered
+    // for. Pre-#4668 chroxy stored a single pending answer in a field
+    // and respondToQuestion always read THAT field — so when claude TUI
+    // emitted parallel AskUserQuestion tool_use blocks in one turn, the
+    // field got overwritten and the user's answer landed in the wrong
+    // toolUseId's slot. Now: if the dashboard supplied a toolUseId, look
+    // it up in the Map; if not (legacy clients), fall back to the most-
+    // recently-set entry via the back-compat getter so behaviour matches
+    // pre-#4668 for the single-pending case.
+    let entry = null
+    if (toolUseId && this._pendingUserAnswers.has(toolUseId)) {
+      entry = this._pendingUserAnswers.get(toolUseId)
+    } else if (toolUseId && this._pendingUserAnswers.size > 0) {
+      // Dashboard sent a toolUseId we don't have a pending entry for.
+      // Common cause: stale answer arriving after the turn's teardown
+      // cleared the Map (watchdog fire, user gave up + the late answer
+      // came in). Log + drop rather than write keystrokes into whatever
+      // form happens to be currently rendered.
+      log.warn(`respondToQuestion: dashboard sent toolUseId=${toolUseId} but no matching pending entry (Map.size=${this._pendingUserAnswers.size} keys=${[...this._pendingUserAnswers.keys()].join(',')}) — dropping`)
+      return
+    } else {
+      // Legacy / unidentified path: route to the most-recent entry via
+      // the back-compat getter. Maintains the pre-#4668 behaviour for
+      // single-pending cases and for callers that haven't been updated
+      // to pass toolUseId.
+      entry = this._pendingUserAnswer
+    }
+    const prevToolUseId = entry?.toolUseId || null
+    const pendingQuestions = entry?.questions || []
     const answersMapKeyCount = answersMap && typeof answersMap === 'object' ? Object.keys(answersMap).length : 0
-    log.info(`respondToQuestion: tool=${prevToolUseId || '?'} text.length=${(text || '').length} answersMap.keys=${answersMapKeyCount} questions=${pendingQuestions.length} options=${this._pendingUserAnswer?.options?.length || 0}`)
-    if (!this._pendingUserAnswer) return
+    log.info(`respondToQuestion: tool=${prevToolUseId || '?'} dashboardToolUseId=${toolUseId || 'none'} text.length=${(text || '').length} answersMap.keys=${answersMapKeyCount} questions=${pendingQuestions.length} options=${entry?.options?.length || 0} pendingMapSize=${this._pendingUserAnswers.size}`)
+    if (!entry) return
     // Single-question / free-text path requires a non-empty `text`. The
     // multi-question path is driven from answersMap (text is ignored when
     // a map is present) so an empty string is permitted there.
     if (typeof text !== 'string') return
     if (text.length === 0 && answersMapKeyCount === 0) return
-    const { options } = this._pendingUserAnswer
-    // pendingQuestions captured at the top so the .length read survives
-    // entries that only ever set { toolUseId, options } (pre-Chunk-B
-    // tests, the watchdog test fixtures, and any legacy caller).
+    const { options } = entry
     const questions = pendingQuestions
-    this._pendingUserAnswer = null
+    // #4668: clear only this specific entry; sibling pending answers
+    // (from parallel AskUserQuestion calls in the same turn) survive.
+    this._clearPendingAnswerByToolUseId(entry.toolUseId)
     if (!this._term) return
+    // #4668 diagnostic: capture the PTY output tail just before we write
+    // the answer keystroke. The wedge symptom observed 2026-06-01 was
+    // "chroxy wrote bytes=1 → TUI silent for 30s → watchdog fires" with
+    // no visibility into whether the TUI's input prompt was actually
+    // ready to receive a digit. Logging the tail hex dump at write-time
+    // tells us exactly what the TUI was showing when our keystroke
+    // landed — single-keystroke wedges almost always come from a form
+    // misalignment that's visible in the trailing render bytes.
+    log.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
 
     const armWatchdog = () => {
       // #4604: arm a stall watchdog. If claude TUI never emits PostToolUse
@@ -2013,6 +2130,7 @@ export class ClaudeTuiSession extends BaseSession {
     const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : 0
 
     this._pendingUserAnswer = null
+    this._clearAskUserQuestionLock()
     // #4616: emit a synthetic tool_result FIRST so the dashboard's
     // activeTools entry for this AskUserQuestion is cleared. Without it
     // the footer "Running AskUserQuestion · Ns" pill keeps ticking
@@ -2084,6 +2202,7 @@ export class ClaudeTuiSession extends BaseSession {
     // #4278: drop any pending AskUserQuestion so a late
     // user_question_response can't write into a dead PTY.
     this._pendingUserAnswer = null
+    this._clearAskUserQuestionLock()
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
     // #4638: clear the stream-stall watchdog on destroy too — otherwise

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1427,17 +1427,26 @@ export class ClaudeTuiSession extends BaseSession {
     // clearing was all-or-nothing; with the Map there may be sibling
     // pending answers from other tool_uses in the same turn that
     // shouldn't be wiped when this one completes.
-    if (toolName === 'AskUserQuestion' && payload.tool_use_id) {
-      this._clearPendingAnswerByToolUseId(payload.tool_use_id)
+    //
+    // #4689: clear by the resolved local `toolUseId`, not by raw
+    // `payload.tool_use_id`. When the hook payload omits `tool_use_id`
+    // (older claude builds, certain MCP tools), `_emitToolHookEvent`
+    // synthesizes a stable id at line ~1340 and the PreToolUse branch
+    // above stores the pending entry under THAT synthesized id. Gating
+    // cleanup on `payload.tool_use_id` would skip the clear for those
+    // builds and leak Map entries indefinitely.
+    if (toolName === 'AskUserQuestion' && toolUseId) {
+      this._clearPendingAnswerByToolUseId(toolUseId)
     }
     // #4669 cleanup: drop the askuserquestion-active sibling lock for THIS
     // tool_use's PostToolUse (the original PostToolUse hook in
     // writeHookSettings() does this via tee/grep/rm — duplicated here for
     // the defensive path where the hook script's cleanup didn't run, e.g.
     // when claude TUI emitted PostToolUse but the hook chain raced with
-    // turn teardown). Cheap idempotent rm.
-    if (toolName === 'AskUserQuestion' && this._sinkDir) {
-      try { rmSync(join(this._sinkDir, 'askuserquestion-active'), { recursive: true, force: true }) } catch {}
+    // turn teardown). Cheap idempotent rm via the canonical helper so
+    // teardown/cleanup behaviour stays consistent (#4692).
+    if (toolName === 'AskUserQuestion') {
+      this._clearAskUserQuestionLock()
     }
     // #4604: PostToolUse means claude accepted the answer (single-question
     // happy path). Cancel the stall watchdog so it doesn't fire a spurious
@@ -1879,6 +1888,14 @@ export class ClaudeTuiSession extends BaseSession {
       // the back-compat getter. Maintains the pre-#4668 behaviour for
       // single-pending cases and for callers that haven't been updated
       // to pass toolUseId.
+      //
+      // #4688: warn when the dashboard omitted toolUseId AND we have
+      // multiple pending entries — the back-compat fallback picks the
+      // most-recent entry by insertion order, which may not be what
+      // the user intended. Loud log so the wedge symptom is greppable.
+      if (!toolUseId && this._pendingUserAnswers.size > 1) {
+        log.warn(`respondToQuestion: dashboard omitted toolUseId but ${this._pendingUserAnswers.size} pending entries exist (keys=${[...this._pendingUserAnswers.keys()].join(',')}) — falling back to most-recent which may misroute`)
+      }
       entry = this._pendingUserAnswer
     }
     const prevToolUseId = entry?.toolUseId || null

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -543,7 +543,14 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
     // count distinguishes the SDK's per-question form from the TUI's
     // single-answer string).
     log.info(`user_question_response received: toolUseId=${msg.toolUseId || '?'} answer.length=${(msg.answer || '').length} answers.keys=${msg.answers ? Object.keys(msg.answers).length : 0}`)
-    entry.session.respondToQuestion(msg.answer, msg.answers)
+    // #4668: forward msg.toolUseId so claude-tui-session can route the
+    // answer to the right pending entry in its Map. Sessions that don't
+    // care about toolUseId (cli-session, sdk-session via permission-
+    // manager) ignore the extra argument — JS positional args make this
+    // a safe addition. ByokSession's respondToQuestion forwards to
+    // _permissions.respondToQuestion which similarly ignores trailing
+    // args it doesn't read.
+    entry.session.respondToQuestion(msg.answer, msg.answers, msg.toolUseId)
   }
 }
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2365,6 +2365,77 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._pendingUserAnswer, null, 'pending cleared')
     })
 
+    // #4668 — when claude TUI emits parallel AskUserQuestion tool_use
+    // blocks in one assistant turn (observed post-#4648 deny), chroxy's
+    // pre-#4668 single-field `_pendingUserAnswer` got overwritten by
+    // each new tool_use → user answers routed to the wrong toolUseId's
+    // slot. New behaviour: a Map keyed by toolUseId preserves every
+    // pending entry; respondToQuestion(text, answersMap, toolUseId)
+    // routes by toolUseId to the right entry. Per-entry cleanup leaves
+    // sibling pending answers alive.
+    it('Map-keyed _pendingUserAnswers preserves sibling tool_uses; respondToQuestion routes by toolUseId (#4668)', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      // Two parallel AskUserQuestion tool_uses arrive in one turn.
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_first',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'Q1?', options: [{ label: 'A' }, { label: 'B' }] }] },
+      }, 'msg-1')
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_second',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'Q2?', options: [{ label: 'X' }, { label: 'Y' }, { label: 'Z' }] }] },
+      }, 'msg-1')
+
+      // Both entries present in the Map — pre-#4668 the second overwrote the first.
+      assert.equal(session._pendingUserAnswers.size, 2, 'both tool_uses tracked independently')
+      assert.ok(session._pendingUserAnswers.has('toolu_first'), 'first preserved')
+      assert.ok(session._pendingUserAnswers.has('toolu_second'), 'second present')
+
+      // Dashboard answers the FIRST one (by toolUseId).
+      session.respondToQuestion('A', undefined, 'toolu_first')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // Wrote '1' (1-indexed option for 'A') — proving the route went to the first entry's options.
+      assert.equal(writes[1], '1', 'wrote 1-indexed digit for first entry\'s option A')
+      // First entry cleared; SECOND entry preserved (no all-or-nothing wipe).
+      assert.ok(!session._pendingUserAnswers.has('toolu_first'), 'first entry cleared after response')
+      assert.ok(session._pendingUserAnswers.has('toolu_second'), 'second sibling entry SURVIVES first\'s response')
+
+      // Now dashboard answers the SECOND one.
+      writes.length = 0
+      session.respondToQuestion('Z', undefined, 'toolu_second')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      assert.equal(writes[1], '3', 'wrote 1-indexed digit for second entry\'s option Z')
+      assert.equal(session._pendingUserAnswers.size, 0, 'Map empty after both answered')
+    })
+
+    // #4668 — defensive: dashboard sends an answer for a toolUseId that's
+    // already been cleared (late arrival after watchdog teardown). Pre-fix
+    // this would write keystrokes into whatever pending entry happened to
+    // exist (or into nothing). Now: log warn + drop, never write.
+    it('respondToQuestion drops + logs when toolUseId has no matching pending entry (#4668)', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_live',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'Q?', options: [{ label: 'A' }] }] },
+      }, 'msg-1')
+
+      // Dashboard sends an answer for a DIFFERENT (stale) toolUseId.
+      session.respondToQuestion('A', undefined, 'toolu_stale_or_missing')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // No PTY writes — the stale answer was dropped, not written into the live entry's slot.
+      assert.equal(writes.length, 0, 'no PTY writes for stale toolUseId')
+      // Live entry still pending, ready for its own answer.
+      assert.ok(session._pendingUserAnswers.has('toolu_live'), 'live entry untouched')
+    })
+
     it('respondToQuestion writes the label text when the answer does NOT match any option (custom / Other path)', async () => {
       const writes = []
       session._term = { write: (data) => { writes.push(data) }, kill: () => {} }

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -475,7 +475,11 @@ describe('handleSessionMessage', () => {
         answer: 'yes please',
       }, ctx)
       assert.equal(entry.session.respondToQuestion.callCount, 1)
-      assert.deepStrictEqual(entry.session.respondToQuestion.lastCall, ['yes please', undefined])
+      // #4668: handler forwards msg.toolUseId so claude-tui-session can
+      // route to the right pending entry in its Map. Old 2-arg shape
+      // (answer, answersMap) is preserved positionally; toolUseId is the
+      // new trailing optional arg passed to every session type.
+      assert.deepStrictEqual(entry.session.respondToQuestion.lastCall, ['yes please', undefined, 'tool-xyz'])
     })
 
     it('forwards answers map to respondToQuestion', async () => {
@@ -490,7 +494,7 @@ describe('handleSessionMessage', () => {
         answers: answersMap,
       }, ctx)
       assert.equal(entry.session.respondToQuestion.callCount, 1)
-      assert.deepStrictEqual(entry.session.respondToQuestion.lastCall, ['yes', answersMap])
+      assert.deepStrictEqual(entry.session.respondToQuestion.lastCall, ['yes', answersMap, 'tool-abc'])
     })
   })
 

--- a/packages/server/tests/ws-server-broadcast.test.js
+++ b/packages/server/tests/ws-server-broadcast.test.js
@@ -451,7 +451,8 @@ describe('user_question_response forwarding (single-session)', () => {
 
     // Spy records calls — no manual tracking needed
     assert.equal(mockSession.respondToQuestion.callCount, 1, 'respondToQuestion should be called once')
-    assert.deepStrictEqual(mockSession.respondToQuestion.lastCall, ['Option A', undefined], 'Answer should be forwarded to cliSession')
+    // #4668: handler now forwards msg.toolUseId as the third arg (undefined here — not in the wire message).
+    assert.deepStrictEqual(mockSession.respondToQuestion.lastCall, ['Option A', undefined, undefined], 'Answer should be forwarded to cliSession')
 
     ws.close()
   })
@@ -476,7 +477,8 @@ describe('user_question_response forwarding (single-session)', () => {
     await waitFor(() => mockSession.respondToQuestion.callCount >= 1, { label: 'respondToQuestion called' })
 
     assert.equal(mockSession.respondToQuestion.callCount, 1, 'respondToQuestion should be called once')
-    assert.deepStrictEqual(mockSession.respondToQuestion.lastCall, ['yes', answersMap], 'Both answer and answers map should be forwarded')
+    // #4668: handler forwards msg.toolUseId as the third arg (undefined — not in this wire message).
+    assert.deepStrictEqual(mockSession.respondToQuestion.lastCall, ['yes', answersMap, undefined], 'Both answer and answers map should be forwarded')
 
     ws.close()
   })


### PR DESCRIPTION
Closes #4668.

## Root cause (from v0.9.30 instrumentation)

The v0.9.30 timing logs ([#4681](https://github.com/blamechris/chroxy/pull/4681)) produced a complete diagnosis on the first repro 2026-06-01 — captured in detail in [docs/investigations/prompt-delivery-wedge.md](docs/investigations/prompt-delivery-wedge.md). Headline:

- claude TUI emits parallel \`AskUserQuestion\` tool_use blocks in one assistant turn (post-#4648 deny pattern)
- Pre-fix chroxy stored pending answers in a single field → each new tool_use **overwrote** the previous
- User's answer to question 1 routed to question 4's slot
- Keystroke landed in a TUI form bound to a different toolUseId
- PostToolUse never fires → 30s watchdog tears the turn down
- Dashboard shows "Couldn't deliver your answers"

This is **NOT** the multi-session-restore wedge we originally chased under #4678. Same opaque symptom, completely different root cause.

## Changes

### \`_pendingUserAnswer\` → Map keyed by toolUseId
- Single field becomes \`_pendingUserAnswers\` (Map)
- Back-compat getter/setter preserves the old field name — legacy callers and the 6 turn-teardown sites that write \`= null\` keep working unchanged
- \`_clearPendingAnswerByToolUseId(id)\` helper for per-entry cleanup on PostToolUse
- Sibling pending answers from other tool_uses in the same turn survive when one completes

### \`respondToQuestion(text, answersMap, toolUseId?)\` signature change
- Dashboard's user_question_response carries toolUseId; now plumbed through input-handlers.js to the session
- Three routing paths: (a) toolUseId matches a pending entry → use it; (b) toolUseId given but no match → log warn + drop; (c) no toolUseId → back-compat (most-recent entry via getter)
- The drop path prevents stale answers from writing keystrokes into whatever form happens to be currently rendered

### Lock cleanup on EVERY teardown path
- The permission-hook.sh's PostToolUse cleanup (\`tee | grep | rm\`) handles the happy path only
- When a turn tears down for ANY other reason (watchdog, stream stall, hard timeout, interrupt, PTY exit mid-turn, destroy) the \`askuserquestion-active\` sibling lock from #4669 leaked into the next turn
- Added \`_clearAskUserQuestionLock()\` helper called from all 6 teardown sites; cheap idempotent rm

### Output-tail diagnostic in respondToQuestion
- Logs \`_outputTailHexDump()\` just before writing the answer keystroke
- The wedge symptom we just diagnosed had chroxy writing 1 byte and TUI going silent — without the trailing render bytes at write-time we can't tell whether the form was actually ready to receive a digit
- Single-keystroke wedges are almost always form-misalignment that's visible in the tail

## Tests

- **New (#4668):** Map-keyed sibling routing — two parallel tool_uses, each answered via toolUseId, sibling survives when one completes
- **New (#4668):** stale-toolUseId drop — log warn + return when the dashboard sends an answer for a toolUseId not in the pending Map
- **Updated:** ws-message-handlers tests assert the third toolUseId arg (back-compat positional, optional)
- 132/132 pass locally in claude-tui-session*.test.js + ws-message-handler*.test.js + permission-hook*.test.js + handlers/input-handlers.test.js

## Out of scope (deferred)

- #4685 (AskUserQuestion content visible before user clicks Allow — dashboard rendering ordering, separate fix)
- #4667 (raw JSON in AskUserQuestion bubble — dashboard renderer, separate fix)
- #4654 (long-term native multi-question form support — needs #4635 keystroke empirical pass first)

## Test plan
- [x] 132/132 tests pass locally on affected files
- [ ] CI green on the broader suite (any breakage will be the pre-existing flakes we've seen across runs OR a downstream test that needs the new toolUseId arg)
- [ ] After merge: cut v0.9.31, rebuild Tauri, reproduce the wedge with the test prompt → expect (a) no overwrite when sibling tool_uses arrive, (b) successful answer round-trip with PostToolUse fire, (c) clean teardown if it still wedges with PTY tail in the log for next-round investigation