### PR TITLE
fix(store-core): honor wire timestamp in handleUserQuestion (#4613)

### DIFF
--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -4433,6 +4433,58 @@ describe('handleUserQuestion', () => {
     expect(typeof out!.chatMessage.timestamp).toBe('number')
   })
 
+  // #4613 — mirrors the #4607 fix for handleToolStart. The server's history
+  // ring buffer stamps `timestamp: Date.now()` at append time and forwards it
+  // on every replay (session-message-history.js:208-216). When the dashboard
+  // rebuilds the `prompt` ChatMessage during history_replay (the question
+  // event is part of the replayed ring buffer), it must honour that wire
+  // timestamp instead of stamping a new Date.now(). Without this, a question
+  // prompt that originally fired at 10:00 shows as "just now" if you tab
+  // away and back. Lower-impact than #4607 (affects bubble display only, not
+  // the timer pill), but still a correctness bug.
+  it('honours wire `timestamp` field on the user_question payload (#4613)', () => {
+    const wireTimestamp = 1_700_000_000_000
+    const out = handleUserQuestion(
+      {
+        questions: [{ question: 'Pick a colour' }],
+        timestamp: wireTimestamp,
+      },
+      'sess-active',
+    )
+    expect(out).not.toBeNull()
+    expect(out!.chatMessage.timestamp).toBe(wireTimestamp)
+  })
+
+  it('falls back to Date.now() when wire `timestamp` is missing (live user_question, #4613)', () => {
+    const before = Date.now()
+    const out = handleUserQuestion(
+      { questions: [{ question: 'Pick a colour' }] },
+      'sess-active',
+    )
+    const after = Date.now()
+    expect(out).not.toBeNull()
+    expect(out!.chatMessage.timestamp).toBeGreaterThanOrEqual(before)
+    expect(out!.chatMessage.timestamp).toBeLessThanOrEqual(after)
+  })
+
+  it('ignores non-finite wire `timestamp` and falls back to Date.now() (#4613)', () => {
+    // Defensive: a malformed wire payload (NaN, Infinity, string-coerced)
+    // must not poison the displayed bubble timestamp with NaN-driven
+    // arithmetic downstream.
+    const before = Date.now()
+    const out = handleUserQuestion(
+      {
+        questions: [{ question: 'Pick a colour' }],
+        timestamp: Number.NaN,
+      },
+      'sess-active',
+    )
+    const after = Date.now()
+    expect(out).not.toBeNull()
+    expect(out!.chatMessage.timestamp).toBeGreaterThanOrEqual(before)
+    expect(out!.chatMessage.timestamp).toBeLessThanOrEqual(after)
+  })
+
   it('uses msg.sessionId when present', () => {
     const out = handleUserQuestion(
       { questions: [{ question: 'Q?' }], sessionId: 'sess-9' },

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3117,6 +3117,21 @@ export function handleUserQuestion(
   if (firstNormalized == null) return null
   const questionContent = firstNormalized.question
   const options = firstNormalized.options
+  // #4613 — honour the wire `timestamp` field when present (number). Mirrors
+  // the #4607 fix for handleToolStart. The server's history ring buffer
+  // stamps `timestamp: Date.now()` at append time
+  // (session-message-history.js:208-216) and forwards it on every replay —
+  // question events are part of that ring buffer. Pre-#4613 we always
+  // overwrote with `Date.now()`, so a question prompt that originally fired
+  // at 10:00 showed as "just now" if the user tabbed away and the dashboard
+  // rebuilt the prompt ChatMessage during history_replay. Lower-impact than
+  // #4607 (affects bubble display only, not the timer pill), but still a
+  // correctness bug. The fallback to `Date.now()` covers live (non-replay)
+  // user_question broadcasts, which never carry `msg.timestamp` on the wire.
+  const wireTimestamp =
+    typeof msg.timestamp === 'number' && Number.isFinite(msg.timestamp)
+      ? msg.timestamp
+      : Date.now()
   const chatMessage: ChatMessage = {
     id: nextMessageId('question'),
     type: 'prompt',
@@ -3126,7 +3141,7 @@ export function handleUserQuestion(
     // is just an N=1 case of the multi-question shape). Renderers can
     // detect multi-question by `questions.length > 1` and switch UI.
     questions: normalizedAll,
-    timestamp: Date.now(),
+    timestamp: wireTimestamp,
   }
   if (typeof msg.toolUseId === 'string') {
     chatMessage.toolUseId = msg.toolUseId


### PR DESCRIPTION
## Summary

- Mirrors the #4607 fix (PR #4612) for `handleToolStart`, applied to `handleUserQuestion` in `packages/store-core/src/handlers/index.ts`.
- The server's history ring buffer stamps `timestamp: Date.now()` at append time and forwards it on replay. The prompt ChatMessage rebuilt during `history_replay` now honors that wire timestamp instead of stamping a new `Date.now()`, so a question that originally fired at 10:00 no longer shows as "just now" after tab-switch.
- Lower-impact than #4607 (affects only the bubble's displayed timestamp, not the "Running X" timer pill), but a correctness bug per the original review comment on PR #4612.

## Implementation

- Defensive `Number.isFinite` guard mirrors `handleToolStart` exactly, so NaN / Infinity / non-number wire payloads fall back cleanly to `Date.now()`.
- Live (non-replay) `user_question` broadcasts never carry `msg.timestamp` on the wire — the fallback branch covers them unchanged.

## Tests

Three new pinned tests in `handlers.test.ts > handleUserQuestion`:

- honors a finite wire `timestamp` (#4613)
- falls back to `Date.now()` when wire timestamp is missing
- ignores non-finite (`NaN`) wire timestamp and falls back

All 905 store-core tests pass.

## Test plan

- [x] `cd packages/store-core && npm test` — 905/905 pass
- [x] New "honors wire timestamp" test fails on the pre-fix code, passes post-fix (TDD)
- [x] No call-site changes required — return shape unchanged

Closes #4613