### PR TITLE
fix(scripts): flush JSONL before exiting tui-form-recorder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,3 +440,6 @@ jobs:
 
       - name: Run bump-version.sh tests
         run: bash scripts/__tests__/bump-version.test.sh
+
+      - name: Run flush-and-exit.mjs tests
+        run: node scripts/__tests__/flush-and-exit.test.mjs

--- a/scripts/__tests__/flush-and-exit.test.mjs
+++ b/scripts/__tests__/flush-and-exit.test.mjs
@@ -133,7 +133,45 @@ await test('fallback timeout calls exit if finish event never fires', async () =
   }
 })
 
-// --- Test 4: fallback timer is unref'd so it doesn't keep node alive -----
+// --- Test 4: caller's "closed" guard prevents write-after-end -------------
+// This documents the pattern the recorder uses: a `closed` flag flipped
+// before invoking flushAndExit, so any late writes (e.g. a PTY chunk
+// arriving after Ctrl+D triggered SIGTERM) become no-ops instead of
+// throwing ERR_STREAM_WRITE_AFTER_END on the underlying stream.
+await test('write-after-flushAndExit guarded by caller flag does not throw', async () => {
+  const path = join(tmpdir(), `flush-and-exit-test-${process.pid}-${Date.now()}-4.txt`)
+  const stream = createWriteStream(path, { encoding: 'utf8' })
+  stream.write('first\n')
+
+  let closed = false
+  const safeLog = (line) => {
+    if (closed) return
+    stream.write(line)
+  }
+
+  await new Promise((resolveP) => {
+    closed = true
+    flushAndExit(stream, 0, {
+      exitFn: () => resolveP(),
+    })
+  })
+
+  // Simulate late writes arriving after shutdown started — must be silent.
+  let threw = false
+  try {
+    safeLog('late chunk 1\n')
+    safeLog('late chunk 2\n')
+  } catch {
+    threw = true
+  }
+  assert(!threw, 'safeLog should swallow late writes once closed flag is set')
+
+  const contents = readFileSync(path, 'utf8')
+  assert(contents === 'first\n', `file should contain only the pre-close write, got: ${JSON.stringify(contents)}`)
+  rmSync(path, { force: true })
+})
+
+// --- Test 5: fallback timer is unref'd so it doesn't keep node alive -----
 await test('fallback timer is unref-ed', async () => {
   // Spawn a small node process that calls flushAndExit on a stuck stream
   // with a long fallback timeout. If the timer is unref-ed, the process

--- a/scripts/__tests__/flush-and-exit.test.mjs
+++ b/scripts/__tests__/flush-and-exit.test.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+/**
+ * flush-and-exit.test.mjs — node test harness for scripts/flush-and-exit.mjs.
+ *
+ * No external test framework. Each `test()` block runs in series and pushes
+ * pass/fail into a counter. Exit status is 0 if all pass, 1 otherwise.
+ *
+ * Run from repo root:
+ *   node scripts/__tests__/flush-and-exit.test.mjs
+ */
+
+import { createWriteStream, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { Writable } from 'node:stream'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const helperPath = resolve(__dirname, '..', 'flush-and-exit.mjs')
+
+const { flushAndExit } = await import(helperPath)
+
+let pass = 0
+let fail = 0
+const failures = []
+
+const test = async (name, fn) => {
+  try {
+    await fn()
+    pass++
+    process.stdout.write(`  ok ${name}\n`)
+  } catch (err) {
+    fail++
+    failures.push({ name, err })
+    process.stdout.write(`  FAIL ${name}: ${err.message}\n`)
+  }
+}
+
+const assert = (cond, msg) => {
+  if (!cond) throw new Error(msg || 'assertion failed')
+}
+
+// --- Test 1: writes are flushed to disk before exit callback fires --------
+await test('flushes buffered writes to file before exit callback', async () => {
+  const path = join(tmpdir(), `flush-and-exit-test-${process.pid}-${Date.now()}.txt`)
+  const stream = createWriteStream(path, { encoding: 'utf8' })
+
+  // Write a chunk of data that may still be buffered when we call end()
+  const payload = 'final line: <<CTRL-D EXIT>>\n'
+  stream.write(payload)
+
+  // Use a callback instead of process.exit so the test can observe it
+  let exitCalled = false
+  let exitCode = null
+  await new Promise((resolveP) => {
+    flushAndExit(stream, 0, {
+      exitFn: (code) => {
+        exitCalled = true
+        exitCode = code
+        resolveP()
+      },
+    })
+  })
+
+  assert(exitCalled, 'exit callback should be called')
+  assert(exitCode === 0, `exit code should be 0, got ${exitCode}`)
+
+  const contents = readFileSync(path, 'utf8')
+  assert(contents === payload, `file should contain payload, got: ${JSON.stringify(contents)}`)
+
+  rmSync(path, { force: true })
+})
+
+// --- Test 2: exit callback called exactly once even if finish fires late --
+await test('calls exit callback exactly once when finish fires before timeout', async () => {
+  const path = join(tmpdir(), `flush-and-exit-test-${process.pid}-${Date.now()}.txt`)
+  const stream = createWriteStream(path, { encoding: 'utf8' })
+  stream.write('x\n')
+
+  let callCount = 0
+  await new Promise((resolveP) => {
+    flushAndExit(stream, 0, {
+      exitFn: () => {
+        callCount++
+        if (callCount === 1) resolveP()
+      },
+      fallbackMs: 500,
+    })
+  })
+
+  // Wait past the fallback to make sure timer doesn't also fire
+  await new Promise((r) => setTimeout(r, 700))
+  assert(callCount === 1, `exit callback should fire exactly once, got ${callCount}`)
+  rmSync(path, { force: true })
+})
+
+// --- Test 3: fallback timeout fires if finish never arrives --------------
+await test('fallback timeout calls exit if finish event never fires', async () => {
+  // A Writable that never emits finish (calls neither callback nor flushes)
+  const stuckStream = new Writable({
+    write(_chunk, _enc, _cb) {
+      // intentionally never calls cb -> never drains, never finishes
+    },
+  })
+  stuckStream.write('stuck')
+
+  // Keep the event loop alive during the test so the unref'd fallback timer
+  // has a chance to fire (the production process has other handles —
+  // stdin, the PTY — that keep the loop alive). Without this guard, node
+  // can exit before the fallback fires when the test's Promise is the only
+  // pending awaitable.
+  const keepAlive = setInterval(() => {}, 100)
+
+  try {
+    const t0 = Date.now()
+    let exitCode = null
+    await new Promise((resolveP) => {
+      flushAndExit(stuckStream, 42, {
+        exitFn: (code) => {
+          exitCode = code
+          resolveP()
+        },
+        fallbackMs: 200,
+      })
+    })
+    const elapsed = Date.now() - t0
+    assert(exitCode === 42, `exit code should be 42, got ${exitCode}`)
+    assert(elapsed >= 180, `should wait at least ~200ms for fallback, waited ${elapsed}ms`)
+    assert(elapsed < 1500, `should not hang forever, waited ${elapsed}ms`)
+  } finally {
+    clearInterval(keepAlive)
+  }
+})
+
+// --- Test 4: fallback timer is unref'd so it doesn't keep node alive -----
+await test('fallback timer is unref-ed', async () => {
+  // Spawn a small node process that calls flushAndExit on a stuck stream
+  // with a long fallback timeout. If the timer is unref-ed, the process
+  // exits immediately after the event loop drains; otherwise it hangs
+  // for the full fallback duration.
+  const { spawn } = await import('node:child_process')
+  const script = `
+    import { Writable } from 'node:stream'
+    const { flushAndExit } = await import('${helperPath}')
+    const stuck = new Writable({ write() {} })
+    stuck.write('x')
+    // 30s fallback. If unref works, node still exits in ~ms because no
+    // other handles are active. If unref is missing, node hangs 30s.
+    flushAndExit(stuck, 0, { fallbackMs: 30000 })
+  `
+  const t0 = Date.now()
+  await new Promise((resolveP, rejectP) => {
+    const child = spawn(process.execPath, ['--input-type=module', '-e', script], {
+      stdio: 'ignore',
+    })
+    const killer = setTimeout(() => {
+      child.kill('SIGKILL')
+      rejectP(new Error('child hung longer than 3s — fallback timer not unref-ed'))
+    }, 3000)
+    child.on('exit', () => {
+      clearTimeout(killer)
+      resolveP()
+    })
+  })
+  const elapsed = Date.now() - t0
+  assert(elapsed < 3000, `should exit quickly, took ${elapsed}ms`)
+})
+
+// --- summary --------------------------------------------------------------
+process.stdout.write(`\n${pass} passed, ${fail} failed\n`)
+if (fail > 0) {
+  for (const f of failures) {
+    process.stderr.write(`\n[FAIL] ${f.name}\n${f.err.stack || f.err.message}\n`)
+  }
+  process.exit(1)
+}
+process.exit(0)

--- a/scripts/flush-and-exit.mjs
+++ b/scripts/flush-and-exit.mjs
@@ -1,0 +1,50 @@
+/**
+ * flush-and-exit.mjs — wait for a writable stream's `finish` event before
+ * exiting the process so buffered writes are not truncated.
+ *
+ * Background (#4729): tui-form-recorder.mjs originally called
+ * `recording.end()` and then `process.exit()` in the same tick. `process.exit`
+ * does not wait for the stream to flush, so under load — especially in the
+ * Ctrl+D path where the child PTY is also killed with SIGTERM the same tick —
+ * the final bytes of the captured JSONL were truncated, silently corrupting
+ * the byte fixtures we pin in the multi-question form handler.
+ *
+ * Usage:
+ *   import { flushAndExit } from './flush-and-exit.mjs'
+ *   recording.write(lastLine)
+ *   flushAndExit(recording, exitCode)   // returns immediately, exits async
+ *
+ * The exit happens whichever fires first:
+ *   1. the stream's `finish` event (preferred, guarantees all bytes drained), or
+ *   2. a fallback `fallbackMs` timeout so a misbehaving stream cannot hang
+ *      the recorder forever.
+ *
+ * The fallback timer is `.unref()`-ed so it never keeps node alive on its own.
+ */
+
+/**
+ * @param {import('node:stream').Writable} stream - the writable to flush
+ * @param {number} exitCode - process exit code
+ * @param {{ exitFn?: (code: number) => void, fallbackMs?: number }} [options]
+ *   - exitFn: override for process.exit (test seam)
+ *   - fallbackMs: max ms to wait for `finish` before forcing exit (default 1000)
+ */
+export const flushAndExit = (stream, exitCode, options = {}) => {
+  const exitFn = options.exitFn || ((code) => process.exit(code))
+  const fallbackMs = options.fallbackMs ?? 1000
+
+  let exited = false
+  const exitOnce = () => {
+    if (exited) return
+    exited = true
+    exitFn(exitCode)
+  }
+
+  stream.once('finish', exitOnce)
+  stream.once('error', exitOnce)
+  stream.end()
+
+  const timer = setTimeout(exitOnce, fallbackMs)
+  // Don't let the fallback timer alone keep the event loop alive.
+  if (typeof timer.unref === 'function') timer.unref()
+}

--- a/scripts/tui-form-recorder.mjs
+++ b/scripts/tui-form-recorder.mjs
@@ -44,12 +44,25 @@ const recordingPath = join(tmpdir(), `tui-form-recording-${Date.now()}.jsonl`)
 const recording = createWriteStream(recordingPath, { encoding: 'utf8' })
 const startMs = Date.now()
 
+// Once true, log() becomes a no-op. flushAndExit() calls recording.end()
+// internally and any later log() (e.g. a late term.onData chunk arriving
+// after we kicked off shutdown in the Ctrl+D path) would otherwise throw
+// ERR_STREAM_WRITE_AFTER_END (#4729 review feedback).
+let recordingClosed = false
+
 const log = (kind, data) => {
+  if (recordingClosed) return
   recording.write(JSON.stringify({
     t: Date.now() - startMs,
     kind,
     data,
   }) + '\n')
+}
+
+const closeRecording = (exitCode) => {
+  if (recordingClosed) return
+  recordingClosed = true
+  flushAndExit(recording, exitCode)
 }
 
 process.stdout.write(`\x1b[33m=== tui-form-recorder ===\x1b[0m\n`)
@@ -79,8 +92,9 @@ term.onExit(({ exitCode, signal }) => {
   process.stdout.write(`Recording: ${recordingPath}\n`)
   // Wait for the recording stream to flush before exiting — process.exit
   // does not wait for buffered writes and was silently truncating the JSONL
-  // (#4729). flushAndExit calls recording.end() internally.
-  flushAndExit(recording, exitCode || 0)
+  // (#4729). closeRecording guards against double-close from the Ctrl+D
+  // path also triggering onExit via SIGTERM.
+  closeRecording(exitCode || 0)
 })
 
 // Raw mode so we capture every keystroke (arrow keys, Tab, etc.) as bytes
@@ -119,8 +133,10 @@ process.stdin.on('data', (buf) => {
     term.kill('SIGTERM')
     // Wait for the recording stream to flush before exiting — the SIGTERM
     // above races the JSONL flush, and process.exit does not wait for
-    // buffered writes (#4729). flushAndExit calls recording.end() internally.
-    flushAndExit(recording, 0)
+    // buffered writes (#4729). closeRecording also flips recordingClosed
+    // so any late onData chunk arriving after kill() becomes a no-op
+    // instead of throwing ERR_STREAM_WRITE_AFTER_END.
+    closeRecording(0)
     return
   }
   // Pass through to claude + log

--- a/scripts/tui-form-recorder.mjs
+++ b/scripts/tui-form-recorder.mjs
@@ -32,6 +32,7 @@ import { resolve } from 'node:path'
 import { writeFileSync, createWriteStream } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { flushAndExit } from './flush-and-exit.mjs'
 
 // npm workspaces hoists node-pty to the root node_modules/.
 const ptyMod = await import('/Users/blamechris/Projects/chroxy/node_modules/node-pty/lib/index.js')
@@ -74,10 +75,12 @@ term.onData((chunk) => {
 })
 
 term.onExit(({ exitCode, signal }) => {
-  recording.end()
   process.stdout.write(`\n\x1b[33m=== claude exited (code=${exitCode} signal=${signal}) ===\x1b[0m\n`)
   process.stdout.write(`Recording: ${recordingPath}\n`)
-  process.exit(exitCode || 0)
+  // Wait for the recording stream to flush before exiting — process.exit
+  // does not wait for buffered writes and was silently truncating the JSONL
+  // (#4729). flushAndExit calls recording.end() internally.
+  flushAndExit(recording, exitCode || 0)
 })
 
 // Raw mode so we capture every keystroke (arrow keys, Tab, etc.) as bytes
@@ -113,9 +116,12 @@ process.stdin.on('data', (buf) => {
   if (CTRL_D_SEQUENCES.has(data)) {
     process.stdout.write(`\n\x1b[33m=== ending recording (Ctrl+D) ===\x1b[0m\n`)
     log('in', '<<CTRL-D EXIT>>')
-    recording.end()
     term.kill('SIGTERM')
-    process.exit(0)
+    // Wait for the recording stream to flush before exiting — the SIGTERM
+    // above races the JSONL flush, and process.exit does not wait for
+    // buffered writes (#4729). flushAndExit calls recording.end() internally.
+    flushAndExit(recording, 0)
+    return
   }
   // Pass through to claude + log
   log('in', data)


### PR DESCRIPTION
## Summary

- `tui-form-recorder.mjs` called `recording.end()` and then `process.exit()` in the same tick, which does not wait for the underlying write stream to flush — the Ctrl+D path was the worst case because it also kills the child PTY with `SIGTERM` the same tick, racing the flush and silently truncating the JSONL we then pin as multi-question form fixtures (#4604 / #4648 / #4668 work).
- Extract a tiny `flushAndExit(stream, exitCode, { exitFn, fallbackMs })` helper into `scripts/flush-and-exit.mjs` that waits for the stream's `finish` event, with a 1s `.unref()`-ed fallback so a misbehaving stream cannot hang the recorder.
- Wire the helper into both exit paths (`term.onExit` and the Ctrl+D handler). Add a self-contained node test harness (`scripts/__tests__/flush-and-exit.test.mjs`) covering flush-to-disk, single-fire exit, fallback timeout, and the unref behaviour. Hook it into the existing `scripts-tests` CI job alongside `bump-version.test.sh`.

## Test plan

- [x] `node scripts/__tests__/flush-and-exit.test.mjs` — all 4 cases pass locally on Node 22
- [x] `node --check scripts/tui-form-recorder.mjs && node --check scripts/flush-and-exit.mjs`
- [ ] CI `scripts-tests` job runs both `bump-version.test.sh` and the new `flush-and-exit.test.mjs`
- [ ] Manual smoke (developer-only script): run `node scripts/tui-form-recorder.mjs`, press Ctrl+D, confirm the JSONL ends with the `<<CTRL-D EXIT>>` event and not a truncated mid-event line

Closes #4729