### PR TITLE
test(server): add E2E coverage for CLI commands

### DIFF
--- a/packages/server/tests/cli/__helpers/spawn-cli.js
+++ b/packages/server/tests/cli/__helpers/spawn-cli.js
@@ -65,11 +65,15 @@ export function pickPort() {
  * @returns {Promise<{ stdout: string, stderr: string, code: number|null, signal: string|null, timedOut: boolean }>}
  */
 export function runCli(args, opts = {}) {
+  // If the caller didn't provide a HOME, mint one here and tear it down
+  // on child exit so ad-hoc callers don't silently leak tmpdirs.
+  const ownsHome = !opts.home
   const home = opts.home || mkdtempSync(join(tmpdir(), 'chroxy-cli-test-'))
   const timeoutMs = opts.timeoutMs ?? 15000
 
-  // Use Node 22 from homebrew if present; otherwise fall back to whatever
-  // node ran the test (which is also expected to be 22).
+  // The child runs under `process.execPath`, i.e. whichever Node binary
+  // ran this test. We do not modify PATH to select a different Node;
+  // callers are expected to invoke the test runner with Node 22 already.
   const env = {
     PATH: process.env.PATH,
     HOME: home,
@@ -112,8 +116,16 @@ export function runCli(args, opts = {}) {
       stderr += chunk.toString()
     })
 
+    const tearDownTempHome = () => {
+      if (!ownsHome) return
+      try {
+        rmSync(home, { recursive: true, force: true })
+      } catch {}
+    }
+
     child.on('error', (err) => {
       clearTimeout(timer)
+      tearDownTempHome()
       resolvePromise({
         stdout,
         stderr: stderr + `\n[spawn error] ${err.message}`,
@@ -125,6 +137,7 @@ export function runCli(args, opts = {}) {
 
     child.on('close', (code, signal) => {
       clearTimeout(timer)
+      tearDownTempHome()
       resolvePromise({ stdout, stderr, code, signal, timedOut })
     })
 

--- a/packages/server/tests/cli/__helpers/spawn-cli.js
+++ b/packages/server/tests/cli/__helpers/spawn-cli.js
@@ -1,0 +1,159 @@
+/**
+ * Helper for spawning the chroxy CLI as a subprocess.
+ *
+ * Every spawn isolates HOME (and CHROXY_CONFIG_DIR) into a temp directory so
+ * tests can never touch the real ~/.chroxy/. The helper captures stdout,
+ * stderr, and the exit code and resolves once the process exits or the
+ * timeout fires.
+ */
+import { spawn } from 'child_process'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const HERE = resolve(__filename, '..')
+// tests/cli/__helpers -> tests/cli -> tests -> packages/server
+const SERVER_PKG = resolve(HERE, '..', '..', '..')
+export const CLI_PATH = join(SERVER_PKG, 'src', 'cli.js')
+
+/**
+ * Create a temp HOME directory. Returns the path and a cleanup function.
+ *
+ * @returns {{ home: string, cleanup: () => void }}
+ */
+export function makeTempHome() {
+  const home = mkdtempSync(join(tmpdir(), 'chroxy-cli-test-'))
+  return {
+    home,
+    cleanup: () => {
+      try {
+        rmSync(home, { recursive: true, force: true })
+      } catch {}
+    },
+  }
+}
+
+/**
+ * Pick a high random port unlikely to collide. We avoid the canonical 8765
+ * Chroxy port because parallel test runs would step on each other.
+ */
+export function pickPort() {
+  return 40000 + Math.floor(Math.random() * 20000)
+}
+
+/**
+ * Spawn the chroxy CLI with isolated HOME and capture all output.
+ *
+ * @param {string[]} args - CLI arguments
+ * @param {object} [opts]
+ * @param {string} [opts.home] - Override HOME (default: fresh tmpdir, leaked — pass home for cleanup)
+ * @param {object} [opts.env] - Extra env vars merged on top of base env
+ * @param {string} [opts.cwd] - Working directory
+ * @param {string|Buffer} [opts.input] - Data piped to stdin
+ * @param {boolean} [opts.keepStdinOpen] - Write input but don't close stdin
+ *   afterwards. Necessary for commands that use readline.question, which
+ *   does not invoke its callback on stdin EOF — the promise would never
+ *   resolve and the child would exit silently.
+ * @param {string[]} [opts.lines] - Send one line at a time, separated by
+ *   small delays. Required for commands (like `chroxy init`) that build a
+ *   fresh readline interface per prompt — a single bulk write loses
+ *   buffered bytes between interface lifetimes.
+ * @param {number} [opts.lineDelayMs] - Delay between lines (default: 200ms)
+ * @param {number} [opts.timeoutMs] - Kill the child if it hasn't exited by then (default: 15000)
+ * @returns {Promise<{ stdout: string, stderr: string, code: number|null, signal: string|null, timedOut: boolean }>}
+ */
+export function runCli(args, opts = {}) {
+  const home = opts.home || mkdtempSync(join(tmpdir(), 'chroxy-cli-test-'))
+  const timeoutMs = opts.timeoutMs ?? 15000
+
+  // Use Node 22 from homebrew if present; otherwise fall back to whatever
+  // node ran the test (which is also expected to be 22).
+  const env = {
+    PATH: process.env.PATH,
+    HOME: home,
+    USERPROFILE: home,
+    // Sandbox every persistent path that has an env override available so
+    // tests can't accidentally write into real config/state directories.
+    CHROXY_CONFIG_DIR: join(home, '.chroxy'),
+    NODE_ENV: 'test',
+    ...(opts.env || {}),
+  }
+
+  return new Promise((resolvePromise) => {
+    const child = spawn(process.execPath, [CLI_PATH, ...args], {
+      env,
+      cwd: opts.cwd || home,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      try {
+        child.kill('SIGTERM')
+      } catch {}
+      // Hard kill after another second if SIGTERM didn't take.
+      setTimeout(() => {
+        try {
+          child.kill('SIGKILL')
+        } catch {}
+      }, 1000).unref()
+    }, timeoutMs)
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString()
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString()
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      resolvePromise({
+        stdout,
+        stderr: stderr + `\n[spawn error] ${err.message}`,
+        code: null,
+        signal: null,
+        timedOut,
+      })
+    })
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timer)
+      resolvePromise({ stdout, stderr, code, signal, timedOut })
+    })
+
+    if (Array.isArray(opts.lines) && opts.lines.length > 0) {
+      // Drip-feed lines so each readline.createInterface invocation in
+      // the child captures its own line. Keep stdin open the whole
+      // time; the child exits on its own when its prompts complete.
+      const delay = opts.lineDelayMs ?? 200
+      const lines = [...opts.lines]
+      const drip = () => {
+        if (lines.length === 0 || child.exitCode != null) return
+        const next = lines.shift()
+        try {
+          child.stdin.write(next.endsWith('\n') ? next : next + '\n')
+        } catch {}
+        setTimeout(drip, delay).unref()
+      }
+      setTimeout(drip, delay).unref()
+    } else if (opts.input != null) {
+      if (opts.keepStdinOpen) {
+        // readline.question() doesn't fire its callback on stdin EOF, so
+        // for interactive commands we write the answers and leave the
+        // pipe open. The child exits when its own logic completes.
+        child.stdin.write(opts.input)
+      } else {
+        child.stdin.end(opts.input)
+      }
+    } else if (!opts.keepStdinOpen) {
+      child.stdin.end()
+    }
+  })
+}

--- a/packages/server/tests/cli/cli.test.js
+++ b/packages/server/tests/cli/cli.test.js
@@ -1,0 +1,47 @@
+/**
+ * Top-level chroxy CLI entry tests — version, help, unknown commands.
+ *
+ * Covers src/cli.js (the Commander dispatch root).
+ */
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const SERVER_PKG = join(dirname(__filename), '..', '..')
+const pkg = JSON.parse(readFileSync(join(SERVER_PKG, 'package.json'), 'utf-8'))
+
+describe('chroxy CLI entry (cli.js)', () => {
+  const { home, cleanup } = makeTempHome()
+  after(cleanup)
+
+  it('prints help with --help and exits 0', async () => {
+    const r = await runCli(['--help'], { home })
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+    assert.match(r.stdout, /Usage: chroxy/)
+    assert.match(r.stdout, /Remote terminal for Claude Code/)
+    // All 12 registered commands should appear in help output.
+    for (const cmd of [
+      'init', 'start', 'dev', 'config', 'tunnel', 'doctor',
+      'deploy', 'sessions', 'resume', 'service', 'update', 'status',
+    ]) {
+      assert.match(r.stdout, new RegExp(`\\b${cmd}\\b`), `help missing command: ${cmd}`)
+    }
+  })
+
+  it('prints the package.json version with --version', async () => {
+    const r = await runCli(['--version'], { home })
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+    assert.equal(r.stdout.trim(), pkg.version)
+  })
+
+  it('rejects unknown commands with non-zero exit', async () => {
+    const r = await runCli(['definitely-not-a-real-command'], { home })
+    assert.notEqual(r.code, 0)
+    // Commander writes the error to stderr.
+    assert.match(r.stderr + r.stdout, /unknown command|error/i)
+  })
+})

--- a/packages/server/tests/cli/config-cmd.test.js
+++ b/packages/server/tests/cli/config-cmd.test.js
@@ -1,0 +1,54 @@
+/**
+ * E2E coverage for `chroxy config`.
+ *
+ * Covers src/cli/config-cmd.js. There's no `set` subcommand — `chroxy
+ * config` just prints the resolved config — so we exercise both the
+ * "no config" error path and the happy "config exists" path.
+ *
+ * NB: The shared.js CONFIG_FILE is resolved from os.homedir() at module
+ * load time, so we exercise the path via the spawn helper which sets HOME.
+ */
+import { describe, it, after, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+describe('chroxy config', () => {
+  const { home, cleanup } = makeTempHome()
+  after(cleanup)
+
+  it('errors when no config file exists', async () => {
+    const r = await runCli(['config'], { home })
+    assert.equal(r.code, 1)
+    assert.match(r.stdout, /No config found/)
+  })
+
+  describe('with config present', () => {
+    const populatedHome = makeTempHome()
+    after(populatedHome.cleanup)
+
+    before(() => {
+      const configDir = join(populatedHome.home, '.chroxy')
+      mkdirSync(configDir, { recursive: true })
+      writeFileSync(
+        join(configDir, 'config.json'),
+        JSON.stringify({
+          port: 9876,
+          apiToken: 'test-token-xyz',
+          providers: ['claude-sdk'],
+          tunnel: 'quick',
+        }, null, 2),
+      )
+    })
+
+    it('prints the configured port, tunnel mode, and token', async () => {
+      const r = await runCli(['config'], { home: populatedHome.home })
+      assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+      assert.match(r.stdout, /Current Configuration/)
+      assert.match(r.stdout, /Port: 9876/)
+      assert.match(r.stdout, /Tunnel: Quick/)
+      assert.match(r.stdout, /test-token-xyz/)
+    })
+  })
+})

--- a/packages/server/tests/cli/deploy-cmd.test.js
+++ b/packages/server/tests/cli/deploy-cmd.test.js
@@ -1,0 +1,36 @@
+/**
+ * E2E coverage for `chroxy deploy`.
+ *
+ * Covers src/cli/deploy-cmd.js. The real deploy command shells out to
+ * `git status` and inspects the supervisor PID file; we only exercise
+ * the help and dirty-tree paths to avoid mutating git state or signaling
+ * a real supervisor.
+ */
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+describe('chroxy deploy', () => {
+  const { home, cleanup } = makeTempHome()
+  after(cleanup)
+
+  it('--help advertises --dry-run and --skip-tests', async () => {
+    const r = await runCli(['deploy', '--help'], { home })
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+    assert.match(r.stdout, /--dry-run/)
+    assert.match(r.stdout, /--skip-tests/)
+  })
+
+  it('exits non-zero outside a git repo (cwd: temp HOME)', async () => {
+    // home is a fresh tmpdir with no .git — `git status --porcelain` will
+    // fail, which deploy treats as a fatal pre-check.
+    const r = await runCli(
+      ['deploy', '--dry-run', '--skip-tests'],
+      { home, cwd: home, timeoutMs: 15000 },
+    )
+    assert.notEqual(r.code, 0)
+    // The exact wording differs ("not a git repo" vs git's own error),
+    // so just check the deploy preamble printed.
+    assert.match(r.stdout + r.stderr, /\[deploy\]|not a git/i)
+  })
+})

--- a/packages/server/tests/cli/doctor-cmd.test.js
+++ b/packages/server/tests/cli/doctor-cmd.test.js
@@ -1,0 +1,32 @@
+/**
+ * E2E coverage for `chroxy doctor`.
+ *
+ * Covers src/cli/doctor-cmd.js.
+ */
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { pickPort, runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+describe('chroxy doctor', () => {
+  const { home, cleanup } = makeTempHome()
+  after(cleanup)
+
+  it('prints the Chroxy Doctor banner and a summary line', async () => {
+    // Bind to a random free port to avoid flagging "port in use" on the
+    // default 8765 if some other dev server is listening there locally.
+    const r = await runCli(['doctor', '--port', String(pickPort())], { home })
+    // Exit code can be 0 or 1 depending on whether cloudflared/other
+    // optional deps are installed on the test machine, so don't assert
+    // on it directly.
+    assert.match(r.stdout, /Chroxy Doctor/)
+    // Final summary line is one of these two messages.
+    assert.match(r.stdout, /(All checks passed\.|Some checks failed\.)/)
+  })
+
+  it('prints --help with the expected flags', async () => {
+    const r = await runCli(['doctor', '--help'], { home })
+    assert.equal(r.code, 0)
+    assert.match(r.stdout, /--port/)
+    assert.match(r.stdout, /--provider/)
+  })
+})

--- a/packages/server/tests/cli/doctor-cmd.test.js
+++ b/packages/server/tests/cli/doctor-cmd.test.js
@@ -12,8 +12,9 @@ describe('chroxy doctor', () => {
   after(cleanup)
 
   it('prints the Chroxy Doctor banner and a summary line', async () => {
-    // Bind to a random free port to avoid flagging "port in use" on the
-    // default 8765 if some other dev server is listening there locally.
+    // Pass a high random port (not reserved, just unlikely-to-be-bound)
+    // so the "port in use" probe doesn't flag the default 8765 when a
+    // local dev server is already listening there.
     const r = await runCli(['doctor', '--port', String(pickPort())], { home })
     // Exit code can be 0 or 1 depending on whether cloudflared/other
     // optional deps are installed on the test machine, so don't assert

--- a/packages/server/tests/cli/init-cmd.test.js
+++ b/packages/server/tests/cli/init-cmd.test.js
@@ -1,0 +1,59 @@
+/**
+ * E2E coverage for `chroxy init` via the CLI subprocess.
+ *
+ * The fully-interactive provider-picker happy path is covered by
+ * `cli-init-cmd.test.js` (which stubs prompt/fs and exercises runInitCmd
+ * directly). Here we focus on the spawn boundary: the binary launches,
+ * prints its banner, advertises --force, and the overwrite-confirmation
+ * prompt-and-decline path exits cleanly without touching disk.
+ *
+ * Why we don't drip-feed multiple newlines: shared.js creates a fresh
+ * readline.createInterface() per prompt. When the first interface is
+ * closed, buffered stdin bytes are not handed off to the next interface,
+ * so any input intended for prompt #2 is silently dropped. The single-
+ * prompt "decline overwrite" path sidesteps that quirk entirely.
+ */
+import { describe, it, after, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+describe('chroxy init', () => {
+  describe('with existing config', () => {
+    const { home, cleanup } = makeTempHome()
+    after(cleanup)
+
+    const configPath = join(home, '.chroxy', 'config.json')
+    const originalContents = JSON.stringify({ port: 9999, providers: ['claude-sdk'] }, null, 2)
+
+    before(() => {
+      mkdirSync(join(home, '.chroxy'), { recursive: true })
+      writeFileSync(configPath, originalContents)
+    })
+
+    it('prompts to overwrite and exits cleanly when the user declines', async () => {
+      const r = await runCli(['init'], { home, input: 'n\n', keepStdinOpen: true })
+      assert.equal(r.code, 0, `init failed: ${r.stderr}`)
+      assert.match(r.stdout, /Chroxy Setup/)
+      assert.match(r.stdout, /Config already exists/)
+      assert.match(r.stdout, /Keeping existing config/)
+      // Config file must not have been modified.
+      assert.ok(existsSync(configPath))
+      const afterContents = readFileSync(configPath, 'utf-8')
+      assert.equal(afterContents, originalContents)
+    })
+  })
+
+  it('--help prints the expected flags', async () => {
+    const { home, cleanup } = makeTempHome()
+    try {
+      const r = await runCli(['init', '--help'], { home })
+      assert.equal(r.code, 0)
+      assert.match(r.stdout, /--force/)
+      assert.match(r.stdout, /Initialize Chroxy configuration/)
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/packages/server/tests/cli/server-cmd.test.js
+++ b/packages/server/tests/cli/server-cmd.test.js
@@ -1,0 +1,47 @@
+/**
+ * E2E coverage for `chroxy start` and `chroxy dev`.
+ *
+ * Covers src/cli/server-cmd.js. We never let the real server run — we
+ * either pass --help, or rely on the missing-config / bad-flag error
+ * paths so the CLI exits in milliseconds.
+ */
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+describe('chroxy start / dev', () => {
+  const { home, cleanup } = makeTempHome()
+  after(cleanup)
+
+  it('start --help lists the shared server flags', async () => {
+    const r = await runCli(['start', '--help'], { home })
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+    assert.match(r.stdout, /Start the Chroxy server/)
+    assert.match(r.stdout, /--config/)
+    assert.match(r.stdout, /--tunnel/)
+    assert.match(r.stdout, /--port|--config/) // sanity: at least one shared opt
+  })
+
+  it('dev --help describes development mode', async () => {
+    const r = await runCli(['dev', '--help'], { home })
+    assert.equal(r.code, 0)
+    assert.match(r.stdout, /development mode/i)
+  })
+
+  it('start exits 1 when no config exists (missing init)', async () => {
+    // Fresh HOME → no ~/.chroxy/config.json → loadAndMergeConfig() will
+    // print "No config found" and process.exit(1) immediately.
+    const r = await runCli(['start'], { home, timeoutMs: 10000 })
+    assert.equal(r.code, 1, `stdout: ${r.stdout} stderr: ${r.stderr}`)
+    assert.match(r.stderr, /No config found/)
+  })
+
+  it('start with --config pointing at a missing file errors and exits 1', async () => {
+    const r = await runCli(
+      ['start', '--config', '/tmp/definitely-not-a-real-config-12345.json'],
+      { home, timeoutMs: 10000 },
+    )
+    assert.equal(r.code, 1)
+    assert.match(r.stderr, /Config file not found/)
+  })
+})

--- a/packages/server/tests/cli/server-cmd.test.js
+++ b/packages/server/tests/cli/server-cmd.test.js
@@ -19,7 +19,10 @@ describe('chroxy start / dev', () => {
     assert.match(r.stdout, /Start the Chroxy server/)
     assert.match(r.stdout, /--config/)
     assert.match(r.stdout, /--tunnel/)
-    assert.match(r.stdout, /--port|--config/) // sanity: at least one shared opt
+    // --cwd is registered by addServerOptions(); asserting it gives us
+    // real coverage of the shared-options dispatch instead of duplicating
+    // the --config assertion above.
+    assert.match(r.stdout, /--cwd/)
   })
 
   it('dev --help describes development mode', async () => {

--- a/packages/server/tests/cli/service-cmd.test.js
+++ b/packages/server/tests/cli/service-cmd.test.js
@@ -1,0 +1,57 @@
+/**
+ * E2E coverage for `chroxy service`.
+ *
+ * Covers src/cli/service-cmd.js. We never actually install or start a
+ * launchd/systemd service — that would mutate the user's machine. The
+ * tests focus on the help output and the "not installed" path of the
+ * status / start / stop subcommands.
+ */
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+describe('chroxy service', () => {
+  const { home, cleanup } = makeTempHome()
+  after(cleanup)
+
+  it('--help lists the install / uninstall / start / stop / status subcommands', async () => {
+    const r = await runCli(['service', '--help'], { home })
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+    for (const sub of ['install', 'uninstall', 'start', 'stop', 'status']) {
+      assert.match(r.stdout, new RegExp(`\\b${sub}\\b`), `missing subcommand: ${sub}`)
+    }
+  })
+
+  it('service status reports "Installed: No" on a fresh HOME', async () => {
+    const r = await runCli(['service', 'status'], { home })
+    // Status prints the banner and exits 0 even when not installed.
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+    assert.match(r.stdout, /Chroxy Service Status/)
+    assert.match(r.stdout, /Installed:\s+No/)
+  })
+
+  it('service start fails with a helpful message when not installed', async () => {
+    const r = await runCli(['service', 'start'], { home })
+    assert.equal(r.code, 1)
+    assert.match(r.stderr, /not installed/)
+  })
+
+  it('service stop fails with a helpful message when not installed', async () => {
+    const r = await runCli(['service', 'stop'], { home })
+    assert.equal(r.code, 1)
+    assert.match(r.stderr, /not installed/)
+  })
+
+  it('service uninstall fails when nothing is installed', async () => {
+    const r = await runCli(['service', 'uninstall'], { home })
+    assert.equal(r.code, 1)
+    assert.match(r.stderr, /not installed/)
+  })
+
+  // Skipped: actually installing a system service mutates ~/Library or
+  // /etc/systemd. Re-enable manually when triaging install-cmd regressions.
+  it.skip('service install registers a launchd plist', async () => {
+    const r = await runCli(['service', 'install'], { home })
+    assert.equal(r.code, 0)
+  })
+})

--- a/packages/server/tests/cli/session-cmd.test.js
+++ b/packages/server/tests/cli/session-cmd.test.js
@@ -1,0 +1,97 @@
+/**
+ * E2E coverage for `chroxy sessions` and `chroxy resume`.
+ *
+ * Covers src/cli/session-cmd.js. We never exec the real `claude` binary —
+ * the "resume" tests focus on argument validation and listing.
+ *
+ * MEMORY WARNING: session-state.json is read from ~/.chroxy/. Every test
+ * isolates HOME to prevent overwriting the real file.
+ */
+import { describe, it, after, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+describe('chroxy sessions', () => {
+  describe('with no session-state.json', () => {
+    const { home, cleanup } = makeTempHome()
+    after(cleanup)
+
+    it('reports "No saved sessions found." and exits 0', async () => {
+      const r = await runCli(['sessions'], { home })
+      assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+      assert.match(r.stdout, /No saved sessions found/)
+    })
+  })
+
+  describe('with an empty sessions array', () => {
+    const { home, cleanup } = makeTempHome()
+    after(cleanup)
+
+    before(() => {
+      const dir = join(home, '.chroxy')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(
+        join(dir, 'session-state.json'),
+        JSON.stringify({ sessions: [], timestamp: Date.now() }),
+      )
+    })
+
+    it('prints "No saved sessions."', async () => {
+      const r = await runCli(['sessions'], { home })
+      assert.equal(r.code, 0)
+      assert.match(r.stdout, /No saved sessions\./)
+    })
+  })
+
+  describe('with populated sessions', () => {
+    const { home, cleanup } = makeTempHome()
+    after(cleanup)
+
+    before(() => {
+      const dir = join(home, '.chroxy')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(
+        join(dir, 'session-state.json'),
+        JSON.stringify({
+          sessions: [
+            {
+              name: 'work',
+              cwd: '/tmp/work-dir',
+              conversationId: 'conv-abc-123',
+            },
+            {
+              name: 'play',
+              cwd: '/tmp/play-dir',
+              sdkSessionId: 'sdk-def-456',
+            },
+          ],
+          timestamp: Date.now(),
+        }),
+      )
+    })
+
+    it('lists every session name, cwd, and resume hint', async () => {
+      const r = await runCli(['sessions'], { home })
+      assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+      assert.match(r.stdout, /Saved Sessions \(2\)/)
+      assert.match(r.stdout, /work/)
+      assert.match(r.stdout, /play/)
+      assert.match(r.stdout, /conv-abc-123/)
+      assert.match(r.stdout, /sdk-def-456/)
+      assert.match(r.stdout, /claude --resume/)
+    })
+  })
+
+  describe('resume', () => {
+    const { home, cleanup } = makeTempHome()
+    after(cleanup)
+
+    it('exits 1 with a clear error when no sessions file exists', async () => {
+      const r = await runCli(['resume'], { home })
+      assert.equal(r.code, 1)
+      assert.match(r.stderr, /No saved sessions found/)
+    })
+  })
+})

--- a/packages/server/tests/cli/status-cmd.test.js
+++ b/packages/server/tests/cli/status-cmd.test.js
@@ -1,0 +1,65 @@
+/**
+ * E2E coverage for `chroxy status`.
+ *
+ * Covers src/cli/status-cmd.js. We don't start a real server — we just
+ * verify the "not running" path and that --json emits parseable JSON.
+ *
+ * NOTE: status pings 127.0.0.1:<port>/ where <port> comes from connection.json
+ * or defaults to 8765. The dev machine running these tests may have its own
+ * chroxy listening on 8765, so we plant a fake connection.json that points
+ * status at a guaranteed-dead high random port.
+ */
+import { describe, it, after, before } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, writeFileSync } from 'fs'
+import { join } from 'path'
+import { pickPort, runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+function plantDeadConnectionInfo(home) {
+  const dir = join(home, '.chroxy')
+  mkdirSync(dir, { recursive: true })
+  const deadPort = pickPort()
+  // Omit `pid` — readConnectionInfo() only PID-checks if pid is set, so
+  // leaving it null means the fake info is returned as-is.
+  writeFileSync(
+    join(dir, 'connection.json'),
+    JSON.stringify({
+      httpUrl: `http://127.0.0.1:${deadPort}/`,
+      wsUrl: `ws://127.0.0.1:${deadPort}`,
+      tunnelMode: 'none',
+      startedAt: new Date().toISOString(),
+    }),
+  )
+  return deadPort
+}
+
+describe('chroxy status', () => {
+  const { home, cleanup } = makeTempHome()
+  after(cleanup)
+
+  before(() => {
+    plantDeadConnectionInfo(home)
+  })
+
+  it('reports "Not running" when no server is up (exit 1)', async () => {
+    const r = await runCli(['status'], { home })
+    // Exit code is 1 when not running (set via process.exitCode).
+    assert.equal(r.code, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
+    assert.match(r.stdout, /Chroxy v/)
+    assert.match(r.stdout, /Not running/)
+  })
+
+  it('emits valid JSON with --json', async () => {
+    const r = await runCli(['status', '--json'], { home })
+    assert.equal(r.code, 1, `stdout: ${r.stdout}\nstderr: ${r.stderr}`)
+    const parsed = JSON.parse(r.stdout)
+    assert.equal(parsed.running, false)
+    assert.ok(typeof parsed.version === 'string')
+  })
+
+  it('--help prints --json flag', async () => {
+    const r = await runCli(['status', '--help'], { home })
+    assert.equal(r.code, 0)
+    assert.match(r.stdout, /--json/)
+  })
+})

--- a/packages/server/tests/cli/status-cmd.test.js
+++ b/packages/server/tests/cli/status-cmd.test.js
@@ -6,8 +6,9 @@
  *
  * NOTE: status pings 127.0.0.1:<port>/ where <port> comes from connection.json
  * or defaults to 8765. The dev machine running these tests may have its own
- * chroxy listening on 8765, so we plant a fake connection.json that points
- * status at a guaranteed-dead high random port.
+ * chroxy listening on 8765, so we plant a fake connection.json pointing at
+ * a high random port — not reserved, just unlikely-to-be-bound — so the
+ * ping fails fast and exercises the "not running" path.
  */
 import { describe, it, after, before } from 'node:test'
 import assert from 'node:assert/strict'

--- a/packages/server/tests/cli/tunnel-cmd.test.js
+++ b/packages/server/tests/cli/tunnel-cmd.test.js
@@ -1,0 +1,27 @@
+/**
+ * E2E coverage for `chroxy tunnel`.
+ *
+ * Covers src/cli/tunnel-cmd.js. The setup flow is fully interactive and
+ * shells out to `cloudflared`, so we only smoke-test help output here.
+ */
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+describe('chroxy tunnel', () => {
+  const { home, cleanup } = makeTempHome()
+  after(cleanup)
+
+  it('prints --help showing the setup subcommand', async () => {
+    const r = await runCli(['tunnel', '--help'], { home })
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+    assert.match(r.stdout, /tunnel/)
+    assert.match(r.stdout, /setup/)
+  })
+
+  it('tunnel setup --help describes the setup flow', async () => {
+    const r = await runCli(['tunnel', 'setup', '--help'], { home })
+    assert.equal(r.code, 0)
+    assert.match(r.stdout, /Interactive Cloudflare Named Tunnel setup/)
+  })
+})

--- a/packages/server/tests/cli/update-cmd.test.js
+++ b/packages/server/tests/cli/update-cmd.test.js
@@ -1,0 +1,30 @@
+/**
+ * E2E coverage for `chroxy update`.
+ *
+ * Covers src/cli/update-cmd.js. The real update command hits the GitHub
+ * Releases API, which we don't want to depend on in tests, so we only
+ * exercise the --help path. A full happy-path test would need to stub
+ * global.fetch, which isn't possible across a subprocess boundary.
+ */
+import { describe, it, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { runCli, makeTempHome } from './__helpers/spawn-cli.js'
+
+describe('chroxy update', () => {
+  const { home, cleanup } = makeTempHome()
+  after(cleanup)
+
+  it('--help describes the update command', async () => {
+    const r = await runCli(['update', '--help'], { home })
+    assert.equal(r.code, 0, `stderr: ${r.stderr}`)
+    assert.match(r.stdout, /Check for available updates/)
+  })
+
+  // Skipped: the live update check makes an outbound HTTPS request to
+  // GitHub. Re-enable manually when triaging update-cmd regressions.
+  it.skip('chroxy update queries the GitHub Releases API', async () => {
+    const r = await runCli(['update'], { home, timeoutMs: 20000 })
+    assert.ok(r.code === 0 || r.code === 1, `unexpected code: ${r.code}`)
+    assert.match(r.stdout + r.stderr, /Chroxy v|Update available|Failed to check/)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the first end-to-end test coverage for the 12 user-facing CLI modules under `packages/server/src/cli/`. Before this PR, a regression in flag parsing, exit codes, or top-level error messages would slip past every existing test — the audit flagged that the entire CLI layer had zero coverage.

Tests spawn the CLI as a subprocess (`spawn(node, [cli.js, ...args])`), capture stdout/stderr/exit-code, and assert at the binary boundary. Every spawn isolates `HOME` and `CHROXY_CONFIG_DIR` into a fresh tmpdir so tests can never touch the real `~/.chroxy/` (per the documented test-state-contamination memory).

## What's covered

| Source file | Test file | Tests |
|---|---|---|
| `cli.js` | `cli.test.js` | `--help`, `--version`, unknown command |
| `cli/config-cmd.js` | `config-cmd.test.js` | no-config error + populated config print |
| `cli/deploy-cmd.js` | `deploy-cmd.test.js` | `--help`, dirty-tree exit |
| `cli/doctor-cmd.js` | `doctor-cmd.test.js` | banner output, `--help` |
| `cli/init-cmd.js` | `init-cmd.test.js` | overwrite-decline path, `--help` |
| `cli/server-cmd.js` | `server-cmd.test.js` | `start --help`, `dev --help`, missing-config / bad-config errors |
| `cli/service-cmd.js` | `service-cmd.test.js` | subcommand help + every not-installed error path |
| `cli/session-cmd.js` | `session-cmd.test.js` | no state, empty state, populated state, `resume` missing-state |
| `cli/status-cmd.js` | `status-cmd.test.js` | not-running text + JSON, `--help` |
| `cli/tunnel-cmd.js` | `tunnel-cmd.test.js` | `tunnel --help`, `tunnel setup --help` |
| `cli/update-cmd.js` | `update-cmd.test.js` | `--help`; live network test `it.skip`'d |
| `cli/shared.js` | exercised indirectly via every other test |

**30 tests pass, 2 intentionally skipped** (`chroxy update` would hit GitHub Releases API; `chroxy service install` would mutate the user's launchd/systemd).

## Helper

`tests/cli/__helpers/spawn-cli.js` exposes:
- `runCli(args, opts)` — spawn with isolated HOME, capture output, timeout (default 15s)
- `makeTempHome()` — `mkdtempSync` + cleanup
- `pickPort()` — high random port (never 8765, which collides with a running dev daemon)

The helper supports three stdin modes: bulk-write-then-close (default), keep-stdin-open (for `readline.question` which doesn't fire on EOF), and drip-fed `lines` (for commands that build a fresh readline interface per prompt).

## Test plan

- [x] All 30 new tests pass (`node --test ./tests/cli/*.test.js`)
- [x] No real `~/.chroxy/` files are touched (verified by `find ~/.chroxy/ -newer …`)
- [x] No port collisions (tests don't bind sockets; status pings a planted dead-port `connection.json`)
- [x] 2 skipped tests are documented with re-enable instructions
- [x] Lint passes (no test-file lint changes; pre-existing src warnings unchanged)

Closes #4699