### PR TITLE
fix(dashboard): collapse unknown tool_input shapes instead of leaking raw JSON

### DIFF
--- a/packages/app/src/components/__tests__/ToolBubblePartialSummary.test.tsx
+++ b/packages/app/src/components/__tests__/ToolBubblePartialSummary.test.tsx
@@ -110,15 +110,21 @@ describe('ToolBubble collapsed preview — partial-input field priority (#4243)'
       expect(getCollapsedPreview(root)).toBe('do the thing');
     });
 
-    it('falls back to the raw pretty-printed JSON when partial has no priority field', () => {
-      // No command/file_path/path/description — preserve legacy behaviour
-      // so the user still sees what fields are forming.
+    it('renders compact key:value summary when partial has no priority field (#4655)', () => {
+      // No command/file_path/path/description — pre-#4655 this fell
+      // through to raw JSON head (`{"foo":"bar","baz":"qux"}`). The
+      // generic-fallback summary in `tool-summary.ts` now renders a
+      // compact key:value listing so unknown-shape tools (ToolSearch,
+      // MCP tools, custom user tools) never leak raw JSON.
       const root = renderBubble(makeToolMessage({
         toolInputPartial: '{"foo":"bar","baz":"qux"}',
       }));
       const preview = getCollapsedPreview(root);
-      expect(preview).toMatch(/"foo"/);
-      expect(preview).toMatch(/"bar"/);
+      // Compact key:value form — value strings are quoted, keys are not.
+      expect(preview).toContain('foo: "bar"');
+      expect(preview).toContain('baz: "qux"');
+      // The raw JSON object brace must NEVER appear in the collapsed bubble.
+      expect(preview).not.toContain('{"foo"');
     });
   });
 
@@ -152,13 +158,18 @@ describe('ToolBubble collapsed preview — partial-input field priority (#4243)'
       expect(getCollapsedPreview(root)).toBe('plain text input that should pass through unchanged');
     });
 
-    it('falls back to legacy truncated content when content JSON has no priority fields', () => {
+    it('renders compact key:value summary when content JSON has no priority fields (#4655)', () => {
+      // Pre-#4655: the legacy fallback showed the raw JSON head
+      // (`{"foo":"bar","baz":"qux"}`). The generic-fallback summary
+      // now renders compact key:value form so unknown-shape tools
+      // (ToolSearch, MCP, etc.) never leak raw JSON.
       const root = renderBubble(makeToolMessage({
         content: JSON.stringify({ foo: 'bar', baz: 'qux' }),
       }));
       const preview = getCollapsedPreview(root);
-      // No priority field → no extraction → show the raw JSON head.
-      expect(preview).toMatch(/"foo"/);
+      expect(preview).toContain('foo: "bar"');
+      expect(preview).toContain('baz: "qux"');
+      expect(preview).not.toContain('{"foo"');
     });
 
     it('truncates extracted summaries longer than 60 chars with the legacy ellipsis', () => {
@@ -194,6 +205,50 @@ describe('ToolBubble collapsed preview — partial-input field priority (#4243)'
         toolInputPartial: '{"command":"streaming-stale"}',
       }));
       expect(getCollapsedPreview(root)).toBe('final-cmd');
+    });
+  });
+
+  // #4655 — collapsed bubbles must never leak raw `tool_input` JSON for
+  // tools whose input shape has none of the hardcoded PRIORITY_FIELDS
+  // (ToolSearch, MCP tools, custom user tools, future Anthropic tools).
+  // The fix lives in `tool-summary.ts` (generic key:value fallback);
+  // these fixtures pin the mobile contract so iOS/Android stay in lock-
+  // step with the dashboard.
+  describe('unknown-shape tool_input never leaks raw JSON (#4655)', () => {
+    it('renders ToolSearch input as compact key:value summary instead of raw JSON', () => {
+      // Canonical bug fixture — reported live during v0.9.24 dogfood.
+      const root = renderBubble(makeToolMessage({
+        tool: 'ToolSearch',
+        content: 'ToolSearch',
+        toolInputPartial: '{"query":"select:AskUserQuestion","max_results":5}',
+      }));
+      const preview = getCollapsedPreview(root);
+      expect(preview).toContain('query: "select:AskUserQuestion"');
+      expect(preview).toContain('max_results: 5');
+      expect(preview).not.toContain('{"query"');
+    });
+
+    it('renders MCP tool input with arbitrary keys as compact summary', () => {
+      // MCP tools have per-server schemas — no allowlist can keep up.
+      const root = renderBubble(makeToolMessage({
+        tool: 'mcp__fs__read_file',
+        content: JSON.stringify({ url: 'https://example.com', timeout_ms: 5000 }),
+      }));
+      const preview = getCollapsedPreview(root);
+      expect(preview).toContain('url: "https://example.com"');
+      expect(preview).toContain('timeout_ms: 5000');
+      expect(preview).not.toContain('{"url"');
+    });
+
+    it('collapses nested object values to `{...}` placeholders, never raw JSON', () => {
+      const root = renderBubble(makeToolMessage({
+        tool: 'custom_tool',
+        content: JSON.stringify({ options: { recursive: true }, name: 'scan' }),
+      }));
+      const preview = getCollapsedPreview(root);
+      expect(preview).toContain('options: {...}');
+      expect(preview).toContain('name: "scan"');
+      expect(preview).not.toContain('"recursive"');
     });
   });
 });

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -586,6 +586,9 @@ describe('ToolBubble', () => {
       // the tool already resolved (even with no output).
       fireEvent.click(screen.getByRole('button'))
       expect(screen.queryByTestId('tool-input-partial-bash-empty-result')).not.toBeInTheDocument()
+    })
+  })
+
   // #4655 — collapsed bubbles must never leak raw `tool_input` JSON for tools
   // whose input shape has none of the hardcoded PRIORITY_FIELDS (ToolSearch,
   // MCP tools, custom user tools, future Anthropic tools). The fix lives in

