### PR TITLE
feat(ci): merge per-platform Tauri updater feeds into combined latest.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,6 +348,34 @@ jobs:
           name: chroxy-windows
           path: artifacts/
 
+      - name: Merge Tauri updater feeds
+        shell: bash
+        run: |
+          # Each desktop job emits its own latest.json with only the
+          # platforms it built (darwin-* from macOS, windows-* from
+          # Windows). Tauri's auto-updater expects a single feed with all
+          # `platforms` entries merged, so combine them into one file
+          # before attaching to the release.
+          #
+          # When updater signing is disabled for a job (no
+          # TAURI_SIGNING_PRIVATE_KEY), that job won't have produced a
+          # latest.json; the merge script tolerates missing inputs and
+          # exits non-zero only if NO inputs contributed platforms.
+          mkdir -p artifacts/updater
+          # Newline-separated list — safe because no path in artifacts/ can
+          # contain a newline (download-artifact preserves the on-runner
+          # paths, all of which are inside the workflow workspace).
+          FEEDS=$(find artifacts -type f -name latest.json -not -path 'artifacts/updater/*' | sort)
+          if [ -z "$FEEDS" ]; then
+            echo "::notice::No latest.json fragments found — auto-updater feed will not be published this release"
+            exit 0
+          fi
+          echo "Merging updater feeds:"
+          printf '  %s\n' "$FEEDS"
+          # shellcheck disable=SC2086 # intentional word-splitting to expand FEEDS into argv
+          node scripts/merge-updater-feeds.mjs --output artifacts/updater/latest.json $FEEDS
+          cat artifacts/updater/latest.json
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
@@ -358,6 +386,6 @@ jobs:
             artifacts/**/*.msi.zip
             artifacts/**/*.tar.gz
             artifacts/**/*.sig
