### PR TITLE
fix(dashboard): sync Working banner to server isBusy across tab swaps

### DIFF
--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2051,6 +2051,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // switch_session WS message is processed.
       // Reset all session-scoped fields so the previous session's values don't bleed through
       // during the server round-trip.
+      //
+      // #4639: seed `isIdle` from the most-recent `session_list` snapshot
+      // (where the server reports `isBusy` per session) instead of hardcoding
+      // `true`. Without this, clicking a tab whose session is still in-flight
+      // on the server would silently drop the Working banner and the Stop
+      // button until the next server event lands.
+      const sessionInfo = get().sessions.find((s) => s.sessionId === sessionId);
+      const seedIsIdle = typeof sessionInfo?.isBusy === 'boolean' ? !sessionInfo.isBusy : true;
       set({
         activeSessionId: sessionId,
         messages: [],
@@ -2061,7 +2069,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         contextUsage: null,
         lastResultCost: null,
         lastResultDuration: null,
-        isIdle: true,
+        isIdle: seedIsIdle,
         sessionNotifications: filteredNotifications,
       });
     }

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3556,4 +3556,172 @@ describe('dashboard message-handler dispatch', () => {
       expect(ssB.lastClientActivityAt).toBe(100)
     })
   })
+
+  // #4639 — the Working banner desyncs across tabs / remounts because
+  // `sessionStates[id].isIdle` is initialised to `true` and only flipped by
+  // local events (`agent_busy` / `agent_idle`). When a new tab opens, when
+  // session_state is rebuilt for a previously-unobserved session, or when
+  // the server tells us via `session_activity` that a session is still
+  // in-flight, the dashboard must trust the server's authoritative `isBusy`
+  // flag over the local default.
+  describe('isIdle authoritative sync (#4639)', () => {
+    it('session_list seeds isIdle from server isBusy for a brand new session entry', () => {
+      // Fresh store with no session state for s1. session_list arrives with
+      // isBusy: true (the server considers the session in-flight). Pre-fix
+      // the dashboard would default isIdle to true and the Working banner
+      // would not render until the next live event landed.
+      store = createMockStore(baseState())
+      setStore(store)
+      handleMessage(
+        {
+          type: 'session_list',
+          sessions: [
+            { sessionId: 's1', name: 'S1', isBusy: true } as any,
+          ],
+        },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss).toBeDefined()
+      expect(ss.isIdle).toBe(false)
+    })
+
+    it('session_list seeds isIdle: true for an idle session', () => {
+      store = createMockStore(baseState())
+      setStore(store)
+      handleMessage(
+        {
+          type: 'session_list',
+          sessions: [
+            { sessionId: 's1', name: 'S1', isBusy: false } as any,
+          ],
+        },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.isIdle).toBe(true)
+    })
+
+    it('session_list resyncs isIdle on an existing session when server flips to busy', () => {
+      // Tab swap path: the session state exists with isIdle: true (default
+      // after createEmptySessionState), but the server is still in-flight.
+      // A periodic session_list snapshot should correct the local state so
+      // the banner re-appears for the user.
+      store = createMockStore(
+        baseState({
+          sessionStates: {
+            s1: { ...createEmptySessionState(), isIdle: true },
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'session_list',
+          sessions: [
+            { sessionId: 's1', name: 'S1', isBusy: true } as any,
+          ],
+        },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.isIdle).toBe(false)
+    })
+
+    it('session_list resyncs isIdle on an existing session when server flips to idle', () => {
+      // The reverse case: a stuck local `isIdle: false` (e.g. missed an
+      // agent_idle event) gets corrected on the next snapshot.
+      store = createMockStore(
+        baseState({
+          sessionStates: {
+            s1: { ...createEmptySessionState(), isIdle: false },
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        {
+          type: 'session_list',
+          sessions: [
+            { sessionId: 's1', name: 'S1', isBusy: false } as any,
+          ],
+        },
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.isIdle).toBe(true)
+    })
+
+    it('session_activity sets isIdle: false when server reports busy', () => {
+      // The server already emits `session_activity` on stream_start / result
+      // (ws-forwarding.js), but pre-fix the dashboard had no handler for it
+      // — so peer-tab busy state never propagated. Wire it up.
+      store = createMockStore(
+        baseState({
+          sessionStates: {
+            s1: { ...createEmptySessionState(), isIdle: true },
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        { type: 'session_activity', sessionId: 's1', isBusy: true } as any,
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.isIdle).toBe(false)
+    })
+
+    it('session_activity sets isIdle: true when server reports idle', () => {
+      store = createMockStore(
+        baseState({
+          sessionStates: {
+            s1: { ...createEmptySessionState(), isIdle: false },
+          },
+        }),
+      )
+      setStore(store)
+      handleMessage(
+        { type: 'session_activity', sessionId: 's1', isBusy: false } as any,
+        ctx() as any,
+      )
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.isIdle).toBe(true)
+    })
+
+    it('session_activity is a no-op when the session is not in sessionStates', () => {
+      // Defensive: a session_activity for an unknown session must not crash
+      // or create a phantom entry — the session_list path is responsible
+      // for seeding new sessions.
+      store = createMockStore(baseState())
+      setStore(store)
+      handleMessage(
+        { type: 'session_activity', sessionId: 'unknown', isBusy: true } as any,
+        ctx() as any,
+      )
+      const states = (store.getState() as any).sessionStates
+      expect(states.unknown).toBeUndefined()
+    })
+
+    it('session_activity syncs the flat isIdle when the active session changes', () => {
+      // When the active session's busy state changes, the flat-state mirror
+      // (read by App.tsx's `isBusy={!isIdle}` props) must update too so the
+      // Stop/Send button switches without a tab interaction.
+      store = createMockStore(
+        baseState({
+          activeSessionId: 's1',
+          sessionStates: {
+            s1: { ...createEmptySessionState(), isIdle: true },
+          },
+          isIdle: true,
+        } as any),
+      )
+      setStore(store)
+      handleMessage(
+        { type: 'session_activity', sessionId: 's1', isBusy: true } as any,
+        ctx() as any,
+      )
+      expect((store.getState() as any).isIdle).toBe(false)
+    })
+  })
 })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2192,18 +2192,38 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             set({ activeModel: matched ? matched.id : fullId });
           }
         }
-        // Initialize session state for any new sessions not yet tracked
+        // Initialize session state for any new sessions not yet tracked.
+        // #4639: seed `isIdle` from the server's authoritative `isBusy` so a
+        // fresh tab / new-session entry reflects the real working state
+        // instead of defaulting to `isIdle: true` and silently dropping the
+        // Working banner until the next live event arrives.
         const currentStates = get().sessionStates;
         const newInitStates = { ...currentStates };
         let initStatesChanged = false;
         for (const s of sessionList) {
           if (!newInitStates[s.sessionId]) {
-            newInitStates[s.sessionId] = createEmptySessionState();
+            const fresh = createEmptySessionState();
+            if (typeof s.isBusy === 'boolean') fresh.isIdle = !s.isBusy;
+            newInitStates[s.sessionId] = fresh;
             initStatesChanged = true;
           }
         }
         if (initStatesChanged) {
           set({ sessionStates: newInitStates });
+        }
+        // #4639: resync `isIdle` on EXISTING session states against the
+        // snapshot's `isBusy`. Without this, a session that became busy on
+        // the server while the dashboard's local handlers missed the flip
+        // (tab swap during a long turn, peer-tab triggered the work, race
+        // between agent_busy and history_replay) shows the wrong banner and
+        // the wrong Send/Stop button. The snapshot is the source of truth.
+        for (const s of sessionList) {
+          if (typeof s.isBusy !== 'boolean') continue;
+          if (!get().sessionStates[s.sessionId]) continue;
+          const desiredIsIdle = !s.isBusy;
+          updateSession(s.sessionId, (ss) =>
+            ss.isIdle === desiredIsIdle ? {} : { isIdle: desiredIsIdle }
+          );
         }
         // Sync conversationId from session list into session states
         for (const s of sessionList) {
@@ -2269,6 +2289,28 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const { sessionId: ctxSessionId, patch } = sharedSessionContext(msg, get().activeSessionId);
       if (ctxSessionId && get().sessionStates[ctxSessionId]) {
         updateSession(ctxSessionId, () => patch);
+      }
+      break;
+    }
+
+    case 'session_activity': {
+      // #4639: server-emitted busy/idle broadcast (ws-forwarding.js fires it
+      // on stream_start and result for every session, to every authenticated
+      // client). Pre-fix the dashboard had no handler, so a peer tab driving
+      // the session — or this tab's own session_list snapshot — was the only
+      // way to learn about busy state changes for non-active sessions. That
+      // gap is what made the Working banner desync after a tab swap.
+      //
+      // Defensive: ignore if either field is missing/wrong type, and skip
+      // unknown sessions (session_list is responsible for seeding new
+      // entries — we don't want session_activity racing it).
+      const activitySessionId = typeof msg.sessionId === 'string' ? msg.sessionId : null;
+      const activityIsBusy = typeof msg.isBusy === 'boolean' ? msg.isBusy : null;
+      if (activitySessionId && activityIsBusy !== null && get().sessionStates[activitySessionId]) {
+        const desiredIsIdle = !activityIsBusy;
+        updateSession(activitySessionId, (ss) =>
+          ss.isIdle === desiredIsIdle ? {} : { isIdle: desiredIsIdle }
+        );
       }
       break;
     }

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -42,7 +42,6 @@ const INTENTIONALLY_UNHANDLED = new Set([
   // 'error' removed — both handlers now implement case 'error': (PR #2742)
   'session_created',    // ack handled via session_list refresh, no dedicated case needed
   'session_destroyed',  // ack handled via session_list refresh, no dedicated case needed
-  'session_activity',   // server-side session activity tracking, not displayed in handlers
   'discovered_sessions', // multi-server discovery, handled at connection layer
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
@@ -98,6 +97,7 @@ const PLATFORM_SPECIFIC = {
   'skill_trust_granted': 'dashboard',  // community trust granted broadcast (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_grant_ok': 'dashboard', // ack for skill_trust_grant handler (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'byok_credentials_status': 'dashboard', // paste-API-key form is dashboard-only (#4052); mobile app exposure tracked under the BYOK epic #4047
+  'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The dashboard's Working banner (and red Stop button, and follow-up placeholder) was driven by a local-only `isIdle` flag flipped only by `agent_busy` / `agent_idle` events. When a session view unmounted (tab swap) and remounted, or when a new tab opened mid-session, the default `isIdle: true` dropped the banner even though the server still considered the session in-flight.
- Fix is to treat the server's `isBusy` field as authoritative. Three wire-up points:
  - `session_list` snapshots seed `isIdle` from `!isBusy` for brand-new entries and resync existing entries that drifted.
  - `session_activity` (already broadcast by `ws-forwarding.js` on `stream_start` / `result`) now has a dashboard handler so peer-tab flips propagate without waiting for the next snapshot.
  - `switchSession` seeds `isIdle` from `sessions[].isBusy` instead of hardcoding `true`, so the first paint after a tab click matches reality.
- Scope-limited to the dashboard — no server changes; the protocol fields already exist.

## Test plan

- [x] 8 new unit tests in `message-handler.test.ts` cover: new session seed (busy + idle), existing session resync in both directions, `session_activity` busy + idle, unknown-session no-op, and flat-state sync on active session change.
- [x] Full `message-handler.test.ts` suite: 158/158 pass.
- [x] Full `store-core` test suite: 905/905 pass.
- [x] Type check on changed files: clean (pre-existing project-wide TS errors are unrelated).
- [ ] Manual verification across two browser tabs of the same session — busy banner persists on tab swap and shows up on a freshly-opened second tab.

Closes #4639