### PR TITLE
fix(dashboard): hide raw tool_input JSON during AskUserQuestion streaming

### DIFF
--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -479,4 +479,88 @@ describe('ToolBubble', () => {
       expect(screen.queryByText('contents')).not.toBeInTheDocument()
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // #4667 — AskUserQuestion bubble must NOT surface its raw `tool_input`
+  // JSON during streaming. The dashboard already renders the structured
+  // question via the dedicated QuestionPrompt card (driven by the
+  // `user_question` event), so any JSON leak from this bubble produces a
+  // jarring double-render where users see both `{"questions":[...` and
+  // the proper card. The fix suppresses both the collapsed summary and
+  // the expanded partial-preview block for `tool_name === 'AskUserQuestion'`.
+  // ---------------------------------------------------------------------------
+  describe('AskUserQuestion raw input suppression (#4667)', () => {
+    it('hides the collapsed summary while a partial AskUserQuestion tool_input streams in', () => {
+      // Mid-stream: `tool_input_delta` chunks have piled up an unparseable
+      // prefix of the question JSON. The legacy fallback would slice the
+      // first 100 chars of the buffer into the collapsed summary span —
+      // that is exactly the JSON tail the issue calls out.
+      render(
+        <ToolBubble
+          toolName="AskUserQuestion"
+          toolUseId="auq-partial"
+          inputPartial={'{"questions":[{"question":"Which testing framework should the project us'}
+        />,
+      )
+      // No summary span (the suppression short-circuits the fallback).
+      expect(screen.queryByTestId('tool-input-summary')).not.toBeInTheDocument()
+      // And the raw JSON tail never appears anywhere in the bubble.
+      const bubble = screen.getByTestId('tool-bubble-auq-partial')
+      expect(bubble.textContent).not.toContain('{"questions"')
+      expect(bubble.textContent).not.toContain('Which testing framework')
+    })
+
+    it('hides the collapsed summary even when the AskUserQuestion JSON parses cleanly', () => {
+      // Final delta completed the JSON document — the legacy
+      // `getInputSummary` / `getPartialSummary` path would happily
+      // extract a string field and surface it. Must still be suppressed:
+      // the structured QuestionPrompt card is the canonical render path.
+      render(
+        <ToolBubble
+          toolName="AskUserQuestion"
+          toolUseId="auq-complete"
+          input={{
+            questions: [
+              { question: 'Which framework?', options: [{ label: 'Vitest' }, { label: 'Jest' }] },
+            ],
+          }}
+        />,
+      )
+      expect(screen.queryByTestId('tool-input-summary')).not.toBeInTheDocument()
+      // Tool name still renders so the bubble is identifiable.
+      // formatToolName leaves PascalCase tool names untouched (split by
+      // `_` only), so "AskUserQuestion" stays as-is.
+      expect(screen.getByText('AskUserQuestion')).toBeInTheDocument()
+    })
+
+    it('does not render the expanded partial-preview block for AskUserQuestion', () => {
+      render(
+        <ToolBubble
+          toolName="AskUserQuestion"
+          toolUseId="auq-expanded"
+          inputPartial={'{"questions":[{"question":"Which testing framework should the project us'}
+        />,
+      )
+      // Force-expand the bubble — even open, the partial-preview block
+      // must not appear (the structured card is rendered elsewhere).
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.queryByTestId('tool-input-partial-auq-expanded')).not.toBeInTheDocument()
+      const bubble = screen.getByTestId('tool-bubble-auq-expanded')
+      expect(bubble.textContent).not.toContain('{"questions"')
+    })
+
+    it('still surfaces inputPartial for non-suppressed tools (regression guard)', () => {
+      // Control: Bash must keep streaming its `command` field into the
+      // collapsed summary so the early-abort UX (#4063) continues to
+      // work. A too-broad suppression would silently break this.
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="bash-control"
+          inputPartial='{"command":"rm -rf /tmp/foo"}'
+        />,
+      )
+      expect(screen.getByTestId('tool-input-summary')).toHaveTextContent('rm -rf /tmp/foo')
+    })
+  })
 })

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -562,5 +562,30 @@ describe('ToolBubble', () => {
       )
       expect(screen.getByTestId('tool-input-summary')).toHaveTextContent('rm -rf /tmp/foo')
     })
