### PR TITLE
fix(server): reject array-typed devices in notification_prefs_set (#4610)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -495,6 +495,17 @@ function handleNotificationPrefsSet(ws, client, msg, ctx) {
   // whole patch on the first bad key (no partial-apply) so the
   // on-disk state stays clean.
   if (patch.devices && typeof patch.devices === 'object') {
+    // #4610 — `typeof [] === 'object'` so an array-typed `devices`
+    // payload would otherwise reach the key-format loop and reject
+    // with a misleading "Invalid device token format" error (true,
+    // since '0'/'1'/... fail the 20-char gate, but it mis-describes
+    // the real shape mismatch). Reject arrays explicitly with a
+    // shape-specific message so misbehaving clients get a clear
+    // signal that `devices` must be a map keyed by push token.
+    if (Array.isArray(patch.devices)) {
+      sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'devices must be an object, not an array')
+      return
+    }
     for (const key of Object.keys(patch.devices)) {
       if (!PushManager.isValidPushTokenFormat(key)) {
         sendError(ws, msg?.requestId, 'INVALID_REQUEST', 'Invalid device token format in notification_prefs_set')

--- a/packages/server/tests/handlers/notification-prefs-handlers.test.js
+++ b/packages/server/tests/handlers/notification-prefs-handlers.test.js
@@ -213,6 +213,35 @@ describe('notification prefs handlers (#4541)', () => {
       assert.equal(existsSync(prefsPath), false, 'prefs file must not exist after rejection')
     })
 
+    // #4610 — `typeof [] === 'object'` so an array-typed `devices` payload
+    // would otherwise reach the key-format loop and reject with the wrong
+    // error message ("Invalid device token format" — true but misleading
+    // about the actual shape mismatch). Reject arrays explicitly up front
+    // with a shape-specific message so misbehaving clients get a clear
+    // signal and the on-disk state stays untouched.
+    it('rejects array-typed devices payload with a shape-specific message (#4610)', () => {
+      const setPrefsSpy = createSpy((patch, opts) => pushManager.setPrefs(patch, opts))
+      const wrappedManager = Object.assign(Object.create(Object.getPrototypeOf(pushManager)), pushManager, {
+        setPrefs: setPrefsSpy,
+      })
+      const ctx = makeCtx(wrappedManager)
+      const ws = makeWs()
+      const before = JSON.parse(JSON.stringify(pushManager.getPrefs()))
+      inputHandlers.notification_prefs_set(
+        ws, { id: 'c1' },
+        { requestId: 'r1', prefs: { devices: ['foo', 'bar'] } },
+        ctx,
+      )
+      const err = ws._messages.find((m) => m.type === 'error')
+      assert.ok(err, 'expected an error reply')
+      assert.equal(err.code, 'INVALID_REQUEST')
+      assert.match(err.message, /devices must be an object, not an array/)
+      // No partial-apply: setPrefs must not be invoked and disk stays clean.
+      assert.equal(setPrefsSpy.callCount, 0, 'setPrefs must not be invoked on array-typed devices')
+      assert.deepEqual(pushManager.getPrefs(), before, 'prefs snapshot must be unchanged')
+      assert.equal(existsSync(prefsPath), false, 'prefs file must not exist after rejection')
+    })
+
     it('rejects notification_prefs_set when device key is too short', () => {
       const setPrefsSpy = createSpy((patch, opts) => pushManager.setPrefs(patch, opts))
       const wrappedManager = Object.assign(Object.create(Object.getPrototypeOf(pushManager)), pushManager, {


### PR DESCRIPTION
## Summary

`typeof [] === 'object'` so an array-typed `devices` payload (e.g. `devices: ['foo', 'bar']`) currently slips past the existing `typeof patch.devices === 'object'` gate in `handleNotificationPrefsSet` and reaches the key-format loop. It rejects safely-by-accident — `Object.keys(['foo'])` yields `['0']`, which fails `isValidPushTokenFormat` (length < 20) — but the resulting `'Invalid device token format in notification_prefs_set'` error mis-describes the actual problem.

Adds an explicit `Array.isArray(patch.devices)` guard up front so misbehaving clients get a shape-specific message and the on-disk prefs file stays untouched (no partial-apply).

- `packages/server/src/handlers/input-handlers.js` — early-return with `INVALID_REQUEST` + `'devices must be an object, not an array'` when `devices` is an array.
- `packages/server/tests/handlers/notification-prefs-handlers.test.js` — new TDD-first test asserts the new error code/message, verifies `setPrefs` is never invoked, and confirms the prefs file is not created on rejection.

Closes #4610

## Test plan

- [x] New test fails against the unfixed handler (red): wrong message string surfaces (`'Invalid device token format ...'`).
- [x] New test passes after the fix (green).
- [x] Full `tests/handlers/notification-prefs-handlers.test.js` suite passes (14/14).
- [x] Broader notification-prefs suite passes (127/127 across `notification-prefs.test.js`, `notification-prefs-quiet-hours.test.js`, `handlers/notification-prefs-handlers.test.js`).