### PR TITLE
feat(dashboard,protocol): per-question answer wire format + multi-question UI

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -331,11 +331,28 @@ export function App() {
     [activeMismatched],
   )
 
+  // #4735: the multi-question AskUserQuestion form is gated per session
+  // type. TUI sessions (`claude-tui`) keep the #4666 deferred notice
+  // because the permission-hook denies multi-question tool_uses there
+  // and answers would misroute through `_pendingUserAnswer`. SDK / BYOK
+  // / Codex sessions support per-question delivery natively (#4731), so
+  // the dashboard renders the interactive `MultiQuestionForm` for them
+  // and submits per-question answers (including multi-select arrays) on
+  // the widened wire.
+  const activeSessionProvider = useMemo(
+    () => sessions.find(s => s.sessionId === activeSessionId)?.provider,
+    [sessions, activeSessionId],
+  )
+  const allowMultiQuestionForm = useMemo(
+    () => activeSessionProvider != null && activeSessionProvider !== 'claude-tui',
+    [activeSessionProvider],
+  )
+
   // #3839: dropdown-gating flags derived from the active session's provider
   // capabilities. Hoisted out of the JSX so the lookups don't re-run on every
   // render of <App>, which fires on most WS messages.
   const dropdownFlags = useMemo(() => {
-    const activeProvider = sessions.find(s => s.sessionId === activeSessionId)?.provider
+    const activeProvider = activeSessionProvider
     const providerInfo = availableProviders.find(p => p.name === activeProvider)
     const caps = providerInfo?.capabilities
     // The store carries one `availableModels` slot tagged with the provider
@@ -356,7 +373,7 @@ export function App() {
       showPermissionMode: caps?.permissionModeSwitch !== false,
       showThinkingLevel: !!caps?.thinkingLevel,
     }
-  }, [sessions, activeSessionId, availableProviders, availableModelsProvider, activeModel])
+  }, [activeSessionProvider, availableProviders, availableModelsProvider, activeModel])
 
   // Fire native notifications for permission requests when window is not focused
   const permissionPrompts = useMemo<PermissionPromptInfo[]>(() =>
@@ -1493,15 +1510,21 @@ export function App() {
           options={storeMsg.options}
           questions={storeMsg.questions}
           answered={storeMsg.answered}
+          // #4735 — SDK-mode sessions get the interactive
+          // MultiQuestionForm; TUI sessions keep the #4666 deferred
+          // notice. Derivation lives at activeSessionProvider above so
+          // the flag flips correctly on session-switch without a full
+          // re-render of every prompt.
+          allowMultiQuestion={allowMultiQuestionForm}
           onSelect={(answer) => {
-            // #4604 Chunk B — answer is `string` for single-question /
-            // free-text paths and `Record<string,string>` for multi-question
-            // forms. sendUserQuestionResponse handles both shapes;
-            // markPromptAnswered records a string summary on the bubble so
-            // the post-answer collapse UI has something readable to show.
-            // #4622 — formatQuestionAnswerSummary pretty-prints multi-select
-            // JSON-stringified arrays as comma-joined labels so the chip
-            // doesn't leak `["App","Tests"]` JSON syntax into UX copy.
+            // #4604 Chunk B / #4735 — answer is `string` for
+            // single-question / free-text paths and
+            // `Record<string, string | string[]>` for multi-question
+            // forms (multi-select values are native arrays on the
+            // widened wire). sendUserQuestionResponse handles both
+            // shapes; markPromptAnswered records a string summary on
+            // the bubble so the post-answer collapse UI has something
+            // readable to show.
             sendUserQuestionResponse(answer, storeMsg.toolUseId)
             markPromptAnswered(storeMsg.id, formatQuestionAnswerSummary(answer))
           }}
@@ -1568,7 +1591,7 @@ export function App() {
 
     // Default rendering
     return null
-  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs])
+  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs, allowMultiQuestionForm])
 
   // #4412: registry-driven cheat sheet. Recomputed on every render —
   // not memoised, by design. The shortcut registry hook re-renders

--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -464,6 +464,85 @@ describe('QuestionPrompt', () => {
       expect(screen.queryByTestId('multi-question-deferred-notice')).not.toBeInTheDocument()
     })
 
