### PR TITLE
feat(dashboard): per-provider copy + view-logs affordance on StreamStallChip

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -267,6 +267,14 @@ export function App() {
   const activeSessionCwd = useConnectionStore(s =>
     s.sessions.find(sess => sess.sessionId === s.activeSessionId)?.cwd ?? null,
   )
+  // #4603: active session's provider name (e.g. `'claude-sdk'`,
+  // `'claude-cli'`) so the StreamStallChip can prefix its headline
+  // with the provider short label for one-glance triage. Subscribed
+  // here so a tab switch updates the chip's variant on the next render
+  // without a full message-map rebuild.
+  const activeSessionProvider = useConnectionStore(s =>
+    s.sessions.find(sess => sess.sessionId === s.activeSessionId)?.provider ?? null,
+  )
   const defaultCwd = useConnectionStore(s => s.defaultCwd)
   const sessions = useConnectionStore(s => s.sessions)
   const sessionStates = useConnectionStore(s => s.sessionStates)
@@ -1552,6 +1560,14 @@ export function App() {
     // most recent bubble (chatTailMessageId) — replayed historical stalls
     // surface the chip text + tooltip for diagnostics, but resending an
     // ancient user_input from a long-finished turn would be misleading.
+    //
+    // #4603: thread the active session's provider through so the chip
+    // headline can carry a short label ("SDK · ...", "CLI · ...") for
+    // one-glance triage, and hand the View-logs affordance a closure
+    // that switches the view to the System pane (where session-level
+    // context lives). The View-logs button is only shown on the tail
+    // entry — replaying historical stalls shouldn't offer to jump the
+    // operator out of the chat for an old event.
     if (storeMsg.type === 'error' && storeMsg.code === 'stream_stall') {
       const isTail = msg.id === chatTailMessageId
       const lastUserInput = isTail
@@ -1562,13 +1578,15 @@ export function App() {
           errorText={storeMsg.content}
           onRetry={lastUserInput ? () => sendInput(lastUserInput.content) : undefined}
           timeoutMs={streamStallTimeoutMs ?? undefined}
+          provider={activeSessionProvider ?? undefined}
+          onViewLogs={isTail ? () => setViewMode('system') : undefined}
         />
       )
     }
 
     // Default rendering
     return null
-  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs])
+  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs, activeSessionProvider, setViewMode])
 
   // #4412: registry-driven cheat sheet. Recomputed on every render —
   // not memoised, by design. The shortcut registry hook re-renders

--- a/packages/dashboard/src/components/StreamStallChip.test.tsx
+++ b/packages/dashboard/src/components/StreamStallChip.test.tsx
@@ -116,4 +116,89 @@ describe('StreamStallChip (#4476)', () => {
       }
     })
   })
