### PR TITLE
feat(dashboard): voice input continuous mode + settings toggle

### DIFF
--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -312,6 +312,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   inputSettings: {
     chatEnterToSend: true,
     terminalEnterToSend: false,
+    // #4785: mobile voice path lives in useSpeechRecognition (expo-speech-recognition),
+    // which has its own end-of-utterance semantics. Field is type-satisfied here so
+    // the shared @chroxy/store-core InputSettings stays a single shape across app +
+    // dashboard; wiring it to mobile behaviour is tracked separately.
+    voiceInputMode: 'continuous',
   },
   viewingCachedSession: false,
   viewMode: 'chat',

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -292,8 +292,12 @@ export function App() {
   // Listen for Tauri desktop events (no-op in browser context)
   useTauriEvents()
 
-  // Voice input (Tauri only — no-op in browser)
-  const voiceInput = useVoiceInput()
+  // Voice input mode is persisted on inputSettings (#4785). Default is
+  // 'continuous' — click to start, click to stop, mic stays lit across
+  // silence gaps. Pre-#4785 behaviour ('auto-pause' on silence) available
+  // via the Voice input section of SettingsPanel.
+  const voiceInputMode = useConnectionStore(s => s.inputSettings.voiceInputMode)
+  const voiceInput = useVoiceInput({ mode: voiceInputMode })
 
   // Session-level state via useShallow — includes messages from sessionStates.
   // stream_end/result handlers force a new messages[] reference so useShallow

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -987,6 +987,13 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
     updateInputSettings({ chatEnterToSend: e.target.value === 'enter' })
   }, [updateInputSettings])
 