+    // #4735 — `allowMultiQuestion` opt-in lifts the deferred-notice
+    // suppression for SDK-mode sessions whose underlying delivery path
+    // supports per-question answers natively (#4731). TUI sessions keep
+    // the deferred notice as before because their permission-hook denies
+    // multi-question tool_uses. App.tsx derives the flag from
+    // `session.provider !== 'claude-tui'`.
+    describe('allowMultiQuestion opt-in (#4735)', () => {
+      it('renders the interactive MultiQuestionForm when allowMultiQuestion is true', () => {
+        render(
+          <QuestionPrompt
+            question={q1.question}
+            options={q1.options}
+            questions={multiQuestions}
+            allowMultiQuestion
+            onSelect={vi.fn()}
+          />
+        )
+        expect(screen.getByTestId('question-prompt-multi')).toBeInTheDocument()
+        expect(screen.getByTestId('question-multi-submit')).toBeInTheDocument()
+        expect(screen.queryByTestId('multi-question-deferred-notice')).not.toBeInTheDocument()
+      })
+
+      it('renders the deferred notice when allowMultiQuestion is false (default)', () => {
+        render(
+          <QuestionPrompt
+            question={q1.question}
+            options={q1.options}
+            questions={multiQuestions}
+            allowMultiQuestion={false}
+            onSelect={vi.fn()}
+          />
+        )
+        expect(screen.getByTestId('multi-question-deferred-notice')).toBeInTheDocument()
+        expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
+      })
+
+      it('still falls back to the single-question UI for N=1 even when allowMultiQuestion is true', () => {
+        // The opt-in flag only lifts the multi-question suppression; the
+        // N=1 path is unchanged so single-question regressions stay green.
+        render(
+          <QuestionPrompt
+            question="Just one?"
+            options={[{ label: 'Yes', value: 'Yes' }, { label: 'No', value: 'No' }]}
+            questions={[{ question: 'Just one?', options: [{ label: 'Yes', value: 'Yes' }, { label: 'No', value: 'No' }] }]}
+            allowMultiQuestion
+            onSelect={vi.fn()}
+          />
+        )
+        expect(screen.getByTestId('question-prompt')).toBeInTheDocument()
+        expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('multi-question-deferred-notice')).not.toBeInTheDocument()
+      })
+
+      it('submitting the MultiQuestionForm propagates the answersMap through onSelect', () => {
+        const onSelect = vi.fn()
+        render(
+          <QuestionPrompt
+            question={q1.question}
+            options={q1.options}
+            questions={multiQuestions}
+            allowMultiQuestion
+            onSelect={onSelect}
+          />
+        )
+        // Strategy: pick "Patch"; Targets: pick "App" + "Tests"; Confirm: "Yes"
+        fireEvent.click(screen.getByTestId('question-multi-option-0-Patch').querySelector('input')!)
+        fireEvent.click(screen.getByTestId('question-multi-option-1-App').querySelector('input')!)
+        fireEvent.click(screen.getByTestId('question-multi-option-1-Tests').querySelector('input')!)
+        fireEvent.click(screen.getByTestId('question-multi-option-2-Yes').querySelector('input')!)
+        fireEvent.click(screen.getByTestId('question-multi-submit'))
+        expect(onSelect).toHaveBeenCalledTimes(1)
+        const arg = onSelect.mock.calls[0]?.[0] as Record<string, string | string[]> | undefined
+        expect(arg!['Which release strategy?']).toBe('Patch')
+        // Native string[] per #4735, not a JSON-stringified envelope.
+        expect(arg!['Which targets?']).toEqual(['App', 'Tests'])
+        expect(arg!['Confirm?']).toBe('Yes')
+      })
+    })
+
     it('falls back to single-question UI when answered is already set (multi-question post-answer summary path)', () => {
       // Once an answer is recorded, render the single-question collapse
       // UI — even for a multi-question payload. The deferred notice is
@@ -515,9 +594,72 @@ describe('QuestionPrompt', () => {
       fireEvent.click(screen.getByTestId('question-multi-option-1-Yes').querySelector('input')!)
       fireEvent.click(screen.getByTestId('question-multi-submit'))
       expect(onSelect).toHaveBeenCalledTimes(1)
-      const arg = onSelect.mock.calls[0]?.[0] as Record<string, string> | undefined
+      const arg = onSelect.mock.calls[0]?.[0] as Record<string, string | string[]> | undefined
       expect(arg!['Which release strategy?']).toBe('Minor')
       expect(arg!['Confirm?']).toBe('Yes')
+    })
+
+    // #4735 — multi-select answers used to be JSON.stringify'd into a
+    // single string because the wire schema was Record<string,string>.
+    // Post-#4735 the wire accepts Record<string, string | string[]>, so
+    // the form emits native arrays. The server still accepts the old
+    // JSON-string shape for back-compat; the dashboard prefers arrays
+    // so the SDK canUseTool callback receives the structured form
+    // without a JSON.parse hop.
+    describe('multi-select native array emission (#4735)', () => {
+      const qMulti = {
+        question: 'Which targets?',
+        multiSelect: true,
+        options: [
+          { label: 'App', value: 'App' },
+          { label: 'Docs', value: 'Docs' },
+          { label: 'Tests', value: 'Tests' },
+        ],
+      }
+
+      it('emits multi-select answers as a native string[]', () => {
+        const onSelect = vi.fn()
+        render(<MultiQuestionForm questions={[qMulti]} onSelect={onSelect} />)
+        fireEvent.click(screen.getByTestId('question-multi-option-0-App').querySelector('input')!)
+        fireEvent.click(screen.getByTestId('question-multi-option-0-Tests').querySelector('input')!)
+        fireEvent.click(screen.getByTestId('question-multi-submit'))
+        expect(onSelect).toHaveBeenCalledTimes(1)
+        const arg = onSelect.mock.calls[0]?.[0] as Record<string, string | string[]> | undefined
+        const val = arg!['Which targets?']
+        expect(Array.isArray(val)).toBe(true)
+        expect(val).toEqual(['App', 'Tests'])
+      })
+
+      it('emits empty multi-select as an empty array (not "[]" string)', () => {
+        const onSelect = vi.fn()
+        render(<MultiQuestionForm questions={[qMulti]} onSelect={onSelect} />)
+        fireEvent.click(screen.getByTestId('question-multi-submit'))
+        expect(onSelect).toHaveBeenCalledTimes(1)
+        const arg = onSelect.mock.calls[0]?.[0] as Record<string, string | string[]> | undefined
+        const val = arg!['Which targets?']
+        expect(Array.isArray(val)).toBe(true)
+        expect(val).toEqual([])
+      })
+
+      it('mixes native string single-select with native string[] multi-select per question', () => {
+        const qSingle = {
+          question: 'Strategy?',
+          options: [
+            { label: 'Patch', value: 'Patch' },
+            { label: 'Minor', value: 'Minor' },
+          ],
+        }
+        const onSelect = vi.fn()
+        render(<MultiQuestionForm questions={[qSingle, qMulti]} onSelect={onSelect} />)
+        fireEvent.click(screen.getByTestId('question-multi-option-0-Patch').querySelector('input')!)
+        fireEvent.click(screen.getByTestId('question-multi-option-1-App').querySelector('input')!)
+        fireEvent.click(screen.getByTestId('question-multi-option-1-Docs').querySelector('input')!)
+        fireEvent.click(screen.getByTestId('question-multi-submit'))
+        expect(onSelect).toHaveBeenCalledTimes(1)
+        const arg = onSelect.mock.calls[0]?.[0] as Record<string, string | string[]> | undefined
+        expect(arg!['Strategy?']).toBe('Patch')
+        expect(arg!['Which targets?']).toEqual(['App', 'Docs'])
+      })
     })
 
     // #4624 — a11y: each per-question options block must be exposed to

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -13,14 +13,33 @@
  * rendered by the parent and remains visible at all times.
  *
  * #4604 Chunk B — multi-question forms: when `questions` is supplied
- * with more than one entry, the component renders an inline form with
- * one selection control per question (radio for single-select,
- * checkboxes for multiSelect) and a single Submit button at the bottom
- * that fires `onSelect(answersMap)`. The N=1 case falls back to the
- * legacy single-question UI so single-question pins keep passing.
+ * with more than one entry AND `allowMultiQuestion` is true (#4735),
+ * the component renders an inline form with one selection control per
+ * question (radio for single-select, checkboxes for multiSelect) and a
+ * single Submit button at the bottom that fires `onSelect(answersMap)`.
+ * The N=1 case falls back to the legacy single-question UI so
+ * single-question pins keep passing.
+ *
+ * #4666 / #4735 — when `allowMultiQuestion` is false (TUI sessions whose
+ * permission-hook denies multi-question), the component renders a
+ * non-interactive deferred notice instead so the user can't submit
+ * answers that misroute through `_pendingUserAnswer`. SDK-mode sessions
+ * (#4731 native delivery) pass `allowMultiQuestion={true}` to lift the
+ * suppression.
  */
 import { useId, useState, useRef, useEffect } from 'react'
 import { OTHER_OPTION_VALUE, type ChatMessageQuestion } from '@chroxy/store-core'
+
+/**
+ * #4735 — per-question answer payload emitted by the multi-question form.
+ * Values are either a string (single-select chosen value, free-form
+ * "Other" text) or a string[] (multi-select chosen values). The wire
+ * schema (`UserQuestionResponseSchema`) and server consumers
+ * (`PermissionManager.respondToQuestion`, `ClaudeTuiSession`) accept
+ * both shapes; pre-#4735 builds used to JSON-stringify the array into a
+ * single string for back-compat, but the native form is preferred.
+ */
+export type MultiQuestionAnswersMap = Record<string, string | string[]>
 
 export interface QuestionPromptProps {
   question: string
@@ -35,28 +54,40 @@ export interface QuestionPromptProps {
    */
   questions?: ChatMessageQuestion[]
   /**
-   * Fires with either a plain string (single-question / free-text path,
-   * back-compat) or a `Record<string,string>` map (multi-question form,
-   * keyed by `question.question` with multi-select values
-   * JSON-stringified arrays of chosen labels).
+   * #4735 — opt-in flag for SDK-mode sessions to render the interactive
+   * `MultiQuestionForm` instead of the #4666 deferred notice. TUI
+   * sessions (`provider === 'claude-tui'`) leave this false because the
+   * permission-hook denies multi-question tool_uses there; SDK / BYOK
+   * / Codex sessions pass `true` because the underlying delivery path
+   * supports per-question answers natively (#4731). Defaults to false
+   * so existing callers (and tests) keep their #4666 deferred-notice
+   * behaviour unless they explicitly opt in.
    */
-  onSelect: (answer: string | Record<string, string>) => void
+  allowMultiQuestion?: boolean
+  /**
+   * Fires with either a plain string (single-question / free-text path,
+   * back-compat) or a `MultiQuestionAnswersMap` keyed by question text
+   * (multi-question form). Multi-select values are emitted as native
+   * `string[]` arrays per the widened wire (#4735).
+   */
+  onSelect: (answer: string | MultiQuestionAnswersMap) => void
 }
 
-export function QuestionPrompt({ question, options, answered, questions, onSelect }: QuestionPromptProps) {
+export function QuestionPrompt({ question, options, answered, questions, allowMultiQuestion, onSelect }: QuestionPromptProps) {
   const isMultiQuestion = Array.isArray(questions) && questions.length > 1
 
-  // #4666: the permission-hook (`packages/server/hooks/permission-hook.sh`,
-  // shipped in #4648 / v0.9.24) unconditionally denies any AskUserQuestion
-  // whose `questions[]` has length > 1 because the TUI keystroke driver
-  // can't reliably answer combined multi-question forms. The dashboard
-  // still receives the tool_use event though (broadcast is independent of
-  // the permission decision), so rendering the interactive MultiQuestionForm
-  // here would let the user submit answers that route through
-  // `_pendingUserAnswer` to the wrong question slot — see the live trace in
-  // #4666 / #4668. Render a non-interactive placeholder instead so the user
-  // understands chroxy is waiting for Claude to retry one-at-a-time.
+  // #4666 / #4735 — TUI sessions: permission-hook denies any AskUserQuestion
+  // with `questions[]` length > 1 because the TUI keystroke driver can't
+  // reliably answer combined forms. The dashboard still receives the
+  // tool_use event (broadcast is independent of the deny), so we render a
+  // non-interactive notice to prevent misrouted answers via
+  // `_pendingUserAnswer`. SDK-mode sessions (#4731) flip
+  // `allowMultiQuestion` on and render the live `MultiQuestionForm` so
+  // per-question answers reach the SDK's canUseTool callback natively.
   if (isMultiQuestion && answered == null) {
+    if (allowMultiQuestion) {
+      return <MultiQuestionForm questions={questions} onSelect={onSelect} />
+    }
     return <MultiQuestionDeferredNotice count={questions.length} />
   }
 
@@ -94,22 +125,26 @@ function MultiQuestionDeferredNotice({ count }: { count: number }) {
  * #4604 Chunk B — N-question form. Each question gets its own selection
  * control (radio for single-select, checkboxes for multiSelect); the
  * single Submit button at the bottom fires `onSelect(answersMap)` with
- * one entry per question (multi-select values are JSON-stringified
- * arrays so the wire shape `Record<string,string>` is preserved — the
- * server's respondToQuestion JSON.parse handles the round trip).
+ * one entry per question.
  *
- * #4666 — intentionally retained but not currently rendered by
- * `QuestionPrompt`. The permission-hook denies multi-question
- * AskUserQuestion tool_uses, so showing the interactive form would let
- * the user submit answers that misroute via the single `_pendingUserAnswer`
- * field. Once #4668's `Map<toolUseId, ...>` refactor lands, native
- * multi-question support can be re-enabled by flipping the gate in
- * `QuestionPrompt` back to rendering this component. Exported so that
- * `noUnusedLocals` doesn't strip it while it sits dormant.
+ * #4735 — multi-select values are emitted as native `string[]` arrays
+ * via the widened wire shape (`Record<string, string | string[]>`).
+ * Pre-#4735 builds JSON-stringified the array into a single string for
+ * back-compat; the server still accepts both shapes
+ * (`ClaudeTuiSession.resolveQuestionDigits` parses JSON or comma-joined
+ * strings, `PermissionManager.respondToQuestion` passes the value
+ * through unchanged so the SDK receives the array on its canUseTool
+ * callback).
+ *
+ * #4666 / #4735 — gated behind `allowMultiQuestion` in `QuestionPrompt`
+ * so TUI sessions fall back to the deferred notice (the TUI keystroke
+ * driver can't reliably answer combined multi-question forms). SDK /
+ * BYOK / Codex sessions render this form directly because the SDK's
+ * canUseTool delivery accepts per-question answers natively (#4731).
  */
 export interface MultiQuestionFormProps {
   questions: ChatMessageQuestion[]
-  onSelect: (answersMap: Record<string, string>) => void
+  onSelect: (answersMap: MultiQuestionAnswersMap) => void
 }
 
 export function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProps) {
@@ -141,15 +176,18 @@ export function MultiQuestionForm({ questions, onSelect }: MultiQuestionFormProp
   const handleSubmit = () => {
     if (submittedRef.current) return
     submittedRef.current = true
-    const answersMap: Record<string, string> = {}
+    const answersMap: MultiQuestionAnswersMap = {}
     questions.forEach((q, idx) => {
       if (q.multiSelect) {
-        const chosen = multiSelectByIdx[idx] || []
-        // JSON-encode multi-select answers so the wire shape
-        // (Record<string,string>) is preserved. The server's
-        // respondToQuestion JSON.parse splits this back into per-option
-        // digits + Tab to commit + advance.
-        answersMap[q.question] = JSON.stringify(chosen)
+        // #4735 — emit multi-select as a native `string[]` via the
+        // widened wire shape. Pre-#4735 dashboards JSON.stringified the
+        // array so the schema (`Record<string,string>`) accepted it;
+        // the server side already handled both forms (the TUI driver
+        // parses JSON or comma-joined strings; the SDK path passes the
+        // value through unchanged). Sending arrays natively gives the
+        // SDK canUseTool callback the structured shape it expects
+        // without a JSON.parse hop.
+        answersMap[q.question] = multiSelectByIdx[idx] || []
       } else {
         const chosen = singleSelectByIdx[idx]
         if (chosen != null) answersMap[q.question] = chosen

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -73,6 +73,7 @@ import {
   markServerConnected,
 } from './server-registry';
 import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, withJitter } from './utils';
+import { formatQuestionAnswerSummary } from '../utils/questionAnswerSummary';
 import {
   setStore,
   wsSend,
@@ -1564,12 +1565,19 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     //   Multi-select values flow through as native arrays — the
     //   summary helper flattens them to comma-joined labels so the
     //   string-only `answer` field stays readable.
+    //
+    //   Delegate to `formatQuestionAnswerSummary` so the legacy
+    //   JSON-stringified array envelope (pre-#4735 wire: a single
+    //   value like `'["App","Tests"]'` for multi-select) is also
+    //   flattened here — otherwise the terminal echo + the required
+    //   string `answer` field can leak `["App","Tests"]` JSON syntax
+    //   when mixed-version rehydrated state replays an old answersMap.
+    //   The helper detects array-shaped values AND JSON-stringified
+    //   arrays and renders both the same way (comma-joined labels).
     const isMultiAnswer = typeof answer !== 'string'
-    const answerSummary = isMultiAnswer
-      ? Object.entries(answer as Record<string, string | string[]>)
-          .map(([q, v]) => `${q}: ${Array.isArray(v) ? v.join(', ') : v}`)
-          .join(' | ')
-      : (answer as string);
+    const answerSummary = formatQuestionAnswerSummary(
+      answer as string | Record<string, string | string[]>,
+    );
     const payload: Record<string, unknown> = { type: 'user_question_response', answer: answerSummary };
     if (isMultiAnswer) {
       payload.answers = answer;

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1549,20 +1549,26 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }));
   },
 
-  sendUserQuestionResponse: (answer: string | Record<string, string>, toolUseId?: string) => {
+  sendUserQuestionResponse: (answer: string | Record<string, string | string[]>, toolUseId?: string) => {
     const { socket, activeSessionId, sessionStates } = get();
-    // #4604 Chunk B — split the wire payload by call shape:
+    // #4604 Chunk B / #4735 — split the wire payload by call shape:
     // - string `answer`: legacy single-question / free-text path. Wire
     //   shape stays `{ type, answer, toolUseId? }` so older servers
     //   keep working without schema migration.
-    // - Record `answer`: multi-question form (Chunk B). Populate the
-    //   `answers` field (protocol already supports it) AND a string
+    // - Record `answer`: multi-question form. Populate the `answers`
+    //   field (`UserQuestionResponseSchema` accepts
+    //   `Record<string, string | string[]>` per #4735) AND a string
     //   `answer` summary so a server running an older build that only
     //   reads `answer` falls through to its default-to-option-1 path
     //   (a noisy WARN in chroxy.log) instead of stalling the form.
+    //   Multi-select values flow through as native arrays — the
+    //   summary helper flattens them to comma-joined labels so the
+    //   string-only `answer` field stays readable.
     const isMultiAnswer = typeof answer !== 'string'
     const answerSummary = isMultiAnswer
-      ? Object.entries(answer as Record<string, string>).map(([q, v]) => `${q}: ${v}`).join(' | ')
+      ? Object.entries(answer as Record<string, string | string[]>)
+          .map(([q, v]) => `${q}: ${Array.isArray(v) ? v.join(', ') : v}`)
+          .join(' | ')
       : (answer as string);
     const payload: Record<string, unknown> = { type: 'user_question_response', answer: answerSummary };
     if (isMultiAnswer) {

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1433,6 +1433,49 @@ describe('sendUserQuestionResponse Output-tab echo (#4296)', () => {
     expect(terminalRawBuffer).not.toContain('User answered:');
   });
 
+  // #4735 — answerSummary flattens BOTH native string[] values AND the
+  // legacy JSON-stringified array envelope (pre-#4735 wire). Without
+  // this, a mixed-version replay where an old dashboard had stashed a
+  // JSON-stringified answer in local storage would leak `["App","Tests"]`
+  // syntax through the terminal echo and the `answer` summary field.
+  it('flattens legacy JSON-stringified array envelopes in the answer summary (#4735 back-compat)', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    const legacyAnswersMap = {
+      'Which targets?': JSON.stringify(['App', 'Tests']),
+      'Confirm?': 'Yes',
+    };
+    useConnectionStore.getState().sendUserQuestionResponse(legacyAnswersMap, 'toolu_legacy');
+
+    expect(sent).toHaveLength(1);
+    const payload = sent[0] as { type: string; answer: string; answers: Record<string, unknown>; toolUseId: string };
+    expect(payload.type).toBe('user_question_response');
+    // Wire `answers` field passes the legacy JSON-string shape through
+    // unchanged (server back-compat for old encoders).
+    expect(payload.answers).toEqual(legacyAnswersMap);
+    // Summary string flattens BOTH the legacy JSON-string envelope and
+    // any native string[] values for the readable `answer` field.
+    expect(payload.answer).toBe(
+      'Which targets?: App, Tests | Confirm?: Yes',
+    );
+    // Terminal echo carries the flattened summary, NOT the JSON syntax.
+    const { terminalBuffer } = useConnectionStore.getState();
+    expect(terminalBuffer).toContain('User answered: Which targets?: App, Tests | Confirm?: Yes');
+    expect(terminalBuffer).not.toContain('["App"');
+  });
+
   // #4735 — multi-question multi-select wire format. The widened wire
   // (UserQuestionResponseSchema) accepts `string | string[]` per question.
   // The store should forward the answers map shape verbatim AND populate

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1432,6 +1432,52 @@ describe('sendUserQuestionResponse Output-tab echo (#4296)', () => {
     // nothing.
     expect(terminalRawBuffer).not.toContain('User answered:');
   });
+
+  // #4735 — multi-question multi-select wire format. The widened wire
+  // (UserQuestionResponseSchema) accepts `string | string[]` per question.
+  // The store should forward the answers map shape verbatim AND populate
+  // the `answer` summary field with a comma-joined flattening of any
+  // array values so older servers reading only `answer` still see a
+  // human-readable line.
+  it('forwards multi-question Record<string, string | string[]> verbatim and flattens arrays in the answer summary (#4735)', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    const answersMap = {
+      'Which release strategy?': 'Patch',
+      'Which targets?': ['App', 'Tests'],
+      'Confirm?': 'Yes',
+    };
+    useConnectionStore.getState().sendUserQuestionResponse(answersMap, 'toolu_multi');
+
+    expect(sent).toHaveLength(1);
+    const payload = sent[0] as { type: string; answer: string; answers: Record<string, unknown>; toolUseId: string };
+    expect(payload.type).toBe('user_question_response');
+    expect(payload.toolUseId).toBe('toolu_multi');
+    // answers field passes the map through unchanged — arrays stay arrays.
+    expect(payload.answers).toEqual({
+      'Which release strategy?': 'Patch',
+      'Which targets?': ['App', 'Tests'],
+      'Confirm?': 'Yes',
+    });
+    expect(Array.isArray(payload.answers['Which targets?'])).toBe(true);
+    // Summary string flattens arrays as comma-joined labels so the
+    // string-only `answer` field stays readable on older servers.
+    expect(payload.answer).toBe(
+      'Which release strategy?: Patch | Which targets?: App, Tests | Confirm?: Yes',
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -629,14 +629,17 @@ export interface ConnectionState {
    * requestId — last write wins. */
   markPermissionResolved: (requestId: string, decision: PermissionDecision) => void;
   /**
-   * #4604 Chunk B — answer may be either a plain string (single-question /
-   * free-text path, back-compat) or a `Record<string,string>` map
-   * (multi-question form, keyed by question text with multi-select values
-   * JSON-stringified arrays). The Record path populates the wire's
-   * `answers` field; both paths populate `answer` with a human-readable
-   * summary so older servers stay functional.
+   * #4604 Chunk B / #4735 — answer may be either a plain string
+   * (single-question / free-text path, back-compat) or a
+   * `Record<string, string | string[]>` map (multi-question form, keyed
+   * by question text). Multi-select values are native string arrays per
+   * the widened wire (#4735); pre-#4735 builds JSON-stringified the
+   * array into a single string for back-compat (still accepted by the
+   * server). The Record path populates the wire's `answers` field; both
+   * paths populate `answer` with a human-readable summary so older
+   * servers stay functional.
    */
-  sendUserQuestionResponse: (answer: string | Record<string, string>, toolUseId?: string) => 'sent' | 'queued' | false;
+  sendUserQuestionResponse: (answer: string | Record<string, string | string[]>, toolUseId?: string) => 'sent' | 'queued' | false;
   markPromptAnswered: (messageId: string, answer: string) => void;
   markPromptAnsweredByRequestId: (requestId: string, answer: string) => void;
   setModel: (model: string) => void;

--- a/packages/dashboard/src/utils/questionAnswerSummary.test.ts
+++ b/packages/dashboard/src/utils/questionAnswerSummary.test.ts
@@ -116,4 +116,45 @@ describe('formatQuestionAnswerSummary', () => {
       )
     })
   })
+
+  // #4735 — per-question wire was widened to
+  // `Record<string, string | string[]>` so multi-select answers can be
+  // emitted as native arrays. The summary helper renders the array form
+  // the same way as the pre-#4735 JSON-stringified form so mixed-version
+  // rehydrated state stays readable end-to-end.
+  describe('native string[] multi-select (#4735)', () => {
+    it('renders a native string[] multi-select as comma-joined labels', () => {
+      const answer = {
+        'Which areas?': ['App', 'Tests'],
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'Which areas?: App, Tests',
+      )
+    })
+
+    it('renders a mixed string + string[] payload readably', () => {
+      const answer = {
+        'Which release strategy?': 'Minor',
+        'Which areas?': ['App', 'Tests', 'Docs'],
+        'Confirm?': 'Yes',
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe(
+        'Which release strategy?: Minor | Which areas?: App, Tests, Docs | Confirm?: Yes',
+      )
+    })
+
+    it('renders an empty native string[] as an empty value', () => {
+      const answer = {
+        'Which areas?': [],
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe('Which areas?: ')
+    })
+
+    it('renders a single-item native string[] without brackets or quotes', () => {
+      const answer = {
+        'Which areas?': ['App'],
+      }
+      expect(formatQuestionAnswerSummary(answer)).toBe('Which areas?: App')
+    })
+  })
 })

--- a/packages/dashboard/src/utils/questionAnswerSummary.ts
+++ b/packages/dashboard/src/utils/questionAnswerSummary.ts
@@ -8,27 +8,32 @@
  *
  * 1. `string` — the legacy single-question / free-text path. Returned
  *    verbatim.
- * 2. `Record<string,string>` — the multi-question form path (#4604
- *    Chunk B). One entry per question, keyed by question text.
- *    Multi-select values arrive as JSON-stringified string arrays
- *    (see `MultiQuestionForm.handleSubmit` — the wire shape is
- *    `Record<string,string>`, and the server's `respondToQuestion`
- *    JSON.parse splits it back). The summary helper detects and
- *    pretty-prints those arrays as `App, Tests` instead of leaking
- *    `["App","Tests"]` JSON syntax into the UX copy.
+ * 2. `Record<string, string | string[]>` — the multi-question form path
+ *    (#4604 Chunk B, widened in #4735). One entry per question, keyed
+ *    by question text. Multi-select values arrive as native `string[]`
+ *    arrays via the post-#4735 wire (`UserQuestionResponseSchema`
+ *    accepts `string | string[]` per question). The summary helper
+ *    pretty-prints those arrays as `App, Tests`.
  *
- * Non-array JSON shapes (objects, numbers) are kept as their raw
- * stringified form — `MultiQuestionForm` only ever JSON-encodes
- * arrays, so anything else didn't come from the form and we'd rather
- * surface it as-is than mangle it.
+ * Back-compat: pre-#4735 dashboards JSON-stringified multi-select
+ * arrays into a single string (`["App","Tests"]`) so the wire shape
+ * stayed `Record<string,string>`. The helper still recognises that
+ * encoding and renders it the same way as the native-array form so
+ * mixed-version rehydrated state stays readable. Non-array JSON shapes
+ * (objects, numbers) are kept as their raw stringified form — only
+ * arrays trigger the pretty-print path.
  */
 
 /**
- * Pretty-print a single answer value. If the value parses as a JSON
- * array of primitives we render it as a comma-joined list (no
- * brackets, no quotes); otherwise the value is returned unchanged.
+ * Pretty-print a single answer value. Arrays render as comma-joined
+ * label lists (no brackets, no quotes); a JSON-stringified array string
+ * (pre-#4735 wire) is parsed and rendered the same way; everything else
+ * is returned unchanged.
  */
-function formatMultiSelectValue(value: string): string {
+function formatAnswerValue(value: string | string[]): string {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item)).join(', ')
+  }
   // Cheap pre-check to avoid JSON.parse-ing every short-string answer.
   if (!value.startsWith('[')) return value
   let parsed: unknown
@@ -42,10 +47,10 @@ function formatMultiSelectValue(value: string): string {
 }
 
 export function formatQuestionAnswerSummary(
-  answer: string | Record<string, string>,
+  answer: string | Record<string, string | string[]>,
 ): string {
   if (typeof answer === 'string') return answer
   return Object.entries(answer)
-    .map(([question, value]) => `${question}: ${formatMultiSelectValue(value)}`)
+    .map(([question, value]) => `${question}: ${formatAnswerValue(value)}`)
     .join(' | ')
 }

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -338,10 +338,26 @@ export declare const NotificationPrefsSetSchema: z.ZodObject<{
         bypassCategories: z.ZodOptional<z.ZodArray<z.ZodString>>;
     }, z.core.$strip>;
 }, z.core.$loose>;
+/**
+ * #4735 — per-question answer wire format.
+ *
+ * `answers` is a map keyed by question text. Values are either:
+ * - `string` — single-select label or a free-form ("Other"/text) answer
+ * - `string[]` — multi-select labels (one entry per selected option)
+ *
+ * Pre-#4735 clients JSON-stringified multi-select arrays into a single
+ * string so the wire shape `Record<string, string>` was preserved; the
+ * widened union accepts the native array form so newer dashboard / app
+ * builds can submit multi-select answers without the JSON envelope. The
+ * server-side consumers (`PermissionManager.respondToQuestion`,
+ * `ClaudeTuiSession.respondToQuestion`) already accept both shapes —
+ * see `resolveQuestionDigits` in `claude-tui-session.js` for the TUI
+ * path that handles the array variant directly.
+ */
 export declare const UserQuestionResponseSchema: z.ZodObject<{
     type: z.ZodLiteral<"user_question_response">;
     answer: z.ZodString;
-    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
+    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>>>;
     toolUseId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const ListDirectorySchema: z.ZodObject<{
@@ -700,7 +716,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"user_question_response">;
     answer: z.ZodString;
-    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
+    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>>>;
     toolUseId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_directory">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -368,10 +368,29 @@ export const NotificationPrefsSetSchema = z.object({
     requestId: z.string().max(128).optional(),
     prefs: NotificationPrefsPatchSchema,
 }).passthrough();
+/**
+ * #4735 — per-question answer wire format.
+ *
+ * `answers` is a map keyed by question text. Values are either:
+ * - `string` — single-select label or a free-form ("Other"/text) answer
+ * - `string[]` — multi-select labels (one entry per selected option)
+ *
+ * Pre-#4735 clients JSON-stringified multi-select arrays into a single
+ * string so the wire shape `Record<string, string>` was preserved; the
+ * widened union accepts the native array form so newer dashboard / app
+ * builds can submit multi-select answers without the JSON envelope. The
+ * server-side consumers (`PermissionManager.respondToQuestion`,
+ * `ClaudeTuiSession.respondToQuestion`) already accept both shapes —
+ * see `resolveQuestionDigits` in `claude-tui-session.js` for the TUI
+ * path that handles the array variant directly.
+ */
 export const UserQuestionResponseSchema = z.object({
     type: z.literal('user_question_response'),
     answer: z.string().max(100_000),
-    answers: z.record(z.string(), z.string().max(100_000)).refine((obj) => Object.keys(obj).length <= 100, { message: 'Too many answers (max 100)' }).optional(),
+    answers: z.record(z.string(), z.union([
+        z.string().max(100_000),
+        z.array(z.string().max(100_000)).max(100),
+    ])).refine((obj) => Object.keys(obj).length <= 100, { message: 'Too many answers (max 100)' }).optional(),
     toolUseId: z.string().max(256).optional(),
 });
 export const ListDirectorySchema = z.object({

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -415,10 +415,32 @@ export const NotificationPrefsSetSchema = z.object({
   prefs: NotificationPrefsPatchSchema,
 }).passthrough()
 
+/**
+ * #4735 — per-question answer wire format.
+ *
+ * `answers` is a map keyed by question text. Values are either:
+ * - `string` — single-select label or a free-form ("Other"/text) answer
+ * - `string[]` — multi-select labels (one entry per selected option)
+ *
+ * Pre-#4735 clients JSON-stringified multi-select arrays into a single
+ * string so the wire shape `Record<string, string>` was preserved; the
+ * widened union accepts the native array form so newer dashboard / app
+ * builds can submit multi-select answers without the JSON envelope. The
+ * server-side consumers (`PermissionManager.respondToQuestion`,
+ * `ClaudeTuiSession.respondToQuestion`) already accept both shapes —
+ * see `resolveQuestionDigits` in `claude-tui-session.js` for the TUI
+ * path that handles the array variant directly.
+ */
 export const UserQuestionResponseSchema = z.object({
   type: z.literal('user_question_response'),
   answer: z.string().max(100_000),
-  answers: z.record(z.string(), z.string().max(100_000)).refine(
+  answers: z.record(
+    z.string(),
+    z.union([
+      z.string().max(100_000),
+      z.array(z.string().max(100_000)).max(100),
+    ]),
+  ).refine(
     (obj) => Object.keys(obj).length <= 100,
     { message: 'Too many answers (max 100)' }
   ).optional(),

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -1638,4 +1638,76 @@ describe('@chroxy/protocol schemas', () => {
       assert.ok(ByokClearCredentialsSchema.safeParse({ type: 'byok_clear_credentials' }).success)
     })
   })
+
+  // #4735 — per-question answer wire format. Values may be either a
+  // string (single-select / free-form) or string[] (multi-select). The
+  // back-compat string-only shape must still validate; the new array
+  // shape must validate too.
+  describe('UserQuestionResponseSchema per-question answer values (#4735)', () => {
+    it('accepts string answers (back-compat single-select / free-form)', async () => {
+      const { UserQuestionResponseSchema } = await import('../src/schemas/client.ts')
+      const result = UserQuestionResponseSchema.safeParse({
+        type: 'user_question_response',
+        answer: 'Patch',
+        answers: { 'Which release strategy?': 'Patch', 'Confirm?': 'Yes' },
+      })
+      assert.ok(result.success, JSON.stringify(result))
+    })
+
+    it('accepts string[] answers (multi-select native array)', async () => {
+      const { UserQuestionResponseSchema } = await import('../src/schemas/client.ts')
+      const result = UserQuestionResponseSchema.safeParse({
+        type: 'user_question_response',
+        answer: 'App, Tests',
+        answers: { 'Which targets?': ['App', 'Tests'] },
+      })
+      assert.ok(result.success, JSON.stringify(result))
+    })
+
+    it('accepts mixed string and string[] across questions', async () => {
+      const { UserQuestionResponseSchema } = await import('../src/schemas/client.ts')
+      const result = UserQuestionResponseSchema.safeParse({
+        type: 'user_question_response',
+        answer: 'summary',
+        answers: {
+          'Which release strategy?': 'Patch',
+          'Which targets?': ['App', 'Tests'],
+          'Confirm?': 'Yes',
+        },
+      })
+      assert.ok(result.success, JSON.stringify(result))
+    })
+
+    it('rejects non-string array entries', async () => {
+      const { UserQuestionResponseSchema } = await import('../src/schemas/client.ts')
+      const result = UserQuestionResponseSchema.safeParse({
+        type: 'user_question_response',
+        answer: 'x',
+        answers: { 'q?': [1, 2, 3] },
+      })
+      assert.ok(!result.success)
+    })
+
+    it('caps multi-select array length at 100', async () => {
+      const { UserQuestionResponseSchema } = await import('../src/schemas/client.ts')
+      const big = Array.from({ length: 101 }, (_, i) => `opt${i}`)
+      const result = UserQuestionResponseSchema.safeParse({
+        type: 'user_question_response',
+        answer: 'x',
+        answers: { 'q?': big },
+      })
+      assert.ok(!result.success)
+    })
+
+    it('caps individual array entries at 100k chars', async () => {
+      const { UserQuestionResponseSchema } = await import('../src/schemas/client.ts')
+      const huge = 'x'.repeat(100_001)
+      const result = UserQuestionResponseSchema.safeParse({
+        type: 'user_question_response',
+        answer: 'x',
+        answers: { 'q?': [huge] },
+      })
+      assert.ok(!result.success)
+    })
+  })
 })

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2097,8 +2097,10 @@ export class ClaudeTuiSession extends BaseSession {
       if (q.multiSelect) {
         // multi-select expects 0+ choices. Accept array, JSON-encoded
         // array string, or comma-joined list — the wire schema is
-        // string-only (Record<string,string>) so the dashboard encodes
-        // multi-selects as JSON.
+        // `Record<string, string | string[]>` post-#4735 so newer
+        // dashboard / app builds send the native array form; pre-#4735
+        // builds JSON-stringified the array into a single string for
+        // back-compat. Both shapes resolve here.
         let labels = []
         if (Array.isArray(rawAnswer)) {
           labels = rawAnswer.filter((s) => typeof s === 'string')

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -497,6 +497,50 @@ describe('PermissionManager', () => {
       assert.deepEqual(result.updatedInput.answers, { 'Color?': 'Red' })
       assert.ok(!('Unknown?' in result.updatedInput.answers))
     })
+
+    // #4735 — per-question answer wire format. Multi-select answers may
+    // arrive as `string[]` (native array) from #4735+ clients. The
+    // PermissionManager passes the value through to `updatedInput.answers`
+    // unchanged so the SDK's canUseTool callback receives the array as the
+    // value for that question — the SDK accepts both shapes per the
+    // AskUserQuestion contract. Older clients that JSON-stringified the
+    // array continue to flow through as plain strings (unchanged).
+    it('passes string[] answers through to updatedInput.answers (#4735 multi-select native array)', async () => {
+      const questions = [
+        { question: 'Which targets?', multiSelect: true, options: [
+          { label: 'App' }, { label: 'Docs' }, { label: 'Tests' },
+        ] },
+      ]
+      const promise = pm._handleAskUserQuestion({ questions }, null)
+
+      pm.respondToQuestion('summary', { 'Which targets?': ['App', 'Tests'] })
+      const result = await promise
+      assert.deepEqual(result.updatedInput.answers, { 'Which targets?': ['App', 'Tests'] })
+      assert.ok(Array.isArray(result.updatedInput.answers['Which targets?']))
+    })
+
+    it('passes mixed string + string[] answers through unchanged (#4735)', async () => {
+      const questions = [
+        { question: 'Strategy?', options: [{ label: 'Patch' }, { label: 'Minor' }] },
+        { question: 'Targets?', multiSelect: true, options: [
+          { label: 'App' }, { label: 'Docs' },
+        ] },
+        { question: 'Confirm?', options: [{ label: 'Yes' }, { label: 'No' }] },
+      ]
+      const promise = pm._handleAskUserQuestion({ questions }, null)
+
+      pm.respondToQuestion('summary', {
+        'Strategy?': 'Patch',
+        'Targets?': ['App', 'Docs'],
+        'Confirm?': 'Yes',
+      })
+      const result = await promise
+      assert.deepEqual(result.updatedInput.answers, {
+        'Strategy?': 'Patch',
+        'Targets?': ['App', 'Docs'],
+        'Confirm?': 'Yes',
+      })
+    })
   })
 
   // -- clearAll --


### PR DESCRIPTION
## Summary

- Widens `UserQuestionResponseSchema.answers` from `Record<string, string>` to `Record<string, string | string[]>` so multi-select AskUserQuestion answers can transit as native arrays. Pre-#4735 dashboards JSON-stringified the array into a single string for back-compat; the server already accepted both shapes.
- Adds an `allowMultiQuestion` opt-in on `QuestionPrompt`. When `true` (SDK / BYOK / Codex sessions) the interactive `MultiQuestionForm` renders directly; when `false` (TUI sessions whose permission-hook denies multi-question tool_uses) the #4666 deferred notice stays in place. App.tsx derives the flag from `session.provider !== 'claude-tui'`.
- `MultiQuestionForm` now emits multi-select answers as native `string[]` arrays end-to-end (dashboard → wire → server → SDK `updatedInput.answers`). Empty multi-selects send `[]` instead of `'[]'`.
- `formatQuestionAnswerSummary` and `sendUserQuestionResponse` handle both the native-array form and the legacy JSON-string envelope so post-answer chips and the `answer` summary string stay readable across mixed-version rehydrated state.
- "Other" / freeform answers continue to flow through as plain strings on the per-question map (the existing free-text path is unchanged — it just emits a string value for that question key).

## Test plan

- [x] `cd packages/protocol && npm test` — 151/151 pass, including 6 new tests pinning the widened schema (string, string[], mixed, rejects non-string array entries, caps array length at 100, caps array entry length at 100k).
- [x] `cd packages/server && node --test tests/permission-manager.test.js tests/sdk-session-question.test.js tests/ws-schemas.test.js` — 252/252 pass, including 2 new tests pinning string[] passthrough through `PermissionManager.respondToQuestion`.
- [x] `cd packages/dashboard && npm test` — 2421/2421 pass, including new coverage for:
  - `MultiQuestionForm` emits native `string[]` for multi-select (empty, single, multi-item) and mixes string single-select with string[] multi-select per question.
  - `QuestionPrompt` renders interactive form when `allowMultiQuestion=true`, deferred notice when `false`, N=1 single-question path unchanged.
  - `formatQuestionAnswerSummary` renders native `string[]` as comma-joined labels alongside the existing JSON-string handling.
  - `sendUserQuestionResponse` forwards mixed string + string[] answersMap verbatim on the wire and flattens arrays in the `answer` summary field.
- [x] `cd packages/dashboard && npm run typecheck` — clean.
- [x] `cd packages/dashboard && npm run build` — clean.

## Out of scope (filed as follow-ups if needed)

- Mobile app parity: `packages/app/src/store/connection.ts` still types `sendQuestionResponse` answer as plain string. The mobile chat doesn't currently render multi-question forms so no behavioural change is needed yet; follow-up issue tracks the wire-type widening if/when the mobile renderer grows multi-question support.
- Maestro multi-question E2E flow — depends on `mock-server.mjs` emitting an SDK-mode multi-question `tool_start` + canUseTool-equivalent path. Will land as a separate PR once #4731 lays the smallest seed (mock canUseTool resolver in test fixtures).

Closes #4735