### PR TITLE
perf(server): rate-limit respondToQuestion PTY hex dump (#4693)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1922,7 +1922,28 @@ export class ClaudeTuiSession extends BaseSession {
     // tells us exactly what the TUI was showing when our keystroke
     // landed — single-keystroke wedges almost always come from a form
     // misalignment that's visible in the trailing render bytes.
-    log.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
+    //
+    // #4693: rate-limit to once per turn. The multi-question retry-as-
+    // singles wedge fires 4+ respondToQuestion calls in succession; each
+    // hex dump is ~70 lines (1024 bytes formatted 16/line + header), so an
+    // unbounded emission pumps 280+ lines of diagnostic per affected turn.
+    // We stash the emission flag on the active turn object so it resets
+    // automatically on every new sendMessage() (which allocates a fresh
+    // `_activeTurn`). Subsequent answers in the same turn emit a compact
+    // one-line skip notice carrying the tool ids so a log reader can still
+    // grep all answer-write events without scanning past 200+ hex lines.
+    const turn = this._activeTurn
+    if (turn && !turn.hexDumpEmitted) {
+      log.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
+      turn.hexDumpEmitted = true
+    } else if (turn) {
+      log.info(`respondToQuestion PTY tail hex dump skipped (tool=${prevToolUseId || '?'}) — already emitted for turn msg=${turn.messageId || '?'}`)
+    } else {
+      // No active turn (defensive — tests that drive respondToQuestion
+      // directly without sendMessage(), late watchdog teardown races).
+      // Emit the dump so the diagnostic is still useful in those paths.
+      log.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
+    }
 
     const armWatchdog = () => {
       // #4604: arm a stall watchdog. If claude TUI never emits PostToolUse

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2648,6 +2648,72 @@ describe('ClaudeTuiSession', () => {
       session._handleHardTimeout()
       assert.equal(session._pendingUserAnswer, null, 'hard timeout clears pending answer')
     })
+
+    // #4693 — the diagnostic added in #4687 (PTY tail hex dump before each
+    // answer write) is unbounded per-turn: a multi-question retry-as-singles
+    // wedge can fire 4+ respondToQuestion calls in succession, each pumping
+    // ~70 hex-dump lines into chroxy.log. Rate-limit to once per turn — the
+    // first answer write still captures the diagnostic; subsequent writes
+    // in the same turn emit a compact one-line skip notice instead of the
+    // full dump.
+    it('respondToQuestion PTY tail hex dump is rate-limited to once per turn (#4693)', async () => {
+      const hexDumpLines = []
+      const skipLines = []
+      const logSpy = (entry) => {
+        if (entry.component !== 'claude-tui-session') return
+        if (entry.level !== 'info') return
+        if (/respondToQuestion PTY tail before write/.test(entry.message)) hexDumpLines.push(entry.message)
+        if (/respondToQuestion PTY tail hex dump skipped/.test(entry.message)) skipLines.push(entry.message)
+      }
+      addLogListener(logSpy)
+      try {
+        session._term = { write: () => {}, kill: () => {} }
+        // Mark a single active turn so the rate-limiter has a stable scope.
+        session._activeTurn = { messageId: 'msg-hex-rate', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+
+        // Three sibling AskUserQuestion tool_uses in the SAME turn (mirrors
+        // the multi-question retry-as-singles wedge that motivated #4693).
+        for (const id of ['toolu_one', 'toolu_two', 'toolu_three']) {
+          session._emitToolHookEvent('PreToolUse', {
+            tool_use_id: id,
+            tool_name: 'AskUserQuestion',
+            tool_input: { questions: [{ question: 'Q?', options: [{ label: 'A' }, { label: 'B' }] }] },
+          }, 'msg-hex-rate')
+        }
+
+        // Dashboard answers all three in quick succession.
+        session.respondToQuestion('A', undefined, 'toolu_one')
+        session.respondToQuestion('B', undefined, 'toolu_two')
+        session.respondToQuestion('A', undefined, 'toolu_three')
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        assert.equal(
+          hexDumpLines.length, 1,
+          `expected exactly 1 hex dump for 3 same-turn answers, got ${hexDumpLines.length}: ${JSON.stringify(hexDumpLines.map((l) => l.split('\n')[0]))}`,
+        )
+        assert.equal(
+          skipLines.length, 2,
+          `expected 2 compact skip notices for the rate-limited calls, got ${skipLines.length}`,
+        )
+
+        // After a new turn starts, the next answer emits a fresh hex dump.
+        hexDumpLines.length = 0
+        skipLines.length = 0
+        session._activeTurn = { messageId: 'msg-hex-rate-2', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+        session._emitToolHookEvent('PreToolUse', {
+          tool_use_id: 'toolu_turn2',
+          tool_name: 'AskUserQuestion',
+          tool_input: { questions: [{ question: 'Q?', options: [{ label: 'A' }] }] },
+        }, 'msg-hex-rate-2')
+        session.respondToQuestion('A', undefined, 'toolu_turn2')
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        assert.equal(hexDumpLines.length, 1, 'new turn resets the rate-limit; first answer emits the dump again')
+        assert.equal(skipLines.length, 0, 'no skip notice on the first answer of a new turn')
+      } finally {
+        removeLogListener(logSpy)
+      }
+    })
   })
 
   // #4604 — observability + watchdog around AskUserQuestion. The root


### PR DESCRIPTION
## Summary

- Rate-limit the PTY tail hex dump added in #4687 to once per turn — first answer of the turn captures the full ~70-line dump, subsequent answers emit a compact one-line skip notice carrying the toolUseId.
- Multi-question retry-as-singles wedge previously pumped 280+ lines per affected turn into chroxy.log; now bounded to ~70 lines plus N-1 skip notices.
- State stashed on `_activeTurn.hexDumpEmitted` so it resets automatically on every `sendMessage()` (fresh `_activeTurn` allocation). Defensive: when `_activeTurn` is null (test paths, late watchdog teardown races) the dump still emits so the diagnostic remains useful.

The diagnostic itself is preserved — first repro per turn still captures the form-misalignment evidence #4687 needs.

Closes #4693

## Test plan

- [x] New test `respondToQuestion PTY tail hex dump is rate-limited to once per turn (#4693)` — drives 3 sibling AskUserQuestion answers in one turn, asserts exactly 1 hex dump + 2 skip notices, then asserts a new turn re-emits the dump.
- [x] Confirmed failing before the fix (3 dumps logged); passing after.
- [x] Full `tests/claude-tui-session.test.js` suite green: 134/134.