### PR TITLE
refactor(server): extract ClaudeStreamParser to dedupe wire-format parsing

### DIFF
--- a/packages/server/src/claude-stream-parser.js
+++ b/packages/server/src/claude-stream-parser.js
@@ -1,0 +1,106 @@
+/**
+ * Claude wire-format stream parser.
+ *
+ * Shared by CliSession (which parses `--include-partial-messages` JSON
+ * stream events from `claude -p`) and SdkSession (which receives full
+ * assistant message blocks from the Agent SDK) so the two providers
+ * cannot drift in how they interpret Anthropic streaming-protocol
+ * primitives.
+ *
+ * Pure functions only — no I/O, no state. Callers own the per-turn
+ * context and event emission; the parser just translates wire-format
+ * input into emit-ready payloads / semantic descriptors.
+ *
+ * Public API:
+ *
+ *   extractToolInputSemantics(toolName, parsedInput)
+ *     -> { kind, payload } | null
+ *     Single source for Task / AskUserQuestion / EnterPlanMode /
+ *     ExitPlanMode tool-input interpretation. `parsedInput` is the
+ *     already-JSON-parsed object (CliSession parses accumulated
+ *     partial_json chunks; SdkSession receives `block.input` directly).
+ *
+ *   buildToolStartData(messageId, contentBlock)
+ *     -> { messageId, toolUseId, tool, input, serverName? }
+ *     Shape of the `tool_start` event for both providers. Reuses a
+ *     single derived toolId for both `messageId` and `toolUseId` so
+ *     the wire schema (`ServerToolStartSchema.toolUseId: z.string()`)
+ *     holds even on the defensive fallback path when `content_block.id`
+ *     is absent.
+ */
+
+import { parseMcpToolName } from './mcp-tools.js'
+
+/**
+ * Tools whose input fields drive session-level state (plan mode, agent
+ * tracking, user-question prompts). The semantics returned here are
+ * applied by the caller to its own state (CliSession or SdkSession)
+ * via the `kind` discriminator.
+ *
+ * @param {string} toolName
+ * @param {unknown} parsedInput - JSON-parsed tool input object, or null
+ * @returns {{ kind: 'ask_user_question' | 'task' | 'enter_plan' | 'exit_plan', payload: object } | null}
+ */
+export function extractToolInputSemantics(toolName, parsedInput) {
+  if (!toolName) return null
+  const input = parsedInput && typeof parsedInput === 'object' ? parsedInput : {}
+
+  switch (toolName) {
+    case 'AskUserQuestion':
+      return {
+        kind: 'ask_user_question',
+        payload: { questions: input.questions },
+      }
+
+    case 'Task': {
+      const description = (typeof input.description === 'string'
+        ? input.description
+        : 'Background task').slice(0, 200)
+      return {
+        kind: 'task',
+        payload: { description },
+      }
+    }
+
+    case 'EnterPlanMode':
+      return { kind: 'enter_plan', payload: {} }
+
+    case 'ExitPlanMode': {
+      const allowedPrompts = Array.isArray(input.allowedPrompts)
+        ? input.allowedPrompts
+        : []
+      return { kind: 'exit_plan', payload: { allowedPrompts } }
+    }
+
+    default:
+      return null
+  }
+}
+
+/**
+ * Build the `tool_start` event payload from a `content_block_start`
+ * event's content_block object.
+ *
+ * @param {string} messageId - The current turn-level messageId, used
+ *   as the fallback toolId source when `contentBlock.id` is missing.
+ * @param {{ id?: string, name: string, type: string }} contentBlock
+ * @returns {{ messageId: string, toolUseId: string, tool: string, input: null, serverName?: string }}
+ */
+export function buildToolStartData(messageId, contentBlock) {
+  // Use the tool's content_block.id as the tool_start messageId so each
+  // tool in a multi-tool turn has a distinct id. Sharing the turn-level
+  // messageId across tools collides with the post-tool stream_start id
+  // and corrupts client message state. Reused for toolUseId so the wire
+  // schema (`ServerToolStartSchema.toolUseId: z.string()`) holds even
+  // on the defensive fallback path.
+  const toolId = contentBlock.id || `${messageId}-tool`
+  const data = {
+    messageId: toolId,
+    toolUseId: toolId,
+    tool: contentBlock.name,
+    input: null,
+  }
+  const mcp = parseMcpToolName(contentBlock.name)
+  if (mcp) data.serverName = mcp.serverName
+  return data
+}

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -871,10 +871,18 @@ export class CliSession extends BaseSession {
   _applyToolInputSemantics(ctx) {
     const toolName = ctx.currentToolName
     const toolUseId = ctx.currentToolUseId
+    // `parseSucceeded` tracks whether the buffered JSON parsed without
+    // throwing — distinct from `parsed != null`, because JSON.parse can
+    // legally return falsy values (0, false, '', null) and the
+    // pre-extraction code emitted on any successful parse regardless of
+    // the parsed value. Gating on truthiness would silently drop those
+    // payloads. (#4774 Copilot review)
     let parsed = null
+    let parseSucceeded = false
     if (ctx.toolInputChunks) {
       try {
         parsed = JSON.parse(ctx.toolInputChunks)
+        parseSucceeded = true
       } catch (err) {
         // Parse-failure logging matches the per-tool pre-extraction
         // messages so existing log scraping continues to work.
@@ -888,8 +896,8 @@ export class CliSession extends BaseSession {
         }
         if (toolName === 'ExitPlanMode') {
           log.warn(`Failed to parse ExitPlanMode input: ${err.message}`)
-          // ExitPlanMode falls through with parsed=null so the empty
-          // allowedPrompts default still applies.
+          // ExitPlanMode falls through with parseSucceeded=false so the
+          // empty allowedPrompts default still applies.
         }
       }
     }
@@ -899,9 +907,11 @@ export class CliSession extends BaseSession {
 
     switch (semantics.kind) {
       case 'ask_user_question': {
-        // The pre-extraction code required successfully-parsed input to
-        // proceed; preserve that by gating on a non-null parsed payload.
-        if (!parsed) return
+        // The pre-extraction code required a non-empty buffer AND a
+        // successful parse before emitting; preserve that gate via
+        // `parseSucceeded` (truthiness of `parsed` would drop legal
+        // falsy JSON values).
+        if (!parseSucceeded) return
         log.info(`AskUserQuestion detected (${toolUseId})`)
         this._waitingForAnswer = true
         this.emit('user_question', {
@@ -911,7 +921,7 @@ export class CliSession extends BaseSession {
         return
       }
       case 'task': {
-        if (!parsed) return
+        if (!parseSucceeded) return
         const agentInfo = {
           toolUseId,
           description: semantics.payload.description,

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -10,7 +10,7 @@ import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContex
 import { forceKill } from './platform.js'
 import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
-import { parseMcpToolName } from './mcp-tools.js'
+import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
 import { createLogger } from './logger.js'
@@ -716,26 +716,14 @@ export class CliSession extends BaseSession {
               ctx.toolInputChunks = ''
               ctx.toolInputBytes = 0
               ctx.toolInputOverflow = false
-              // Use the tool's content_block.id as the tool_start messageId
-              // so each tool in a multi-tool turn has a distinct id. Sharing
-              // the turn-level messageId across tools collides with the
-              // post-tool stream_start id and corrupts client message state.
-              // Mirrors sdk-session.js. Reused for toolUseId so the wire
-              // schema (`ServerToolStartSchema.toolUseId: z.string()`) holds
-              // even on the defensive fallback path.
-              const toolId = event.content_block.id || `${messageId}-tool`
-              const toolStartData = {
-                messageId: toolId,
-                toolUseId: toolId,
-                tool: event.content_block.name,
-                input: null,
-              }
-              const mcp = parseMcpToolName(event.content_block.name)
-              if (mcp) toolStartData.serverName = mcp.serverName
+              // Delegate to the shared parser so CliSession + SdkSession
+              // emit identical tool_start payloads (see
+              // claude-stream-parser.js for the toolId-derivation rules).
+              const toolStartData = buildToolStartData(messageId, event.content_block)
               this.emit('tool_start', toolStartData)
               // #4628: track so _clearMessageState (or _emitResult) can
               // sweep on turn-end if the API ever drops a tool_result.
-              this._trackToolStart(toolId, event.content_block.name)
+              this._trackToolStart(toolStartData.toolUseId, event.content_block.name)
             }
             break
           }
@@ -771,52 +759,8 @@ export class CliSession extends BaseSession {
           }
 
           case 'content_block_stop': {
-            // toolInputChunks is falsy ('') after overflow discard, so the
-            // AskUserQuestion parse path is naturally skipped on overflow.
-            if (ctx && ctx.currentToolName === 'AskUserQuestion' && ctx.toolInputChunks) {
-              try {
-                const input = JSON.parse(ctx.toolInputChunks)
-                log.info(`AskUserQuestion detected (${ctx.currentToolUseId})`)
-                this._waitingForAnswer = true
-                this.emit('user_question', {
-                  toolUseId: ctx.currentToolUseId,
-                  questions: input.questions,
-                })
-              } catch (err) {
-                log.error(`Failed to parse AskUserQuestion input: ${err.message}`)
-              }
-            }
-            if (ctx && ctx.currentToolName === 'Task' && ctx.toolInputChunks) {
-              try {
-                const input = JSON.parse(ctx.toolInputChunks)
-                const description = (typeof input.description === 'string'
-                  ? input.description : 'Background task').slice(0, 200)
-                const agentInfo = {
-                  toolUseId: ctx.currentToolUseId,
-                  description,
-                  startedAt: Date.now(),
-                }
-                this._activeAgents.set(ctx.currentToolUseId, agentInfo)
-                this.emit('agent_spawned', agentInfo)
-              } catch (err) {
-                log.warn(`Failed to parse Task tool input: ${err.message}`)
-              }
-            }
-            if (ctx && ctx.currentToolName === 'EnterPlanMode') {
-              this._inPlanMode = true
-              this.emit('plan_started')
-            }
-            if (ctx && ctx.currentToolName === 'ExitPlanMode') {
-              let allowedPrompts = []
-              if (ctx.toolInputChunks) {
-                try {
-                  const input = JSON.parse(ctx.toolInputChunks)
-                  allowedPrompts = Array.isArray(input.allowedPrompts) ? input.allowedPrompts : []
-                } catch (err) {
-                  log.warn(`Failed to parse ExitPlanMode input: ${err.message}`)
-                }
-              }
-              this._planAllowedPrompts = allowedPrompts
+            if (ctx && ctx.currentToolName) {
+              this._applyToolInputSemantics(ctx)
             }
             if (ctx) {
               ctx.currentContentBlockType = null
@@ -903,6 +847,88 @@ export class CliSession extends BaseSession {
         // Message complete — ready for next message
         this._clearMessageState()
         break
+      }
+    }
+  }
+
+  /**
+   * Apply session-state side effects for tools whose accumulated
+   * `toolInputChunks` JSON drives plan-mode flags, agent tracking, or
+   * user-question prompts. Called at `content_block_stop` once the full
+   * tool input has been buffered. Delegates the wire-format parsing to
+   * the shared {@link extractToolInputSemantics} so SdkSession (which
+   * receives the full input directly in `_handleToolUseBlock`) cannot
+   * drift in how it interprets the same tool names.
+   *
+   * `ctx.toolInputChunks` is the empty string after overflow discard, so
+   * AskUserQuestion / Task / ExitPlanMode paths that need a real payload
+   * are naturally skipped on overflow; EnterPlanMode takes the no-input
+   * path and still fires.
+   *
+   * @param {{ currentToolName: string|null, currentToolUseId: string|null, toolInputChunks: string }} ctx
+   * @private
+   */
+  _applyToolInputSemantics(ctx) {
+    const toolName = ctx.currentToolName
+    const toolUseId = ctx.currentToolUseId
+    let parsed = null
+    if (ctx.toolInputChunks) {
+      try {
+        parsed = JSON.parse(ctx.toolInputChunks)
+      } catch (err) {
+        // Parse-failure logging matches the per-tool pre-extraction
+        // messages so existing log scraping continues to work.
+        if (toolName === 'AskUserQuestion') {
+          log.error(`Failed to parse AskUserQuestion input: ${err.message}`)
+          return
+        }
+        if (toolName === 'Task') {
+          log.warn(`Failed to parse Task tool input: ${err.message}`)
+          return
+        }
+        if (toolName === 'ExitPlanMode') {
+          log.warn(`Failed to parse ExitPlanMode input: ${err.message}`)
+          // ExitPlanMode falls through with parsed=null so the empty
+          // allowedPrompts default still applies.
+        }
+      }
+    }
+
+    const semantics = extractToolInputSemantics(toolName, parsed)
+    if (!semantics) return
+
+    switch (semantics.kind) {
+      case 'ask_user_question': {
+        // The pre-extraction code required successfully-parsed input to
+        // proceed; preserve that by gating on a non-null parsed payload.
+        if (!parsed) return
+        log.info(`AskUserQuestion detected (${toolUseId})`)
+        this._waitingForAnswer = true
+        this.emit('user_question', {
+          toolUseId,
+          questions: semantics.payload.questions,
+        })
+        return
+      }
+      case 'task': {
+        if (!parsed) return
+        const agentInfo = {
+          toolUseId,
+          description: semantics.payload.description,
+          startedAt: Date.now(),
+        }
+        this._activeAgents.set(toolUseId, agentInfo)
+        this.emit('agent_spawned', agentInfo)
+        return
+      }
+      case 'enter_plan': {
+        this._inPlanMode = true
+        this.emit('plan_started')
+        return
+      }
+      case 'exit_plan': {
+        this._planAllowedPrompts = semantics.payload.allowedPrompts
+        return
       }
     }
   }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -11,7 +11,7 @@ import {
   isRunInBackgroundInput,
   parseBashOutputShellId,
 } from './background-shells.js'
-import { parseMcpToolName } from './mcp-tools.js'
+import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
 import { createLogger } from './logger.js'
 import { PermissionManager } from './permission-manager.js'
 import { formatBytes } from './utils/format-bytes.js'
@@ -677,23 +677,14 @@ export class SdkSession extends BaseSession {
                     this.emit('stream_start', { messageId })
                   }
                 } else if (blockType === 'tool_use') {
-                  // Reuse a single derived toolId for both fields so the wire
-                  // schema (`ServerToolStartSchema.toolUseId: z.string()`)
-                  // holds even on the defensive fallback path. Mirrors
-                  // cli-session.js.
-                  const toolId = event.content_block.id || `${messageId}-tool`
-                  const toolStartData = {
-                    messageId: toolId,
-                    toolUseId: toolId,
-                    tool: event.content_block.name,
-                    input: null,
-                  }
-                  const mcp = parseMcpToolName(event.content_block.name)
-                  if (mcp) toolStartData.serverName = mcp.serverName
+                  // Delegate to the shared parser so CliSession + SdkSession
+                  // emit identical tool_start payloads (see
+                  // claude-stream-parser.js for the toolId-derivation rules).
+                  const toolStartData = buildToolStartData(messageId, event.content_block)
                   this.emit('tool_start', toolStartData)
                   // #4628: defense-in-depth — track so _emitResult sweep
                   // catches any orphan if the API ever drops a tool_result.
-                  this._trackToolStart(toolId, event.content_block.name)
+                  this._trackToolStart(toolStartData.toolUseId, event.content_block.name)
                 }
                 break
               }
@@ -1062,18 +1053,25 @@ export class SdkSession extends BaseSession {
       this.clearBackgroundShell(bashOutputId)
     }
 
-    if (block.name === 'Task') {
-      const input = block.input || {}
-      const description = (typeof input.description === 'string'
-        ? input.description : 'Background task').slice(0, 200)
+    // Delegate Task / EnterPlanMode / ExitPlanMode interpretation to the
+    // shared parser so SdkSession and CliSession cannot drift on tool
+    // semantics. AskUserQuestion is intentionally skipped here — it flows
+    // through the canUseTool callback in _handleAskUserQuestion() and
+    // never reaches this code path.
+    const semantics = extractToolInputSemantics(block.name, block.input)
+    if (!semantics) return
+    if (semantics.kind === 'task') {
       const agentInfo = {
         toolUseId: block.id,
-        description,
+        description: semantics.payload.description,
         startedAt: Date.now(),
       }
       this._activeAgents.set(block.id, agentInfo)
       this.emit('agent_spawned', agentInfo)
     }
+    // EnterPlanMode / ExitPlanMode are not currently surfaced by SdkSession
+    // (plan-mode flow is CliSession-only today). Extracting via the shared
+    // parser leaves the door open without changing observable behavior.
   }
 
   /**

--- a/packages/server/tests/claude-stream-parser.test.js
+++ b/packages/server/tests/claude-stream-parser.test.js
@@ -1,0 +1,174 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  extractToolInputSemantics,
+  buildToolStartData,
+} from '../src/claude-stream-parser.js'
+
+/**
+ * Boundary tests for the ClaudeStreamParser module.
+ *
+ * The parser is a pure-function module shared by CliSession and SdkSession
+ * to dedupe Anthropic streaming-protocol parsing. These tests pin its
+ * public contract:
+ *
+ *   - extractToolInputSemantics(toolName, parsedInput) -> { kind, payload }
+ *   - buildToolStartData(messageId, contentBlock) -> { messageId, toolUseId, tool, input, serverName? }
+ *
+ * Behavior preservation across CliSession/SdkSession depends on these
+ * staying byte-for-byte identical to the pre-extraction inline logic.
+ */
+
+describe('extractToolInputSemantics', () => {
+  describe('AskUserQuestion', () => {
+    it('returns ask_user_question kind with the questions array', () => {
+      const result = extractToolInputSemantics('AskUserQuestion', {
+        questions: [{ question: 'A?', options: [] }],
+      })
+      assert.equal(result.kind, 'ask_user_question')
+      assert.deepEqual(result.payload, {
+        questions: [{ question: 'A?', options: [] }],
+      })
+    })
+
+    it('passes through undefined questions field as-is', () => {
+      const result = extractToolInputSemantics('AskUserQuestion', {})
+      assert.equal(result.kind, 'ask_user_question')
+      assert.equal(result.payload.questions, undefined)
+    })
+  })
+
+  describe('Task', () => {
+    it('returns task kind with description and 200-char slice', () => {
+      const result = extractToolInputSemantics('Task', { description: 'Run a thing' })
+      assert.equal(result.kind, 'task')
+      assert.equal(result.payload.description, 'Run a thing')
+    })
+
+    it('clamps description to 200 chars', () => {
+      const long = 'x'.repeat(500)
+      const result = extractToolInputSemantics('Task', { description: long })
+      assert.equal(result.kind, 'task')
+      assert.equal(result.payload.description.length, 200)
+    })
+
+    it('falls back to "Background task" when description is missing', () => {
+      const result = extractToolInputSemantics('Task', {})
+      assert.equal(result.kind, 'task')
+      assert.equal(result.payload.description, 'Background task')
+    })
+
+    it('falls back to "Background task" when description is non-string', () => {
+      const result = extractToolInputSemantics('Task', { description: 123 })
+      assert.equal(result.kind, 'task')
+      assert.equal(result.payload.description, 'Background task')
+    })
+
+    it('handles null/undefined input', () => {
+      const result = extractToolInputSemantics('Task', null)
+      assert.equal(result.kind, 'task')
+      assert.equal(result.payload.description, 'Background task')
+    })
+  })
+
+  describe('EnterPlanMode', () => {
+    it('returns enter_plan kind with empty payload', () => {
+      const result = extractToolInputSemantics('EnterPlanMode', {})
+      assert.equal(result.kind, 'enter_plan')
+      assert.deepEqual(result.payload, {})
+    })
+
+    it('returns enter_plan kind even with no parsed input', () => {
+      const result = extractToolInputSemantics('EnterPlanMode', null)
+      assert.equal(result.kind, 'enter_plan')
+    })
+  })
+
+  describe('ExitPlanMode', () => {
+    it('returns exit_plan kind with parsed allowedPrompts array', () => {
+      const result = extractToolInputSemantics('ExitPlanMode', {
+        allowedPrompts: ['npm test', 'git status'],
+      })
+      assert.equal(result.kind, 'exit_plan')
+      assert.deepEqual(result.payload.allowedPrompts, ['npm test', 'git status'])
+    })
+
+    it('returns empty allowedPrompts when field is missing', () => {
+      const result = extractToolInputSemantics('ExitPlanMode', {})
+      assert.equal(result.kind, 'exit_plan')
+      assert.deepEqual(result.payload.allowedPrompts, [])
+    })
+
+    it('returns empty allowedPrompts when field is not an array', () => {
+      const result = extractToolInputSemantics('ExitPlanMode', {
+        allowedPrompts: 'oops',
+      })
+      assert.equal(result.kind, 'exit_plan')
+      assert.deepEqual(result.payload.allowedPrompts, [])
+    })
+
+    it('returns empty allowedPrompts on null input', () => {
+      const result = extractToolInputSemantics('ExitPlanMode', null)
+      assert.equal(result.kind, 'exit_plan')
+      assert.deepEqual(result.payload.allowedPrompts, [])
+    })
+  })
+
+  describe('unknown tools', () => {
+    it('returns null kind for unknown tool names', () => {
+      const result = extractToolInputSemantics('Bash', { command: 'ls' })
+      assert.equal(result, null)
+    })
+
+    it('returns null for empty/missing tool name', () => {
+      assert.equal(extractToolInputSemantics('', {}), null)
+      assert.equal(extractToolInputSemantics(undefined, {}), null)
+    })
+  })
+})
+
+describe('buildToolStartData', () => {
+  it('uses content_block.id as both messageId and toolUseId', () => {
+    const result = buildToolStartData('turn-msg-1', {
+      type: 'tool_use',
+      id: 'toolu_abc',
+      name: 'Bash',
+    })
+    assert.deepEqual(result, {
+      messageId: 'toolu_abc',
+      toolUseId: 'toolu_abc',
+      tool: 'Bash',
+      input: null,
+    })
+  })
+
+  it('falls back to `${messageId}-tool` when content_block.id is missing', () => {
+    const result = buildToolStartData('turn-msg-1', {
+      type: 'tool_use',
+      name: 'Bash',
+    })
+    // Both fields must reuse the synthesized fallback so the wire schema
+    // (ServerToolStartSchema.toolUseId: z.string()) still holds.
+    assert.equal(result.messageId, 'turn-msg-1-tool')
+    assert.equal(result.toolUseId, 'turn-msg-1-tool')
+  })
+
+  it('attaches serverName for MCP tools', () => {
+    const result = buildToolStartData('turn-1', {
+      type: 'tool_use',
+      id: 'toolu_xyz',
+      name: 'mcp__github__create_issue',
+    })
+    assert.equal(result.tool, 'mcp__github__create_issue')
+    assert.equal(result.serverName, 'github')
+  })
+
+  it('does not attach serverName for built-in tools', () => {
+    const result = buildToolStartData('turn-1', {
+      type: 'tool_use',
+      id: 'toolu_xyz',
+      name: 'Read',
+    })
+    assert.equal('serverName' in result, false)
+  })
+})

--- a/packages/server/tests/cli-session-events.test.js
+++ b/packages/server/tests/cli-session-events.test.js
@@ -349,6 +349,28 @@ describe('CliSession stream-event handling', () => {
       assert.equal(events.length, 0)
       assert.equal(session._waitingForAnswer, false)
     })
+
+    it('still emits when JSON.parse legally returns a falsy value (#4774)', () => {
+      // Regression for Copilot review on #4774: gating the
+      // post-extraction emit on `if (!parsed)` would silently swallow
+      // legal falsy JSON like `0` / `false` / `null`, drifting from the
+      // pre-extraction behavior which only short-circuited on parse
+      // *failure*, not on falsy parsed values. AskUserQuestion in
+      // particular would emit `user_question` with `questions: undefined`
+      // pre-extraction; the refactor must preserve that.
+      const session = createSession()
+      const events = []
+      session.on('user_question', (data) => events.push(data))
+
+      session._handleEvent(toolUseStart('AskUserQuestion', 'toolu_falsy'))
+      session._handleEvent(inputJsonDelta('0'))
+      session._handleEvent(contentBlockStop())
+
+      assert.equal(events.length, 1)
+      assert.equal(events[0].toolUseId, 'toolu_falsy')
+      assert.equal(events[0].questions, undefined)
+      assert.equal(session._waitingForAnswer, true)
+    })
   })
 
   describe('tool_result events', () => {


### PR DESCRIPTION
## Summary

CliSession and SdkSession independently re-implemented the same Anthropic streaming-protocol parsing. Both files even carried copy-pasted *Mirrors X-session.js* comments referencing each other. This PR extracts two pure functions into a new shared `claude-stream-parser.js` module so the two providers cannot drift on tool semantics.

**What changed**
- New `packages/server/src/claude-stream-parser.js` exposes:
  - `buildToolStartData(messageId, contentBlock)` — single source for the `tool_start` event payload shape (toolId derivation, MCP `serverName` attachment, defensive fallback when `content_block.id` is missing).
  - `extractToolInputSemantics(toolName, parsedInput)` — single source for Task / AskUserQuestion / EnterPlanMode / ExitPlanMode interpretation, returning a tagged `{ kind, payload }` discriminator so callers apply their own state side effects.
- `CliSession`:
  - `content_block_start` for tool_use now calls `buildToolStartData`.
  - `content_block_stop` delegates to a new `_applyToolInputSemantics()` method that dispatches on the extractor's `kind`. Per-tool log messages (info/error/warn) preserved verbatim so existing log scrapers continue to work.
- `SdkSession`:
  - `content_block_start` for tool_use now calls `buildToolStartData`.
  - `_handleToolUseBlock` calls `extractToolInputSemantics` for the Task branch. AskUserQuestion stays out of this path (it flows through `canUseTool` / `_handleAskUserQuestion`); EnterPlanMode/ExitPlanMode are no-ops in SdkSession today, with a comment noting the parser is wired up if/when plan-mode lands on SDK.

**What didn't change**
- No wire-format / protocol changes.
- No event names or payload shapes change. `tool_start`, `user_question`, `agent_spawned`, `plan_started`, `plan_ready` all emit identical payloads.
- The 200-char description slice, the overflow-then-skip semantics on `toolInputChunks`, and the parse-failure log messages are all preserved byte-for-byte.
- `claude-tui-session.js` and the multi-question form driver are untouched.

## Behavior preservation

| Surface | Verification |
|---|---|
| `content_block_start` tool_use | Existing `cli-session-events.test.js` (29 tests) and `sdk-session.test.js` (sdk-session suite) pass unchanged. |
| `content_block_stop` AskUserQuestion / Task / EnterPlanMode / ExitPlanMode | Existing CliSession tests cover all 4 paths including malformed JSON, overflow, and missing fields. |
| SdkSession `_handleToolUseBlock` Task branch | Existing sdk-session tests cover agent_spawned emission. |
| Parser pure functions | 19 new boundary tests in `claude-stream-parser.test.js` pin every kind branch, MCP serverName attachment, and the toolId fallback. |
| Lint | `npm run lint` reports 0 errors (only pre-existing warnings in unrelated files). |

Diff size: ~280 LOC of net change (well under the 400 LOC refactor cap).

## Test plan

- [x] `cd packages/server && npm test` — all session test suites green (cli-session-events, cli-session, sdk-session, sdk-session-question, sdk-session-timeout-pause, claude-stream-parser).
- [x] New parser boundary tests cover every `kind` branch (ask_user_question, task, enter_plan, exit_plan), unknown-tool null return, missing/non-string/null inputs, and the description 200-char slice.
- [x] `buildToolStartData` tests cover: content_block.id-as-toolId, fallback to `${messageId}-tool`, MCP serverName attachment, and built-in tools skip serverName.
- [x] Lint: 0 new warnings.

Closes #4768