### PR TITLE
feat(server,dashboard): surface multi-question AskUserQuestion denials

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2224,6 +2224,10 @@ export function App() {
         // #4653: the active session's chroxy-side intervention ring. Empty
         // by default — the chip hides itself when nothing has fired.
         interventions={interventions}
+        // #4653: threaded so the panel collapses on session switch (the
+        // FooterBar instance is shared across sessions, so without this
+        // the open panel would persist with stale entries).
+        activeSessionId={activeSessionId}
       />
 
       {/* Settings panel */}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -321,6 +321,10 @@ export function App() {
     pendingCommunitySkills: activePendingCommunitySkills,
     pendingTrustGrants: activePendingTrustGrants,
     pendingEvaluatorClarify,
+    // #4653: surface chroxy-side interventions (currently only the
+    // multi-question AskUserQuestion deny shipped in #4648) in the
+    // FooterBar counter chip so users can tell when chroxy intervened.
+    interventions,
   } = useConnectionStore(useShallow(s => s.getActiveSessionState()))
 
   // #3205: stable Set for SkillsPanel mismatch indicator. useMemo
@@ -2217,6 +2221,9 @@ export function App() {
         // when there's an active session to route the input through — without
         // that, the chip would have nowhere to send /compact to.
         onCompact={isConnected && activeSessionId ? () => sendInput('/compact') : undefined}
+        // #4653: the active session's chroxy-side intervention ring. Empty
+        // by default — the chip hides itself when nothing has fired.
+        interventions={interventions}
       />
 
       {/* Settings panel */}

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -5,7 +5,7 @@
  * busy indicator, and agent count.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import { FooterBar } from './FooterBar'
 
 afterEach(cleanup)
@@ -282,6 +282,124 @@ describe('FooterBar', () => {
     it('chip is hidden when contextPercent is null (no usage data yet)', () => {
       render(<FooterBar {...baseProps} context="0 tokens" contextPercent={null} onCompact={vi.fn()} />)
       expect(screen.queryByTestId('btn-compact-session')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('#4653 chroxy intervention counter', () => {
+    it('hides the chip when interventions is empty or undefined', () => {
+      const { rerender } = render(<FooterBar {...baseProps} />)
+      expect(screen.queryByTestId('footer-interventions')).not.toBeInTheDocument()
+      rerender(<FooterBar {...baseProps} interventions={[]} />)
+      expect(screen.queryByTestId('footer-interventions')).not.toBeInTheDocument()
+    })
+
+    it('shows the counter chip with singular label for exactly one intervention', () => {
+      render(
+        <FooterBar
+          {...baseProps}
+          interventions={[
+            { kind: 'multi_question', toolUseId: 'toolu_1', count: 3, timestamp: Date.now() },
+          ]}
+        />,
+      )
+      const chip = screen.getByTestId('footer-interventions')
+      expect(chip).toBeInTheDocument()
+      expect(chip).toHaveTextContent('1 intervention')
+    })
+
+    it('shows plural label when count > 1', () => {
+      render(
+        <FooterBar
+          {...baseProps}
+          interventions={[
+            { kind: 'multi_question', toolUseId: 'a', count: 2, timestamp: 1 },
+            { kind: 'multi_question', toolUseId: 'b', count: 3, timestamp: 2 },
+            { kind: 'multi_question', toolUseId: 'c', count: 4, timestamp: 3 },
+          ]}
+        />,
+      )
+      const chip = screen.getByTestId('footer-interventions')
+      expect(chip).toHaveTextContent('3 interventions')
+    })
+
+    it('panel is collapsed by default — list not in the DOM until click', () => {
+      render(
+        <FooterBar
+          {...baseProps}
+          interventions={[
+            { kind: 'multi_question', toolUseId: 'toolu_x', count: 2, timestamp: 1 },
+          ]}
+        />,
+      )
+      expect(screen.queryByTestId('footer-interventions-panel')).not.toBeInTheDocument()
+    })
+
+    it('clicking the chip expands the panel and lists newest-first', () => {
+      const t1 = Date.now() - 60_000 // 1m ago
+      const t2 = Date.now() - 1_000  // 1s ago
+      render(
+        <FooterBar
+          {...baseProps}
+          interventions={[
+            { kind: 'multi_question', toolUseId: 'older', count: 2, timestamp: t1 },
+            { kind: 'multi_question', toolUseId: 'newer', count: 3, timestamp: t2 },
+          ]}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('footer-interventions'))
+      const panel = screen.getByTestId('footer-interventions-panel')
+      expect(panel).toBeInTheDocument()
+      // Newest-first: the "newer" row should appear before "older" in the rendered DOM.
+      const items = Array.from(panel.querySelectorAll('[data-testid^="intervention-"]'))
+      expect(items).toHaveLength(2)
+      expect(items[0]?.getAttribute('data-testid')).toBe('intervention-newer')
+      expect(items[1]?.getAttribute('data-testid')).toBe('intervention-older')
+    })
+
+    it('aria-expanded reflects the panel state', () => {
+      render(
+        <FooterBar
+          {...baseProps}
+          interventions={[
+            { kind: 'multi_question', toolUseId: 'toolu_a', count: 2, timestamp: Date.now() },
+          ]}
+        />,
+      )
+      const chip = screen.getByTestId('footer-interventions')
+      expect(chip).toHaveAttribute('aria-expanded', 'false')
+      fireEvent.click(chip)
+      expect(chip).toHaveAttribute('aria-expanded', 'true')
+      fireEvent.click(chip)
+      expect(chip).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('describes the multi_question kind with the question count', () => {
+      render(
+        <FooterBar
+          {...baseProps}
+          interventions={[
+            { kind: 'multi_question', toolUseId: 'toolu_q', count: 4, timestamp: Date.now() },
+          ]}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('footer-interventions'))
+      expect(screen.getByTestId('intervention-toolu_q')).toHaveTextContent('4 questions')
+      expect(screen.getByTestId('intervention-toolu_q')).toHaveTextContent(/ask one at a time/i)
+    })
+
+    it('close button collapses the panel', () => {
+      render(
+        <FooterBar
+          {...baseProps}
+          interventions={[
+            { kind: 'multi_question', toolUseId: 'toolu_c', count: 2, timestamp: Date.now() },
+          ]}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('footer-interventions'))
+      expect(screen.getByTestId('footer-interventions-panel')).toBeInTheDocument()
+      fireEvent.click(screen.getByLabelText('Close interventions panel'))
+      expect(screen.queryByTestId('footer-interventions-panel')).not.toBeInTheDocument()
     })
   })
 })

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -401,5 +401,34 @@ describe('FooterBar', () => {
       fireEvent.click(screen.getByLabelText('Close interventions panel'))
       expect(screen.queryByTestId('footer-interventions-panel')).not.toBeInTheDocument()
     })
+
+    it('collapses the panel when the active session changes (#4653 Copilot review)', () => {
+      // The FooterBar is a single instance shared across sessions (not keyed
+      // on activeSessionId), so without an explicit effect the panel would
+      // stay open showing the OLD session's entries after a switch. This
+      // pins the reset-on-switch behavior.
+      const { rerender } = render(
+        <FooterBar
+          {...baseProps}
+          activeSessionId="sess-a"
+          interventions={[
+            { kind: 'multi_question', toolUseId: 'toolu_a', count: 2, timestamp: Date.now() },
+          ]}
+        />,
+      )
+      fireEvent.click(screen.getByTestId('footer-interventions'))
+      expect(screen.getByTestId('footer-interventions-panel')).toBeInTheDocument()
+      // Switch to a different session — panel must collapse.
+      rerender(
+        <FooterBar
+          {...baseProps}
+          activeSessionId="sess-b"
+          interventions={[
+            { kind: 'multi_question', toolUseId: 'toolu_b', count: 3, timestamp: Date.now() },
+          ]}
+        />,
+      )
+      expect(screen.queryByTestId('footer-interventions-panel')).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -2,10 +2,13 @@
  * FooterBar — VSCode-style status bar pinned to the bottom of the window.
  *
  * Left: version, connection status, session cwd breadcrumb.
- * Right: model, cost, context tokens, busy indicator, agent count.
+ * Right: model, cost, context tokens, busy indicator, agent count,
+ * intervention counter (#4653).
  * Spans full width across sidebar + main content (grid-column: 1 / -1).
  */
 
+import { useState } from 'react'
+import type { SessionIntervention } from '@chroxy/store-core'
 import {
   costTooltip,
   contextTooltip,
@@ -48,6 +51,13 @@ export interface FooterBarProps {
    * surface a CTA that won't fire.
    */
   onCompact?: () => void
+  /**
+   * #4653 — chroxy-side intervention ring for the active session. The
+   * FooterBar renders a small clickable counter chip "{N} chroxy
+   * interventions" when non-empty; clicking expands an inline list with
+   * timestamps + reasons. Empty array / undefined hides the chip entirely.
+   */
+  interventions?: SessionIntervention[]
 }
 
 /** Abbreviate a full path to the last 2 segments: /Users/foo/Projects/bar → Projects/bar */
@@ -94,7 +104,15 @@ export function FooterBar({
   provider,
   contextWindow,
   onCompact,
+  interventions,
 }: FooterBarProps) {
+  // #4653: collapsed by default — the chip just shows the count, click to
+  // expand the recent-interventions list. Local state because the panel
+  // is per-active-session and the store doesn't need to remember it
+  // across session switches (a session switch will re-render with the new
+  // session's intervention list, dismissing the panel naturally).
+  const [interventionsOpen, setInterventionsOpen] = useState(false)
+  const interventionCount = interventions?.length ?? 0
   const version = serverVersion ?? (typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0')
 
   // Prefer WS-driven serverPhase over polling-based tunnelReady
@@ -157,6 +175,34 @@ export function FooterBar({
           </button>
         )}
         {isBusy && <span className="footer-busy" />}
+        {/*
+         * #4653 — chroxy-side intervention counter. Renders only when at
+         * least one intervention has fired for the active session. Click
+         * toggles an inline list showing the most recent N denials with
+         * timestamps and reasons, so the user can audit "did chroxy
+         * intervene here?" without reading the server log.
+         */}
+        {interventionCount > 0 && (
+          <>
+            <button
+              type="button"
+              className={`footer-interventions${interventionsOpen ? ' open' : ''}`}
+              onClick={() => setInterventionsOpen((v) => !v)}
+              aria-expanded={interventionsOpen}
+              aria-label={`${interventionCount} chroxy ${interventionCount === 1 ? 'intervention' : 'interventions'} (click to ${interventionsOpen ? 'hide' : 'show'} details)`}
+              title="chroxy intervened during this session — click for details"
+              data-testid="footer-interventions"
+            >
+              {interventionCount} {interventionCount === 1 ? 'intervention' : 'interventions'}
+            </button>
+            {interventionsOpen && (
+              <InterventionsPanel
+                interventions={interventions!}
+                onClose={() => setInterventionsOpen(false)}
+              />
+            )}
+          </>
+        )}
         {agentCount != null && agentCount > 0 && (
           <span
             className="footer-agents"
@@ -255,4 +301,99 @@ export function FooterBar({
       </div>
     </footer>
   )
+}
+
+/**
+ * #4653 — expanded list panel for the FooterBar's intervention counter.
+ *
+ * Renders newest-first since the operator just clicked the counter to
+ * understand "what just happened?". Pure presentational: takes the
+ * intervention array verbatim from the active session's state and renders
+ * one row per entry with a humanised reason + relative timestamp. Wired
+ * to the same SessionIntervention shape that store-core writes via
+ * handleMultiQuestionIntervention.
+ */
+interface InterventionsPanelProps {
+  interventions: SessionIntervention[]
+  onClose: () => void
+}
+
+function InterventionsPanel({ interventions, onClose }: InterventionsPanelProps) {
+  // Newest-first — operator clicked the counter to debug "what JUST happened".
+  // Reverse a shallow copy so we don't mutate the array the store handed us.
+  const ordered = [...interventions].reverse()
+  return (
+    <div
+      className="footer-interventions-panel"
+      role="dialog"
+      aria-label="Recent chroxy interventions"
+      data-testid="footer-interventions-panel"
+    >
+      <div className="footer-interventions-panel-header">
+        <span>Recent chroxy interventions</span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close interventions panel"
+          className="footer-interventions-close"
+        >
+          ×
+        </button>
+      </div>
+      <ul className="footer-interventions-list">
+        {ordered.map((iv) => (
+          <li
+            key={iv.toolUseId}
+            className="footer-interventions-item"
+            data-testid={`intervention-${iv.toolUseId}`}
+          >
+            <div className="footer-interventions-reason">
+              {describeIntervention(iv)}
+            </div>
+            <div className="footer-interventions-meta">
+              {formatRelativeTimestamp(iv.timestamp)}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+/**
+ * Humanise an intervention's discriminator into a one-line operator-facing
+ * description. Keep copy short so the panel stays compact; longer help text
+ * (the "why?" link the issue mentions) is intentionally deferred until the
+ * help-docs route exists.
+ */
+function describeIntervention(iv: SessionIntervention): string {
+  switch (iv.kind) {
+    case 'multi_question':
+      return `Multi-question form intercepted (${iv.count} questions) — asked agent to ask one at a time`
+    default: {
+      // Exhaustive fallback for future discriminator additions. Renders the
+      // raw kind so a forgotten case still gives the operator SOMETHING to
+      // grep on rather than an empty row.
+      const _exhaustive: never = iv.kind
+      return `chroxy intervention: ${String(_exhaustive)}`
+    }
+  }
+}
+
+/**
+ * Format a wall-clock timestamp as a short relative string ("3s ago",
+ * "2m ago", "1h ago"). Falls back to ISO date string for entries older
+ * than 24 hours so the operator can still tell which day a stuck-model
+ * session originally went sideways.
+ */
+function formatRelativeTimestamp(ts: number): string {
+  const elapsedMs = Date.now() - ts
+  if (elapsedMs < 0) return 'just now'
+  const seconds = Math.floor(elapsedMs / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  return new Date(ts).toISOString().slice(0, 10)
 }

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -7,7 +7,7 @@
  * Spans full width across sidebar + main content (grid-column: 1 / -1).
  */
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { SessionIntervention } from '@chroxy/store-core'
 import {
   costTooltip,
@@ -58,6 +58,14 @@ export interface FooterBarProps {
    * timestamps + reasons. Empty array / undefined hides the chip entirely.
    */
   interventions?: SessionIntervention[]
+  /**
+   * #4653 — active session id, threaded so the FooterBar can reset the
+   * expanded-panel local state when the user switches sessions. Without
+   * this, the panel would stay open showing the OLD session's entries
+   * after a switch (FooterBar is a single instance with no key reset).
+   * Undefined when no session is active — the panel just stays collapsed.
+   */
+  activeSessionId?: string | null
 }
 
 /** Abbreviate a full path to the last 2 segments: /Users/foo/Projects/bar → Projects/bar */
@@ -105,13 +113,19 @@ export function FooterBar({
   contextWindow,
   onCompact,
   interventions,
+  activeSessionId,
 }: FooterBarProps) {
   // #4653: collapsed by default — the chip just shows the count, click to
   // expand the recent-interventions list. Local state because the panel
-  // is per-active-session and the store doesn't need to remember it
-  // across session switches (a session switch will re-render with the new
-  // session's intervention list, dismissing the panel naturally).
+  // is a transient UI affordance the store doesn't need to remember.
   const [interventionsOpen, setInterventionsOpen] = useState(false)
+  // #4653 Copilot review: FooterBar is a single instance (not keyed by
+  // session id), so the panel-open state survives session switches by
+  // default. Reset it on switch so the user doesn't see the old session's
+  // entries in the panel after switching to a different session.
+  useEffect(() => {
+    setInterventionsOpen(false)
+  }, [activeSessionId])
   const interventionCount = interventions?.length ?? 0
   const version = serverVersion ?? (typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0')
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -211,6 +211,11 @@ const EMPTY_ACTIVE_TOOLS: never[] = [];
 // #4307: stable empty reference for `pendingBackgroundShells` —
 // same `useShallow` stability rationale as the others above.
 const EMPTY_PENDING_BACKGROUND_SHELLS: never[] = [];
+// #4653: stable empty reference for `interventions` — same `useShallow`
+// stability rationale as the others above. SessionIntervention[] in the
+// type system; never[] here because the array is provably empty and
+// TypeScript widens `never[]` to any element type at the call site.
+const EMPTY_INTERVENTIONS: never[] = [];
 
 /** Delay before auto-reconnecting after an unexpected socket close (ms) */
 const AUTO_RECONNECT_DELAY = 1500;
@@ -766,6 +771,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #3899: no warning is ever surfaced in the flat-state fallback;
       // inactivity_warning only arrives once SessionStates is populated.
       inactivityWarning: null,
+      // #4653: no chroxy intervention is ever surfaced in the flat-state
+      // fallback — intervention events are routed by sessionId, which only
+      // populates after a session_list snapshot lands.
+      interventions: EMPTY_INTERVENTIONS,
     };
   },
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3183,6 +3183,154 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  // #4653 — multi_question_intervention dispatch. The server fires this
+  // session_event when ClaudeTuiSession's PreToolUse hook sees a multi-q
+  // AskUserQuestion (the exact deny condition shipped in #4648). The
+  // dashboard appends to the per-session interventions ring + on the FIRST
+  // intervention also pushes a one-time system ChatMessage so the user
+  // actually sees the deny happened.
+  describe('multi_question_intervention dispatch (#4653)', () => {
+    it('appends an intervention entry to the targeted session', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState() } },
+      }))
+      setStore(store)
+
+      handleMessage(
+        {
+          type: 'multi_question_intervention',
+          sessionId: 's1',
+          toolUseId: 'toolu_first',
+          questionCount: 3,
+          reason: 'multi_question',
+          timestamp: 1700000000000,
+        },
+        ctx() as any,
+      )
+
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.interventions).toHaveLength(1)
+      expect(ss.interventions[0]).toEqual({
+        kind: 'multi_question',
+        toolUseId: 'toolu_first',
+        count: 3,
+        timestamp: 1700000000000,
+      })
+    })
+
+    it('pushes a one-time system ChatMessage on the FIRST intervention', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState() } },
+      }))
+      setStore(store)
+
+      handleMessage(
+        {
+          type: 'multi_question_intervention',
+          sessionId: 's1',
+          toolUseId: 'toolu_a',
+          questionCount: 2,
+        },
+        ctx() as any,
+      )
+
+      const messages = (store.getState() as any).sessionStates.s1.messages
+      expect(messages).toHaveLength(1)
+      expect(messages[0].type).toBe('system')
+      expect(messages[0].content).toMatch(/multi-question form/i)
+      expect(messages[0].content).toMatch(/one at a time|single questions/i)
+    })
+
+    it('does NOT push a second system message for subsequent distinct interventions', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState() } },
+      }))
+      setStore(store)
+
+      // First intervention — system message lands.
+      handleMessage(
+        { type: 'multi_question_intervention', sessionId: 's1', toolUseId: 'tu_1', questionCount: 2 },
+        ctx() as any,
+      )
+      // Second distinct intervention — counter ticks, no second system message.
+      handleMessage(
+        { type: 'multi_question_intervention', sessionId: 's1', toolUseId: 'tu_2', questionCount: 4 },
+        ctx() as any,
+      )
+
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.interventions).toHaveLength(2)
+      // Only ONE system message — repeats just bump the counter.
+      const systemMessages = ss.messages.filter((m: any) => m.type === 'system')
+      expect(systemMessages).toHaveLength(1)
+    })
+
+    it('dedups repeats by toolUseId — counter does not tick for stuck-model re-emits', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState() } },
+      }))
+      setStore(store)
+
+      handleMessage(
+        { type: 'multi_question_intervention', sessionId: 's1', toolUseId: 'tu_stuck', questionCount: 3 },
+        ctx() as any,
+      )
+      handleMessage(
+        { type: 'multi_question_intervention', sessionId: 's1', toolUseId: 'tu_stuck', questionCount: 3 },
+        ctx() as any,
+      )
+      handleMessage(
+        { type: 'multi_question_intervention', sessionId: 's1', toolUseId: 'tu_stuck', questionCount: 3 },
+        ctx() as any,
+      )
+
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.interventions).toHaveLength(1)
+    })
+
+    it('drops the event when the targeted session is unknown', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState() } },
+      }))
+      setStore(store)
+
+      handleMessage(
+        {
+          type: 'multi_question_intervention',
+          sessionId: 'unknown-sess',
+          toolUseId: 'tu_x',
+          questionCount: 2,
+        },
+        ctx() as any,
+      )
+
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.interventions).toHaveLength(0)
+      expect(ss.messages).toHaveLength(0)
+    })
+
+    it('ignores malformed payloads (missing toolUseId)', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState() } },
+      }))
+      setStore(store)
+
+      handleMessage(
+        { type: 'multi_question_intervention', sessionId: 's1', questionCount: 2 } as any,
+        ctx() as any,
+      )
+
+      const ss = (store.getState() as any).sessionStates.s1
+      expect(ss.interventions).toHaveLength(0)
+    })
+  })
+
   // #4466: switching tabs sends `switch_session`, which causes the server to
   // dispatch history_replay_start → all past events → history_replay_end.
   // Pre-fix, the dashboard's pre-handler logic ran the lastClientActivityAt

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -32,6 +32,9 @@ import {
   handlePlanStarted as sharedPlanStarted,
   handlePlanReady as sharedPlanReady,
   handleInactivityWarning as sharedInactivityWarning,
+  // #4653: chroxy-side multi-question deny intervention surfaced to the user
+  handleMultiQuestionIntervention as sharedMultiQuestionIntervention,
+  applyInterventionBuilder,
   handleDevPreview as sharedDevPreview,
   handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
@@ -2621,6 +2624,52 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (warning && warning.sessionId && get().sessionStates[warning.sessionId]) {
         updateSession(warning.sessionId, () => warning.patch);
       }
+      break;
+    }
+
+    case 'multi_question_intervention': {
+      // #4653 — chroxy's permission-hook (#4648) just denied a multi-question
+      // AskUserQuestion. Append a SessionIntervention entry so the
+      // FooterBar counter ticks, and on the FIRST such intervention per
+      // session push a one-time system ChatMessage explaining what
+      // happened (without it the deny is invisible — see v0.9.24
+      // dogfood feedback on #4653).
+      //
+      // applyInterventionBuilder dedups by toolUseId (a stuck model
+      // re-emitting the same payload won't double-count) and tells us
+      // whether this was the session's first intervention so the inline
+      // notice only fires once.
+      const builder = sharedMultiQuestionIntervention(msg, get().activeSessionId);
+      if (!builder) break;
+      const targetId = builder.sessionId;
+      if (!targetId) break;
+      const targetState = get().sessionStates[targetId];
+      if (!targetState) break;
+      const { interventions: nextInterventions, isFirst } = applyInterventionBuilder(
+        builder,
+        targetState.interventions,
+      );
+      // Skip the state mutation if nothing changed (dedup'd repeat) so React
+      // doesn't re-render the footer counter on every stuck-model re-emit.
+      if (nextInterventions === targetState.interventions) break;
+      updateSession(targetId, (ss) => {
+        if (isFirst) {
+          return {
+            interventions: nextInterventions,
+            messages: [
+              ...ss.messages,
+              {
+                id: nextMessageId('system'),
+                type: 'system',
+                content:
+                  "chroxy intercepted a multi-question form and asked the agent to break it into single questions.",
+                timestamp: Date.now(),
+              },
+            ],
+          };
+        }
+        return { interventions: nextInterventions };
+      });
       break;
     }
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3659,6 +3659,89 @@
   color: var(--text-secondary);
 }
 
