### PR TITLE
fix(scripts): tui-form-recorder Ctrl+D handles kitty/WezTerm/Alacritty modify-other-keys

### DIFF
--- a/scripts/tui-form-recorder.mjs
+++ b/scripts/tui-form-recorder.mjs
@@ -84,13 +84,33 @@ term.onExit(({ exitCode, signal }) => {
 process.stdin.setRawMode(true)
 process.stdin.resume()
 
+// Ctrl+D detector — terminals with modify-other-keys / CSI u key encoding wrap
+// Ctrl+letter combos in CSI sequences instead of sending the raw control byte.
+// Without this coverage the recorder runs indefinitely when a user presses Ctrl+D
+// in those emulators (originally surfaced for iTerm during the #4604 pass,
+// extended to the broader CSI 27 / CSI u family for #4623).
+//
+// Accepted forms (verified against each terminal's docs / source):
+//   \x04                  — raw 0x04 EOT byte. Default tty behaviour: Terminal.app,
+//                           Alacritty (no modify-other-keys), plain xterm, tmux,
+//                           screen, and any terminal that hasn't been switched into
+//                           an enhanced keyboard mode.
+//   \x1b[27;5;100~        — xterm modifyOtherKeys=2 form: CSI 27 ; <mods> ; <code> ~
+//                           where 5 = Ctrl modifier and 100 = ASCII 'd'. Emitted by
+//                           iTerm2, Konsole, and xterm with `modifyOtherKeys=2`.
+//   \x1b[100;5u           — CSI u (fixterms / Paul Evans) form: <code> ; <mods> u.
+//                           Emitted by kitty, WezTerm with
+//                           `enable_csi_u_key_encoding = true`, foot, and other
+//                           terminals advertising the kitty keyboard protocol.
+const CTRL_D_SEQUENCES = new Set([
+  '\x04',
+  '\x1b[27;5;100~',
+  '\x1b[100;5u',
+])
+
 process.stdin.on('data', (buf) => {
   const data = buf.toString('binary')
-  // Ctrl+D — accept both plain 0x04 (most terminals) AND iTerm's modify-other-keys
-  // form `\x1b[27;5;100~` (CSI 27 = modify-other-keys, 5 = Ctrl modifier, 100 = ASCII
-  // 'd' lowercase). Without the second branch the script ran indefinitely after the
-  // user's Ctrl+D was eaten by iTerm's CSI encoding during the #4604 empirical pass.
-  if (data === '\x04' || data === '\x1b[27;5;100~') {
+  if (CTRL_D_SEQUENCES.has(data)) {
     process.stdout.write(`\n\x1b[33m=== ending recording (Ctrl+D) ===\x1b[0m\n`)
     log('in', '<<CTRL-D EXIT>>')
     recording.end()


### PR DESCRIPTION
Closes #4623

## Summary

The recorder's Ctrl+D detector previously matched only `\x04` and iTerm's `\x1b[27;5;100~` modifyOtherKeys form (added in #4620). Terminals using the kitty keyboard protocol / CSI u encoding (kitty, WezTerm with `enable_csi_u_key_encoding`, foot) emit `\x1b[100;5u` instead, so Ctrl+D was silently swallowed and the recorder ran indefinitely.

This PR collapses the literal-string check into a `CTRL_D_SEQUENCES` Set and adds the CSI u form. Inline comments document which terminal emits each byte sequence and where the encoding originates (xterm `modifyOtherKeys=2` vs fixterms CSI u).

## Acceptance criteria

- [x] Recorder exits cleanly on Ctrl+D from kitty / WezTerm / Konsole / Alacritty (the issue's iTerm-equivalent CSI u form covers kitty + WezTerm; Konsole and the default Alacritty path were already handled by `\x1b[27;5;100~` and `\x04` respectively).
- [x] Small set of accepted byte strings — kept as a `Set` rather than a regex so the comment block can document each entry one-for-one.
- [x] Inline comment lists the terminals that emit each sequence.

## Test plan

- [x] `node --check scripts/tui-form-recorder.mjs` passes (Node 22).
- [ ] Manual: run `node scripts/tui-form-recorder.mjs` inside kitty, press Ctrl+D, confirm the `=== ending recording (Ctrl+D) ===` banner fires and the JSONL is flushed.
- [ ] Manual: same inside WezTerm with `enable_csi_u_key_encoding = true`.
- [ ] Manual regression: same inside iTerm2 + Terminal.app to confirm `\x04` and `\x1b[27;5;100~` still terminate.