### PR TITLE
feat(dashboard): a11y attributes on MultiQuestionForm (#4624)

### DIFF
--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -519,5 +519,82 @@ describe('QuestionPrompt', () => {
       expect(arg!['Which release strategy?']).toBe('Minor')
       expect(arg!['Confirm?']).toBe('Yes')
     })
+
+    // #4624 — a11y: each per-question options block must be exposed to
+    // assistive tech as a labelled group so screen readers announce the
+    // question text once per group rather than re-reading it on every
+    // option. Single-select uses radiogroup + aria-required, multi-select
+    // uses plain group. Question text gets a stable id referenced by
+    // aria-labelledby. Submit mirrors aria-disabled with disabled state.
+    describe('a11y (#4624)', () => {
+      const single = {
+        question: 'Pick exactly one',
+        options: [{ label: 'A', value: 'A' }, { label: 'B', value: 'B' }],
+      }
+      const multi = {
+        question: 'Pick any',
+        options: [{ label: 'X', value: 'X' }, { label: 'Y', value: 'Y' }],
+        multiSelect: true,
+      }
+
+      it('renders single-select options as a radiogroup with aria-labelledby + aria-required', () => {
+        render(<MultiQuestionForm questions={[single]} onSelect={vi.fn()} />)
+        const row = screen.getByTestId('question-multi-row-0')
+        const group = row.querySelector('.question-options')!
+        expect(group.getAttribute('role')).toBe('radiogroup')
+        expect(group.getAttribute('aria-required')).toBe('true')
+        const labelledBy = group.getAttribute('aria-labelledby')
+        expect(labelledBy).toBeTruthy()
+        const labelEl = row.querySelector(`#${labelledBy}`)
+        expect(labelEl).not.toBeNull()
+        expect(labelEl!.textContent).toBe('Pick exactly one')
+      })
+
+      it('renders multi-select options as a group (not radiogroup) with aria-labelledby and no aria-required', () => {
+        render(<MultiQuestionForm questions={[multi]} onSelect={vi.fn()} />)
+        const row = screen.getByTestId('question-multi-row-0')
+        const group = row.querySelector('.question-options')!
+        expect(group.getAttribute('role')).toBe('group')
+        expect(group.getAttribute('aria-required')).toBeNull()
+        const labelledBy = group.getAttribute('aria-labelledby')
+        expect(labelledBy).toBeTruthy()
+        const labelEl = row.querySelector(`#${labelledBy}`)
+        expect(labelEl).not.toBeNull()
+        expect(labelEl!.textContent).toBe('Pick any')
+      })
+
+      it('assigns distinct aria-labelledby ids per question so duplicate text does not collide', () => {
+        render(
+          <MultiQuestionForm
+            questions={[single, multi, { ...single, question: 'Pick exactly one' }]}
+            onSelect={vi.fn()}
+          />
+        )
+        const ids = [0, 1, 2].map((i) => {
+          const row = screen.getByTestId(`question-multi-row-${i}`)
+          return row.querySelector('.question-options')!.getAttribute('aria-labelledby')
+        })
+        expect(new Set(ids).size).toBe(3)
+        ids.forEach((id) => expect(id).toBeTruthy())
+      })
+
+      it('Submit button mirrors aria-disabled with disabled state', () => {
+        const { rerender } = render(<MultiQuestionForm questions={[single]} onSelect={vi.fn()} />)
+        const submit = screen.getByTestId('question-multi-submit')
+        expect(submit).toBeDisabled()
+        expect(submit.getAttribute('aria-disabled')).toBe('true')
+
+        fireEvent.click(screen.getByTestId('question-multi-option-0-A').querySelector('input')!)
+        expect(submit).not.toBeDisabled()
+        expect(submit.getAttribute('aria-disabled')).toBe('false')
+
+        // Re-render with only a multi-select question — Submit is enabled by
+        // default (multi-select can submit zero selections).
+        rerender(<MultiQuestionForm questions={[multi]} onSelect={vi.fn()} />)
+        const submit2 = screen.getByTestId('question-multi-submit')
+        expect(submit2).not.toBeDisabled()
+        expect(submit2.getAttribute('aria-disabled')).toBe('false')
+      })
+    })
   })
 })