-            artifacts/**/latest.json
+            artifacts/updater/latest.json
           draft: false
           prerelease: false

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -13,6 +13,10 @@ Used by both macOS and Windows desktop jobs to sign the auto-update artifacts (`
 
 Both must be set and non-empty for signing to run. If either is missing, the workflow passes `-c '{"bundle":{"createUpdaterArtifacts":false}}'` to `cargo tauri build` to suppress the updater bundle entirely. The MSI / DMG / `.app` still build and upload; the `.sig` / `latest.json` outputs do not. The committed `plugins.updater.pubkey` in `tauri.conf.json` remains untouched — only the runtime artifact generation is skipped.
 
+### Cross-platform feed assembly
+
+The `desktop-macos` and `desktop-windows` jobs each emit their own `latest.json` containing only the platform entries they built. The `github-release` job then downloads both artifacts and runs `scripts/merge-updater-feeds.mjs` to combine them into a single `artifacts/updater/latest.json` whose `platforms` map covers `darwin-aarch64`, `darwin-x86_64`, and `windows-x86_64`. The merged file is what gets attached to the GitHub Release and consumed by the auto-updater endpoint configured in `tauri.conf.json`. If updater signing is disabled for one of the jobs (e.g. signing secrets are only configured for macOS), the merge step still publishes the surviving platform; if neither job produced a feed, no `latest.json` is attached and installed clients keep their existing update endpoint until the next release.
+
 ### Generating a new key
 
 ```bash

--- a/scripts/__tests__/merge-updater-feeds.test.sh
+++ b/scripts/__tests__/merge-updater-feeds.test.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+#
+# merge-updater-feeds.test.sh — Self-contained test harness for
+# scripts/merge-updater-feeds.mjs.
+#
+# Runs in a temp dir and writes per-platform Tauri updater feeds, then
+# asserts the merged output combines them into a single latest.json with
+# all platforms preserved.
+#
+# Run from repo root:
+#   bash scripts/__tests__/merge-updater-feeds.test.sh
+#
+# Exit status: 0 if all tests pass, 1 otherwise.
+#
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+MERGE="$REPO_ROOT/scripts/merge-updater-feeds.mjs"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# Find a Node binary. Prefer Node 22 (project minimum) when available;
+# otherwise fall back to whatever the runner provides.
+if [ -x "/opt/homebrew/opt/node@22/bin/node" ]; then
+  NODE="/opt/homebrew/opt/node@22/bin/node"
+elif command -v node >/dev/null 2>&1; then
+  NODE="$(command -v node)"
+else
+  echo "FATAL: no node binary found"
+  exit 1
+fi
+
+assert_eq() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("$name")
+    echo "  FAIL: $name"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+  fi
+}
+
+assert_contains() {
+  local name="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("$name")
+    echo "  FAIL: $name (expected to find: $needle)"
+    echo "    in: $haystack"
+  fi
+}
+
+assert_not_contains() {
+  local name="$1"
+  local haystack="$2"
+  local needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("$name")
+    echo "  FAIL: $name (expected NOT to find: $needle)"
+    echo "    in: $haystack"
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: $name"
+  fi
+}
+
+run_merge() {
+  # Run the merge script with provided args, capture stdout.
+  "$NODE" "$MERGE" "$@"
+}
+
+# ----------------------------------------------------------------------------
+# Test: merges two single-platform feeds into one multi-platform feed.
+# ----------------------------------------------------------------------------
+test_merges_macos_and_windows() {
+  echo "TEST: merges macOS and Windows feeds"
+  local tmp; tmp="$(mktemp -d)"
+  cat >"$tmp/mac.json" <<'JSON'
+{
+  "version": "v0.9.13",
+  "notes": "Release notes",
+  "pub_date": "2026-06-01T00:00:00Z",
+  "platforms": {
+    "darwin-aarch64": {
+      "signature": "MAC-SIG-AA",
+      "url": "https://example.com/mac.app.tar.gz"
+    },
+    "darwin-x86_64": {
+      "signature": "MAC-SIG-XX",
+      "url": "https://example.com/mac.app.tar.gz"
+    }
+  }
+}
+JSON
+
+  cat >"$tmp/win.json" <<'JSON'
+{
+  "version": "v0.9.13",
+  "notes": "Release notes",
+  "pub_date": "2026-06-01T00:00:00Z",
+  "platforms": {
+    "windows-x86_64": {
+      "signature": "WIN-SIG-XX",
+      "url": "https://example.com/chroxy.msi.zip"
+    }
+  }
+}
+JSON
+
+  local out
+  out="$(run_merge "$tmp/mac.json" "$tmp/win.json" 2>&1)" || {
+    FAIL=$((FAIL + 1)); FAILED_TESTS+=("merges_macos_and_windows: exit nonzero"); echo "    out: $out"; return
+  }
+
+  assert_contains "contains darwin-aarch64" "$out" '"darwin-aarch64"'
+  assert_contains "contains darwin-x86_64"  "$out" '"darwin-x86_64"'
+  assert_contains "contains windows-x86_64" "$out" '"windows-x86_64"'
+  assert_contains "preserves macOS signature" "$out" 'MAC-SIG-AA'
+  assert_contains "preserves windows signature" "$out" 'WIN-SIG-XX'
+  assert_contains "preserves top-level version" "$out" '"version": "v0.9.13"'
+
+  rm -rf "$tmp"
+}
+
+# ----------------------------------------------------------------------------
+# Test: --output flag writes to disk instead of stdout.
+# ----------------------------------------------------------------------------
+test_writes_to_output_file() {
+  echo "TEST: --output flag writes to file"
+  local tmp; tmp="$(mktemp -d)"
+  cat >"$tmp/mac.json" <<'JSON'
+{
+  "version": "v0.1.0",
+  "notes": "n",
+  "pub_date": "2026-01-01T00:00:00Z",
+  "platforms": {
+    "darwin-aarch64": { "signature": "S", "url": "https://e/x" }
+  }
+}
+JSON
+
+  run_merge --output "$tmp/out.json" "$tmp/mac.json" >/dev/null 2>&1 || {
+    FAIL=$((FAIL + 1)); FAILED_TESTS+=("writes_to_output_file: exit nonzero"); return
+  }
+
+  if [ -f "$tmp/out.json" ]; then
+    local body; body="$(cat "$tmp/out.json")"
+    assert_contains "output file has version" "$body" '"version"'
+    assert_contains "output file has darwin entry" "$body" '"darwin-aarch64"'
+  else
+    FAIL=$((FAIL + 1)); FAILED_TESTS+=("writes_to_output_file: file missing")
+    echo "  FAIL: writes_to_output_file: $tmp/out.json was not created"
+  fi
+
+  rm -rf "$tmp"
+}
+
+# ----------------------------------------------------------------------------
+# Test: gracefully ignores missing input files (so the workflow can pass a
+# glob/path that didn't exist when one of the jobs ran without signing).
+# ----------------------------------------------------------------------------
+test_skips_missing_inputs() {
+  echo "TEST: skips missing input files"
+  local tmp; tmp="$(mktemp -d)"
+  cat >"$tmp/mac.json" <<'JSON'
+{
+  "version": "v0.1.0",
+  "notes": "n",
+  "pub_date": "2026-01-01T00:00:00Z",
+  "platforms": {
+    "darwin-aarch64": { "signature": "S", "url": "https://e/x" }
+  }
+}
+JSON
+
+  local out
+  out="$(run_merge "$tmp/mac.json" "$tmp/does-not-exist.json" 2>&1)" || {
+    FAIL=$((FAIL + 1)); FAILED_TESTS+=("skips_missing_inputs: exit nonzero"); echo "    out: $out"; return
+  }
+
+  assert_contains "still emits mac platform" "$out" '"darwin-aarch64"'
+  assert_not_contains "no windows entry" "$out" '"windows-x86_64"'
+
+  rm -rf "$tmp"
+}
+
+# ----------------------------------------------------------------------------
+# Test: fails with non-zero exit when called with no inputs.
+# ----------------------------------------------------------------------------
+test_fails_without_inputs() {
+  echo "TEST: fails without inputs"
+  if run_merge >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); FAILED_TESTS+=("fails_without_inputs: should have failed")
+    echo "  FAIL: fails_without_inputs (expected nonzero exit)"
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: fails_without_inputs"
+  fi
+}
+
+# ----------------------------------------------------------------------------
+# Test: fails when all provided files are missing (no platforms collected).
+# ----------------------------------------------------------------------------
+test_fails_when_all_inputs_missing() {
+  echo "TEST: fails when all inputs missing"
+  local tmp; tmp="$(mktemp -d)"
+  if run_merge "$tmp/nope1.json" "$tmp/nope2.json" >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1)); FAILED_TESTS+=("fails_when_all_inputs_missing: should have failed")
+    echo "  FAIL: fails_when_all_inputs_missing (expected nonzero exit)"
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: fails_when_all_inputs_missing"
+  fi
+  rm -rf "$tmp"
+}
+
+# ----------------------------------------------------------------------------
+# Test: later platforms override earlier ones for the same key (last wins).
+# ----------------------------------------------------------------------------
+test_later_input_overrides_same_platform() {
+  echo "TEST: later input overrides same platform"
+  local tmp; tmp="$(mktemp -d)"
+  cat >"$tmp/a.json" <<'JSON'
+{
+  "version": "v0.1.0",
+  "notes": "n",
+  "pub_date": "2026-01-01T00:00:00Z",
+  "platforms": {
+    "darwin-aarch64": { "signature": "OLD", "url": "https://e/old" }
+  }
+}
+JSON
+
+  cat >"$tmp/b.json" <<'JSON'
+{
+  "version": "v0.1.0",
+  "notes": "n",
+  "pub_date": "2026-01-01T00:00:00Z",
+  "platforms": {
+    "darwin-aarch64": { "signature": "NEW", "url": "https://e/new" }
+  }
+}
+JSON
+
+  local out
+  out="$(run_merge "$tmp/a.json" "$tmp/b.json" 2>&1)" || {
+    FAIL=$((FAIL + 1)); FAILED_TESTS+=("later_input_overrides_same_platform: exit nonzero"); return
+  }
+
+  assert_contains "has NEW signature" "$out" 'NEW'
+  assert_not_contains "OLD signature is gone" "$out" '"signature": "OLD"'
+  rm -rf "$tmp"
+}
+
+# Run all tests.
+test_merges_macos_and_windows
+test_writes_to_output_file
+test_skips_missing_inputs
+test_fails_without_inputs
+test_fails_when_all_inputs_missing
+test_later_input_overrides_same_platform
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failed tests:"
+  for t in "${FAILED_TESTS[@]}"; do
+    echo "  - $t"
+  done
+  exit 1
+fi
+exit 0

