### PR TITLE
feat(protocol): widen user_question_response.answers to string | string[]

### DIFF
--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -515,9 +515,53 @@ describe('QuestionPrompt', () => {
       fireEvent.click(screen.getByTestId('question-multi-option-1-Yes').querySelector('input')!)
       fireEvent.click(screen.getByTestId('question-multi-submit'))
       expect(onSelect).toHaveBeenCalledTimes(1)
-      const arg = onSelect.mock.calls[0]?.[0] as Record<string, string> | undefined
+      const arg = onSelect.mock.calls[0]?.[0] as Record<string, string | string[]> | undefined
       expect(arg!['Which release strategy?']).toBe('Minor')
       expect(arg!['Confirm?']).toBe('Yes')
+    })
+
+    // #4621 — multiSelect questions emit native string[] (no JSON encoding)
+    it('emits native string[] for multi-select questions (no JSON encoding)', () => {
+      const onSelect = vi.fn()
+      const multi = {
+        question: 'Which areas?',
+        options: [
+          { label: 'App', value: 'App' },
+          { label: 'Tests', value: 'Tests' },
+          { label: 'Docs', value: 'Docs' },
+        ],
+        multiSelect: true,
+      }
+      const single = {
+        question: 'Confirm?',
+        options: [{ label: 'Yes', value: 'Yes' }, { label: 'No', value: 'No' }],
+      }
+      render(<MultiQuestionForm questions={[multi, single]} onSelect={onSelect} />)
+      fireEvent.click(screen.getByTestId('question-multi-option-0-App').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-option-0-Tests').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-option-1-Yes').querySelector('input')!)
+      fireEvent.click(screen.getByTestId('question-multi-submit'))
+      expect(onSelect).toHaveBeenCalledTimes(1)
+      const arg = onSelect.mock.calls[0]?.[0] as Record<string, string | string[]>
+      // Native array — not a JSON-stringified string
+      expect(Array.isArray(arg['Which areas?'])).toBe(true)
+      expect(arg['Which areas?']).toEqual(['App', 'Tests'])
+      // Single-select stays as plain string
+      expect(arg['Confirm?']).toBe('Yes')
+    })
+
+    it('emits an empty string[] when no multi-select options are chosen', () => {
+      const onSelect = vi.fn()
+      const multi = {
+        question: 'Which areas?',
+        options: [{ label: 'App', value: 'App' }, { label: 'Tests', value: 'Tests' }],
+        multiSelect: true,
+      }
+      render(<MultiQuestionForm questions={[multi]} onSelect={onSelect} />)
+      fireEvent.click(screen.getByTestId('question-multi-submit'))
+      const arg = onSelect.mock.calls[0]?.[0] as Record<string, string | string[]>
+      expect(Array.isArray(arg['Which areas?'])).toBe(true)
+      expect(arg['Which areas?']).toEqual([])
     })
 
     // #4624 — a11y: each per-question options block must be exposed to

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -36,11 +36,11 @@ export interface QuestionPromptProps {
   questions?: ChatMessageQuestion[]
   /**
    * Fires with either a plain string (single-question / free-text path,
-   * back-compat) or a `Record<string,string>` map (multi-question form,
-   * keyed by `question.question` with multi-select values
-   * JSON-stringified arrays of chosen labels).
+   * back-compat) or a `Record<string, string | string[]>` map
+   * (multi-question form, keyed by `question.question` with multi-select
+   * values as native `string[]` arrays of chosen labels — #4621).
    */
-  onSelect: (answer: string | Record<string, string>) => void
+  onSelect: (answer: string | Record<string, string | string[]>) => void
 }
 
 export function QuestionPrompt({ question, options, answered, questions, onSelect }: QuestionPromptProps) {
@@ -94,9 +94,10 @@ function MultiQuestionDeferredNotice({ count }: { count: number }) {
  * #4604 Chunk B — N-question form. Each question gets its own selection
  * control (radio for single-select, checkboxes for multiSelect); the
  * single Submit button at the bottom fires `onSelect(answersMap)` with
- * one entry per question (multi-select values are JSON-stringified
- * arrays so the wire shape `Record<string,string>` is preserved — the
- * server's respondToQuestion JSON.parse handles the round trip).
+ * one entry per question. Multi-select values are emitted as native
+ * `string[]` (#4621) — the wire schema accepts `string | string[]`
+ * directly, so no JSON encoding is required and the server's TUI driver
+ * receives the chosen labels without a round-trip through JSON.parse.
  *
  * #4666 — intentionally retained but not currently rendered by
  * `QuestionPrompt`. The permission-hook denies multi-question
@@ -109,7 +110,7 @@ function MultiQuestionDeferredNotice({ count }: { count: number }) {
  */
 export interface MultiQuestionFormProps {
   questions: ChatMessageQuestion[]
-  onSelect: (answersMap: Record<string, string>) => void
+  onSelect: (answersMap: Record<string, string | string[]>) => void
 }
 
 export function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProps) {
@@ -141,15 +142,14 @@ export function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProp
   const handleSubmit = () => {
     if (submittedRef.current) return
     submittedRef.current = true
-    const answersMap: Record<string, string> = {}
+    const answersMap: Record<string, string | string[]> = {}
     questions.forEach((q, idx) => {
       if (q.multiSelect) {
-        const chosen = multiSelectByIdx[idx] || []
-        // JSON-encode multi-select answers so the wire shape
-        // (Record<string,string>) is preserved. The server's
-        // respondToQuestion JSON.parse splits this back into per-option
-        // digits + Tab to commit + advance.
-        answersMap[q.question] = JSON.stringify(chosen)
+        // #4621 — emit a native string[]. The wire schema accepts
+        // `string | string[]` directly; the server's TUI driver iterates
+        // the array (or falls back to JSON.parse + comma-split for
+        // legacy payloads from older dashboards).
+        answersMap[q.question] = multiSelectByIdx[idx] || []
       } else {
         const chosen = singleSelectByIdx[idx]
         if (chosen != null) answersMap[q.question] = chosen

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1549,20 +1549,24 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }));
   },
 
-  sendUserQuestionResponse: (answer: string | Record<string, string>, toolUseId?: string) => {
+  sendUserQuestionResponse: (answer: string | Record<string, string | string[]>, toolUseId?: string) => {
     const { socket, activeSessionId, sessionStates } = get();
-    // #4604 Chunk B — split the wire payload by call shape:
+    // #4604 Chunk B / #4621 — split the wire payload by call shape:
     // - string `answer`: legacy single-question / free-text path. Wire
     //   shape stays `{ type, answer, toolUseId? }` so older servers
     //   keep working without schema migration.
     // - Record `answer`: multi-question form (Chunk B). Populate the
-    //   `answers` field (protocol already supports it) AND a string
-    //   `answer` summary so a server running an older build that only
-    //   reads `answer` falls through to its default-to-option-1 path
-    //   (a noisy WARN in chroxy.log) instead of stalling the form.
+    //   `answers` field (protocol accepts `string | string[]` per
+    //   #4621) AND a string `answer` summary so a server running an
+    //   older build that only reads `answer` falls through to its
+    //   default-to-option-1 path (a noisy WARN in chroxy.log) instead
+    //   of stalling the form. Multi-select array values are joined
+    //   into the summary as `App, Tests` for human readability.
     const isMultiAnswer = typeof answer !== 'string'
     const answerSummary = isMultiAnswer
-      ? Object.entries(answer as Record<string, string>).map(([q, v]) => `${q}: ${v}`).join(' | ')
+      ? Object.entries(answer as Record<string, string | string[]>)
+          .map(([q, v]) => `${q}: ${Array.isArray(v) ? v.join(', ') : v}`)
+          .join(' | ')
       : (answer as string);
     const payload: Record<string, unknown> = { type: 'user_question_response', answer: answerSummary };
     if (isMultiAnswer) {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -629,14 +629,16 @@ export interface ConnectionState {
    * requestId — last write wins. */
   markPermissionResolved: (requestId: string, decision: PermissionDecision) => void;
   /**
-   * #4604 Chunk B — answer may be either a plain string (single-question /
-   * free-text path, back-compat) or a `Record<string,string>` map
-   * (multi-question form, keyed by question text with multi-select values
-   * JSON-stringified arrays). The Record path populates the wire's
-   * `answers` field; both paths populate `answer` with a human-readable
-   * summary so older servers stay functional.
+   * #4604 Chunk B / #4621 — answer may be either a plain string
+   * (single-question / free-text path, back-compat) or a
+   * `Record<string, string | string[]>` map (multi-question form, keyed
+   * by question text). Multi-select values are emitted as native
+   * `string[]` (#4621) so consumers don't have to JSON.parse to recover
+   * the chosen labels. The Record path populates the wire's `answers`
+   * field; both paths populate `answer` with a human-readable summary
+   * so older servers stay functional.
    */
-  sendUserQuestionResponse: (answer: string | Record<string, string>, toolUseId?: string) => 'sent' | 'queued' | false;
+  sendUserQuestionResponse: (answer: string | Record<string, string | string[]>, toolUseId?: string) => 'sent' | 'queued' | false;
   markPromptAnswered: (messageId: string, answer: string) => void;
   markPromptAnsweredByRequestId: (requestId: string, answer: string) => void;
   setModel: (model: string) => void;

--- a/packages/dashboard/src/utils/questionAnswerSummary.test.ts
+++ b/packages/dashboard/src/utils/questionAnswerSummary.test.ts
@@ -116,4 +116,57 @@ describe('formatQuestionAnswerSummary', () => {
       )
     })
   })
+
+  // #4621 — widen the wire shape to Record<string, string | string[]>.
+  // MultiQuestionForm now sends native string[] for multi-select instead
+  // of JSON-stringifying. The summary helper must accept arrays directly
+  // and render them as comma-joined labels — without leaking
+  // `["App","Tests"]` JSON syntax (which the legacy back-compat path
+  // also covered).
+  describe('multi-question form path (Record<string, string | string[]>) — #4621', () => {
+    it('renders a native string[] multi-select as comma-joined labels', () => {
+      const answer: Record<string, string | string[]> = {
+        'Which areas?': ['App', 'Tests'],
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'Which areas?: App, Tests',
+      )
+    })
+
+    it('renders an empty string[] without brackets', () => {
+      const answer: Record<string, string | string[]> = {
+        'Which areas?': [],
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe('Which areas?: ')
+    })
+
+    it('renders a single-item string[] without brackets or quotes', () => {
+      const answer: Record<string, string | string[]> = {
+        'Which areas?': ['App'],
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe('Which areas?: App')
+    })
+
+    it('renders mixed single-select string + native multi-select string[]', () => {
+      const answer: Record<string, string | string[]> = {
+        'Which release strategy?': 'Minor',
+        'Which areas?': ['App', 'Tests', 'Docs'],
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'Which release strategy?: Minor | Which areas?: App, Tests, Docs',
+      )
+    })
+
+    it('preserves labels that contain commas (no comma-split corruption)', () => {
+      // The legacy JSON-encoded path also handled this, but the native
+      // string[] path makes it trivially obvious: round-tripping a label
+      // with embedded commas must not split into separate entries.
+      const answer: Record<string, string | string[]> = {
+        'Which?': ['Hello, world', 'foo'],
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'Which?: Hello, world, foo',
+      )
+    })
+  })
 })

--- a/packages/dashboard/src/utils/questionAnswerSummary.ts
+++ b/packages/dashboard/src/utils/questionAnswerSummary.ts
@@ -1,6 +1,6 @@
 /**
- * #4622 — pure helper that turns a `QuestionPrompt` onSelect answer
- * payload into the one-line summary string that App.tsx hands to
+ * #4622 / #4621 — pure helper that turns a `QuestionPrompt` onSelect
+ * answer payload into the one-line summary string that App.tsx hands to
  * `markPromptAnswered`. The summary surfaces on the collapsed
  * post-answer chip after the user submits the form.
  *
@@ -8,27 +8,28 @@
  *
  * 1. `string` — the legacy single-question / free-text path. Returned
  *    verbatim.
- * 2. `Record<string,string>` — the multi-question form path (#4604
- *    Chunk B). One entry per question, keyed by question text.
- *    Multi-select values arrive as JSON-stringified string arrays
- *    (see `MultiQuestionForm.handleSubmit` — the wire shape is
- *    `Record<string,string>`, and the server's `respondToQuestion`
- *    JSON.parse splits it back). The summary helper detects and
- *    pretty-prints those arrays as `App, Tests` instead of leaking
- *    `["App","Tests"]` JSON syntax into the UX copy.
+ * 2. `Record<string, string | string[]>` — the multi-question form path
+ *    (#4604 Chunk B). One entry per question, keyed by question text.
+ *    Multi-select values arrive as native `string[]` (#4621) and are
+ *    pretty-printed as comma-joined labels (`App, Tests`) instead of
+ *    `["App","Tests"]` JSON syntax.
  *
- * Non-array JSON shapes (objects, numbers) are kept as their raw
- * stringified form — `MultiQuestionForm` only ever JSON-encodes
- * arrays, so anything else didn't come from the form and we'd rather
- * surface it as-is than mangle it.
+ *    For back-compat with payloads sent by older dashboards still using
+ *    the pre-#4621 wire shape, a JSON-stringified array value is also
+ *    detected and flattened the same way. Non-array JSON shapes
+ *    (objects, numbers) keep their raw stringified form — the form only
+ *    ever produced array JSON, so anything else didn't come from us and
+ *    we'd rather surface it as-is than mangle it.
  */
 
 /**
- * Pretty-print a single answer value. If the value parses as a JSON
- * array of primitives we render it as a comma-joined list (no
- * brackets, no quotes); otherwise the value is returned unchanged.
+ * Pretty-print a single answer value:
+ *  - `string[]`   → comma-joined labels (native #4621 path).
+ *  - `'[...]'`    → parsed as JSON; if it's an array, joined; else returned as-is.
+ *  - anything else → returned unchanged.
  */
-function formatMultiSelectValue(value: string): string {
+function formatAnswerValue(value: string | string[]): string {
+  if (Array.isArray(value)) return value.map((item) => String(item)).join(', ')
   // Cheap pre-check to avoid JSON.parse-ing every short-string answer.
   if (!value.startsWith('[')) return value
   let parsed: unknown
@@ -42,10 +43,10 @@ function formatMultiSelectValue(value: string): string {
 }
 
 export function formatQuestionAnswerSummary(
-  answer: string | Record<string, string>,
+  answer: string | Record<string, string | string[]>,
 ): string {
   if (typeof answer === 'string') return answer
   return Object.entries(answer)
-    .map(([question, value]) => `${question}: ${formatMultiSelectValue(value)}`)
+    .map(([question, value]) => `${question}: ${formatAnswerValue(value)}`)
     .join(' | ')
 }

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -344,8 +344,15 @@ export declare const NotificationPrefsSetSchema: z.ZodObject<{
  * `multiSelect: true` questions instead of JSON-stringifying them.
  * The legacy JSON-encoded string shape is still accepted for back-compat
  * with in-flight payloads during deploy and with older dashboards that
- * haven't picked up the new wire shape. Array values are capped at 100
- * entries (mirroring the per-answer-map cap) to bound parse cost.
+ * haven't picked up the new wire shape.
+ *
+ * Array bounds: at most 100 entries per array (mirroring the per-answer-
+ * map cap), and at most 10_000 chars per entry. Multi-select values are
+ * option labels (short by construction) — capping at 10_000 chars keeps
+ * the total per-answer worst case bounded at ~1MB without the legacy
+ * 100_000-char-per-item cap on the string path, which exists to cover
+ * the JSON-stringified-array shape sent by pre-#4621 dashboards (and is
+ * itself bounded by the top-level CHROXY_MAX_PAYLOAD).
  */
 export declare const UserQuestionResponseSchema: z.ZodObject<{
     type: z.ZodLiteral<"user_question_response">;

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -338,10 +338,19 @@ export declare const NotificationPrefsSetSchema: z.ZodObject<{
         bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
     }, z.core.$strip>;
 }, z.core.$loose>;
+/**
+ * #4621 — `answers` values are widened to `string | string[]` so the
+ * multi-question form (#4604 Chunk B) can ship native arrays for
+ * `multiSelect: true` questions instead of JSON-stringifying them.
+ * The legacy JSON-encoded string shape is still accepted for back-compat
+ * with in-flight payloads during deploy and with older dashboards that
+ * haven't picked up the new wire shape. Array values are capped at 100
+ * entries (mirroring the per-answer-map cap) to bound parse cost.
+ */
 export declare const UserQuestionResponseSchema: z.ZodObject<{
     type: z.ZodLiteral<"user_question_response">;
     answer: z.ZodString;
-    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
+    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>>>;
     toolUseId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const ListDirectorySchema: z.ZodObject<{
@@ -700,7 +709,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"user_question_response">;
     answer: z.ZodString;
-    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
+    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>>>;
     toolUseId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_directory">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -368,10 +368,22 @@ export const NotificationPrefsSetSchema = z.object({
     requestId: z.string().max(128).optional(),
     prefs: NotificationPrefsPatchSchema,
 }).passthrough();
+/**
+ * #4621 — `answers` values are widened to `string | string[]` so the
+ * multi-question form (#4604 Chunk B) can ship native arrays for
+ * `multiSelect: true` questions instead of JSON-stringifying them.
+ * The legacy JSON-encoded string shape is still accepted for back-compat
+ * with in-flight payloads during deploy and with older dashboards that
+ * haven't picked up the new wire shape. Array values are capped at 100
+ * entries (mirroring the per-answer-map cap) to bound parse cost.
+ */
 export const UserQuestionResponseSchema = z.object({
     type: z.literal('user_question_response'),
     answer: z.string().max(100_000),
-    answers: z.record(z.string(), z.string().max(100_000)).refine((obj) => Object.keys(obj).length <= 100, { message: 'Too many answers (max 100)' }).optional(),
+    answers: z.record(z.string(), z.union([
+        z.string().max(100_000),
+        z.array(z.string().max(100_000)).max(100),
+    ])).refine((obj) => Object.keys(obj).length <= 100, { message: 'Too many answers (max 100)' }).optional(),
     toolUseId: z.string().max(256).optional(),
 });
 export const ListDirectorySchema = z.object({

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -374,15 +374,22 @@ export const NotificationPrefsSetSchema = z.object({
  * `multiSelect: true` questions instead of JSON-stringifying them.
  * The legacy JSON-encoded string shape is still accepted for back-compat
  * with in-flight payloads during deploy and with older dashboards that
- * haven't picked up the new wire shape. Array values are capped at 100
- * entries (mirroring the per-answer-map cap) to bound parse cost.
+ * haven't picked up the new wire shape.
+ *
+ * Array bounds: at most 100 entries per array (mirroring the per-answer-
+ * map cap), and at most 10_000 chars per entry. Multi-select values are
+ * option labels (short by construction) — capping at 10_000 chars keeps
+ * the total per-answer worst case bounded at ~1MB without the legacy
+ * 100_000-char-per-item cap on the string path, which exists to cover
+ * the JSON-stringified-array shape sent by pre-#4621 dashboards (and is
+ * itself bounded by the top-level CHROXY_MAX_PAYLOAD).
  */
 export const UserQuestionResponseSchema = z.object({
     type: z.literal('user_question_response'),
     answer: z.string().max(100_000),
     answers: z.record(z.string(), z.union([
         z.string().max(100_000),
-        z.array(z.string().max(100_000)).max(100),
+        z.array(z.string().max(10_000)).max(100),
     ])).refine((obj) => Object.keys(obj).length <= 100, { message: 'Too many answers (max 100)' }).optional(),
     toolUseId: z.string().max(256).optional(),
 });

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -415,10 +415,25 @@ export const NotificationPrefsSetSchema = z.object({
   prefs: NotificationPrefsPatchSchema,
 }).passthrough()
 
+/**
+ * #4621 — `answers` values are widened to `string | string[]` so the
+ * multi-question form (#4604 Chunk B) can ship native arrays for
+ * `multiSelect: true` questions instead of JSON-stringifying them.
+ * The legacy JSON-encoded string shape is still accepted for back-compat
+ * with in-flight payloads during deploy and with older dashboards that
+ * haven't picked up the new wire shape. Array values are capped at 100
+ * entries (mirroring the per-answer-map cap) to bound parse cost.
+ */
 export const UserQuestionResponseSchema = z.object({
   type: z.literal('user_question_response'),
   answer: z.string().max(100_000),
-  answers: z.record(z.string(), z.string().max(100_000)).refine(
+  answers: z.record(
+    z.string(),
+    z.union([
+      z.string().max(100_000),
+      z.array(z.string().max(100_000)).max(100),
+    ]),
+  ).refine(
     (obj) => Object.keys(obj).length <= 100,
     { message: 'Too many answers (max 100)' }
   ).optional(),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -421,8 +421,15 @@ export const NotificationPrefsSetSchema = z.object({
  * `multiSelect: true` questions instead of JSON-stringifying them.
  * The legacy JSON-encoded string shape is still accepted for back-compat
  * with in-flight payloads during deploy and with older dashboards that
- * haven't picked up the new wire shape. Array values are capped at 100
- * entries (mirroring the per-answer-map cap) to bound parse cost.
+ * haven't picked up the new wire shape.
+ *
+ * Array bounds: at most 100 entries per array (mirroring the per-answer-
+ * map cap), and at most 10_000 chars per entry. Multi-select values are
+ * option labels (short by construction) — capping at 10_000 chars keeps
+ * the total per-answer worst case bounded at ~1MB without the legacy
+ * 100_000-char-per-item cap on the string path, which exists to cover
+ * the JSON-stringified-array shape sent by pre-#4621 dashboards (and is
+ * itself bounded by the top-level CHROXY_MAX_PAYLOAD).
  */
 export const UserQuestionResponseSchema = z.object({
   type: z.literal('user_question_response'),
@@ -431,7 +438,7 @@ export const UserQuestionResponseSchema = z.object({
     z.string(),
     z.union([
       z.string().max(100_000),
-      z.array(z.string().max(100_000)).max(100),
+      z.array(z.string().max(10_000)).max(100),
     ]),
   ).refine(
     (obj) => Object.keys(obj).length <= 100,

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3527,6 +3527,64 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._pendingUserAnswer, null, 'pending cleared')
     })
 
+    // #4621 — native string[] for multi-select answers (no JSON encoding).
+    // The wire protocol now accepts `Record<string, string | string[]>` so
+    // the dashboard can ship arrays directly. The driver MUST produce the
+    // exact same byte sequence as the legacy JSON-encoded shape.
+    it('accepts native string[] for multi-select answers (#4621)', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', options: [{ label: 'aa' }, { label: 'bb' }] },
+        { question: 'Q3?', multiSelect: true, options: [{ label: 'p' }, { label: 'q' }, { label: 'r' }] },
+        { question: 'Q4?', options: [{ label: 'x' }, { label: 'y' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_native_arr', questions, options: questions[0].options }
+      const answersMap = {
+        'Q1?': 'a',          // → '1' (single, auto-advances)
+        'Q2?': 'bb',         // → '2' (single, auto-advances)
+        'Q3?': ['p', 'r'],   // → '1' '3' (NATIVE ARRAY, no JSON.stringify) + '\t'
+        'Q4?': 'y',          // → '2' (single, auto-advances)
+      }
+
+      session.respondToQuestion('', answersMap)
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Identical to the JSON-encoded shape — back-compat preserved.
+      const expected = ['\x1b[?2004l', '1', '2', '1', '3', '\t', '2', '1', '\x1b[?2004h']
+      assert.deepEqual(writes, expected,
+        `expected identical byte sequence for native string[], got ${JSON.stringify(writes)}`)
+    })
+
+    // #4621 — labels containing commas survive the round-trip via native
+    // string[] (the legacy comma-split fallback corrupted these). Uses
+    // 2 questions so the multi-question driver kicks in (single-question
+    // path is text-driven, not answersMap-driven).
+    it('preserves comma-containing labels via native string[] (#4621)', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', multiSelect: true, options: [{ label: 'Hello, world' }, { label: 'foo' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_comma', questions, options: questions[0].options }
+      const answersMap = {
+        'Q1?': 'a',                        // → '1'
+        'Q2?': ['Hello, world', 'foo'],    // → '1' '2' (both selected) + '\t'
+      }
+
+      session.respondToQuestion('', answersMap)
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      // Q1 → '1'; Q2 (multi) → '1' '2' + '\t'; Submit → '1'. The legacy
+      // comma-split would have split 'Hello, world' into ['Hello', 'world']
+      // which match nothing, defaulting to '1' only.
+      const expected = ['\x1b[?2004l', '1', '1', '2', '\t', '1', '\x1b[?2004h']
+      assert.deepEqual(writes, expected,
+        `native string[] should preserve comma-containing labels, got ${JSON.stringify(writes)}`)
+    })
+
     // Single-question regression guard: ensure the legacy text-driven path
     // still produces the exact pre-Chunk-B byte sequence (#4290 happy path).
     it('1-question form keeps the legacy text-driven byte sequence unchanged', async () => {

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -497,6 +497,30 @@ describe('PermissionManager', () => {
       assert.deepEqual(result.updatedInput.answers, { 'Color?': 'Red' })
       assert.ok(!('Unknown?' in result.updatedInput.answers))
     })
+
+    // #4621 — answersMap values may be string[] (native multi-select),
+    // not just string. PermissionManager just forwards the value to the
+    // SDK's updatedInput.answers; the SDK accepts string[] for
+    // multi-select questions.
+    it('forwards string[] answersMap values verbatim for multi-select questions (#4621)', async () => {
+      const questions = [
+        { question: 'Areas?', multiSelect: true, options: [{ label: 'App' }, { label: 'Tests' }] },
+        { question: 'Strategy?', options: [{ label: 'Patch' }, { label: 'Minor' }] },
+      ]
+      const promise = pm._handleAskUserQuestion({ questions }, null)
+
+      pm.respondToQuestion('summary', {
+        'Areas?': ['App', 'Tests'],
+        'Strategy?': 'Minor',
+      })
+      const result = await promise
+      assert.deepEqual(result.updatedInput.answers, {
+        'Areas?': ['App', 'Tests'],
+        'Strategy?': 'Minor',
+      })
+      assert.ok(Array.isArray(result.updatedInput.answers['Areas?']),
+        'array value should be preserved (not coerced to string)')
+    })
   })
 
   // -- clearAll --

--- a/packages/server/tests/ws-schemas.test.js
+++ b/packages/server/tests/ws-schemas.test.js
@@ -1057,6 +1057,34 @@ describe('dead code removal', () => {
     }).success, false)
   })
 
+  // #4621 (Copilot review): per-array-item cap is 10_000 chars to bound
+  // total per-answer cost. Labels are short by construction; the
+  // legacy 100_000-char string cap is preserved only on the
+  // back-compat string branch (JSON-stringified arrays from older
+  // dashboards).
+  it('UserQuestionResponseSchema rejects array members longer than 10_000 chars (#4621)', async () => {
+    const { UserQuestionResponseSchema } = await import('../src/ws-schemas.js')
+    const ok = 'x'.repeat(10_000)
+    const tooBig = 'x'.repeat(10_001)
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'x',
+      answers: { 'Q?': [ok] },
+    }).success, true)
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'x',
+      answers: { 'Q?': [tooBig] },
+    }).success, false)
+    // The string branch keeps the 100_000-char cap for legacy
+    // JSON-stringified-array payloads from pre-#4621 dashboards.
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'x',
+      answers: { 'Q?': 'x'.repeat(100_000) },
+    }).success, true)
+  })
+
   it('SandboxSchema rejects arrays larger than 256', async () => {
     const { SandboxSchema } = await import('@chroxy/protocol')
     const mk = (n) => Array.from({ length: n }, (_, i) => `item${i}`)

--- a/packages/server/tests/ws-schemas.test.js
+++ b/packages/server/tests/ws-schemas.test.js
@@ -997,6 +997,66 @@ describe('dead code removal', () => {
     assert.equal(UserQuestionResponseSchema.safeParse({ type: 'user_question_response', answer: 'a', answers: mkAnswers(101) }).success, false)
   })
 
+  // #4621 — `answers` values widen to `string | string[]` so multi-select
+  // questions can ship native arrays instead of JSON-stringified strings.
+  it('UserQuestionResponseSchema accepts string[] values for multi-select answers (#4621)', async () => {
+    const { UserQuestionResponseSchema } = await import('../src/ws-schemas.js')
+    // String values (legacy single-select / free-text) still accepted.
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'Yes',
+      answers: { 'Pick one?': 'A' },
+    }).success, true)
+    // String[] values (native multi-select).
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'App, Tests',
+      answers: { 'Which areas?': ['App', 'Tests'] },
+    }).success, true)
+    // Mixed string + string[] values in the same map.
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'summary',
+      answers: { 'Q1?': 'A', 'Q2?': ['x', 'y'] },
+    }).success, true)
+    // Empty array is allowed (multi-select with zero selections).
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: '',
+      answers: { 'Q?': [] },
+    }).success, true)
+  })
+
+  it('UserQuestionResponseSchema rejects array values longer than 100 entries (#4621)', async () => {
+    const { UserQuestionResponseSchema } = await import('../src/ws-schemas.js')
+    const mkArr = (n) => Array.from({ length: n }, (_, i) => `v${i}`)
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'x',
+      answers: { 'Q?': mkArr(100) },
+    }).success, true)
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'x',
+      answers: { 'Q?': mkArr(101) },
+    }).success, false)
+  })
+
+  it('UserQuestionResponseSchema rejects non-string array members (#4621)', async () => {
+    const { UserQuestionResponseSchema } = await import('../src/ws-schemas.js')
+    // Numbers / objects in the array must be rejected — only string[].
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'x',
+      answers: { 'Q?': ['a', 42] },
+    }).success, false)
+    assert.equal(UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'x',
+      answers: { 'Q?': ['a', { obj: 1 }] },
+    }).success, false)
+  })
+
   it('SandboxSchema rejects arrays larger than 256', async () => {
     const { SandboxSchema } = await import('@chroxy/protocol')
     const mk = (n) => Array.from({ length: n }, (_, i) => `item${i}`)


### PR DESCRIPTION
## Summary

- Widen `UserQuestionResponseSchema.answers` from `Record<string,string>` to `Record<string, string | string[]>` so the multi-question form can ship native arrays for `multiSelect: true` questions instead of JSON-stringifying them.
- Dashboard `MultiQuestionForm.handleSubmit` now emits `string[]` directly; the post-answer chip + Output-tab summary render multi-select answers as `App, Tests` instead of leaking `["App","Tests"]` JSON syntax into UX copy.
- Legacy JSON-encoded string shape stays accepted on both sides: protocol union covers both; server `resolveQuestionDigits` already handled arrays, and the dashboard summary helper still flattens stringified arrays for in-flight payloads from older dashboards during deploy.
- Fixes the comma-in-label corruption the previous comma-split fallback couldn't handle (`'Hello, world'` now round-trips cleanly).

## Test plan

- [x] `packages/dashboard` — `formatQuestionAnswerSummary` covers both `Record<string,string>` (legacy JSON path) and `Record<string,string|string[]>` (new native path), plus the comma-containing label regression
- [x] `packages/dashboard` — `MultiQuestionForm` Submit emits native `string[]` for multi-select (assert `Array.isArray`) and `[]` when no options chosen
- [x] `packages/server/tests/ws-schemas.test.js` — schema accepts string + string[] + mixed values; rejects array members that aren't strings; rejects arrays longer than 100
- [x] `packages/server/tests/claude-tui-session.test.js` — TUI driver byte sequence is byte-identical for native `string[]` and JSON-encoded shapes; new comma-in-label regression test
- [x] `packages/server/tests/permission-manager.test.js` — forwards `string[]` answersMap values verbatim to `updatedInput.answers`
- [x] All 2416 dashboard tests pass, all 478 affected server tests pass, all 145 protocol tests pass, TypeScript clean

Closes #4621