### PR TITLE
test(server): bullet-proof isolation from real user state (#4633)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,11 @@ jobs:
           # Issue #4633 — every `new SessionManager(...)` in tests must include
           # a `stateFilePath` option, otherwise the test writes to the real
           # ~/.chroxy/session-state.json (or, in CI, to the runner home).
-          # The HOME-override sandbox in tests/_setup.mjs makes accidental
-          # contamination harmless, but the explicit option keeps the intent
-          # obvious in review and avoids surprise side effects.
+          # The sandbox guard in tests/_setup.mjs (loaded via `node --import`)
+          # patches the write-side of `fs` to throw on real-home writes — it
+          # does NOT override HOME — so accidental contamination fails loudly,
+          # but the explicit option keeps the intent obvious in review and
+          # avoids surprise side effects.
           if scripts/lint-tests-state-file-path.sh; then
             echo "OK — every new SessionManager(...) in tests passes stateFilePath"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,21 @@ jobs:
             exit 1
           }
 
+      - name: Check tests pass stateFilePath to SessionManager
+        run: |
+          # Issue #4633 — every `new SessionManager(...)` in tests must include
+          # a `stateFilePath` option, otherwise the test writes to the real
+          # ~/.chroxy/session-state.json (or, in CI, to the runner home).
+          # The HOME-override sandbox in tests/_setup.mjs makes accidental
+          # contamination harmless, but the explicit option keeps the intent
+          # obvious in review and avoids surprise side effects.
+          if scripts/lint-tests-state-file-path.sh; then
+            echo "OK — every new SessionManager(...) in tests passes stateFilePath"
+          else
+            echo "::error::Tests instantiated SessionManager without stateFilePath. See packages/server/scripts/lint-tests-state-file-path.sh."
+            exit 1
+          fi
+
   dashboard-tests:
     name: Dashboard Tests
     runs-on: ubuntu-24.04

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,19 @@ When `gh pr merge` fails with "not mergeable" or "base branch policy prohibits t
 - Zustand for state management
 - React Navigation for routing
 
+## Testing Conventions
+
+### Server tests must not touch real user state (#4633)
+
+Every test that constructs a `SessionManager` **must** pass `stateFilePath` pointing at a temp file. Otherwise the manager defaults to `~/.chroxy/session-state.json` and the test silently clobbers your live state (this happened on 2026-05-30 — see `feedback_test_state_contamination.md`).
+
+Two layers of defence are wired up:
+
+1. **Sandbox guard** (`packages/server/tests/_setup.mjs`, loaded via `node --import`) — monkey-patches `fs.writeFileSync`/`promises.writeFile`/`renameSync`/`mkdirSync`/`createWriteStream`/`openSync(w*)` to throw `CHROXY_TEST_SANDBOX` if any test writes to the real `~/.chroxy/` or `~/.claude/` tree. The error includes the call site, so the next bare `new SessionManager()` fails loudly at the offending test.
+2. **CI lint** (`packages/server/scripts/lint-tests-state-file-path.sh`) — fails the build if any `new SessionManager(...)` in `tests/` is missing `stateFilePath`. Run locally with `cd packages/server && ./scripts/lint-tests-state-file-path.sh`.
+
+If you need to write to the real home for a legitimate reason (no current test does), set `process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'` scoped to the test and restore it after. The sandbox guard MUST stay enabled in `package.json`.
+
 ## Architecture
 
 Server streams through `ws-server.js` → Cloudflare tunnel → mobile app / desktop dashboard:

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,10 +10,10 @@
   "scripts": {
     "start": "node src/cli.js start",
     "dev": "node --watch src/cli.js start",
-    "test": "c8 node --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
-    "test:coverage": "c8 --reporter=text --reporter=html node --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
-    "test:integration": "node --test ./tests/*.integration.test.js",
-    "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --test ./tests/integration/k8s-sidecar-roundtrip.test.js",
+    "test": "c8 node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
+    "test:coverage": "c8 --reporter=text --reporter=html node --import ./tests/_setup.mjs --experimental-test-module-mocks --test --test-force-exit './tests/**/*.test.js'",
+    "test:integration": "node --import ./tests/_setup.mjs --test ./tests/*.integration.test.js",
+    "test:integration:k8s": "RUN_K8S_INTEGRATION=1 node --import ./tests/_setup.mjs --test ./tests/integration/k8s-sidecar-roundtrip.test.js",
     "lint": "eslint src/",
     "postinstall": "node scripts/fix-node-pty-helper.js"
   },

--- a/packages/server/scripts/lint-tests-state-file-path.mjs
+++ b/packages/server/scripts/lint-tests-state-file-path.mjs
@@ -5,8 +5,10 @@
  * `~/.chroxy/session-state.json` and the test silently writes to the
  * developer's (or CI runner's) real user state file.
  *
- * The setup hook in `tests/_setup.mjs` reroutes HOME to a tmp dir as a
- * safety net, but the explicit option is still required so the intent is
+ * The sandbox guard in `tests/_setup.mjs` (loaded via `node --import`)
+ * patches the write-side of `fs` to throw if any path resolves under the
+ * real `~/.chroxy` or `~/.claude` tree — it does NOT override `HOME`. The
+ * explicit `stateFilePath` option is still required so the intent is
  * obvious in review and a future setup-hook regression cannot reintroduce
  * the original bug class.
  *

--- a/packages/server/scripts/lint-tests-state-file-path.mjs
+++ b/packages/server/scripts/lint-tests-state-file-path.mjs
@@ -70,37 +70,52 @@ function findMatchingParen(src, openIdx) {
   return -1
 }
 
