### PR TITLE
fix(dashboard): cancel preamble debounce on session switch + add conflict banner

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -617,6 +617,204 @@ describe('SettingsPanel', () => {
       const input = screen.getByTestId('session-preamble-input') as HTMLTextAreaElement
       expect(input.maxLength).toBe(4000)
     })
+
+    // #4662: cross-session debounce safety + multi-client conflict UX.
+    // Mirrors the QuietHoursEditor pattern (#4570): a pending debounce
+    // closes over the typed text but reads activeSessionId at fire-time
+    // — switching sessions mid-debounce would leak draft A onto session
+    // B. A divergent server broadcast mid-edit was also silently
+    // overwriting the local draft.
+    describe('cross-session debounce safety + multi-client conflict UX (#4662)', () => {
+      it('cancels a pending debounce when activeSessionId changes mid-edit', () => {
+        vi.useFakeTimers()
+        try {
+          const setSessionPreamble = vi.fn()
+          setMockState({
+            activeSessionId: 'sess-A',
+            sessions: [
+              { sessionId: 'sess-A', name: 'A', cwd: '/tmp', sessionPreamble: '' },
+              { sessionId: 'sess-B', name: 'B', cwd: '/tmp', sessionPreamble: '' },
+            ],
+            setSessionPreamble,
+          })
+          const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+          const input = screen.getByTestId('session-preamble-input') as HTMLTextAreaElement
+          fireEvent.change(input, { target: { value: 'session A draft' } })
+          // Switch active session within the debounce window.
+          vi.advanceTimersByTime(100)
+          setMockState({
+            activeSessionId: 'sess-B',
+            sessions: [
+              { sessionId: 'sess-A', name: 'A', cwd: '/tmp', sessionPreamble: '' },
+              { sessionId: 'sess-B', name: 'B', cwd: '/tmp', sessionPreamble: '' },
+            ],
+            setSessionPreamble,
+          })
+          rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+          // Drain past the original debounce window — nothing should fire.
+          vi.advanceTimersByTime(500)
+          expect(setSessionPreamble).not.toHaveBeenCalled()
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+
+      it('hydrates the text area to the new session value after a switch (no stale draft)', () => {
+        setMockState({
+          activeSessionId: 'sess-A',
+          sessions: [
+            { sessionId: 'sess-A', name: 'A', cwd: '/tmp', sessionPreamble: 'A value' },
+            { sessionId: 'sess-B', name: 'B', cwd: '/tmp', sessionPreamble: 'B value' },
+          ],
+          setSessionPreamble: vi.fn(),
+        })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const input = screen.getByTestId('session-preamble-input') as HTMLTextAreaElement
+        expect(input.value).toBe('A value')
+        fireEvent.change(input, { target: { value: 'A draft' } })
+        // Switch sessions before the debounce fires.
+        setMockState({
+          activeSessionId: 'sess-B',
+          sessions: [
+            { sessionId: 'sess-A', name: 'A', cwd: '/tmp', sessionPreamble: 'A value' },
+            { sessionId: 'sess-B', name: 'B', cwd: '/tmp', sessionPreamble: 'B value' },
+          ],
+          setSessionPreamble: vi.fn(),
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const after = screen.getByTestId('session-preamble-input') as HTMLTextAreaElement
+        expect(after.value).toBe('B value')
+      })
+
+      it('surfaces a conflict banner when a divergent snapshot lands mid-edit', () => {
+        setMockState({
+          activeSessionId: 'sess-1',
+          sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: 'original' }],
+          setSessionPreamble: vi.fn(),
+        })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const input = screen.getByTestId('session-preamble-input') as HTMLTextAreaElement
+        fireEvent.change(input, { target: { value: 'my local draft' } })
+        // Divergent snapshot arrives from another client.
+        setMockState({
+          activeSessionId: 'sess-1',
+          sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: 'other client value' }],
+          setSessionPreamble: vi.fn(),
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        expect(screen.getByTestId('session-preamble-conflict-banner')).toBeInTheDocument()
+        expect(screen.getByTestId('session-preamble-conflict-accept')).toBeInTheDocument()
+        expect(screen.getByTestId('session-preamble-conflict-discard')).toBeInTheDocument()
+        // Local draft is preserved while the banner is up.
+        const afterInput = screen.getByTestId('session-preamble-input') as HTMLTextAreaElement
+        expect(afterInput.value).toBe('my local draft')
+      })
+
+      it('clicking discard replaces the draft with the snapshot and clears the banner', () => {
+        setMockState({
+          activeSessionId: 'sess-1',
+          sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: 'original' }],
+          setSessionPreamble: vi.fn(),
+        })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.change(screen.getByTestId('session-preamble-input'), { target: { value: 'my draft' } })
+        setMockState({
+          activeSessionId: 'sess-1',
+          sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: 'other client' }],
+          setSessionPreamble: vi.fn(),
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('session-preamble-conflict-discard'))
+        const after = screen.getByTestId('session-preamble-input') as HTMLTextAreaElement
+        expect(after.value).toBe('other client')
+        expect(screen.queryByTestId('session-preamble-conflict-banner')).toBeNull()
+      })
+
+      it('clicking accept keeps the local draft and clears the banner', () => {
+        setMockState({
+          activeSessionId: 'sess-1',
+          sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: 'original' }],
+          setSessionPreamble: vi.fn(),
+        })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.change(screen.getByTestId('session-preamble-input'), { target: { value: 'my draft' } })
+        setMockState({
+          activeSessionId: 'sess-1',
+          sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: 'other client' }],
+          setSessionPreamble: vi.fn(),
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        fireEvent.click(screen.getByTestId('session-preamble-conflict-accept'))
+        const after = screen.getByTestId('session-preamble-input') as HTMLTextAreaElement
+        expect(after.value).toBe('my draft')
+        expect(screen.queryByTestId('session-preamble-conflict-banner')).toBeNull()
+      })
+
+      it('a snapshot matching the local draft does not surface the banner (own echo)', () => {
+        vi.useFakeTimers()
+        try {
+          const setSessionPreamble = vi.fn()
+          setMockState({
+            activeSessionId: 'sess-1',
+            sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: '' }],
+            setSessionPreamble,
+          })
+          const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+          fireEvent.change(screen.getByTestId('session-preamble-input'), { target: { value: 'echo me' } })
+          vi.advanceTimersByTime(401)
+          expect(setSessionPreamble).toHaveBeenCalledWith('echo me')
+          // Server echoes the same value back.
+          setMockState({
+            activeSessionId: 'sess-1',
+            sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: 'echo me' }],
+            setSessionPreamble,
+          })
+          rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+          expect(screen.queryByTestId('session-preamble-conflict-banner')).toBeNull()
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+
+      it('accepts snapshot updates normally when the editor is clean', () => {
+        setMockState({
+          activeSessionId: 'sess-1',
+          sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: 'initial' }],
+          setSessionPreamble: vi.fn(),
+        })
+        const { rerender } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        // No edits — a fresh snapshot replaces the draft.
+        setMockState({
+          activeSessionId: 'sess-1',
+          sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: 'from server' }],
+          setSessionPreamble: vi.fn(),
+        })
+        rerender(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+        const after = screen.getByTestId('session-preamble-input') as HTMLTextAreaElement
+        expect(after.value).toBe('from server')
+        expect(screen.queryByTestId('session-preamble-conflict-banner')).toBeNull()
+      })
+
+      it('cancels a pending debounce on unmount', () => {
+        vi.useFakeTimers()
+        try {
+          const setSessionPreamble = vi.fn()
+          setMockState({
+            activeSessionId: 'sess-1',
+            sessions: [{ sessionId: 'sess-1', name: 'Test', cwd: '/tmp', sessionPreamble: '' }],
+            setSessionPreamble,
+          })
+          const { unmount } = render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+          fireEvent.change(screen.getByTestId('session-preamble-input'), { target: { value: 'half-typed' } })
+          vi.advanceTimersByTime(100)
+          unmount()
+          vi.advanceTimersByTime(500)
+          expect(setSessionPreamble).not.toHaveBeenCalled()
+        } finally {
+          vi.useRealTimers()
+        }
+      })
+    })
   })
 
   describe('BYOK credentials (#4052)', () => {

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -687,7 +687,14 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   useEffect(() => { preambleDirtyRef.current = preambleDirty }, [preambleDirty])
   // #4662: parked snapshot for the conflict banner. Set when a server
   // broadcast diverges from the dirty draft. `undefined` = no conflict.
+  // The ref mirror lets `handleDiscardPreambleDraft` read the current
+  // snapshot without binding it via closure (which would force the
+  // callback to re-create on every snapshot change and defeat the
+  // `useCallback([])` dep contract). Mirrors the `preambleDirtyRef`
+  // pattern above.
   const [preambleConflict, setPreambleConflict] = useState<string | undefined>(undefined)
+  const preambleConflictRef = useRef<string | undefined>(undefined)
+  useEffect(() => { preambleConflictRef.current = preambleConflict }, [preambleConflict])
   // #4662: track the session the current draft belongs to. When
   // activeSessionId changes mid-edit we MUST cancel the pending
   // debounce — otherwise `setSessionPreamble` reads activeSessionId
@@ -749,18 +756,20 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
 
   // #4662: user takes the remote snapshot — replace the draft, clear
   // dirty, drop any pending debounce so we don't immediately overwrite
-  // the snapshot we just accepted.
+  // the snapshot we just accepted. Side effects live OUTSIDE the
+  // setState updater (StrictMode would otherwise invoke them twice);
+  // we read the parked snapshot off the ref instead of via closure so
+  // the `useCallback([])` dep contract stays valid.
   const handleDiscardPreambleDraft = useCallback(() => {
-    setPreambleConflict((snap) => {
-      if (snap === undefined) return undefined
-      if (preambleDebounceRef.current) {
-        clearTimeout(preambleDebounceRef.current)
-        preambleDebounceRef.current = null
-      }
-      setPreambleDraft(snap)
-      setPreambleDirty(false)
-      return undefined
-    })
+    const snap = preambleConflictRef.current
+    if (snap === undefined) return
+    if (preambleDebounceRef.current) {
+      clearTimeout(preambleDebounceRef.current)
+      preambleDebounceRef.current = null
+    }
+    setPreambleDraft(snap)
+    setPreambleDirty(false)
+    setPreambleConflict(undefined)
   }, [])
 
   // #4559: shared copy for the inline "server disconnected" banner so the

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -677,16 +677,60 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   // forcing a re-render of its own.
   const [preambleDraft, setPreambleDraft] = useState<string>('')
   const preambleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // #4662: dirty-flag tracking mirrors QuietHoursEditor's #4570 pattern.
+  // The dirty flag flips on every edit and clears on session-switch
+  // hydrate / debounce flush / accept-snapshot. Read via a ref inside
+  // the hydration effect so we don't add it to the dep array (which
+  // would re-run the effect and re-apply the snapshot we just held).
+  const [preambleDirty, setPreambleDirty] = useState(false)
+  const preambleDirtyRef = useRef(false)
+  useEffect(() => { preambleDirtyRef.current = preambleDirty }, [preambleDirty])
+  // #4662: parked snapshot for the conflict banner. Set when a server
+  // broadcast diverges from the dirty draft. `undefined` = no conflict.
+  const [preambleConflict, setPreambleConflict] = useState<string | undefined>(undefined)
+  // #4662: track the session the current draft belongs to. When
+  // activeSessionId changes mid-edit we MUST cancel the pending
+  // debounce — otherwise `setSessionPreamble` reads activeSessionId
+  // from the store at fire-time and leaks session A's draft text onto
+  // session B (gap 1 in #4662).
+  const preambleSessionRef = useRef<string | null>(activeSessionId ?? null)
   // Mirror the server-confirmed value into the local draft whenever the
   // active session changes (switching sessions) or the server broadcasts
-  // a new stored value (multi-client edit). Skip the mirror when the
-  // user is mid-edit — measured by whether the draft already matches a
-  // value we're about to flush — so a multi-client confirm doesn't
-  // overwrite half-typed text.
+  // a new stored value (multi-client edit). Two distinct cases:
+  //   1. Session switch — always re-hydrate AND cancel any pending
+  //      debounce. The leaked text would otherwise fire against the
+  //      new session.
+  //   2. Same-session snapshot arrives mid-edit — if it diverges from
+  //      the local draft, park it for the conflict banner. If it
+  //      matches the draft (own echo) clear dirty silently. If the
+  //      editor is clean, apply the snapshot.
   useEffect(() => {
     const serverValue = typeof activeSessionSessionPreamble === 'string' ? activeSessionSessionPreamble : ''
-    if (preambleDebounceRef.current) return  // mid-edit; don't clobber
+    const sessionChanged = preambleSessionRef.current !== (activeSessionId ?? null)
+    if (sessionChanged) {
+      // Drop any pending debounce — it closes over the old session's
+      // draft and would fire against the new active session.
+      if (preambleDebounceRef.current) {
+        clearTimeout(preambleDebounceRef.current)
+        preambleDebounceRef.current = null
+      }
+      preambleSessionRef.current = activeSessionId ?? null
+      setPreambleDraft(serverValue)
+      setPreambleDirty(false)
+      setPreambleConflict(undefined)
+      return
+    }
+    const isDirty = preambleDirtyRef.current
+    const matchesDraft = serverValue === preambleDraft
+    if (isDirty && !matchesDraft) {
+      // Park the snapshot for the user to resolve via the banner.
+      setPreambleConflict(serverValue)
+      return
+    }
+    // Clean apply (or snapshot already matches draft — e.g. our own echo).
     setPreambleDraft(serverValue)
+    setPreambleDirty(false)
+    setPreambleConflict(undefined)
   }, [activeSessionId, activeSessionSessionPreamble])  // eslint-disable-line react-hooks/exhaustive-deps
   // Clean up the pending debounce on unmount so we don't fire a stale
   // WS send after the panel closes.
@@ -695,6 +739,28 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
       clearTimeout(preambleDebounceRef.current)
       preambleDebounceRef.current = null
     }
+  }, [])
+
+  // #4662: user keeps their local draft — discard the parked snapshot.
+  // The next divergent broadcast will re-surface the banner.
+  const handleAcceptPreambleDraft = useCallback(() => {
+    setPreambleConflict(undefined)
+  }, [])
+
+  // #4662: user takes the remote snapshot — replace the draft, clear
+  // dirty, drop any pending debounce so we don't immediately overwrite
+  // the snapshot we just accepted.
+  const handleDiscardPreambleDraft = useCallback(() => {
+    setPreambleConflict((snap) => {
+      if (snap === undefined) return undefined
+      if (preambleDebounceRef.current) {
+        clearTimeout(preambleDebounceRef.current)
+        preambleDebounceRef.current = null
+      }
+      setPreambleDraft(snap)
+      setPreambleDirty(false)
+      return undefined
+    })
   }, [])
 
   // #4559: shared copy for the inline "server disconnected" banner so the
