### PR TITLE
feat(server): SDK end-to-end multi-question AskUserQuestion support

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1487,12 +1487,23 @@ export function App() {
 
     // Question prompt (options or free-text fallback)
     if (storeMsg.type === 'prompt' && storeMsg.options && !storeMsg.requestId) {
+      // #4731 — SDK / BYOK / Codex / Gemini sessions answer multi-question
+      // AskUserQuestion forms natively via the in-process `canUseTool`
+      // permission flow (`packages/server/src/sdk-session.js:30`). TUI /
+      // CLI sessions go through `permission-hook.sh` which still refuses
+      // any multi-question tool_use (#4648), so the deferred-notice render
+      // (#4666) stays the right call there. Anything not explicitly TUI /
+      // CLI is treated as multi-question-capable so newly-added providers
+      // default-on instead of silently regressing.
+      const activeProvider = sessions.find(s => s.sessionId === activeSessionId)?.provider
+      const enableMultiQuestion = activeProvider != null && activeProvider !== 'claude-tui' && activeProvider !== 'claude-cli'
       return (
         <QuestionPrompt
           question={storeMsg.content}
           options={storeMsg.options}
           questions={storeMsg.questions}
           answered={storeMsg.answered}
+          enableMultiQuestion={enableMultiQuestion}
           onSelect={(answer) => {
             // #4604 Chunk B — answer is `string` for single-question /
             // free-text paths and `Record<string,string>` for multi-question

--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -484,6 +484,47 @@ describe('QuestionPrompt', () => {
       // Single-q UI renders the answered summary (free-text variant).
       expect(screen.getByTestId('question-answered-summary')).toBeInTheDocument()
     })
+
+    // #4731 — SDK / BYOK sessions answer multi-question forms natively via
+    // the in-process `canUseTool` permission flow, bypassing the TUI
+    // permission-hook deny. App.tsx looks up the active session's provider
+    // and sets `enableMultiQuestion={true}` for everything except
+    // `claude-tui` / `claude-cli`. When set, the interactive
+    // MultiQuestionForm renders instead of the deferred notice.
+    it('renders MultiQuestionForm (not deferred notice) when enableMultiQuestion is true (#4731)', () => {
+      const onSelect = vi.fn()
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          enableMultiQuestion
+          onSelect={onSelect}
+        />
+      )
+      // Interactive multi-question form renders…
+      expect(screen.getByTestId('question-prompt-multi')).toBeInTheDocument()
+      expect(screen.getByTestId('question-multi-submit')).toBeInTheDocument()
+      // …and the TUI-mode deferred notice is gone.
+      expect(screen.queryByTestId('multi-question-deferred-notice')).not.toBeInTheDocument()
+    })
+
+    it('still renders deferred notice when enableMultiQuestion is explicitly false (#4731)', () => {
+      // Defensive: an explicit `false` from a TUI / CLI session must keep
+      // the existing #4666 behavior so the user can't submit answers that
+      // misroute through the keystroke driver.
+      render(
+        <QuestionPrompt
+          question={q1.question}
+          options={q1.options}
+          questions={multiQuestions}
+          enableMultiQuestion={false}
+          onSelect={vi.fn()}
+        />
+      )
+      expect(screen.getByTestId('multi-question-deferred-notice')).toBeInTheDocument()
+      expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
+    })
   })
 
   // #4666: MultiQuestionForm stays exported but unused by QuestionPrompt.

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -35,6 +35,20 @@ export interface QuestionPromptProps {
    */
   questions?: ChatMessageQuestion[]
   /**
+   * #4731 — opt the active session into the interactive multi-question
+   * form. Pre-#4731, the TUI permission-hook (#4648) refuses any
+   * multi-question AskUserQuestion so the dashboard suppression at
+   * #4666 was always-on. SDK / BYOK sessions never traverse that hook
+   * (in-process `canUseTool` short-circuits it — see
+   * `packages/server/src/sdk-session.js:30`), so they can safely answer
+   * multi-question forms natively. The parent App.tsx looks up the
+   * active session's provider and sets `enableMultiQuestion` true for
+   * everything except `claude-tui` / `claude-cli`; when omitted or
+   * false the legacy deferred-notice render path is kept (back-compat
+   * for tests / older callers).
+   */
+  enableMultiQuestion?: boolean
+  /**
    * Fires with either a plain string (single-question / free-text path,
    * back-compat) or a `Record<string,string>` map (multi-question form,
    * keyed by `question.question` with multi-select values
@@ -43,20 +57,26 @@ export interface QuestionPromptProps {
   onSelect: (answer: string | Record<string, string>) => void
 }
 
-export function QuestionPrompt({ question, options, answered, questions, onSelect }: QuestionPromptProps) {
+export function QuestionPrompt({ question, options, answered, questions, enableMultiQuestion, onSelect }: QuestionPromptProps) {
   const isMultiQuestion = Array.isArray(questions) && questions.length > 1
 
-  // #4666: the permission-hook (`packages/server/hooks/permission-hook.sh`,
-  // shipped in #4648 / v0.9.24) unconditionally denies any AskUserQuestion
-  // whose `questions[]` has length > 1 because the TUI keystroke driver
-  // can't reliably answer combined multi-question forms. The dashboard
-  // still receives the tool_use event though (broadcast is independent of
-  // the permission decision), so rendering the interactive MultiQuestionForm
-  // here would let the user submit answers that route through
-  // `_pendingUserAnswer` to the wrong question slot — see the live trace in
-  // #4666 / #4668. Render a non-interactive placeholder instead so the user
-  // understands chroxy is waiting for Claude to retry one-at-a-time.
+  // #4731: SDK-mode sessions get the interactive MultiQuestionForm because
+  // their `canUseTool` permission flow accepts a per-question `answers`
+  // map natively (`PermissionManager.respondToQuestion`,
+  // `packages/server/src/permission-manager.js:336`). The legacy deferred
+  // notice (#4666) only applies to TUI / CLI sessions where the
+  // permission-hook (`packages/server/hooks/permission-hook.sh`, shipped in
+  // #4648 / v0.9.24) unconditionally denies multi-question forms because
+  // the PTY keystroke driver can't reliably answer them.
   if (isMultiQuestion && answered == null) {
+    if (enableMultiQuestion) {
+      return (
+        <MultiQuestionForm
+          questions={questions}
+          onSelect={(answersMap) => onSelect(answersMap)}
+        />
+      )
+    }
     return <MultiQuestionDeferredNotice count={questions.length} />
   }
 

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -341,7 +341,7 @@ export declare const NotificationPrefsSetSchema: z.ZodObject<{
 export declare const UserQuestionResponseSchema: z.ZodObject<{
     type: z.ZodLiteral<"user_question_response">;
     answer: z.ZodString;
-    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
+    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>>>;
     toolUseId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const ListDirectorySchema: z.ZodObject<{
@@ -700,7 +700,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"user_question_response">;
     answer: z.ZodString;
-    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
+    answers: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<readonly [z.ZodString, z.ZodArray<z.ZodString>]>>>;
     toolUseId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>, z.ZodObject<{
     type: z.ZodLiteral<"list_directory">;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -368,10 +368,30 @@ export const NotificationPrefsSetSchema = z.object({
     requestId: z.string().max(128).optional(),
     prefs: NotificationPrefsPatchSchema,
 }).passthrough();
+/**
+ * #4731 — per-question answer value. Single-select questions arrive as a
+ * plain string; multi-select questions arrive as an array of selected
+ * label values. The server normalizes arrays to the SDK's canonical
+ * comma-separated format inside `PermissionManager.respondToQuestion`
+ * (the SDK's `AskUserQuestionOutput.answers` is typed
+ * `{ [questionText]: string }` and the spec is explicit:
+ * "multi-select answers are comma-separated"). The legacy #4604 Chunk B
+ * dashboard JSON.stringifies multi-select arrays into the string variant —
+ * the server unwraps that shape too, so older dashboards keep working.
+ */
+const UserQuestionAnswerValueSchema = z.union([
+    z.string().max(100_000),
+    // Multi-select array — cap at 32 selections per question to bound
+    // per-answer wire size at the same ~100_000-char ceiling as the string
+    // variant (32 * 4096-char label cap; chroxy never sees forms past 4
+    // options, so 32 is a comfortable safety margin without affecting any
+    // real shape).
+    z.array(z.string().max(4096)).max(32),
+]);
 export const UserQuestionResponseSchema = z.object({
     type: z.literal('user_question_response'),
     answer: z.string().max(100_000),
-    answers: z.record(z.string(), z.string().max(100_000)).refine((obj) => Object.keys(obj).length <= 100, { message: 'Too many answers (max 100)' }).optional(),
+    answers: z.record(z.string(), UserQuestionAnswerValueSchema).refine((obj) => Object.keys(obj).length <= 100, { message: 'Too many answers (max 100)' }).optional(),
     toolUseId: z.string().max(256).optional(),
 });
 export const ListDirectorySchema = z.object({

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -415,10 +415,31 @@ export const NotificationPrefsSetSchema = z.object({
   prefs: NotificationPrefsPatchSchema,
 }).passthrough()
 
+/**
+ * #4731 — per-question answer value. Single-select questions arrive as a
+ * plain string; multi-select questions arrive as an array of selected
+ * label values. The server normalizes arrays to the SDK's canonical
+ * comma-separated format inside `PermissionManager.respondToQuestion`
+ * (the SDK's `AskUserQuestionOutput.answers` is typed
+ * `{ [questionText]: string }` and the spec is explicit:
+ * "multi-select answers are comma-separated"). The legacy #4604 Chunk B
+ * dashboard JSON.stringifies multi-select arrays into the string variant —
+ * the server unwraps that shape too, so older dashboards keep working.
+ */
+const UserQuestionAnswerValueSchema = z.union([
+  z.string().max(100_000),
+  // Multi-select array — cap at 32 selections per question to bound
+  // per-answer wire size at the same ~100_000-char ceiling as the string
+  // variant (32 * 4096-char label cap; chroxy never sees forms past 4
+  // options, so 32 is a comfortable safety margin without affecting any
+  // real shape).
+  z.array(z.string().max(4096)).max(32),
+])
+
 export const UserQuestionResponseSchema = z.object({
   type: z.literal('user_question_response'),
   answer: z.string().max(100_000),
-  answers: z.record(z.string(), z.string().max(100_000)).refine(
+  answers: z.record(z.string(), UserQuestionAnswerValueSchema).refine(
     (obj) => Object.keys(obj).length <= 100,
     { message: 'Too many answers (max 100)' }
   ).optional(),

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -361,7 +361,15 @@ export class PermissionManager extends EventEmitter {
     // downstream synchronous work runs.
     this.emit('permission_resolved', { toolUseId, reason: 'answered' })
 
-    // Build structured answers map: SDK expects { [questionText]: selectedLabel }
+    // Build structured answers map: SDK expects { [questionText]: selectedLabel }.
+    // Per @anthropic-ai/claude-agent-sdk sdk-tools.d.ts (AskUserQuestionOutput.answers,
+    // ~line 2696) the contract is explicit: each value is a plain string,
+    // and multi-select answers are comma-separated. So this layer
+    // normalizes the dashboard's wire shape (native string | string[] post-
+    // #4731, or legacy JSON-stringified arrays from #4604 Chunk B
+    // dashboards) into that canonical string-per-question shape before
+    // resolving the canUseTool Promise — otherwise the model would receive
+    // raw JSON literals like '["A","B"]' as the user's answer text (#4731).
     const answers = {}
     const questions = input.questions || []
     const questionKeys = new Set(questions.map(q => q.question))
@@ -369,7 +377,7 @@ export class PermissionManager extends EventEmitter {
       // Per-question answers provided by the client — only copy known question keys
       for (const key of Object.keys(answersMap)) {
         if (questionKeys.has(key)) {
-          answers[key] = answersMap[key]
+          answers[key] = normalizeAnswerValue(answersMap[key])
         }
       }
     } else if (questions.length > 0) {
@@ -607,4 +615,50 @@ export class PermissionManager extends EventEmitter {
       _fallbackLog.warn(msg)
     }
   }
+}
+
+/**
+ * #4731 — coerce a dashboard-supplied per-question answer value into the
+ * SDK's canonical string shape. The SDK's `AskUserQuestionOutput.answers`
+ * (see `@anthropic-ai/claude-agent-sdk/sdk-tools.d.ts:2696`) types every
+ * value as a plain string with multi-select answers comma-separated.
+ *
+ * Accepted inputs:
+ *   - Array of labels (post-#4731 wire shape from updated dashboards) →
+ *     joined as `"A, B, C"`.
+ *   - JSON-stringified array (`'["A","B"]'` — the legacy #4604 Chunk B
+ *     dashboard JSON.stringifies multi-select arrays to fit the original
+ *     `Record<string,string>` schema) → parsed then joined.
+ *   - Plain string (single-select, freeform, or model-side "Other"
+ *     sentinel) → passed through unchanged.
+ *
+ * Anything else (null, undefined, object, number) coerces to the empty
+ * string — the SDK then receives a null-equivalent answer and the model
+ * surfaces "no preference" semantics, which is safer than throwing and
+ * stalling the canUseTool Promise.
+ */
+function normalizeAnswerValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((v) => String(v ?? '')).join(', ')
+  }
+  if (typeof value === 'string') {
+    // Detect the legacy JSON-stringified-array shape. Bare strings (e.g.
+    // `"Red"`) never look like JSON arrays, so this gate is tight enough
+    // that no plain-string answer is accidentally parsed. The try/catch
+    // means a string that merely starts with `[` but isn't valid JSON
+    // (e.g. someone literally answered `"[note]"`) falls through to the
+    // pass-through return below — no data loss.
+    if (value.length >= 2 && value.startsWith('[') && value.endsWith(']')) {
+      try {
+        const parsed = JSON.parse(value)
+        if (Array.isArray(parsed)) {
+          return parsed.map((v) => String(v ?? '')).join(', ')
+        }
+      } catch {
+        // not JSON — fall through
+      }
+    }
+    return value
+  }
+  return ''
 }

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -498,11 +498,14 @@ describe('PermissionManager', () => {
       assert.ok(!('Unknown?' in result.updatedInput.answers))
     })
 
-    // #4621 — answersMap values may be string[] (native multi-select),
-    // not just string. PermissionManager just forwards the value to the
-    // SDK's updatedInput.answers; the SDK accepts string[] for
-    // multi-select questions.
-    it('forwards string[] answersMap values verbatim for multi-select questions (#4621)', async () => {
+    // #4621 wire shape + #4731 SDK normalization. answersMap values may
+    // arrive as string[] (native multi-select from updated dashboards).
+    // PermissionManager normalizes arrays to the SDK's canonical
+    // comma-separated string shape (see normalizeAnswerValue and
+    // sdk-multi-question-shapes.test.js for the full coverage) because
+    // the SDK's `AskUserQuestionOutput.answers` is typed
+    // `{ [questionText]: string }`. Single-select strings pass through.
+    it('normalizes string[] answersMap values to comma-separated strings for the SDK (#4621 + #4731)', async () => {
       const questions = [
         { question: 'Areas?', multiSelect: true, options: [{ label: 'App' }, { label: 'Tests' }] },
         { question: 'Strategy?', options: [{ label: 'Patch' }, { label: 'Minor' }] },
@@ -515,11 +518,11 @@ describe('PermissionManager', () => {
       })
       const result = await promise
       assert.deepEqual(result.updatedInput.answers, {
-        'Areas?': ['App', 'Tests'],
+        'Areas?': 'App, Tests',
         'Strategy?': 'Minor',
       })
-      assert.ok(Array.isArray(result.updatedInput.answers['Areas?']),
-        'array value should be preserved (not coerced to string)')
+      assert.equal(typeof result.updatedInput.answers['Areas?'], 'string',
+        'multi-select array must be coerced to comma-separated string per SDK contract')
     })
   })
 

--- a/packages/server/tests/sdk-multi-question-shapes.test.js
+++ b/packages/server/tests/sdk-multi-question-shapes.test.js
@@ -1,0 +1,199 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { PermissionManager } from '../src/permission-manager.js'
+
+/**
+ * #4731 — SDK mode end-to-end multi-question AskUserQuestion support.
+ *
+ * SdkSession.respondToQuestion delegates straight through to
+ * PermissionManager.respondToQuestion (`sdk-session.js:1136`), so the
+ * round-trip from the dashboard's wire `answersMap` to the SDK's
+ * `updatedInput.answers` is entirely owned by PermissionManager. These
+ * tests pin the four wedge shapes the TUI driver failed on so the SDK
+ * mode can be enabled with confidence:
+ *
+ *   1. mixed-type        — single-select + multi-select in one form
+ *   2. all-single-select — every question is single-select
+ *   3. all-multi-select  — every question is multi-select
+ *   4. with-Other        — freeform answer for a question whose options
+ *                          list includes the SDK's automatic "Other"
+ *                          sentinel
+ *
+ * The SDK output spec (`@anthropic-ai/claude-agent-sdk/sdk-tools.d.ts:2696`)
+ * is explicit: "The answers provided by the user (question text -> answer
+ * string; multi-select answers are comma-separated)". That dictates the
+ * wire-to-SDK normalization rules pinned below — multi-select arrays from
+ * the dashboard (either native arrays after #4731 schema bump or legacy
+ * JSON-stringified arrays from #4604 Chunk B dashboards) must collapse to
+ * a single comma-separated string per question.
+ */
+
+const silentLog = { info() {}, warn() {} }
+
+function createManager() {
+  return new PermissionManager({ log: silentLog })
+}
+
+describe('SDK multi-question wedge shapes (#4731)', () => {
+  let pm
+
+  beforeEach(() => {
+    pm = createManager()
+  })
+
+  afterEach(() => {
+    pm.destroy()
+  })
+
+  it('mixed-type form: single-select + multi-select answers in one round-trip', async () => {
+    const questions = [
+      { question: 'Color?', header: 'Color', options: [{ label: 'Red' }, { label: 'Blue' }] },
+      { question: 'Features?', header: 'Features', multiSelect: true, options: [{ label: 'Auth' }, { label: 'Tests' }, { label: 'CI' }] },
+    ]
+    const promise = pm._handleAskUserQuestion({ questions }, null)
+
+    // Dashboard sends arrays for multi-select questions (post-#4731 wire)
+    pm.respondToQuestion('', { 'Color?': 'Red', 'Features?': ['Auth', 'Tests'] })
+
+    const result = await promise
+    assert.equal(result.behavior, 'allow')
+    // Per SDK type contract, multi-select arrives as a comma-separated string
+    assert.deepEqual(result.updatedInput.answers, {
+      'Color?': 'Red',
+      'Features?': 'Auth, Tests',
+    })
+  })
+
+  it('all-single-select form: every answer arrives as a plain string', async () => {
+    const questions = [
+      { question: 'Lib?', header: 'Lib', options: [{ label: 'date-fns' }, { label: 'dayjs' }] },
+      { question: 'Style?', header: 'Style', options: [{ label: 'CSS' }, { label: 'Tailwind' }] },
+      { question: 'DB?', header: 'DB', options: [{ label: 'pg' }, { label: 'sqlite' }] },
+    ]
+    const promise = pm._handleAskUserQuestion({ questions }, null)
+
+    pm.respondToQuestion('', { 'Lib?': 'date-fns', 'Style?': 'Tailwind', 'DB?': 'pg' })
+
+    const result = await promise
+    assert.deepEqual(result.updatedInput.answers, {
+      'Lib?': 'date-fns',
+      'Style?': 'Tailwind',
+      'DB?': 'pg',
+    })
+  })
+
+  it('all-multi-select form: every answer is a comma-separated string', async () => {
+    const questions = [
+      { question: 'Features?', header: 'Features', multiSelect: true, options: [{ label: 'A' }, { label: 'B' }] },
+      { question: 'Targets?', header: 'Targets', multiSelect: true, options: [{ label: 'iOS' }, { label: 'Android' }, { label: 'Web' }] },
+    ]
+    const promise = pm._handleAskUserQuestion({ questions }, null)
+
+    pm.respondToQuestion('', {
+      'Features?': ['A', 'B'],
+      'Targets?': ['iOS', 'Web'],
+    })
+
+    const result = await promise
+    assert.deepEqual(result.updatedInput.answers, {
+      'Features?': 'A, B',
+      'Targets?': 'iOS, Web',
+    })
+  })
+
+  it('with-Other / freeform: arbitrary string passes through unchanged', async () => {
+    // The SDK auto-provides an "Other" option whose selection routes a
+    // free-text reply. Per the AskUserQuestionOutput contract, that text
+    // arrives in `answers[questionText]` as a plain string — no schema
+    // transformation, no wrapping. Pin that the freeform text survives
+    // round-trip exactly as the user typed it.
+    const questions = [
+      {
+        question: 'Which framework?',
+        header: 'Framework',
+        options: [{ label: 'React' }, { label: 'Vue' }, { label: 'Other' }],
+      },
+    ]
+    const promise = pm._handleAskUserQuestion({ questions }, null)
+
+    pm.respondToQuestion('', { 'Which framework?': 'Solid.js (via Other)' })
+
+    const result = await promise
+    assert.equal(result.updatedInput.answers['Which framework?'], 'Solid.js (via Other)')
+  })
+
+  it('legacy dashboard JSON-stringified array values are unwrapped to comma-separated strings', async () => {
+    // Pre-#4731 dashboards (and the in-tree #4604 Chunk B MultiQuestionForm)
+    // JSON.stringify multi-select arrays so the wire shape stays
+    // Record<string,string>. The server must transparently unwrap that
+    // legacy shape so the SDK sees the canonical comma-separated string —
+    // otherwise the model receives a raw JSON literal like '["A","B"]' as
+    // the answer text and gets confused. Mixed with a plain-string single-
+    // select to verify each value type is detected independently.
+    const questions = [
+      { question: 'Color?', header: 'Color', options: [{ label: 'Red' }] },
+      { question: 'Features?', header: 'Features', multiSelect: true, options: [{ label: 'A' }, { label: 'B' }] },
+    ]
+    const promise = pm._handleAskUserQuestion({ questions }, null)
+
+    pm.respondToQuestion('', { 'Color?': 'Red', 'Features?': '["A","B"]' })
+
+    const result = await promise
+    assert.deepEqual(result.updatedInput.answers, {
+      'Color?': 'Red',
+      'Features?': 'A, B',
+    })
+  })
+
+  it('regression: single-question happy path unchanged (string answer, no answersMap)', async () => {
+    // The v0.9.4 happy path: dashboard sends a plain string `answer` field
+    // for single-question prompts and no `answers` map. That must still
+    // produce the legacy { [questionText]: <text> } mapping.
+    const questions = [{ question: 'Continue?', header: 'Continue', options: [{ label: 'Yes' }, { label: 'No' }] }]
+    const promise = pm._handleAskUserQuestion({ questions }, null)
+
+    pm.respondToQuestion('Yes')
+
+    const result = await promise
+    assert.equal(result.behavior, 'allow')
+    assert.deepEqual(result.updatedInput.answers, { 'Continue?': 'Yes' })
+  })
+
+  it('empty multi-select array yields an empty string (SDK accepts zero selections)', async () => {
+    // The SDK accepts zero selections for multi-select questions. Per the
+    // comma-separated rule, [] becomes ''. The model is then free to
+    // interpret the empty as "skipped / no preference" — the contract is
+    // owned by the model, not the wire layer.
+    const questions = [
+      { question: 'Optional features?', header: 'Optional', multiSelect: true, options: [{ label: 'A' }] },
+    ]
+    const promise = pm._handleAskUserQuestion({ questions }, null)
+
+    pm.respondToQuestion('', { 'Optional features?': [] })
+
+    const result = await promise
+    assert.equal(result.updatedInput.answers['Optional features?'], '')
+  })
+})
+
+describe('UserQuestionResponseSchema multi-select value (#4731)', () => {
+  it('accepts arrays and strings as per-question answer values', async () => {
+    const { UserQuestionResponseSchema } = await import('../../protocol/dist/schemas/client.js')
+
+    // Pre-#4731 happy path — plain string values
+    const stringOnly = UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: 'Red',
+      answers: { 'Color?': 'Red' },
+    })
+    assert.equal(stringOnly.success, true, 'string-valued answers must still parse')
+
+    // Post-#4731 — array values for multi-select
+    const withArray = UserQuestionResponseSchema.safeParse({
+      type: 'user_question_response',
+      answer: '',
+      answers: { 'Color?': 'Red', 'Features?': ['Auth', 'Tests'] },
+    })
+    assert.equal(withArray.success, true, `array-valued multi-select answers must parse (got: ${JSON.stringify(withArray.error?.issues)})`)
+  })
+})

--- a/packages/server/tests/sdk-multi-question-shapes.test.js
+++ b/packages/server/tests/sdk-multi-question-shapes.test.js
@@ -178,7 +178,11 @@ describe('SDK multi-question wedge shapes (#4731)', () => {
 
 describe('UserQuestionResponseSchema multi-select value (#4731)', () => {
   it('accepts arrays and strings as per-question answer values', async () => {
-    const { UserQuestionResponseSchema } = await import('../../protocol/dist/schemas/client.js')
+    // Import via the package entry rather than reaching into the dist
+    // layout so this test follows the same pattern as other server tests
+    // (e.g. tests/ws-schemas.test.js:1001) and stays decoupled from the
+    // package's internal build structure. Per Copilot review on PR #4763.
+    const { UserQuestionResponseSchema } = await import('@chroxy/protocol')
 
     // Pre-#4731 happy path — plain string values
     const stringOnly = UserQuestionResponseSchema.safeParse({


### PR DESCRIPTION
## Summary

- SDK / BYOK sessions can now answer multi-question `AskUserQuestion` forms natively via the in-process `canUseTool` permission flow. Previously the deny path in #4648 (permission-hook) and the suppression in #4666 (dashboard) were leaking into SDK mode even though SDK sessions never traverse the broken PTY keystroke driver they were written against.
- Schema extended: `UserQuestionResponseSchema.answers` accepts per-question `string | string[]` (multi-select). Server normalizes arrays to comma-separated strings per the SDK's `AskUserQuestionOutput.answers` contract.
- `PermissionManager.respondToQuestion` unwraps native arrays, JSON-stringified arrays (legacy #4604 Chunk B wire shape), and plain strings — so older dashboards keep working without coordinated client updates.
- `QuestionPrompt` gains an `enableMultiQuestion` opt-in prop; App.tsx wires it based on the active session's provider (everything except `claude-tui` / `claude-cli`).
- Refuse-path audit per parent #4654 acceptance criteria:
  - `#4648` permission-hook → confirmed TUI-only by `CHROXY_PORT` gate (SDK never sets it).
  - `#4666` dashboard suppression → was leaking into SDK; gated on session provider here.

## Test plan

- [x] `cd packages/server && PATH=\".../node@22/bin:\$PATH\" node --test tests/sdk-multi-question-shapes.test.js` — 8/8 pass covering the four wedge shapes from the parent audit (mixed-type, all-single-select, all-multi-select, with-Other) + schema parse + regression for single-question happy path + JSON-array unwrap + empty multi-select.
- [x] `cd packages/server && node --test tests/permission-manager.test.js tests/sdk-session-question.test.js tests/sdk-session.test.js` — 237/237 pass (no regressions in permission / SDK session test suites).
- [x] `cd packages/protocol && npm test` — 145/145 pass (schema change clean).
- [x] `cd packages/dashboard && npm test` — 2411/2411 pass (was 2409, +2 for the `enableMultiQuestion` gate).
- [x] `cd packages/dashboard && tsc --noEmit` — clean.
- [ ] Live smoke evidence per AC6 — requires manual BYOK session + 4 AskUserQuestion shapes (mixed-type, all-single-select, all-multi-select, with-Other). Tracked separately; the integration tests here exercise the exact same `PermissionManager.respondToQuestion` round-trip that the live SDK calls into.

## Wire compatibility

The schema extension is additive — pre-#4731 dashboards send JSON-stringified arrays for multi-select; post-#4731 dashboards can send native arrays. The server normalizes both shapes into the SDK's canonical comma-separated format. No client coordination required.

Closes #4731