### PR TITLE
feat(dashboard): tailored chip for ASK_USER_QUESTION_STALL

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -46,6 +46,7 @@ import { ToolGroup } from './components/ToolGroup'
 import { PastedTextModal } from './components/PastedTextModal'
 import { EvaluatorRewriteBanner, EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
 import { StreamStallChip } from './components/StreamStallChip'
+import { AskUserQuestionStallChip } from './components/AskUserQuestionStallChip'
 import { PlanApproval } from './components/PlanApproval'
 import { ReconnectBanner } from './components/ReconnectBanner'
 import { StdinDisabledBanner } from './components/StdinDisabledBanner'
@@ -1437,6 +1438,33 @@ export function App() {
     [storeMessages],
   )
 
+  // #4615: track which `type: 'prompt'` bubbles have been invalidated by a
+  // subsequent ASK_USER_QUESTION_STALL error. The server emits the error
+  // when the Claude TUI never acknowledges an AskUserQuestion answer —
+  // typically a multi-question form wedge. The pending QuestionPrompt is
+  // now dead, so submitting it would fire keystrokes into a session that
+  // already discarded the prompt context. We suppress the interactive
+  // prompt render (the AskUserQuestionStallChip rendered for the error
+  // bubble below it carries the retry affordance).
+  const stalledPromptIds = useMemo(() => {
+    const stalled = new Set<string>()
+    let lastStallIndex = -1
+    for (let i = storeMessages.length - 1; i >= 0; i -= 1) {
+      const m = storeMessages[i]!
+      if (m.type === 'error' && m.code === 'ASK_USER_QUESTION_STALL') {
+        lastStallIndex = i
+        break
+      }
+    }
+    if (lastStallIndex >= 0) {
+      for (let i = 0; i < lastStallIndex; i += 1) {
+        const m = storeMessages[i]!
+        if (m.type === 'prompt' && !m.answered) stalled.add(m.id)
+      }
+    }
+    return stalled
+  }, [storeMessages])
+
   // Custom message renderer for permission prompts and tool bubbles
   const chatTailMessageId = chatMessages.length > 0
     ? chatMessages[chatMessages.length - 1]!.id
@@ -1487,6 +1515,13 @@ export function App() {
 
     // Question prompt (options or free-text fallback)
     if (storeMsg.type === 'prompt' && storeMsg.options && !storeMsg.requestId) {
+      // #4615 — suppress unanswered prompts that have been invalidated by
+      // a subsequent ASK_USER_QUESTION_STALL. The chip rendered for the
+      // stall error carries the retry affordance; leaving the interactive
+      // prompt visible would let the user submit answers into a dead
+      // _pendingUserAnswer slot. Already-answered prompts still render
+      // (their answer summary is part of chat history).
+      if (stalledPromptIds.has(storeMsg.id)) return null
       return (
         <QuestionPrompt
           question={storeMsg.content}
@@ -1566,9 +1601,31 @@ export function App() {
       )
     }
 
+    // #4615: dedicated chip for ASK_USER_QUESTION_STALL errors. The server
+    // emits `error{code: 'ASK_USER_QUESTION_STALL'}` (PR #4614) when the
+    // Claude TUI never acknowledges an AskUserQuestion answer — typically
+    // a multi-question form wedge. Generic red toast reads as "broken";
+    // this affordance signals "recoverable, just retry your original
+    // request" and offers a one-tap resend of the last user message.
+    // Mirrors the StreamStallChip pattern (#4476): retry only on tail
+    // entries so replayed historical stalls show the chip + tooltip for
+    // diagnostics but don't offer a misleading resend button.
+    if (storeMsg.type === 'error' && storeMsg.code === 'ASK_USER_QUESTION_STALL') {
+      const isTail = msg.id === chatTailMessageId
+      const lastUserInput = isTail
+        ? [...storeMessages].reverse().find(m => m.type === 'user_input')
+        : undefined
+      return (
+        <AskUserQuestionStallChip
+          errorText={storeMsg.content}
+          onRetry={lastUserInput ? () => sendInput(lastUserInput.content) : undefined}
+        />
+      )
+    }
+
     // Default rendering
     return null
-  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs])
+  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs, stalledPromptIds])
 
   // #4412: registry-driven cheat sheet. Recomputed on every render —
   // not memoised, by design. The shortcut registry hook re-renders