@@ -1075,15 +1141,60 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                   <label htmlFor="session-preamble-input">
                     Always include this context in every message
                   </label>
+                  {/* #4662: conflict banner mirrors QuietHoursEditor
+                      (#4570). Renders when a divergent server snapshot
+                      arrives while the local draft is dirty. */}
+                  {preambleConflict !== undefined && (
+                    <div
+                      className="settings-hint session-preamble-conflict-banner"
+                      role="alert"
+                      data-testid="session-preamble-conflict-banner"
+                    >
+                      <p>
+                        Another client updated this session's preamble while
+                        you were editing. Keep your unsaved changes, or
+                        discard them and load the latest value?
+                      </p>
+                      <div className="settings-field">
+                        <button
+                          type="button"
+                          onClick={handleAcceptPreambleDraft}
+                          data-testid="session-preamble-conflict-accept"
+                        >
+                          Keep my edits
+                        </button>
+                        <button
+                          type="button"
+                          onClick={handleDiscardPreambleDraft}
+                          data-testid="session-preamble-conflict-discard"
+                        >
+                          Discard and load latest
+                        </button>
+                      </div>
+                    </div>
+                  )}
                   <textarea
                     id="session-preamble-input"
                     value={preambleDraft}
                     onChange={(e) => {
                       const next = e.target.value
                       setPreambleDraft(next)
+                      setPreambleDirty(true)
+                      // #4662: capture the session at schedule-time so the
+                      // debounce only fires when activeSessionId still
+                      // points at the same session. Without this, a
+                      // mid-debounce session switch would call
+                      // setSessionPreamble(stale) against the new active
+                      // session (gap 1 of #4662). The schedule-time guard
+                      // is belt-and-braces — the activeSessionId effect
+                      // already cancels the debounce on switch — but it
+                      // closes the race window inside the timer callback.
+                      const scheduledSession = preambleSessionRef.current
                       if (preambleDebounceRef.current) clearTimeout(preambleDebounceRef.current)
                       preambleDebounceRef.current = setTimeout(() => {
                         preambleDebounceRef.current = null
+                        if (preambleSessionRef.current !== scheduledSession) return
+                        setPreambleDirty(false)
                         setSessionPreamble(next)
                       }, 400)
                     }}


