### PR TITLE
fix(dashboard): wrap chat markdown so code blocks don't overflow window

### DIFF
--- a/packages/dashboard/src/components/ChatMessage.test.tsx
+++ b/packages/dashboard/src/components/ChatMessage.test.tsx
@@ -238,6 +238,73 @@ describe('ChatMessage', () => {
     )
     expect(screen.getByTestId('chat-message-msg-error-ok')).toBeInTheDocument()
   })
+
+  /**
+   * #4757 — chat markdown overflow fix. These tests assert the renderer
+   * still emits the <pre> / <code> structure that the CSS rules in
+   * theme/components.css target (`.msg pre`, `.msg pre code`,
+   * `.msg code`). jsdom doesn't measure layout, so the visual cap +
+   * horizontal-scroll behaviour is verified manually in the dashboard;
+   * here we lock in the contract that long content renders without
+   * throwing and lands inside the right elements so the CSS keeps
+   * applying.
+   */
+  describe('long markdown content (#4757)', () => {
+    it('renders a fenced block with a very long single line inside <pre><code>', () => {
+      const longLine = 'a'.repeat(220)
+      render(
+        <ChatMessage
+          id="msg-long-pre"
+          type="response"
+          content={'before\n```\n' + longLine + '\n```\nafter'}
+          timestamp={Date.now()}
+        />
+      )
+      const el = screen.getByTestId('chat-message-msg-long-pre')
+      const pre = el.querySelector('pre')
+      expect(pre).not.toBeNull()
+      const code = pre!.querySelector('code')
+      expect(code).not.toBeNull()
+      expect(code!.textContent).toContain(longLine)
+    })
+
+    it('renders an inline long-token code span inside <code> (no pre ancestor)', () => {
+      const longToken = 'x'.repeat(180)
+      render(
+        <ChatMessage
+          id="msg-long-inline"
+          type="response"
+          content={'see `' + longToken + '` for the path'}
+          timestamp={Date.now()}
+        />
+      )
+      const el = screen.getByTestId('chat-message-msg-long-inline')
+      const inlineCodes = Array.from(el.querySelectorAll('code')).filter(
+        c => !c.closest('pre')
+      )
+      expect(inlineCodes).toHaveLength(1)
+      expect(inlineCodes[0]!.textContent).toBe(longToken)
+    })
+
+    it('renders mixed inline + fenced content in one message without throwing', () => {
+      const longLine = 'z'.repeat(250)
+      const longToken = 'q'.repeat(150)
+      render(
+        <ChatMessage
+          id="msg-mixed"
+          type="response"
+          content={`Use the \`${longToken}\` flag:\n\n\`\`\`\n${longLine}\n\`\`\``}
+          timestamp={Date.now()}
+        />
+      )
+      const el = screen.getByTestId('chat-message-msg-mixed')
+      expect(el.querySelector('pre code')!.textContent).toContain(longLine)
+      const inline = Array.from(el.querySelectorAll('code')).find(
+        c => !c.closest('pre')
+      )
+      expect(inline!.textContent).toBe(longToken)
+    })
+  })
 })
 
 describe('ToolBubble', () => {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1582,6 +1582,14 @@
 
 .msg {
   max-width: 85%;
+  /* #4757: flex/grid child needs min-width: 0 so a long <pre> or wide
+     inline-code line can't push the bubble past its 85% cap. Without
+     this, intrinsic content width wins and the bubble overflows the
+     chat panel (visible bleed past the right edge on v0.9.32). The
+     same applies inside `.msg-row` where `max-width: unset` removes
+     the bubble's own cap and the parent row's 88% cap is the only
+     wall — without min-width: 0 the bubble blew past it. */
+  min-width: 0;
   padding: 10px 14px;
   border-radius: 12px;
   font-size: var(--text-md);
@@ -1714,6 +1722,14 @@
   background: var(--bg-code-block);
   border-radius: 6px;
   padding: 10px 12px;
+  /* #4757: cap width at the bubble and scroll the long line INSIDE the
+     <pre>. Previously `overflow-x: auto` was set but no max-width, so a
+     200+ char single line still expanded the <pre>'s intrinsic width
+     past the bubble — the scrollbar never engaged because nothing was
+     actually clipped. `100%` against the min-width:0 bubble means the
+     <pre> takes the bubble's available width and the long line scrolls
+     horizontally inside it. */
+  max-width: 100%;
   overflow-x: auto;
   margin: 6px 0;
   font-size: var(--text-base);
@@ -1724,6 +1740,13 @@
   color: #c8d0e0;
   background: none;
   padding: 0;
+  /* #4757: explicitly keep code inside <pre> on its original lines —
+     the `.msg code` rule below applies break-word for inline spans, and
+     we must NOT inherit that into fenced blocks where line breaks are
+     load-bearing (directory trees, ASCII tables, code formatting). */
+  white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
 }
 
 .msg code {
@@ -1733,6 +1756,14 @@
   border-radius: 4px;
   font-size: 0.9em;
   color: #c8d0e0;
+  /* #4757: inline <code> in a paragraph must be able to wrap mid-token
+     when the surrounding text + code exceeds the bubble width.
+     `overflow-wrap: anywhere` is the modern, well-supported answer;
+     `word-break: break-word` adds Safari < 15 coverage. The `.msg pre
+     code` rule above re-asserts `normal` so fenced blocks aren't
+     affected. */
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .msg strong { color: var(--text-heading); }


### PR DESCRIPTION
## Summary
- Add `min-width: 0` to chat message bubble (`.msg`) so the flex child can shrink — matters both at the top level (under `.chat-messages`) and inside `.msg-row` where the bubble's own `max-width` is unset and the row's 88% cap was the only wall content could blow past.
- Add `max-width: 100%` to `.msg pre` (it already had `overflow-x: auto` but with no width cap the `<pre>`'s intrinsic width grew past the bubble and the scrollbar never engaged) so long lines now scroll horizontally INSIDE the bubble.
- Add `overflow-wrap: anywhere; word-break: break-word` to inline `.msg code` and re-assert `white-space: pre; word-break: normal; overflow-wrap: normal` on `.msg pre code` so the break-word rule does not bleed into fenced blocks where line breaks are load-bearing.

## Test plan
- [x] Existing dashboard suite passes (`vitest run` — 2412 tests, 0 failures)
- [x] New `describe('long markdown content (#4757)')` block in `ChatMessage.test.tsx` locks in the renderer contract the CSS targets (220-char fenced line under `<pre><code>`, 180-char inline token under bare `<code>`, mixed content)
- [x] `tsc --noEmit` clean
- [ ] Visual check on the desktop dashboard: render a reply with a long inline-code span and a 200+ char fenced line — chat content stays inside the bubble, scrollbar appears on the `<pre>` only

Closes #4757