### PR TITLE
chore(release): cut v0.9.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.33] - 2026-06-01
+
+Major drain on the `from-review` backlog plus a DRY/SOLID sweep. Two marathon rounds landed 27 PRs across the multi-question / AskUserQuestion surface (server form-driver, dashboard chips, store-core dispatch), per-session settings hardening, and a structural refactor pass that shrunk providers.js from 808→334 LOC and lifted shared store-core dispatch out of duplicated mobile/dashboard handlers. Two latent bugs were caught inside the refactor work: the mobile auth_ok parser was silently dropping `streamStallTimeoutMs`, and the WS broadcaster's session/client_joined paths were bypassing backpressure metrics.
+
+### Added
+
+- **SDK / BYOK end-to-end multi-question AskUserQuestion support (#4731 / #4763):** schema accepts `string | string[]` values; PermissionManager normalizes both shapes (plus legacy JSON-stringified arrays) to the SDK's canonical comma-separated format; dashboard renders MultiQuestionForm for non-TUI providers. 4 wedge shapes (mixed-type, all-single, all-multi, with-Other) pinned by 8 new server tests.
+- **Per-question array answer wire format (#4735 / #4760):** widens `UserQuestionResponseSchema.answers` to `Record<string, string | string[]>`; dashboard MultiQuestionForm emits native arrays for multi-select instead of JSON-stringifying; provider gating via `allowMultiQuestion` opt-in (TUI / CLI still go through permission-hook).
+- **Single-question "Other" / freeform answer support (#4651 / #4753):** two-stage server PTY write (Other digit → 150ms settle → freeform text + Enter); dashboard emits `{otherLabel, freeformText}` payload.
+- **Surface multi-question AskUserQuestion denials end-to-end (#4653 / #4758):** server emits `multi_question_intervention`; store-core normalises into a deduped `SessionIntervention[]` ring; dashboard renders FooterBar counter chip + InterventionsPanel + one-time system message.
+- **Pre-first-output silence watchdog for claude TUI sessions (#4732 / #4749):** arms a separate `FIRST_OUTPUT_TIMEOUT_MS` at `writePtyText` completion. Fixes the live failure where a claude TUI subprocess hung 3+ minutes after spawn with `consumed=0 stopFound=no` and no STREAM_STALL ever firing.
+- **Dedicated dashboard chip for `ASK_USER_QUESTION_STALL` errors (#4615 / #4744):** one-tap Retry affordance + pending-prompt suppression, mirroring the StreamStallChip pattern.
+- **Per-provider StreamStallChip copy + view-logs affordance (#4603 / #4740):** headline prefix per provider.
+- **Surface `ASK_USER_QUESTION_TOO_MANY_OPTIONS` for picks at index >=9 (#4625 / #4741):** previously silently defaulted to option 1; now fires full turn teardown via a shared `_teardownAskUserQuestion` helper.
+- **Per-provider `streamStallTimeoutMs` config (#4601 / #4745):** operators can override recovery window per provider id; default behavior unchanged when omitted.
+- **Multi-client broadcast coverage for per-session settings (#4663 / #4743):** handler-level (server) + receive-side store-mutation (dashboard) for prompt_evaluator, chroxy_context_hint, session_preamble; 24 new tests.
+- **Tauri updater latest.json now merges per-platform fragments (#3809 / #4736):** `scripts/merge-updater-feeds.mjs` + release.yml step combines macOS and Windows feed entries into one cross-platform auto-updater feed.
+
+### Changed
+
+- **providers.js shrunk 808→334 LOC via per-provider `static resolveAuth()` dispatch (#4769 / #4777, OCP):** OAuth probes and credential-file cache extracted to `auth-probes.js`; byte-identical behaviour across 83 provider/auth tests.
+- **Extracted `ClaudeStreamParser` (#4768 / #4774, DRY):** wire-format parsing now shared between `CliSession` and `SdkSession`; 19 new boundary tests + 1 regression test on top of 294 existing tests.
+- **Unified `auth_ok` wire parser in @chroxy/store-core (#4766 / #4781, DRY):** `handleAuthOk` + `parseConnectedClients` migrated app + dashboard onto shared dispatch. **Fixed latent mobile bug:** `streamStallTimeoutMs` was being silently dropped on the mobile side.
+- **Centralized `session_list` dispatch in store-core (#4767 / #4782, DRY):** extracted `buildSessionListPatches` + `cumulativeUsageEquals` + `chunkSubscribeSessionIds`; migrated both consumers.
+- **Moved `getWsCloseMessage` + `getHealthCheckErrorMessage` to @chroxy/store-core (#4771 / #4779, DRY):** dashboard now surfaces close-code-specific copy on socket.onclose and uses the richer health-check error split.
+- **Extracted `useShortcutDispatch` + `useChatMessages` from App.tsx (#4770 / #4776, SRP):** App.tsx 2454→2231 LOC. Stale `useGlobalShortcuts` deleted. 36 new boundary tests.
+- **Extracted `_sendOneWithBackpressure` helper on WsBroadcaster (#4772 / #4775, DRY):** unified 3 copy-pasted backpressure loops. **Fixed latent observability bug:** session/client_joined broadcasts silently bypassed backpressure metrics.
+- **Extracted `sendSessionError` / `resolveSessionOrError` / `requireSessionMethod` helpers from handlers (#4773 / #4783, DRY):** 8 resolve sites + 6 capability gates + ~24 inline envelopes collapsed.
+- **Extracted per-session-setting registry (#4664 / #4751, DRY):** collapsed the 5-site boilerplate that promptEvaluator → chroxyContextHint → sessionPreamble had each hand-written; migrated three existing knobs onto it.
+- **Surgical AskUserQuestion watchdog teardown (#4691 / #4752):** `_onAskUserQuestionStall` now calls `_clearPendingAnswerByToolUseId` so the watchdog only drops the timed-out tool's entry, not every sibling. Other teardown sites keep all-or-nothing semantics.
+
+### Fixed
+
+- **Chat markdown overflows window — code blocks + inline code break wrapping (#4757 / #4759):** `pre` blocks now `max-width: 100%` + `overflow-x: auto`; inline `code` gets `overflow-wrap: anywhere`; chat message bubble gets `min-width: 0` to allow flex shrink.
+- **Dashboard scroll respects user-initiated scroll-up when AskUserQuestion visible (#4652 / #4737):** add `overscroll-behavior: contain` + 60vh cap on multi-question form so chat history scrolls past the form.
+- **Working banner sync to server `isBusy` across tab swaps (#4639 / #4742):** session_list seed/resync + new `session_activity` handler + switchSession seed.
+- **Distinguish intentional SIGINT from child crash in `cli-session.js` (#4602 / #4750):** `_intentionalStop` flag suppresses respawn + emits quiet `stopped` event for user-triggered Stop.
+- **Preamble debounce cancel on session switch + multi-client conflict banner (#4662 / #4738):** mirrors QuietHoursEditor #4570 pattern.
+- **`scripts/tui-form-recorder` flushes JSONL before `process.exit` (#4729 / #4747):** extracted `flushAndExit` helper waits for stream finish before exiting; added `recordingClosed` guard against ERR_STREAM_WRITE_AFTER_END.
+- **Widen `user_question_response.answers` to `Record<string, string | string[]>` (#4621 / #4748):** MultiQuestionForm ships native arrays instead of JSON-stringifying; legacy shape still accepted for back-compat.
+- **CI: Expo Doctor allowlist extended (#4730):** RN directory metadata + Metro config + duplicate-deps categories now skipped (Expo published patch updates mid-marathon broke every post-merge CI rerun).
+
+### Investigated
+
+- **MCP elicitation shim spike (#4734 / #4754):** research doc + spike for Approach 3 (bypass TUI AskUserQuestion via MCP elicitation). Recommendation: **DEFER** until either Anthropic ships a preferred-tool override or claude TUI form-widget drift makes the keystroke driver materially worse than steering risk.
+
 ## [0.9.32] - 2026-06-01
 
 Test-coverage push closing the gaps identified in the 2026-05-31 testing audit. The v0.9.x prompt-delivery wedge fixes (#4668/#4679/#4687/#4648/#4669) were already pinned server-side; this release locks in the surfaces that still had no regression coverage — mobile-side approval flows, the desktop Tauri command surface, the CLI command layer, and the SDK/CLI session persistence roundtrip.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.32",
+      "version": "0.9.33",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.32",
+      "version": "0.9.33",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.32",
+      "version": "0.9.33",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.32"
+      "version": "0.9.33"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.32",
+      "version": "0.9.33",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.32",
+      "version": "0.9.33",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.32",
+      "version": "0.9.33",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.32",
+    "version": "0.9.33",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.32</string>
+    <string>0.9.33</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.32"
+version = "0.9.33"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.32"
+version = "0.9.33"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.32",
+      "version": "0.9.33",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.32",
+  "version": "0.9.33",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Major drain on the `from-review` backlog plus a DRY/SOLID structural refactor sweep.

**Marathon 1 (bug-fix)** — 19 PRs across the multi-question / AskUserQuestion surface, per-session settings hardening, dashboard chips, and watchdog teardown paths. All Approve, zero retries.

**Dogfood-found** — 2 PRs from live testing of v0.9.32: pre-first-output silence watchdog (#4732) and chat markdown overflow (#4757).

**Marathon 2 (refactor)** — 8 PRs implementing the DRY/SOLID sweep findings: providers.js 808→334 LOC, ClaudeStreamParser extraction, store-core dispatch unification (auth_ok + session_list + WS errors), App.tsx SRP extraction, ws-broadcaster backpressure helper, session-resolution handlers. All Approve, zero retries. **Two latent bugs caught inside:** mobile dropping `streamStallTimeoutMs`, WS broadcaster bypassing backpressure metrics.

## Test plan

- [x] All 27 contributing PRs landed via batch-merge with green CI
- [x] CHANGELOG entry covers the full surface organized by Added / Changed / Fixed / Investigated
- [ ] Tauri app rebuild + dogfood after merge (verify #4757 fix shrinks chat content correctly)
- [ ] No-it-all session in chroxy confirms PR #4759 fix (markdown overflow) holds when window is resized smaller

Closes nothing — release PR, all referenced issues already closed by the contributing PRs.