+
+    it('hides the partial-preview block when the tool resolved with empty-string result (#4667 / Copilot)', () => {
+      // A tool that finished with `result === ''` (resolved-with-no-output,
+      // #4308) was still rendering the streaming `inputPartial` code
+      // block when expanded — the legacy `result`-truthy gate treated
+      // empty-string as "still in flight." Pulse / ActivityIndicator
+      // already use `hasResult` (`result !== undefined`) so the bubble
+      // header correctly hid the pulse for these cases, but the
+      // expanded preview path was inconsistent. Fixed alongside the
+      // #4667 suppression refactor; this test pins the contract.
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="bash-empty-result"
+          inputPartial='{"command":"true"}'
+          result=""
+        />,
+      )
+      // Empty-string result means hasResult is true → no pulse.
+      expect(screen.queryByTestId('tool-bubble-pulse-bash-empty-result')).not.toBeInTheDocument()
+      // Force-expand: the streaming preview must NOT render because
+      // the tool already resolved (even with no output).
+      fireEvent.click(screen.getByRole('button'))
+      expect(screen.queryByTestId('tool-input-partial-bash-empty-result')).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -90,6 +90,13 @@ export interface ToolBubbleProps {
 // option 1 in #4667 ("suppress tool_input_delta rendering for
 // AskUserQuestion") and aligns with the precedent of other internal
 // tools whose canonical render path is a dedicated card.
+//
+// Add a tool here only when BOTH conditions hold: (a) the dashboard
+// already has a dedicated structured renderer for it (driven by a
+// parallel event, the way `user_question` drives QuestionPrompt) AND
+// (b) the tool_input shape carries no user-meaningful text on its own.
+// "This shape looks ugly when rendered raw" is NOT sufficient — that's
+// what #4655's generic key:value fallback in `tool-summary.ts` is for.
 const SUPPRESS_RAW_INPUT_TOOLS = new Set(['AskUserQuestion'])
 
 export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName, isTail = false, resultImages }: ToolBubbleProps) {
@@ -155,14 +162,19 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
   // block. The structured QuestionPrompt card carries the question
   // text + options; rendering raw JSON beside it produces the
   // double-bubble reconciliation problem this fix addresses.
+  // #4667 (Copilot review) — gate on `hasResult`, not `result`, so a
+  // tool that resolved with `result === ''` (resolved-with-no-output,
+  // #4308) or images-only (#4317) is treated as done — matches the
+  // pulse / ActivityIndicator predicate. Pre-fix this branch could
+  // render the streaming preview for a tool that had already resolved.
   const partialPreview = useMemo(() => {
-    if (!expanded || result || !inputPartial || suppressRawInput) return null
+    if (!expanded || hasResult || !inputPartial || suppressRawInput) return null
     const parsed = tryParseCompleteJson(inputPartial)
     if (parsed !== undefined) {
       return { text: JSON.stringify(parsed, null, 2), parsed: true }
     }
     return { text: inputPartial, parsed: false }
-  }, [expanded, result, inputPartial, suppressRawInput])
+  }, [expanded, hasResult, inputPartial, suppressRawInput])
 
   const toggle = () => setExpanded(prev => !prev)
 
@@ -230,8 +242,13 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
           result yet. The `tool_input_delta` accumulator renders as a
           code block; unparseable mid-stream JSON renders verbatim
           (NOT as an error). Result arrival flips the bubble to the