--- a/scripts/merge-updater-feeds.mjs
+++ b/scripts/merge-updater-feeds.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * merge-updater-feeds.mjs — Merge per-platform Tauri updater feeds into a
+ * single combined `latest.json` for the release.
+ *
+ * The Tauri auto-updater expects ONE `latest.json` whose `platforms` map
+ * keys (`darwin-aarch64`, `darwin-x86_64`, `windows-x86_64`, ...) point at
+ * the platform-specific bundle + signature. Each `cargo tauri build` run
+ * emits its own `latest.json` containing only the platforms it built, so
+ * when both the macOS and Windows desktop jobs run we end up with two
+ * fragments that need to be combined before publishing.
+ *
+ * Top-level fields (`version`, `notes`, `pub_date`) are taken from the
+ * first non-empty input (they should be identical across platforms in a
+ * coordinated release). `platforms` entries are merged with last-write-wins
+ * semantics, so passing the most authoritative feed last is safe.
+ *
+ * Missing input files are skipped with a warning (the workflow can pass
+ * paths that won't exist when updater signing is disabled for that job)
+ * but at least one input must contribute platforms or the script exits
+ * non-zero so a botched release doesn't ship an empty feed.
+ *
+ * Usage:
+ *   node scripts/merge-updater-feeds.mjs <feed1.json> [<feed2.json> ...]
+ *   node scripts/merge-updater-feeds.mjs --output out.json <feed1.json> ...
+ */
+
+import {readFileSync, writeFileSync, existsSync} from 'node:fs'
+import {argv, exit, stderr, stdout} from 'node:process'
+
+function parseArgs(args) {
+  const inputs = []
+  let output = null
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]
+    if (a === '--output' || a === '-o') {
+      output = args[++i]
+      if (!output) {
+        stderr.write('error: --output requires a path argument\n')
+        exit(2)
+      }
+    } else if (a === '--help' || a === '-h') {
+      stdout.write('usage: merge-updater-feeds.mjs [--output PATH] <feed.json> [<feed.json> ...]\n')
+      exit(0)
+    } else if (a.startsWith('-')) {
+      stderr.write(`error: unknown flag: ${a}\n`)
+      exit(2)
+    } else {
+      inputs.push(a)
+    }
+  }
+  return {inputs, output}
+}
+
+function main() {
+  const {inputs, output} = parseArgs(argv.slice(2))
+
+  if (inputs.length === 0) {
+    stderr.write('error: at least one input feed path is required\n')
+    exit(2)
+  }
+
+  const merged = {
+    version: null,
+    notes: null,
+    pub_date: null,
+    platforms: {},
+  }
+
+  let usedInputs = 0
+  for (const path of inputs) {
+    if (!existsSync(path)) {
+      stderr.write(`warn: skipping missing input ${path}\n`)
+      continue
+    }
+    let raw
+    try {
+      raw = readFileSync(path, 'utf8')
+    } catch (err) {
+      stderr.write(`error: could not read ${path}: ${err.message}\n`)
+      exit(1)
+    }
+    let feed
+    try {
+      feed = JSON.parse(raw)
+    } catch (err) {
+      stderr.write(`error: could not parse ${path}: ${err.message}\n`)
+      exit(1)
+    }
+
+    if (merged.version === null && typeof feed.version === 'string') {
+      merged.version = feed.version
+    }
+    if (merged.notes === null && typeof feed.notes === 'string') {
+      merged.notes = feed.notes
+    }
+    if (merged.pub_date === null && typeof feed.pub_date === 'string') {
+      merged.pub_date = feed.pub_date
+    }
+    if (feed.platforms && typeof feed.platforms === 'object') {
+      for (const [key, value] of Object.entries(feed.platforms)) {
+        merged.platforms[key] = value
+      }
+    }
+    usedInputs++
+  }
+
+  if (usedInputs === 0) {
+    stderr.write('error: no input feeds existed; refusing to write an empty latest.json\n')
+    exit(1)
+  }
+  if (Object.keys(merged.platforms).length === 0) {
+    stderr.write('error: merged feed has no platform entries; refusing to write\n')
+    exit(1)
+  }
+
+  // Strip nulls so the output matches what a single tauri build would have
+  // produced (no surprise extra keys for downstream JSON consumers).
+  const out = {}
+  if (merged.version !== null) out.version = merged.version
+  if (merged.notes !== null) out.notes = merged.notes
+  if (merged.pub_date !== null) out.pub_date = merged.pub_date
+  out.platforms = merged.platforms
+
+  const serialized = JSON.stringify(out, null, 2) + '\n'
+
+  if (output) {
+    writeFileSync(output, serialized)
+    stderr.write(`merged ${usedInputs} feed(s) → ${output} (${Object.keys(merged.platforms).length} platforms)\n`)
+  } else {
+    stdout.write(serialized)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary

- The `desktop-macos` and `desktop-windows` jobs each emit their own `latest.json` containing only the platforms they built (`darwin-*` from macOS, `windows-x86_64` from Windows). Tauri's auto-updater expects a single feed whose `platforms` map covers every published platform.
- Adds `scripts/merge-updater-feeds.mjs` — a small Node helper that combines one or more per-platform `latest.json` files into a single merged feed, preserving top-level metadata from the first non-empty input and last-write-wins on duplicate platform keys.
- Adds a "Merge Tauri updater feeds" step to the `github-release` job that runs the helper against every `latest.json` it can find under `artifacts/` and attaches the combined `artifacts/updater/latest.json` to the GitHub Release (in place of the raw per-platform fragments).
- Tolerates the no-signing path: when one (or both) job(s) run without `TAURI_SIGNING_PRIVATE_KEY` configured, the missing `latest.json` is skipped with a warning. If neither job produced a feed, no `latest.json` is attached and installed clients keep their existing update endpoint until the next release.
- Documents the new merge step in `docs/release-signing.md` alongside the rest of the updater signing pipeline.

## Test plan

- [x] `bash scripts/__tests__/merge-updater-feeds.test.sh` — 14/14 passing (covers merge, `--output`, missing inputs, no-input failure, all-missing failure, override semantics)
- [x] Integration sanity-check: replicate the workflow's `find` invocation against a fake `artifacts/` tree containing macOS + Windows fragments — verified the merged output contains both `darwin-aarch64` and `windows-x86_64`
- [x] `js-yaml` parse of the updated `release.yml` — `github-release` job step count is 5 → 6 as expected
- [ ] CI dry-run: post-merge release dispatch should publish a combined `latest.json` to the GitHub Release once `TAURI_SIGNING_PRIVATE_KEY` is wired into the Windows job (gated on #3808)
- [ ] Manual verification: install the Windows MSI from a release that includes a Windows updater fragment, then confirm `tauri-plugin-updater` self-updates to the next version

Closes #3809