+/* #4653 — chroxy-side intervention counter chip + expandable panel. */
+.footer-interventions {
+  background: var(--accent-amber-light, rgba(255, 193, 7, 0.12));
+  color: var(--accent-amber, #b45309);
+  border: 1px solid var(--accent-amber, #b45309);
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+
+.footer-interventions:hover,
+.footer-interventions.open {
+  background: var(--accent-amber, #b45309);
+  color: var(--text-on-accent, #fff);
+}
+
+.footer-interventions-panel {
+  position: absolute;
+  bottom: 32px;
+  right: 8px;
+  width: min(360px, calc(100vw - 16px));
+  max-height: 50vh;
+  overflow-y: auto;
+  background: var(--bg-secondary, #1e1e1e);
+  border: 1px solid var(--border-primary, #333);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  z-index: 50;
+  font-size: 12px;
+}
+
+.footer-interventions-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-primary, #333);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.footer-interventions-close {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.footer-interventions-close:hover {
+  color: var(--text-primary);
+}
+
+.footer-interventions-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.footer-interventions-item {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-primary, #2a2a2a);
+}
+
+.footer-interventions-item:last-child {
+  border-bottom: none;
+}
+
+.footer-interventions-reason {
+  color: var(--text-primary);
+}
+
+.footer-interventions-meta {
+  color: var(--text-secondary);
+  font-size: 10px;
+  margin-top: 2px;
+}
+
 .footer-busy {
   width: 6px;
   height: 6px;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -264,6 +264,13 @@ export declare const ServerInactivityWarningSchema: z.ZodObject<{
     idleMs: z.ZodNumber;
     prefab: z.ZodString;
 }, z.core.$strip>;
+export declare const ServerMultiQuestionInterventionSchema: z.ZodObject<{
+    type: z.ZodLiteral<"multi_question_intervention">;
+    toolUseId: z.ZodString;
+    questionCount: z.ZodNumber;
+    reason: z.ZodLiteral<"multi_question">;
+    timestamp: z.ZodNumber;
+}, z.core.$strip>;
 export declare const ServerMcpServersSchema: z.ZodObject<{
     type: z.ZodLiteral<"mcp_servers">;
     servers: z.ZodArray<z.ZodObject<{

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -342,6 +342,34 @@ export const ServerInactivityWarningSchema = z.object({
     idleMs: z.number().int().positive().finite().max(MAX_SANE_DURATION_MS),
     prefab: z.string(),
 });
+// #4653: chroxy-side intervention surfaced to the user. Currently only the
+// multi-question AskUserQuestion deny shipped in #4648 fires this event.
+// The dashboard / mobile app append a SessionIntervention entry to the
+// targeted session's interventions ring and render a FooterBar counter
+// chip + (first-time only) inline system ChatMessage so users can tell
+// chroxy intervened — without this surface the deny is invisible.
+//
+// `reason` is a discriminator that lets future intervention kinds land
+// without a wire version bump (sibling-deny from #4668 would extend the
+// enum here). `questionCount >= 2` because the permission-hook only
+// denies multi-question forms — single-question is the happy path.
+export const ServerMultiQuestionInterventionSchema = z.object({
+    type: z.literal('multi_question_intervention'),
+    // Stable id of the tool_use the hook denied. Dashboard dedups by this
+    // so a stuck model re-emitting the same payload doesn't inflate the
+    // counter falsely (the #4666 / #4668 failure mode).
+    toolUseId: z.string(),
+    // Question count from the denied AskUserQuestion form. Hook only fires
+    // for length > 1, so the floor is 2 — defence-in-depth against a server
+    // bug that would otherwise inject a "0 questions" entry into the UI.
+    questionCount: z.number().int().min(2).finite(),
+    reason: z.literal('multi_question'),
+    // Server wall-clock when the deny happened. Allowed to be 0 (epoch) so
+    // a clock-skewed dev environment doesn't bounce the event off the wire,
+    // but typical values are 1.7e12+ (post-2023). The client renders relative
+    // ("3s ago") from this.
+    timestamp: z.number().int().min(0).finite(),
+});
 export const ServerMcpServersSchema = z.object({
     type: z.literal('mcp_servers'),
     servers: z.array(z.object({

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -375,6 +375,35 @@ export const ServerInactivityWarningSchema = z.object({
   prefab: z.string(),
 })
 
+// #4653: chroxy-side intervention surfaced to the user. Currently only the
+// multi-question AskUserQuestion deny shipped in #4648 fires this event.
+// The dashboard / mobile app append a SessionIntervention entry to the
+// targeted session's interventions ring and render a FooterBar counter
+// chip + (first-time only) inline system ChatMessage so users can tell
+// chroxy intervened — without this surface the deny is invisible.
+//
+// `reason` is a discriminator that lets future intervention kinds land
+// without a wire version bump (sibling-deny from #4668 would extend the
+// enum here). `questionCount >= 2` because the permission-hook only
+// denies multi-question forms — single-question is the happy path.
+export const ServerMultiQuestionInterventionSchema = z.object({
+  type: z.literal('multi_question_intervention'),
+  // Stable id of the tool_use the hook denied. Dashboard dedups by this
+  // so a stuck model re-emitting the same payload doesn't inflate the
+  // counter falsely (the #4666 / #4668 failure mode).
+  toolUseId: z.string(),
+  // Question count from the denied AskUserQuestion form. Hook only fires
+  // for length > 1, so the floor is 2 — defence-in-depth against a server
+  // bug that would otherwise inject a "0 questions" entry into the UI.
+  questionCount: z.number().int().min(2).finite(),
+  reason: z.literal('multi_question'),
+  // Server wall-clock when the deny happened. Allowed to be 0 (epoch) so
+  // a clock-skewed dev environment doesn't bounce the event off the wire,
+  // but typical values are 1.7e12+ (post-2023). The client renders relative
+  // ("3s ago") from this.
+  timestamp: z.number().int().min(0).finite(),
+})
+
 export const ServerMcpServersSchema = z.object({
   type: z.literal('mcp_servers'),
   servers: z.array(z.object({

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -98,6 +98,7 @@ const PLATFORM_SPECIFIC = {
   'skill_trust_granted': 'dashboard',  // community trust granted broadcast (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_grant_ok': 'dashboard', // ack for skill_trust_grant handler (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'byok_credentials_status': 'dashboard', // paste-API-key form is dashboard-only (#4052); mobile app exposure tracked under the BYOK epic #4047
+  'multi_question_intervention': 'dashboard', // chroxy permission-hook deny surface (#4653) — dashboard renders a FooterBar counter chip + InterventionsPanel; mobile app exposure tracked as a follow-up since the app has no FooterBar equivalent
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -293,6 +293,22 @@ export class ClaudeTuiSession extends BaseSession {
     return { id, label: id, fullId, contextWindow: resolveClaudeContextWindow(fullId), description: '' }
   }
 
+  /**
+   * #4653: provider-specific events the SessionManager should forward as
+   * transient `session_event`s. `multi_question_intervention` fires from
+   * `_emitToolHookEvent` whenever PreToolUse sees an AskUserQuestion whose
+   * `questions[]` has length > 1 — i.e. the EXACT condition the bash
+   * permission-hook (`packages/server/hooks/permission-hook.sh`, #4648)
+   * denies on. The dashboard renders an inline notice + a session-footer
+   * counter so the user knows chroxy intercepted the multi-question form.
+   * Without this surface the user wonders if the model is being clever
+   * (asking one at a time naturally) or if chroxy is intervening — see
+   * the v0.9.24 dogfood feedback captured on #4653.
+   */
+  static get customEvents() {
+    return ['multi_question_intervention']
+  }
+
   constructor({ cwd, model, permissionMode, port, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, skipPermissions } = {}) {
     super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-tui', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs })
 
@@ -1410,6 +1426,21 @@ export class ClaudeTuiSession extends BaseSession {
           // means even old dashboards no longer wedge the session, just
           // pick defaults the user can re-prompt past.
           log.warn(`AskUserQuestion has ${questionCount} questions — multi-question forms are not yet supported (see #4604). Only question 1 will be answered.`)
+          // #4653: surface the deny to the user. The bash permission-hook
+          // returns `permissionDecision: deny` for this exact payload
+          // shape (questions.length > 1), so this server-side mirror
+          // event reports the same decision through the WS wire. Without
+          // it, the deny is invisible — the user wonders if the model is
+          // being clever (asking one at a time naturally) or if chroxy
+          // intervened. Per-toolUseId so the dashboard can dedup repeats
+          // when claude TUI re-emits the same multi-q payload (a known
+          // failure mode pre-#4668).
+          this.emit('multi_question_intervention', {
+            toolUseId,
+            questionCount,
+            reason: 'multi_question',
+            timestamp: Date.now(),
+          })
         }
         this.emit('user_question', { toolUseId, questions })
       }

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -250,6 +250,22 @@ Object.assign(EVENT_MAP, {
     }],
   }),
 
+  // #4653: chroxy-side multi-question AskUserQuestion deny — surfaces the
+  // permission-hook's silent intervention (#4648) as a user-visible event.
+  // Forwarded only to subscribers of THIS session: the counter is per-
+  // session and a deny on session A shouldn't tick the chip on session B.
+  multi_question_intervention: (data) => ({
+    messages: [{
+      msg: {
+        type: 'multi_question_intervention',
+        toolUseId: data.toolUseId,
+        questionCount: data.questionCount,
+        reason: data.reason,
+        timestamp: data.timestamp,
+      },
+    }],
+  }),
+
   result: (data, ctx) => {
     const messages = [
       { msg: { type: 'result', cost: data.cost, duration: data.duration, usage: data.usage, sessionId: data.sessionId } },

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -309,6 +309,7 @@ function _isSecureRequest(req) {
  *   { type: 'plan_started' }                         — Claude entered plan mode (transient)
  *   { type: 'plan_ready', allowedPrompts }           — plan complete, awaiting approval (transient)
  *   { type: 'inactivity_warning', messageId, idleMs, prefab } — soft check-in prompt, session stays alive (#3899)
+ *   { type: 'multi_question_intervention', toolUseId, questionCount, reason, timestamp } — chroxy permission-hook denied a multi-question AskUserQuestion (#4653)
  *   { type: 'server_shutdown', reason, restartEtaMs } — server shutting down (reason: 'restart'|'shutdown')
  *   { type: 'server_status', message }               — non-error status update (e.g., recovery)
  *   { type: 'server_error', category, message, recoverable, sessionId? } — server-side error forwarded to app

--- a/packages/server/tests/claude-tui-multi-question-intervention.test.js
+++ b/packages/server/tests/claude-tui-multi-question-intervention.test.js
@@ -1,0 +1,165 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+
+/**
+ * #4653 — Surface multi-question AskUserQuestion denials to the user.
+ *
+ * The permission-hook (`packages/server/hooks/permission-hook.sh`, shipped in
+ * #4648) denies any AskUserQuestion whose `questions[]` has length > 1 so the
+ * model re-emits as N sequential single-question calls. That deny is currently
+ * invisible to the user: the model just "happens" to ask one at a time.
+ *
+ * This test pins the server-side observability the dashboard renders: when
+ * ClaudeTuiSession's PreToolUse handler sees a multi-question AskUserQuestion
+ * (the EXACT condition the bash hook denies on), it emits a
+ * `multi_question_intervention` event so SessionManager can broadcast it as a
+ * `session_event`. That broadcast drives the dashboard's intervention counter
+ * + inline notice.
+ *
+ * Why mirror the deny condition in JS rather than parse hook stdout: the bash
+ * hook runs in claude's child process and writes to claude's stdin, not to
+ * chroxy. The server already sees the same PreToolUse payload that the hook
+ * sees (via the `cat > pre-*.json` sibling hook in writeHookSettings), so
+ * applying the same length check at the same call site keeps the two layers
+ * trivially in sync without adding a hook→server side-channel.
+ */
+describe('ClaudeTuiSession — multi-question intervention event (#4653)', () => {
+  let emptySkillsDir
+  let session
+
+  beforeEach(() => {
+    emptySkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-skills-'))
+    session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+    // _emitToolHookEvent reads _activeTurn for the synth-id fallback path.
+    // Tests drive it directly without going through start() / sendMessage().
+    session._activeTurn = { messageId: 'msg-test', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+  })
+
+  afterEach(async () => {
+    if (session) {
+      try { await session.destroy() } catch { /* ignore */ }
+      session = null
+    }
+    if (emptySkillsDir) rmSync(emptySkillsDir, { recursive: true, force: true })
+    emptySkillsDir = null
+  })
+
+  it('declares multi_question_intervention as a customEvent', () => {
+    // The static `customEvents` getter is what SessionManager._wireSessionEvents
+    // reads to decide which provider-specific events to proxy as transient
+    // session_events. Without this declaration the event would fire on the
+    // session but never reach the WS wire — silent loss, hard to debug.
+    const customEvents = ClaudeTuiSession.customEvents || []
+    assert.ok(
+      customEvents.includes('multi_question_intervention'),
+      `customEvents must declare multi_question_intervention so SessionManager forwards it; got ${JSON.stringify(customEvents)}`,
+    )
+  })
+
+  it('emits multi_question_intervention for a 2-question AskUserQuestion PreToolUse', () => {
+    const events = []
+    session.on('multi_question_intervention', (data) => events.push(data))
+
+    session._emitToolHookEvent('PreToolUse', {
+      tool_name: 'AskUserQuestion',
+      tool_use_id: 'toolu_multi_1',
+      tool_input: {
+        questions: [
+          { question: 'Which provider?', header: 'Provider', options: [{ label: 'A', value: 'a' }] },
+          { question: 'Which transport?', header: 'Transport', options: [{ label: 'B', value: 'b' }] },
+        ],
+      },
+    }, 'msg-test')
+
+    assert.equal(events.length, 1, 'one intervention event per multi-q AskUserQuestion')
+    const ev = events[0]
+    assert.equal(ev.toolUseId, 'toolu_multi_1', 'toolUseId from payload propagates so the dashboard can dedup repeats')
+    assert.equal(ev.questionCount, 2, 'questionCount matches questions[] length')
+    assert.equal(ev.reason, 'multi_question', 'reason tag — extensible for future intervention types')
+    assert.equal(typeof ev.timestamp, 'number', 'timestamp populated so the UI can render "Ns ago"')
+    assert.ok(ev.timestamp <= Date.now(), 'timestamp is wall-clock, not future-dated')
+  })
+
+  it('does NOT emit multi_question_intervention for a single-question AskUserQuestion', () => {
+    const events = []
+    session.on('multi_question_intervention', (data) => events.push(data))
+
+    session._emitToolHookEvent('PreToolUse', {
+      tool_name: 'AskUserQuestion',
+      tool_use_id: 'toolu_single_1',
+      tool_input: {
+        questions: [
+          { question: 'Only one?', header: 'Only', options: [{ label: 'A', value: 'a' }] },
+        ],
+      },
+    }, 'msg-test')
+
+    assert.equal(events.length, 0,
+      'single-question AskUserQuestion is the happy path — no intervention')
+  })
+
+  it('does NOT emit multi_question_intervention for non-AskUserQuestion tools', () => {
+    const events = []
+    session.on('multi_question_intervention', (data) => events.push(data))
+
+    session._emitToolHookEvent('PreToolUse', {
+      tool_name: 'Bash',
+      tool_use_id: 'toolu_bash_1',
+      tool_input: { command: 'ls' },
+    }, 'msg-test')
+
+    assert.equal(events.length, 0, 'Bash and friends never intervene here')
+  })
+
+  it('does NOT emit on PostToolUse — only PreToolUse matches the hook deny window', () => {
+    const events = []
+    session.on('multi_question_intervention', (data) => events.push(data))
+
+    session._emitToolHookEvent('PostToolUse', {
+      tool_name: 'AskUserQuestion',
+      tool_use_id: 'toolu_post_1',
+      tool_input: {
+        questions: [
+          { question: 'q1?', header: 'q1', options: [{ label: 'A', value: 'a' }] },
+          { question: 'q2?', header: 'q2', options: [{ label: 'B', value: 'b' }] },
+        ],
+      },
+      tool_response: 'ok',
+    }, 'msg-test')
+
+    assert.equal(events.length, 0,
+      'PostToolUse runs AFTER the deny would have fired; emitting again would double-count')
+  })
+
+  it('emits with synthesized toolUseId when payload omits tool_use_id', () => {
+    // Older claude builds / certain MCP tools omit tool_use_id. The existing
+    // _emitToolHookEvent synth path covers tool_start; the intervention path
+    // must use the same id so the dashboard dedup-by-id key matches across
+    // tool_start + intervention.
+    const events = []
+    session.on('multi_question_intervention', (data) => events.push(data))
+
+    session._emitToolHookEvent('PreToolUse', {
+      tool_name: 'AskUserQuestion',
+      // tool_use_id intentionally absent
+      tool_input: {
+        questions: [
+          { question: 'q1?', header: 'q1', options: [{ label: 'A', value: 'a' }] },
+          { question: 'q2?', header: 'q2', options: [{ label: 'B', value: 'b' }] },
+          { question: 'q3?', header: 'q3', options: [{ label: 'C', value: 'c' }] },
+        ],
+      },
+    }, 'msg-test')
+
+    assert.equal(events.length, 1, 'still emits even without payload tool_use_id')
+    assert.ok(
+      typeof events[0].toolUseId === 'string' && events[0].toolUseId.length > 0,
+      'synthesized toolUseId is a non-empty string',
+    )
+    assert.equal(events[0].questionCount, 3)
+  })
+})

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -351,6 +351,35 @@ describe('EventNormalizer', () => {
     })
   })
 
+  // ---- EVENT_MAP: multi_question_intervention (#4653) ----
+
+  describe('multi_question_intervention event', () => {
+    it('forwards toolUseId, questionCount, reason and timestamp to the WS payload', () => {
+      const data = {
+        toolUseId: 'toolu_norm',
+        questionCount: 4,
+        reason: 'multi_question',
+        timestamp: 1700000000000,
+      }
+      const result = normalizer.normalize('multi_question_intervention', data, makeCtx())
+      assert.equal(result.messages.length, 1)
+      assert.deepEqual(result.messages[0].msg, {
+        type: 'multi_question_intervention',
+        toolUseId: 'toolu_norm',
+        questionCount: 4,
+        reason: 'multi_question',
+        timestamp: 1700000000000,
+      })
+    })
+
+    it('does not emit any sibling messages (session stays alive — no agent_idle/result)', () => {
+      const data = { toolUseId: 't', questionCount: 2, reason: 'multi_question', timestamp: 1 }
+      const result = normalizer.normalize('multi_question_intervention', data, makeCtx())
+      const types = result.messages.map((m) => m.msg.type)
+      assert.deepEqual(types, ['multi_question_intervention'])
+    })
+  })
+
   // ---- EVENT_MAP: result ----
 
   describe('result event', () => {

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -19,6 +19,8 @@ import {
   handlePlanStarted,
   handlePlanReady,
   handleInactivityWarning,
+  handleMultiQuestionIntervention,
+  applyInterventionBuilder,
   handleDevPreview,
   handleDevPreviewStopped,
   handleAuthOk,
@@ -6585,5 +6587,180 @@ describe('handleResultUsage', () => {
     expect(
       handleResultUsage({ sessionId: null }, 'active-1').sessionId,
     ).toBe('active-1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleMultiQuestionIntervention (#4653)
+// ---------------------------------------------------------------------------
+describe('handleMultiQuestionIntervention', () => {
+  it('appends a new intervention entry when toolUseId is unseen', () => {
+    const builder = handleMultiQuestionIntervention(
+      {
+        sessionId: 'sess-1',
+        toolUseId: 'toolu_1',
+        questionCount: 3,
+        reason: 'multi_question',
+        timestamp: 1700000000000,
+      },
+      'active-1',
+    )
+    expect(builder).not.toBeNull()
+    expect(builder!.sessionId).toBe('sess-1')
+    const { interventions } = builder!.applyTo([])
+    expect(interventions).toHaveLength(1)
+    expect(interventions[0]).toEqual({
+      kind: 'multi_question',
+      toolUseId: 'toolu_1',
+      count: 3,
+      timestamp: 1700000000000,
+    })
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_2', questionCount: 2 },
+      'active-1',
+    )
+    expect(builder!.sessionId).toBe('active-1')
+  })
+
+  it('dedups repeats by toolUseId — returns the array unchanged so React skips a re-render', () => {
+    const existing = [
+      { kind: 'multi_question' as const, toolUseId: 'toolu_dup', count: 4, timestamp: 100 },
+    ]
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_dup', questionCount: 4, timestamp: 200 },
+      'active-1',
+    )
+    const { interventions } = builder!.applyTo(existing)
+    // Same reference — referential equality preserved for the React diff.
+    expect(interventions).toBe(existing)
+  })
+
+  it('appends second distinct intervention to existing list', () => {
+    const existing = [
+      { kind: 'multi_question' as const, toolUseId: 'toolu_a', count: 2, timestamp: 100 },
+    ]
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_b', questionCount: 5, timestamp: 200 },
+      'active-1',
+    )
+    const { interventions } = builder!.applyTo(existing)
+    expect(interventions).toHaveLength(2)
+    expect(interventions[1].toolUseId).toBe('toolu_b')
+    expect(interventions[1].count).toBe(5)
+  })
+
+  it('defaults timestamp to Date.now() when payload omits it', () => {
+    const before = Date.now()
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_now', questionCount: 2 },
+      'active-1',
+    )
+    const after = Date.now()
+    const { interventions } = builder!.applyTo([])
+    expect(interventions[0].timestamp).toBeGreaterThanOrEqual(before)
+    expect(interventions[0].timestamp).toBeLessThanOrEqual(after)
+  })
+
+  it('floors fractional questionCount (defence-in-depth against malformed payloads)', () => {
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_frac', questionCount: 3.7 },
+      'active-1',
+    )
+    const { interventions } = builder!.applyTo([])
+    expect(interventions[0].count).toBe(3)
+  })
+
+  it('returns null when toolUseId is missing or non-string', () => {
+    expect(
+      handleMultiQuestionIntervention({ questionCount: 2 }, 'active-1'),
+    ).toBeNull()
+    expect(
+      handleMultiQuestionIntervention({ toolUseId: '', questionCount: 2 }, 'active-1'),
+    ).toBeNull()
+    expect(
+      handleMultiQuestionIntervention({ toolUseId: 123, questionCount: 2 }, 'active-1'),
+    ).toBeNull()
+  })
+
+  it('returns null when questionCount is missing, non-finite, or negative', () => {
+    expect(
+      handleMultiQuestionIntervention({ toolUseId: 'a' }, 'active-1'),
+    ).toBeNull()
+    expect(
+      handleMultiQuestionIntervention({ toolUseId: 'a', questionCount: NaN }, 'active-1'),
+    ).toBeNull()
+    expect(
+      handleMultiQuestionIntervention(
+        { toolUseId: 'a', questionCount: Number.POSITIVE_INFINITY },
+        'active-1',
+      ),
+    ).toBeNull()
+    expect(
+      handleMultiQuestionIntervention({ toolUseId: 'a', questionCount: -1 }, 'active-1'),
+    ).toBeNull()
+  })
+
+  it('ring-caps the array at MAX_SESSION_INTERVENTIONS (drops oldest entries)', async () => {
+    const { MAX_SESSION_INTERVENTIONS } = await import('../utils')
+    // Pre-fill exactly to the cap with synthetic entries
+    const existing = Array.from({ length: MAX_SESSION_INTERVENTIONS }, (_, i) => ({
+      kind: 'multi_question' as const,
+      toolUseId: `toolu_${i}`,
+      count: 2,
+      timestamp: i,
+    }))
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_new', questionCount: 7, timestamp: 9999 },
+      'active-1',
+    )
+    const { interventions } = builder!.applyTo(existing)
+    expect(interventions).toHaveLength(MAX_SESSION_INTERVENTIONS)
+    // Oldest dropped, newest at the end.
+    expect(interventions[0].toolUseId).toBe('toolu_1')
+    expect(interventions[interventions.length - 1].toolUseId).toBe('toolu_new')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyInterventionBuilder (#4653)
+// ---------------------------------------------------------------------------
+describe('applyInterventionBuilder', () => {
+  it('reports isFirst=true when this is the first intervention in an empty session', () => {
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_first', questionCount: 2 },
+      'a',
+    )!
+    const { interventions, isFirst } = applyInterventionBuilder(builder, [])
+    expect(interventions).toHaveLength(1)
+    expect(isFirst).toBe(true)
+  })
+
+  it('reports isFirst=false on subsequent distinct interventions', () => {
+    const existing = [
+      { kind: 'multi_question' as const, toolUseId: 'toolu_prev', count: 2, timestamp: 1 },
+    ]
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_next', questionCount: 3 },
+      'a',
+    )!
+    const { interventions, isFirst } = applyInterventionBuilder(builder, existing)
+    expect(interventions).toHaveLength(2)
+    expect(isFirst).toBe(false)
+  })
+
+  it('reports isFirst=false when a duplicate skips the append (no inline-notice on stuck-model re-emit)', () => {
+    const existing = [
+      { kind: 'multi_question' as const, toolUseId: 'toolu_dup', count: 2, timestamp: 1 },
+    ]
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_dup', questionCount: 2 },
+      'a',
+    )!
+    const { interventions, isFirst } = applyInterventionBuilder(builder, existing)
+    expect(interventions).toBe(existing)
+    expect(isFirst).toBe(false)
   })
 })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -6670,6 +6670,7 @@ describe('handleMultiQuestionIntervention', () => {
       'active-1',
     )
     const { interventions } = builder!.applyTo([])
+    // 3.7 floors to 3 — still >= 2, so it's accepted with the floored value.
     expect(interventions[0].count).toBe(3)
   })
 
@@ -6685,7 +6686,7 @@ describe('handleMultiQuestionIntervention', () => {
     ).toBeNull()
   })
 
-  it('returns null when questionCount is missing, non-finite, or negative', () => {
+  it('returns null when questionCount is missing, non-finite, or < 2 (mirrors wire schema)', () => {
     expect(
       handleMultiQuestionIntervention({ toolUseId: 'a' }, 'active-1'),
     ).toBeNull()
@@ -6698,9 +6699,37 @@ describe('handleMultiQuestionIntervention', () => {
         'active-1',
       ),
     ).toBeNull()
+    // < 2 — the permission-hook never denies single-q forms, so a 0/1
+    // count is a malformed payload and would render a misleading
+    // "0 questions" or "1 question" in the UI.
     expect(
       handleMultiQuestionIntervention({ toolUseId: 'a', questionCount: -1 }, 'active-1'),
     ).toBeNull()
+    expect(
+      handleMultiQuestionIntervention({ toolUseId: 'a', questionCount: 0 }, 'active-1'),
+    ).toBeNull()
+    expect(
+      handleMultiQuestionIntervention({ toolUseId: 'a', questionCount: 1 }, 'active-1'),
+    ).toBeNull()
+    // 1.9 floors to 1 — also rejected (defence against fractional payloads
+    // that would sneak past a naive `>= 2` check).
+    expect(
+      handleMultiQuestionIntervention({ toolUseId: 'a', questionCount: 1.9 }, 'active-1'),
+    ).toBeNull()
+    // Boundary: exactly 2 is the smallest valid count.
+    expect(
+      handleMultiQuestionIntervention({ toolUseId: 'a', questionCount: 2 }, 'active-1'),
+    ).not.toBeNull()
+  })
+
+  it('accepts timestamp === 0 (epoch is valid per protocol — clock-skewed dev environments)', () => {
+    const builder = handleMultiQuestionIntervention(
+      { toolUseId: 'toolu_epoch', questionCount: 2, timestamp: 0 },
+      'a',
+    )
+    expect(builder).not.toBeNull()
+    const { interventions } = builder!.applyTo([])
+    expect(interventions[0].timestamp).toBe(0)
   })
 
   it('ring-caps the array at MAX_SESSION_INTERVENTIONS (drops oldest entries)', async () => {

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -29,10 +29,11 @@ import type {
   SearchResult,
   ServerError,
   SessionInfo,
+  SessionIntervention,
   ToolResultImage,
   WebTask,
 } from '../types'
-import { nextMessageId, stripAnsi } from '../utils'
+import { MAX_SESSION_INTERVENTIONS, nextMessageId, stripAnsi } from '../utils'
 import { parseUserInputMessage } from '../user-input-handler'
 import { isReplayDuplicate } from '../replay-dedup'
 import { resolveStreamId } from '../stream-id'
@@ -466,6 +467,127 @@ export function handleInactivityWarning(
         receivedAt: Date.now(),
       },
     },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// multi_question_intervention (#4653)
+//
+// Server fires this event when ClaudeTuiSession's PreToolUse handler sees a
+// multi-question AskUserQuestion — i.e. the exact condition the permission-
+// hook bash script (#4648) denies on. The dashboard renders a per-session
+// counter + a first-time inline notice so the user can tell chroxy intervened
+// (rather than wondering why the model is suddenly being polite).
+//
+// Builder shape (not a flat patch): the new array is computed from the
+// existing one — dedup-by-toolUseId so a stuck model re-emitting the same
+// multi-q payload doesn't inflate the counter falsely, and ring-cap at
+// MAX_SESSION_INTERVENTIONS so long-running sessions don't accumulate memory.
+// ---------------------------------------------------------------------------
+
+/** Builder result for handlers whose patch depends on existing intervention state. */
+export interface SessionInterventionBuilder {
+  /** Session ID the patch targets (may be null if no session context). */
+  sessionId: string | null
+  /**
+   * `true` when this intervention is the FIRST one in this session (the caller
+   * uses it to gate a one-time inline notice / system ChatMessage — repeat
+   * denials should just bump the counter, not re-spam the chat). Always `false`
+   * when the toolUseId duplicates an existing entry (no append happens).
+   */
+  isFirst: boolean
+  /** Apply the builder to the session's current interventions list. */
+  applyTo: (current: SessionIntervention[]) => { interventions: SessionIntervention[] }
+}
+
+/**
+ * Parse a `multi_question_intervention` session_event payload (wire shape
+ * `{ toolUseId, questionCount, reason: 'multi_question', timestamp }` — see
+ * `ClaudeTuiSession._emitToolHookEvent` in packages/server) and produce a
+ * builder that appends a {@link SessionIntervention} entry to the targeted
+ * session's `interventions` array.
+ *
+ * Returns null when the payload is malformed (missing/non-string toolUseId,
+ * non-finite questionCount). Callers should leave existing state alone — the
+ * counter just doesn't tick, no fallback "unknown intervention" entry is
+ * inserted (those would lie about what happened).
+ *
+ * Dedup-by-toolUseId: the caller's `applyTo` returns the existing array
+ * unchanged when an entry with the same `toolUseId` is already present (the
+ * known-stuck-model re-emit pattern from #4666 / #4668). When that happens
+ * `isFirst` is also false even on the very first event the session sees, so
+ * the inline-notice gate stays consistent with what's actually appended.
+ *
+ * Ring-cap at MAX_SESSION_INTERVENTIONS: when the new array would exceed the
+ * cap, the oldest entry is dropped (`.slice(-MAX)` — FIFO).
+ */
+export function handleMultiQuestionIntervention(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): SessionInterventionBuilder | null {
+  const toolUseIdRaw = msg.toolUseId
+  if (typeof toolUseIdRaw !== 'string' || toolUseIdRaw.length === 0) return null
+
+  const countRaw = msg.questionCount
+  // `questionCount` from the server is always >= 2 (the hook only fires
+  // for multi-q). Defensive lower-bound at 0 here so a malformed payload
+  // doesn't store a negative — the counter UI would render "-3 questions"
+  // which is worse than dropping the entry.
+  if (typeof countRaw !== 'number' || !Number.isFinite(countRaw) || countRaw < 0) {
+    return null
+  }
+  const count = Math.floor(countRaw)
+
+  const tsRaw = msg.timestamp
+  const timestamp =
+    typeof tsRaw === 'number' && Number.isFinite(tsRaw) && tsRaw > 0
+      ? Math.floor(tsRaw)
+      : Date.now()
+
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    isFirst: false, // recomputed by applyTo based on the current list
+    applyTo: (current) => {
+      const dup = current.some((iv) => iv.toolUseId === toolUseIdRaw)
+      if (dup) {
+        // Stuck-model re-emit — return the array unchanged so the counter
+        // stays accurate and React's referential-equality skips a re-render.
+        return { interventions: current }
+      }
+      const entry: SessionIntervention = {
+        kind: 'multi_question',
+        toolUseId: toolUseIdRaw,
+        count,
+        timestamp,
+      }
+      const next = [...current, entry]
+      // Ring-cap from the OLDEST side — newest entry always stays so the
+      // user sees the most recent intervention reflected in the counter.
+      const capped = next.length > MAX_SESSION_INTERVENTIONS
+        ? next.slice(-MAX_SESSION_INTERVENTIONS)
+        : next
+      return { interventions: capped }
+    },
+  }
+}
+
+/**
+ * #4653 helper — runs the builder against a current array and returns BOTH
+ * the new array AND whether this intervention was the session's first (i.e.
+ * the previous array was empty AND this call actually appended an entry).
+ * Lets the call site gate a one-time inline notice without re-walking the
+ * dedup state itself.
+ */
+export function applyInterventionBuilder(
+  builder: SessionInterventionBuilder,
+  current: SessionIntervention[],
+): { interventions: SessionIntervention[]; isFirst: boolean } {
+  const wasEmpty = current.length === 0
+  const result = builder.applyTo(current)
+  const actuallyAppended = result.interventions.length > current.length
+  return {
+    interventions: result.interventions,
+    isFirst: wasEmpty && actuallyAppended,
   }
 }
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -529,18 +529,26 @@ export function handleMultiQuestionIntervention(
   if (typeof toolUseIdRaw !== 'string' || toolUseIdRaw.length === 0) return null
 
   const countRaw = msg.questionCount
-  // `questionCount` from the server is always >= 2 (the hook only fires
-  // for multi-q). Defensive lower-bound at 0 here so a malformed payload
-  // doesn't store a negative — the counter UI would render "-3 questions"
-  // which is worse than dropping the entry.
-  if (typeof countRaw !== 'number' || !Number.isFinite(countRaw) || countRaw < 0) {
+  // `questionCount` from the server is always >= 2 (the permission-hook
+  // only denies multi-question forms — single-q is the happy path). Mirror
+  // the protocol Zod schema (`ServerMultiQuestionInterventionSchema`) here
+  // as defence in depth: floor BEFORE the threshold check so 1.9 doesn't
+  // sneak past as 1, then drop anything < 2 so a malformed payload doesn't
+  // render "0 questions" or "1 question" in the counter UI (both would lie
+  // about what happened — the hook only fires for >= 2).
+  if (typeof countRaw !== 'number' || !Number.isFinite(countRaw)) {
     return null
   }
   const count = Math.floor(countRaw)
+  if (count < 2) return null
 
   const tsRaw = msg.timestamp
+  // Mirror the protocol schema's `timestamp >= 0` bound — epoch 0 is
+  // explicitly allowed so a clock-skewed dev environment doesn't bounce
+  // the event off the wire. Only fall back to Date.now() when the payload
+  // is missing or non-numeric, NOT when timestamp is legitimately 0.
   const timestamp =
-    typeof tsRaw === 'number' && Number.isFinite(tsRaw) && tsRaw > 0
+    typeof tsRaw === 'number' && Number.isFinite(tsRaw) && tsRaw >= 0
       ? Math.floor(tsRaw)
       : Date.now()
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -53,6 +53,8 @@ export type {
   Checkpoint,
   BaseSessionState,
   InactivityWarning,
+  // #4653: chroxy-side intervention ring (multi-q deny etc.)
+  SessionIntervention,
   // Git result element types (#3132)
   GitFileStatus,
   GitBranch,
@@ -139,6 +141,8 @@ export {
   createEmptyBaseSessionState,
   ACTIVITY_EVENT_TYPES,
   isActivityEvent,
+  // #4653: ring cap for SessionIntervention list on BaseSessionState
+  MAX_SESSION_INTERVENTIONS,
 } from './utils'
 
 // #4123: shared cost formatters used by both dashboard sidebar badge
@@ -239,6 +243,8 @@ export type {
   PlanAllowedPrompt,
   ThinkingLevel,
   DevPreviewBuilder,
+  // #4653 — builder for the chroxy-side intervention append/dedup/ring-cap path
+  SessionInterventionBuilder,
   AgentInfoBuilder,
   PendingBackgroundShellsBuilder,
   ServerMode,
@@ -309,6 +315,9 @@ export {
   handlePlanStarted,
   handlePlanReady,
   handleInactivityWarning,
+  // #4653 — chroxy-side multi-question deny notification
+  handleMultiQuestionIntervention,
+  applyInterventionBuilder,
   handleDevPreview,
   handleDevPreviewStopped,
   handleAuthOk,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -537,6 +537,29 @@ export interface InactivityWarning {
 }
 
 /**
+ * #4653 — one entry per chroxy-side intervention surfaced to the user.
+ *
+ * Currently only `multi_question` (the permission-hook deny for multi-question
+ * AskUserQuestion forms shipped in #4648). The shape is intentionally
+ * extensible so future intervention kinds (e.g. sibling-deny from #4668,
+ * stream-stall auto-recovery from #4475) can land here without a wire
+ * version bump.
+ *
+ * - `kind`: discriminator the renderer switches on for icon + copy
+ * - `toolUseId`: stable id of the original tool_use; the dashboard dedups
+ *   repeats by this so a stuck model re-emitting the same payload doesn't
+ *   inflate the counter falsely
+ * - `count`: secondary detail (e.g. number of questions in the denied form)
+ * - `timestamp`: server wall-clock when the deny happened
+ */
+export interface SessionIntervention {
+  kind: 'multi_question';
+  toolUseId: string;
+  count: number;
+  timestamp: number;
+}
+
+/**
  * Base session state shared by both the mobile app and web dashboard.
  *
  * Each consumer extends this with platform-specific fields:
@@ -622,4 +645,21 @@ export interface BaseSessionState {
   // user replies, and on `socket.onclose` since the server does not
   // replay `inactivity_warning` on reconnect.
   inactivityWarning: InactivityWarning | null;
+  /**
+   * #4653 — chroxy-side interventions surfaced to the user for this session.
+   * Append-only ring (max ~50 entries — see {@link MAX_SESSION_INTERVENTIONS}).
+   * Empty array when no intervention has fired; never `null` so the renderer's
+   * `.length` check is safe.
+   *
+   * Currently driven only by `multi_question_intervention` (the permission-hook
+   * deny for multi-question AskUserQuestion shipped in #4648); future
+   * intervention kinds (sibling-deny #4668, stream-stall auto-recovery #4475)
+   * append entries with their own discriminator without a wire version bump.
+   *
+   * NOT persisted across reconnects — the server does not replay intervention
+   * events, so the array resets on a fresh session_list snapshot. This is
+   * acceptable: the counter is a "what just happened" affordance, not an
+   * audit log.
+   */
+  interventions: SessionIntervention[];
 }

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -37,6 +37,9 @@ describe('createEmptyBaseSessionState', () => {
       mcpServers: [],
       devPreviews: [],
       inactivityWarning: null,
+      // #4653: chroxy-side intervention ring — empty array on init,
+      // populated by multi_question_intervention events.
+      interventions: [],
     })
   })
 
@@ -52,6 +55,9 @@ describe('createEmptyBaseSessionState', () => {
     expect(a.planAllowedPrompts).not.toBe(b.planAllowedPrompts)
     expect(a.mcpServers).not.toBe(b.mcpServers)
     expect(a.devPreviews).not.toBe(b.devPreviews)
+    // #4653: interventions ring is per-session — each fresh state must
+    // get its own array so a deny on session A doesn't bleed into session B.
+    expect(a.interventions).not.toBe(b.interventions)
   })
 
   it('satisfies the BaseSessionState type', () => {

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -93,8 +93,21 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     mcpServers: [],
     devPreviews: [],
     inactivityWarning: null,
+    // #4653: empty ring for chroxy-side interventions. Never null so the
+    // dashboard's `.length`/`map` call sites don't need a guard.
+    interventions: [],
   };
 }
+
+/**
+ * #4653 — cap on the per-session intervention ring buffer. The dashboard
+ * counter only ever shows a number + a list of "recent" entries, so we don't
+ * need to keep more than this — a sustained intervention storm (e.g. a model
+ * fighting the multi-question deny) would otherwise bloat the in-memory state
+ * indefinitely. Chosen at 50 to comfortably show "the last batch" without
+ * imposing a UX cliff if the user is mid-debug-session.
+ */
+export const MAX_SESSION_INTERVENTIONS = 50
 
 /**
  * WS message types that count as agent activity for the


### PR DESCRIPTION
## Summary

- `ClaudeTuiSession` fires a new `multi_question_intervention` event when PreToolUse sees a multi-question AskUserQuestion (the exact condition the permission-hook bash script denies on). The event flows through SessionManager → event-normalizer → WS wire.
- store-core adds a `SessionIntervention` type, an `interventions[]` ring on `BaseSessionState`, and a `handleMultiQuestionIntervention` builder that dedups by toolUseId and ring-caps at 50 entries. A sibling `applyInterventionBuilder` reports whether the append was the session's first.
- The dashboard appends the entry on every event and pushes a one-time system ChatMessage on the FIRST intervention per session; subsequent denials only tick the counter. `FooterBar` renders a clickable counter chip + expandable `InterventionsPanel` showing newest-first entries with relative timestamps.
- The protocol Zod schema pins the wire shape so future intervention kinds extend the discriminator without a protocol version bump.

Without this, the user couldn't tell whether the model was naturally asking one at a time or whether chroxy was intercepting. The v0.9.24 dogfood feedback explicitly asked for this transparency.

## Test plan

- [x] `packages/server` — 6 new tests in `claude-tui-multi-question-intervention.test.js` pin the customEvents declaration, the emit-on-multi-q condition, and the no-emit invariants (single-q, non-AskUserQuestion, PostToolUse, synthesized toolUseId)
- [x] `packages/server` — 2 new tests in `event-normalizer.test.js` pin the wire-shape forwarding
- [x] `packages/store-core` — 12 new tests covering the handler dedup, ring-cap, first-detection, payload validation, and empty-state defaults
- [x] `packages/dashboard` — 7 new `FooterBar` tests cover the counter chip (hidden/single/plural), aria-expanded, panel expand/collapse, newest-first ordering, multi-q description, and close button
- [x] `packages/dashboard` — 6 new message-handler dispatch tests cover the targeted-session append, one-time system message on first, dedup on stuck-model re-emit, drop on unknown session, and malformed payload handling
- [x] `cd packages/server && npm test` for affected files: 414 tests pass
- [x] `cd packages/store-core && npx vitest run`: 917 tests pass
- [x] `cd packages/dashboard && npx vitest run`: 2423 tests pass
- [x] `cd packages/dashboard && npm run typecheck` clean

Closes #4653