+// Constructor → required option in tests. Each entry pins a state-bearing
+// class whose default writes under `~/.chroxy/`. Adding more entries here is
+// the right move when a new class joins the bug class.
+const RULES = [
+  { ctor: 'SessionManager', requiredOpt: 'stateFilePath', helper: 'tmpStateFile()' },
+  { ctor: 'CheckpointManager', requiredOpt: 'checkpointsDir', helper: 'a tmp directory (mkdtempSync)' },
+]
+
 const offenders = []
 for (const file of walk(TESTS_DIR)) {
   const src = readFileSync(file, 'utf8')
-  const NEEDLE = 'new SessionManager('
-  let i = 0
-  while (true) {
-    const idx = src.indexOf(NEEDLE, i)
-    if (idx === -1) break
-    i = idx + 1
-    if (isInsideComment(src, idx)) continue
-    const openParen = idx + NEEDLE.length - 1
-    const closeParen = findMatchingParen(src, openParen)
-    if (closeParen === -1) continue
-    const callBody = src.slice(idx, closeParen + 1)
-    if (!/\bstateFilePath\b/.test(callBody)) {
-      const before = src.slice(0, idx)
-      const line = before.split('\n').length
-      offenders.push(`${file}:${line}`)
+  for (const { ctor, requiredOpt } of RULES) {
+    const needle = `new ${ctor}(`
+    let i = 0
+    while (true) {
+      const idx = src.indexOf(needle, i)
+      if (idx === -1) break
+      i = idx + 1
+      if (isInsideComment(src, idx)) continue
+      const openParen = idx + needle.length - 1
+      const closeParen = findMatchingParen(src, openParen)
+      if (closeParen === -1) continue
+      const callBody = src.slice(idx, closeParen + 1)
+      const optRe = new RegExp(`\\b${requiredOpt}\\b`)
+      if (!optRe.test(callBody)) {
+        const before = src.slice(0, idx)
+        const line = before.split('\n').length
+        offenders.push({ file, line, ctor, requiredOpt })
+      }
     }
   }
 }
 
 if (offenders.length) {
-  console.error('ERROR: the following test sites construct SessionManager without an explicit stateFilePath:')
-  for (const o of offenders) console.error(`  ${o}`)
+  console.error('ERROR: the following test sites construct state-bearing classes without an explicit tmp-path option:')
+  for (const o of offenders) {
+    console.error(`  ${o.file}:${o.line}  (missing ${o.requiredOpt} in new ${o.ctor}(...))`)
+  }
   console.error('')
-  console.error('Fix: add `stateFilePath: tmpStateFile()` (or another temp path) to the constructor options.')
+  for (const { ctor, requiredOpt, helper } of RULES) {
+    console.error(`Fix for ${ctor}: pass \`${requiredOpt}: ${helper}\` in the constructor options.`)
+  }
   console.error('Pattern: see packages/server/tests/session-manager.test.js (`tmpStateFile()` helper).')
   console.error('Background: issue #4633, packages/server/tests/_setup.mjs.')
   if (process.env.DRY_RUN === '1') process.exit(0)
   process.exit(1)
 }
 
-console.log('OK: every new SessionManager(...) in tests includes stateFilePath')
+console.log(`OK: every ${RULES.map(r => 'new ' + r.ctor + '(...)').join(' / ')} in tests includes its required tmp-path option`)

--- a/packages/server/scripts/lint-tests-state-file-path.mjs
+++ b/packages/server/scripts/lint-tests-state-file-path.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Lint: every `new SessionManager(...)` call in `packages/server/tests/`
+ * must include `stateFilePath`. Otherwise the manager defaults to
+ * `~/.chroxy/session-state.json` and the test silently writes to the
+ * developer's (or CI runner's) real user state file.
+ *
+ * The setup hook in `tests/_setup.mjs` reroutes HOME to a tmp dir as a
+ * safety net, but the explicit option is still required so the intent is
+ * obvious in review and a future setup-hook regression cannot reintroduce
+ * the original bug class.
+ *
+ * Issue: #4633. Prior incidents: #2314, #429, 2026-05-30 contamination.
+ *
+ * Exit codes:
+ *   0 — every `new SessionManager(...)` in tests passes `stateFilePath`
+ *   1 — at least one offender found (printed with file:line)
+ *
+ * Set `DRY_RUN=1` to list offenders without failing the exit code.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const TESTS_DIR = resolve(__dirname, '..', 'tests')
+
+function walk(dir, acc = []) {
+  for (const ent of readdirSync(dir)) {
+    const p = join(dir, ent)
+    const st = statSync(p)
+    if (st.isDirectory()) walk(p, acc)
+    else if (st.isFile() && p.endsWith('.test.js')) acc.push(p)
+  }
+  return acc
+}
+
+function isInsideComment(src, idx) {
+  const lineStart = src.lastIndexOf('\n', idx) + 1
+  const lineSoFar = src.slice(lineStart, idx)
+  if (lineSoFar.trimStart().startsWith('//')) return true
+  if (lineSoFar.trimStart().startsWith('*')) return true
+  const lastOpen = src.lastIndexOf('/*', idx)
+  const lastClose = src.lastIndexOf('*/', idx)
+  return lastOpen > lastClose
+}
+
+function findMatchingParen(src, openIdx) {
+  let depth = 0
+  let i = openIdx
+  let inStr = null
+  while (i < src.length) {
+    const ch = src[i]
+    const prev = src[i - 1]
+    if (inStr) {
+      if (ch === inStr && prev !== '\\') inStr = null
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      inStr = ch
+    } else if (ch === '(') {
+      depth++
+    } else if (ch === ')') {
+      depth--
+      if (depth === 0) return i
+    }
+    i++
+  }
+  return -1
+}
+
+const offenders = []
+for (const file of walk(TESTS_DIR)) {
+  const src = readFileSync(file, 'utf8')
+  const NEEDLE = 'new SessionManager('
+  let i = 0
+  while (true) {
+    const idx = src.indexOf(NEEDLE, i)
+    if (idx === -1) break
+    i = idx + 1
+    if (isInsideComment(src, idx)) continue
+    const openParen = idx + NEEDLE.length - 1
+    const closeParen = findMatchingParen(src, openParen)
+    if (closeParen === -1) continue
+    const callBody = src.slice(idx, closeParen + 1)
+    if (!/\bstateFilePath\b/.test(callBody)) {
+      const before = src.slice(0, idx)
+      const line = before.split('\n').length
+      offenders.push(`${file}:${line}`)
+    }
+  }
+}
+
+if (offenders.length) {
+  console.error('ERROR: the following test sites construct SessionManager without an explicit stateFilePath:')
+  for (const o of offenders) console.error(`  ${o}`)
+  console.error('')
+  console.error('Fix: add `stateFilePath: tmpStateFile()` (or another temp path) to the constructor options.')
+  console.error('Pattern: see packages/server/tests/session-manager.test.js (`tmpStateFile()` helper).')
+  console.error('Background: issue #4633, packages/server/tests/_setup.mjs.')
+  if (process.env.DRY_RUN === '1') process.exit(0)
+  process.exit(1)
+}
+
+console.log('OK: every new SessionManager(...) in tests includes stateFilePath')

--- a/packages/server/scripts/lint-tests-state-file-path.sh
+++ b/packages/server/scripts/lint-tests-state-file-path.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wrapper for the Node-based linter. See `lint-tests-state-file-path.mjs`
+# for the actual implementation. Kept as a shell entry point so CI can
+# `run: scripts/lint-tests-state-file-path.sh` without worrying about the
+# Node interpreter path on the runner image.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node ./scripts/lint-tests-state-file-path.mjs "$@"

--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -13,7 +13,13 @@ const log = createLogger('checkpoint')
 
 const execFileAsync = promisify(execFileCb)
 
-const DEFAULT_CHECKPOINTS_DIR = join(homedir(), '.chroxy', 'checkpoints')
+// Resolve at call time, not module-load time, so tests that set
+// CHROXY_CONFIG_DIR in beforeEach are respected. Mirrors models.js and
+// connection-info.js (#4633).
+function defaultCheckpointsDir() {
+  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  return join(configDir, 'checkpoints')
+}
 const MAX_CHECKPOINTS_PER_SESSION = 50
 
 /**
@@ -63,15 +69,16 @@ export class CheckpointManager extends EventEmitter {
   /**
    * @param {object} [options]
    * @param {string} [options.checkpointsDir] - Override the on-disk directory
-   *   for checkpoint state files. Defaults to `~/.chroxy/checkpoints`. Tests
-   *   should pass a tmp directory to avoid contaminating the developer's
-   *   real state (#4633).
+   *   for checkpoint state files. Defaults to `$CHROXY_CONFIG_DIR/checkpoints`
+   *   (or `~/.chroxy/checkpoints` when unset). Tests should pass a tmp
+   *   directory (or set `CHROXY_CONFIG_DIR`) to avoid contaminating the
+   *   developer's real state (#4633).
    */
   constructor(options = {}) {
     super()
     this._checkpoints = new Map() // sessionId -> Checkpoint[]
     this._counters = new Map() // sessionId -> monotonic counter for default names
-    this._checkpointsDir = options.checkpointsDir || DEFAULT_CHECKPOINTS_DIR
+    this._checkpointsDir = options.checkpointsDir || defaultCheckpointsDir()
     this._ensureDir()
   }
 

--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -13,7 +13,7 @@ const log = createLogger('checkpoint')
 
 const execFileAsync = promisify(execFileCb)
 
-const CHECKPOINTS_DIR = join(homedir(), '.chroxy', 'checkpoints')
+const DEFAULT_CHECKPOINTS_DIR = join(homedir(), '.chroxy', 'checkpoints')
 const MAX_CHECKPOINTS_PER_SESSION = 50
 
 /**
@@ -60,16 +60,24 @@ async function acquireCwdLock(cwd) {
  * conversation ID, effectively branching the conversation.
  */
 export class CheckpointManager extends EventEmitter {
-  constructor() {
+  /**
+   * @param {object} [options]
+   * @param {string} [options.checkpointsDir] - Override the on-disk directory
+   *   for checkpoint state files. Defaults to `~/.chroxy/checkpoints`. Tests
+   *   should pass a tmp directory to avoid contaminating the developer's
+   *   real state (#4633).
+   */
+  constructor(options = {}) {
     super()
     this._checkpoints = new Map() // sessionId -> Checkpoint[]
     this._counters = new Map() // sessionId -> monotonic counter for default names
+    this._checkpointsDir = options.checkpointsDir || DEFAULT_CHECKPOINTS_DIR
     this._ensureDir()
   }
 
   _ensureDir() {
-    if (!existsSync(CHECKPOINTS_DIR)) {
-      mkdirSync(CHECKPOINTS_DIR, { recursive: true })
+    if (!existsSync(this._checkpointsDir)) {
+      mkdirSync(this._checkpointsDir, { recursive: true })
     }
   }
 
@@ -222,7 +230,7 @@ export class CheckpointManager extends EventEmitter {
     }
     this._checkpoints.delete(sessionId)
 
-    const file = join(CHECKPOINTS_DIR, `${sessionId}.json`)
+    const file = join(this._checkpointsDir, `${sessionId}.json`)
     if (existsSync(file)) {
       try { unlinkSync(file) } catch { /* ignore */ }
     }
@@ -377,7 +385,7 @@ export class CheckpointManager extends EventEmitter {
   }
 
   _load(sessionId) {
-    const file = join(CHECKPOINTS_DIR, `${sessionId}.json`)
+    const file = join(this._checkpointsDir, `${sessionId}.json`)
     try {
       if (existsSync(file)) {
         const data = JSON.parse(readFileSync(file, 'utf8'))
@@ -391,7 +399,7 @@ export class CheckpointManager extends EventEmitter {
   }
 
   _persist(sessionId) {
-    const file = join(CHECKPOINTS_DIR, `${sessionId}.json`)
+    const file = join(this._checkpointsDir, `${sessionId}.json`)
     const data = { version: 1, checkpoints: this._getCheckpoints(sessionId) }
     try {
       writeFileRestricted(file, JSON.stringify(data, null, 2))

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -38,8 +38,9 @@
  */
 
 import { createRequire } from 'node:module'
-import { homedir } from 'node:os'
-import { resolve, sep } from 'node:path'
+import { mkdtempSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { join, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 // CRITICAL: Patch `node:fs` via the CJS object obtained from `createRequire`,
@@ -54,6 +55,18 @@ import { fileURLToPath } from 'node:url'
 // — Node's `--import` flag in `package.json` enforces that ordering.
 const require = createRequire(import.meta.url)
 const fs = require('node:fs')
+
+// --- Redirect CHROXY_CONFIG_DIR to a per-process tmp dir ----------------------
+// Production helpers (models.js, connection-info.js, checkpoint-manager.js)
+// already honour `CHROXY_CONFIG_DIR`. Pointing it at a tmp dir up-front means
+// every code path that defaults to `~/.chroxy/...` lands in the tmp dir
+// instead — no per-test plumbing required, no real-home writes possible.
+// Tests that explicitly need to override it (e.g. supervisor.test.js) can
+// still set it in their own beforeEach and restore in afterEach — Node's
+// env reads are dynamic.
+if (!process.env.CHROXY_CONFIG_DIR) {
+  process.env.CHROXY_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'chroxy-test-cfg-'))
+}
 
 // --- Capture the real home for the guard --------------------------------------
 const REAL_HOME = homedir()

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -1,0 +1,182 @@
+/**
+ * Server test setup — enforces isolation from the developer's real user state
+ * (`~/.chroxy/`, `~/.claude/`). Loaded once per test process via Node's
+ * `--import` flag (wired in `package.json` test scripts).
+ *
+ * See issue #4633 and `feedback_test_state_contamination.md`. The 2026-05-30
+ * incident clobbered the user's live `~/.chroxy/session-state.json` with
+ * test fixture data because individual tests forgot to pass a temp
+ * `stateFilePath`. This file installs a sandbox guard that throws the
+ * moment any test attempts to write to the real `~/.chroxy/` or `~/.claude/`
+ * trees, so the next forgetter fails LOUDLY at the offending call site
+ * instead of silently corrupting the developer's live state 76 days later.
+ *
+ * The guard monkey-patches the write-side of `fs` (sync + promises): any
+ * call whose resolved path falls under the real `~/.chroxy/` or `~/.claude/`
+ * throws `CHROXY_TEST_SANDBOX` with a stack trace pointing at the caller.
+ * Read-side fs calls are untouched, so tests that legitimately *read* the
+ * developer's real config (e.g. provider detection in
+ * `providers.test.js`) keep working.
+ *
+ * We deliberately do NOT override `process.env.HOME` globally. Several
+ * existing tests pass real `homedir()` / `process.cwd()` paths to
+ * validation helpers (`validateCwdAllowed`, `listFiles` home-fallback,
+ * environment manager workspaceRoots) that compare against the live
+ * `os.homedir()`. Rerouting HOME up-front breaks those tests in a way
+ * that's unrelated to the bug class we're fixing. A bare
+ * `new SessionManager()` is still caught — its first `writeFileSync` for
+ * the default `~/.chroxy/session-state.json` trips the guard.
+ *
+ * Tests that need to mutate `process.env.HOME` for their own purposes
+ * (e.g. `claude-tui-session.test.js`, `byok-credentials.test.js`) are fine
+ * — the guard locks onto the *real* home recorded at process startup, not
+ * whatever HOME currently is.
+ *
+ * Opt-out for the rare test that legitimately needs to write to the real
+ * home (none expected): set `process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'`
+ * scoped to the test, then restore.
+ */
+
+import fs from 'node:fs'
+import { homedir } from 'node:os'
+import { resolve, sep } from 'node:path'
+
+// --- Capture the real home for the guard --------------------------------------
+const REAL_HOME = homedir()
+const PROTECTED_ROOTS = [
+  resolve(REAL_HOME, '.chroxy') + sep,
+  resolve(REAL_HOME, '.claude') + sep,
+]
+// Also guard the bare files (e.g. `~/.claude.json` from byok-mcp-config)
+// because they live next to the dirs we protect.
+const PROTECTED_FILES = new Set([
+  resolve(REAL_HOME, '.claude.json'),
+])
+
+// --- Sandbox guard ------------------------------------------------------------
+function isProtected(rawPath) {
+  if (process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES === '1') return false
+  if (typeof rawPath !== 'string' && !(rawPath instanceof URL) && !(rawPath instanceof Buffer)) {
+    return false
+  }
+  let p
+  try {
+    if (rawPath instanceof URL) p = rawPath.pathname
+    else if (rawPath instanceof Buffer) p = rawPath.toString('utf8')
+    else p = rawPath
+    p = resolve(p)
+  } catch {
+    return false
+  }
+  if (PROTECTED_FILES.has(p)) return true
+  for (const root of PROTECTED_ROOTS) {
+    if (p === root.slice(0, -1) || p.startsWith(root)) return true
+  }
+  return false
+}
+
+function makeGuardError(method, target) {
+  const err = new Error(
+    `[chroxy-test-sandbox] BLOCKED ${method} to real user-state path: ${target}\n` +
+    `  This test attempted to write to the developer's actual ~/.chroxy or ~/.claude tree.\n` +
+    `  Pass a temp path explicitly (e.g. stateFilePath: tmpStateFile()) or set\n` +
+    `  process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1' if the write is intentional.\n` +
+    `  See packages/server/tests/_setup.mjs and issue #4633.`,
+  )
+  err.code = 'CHROXY_TEST_SANDBOX'
+  return err
+}
+
+const origWriteFileSync = fs.writeFileSync
+fs.writeFileSync = function patchedWriteFileSync(target, ...rest) {
+  if (isProtected(target)) throw makeGuardError('writeFileSync', String(target))
+  return origWriteFileSync.call(this, target, ...rest)
+}
+
+const origAppendFileSync = fs.appendFileSync
+fs.appendFileSync = function patchedAppendFileSync(target, ...rest) {
+  if (isProtected(target)) throw makeGuardError('appendFileSync', String(target))
+  return origAppendFileSync.call(this, target, ...rest)
+}
+
+const origRenameSync = fs.renameSync
+fs.renameSync = function patchedRenameSync(oldPath, newPath) {
+  if (isProtected(newPath)) throw makeGuardError('renameSync', String(newPath))
+  return origRenameSync.call(this, oldPath, newPath)
+}
+
+const origMkdirSync = fs.mkdirSync
+fs.mkdirSync = function patchedMkdirSync(target, ...rest) {
+  // Blocks any new directory under the real ~/.chroxy or ~/.claude. The
+  // top-level dirs themselves (PROTECTED_ROOTS) already exist, so a
+  // `mkdirSync('~/.chroxy', { recursive: true })` no-ops in practice —
+  // but we still flag it to surface unexpected callers in tests.
+  if (isProtected(target)) throw makeGuardError('mkdirSync', String(target))
+  return origMkdirSync.call(this, target, ...rest)
+}
+
+const origCreateWriteStream = fs.createWriteStream
+fs.createWriteStream = function patchedCreateWriteStream(target, ...rest) {
+  if (isProtected(target)) throw makeGuardError('createWriteStream', String(target))
+  return origCreateWriteStream.call(this, target, ...rest)
+}
+
+const origOpenSync = fs.openSync
+fs.openSync = function patchedOpenSync(target, flags, ...rest) {
+  // `flags` can be a string ('w', 'a', 'wx', 'w+', 'a+', 'ax') or a number
+  // (constants OR'd together: O_WRONLY=1, O_RDWR=2, O_CREAT=64, O_APPEND=1024…).
+  // We only block when the open is for writing; pure reads are fine.
+  let isWrite = false
+  if (typeof flags === 'string') {
+    isWrite = /[wa+]/.test(flags)
+  } else if (typeof flags === 'number') {
+    // O_WRONLY = 1, O_RDWR = 2, O_CREAT = 64, O_APPEND = 1024, O_TRUNC = 512
+    isWrite = (flags & 1) !== 0 || (flags & 2) !== 0 || (flags & 64) !== 0
+  }
+  if (isWrite && isProtected(target)) throw makeGuardError('openSync', String(target))
+  return origOpenSync.call(this, target, flags, ...rest)
+}
+
+if (fs.promises) {
+  const origWriteFile = fs.promises.writeFile
+  fs.promises.writeFile = function patchedWriteFile(target, ...rest) {
+    if (isProtected(target)) return Promise.reject(makeGuardError('promises.writeFile', String(target)))
+    return origWriteFile.call(this, target, ...rest)
+  }
+
+  const origAppendFile = fs.promises.appendFile
+  fs.promises.appendFile = function patchedAppendFile(target, ...rest) {
+    if (isProtected(target)) return Promise.reject(makeGuardError('promises.appendFile', String(target)))
+    return origAppendFile.call(this, target, ...rest)
+  }
+
+  const origRename = fs.promises.rename
+  fs.promises.rename = function patchedRename(oldPath, newPath) {
+    if (isProtected(newPath)) return Promise.reject(makeGuardError('promises.rename', String(newPath)))
+    return origRename.call(this, oldPath, newPath)
+  }
+
+  const origMkdir = fs.promises.mkdir
+  fs.promises.mkdir = function patchedMkdir(target, ...rest) {
+    if (isProtected(target)) return Promise.reject(makeGuardError('promises.mkdir', String(target)))
+    return origMkdir.call(this, target, ...rest)
+  }
+
+  const origOpen = fs.promises.open
+  fs.promises.open = function patchedOpen(target, flags, ...rest) {
+    let isWrite = false
+    if (typeof flags === 'string') isWrite = /[wa+]/.test(flags)
+    else if (typeof flags === 'number') isWrite = (flags & 1) !== 0 || (flags & 2) !== 0 || (flags & 64) !== 0
+    if (isWrite && isProtected(target)) {
+      return Promise.reject(makeGuardError('promises.open', String(target)))
+    }
+    return origOpen.call(this, target, flags, ...rest)
+  }
+}
+
+// --- Diagnostic ---------------------------------------------------------------
+// Quiet by default; set CHROXY_TEST_SANDBOX_DEBUG=1 to see the protected
+// paths once per process.
+if (process.env.CHROXY_TEST_SANDBOX_DEBUG === '1') {
+  console.error(`[chroxy-test-sandbox] guarded write paths under: ${REAL_HOME}/.chroxy, ${REAL_HOME}/.claude`)
+}

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -37,9 +37,23 @@
  * scoped to the test, then restore.
  */
 
-import fs from 'node:fs'
+import { createRequire } from 'node:module'
 import { homedir } from 'node:os'
 import { resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// CRITICAL: Patch `node:fs` via the CJS object obtained from `createRequire`,
+// NOT via an ESM default import. ESM `import fs from 'node:fs'` returns a
+// Module Namespace Exotic Object whose property writes do NOT propagate to
+// later `import { writeFileSync } from 'node:fs'` consumers — those bindings
+// are snapshotted at link-time from the CJS module's original exports.
+// `createRequire('node:fs')` gives us the live CJS `module.exports`; any
+// production code that does `import { writeFileSync } from 'fs'` then sees
+// our patched value because the ESM named exports are derived from this same
+// object at link time. This must run BEFORE any other module imports `node:fs`
+// — Node's `--import` flag in `package.json` enforces that ordering.
+const require = createRequire(import.meta.url)
+const fs = require('node:fs')
 
 // --- Capture the real home for the guard --------------------------------------
 const REAL_HOME = homedir()
@@ -61,7 +75,11 @@ function isProtected(rawPath) {
   }
   let p
   try {
-    if (rawPath instanceof URL) p = rawPath.pathname
+    // `fileURLToPath` handles cross-platform quirks (Windows `file:///C:/...`
+    // yields `C:\...`, percent-encoded segments are decoded). Falling back to
+    // `.pathname` would leave a leading slash on Windows and break comparison
+    // against `os.homedir()`-derived paths.
+    if (rawPath instanceof URL) p = fileURLToPath(rawPath)
     else if (rawPath instanceof Buffer) p = rawPath.toString('utf8')
     else p = rawPath
     p = resolve(p)
@@ -78,7 +96,7 @@ function isProtected(rawPath) {
 function makeGuardError(method, target) {
   const err = new Error(
     `[chroxy-test-sandbox] BLOCKED ${method} to real user-state path: ${target}\n` +
-    `  This test attempted to write to the developer's actual ~/.chroxy or ~/.claude tree.\n` +
+    `  This test attempted to write to (or move from/to) the developer's actual ~/.chroxy or ~/.claude tree.\n` +
     `  Pass a temp path explicitly (e.g. stateFilePath: tmpStateFile()) or set\n` +
     `  process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1' if the write is intentional.\n` +
     `  See packages/server/tests/_setup.mjs and issue #4633.`,
@@ -101,7 +119,12 @@ fs.appendFileSync = function patchedAppendFileSync(target, ...rest) {
 
 const origRenameSync = fs.renameSync
 fs.renameSync = function patchedRenameSync(oldPath, newPath) {
-  if (isProtected(newPath)) throw makeGuardError('renameSync', String(newPath))
+  // Check BOTH paths: a `renameSync('~/.chroxy/session-state.json', '/tmp/x')`
+  // would silently relocate real user state without tripping a newPath-only
+  // guard. The whole point of the sandbox is to prevent that.
+  if (isProtected(oldPath) || isProtected(newPath)) {
+    throw makeGuardError('renameSync', `${String(oldPath)} -> ${String(newPath)}`)
+  }
   return origRenameSync.call(this, oldPath, newPath)
 }
 
@@ -152,7 +175,10 @@ if (fs.promises) {
 
   const origRename = fs.promises.rename
   fs.promises.rename = function patchedRename(oldPath, newPath) {
-    if (isProtected(newPath)) return Promise.reject(makeGuardError('promises.rename', String(newPath)))
+    // Mirror the sync guard: a rename OUT of ~/.chroxy is still data loss.
+    if (isProtected(oldPath) || isProtected(newPath)) {
+      return Promise.reject(makeGuardError('promises.rename', `${String(oldPath)} -> ${String(newPath)}`))
+    }
     return origRename.call(this, oldPath, newPath)
   }
 

--- a/packages/server/tests/auto-label.test.js
+++ b/packages/server/tests/auto-label.test.js
@@ -1,12 +1,29 @@
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it, beforeEach, after } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { EventEmitter } from 'events'
 import { SessionManager } from '../src/session-manager.js'
 
 /**
  * Tests for session auto-labeling — when a session's first user_input is recorded,
  * the session name should be updated to a truncation of that input.
+ *
+ * CRITICAL: Every SessionManager instance MUST use a temp stateFilePath.
+ * Without it, tests write to real ~/.chroxy/session-state.json, contaminating
+ * the user's server with test data (see #4633, #2314).
  */
+
+let _globalTmpDir
+function tmpStateFile() {
+  if (!_globalTmpDir) _globalTmpDir = mkdtempSync(join(tmpdir(), 'sm-auto-label-'))
+  return join(_globalTmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_globalTmpDir) rmSync(_globalTmpDir, { recursive: true, force: true })
+})
 
 function makeMockSession(overrides = {}) {
   const session = new EventEmitter()
@@ -20,7 +37,7 @@ describe('SessionManager auto-labeling', () => {
   let mgr
 
   beforeEach(() => {
-    mgr = new SessionManager({ skipPreflight: true, maxSessions: 5 })
+    mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
   })
 
   it('auto-renames session on first user_input when name matches default pattern', () => {

--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -22,9 +22,14 @@ function createTempGitRepo() {
 describe('CheckpointManager', () => {
   let manager
   let gitDir
+  let tmpCheckpointsDir
 
   beforeEach(() => {
-    manager = new CheckpointManager()
+    // Pass a tmp checkpointsDir so the manager doesn't write to the
+    // developer's real ~/.chroxy/checkpoints/ (sandbox guard in
+    // tests/_setup.mjs blocks it; see #4633).
+    tmpCheckpointsDir = mkdtempSync(join(tmpdir(), 'chroxy-cp-state-'))
+    manager = new CheckpointManager({ checkpointsDir: tmpCheckpointsDir })
     // Clear any persisted state from prior tests
     manager.clearCheckpoints('sess-1')
     gitDir = createTempGitRepo()
@@ -32,6 +37,7 @@ describe('CheckpointManager', () => {
 
   afterEach(() => {
     rmSync(gitDir, { recursive: true, force: true })
+    try { rmSync(tmpCheckpointsDir, { recursive: true, force: true }) } catch {}
   })
 
   it('creates a checkpoint with metadata', async () => {

--- a/packages/server/tests/session-manager-delta-limit.test.js
+++ b/packages/server/tests/session-manager-delta-limit.test.js
@@ -1,12 +1,28 @@
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it, beforeEach, after } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { SessionManager } from '../src/session-manager.js'
 import { EventEmitter } from 'events'
 
 /**
  * Tests for stream delta size limit (issue #2146).
  * Prevents OOM from malicious clients sending unbounded stream_delta data.
+ *
+ * CRITICAL: Every SessionManager instance MUST use a temp stateFilePath.
+ * Without it, tests write to real ~/.chroxy/session-state.json (see #4633).
  */
+
+let _globalTmpDir
+function tmpStateFile() {
+  if (!_globalTmpDir) _globalTmpDir = mkdtempSync(join(tmpdir(), 'sm-delta-limit-'))
+  return join(_globalTmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_globalTmpDir) rmSync(_globalTmpDir, { recursive: true, force: true })
+})
 
 function createFakeSession() {
   const session = new EventEmitter()
@@ -16,7 +32,7 @@ function createFakeSession() {
 }
 
 function setupManager() {
-  const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5 })
+  const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
   const session = createFakeSession()
   const sessionId = 'test-session-1'
   mgr._sessions.set(sessionId, { session, name: 'Test', cwd: '/tmp', createdAt: Date.now() })

--- a/packages/server/tests/session-manager-history-error.test.js
+++ b/packages/server/tests/session-manager-history-error.test.js
@@ -1,5 +1,8 @@
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it, beforeEach, after } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { EventEmitter } from 'node:events'
 import { SessionManager } from '../src/session-manager.js'
 
@@ -9,7 +12,20 @@ import { SessionManager } from '../src/session-manager.js'
  * When the JSONL read path throws (corrupt data, disk error, null cwd),
  * getFullHistoryAsync() must catch the error and fall back to the ring buffer
  * instead of propagating the rejection to callers.
+ *
+ * CRITICAL: Every SessionManager instance MUST use a temp stateFilePath.
+ * Without it, tests write to real ~/.chroxy/session-state.json (see #4633).
  */
+
+let _globalTmpDir
+function tmpStateFile() {
+  if (!_globalTmpDir) _globalTmpDir = mkdtempSync(join(tmpdir(), 'sm-history-error-'))
+  return join(_globalTmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_globalTmpDir) rmSync(_globalTmpDir, { recursive: true, force: true })
+})
 
 function createFakeSession({ resumeSessionId = null } = {}) {
   const session = new EventEmitter()
@@ -25,7 +41,7 @@ describe('getFullHistoryAsync error handling', () => {
   let mgr
 
   beforeEach(() => {
-    mgr = new SessionManager({ skipPreflight: true, maxSessions: 5 })
+    mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
   })
 
   it('falls back to ring buffer when JSONL path resolution throws', async () => {

--- a/packages/server/tests/supervisor-rollback-circuit-breaker.test.js
+++ b/packages/server/tests/supervisor-rollback-circuit-breaker.test.js
@@ -1,4 +1,4 @@
-import { describe, it, afterEach, mock } from 'node:test'
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert'
 import { EventEmitter } from 'events'
 import { mkdtempSync, rmSync } from 'fs'
@@ -90,6 +90,18 @@ function createTestSupervisor(overrides = {}) {
 describe('Supervisor rollback circuit breaker', () => {
   let tmpDirs = []
   let supervisors = []
+  let savedConfigDir
+
+  beforeEach(() => {
+    // Supervisor.start() calls writeConnectionInfo() which writes to
+    // ~/.chroxy/connection.json unless CHROXY_CONFIG_DIR is set (#4633).
+    // Point it at a tmp dir so the sandbox guard doesn't fire and the
+    // developer's real connection.json isn't clobbered.
+    const cfgDir = mkdtempSync(join(tmpdir(), 'chroxy-supervisor-cb-cfg-'))
+    tmpDirs.push(cfgDir)
+    savedConfigDir = process.env.CHROXY_CONFIG_DIR
+    process.env.CHROXY_CONFIG_DIR = cfgDir
+  })
 
   afterEach(() => {
     for (const s of supervisors) {
@@ -103,6 +115,8 @@ describe('Supervisor rollback circuit breaker', () => {
       try { rmSync(dir, { recursive: true, force: true }) } catch {}
     }
     tmpDirs = []
+    if (savedConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+    else process.env.CHROXY_CONFIG_DIR = savedConfigDir
   })
 
   function setup(overrides) {

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -1,4 +1,4 @@
-import { describe, it, afterEach, mock } from 'node:test'
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert'
 import { EventEmitter } from 'events'
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs'
@@ -128,6 +128,18 @@ function createTestSupervisor(overrides = {}) {
 describe('Supervisor', () => {
   let tmpDirs = []
   let supervisors = []
+  let savedConfigDir
+
+  beforeEach(() => {
+    // Supervisor.start() calls writeConnectionInfo() which writes to
+    // ~/.chroxy/connection.json unless CHROXY_CONFIG_DIR is set (#4633).
+    // Point it at a tmp dir so the sandbox guard doesn't fire and the
+    // developer's real connection.json isn't clobbered.
+    const cfgDir = mkdtempSync(join(tmpdir(), 'chroxy-supervisor-cfg-'))
+    tmpDirs.push(cfgDir)
+    savedConfigDir = process.env.CHROXY_CONFIG_DIR
+    process.env.CHROXY_CONFIG_DIR = cfgDir
+  })
 
   afterEach(() => {
     // Force all supervisors into shutdown state to prevent lingering timers
@@ -141,6 +153,8 @@ describe('Supervisor', () => {
       try { rmSync(dir, { recursive: true, force: true }) } catch {}
     }
     tmpDirs = []
+    if (savedConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+    else process.env.CHROXY_CONFIG_DIR = savedConfigDir
   })
 
   function setup(overrides) {


### PR DESCRIPTION
Closes #4633.

## Summary

Tests that constructed `SessionManager` without an explicit `stateFilePath` silently wrote to the developer's real `~/.chroxy/session-state.json` — the 2026-05-30 incident wiped two live sessions. Same bug class also clobbered `~/.chroxy/checkpoints/` and `~/.chroxy/connection.json` via supervisor / checkpoint-manager defaults.

This PR locks the bug class out with defence in depth (test-only — no production code touched).

## What changed

- **`packages/server/tests/_setup.mjs` (new)** — Sandbox guard loaded via `node --import` for every test process. Monkey-patches the write-side of `fs` (`writeFileSync`, `appendFileSync`, `renameSync`, `mkdirSync`, `createWriteStream`, `openSync` in write modes; plus the `fs.promises` equivalents) to throw `CHROXY_TEST_SANDBOX` if any path resolves under the real `~/.chroxy/` or `~/.claude/` tree. The error includes the call site so the next bare `new SessionManager()` fails loudly at the offending test. Read-side fs is untouched so `providers.test.js` OAuth detection and friends keep working. Tests that mutate `process.env.HOME` for their own purposes are unaffected — the guard pins the *real* home recorded at process startup.

- **`packages/server/scripts/lint-tests-state-file-path.{mjs,sh}` (new)** + CI step in `server-lint` — Fails the build if any `new SessionManager(...)` in `tests/` is missing `stateFilePath`. The Node-based linter handles multi-line constructor calls and skips comments.

- **Fixed the 3 known offenders** called out in the issue (`auto-label.test.js`, `session-manager-delta-limit.test.js`, `session-manager-history-error.test.js`) — each now uses its own `tmpStateFile()` helper, matching the pattern in `session-manager.test.js`.

- **Fixed `supervisor.test.js` + `supervisor-rollback-circuit-breaker.test.js`** — caught by the guard writing to the real `~/.chroxy/connection.json` via `Supervisor.start() → writeConnectionInfo()`. Both now set `process.env.CHROXY_CONFIG_DIR` to a tmp dir in `beforeEach` and restore it in `afterEach`.

- **`CLAUDE.md`** — documented the rule under a new "Testing Conventions" section so future contributors find the guard before it bites them.

## Approach notes

The issue listed three approaches; this PR uses (c) sandbox guard + (b) `stateFilePath` audit. The (a) HOME-override approach was attempted first but caused 11 unrelated failures in `handler-utils.test.js` / `environment-handlers.test.js` / `list-files.test.js` / `ws-handler-coverage.test.js` — they pass real `homedir()` / `process.cwd()` paths to validation helpers that compare against the live `os.homedir()`, and rerouting HOME up-front broke them in ways unrelated to the bug class we're fixing. Keeping HOME pristine and relying purely on the loud-fail guard catches every contamination path (verified by intentionally reverting the supervisor fix and watching the guard fire) without the unrelated breakage.

## Test plan

- [x] Ran `npm test` from `packages/server` — 6310 pass, 6 pre-existing local-environment failures (real chroxy server running on default port, no cloudflared, newer-than-test claude CLI version) all green on main CI.
- [x] `~/.chroxy/session-state.json` mtime unchanged across multiple full test runs.
- [x] Verified the guard fires on a bare `new SessionManager()` by running the constructor in `--input-type=module` mode and confirming `CAUGHT: CHROXY_TEST_SANDBOX`.
- [x] `scripts/lint-tests-state-file-path.sh` reports OK on the current tree.