### PR TITLE
fix(dashboard): render multi-select labels readably in MultiQuestionForm post-answer summary

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -64,6 +64,7 @@ import { useShortcutRegistry } from './shortcuts/useShortcutRegistry'
 import { formatBindingForDisplay, parseBinding } from './shortcuts/registry'
 import { readClipboardImage } from './utils/clipboard-image'
 import { writeText as clipboardWriteText } from './utils/clipboard'
+import { formatQuestionAnswerSummary } from './utils/questionAnswerSummary'
 import { useTauriEvents } from './hooks/useTauriEvents'
 import { isTauri } from './utils/tauri'
 import { startServer, revealInFinder } from './hooks/useTauriIPC'
@@ -1498,11 +1499,11 @@ export function App() {
             // forms. sendUserQuestionResponse handles both shapes;
             // markPromptAnswered records a string summary on the bubble so
             // the post-answer collapse UI has something readable to show.
+            // #4622 — formatQuestionAnswerSummary pretty-prints multi-select
+            // JSON-stringified arrays as comma-joined labels so the chip
+            // doesn't leak `["App","Tests"]` JSON syntax into UX copy.
             sendUserQuestionResponse(answer, storeMsg.toolUseId)
-            const summary = typeof answer === 'string'
-              ? answer
-              : Object.entries(answer).map(([q, v]) => `${q}: ${v}`).join(' | ')
-            markPromptAnswered(storeMsg.id, summary)
+            markPromptAnswered(storeMsg.id, formatQuestionAnswerSummary(answer))
           }}
         />
       )

