### PR TITLE
chore(release): cut v0.9.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.32] - 2026-06-01
+
+Test-coverage push closing the gaps identified in the 2026-05-31 testing audit. The v0.9.x prompt-delivery wedge fixes (#4668/#4679/#4687/#4648/#4669) were already pinned server-side; this release locks in the surfaces that still had no regression coverage — mobile-side approval flows, the desktop Tauri command surface, the CLI command layer, and the SDK/CLI session persistence roundtrip.
+
+### Added
+
+- **Pin #4689 synthesized toolUseId edge case for PostToolUse cleanup (#4703):** new regression test in `claude-tui-session.test.js` that arms a pending entry via PreToolUse with no `tool_use_id` (forces `_emitToolHookEvent` to synthesize one), then asserts PostToolUse with the same synthesized id clears both the `_pendingUserAnswers` Map entry and the `askuserquestion-active` lock dir. Reverting the #4689 fix at line 1438 of `claude-tui-session.js` fails the test.
+- **Maestro E2E coverage for plan-mode approval flow (#4704):** `plan-approval.yaml` (approve path) and `plan-approval-deny.yaml` (Give Feedback path) wired to a new `show-plan-approval` mock-server trigger that emits the production `plan_ready` envelope. testIDs added to `PlanApprovalCard` in `ChatView.tsx` (`plan-approval-card`, `plan-content`, `plan-approve-button`, `plan-deny-button`).
+- **Tauri command integration test harness (#4705):** new `packages/desktop/src-tauri/tests/command_integration.rs` with 46 integration tests covering all 21 registered Tauri commands beyond the existing `command_drift.rs` name-sync check. Includes a `save_setup_config` → `get_setup_state` roundtrip pinning the first-run wizard contract.
+- **Maestro E2E for terminal view + reconnect-after-tunnel-drop (#4706):** `terminal-view.yaml` exercises the Terminal mode toggle + xterm WebView mount via a new `show-terminal` mock-server trigger. `reconnect.yaml` simulates a tunnel drop via `simulate-disconnect` (now using `ws.terminate()`, see Fixed below) and verifies the reconnect banner + spinner appear and clear.
+- **Maestro E2E for AskUserQuestion approve/deny (#4697 / #4707):** `ask-user-question.yaml` (approve), `ask-user-question-deny.yaml` (deny), and `ask-user-question-multi.yaml` (4-question form per #4604 Chunk B). Pins the mobile-side approval round-trip — the exact surface where the v0.9.x prompt-delivery wedges manifested but where mobile E2E had zero coverage until now. testIDs added to `MessageBubble.tsx` (`approval-card-<id>`, `approval-question-<index>`, `approval-button-<value>`).
+- **SDK/CLI session-state persistence roundtrip coverage (#4700 / #4708):** every test in `sdk-session.test.js` and `cli-session.test.js` now uses a per-test temp `stateFilePath` (mirroring `session-manager.test.js`), and 8 new roundtrip tests pin the contract: happy-path metadata equality, corrupt-state graceful null, mismatched-id ignored, and Map serialization (the `[...map.entries()]` workaround that #4687 introduced for `_pendingUserAnswers`).
+- **E2E coverage for CLI commands (#4699 / #4709):** 30 tests across all 12 CLI command modules under `packages/server/tests/cli/`, with a new reusable `spawn-cli.js` helper that isolates HOME + `CHROXY_CONFIG_DIR` per spawn so tests never touch real `~/.chroxy/`. Random high-port allocation (40000–60000) avoids collisions with the dev daemon on 8765.
+
+### Changed
+
+- Added a small `RNActivityIndicator` to the reconnect banner in `SessionScreen.tsx` so the spinner is visible during tunnel-drop recovery (part of #4706 — wrapped in the existing flex row, no layout side effects).
+- Flipped 7 internal-crate modules in `packages/desktop/src-tauri/src/` from `private` to `pub` so they're callable from the new Tauri command integration test harness (part of #4705). No external API surface impact — `command_drift.rs` continues to pass unchanged.
+
+### Fixed
+
+- **Mock-server reconnect simulation: `ws.terminate()` instead of `ws.close(1006, ...)` (#4706):** RFC 6455 reserves close code 1006 — it cannot be sent in a Close frame. The `ws` library throws on the attempt, which the `try/catch` was swallowing, leaving the socket open and the reconnect flow hanging. `ws.terminate()` does an abrupt TCP teardown which clients observe as a local 1006 — exactly the shape of a real tunnel drop.
+
 ## [0.9.31] - 2026-05-31
 
 Phase 3 of `docs/investigations/prompt-delivery-wedge.md` — targeted fix for #4668 using the diagnosis produced by v0.9.30's instrumentation. When claude TUI emits parallel `AskUserQuestion` tool_use blocks in one assistant turn (which it does post-#4648 multi-question deny), the pre-fix single-field `_pendingUserAnswer` was overwritten by each new tool_use → the user's answer to question 1 routed to question 4's slot → the keystroke landed in a TUI form bound to the wrong toolUseId → PostToolUse never fired → 30s watchdog tore the turn down → dashboard showed "Couldn't deliver your answers". Same opaque symptom we had been chasing under #4678 for weeks, completely different root cause.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.31",
+      "version": "0.9.32",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.31",
+      "version": "0.9.32",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.31",
+      "version": "0.9.32",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.31"
+      "version": "0.9.32"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.31",
+      "version": "0.9.32",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.31",
+      "version": "0.9.32",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.31",
+      "version": "0.9.32",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.31",
+    "version": "0.9.32",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.31</string>
+    <string>0.9.32</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.31"
+version = "0.9.32"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.31"
+version = "0.9.32"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.31",
+      "version": "0.9.32",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.31",
+  "version": "0.9.32",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Cuts v0.9.32 — the testing-coverage push closing the gaps identified in the 2026-05-31 audit.

Includes:
- #4703 — pin #4689 synthesized toolUseId
- #4704 — Maestro plan-approval E2E
- #4705 — Tauri command integration harness (46 tests, 21/21 commands)
- #4706 — Maestro terminal + reconnect E2E (with RFC-6455 `ws.terminate()` fix)
- #4707 — Maestro AskUserQuestion approve/deny E2E
- #4708 — SDK/CLI stateFilePath + roundtrip coverage
- #4709 — CLI command E2E (30 tests, 12/12 modules)

See CHANGELOG.md for full details.

## Test plan

- [ ] CI green on all 13 checks
- [ ] Tauri build succeeds locally (already validated in worktree)
- [ ] Desktop app launches with v0.9.32 in About menu