### PR TITLE
feat(server): surface ASK_USER_QUESTION_TOO_MANY_OPTIONS for 10+ option picks

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2052,6 +2052,57 @@ export class ClaudeTuiSession extends BaseSession {
       log.warn(`AskUserQuestion multi-question: dashboard didn't send answersMap (tool=${prevToolUseId || '?'}, questions=${questions.length}) — defaulting every question to option 1. Update the client to populate the per-question answers map.`)
     }
 
+    // #4625 — claude TUI's hotkey alphabet is single-digit '1'..'9' only,
+    // which covers options at indices 0..8. When a question has 10+ options
+    // AND the user explicitly picked one at index ≥ 9, we have no
+    // representable keystroke. Pre-#4625 the driver silently defaulted
+    // such picks to option 1 (with only a buried WARN in chroxy.log),
+    // dropping the user's explicit pick without UI feedback. Detect the
+    // condition up-front and surface a structured
+    // ASK_USER_QUESTION_TOO_MANY_OPTIONS error so the dashboard can
+    // render a toast prompting the user to re-prompt the agent for fewer
+    // options. Bails BEFORE any PTY write so the form stays in its
+    // initial state — claude TUI's watchdog or the user's Ctrl-C unsticks
+    // it. We deliberately scope the check to explicit user picks: a
+    // 10+ option question with no per-question answer still falls back
+    // to option 1 (back-compat for old clients), which is acceptable
+    // because nothing was silently dropped.
+    if (haveMap) {
+      const unrepresentable = []
+      for (const q of questions) {
+        const opts = Array.isArray(q.options) ? q.options : []
+        if (opts.length <= 9) continue
+        const raw = map[q.question]
+        // Gather every label the user picked for this question (single- or multi-select).
+        let labels = []
+        if (typeof raw === 'string' && raw.length > 0) {
+          let parsed = null
+          try { parsed = JSON.parse(raw) } catch { parsed = null }
+          labels = Array.isArray(parsed)
+            ? parsed.filter((s) => typeof s === 'string')
+            : [raw]
+        } else if (Array.isArray(raw)) {
+          labels = raw.filter((s) => typeof s === 'string')
+        }
+        for (const label of labels) {
+          const idx = opts.findIndex((o) => o && o.label === label)
+          if (idx >= 9) unrepresentable.push({ question: q.question, label, index: idx, total: opts.length })
+        }
+      }
+      if (unrepresentable.length > 0) {
+        const first = unrepresentable[0]
+        log.warn(`AskUserQuestion multi-question: question has ${first.total} options and the user picked option ${first.index + 1} ("${(first.label || '').slice(0, 40)}") which is outside claude TUI's 1..9 hotkey alphabet — surfacing ASK_USER_QUESTION_TOO_MANY_OPTIONS instead of silently defaulting to option 1 (tool=${prevToolUseId || '?'})`)
+        this._pendingUserAnswer = null
+        this._clearAskUserQuestionLock()
+        this.emit('error', {
+          code: 'ASK_USER_QUESTION_TOO_MANY_OPTIONS',
+          message: `Couldn't answer: a question has ${first.total} options and you picked option ${first.index + 1}, which is beyond the 9 the claude TUI form can drive. Re-prompt the agent to ask with 9 or fewer options.`,
+          toolUseId: prevToolUseId,
+        })
+        return
+      }
+    }
+
     /** Resolve a single label to its 1-indexed digit; null if no usable digit. */
     const labelToDigit = (q, label) => {
       if (!q || !Array.isArray(q.options) || q.options.length === 0) return null

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2092,12 +2092,18 @@ export class ClaudeTuiSession extends BaseSession {
       if (unrepresentable.length > 0) {
         const first = unrepresentable[0]
         log.warn(`AskUserQuestion multi-question: question has ${first.total} options and the user picked option ${first.index + 1} ("${(first.label || '').slice(0, 40)}") which is outside claude TUI's 1..9 hotkey alphabet — surfacing ASK_USER_QUESTION_TOO_MANY_OPTIONS instead of silently defaulting to option 1 (tool=${prevToolUseId || '?'})`)
-        this._pendingUserAnswer = null
-        this._clearAskUserQuestionLock()
-        this.emit('error', {
-          code: 'ASK_USER_QUESTION_TOO_MANY_OPTIONS',
-          message: `Couldn't answer: a question has ${first.total} options and you picked option ${first.index + 1}, which is beyond the 9 the claude TUI form can drive. Re-prompt the agent to ask with 9 or fewer options.`,
-          toolUseId: prevToolUseId,
+        // Full AskUserQuestion teardown: synth tool_result + Ctrl-C the
+        // TUI + clear inactivity timers + stream_end + _emitResult +
+        // error (in that order). Without the full teardown the dashboard
+        // would leave the Working banner + Stop button up and the
+        // "Running AskUserQuestion · Ns" pill ticking even though
+        // chroxy gave up before writing any keystrokes (#4625 hands the
+        // form's resolution back to the user via the error toast).
+        this._teardownAskUserQuestion(prevToolUseId, {
+          synthResult: `AskUserQuestion failed: question has ${first.total} options and you picked option ${first.index + 1}, beyond the 9 the claude TUI form can drive (#4625).`,
+          emitResultReason: 'ask_user_question_too_many_options',
+          errorCode: 'ASK_USER_QUESTION_TOO_MANY_OPTIONS',
+          errorMessage: `Couldn't answer: a question has ${first.total} options and you picked option ${first.index + 1}, which is beyond the 9 the claude TUI form can drive. Re-prompt the agent to ask with 9 or fewer options.`,
         })
         return
       }
@@ -2263,6 +2269,41 @@ export class ClaudeTuiSession extends BaseSession {
 
     log.warn(`AskUserQuestion stall: tool=${toolUseId} — claude TUI never emitted PostToolUse after answer write (${ASK_USER_QUESTION_WATCHDOG_MS}ms). Likely a multi-question form (#4604). Tearing down turn so the session is recoverable.`)
 
+    this._teardownAskUserQuestion(toolUseId, {
+      synthResult: 'AskUserQuestion stalled — no response from claude TUI within 30s. Likely a multi-question form (#4604).',
+      emitResultReason: 'ask_user_question_stall',
+      errorCode: 'ASK_USER_QUESTION_STALL',
+      // #4648: dropped the "likely a multi-question form" jargon. The
+      // permission-hook deny path (also #4648) prevents most multi-question
+      // forms from reaching this code path at all, and for the cases that
+      // slip through, the user doesn't care about chroxy internals — they
+      // care about how to recover. The new copy is action-oriented.
+      errorMessage: 'Couldn\'t deliver your answers. Tap Retry to resend your original request.',
+    })
+  }
+
+  /**
+   * Shared teardown for AskUserQuestion failure modes. Used by both the
+   * 30s post-write stall watchdog (#4604) and the up-front
+   * too-many-options detector (#4625). Mirrors the end-to-end teardown
+   * order pinned in #4645: synthetic tool_result → Ctrl-C the TUI →
+   * clear inactivity timers → null active turn / busy state →
+   * stream_end + _emitResult → error event last. The caller supplies the
+   * synth result text, _emitResult reason tag, and error code/message so
+   * the same teardown serves both call sites.
+   *
+   * Splitting this out (vs the original inline form in
+   * _onAskUserQuestionStall) is intentional: #4625's too-many-options
+   * path needs the full teardown so the dashboard's Working banner +
+   * Stop button + activeTools entry all clear immediately, but the
+   * trigger and copy differ from the 30s stall path. Inlining the
+   * teardown twice risked drift; folding both into _teardownTurn would
+   * widen the helper's surface (synth tool_result + 3-timer clear +
+   * toolUseId-carrying error don't generalise to the other teardown
+   * sites), so a dedicated AskUserQuestion teardown helper earns its
+   * keep.
+   */
+  _teardownAskUserQuestion(toolUseId, { synthResult, emitResultReason, errorCode, errorMessage }) {
     const messageId = this._currentMessageId
     const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : 0
 
@@ -2271,14 +2312,13 @@ export class ClaudeTuiSession extends BaseSession {
     // #4616: emit a synthetic tool_result FIRST so the dashboard's
     // activeTools entry for this AskUserQuestion is cleared. Without it
     // the footer "Running AskUserQuestion · Ns" pill keeps ticking
-    // forever even though _isBusy is clear and the user sees the
-    // ASK_USER_QUESTION_STALL error toast. The handler ignores any
-    // fields beyond {toolUseId, result, truncated, images} (see
-    // store-core handleToolResult); pairing-by-toolUseId is what drives
-    // the activeTools removal in store-core handlers.
+    // forever even though _isBusy is clear and the user sees the error
+    // toast. The handler ignores any fields beyond {toolUseId, result,
+    // truncated, images} (see store-core handleToolResult); pairing-by-
+    // toolUseId is what drives the activeTools removal in store-core handlers.
     this.emit('tool_result', {
       toolUseId,
-      result: 'AskUserQuestion stalled — no response from claude TUI within 30s. Likely a multi-question form (#4604).',
+      result: synthResult,
       truncated: false,
     })
     // #4628: matching tool_start resolved — drop from the in-flight map.
@@ -2299,9 +2339,8 @@ export class ClaudeTuiSession extends BaseSession {
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }
     if (this._streamStallTimeout) { clearTimeout(this._streamStallTimeout); this._streamStallTimeout = null }
 
-    // #4022: drop per-turn attachment dir on stall (same as the other
-    // teardown paths) so a stalled turn doesn't leak materialized files
-    // until destroy().
+    // #4022: drop per-turn attachment dir (same as the other teardown
+    // paths) so a failed turn doesn't leak materialized files until destroy().
     this._cleanupTurnAttachments(this._activeTurn)
     this._activeTurn = null
     this._isBusy = false
@@ -2317,16 +2356,11 @@ export class ClaudeTuiSession extends BaseSession {
     if (messageId) this.emit('stream_end', { messageId })
     this._emitResult(
       { cost: null, duration, usage: null, sessionId: this._sessionId },
-      'ask_user_question_stall',
+      emitResultReason,
     )
     this.emit('error', {
-      code: 'ASK_USER_QUESTION_STALL',
-      // #4648: dropped the "likely a multi-question form" jargon. The
-      // permission-hook deny path (also #4648) prevents most multi-question
-      // forms from reaching this code path at all, and for the cases that
-      // slip through, the user doesn't care about chroxy internals — they
-      // care about how to recover. The new copy is action-oriented.
-      message: 'Couldn\'t deliver your answers. Tap Retry to resend your original request.',
+      code: errorCode,
+      message: errorMessage,
       toolUseId,
     })
   }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2073,16 +2073,30 @@ export class ClaudeTuiSession extends BaseSession {
         const opts = Array.isArray(q.options) ? q.options : []
         if (opts.length <= 9) continue
         const raw = map[q.question]
-        // Gather every label the user picked for this question (single- or multi-select).
+        // Gather every label the user picked for this question (single- or
+        // multi-select). MUST mirror resolveQuestionDigits' multi-select
+        // parsing — array → JSON-encoded array → comma-joined list — so
+        // an unrepresentable pick sent via the comma-joined fallback
+        // (e.g. "a,k") isn't accidentally treated as a single 3-char
+        // label and missed (Copilot review feedback). For single-select
+        // we don't split on comma because option labels may legitimately
+        // contain commas; the multi-select code path is the only one
+        // that defined comma-joining as a wire encoding.
         let labels = []
-        if (typeof raw === 'string' && raw.length > 0) {
-          let parsed = null
-          try { parsed = JSON.parse(raw) } catch { parsed = null }
-          labels = Array.isArray(parsed)
-            ? parsed.filter((s) => typeof s === 'string')
-            : [raw]
-        } else if (Array.isArray(raw)) {
+        if (Array.isArray(raw)) {
           labels = raw.filter((s) => typeof s === 'string')
+        } else if (typeof raw === 'string' && raw.length > 0) {
+          if (q.multiSelect) {
+            let parsed = null
+            try { parsed = JSON.parse(raw) } catch { parsed = null }
+            if (Array.isArray(parsed)) {
+              labels = parsed.filter((s) => typeof s === 'string')
+            } else {
+              labels = raw.split(',').map((s) => s.trim()).filter(Boolean)
+            }
+          } else {
+            labels = [raw]
+          }
         }
         for (const label of labels) {
           const idx = opts.findIndex((o) => o && o.label === label)

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3662,6 +3662,150 @@ describe('ClaudeTuiSession', () => {
       assert.deepEqual(session._pendingUserAnswer.options, questions[0].options,
         'options still points at questions[0].options for back-compat')
     })
+
+    // #4625 — 10+ option questions. claude TUI's single-digit hotkey
+    // alphabet only covers indices 0..8 (digits '1'..'9'). The pre-#4625
+    // driver silently defaulted picks of options 10+ to option 1 (with a
+    // WARN buried in chroxy.log), so the user's explicit pick was
+    // dropped without any UI feedback. The fix surfaces a structured
+    // error before any keystroke is written so the dashboard can prompt
+    // the user to re-ask with fewer options.
+    describe('10+ option support (#4625)', () => {
+      // The 10-option case: user picked option 10 (index 9). The driver
+      // can't express index 9 in single-digit hotkey land, so it MUST
+      // emit ASK_USER_QUESTION_TOO_MANY_OPTIONS and tear down the turn
+      // instead of writing keystrokes that would silently land on option 1.
+      it('multi-question: pick of option 10+ surfaces ASK_USER_QUESTION_TOO_MANY_OPTIONS error + no PTY writes', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        // Q1 has 12 options; user picked option 10 (label 'j').
+        const tenPlusOptions = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l']
+          .map((label) => ({ label }))
+        const questions = [
+          { question: 'Q1?', options: tenPlusOptions },
+          { question: 'Q2?', options: [{ label: 'x' }, { label: 'y' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_big', questions, options: questions[0].options }
+
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        session.respondToQuestion('', { 'Q1?': 'j', 'Q2?': 'x' })
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        // No keystrokes written — bailed out before the PTY write path.
+        assert.deepEqual(writes, [], `expected no PTY writes, got ${JSON.stringify(writes)}`)
+
+        // Structured error surfaced so the dashboard can render a toast
+        // and clear the Working banner.
+        assert.equal(errors.length, 1, 'exactly one error emitted')
+        assert.equal(errors[0].code, 'ASK_USER_QUESTION_TOO_MANY_OPTIONS')
+        assert.equal(errors[0].toolUseId, 'toolu_big')
+        assert.match(errors[0].message, /option/i,
+          `error message mentions the option-count limitation, got ${errors[0].message}`)
+
+        // Pending cleared so subsequent answers don't write into a
+        // resolved-but-now-torn-down turn.
+        assert.equal(session._pendingUserAnswer, null, 'pending cleared after too-many error')
+
+        // No stall watchdog armed — the error is the resolution.
+        assert.equal(session._askUserQuestionWatchdog, null, 'watchdog NOT armed (error is the resolution)')
+
+        // WARN in chroxy.log so the wedge is greppable.
+        const warn = warnLines.find((m) => /AskUserQuestion multi-question: question has \d+ options/.test(m))
+        assert.ok(warn, `expected too-many-options WARN, got ${JSON.stringify(warnLines)}`)
+      })
+
+      // Boundary: a 10-option question where the user picked option 9 (the
+      // LAST representable digit) — driver MUST drive normally, not bail.
+      // This pins the exact edge of the supported range.
+      it('multi-question: pick of option 9 in a 10-option question still drives normally', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        const tenOptions = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+          .map((label) => ({ label }))
+        const questions = [
+          { question: 'Q1?', options: tenOptions },
+          { question: 'Q2?', options: [{ label: 'x' }, { label: 'y' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_edge', questions, options: questions[0].options }
+
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        // 'i' is index 8 → digit '9' (the highest supported digit).
+        session.respondToQuestion('', { 'Q1?': 'i', 'Q2?': 'x' })
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        // Driver wrote normally — no too-many error.
+        assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
+        // Q1 → '9', Q2 → '1', Submit → '1', wrapped in paste toggles.
+        assert.deepEqual(writes, ['\x1b[?2004l', '9', '1', '1', '\x1b[?2004h'],
+          `expected '9' + '1' + Submit sequence, got ${JSON.stringify(writes)}`)
+      })
+
+      // Multi-select toggle of an option at index ≥ 9 also fires the error.
+      // (Mirror of the single-select case to make sure the multi-select
+      // branch isn't accidentally exempt — both go through labelToDigit.)
+      // Form has 2 questions so the multi-question driver path is taken
+      // (the questions.length===1 branch falls into the legacy single-q
+      // writer which has its own #4292 fall-through-to-label-text path).
+      it('multi-question (multi-select): toggle of option 10+ surfaces ASK_USER_QUESTION_TOO_MANY_OPTIONS', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        const elevenOptions = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
+          .map((label) => ({ label }))
+        const questions = [
+          { question: 'Q1?', multiSelect: true, options: elevenOptions },
+          { question: 'Q2?', options: [{ label: 'x' }, { label: 'y' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_multi_big', questions, options: questions[0].options }
+
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        // User toggled options 'a' (index 0 → digit '1') AND 'k' (index 10 → unrepresentable).
+        session.respondToQuestion('', { 'Q1?': JSON.stringify(['a', 'k']), 'Q2?': 'x' })
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        assert.deepEqual(writes, [], 'no PTY writes once any pick is unrepresentable')
+        assert.equal(errors.length, 1, 'one error emitted')
+        assert.equal(errors[0].code, 'ASK_USER_QUESTION_TOO_MANY_OPTIONS')
+        assert.equal(errors[0].toolUseId, 'toolu_multi_big')
+      })
+
+      // Negative: a 10+ option question where the dashboard sent NO
+      // answersMap (back-compat fallback). The pre-#4625 behavior of
+      // defaulting to option 1 is preserved — no error fires because
+      // the user didn't make an unrepresentable pick.
+      it('multi-question: 10+ options with NO answersMap keeps the default-to-option-1 back-compat (no error)', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        const tenPlus = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
+          .map((label) => ({ label }))
+        const questions = [
+          { question: 'Q1?', options: tenPlus },
+          { question: 'Q2?', options: [{ label: 'x' }, { label: 'y' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_nomap_big', questions, options: questions[0].options }
+
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        // Old client: just text, no answersMap.
+        session.respondToQuestion('a')
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        // No error — the user's pick (option 1) IS representable; the
+        // default-to-option-1 fallback honors it for Q2 too. This is the
+        // pre-#4625 path; #4625 only fires when the user EXPLICITLY picks
+        // an index ≥ 9.
+        assert.equal(errors.length, 0, `expected no errors for back-compat path, got ${JSON.stringify(errors)}`)
+        // Q1 → '1', Q2 → '1', Submit → '1'.
+        assert.deepEqual(writes, ['\x1b[?2004l', '1', '1', '1', '\x1b[?2004h'],
+          `expected default-to-1 sequence even with 10+ options, got ${JSON.stringify(writes)}`)
+      })
+    })
   })
 
   // #4044: per-session option that spawns claude TUI with the literal

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3677,7 +3677,14 @@ describe('ClaudeTuiSession', () => {
       // instead of writing keystrokes that would silently land on option 1.
       it('multi-question: pick of option 10+ surfaces ASK_USER_QUESTION_TOO_MANY_OPTIONS error + no PTY writes', async () => {
         const writes = []
+        // The teardown writes Ctrl-C ('\x03') to unstick the TUI form,
+        // matching _onAskUserQuestionStall. Captured so we can assert
+        // the form bytes are NOT written (driver bailed before any digit
+        // keystroke), and the Ctrl-C IS written (recoverable teardown).
         session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        session._isBusy = true
+        session._currentMessageId = 'msg_big'
+        session._activeTurn = { uuid: 'turn_big', synthSeq: 0, startedAt: Date.now() }
         // Q1 has 12 options; user picked option 10 (label 'j').
         const tenPlusOptions = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l']
           .map((label) => ({ label }))
@@ -3688,21 +3695,40 @@ describe('ClaudeTuiSession', () => {
         session._pendingUserAnswer = { toolUseId: 'toolu_big', questions, options: questions[0].options }
 
         const errors = []
+        const toolResults = []
+        const streamEnds = []
+        const results = []
         session.on('error', (e) => errors.push(e))
+        session.on('tool_result', (tr) => toolResults.push(tr))
+        session.on('stream_end', (se) => streamEnds.push(se))
+        session.on('result', (r) => results.push(r))
 
         session.respondToQuestion('', { 'Q1?': 'j', 'Q2?': 'x' })
         await new Promise((resolve) => setTimeout(resolve, 50))
 
-        // No keystrokes written — bailed out before the PTY write path.
-        assert.deepEqual(writes, [], `expected no PTY writes, got ${JSON.stringify(writes)}`)
+        // No FORM keystrokes written — bailed out before the PTY write
+        // path. The teardown's Ctrl-C ('\x03') IS expected so claude TUI
+        // unsticks from the form screen for the next turn.
+        assert.deepEqual(writes, ['\x03'],
+          `expected only Ctrl-C teardown write, got ${JSON.stringify(writes)}`)
 
-        // Structured error surfaced so the dashboard can render a toast
-        // and clear the Working banner.
+        // Structured error surfaced so the dashboard can render a toast.
         assert.equal(errors.length, 1, 'exactly one error emitted')
         assert.equal(errors[0].code, 'ASK_USER_QUESTION_TOO_MANY_OPTIONS')
         assert.equal(errors[0].toolUseId, 'toolu_big')
         assert.match(errors[0].message, /option/i,
           `error message mentions the option-count limitation, got ${errors[0].message}`)
+
+        // Full teardown so the dashboard's Working banner + Stop button +
+        // activeTools entry all clear (mirrors _onAskUserQuestionStall).
+        assert.equal(toolResults.length, 1, 'synthetic tool_result for activeTools clear')
+        assert.equal(toolResults[0].toolUseId, 'toolu_big')
+        assert.equal(streamEnds.length, 1, 'stream_end emitted to clear streamingMessageId')
+        assert.equal(streamEnds[0].messageId, 'msg_big')
+        assert.equal(results.length, 1, '_emitResult fanned for agent_idle')
+        assert.equal(session._isBusy, false, '_isBusy cleared')
+        assert.equal(session._currentMessageId, null, '_currentMessageId cleared')
+        assert.equal(session._activeTurn, null, '_activeTurn cleared')
 
         // Pending cleared so subsequent answers don't write into a
         // resolved-but-now-torn-down turn.
@@ -3753,6 +3779,9 @@ describe('ClaudeTuiSession', () => {
       it('multi-question (multi-select): toggle of option 10+ surfaces ASK_USER_QUESTION_TOO_MANY_OPTIONS', async () => {
         const writes = []
         session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        session._isBusy = true
+        session._currentMessageId = 'msg_mb'
+        session._activeTurn = { uuid: 'turn_mb', synthSeq: 0, startedAt: Date.now() }
         const elevenOptions = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
           .map((label) => ({ label }))
         const questions = [
@@ -3768,7 +3797,10 @@ describe('ClaudeTuiSession', () => {
         session.respondToQuestion('', { 'Q1?': JSON.stringify(['a', 'k']), 'Q2?': 'x' })
         await new Promise((resolve) => setTimeout(resolve, 50))
 
-        assert.deepEqual(writes, [], 'no PTY writes once any pick is unrepresentable')
+        // No FORM keystrokes — bailed before any digit write. Only the
+        // teardown Ctrl-C ('\x03') is present.
+        assert.deepEqual(writes, ['\x03'],
+          `expected only Ctrl-C teardown write, got ${JSON.stringify(writes)}`)
         assert.equal(errors.length, 1, 'one error emitted')
         assert.equal(errors[0].code, 'ASK_USER_QUESTION_TOO_MANY_OPTIONS')
         assert.equal(errors[0].toolUseId, 'toolu_multi_big')

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3806,6 +3806,39 @@ describe('ClaudeTuiSession', () => {
         assert.equal(errors[0].toolUseId, 'toolu_multi_big')
       })
 
+      // Multi-select via the comma-joined fallback wire encoding (the
+      // pre-Chunk-B back-compat path that resolveQuestionDigits accepts).
+      // Copilot review feedback: the pre-scan MUST split comma-joined
+      // multi-select strings same as resolveQuestionDigits, else an
+      // unrepresentable pick sent as "a,k" is treated as a single 3-char
+      // label and slips through to the silent default-to-option-1 path.
+      it('multi-question (multi-select): comma-joined "a,k" with k at index 10 surfaces the too-many error', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        session._isBusy = true
+        session._currentMessageId = 'msg_cj'
+        session._activeTurn = { uuid: 'turn_cj', synthSeq: 0, startedAt: Date.now() }
+        const elevenOptions = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k']
+          .map((label) => ({ label }))
+        const questions = [
+          { question: 'Q1?', multiSelect: true, options: elevenOptions },
+          { question: 'Q2?', options: [{ label: 'x' }, { label: 'y' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_cj', questions, options: questions[0].options }
+
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+
+        // Comma-joined "a,k" — NOT JSON. k is at index 10 (unrepresentable).
+        session.respondToQuestion('', { 'Q1?': 'a,k', 'Q2?': 'x' })
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        assert.deepEqual(writes, ['\x03'],
+          `expected Ctrl-C teardown only, got ${JSON.stringify(writes)}`)
+        assert.equal(errors.length, 1, 'one error emitted')
+        assert.equal(errors[0].code, 'ASK_USER_QUESTION_TOO_MANY_OPTIONS')
+      })
+
       // Negative: a 10+ option question where the dashboard sent NO
       // answersMap (back-compat fallback). The pre-#4625 behavior of
       // defaulting to option 1 is preserved — no error fires because

--- a/scripts/tui-form-recorder.mjs
+++ b/scripts/tui-form-recorder.mjs
@@ -23,6 +23,27 @@
  * Analysis: tail the JSONL file to find the keystroke patterns that
  * advance between questions, toggle multiSelect, and reach Submit.
  *
+ * 10+ option questions (#4625):
+ *   The 2026-05-30 empirical recording only covered questions with ≤9
+ *   options (single-digit hotkeys '1'..'9'). For questions with 10+
+ *   options, two TUI keystroke paths are theoretically possible — neither
+ *   has been verified live:
+ *     - Arrow-key navigation: '\x1b[B' (down) N-1 times + '\r' (Enter)
+ *       to commit. Risk: claude TUI's multi-question form layout may not
+ *       accept arrow keys (no empirical recording exists).
+ *     - Multi-digit hotkey (e.g. '10', '11'): the v0.9.x single-digit
+ *       commit-on-keystroke behaviour pinned in #4292 makes this
+ *       unlikely to work; the second digit would either be dropped or
+ *       parsed as the next question's input.
+ *   Until a recorder pass exists for either path, the chroxy driver
+ *   (claude-tui-session.js) bails with ASK_USER_QUESTION_TOO_MANY_OPTIONS
+ *   when the user picks an option at index ≥9 — the dashboard surfaces a
+ *   toast asking the user to re-prompt with fewer options. To extend the
+ *   driver, record a session against a 10+ option question and pick
+ *   options 10, 11, etc. with whichever keystroke pattern works, then
+ *   add the supported keys to the multi-question driver and remove the
+ *   too-many-options guard.
+ *
  * Exit:
  *   Ctrl+D — clean exit (closes recording file)
  *   Ctrl+\ — kill claude immediately


### PR DESCRIPTION
## Summary

- The multi-question form driver's `labelToDigit` helper returns `null` for options at index >=9 (claude TUI single-digit hotkey alphabet '1'..'9'). Pre-fix, the driver silently fell back to `defaultDigit = '1'` for picks of options 10+, dropping the user's explicit pick with only a buried WARN.
- Now: when `answersMap` contains a pick at index >=9, the driver scans up-front and emits a structured `ASK_USER_QUESTION_TOO_MANY_OPTIONS` error before any PTY write. The dashboard's existing error toast handler surfaces this so the user can re-prompt the agent for fewer options.
- Pre-fix default-to-option-1 fallback preserved for old clients that send no `answersMap` (where no explicit pick is being dropped).
- Documents the 10+ option limitation in `scripts/tui-form-recorder.mjs` notes so a future recorder pass can pin the supported keystroke pattern (likely arrow-key navigation) and lift the guard.

## Test plan

- [x] New tests in `packages/server/tests/claude-tui-session.test.js` (4 cases in the `10+ option support (#4625)` describe block):
  - [x] Multi-question single-select pick of option 10+ surfaces error + no PTY writes
  - [x] Boundary: pick of option 9 in a 10-option question still drives normally
  - [x] Multi-question multi-select toggle of option 10+ surfaces error
  - [x] 10+ options with NO answersMap keeps the default-to-option-1 back-compat
- [x] `npm test` — full `claude-tui-session.test.js` suite passes (148/148)
- [x] `npm test` — AskUserQuestion subset passes (37/37) including the existing Chunk B byte-sequence guards
- [x] Memory `tui_multi_question_form_keys` updated with the #4625 status

Closes #4625