--- a/packages/dashboard/src/components/ToolBubble.test.tsx
+++ b/packages/dashboard/src/components/ToolBubble.test.tsx
@@ -586,6 +586,137 @@ describe('ToolBubble', () => {
       // the tool already resolved (even with no output).
       fireEvent.click(screen.getByRole('button'))
       expect(screen.queryByTestId('tool-input-partial-bash-empty-result')).not.toBeInTheDocument()
+  // #4655 — collapsed bubbles must never leak raw `tool_input` JSON for tools
+  // whose input shape has none of the hardcoded PRIORITY_FIELDS (ToolSearch,
+  // MCP tools, custom user tools, future Anthropic tools). The fix lives in
+  // `tool-summary.ts` (generic key:value fallback); these fixtures pin the
+  // dashboard render contract end-to-end so the leak surface stays sealed.
+  //
+  // The canonical bug fixture is ToolSearch — reported live during the
+  // v0.9.24 dogfood as
+  //   `ToolSearch {"matches":["AskUserQuestion"],"query":"select:AskUser...`
+  // (raw JSON head). The fix renders
+  //   `ToolSearch query: "select:AskUserQuestion", max_results: 5`
+  // instead.
+  // ---------------------------------------------------------------------------
+  describe('unknown-shape tool_input never leaks raw JSON (#4655)', () => {
+    it('renders ToolSearch input as a compact key:value summary instead of raw JSON', () => {
+      render(
+        <ToolBubble
+          toolName="ToolSearch"
+          toolUseId="ts-final"
+          input={{ query: 'select:AskUserQuestion', max_results: 5 }}
+          result="matched 1 tool"
+        />,
+      )
+      const summary = screen.getByTestId('tool-input-summary')
+      // Compact, key:value form — generic fallback.
+      expect(summary).toHaveTextContent('query: "select:AskUserQuestion", max_results: 5')
+      // The canonical leak: a raw JSON object brace must NEVER appear in the
+      // collapsed summary for any unknown-shape tool input.
+      expect(summary.textContent).not.toContain('{"query"')
+      expect(summary.textContent).not.toContain('"matches"')
+    })
+
+    it('renders MCP tool input with arbitrary keys as compact key:value summary', () => {
+      // MCP tools have per-server schemas — no allowlist can keep up. The
+      // generic fallback is the only sustainable answer.
+      render(
+        <ToolBubble
+          toolName="mcp__fs__list_directory"
+          toolUseId="mcp-final"
+          serverName="fs"
+          input={{ url: 'https://example.com', timeout_ms: 5000 }}
+          result="[]"
+        />,
+      )
+      const summary = screen.getByTestId('tool-input-summary')
+      expect(summary).toHaveTextContent('url: "https://example.com", timeout_ms: 5000')
+      expect(summary.textContent).not.toContain('{"url"')
+    })
+
+    it('renders generic unknown-shape input (no priority field, no recognised structure)', () => {
+      // Catch-all: future tool with totally arbitrary shape. The generic
+      // fallback must still produce a useful preview, never raw JSON.
+      render(
+        <ToolBubble
+          toolName="future_tool"
+          toolUseId="future-final"
+          input={{ foo: 'bar', enabled: true, retries: 3 }}
+          result=""
+        />,
+      )
+      const summary = screen.getByTestId('tool-input-summary')
+      expect(summary).toHaveTextContent('foo: "bar", enabled: true, retries: 3')
+      expect(summary.textContent).not.toContain('{"foo"')
+    })
+
+    it('renders ToolSearch inputPartial as compact summary during streaming (parseable)', () => {
+      // Streaming finished — the partial buffer is now valid JSON but still
+      // lacks a priority field. Pre-fix this fell through to `inputPartial
+      // .slice(0, 100)` and leaked raw JSON head into the collapsed bubble.
+      render(
+        <ToolBubble
+          toolName="ToolSearch"
+          toolUseId="ts-partial"
+          inputPartial='{"query":"select:AskUserQuestion","max_results":5}'
+        />,
+      )
+      const summary = screen.getByTestId('tool-input-summary')
+      expect(summary).toHaveTextContent('query: "select:AskUserQuestion", max_results: 5')
+      expect(summary.textContent).not.toContain('{"query"')
+    })
+
+    it('renders a nested unknown-shape input without leaking nested JSON', () => {
+      // Object-shape value at top level — the canonical worst-case leak
+      // (Read tool nested input was the #4648 case). Generic fallback
+      // collapses nested objects to `{...}` placeholders.
+      render(
+        <ToolBubble
+          toolName="custom_tool"
+          toolUseId="custom-nested"
+          input={{ options: { recursive: true, follow: false }, name: 'scan' }}
+          result="done"
+        />,
+      )
+      const summary = screen.getByTestId('tool-input-summary')
+      expect(summary).toHaveTextContent('options: {...}, name: "scan"')
+      // The nested object's keys must NOT leak as raw JSON.
+      expect(summary.textContent).not.toContain('"recursive"')
+      expect(summary.textContent).not.toContain('"follow"')
+    })
+
+    it('preserves the verbatim mid-stream fallback for genuinely unparseable inputPartial', () => {
+      // Regression guard: the mid-stream Bash early-abort UX (#4063)
+      // depends on the verbatim-tail fallback when the buffer can't yet
+      // parse. The generic fallback only applies to parsed objects.
+      render(
+        <ToolBubble
+          toolName="ToolSearch"
+          toolUseId="ts-midstream"
+          inputPartial='{"query":"select:Ask'
+        />,
+      )
+      const summary = screen.getByTestId('tool-input-summary')
+      // Mid-stream: still shows the verbatim head so users see the
+      // buffer forming.
+      expect(summary.textContent).toContain('{"query":"select:Ask')
+    })
+
+    it('preserves the existing Bash priority-field summary (regression guard)', () => {
+      // Belt-and-braces: a known-shape tool must keep its nice extracted
+      // summary even after the generic-fallback path lands.
+      render(
+        <ToolBubble
+          toolName="Bash"
+          toolUseId="bash-regression"
+          input={{ command: 'rm -rf node_modules' }}
+        />,
+      )
+      const summary = screen.getByTestId('tool-input-summary')
+      expect(summary).toHaveTextContent('rm -rf node_modules')
+      // No generic key:value rendering for known shapes.
+      expect(summary.textContent).not.toContain('command:')
     })
   })
 })

