### PR TITLE
refactor(server): extract per-session setting boilerplate into a shared registry

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -15,6 +15,10 @@ import {
 import { loadActiveSkillsLayered, findRepoSkillsDir, findSkillForRetrust, DEFAULT_SKILLS_DIR, _isCommunityNamespace } from '../skills-loader.js'
 import { realpathSync, readdirSync, statSync } from 'fs'
 import { createLogger } from '../logger.js'
+import {
+  PER_SESSION_SETTINGS,
+  buildPerSessionSettingHandler,
+} from '../per-session-settings.js'
 
 // Tools that are eligible to be whitelisted via set_permission_rules.
 // These are safe file-operation tools that don't execute code or make network requests.
@@ -1110,68 +1114,6 @@ async function handleSetThinkingLevel(ws, client, msg, ctx) {
 }
 
 /**
- * #3185 — toggle the per-session promptEvaluator flag. Strict-boolean
- * payload validation, idempotent (no-op when value unchanged so the
- * dashboard can re-send the current value without churning state-file
- * writes), and broadcast on actual change so multi-client UIs stay in
- * sync.
- *
- * Persistence is an immediate `serializeState()` flush rather than the
- * debounced `schedulePersist` other handlers use. Toggles are operator
- * actions — rare enough that the synchronous write is free, and a crash
- * within the debounce window would otherwise silently lose the change.
- */
-function handleSetPromptEvaluator(ws, client, msg, ctx) {
-  if (typeof msg.value !== 'boolean') {
-    ctx.send(ws, {
-      type: 'session_error',
-      message: 'set_prompt_evaluator requires a boolean `value`',
-    })
-    return
-  }
-
-  const sessionId = msg.sessionId || client.activeSessionId
-  const entry = resolveSession(ctx, msg, client)
-  if (!entry) {
-    ctx.send(ws, { type: 'session_error', message: 'No active session' })
-    return
-  }
-
-  if (typeof entry.session.setPromptEvaluator !== 'function') {
-    // Defensive — every shipping provider extends BaseSession which adds
-    // the setter. A custom provider that bypasses BaseSession would land
-    // here; refuse rather than silently dropping the toggle.
-    ctx.send(ws, { type: 'session_error', message: 'This provider does not support promptEvaluator toggling' })
-    return
-  }
-
-  const changed = entry.session.setPromptEvaluator(msg.value)
-  if (!changed) {
-    // Either invalid input (already validated above so unreachable) or
-    // a redundant set. Either way: no broadcast, no persist — the
-    // dashboard already shows the current value.
-    return
-  }
-
-  ctx.broadcastToSession(sessionId, {
-    type: 'prompt_evaluator_changed',
-    sessionId,
-    value: entry.session.promptEvaluator,
-  })
-
-  // Persist immediately rather than waiting for the debounced
-  // schedulePersist — toggles are rare enough that the extra write is
-  // free, and a crash within the debounce window would otherwise
-  // silently lose the change. Keep best-effort: failures here log but
-  // don't surface to the client (the in-memory state is correct).
-  try {
-    ctx.sessionManager?.serializeState?.()
-  } catch (err) {
-    log.warn(`Failed to persist promptEvaluator toggle for ${sessionId}: ${err?.message || err}`)
-  }
-}
-
-/**
  * #3639 — set the per-session promptEvaluatorSkipPattern. Mirrors the
  * #3185 toggle handler: strict-typed payload validation, idempotent on
  * unchanged input, broadcast on actual change, immediate persist (rather
@@ -1252,121 +1194,6 @@ function handleSetPromptEvaluatorSkipPattern(ws, client, msg, ctx) {
   }
 }
 
-/**
- * #3805 — toggle the per-session Chroxy context hint flag. Mirrors the
- * #3185 promptEvaluator handler: strict-boolean payload validation,
- * idempotent (no-op when value unchanged so the dashboard can re-send
- * the current value without churning state-file writes), and broadcast
- * on actual change so multi-client UIs stay in sync.
- *
- * Persistence is an immediate `serializeState()` flush rather than the
- * debounced `schedulePersist` other handlers use. Toggles are operator
- * actions — rare enough that the synchronous write is free, and a crash
- * within the debounce window would otherwise silently lose the change.
- */
-function handleSetChroxyContextHint(ws, client, msg, ctx) {
-  if (typeof msg.value !== 'boolean') {
-    ctx.send(ws, {
-      type: 'session_error',
-      message: 'set_chroxy_context_hint requires a boolean `value`',
-    })
-    return
-  }
-
-  const sessionId = msg.sessionId || client.activeSessionId
-  const entry = resolveSession(ctx, msg, client)
-  if (!entry) {
-    ctx.send(ws, { type: 'session_error', message: 'No active session' })
-    return
-  }
-
-  if (typeof entry.session.setChroxyContextHint !== 'function') {
-    // Defensive — every shipping provider extends BaseSession which adds
-    // the setter. A custom provider that bypasses BaseSession would land
-    // here; refuse rather than silently dropping the toggle.
-    ctx.send(ws, { type: 'session_error', message: 'This provider does not support chroxyContextHint toggling' })
-    return
-  }
-
-  const changed = entry.session.setChroxyContextHint(msg.value)
-  if (!changed) {
-    // Either invalid input (already validated above so unreachable) or a
-    // redundant set. Either way: no broadcast, no persist.
-    return
-  }
-
-  ctx.broadcastToSession(sessionId, {
-    type: 'chroxy_context_hint_changed',
-    sessionId,
-    value: entry.session.chroxyContextHint,
-  })
-
-  try {
-    ctx.sessionManager?.serializeState?.()
-  } catch (err) {
-    log.warn(`Failed to persist chroxyContextHint toggle for ${sessionId}: ${err?.message || err}`)
-  }
-}
-
-/**
- * #4660 — set the per-session preamble (free-text context prepended to the
- * system prompt every turn). Mirrors the #3805 chroxyContextHint handler:
- * string-typed payload validation, idempotent (no-op when the trimmed value
- * matches what's already stored so the dashboard can re-emit on every
- * keystroke without churning state-file writes), and broadcast on actual
- * change so multi-client UIs stay in sync.
- *
- * Persistence is an immediate `serializeState()` flush rather than the
- * debounced `schedulePersist` other handlers use — same justification as
- * #3805: per-session settings are infrequent operator actions where the
- * sync write is free, and a crash within the debounce window would
- * otherwise silently lose the change.
- */
-function handleSetSessionPreamble(ws, client, msg, ctx) {
-  if (typeof msg.value !== 'string') {
-    ctx.send(ws, {
-      type: 'session_error',
-      message: 'set_session_preamble requires a string `value`',
-    })
-    return
-  }
-
-  const sessionId = msg.sessionId || client.activeSessionId
-  const entry = resolveSession(ctx, msg, client)
-  if (!entry) {
-    ctx.send(ws, { type: 'session_error', message: 'No active session' })
-    return
-  }
-
-  if (typeof entry.session.setSessionPreamble !== 'function') {
-    // Defensive — every shipping provider extends BaseSession which adds
-    // the setter. A custom provider that bypasses BaseSession would land
-    // here; refuse rather than silently dropping the update.
-    ctx.send(ws, { type: 'session_error', message: 'This provider does not support sessionPreamble' })
-    return
-  }
-
-  const changed = entry.session.setSessionPreamble(msg.value)
-  if (!changed) {
-    // No actual change (either redundant set, type-rejected at the setter,
-    // or a string that trims to the same stored value). No broadcast,
-    // no persist.
-    return
-  }
-
-  ctx.broadcastToSession(sessionId, {
-    type: 'session_preamble_changed',
-    sessionId,
-    value: entry.session.sessionPreamble,
-  })
-
-  try {
-    ctx.sessionManager?.serializeState?.()
-  } catch (err) {
-    log.warn(`Failed to persist sessionPreamble for ${sessionId}: ${err?.message || err}`)
-  }
-}
-
 function handleSetPermissionRules(ws, client, msg, ctx) {
   const rules = msg.rules
 
@@ -1431,6 +1258,18 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
   log.info(`Permission rules updated by ${client.id} on session ${sessionId}: ${rules.length} rule(s)`)
 }
 
+// #4664: assemble the per-session-setting WS handlers from the registry.
+// Each setting's `requestType` (e.g. `'set_prompt_evaluator'`) is the
+// message-type key the dispatcher looks up; the factory-built handler
+// covers payload validation, session resolution, setter invocation,
+// broadcast, and immediate persist with the same shape every existing
+// hand-written handler used. Adding a new setting means appending one
+// entry to PER_SESSION_SETTINGS — no new handler boilerplate.
+const perSessionSettingHandlers = {}
+for (const settingDef of PER_SESSION_SETTINGS) {
+  perSessionSettingHandlers[settingDef.requestType] = buildPerSessionSettingHandler(settingDef)
+}
+
 export const settingsHandlers = {
   set_model: handleSetModel,
   set_permission_mode: handleSetPermissionMode,
@@ -1440,10 +1279,13 @@ export const settingsHandlers = {
   list_skills: handleListSkills,
   set_thinking_level: handleSetThinkingLevel,
   set_permission_rules: handleSetPermissionRules,
-  set_prompt_evaluator: handleSetPromptEvaluator,
+  // promptEvaluatorSkipPattern keeps its bespoke handler because the
+  // payload shape (string-or-null + pre-validation regex compile to
+  // surface a distinct error code) doesn't fit the boolean/string
+  // factory. The other three per-session settings come from the
+  // registry above.
   set_prompt_evaluator_skip_pattern: handleSetPromptEvaluatorSkipPattern,
-  set_chroxy_context_hint: handleSetChroxyContextHint,
-  set_session_preamble: handleSetSessionPreamble,
+  ...perSessionSettingHandlers,
   skill_activate: handleSkillActivate,
   skill_deactivate: handleSkillDeactivate,
   skill_trust_accept: handleSkillTrustAccept,

--- a/packages/server/src/per-session-settings.js
+++ b/packages/server/src/per-session-settings.js
@@ -237,11 +237,15 @@ export function forwardPerSessionSettingsToProviderOpts(providerOpts, source) {
 
 /**
  * Build the serialized per-session-settings dict for `serializeState`.
- * Each value is run through its `coerce` so a custom provider that
- * skipped BaseSession's field initialiser still writes a valid shape to
- * the state file (the same defensive-coerce guard the per-knob sites
- * already used: `!!entry.session.chroxyContextHint`,
- * `typeof entry.session.sessionPreamble === 'string' ? ... : ''`).
+ * Each value falls back to the setting's `defaultValue` when the session
+ * field is `undefined` (custom provider that skipped BaseSession's field
+ * initialiser, or a hand-edited state file), then runs through `coerce`
+ * to guarantee a wire-shape match (`boolean` for toggles, `string` for
+ * preamble). This mirrors the defensive guards the pre-refactor per-knob
+ * sites used (`!!entry.session.chroxyContextHint`,
+ * `typeof entry.session.sessionPreamble === 'string' ? ... : ''`) while
+ * giving `defaultValue` a single observable purpose (Copilot review on
+ * PR #4751).
  *
  * @param {object} session — a session instance (BaseSession subclass)
  * @returns {Record<string, any>} — dict ready to spread into the state-file entry
@@ -249,7 +253,9 @@ export function forwardPerSessionSettingsToProviderOpts(providerOpts, source) {
 export function serializePerSessionSettings(session) {
   const out = {}
   for (const def of PER_SESSION_SETTINGS) {
-    out[def.id] = def.coerce(session[def.id])
+    const raw = session[def.id]
+    const seed = raw === undefined ? def.defaultValue : raw
+    out[def.id] = def.coerce(seed)
   }
   return out
 }

--- a/packages/server/src/per-session-settings.js
+++ b/packages/server/src/per-session-settings.js
@@ -1,0 +1,367 @@
+/**
+ * Per-session settings registry (#4664).
+ *
+ * Collapses the boilerplate around the per-session toggle pattern that
+ * promptEvaluator (#3185), chroxyContextHint (#3805), and sessionPreamble
+ * (#4660) each hand-wrote across SessionManager (createSession forwarding +
+ * serializeState + restoreState) and settings-handlers.js (WS handler +
+ * broadcast + immediate persist).
+ *
+ * Three iterations in, the next addition (snippet library, sticky visible
+ * prefix in the issue body) would be the 4th time someone hand-writes the
+ * same 5 sites and risks dropping the jsonl-subprocess middle layer (see
+ * memory `[[feedback_jsonl_subprocess_middle_layer]]`).
+ *
+ * Scope of this module:
+ *
+ *   - `definePerSessionSetting()` — declarative shape per knob.
+ *   - `PER_SESSION_SETTINGS` — registry of the three existing knobs.
+ *   - `forwardPerSessionSettingsToProviderOpts()` — used by
+ *     SessionManager.createSession to feed providerOpts.
+ *   - `serializePerSessionSettings()` / `restorePerSessionSettings()` —
+ *     used by SessionManager.serializeState / restoreState so adding a
+ *     new knob takes ONE registry entry instead of a 3-site edit.
+ *   - `buildPerSessionSettingHandler()` — generates the WS handler
+ *     function for a setting (replaces the three near-identical 50-LOC
+ *     handlers in settings-handlers.js).
+ *
+ * Out of scope (intentionally — keeps the refactor narrow):
+ *
+ *   - BaseSession field declarations + `_coerceXxxOpt()` validators +
+ *     `setX()` setters: each knob still hand-writes these on BaseSession
+ *     so the existing tests + `_buildSystemPrompt()` ordering stay
+ *     byte-identical. The registry references the setter by NAME so the
+ *     handler factory calls `session[setterName](value)` — see
+ *     `buildPerSessionSettingHandler`.
+ *   - Provider middle layers (cli-session, sdk-session, claude-tui-session,
+ *     codex-session, gemini-session, jsonl-subprocess-session) still
+ *     destructure each opt and forward to `super({...})`. The list of opt
+ *     keys per provider is small and stable; the issue note about
+ *     "...opts everywhere" matches the byok/deepseek pattern but
+ *     reworking every provider's signature is a bigger refactor than the
+ *     issue warrants. Adding `[id]` to that list per provider is a
+ *     mechanical lift if/when a new knob lands.
+ *   - Dashboard side: still requires the Zustand action +
+ *     `message-handler.ts` entry + `store/types.ts` field. The capability
+ *     gate / per-knob UI shape (text area vs checkbox) means a single
+ *     dashboard helper would over-fit; the README in #4664 calls this
+ *     out as "document the checklist" instead of "abstract."
+ */
+
+import { createLogger } from './logger.js'
+import { resolveSession } from './handler-utils.js'
+
+const log = createLogger('per-session-settings')
+
+const REQUIRED_DEFINITION_KEYS = [
+  'id',
+  'defaultValue',
+  'coerce',
+  'acceptFromWire',
+  'acceptFromConstructor',
+  'requestType',
+  'broadcastType',
+  'setterName',
+  'handlerInvalidValueMessage',
+  'handlerUnsupportedMessage',
+]
+
+/**
+ * Define a per-session setting. Returns a frozen object that the helpers
+ * below iterate.
+ *
+ * @param {object} opts
+ * @param {string} opts.id — field name on the session AND key on the
+ *   serialized state file. Must match the BaseSession field declaration
+ *   (e.g. `'promptEvaluator'`).
+ * @param {boolean|string} opts.defaultValue — value when the field is
+ *   unset on a session (used by serializePerSessionSettings's read-back
+ *   guard so a custom provider that skips BaseSession's initialiser still
+ *   round-trips a valid wire shape).
+ * @param {(v: any) => any} opts.coerce — applied to the session field
+ *   when serialising. For booleans: `(v) => !!v`. For strings: a coerce
+ *   that returns `''` for non-string values.
+ * @param {(v: any) => boolean} opts.acceptFromWire — predicate gating
+ *   forwarding into `providerOpts` in `createSession`. Reject is silent —
+ *   BaseSession's constructor coerce will apply its own default. Mirrors
+ *   the existing `typeof x === 'boolean'` / `typeof x === 'string'`
+ *   guards at the createSession call site.
+ * @param {(v: any) => boolean} opts.acceptFromConstructor — predicate
+ *   gating restoration from the state file. Same shape as
+ *   `acceptFromWire` but kept separate so a future setting could relax
+ *   either side independently (e.g. accept wider shapes during
+ *   restore for forward-compat).
+ * @param {string} opts.requestType — wire message `type` field (e.g.
+ *   `'set_prompt_evaluator'`).
+ * @param {string} opts.broadcastType — wire broadcast `type` field (e.g.
+ *   `'prompt_evaluator_changed'`).
+ * @param {string} opts.setterName — method name to call on the session
+ *   when applying the update. The setter MUST return `true` when state
+ *   changed, `false` for redundant / rejected updates. This is the
+ *   existing BaseSession setter contract — handlers branch on it to
+ *   decide whether to broadcast.
+ * @param {string} opts.handlerInvalidValueMessage — user-facing error
+ *   for malformed payloads.
+ * @param {string} opts.handlerUnsupportedMessage — user-facing error
+ *   when the session lacks the setter (defensive — every shipping
+ *   provider extends BaseSession, so this only fires for custom
+ *   providers).
+ * @returns {Readonly<object>}
+ */
+export function definePerSessionSetting(opts) {
+  for (const k of REQUIRED_DEFINITION_KEYS) {
+    // `defaultValue: false` is legal — the check is "key present" not "truthy".
+    if (!(k in opts)) {
+      throw new Error(`definePerSessionSetting: missing required field '${k}'`)
+    }
+  }
+  return Object.freeze({
+    id: opts.id,
+    defaultValue: opts.defaultValue,
+    coerce: opts.coerce,
+    acceptFromWire: opts.acceptFromWire,
+    acceptFromConstructor: opts.acceptFromConstructor,
+    requestType: opts.requestType,
+    broadcastType: opts.broadcastType,
+    setterName: opts.setterName,
+    handlerInvalidValueMessage: opts.handlerInvalidValueMessage,
+    handlerUnsupportedMessage: opts.handlerUnsupportedMessage,
+  })
+}
+
+// --- Concrete settings -------------------------------------------------------
+
+/**
+ * `promptEvaluator` (#3185): boolean toggle for the auto-evaluator chain.
+ * Default `false` so the manual `evaluate_draft` flow (PR #3089) is the
+ * only behaviour until the operator opts in.
+ */
+const promptEvaluatorDef = definePerSessionSetting({
+  id: 'promptEvaluator',
+  defaultValue: false,
+  coerce: (v) => !!v,
+  acceptFromWire: (v) => typeof v === 'boolean',
+  acceptFromConstructor: (v) => typeof v === 'boolean',
+  requestType: 'set_prompt_evaluator',
+  broadcastType: 'prompt_evaluator_changed',
+  setterName: 'setPromptEvaluator',
+  handlerInvalidValueMessage: 'set_prompt_evaluator requires a boolean `value`',
+  handlerUnsupportedMessage: 'This provider does not support promptEvaluator toggling',
+})
+
+/**
+ * `chroxyContextHint` (#3805): boolean toggle for the canned Chroxy
+ * context paragraph prepended to the system prompt so the model can
+ * adjust output for mobile clients. Default `false` — existing users
+ * see no observable change.
+ */
+const chroxyContextHintDef = definePerSessionSetting({
+  id: 'chroxyContextHint',
+  defaultValue: false,
+  coerce: (v) => !!v,
+  acceptFromWire: (v) => typeof v === 'boolean',
+  acceptFromConstructor: (v) => typeof v === 'boolean',
+  requestType: 'set_chroxy_context_hint',
+  broadcastType: 'chroxy_context_hint_changed',
+  setterName: 'setChroxyContextHint',
+  handlerInvalidValueMessage: 'set_chroxy_context_hint requires a boolean `value`',
+  handlerUnsupportedMessage: 'This provider does not support chroxyContextHint toggling',
+})
+
+/**
+ * `sessionPreamble` (#4660): user-authored free text prepended to the
+ * system prompt every turn. Empty string is the OFF default — non-string
+ * inputs coerce to '' so a hand-edited state file with a number / object
+ * round-trips safely.
+ */
+const sessionPreambleDef = definePerSessionSetting({
+  id: 'sessionPreamble',
+  defaultValue: '',
+  // The actual trim + length cap lives in BaseSession's
+  // `_coerceSessionPreambleOpt` so the wire-level cap stays the single
+  // source of truth. The coerce here is only used by
+  // serializePerSessionSettings — at that point the field has already
+  // been through BaseSession's coerce, so we only defend against the
+  // custom-provider case (no field initialiser).
+  coerce: (v) => (typeof v === 'string' ? v : ''),
+  acceptFromWire: (v) => typeof v === 'string',
+  acceptFromConstructor: (v) => typeof v === 'string',
+  requestType: 'set_session_preamble',
+  broadcastType: 'session_preamble_changed',
+  setterName: 'setSessionPreamble',
+  handlerInvalidValueMessage: 'set_session_preamble requires a string `value`',
+  handlerUnsupportedMessage: 'This provider does not support sessionPreamble',
+})
+
+/**
+ * Registry of every per-session setting. Order is the order in which
+ * fields appear on the wire payload (alphabetical here so a future
+ * `git diff` is predictable). New knobs MUST be added in alphabetical
+ * order so review diffs stay tight.
+ */
+export const PER_SESSION_SETTINGS = Object.freeze([
+  chroxyContextHintDef,
+  promptEvaluatorDef,
+  sessionPreambleDef,
+])
+
+// --- SessionManager helpers --------------------------------------------------
+
+/**
+ * Forward each registered setting from `source` (a destructured opts
+ * object — typically `createSession` arguments) into `providerOpts` when
+ * the setting's `acceptFromWire` predicate accepts. Mirrors the per-knob
+ * `if (typeof x === 'boolean') providerOpts.x = x` shape at the
+ * createSession call site.
+ *
+ * Mutates `providerOpts` and returns it for chaining.
+ *
+ * @param {object} providerOpts — target object passed to the provider constructor
+ * @param {object} source — object containing per-session-setting values keyed by id
+ * @returns {object} the same `providerOpts`
+ */
+export function forwardPerSessionSettingsToProviderOpts(providerOpts, source) {
+  for (const def of PER_SESSION_SETTINGS) {
+    if (!Object.prototype.hasOwnProperty.call(source, def.id)) continue
+    const value = source[def.id]
+    if (def.acceptFromWire(value)) {
+      providerOpts[def.id] = value
+    }
+    // Reject is silent — BaseSession's coerce applies the default. This
+    // matches the existing per-knob behaviour exactly: passing
+    // `{ chroxyContextHint: 'not-bool' }` to createSession drops the key,
+    // and BaseSession initialises the field to `false`.
+  }
+  return providerOpts
+}
+
+/**
+ * Build the serialized per-session-settings dict for `serializeState`.
+ * Each value is run through its `coerce` so a custom provider that
+ * skipped BaseSession's field initialiser still writes a valid shape to
+ * the state file (the same defensive-coerce guard the per-knob sites
+ * already used: `!!entry.session.chroxyContextHint`,
+ * `typeof entry.session.sessionPreamble === 'string' ? ... : ''`).
+ *
+ * @param {object} session — a session instance (BaseSession subclass)
+ * @returns {Record<string, any>} — dict ready to spread into the state-file entry
+ */
+export function serializePerSessionSettings(session) {
+  const out = {}
+  for (const def of PER_SESSION_SETTINGS) {
+    out[def.id] = def.coerce(session[def.id])
+  }
+  return out
+}
+
+/**
+ * Build the createSession-arguments dict for `restoreState`. Each value
+ * is either forwarded as-is when `acceptFromConstructor` accepts, or
+ * `undefined` (so `forwardPerSessionSettingsToProviderOpts` skips it and
+ * BaseSession's constructor coerce applies the default).
+ *
+ * `undefined` (not `null`) is deliberate — `null` would survive the
+ * acceptFromConstructor predicate's `typeof` check on some shapes and
+ * land in providerOpts as a real value; `undefined` is the universal
+ * "key absent" signal that mirrors the pre-refactor per-knob code.
+ *
+ * @param {object} saved — entry from `state.sessions[i]` in the state file
+ * @returns {Record<string, any|undefined>}
+ */
+export function restorePerSessionSettings(saved) {
+  const out = {}
+  for (const def of PER_SESSION_SETTINGS) {
+    const value = saved?.[def.id]
+    if (def.acceptFromConstructor(value)) {
+      // sessionPreamble special case: empty string is the OFF default —
+      // forward it so a session that the user explicitly cleared
+      // round-trips as cleared rather than as the BaseSession default
+      // (which happens to be the same value, but the explicit-forward is
+      // clearer and matches the pre-refactor behaviour). For string
+      // settings with a non-empty default this also matters.
+      out[def.id] = value
+    } else {
+      out[def.id] = undefined
+    }
+  }
+  return out
+}
+
+// --- WS handler factory ------------------------------------------------------
+
+/**
+ * Build the WS handler function for a per-session setting. Replaces the
+ * three near-identical 50-line handlers in settings-handlers.js with one
+ * factory call per knob.
+ *
+ * The handler:
+ *   1. Validates the inbound payload with `def.acceptFromWire`.
+ *   2. Resolves the bound session (via the standard handler-utils path).
+ *   3. Calls `session[def.setterName](value)`.
+ *   4. On a real change (setter returns true): broadcasts
+ *      `{ type: def.broadcastType, sessionId, value }` to all session
+ *      clients AND triggers an immediate `serializeState()` flush.
+ *
+ * Persistence is an immediate flush rather than the debounced
+ * `schedulePersist` so a crash within the debounce window doesn't
+ * silently lose the change — matches the existing per-knob behaviour.
+ *
+ * @param {object} settingDef — definition from definePerSessionSetting
+ * @returns {(ws: any, client: any, msg: any, ctx: any) => void}
+ */
+export function buildPerSessionSettingHandler(settingDef) {
+  return function perSessionSettingHandler(ws, client, msg, ctx) {
+    if (!settingDef.acceptFromWire(msg?.value)) {
+      ctx.send(ws, {
+        type: 'session_error',
+        message: settingDef.handlerInvalidValueMessage,
+      })
+      return
+    }
+
+    const sessionId = msg?.sessionId || client?.activeSessionId
+    // Use the same resolveSession path every other settings handler uses
+    // — it enforces session-token binding for bound clients and falls
+    // back to `client.activeSessionId` otherwise. Calling
+    // `ctx.sessionManager.getSession(sessionId)` directly here would
+    // bypass that gate.
+    const entry = resolveSession(ctx, msg, client)
+    if (!entry) {
+      ctx.send(ws, { type: 'session_error', message: 'No active session' })
+      return
+    }
+
+    const setter = entry.session?.[settingDef.setterName]
+    if (typeof setter !== 'function') {
+      // Defensive — every shipping provider extends BaseSession which
+      // adds the setter. A custom provider that bypasses BaseSession
+      // would land here; refuse rather than silently dropping the update.
+      ctx.send(ws, { type: 'session_error', message: settingDef.handlerUnsupportedMessage })
+      return
+    }
+
+    const changed = setter.call(entry.session, msg.value)
+    if (!changed) {
+      // Setter no-op (redundant set, type-rejected at setter, or a
+      // string that trims to the same stored value). No broadcast, no
+      // persist — the dashboard already shows the current value.
+      return
+    }
+
+    // Surface the STORED value (BaseSession coerces trim + cap), not the
+    // raw payload, so subscribed clients see a stable shape.
+    const storedValue = entry.session[settingDef.id]
+    ctx.broadcastToSession(sessionId, {
+      type: settingDef.broadcastType,
+      sessionId,
+      value: storedValue,
+    })
+
+    try {
+      ctx.sessionManager?.serializeState?.()
+    } catch (err) {
+      log.warn(`Failed to persist ${settingDef.id} for ${sessionId}: ${err?.message || err}`)
+    }
+  }
+}
+

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -18,6 +18,11 @@ import { SessionTimeoutManager, formatIdleDuration } from './session-timeout-man
 import { SessionMessageHistory } from './session-message-history.js'
 import { createLogger } from './logger.js'
 import { metrics } from './metrics.js'
+import {
+  forwardPerSessionSettingsToProviderOpts,
+  serializePerSessionSettings,
+  restorePerSessionSettings,
+} from './per-session-settings.js'
 
 const log = createLogger('session-manager')
 const DEFAULT_STATE_FILE = join(homedir(), '.chroxy', 'session-state.json')
@@ -646,37 +651,28 @@ export class SessionManager extends EventEmitter {
     if (this._trustMismatchMode !== null) {
       providerOpts.trustMismatchMode = this._trustMismatchMode
     }
-    // Per-session promptEvaluator toggle (#3185). Forwarded as-is —
-    // BaseSession coerces to a strict boolean, so passing `undefined`
-    // (omitted by client) yields the safe `false` default. Restored
-    // sessions persist this in session-state.json (see serializeState).
-    if (typeof promptEvaluator === 'boolean') {
-      providerOpts.promptEvaluator = promptEvaluator
-    }
-    // #3639: per-session promptEvaluatorSkipPattern. Same shape as
-    // promptEvaluator above — only string sources are forwarded; null,
-    // empty string, or non-string values use BaseSession's `null`
-    // default. Validation (regex compile) happens inside BaseSession
-    // so a hand-edited state file with a malformed source falls back
-    // to null without crashing session creation.
+    // #4664: per-session toggle/string settings (promptEvaluator,
+    // chroxyContextHint, sessionPreamble) are forwarded through the
+    // registry so adding a new knob is one entry in
+    // PER_SESSION_SETTINGS rather than another `if (typeof x === ...)`
+    // block here. Each registry entry's `acceptFromWire` predicate
+    // mirrors the original per-knob shape — non-matching values are
+    // dropped so BaseSession's constructor coerce applies the default.
+    forwardPerSessionSettingsToProviderOpts(providerOpts, {
+      promptEvaluator,
+      chroxyContextHint,
+      sessionPreamble,
+    })
+    // #3639: per-session promptEvaluatorSkipPattern. Kept out of the
+    // per-session-settings registry because the wire shape ('non-empty
+    // string OR null/empty to clear', with pre-validation regex compile)
+    // doesn't fit the boolean/string factory. Only string sources are
+    // forwarded; null, empty string, or non-string values use
+    // BaseSession's `null` default. Validation (regex compile) happens
+    // inside BaseSession so a hand-edited state file with a malformed
+    // source falls back to null without crashing session creation.
     if (typeof promptEvaluatorSkipPattern === 'string' && promptEvaluatorSkipPattern.length > 0) {
       providerOpts.promptEvaluatorSkipPattern = promptEvaluatorSkipPattern
-    }
-    // #3805: per-session Chroxy context hint. Same shape as the
-    // promptEvaluator path — only forward when an explicit boolean is
-    // present so omitting the field keeps BaseSession's `false`
-    // default. Restored sessions persist this in session-state.json
-    // (see serializeState below).
-    if (typeof chroxyContextHint === 'boolean') {
-      providerOpts.chroxyContextHint = chroxyContextHint
-    }
-    // #4660: per-session preamble. Only forward when a string is supplied
-    // so omitting the field keeps BaseSession's `''` default. Trimming +
-    // length-capping happens inside BaseSession (single coercion site).
-    // Restored sessions persist this in session-state.json (see
-    // serializeState below).
-    if (typeof sessionPreamble === 'string') {
-      providerOpts.sessionPreamble = sessionPreamble
     }
     // #3540: hydrate the persisted stdin_disabled flag onto the new
     // session so restoreState() round-trips correctly. Only forwarded
@@ -868,11 +864,13 @@ export class SessionManager extends EventEmitter {
         worktree: entry.worktreePath != null,
         repoCwd: entry.worktreeRepoDir || null,
         isolation: entry.isolation || 'none',
-        // #3185: surface the per-session promptEvaluator toggle so the
-        // dashboard can render the toggle's current state without a
-        // separate round-trip. Defensive coerce in case a custom
-        // provider class skips the BaseSession field initialiser.
-        promptEvaluator: !!entry.session.promptEvaluator,
+        // #4664: per-session toggle/string settings (promptEvaluator,
+        // chroxyContextHint, sessionPreamble) surface through the
+        // registry so the dashboard can hydrate every knob's current
+        // state without a separate round-trip. Each registry entry's
+        // `coerce` doubles as the defensive cast guarding against a
+        // custom provider that skipped BaseSession's field initialiser.
+        ...serializePerSessionSettings(entry.session),
         // #3639: surface the per-session skip-pattern source so the
         // dashboard can show / edit the per-session override without
         // having to introspect via a separate request. `null` when
@@ -880,25 +878,14 @@ export class SessionManager extends EventEmitter {
         // applies as a fallback (see input-handlers.js). Treat empty
         // string as unset so the wire shape stays stable across the
         // setter/constructor (which normalise '' to null) and a
-        // serialise -> restore round-trip.
+        // serialise -> restore round-trip. Kept out of the registry
+        // because the empty-as-null shape doesn't fit the
+        // boolean/string factory.
         promptEvaluatorSkipPattern:
           typeof entry.session.promptEvaluatorSkipPattern === 'string' &&
           entry.session.promptEvaluatorSkipPattern.length > 0
             ? entry.session.promptEvaluatorSkipPattern
             : null,
-        // #3805: surface the per-session Chroxy-context-hint toggle so the
-        // dashboard can render its checkbox without a separate round-trip.
-        // Strict-boolean coerce so a hypothetical custom provider that
-        // skips the BaseSession field initialiser still round-trips a
-        // valid boolean on the wire.
-        chroxyContextHint: !!entry.session.chroxyContextHint,
-        // #4660: surface the per-session preamble so the dashboard can
-        // hydrate its text area without a separate round-trip. String
-        // coerce so a custom provider that skips the BaseSession field
-        // initialiser still round-trips a valid string on the wire.
-        sessionPreamble: typeof entry.session.sessionPreamble === 'string'
-          ? entry.session.sessionPreamble
-          : '',
         // #3540: surface the latched stdin_disabled flag so reconnecting
         // clients (and clients connecting after a server restart) see
         // the disabled state without waiting for a fresh `error` event.
@@ -1179,11 +1166,11 @@ export class SessionManager extends EventEmitter {
         name: entry.name,
         lastActivityAt: this._sessionLastActivityAt.get(id) || entry.createdAt,
         history,
-        // #3185: persist promptEvaluator so reconnects across restarts
-        // preserve the user's toggle state. Strict-boolean coerce so
-        // older state files (pre-#3185) round-trip as `false` rather
-        // than `undefined` after restore.
-        promptEvaluator: !!entry.session.promptEvaluator,
+        // #4664: persist per-session toggle/string settings via the
+        // shared registry — each entry's coerce produces the same
+        // strict-boolean/string-default shape the pre-refactor per-knob
+        // code wrote (so an old state file round-trips identically).
+        ...serializePerSessionSettings(entry.session),
         // #3639: persist the per-session skip-pattern source. Null when
         // unset — old state files (pre-#3639) restore as null (the
         // BaseSession default) so this is fully backward compatible.
@@ -1196,19 +1183,6 @@ export class SessionManager extends EventEmitter {
           entry.session.promptEvaluatorSkipPattern.length > 0
             ? entry.session.promptEvaluatorSkipPattern
             : null,
-        // #3805: persist the Chroxy-context-hint toggle so reconnects
-        // across restarts preserve the user's choice. Strict-boolean
-        // coerce so older state files (pre-#3805) round-trip as
-        // `false` rather than `undefined` after restore.
-        chroxyContextHint: !!entry.session.chroxyContextHint,
-        // #4660: persist the user-authored preamble so reconnects
-        // across restarts preserve the user's pre-loaded context.
-        // String coerce so a custom provider that skips the BaseSession
-        // field initialiser still writes a valid string to the state
-        // file instead of `undefined`.
-        sessionPreamble: typeof entry.session.sessionPreamble === 'string'
-          ? entry.session.sessionPreamble
-          : '',
         // #3540: persist the SidecarProcess `stdin_disabled` latch so a
         // server restart preserves the disabled state. Without this, a
         // client connecting after restart would not see the banner — the
@@ -1285,26 +1259,21 @@ export class SessionManager extends EventEmitter {
           permissionMode: saved.permissionMode,
           resumeSessionId: saved.sdkSessionId,
           provider: saved.provider || undefined,
-          // #3185: forward the persisted toggle through the typed
-          // pathway. createSession ignores non-boolean inputs (older
-          // state files lack the field), so this round-trips cleanly.
-          promptEvaluator: typeof saved.promptEvaluator === 'boolean' ? saved.promptEvaluator : undefined,
-          // #3639: same pattern — forward the persisted skip-pattern
-          // source. Non-string / empty values are dropped (createSession
-          // ignores them) so older state files restore as null.
+          // #4664: restore per-session toggle/string settings via the
+          // shared registry. Each registry entry's `acceptFromConstructor`
+          // predicate drops malformed values to `undefined` so
+          // createSession applies BaseSession's default — exact match for
+          // the pre-refactor per-knob behaviour, and older state files
+          // (without these fields) round-trip cleanly.
+          ...restorePerSessionSettings(saved),
+          // #3639: forward the persisted skip-pattern source. Non-string /
+          // empty values are dropped (createSession ignores them) so older
+          // state files restore as null. Kept out of the registry because
+          // the empty-string-as-null wire shape doesn't fit the
+          // boolean/string factory.
           promptEvaluatorSkipPattern: typeof saved.promptEvaluatorSkipPattern === 'string' && saved.promptEvaluatorSkipPattern.length > 0
             ? saved.promptEvaluatorSkipPattern
             : undefined,
-          // #3805: restore the per-session Chroxy-context-hint flag from
-          // disk so reconnects across server restarts preserve the
-          // user's choice. createSession ignores non-boolean inputs so
-          // older state files (pre-#3805, no field) restore as `false`.
-          chroxyContextHint: typeof saved.chroxyContextHint === 'boolean' ? saved.chroxyContextHint : undefined,
-          // #4660: restore the user-authored preamble from disk so
-          // reconnects across server restarts preserve the user's
-          // pre-loaded context. createSession ignores non-string inputs
-          // so older state files (pre-#4660, no field) restore as `''`.
-          sessionPreamble: typeof saved.sessionPreamble === 'string' ? saved.sessionPreamble : undefined,
           // #3540: forward the persisted stdin_disabled latch. Only
           // truthy values flip the flag; pre-#3540 state files (no
           // field) restore as `false`. The SdkSession constructor

--- a/packages/server/tests/per-session-settings.test.js
+++ b/packages/server/tests/per-session-settings.test.js
@@ -134,11 +134,11 @@ describe('forwardPerSessionSettingsToProviderOpts', () => {
 // ---- serializePerSessionSettings -------------------------------------------
 
 describe('serializePerSessionSettings', () => {
-  it('reads each setting through its coerce so corrupt session fields become safe values', () => {
+  it('falls back to defaultValue when the session field is undefined (Copilot review on #4751)', () => {
     const session = {
       // Simulate a custom provider that skips BaseSession's field
-      // initialiser — every defensive coerce in serializeState must still
-      // produce a valid wire shape.
+      // initialiser — defaultValue feeds the coerce so the wire shape
+      // is right (`false` / `false` / `''`), not `undefined` everywhere.
       promptEvaluator: undefined,
       chroxyContextHint: undefined,
       sessionPreamble: undefined,
@@ -147,6 +147,24 @@ describe('serializePerSessionSettings', () => {
     assert.equal(out.promptEvaluator, false)
     assert.equal(out.chroxyContextHint, false)
     assert.equal(out.sessionPreamble, '')
+  })
+
+  it('coerces a present but wrong-shape session field to the wire-safe form', () => {
+    // A hand-edited state file or a custom provider that initialised the
+    // field to a non-typeof-correct value: the coerce still runs and
+    // produces the safe wire shape (boolean via `!!v`, '' via
+    // `typeof v === 'string' ? v : ''`). defaultValue is NOT used here
+    // because the raw value is defined — only `undefined` triggers the
+    // defaultValue fallback.
+    const session = {
+      promptEvaluator: 'truthy-string',
+      chroxyContextHint: 0,
+      sessionPreamble: 42,
+    }
+    const out = serializePerSessionSettings(session)
+    assert.equal(out.promptEvaluator, true) // !! on truthy string
+    assert.equal(out.chroxyContextHint, false) // !! on 0
+    assert.equal(out.sessionPreamble, '') // non-string → ''
   })
 
   it('round-trips set values', () => {

--- a/packages/server/tests/per-session-settings.test.js
+++ b/packages/server/tests/per-session-settings.test.js
@@ -1,0 +1,321 @@
+/**
+ * Tests for the per-session settings registry (#4664).
+ *
+ * The registry collapses the per-session-setting boilerplate that the
+ * promptEvaluator (#3185) → chroxyContextHint (#3805) → sessionPreamble
+ * (#4660) iterations each hand-wrote across SessionManager (createSession
+ * forwarding + serializeState + restoreState) and settings-handlers.js
+ * (WS handler + broadcast + immediate persist).
+ *
+ * These tests describe the abstraction's contract — a single declaration
+ * per knob, with derived helpers that drive the WS handler factory, the
+ * createSession providerOpts forwarder, and the serialize / restore
+ * pair. The existing per-knob behaviour (BaseSession field declarations,
+ * setter validation, jsonl-subprocess middle layer forwarding) is
+ * unchanged and continues to be covered by base-session.test.js +
+ * jsonl-subprocess-session.test.js.
+ */
+import { describe, it, beforeEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  definePerSessionSetting,
+  PER_SESSION_SETTINGS,
+  forwardPerSessionSettingsToProviderOpts,
+  serializePerSessionSettings,
+  restorePerSessionSettings,
+  buildPerSessionSettingHandler,
+} from '../src/per-session-settings.js'
+
+// ---- definePerSessionSetting ------------------------------------------------
+
+describe('definePerSessionSetting', () => {
+  it('returns a frozen definition with the supplied fields', () => {
+    const def = definePerSessionSetting({
+      id: 'foo',
+      defaultValue: false,
+      // Boolean coerce + accept predicate are the simplest pair — mirrors
+      // the promptEvaluator shape.
+      coerce: (v) => !!v,
+      acceptFromWire: (v) => typeof v === 'boolean',
+      acceptFromConstructor: (v) => typeof v === 'boolean',
+      requestType: 'set_foo',
+      broadcastType: 'foo_changed',
+      handlerInvalidValueMessage: 'set_foo requires a boolean `value`',
+      handlerUnsupportedMessage: 'This provider does not support foo',
+      setterName: 'setFoo',
+    })
+    assert.equal(def.id, 'foo')
+    assert.equal(def.defaultValue, false)
+    assert.equal(typeof def.coerce, 'function')
+    assert.equal(def.requestType, 'set_foo')
+    assert.equal(def.broadcastType, 'foo_changed')
+    // Defensive freeze — handlers iterate the registry; a stray mutation
+    // would silently change behaviour at every call site.
+    assert.throws(() => { def.id = 'bar' }, /read.only|Cannot assign/)
+  })
+
+  it('throws when a required field is missing', () => {
+    assert.throws(
+      () => definePerSessionSetting({ id: 'foo' }),
+      /defaultValue|coerce|requestType|broadcastType|setterName/,
+    )
+  })
+})
+
+// ---- PER_SESSION_SETTINGS registry -----------------------------------------
+
+describe('PER_SESSION_SETTINGS registry', () => {
+  it('includes the three current per-session settings', () => {
+    const ids = PER_SESSION_SETTINGS.map((s) => s.id).sort()
+    assert.deepEqual(ids, ['chroxyContextHint', 'promptEvaluator', 'sessionPreamble'])
+  })
+
+  it('every entry has the wire request + broadcast pair', () => {
+    for (const def of PER_SESSION_SETTINGS) {
+      assert.equal(typeof def.requestType, 'string', `${def.id} missing requestType`)
+      assert.equal(typeof def.broadcastType, 'string', `${def.id} missing broadcastType`)
+      assert.equal(typeof def.setterName, 'string', `${def.id} missing setterName`)
+      assert.equal(typeof def.coerce, 'function', `${def.id} missing coerce`)
+    }
+  })
+
+  // Locks in the exact wire types so a future rename in the registry can't
+  // silently break dashboard clients that hard-code the strings.
+  it('wire types match the existing protocol', () => {
+    const byId = new Map(PER_SESSION_SETTINGS.map((s) => [s.id, s]))
+    assert.equal(byId.get('promptEvaluator').requestType, 'set_prompt_evaluator')
+    assert.equal(byId.get('promptEvaluator').broadcastType, 'prompt_evaluator_changed')
+    assert.equal(byId.get('chroxyContextHint').requestType, 'set_chroxy_context_hint')
+    assert.equal(byId.get('chroxyContextHint').broadcastType, 'chroxy_context_hint_changed')
+    assert.equal(byId.get('sessionPreamble').requestType, 'set_session_preamble')
+    assert.equal(byId.get('sessionPreamble').broadcastType, 'session_preamble_changed')
+  })
+})
+
+// ---- forwardPerSessionSettingsToProviderOpts -------------------------------
+
+describe('forwardPerSessionSettingsToProviderOpts', () => {
+  it('copies declared keys when the wire-accept predicate returns true', () => {
+    const out = {}
+    forwardPerSessionSettingsToProviderOpts(out, {
+      promptEvaluator: true,
+      chroxyContextHint: false,
+      sessionPreamble: '  hello  ',
+    })
+    assert.equal(out.promptEvaluator, true)
+    assert.equal(out.chroxyContextHint, false)
+    assert.equal(out.sessionPreamble, '  hello  ')
+  })
+
+  it('skips a key when the accept predicate rejects (preserves BaseSession defaults)', () => {
+    const out = {}
+    forwardPerSessionSettingsToProviderOpts(out, {
+      promptEvaluator: 'not-a-bool',
+      chroxyContextHint: 1,
+      sessionPreamble: 42,
+    })
+    // None of the three forwarded — BaseSession's constructor coerce will
+    // apply its own default for each.
+    assert.equal('promptEvaluator' in out, false)
+    assert.equal('chroxyContextHint' in out, false)
+    assert.equal('sessionPreamble' in out, false)
+  })
+
+  it('does not include keys absent from source', () => {
+    const out = {}
+    forwardPerSessionSettingsToProviderOpts(out, {})
+    assert.equal('promptEvaluator' in out, false)
+    assert.equal('chroxyContextHint' in out, false)
+    assert.equal('sessionPreamble' in out, false)
+  })
+})
+
+// ---- serializePerSessionSettings -------------------------------------------
+
+describe('serializePerSessionSettings', () => {
+  it('reads each setting through its coerce so corrupt session fields become safe values', () => {
+    const session = {
+      // Simulate a custom provider that skips BaseSession's field
+      // initialiser — every defensive coerce in serializeState must still
+      // produce a valid wire shape.
+      promptEvaluator: undefined,
+      chroxyContextHint: undefined,
+      sessionPreamble: undefined,
+    }
+    const out = serializePerSessionSettings(session)
+    assert.equal(out.promptEvaluator, false)
+    assert.equal(out.chroxyContextHint, false)
+    assert.equal(out.sessionPreamble, '')
+  })
+
+  it('round-trips set values', () => {
+    const session = {
+      promptEvaluator: true,
+      chroxyContextHint: true,
+      sessionPreamble: 'hello world',
+    }
+    const out = serializePerSessionSettings(session)
+    assert.equal(out.promptEvaluator, true)
+    assert.equal(out.chroxyContextHint, true)
+    assert.equal(out.sessionPreamble, 'hello world')
+  })
+})
+
+// ---- restorePerSessionSettings ---------------------------------------------
+
+describe('restorePerSessionSettings', () => {
+  it('returns undefined for fields absent from the state file', () => {
+    const out = restorePerSessionSettings({})
+    // undefined → createSession leaves BaseSession's constructor default
+    // in place. Cleanest backward-compat — pre-existing state files
+    // round-trip unchanged.
+    assert.equal(out.promptEvaluator, undefined)
+    assert.equal(out.chroxyContextHint, undefined)
+    assert.equal(out.sessionPreamble, undefined)
+  })
+
+  it('forwards explicit values', () => {
+    const out = restorePerSessionSettings({
+      promptEvaluator: true,
+      chroxyContextHint: false,
+      sessionPreamble: 'hi',
+    })
+    assert.equal(out.promptEvaluator, true)
+    assert.equal(out.chroxyContextHint, false)
+    assert.equal(out.sessionPreamble, 'hi')
+  })
+
+  it('drops bad shapes (non-string sessionPreamble, non-boolean toggles) so createSession ignores them', () => {
+    const out = restorePerSessionSettings({
+      promptEvaluator: 'truthy-not-boolean',
+      chroxyContextHint: 0,
+      sessionPreamble: 42,
+    })
+    // All three drop → createSession applies BaseSession defaults rather
+    // than feeding the malformed value through. Matches the pre-refactor
+    // per-knob behaviour in session-manager.js.
+    assert.equal(out.promptEvaluator, undefined)
+    assert.equal(out.chroxyContextHint, undefined)
+    assert.equal(out.sessionPreamble, undefined)
+  })
+})
+
+// ---- buildPerSessionSettingHandler -----------------------------------------
+
+describe('buildPerSessionSettingHandler', () => {
+  // Reusable boolean test definition. Mirrors the promptEvaluator wiring.
+  const booleanDef = definePerSessionSetting({
+    id: 'fooFlag',
+    defaultValue: false,
+    coerce: (v) => !!v,
+    acceptFromWire: (v) => typeof v === 'boolean',
+    acceptFromConstructor: (v) => typeof v === 'boolean',
+    requestType: 'set_foo_flag',
+    broadcastType: 'foo_flag_changed',
+    setterName: 'setFooFlag',
+    handlerInvalidValueMessage: 'set_foo_flag requires a boolean `value`',
+    handlerUnsupportedMessage: 'This provider does not support fooFlag',
+  })
+
+  function makeCtx(session, overrides = {}) {
+    const sessionMap = new Map()
+    if (session) sessionMap.set('sess-1', { session, name: 'test' })
+    return {
+      sessionManager: {
+        getSession: (id) => sessionMap.get(id) ?? null,
+        serializeState: mock.fn(() => null),
+      },
+      send: mock.fn(),
+      broadcast: mock.fn(),
+      broadcastToSession: mock.fn(),
+      _sessions: sessionMap,
+      ...overrides,
+    }
+  }
+
+  const client = { id: 'c1', activeSessionId: 'sess-1' }
+
+  it('rejects payload with the wrong-shape value (sends session_error and no broadcast)', () => {
+    const session = { fooFlag: false, setFooFlag: mock.fn(() => true) }
+    const ctx = makeCtx(session)
+    const handler = buildPerSessionSettingHandler(booleanDef)
+    handler({}, client, { type: 'set_foo_flag', value: 'not-a-bool' }, ctx)
+
+    assert.equal(ctx.broadcastToSession.mock.callCount(), 0)
+    assert.equal(session.setFooFlag.mock.callCount(), 0)
+    assert.equal(ctx.send.mock.callCount(), 1)
+    const reply = ctx.send.mock.calls[0].arguments[1]
+    assert.equal(reply.type, 'session_error')
+    assert.match(reply.message, /boolean.*value/i)
+  })
+
+  it('sends session_error when no session is bound', () => {
+    const ctx = makeCtx(null)
+    const handler = buildPerSessionSettingHandler(booleanDef)
+    handler({}, { id: 'c1', activeSessionId: 'sess-missing' }, { type: 'set_foo_flag', value: true }, ctx)
+
+    assert.equal(ctx.broadcastToSession.mock.callCount(), 0)
+    assert.equal(ctx.send.mock.callCount(), 1)
+    assert.equal(ctx.send.mock.calls[0].arguments[1].type, 'session_error')
+  })
+
+  it('sends session_error when session lacks the setter (defensive)', () => {
+    // No setFooFlag method — a custom provider that bypasses BaseSession.
+    const session = { fooFlag: false }
+    const ctx = makeCtx(session)
+    const handler = buildPerSessionSettingHandler(booleanDef)
+    handler({}, client, { type: 'set_foo_flag', value: true }, ctx)
+
+    assert.equal(ctx.broadcastToSession.mock.callCount(), 0)
+    assert.equal(ctx.send.mock.callCount(), 1)
+    assert.match(ctx.send.mock.calls[0].arguments[1].message, /does not support/i)
+  })
+
+  it('broadcasts when the setter returns true (state actually changed)', () => {
+    const session = { fooFlag: true, setFooFlag: mock.fn(() => true) }
+    const ctx = makeCtx(session)
+    const handler = buildPerSessionSettingHandler(booleanDef)
+    handler({}, client, { type: 'set_foo_flag', value: true }, ctx)
+
+    assert.equal(session.setFooFlag.mock.callCount(), 1)
+    assert.equal(session.setFooFlag.mock.calls[0].arguments[0], true)
+    assert.equal(ctx.broadcastToSession.mock.callCount(), 1)
+    const [sessionId, broadcast] = ctx.broadcastToSession.mock.calls[0].arguments
+    assert.equal(sessionId, 'sess-1')
+    assert.equal(broadcast.type, 'foo_flag_changed')
+    assert.equal(broadcast.value, true)
+    // Immediate persist — toggles are rare operator actions; matches the
+    // existing per-knob behaviour.
+    assert.equal(ctx.sessionManager.serializeState.mock.callCount(), 1)
+  })
+
+  it('skips broadcast + persist when the setter reports a no-op (false)', () => {
+    const session = { fooFlag: false, setFooFlag: mock.fn(() => false) }
+    const ctx = makeCtx(session)
+    const handler = buildPerSessionSettingHandler(booleanDef)
+    handler({}, client, { type: 'set_foo_flag', value: false }, ctx)
+
+    assert.equal(session.setFooFlag.mock.callCount(), 1)
+    assert.equal(ctx.broadcastToSession.mock.callCount(), 0)
+    assert.equal(ctx.sessionManager.serializeState.mock.callCount(), 0)
+    assert.equal(ctx.send.mock.callCount(), 0)
+  })
+
+  it('does not throw when persist itself fails (best-effort)', () => {
+    const session = { fooFlag: true, setFooFlag: mock.fn(() => true) }
+    const ctx = makeCtx(session, {
+      sessionManager: {
+        getSession: (id) => ({ session, name: 'test' }),
+        serializeState: mock.fn(() => { throw new Error('disk full') }),
+      },
+    })
+    const handler = buildPerSessionSettingHandler(booleanDef)
+    // Must not throw — the in-memory state is correct; the persist is
+    // best-effort with a log line only.
+    assert.doesNotThrow(() => {
+      handler({}, client, { type: 'set_foo_flag', value: true }, ctx)
+    })
+    assert.equal(ctx.broadcastToSession.mock.callCount(), 1)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `packages/server/src/per-session-settings.js` — a registry + helper module that collapses the per-session-setting boilerplate the `promptEvaluator` (#3185) → `chroxyContextHint` (#3805) → `sessionPreamble` (#4660) iterations each hand-wrote across 5 sites.
- Migrates the three existing knobs onto the registry: WS handlers, `createSession` provider-opts forwarding, `serializeState`, and `restoreState` are all driven by `PER_SESSION_SETTINGS` entries.
- `promptEvaluatorSkipPattern` stays out of the registry — the string-or-null shape plus pre-validation regex compile doesn't fit the boolean/string factory and would dilute the abstraction.
- Adding a new knob is now one entry in `PER_SESSION_SETTINGS` plus the existing BaseSession field + setter declarations; the module's JSDoc documents what each new knob still owns (provider middle layers, dashboard side, BaseSession field — all deliberately left in place to keep the refactor narrow).

Net diff: `settings-handlers.js` -157 LOC (3 handlers → factory loop), `session-manager.js` -61 LOC (5 inline forwarding / serialize / restore sites collapse to 3 helper calls), +366 LOC for the new module + tests.

Wire behaviour is unchanged: every existing settings-handler unit test, session-manager test, ws-server test, and base-session test stays green.

## Test plan

- [x] `node --test tests/per-session-settings.test.js` — 19 new tests covering the registry, helpers, and handler factory
- [x] `node --test tests/base-session.test.js` — existing per-knob constructor / setter behaviour unchanged
- [x] `node --test tests/session-manager.test.js` — createSession / serializeState / restoreState round-trip
- [x] `node --test tests/ws-server.test.js` — WS dispatch + broadcast
- [x] `node --test tests/ws-history.test.js` — session_list payload shape
- [x] `node --test tests/ws-schemas.test.js` — protocol validation
- [x] `node --test tests/jsonl-subprocess-session.test.js` — middle-layer forwarding still works (untouched)
- [x] `node --test tests/codex-session.test.js tests/cli-session.test.js tests/prompt-evaluator.test.js tests/prompt-evaluator-auto.test.js` — provider integration

Closes #4664