### PR TITLE
chore(ci): extend expo-doctor allowlist (unblock batch merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,9 +313,28 @@ jobs:
           #    drift it was trying to resolve. Treated as an upkeep task that
           #    lands in a dedicated PR when the whole transitive set has caught
           #    up, not a per-PR release blocker.
+          #
+          # 3. "issues with Metro config" — the monorepo intentionally uses a
+          #    custom metro.config.js that does NOT extend "expo/metro-config"
+          #    because the chroxy mock-server resolver + workspace symlink
+          #    handling require a hand-built config. Tracked as a P2 migration.
+          #
+          # 4. "no duplicate dependencies are installed" — npm workspaces hoist
+          #    some expo-* packages to the root while expo's own nested deps
+          #    keep their own copies (expo-font, expo-asset, expo-modules-core,
+          #    @expo/fingerprint). Harmless at runtime; same upkeep-task class
+          #    as (2) above.
+          #
+          # 5. "Validate packages against React Native Directory" — the RN
+          #    directory metadata occasionally flags packages as unmaintained
+          #    upstream (e.g. expo-live-activity). We accept the warning until
+          #    a replacement lands; not a per-PR release blocker.
           filtered_failures=$(printf '%s\n' "$failures" \
             | grep -v "Check for app config fields that may not be synced in a non-CNG project" \
             | grep -v "Check that packages match versions required by installed Expo SDK" \
+            | grep -v "Check for issues with Metro config" \
+            | grep -v "Check that no duplicate dependencies are installed" \
+            | grep -v "Validate packages against React Native Directory package metadata" \
             || true)
           if [ -n "$filtered_failures" ]; then
             echo "::error::expo-doctor reported check failures above. Fix them or extend the allowlist in .github/workflows/ci.yml if the warning is genuinely accepted."


### PR DESCRIPTION
## Summary

Expo Doctor started flagging 3 new categories of warnings after upstream RN directory metadata + SDK 54.x patch releases between 08:53 and 18:03 UTC today, blocking every post-merge CI run. All 3 are known-accepted (same upkeep-task class as the 2 existing allowlist entries):

- **Metro config not extending expo/metro-config** — intentional monorepo custom config
- **Duplicate native module deps** (expo-font, expo-asset, expo-modules-core, @expo/fingerprint) — npm workspace hoisting interaction with expo's nested deps, harmless at runtime
- **expo-live-activity flagged unmaintained** by React Native Directory — known, awaiting replacement

Extends the `.github/workflows/ci.yml` allowlist with grep filters + comments for each. No `expo install --fix` cascade since the workflow comment explicitly warns against that path.

This unblocks the 18-PR batch merge already in progress.

## Test plan

- [ ] CI green on this PR (Expo Doctor passes via allowlist)
- [ ] Resume batch-merge after this lands