--- a/packages/store-core/src/tool-summary.test.ts
+++ b/packages/store-core/src/tool-summary.test.ts
@@ -35,12 +35,19 @@ describe('getPartialSummary (#4243)', () => {
     expect(getPartialSummary('{"command":"rm -rf ')).toBeNull()
   })
 
-  it('returns null when none of the priority fields are strings', () => {
-    expect(getPartialSummary('{"foo":"bar"}')).toBeNull()
+  // #4655 — these used to return null and let the dashboard render
+  // `inputPartial.slice(0, 100)` (raw JSON head) as the collapsed
+  // preview. Now the generic-summary fallback kicks in so the bubble
+  // never leaks raw JSON for unknown shapes (ToolSearch, MCP tools,
+  // etc.). The priority-field path is still preferred when present.
+  it('falls back to generic key:value summary when no priority field is a string (#4655)', () => {
+    expect(getPartialSummary('{"foo":"bar"}')).toBe('foo: "bar"')
   })
 
-  it('returns null when a priority field is present but not a string', () => {
-    expect(getPartialSummary('{"command":42}')).toBeNull()
+  it('falls back to generic key:value summary when a priority field is present but not a string (#4655)', () => {
+    // The non-string priority field is rendered like any other key —
+    // we no longer special-case it as "missing".
+    expect(getPartialSummary('{"command":42}')).toBe('command: 42')
   })
 
   it('returns null on null / non-object parses', () => {
@@ -120,14 +127,19 @@ describe('nested priority-field walk (#4648 — Read tool input)', () => {
 
   it('nested walk stops at one level (no recursion)', () => {
     // Pathological deep nesting must NOT be walked — bounded preview cost
-    // is load-bearing on hot ToolBubble render path.
+    // is load-bearing on hot ToolBubble render path. #4655: the
+    // generic-fallback now renders the top-level key as `{...}` so
+    // unknown shapes never leak raw JSON; the nested filePath is
+    // intentionally not extracted.
     const deep = { a: { b: { c: { filePath: '/should/not/match' } } } }
-    expect(getInputSummary(deep)).toBe('')
+    expect(getInputSummary(deep)).toBe('a: {...}')
   })
 
   it('nested walk does not descend into arrays', () => {
+    // #4655: same as above — the array renders as `[N]`, never
+    // recursing into its elements to extract a nested filePath.
     const arr = { items: [{ filePath: '/should/not/match' }] }
-    expect(getInputSummary(arr)).toBe('')
+    expect(getInputSummary(arr)).toBe('items: [1]')
   })
 
   it('top-level priority wins over nested priority', () => {
@@ -139,5 +151,105 @@ describe('nested priority-field walk (#4648 — Read tool input)', () => {
   it('nested walk caps at PREVIEW_MAX_LEN like top-level', () => {
     const long = 'z'.repeat(500)
     expect(getInputSummary({ file: { filePath: long } })).toHaveLength(100)
+  })
+})
+
+// #4655 — generic-fallback summary for tools whose input shape has none
+// of the PRIORITY_FIELDS. Pre-fix this fell through to raw JSON head
+// (`{"matches":["AskUser..."],"query":"select:...","total_d...`) in the
+// collapsed bubble — verified live during v0.9.24 dogfood for the
+// ToolSearch tool. The class of bug grows with every new tool shape
+// (MCP tools, custom user tools, future Anthropic tools) — extending
+// PRIORITY_FIELDS per-tool is unbounded maintenance, hence the
+// generic-fallback path.
+describe('generic-fallback summary for unknown tool shapes (#4655)', () => {
+  describe('getInputSummary', () => {
+    it('renders ToolSearch input as compact key:value list', () => {
+      // Real ToolSearch shape — no priority field, two top-level keys.
+      // The collapsed bubble previously leaked the raw JSON head.
+      expect(getInputSummary({ query: 'select:AskUserQuestion', max_results: 5 }))
+        .toBe('query: "select:AskUserQuestion", max_results: 5')
+    })
+
+    it('renders MCP-style input with arbitrary keys as compact key:value list', () => {
+      // MCP tool inputs follow per-server schemas; no allowlist can keep up.
+      expect(getInputSummary({ url: 'https://example.com', timeout_ms: 5000 }))
+        .toBe('url: "https://example.com", timeout_ms: 5000')
+    })
+
+    it('renders boolean and null values inline', () => {
+      // Primitive rendering must cover the JSON value spectrum.
+      expect(getInputSummary({ enabled: true, retries: 0, cursor: null }))
+        .toBe('enabled: true, retries: 0, cursor: null')
+    })
+
+    it('renders nested objects as `{...}` placeholders, never raw JSON', () => {
+      // A nested object in an unknown-shape input is the canonical leak
+      // vector — must NOT inline-render its contents.
+      const out = getInputSummary({ options: { recursive: true, follow: false }, name: 'scan' })
+      expect(out).toBe('options: {...}, name: "scan"')
+      // Defensively pin: no curly brace from a nested object payload should leak.
+      expect(out).not.toContain('"recursive"')
+    })
+
+    it('renders arrays as `[N]` length placeholders', () => {
+      expect(getInputSummary({ items: [1, 2, 3], action: 'sort' }))
+        .toBe('items: [3], action: "sort"')
+    })
+
+    it('truncates long string values inside quotes so structure stays visible', () => {
+      const long = 'a'.repeat(120)
+      const out = getInputSummary({ query: long })
+      // Quoted, truncated to 37 chars + ellipsis inside the quotes.
+      expect(out).toBe(`query: "${'a'.repeat(37)}..."`)
+    })
+
+    it('caps the whole summary at PREVIEW_MAX_LEN (100 chars)', () => {
+      // Many short keys whose combined render exceeds the budget —
+      // later keys must be dropped, not truncated mid-value.
+      const wide: Record<string, unknown> = {}
+      for (let i = 0; i < 30; i++) wide[`k${i}`] = `v${i}`
+      const out = getInputSummary(wide)
+      expect(out.length).toBeLessThanOrEqual(100)
+    })
+
+    it('degrades to key-count summary when the first key:value would overflow', () => {
+      // The first key is itself longer than the budget — fall back to a
+      // plain "N keys: ..." listing so something useful still renders.
+      const longKey = 'x'.repeat(150)
+      const out = getInputSummary({ [longKey]: 'value', a: 1, b: 2 })
+      expect(out.startsWith('3 keys: ')).toBe(true)
+      expect(out.length).toBeLessThanOrEqual(100)
+    })
+
+    it('returns "" for an empty object (no keys to summarize)', () => {
+      expect(getInputSummary({})).toBe('')
+    })
+
+    it('priority field wins over generic fallback even when both could apply', () => {
+      // Regression guard: adding the generic fallback must not displace
+      // the existing field-priority behaviour for known shapes.
+      expect(getInputSummary({ command: 'ls', extra: 'meta' })).toBe('ls')
+    })
+  })
+
+  describe('getPartialSummary', () => {
+    it('renders parseable ToolSearch input via the generic fallback', () => {
+      // The collapsed bubble must never leak raw JSON for unknown shapes —
+      // this is the canonical regression fixture.
+      const json = JSON.stringify({ query: 'select:AskUserQuestion', max_results: 5 })
+      expect(getPartialSummary(json)).toBe('query: "select:AskUserQuestion", max_results: 5')
+    })
+
+    it('still returns null for mid-stream unparseable buffers', () => {
+      // The Bash early-abort UX (#4063) depends on the verbatim-tail
+      // fallback for mid-stream chunks — the generic fallback only
+      // applies to fully-parsed structured objects.
+      expect(getPartialSummary('{"query":"select:')).toBeNull()
+    })
+
+    it('returns null for parseable but empty object (nothing to summarize)', () => {
+      expect(getPartialSummary('{}')).toBeNull()
+    })
   })
 })

--- a/packages/store-core/src/tool-summary.test.ts
+++ b/packages/store-core/src/tool-summary.test.ts
@@ -222,6 +222,55 @@ describe('generic-fallback summary for unknown tool shapes (#4655)', () => {
       expect(out.length).toBeLessThanOrEqual(100)
     })
 
+    it('degrades cleanly without slicing mid-key when the first key name overflows', () => {
+      // Regression guard for Copilot finding on the degradation branch:
+      // a 150-char first key must NOT appear as a sliced partial
+      // identifier. The fallback drops keys that don't fit and emits
+      // only the prefix + any fitting names — never a half-rendered
+      // identifier.
+      const longKey = 'x'.repeat(150)
+      const out = getInputSummary({ [longKey]: 'value', shortA: 1, shortB: 2 })
+      expect(out.startsWith('3 keys: ')).toBe(true)
+      // The over-budget key must NOT appear at all (even partially):
+      // the rest after the prefix may only contain shorter key names
+      // that fit. No `xxxxxxxx...` partial-identifier leaks.
+      expect(out).not.toMatch(/xxxx/)
+      expect(out.length).toBeLessThanOrEqual(100)
+    })
+
+    it('degrades to key-count summary listing only keys that fit within budget', () => {
+      // Long first key, shorter follow-ups — the prefix + shorter keys
+      // should fit, the long key should be dropped entirely.
+      const longKey = 'x'.repeat(150)
+      const out = getInputSummary({ [longKey]: 'value', foo: 1, bar: 2 })
+      // Shorter keys remain visible; long key omitted entirely.
+      expect(out).toContain('foo')
+      expect(out).toContain('bar')
+      expect(out).not.toContain('x')
+    })
+
+    it('escapes embedded quotes in string values so previews stay unambiguous', () => {
+      // Naive `"${value}"` produced ambiguous `"foo "bar" baz"` previews —
+      // route through JSON.stringify so embedded quotes are escaped.
+      expect(getInputSummary({ note: 'foo "bar" baz' }))
+        .toBe('note: "foo \\"bar\\" baz"')
+    })
+
+    it('escapes embedded newlines so collapsed bubbles stay single-line', () => {
+      // A `\n` in the string would otherwise produce a multi-line
+      // collapsed summary and blow the bubble height. JSON.stringify
+      // emits `\\n` (escape sequence), keeping the preview one line.
+      expect(getInputSummary({ note: 'line1\nline2' }))
+        .toBe('note: "line1\\nline2"')
+    })
+
+    it('escapes backslashes in string values', () => {
+      // Use a non-PRIORITY_FIELD key (`win_path`) so we hit the generic
+      // fallback rather than the priority-field path.
+      expect(getInputSummary({ win_path: 'C:\\Users\\foo' }))
+        .toBe('win_path: "C:\\\\Users\\\\foo"')
+    })
+
     it('returns "" for an empty object (no keys to summarize)', () => {
       expect(getInputSummary({})).toBe('')
     })

--- a/packages/store-core/src/tool-summary.ts
+++ b/packages/store-core/src/tool-summary.ts
@@ -28,6 +28,64 @@ const PRIORITY_FIELDS = ['command', 'file_path', 'filePath', 'path', 'descriptio
 
 const PREVIEW_MAX_LEN = 100
 
+// #4655 — generic-fallback summary for tools whose input shape has none
+// of the PRIORITY_FIELDS (ToolSearch `{query, max_results}`, arbitrary
+// MCP tool inputs, custom tools, future Anthropic tools, etc.). Without
+// this, callers fall through to rendering raw JSON head (`{"matches":
+// ["Ask...`) in the collapsed bubble — a leak surface that grows with
+// every new tool shape. The generic summary trades structural-but-ugly
+// JSON for a compact key:value listing that's still legible.
+//
+// Cap at PREVIEW_MAX_LEN to match the priority-field summary contract.
+// Nested objects/arrays render as `{...}` / `[N]` placeholders so a
+// big value doesn't blow the budget on one key. When the first key
+// would already overflow, fall back to listing key names only.
+function buildGenericSummary(obj: Record<string, unknown>): string | null {
+  const keys = Object.keys(obj)
+  if (keys.length === 0) return null
+
+  const parts: string[] = []
+  let totalLen = 0
+  for (const key of keys) {
+    const value = obj[key]
+    const rendered = `${key}: ${renderGenericValue(value)}`
+    // +2 for the ", " separator between parts after the first.
+    const additional = parts.length === 0 ? rendered.length : rendered.length + 2
+    if (totalLen + additional > PREVIEW_MAX_LEN) break
+    parts.push(rendered)
+    totalLen += additional
+  }
+
+  if (parts.length === 0) {
+    // First key:value already overflowed — degrade to a bare key-count
+    // summary so something useful still shows ("3 keys: query,
+    // max_results, foo"). Caps at PREVIEW_MAX_LEN.
+    const head = `${keys.length} key${keys.length === 1 ? '' : 's'}: ${keys.join(', ')}`
+    return head.slice(0, PREVIEW_MAX_LEN)
+  }
+
+  const joined = parts.join(', ')
+  // The remaining keys are implied by the truncation; we don't tack on
+  // `…` because the bubble itself is already a disclosure widget that
+  // expands to the full JSON.
+  return joined.slice(0, PREVIEW_MAX_LEN)
+}
+
+function renderGenericValue(value: unknown): string {
+  if (value === null) return 'null'
+  if (value === undefined) return 'undefined'
+  if (typeof value === 'string') {
+    // Quoted so it's visually distinct from key names. Long strings get
+    // truncated inside the quotes so the suffix is still visible
+    // structure.
+    return value.length > 40 ? `"${value.slice(0, 37)}..."` : `"${value}"`
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (Array.isArray(value)) return `[${value.length}]`
+  if (typeof value === 'object') return '{...}'
+  return String(value)
+}
+
 function pickPriorityString(obj: Record<string, unknown>): string | null {
   // Top-level pass first — the common case for documented tool input shapes.
   for (const field of PRIORITY_FIELDS) {
@@ -58,7 +116,6 @@ function pickPriorityString(obj: Record<string, unknown>): string | null {
  *
  *   - the buffer isn't yet valid JSON (mid-stream)
  *   - the parse yields a non-object (`null`, string, number)
- *   - none of the priority fields are non-empty strings
  *
  * Callers render the verbatim accumulator head when this returns null
  * so the JSON still shows assembling on-screen.
@@ -66,13 +123,23 @@ function pickPriorityString(obj: Record<string, unknown>): string | null {
  * #4242: route the parse through `tryParseCompleteJson` so a chunk
  * that can't structurally be complete JSON yet (doesn't end in `}` or
  * `]`) short-circuits without paying the parse cost.
+ *
+ * #4655: when the parsed object has no priority field, fall back to a
+ * generic key:value summary (`query: "select:foo", max_results: 5`)
+ * instead of returning null and letting the caller leak raw JSON head.
+ * The old behaviour was bounded only by the hardcoded PRIORITY_FIELDS
+ * allowlist — every new tool shape (ToolSearch, MCP tools, custom
+ * user tools, future Anthropic tools) extended the leak surface. The
+ * generic fallback removes the per-tool maintenance burden.
  */
 export function getPartialSummary(partial: string): string | null {
   const parsed = tryParseCompleteJson(partial)
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null
   const summary = pickPriorityString(parsed as Record<string, unknown>)
-  if (!summary) return null
-  return summary.slice(0, PREVIEW_MAX_LEN)
+  if (summary) return summary.slice(0, PREVIEW_MAX_LEN)
+  // #4655: structured-but-unknown shape — build a compact key:value
+  // summary so collapsed bubbles never leak raw JSON.
+  return buildGenericSummary(parsed as Record<string, unknown>)
 }
 
 /**
@@ -112,5 +179,10 @@ export function getInputSummary(input: Record<string, unknown> | string | null |
       if (typeof nested === 'string' && nested.length > 0) return nested.slice(0, PREVIEW_MAX_LEN)
     }
   }
-  return ''
+  // #4655: structured-but-unknown shape (ToolSearch, MCP tools, etc.) —
+  // build a compact key:value summary so callers never have to fall
+  // back to raw JSON head. The bubble itself remains a disclosure
+  // widget that expands to the full pretty-printed JSON.
+  const generic = buildGenericSummary(inputObj)
+  return generic ?? ''
 }

--- a/packages/store-core/src/tool-summary.ts
+++ b/packages/store-core/src/tool-summary.ts
@@ -59,26 +59,56 @@ function buildGenericSummary(obj: Record<string, unknown>): string | null {
   if (parts.length === 0) {
     // First key:value already overflowed — degrade to a bare key-count
     // summary so something useful still shows ("3 keys: query,
-    // max_results, foo"). Caps at PREVIEW_MAX_LEN.
-    const head = `${keys.length} key${keys.length === 1 ? '' : 's'}: ${keys.join(', ')}`
-    return head.slice(0, PREVIEW_MAX_LEN)
+    // max_results, foo"). Append key names one at a time inside the
+    // budget so we never cut mid-identifier (Copilot #4655 review:
+    // mid-key slice produces a confusing partial identifier — the
+    // whole point of the fallback is "drop later items, never
+    // truncate mid-value").
+    const prefix = `${keys.length} key${keys.length === 1 ? '' : 's'}: `
+    const keyParts: string[] = []
+    let keyTotalLen = prefix.length
+    for (const key of keys) {
+      // Skip (not break) over keys that don't fit — a later shorter
+      // key may still earn a spot in the budget. The whole point of
+      // the fallback is "drop later items, never truncate mid-value",
+      // and "later" here means "by budget fit", not "by index".
+      const additional = keyParts.length === 0 ? key.length : key.length + 2
+      if (keyTotalLen + additional > PREVIEW_MAX_LEN) continue
+      keyParts.push(key)
+      keyTotalLen += additional
+    }
+    // If no key name fits alongside the prefix, emit just the prefix —
+    // readable, no broken identifier. Caller can still expand the
+    // bubble to see the full JSON.
+    return `${prefix}${keyParts.join(', ')}`
   }
 
-  const joined = parts.join(', ')
-  // The remaining keys are implied by the truncation; we don't tack on
-  // `…` because the bubble itself is already a disclosure widget that
-  // expands to the full JSON.
-  return joined.slice(0, PREVIEW_MAX_LEN)
+  // No `.slice` here — the budget loop above already kept us under
+  // PREVIEW_MAX_LEN, so slicing the joined string would only ever
+  // truncate mid-value (the exact foot-gun we documented avoiding).
+  return parts.join(', ')
 }
 
 function renderGenericValue(value: unknown): string {
   if (value === null) return 'null'
   if (value === undefined) return 'undefined'
   if (typeof value === 'string') {
-    // Quoted so it's visually distinct from key names. Long strings get
-    // truncated inside the quotes so the suffix is still visible
-    // structure.
-    return value.length > 40 ? `"${value.slice(0, 37)}..."` : `"${value}"`
+    // Route through `JSON.stringify` so embedded quotes, backslashes,
+    // and control chars (newline / tab) are properly escaped — naive
+    // `"${value}"` produced ambiguous previews like `"foo "bar" baz"`
+    // and multi-line collapsed bubbles for any string containing `\n`
+    // (Copilot #4655 review). Truncate inside the quotes when long so
+    // the structure remains visible.
+    if (value.length > 40) {
+      // Truncate BEFORE stringify so the rendered length stays bounded
+      // even when the truncated prefix happens to contain escapable
+      // chars (a `"` at position 36 would otherwise expand to `\"`).
+      const head = JSON.stringify(value.slice(0, 37))
+      // `JSON.stringify` returns `"foo"` — drop the trailing quote,
+      // append the ellipsis and re-close so we land on `"foo..."`.
+      return `${head.slice(0, -1)}..."`
+    }
+    return JSON.stringify(value)
   }
   if (typeof value === 'number' || typeof value === 'boolean') return String(value)
   if (Array.isArray(value)) return `[${value.length}]`
@@ -111,11 +141,12 @@ function pickPriorityString(obj: Record<string, unknown>): string | null {
 /**
  * Extract the most useful single-field preview from a partial-JSON
  * buffer streamed via `tool_input_delta`. Prefers `command`,
- * `file_path`, `path`, `description` in that order. Returns `null`
- * when:
+ * `file_path`, `filePath`, `path`, `description` in that order (see
+ * PRIORITY_FIELDS). Returns `null` when:
  *
  *   - the buffer isn't yet valid JSON (mid-stream)
- *   - the parse yields a non-object (`null`, string, number)
+ *   - the parse yields a non-object value (`null`, string, number, array)
+ *   - the parsed object has zero keys (#4655 generic fallback can't render)
  *
  * Callers render the verbatim accumulator head when this returns null
  * so the JSON still shows assembling on-screen.


### PR DESCRIPTION
## Summary

Closes #4655.

When a tool's input has none of the hardcoded `PRIORITY_FIELDS`
(`command` / `file_path` / `filePath` / `path` / `description`),
both the dashboard and mobile collapsed-bubble fell through to
rendering raw JSON head — e.g.
`ToolSearch {"matches":["AskUserQuestion"],"query":"select:AskUser..."}`.
Verified live during v0.9.24 dogfood for the `ToolSearch` tool.

The class of bug grows with every new tool shape (MCP tools, custom
user tools, future Anthropic tools) — extending `PRIORITY_FIELDS`
per-tool is unbounded maintenance.

This PR adds a **generic key:value fallback** in `tool-summary.ts`
that activates whenever the priority-field walk finds nothing. Both
`getInputSummary` (final input) and `getPartialSummary` (streaming
`tool_input_delta`) call it, so the dashboard `ToolBubble` and the
mobile `ToolBubble` derive the same preview from the same logic.

## Behaviour

| Input | Pre-fix collapsed preview | Post-fix collapsed preview |
|---|---|---|
| `{query: "select:Foo", max_results: 5}` (ToolSearch) | `{"query":"select:Foo","max_results":5}` | `query: "select:Foo", max_results: 5` |
| `{url: "...", timeout_ms: 5000}` (MCP) | `{"url":"...","timeout_ms":5000}` | `url: "...", timeout_ms: 5000` |
| `{options: {recursive: true}, name: "scan"}` | `{"options":{"recursive":...` | `options: {...}, name: "scan"` |
| `{command: "rm -rf node_modules"}` (Bash) | `rm -rf node_modules` (unchanged) | `rm -rf node_modules` (unchanged) |

Rules:

- Strings quoted; numbers/booleans inline; nested objects as `{...}`; arrays as `[N]`.
- Caps at `PREVIEW_MAX_LEN` (100 chars), dropping later keys rather than truncating mid-value.
- Degrades to `N keys: ...` when the first key already overflows.
- Empty objects still return null/'' so the summary span stays hidden.
- Mid-stream unparseable buffers still use the verbatim-tail fallback
  (the Bash early-abort UX #4063 depends on it).

## Test plan

- [x] `packages/store-core` — 13 new fixtures in `tool-summary.test.ts` covering ToolSearch / MCP / nested object / array / truncation / overflow degradation / empty object / priority-field regression. All 915 store-core tests pass.
- [x] `packages/dashboard` — 7 new fixtures in `ToolBubble.test.tsx` pinning the dashboard render contract for unknown shapes plus a Bash regression guard. All 2397 dashboard tests pass.
- [x] `packages/app` — 3 new fixtures in `ToolBubblePartialSummary.test.tsx` mirroring the contract on mobile. All 16 partial-summary tests pass.
- [x] Two pre-existing tests that pinned the old leak surface updated to assert the new compact summary.

## Notes

- **UI rendering only** — no protocol / wire changes.
- No new dependencies.
- The dashboard `ToolBubble.tsx` itself is unchanged — the fix lives entirely in shared `store-core` helpers, so dashboard + mobile stay in lockstep automatically.