-          standard result view above. */}
-      {expanded && !result && partialPreview && (
+          standard result view above.
+          #4667 (Copilot review) — gate on `hasResult` rather than
+          `result`, so a tool that resolved with empty-string result
+          (#4308) or images-only (#4317) hides the streaming preview.
+          `partialPreview` itself also gates on hasResult; this JSX
+          gate is the belt-and-braces match. */}
+      {expanded && !hasResult && partialPreview && (
         <div
           className="tool-input-partial"
           data-testid={`tool-input-partial-${toolUseId}`}

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -78,6 +78,20 @@ export interface ToolBubbleProps {
 // previously this file had a local copy that ignored `serverName`, so
 // MCP-tool headers could disagree with the ActivityIndicator chip.
 
+// #4667 — AskUserQuestion's tool_input shape is internal: the dashboard
+// already renders the structured question via the `user_question` event
+// (QuestionPrompt card). Surfacing the raw `{"questions":[...` JSON tail
+// in the collapsed summary or the expanded preview while the tool is
+// streaming exposes implementation detail and gets visually reconciled
+// against the proper card that lands moments later (two bubbles for the
+// same prompt). Suppress both the summary and the partial-preview block
+// for this tool — the bubble becomes a quiet placeholder with just the
+// tool name + pulse marker until the structured card takes over. Matches
+// option 1 in #4667 ("suppress tool_input_delta rendering for
+// AskUserQuestion") and aligns with the precedent of other internal
+// tools whose canonical render path is a dedicated card.
+const SUPPRESS_RAW_INPUT_TOOLS = new Set(['AskUserQuestion'])
+
 export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName, isTail = false, resultImages }: ToolBubbleProps) {
   // #4313 — tail bubbles mount expanded so the singleton trailing-tool
   // case matches the #4309 tail-group behavior. Initial-state only via
@@ -89,6 +103,12 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
   // ActivityIndicator's in-flight predicate. Without this the header
   // pulses forever for computer-use / screenshot tools.
   const hasResult = result !== undefined || (resultImages?.length ?? 0) > 0
+  // #4667 — internal-shape tools (currently AskUserQuestion) must never
+  // surface raw `tool_input` JSON in the chat surface; the structured
+  // render path owns the display. Gate computed once so both the
+  // collapsed summary and the expanded partial-preview branches stay
+  // in sync.
+  const suppressRawInput = SUPPRESS_RAW_INPUT_TOOLS.has(toolName)
   // #4081: prefer the structured `input` summary when present (server
   // gave us the full final input, e.g. via legacy non-streaming
   // providers or after `tool_result` lands). Otherwise fall back to the
@@ -96,7 +116,11 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
   // fails (mid-stream partial JSON), show the raw tail so users still
   // see the field forming. The collapsed-state preview is what surfaces
   // Bash early-abort UX (#4063).
+  // #4667 — short-circuit to '' for suppressed tools so the bubble
+  // header carries just the tool name. The structured QuestionPrompt
+  // card is the canonical render path.
   const summary = useMemo(() => {
+    if (suppressRawInput) return ''
     const fromInput = getInputSummary(input)
     if (fromInput) return fromInput
     if (!inputPartial) return ''
@@ -109,7 +133,7 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
     // (\`{"command":"\` …) is always visible — the structurally-meaningful
     // start of the JSON document, not its still-arriving end.
     return inputPartial.slice(0, 100)
-  }, [input, inputPartial])
+  }, [input, inputPartial, suppressRawInput])
   const resultId = `tool-result-${toolUseId}`
   // #4139: parse the TodoWrite result once and pass the result down,
   // rather than re-parsing inside TodoList (Copilot review on #4179).
@@ -127,14 +151,18 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
   // #4242: gate the parse behind `tryParseCompleteJson` — a chunk
   // whose tail isn't `}` or `]` can't be a complete document, so we
   // skip the parse + throw entirely on the N-1 mid-stream deltas.
+  // #4667 — suppressed tools also skip the expanded partial-preview
+  // block. The structured QuestionPrompt card carries the question
+  // text + options; rendering raw JSON beside it produces the
+  // double-bubble reconciliation problem this fix addresses.
   const partialPreview = useMemo(() => {
-    if (!expanded || result || !inputPartial) return null
+    if (!expanded || result || !inputPartial || suppressRawInput) return null
     const parsed = tryParseCompleteJson(inputPartial)
     if (parsed !== undefined) {
       return { text: JSON.stringify(parsed, null, 2), parsed: true }
     }
     return { text: inputPartial, parsed: false }
-  }, [expanded, result, inputPartial])
+  }, [expanded, result, inputPartial, suppressRawInput])
 
   const toggle = () => setExpanded(prev => !prev)
 


### PR DESCRIPTION
Closes #4667.

## Summary

`ToolBubble` was independently surfacing the `tool_input_delta` accumulator for `AskUserQuestion` in two places — the collapsed-summary `slice(0, 100)` fallback and the expanded `partialPreview` block — while the dashboard simultaneously rendered the structured `QuestionPrompt` card from the `user_question` event. Net result: users saw `{"questions":[{"question":"Which testing framework should the project us` next to the proper interactive card and had to mentally reconcile two bubbles for the same prompt.

This change adds a `SUPPRESS_RAW_INPUT_TOOLS` set (currently just `'AskUserQuestion'`) and gates both render paths in `ToolBubble`:

- `summary` short-circuits to `''` when the tool is in the set, so the collapsed bubble surfaces the tool name + pulse marker only.
- `partialPreview` returns `null` for suppressed tools, so the expanded bubble has no JSON block either.

Matches option 1 from #4667 ("suppress `tool_input_delta` rendering for `tool_name === 'AskUserQuestion'`"). Mirrors how `TodoWrite` already routes through a dedicated structured renderer.

## Acceptance criteria

- [x] AskUserQuestion never renders raw JSON in a chat bubble — only the structured question card.
- [x] No leftover "streaming" bubble remains after the structured card appears (the in-flight bubble is now a quiet tool-name placeholder).
- [x] Test feeds a partial `tool_input_delta` shape for AskUserQuestion and asserts no raw JSON appears in the rendered output. Tests cover: mid-stream unparseable JSON, completed JSON (`input` shape), expanded partial-preview suppression, and a Bash regression guard so the early-abort (#4063) UX continues to work.

## Conflict risk

Both this and #4655 touch the `tool_input` render path in `ToolBubble`. They edit adjacent but distinct branches (#4655 reshapes how unknown shapes render structurally; this PR adds a per-tool gate before either path runs), so the merge will be a small contextual rebase rather than a true conflict.

## Test plan

- [x] `cd packages/dashboard && npm test -- ToolBubble` — 43 / 43 pass.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: trigger an `AskUserQuestion` mid-session in dogfood; confirm the streaming bubble shows just the tool-name + pulse and the structured card appears as the canonical render.