### PR TITLE
fix(dashboard): preserve scroll position when AskUserQuestion is visible

### DIFF
--- a/packages/dashboard/src/components/ChatView.test.tsx
+++ b/packages/dashboard/src/components/ChatView.test.tsx
@@ -126,11 +126,67 @@ describe('ChatView', () => {
     await act(() => { vi.advanceTimersByTime(50) })
     expect(container.scrollTop).toBe(200)
 
-    // Now add a new message — auto-scroll SHOULD fire (new count resets)
+    // #4652 — even when a new message arrives, a user who is actively
+    // scrolled up should NOT be snapped back to the bottom. They keep
+    // their reading position and can click the scroll-to-bottom button
+    // (which appears) when they're ready. Previously the count-change
+    // effect unconditionally reset `userScrolledUp` and scrolled — that
+    // made history unreachable while an AskUserQuestion form was open
+    // and downstream tool_use events kept arriving.
+    const moreMessages = makeMessages(4)
+    rerender(<ChatView messages={moreMessages} isStreaming={false} />)
+    await act(() => { vi.advanceTimersByTime(50) })
+    expect(container.scrollTop).toBe(200)
+    expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+    vi.useRealTimers()
+  })
+
+  it('auto-scrolls on new message when user is at bottom (#4652)', async () => {
+    vi.useFakeTimers()
+    const messages = makeMessages(3)
+    const { rerender } = render(<ChatView messages={messages} isStreaming={false} />)
+    const container = screen.getByTestId('chat-messages')
+
+    // Setup: at bottom; user has not scrolled up
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 1000, writable: true, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
+    await act(() => { vi.advanceTimersByTime(50) })
+
+    // New message arrives — should snap to bottom (user is at bottom, so no
+    // disruption).
     const moreMessages = makeMessages(4)
     rerender(<ChatView messages={moreMessages} isStreaming={false} />)
     await act(() => { vi.advanceTimersByTime(50) })
     expect(container.scrollTop).toBe(1000)
+    vi.useRealTimers()
+  })
+
+  it('preserves scrolled-up position when streaming ends mid-history-read (#4652)', async () => {
+    // Repro for the AskUserQuestion scenario: streaming flips to false
+    // when the question arrives. Previously, the streaming-end effect
+    // unconditionally reset `userScrolledUp` to false — snapping the
+    // user back to the bottom while they were reading history.
+    vi.useFakeTimers()
+    const messages = makeMessages(3)
+    const { rerender } = render(<ChatView messages={messages} isStreaming />)
+    const container = screen.getByTestId('chat-messages')
+
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(container, 'scrollTop', { value: 1000, writable: true, configurable: true })
+    Object.defineProperty(container, 'clientHeight', { value: 400, configurable: true })
+    await act(() => { vi.advanceTimersByTime(50) })
+
+    // User scrolls up while assistant is still streaming
+    container.scrollTop = 100
+    await act(() => { fireEvent.scroll(container) })
+    expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
+
+    // Streaming ends (AskUserQuestion arrived); user is still scrolled up
+    rerender(<ChatView messages={messages} isStreaming={false} />)
+    await act(() => { vi.advanceTimersByTime(50) })
+    expect(container.scrollTop).toBe(100)
+    expect(screen.getByTestId('scroll-to-bottom')).toBeInTheDocument()
     vi.useRealTimers()
   })
 

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -189,21 +189,32 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
     requestAnimationFrame(() => { programmaticScrollRef.current = false })
   }, [])
 
-  // Reset userScrolledUp when streaming ends — show the final response
+  // #4652: when streaming ends, only re-anchor to the bottom if the user
+  // is still at the bottom. The original behavior unconditionally reset
+  // `userScrolledUp` to false — which snapped the user back down the
+  // moment an AskUserQuestion arrived (the question flips `isStreaming`
+  // from true to false), making it impossible to read history while a
+  // prompt was visible. Now we leave their scroll position alone and
+  // the existing scroll-to-bottom button gives them a one-click return.
   useEffect(() => {
-    if (prevStreamingRef.current && !isStreaming) {
+    if (prevStreamingRef.current && !isStreaming && !userScrolledUp) {
       setUserScrolledUp(false)
     }
     prevStreamingRef.current = isStreaming
-  }, [isStreaming])
+  }, [isStreaming, userScrolledUp])
 
