### PR TITLE
style(server): minor polish from #4606 review (#4611)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -487,13 +487,13 @@ function handleNotificationPrefsSet(ws, client, msg, ctx) {
     return
   }
   // #4551 — validate every device-key against the same gate
-  // register_push_token uses (>= 20 chars, no whitespace/punctuation).
-  // The Zod schema caps the devices map size as a DoS guard but does
-  // not check key format, so without this an authenticated client can
-  // stuff arbitrary strings into ~/.chroxy/notification-prefs.json and
-  // have them re-served on every notification_prefs_get. Reject the
-  // whole patch on the first bad key (no partial-apply) so the
-  // on-disk state stays clean.
+  // register_push_token enforces (see PushManager.isValidPushTokenFormat
+  // for the canonical rules). The Zod schema caps the devices map size
+  // as a DoS guard but does not check key format, so without this an
+  // authenticated client can stuff arbitrary strings into
+  // ~/.chroxy/notification-prefs.json and have them re-served on every
+  // notification_prefs_get. Reject the whole patch on the first bad key
+  // (no partial-apply) so the on-disk state stays clean.
   if (patch.devices && typeof patch.devices === 'object') {
     for (const key of Object.keys(patch.devices)) {
       if (!PushManager.isValidPushTokenFormat(key)) {

--- a/packages/server/tests/handlers/notification-prefs-handlers.test.js
+++ b/packages/server/tests/handlers/notification-prefs-handlers.test.js
@@ -232,8 +232,8 @@ describe('notification prefs handlers (#4541)', () => {
       assert.equal(existsSync(prefsPath), false)
     })
 
-    it('accepts a valid 64-char hex device key', () => {
-      const validKey = 'a'.repeat(64)
+    it('accepts a valid Expo-shaped device key', () => {
+      const validKey = 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'
       const ctx = makeCtx(pushManager)
       inputHandlers.notification_prefs_set(
         makeWs(), { id: 'c1' },


### PR DESCRIPTION
## Summary
- `handlers/input-handlers.js`: rewrite the device-key validation comment so it defers to `PushManager.isValidPushTokenFormat` as the canonical source of truth instead of re-describing the regex inline (the inline description was already drifting from the actual rules).
- `tests/handlers/notification-prefs-handlers.test.js`: replace the `'a'.repeat(64)` fixture with a representative `ExponentPushToken[...]` string so the test is self-documenting about which real-world token shape it accepts.

Style-only changes, no behavior change. Both items are the nitpicks called out in the issue from the #4606 agent review.

## Test plan
- [x] `node --test tests/handlers/notification-prefs-handlers.test.js` — all 13 tests still pass
- [x] No production logic touched; the `isValidPushTokenFormat` gate is unchanged

Closes #4611