+  const handleVoiceInputModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    const next = e.target.value
+    if (next === 'continuous' || next === 'auto-pause') {
+      updateInputSettings({ voiceInputMode: next })
+    }
+  }, [updateInputSettings])
+
   useEffect(() => {
     if (!isOpen) return
     const handler = (e: KeyboardEvent) => {
@@ -1087,6 +1094,23 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
               >
                 <option value="enter">Enter</option>
                 <option value="cmd-enter">Cmd/Ctrl+Enter</option>
+              </select>
+            </div>
+            {/* #4785: voice input behaviour. `continuous` keeps the mic
+                lit across silence gaps until the user clicks stop.
+                `auto-pause` is the pre-#4785 behaviour (Web Speech ends
+                on silence). Only affects the web engine; the Tauri
+                native engine has its own end-of-utterance semantics. */}
+            <div className="settings-field">
+              <label htmlFor="voice-input-mode">Voice input</label>
+              <select
+                id="voice-input-mode"
+                aria-label="Voice input mode"
+                value={inputSettings.voiceInputMode}
+                onChange={handleVoiceInputModeChange}
+              >
+                <option value="continuous">Keep listening until I click stop</option>
+                <option value="auto-pause">Stop automatically on pause</option>
               </select>
             </div>
           </section>

--- a/packages/dashboard/src/hooks/useVoiceInput.test.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.test.ts
@@ -296,8 +296,8 @@ describe('useVoiceInput', () => {
       expect(result.current.isRecording).toBe(false)
     })
 
-    it('clears recording on onend', async () => {
-      const { result } = renderHook(() => useVoiceInput())
+    it('clears recording on onend in auto-pause mode', async () => {
+      const { result } = renderHook(() => useVoiceInput({ mode: 'auto-pause' }))
 
       await waitFor(() => expect(result.current.isAvailable).toBe(true))
 
@@ -310,6 +310,143 @@ describe('useVoiceInput', () => {
         lastRecognition!.onend?.()
       })
       expect(result.current.isRecording).toBe(false)
+    })
+
+    // #4785: continuous mode is the new default. The Web Speech API auto-ends
+    // recognition after ~5-10s of silence; the hook compensates by restarting
+    // on each `onend` until the user explicitly clicks stop.
+    describe('continuous mode (#4785)', () => {
+      it('default mode is continuous — silence-triggered onend restarts recognition', async () => {
+        const { result } = renderHook(() => useVoiceInput())
+
+        await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+        act(() => {
+          result.current.start()
+        })
+        const recognition = lastRecognition!
+        expect(recognition.start).toHaveBeenCalledTimes(1)
+        expect(result.current.isRecording).toBe(true)
+
+        act(() => {
+          recognition.onend?.()
+        })
+
+        // Restart was issued; isRecording stays true (no UI flicker).
+        expect(recognition.start).toHaveBeenCalledTimes(2)
+        expect(result.current.isRecording).toBe(true)
+      })
+
+      it('explicit user stop does NOT trigger restart in continuous mode', async () => {
+        const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+        await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+        act(() => {
+          result.current.start()
+        })
+        const recognition = lastRecognition!
+
+        act(() => {
+          result.current.stop()
+          // stop() flips userStoppedRef → onend should clear isRecording, not restart.
+          recognition.onend?.()
+        })
+
+        expect(recognition.start).toHaveBeenCalledTimes(1) // no restart
+        expect(result.current.isRecording).toBe(false)
+      })
+
+      it('auto-pause mode does NOT restart on onend even after multiple cycles', async () => {
+        const { result } = renderHook(() => useVoiceInput({ mode: 'auto-pause' }))
+
+        await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+        act(() => {
+          result.current.start()
+        })
+        const recognition = lastRecognition!
+
+        act(() => {
+          recognition.onend?.()
+        })
+
+        expect(recognition.start).toHaveBeenCalledTimes(1) // no restart
+        expect(result.current.isRecording).toBe(false)
+      })
+
+      it('hard errors (not-allowed) stop continuous mode without restart', async () => {
+        const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+        await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+        act(() => {
+          result.current.start()
+        })
+        const recognition = lastRecognition!
+
+        act(() => {
+          // Hard error → marks user-stop and clears isRecording. The subsequent
+          // onend from the underlying engine should NOT restart.
+          recognition.onerror?.({ error: 'not-allowed' })
+          recognition.onend?.()
+        })
+
+        expect(recognition.start).toHaveBeenCalledTimes(1) // no restart
+        expect(result.current.isRecording).toBe(false)
+        expect(result.current.error).toMatch(/permission|microphone/i)
+      })
+
+      it('caps continuous restarts at MAX_CONTINUOUS_RESTARTS to avoid wedge loops', async () => {
+        const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+        await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+        act(() => {
+          result.current.start()
+        })
+        const recognition = lastRecognition!
+
+        // Fire onend repeatedly with no intervening onresult — restart counter
+        // increments each time and eventually the hook gives up.
+        for (let i = 0; i < 10; i++) {
+          act(() => { recognition.onend?.() })
+        }
+
+        // Initial start + 5 restarts = 6 total calls; subsequent onends are no-ops.
+        expect(recognition.start).toHaveBeenCalledTimes(6)
+        expect(result.current.isRecording).toBe(false)
+      })
+
+      it('successful onresult resets the restart counter (long sessions stay healthy)', async () => {
+        const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+        await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+        act(() => {
+          result.current.start()
+        })
+        const recognition = lastRecognition!
+
+        // Burn 3 restarts with no transcript, then deliver one.
+        for (let i = 0; i < 3; i++) {
+          act(() => { recognition.onend?.() })
+        }
+        act(() => {
+          recognition.onresult?.({
+            resultIndex: 0,
+            results: [{ isFinal: true, 0: { transcript: 'hi' } }],
+          })
+        })
+
+        // After a successful onresult, counter resets → 5 fresh restarts allowed.
+        for (let i = 0; i < 5; i++) {
+          act(() => { recognition.onend?.() })
+        }
+
+        // Initial + 3 (pre-result) + 5 (post-result) = 9
+        expect(recognition.start).toHaveBeenCalledTimes(9)
+      })
     })
 
     it('stop() calls recognition.stop()', async () => {

--- a/packages/dashboard/src/hooks/useVoiceInput.test.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.test.ts
@@ -312,6 +312,44 @@ describe('useVoiceInput', () => {
       expect(result.current.isRecording).toBe(false)
     })
 
+    // Regression guard for #4786 review: auto-pause mode must preserve the
+    // pre-#4785 behaviour of surfacing soft errors (no-speech, network) to
+    // the user. Continuous mode deliberately swallows them so the restart
+    // loop doesn't flash a toast on every silence gap, but auto-pause is
+    // the "old behaviour" mode and the error channel must keep working.
+    it('surfaces soft errors (no-speech) in auto-pause mode', async () => {
+      const { result } = renderHook(() => useVoiceInput({ mode: 'auto-pause' }))
+
+      await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+      act(() => {
+        result.current.start()
+      })
+
+      act(() => {
+        lastRecognition!.onerror?.({ error: 'no-speech' })
+      })
+
+      expect(result.current.error).toMatch(/no speech/i)
+      expect(result.current.isRecording).toBe(false)
+    })
+
+    it('does NOT surface soft errors in continuous mode (silent restart path)', async () => {
+      const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+      await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+      act(() => {
+        result.current.start()
+      })
+
+      act(() => {
+        lastRecognition!.onerror?.({ error: 'no-speech' })
+      })
+
+      expect(result.current.error).toBeNull()
+    })
+
     // #4785: continuous mode is the new default. The Web Speech API auto-ends
     // recognition after ~5-10s of silence; the hook compensates by restarting
     // on each `onend` until the user explicitly clicks stop.

--- a/packages/dashboard/src/hooks/useVoiceInput.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.ts
@@ -343,12 +343,24 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
 
       recognition.onerror = (event) => {
         // Hard errors (permission denied, mic gone, user aborted) always
-        // surface to the user and stop the session even in continuous mode.
-        // Soft errors (no-speech, network) get the silent restart treatment
-        // via onend below — that's the whole point of continuous mode.
+        // surface to the user and stop the session in both modes.
         if (HARD_STOP_ERRORS.has(event.error)) {
           setError(permissionMessageForError(event.error))
           userStoppedRef.current = true
+          setIsRecording(false)
+          return
+        }
+        // Soft errors (no-speech, network):
+        //   - In `auto-pause` mode we preserve pre-#4785 behaviour and surface
+        //     every error to the user so the message channel still works the
+        //     same way it did before this PR.
+        //   - In `continuous` mode we deliberately swallow soft errors so the
+        //     `onend` restart path can re-arm without the UI flashing a
+        //     `no-speech` toast on every silence gap — that's the whole point
+        //     of continuous mode. `isRecording` is left alone here; `onend`
+        //     is the single source of truth for clearing it.
+        if (modeRef.current === 'auto-pause') {
+          setError(permissionMessageForError(event.error))
           setIsRecording(false)
         }
       }

--- a/packages/dashboard/src/hooks/useVoiceInput.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.ts
@@ -111,6 +111,28 @@ function permissionMessageForError(error: string): string {
   return `Speech recognition error: ${error}`
 }
 
+/**
+ * Voice input behaviour. See `InputSettings.voiceInputMode` in store-core for
+ * the persisted setting; this hook accepts it as a runtime option so the
+ * caller (App.tsx) reads the store once and the hook stays store-agnostic.
+ *
+ * - `'continuous'`: when the Web Speech engine fires `onend` due to silence,
+ *   the hook restarts recognition automatically. The mic stays lit until the
+ *   user explicitly calls `stop()`. This is the click-to-start / click-to-stop
+ *   experience #4785 was filed for.
+ *
+ * - `'auto-pause'`: original behaviour — `onend` ends the session. Kept for
+ *   users who prefer the browser's silence-stop semantics.
+ *
+ * Only the web engine is affected. The native (Tauri) engine has its own
+ * end-of-utterance semantics driven by the Swift helper and is out of scope.
+ */
+export type VoiceInputMode = 'continuous' | 'auto-pause'
+
+export interface UseVoiceInputOptions {
+  mode?: VoiceInputMode
+}
+
 export interface UseVoiceInputReturn {
   isRecording: boolean
   transcript: string
@@ -121,7 +143,26 @@ export interface UseVoiceInputReturn {
   stop: () => void
 }
 
-export function useVoiceInput(): UseVoiceInputReturn {
+/**
+ * Errors that should NOT trigger a continuous-mode restart loop. `no-speech`
+ * is technically the most common loop-trigger (silence followed by silence)
+ * but Web Speech raises it benignly during normal pauses — we treat it as a
+ * soft end and let the restart proceed. The hard-stop set below is for
+ * conditions where retrying would mask a real problem (permission denied,
+ * mic hardware gone, user aborted).
+ */
+const HARD_STOP_ERRORS = new Set([
+  'not-allowed',
+  'service-not-allowed',
+  'audio-capture',
+  'aborted',
+])
+
+/** Maximum consecutive restart attempts before continuous mode gives up. */
+const MAX_CONTINUOUS_RESTARTS = 5
+
+export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInputReturn {
+  const mode: VoiceInputMode = options.mode ?? 'continuous'
   const [isRecording, setIsRecording] = useState(false)
   const [transcript, setTranscript] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -133,6 +174,16 @@ export function useVoiceInput(): UseVoiceInputReturn {
   const recognitionRef = useRef<WebSpeechRecognition | null>(null)
   const finalTranscriptRef = useRef<string>('')
   const unlistenRefs = useRef<UnlistenFn[]>([])
+
+  // Continuous-mode restart bookkeeping. `userStoppedRef` flips true when
+  // `stop()` is called so the `onend` handler can distinguish a user-initiated
+  // stop from a silence-triggered one. `restartCountRef` bounds the retry
+  // loop so a wedged backend doesn't spin forever — counter resets on each
+  // successful `onresult` or explicit `start()`.
+  const userStoppedRef = useRef<boolean>(false)
+  const restartCountRef = useRef<number>(0)
+  const modeRef = useRef<VoiceInputMode>(mode)
+  modeRef.current = mode
 
   // ---- Engine selection (runs once on mount) ----
   useEffect(() => {
@@ -229,6 +280,10 @@ export function useVoiceInput(): UseVoiceInputReturn {
 
   const start = useCallback(() => {
     setError(null)
+    // Fresh user-initiated start: clear the continuous-mode bookkeeping so
+    // a prior session's user-stop or restart-counter doesn't carry over.
+    userStoppedRef.current = false
+    restartCountRef.current = 0
 
     if (engine === 'native') {
       const invoke = getTauriInvoke()
@@ -280,14 +335,44 @@ export function useVoiceInput(): UseVoiceInputReturn {
           }
         }
         setTranscript(finalTranscriptRef.current + interim)
+        // Any successful transcript resets the restart counter — proves
+        // recognition is healthy, so a silence-stop after this point should
+        // not count against the budget.
+        restartCountRef.current = 0
       }
 
       recognition.onerror = (event) => {
-        setError(permissionMessageForError(event.error))
-        setIsRecording(false)
+        // Hard errors (permission denied, mic gone, user aborted) always
+        // surface to the user and stop the session even in continuous mode.
+        // Soft errors (no-speech, network) get the silent restart treatment
+        // via onend below — that's the whole point of continuous mode.
+        if (HARD_STOP_ERRORS.has(event.error)) {
+          setError(permissionMessageForError(event.error))
+          userStoppedRef.current = true
+          setIsRecording(false)
+        }
       }
 
       recognition.onend = () => {
+        // Continuous mode: if the user hasn't pressed stop, the silence-stop
+        // is what we're correcting for. Re-issue start() on the same recogniser
+        // — bounded by MAX_CONTINUOUS_RESTARTS so a wedged backend can't spin.
+        if (
+          modeRef.current === 'continuous' &&
+          !userStoppedRef.current &&
+          restartCountRef.current < MAX_CONTINUOUS_RESTARTS
+        ) {
+          restartCountRef.current += 1
+          try {
+            recognition.start()
+            // isRecording stays true — the UI doesn't flicker the mic icon
+            // during the restart blip.
+            return
+          } catch {
+            // start() can throw InvalidStateError if the engine is still in
+            // the tail of the previous session; fall through to stop.
+          }
+        }
         setIsRecording(false)
       }
 
@@ -308,6 +393,11 @@ export function useVoiceInput(): UseVoiceInputReturn {
   }, [engine])
 
   const stop = useCallback(() => {
+    // Mark the stop as user-initiated BEFORE invoking the engine stop, so
+    // the silence-restart path in `onend` (web) sees the flag and exits
+    // cleanly rather than re-arming a session the user just cancelled.
+    userStoppedRef.current = true
+
     if (engine === 'native') {
       const invoke = getTauriInvoke()
       if (!invoke) return

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -61,6 +61,7 @@ import type {
   ChatMessage,
   ConnectionContext,
   ConnectionState,
+  InputSettings,
   ServerEntry,
   SessionInfo,
   SessionState,
@@ -416,6 +417,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   inputSettings: {
     chatEnterToSend: true,
     terminalEnterToSend: false,
+    voiceInputMode: 'continuous',
   },
   savedConnection: null,
   userDisconnected: false,
@@ -793,8 +795,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const raw = localStorage.getItem(STORAGE_KEY_INPUT_SETTINGS);
       if (raw) {
         const parsed = JSON.parse(raw);
-        if (typeof parsed.chatEnterToSend === 'boolean' || typeof parsed.terminalEnterToSend === 'boolean') {
-          set((state) => ({ inputSettings: { ...state.inputSettings, ...parsed } }));
+        // Validated, narrowed merge so a stray key in localStorage can't
+        // shoehorn arbitrary state into the store. Each field is checked
+        // independently because the persisted blob may pre-date #4785 and
+        // not include `voiceInputMode`.
+        const next: Partial<InputSettings> = {};
+        if (typeof parsed.chatEnterToSend === 'boolean') next.chatEnterToSend = parsed.chatEnterToSend;
+        if (typeof parsed.terminalEnterToSend === 'boolean') next.terminalEnterToSend = parsed.terminalEnterToSend;
+        if (parsed.voiceInputMode === 'continuous' || parsed.voiceInputMode === 'auto-pause') {
+          next.voiceInputMode = parsed.voiceInputMode;
+        }
+        if (Object.keys(next).length > 0) {
+          set((state) => ({ inputSettings: { ...state.inputSettings, ...next } }));
         }
       }
     } catch {

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -152,6 +152,15 @@ export interface ContextUsage {
 export interface InputSettings {
   chatEnterToSend: boolean;
   terminalEnterToSend: boolean;
+  /**
+   * Voice input behaviour. `'continuous'` keeps the mic open across silence
+   * gaps until the user explicitly clicks stop (the hook restarts Web Speech
+   * recognition on each silence-triggered `onend`). `'auto-pause'` lets the
+   * browser auto-stop on silence — the previous behaviour, kept for users who
+   * prefer it (#4785). Defaults to `'continuous'` so new users get the
+   * click-to-start / click-to-stop experience by default.
+   */
+  voiceInputMode: 'continuous' | 'auto-pause';
 }
 
 /** Default context window size (tokens) used when model metadata doesn't specify one. */


### PR DESCRIPTION
## Summary

Voice input now actually behaves as click-to-start / click-to-stop. The Web Speech API auto-ends recognition after ~5-10s of silence — the previous code treated that as a user stop, so the mic died the moment you paused to think.

- `useVoiceInput` distinguishes silence-stops from user-stops and restarts the recogniser on each silence-triggered `onend` in the new default `'continuous'` mode
- Existing behaviour preserved as `'auto-pause'` mode for users who prefer browser silence-detection
- Bounded by `MAX_CONTINUOUS_RESTARTS = 5` to avoid wedge loops; successful `onresult` resets the counter so long sessions stay healthy
- Hard errors (`not-allowed`, `audio-capture`, `aborted`, `service-not-allowed`) skip the restart and surface to the user as before
- `inputSettings.voiceInputMode` persisted via the existing localStorage path (`chroxy_input_settings`); narrowed merge protects against stray keys
- Settings UI: select control in the Input section of SettingsPanel, next to the send-shortcut picker
- Mobile uses `expo-speech-recognition` with different end-of-utterance semantics — type-satisfied for the shared store-core `InputSettings` shape; mobile parity deferred per issue body

## Test plan

- [x] `useVoiceInput.test.ts`: 7 new tests for continuous mode (default behaviour, user-stop suppresses restart, auto-pause skipped, hard-error stops, restart cap, counter reset on `onresult`)
- [x] Existing `clears recording on onend` test updated to assert against the `'auto-pause'` mode explicitly (the previously asserted behaviour)
- [x] `npx vitest run` packages/dashboard: 2510/2510 pass
- [x] `npx tsc --noEmit` packages/dashboard: clean
- [x] `npx tsc --noEmit` packages/app: clean (mobile type still satisfied via type-only update)
- [x] `npm test` packages/store-core: 984/984 pass
- [ ] Manual dogfood: open SettingsPanel, switch between the two voice input modes, verify mic stays lit through pauses in continuous mode and auto-stops in auto-pause mode

Closes #4785