-  // Auto-scroll on new messages or busy state change (stable count-based trigger).
+  // #4652: auto-scroll on new messages (stable count-based trigger) only
+  // when the user is at the bottom. Previously we unconditionally snapped
+  // to bottom on every count change, which made scrolling up through
+  // history while an AskUserQuestion form was open impossible — any
+  // downstream tool_use / tool_result event would yank the viewport back
+  // down. The scroll-to-bottom button (already rendered when
+  // `userScrolledUp`) is the user's one-click escape hatch.
   const prevCountRef = useRef(dedupedMessages.length)
   useEffect(() => {
     const countChanged = dedupedMessages.length !== prevCountRef.current
     prevCountRef.current = dedupedMessages.length
-    if (countChanged) {
-      setUserScrolledUp(false)
+    if (countChanged && !userScrolledUp) {
       requestAnimationFrame(() => {
         const el = containerRef.current
         if (el) {

--- a/packages/dashboard/src/components/ChatView.tsx
+++ b/packages/dashboard/src/components/ChatView.tsx
@@ -146,7 +146,6 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
   const containerRef = useRef<HTMLDivElement>(null)
   const [userScrolledUp, setUserScrolledUp] = useState(false)
   const programmaticScrollRef = useRef(false)
-  const prevStreamingRef = useRef(isStreaming)
 
   // Deduplicate by id — keep first occurrence
   const dedupedMessages = useMemo(() => {
@@ -189,19 +188,14 @@ function ChatViewImpl({ messages, isStreaming, isBusy, renderMessage }: ChatView
     requestAnimationFrame(() => { programmaticScrollRef.current = false })
   }, [])
 
-  // #4652: when streaming ends, only re-anchor to the bottom if the user
-  // is still at the bottom. The original behavior unconditionally reset
-  // `userScrolledUp` to false — which snapped the user back down the
-  // moment an AskUserQuestion arrived (the question flips `isStreaming`
-  // from true to false), making it impossible to read history while a
-  // prompt was visible. Now we leave their scroll position alone and
-  // the existing scroll-to-bottom button gives them a one-click return.
-  useEffect(() => {
-    if (prevStreamingRef.current && !isStreaming && !userScrolledUp) {
-      setUserScrolledUp(false)
-    }
-    prevStreamingRef.current = isStreaming
-  }, [isStreaming, userScrolledUp])
+  // #4652: previously a separate streaming-end effect reset
+  // `userScrolledUp` to false — that snapped the user back to the
+  // bottom the moment an AskUserQuestion arrived (the question flips
+  // `isStreaming` from true to false), making it impossible to read
+  // history while a prompt was visible. The reset is no longer needed:
+  // the count-change effect below handles the "follow latest" path
+  // when the user is at the bottom, and the scroll-to-bottom button
+  // gives a one-click return when they're scrolled up.
 
   // #4652: auto-scroll on new messages (stable count-based trigger) only
   // when the user is at the bottom. Previously we unconditionally snapped

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1553,6 +1553,12 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  /* #4652: keep wheel/touchpad scroll inside the chat panel even when
+     an AskUserQuestion form is open. Without `contain`, reaching the
+     top/bottom of the chat lets the scroll bubble up to the outer page
+     (or the form's own inputs absorb the wheel before the chat does),
+     which felt like scrolling was "stuck" while a prompt was visible. */
+  overscroll-behavior: contain;
 }
 
 /* ---- Message rows with sender icons ---- */
@@ -2236,11 +2242,20 @@
 /* #4634: multi-question AskUserQuestion form (#4604 Chunk B / #4620).
    The component renders these class names but they previously had no
    CSS rules — Submit fell back to the native browser button (gray-on-
-   dark, unreadable) and questions had no visual separation. */
+   dark, unreadable) and questions had no visual separation.
+
+   #4652: cap height to the viewport and let the form scroll internally
+   when it would otherwise grow taller than the chat pane. Without this
+   cap a large multi-question form pushed messages off-screen and
+   trapped wheel events because the chat-messages container had no room
+   to scroll past the form. */
 .question-prompt--multi {
   display: flex;
   flex-direction: column;
   gap: 16px;
+  max-height: 60vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .question-prompt-multi-row {


### PR DESCRIPTION
## Summary

- Auto-scroll on count change now respects `userScrolledUp` — new tool_use / tool_result events no longer yank the viewport back to the bottom while the user is reading history with an AskUserQuestion form open
- Streaming-end no longer resets `userScrolledUp` (AskUserQuestion flips `isStreaming` false on arrival; that previously snapped users away from their reading position)
- `.chat-messages` gets `overscroll-behavior: contain` so wheel/touchpad scroll stays inside the chat panel instead of bubbling to the outer page when reaching the boundary
- `.question-prompt--multi` is capped at `60vh` with internal scroll so a large multi-question form can never push messages out of the visible chat area

The existing scroll-to-bottom button (already rendered when `userScrolledUp` is true) is the one-click escape hatch for users to return to the latest message.

## Test plan

- [x] `cd packages/dashboard && npx vitest run src/components/ChatView.test.tsx` — 24 tests pass (2 new regression tests for #4652, 1 existing #1180 test updated to match new chat-app behavior)
- [x] Full dashboard suite: `npx vitest run` — 2411 tests pass
- [x] Typecheck clean: `npm run typecheck`
- [ ] Manual: trigger an AskUserQuestion, scroll up while form is visible, confirm history is reachable and scroll-to-bottom button appears
- [ ] Manual: trigger multi-question deferred-notice variant (when permission-hook denies) — confirm placeholder still renders and scroll behavior unchanged

Closes #4652