### PR TITLE
chore(ci): exempt pinned/blocked PRs from stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,6 +26,11 @@ jobs:
           # Never stale the repo owner's own PRs
           exempt-pr-authors: blamechris
 
+          # PRs carrying any of these labels are parked indefinitely.
+          # actions/stale@v9 matches labels literally (no glob support),
+          # so enumerate each blocked:* label explicitly.
+          exempt-pr-labels: 'pinned,needs-discussion,blocked:developer-program,priority: critical,priority: high'
+
           stale-pr-label: stale
 
           stale-pr-message: >

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,17 @@ To keep the PR queue manageable, external contributions follow an automated stal
 
 PRs from the repo owner are exempt. Issues are not affected by this policy.
 
+### Exempt labels
+
+A PR carrying any of the following labels is parked indefinitely and will not be marked stale:
+
+- `pinned` — long-running work the maintainers want to keep visible
+- `needs-discussion` — waiting on a design or scope decision
+- `blocked:developer-program` — blocked on upstream (e.g. Apple/Google developer program access)
+- `priority: critical`, `priority: high` — high-priority work that shouldn't be auto-closed while in the queue
+
+If your PR is legitimately blocked on something outside your control, ask a maintainer to apply one of these labels.
+
 ### How to keep your PR open
 
 Just comment on the PR (anything works — a status update, a question, or a "still working on this") to reset the timer. Pushing new commits also counts as activity.


### PR DESCRIPTION
## Summary

- Adds `exempt-pr-labels` to `.github/workflows/stale.yml` so PRs carrying `pinned`, `needs-discussion`, `blocked:developer-program`, `priority: critical`, or `priority: high` are parked indefinitely instead of being auto-stale-closed.
- `actions/stale@v9` matches labels literally (no glob support), so each `blocked:*` label is enumerated explicitly.
- Documents the exempt labels in `CONTRIBUTING.md`'s "Stale PR policy" section under a new "Exempt labels" subsection.

## Acceptance criteria

- [x] Add `exempt-pr-labels: pinned, needs-discussion, blocked:developer-program` (plus high-priority labels) to `.github/workflows/stale.yml`
- [x] Document the exempt labels in `CONTRIBUTING.md`'s "Stale PR policy" section
- [x] Confirmed `actions/stale@v9` does not support `blocked:*` glob syntax; each label is enumerated explicitly

## Test plan

- [ ] Workflow YAML parses (next scheduled / `workflow_dispatch` run will confirm)
- [ ] Visual confirmation that the exempt labels list renders correctly in `CONTRIBUTING.md`

Closes #4609