--- a/packages/dashboard/src/components/AskUserQuestionStallChip.test.tsx
+++ b/packages/dashboard/src/components/AskUserQuestionStallChip.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * AskUserQuestionStallChip tests — #4615
+ *
+ * Asserts the dedicated chip (not the generic red toast) renders for
+ * `error{code: 'ASK_USER_QUESTION_STALL'}` (server emits this when the
+ * Claude TUI never acknowledges an AskUserQuestion answer — multi-question
+ * form wedge). Mirrors the StreamStallChip pattern (#4476): action-oriented
+ * copy, Retry button that re-fires the last user message, raw server text
+ * preserved on the tooltip for diagnostics.
+ */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { AskUserQuestionStallChip } from './AskUserQuestionStallChip'
+
+afterEach(cleanup)
+
+describe('AskUserQuestionStallChip (#4615)', () => {
+  it('renders an action-oriented headline', () => {
+    render(<AskUserQuestionStallChip errorText="Couldn't deliver your answers." />)
+    const chip = screen.getByTestId('ask-user-question-stall-chip')
+    expect(chip).toBeInTheDocument()
+    // Action-oriented: prompts the user to retry, not jargon-y "stall".
+    expect(chip.textContent).toMatch(/retry/i)
+  })
+
+  it('preserves the raw server error text via the title attribute', () => {
+    // Operators investigating the wedge need the original server message —
+    // the chip's prose is friendly, but the diagnostic must remain
+    // accessible via tooltip.
+    const raw = 'Couldn\'t deliver your answers. Tap Retry to resend your original request.'
+    render(<AskUserQuestionStallChip errorText={raw} />)
+    const chip = screen.getByTestId('ask-user-question-stall-chip')
+    expect(chip.getAttribute('title')).toBe(raw)
+  })
+
+  it('shows a Retry button when onRetry is provided', () => {
+    const onRetry = vi.fn()
+    render(<AskUserQuestionStallChip errorText="x" onRetry={onRetry} />)
+    expect(screen.getByTestId('ask-user-question-stall-chip-retry')).toBeInTheDocument()
+  })
+
+  it('hides the Retry button when onRetry is omitted', () => {
+    // For historical/replayed entries the original user input is no longer
+    // the obvious target to resend — render the chip without the button
+    // rather than wire it to a misleading action. Mirrors StreamStallChip.
+    render(<AskUserQuestionStallChip errorText="x" />)
+    expect(screen.queryByTestId('ask-user-question-stall-chip-retry')).toBeNull()
+  })
+
+  it('invokes onRetry when the Retry button is clicked', () => {
+    const onRetry = vi.fn()
+    render(<AskUserQuestionStallChip errorText="x" onRetry={onRetry} />)
+    fireEvent.click(screen.getByTestId('ask-user-question-stall-chip-retry'))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses role="status" so assistive tech announces the stall', () => {
+    // Same accessibility rationale as StreamStallChip: a recoverable
+    // failure must be announced to users not actively watching the chat.
+    render(<AskUserQuestionStallChip errorText="x" />)
+    const chip = screen.getByTestId('ask-user-question-stall-chip')
+    expect(chip.getAttribute('role')).toBe('status')
+  })
+
+  it('does not collide with the StreamStallChip testID', () => {
+    // Both chips are amber-warning variants; the testID disambiguates so
+    // E2E tests can target the correct affordance.
+    render(<AskUserQuestionStallChip errorText="x" />)
+    expect(screen.queryByTestId('stream-stall-chip')).toBeNull()
+  })
+})

--- a/packages/dashboard/src/components/AskUserQuestionStallChip.tsx
+++ b/packages/dashboard/src/components/AskUserQuestionStallChip.tsx
@@ -1,0 +1,65 @@
+/**
+ * AskUserQuestionStallChip — #4615
+ *
+ * Replaces the generic red error toast when the server emits
+ * `error{code: 'ASK_USER_QUESTION_STALL'}` (server PR #4614). The server
+ * fires this code when the Claude TUI never acknowledges an AskUserQuestion
+ * answer — typically a multi-question form wedge where the keystroke
+ * driver can't reliably deliver answers to the combined form.
+ *
+ * Signals "recoverable, just resend your request" rather than "something
+ * is broken" via a distinct chip affordance, and provides a one-tap retry
+ * button that re-sends the last user message. The full server error text
+ * remains accessible via the title attribute so diagnostics aren't lost —
+ * operators investigating a wedge pattern can hover for the underlying
+ * message.
+ *
+ * Mirrors StreamStallChip (#4476). Distinct testID + headline copy so
+ * E2E tests can target the correct affordance, but reuses the
+ * `stream-stall-chip` CSS classes (amber-warning palette already conveys
+ * "recoverable" — adding a second nearly-identical class set would just
+ * duplicate the theme tokens for no UX benefit).
+ */
+import { useCallback } from 'react'
+
+export interface AskUserQuestionStallChipProps {
+  /** The raw error text from the server (action-oriented copy, currently
+   *  "Couldn't deliver your answers. Tap Retry to resend your original
+   *  request."). */
+  errorText: string
+  /**
+   * Invoked when the user taps Retry. Caller is responsible for resending
+   * the last user message — the chip itself doesn't know which message to
+   * resend. Setting this to undefined hides the retry button (e.g. for
+   * historical entries replayed from session_messages where the original
+   * user input is no longer the obvious target).
+   */
+  onRetry?: () => void
+}
+
+export function AskUserQuestionStallChip({ errorText, onRetry }: AskUserQuestionStallChipProps) {
+  const handleClick = useCallback(() => {
+    onRetry?.()
+  }, [onRetry])
+
+  return (
+    <div
+      className="stream-stall-chip"
+      data-testid="ask-user-question-stall-chip"
+      role="status"
+      title={errorText}
+    >
+      <span className="stream-stall-chip-text">Question delivery failed — retry?</span>
+      {onRetry && (
+        <button
+          type="button"
+          className="stream-stall-chip-retry"
+          data-testid="ask-user-question-stall-chip-retry"
+          onClick={handleClick}
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds `AskUserQuestionStallChip` — a distinct amber-warning chip that replaces the generic red error toast when the server emits `error{code: 'ASK_USER_QUESTION_STALL'}` (server PR #4614).
- One-tap **Retry** button resends the last user message (no scroll-up + copy-paste required).
- Suppresses any unanswered `type: 'prompt'` bubble that's been invalidated by the stall — submitting it would route keystrokes into a dead `_pendingUserAnswer` slot.
- Mirrors the StreamStallChip pattern (#4476): reuses the same CSS class set (amber-warning palette already conveys "recoverable"), retry only on tail entries so replayed historical stalls show the chip + tooltip for diagnostics but don't offer a misleading resend.

## Test plan

- [x] `packages/dashboard/src/components/AskUserQuestionStallChip.test.tsx` — 7 unit tests cover headline, tooltip, retry visibility, click handling, accessibility role, and testID isolation from StreamStallChip
- [x] `npx vitest run` — full dashboard suite passes (130 files, 2416 tests)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: trigger an `ASK_USER_QUESTION_STALL` via the multi-question wedge repro (see #4604 Chunk B) and confirm:
  - distinct amber chip renders instead of the red toast
  - clicking Retry resends the last user message
  - the pending QuestionPrompt above the chip disappears

Closes #4615