### PR TITLE
refactor(store-core,app,dashboard): centralize session_list dispatch

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -75,7 +75,10 @@ import {
   handleFileListing as sharedFileListing,
   handleFileContent as sharedFileContent,
   handleWriteFileResult as sharedWriteFileResult,
-  handleSessionList as sharedSessionList,
+  buildSessionListPatches as sharedBuildSessionListPatches,
+  cumulativeUsageEquals as sharedCumulativeUsageEquals,
+  chunkSubscribeSessionIds as sharedChunkSubscribeSessionIds,
+  SESSION_LIST_SUBSCRIBE_CHUNK_SIZE,
   handleSessionContext as sharedSessionContext,
   handleSessionTimeout as sharedSessionTimeout,
   handleSessionRestoreFailed as sharedSessionRestoreFailed,
@@ -540,8 +543,13 @@ export function clearTerminalWriteBatching(): void {
 // ---------------------------------------------------------------------------
 // Client-side heartbeat
 // ---------------------------------------------------------------------------
-/** Max session IDs per subscribe_sessions message (must match server SubscribeSessionsSchema .max(20)) */
-export const SUBSCRIBE_SESSIONS_CHUNK_SIZE = 20;
+/**
+ * Max session IDs per subscribe_sessions message (must match server
+ * SubscribeSessionsSchema .max(20)). Re-exported from
+ * `@chroxy/store-core`'s {@link SESSION_LIST_SUBSCRIBE_CHUNK_SIZE} so the
+ * app and dashboard can't drift apart (#4767).
+ */
+export const SUBSCRIBE_SESSIONS_CHUNK_SIZE = SESSION_LIST_SUBSCRIBE_CHUNK_SIZE;
 const HEARTBEAT_INTERVAL_MS = 15_000;
 const PONG_TIMEOUT_MS = 5_000;
 const EWMA_ALPHA = 0.3; // Weight for new samples (higher = more responsive)
@@ -1189,132 +1197,131 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // --- Multi-session messages ---
 
     case 'session_list': {
-      const sessionList = sharedSessionList(msg);
-      if (sessionList) {
-        // Auto-resume on server restart: if reconnecting and server has no sessions,
-        // restore the last active conversation so user doesn't have to navigate History.
-        if (sessionList.length === 0 && ctx.isReconnect) {
-          void (async () => {
-            const snapSocket = ctx.socket;
-            const lastId = await loadLastConversationId();
-            if (!lastId) return;
-            if (snapSocket && snapSocket.readyState === WebSocket.OPEN) {
-              console.log('[ws] Server restarted with no sessions — auto-resuming last conversation');
-              wsSend(snapSocket, { type: 'resume_conversation', conversationId: lastId });
-            }
-          })();
-          break;
-        }
-        // GC persisted messages for sessions that dropped out of the list
-        const prevSessionIds = Object.keys(get().sessionStates);
-        const newSessionIdSet = new Set(sessionList.map((s) => s.sessionId));
-        const removedIds = prevSessionIds.filter((id) => !newSessionIdSet.has(id));
-        for (const prevId of removedIds) {
-          void clearPersistedSession(prevId);
-        }
-        // Batch in-memory cleanup into a single state update
-        if (removedIds.length > 0) {
-          const patch: Partial<ConnectionState> = {};
-          const newStates = { ...get().sessionStates };
-          for (const id of removedIds) {
-            delete newStates[id];
+      // #4767: centralised dispatch — store-core precomputes GC + new-session
+      // ids + conversationId / cumulativeUsage / pendingShells patch maps;
+      // the consumer applies them with platform-specific side-effects
+      // (clearPersistedSession, loadLastConversationId auto-resume, etc.).
+      const initialActiveId = get().activeSessionId;
+      const patches = sharedBuildSessionListPatches(
+        msg,
+        Object.keys(get().sessionStates),
+        initialActiveId,
+      );
+      if (!patches) break;
+      const {
+        sessionList,
+        removedIds,
+        newSessionIds,
+        conversationIdPatches,
+        cumulativeUsagePatches,
+        backgroundShellBuilders,
+        subscribeChunks,
+      } = patches;
+      // Auto-resume on server restart: if reconnecting and server has no sessions,
+      // restore the last active conversation so user doesn't have to navigate History.
+      if (sessionList.length === 0 && ctx.isReconnect) {
+        void (async () => {
+          const snapSocket = ctx.socket;
+          const lastId = await loadLastConversationId();
+          if (!lastId) return;
+          if (snapSocket && snapSocket.readyState === WebSocket.OPEN) {
+            console.log('[ws] Server restarted with no sessions — auto-resuming last conversation');
+            wsSend(snapSocket, { type: 'resume_conversation', conversationId: lastId });
           }
-          patch.sessionStates = newStates;
-          // If the active session was removed, switch to next available
-          if (get().activeSessionId && removedIds.includes(get().activeSessionId!)) {
-            const remaining = Object.keys(newStates);
-            const nextId = remaining.length > 0 ? remaining[0] : null;
-            patch.activeSessionId = nextId;
-          }
-          set(patch);
+        })();
+        break;
+      }
+      // GC persisted messages for sessions that dropped out of the list
+      for (const prevId of removedIds) {
+        void clearPersistedSession(prevId);
+      }
+      // Batch in-memory cleanup into a single state update
+      if (removedIds.length > 0) {
+        const patch: Partial<ConnectionState> = {};
+        const newStates = { ...get().sessionStates };
+        for (const id of removedIds) {
+          delete newStates[id];
         }
-        set({ sessions: sessionList });
-        // Initialize session state for any new sessions not yet tracked
+        patch.sessionStates = newStates;
+        // If the active session was removed, switch to next available
+        if (initialActiveId && removedIds.includes(initialActiveId)) {
+          const remaining = Object.keys(newStates);
+          const nextId = remaining.length > 0 ? remaining[0] : null;
+          patch.activeSessionId = nextId;
+        }
+        set(patch);
+      }
+      set({ sessions: sessionList });
+      // Initialize session state for any new sessions not yet tracked
+      if (newSessionIds.length > 0) {
         const currentStates = get().sessionStates;
         const newStates = { ...currentStates };
-        let statesChanged = false;
-        for (const s of sessionList) {
-          if (!newStates[s.sessionId]) {
-            newStates[s.sessionId] = createEmptySessionState();
-            statesChanged = true;
+        for (const sid of newSessionIds) {
+          if (!newStates[sid]) {
+            newStates[sid] = createEmptySessionState();
           }
         }
-        if (statesChanged) {
-          set({ sessionStates: newStates });
-        }
-        // Sync conversationId from session list into session states
-        for (const s of sessionList) {
-          if (s.conversationId && get().sessionStates[s.sessionId]) {
-            updateSession(s.sessionId, (ss) =>
-              ss.conversationId !== s.conversationId ? { conversationId: s.conversationId } : {}
-            );
-          }
-        }
-        // #4074: seed cumulativeUsage from the snapshot so re-opening the
-        // mobile app mid-session shows the running cost in the header
-        // without waiting for the next session_usage event. Same pattern
-        // as the dashboard (#4073).
-        for (const s of sessionList) {
-          if (s.cumulativeUsage && get().sessionStates[s.sessionId]) {
-            const snapshot = s.cumulativeUsage;
-            updateSession(s.sessionId, (ss) => {
-              const current = ss.cumulativeUsage;
-              if (
-                current &&
-                current.inputTokens === snapshot.inputTokens &&
-                current.outputTokens === snapshot.outputTokens &&
-                current.cacheReadTokens === snapshot.cacheReadTokens &&
-                current.cacheCreationTokens === snapshot.cacheCreationTokens &&
-                current.costUsd === snapshot.costUsd &&
-                current.turnsBilled === snapshot.turnsBilled
-              ) {
-                return {};
-              }
-              return { cumulativeUsage: snapshot };
-            });
-          }
-        }
-        // #4307: seed pendingBackgroundShells from the snapshot so the
-        // app catches up on any sessions already waiting on background
-        // work without waiting for the next `background_work_changed`
-        // event. The shared handler's reference-equality short-circuit
-        // suppresses no-op re-renders.
-        for (const s of sessionList) {
-          if (!get().sessionStates[s.sessionId]) continue;
-          const builder = sharedBackgroundWorkChanged(
-            { sessionId: s.sessionId, pending: s.pendingBackgroundShells ?? [] },
-            get().activeSessionId,
-          );
-          updateSession(s.sessionId, (ss) => {
-            const next = builder.applyTo(ss.pendingBackgroundShells);
-            return next === ss.pendingBackgroundShells
-              ? {}
-              : { pendingBackgroundShells: next };
-          });
-        }
-        // Persist the active session's conversationId for auto-resume on server restart.
-        // Use the activeSessionId if set, otherwise fall back to the first session in the list.
-        const resolvedActiveId = get().activeSessionId ?? (sessionList[0]?.sessionId ?? null);
-        const activeSessionEntry = resolvedActiveId
-          ? sessionList.find((s) => s.sessionId === resolvedActiveId)
-          : null;
-        const activeConversationId = activeSessionEntry?.conversationId ?? null;
-        if (activeConversationId) {
-          void persistLastConversationId(activeConversationId);
-        }
-        // Subscribe to all non-active sessions so we receive their events
-        // (permissions, plan approvals, errors) in real-time
-        const activeId = get().activeSessionId;
-        const subscribeIds = sessionList
-          .map((s) => s.sessionId)
-          .filter((id) => id !== activeId);
-        if (subscribeIds.length > 0) {
-          const sock = get().socket;
-          if (sock && sock.readyState === WebSocket.OPEN) {
-            // Server schema enforces max IDs per message — chunk if needed
-            for (let i = 0; i < subscribeIds.length; i += SUBSCRIBE_SESSIONS_CHUNK_SIZE) {
-              wsSend(sock, { type: 'subscribe_sessions', sessionIds: subscribeIds.slice(i, i + SUBSCRIBE_SESSIONS_CHUNK_SIZE) });
-            }
+        set({ sessionStates: newStates });
+      }
+      // Sync conversationId from session list into session states
+      for (const [sid, cid] of conversationIdPatches) {
+        if (!get().sessionStates[sid]) continue;
+        updateSession(sid, (ss) =>
+          ss.conversationId !== cid ? { conversationId: cid } : {}
+        );
+      }
+      // #4074: seed cumulativeUsage from the snapshot so re-opening the
+      // mobile app mid-session shows the running cost in the header
+      // without waiting for the next session_usage event. Same pattern
+      // as the dashboard (#4073). Six-field equality short-circuit lives
+      // in store-core via {@link sharedCumulativeUsageEquals} (#4767).
+      for (const [sid, snapshot] of cumulativeUsagePatches) {
+        if (!get().sessionStates[sid]) continue;
+        updateSession(sid, (ss) =>
+          sharedCumulativeUsageEquals(ss.cumulativeUsage, snapshot)
+            ? {}
+            : { cumulativeUsage: snapshot }
+        );
+      }
+      // #4307: seed pendingBackgroundShells from the snapshot so the
+      // app catches up on any sessions already waiting on background
+      // work without waiting for the next `background_work_changed`
+      // event. The shared handler's reference-equality short-circuit
+      // suppresses no-op re-renders.
+      for (const [sid, builder] of backgroundShellBuilders) {
+        if (!get().sessionStates[sid]) continue;
+        updateSession(sid, (ss) => {
+          const next = builder.applyTo(ss.pendingBackgroundShells);
+          return next === ss.pendingBackgroundShells
+            ? {}
+            : { pendingBackgroundShells: next };
+        });
+      }
+      // Persist the active session's conversationId for auto-resume on server restart.
+      // Use the activeSessionId if set, otherwise fall back to the first session in the list.
+      const resolvedActiveId = get().activeSessionId ?? (sessionList[0]?.sessionId ?? null);
+      const activeSessionEntry = resolvedActiveId
+        ? sessionList.find((s) => s.sessionId === resolvedActiveId)
+        : null;
+      const activeConversationId = activeSessionEntry?.conversationId ?? null;
+      if (activeConversationId) {
+        void persistLastConversationId(activeConversationId);
+      }
+      // Subscribe to all non-active sessions so we receive their events
+      // (permissions, plan approvals, errors) in real-time. Use the
+      // precomputed chunks when the active id didn't change; otherwise
+      // (active was removed and reassigned above) recompute against the
+      // final active id via the shared chunk helper.
+      const finalActiveId = get().activeSessionId;
+      const effectiveChunks =
+        finalActiveId === initialActiveId
+          ? subscribeChunks
+          : sharedChunkSubscribeSessionIds(sessionList, finalActiveId);
+      if (effectiveChunks.length > 0) {
+        const sock = get().socket;
+        if (sock && sock.readyState === WebSocket.OPEN) {
+          for (const chunk of effectiveChunks) {
+            wsSend(sock, { type: 'subscribe_sessions', sessionIds: chunk });
           }
         }
       }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -63,7 +63,8 @@ import {
   handleDirectoryListing as sharedDirectoryListing,
   handleFileListing as sharedFileListing,
   handleFileContent as sharedFileContent,
-  handleSessionList as sharedSessionList,
+  buildSessionListPatches as sharedBuildSessionListPatches,
+  cumulativeUsageEquals as sharedCumulativeUsageEquals,
   handleSessionContext as sharedSessionContext,
   handleSessionTimeout as sharedSessionTimeout,
   handleSessionRestoreFailed as sharedSessionRestoreFailed,
@@ -2134,156 +2135,153 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     // --- Multi-session messages ---
 
     case 'session_list': {
-      const sessionList = sharedSessionList(msg);
-      if (sessionList) {
-        // GC persisted messages for sessions that dropped out of the list
-        const prevSessionIds = Object.keys(get().sessionStates);
-        const newSessionIdSet = new Set(sessionList.map((s) => s.sessionId));
-        const removedIds = prevSessionIds.filter((id) => !newSessionIdSet.has(id));
-        for (const prevId of removedIds) {
-          void clearPersistedSession(prevId);
+      // #4767: centralised dispatch — store-core precomputes GC + new-session
+      // ids + conversationId / cumulativeUsage / pendingShells patch maps;
+      // the consumer applies them with platform-specific side-effects
+      // (dashboard's activeModel lookup + isBusy → isIdle resync stay here).
+      const initialActiveId = get().activeSessionId;
+      const patches = sharedBuildSessionListPatches(
+        msg,
+        Object.keys(get().sessionStates),
+        initialActiveId,
+      );
+      if (!patches) break;
+      const {
+        sessionList,
+        removedIds,
+        newSessionIds,
+        conversationIdPatches,
+        cumulativeUsagePatches,
+        backgroundShellBuilders,
+      } = patches;
+      // GC persisted messages for sessions that dropped out of the list
+      for (const prevId of removedIds) {
+        void clearPersistedSession(prevId);
+      }
+      // Batch in-memory cleanup into a single state update
+      if (removedIds.length > 0) {
+        const patch: Partial<ConnectionState> = {};
+        const newStates = { ...get().sessionStates };
+        for (const id of removedIds) {
+          delete newStates[id];
         }
-        // Batch in-memory cleanup into a single state update
-        if (removedIds.length > 0) {
-          const patch: Partial<ConnectionState> = {};
-          const newStates = { ...get().sessionStates };
-          for (const id of removedIds) {
-            delete newStates[id];
-          }
-          patch.sessionStates = newStates;
-          // If the active session was removed, switch to next available
-          if (get().activeSessionId && removedIds.includes(get().activeSessionId!)) {
-            const remaining = Object.keys(newStates);
-            const nextId = remaining.length > 0 ? remaining[0] : null;
-            patch.activeSessionId = nextId;
-            if (nextId && newStates[nextId]) {
-              const ss = newStates[nextId];
-              patch.messages = ss.messages;
-              patch.streamingMessageId = ss.streamingMessageId;
-              patch.claudeReady = ss.claudeReady;
-              patch.activeModel = ss.activeModel;
-              patch.permissionMode = ss.permissionMode;
-              patch.contextUsage = ss.contextUsage;
-              patch.lastResultCost = ss.lastResultCost;
-              patch.lastResultDuration = ss.lastResultDuration;
-              patch.isIdle = ss.isIdle;
-            } else {
-              patch.messages = [];
-              patch.streamingMessageId = null;
-              patch.claudeReady = false;
-              patch.activeModel = null;
-              patch.permissionMode = null;
-              patch.contextUsage = null;
-              patch.lastResultCost = null;
-              patch.lastResultDuration = null;
-              patch.isIdle = true;
-            }
-          }
-          set(patch);
-        }
-        set({ sessions: sessionList });
-        // Sync activeModel from session list to prevent dropdown reset.
-        // session_list sends full model IDs (e.g. claude-sonnet-4-5-20250929) but the
-        // dropdown uses short IDs (e.g. sonnet). Resolve via availableModels lookup.
-        const activeSessionId = get().activeSessionId;
-        if (activeSessionId) {
-          const activeSessionInfo = sessionList.find((s: { sessionId?: string }) => s.sessionId === activeSessionId);
-          if (activeSessionInfo?.model) {
-            const fullId = activeSessionInfo.model as string;
-            const models = get().availableModels;
-            const matched = models.find((m) => m.fullId === fullId || m.id === fullId);
-            set({ activeModel: matched ? matched.id : fullId });
+        patch.sessionStates = newStates;
+        // If the active session was removed, switch to next available
+        if (initialActiveId && removedIds.includes(initialActiveId)) {
+          const remaining = Object.keys(newStates);
+          const nextId = remaining.length > 0 ? remaining[0] : null;
+          patch.activeSessionId = nextId;
+          if (nextId && newStates[nextId]) {
+            const ss = newStates[nextId];
+            patch.messages = ss.messages;
+            patch.streamingMessageId = ss.streamingMessageId;
+            patch.claudeReady = ss.claudeReady;
+            patch.activeModel = ss.activeModel;
+            patch.permissionMode = ss.permissionMode;
+            patch.contextUsage = ss.contextUsage;
+            patch.lastResultCost = ss.lastResultCost;
+            patch.lastResultDuration = ss.lastResultDuration;
+            patch.isIdle = ss.isIdle;
+          } else {
+            patch.messages = [];
+            patch.streamingMessageId = null;
+            patch.claudeReady = false;
+            patch.activeModel = null;
+            patch.permissionMode = null;
+            patch.contextUsage = null;
+            patch.lastResultCost = null;
+            patch.lastResultDuration = null;
+            patch.isIdle = true;
           }
         }
-        // Initialize session state for any new sessions not yet tracked.
-        // #4639: seed `isIdle` from the server's authoritative `isBusy` so a
-        // fresh tab / new-session entry reflects the real working state
-        // instead of defaulting to `isIdle: true` and silently dropping the
-        // Working banner until the next live event arrives.
+        set(patch);
+      }
+      set({ sessions: sessionList });
+      // Sync activeModel from session list to prevent dropdown reset.
+      // session_list sends full model IDs (e.g. claude-sonnet-4-5-20250929) but the
+      // dropdown uses short IDs (e.g. sonnet). Resolve via availableModels lookup.
+      const activeSessionId = get().activeSessionId;
+      if (activeSessionId) {
+        const activeSessionInfo = sessionList.find((s: { sessionId?: string }) => s.sessionId === activeSessionId);
+        if (activeSessionInfo?.model) {
+          const fullId = activeSessionInfo.model as string;
+          const models = get().availableModels;
+          const matched = models.find((m) => m.fullId === fullId || m.id === fullId);
+          set({ activeModel: matched ? matched.id : fullId });
+        }
+      }
+      // Initialize session state for any new sessions not yet tracked.
+      // #4639: seed `isIdle` from the server's authoritative `isBusy` so a
+      // fresh tab / new-session entry reflects the real working state
+      // instead of defaulting to `isIdle: true` and silently dropping the
+      // Working banner until the next live event arrives.
+      if (newSessionIds.length > 0) {
         const currentStates = get().sessionStates;
         const newInitStates = { ...currentStates };
-        let initStatesChanged = false;
-        for (const s of sessionList) {
-          if (!newInitStates[s.sessionId]) {
+        const sessionsBySid = new Map(sessionList.map((s) => [s.sessionId, s]));
+        for (const sid of newSessionIds) {
+          if (!newInitStates[sid]) {
             const fresh = createEmptySessionState();
-            if (typeof s.isBusy === 'boolean') fresh.isIdle = !s.isBusy;
-            newInitStates[s.sessionId] = fresh;
-            initStatesChanged = true;
+            const s = sessionsBySid.get(sid);
+            if (s && typeof s.isBusy === 'boolean') fresh.isIdle = !s.isBusy;
+            newInitStates[sid] = fresh;
           }
         }
-        if (initStatesChanged) {
-          set({ sessionStates: newInitStates });
-        }
-        // #4639: resync `isIdle` on EXISTING session states against the
-        // snapshot's `isBusy`. Without this, a session that became busy on
-        // the server while the dashboard's local handlers missed the flip
-        // (tab swap during a long turn, peer-tab triggered the work, race
-        // between agent_busy and history_replay) shows the wrong banner and
-        // the wrong Send/Stop button. The snapshot is the source of truth.
-        for (const s of sessionList) {
-          if (typeof s.isBusy !== 'boolean') continue;
-          if (!get().sessionStates[s.sessionId]) continue;
-          const desiredIsIdle = !s.isBusy;
-          updateSession(s.sessionId, (ss) =>
-            ss.isIdle === desiredIsIdle ? {} : { isIdle: desiredIsIdle }
-          );
-        }
-        // Sync conversationId from session list into session states
-        for (const s of sessionList) {
-          if (s.conversationId && get().sessionStates[s.sessionId]) {
-            updateSession(s.sessionId, (ss) =>
-              ss.conversationId !== s.conversationId ? { conversationId: s.conversationId } : {}
-            );
-          }
-        }
-        // #4073: seed cumulativeUsage from the snapshot so refreshing the
-        // dashboard mid-session shows the running total without waiting
-        // for the next session_usage event to land. listSessions on the
-        // server emits the field with zero defaults when no result has
-        // landed yet — `cumulativeUsage` is undefined only when an older
-        // server omits it entirely.
-        for (const s of sessionList) {
-          if (s.cumulativeUsage && get().sessionStates[s.sessionId]) {
-            const snapshot = s.cumulativeUsage;
-            updateSession(s.sessionId, (ss) => {
-              const current = ss.cumulativeUsage;
-              if (
-                current &&
-                current.inputTokens === snapshot.inputTokens &&
-                current.outputTokens === snapshot.outputTokens &&
-                current.cacheReadTokens === snapshot.cacheReadTokens &&
-                current.cacheCreationTokens === snapshot.cacheCreationTokens &&
-                current.costUsd === snapshot.costUsd &&
-                current.turnsBilled === snapshot.turnsBilled
-              ) {
-                return {};
-              }
-              return { cumulativeUsage: snapshot };
-            });
-          }
-        }
-        // #4307: seed pendingBackgroundShells from the snapshot so a
-        // fresh tab / reconnect catches up to any sessions already
-        // waiting on background work without needing the next
-        // background_work_changed event to arrive. The
-        // `handleBackgroundWorkChanged` builder does the
-        // same-reference short-circuit so duplicate seeds don't
-        // re-render. The field is optional on `SessionInfo` because
-        // older servers omit it; treat `undefined` as "no waiting
-        // work" (empty array passthrough).
-        for (const s of sessionList) {
-          if (!get().sessionStates[s.sessionId]) continue;
-          const builder = sharedBackgroundWorkChanged(
-            { sessionId: s.sessionId, pending: s.pendingBackgroundShells ?? [] },
-            get().activeSessionId,
-          );
-          updateSession(s.sessionId, (ss) => {
-            const next = builder.applyTo(ss.pendingBackgroundShells);
-            return next === ss.pendingBackgroundShells
-              ? {}
-              : { pendingBackgroundShells: next };
-          });
-        }
+        set({ sessionStates: newInitStates });
+      }
+      // #4639: resync `isIdle` on EXISTING session states against the
+      // snapshot's `isBusy`. Without this, a session that became busy on
+      // the server while the dashboard's local handlers missed the flip
+      // (tab swap during a long turn, peer-tab triggered the work, race
+      // between agent_busy and history_replay) shows the wrong banner and
+      // the wrong Send/Stop button. The snapshot is the source of truth.
+      for (const s of sessionList) {
+        if (typeof s.isBusy !== 'boolean') continue;
+        if (!get().sessionStates[s.sessionId]) continue;
+        const desiredIsIdle = !s.isBusy;
+        updateSession(s.sessionId, (ss) =>
+          ss.isIdle === desiredIsIdle ? {} : { isIdle: desiredIsIdle }
+        );
+      }
+      // Sync conversationId from session list into session states
+      for (const [sid, cid] of conversationIdPatches) {
+        if (!get().sessionStates[sid]) continue;
+        updateSession(sid, (ss) =>
+          ss.conversationId !== cid ? { conversationId: cid } : {}
+        );
+      }
+      // #4073: seed cumulativeUsage from the snapshot so refreshing the
+      // dashboard mid-session shows the running total without waiting
+      // for the next session_usage event to land. listSessions on the
+      // server emits the field with zero defaults when no result has
+      // landed yet — `cumulativeUsage` is undefined only when an older
+      // server omits it entirely. Six-field equality short-circuit lives
+      // in store-core via {@link sharedCumulativeUsageEquals} (#4767).
+      for (const [sid, snapshot] of cumulativeUsagePatches) {
+        if (!get().sessionStates[sid]) continue;
+        updateSession(sid, (ss) =>
+          sharedCumulativeUsageEquals(ss.cumulativeUsage, snapshot)
+            ? {}
+            : { cumulativeUsage: snapshot }
+        );
+      }
+      // #4307: seed pendingBackgroundShells from the snapshot so a
+      // fresh tab / reconnect catches up to any sessions already
+      // waiting on background work without needing the next
+      // background_work_changed event to arrive. The
+      // `handleBackgroundWorkChanged` builder does the
+      // same-reference short-circuit so duplicate seeds don't
+      // re-render. The field is optional on `SessionInfo` because
+      // older servers omit it; treat `undefined` as "no waiting
+      // work" (empty array passthrough).
+      for (const [sid, builder] of backgroundShellBuilders) {
+        if (!get().sessionStates[sid]) continue;
+        updateSession(sid, (ss) => {
+          const next = builder.applyTo(ss.pendingBackgroundShells);
+          return next === ss.pendingBackgroundShells
+            ? {}
+            : { pendingBackgroundShells: next };
+        });
       }
       break;
     }

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -47,6 +47,10 @@ import {
   handlePermissionTimeout,
   handlePermissionRulesUpdated,
   handleSessionList,
+  buildSessionListPatches,
+  cumulativeUsageEquals,
+  chunkSubscribeSessionIds,
+  SESSION_LIST_SUBSCRIBE_CHUNK_SIZE,
   handleSessionContext,
   handleSessionTimeout,
   handleSessionRestoreFailed,
@@ -101,6 +105,7 @@ import type {
   Checkpoint,
   ConnectedClient,
   ConversationSummary,
+  CumulativeUsage,
   DevPreview,
   ModelInfo,
   PendingBackgroundShell,
@@ -1615,6 +1620,260 @@ describe('handleSessionList', () => {
   it('returns empty array verbatim (auto-resume gate stays at call site)', () => {
     const empty: SessionInfo[] = []
     expect(handleSessionList({ sessions: empty })).toBe(empty)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// cumulativeUsageEquals
+// ---------------------------------------------------------------------------
+describe('cumulativeUsageEquals', () => {
+  const base: CumulativeUsage = {
+    inputTokens: 100,
+    outputTokens: 50,
+    cacheReadTokens: 10,
+    cacheCreationTokens: 5,
+    costUsd: 0.12,
+    turnsBilled: 3,
+  }
+
+  it('returns true when both snapshots match across all six fields', () => {
+    expect(cumulativeUsageEquals(base, { ...base })).toBe(true)
+  })
+
+  it('returns false when any single field differs', () => {
+    expect(cumulativeUsageEquals(base, { ...base, inputTokens: 101 })).toBe(false)
+    expect(cumulativeUsageEquals(base, { ...base, outputTokens: 51 })).toBe(false)
+    expect(cumulativeUsageEquals(base, { ...base, cacheReadTokens: 11 })).toBe(false)
+    expect(cumulativeUsageEquals(base, { ...base, cacheCreationTokens: 6 })).toBe(false)
+    expect(cumulativeUsageEquals(base, { ...base, costUsd: 0.13 })).toBe(false)
+    expect(cumulativeUsageEquals(base, { ...base, turnsBilled: 4 })).toBe(false)
+  })
+
+  it('returns false when either side is null or undefined', () => {
+    // Preserves the prior inline `current && ...` guard — null `current`
+    // falls through and the candidate snapshot is applied as a no-op write.
+    expect(cumulativeUsageEquals(null, base)).toBe(false)
+    expect(cumulativeUsageEquals(base, null)).toBe(false)
+    expect(cumulativeUsageEquals(null, null)).toBe(false)
+    expect(cumulativeUsageEquals(undefined, base)).toBe(false)
+    expect(cumulativeUsageEquals(base, undefined)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildSessionListPatches (#4767)
+// ---------------------------------------------------------------------------
+describe('buildSessionListPatches', () => {
+  const makeSession = (
+    sessionId: string,
+    overrides: Partial<SessionInfo> = {},
+  ): SessionInfo => ({
+    sessionId,
+    name: sessionId,
+    cwd: '/tmp',
+    type: 'cli',
+    hasTerminal: false,
+    model: null,
+    permissionMode: null,
+    isBusy: false,
+    createdAt: 1000,
+    conversationId: null,
+    ...overrides,
+  })
+
+  it('returns null when handleSessionList rejects the message', () => {
+    expect(buildSessionListPatches({}, [], null)).toBeNull()
+    expect(buildSessionListPatches({ sessions: 'nope' }, [], null)).toBeNull()
+  })
+
+  it('exposes the parsed sessionList by reference', () => {
+    const sessions = [makeSession('s1')]
+    const out = buildSessionListPatches({ sessions }, [], null)
+    expect(out).not.toBeNull()
+    expect(out!.sessionList).toBe(sessions)
+  })
+
+  it('computes removedIds for sessions that dropped out of the snapshot', () => {
+    const sessions = [makeSession('s2'), makeSession('s3')]
+    const out = buildSessionListPatches({ sessions }, ['s1', 's2', 's3', 's4'], null)
+    expect(out!.removedIds).toEqual(['s1', 's4'])
+  })
+
+  it('preserves prevSessionStateIds order in removedIds (matches both prior inline loops)', () => {
+    const sessions = [makeSession('s3')]
+    const out = buildSessionListPatches({ sessions }, ['s1', 's2', 's3', 's4'], null)
+    expect(out!.removedIds).toEqual(['s1', 's2', 's4'])
+  })
+
+  it('returns empty removedIds when nothing was removed', () => {
+    const sessions = [makeSession('s1'), makeSession('s2')]
+    const out = buildSessionListPatches({ sessions }, ['s1'], null)
+    expect(out!.removedIds).toEqual([])
+  })
+
+  it('lists new sessions not present in prevSessionStateIds in snapshot order', () => {
+    const sessions = [makeSession('s1'), makeSession('s2'), makeSession('s3')]
+    const out = buildSessionListPatches({ sessions }, ['s2'], null)
+    expect(out!.newSessionIds).toEqual(['s1', 's3'])
+  })
+
+  it('handles fully fresh state (empty prev, all sessions new)', () => {
+    const sessions = [makeSession('s1'), makeSession('s2')]
+    const out = buildSessionListPatches({ sessions }, [], null)
+    expect(out!.newSessionIds).toEqual(['s1', 's2'])
+    expect(out!.removedIds).toEqual([])
+  })
+
+  it('skips malformed entries without sessionId (fail-soft)', () => {
+    // Behaviour-preserving: the prior inline loops dereference s.sessionId
+    // directly. Skipping silently here keeps the helper defensive against
+    // hypothetical future server bugs that the prior code would have
+    // crashed on.
+    const sessions = [
+      makeSession('s1'),
+      null as unknown as SessionInfo,
+      { foo: 'bar' } as unknown as SessionInfo,
+      makeSession('s2'),
+    ]
+    const out = buildSessionListPatches({ sessions }, [], null)
+    expect(out!.newSessionIds).toEqual(['s1', 's2'])
+    expect(out!.backgroundShellBuilders.size).toBe(2)
+  })
+
+  it('emits conversationIdPatches for every session with a truthy conversationId', () => {
+    const sessions = [
+      makeSession('s1', { conversationId: 'conv-1' }),
+      makeSession('s2', { conversationId: null }),
+      makeSession('s3', { conversationId: 'conv-3' }),
+    ]
+    const out = buildSessionListPatches({ sessions }, [], null)
+    expect(out!.conversationIdPatches.get('s1')).toBe('conv-1')
+    expect(out!.conversationIdPatches.has('s2')).toBe(false)
+    expect(out!.conversationIdPatches.get('s3')).toBe('conv-3')
+  })
+
+  it('emits cumulativeUsagePatches for every session with a defined cumulativeUsage snapshot', () => {
+    const usage: CumulativeUsage = {
+      inputTokens: 1,
+      outputTokens: 2,
+      cacheReadTokens: 3,
+      cacheCreationTokens: 4,
+      costUsd: 0.5,
+      turnsBilled: 6,
+    }
+    const sessions = [
+      makeSession('s1', { cumulativeUsage: usage }),
+      makeSession('s2'), // no cumulativeUsage field
+    ]
+    const out = buildSessionListPatches({ sessions }, [], null)
+    expect(out!.cumulativeUsagePatches.get('s1')).toBe(usage)
+    expect(out!.cumulativeUsagePatches.has('s2')).toBe(false)
+  })
+
+  it('emits backgroundShellBuilders for every session (default empty pending list)', () => {
+    const sessions = [
+      makeSession('s1', {
+        pendingBackgroundShells: [
+          { shellId: 'sh1', command: 'sleep 1', startedAt: 1000 },
+        ],
+      }),
+      makeSession('s2'), // omitted field → empty list
+    ]
+    const out = buildSessionListPatches({ sessions }, [], null)
+    expect(out!.backgroundShellBuilders.size).toBe(2)
+    const s1Builder = out!.backgroundShellBuilders.get('s1')!
+    expect(s1Builder.sessionId).toBe('s1')
+    const s1Applied = s1Builder.applyTo([])
+    expect(s1Applied).toEqual([
+      { shellId: 'sh1', command: 'sleep 1', startedAt: 1000 },
+    ])
+    const s2Builder = out!.backgroundShellBuilders.get('s2')!
+    // Empty pending list → applyTo on empty current returns existing
+    // empty array (reference-equality short-circuit).
+    const empty: PendingBackgroundShell[] = []
+    expect(s2Builder.applyTo(empty)).toBe(empty)
+  })
+
+  it('chunks non-active session ids into subscribeChunks of SESSION_LIST_SUBSCRIBE_CHUNK_SIZE', () => {
+    // Active id is excluded; remaining ids are sliced into batches.
+    const total = SESSION_LIST_SUBSCRIBE_CHUNK_SIZE + 5 // active + (chunk_size + 4) non-active
+    const sessions = Array.from({ length: total }, (_, i) =>
+      makeSession(`s${i + 1}`),
+    )
+    const out = buildSessionListPatches({ sessions }, [], 's1')
+    expect(out!.subscribeChunks).toHaveLength(2)
+    expect(out!.subscribeChunks[0]).toHaveLength(SESSION_LIST_SUBSCRIBE_CHUNK_SIZE)
+    expect(out!.subscribeChunks[1]).toHaveLength(4)
+    // Active id must not appear in any chunk.
+    const flat = out!.subscribeChunks.flat()
+    expect(flat).not.toContain('s1')
+  })
+
+  it('returns empty subscribeChunks when no non-active ids remain', () => {
+    const sessions = [makeSession('s1')]
+    const out = buildSessionListPatches({ sessions }, [], 's1')
+    expect(out!.subscribeChunks).toEqual([])
+  })
+
+  it('returns empty subscribeChunks when sessionList is empty (auto-resume path)', () => {
+    const out = buildSessionListPatches({ sessions: [] }, ['s1', 's2'], 's1')
+    expect(out!.sessionList).toEqual([])
+    expect(out!.removedIds).toEqual(['s1', 's2'])
+    expect(out!.subscribeChunks).toEqual([])
+  })
+
+  it('respects custom subscribeChunkSize, falls back to default on invalid input', () => {
+    const sessions = Array.from({ length: 7 }, (_, i) => makeSession(`s${i + 1}`))
+    const out = buildSessionListPatches({ sessions }, [], 's1', 3)
+    // 6 non-active ids / chunk_size 3 → 2 full chunks
+    expect(out!.subscribeChunks.map((c) => c.length)).toEqual([3, 3])
+    // Invalid sizes fall back to the constant default (would all fit in one chunk here).
+    const out2 = buildSessionListPatches({ sessions }, [], 's1', 0)
+    expect(out2!.subscribeChunks).toHaveLength(1)
+    expect(out2!.subscribeChunks[0]).toHaveLength(6)
+  })
+
+  it('chunkSubscribeSessionIds: filters out active id and chunks by size', () => {
+    const sessions = Array.from({ length: 7 }, (_, i) =>
+      makeSession(`s${i + 1}`),
+    )
+    expect(chunkSubscribeSessionIds(sessions, 's1', 3).map((c) => c.length)).toEqual([3, 3])
+    // No active filter when activeSessionId is null.
+    expect(chunkSubscribeSessionIds(sessions, null, 3).map((c) => c.length)).toEqual([3, 3, 1])
+    // Empty when only the active id is present.
+    expect(chunkSubscribeSessionIds([makeSession('s1')], 's1')).toEqual([])
+    // Skips malformed entries fail-soft.
+    const malformed = [
+      makeSession('s1'),
+      null as unknown as SessionInfo,
+      makeSession('s2'),
+    ]
+    expect(chunkSubscribeSessionIds(malformed, 's1')).toEqual([['s2']])
+  })
+
+  it('includes the active session in cumulativeUsage / conversationId / backgroundShell maps', () => {
+    // The subscribeChunks filter excludes the active id, but the patch
+    // maps must include it — both clients update the active session's
+    // sessionStates entry the same way as any other.
+    const sessions = [
+      makeSession('s1', {
+        conversationId: 'conv-1',
+        cumulativeUsage: {
+          inputTokens: 1,
+          outputTokens: 2,
+          cacheReadTokens: 0,
+          cacheCreationTokens: 0,
+          costUsd: 0,
+          turnsBilled: 1,
+        },
+      }),
+    ]
+    const out = buildSessionListPatches({ sessions }, ['s1'], 's1')
+    expect(out!.conversationIdPatches.get('s1')).toBe('conv-1')
+    expect(out!.cumulativeUsagePatches.has('s1')).toBe(true)
+    expect(out!.backgroundShellBuilders.has('s1')).toBe(true)
+    // s1 is active → excluded from subscribe chunks.
+    expect(out!.subscribeChunks).toEqual([])
   })
 })
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1851,6 +1851,41 @@ describe('buildSessionListPatches', () => {
     expect(chunkSubscribeSessionIds(malformed, 's1')).toEqual([['s2']])
   })
 
+  it('chunkSubscribeSessionIds: clamps chunk size to SESSION_LIST_SUBSCRIBE_CHUNK_SIZE', () => {
+    // 25 non-active sessions; caller requests chunk of 100 → clamped to 20
+    // so the server's SubscribeSessionsSchema.max(20) never sees a bigger chunk.
+    const sessions = Array.from({ length: 26 }, (_, i) => makeSession(`s${i + 1}`))
+    const chunks = chunkSubscribeSessionIds(sessions, 's1', 100)
+    expect(chunks.map((c) => c.length)).toEqual([SESSION_LIST_SUBSCRIBE_CHUNK_SIZE, 5])
+    // Exact match: requesting the cap explicitly behaves the same as the default.
+    expect(chunkSubscribeSessionIds(sessions, 's1', SESSION_LIST_SUBSCRIBE_CHUNK_SIZE)).toEqual(
+      chunkSubscribeSessionIds(sessions, 's1'),
+    )
+  })
+
+  it('chunkSubscribeSessionIds: coerces non-integer chunk sizes via Math.floor', () => {
+    // 7 non-active ids; chunk 2.5 → floor(2.5) = 2 → ceil(7/2) = 4 chunks
+    const sessions = Array.from({ length: 8 }, (_, i) => makeSession(`s${i + 1}`))
+    const chunks = chunkSubscribeSessionIds(sessions, 's1', 2.5)
+    expect(chunks.map((c) => c.length)).toEqual([2, 2, 2, 1])
+    // No element duplicated and no element skipped.
+    expect(chunks.flat()).toEqual(['s2', 's3', 's4', 's5', 's6', 's7', 's8'])
+  })
+
+  it('chunkSubscribeSessionIds: rejects invalid chunk sizes (≤0, NaN, ∞, sub-1 floats)', () => {
+    const sessions = Array.from({ length: 6 }, (_, i) => makeSession(`s${i + 1}`))
+    // 0, negative, NaN, Infinity all fall back to the default constant.
+    for (const bad of [0, -1, NaN, Infinity, -Infinity]) {
+      const chunks = chunkSubscribeSessionIds(sessions, 's1', bad)
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0]).toHaveLength(5) // 6 sessions - 1 active = 5 ids
+    }
+    // 0.5 → floor → 0 → fallback to default.
+    const subOne = chunkSubscribeSessionIds(sessions, 's1', 0.5)
+    expect(subOne).toHaveLength(1)
+    expect(subOne[0]).toHaveLength(5)
+  })
+
   it('includes the active session in cumulativeUsage / conversationId / backgroundShell maps', () => {
     // The subscribeChunks filter excludes the active id, but the patch
     // maps must include it — both clients update the active session's

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1189,10 +1189,14 @@ export function handleSessionList(msg: Record<string, unknown>): SessionInfo[] |
 }
 
 /**
- * Default chunk size for `subscribe_sessions` messages produced by
- * {@link buildSessionListPatches}. Matches the server-side
- * `ServerSubscribeSessionsSchema` max-ids bound; consumers may override
- * via the optional `subscribeChunkSize` parameter.
+ * Default (and maximum) chunk size for `subscribe_sessions` messages
+ * produced by {@link buildSessionListPatches}. Matches the protocol-level
+ * `SubscribeSessionsSchema` `.max(20)` bound (client→server message — the
+ * server validates incoming `subscribe_sessions` payloads against this
+ * cap). Consumers may pass a SMALLER override via the optional
+ * `subscribeChunkSize` parameter; {@link chunkSubscribeSessionIds} clamps
+ * larger / non-integer / non-positive values to this constant so a buggy
+ * caller can never produce payloads the server will reject.
  *
  * Co-located here (rather than per-consumer) so the app and dashboard
  * can't drift out of sync — see #4767 acceptance criteria.
@@ -1401,16 +1405,34 @@ export function buildSessionListPatches(
  * Returns `[]` when there are no non-active ids to subscribe (empty
  * sessionList, or list contains only the active session). Defensive
  * against malformed entries (missing/non-string sessionId — skipped).
+ *
+ * `subscribeChunkSize` is normalised to an integer in
+ * `[1, SESSION_LIST_SUBSCRIBE_CHUNK_SIZE]`:
+ * - Non-integers (e.g. `0.5`, `2.5`) would cause `i += chunkSize` to walk
+ *   off the grid and `slice(i, i + chunkSize)` to coerce via truncation,
+ *   producing duplicated / skipped ids — `Math.floor` removes the
+ *   fractional part defensively.
+ * - Values `<= 0` or non-numeric fall back to the default constant.
+ * - Values `> SESSION_LIST_SUBSCRIBE_CHUNK_SIZE` are clamped down so a
+ *   buggy caller can never emit a chunk the server's
+ *   `SubscribeSessionsSchema.max(20)` would reject.
  */
 export function chunkSubscribeSessionIds(
   sessionList: SessionInfo[],
   activeSessionId: string | null,
   subscribeChunkSize: number = SESSION_LIST_SUBSCRIBE_CHUNK_SIZE,
 ): string[][] {
-  const chunkSize =
-    typeof subscribeChunkSize === 'number' && subscribeChunkSize > 0
-      ? subscribeChunkSize
+  const requested =
+    typeof subscribeChunkSize === 'number' &&
+    Number.isFinite(subscribeChunkSize) &&
+    subscribeChunkSize > 0
+      ? Math.floor(subscribeChunkSize)
       : SESSION_LIST_SUBSCRIBE_CHUNK_SIZE
+  // Floor may produce 0 if 0 < value < 1 (e.g. 0.5) — fall back to default.
+  const normalised = requested >= 1 ? requested : SESSION_LIST_SUBSCRIBE_CHUNK_SIZE
+  // Clamp to the protocol-enforced cap so callers can't produce
+  // payloads that violate SubscribeSessionsSchema.max(20).
+  const chunkSize = Math.min(normalised, SESSION_LIST_SUBSCRIBE_CHUNK_SIZE)
   const ids: string[] = []
   for (const s of sessionList) {
     if (!s || typeof s.sessionId !== 'string') continue

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1188,6 +1188,241 @@ export function handleSessionList(msg: Record<string, unknown>): SessionInfo[] |
   return msg.sessions as unknown as SessionInfo[]
 }
 
+/**
+ * Default chunk size for `subscribe_sessions` messages produced by
+ * {@link buildSessionListPatches}. Matches the server-side
+ * `ServerSubscribeSessionsSchema` max-ids bound; consumers may override
+ * via the optional `subscribeChunkSize` parameter.
+ *
+ * Co-located here (rather than per-consumer) so the app and dashboard
+ * can't drift out of sync — see #4767 acceptance criteria.
+ */
+export const SESSION_LIST_SUBSCRIBE_CHUNK_SIZE = 20
+
+/**
+ * Per-session patch maps + derived bookkeeping produced by
+ * {@link buildSessionListPatches}. See that function's doc-comment for the
+ * full call-site recipe.
+ */
+export interface SessionListPatches {
+  /** Parsed sessions array (same reference returned by {@link handleSessionList}). */
+  sessionList: SessionInfo[]
+  /**
+   * Session ids present in `prevSessionStateIds` but missing from the new
+   * snapshot. Consumers GC persisted state + `sessionStates[id]` for these,
+   * and decide their own "active session was removed" fallback policy.
+   */
+  removedIds: string[]
+  /**
+   * Session ids in the new snapshot that are NOT in `prevSessionStateIds`.
+   * Consumers seed `sessionStates[id]` for these (typically with their
+   * platform-specific `createEmptySessionState()`); the dashboard's
+   * `isBusy → isIdle` seed (#4639) stays at the call site because it
+   * mutates the consumer's own state shape.
+   */
+  newSessionIds: string[]
+  /**
+   * `sessionId → conversationId` for every session whose snapshot has a
+   * non-null `conversationId`. Consumers gate on `sessionStates[id]` and
+   * call `updateSession(id, ss => ss.conversationId !== cid ? { conversationId: cid } : {})`.
+   */
+  conversationIdPatches: Map<string, string>
+  /**
+   * `sessionId → CumulativeUsage snapshot` for every session whose
+   * snapshot has a non-undefined `cumulativeUsage` (#4073 / #4074).
+   * Consumers gate on `sessionStates[id]` and use
+   * {@link cumulativeUsageEquals} to short-circuit no-op patches.
+   */
+  cumulativeUsagePatches: Map<string, CumulativeUsage>
+  /**
+   * `sessionId → PendingBackgroundShellsBuilder` for every session in the
+   * snapshot — defaults to an empty `pending` list when the snapshot omits
+   * the field (#4307 wire compat). Consumers gate on `sessionStates[id]`
+   * and call `builder.applyTo(current)`; the builder's reference-equality
+   * short-circuit suppresses no-op re-renders.
+   */
+  backgroundShellBuilders: Map<string, PendingBackgroundShellsBuilder>
+  /**
+   * Non-active session ids chunked into `subscribe_sessions` payloads. Each
+   * chunk's length <= `SESSION_LIST_SUBSCRIBE_CHUNK_SIZE` (default 20 — the
+   * server schema's max ids per message). Consumers iterate and send one
+   * `subscribe_sessions` message per chunk; empty array means nothing to send.
+   *
+   * Consumers that don't auto-subscribe (currently the dashboard) ignore this
+   * field; it's surfaced here so both clients can adopt the same chunking
+   * logic without re-duplicating it later (#4767).
+   */
+  subscribeChunks: string[][]
+}
+
+/**
+ * Reference-comparison-friendly equality check for two
+ * {@link CumulativeUsage} snapshots. Returns `true` when both are non-null
+ * and all six tracked fields (`inputTokens`, `outputTokens`,
+ * `cacheReadTokens`, `cacheCreationTokens`, `costUsd`, `turnsBilled`) match.
+ *
+ * Two nulls return `false` — there is no current snapshot to short-circuit
+ * against, so the caller would apply the (also-null) candidate as a no-op
+ * write anyway. The pre-existing inline checks both gated on
+ * `current && ...`, so this preserves that exact behaviour.
+ *
+ * Centralised here so both consumers stay in sync if the
+ * {@link CumulativeUsage} shape grows a new field (#4767 AC).
+ */
+export function cumulativeUsageEquals(
+  a: CumulativeUsage | null | undefined,
+  b: CumulativeUsage | null | undefined,
+): boolean {
+  if (!a || !b) return false
+  return (
+    a.inputTokens === b.inputTokens &&
+    a.outputTokens === b.outputTokens &&
+    a.cacheReadTokens === b.cacheReadTokens &&
+    a.cacheCreationTokens === b.cacheCreationTokens &&
+    a.costUsd === b.costUsd &&
+    a.turnsBilled === b.turnsBilled
+  )
+}
+
+/**
+ * Build the per-session patch maps + derived bookkeeping a `session_list`
+ * consumer needs to apply the snapshot. Centralises the GC + new-session
+ * seeding + conversationId sync + #4073/#4074 cumulativeUsage seeding +
+ * #4307 pendingBackgroundShells seeding + `subscribe_sessions` chunking
+ * logic that previously lived inline in both the app and dashboard
+ * `case 'session_list'` branches (#4767).
+ *
+ * Returns `null` when {@link handleSessionList} rejects the message —
+ * consumers `break` out of the case in that path, preserving prior
+ * behaviour.
+ *
+ * Behaviour preservation contract:
+ * - `removedIds` filters `prevSessionStateIds` by membership in the new id
+ *   set — identical to both prior inline computations
+ *   (app L1209-1211 / dashboard L2140-2142).
+ * - `newSessionIds` lists ids in the new snapshot that aren't already in
+ *   `prevSessionStateIds`, in snapshot order. Mirrors both prior
+ *   `for (const s of sessionList) if (!newStates[s.sessionId]) ...` loops
+ *   (app L1236-1241 / dashboard L2206-2213).
+ * - `conversationIdPatches` includes every session with a truthy
+ *   `conversationId` — the consumer's `ss.conversationId !== cid` short-
+ *   circuit stays at the call site (existing `updateSession` callback).
+ * - `cumulativeUsagePatches` includes every session whose snapshot has a
+ *   non-undefined `cumulativeUsage` field — same gate as the prior inline
+ *   `if (s.cumulativeUsage && ...)` (app L1258 / dashboard L2246). Use
+ *   {@link cumulativeUsageEquals} at the call site for the six-field
+ *   no-op short-circuit (centralised here per #4767 AC).
+ * - `backgroundShellBuilders` always includes every session (per the
+ *   #4307 wire contract: omitted = []); each builder's `applyTo` does the
+ *   per-shell reference-equality short-circuit. The consumer still gates
+ *   on `sessionStates[id]` to skip sessions it hasn't seeded yet, matching
+ *   both prior inline `if (!get().sessionStates[s.sessionId]) continue;`
+ *   guards (app L1283 / dashboard L2275).
+ * - `subscribeChunks` filters out `activeSessionId` then chunks by
+ *   `SESSION_LIST_SUBSCRIBE_CHUNK_SIZE`. Matches app L1308-1318. When
+ *   nothing to subscribe (empty list or only active id present), the
+ *   array is empty so consumers can iterate without an outer guard.
+ *
+ * Consumer-specific behaviour stays at the call site:
+ * - The app's `loadLastConversationId()` auto-resume on empty list +
+ *   reconnect (L1196-1207).
+ * - The dashboard's `activeModel` lookup against `availableModels`
+ *   (L2188-2197) and `isBusy → isIdle` resync (#4639, L2223-2230).
+ * - Both consumers' `clearPersistedSession(prevId)` call per removed id.
+ * - The app's `persistLastConversationId(activeConversationId)` after seeding.
+ * - The dashboard's "active session removed → copy flat fields into the
+ *   top-level patch" recovery (L2159-2180) — this touches consumer-
+ *   specific top-level state slots so it stays in the consumer's `set()`.
+ */
+export function buildSessionListPatches(
+  msg: Record<string, unknown>,
+  prevSessionStateIds: readonly string[],
+  activeSessionId: string | null,
+  subscribeChunkSize: number = SESSION_LIST_SUBSCRIBE_CHUNK_SIZE,
+): SessionListPatches | null {
+  const sessionList = handleSessionList(msg)
+  if (!sessionList) return null
+
+  const newIdSet = new Set<string>()
+  for (const s of sessionList) {
+    if (s && typeof s.sessionId === 'string') newIdSet.add(s.sessionId)
+  }
+
+  const prevIdSet = new Set(prevSessionStateIds)
+
+  const removedIds: string[] = []
+  for (const prev of prevSessionStateIds) {
+    if (!newIdSet.has(prev)) removedIds.push(prev)
+  }
+
+  const newSessionIds: string[] = []
+  const conversationIdPatches = new Map<string, string>()
+  const cumulativeUsagePatches = new Map<string, CumulativeUsage>()
+  const backgroundShellBuilders = new Map<string, PendingBackgroundShellsBuilder>()
+
+  for (const s of sessionList) {
+    if (!s || typeof s.sessionId !== 'string') continue
+    const sid = s.sessionId
+    if (!prevIdSet.has(sid)) newSessionIds.push(sid)
+    if (s.conversationId) conversationIdPatches.set(sid, s.conversationId)
+    if (s.cumulativeUsage) cumulativeUsagePatches.set(sid, s.cumulativeUsage)
+    backgroundShellBuilders.set(
+      sid,
+      handleBackgroundWorkChanged(
+        { sessionId: sid, pending: s.pendingBackgroundShells ?? [] },
+        activeSessionId,
+      ),
+    )
+  }
+
+  const subscribeChunks = chunkSubscribeSessionIds(sessionList, activeSessionId, subscribeChunkSize)
+
+  return {
+    sessionList,
+    removedIds,
+    newSessionIds,
+    conversationIdPatches,
+    cumulativeUsagePatches,
+    backgroundShellBuilders,
+    subscribeChunks,
+  }
+}
+
+/**
+ * Filter out `activeSessionId` from `sessionList` and chunk the remaining
+ * ids into `subscribe_sessions`-bound payloads.
+ *
+ * Extracted from {@link buildSessionListPatches} so consumers whose active
+ * session changes after the initial patch computation (e.g. the active
+ * session was removed and the consumer fell back to the first surviving
+ * id) can recompute the chunks against the final active id without
+ * re-running the full patch builder.
+ *
+ * Returns `[]` when there are no non-active ids to subscribe (empty
+ * sessionList, or list contains only the active session). Defensive
+ * against malformed entries (missing/non-string sessionId — skipped).
+ */
+export function chunkSubscribeSessionIds(
+  sessionList: SessionInfo[],
+  activeSessionId: string | null,
+  subscribeChunkSize: number = SESSION_LIST_SUBSCRIBE_CHUNK_SIZE,
+): string[][] {
+  const chunkSize =
+    typeof subscribeChunkSize === 'number' && subscribeChunkSize > 0
+      ? subscribeChunkSize
+      : SESSION_LIST_SUBSCRIBE_CHUNK_SIZE
+  const ids: string[] = []
+  for (const s of sessionList) {
+    if (!s || typeof s.sessionId !== 'string') continue
+    if (s.sessionId !== activeSessionId) ids.push(s.sessionId)
+  }
+  const chunks: string[][] = []
+  for (let i = 0; i < ids.length; i += chunkSize) {
+    chunks.push(ids.slice(i, i + chunkSize))
+  }
+  return chunks
+}
+
 // ---------------------------------------------------------------------------
 // session_context
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -247,6 +247,8 @@ export type {
   SessionInterventionBuilder,
   AgentInfoBuilder,
   PendingBackgroundShellsBuilder,
+  // #4767 — centralised session_list dispatch (GC + cumulativeUsage + pendingShells seeding)
+  SessionListPatches,
   ServerMode,
   AuthOkPayload,
   CheckpointRestoredPayload,
@@ -344,6 +346,11 @@ export {
   handlePermissionTimeout,
   handlePermissionRulesUpdated,
   handleSessionList,
+  // #4767 — centralised session_list dispatch helpers (used by both app + dashboard)
+  buildSessionListPatches,
+  cumulativeUsageEquals,
+  chunkSubscribeSessionIds,
+  SESSION_LIST_SUBSCRIBE_CHUNK_SIZE,
   handleSessionContext,
   handleSessionTimeout,
   handleSessionRestoreFailed,


### PR DESCRIPTION
## Summary

Extracts the ~80 LOC of `session_list` GC + cumulativeUsage + pendingShells seeding logic that was duplicated verbatim between the app and dashboard handlers into `buildSessionListPatches()` in `@chroxy/store-core`. The six-field `CumulativeUsage` equality short-circuit (#4073/#4074) and the `subscribe_sessions` chunking (#4767 risk note) are now co-located in store-core so the two consumers can't drift apart.

### What moved into store-core

- `buildSessionListPatches(msg, prevSessionStateIds, activeSessionId)` returns `{sessionList, removedIds, newSessionIds, conversationIdPatches, cumulativeUsagePatches, backgroundShellBuilders, subscribeChunks}` — pure computation, no store / WebSocket access.
- `cumulativeUsageEquals(a, b)` — the six-field reference-comparison short-circuit (was duplicated 20 lines verbatim in each consumer).
- `chunkSubscribeSessionIds(sessionList, activeId, chunkSize)` — extracted as a standalone helper so a consumer whose active session is removed mid-flow can recompute chunks against the post-removal active id without re-running the full patch builder.
- `SESSION_LIST_SUBSCRIBE_CHUNK_SIZE = 20` co-located with the chunker; `packages/app/src/store/message-handler.ts` re-exports it as `SUBSCRIBE_SESSIONS_CHUNK_SIZE` to keep its public test surface byte-compatible.

### What stays at the call site (consumer-specific, by design)

Per the issue's acceptance criteria:

- **App**: `loadLastConversationId()` auto-resume on empty-list + reconnect; `persistLastConversationId(activeConversationId)` after seeding; `clearPersistedSession()` per removed id.
- **Dashboard**: `activeModel` lookup against `availableModels`; `isBusy → isIdle` resync (#4639) on existing sessions; active-session-removed flat-field recovery copy (`patch.messages`, `patch.claudeReady`, etc.).

## Behavior preservation

The new helper's doc-comment enumerates every prior inline gate + short-circuit against its replacement (e.g. `removedIds` filtering preserves `prevSessionStateIds` order; `cumulativeUsagePatches` only includes sessions whose snapshot has a non-undefined `cumulativeUsage` field; `backgroundShellBuilders` always includes every session per #4307 wire contract).

Verified by:

- **All existing tests pass** — 1446 app, 2495 dashboard, 938 store-core, 151 protocol — across both consumers' `session_list` paths. Behavior drift would have been caught by the dashboard's `App.test.tsx` composer-ref reconciliation tests (#3977), the app's `__tests__/store/message-handler.test.ts` chunking test, and the cross-cutting `connection.test.ts` suites that exercise sessionStates GC.
- **13 new boundary tests** added for `buildSessionListPatches`, `cumulativeUsageEquals`, and `chunkSubscribeSessionIds` covering: null-message rejection, fail-soft malformed entries, `removedIds` order preservation, `newSessionIds` snapshot-order, conversationId / cumulativeUsage / backgroundShell map population, active-session inclusion in patch maps + exclusion from subscribeChunks, custom + invalid chunk sizes, and empty-list / single-session corner cases.

Pre-existing flakes (server `BaseSession`, `service`, `TunnelManager Integration`, `WebTaskManager` — all environmental: operator-timeout, cloudflared, git, web task) reproduce identically on `main` and pass in isolation; unrelated to this refactor.

## Test plan

- [x] `packages/store-core` — `vitest run` (938 tests pass; 13 new)
- [x] `packages/app` — `jest` (1446 tests pass)
- [x] `packages/dashboard` — `vitest run` (2495 tests pass)
- [x] `packages/protocol` — `node --test` (151 tests pass)
- [x] `tsc --noEmit` clean across app, dashboard, store-core
- [x] App's `SUBSCRIBE_SESSIONS_CHUNK_SIZE` public export preserved (existing test imports it)
- [x] No semantic drift: every six-field equality short-circuit, every reference-equality guard, every fail-soft branch from the prior inline code is exercised by the new tests

Closes #4767