### PR TITLE
test(app): add Maestro E2E for terminal view + reconnect-after-tunnel-drop

### DIFF
--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -83,7 +83,12 @@ wss.on('connection', (ws) => {
             name: 'Mock Session',
             cwd: '/tmp/mock-project',
             type: 'cli',
-            hasTerminal: false,
+            // #4701: report `hasTerminal: true` so the SessionScreen
+            // mode toggle includes the Terminal button (which the
+            // terminal-view.yaml flow taps). Existing flows do not
+            // assert on the absence of the Term button, so flipping
+            // this default is safe.
+            hasTerminal: true,
             model: 'sonnet',
             permissionMode: 'approve',
             isBusy: false,
@@ -192,6 +197,54 @@ wss.on('connection', (ws) => {
       case 'input': {
         const text = msg.data || ''
         console.log(`[mock] Input: "${text}"`)
+
+        // #4701: trigger phrase 'show-terminal' emits a synthetic `raw`
+        // terminal-data envelope so the Maestro `terminal-view.yaml`
+        // flow can exercise the TerminalView WebView render on a real
+        // simulator. Mirrors the production wire shape — PTY-mode
+        // servers stream PTY output as `{ type: 'raw', data: '...' }`
+        // (see packages/server/src/ws-server.js terminal forwarding +
+        // packages/app/src/store/message-handler.ts `case 'raw'`).
+        // The handler calls `appendTerminalData(data)` which both
+        // updates `terminalRawBuffer` and forwards to the WebView via
+        // the `terminalWrite` imperative callback wired in
+        // SessionScreen.useEffect when `viewMode === 'terminal'`.
+        // We emit ANSI escape colors so the output is visually
+        // distinguishable in screenshots without polluting the
+        // `assertVisible` text comparison done downstream — Maestro's
+        // matcher reads accessibility text, not pixel content, and
+        // the WebView's xterm.js layer isn't introspectable anyway,
+        // so the test only asserts the `terminal-view` testID is
+        // present (the render path itself is what we're pinning).
+        if (text.trim() === 'show-terminal') {
+          // Trip a CR + carriage return so xterm renders cleanly,
+          // then a styled line + reset.
+          send(ws, {
+            type: 'raw',
+            sessionId: 'mock-sess-1',
+            data: '\r\n\x1b[32mmaestro-terminal-fixture\x1b[0m\r\n$ ',
+          })
+          break
+        }
+
+        // #4701: trigger phrase 'simulate-disconnect' closes the
+        // WebSocket from the server side after a 1s delay so the
+        // Maestro `reconnect.yaml` flow can exercise the
+        // ConnectionPhase `connected → reconnecting → connected`
+        // transition on a real RN runtime. Production scenario —
+        // Cloudflare tunnel drops + the client auto-reconnects via
+        // `AUTO_RECONNECT_DELAY` (see packages/app/src/store/
+        // connection.ts socket.onclose). The 1s delay gives the
+        // client time to ack the input before the close lands, and
+        // mirrors the production case where the server is still
+        // processing the in-flight request when the tunnel drops.
+        if (text.trim() === 'simulate-disconnect') {
+          setTimeout(() => {
+            console.log('[mock] simulate-disconnect — closing WS')
+            try { ws.close(1006, 'simulate-disconnect') } catch {}
+          }, 1000)
+          break
+        }
 
         // #4507: trigger phrase 'show-stream-stall' emits a recoverable
         // `error{code:'stream_stall'}` so the Maestro stream-stall-chip

--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -227,9 +227,9 @@ wss.on('connection', (ws) => {
           break
         }
 
-        // #4701: trigger phrase 'simulate-disconnect' closes the
-        // WebSocket from the server side after a 1s delay so the
-        // Maestro `reconnect.yaml` flow can exercise the
+        // #4701: trigger phrase 'simulate-disconnect' abruptly tears
+        // down the WebSocket from the server side after a 1s delay so
+        // the Maestro `reconnect.yaml` flow can exercise the
         // ConnectionPhase `connected → reconnecting → connected`
         // transition on a real RN runtime. Production scenario —
         // Cloudflare tunnel drops + the client auto-reconnects via
@@ -238,10 +238,18 @@ wss.on('connection', (ws) => {
         // client time to ack the input before the close lands, and
         // mirrors the production case where the server is still
         // processing the in-flight request when the tunnel drops.
+        //
+        // Use `ws.terminate()` (not `ws.close(1006, ...)`) — close code
+        // 1006 is reserved by RFC 6455 and must not be sent in a Close
+        // frame; the `ws` library throws on it (which we'd swallow via
+        // the try/catch, leaving the socket open and the flow
+        // hanging). `terminate()` rips the TCP socket without a Close
+        // frame, which is exactly what an abrupt tunnel drop looks
+        // like — the client observes a 1006 close code locally.
         if (text.trim() === 'simulate-disconnect') {
           setTimeout(() => {
-            console.log('[mock] simulate-disconnect — closing WS')
-            try { ws.close(1006, 'simulate-disconnect') } catch {}
+            console.log('[mock] simulate-disconnect — terminating WS')
+            try { ws.terminate() } catch {}
           }, 1000)
           break
         }

--- a/packages/app/.maestro/reconnect.yaml
+++ b/packages/app/.maestro/reconnect.yaml
@@ -1,0 +1,149 @@
+appId: com.blamechris.chroxy
+name: Reconnect after tunnel drop (#4701)
+---
+
+# #4701 — End-to-end coverage for the ConnectionPhase
+# `connected → reconnecting → connected` transition after the WebSocket
+# drops. Unit tests in `__tests__/store/connection.*.test.ts` pin the
+# state-machine transitions, but no E2E ever exercised the visual
+# reconnect banner / spinner on a real RN runtime. Production scenario
+# — Cloudflare tunnel drops, the app's `socket.onclose` handler bumps
+# phase to `reconnecting`, the auto-reconnect timer fires after
+# `AUTO_RECONNECT_DELAY`, and (when the server is reachable again)
+# phase returns to `connected`.
+#
+# This flow pins:
+#   (a) The `reconnect-banner` testID (added in this PR to
+#       SessionScreen.tsx) becomes visible when phase enters
+#       `reconnecting`,
+#   (b) The `reconnect-spinner` testID (RNActivityIndicator inside the
+#       banner) is wired,
+#   (c) The auto-reconnect succeeds — the banner clears and the chat
+#       input is usable again (we re-tap the input and assert the
+#       send button is reachable).
+#
+# Trigger: 'simulate-disconnect' user input → mock-server schedules a
+# `ws.close(1006)` after a 1s delay. The 1s buffer lets the app ack
+# the input before the close lands and mirrors the production case
+# where the server is mid-stream when the tunnel drops. After the
+# AUTO_RECONNECT_DELAY (currently 1000ms in connection.ts), the app
+# auto-reconnects to the same URL — and because the mock-server is
+# still up on port 9876, the reconnect succeeds.
+#
+# Reconnect timing is inherently flakey on a simulator (Metro pause,
+# bridge GC, network throttle), so the assertion uses generous
+# `extendedWaitUntil` timeouts. The fixture seeding pattern is
+# documented in CLAUDE.md → "Fixture Seeding for Structured
+# Renderers".
+#
+# Tested devices: portrait iPhone (iOS 17+). Mirrors chat-todolist /
+# stream-stall-chip flows.
+# Requires: dev client installed + mock server on port 9876
+#   cd packages/app && npx expo run:ios
+#   bash packages/app/.maestro/scripts/start-mock-server.sh
+#
+# Self-contained (no `runFlow: setup/...`) because the existing setup/
+# flows target Expo Go (appId host.exp.Exponent), whereas this needs
+# the chroxy dev client (com.blamechris.chroxy).
+
+- launchApp:
+    clearState: true
+- openLink: "exp+chroxy://expo-development-client/?url=http://localhost:8081"
+
+# Dismiss the dev menu sheet (intro 'Continue' OR main menu close).
+- tapOn:
+    text: "Continue"
+    optional: true
+- tapOn:
+    point: "50%,10%"
+    optional: true
+
+# Skip onboarding carousel post-clearState.
+- tapOn:
+    text: "Skip"
+    optional: true
+
+# Wait until either ConnectScreen OR Chat lands.
+- extendedWaitUntil:
+    visible:
+      text: "Connect to Chroxy|Chat"
+    timeout: 30000
+
+# If we landed on ConnectScreen, fill the manual-entry form.
+- runFlow:
+    when:
+      visible: "Connect to Chroxy"
+    commands:
+      - tapOn:
+          id: "connect-manual-toggle"
+
+      - tapOn:
+          id: "connect-server-url"
+      - eraseText: 50
+      - inputText: "ws://localhost:9876"
+
+      - tapOn:
+          id: "connect-api-token"
+      - eraseText: 50
+      - inputText: "test-token-maestro"
+
+      - hideKeyboard
+
+      - tapOn:
+          id: "connect-submit"
+
+      - extendedWaitUntil:
+          visible: "Chat"
+          timeout: 10000
+
+# Ensure Chat tab is selected.
+- tapOn: "Chat"
+- waitForAnimationToEnd
+
+# Send the simulate-disconnect trigger. Mock-server schedules a WS
+# close 1s after receiving this input, so we get a clean ack first.
+- tapOn:
+    id: "chat-message-input"
+- inputText: "simulate-disconnect"
+
+- tapOn:
+    id: "chat-send-button"
+
+- hideKeyboard
+
+# Wait for the reconnect banner to appear. The mock-server's 1s
+# scheduled close + AUTO_RECONNECT_DELAY (1s) + a generous Metro
+# bridge buffer warrants the long timeout. We assert on the testID
+# rather than the banner text because text varies by retry count
+# (`Reconnecting...` vs `Reconnecting (attempt 2)...`).
+- extendedWaitUntil:
+    visible:
+      id: "reconnect-banner"
+    timeout: 15000
+
+# Spinner is wired inside the banner (RNActivityIndicator).
+- assertVisible:
+    id: "reconnect-spinner"
+
+- takeScreenshot: reconnect-banner-visible
+
+# Wait for the reconnect to succeed. The mock-server stays up on port
+# 9876 so the auto-reconnect lands → phase flips back to `connected`
+# → the banner unmounts. Long timeout because the reconnect may take
+# multiple attempts on a slow simulator. We assert by `notVisible`
+# on the banner, with a fallback positive assertion that the chat
+# input is reachable (i.e. SessionScreen is in its happy-path layout).
+- extendedWaitUntil:
+    notVisible:
+      id: "reconnect-banner"
+    timeout: 30000
+
+# Positive confirmation: the input bar is still wired and we can
+# focus it (proves the SessionScreen is in a usable state, not stuck
+# in a disconnected / cached-history fallback).
+- tapOn:
+    id: "chat-message-input"
+- assertVisible:
+    id: "chat-send-button"
+
+- takeScreenshot: reconnect-completed

--- a/packages/app/.maestro/reconnect.yaml
+++ b/packages/app/.maestro/reconnect.yaml
@@ -23,10 +23,12 @@ name: Reconnect after tunnel drop (#4701)
 #       send button is reachable).
 #
 # Trigger: 'simulate-disconnect' user input → mock-server schedules a
-# `ws.close(1006)` after a 1s delay. The 1s buffer lets the app ack
+# `ws.terminate()` after a 1s delay (abrupt TCP teardown, mirrors a
+# Cloudflare tunnel drop — the client observes a 1006 close locally
+# without a Close frame on the wire). The 1s buffer lets the app ack
 # the input before the close lands and mirrors the production case
 # where the server is mid-stream when the tunnel drops. After the
-# AUTO_RECONNECT_DELAY (currently 1000ms in connection.ts), the app
+# AUTO_RECONNECT_DELAY (currently 1500ms in connection.ts), the app
 # auto-reconnects to the same URL — and because the mock-server is
 # still up on port 9876, the reconnect succeeds.
 #

--- a/packages/app/.maestro/run-all.yaml
+++ b/packages/app/.maestro/run-all.yaml
@@ -60,3 +60,14 @@ name: All E2E flows
 # dismissing the card, and that sending a rebuttal afterwards clears
 # plan state.
 - runFlow: plan-approval-deny.yaml
+
+# Flow 14: TerminalView render (#4701) — exercises the Terminal mode
+# toggle and the WebView mount on the chroxy dev client via
+# mock-server 'show-terminal' trigger.
+- runFlow: terminal-view.yaml
+
+# Flow 15: Reconnect after tunnel drop (#4701) — exercises the
+# ConnectionPhase `connected → reconnecting → connected` transition +
+# the reconnect banner / spinner via mock-server 'simulate-disconnect'
+# trigger.
+- runFlow: reconnect.yaml

--- a/packages/app/.maestro/terminal-view.yaml
+++ b/packages/app/.maestro/terminal-view.yaml
@@ -1,0 +1,134 @@
+appId: com.blamechris.chroxy
+name: TerminalView render + raw data forwarding (#4701)
+---
+
+# #4701 — End-to-end coverage for the TerminalView (xterm.js WebView)
+# render path. Unit + integration tests cover the imperative `write` +
+# `clear` handle and the message-handler's `case 'raw'` branch, but no
+# E2E ever switched to the Terminal mode toggle or asserted that the
+# WebView actually mounts when `viewMode === 'terminal'`. This flow
+# pins:
+#   (a) The Terminal mode button renders when `activeSession.hasTerminal`
+#       is true (mock-server now reports `hasTerminal: true`),
+#   (b) tapping the Terminal mode button sets `viewMode === 'terminal'`
+#       which renders the `<TerminalView />` branch in SessionScreen,
+#   (c) the `terminal-view` testID is reachable on the WebView wrapper
+#       (added in this PR to TerminalView.tsx),
+#   (d) the wire path message-handler `case 'raw'` →
+#       `appendTerminalData(data)` → the imperative `terminalWrite`
+#       callback fires without throwing (we don't introspect xterm.js
+#       inside the WebView — the testID on the wrapper is what we
+#       assert).
+#
+# Trigger: 'show-terminal' user input → mock-server emits a `raw` event
+# with ANSI-styled fixture text. The fixture seeding pattern is
+# documented in CLAUDE.md → "Fixture Seeding for Structured Renderers".
+#
+# Tested devices: portrait iPhone (iOS 17+). Mirrors chat-todolist /
+# stream-stall-chip flows.
+# Requires: dev client installed + mock server on port 9876
+#   cd packages/app && npx expo run:ios
+#   bash packages/app/.maestro/scripts/start-mock-server.sh
+#
+# Self-contained (no `runFlow: setup/...`) because the existing setup/
+# flows target Expo Go (appId host.exp.Exponent), whereas this needs
+# the chroxy dev client (com.blamechris.chroxy). Mirrors the
+# chat-todolist.yaml / stream-stall-chip.yaml structure.
+
+- launchApp:
+    clearState: true
+- openLink: "exp+chroxy://expo-development-client/?url=http://localhost:8081"
+
+# Dismiss the dev menu sheet (intro 'Continue' OR main menu close).
+- tapOn:
+    text: "Continue"
+    optional: true
+- tapOn:
+    point: "50%,10%"
+    optional: true
+
+# Skip onboarding carousel post-clearState.
+- tapOn:
+    text: "Skip"
+    optional: true
+
+# Wait until either ConnectScreen OR Chat lands.
+- extendedWaitUntil:
+    visible:
+      text: "Connect to Chroxy|Chat"
+    timeout: 30000
+
+# If we landed on ConnectScreen, fill the manual-entry form.
+- runFlow:
+    when:
+      visible: "Connect to Chroxy"
+    commands:
+      - tapOn:
+          id: "connect-manual-toggle"
+
+      - tapOn:
+          id: "connect-server-url"
+      - eraseText: 50
+      - inputText: "ws://localhost:9876"
+
+      - tapOn:
+          id: "connect-api-token"
+      - eraseText: 50
+      - inputText: "test-token-maestro"
+
+      - hideKeyboard
+
+      - tapOn:
+          id: "connect-submit"
+
+      - extendedWaitUntil:
+          visible: "Chat"
+          timeout: 10000
+
+# Verify the Terminal mode toggle is present — mock-server reports
+# `hasTerminal: true` so SessionScreen renders the Term button.
+- extendedWaitUntil:
+    visible:
+      id: "terminal-mode-button"
+    timeout: 5000
+
+# Tap Terminal mode — switches `viewMode === 'terminal'`.
+- tapOn:
+    id: "terminal-mode-button"
+- waitForAnimationToEnd
+
+# Assert the TerminalView root testID is reachable. This proves the
+# `<TerminalView />` branch of the SessionScreen render switch fired
+# (and the WebView wrapper mounted).
+- extendedWaitUntil:
+    visible:
+      id: "terminal-view"
+    timeout: 5000
+
+- takeScreenshot: terminal-view-mounted
+
+# Seed terminal data via the mock-server `show-terminal` trigger.
+# Send the trigger from the input bar — even in terminal viewMode the
+# input bar appends \r and forwards via `sendInput`, which the
+# mock-server's `case 'input'` handler reads and responds to with a
+# `raw` envelope. The store's `case 'raw'` handler calls
+# `appendTerminalData(data)` → the imperative `terminalWrite`
+# callback fires → xterm.js inside the WebView renders the text.
+- tapOn:
+    id: "chat-message-input"
+- inputText: "show-terminal"
+
+- tapOn:
+    id: "chat-send-button"
+
+- hideKeyboard
+
+# Re-assert the TerminalView is still mounted post-raw-write. The
+# WebView is not introspectable from Maestro (xterm.js text lives
+# inside a child <canvas>), so we cannot grep for the ANSI fixture
+# string itself — but the round-trip is exercised by the wire and
+# any throw inside `injectJavaScript` would surface as a JS error.
+- assertVisible:
+    id: "terminal-view"
+
+- takeScreenshot: terminal-view-after-raw-write

--- a/packages/app/src/components/TerminalView.tsx
+++ b/packages/app/src/components/TerminalView.tsx
@@ -107,7 +107,7 @@ export const TerminalView = forwardRef<TerminalHandle, TerminalViewProps>(functi
   }, []);
 
   return (
-    <View style={styles.wrapper}>
+    <View style={styles.wrapper} testID="terminal-view">
       {recovering && (
         <View style={styles.recoveryBanner}>
           <Text style={styles.recoveryText}>Terminal recovering...</Text>

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -13,6 +13,7 @@ import {
   Modal,
   Pressable,
   LayoutAnimation,
+  ActivityIndicator as RNActivityIndicator,
 } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -856,6 +857,7 @@ export function SessionScreen() {
           )}
           {hasTerminal && (
             <TouchableOpacity
+              testID="terminal-mode-button"
               style={[styles.modeButton, viewMode === 'terminal' && styles.modeButtonActive]}
               onPress={() => setViewMode('terminal')}
               accessibilityRole="button"
@@ -1036,8 +1038,14 @@ export function SessionScreen() {
 
       {/* Reconnecting / restarting banner */}
       {(connectionPhase === 'reconnecting' || connectionPhase === 'server_restarting') && (
-        <View style={styles.reconnectingBanner}>
+        <View testID="reconnect-banner" style={styles.reconnectingBanner}>
           <View style={styles.reconnectingRow}>
+            <RNActivityIndicator
+              testID="reconnect-spinner"
+              size="small"
+              color={COLORS.accentBlue}
+              style={styles.reconnectingSpinner}
+            />
             <Text style={[styles.reconnectingText, { flex: 1 }]}>
               {connectionPhase === 'server_restarting'
                 ? shutdownReason === 'shutdown'
@@ -1623,6 +1631,9 @@ const styles = StyleSheet.create({
     flexDirection: 'row' as const,
     alignItems: 'center' as const,
     gap: 8,
+  },
+  reconnectingSpinner: {
+    marginRight: 4,
   },
   reconnectDisconnect: {
     paddingHorizontal: 10,


### PR DESCRIPTION
## Summary

Adds end-to-end Maestro coverage for two mobile flows previously missing E2E runs (identified in the 2026-05-31 testing audit).

**Part A — Terminal view (`terminal-view.yaml`)**
- `terminal-view` testID on the `TerminalView` WebView wrapper
- `terminal-mode-button` testID on the SessionScreen mode toggle
- Mock server now reports `hasTerminal: true` so the Term button shows, and a `show-terminal` input trigger emits a `raw` wire envelope to exercise the message-handler → `appendTerminalData` → imperative `terminalWrite` callback path.

**Part B — Reconnect after tunnel drop (`reconnect.yaml`)**
- `reconnect-banner` testID on the SessionScreen reconnecting banner, plus a new `RNActivityIndicator` carrying the `reconnect-spinner` testID
- `simulate-disconnect` mock-server trigger that closes the WS after a 1s delay; the flow asserts the banner appears, then clears once the auto-reconnect succeeds against the still-up mock server

Both flows registered in `run-all.yaml`.

## Test plan

- [ ] `maestro test --device <id> packages/app/.maestro/terminal-view.yaml` passes on iPhone 15 Pro (iOS 17+)
- [ ] `maestro test --device <id> packages/app/.maestro/reconnect.yaml` passes on iPhone 15 Pro (iOS 17+)
- [ ] `maestro test --device <id> packages/app/.maestro/run-all.yaml` still passes end-to-end
- [ ] Screenshots saved during runs: `terminal-view-mounted`, `terminal-view-after-raw-write`, `reconnect-banner-visible`, `reconnect-completed`

Closes #4701