--- a/packages/dashboard/src/utils/questionAnswerSummary.test.ts
+++ b/packages/dashboard/src/utils/questionAnswerSummary.test.ts
@@ -1,0 +1,119 @@
+/**
+ * #4622 — MultiQuestionForm post-answer summary should render multi-select
+ * answers as human-readable comma-joined labels, not JSON-stringified
+ * arrays.
+ *
+ * `MultiQuestionForm.handleSubmit` JSON-encodes multi-select answers
+ * (`JSON.stringify(['App','Tests'])` → `'["App","Tests"]'`) before passing
+ * them to `onSelect`, because the wire shape is
+ * `Record<string,string>` and the server's `respondToQuestion` JSON.parse
+ * splits it back. The dashboard's post-answer summary chip (rendered via
+ * `markPromptAnswered(storeMsg.id, summary)`) must not leak that JSON
+ * syntax into UX copy.
+ *
+ * `formatQuestionAnswerSummary` is the pure helper that App.tsx uses to
+ * build the summary string from the `onSelect` answer payload — it
+ * accepts both the legacy `string` shape (single-question / free-text
+ * path) and the `Record<string,string>` shape (multi-question form, with
+ * multi-select values JSON-stringified arrays).
+ */
+import { describe, it, expect } from 'vitest'
+import { formatQuestionAnswerSummary } from './questionAnswerSummary'
+
+describe('formatQuestionAnswerSummary', () => {
+  describe('legacy single-question / free-text path', () => {
+    it('returns plain string answers verbatim', () => {
+      expect(formatQuestionAnswerSummary('Yes')).toBe('Yes')
+    })
+
+    it('returns free-text answers verbatim (no JSON treatment)', () => {
+      expect(formatQuestionAnswerSummary('Some custom response')).toBe(
+        'Some custom response',
+      )
+    })
+
+    it('does not treat a stringified array as JSON when handed a bare string', () => {
+      // Defensive: a single-question answer that happens to look like a
+      // JSON array (very unlikely, but possible if Claude offers literal
+      // bracket-prefixed option text) should still render verbatim.
+      expect(formatQuestionAnswerSummary('[a,b]')).toBe('[a,b]')
+    })
+  })
+
+  describe('multi-question form path (Record<string,string>)', () => {
+    it('joins single-select answers with " | " between questions', () => {
+      const answer = {
+        'Which release strategy?': 'Minor',
+        'Confirm?': 'Yes',
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'Which release strategy?: Minor | Confirm?: Yes',
+      )
+    })
+
+    it('renders multi-select JSON-stringified arrays as comma-joined labels', () => {
+      // Repro for #4622: the user sees `["App","Tests"]` instead of
+      // `App, Tests` in the post-answer summary chip.
+      const answer = {
+        'Which areas?': JSON.stringify(['App', 'Tests']),
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'Which areas?: App, Tests',
+      )
+    })
+
+    it('renders a mixed single-select + multi-select payload readably', () => {
+      const answer = {
+        'Which release strategy?': 'Minor',
+        'Which areas?': JSON.stringify(['App', 'Tests', 'Docs']),
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'Which release strategy?: Minor | Which areas?: App, Tests, Docs',
+      )
+    })
+
+    it('renders an empty multi-select array as an empty value (no brackets)', () => {
+      // Multi-select with zero selections is allowed by the SDK; the
+      // chip should not show `[]`.
+      const answer = {
+        'Which areas?': JSON.stringify([]),
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe('Which areas?: ')
+    })
+
+    it('renders a single-item multi-select array without brackets or quotes', () => {
+      const answer = {
+        'Which areas?': JSON.stringify(['App']),
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe('Which areas?: App')
+    })
+
+    it('leaves malformed JSON-looking strings as-is rather than crashing', () => {
+      // Defensive: if a value starts with `[` but fails JSON.parse,
+      // fall back to the raw string so the chip still renders something
+      // useful instead of throwing.
+      const answer = {
+        'Which areas?': '[not valid json',
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'Which areas?: [not valid json',
+      )
+    })
+
+    it('only flattens arrays — non-array JSON values are kept as the raw string', () => {
+      // MultiQuestionForm.handleSubmit only ever JSON-stringifies arrays
+      // of option values (see handleSubmit in QuestionPrompt.tsx). The
+      // summary helper therefore only treats array-parse results
+      // specially; any other JSON shape that happens to arrive (object,
+      // number, etc.) keeps its raw representation so we don't silently
+      // mangle unrelated data.
+      const answer = {
+        'A?': JSON.stringify({ a: 1 }),
+        'B?': JSON.stringify(42),
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'A?: {"a":1} | B?: 42',
+      )
+    })
+  })
+})

--- a/packages/dashboard/src/utils/questionAnswerSummary.ts
+++ b/packages/dashboard/src/utils/questionAnswerSummary.ts
@@ -1,0 +1,51 @@
+/**
+ * #4622 — pure helper that turns a `QuestionPrompt` onSelect answer
+ * payload into the one-line summary string that App.tsx hands to
+ * `markPromptAnswered`. The summary surfaces on the collapsed
+ * post-answer chip after the user submits the form.
+ *
+ * Two answer shapes flow through here:
+ *
+ * 1. `string` — the legacy single-question / free-text path. Returned
+ *    verbatim.
+ * 2. `Record<string,string>` — the multi-question form path (#4604
+ *    Chunk B). One entry per question, keyed by question text.
+ *    Multi-select values arrive as JSON-stringified string arrays
+ *    (see `MultiQuestionForm.handleSubmit` — the wire shape is
+ *    `Record<string,string>`, and the server's `respondToQuestion`
+ *    JSON.parse splits it back). The summary helper detects and
+ *    pretty-prints those arrays as `App, Tests` instead of leaking
+ *    `["App","Tests"]` JSON syntax into the UX copy.
+ *
+ * Non-array JSON shapes (objects, numbers) are kept as their raw
+ * stringified form — `MultiQuestionForm` only ever JSON-encodes
+ * arrays, so anything else didn't come from the form and we'd rather
+ * surface it as-is than mangle it.
+ */
+
+/**
+ * Pretty-print a single answer value. If the value parses as a JSON
+ * array of primitives we render it as a comma-joined list (no
+ * brackets, no quotes); otherwise the value is returned unchanged.
+ */
+function formatMultiSelectValue(value: string): string {
+  // Cheap pre-check to avoid JSON.parse-ing every short-string answer.
+  if (!value.startsWith('[')) return value
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    return value
+  }
+  if (!Array.isArray(parsed)) return value
+  return parsed.map((item) => String(item)).join(', ')
+}
+
+export function formatQuestionAnswerSummary(
+  answer: string | Record<string, string>,
+): string {
+  if (typeof answer === 'string') return answer
+  return Object.entries(answer)
+    .map(([question, value]) => `${question}: ${formatMultiSelectValue(value)}`)
+    .join(' | ')
+}


### PR DESCRIPTION
## Summary

`MultiQuestionForm.handleSubmit` JSON-encodes multi-select answers before they hit `onSelect` so the wire shape `Record<string,string>` is preserved end-to-end. The App.tsx `onSelect` handler then built the one-line summary chip with `Object.entries(answer).map(([q,v]) => \`${q}: ${v}\`).join(' | ')`, which leaked the JSON syntax into UX copy — the user saw `Which areas?: ["App","Tests"]` instead of `Which areas?: App, Tests`.

This PR extracts the summary-building logic into a pure `formatQuestionAnswerSummary(answer)` helper that pretty-prints JSON-array values as comma-joined labels, then wires App.tsx to it. The wire/protocol layer is untouched — only the post-answer summary chip rendering changes.

## Changes

- `packages/dashboard/src/utils/questionAnswerSummary.ts` — new pure helper. Accepts both `string` (legacy single-question / free-text path) and `Record<string,string>` (multi-question form). Detects JSON-array values (cheap `[` prefix check + `JSON.parse` + `Array.isArray`) and joins them with `", "`. Non-array JSON shapes (objects, numbers) keep their raw representation since `MultiQuestionForm` only ever JSON-encodes arrays.
- `packages/dashboard/src/utils/questionAnswerSummary.test.ts` — 10 vitest cases: legacy string verbatim, free-text verbatim, bracket-prefixed string verbatim, single-select map, multi-select array repro for #4622, mixed map, empty array, single-item array, malformed JSON fallback, non-array JSON shapes.
- `packages/dashboard/src/App.tsx` — replace the inline summary builder with `formatQuestionAnswerSummary(answer)`.

## Test plan

- [x] `cd packages/dashboard && npm test -- questionAnswerSummary QuestionPrompt App.test --run` — 100 passed
- [x] Full dashboard suite: 2400/2400 passed
- [x] `npx tsc --noEmit` clean

Closes #4622