### PR DESCRIPTION
## Summary

Closes the two correctness gaps in the per-session preamble editor identified during review of #4661.

- **Gap 1 — cross-session debounce leakage:** The textarea's 400ms debounce closes over the typed text but `setSessionPreamble` reads `activeSessionId` from the store at fire-time. Switching from session A to session B within the debounce window leaked A's draft onto B. Fix: track the schedule-time session in a ref. The `activeSessionId` effect cancels any pending debounce on switch, and the timer callback also bails if the session ref changed (belt and braces against renderer/store ordering races).
- **Gap 2 — multi-client conflict:** A divergent `session_preamble_changed` broadcast arriving mid-edit silently overwrote the local draft. Mirrors the `QuietHoursEditor` #4570 pattern: dirty-flag + parked snapshot + a conflict banner with explicit Keep / Discard affordances.
- **Unmount cleanup** (already correct) is preserved and now covered by a regression test.

## Test plan

- [x] 8 new vitest cases under `cross-session debounce safety + multi-client conflict UX (#4662)`
  - Pending debounce cancels on `activeSessionId` change (no leaked send)
  - Hydrates to new session's value after a switch
  - Divergent snapshot mid-edit surfaces the conflict banner
  - Discard replaces draft with snapshot
  - Accept keeps local draft
  - Own-echo snapshot does NOT raise the banner
  - Clean editor still accepts snapshots normally
  - Unmount-mid-debounce cancels (regression)
- [x] Full `SettingsPanel.test.tsx` — 126 passed
- [x] Full dashboard suite — 2417 passed
- [x] `tsc --noEmit` clean

## Follow-up considered (not in scope)

Acceptance criteria mentions a possible `useDebouncedSetter` hook extraction for #3805 / #3185 reuse. Deferred — those call sites have different cancel/conflict semantics; will land as a separate refactor PR if/when a third call site appears.

Closes #4662