+
+  // #4603 — per-provider copy variants. Different providers stall in
+  // qualitatively different ways (SDK = half-open HTTPS to Anthropic API,
+  // CLI = subprocess pipe wedge, TUI = PTY write back-pressure). Surfacing
+  // the provider short label in the chip headline gives the operator a
+  // one-glance hint about WHICH stack stalled without forcing them to dig
+  // through logs to correlate.
+  describe('per-provider copy (#4603)', () => {
+    it('prefixes the headline with the provider short label when provided', () => {
+      render(<StreamStallChip errorText="raw" provider="claude-sdk" />)
+      const chip = screen.getByTestId('stream-stall-chip')
+      expect(chip.textContent).toMatch(/SDK · Stream stalled — retry\?/)
+    })
+
+    it('combines the provider prefix with the humanised timeout when both are present', () => {
+      render(<StreamStallChip errorText="raw" provider="claude-cli" timeoutMs={300_000} />)
+      const chip = screen.getByTestId('stream-stall-chip')
+      expect(chip.textContent).toMatch(/CLI · No response for 5 minutes — retry\?/)
+    })
+
+    it('falls back gracefully for unknown providers', () => {
+      // Unknown providers should still render — getProviderInfo's fallback
+      // path uppercases the raw name. The chip should not crash and the
+      // headline should still contain a sensible short label.
+      render(<StreamStallChip errorText="raw" provider="weird-custom-provider" />)
+      const chip = screen.getByTestId('stream-stall-chip')
+      // Unknown provider gets uppercased fallback short.
+      expect(chip.textContent).toMatch(/WEIRD-CUSTOM-PROVIDER · Stream stalled — retry\?/)
+    })
+
+    it('omits the prefix entirely when provider is undefined, empty, or whitespace', () => {
+      // No regression — older render paths (and replayed historical entries
+      // before provider was threaded in) must continue to render the
+      // bare headline without a stray "· " or "undefined · " artefact.
+      for (const bad of [undefined, '', '   ']) {
+        cleanup()
+        render(<StreamStallChip errorText="raw" provider={bad} />)
+        const chip = screen.getByTestId('stream-stall-chip')
+        expect(chip.textContent).toMatch(/^Stream stalled — retry\?$/)
+      }
+    })
+  })
+
+  // #4603 — telemetry / log link from the chip for triage. Operators
+  // investigating a recurring stall pattern need a one-tap route to the
+  // session's system pane (where the stall + surrounding context is
+  // surfaced). The chip stays decoupled from view-mode plumbing by
+  // accepting an `onViewLogs` callback — the dashboard wires it to
+  // `setViewMode('system')`; the mobile app can wire it differently
+  // or omit it entirely.
+  describe('view-logs affordance (#4603)', () => {
+    it('renders a View logs button when onViewLogs is provided', () => {
+      const onViewLogs = vi.fn()
+      render(<StreamStallChip errorText="raw" onViewLogs={onViewLogs} />)
+      expect(screen.getByTestId('stream-stall-chip-view-logs')).toBeInTheDocument()
+    })
+
+    it('hides the View logs button when onViewLogs is omitted', () => {
+      // Mobile / minimal contexts that don't have a logs view shouldn't
+      // show a dangling affordance.
+      render(<StreamStallChip errorText="raw" />)
+      expect(screen.queryByTestId('stream-stall-chip-view-logs')).toBeNull()
+    })
+
+    it('invokes onViewLogs when the View logs button is clicked', () => {
+      const onViewLogs = vi.fn()
+      render(<StreamStallChip errorText="raw" onViewLogs={onViewLogs} />)
+      fireEvent.click(screen.getByTestId('stream-stall-chip-view-logs'))
+      expect(onViewLogs).toHaveBeenCalledTimes(1)
+    })
+
+    it('renders Retry and View logs side-by-side when both callbacks are provided', () => {
+      // Common case: live stall with both affordances available. Both
+      // buttons must be present and independently clickable so the user
+      // can pick the resolution path that fits their situation.
+      const onRetry = vi.fn()
+      const onViewLogs = vi.fn()
+      render(<StreamStallChip errorText="raw" onRetry={onRetry} onViewLogs={onViewLogs} />)
+      expect(screen.getByTestId('stream-stall-chip-retry')).toBeInTheDocument()
+      expect(screen.getByTestId('stream-stall-chip-view-logs')).toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('stream-stall-chip-view-logs'))
+      expect(onViewLogs).toHaveBeenCalledTimes(1)
+      expect(onRetry).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/dashboard/src/components/StreamStallChip.tsx
+++ b/packages/dashboard/src/components/StreamStallChip.tsx
@@ -10,8 +10,14 @@
  * The full error text remains accessible via the title attribute so
  * diagnostics aren't lost — operators investigating a stall pattern can
  * hover for the underlying server message.
+ *
+ * #4603 — polish: per-provider short label in the headline (so the
+ * operator can tell at a glance which stack stalled) and an optional
+ * "View logs" affordance that hands off to the host app (the dashboard
+ * wires it to `setViewMode('system')`).
  */
 import { useCallback } from 'react'
+import { getProviderInfo } from '@chroxy/store-core'
 import { formatDurationVerbose } from '../utils/duration'
 
 export interface StreamStallChipProps {
@@ -40,6 +46,33 @@ export interface StreamStallChipProps {
    * concern only.
    */
   timeoutMs?: number
+  /**
+   * #4603 — the active session's provider name (e.g. `'claude-sdk'`,
+   * `'claude-cli'`, `'claude-tui'`, `'codex'`, `'gemini'`). When
+   * provided, the chip prefixes the headline with the provider's short
+   * label (e.g. "SDK · No response for 5 minutes — retry?") so operators
+   * triaging recurring stalls can tell at a glance which stack is
+   * responsible. Different providers stall for qualitatively different
+   * reasons — SDK half-open HTTPS to the Anthropic API, CLI subprocess
+   * pipe wedge, TUI PTY back-pressure — and the prefix avoids forcing
+   * the operator to dig through logs to correlate.
+   *
+   * Whitespace-only and empty strings are treated as omitted so a stale
+   * store value can't degrade the headline. Unknown providers fall
+   * through `getProviderInfo`'s uppercase fallback (shared with the
+   * mobile app via `@chroxy/store-core/provider-labels`).
+   */
+  provider?: string
+  /**
+   * #4603 — optional callback invoked when the user taps the "View logs"
+   * affordance. The chip stays decoupled from view-mode plumbing: the
+   * dashboard wires this to `setViewMode('system')` so the session's
+   * surrounding context surfaces in the System pane; the mobile app
+   * can wire it differently or omit it entirely. When omitted, the
+   * button is not rendered at all (no dangling affordance on hosts
+   * without a logs view).
+   */
+  onViewLogs?: () => void
 }
 
 // #4497 — verbose duration humaniser tailored for the stall headline copy.
@@ -47,18 +80,38 @@ export interface StreamStallChipProps {
 // (`formatDurationVerbose`), shared with any other prose-register consumer.
 // Headline copy still reads "No response for ${verbose(ms)} — retry?".
 
-export function StreamStallChip({ errorText, onRetry, timeoutMs }: StreamStallChipProps) {
-  const handleClick = useCallback(() => {
+export function StreamStallChip({
+  errorText,
+  onRetry,
+  timeoutMs,
+  provider,
+  onViewLogs,
+}: StreamStallChipProps) {
+  const handleRetry = useCallback(() => {
     onRetry?.()
   }, [onRetry])
+
+  const handleViewLogs = useCallback(() => {
+    onViewLogs?.()
+  }, [onViewLogs])
 
   // #4497: humanise only when the server actually advertised a usable
   // window. Guard against 0 (explicitly disabled, per protocol) and
   // non-finite values so a malformed auth_ok can't degrade the UI.
-  const headline =
+  const body =
     typeof timeoutMs === 'number' && Number.isFinite(timeoutMs) && timeoutMs > 0
       ? `No response for ${formatDurationVerbose(timeoutMs)} — retry?`
       : 'Stream stalled — retry?'
+
+  // #4603: prefix the body with the provider short label (e.g. "SDK · ")
+  // only when the prop is a non-empty, non-whitespace string. An empty
+  // or whitespace value would render as a stray "· " separator with no
+  // label, which is worse than no prefix at all.
+  const providerShort =
+    typeof provider === 'string' && provider.trim().length > 0
+      ? getProviderInfo(provider.trim()).short
+      : null
+  const headline = providerShort ? `${providerShort} · ${body}` : body
 
   return (
     <div
@@ -73,9 +126,19 @@ export function StreamStallChip({ errorText, onRetry, timeoutMs }: StreamStallCh
           type="button"
           className="stream-stall-chip-retry"
           data-testid="stream-stall-chip-retry"
-          onClick={handleClick}
+          onClick={handleRetry}
         >
           Retry
+        </button>
+      )}
+      {onViewLogs && (
+        <button
+          type="button"
+          className="stream-stall-chip-view-logs"
+          data-testid="stream-stall-chip-view-logs"
+          onClick={handleViewLogs}
+        >
+          View logs
         </button>
       )}
     </div>

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1642,7 +1642,8 @@
 .stream-stall-chip-text {
   white-space: nowrap;
 }
-.stream-stall-chip-retry {
+.stream-stall-chip-retry,
+.stream-stall-chip-view-logs {
   background: transparent;
   border: 1px solid currentColor;
   color: inherit;
@@ -1652,10 +1653,20 @@
   cursor: pointer;
 }
 .stream-stall-chip-retry:hover,
-.stream-stall-chip-retry:focus {
+.stream-stall-chip-retry:focus,
+.stream-stall-chip-view-logs:hover,
+.stream-stall-chip-view-logs:focus {
   background: var(--warning-fg);
   color: var(--bg-primary);
   outline: none;
+}
+
+/* #4603: secondary affordance — visually de-emphasised vs Retry so the
+   primary recovery path (resending the user input) stays the obvious
+   target while still surfacing a triage shortcut for operators. */
+.stream-stall-chip-view-logs {
+  opacity: 0.85;
+  font-weight: normal;
 }
 
 .msg.thinking {


### PR DESCRIPTION
## Summary

Follow-up polish from #4467/#4476/#4603 on the dashboard's STREAM_STALL chip:

- **Per-provider headline prefix.** When the active session's provider is known, the chip prefixes its headline with the provider short label (e.g. `SDK · No response for 5 minutes — retry?`, `CLI · ...`, `TUI · ...`). Different providers stall for qualitatively different reasons — SDK half-open HTTPS to the Anthropic API, CLI subprocess pipe wedge, TUI PTY back-pressure — and the prefix gives operators triaging recurring stalls a one-glance cue about which stack is responsible.
- **Optional "View logs" affordance.** Secondary chip button that hands off to a host-supplied `onViewLogs` callback. The dashboard wires it to switch to the System pane (where session-level context lives); the mobile app can wire it differently or omit it. Only rendered on the tail entry — replayed historical stalls shouldn't offer to jump out for an old event.
- **SDK stall surfacing** — already in place via #4616; no additional server work needed for this PR (the chip already lights up on SDK stalls).

Empty/whitespace `provider` and missing `onViewLogs` both degrade gracefully so older render paths and replayed historical entries continue rendering correctly.

## Test plan

- [x] `cd packages/dashboard && npm test` — 2417 tests pass, 21 of them StreamStallChip (6 new for #4603)
- [x] `tsc --noEmit` clean
- [ ] Manual: trigger a stream stall on each provider (SDK/CLI/TUI) and verify the chip prefix matches the active tab's provider
- [ ] Manual: click "View logs" and confirm the view switches to the System pane

Closes #4603