### PR TITLE
test(server,dashboard): cover multi-client broadcast for per-session settings

### DIFF
--- a/packages/dashboard/src/store/message-handler-per-session-settings.test.ts
+++ b/packages/dashboard/src/store/message-handler-per-session-settings.test.ts
@@ -1,0 +1,394 @@
+/**
+ * #4663 — Multi-client broadcast coverage for per-session setting handlers
+ * (dashboard side).
+ *
+ * Companion to packages/server/tests/handlers/settings-handlers-multi-client-broadcast.test.js.
+ * Together they pin the full handler-level pipeline:
+ *
+ *   1. Server-side: a `set_xxx` from Client A produces a `xxx_changed`
+ *      broadcast that lands at every client subscribed to that session
+ *      (covered server-side).
+ *   2. Dashboard-side (this file): when an `xxx_changed` event arrives,
+ *      `handle*Changed` updates the entry in the `sessions` array
+ *      without losing any unrelated session state (other sessions, other
+ *      fields on the targeted session, sessionStates, etc.).
+ *
+ * Coverage previously stopped at the input → action → wire send level
+ * (see SettingsPanel.test.tsx) — the receive-side store mutation was
+ * untested, which hid the cross-session-switch bug noted in #4662 and
+ * any future regression where a handler clobbers state it shouldn't
+ * touch.
+ *
+ * The three handlers covered:
+ *   - handlePromptEvaluatorChanged          (#3185 → prompt_evaluator_changed)
+ *   - handleChroxyContextHintChanged        (#3805 → chroxy_context_hint_changed)
+ *   - handleSessionPreambleChanged          (#4660 → session_preamble_changed)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import { createEmptySessionState } from './utils'
+import type { ConnectionState, SessionState } from './types'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+/**
+ * Build a base store state with two sessions so we can assert that
+ * routing only touches the targeted session and the untouched session
+ * keeps its full shape.
+ */
+function baseStateWithTwoSessions(): Partial<ConnectionState> {
+  const s1State: SessionState = {
+    ...createEmptySessionState(),
+    // Stuff some content into s1 so we can prove it isn't clobbered.
+    messages: [{ id: 'm-1', type: 'response', content: 'hello', timestamp: 1 } as any],
+  }
+  const s2State: SessionState = {
+    ...createEmptySessionState(),
+    messages: [{ id: 'm-2', type: 'response', content: 'goodbye', timestamp: 2 } as any],
+  }
+
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [
+      {
+        sessionId: 's1',
+        name: 'Session 1',
+        cwd: '/tmp/s1',
+        promptEvaluator: false,
+        chroxyContextHint: false,
+        sessionPreamble: '',
+      } as any,
+      {
+        sessionId: 's2',
+        name: 'Session 2',
+        cwd: '/tmp/s2',
+        promptEvaluator: false,
+        chroxyContextHint: false,
+        sessionPreamble: '',
+      } as any,
+    ],
+    activeSessionId: 's1',
+    sessionStates: { s1: s1State, s2: s2State },
+    messages: [],
+    myClientId: 'client-1',
+    terminalBuffer: '',
+    terminalRawBuffer: '',
+    serverErrors: [],
+    addServerError: () => {},
+    appendTerminalData: () => {},
+    serverProtocolVersion: null,
+  } as unknown as Partial<ConnectionState>
+}
+
+describe('dashboard message-handler — per-session setting broadcast receivers (#4663)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseStateWithTwoSessions())
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  describe('prompt_evaluator_changed (#3185)', () => {
+    it('updates the targeted session entry and leaves the other session untouched', () => {
+      handleMessage(
+        { type: 'prompt_evaluator_changed', sessionId: 's1', value: true },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      const s2 = state.sessions.find((s) => s.sessionId === 's2')!
+
+      expect(s1.promptEvaluator).toBe(true)
+      // Bystander session must keep its original value — regression
+      // guard for the cross-session-switch bug noted in #4662.
+      expect(s2.promptEvaluator).toBe(false)
+    })
+
+    it('preserves unrelated fields on the targeted session entry', () => {
+      handleMessage(
+        { type: 'prompt_evaluator_changed', sessionId: 's1', value: true },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+
+      // The other per-session settings must not be touched.
+      expect(s1.chroxyContextHint).toBe(false)
+      expect(s1.sessionPreamble).toBe('')
+      expect(s1.name).toBe('Session 1')
+      expect(s1.cwd).toBe('/tmp/s1')
+    })
+
+    it('does not touch sessionStates (messages, transient state)', () => {
+      handleMessage(
+        { type: 'prompt_evaluator_changed', sessionId: 's1', value: true },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      // The handler operates on the `sessions` summary list only — the
+      // per-session message log lives in `sessionStates` and must be
+      // left alone.
+      expect(state.sessionStates.s1!.messages).toHaveLength(1)
+      expect(state.sessionStates.s1!.messages[0]!.id).toBe('m-1')
+      expect(state.sessionStates.s2!.messages).toHaveLength(1)
+      expect(state.sessionStates.s2!.messages[0]!.id).toBe('m-2')
+    })
+
+    it('drops the event when value is not a boolean (defensive)', () => {
+      handleMessage(
+        { type: 'prompt_evaluator_changed', sessionId: 's1', value: 'true' as any },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      // No mutation on malformed payload.
+      expect(s1.promptEvaluator).toBe(false)
+    })
+
+    it('falls back to activeSessionId when sessionId is missing on the wire', () => {
+      // Some legacy server paths omit sessionId in favour of the
+      // active-session implicit-target convention. The handler uses
+      // resolveSessionId which falls back to get().activeSessionId.
+      handleMessage(
+        { type: 'prompt_evaluator_changed', value: true },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      expect(s1.promptEvaluator).toBe(true)
+    })
+  })
+
+  describe('chroxy_context_hint_changed (#3805)', () => {
+    it('updates the targeted session entry and leaves the other session untouched', () => {
+      handleMessage(
+        { type: 'chroxy_context_hint_changed', sessionId: 's1', value: true },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      const s2 = state.sessions.find((s) => s.sessionId === 's2')!
+
+      expect(s1.chroxyContextHint).toBe(true)
+      expect(s2.chroxyContextHint).toBe(false)
+    })
+
+    it('preserves unrelated fields on the targeted session entry', () => {
+      handleMessage(
+        { type: 'chroxy_context_hint_changed', sessionId: 's1', value: true },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+
+      expect(s1.promptEvaluator).toBe(false)
+      expect(s1.sessionPreamble).toBe('')
+      expect(s1.name).toBe('Session 1')
+    })
+
+    it('drops the event when value is not a boolean (defensive)', () => {
+      handleMessage(
+        { type: 'chroxy_context_hint_changed', sessionId: 's1', value: 1 as any },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      expect(s1.chroxyContextHint).toBe(false)
+    })
+  })
+
+  describe('session_preamble_changed (#4660)', () => {
+    it('updates the targeted session entry and leaves the other session untouched', () => {
+      handleMessage(
+        {
+          type: 'session_preamble_changed',
+          sessionId: 's1',
+          value: 'always use bullet points',
+        },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      const s2 = state.sessions.find((s) => s.sessionId === 's2')!
+
+      expect(s1.sessionPreamble).toBe('always use bullet points')
+      expect(s2.sessionPreamble).toBe('')
+    })
+
+    it('accepts an empty string payload (clears the preamble)', () => {
+      // Seed s1 with a preamble so we can verify the clear path.
+      store.setState((prev: any) => ({
+        sessions: prev.sessions.map((s: any) =>
+          s.sessionId === 's1' ? { ...s, sessionPreamble: 'old text' } : s,
+        ),
+      }))
+
+      handleMessage(
+        { type: 'session_preamble_changed', sessionId: 's1', value: '' },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      expect(s1.sessionPreamble).toBe('')
+    })
+
+    it('preserves unrelated fields on the targeted session entry', () => {
+      handleMessage(
+        {
+          type: 'session_preamble_changed',
+          sessionId: 's1',
+          value: 'new preamble',
+        },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+
+      expect(s1.promptEvaluator).toBe(false)
+      expect(s1.chroxyContextHint).toBe(false)
+      expect(s1.name).toBe('Session 1')
+      expect(s1.cwd).toBe('/tmp/s1')
+    })
+
+    it('drops the event when value is not a string (defensive)', () => {
+      handleMessage(
+        {
+          type: 'session_preamble_changed',
+          sessionId: 's1',
+          value: 42 as any,
+        },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      expect(s1.sessionPreamble).toBe('')
+    })
+  })
+
+  // #4663 — the original bug class is "Client A sends set_xxx, Client B's
+  // dashboard receives the broadcast but doesn't update because the
+  // `sessions` array is shared by reference and another component mutates
+  // it elsewhere." This test pins the immutability contract: the handler
+  // creates a NEW sessions array (so React/Zustand selectors see a
+  // reference change) AND new entry objects (so deep-equal selectors
+  // see a change on the affected entry only).
+  describe('immutability contract — selectors get reference changes', () => {
+    it('handlePromptEvaluatorChanged returns a new sessions array', () => {
+      const before = (store.getState() as ConnectionState).sessions
+      handleMessage(
+        { type: 'prompt_evaluator_changed', sessionId: 's1', value: true },
+        ctx() as any,
+      )
+      const after = (store.getState() as ConnectionState).sessions
+      expect(after).not.toBe(before)
+    })
+
+    it('handleChroxyContextHintChanged returns a new sessions array', () => {
+      const before = (store.getState() as ConnectionState).sessions
+      handleMessage(
+        { type: 'chroxy_context_hint_changed', sessionId: 's1', value: true },
+        ctx() as any,
+      )
+      const after = (store.getState() as ConnectionState).sessions
+      expect(after).not.toBe(before)
+    })
+
+    it('handleSessionPreambleChanged returns a new sessions array and a new s1 entry', () => {
+      const before = (store.getState() as ConnectionState).sessions
+      const beforeS1 = before.find((s) => s.sessionId === 's1')!
+      const beforeS2 = before.find((s) => s.sessionId === 's2')!
+
+      handleMessage(
+        { type: 'session_preamble_changed', sessionId: 's1', value: 'x' },
+        ctx() as any,
+      )
+
+      const after = (store.getState() as ConnectionState).sessions
+      const afterS1 = after.find((s) => s.sessionId === 's1')!
+      const afterS2 = after.find((s) => s.sessionId === 's2')!
+
+      expect(after).not.toBe(before)
+      expect(afterS1).not.toBe(beforeS1)
+      // Bystander session entry can be reused (map only replaces the
+      // matched entry) — pin that contract so a future refactor that
+      // copies every entry is caught and reviewed.
+      expect(afterS2).toBe(beforeS2)
+    })
+  })
+})

--- a/packages/dashboard/src/store/message-handler-per-session-settings.test.ts
+++ b/packages/dashboard/src/store/message-handler-per-session-settings.test.ts
@@ -267,6 +267,21 @@ describe('dashboard message-handler — per-session setting broadcast receivers 
       const s1 = state.sessions.find((s) => s.sessionId === 's1')!
       expect(s1.chroxyContextHint).toBe(false)
     })
+
+    it('falls back to activeSessionId when sessionId is missing on the wire', () => {
+      // Mirrors the prompt_evaluator_changed legacy-compat case — older
+      // servers (or replays) may omit sessionId. resolveSessionId falls
+      // back to get().activeSessionId so the active session still
+      // updates instead of the event being silently dropped.
+      handleMessage(
+        { type: 'chroxy_context_hint_changed', value: true },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      expect(s1.chroxyContextHint).toBe(true)
+    })
   })
 
   describe('session_preamble_changed (#4660)', () => {
@@ -338,6 +353,21 @@ describe('dashboard message-handler — per-session setting broadcast receivers 
       const state = store.getState() as ConnectionState
       const s1 = state.sessions.find((s) => s.sessionId === 's1')!
       expect(s1.sessionPreamble).toBe('')
+    })
+
+    it('falls back to activeSessionId when sessionId is missing on the wire', () => {
+      // Mirrors the prompt_evaluator_changed legacy-compat case — older
+      // servers (or replays) may omit sessionId. resolveSessionId falls
+      // back to get().activeSessionId so the active session still
+      // updates instead of the event being silently dropped.
+      handleMessage(
+        { type: 'session_preamble_changed', value: 'no sessionId on wire' },
+        ctx() as any,
+      )
+
+      const state = store.getState() as ConnectionState
+      const s1 = state.sessions.find((s) => s.sessionId === 's1')!
+      expect(s1.sessionPreamble).toBe('no sessionId on wire')
     })
   })
 

--- a/packages/server/tests/handlers/settings-handlers-multi-client-broadcast.test.js
+++ b/packages/server/tests/handlers/settings-handlers-multi-client-broadcast.test.js
@@ -1,0 +1,259 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { settingsHandlers } from '../../src/handlers/settings-handlers.js'
+import { createSpy, createMockSession } from '../test-helpers.js'
+
+/**
+ * #4663 — Multi-client broadcast coverage for per-session setting handlers.
+ *
+ * Identified during review of PR #4661 (per-session preamble), but applies
+ * to the entire family of per-session settings handlers (#3185
+ * promptEvaluator, #3805 chroxyContextHint, #4660 sessionPreamble).
+ *
+ * The pre-existing settings-handlers.test.js suite mocked
+ * `ctx.broadcastToSession` as a simple recording spy, which proved the
+ * handler called it with the right payload — but did NOT prove the
+ * `*_changed` event would actually land at a SECOND client subscribed to
+ * the same session. The bug class hidden by that gap is real: any future
+ * regression in the session-scoped filter inside `WsBroadcaster._broadcastToSession`
+ * (or in how clients populate `activeSessionId` / `subscribedSessionIds`)
+ * would silently break multi-client UX.
+ *
+ * These tests close the gap by simulating the full
+ * `broadcastToSession` → recipient-selection → ws.send` loop with two
+ * fake clients (different `client.id`) and asserting:
+ *
+ *   1. Client A sends `set_xxx`.
+ *   2. Server validates, calls the setter, broadcasts `xxx_changed`.
+ *   3. Client B (subscribed to the same session, different client.id)
+ *      receives the broadcast with the correct payload (incl. `sessionId`).
+ *   4. A THIRD client subscribed to a DIFFERENT session does NOT receive
+ *      the broadcast (cross-session leak guard).
+ *   5. The originating client A also receives the broadcast (it's
+ *      subscribed too) — this pins the "originating client gets the echo"
+ *      contract.
+ *
+ * Note: this is a handler-level test that mirrors the production
+ * broadcaster filter inline (see `WsBroadcaster._broadcastToSession` in
+ * `packages/server/src/ws-broadcaster.js`). The mirror is intentional —
+ * a full WS round-trip integration test for these handlers lives in
+ * `ws-server-broadcast.test.js`, but exercising the filter at the
+ * handler level catches regressions to the payload shape and
+ * `broadcastToSession` invocation contract without standing up a real
+ * server.
+ */
+
+/**
+ * Build a multi-client broadcast harness mirroring the production
+ * `WsBroadcaster._broadcastToSession` filter.
+ *
+ * @param {Array<{id: string, activeSessionId?: string, subscribedSessionIds?: Set<string>}>} clients
+ * @returns {{ctx: object, perClientMessages: Map<string, object[]>}}
+ */
+function makeMultiClientCtx(clients, sessions = new Map()) {
+  // Each client gets its own message sink. The fake broadcaster filters
+  // by the same rule as WsBroadcaster: deliver only when
+  // `activeSessionId === sessionId || subscribedSessionIds.has(sessionId)`.
+  const perClientMessages = new Map()
+  for (const c of clients) {
+    perClientMessages.set(c.id, [])
+    if (!c.subscribedSessionIds) c.subscribedSessionIds = new Set()
+  }
+
+  const ctx = {
+    send: createSpy((_ws, msg) => {
+      // Single-client send path — used for session_error. For multi-client
+      // tests we only care about broadcast routing, so leave this as a
+      // simple recorder.
+      ctx._sent.push(msg)
+    }),
+    broadcast: createSpy(),
+    broadcastToSession: createSpy((sessionId, msg) => {
+      const tagged = { ...msg, sessionId }
+      for (const c of clients) {
+        if (
+          c.activeSessionId === sessionId ||
+          c.subscribedSessionIds.has(sessionId)
+        ) {
+          perClientMessages.get(c.id).push(tagged)
+        }
+      }
+    }),
+    sessionManager: {
+      getSession: createSpy((id) => sessions.get(id)),
+      serializeState: createSpy(),
+    },
+    permissionSessionMap: new Map(),
+    pendingPermissions: new Map(),
+    permissions: null,
+    _sent: [],
+  }
+  return { ctx, perClientMessages }
+}
+
+function makeWs() {
+  const messages = []
+  return {
+    readyState: 1,
+    send: createSpy((raw) => { messages.push(JSON.parse(raw)) }),
+    _messages: messages,
+  }
+}
+
+describe('multi-client broadcast coverage for per-session settings (#4663)', () => {
+  // Shared setup: three clients on session 's1', one bystander client on
+  // a different session 's2'. Client A is the sender.
+  function makeSessionTriad() {
+    const sessions = new Map()
+    const sessionA = createMockSession()
+    sessions.set('s1', { session: sessionA, name: 'Session-A', cwd: '/tmp' })
+    sessions.set('s2', { session: createMockSession(), name: 'Session-B', cwd: '/tmp' })
+
+    const clientA = { id: 'client-A', activeSessionId: 's1', subscribedSessionIds: new Set() }
+    const clientB = { id: 'client-B', activeSessionId: 's1', subscribedSessionIds: new Set() }
+    const clientC = { id: 'client-C', activeSessionId: 's2', subscribedSessionIds: new Set() }
+
+    const { ctx, perClientMessages } = makeMultiClientCtx(
+      [clientA, clientB, clientC],
+      sessions,
+    )
+
+    return { ctx, perClientMessages, clientA, clientB, clientC, sessionA, sessions }
+  }
+
+  describe('set_prompt_evaluator (#3185)', () => {
+    it('routes prompt_evaluator_changed to all subscribers of s1, not to s2-only clients', () => {
+      const { ctx, perClientMessages, clientA } = makeSessionTriad()
+
+      settingsHandlers.set_prompt_evaluator(makeWs(), clientA, { value: true }, ctx)
+
+      // Client A (sender) AND Client B (also bound to s1) both see the broadcast.
+      const aMessages = perClientMessages.get('client-A')
+      const bMessages = perClientMessages.get('client-B')
+      const cMessages = perClientMessages.get('client-C')
+
+      assert.equal(aMessages.length, 1, 'client A receives its own echo')
+      assert.equal(bMessages.length, 1, 'client B receives the broadcast')
+      assert.equal(cMessages.length, 0, 'client C (on s2) must NOT receive an s1 broadcast')
+
+      // Payload assertions — pin the wire shape that
+      // handlePromptEvaluatorChanged on the dashboard reads.
+      for (const msg of [aMessages[0], bMessages[0]]) {
+        assert.equal(msg.type, 'prompt_evaluator_changed')
+        assert.equal(msg.value, true)
+        assert.equal(msg.sessionId, 's1',
+          'broadcaster must tag the message with sessionId so multi-session dashboards can route it')
+      }
+    })
+
+    it('also reaches a subscribed-but-not-active client (subscribedSessionIds path)', () => {
+      // Client D's *active* session is s2, but it's also subscribed to s1
+      // (e.g. an Activity Indicator stream watching a background session).
+      // The broadcast must reach D too.
+      const sessions = new Map()
+      sessions.set('s1', { session: createMockSession(), name: 'Sess', cwd: '/tmp' })
+
+      const clientA = { id: 'client-A', activeSessionId: 's1', subscribedSessionIds: new Set() }
+      const clientD = { id: 'client-D', activeSessionId: 's2', subscribedSessionIds: new Set(['s1']) }
+
+      const { ctx, perClientMessages } = makeMultiClientCtx([clientA, clientD], sessions)
+
+      settingsHandlers.set_prompt_evaluator(makeWs(), clientA, { value: true }, ctx)
+
+      assert.equal(perClientMessages.get('client-D').length, 1,
+        'subscribed-but-not-active client receives the broadcast')
+      assert.equal(perClientMessages.get('client-D')[0].type, 'prompt_evaluator_changed')
+    })
+
+    it('no broadcast on no-op (already-true → true): zero clients see anything', () => {
+      const { ctx, perClientMessages, clientA, sessionA } = makeSessionTriad()
+      sessionA.promptEvaluator = true // already in the requested state
+
+      settingsHandlers.set_prompt_evaluator(makeWs(), clientA, { value: true }, ctx)
+
+      assert.equal(perClientMessages.get('client-A').length, 0)
+      assert.equal(perClientMessages.get('client-B').length, 0)
+      assert.equal(perClientMessages.get('client-C').length, 0)
+    })
+  })
+
+  describe('set_chroxy_context_hint (#3805)', () => {
+    it('routes chroxy_context_hint_changed to all subscribers of s1, not to s2-only clients', () => {
+      const { ctx, perClientMessages, clientA } = makeSessionTriad()
+
+      settingsHandlers.set_chroxy_context_hint(makeWs(), clientA, { value: true }, ctx)
+
+      const aMessages = perClientMessages.get('client-A')
+      const bMessages = perClientMessages.get('client-B')
+      const cMessages = perClientMessages.get('client-C')
+
+      assert.equal(aMessages.length, 1)
+      assert.equal(bMessages.length, 1)
+      assert.equal(cMessages.length, 0, 'cross-session leak guard')
+
+      for (const msg of [aMessages[0], bMessages[0]]) {
+        assert.equal(msg.type, 'chroxy_context_hint_changed')
+        assert.equal(msg.value, true)
+        assert.equal(msg.sessionId, 's1')
+      }
+    })
+
+    it('no broadcast on no-op: zero clients see anything', () => {
+      const { ctx, perClientMessages, clientA } = makeSessionTriad()
+      // mock default chroxyContextHint = false; setting to false again is a no-op.
+
+      settingsHandlers.set_chroxy_context_hint(makeWs(), clientA, { value: false }, ctx)
+
+      assert.equal(perClientMessages.get('client-A').length, 0)
+      assert.equal(perClientMessages.get('client-B').length, 0)
+      assert.equal(perClientMessages.get('client-C').length, 0)
+    })
+  })
+
+  describe('set_session_preamble (#4660)', () => {
+    it('routes session_preamble_changed to all subscribers of s1 with the trimmed stored value', () => {
+      const { ctx, perClientMessages, clientA } = makeSessionTriad()
+
+      // Send with whitespace — broadcast must carry the trimmed value
+      // that the server actually stored, not the raw payload.
+      settingsHandlers.set_session_preamble(
+        makeWs(),
+        clientA,
+        { value: '  always use bullet points  ' },
+        ctx,
+      )
+
+      const aMessages = perClientMessages.get('client-A')
+      const bMessages = perClientMessages.get('client-B')
+      const cMessages = perClientMessages.get('client-C')
+
+      assert.equal(aMessages.length, 1)
+      assert.equal(bMessages.length, 1)
+      assert.equal(cMessages.length, 0, 'cross-session leak guard')
+
+      for (const msg of [aMessages[0], bMessages[0]]) {
+        assert.equal(msg.type, 'session_preamble_changed')
+        assert.equal(msg.value, 'always use bullet points',
+          'broadcast must carry trimmed stored value, not raw payload')
+        assert.equal(msg.sessionId, 's1')
+      }
+    })
+
+    it('no broadcast when trimmed value matches current (idempotent)', () => {
+      const { ctx, perClientMessages, clientA, sessionA } = makeSessionTriad()
+      sessionA.sessionPreamble = 'pinned'
+
+      // Whitespace-only difference → setter returns false → no broadcast.
+      settingsHandlers.set_session_preamble(
+        makeWs(),
+        clientA,
+        { value: '   pinned   ' },
+        ctx,
+      )
+
+      assert.equal(perClientMessages.get('client-A').length, 0)
+      assert.equal(perClientMessages.get('client-B').length, 0)
+      assert.equal(perClientMessages.get('client-C').length, 0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds handler-level multi-client broadcast coverage for the three per-session settings handlers (`set_prompt_evaluator`, `set_chroxy_context_hint`, `set_session_preamble`) that previously had no test exercising the second-client receive path.
- Adds dashboard-side coverage for the matching receive handlers (`handlePromptEvaluatorChanged`, `handleChroxyContextHintChanged`, `handleSessionPreambleChanged`), including the immutability contract that Zustand selectors rely on.
- Pure test additions — no production code changes.

## Coverage details

### Server (`packages/server/tests/handlers/settings-handlers-multi-client-broadcast.test.js`, 7 tests)

Simulates three clients via a fake broadcaster that mirrors `WsBroadcaster._broadcastToSession`'s filter (`activeSessionId === sessionId || subscribedSessionIds.has(sessionId)`):

- Client A (sender, active on s1)
- Client B (also active on s1) — must receive
- Client C (active on s2) — must NOT receive

Plus a separate case for the subscribed-but-not-active path (Client D active on s2, subscribed to s1) and idempotent no-op verification for all three handlers.

### Dashboard (`packages/dashboard/src/store/message-handler-per-session-settings.test.ts`, 15 tests)

Two sessions seeded in the store, each with content in `sessionStates`. For each of the three change events, asserts:

- Targeted session entry updates, bystander untouched
- Unrelated fields on the targeted entry preserved
- `sessionStates` (messages) untouched
- Defensive type-rejection on malformed payloads
- Empty-string clear path for `session_preamble_changed`
- Active-session fallback when `sessionId` omitted
- Immutability: new `sessions` array returned, new entry for targeted session, bystander entry reused by reference

## Test plan

- [x] `cd packages/server && node --import ./tests/_setup.mjs --test tests/handlers/settings-handlers-multi-client-broadcast.test.js` — 7/7 pass
- [x] `cd packages/dashboard && npx vitest run src/store/message-handler-per-session-settings.test.ts` — 15/15 pass
- [x] Existing settings-handlers and message-handler suites still pass (no regressions to surrounding tests)
- [x] `tsc --noEmit` clean for dashboard

Closes #4663