### PR TITLE
feat(server,dashboard,protocol): single-question Other / freeform answer support

### DIFF
--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -281,6 +281,13 @@ describe('QuestionPrompt', () => {
     })
 
     it('submits the typed answer when Send is clicked from Other mode', () => {
+      // #4651 — Other-mode submissions now emit an object payload carrying
+      // both the typed text AND the option label that triggered Other-mode
+      // ("Other" by default; a model-supplied label like "Custom" if the
+      // model overrode the label). The connection store reads this shape
+      // to send a two-stage `user_question_response` (digit → freeform
+      // text) to the server, so claude TUI's text-input prompt receives
+      // the freeform answer instead of jump-nav-ing on the menu.
       const onSelect = vi.fn()
       render(
         <QuestionPrompt
@@ -292,7 +299,27 @@ describe('QuestionPrompt', () => {
       fireEvent.click(screen.getByText('Other'))
       fireEvent.change(screen.getByPlaceholderText('Type your response…'), { target: { value: 'custom answer' } })
       fireEvent.click(screen.getByRole('button', { name: 'Send' }))
-      expect(onSelect).toHaveBeenCalledWith('custom answer')
+      expect(onSelect).toHaveBeenCalledWith({ otherLabel: 'Other', freeformText: 'custom answer' })
+    })
+
+    it('still emits a plain string when no options exist (free-text-only AskUserQuestion)', () => {
+      // #4651 — the freeform object shape is reserved for the
+      // "Other option exists in a menu" path. A question with zero
+      // options (free-text-only fallback, #1245) doesn't render an
+      // "Other" button at all, so onSelect must keep the legacy
+      // string shape for back-compat with the server's free-text
+      // handler.
+      const onSelect = vi.fn()
+      render(
+        <QuestionPrompt
+          question="Any thoughts?"
+          options={[]}
+          onSelect={onSelect}
+        />
+      )
+      fireEvent.change(screen.getByPlaceholderText('Type your response…'), { target: { value: 'free text' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+      expect(onSelect).toHaveBeenCalledWith('free text')
     })
 
     it('Cancel returns to the option buttons without submitting', () => {

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -22,6 +22,18 @@
 import { useId, useState, useRef, useEffect } from 'react'
 import { OTHER_OPTION_VALUE, type ChatMessageQuestion } from '@chroxy/store-core'
 
+/**
+ * #4651 — payload shape emitted when the user picks "Other" on a single-
+ * question AskUserQuestion and types freeform text. The store reads this
+ * shape to send a two-stage `user_question_response` (server writes the
+ * Other digit to claude TUI, waits for the text-input prompt swap, then
+ * writes the freeform text + Enter).
+ */
+export interface OtherFreeformAnswer {
+  otherLabel: string
+  freeformText: string
+}
+
 export interface QuestionPromptProps {
   question: string
   options: { label: string; value: string }[]
@@ -35,12 +47,16 @@ export interface QuestionPromptProps {
    */
   questions?: ChatMessageQuestion[]
   /**
-   * Fires with either a plain string (single-question / free-text path,
-   * back-compat) or a `Record<string,string>` map (multi-question form,
-   * keyed by `question.question` with multi-select values
-   * JSON-stringified arrays of chosen labels).
+   * Fires with one of three shapes:
+   * - `string` — legacy single-question / free-text-only path (back-compat).
+   * - `Record<string,string>` — multi-question form (#4604 Chunk B), keyed
+   *   by `question.question` with multi-select values JSON-stringified
+   *   arrays of chosen labels.
+   * - `OtherFreeformAnswer` — single-question "Other" with freeform text
+   *   (#4651), carrying both the Other option's label (for digit lookup
+   *   on the server) and the typed text.
    */
-  onSelect: (answer: string | Record<string, string>) => void
+  onSelect: (answer: string | Record<string, string> | OtherFreeformAnswer) => void
 }
 
 export function QuestionPrompt({ question, options, answered, questions, onSelect }: QuestionPromptProps) {
@@ -227,12 +243,20 @@ interface SingleQuestionPromptProps {
   question: string
   options: { label: string; value: string }[]
   answered?: string
-  onSelect: (value: string) => void
+  onSelect: (value: string | OtherFreeformAnswer) => void
 }
 
 function SingleQuestionPrompt({ question, options, answered, onSelect }: SingleQuestionPromptProps) {
   const [text, setText] = useState('')
   const [otherActive, setOtherActive] = useState(false)
+  // #4651 — when the user clicks the Other option button, stash the option's
+  // label so handleSubmit can emit it back to the server. The server uses
+  // the label to resolve Other → 1-indexed digit (claude TUI hotkey) and
+  // then writes the digit BEFORE the freeform text so the TUI's text-
+  // input prompt is open when the text lands. Default 'Other' covers the
+  // synthesized-sentinel case (#3746) where options[*].value ===
+  // OTHER_OPTION_VALUE but no real option carries that label.
+  const [otherLabel, setOtherLabel] = useState<string>('Other')
   // #4312: post-answer the option block collapses to a one-line summary;
   // user can re-expand to inspect the full disabled-button list. Default
   // collapsed once `answered` is set, including the remote-answered case
@@ -258,7 +282,18 @@ function SingleQuestionPrompt({ question, options, answered, onSelect }: SingleQ
     const trimmed = text.trim()
     if (!trimmed) return
     submittedRef.current = true
-    onSelect(trimmed)
+    // #4651 — when the user reached this form by clicking the "Other"
+    // option (otherActive), emit the structured payload so the server
+    // can drive the two-stage TUI write (Other digit → text-input prompt
+    // → freeform text + Enter). When otherActive is false the user is
+    // in the zero-options free-text-only path (#1245) — keep emitting
+    // a plain string so the server's existing free-text handler
+    // continues to work unchanged.
+    if (otherActive) {
+      onSelect({ otherLabel, freeformText: trimmed })
+    } else {
+      onSelect(trimmed)
+    }
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -270,6 +305,12 @@ function SingleQuestionPrompt({ question, options, answered, onSelect }: SingleQ
 
   const handleOptionClick = (value: string) => {
     if (value === OTHER_OPTION_VALUE) {
+      // #4651 — capture the label of the option the user actually clicked
+      // so the freeform payload carries the right label for the server's
+      // digit lookup. Synthetic sentinel options use the label 'Other';
+      // model-supplied custom labels (rare) preserve their text.
+      const clicked = options.find((o) => o.value === value)
+      setOtherLabel(clicked?.label || 'Other')
       setOtherActive(true)
       return
     }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1549,9 +1549,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }));
   },
 
-  sendUserQuestionResponse: (answer: string | Record<string, string>, toolUseId?: string) => {
+  sendUserQuestionResponse: (
+    answer: string | Record<string, string> | { otherLabel: string; freeformText: string },
+    toolUseId?: string,
+  ) => {
     const { socket, activeSessionId, sessionStates } = get();
-    // #4604 Chunk B — split the wire payload by call shape:
+    // #4604 Chunk B / #4651 — split the wire payload by call shape:
     // - string `answer`: legacy single-question / free-text path. Wire
     //   shape stays `{ type, answer, toolUseId? }` so older servers
     //   keep working without schema migration.
@@ -1560,13 +1563,34 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     //   `answer` summary so a server running an older build that only
     //   reads `answer` falls through to its default-to-option-1 path
     //   (a noisy WARN in chroxy.log) instead of stalling the form.
-    const isMultiAnswer = typeof answer !== 'string'
-    const answerSummary = isMultiAnswer
-      ? Object.entries(answer as Record<string, string>).map(([q, v]) => `${q}: ${v}`).join(' | ')
-      : (answer as string);
-    const payload: Record<string, unknown> = { type: 'user_question_response', answer: answerSummary };
+    // - {otherLabel, freeformText} (#4651): single-question Other path.
+    //   `answer` carries the Other option's label so the server can
+    //   resolve it to a 1-indexed digit; `freeformText` carries the
+    //   typed text so the server can drive a two-stage TUI write
+    //   (digit → text-input prompt → freeform text + Enter). Older
+    //   servers that ignore `freeformText` fall through to the legacy
+    //   path and type the label literally — a clean degradation.
+    const isFreeformAnswer = typeof answer === 'object' && answer !== null
+      && 'freeformText' in answer && 'otherLabel' in answer;
+    const isMultiAnswer = !isFreeformAnswer && typeof answer !== 'string';
+    let answerSummary: string;
+    if (isFreeformAnswer) {
+      const f = answer as { otherLabel: string; freeformText: string };
+      answerSummary = f.freeformText;
+    } else if (isMultiAnswer) {
+      answerSummary = Object.entries(answer as Record<string, string>)
+        .map(([q, v]) => `${q}: ${v}`).join(' | ');
+    } else {
+      answerSummary = answer as string;
+    }
+    const payload: Record<string, unknown> = { type: 'user_question_response', answer: isFreeformAnswer
+      ? (answer as { otherLabel: string; freeformText: string }).otherLabel
+      : answerSummary };
     if (isMultiAnswer) {
       payload.answers = answer;
+    }
+    if (isFreeformAnswer) {
+      payload.freeformText = (answer as { otherLabel: string; freeformText: string }).freeformText;
     }
     if (toolUseId) payload.toolUseId = toolUseId;
     // #4296: echo the resolved answer to the terminal buffer so the Output

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1570,8 +1570,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     //   (digit → text-input prompt → freeform text + Enter). Older
     //   servers that ignore `freeformText` fall through to the legacy
     //   path and type the label literally — a clean degradation.
+    // Copilot review (#4753): tighten the freeform-shape detection to
+    // avoid misclassifying a multi-question Record<string,string> whose
+    // question keys happen to be literally "freeformText" and "otherLabel"
+    // (rare, but possible if the model phrases a question that way).
+    // The freeform shape is `Record<string,string>` with EXACTLY those
+    // two keys AND both string values — anything else falls through to
+    // the multi-question path.
     const isFreeformAnswer = typeof answer === 'object' && answer !== null
-      && 'freeformText' in answer && 'otherLabel' in answer;
+      && !Array.isArray(answer)
+      && Object.keys(answer).length === 2
+      && 'freeformText' in answer && 'otherLabel' in answer
+      && typeof (answer as Record<string, unknown>).freeformText === 'string'
+      && typeof (answer as Record<string, unknown>).otherLabel === 'string';
     const isMultiAnswer = !isFreeformAnswer && typeof answer !== 'string';
     let answerSummary: string;
     if (isFreeformAnswer) {

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1432,6 +1432,48 @@ describe('sendUserQuestionResponse Output-tab echo (#4296)', () => {
     // nothing.
     expect(terminalRawBuffer).not.toContain('User answered:');
   });
+
+  it('emits {answer:<otherLabel>, freeformText} when called with the Other / freeform shape (#4651)', async () => {
+    // #4651 — single-question "Other" path. The dashboard sends both:
+    // - `answer` = the Other option's label, so the server can resolve
+    //   it to a 1-indexed digit (claude TUI hotkey) and write the digit
+    //   FIRST to swap the menu into text-input mode.
+    // - `freeformText` = the typed text, which the server writes after
+    //   the prompt-swap settles + Enter to submit.
+    // The Output-tab echo surfaces the typed text (not the literal
+    // "Other" label) to match the user's mental model of what they sent.
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse(
+      { otherLabel: 'Other', freeformText: 'my custom answer' },
+      'toolu_other_freeform',
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      type: 'user_question_response',
+      answer: 'Other',
+      freeformText: 'my custom answer',
+      toolUseId: 'toolu_other_freeform',
+    });
+    // No `answers` field — that's reserved for multi-question forms.
+    expect(sent[0]).not.toHaveProperty('answers');
+
+    const { terminalBuffer } = useConnectionStore.getState();
+    expect(terminalBuffer).toContain('User answered: my custom answer');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -629,14 +629,24 @@ export interface ConnectionState {
    * requestId — last write wins. */
   markPermissionResolved: (requestId: string, decision: PermissionDecision) => void;
   /**
-   * #4604 Chunk B — answer may be either a plain string (single-question /
-   * free-text path, back-compat) or a `Record<string,string>` map
-   * (multi-question form, keyed by question text with multi-select values
-   * JSON-stringified arrays). The Record path populates the wire's
-   * `answers` field; both paths populate `answer` with a human-readable
-   * summary so older servers stay functional.
+   * #4604 Chunk B / #4651 — answer may be one of three shapes:
+   * - `string`: legacy single-question / free-text path (back-compat).
+   * - `Record<string,string>`: multi-question form, keyed by question text
+   *   with multi-select values JSON-stringified arrays. The Record path
+   *   populates the wire's `answers` field.
+   * - `{otherLabel, freeformText}`: single-question "Other" with freeform
+   *   text (#4651). The store sets `answer` to `otherLabel` (so the server
+   *   can resolve it to a 1-indexed TUI digit) and `freeformText` to the
+   *   typed text. The server writes the digit first, waits for claude
+   *   TUI's text-input prompt swap, then writes the freeform text + Enter.
+   *
+   * All paths populate `answer` with a human-readable label so older servers
+   * stay functional.
    */
-  sendUserQuestionResponse: (answer: string | Record<string, string>, toolUseId?: string) => 'sent' | 'queued' | false;
+  sendUserQuestionResponse: (
+    answer: string | Record<string, string> | { otherLabel: string; freeformText: string },
+    toolUseId?: string,
+  ) => 'sent' | 'queued' | false;
   markPromptAnswered: (messageId: string, answer: string) => void;
   markPromptAnsweredByRequestId: (requestId: string, answer: string) => void;
   setModel: (model: string) => void;

--- a/packages/dashboard/src/utils/questionAnswerSummary.test.ts
+++ b/packages/dashboard/src/utils/questionAnswerSummary.test.ts
@@ -100,6 +100,18 @@ describe('formatQuestionAnswerSummary', () => {
       )
     })
 
+    it('renders Other / freeform single-question answers as the typed text (#4651)', () => {
+      // #4651 — single-question "Other" with freeform text. The summary
+      // chip should show the user's typed text, not the literal "Other"
+      // label that was used to pick the Other option in the menu.
+      expect(
+        formatQuestionAnswerSummary({
+          otherLabel: 'Other',
+          freeformText: 'my freeform thought',
+        }),
+      ).toBe('my freeform thought')
+    })
+
     it('only flattens arrays — non-array JSON values are kept as the raw string', () => {
       // MultiQuestionForm.handleSubmit only ever JSON-stringifies arrays
       // of option values (see handleSubmit in QuestionPrompt.tsx). The

--- a/packages/dashboard/src/utils/questionAnswerSummary.ts
+++ b/packages/dashboard/src/utils/questionAnswerSummary.ts
@@ -50,7 +50,18 @@ export function formatQuestionAnswerSummary(
   // the literal label "Other" — matching the post-answer UX of the
   // free-text-only path (#1245) where the typed text becomes the
   // chip content directly.
-  if ('freeformText' in answer && 'otherLabel' in answer) {
+  //
+  // Copilot review (#4753): tight detection — require EXACTLY two keys
+  // (`freeformText` + `otherLabel`) AND string values for both. A
+  // multi-question Record<string,string> whose question keys happen to
+  // be those exact strings would otherwise misclassify here.
+  if (
+    !Array.isArray(answer)
+    && Object.keys(answer).length === 2
+    && 'freeformText' in answer && 'otherLabel' in answer
+    && typeof (answer as Record<string, unknown>).freeformText === 'string'
+    && typeof (answer as Record<string, unknown>).otherLabel === 'string'
+  ) {
     return (answer as { freeformText: string }).freeformText
   }
   return Object.entries(answer as Record<string, string>)

--- a/packages/dashboard/src/utils/questionAnswerSummary.ts
+++ b/packages/dashboard/src/utils/questionAnswerSummary.ts
@@ -42,10 +42,18 @@ function formatMultiSelectValue(value: string): string {
 }
 
 export function formatQuestionAnswerSummary(
-  answer: string | Record<string, string>,
+  answer: string | Record<string, string> | { otherLabel: string; freeformText: string },
 ): string {
   if (typeof answer === 'string') return answer
-  return Object.entries(answer)
+  // #4651 — single-question Other / freeform path. The summary chip
+  // should surface the typed text (what the user actually wrote), not
+  // the literal label "Other" — matching the post-answer UX of the
+  // free-text-only path (#1245) where the typed text becomes the
+  // chip content directly.
+  if ('freeformText' in answer && 'otherLabel' in answer) {
+    return (answer as { freeformText: string }).freeformText
+  }
+  return Object.entries(answer as Record<string, string>)
     .map(([question, value]) => `${question}: ${formatMultiSelectValue(value)}`)
     .join(' | ')
 }

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -343,6 +343,7 @@ export declare const UserQuestionResponseSchema: z.ZodObject<{
     answer: z.ZodString;
     answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
     toolUseId: z.ZodOptional<z.ZodString>;
+    freeformText: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const ListDirectorySchema: z.ZodObject<{
     type: z.ZodLiteral<"list_directory">;
@@ -702,6 +703,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     answer: z.ZodString;
     answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
     toolUseId: z.ZodOptional<z.ZodString>;
+    freeformText: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_directory">;
     path: z.ZodOptional<z.ZodString>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -373,6 +373,12 @@ export const UserQuestionResponseSchema = z.object({
     answer: z.string().max(100_000),
     answers: z.record(z.string(), z.string().max(100_000)).refine((obj) => Object.keys(obj).length <= 100, { message: 'Too many answers (max 100)' }).optional(),
     toolUseId: z.string().max(256).optional(),
+    // #4651 — single-question "Other" / freeform path. When set, the server
+    // resolves the chosen option (`answer`) to its 1-indexed digit, writes
+    // the digit to open claude TUI's text-input prompt, then writes
+    // `freeformText` + Enter to submit. Mutually exclusive with `answers`
+    // (multi-question forms are out of scope per #4648 / #4651).
+    freeformText: z.string().max(100_000).optional(),
 });
 export const ListDirectorySchema = z.object({
     type: z.literal('list_directory'),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -423,6 +423,12 @@ export const UserQuestionResponseSchema = z.object({
     { message: 'Too many answers (max 100)' }
   ).optional(),
   toolUseId: z.string().max(256).optional(),
+  // #4651 — single-question "Other" / freeform path. When set, the server
+  // resolves the chosen option (`answer`) to its 1-indexed digit, writes
+  // the digit to open claude TUI's text-input prompt, then writes
+  // `freeformText` + Enter to submit. Mutually exclusive with `answers`
+  // (multi-question forms are out of scope per #4648 / #4651).
+  freeformText: z.string().max(100_000).optional(),
 })
 
 export const ListDirectorySchema = z.object({

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -101,6 +101,22 @@ const CLAUDE = resolveBinary('claude', [
 // dashboard can prompt the user to retry. Root cause is fixed in Chunk B.
 const ASK_USER_QUESTION_WATCHDOG_MS = 30 * 1000
 
+// #4651 — settle delay between the "Other" digit write and the freeform
+// text write. After we press the Other digit, claude TUI swaps from the
+// option-select menu to a text-input prompt. Writing the freeform text
+// too quickly races that swap (the keystrokes land at the menu and jump-
+// nav fires — same footgun as #4288). 150 ms covers the observed local-
+// loop swap time with comfortable margin; tune via the empirical
+// recording in scripts/tui-form-recorder.mjs if dogfood reveals a wedge.
+const OTHER_FREEFORM_SETTLE_MS = 150
+
+// #4651 — additional watchdog window granted after the Other digit lands
+// so the freeform text write + claude TUI's text-input acknowledgement
+// have time to complete. Without this, the existing 30s ASK_USER_QUESTION
+// watchdog can fire mid-freeform-write on a slow PTY (laggy tunnel,
+// emoji-heavy text) and tear down a turn that's actively progressing.
+const OTHER_FREEFORM_WATCHDOG_MS = 30 * 1000
+
 // Pre-trust the cwd in ~/.claude.json so the workspace-trust dialog doesn't
 // block headless spawn. The dialog is interactive-only — without this, the
 // PTY would render "Is this a project you trust?" and wait for Enter.
@@ -1904,7 +1920,7 @@ export class ClaudeTuiSession extends BaseSession {
    * @param {string} text — the chosen answer (single-question path); ignored on the multi-question path when answersMap is populated
    * @param {object} [answersMap] — `{ [questionText]: string | string[] }`; required for multi-question forms (Chunk B)
    */
-  respondToQuestion(text, answersMap, toolUseId) {
+  respondToQuestion(text, answersMap, toolUseId, opts) {
     // #4668: route to the specific pending entry the dashboard answered
     // for. Pre-#4668 chroxy stored a single pending answer in a field
     // and respondToQuestion always read THAT field — so when claude TUI
@@ -1914,6 +1930,16 @@ export class ClaudeTuiSession extends BaseSession {
     // it up in the Map; if not (legacy clients), fall back to the most-
     // recently-set entry via the back-compat getter so behaviour matches
     // pre-#4668 for the single-pending case.
+    //
+    // #4651: `opts.freeformText` triggers the Other / freeform path —
+    // server resolves the chosen option label to its 1-indexed digit,
+    // writes the digit to open claude TUI's text-input prompt, waits
+    // ~150 ms for the prompt swap, then writes the freeform text + Enter
+    // to submit. Mutually exclusive with answersMap (multi-question
+    // Other is out of scope per #4648).
+    const freeformText = (opts && typeof opts.freeformText === 'string' && opts.freeformText.length > 0)
+      ? opts.freeformText
+      : null
     let entry = null
     if (toolUseId && this._pendingUserAnswers.has(toolUseId)) {
       entry = this._pendingUserAnswers.get(toolUseId)
@@ -2008,6 +2034,60 @@ export class ClaudeTuiSession extends BaseSession {
     // single-q path is text-driven, not answersMap-driven.
     if (questions.length <= 1) {
       if (text.length === 0) return
+
+      // #4651 — Other / freeform path. The dashboard picked the "Other"
+      // option AND typed freeform text. claude TUI accepts this as a
+      // two-stage flow: press the Other digit (swaps the option-select
+      // menu to a text-input prompt), wait for the swap, then type the
+      // freeform text + Enter. Resolve the chosen label → digit via the
+      // same 1-indexed lookup as the happy path. When the chosen option
+      // doesn't exist (or sits beyond the single-digit hotkey range),
+      // drop the answer — blindly writing the freeform text at the
+      // digit menu is the #4288 jump-nav footgun and the dashboard
+      // shouldn't have been able to send freeformText for an
+      // AskUserQuestion without an Other option in the first place.
+      if (freeformText) {
+        if (!Array.isArray(options) || options.length === 0) {
+          log.warn(`respondToQuestion: freeformText supplied for question with no options (tool=${prevToolUseId || '?'}) — dropping`)
+          return
+        }
+        const otherIdx = options.findIndex((o) => o && o.label === text)
+        if (otherIdx < 0 || otherIdx >= 9) {
+          log.warn(`respondToQuestion: freeformText supplied but chosen option "${text}" not found (or beyond single-digit hotkey range) in pending options for tool=${prevToolUseId || '?'} — dropping`)
+          return
+        }
+        const otherDigit = String(otherIdx + 1)
+        // Stage 1: write the digit. _writePtyTextThrottled appends \r —
+        // for the option-select menu the trailing \r commits the digit
+        // (same shape as the happy single-select path).
+        // Stage 2: after OTHER_FREEFORM_SETTLE_MS, write the freeform
+        // text + \r via the same throttled writer. claude TUI's text-
+        // input prompt accepts typed input directly (no jump-nav),
+        // and the trailing \r submits.
+        const tag = prevToolUseId || '?'
+        ;(async () => {
+          const stage1ok = await this._writePtyTextThrottled(otherDigit).catch((err) => {
+            log.warn(`respondToQuestion Other-digit PTY write failed: ${err.message} (tool=${tag})`)
+            return false
+          })
+          if (!stage1ok) return
+          await new Promise((resolve) => setTimeout(resolve, OTHER_FREEFORM_SETTLE_MS))
+          // Re-arm the watchdog so the freeform write phase has a fresh
+          // OTHER_FREEFORM_WATCHDOG_MS window — the stage-1 arm already
+          // counted the settle delay against the original 30s budget.
+          if (this._askUserQuestionWatchdog) clearTimeout(this._askUserQuestionWatchdog)
+          this._askUserQuestionWatchdog = setTimeout(() => {
+            this._askUserQuestionWatchdog = null
+            this._onAskUserQuestionStall(prevToolUseId)
+          }, OTHER_FREEFORM_WATCHDOG_MS)
+          await this._writePtyTextThrottled(freeformText).catch((err) => {
+            log.warn(`respondToQuestion Other-freeform PTY write failed: ${err.message} (tool=${tag})`)
+          })
+        })()
+        armWatchdog()
+        return
+      }
+
       // #4290: if the chosen label matches one of the structured options
       // exactly, write the 1-indexed TUI shortcut (e.g. "2") instead of
       // the label text. v0.9.3 wrote the raw label and claude TUI's

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1917,8 +1917,22 @@ export class ClaudeTuiSession extends BaseSession {
    *
    * No-op when no pending answer.
    *
-   * @param {string} text — the chosen answer (single-question path); ignored on the multi-question path when answersMap is populated
-   * @param {object} [answersMap] — `{ [questionText]: string | string[] }`; required for multi-question forms (Chunk B)
+   * @param {string} text — the chosen answer (single-question path); on the
+   *   Other / freeform path (#4651) this is the Other option's label, used
+   *   to resolve the 1-indexed TUI digit. Ignored on the multi-question
+   *   path when answersMap is populated.
+   * @param {object} [answersMap] — `{ [questionText]: string | string[] }`;
+   *   required for multi-question forms (Chunk B).
+   * @param {string} [toolUseId] — #4668: target the specific pending entry
+   *   to answer when multiple AskUserQuestion tool_uses are in flight in
+   *   the same turn. When omitted, falls back to the most-recently-set
+   *   pending entry via the back-compat getter.
+   * @param {object} [opts] — extra options.
+   * @param {string} [opts.freeformText] — #4651 single-question Other path:
+   *   when set, the session writes the Other digit (resolved from `text`),
+   *   waits ~150 ms for claude TUI's option-menu → text-input prompt swap,
+   *   then writes `freeformText` + Enter. Dropped when the chosen option
+   *   doesn't exist or sits beyond the single-digit hotkey range.
    */
   respondToQuestion(text, answersMap, toolUseId, opts) {
     // #4668: route to the specific pending entry the dashboard answered

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -553,7 +553,10 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
     // wedge is correlatable from chroxy.log alone (toolUseId + map-key
     // count distinguishes the SDK's per-question form from the TUI's
     // single-answer string).
-    log.info(`user_question_response received: toolUseId=${msg.toolUseId || '?'} answer.length=${(msg.answer || '').length} answers.keys=${msg.answers ? Object.keys(msg.answers).length : 0}`)
+    // #4651: log freeformText presence so the Other-path two-stage write
+    // is greppable in chroxy.log without leaking the user's text.
+    const hasFreeform = msg.freeformText && typeof msg.freeformText === 'string' && msg.freeformText.length > 0
+    log.info(`user_question_response received: toolUseId=${msg.toolUseId || '?'} answer.length=${(msg.answer || '').length} answers.keys=${msg.answers ? Object.keys(msg.answers).length : 0} freeform=${hasFreeform ? msg.freeformText.length : 0}`)
     // #4668: forward msg.toolUseId so claude-tui-session can route the
     // answer to the right pending entry in its Map. Sessions that don't
     // care about toolUseId (cli-session, sdk-session via permission-
@@ -561,7 +564,12 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
     // a safe addition. ByokSession's respondToQuestion forwards to
     // _permissions.respondToQuestion which similarly ignores trailing
     // args it doesn't read.
-    entry.session.respondToQuestion(msg.answer, msg.answers, msg.toolUseId)
+    // #4651: forward msg.freeformText as a final opts object — claude-tui-
+    // session uses it to drive the two-stage Other-path write (digit →
+    // text-input prompt → freeform text + Enter). Other providers ignore
+    // the trailing arg.
+    const opts = hasFreeform ? { freeformText: msg.freeformText } : undefined
+    entry.session.respondToQuestion(msg.answer, msg.answers, msg.toolUseId, opts)
   }
 }
 

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -555,7 +555,10 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
     // single-answer string).
     // #4651: log freeformText presence so the Other-path two-stage write
     // is greppable in chroxy.log without leaking the user's text.
-    const hasFreeform = msg.freeformText && typeof msg.freeformText === 'string' && msg.freeformText.length > 0
+    // Copilot review (#4753): explicit boolean — `&&` of a string yields
+    // the string, not a boolean, which downstream conditionals can read
+    // but is confusing in a `freeform=${...}` log template.
+    const hasFreeform = typeof msg.freeformText === 'string' && msg.freeformText.length > 0
     log.info(`user_question_response received: toolUseId=${msg.toolUseId || '?'} answer.length=${(msg.answer || '').length} answers.keys=${msg.answers ? Object.keys(msg.answers).length : 0} freeform=${hasFreeform ? msg.freeformText.length : 0}`)
     // #4668: forward msg.toolUseId so claude-tui-session can route the
     // answer to the right pending entry in its Map. Sessions that don't

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2704,6 +2704,91 @@ describe('ClaudeTuiSession', () => {
       assert.equal(writes.length, 0, 'no PTY writes when there is no pending answer')
     })
 
+    // #4651 — "Other" / freeform answer support. claude TUI's AskUserQuestion
+    // renders an "Other" option that, when picked via its digit, opens a
+    // text-input prompt. Pre-#4651 the dashboard's freeform Other path sent
+    // only the typed string; the server then tried to type that string at
+    // the digit-select menu (jump-nav landed wherever the first char
+    // happened to point — #4288). New protocol: dashboard sends the typed
+    // text in `freeformText`, with `answer` = the Other option label. The
+    // server resolves Other → digit, writes the digit to enter text-input
+    // mode, then writes the freeform text + Enter to submit.
+    describe('Other / freeform answer (#4651)', () => {
+      it('writes the Other digit, then the freeform text + Enter', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_other_freeform',
+          options: [
+            { label: 'Patch' },
+            { label: 'Minor' },
+            { label: 'Other' },
+          ],
+        }
+
+        // Dashboard sends: answer='Other' (the Other option label),
+        // freeformText='my custom answer' (the typed text).
+        session.respondToQuestion('Other', undefined, 'toolu_aq_other_freeform', {
+          freeformText: 'my custom answer',
+        })
+        // Allow throttled writes (digit + settle + per-char text) to drain.
+        await new Promise((resolve) => setTimeout(resolve, 250))
+
+        // Sequence shape: [paste-disable, '3' (Other digit), <settle pause>,
+        // paste-disable-again, per-char text, '\r', paste-enable]. We pin
+        // the digit and the text presence to keep the assertion stable
+        // regardless of intermediate enable/disable toggles.
+        const joined = writes.join('')
+        assert.ok(joined.includes('3'), `expected Other digit "3" in writes, got: ${JSON.stringify(writes)}`)
+        assert.ok(joined.includes('my custom answer'), `expected freeform text in writes, got: ${JSON.stringify(writes)}`)
+        const otherIdx = writes.indexOf('3')
+        const firstTextCharIdx = writes.indexOf('m')
+        assert.ok(otherIdx >= 0 && firstTextCharIdx > otherIdx, 'Other digit must be written BEFORE the freeform text')
+        // Trailing Enter so claude TUI submits the text-input prompt.
+        assert.ok(writes.includes('\r'), 'trailing Enter submits the freeform answer')
+        assert.equal(session._pendingUserAnswer, null, 'pending cleared after answer write')
+      })
+
+      it('falls through to legacy single-write path when no freeformText is supplied', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_other_legacy',
+          options: [
+            { label: 'Patch' },
+            { label: 'Other' },
+          ],
+        }
+
+        // Legacy path: answer matches an option label exactly → 1-indexed digit.
+        session.respondToQuestion('Patch')
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        // disable + '1' + \\r + enable = 4 writes (matches the #4290 test shape).
+        assert.equal(writes.length, 4, `expected 4 writes for legacy path, got ${writes.length}: ${JSON.stringify(writes)}`)
+        assert.equal(writes[1], '1', 'legacy index path unchanged when freeformText is absent')
+      })
+
+      it('is a no-op when freeformText is supplied but no Other option exists', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        session._pendingUserAnswer = {
+          toolUseId: 'toolu_aq_no_other',
+          options: [{ label: 'A' }, { label: 'B' }],
+        }
+
+        // Defensive: dashboard sent freeformText for an AskUserQuestion that
+        // has no "Other" option. Don't blindly write the freeform text at
+        // the digit menu (that's the #4288 jump-nav footgun). Drop + clear.
+        session.respondToQuestion('Other', undefined, 'toolu_aq_no_other', {
+          freeformText: 'should be dropped',
+        })
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        assert.equal(writes.length, 0, `no PTY writes when freeform requested but no Other option exists, got: ${JSON.stringify(writes)}`)
+      })
+    })
+
     it('PostToolUse for AskUserQuestion clears _pendingUserAnswer if it was still set', () => {
       // Cleanup invariant: claude eventually resolved its own prompt
       // (maybe via the underlying terminal multiplexer, maybe via the

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -327,6 +327,46 @@ describe('input-handlers', () => {
       assert.equal(session.respondToQuestion.callCount, 1)
       assert.equal(session.respondToQuestion.lastCall[0], 'yes')
     })
+
+    // #4651 — forward freeformText as a 4th positional `opts` arg when the
+    // wire message carries it. Sessions that don't care about freeform
+    // (cli-session, sdk-session) ignore the trailing arg; claude-tui-session
+    // reads opts.freeformText to drive the two-stage Other-path write.
+    it('forwards freeformText as opts.freeformText', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      inputHandlers.user_question_response(makeWs(), client, {
+        answer: 'Other',
+        freeformText: 'typed text',
+        toolUseId: 'tool-1',
+      }, ctx)
+
+      assert.equal(session.respondToQuestion.callCount, 1)
+      assert.deepStrictEqual(session.respondToQuestion.lastCall, ['Other', undefined, 'tool-1', { freeformText: 'typed text' }])
+    })
+
+    it('omits opts entirely when freeformText is empty', () => {
+      // Empty-string freeformText must not get treated as present — the
+      // server should fall through to the legacy single-write path.
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      inputHandlers.user_question_response(makeWs(), client, {
+        answer: 'Patch',
+        freeformText: '',
+        toolUseId: 'tool-2',
+      }, ctx)
+
+      assert.equal(session.respondToQuestion.callCount, 1)
+      assert.deepStrictEqual(session.respondToQuestion.lastCall, ['Patch', undefined, 'tool-2', undefined])
+    })
   })
 
   // #3186: auto-evaluation hook on user_input. When session.promptEvaluator

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -479,7 +479,9 @@ describe('handleSessionMessage', () => {
       // route to the right pending entry in its Map. Old 2-arg shape
       // (answer, answersMap) is preserved positionally; toolUseId is the
       // new trailing optional arg passed to every session type.
-      assert.deepStrictEqual(entry.session.respondToQuestion.lastCall, ['yes please', undefined, 'tool-xyz'])
+      // #4651: 4th arg is opts ({freeformText}); undefined when no
+      // freeformText present on the wire.
+      assert.deepStrictEqual(entry.session.respondToQuestion.lastCall, ['yes please', undefined, 'tool-xyz', undefined])
     })
 
     it('forwards answers map to respondToQuestion', async () => {
@@ -494,7 +496,8 @@ describe('handleSessionMessage', () => {
         answers: answersMap,
       }, ctx)
       assert.equal(entry.session.respondToQuestion.callCount, 1)
-      assert.deepStrictEqual(entry.session.respondToQuestion.lastCall, ['yes', answersMap, 'tool-abc'])
+      // #4651: 4th positional arg is opts; undefined here (no freeformText).
+      assert.deepStrictEqual(entry.session.respondToQuestion.lastCall, ['yes', answersMap, 'tool-abc', undefined])
     })
   })
 

--- a/packages/server/tests/ws-server-broadcast.test.js
+++ b/packages/server/tests/ws-server-broadcast.test.js
@@ -452,7 +452,8 @@ describe('user_question_response forwarding (single-session)', () => {
     // Spy records calls — no manual tracking needed
     assert.equal(mockSession.respondToQuestion.callCount, 1, 'respondToQuestion should be called once')
     // #4668: handler now forwards msg.toolUseId as the third arg (undefined here — not in the wire message).
-    assert.deepStrictEqual(mockSession.respondToQuestion.lastCall, ['Option A', undefined, undefined], 'Answer should be forwarded to cliSession')
+    // #4651: 4th positional arg is opts ({freeformText}); undefined when no freeformText on the wire.
+    assert.deepStrictEqual(mockSession.respondToQuestion.lastCall, ['Option A', undefined, undefined, undefined], 'Answer should be forwarded to cliSession')
 
     ws.close()
   })
@@ -478,7 +479,8 @@ describe('user_question_response forwarding (single-session)', () => {
 
     assert.equal(mockSession.respondToQuestion.callCount, 1, 'respondToQuestion should be called once')
     // #4668: handler forwards msg.toolUseId as the third arg (undefined — not in this wire message).
-    assert.deepStrictEqual(mockSession.respondToQuestion.lastCall, ['yes', answersMap, undefined], 'Both answer and answers map should be forwarded')
+    // #4651: 4th positional arg is opts ({freeformText}); undefined when no freeformText on the wire.
+    assert.deepStrictEqual(mockSession.respondToQuestion.lastCall, ['yes', answersMap, undefined, undefined], 'Both answer and answers map should be forwarded')
 
     ws.close()
   })


### PR DESCRIPTION
## Summary

- `claude` TUI's `AskUserQuestion` renders an "Other" option that, when picked via its digit, opens a text-input prompt. Pre-#4651 the dashboard typed the freeform text directly at the digit-select menu, where claude TUI's single-character jump-navigation (the #4288 footgun) landed wherever the first char of the text pointed — the session wedged or resolved to the wrong choice.
- New protocol: dashboard sends `{answer: <Other-label>, freeformText: <typed-text>, toolUseId}`. The server resolves Other → 1-indexed TUI digit, writes the digit to swap the menu into text-input mode, waits 150 ms for the swap to settle, then writes the freeform text + Enter. The `_askUserQuestionWatchdog` re-arms after the digit write so the freeform phase has its own 30 s window.
- Scope is single-question only — multi-question Other remains blocked by the permission-hook (#4648); the dashboard's existing deferred-notice renders for those forms. Older servers that ignore `freeformText` fall through to the legacy literal-text write (no schema crash).

## Out of scope

- Mobile app parity. The mobile `MessageBubble` already renders the Other → freetext input UI but currently sends only the typed string. Deferred to a follow-up issue to keep this PR within budget.

## Test plan

- [x] `packages/server/tests/claude-tui-session.test.js` — 3 new tests covering the two-stage write, the legacy fallthrough when no `freeformText`, and the defensive drop when freeform requested but no Other option exists.
- [x] `packages/dashboard/src/components/QuestionPrompt.test.tsx` — updated the Other Send test to assert the new payload shape; added a free-text-only test to confirm the legacy string shape still flows for `options: []`.
- [x] `packages/dashboard/src/store/store.test.ts` — new test pinning the wire payload (`answer: <Other-label>`, `freeformText`, no `answers`) and the Output-tab echo of the typed text.
- [x] `packages/dashboard/src/utils/questionAnswerSummary.test.ts` — new test pinning summary-chip rendering for the freeform shape (renders the typed text, not the "Other" label).
- [x] Existing `AskUserQuestion` regression suite (36 tests) still green.
- [x] All dashboard tests (2412) and protocol tests (145) green.
- [ ] Dogfood: trigger a real `AskUserQuestion` with an Other option, click Other, type a freeform answer, confirm claude TUI receives it without wedge.
- [ ] Verify the empirical recording in `scripts/tui-form-recorder.mjs` agrees with the 150 ms settle delay (or tune if dogfood reveals a longer swap).

Closes #4651