--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -545,7 +545,10 @@ describe('QuestionPrompt', () => {
         expect(group.getAttribute('aria-required')).toBe('true')
         const labelledBy = group.getAttribute('aria-labelledby')
         expect(labelledBy).toBeTruthy()
-        const labelEl = row.querySelector(`#${labelledBy}`)
+        // useId() returns ids containing ':' which need CSS escaping for
+        // querySelector; getElementById takes a raw id string and matches
+        // the pattern used by the Modal tests.
+        const labelEl = document.getElementById(labelledBy!)
         expect(labelEl).not.toBeNull()
         expect(labelEl!.textContent).toBe('Pick exactly one')
       })
@@ -558,7 +561,7 @@ describe('QuestionPrompt', () => {
         expect(group.getAttribute('aria-required')).toBeNull()
         const labelledBy = group.getAttribute('aria-labelledby')
         expect(labelledBy).toBeTruthy()
-        const labelEl = row.querySelector(`#${labelledBy}`)
+        const labelEl = document.getElementById(labelledBy!)
         expect(labelEl).not.toBeNull()
         expect(labelEl!.textContent).toBe('Pick any')
       })

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -19,7 +19,7 @@
  * that fires `onSelect(answersMap)`. The N=1 case falls back to the
  * legacy single-question UI so single-question pins keep passing.
  */
-import { useState, useRef, useEffect } from 'react'
+import { useId, useState, useRef, useEffect } from 'react'
 import { OTHER_OPTION_VALUE, type ChatMessageQuestion } from '@chroxy/store-core'
 
 export interface QuestionPromptProps {
@@ -119,6 +119,10 @@ export function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProp
   const [singleSelectByIdx, setSingleSelectByIdx] = useState<Record<number, string>>({})
   const [multiSelectByIdx, setMultiSelectByIdx] = useState<Record<number, string[]>>({})
   const submittedRef = useRef(false)
+  // #4624 — stable id prefix for aria-labelledby. Each question text gets
+  // `${labelIdPrefix}-${idx}` so duplicate question texts don't collide
+  // and screen readers can announce the group label.
+  const labelIdPrefix = useId()
 
   const handleRadioChange = (idx: number, value: string) => {
     setSingleSelectByIdx((prev) => ({ ...prev, [idx]: value }))
@@ -164,10 +168,18 @@ export function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProp
 
   return (
     <div className="question-prompt question-prompt--multi" data-testid="question-prompt-multi">
-      {questions.map((q, idx) => (
+      {questions.map((q, idx) => {
+        const isMultiSelect = q.multiSelect === true
+        const labelId = `${labelIdPrefix}-q-${idx}`
+        return (
         <div key={`q-${idx}`} className="question-prompt-multi-row" data-testid={`question-multi-row-${idx}`}>
-          <div className="question-text">{q.question}</div>
-          <div className={`question-options${q.multiSelect ? ' question-options--multi' : ''}`}>
+          <div className="question-text" id={labelId}>{q.question}</div>
+          <div
+            className={`question-options${isMultiSelect ? ' question-options--multi' : ''}`}
+            role={isMultiSelect ? 'group' : 'radiogroup'}
+            aria-labelledby={labelId}
+            {...(isMultiSelect ? {} : { 'aria-required': true })}
+          >
             {q.options.map((opt) => {
               const inputId = `q-${idx}-${opt.value}`
               const inputName = `q-${idx}`
@@ -195,12 +207,14 @@ export function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProp
             })}
           </div>
         </div>
-      ))}
+        )
+      })}
       <button
         type="button"
         className="question-multi-submit"
         data-testid="question-multi-submit"
         disabled={!canSubmit}
+        aria-disabled={!canSubmit}
         onClick={handleSubmit}
       >
         Submit


### PR DESCRIPTION
## Summary

a11y-only enhancement to `MultiQuestionForm` so each per-question options block is exposed as a labelled group to assistive tech (previously screen readers announced each bare `<input>` without grouping context).

- `role="radiogroup"` for single-select questions, `role="group"` for multi-select
- `aria-labelledby` on the group references a stable per-question id (`useId` prefix + idx) added to the question text; distinct ids prevent duplicate-text collisions
- `aria-required="true"` on single-select groups (Submit is gated on them)
- Submit button mirrors `aria-disabled` with its `disabled` state

Layout, styling, keystroke navigation, and submit/answersMap logic are untouched.

## Test plan

- [x] `npm test -- QuestionPrompt --run` in `packages/dashboard` — 33/33 pass, including 4 new TDD a11y assertions
- [x] `tsc --noEmit` clean
- [ ] Manual VoiceOver pass once #4666 re-enables interactive multi-question rendering

Closes #4624