### PR TITLE
fix(dashboard): close voice input unmount race + dual-recognition window (#4789)

### DIFF
--- a/packages/dashboard/src/hooks/useVoiceInput.test.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.test.ts
@@ -485,6 +485,136 @@ describe('useVoiceInput', () => {
         // Initial + 3 (pre-result) + 5 (post-result) = 9
         expect(recognition.start).toHaveBeenCalledTimes(9)
       })
+
+      // #4789 audit P0.3 regression — three races introduced by #4786:
+      //
+      //   Bug 1: Unmount effect calls rec.abort() without first flipping
+      //          userStoppedRef. abort() fires onend, which sees continuous
+      //          mode + !userStopped + counter<5 and calls recognition.start()
+      //          on a recogniser whose React owner has already unmounted.
+      //   Bug 2: start() aborts the prior recognition AFTER clearing
+      //          userStoppedRef, so the OLD onend re-arms while the new
+      //          recogniser already owns recognitionRef → dual-mic window.
+      //   Bug 3: onresult unconditionally resets restartCountRef even when
+      //          the result carries no transcript text, letting a wedged
+      //          backend bypass MAX_CONTINUOUS_RESTARTS.
+      describe('regression #4789 (audit P0.3)', () => {
+        it('unmount does NOT re-arm recognition via the onend restart path (bug 1)', async () => {
+          const { result, unmount } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+          await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+          act(() => {
+            result.current.start()
+          })
+          const recognition = lastRecognition!
+          expect(recognition.start).toHaveBeenCalledTimes(1)
+
+          // Simulate the W3C Web Speech spec behaviour: abort() (called by the
+          // unmount effect) fires onend synchronously or microtask-later. The
+          // recogniser is detached; if onend re-arms via start() we've leaked.
+          unmount()
+          act(() => {
+            recognition.onend?.()
+          })
+
+          // start() must NOT have been called again — userStoppedRef should
+          // have been set before abort() in the unmount cleanup.
+          expect(recognition.start).toHaveBeenCalledTimes(1)
+        })
+
+        it('start() while a prior recognition is in-flight does not let the old onend re-arm (bug 2)', async () => {
+          const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+          await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+          act(() => {
+            result.current.start()
+          })
+          const firstRecognition = lastRecognition!
+          expect(firstRecognition.start).toHaveBeenCalledTimes(1)
+
+          // Begin a fresh recognition. The hook should abort the prior one
+          // AND mark it as user-stopped so its onend exits cleanly without
+          // racing the new recogniser.
+          act(() => {
+            result.current.start()
+          })
+          const secondRecognition = lastRecognition!
+          expect(secondRecognition).not.toBe(firstRecognition)
+          expect(secondRecognition.start).toHaveBeenCalledTimes(1)
+
+          // Now fire the OLD recognition's onend (the abort-triggered one).
+          // It must NOT call start() on itself — that would create two
+          // concurrent recognitions holding the mic.
+          act(() => {
+            firstRecognition.onend?.()
+          })
+
+          // First recogniser stayed at 1 call (no re-arm); second stayed at 1.
+          expect(firstRecognition.start).toHaveBeenCalledTimes(1)
+          expect(secondRecognition.start).toHaveBeenCalledTimes(1)
+        })
+
+        it('empty onresult does NOT reset the restart counter (bug 3 — wedge guard)', async () => {
+          const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+          await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+          act(() => {
+            result.current.start()
+          })
+          const recognition = lastRecognition!
+
+          // Burn 3 restarts with no transcript.
+          for (let i = 0; i < 3; i++) {
+            act(() => { recognition.onend?.() })
+          }
+          // A wedged backend fires onresult with empty transcript text. This
+          // must NOT reset the counter — otherwise the cap is bypassed.
+          act(() => {
+            recognition.onresult?.({
+              resultIndex: 0,
+              results: [{ isFinal: false, 0: { transcript: '' } }],
+            })
+          })
+          // Only 2 more restarts should be allowed (counter at 3, cap at 5).
+          for (let i = 0; i < 10; i++) {
+            act(() => { recognition.onend?.() })
+          }
+
+          // Initial + 3 (pre-empty) + 2 (post-empty, until cap) = 6
+          expect(recognition.start).toHaveBeenCalledTimes(6)
+          expect(result.current.isRecording).toBe(false)
+        })
+
+        it('whitespace-only onresult does NOT reset the restart counter', async () => {
+          const { result } = renderHook(() => useVoiceInput({ mode: 'continuous' }))
+
+          await waitFor(() => expect(result.current.isAvailable).toBe(true))
+
+          act(() => {
+            result.current.start()
+          })
+          const recognition = lastRecognition!
+
+          for (let i = 0; i < 3; i++) {
+            act(() => { recognition.onend?.() })
+          }
+          act(() => {
+            recognition.onresult?.({
+              resultIndex: 0,
+              results: [{ isFinal: false, 0: { transcript: '   \t  ' } }],
+            })
+          })
+          for (let i = 0; i < 10; i++) {
+            act(() => { recognition.onend?.() })
+          }
+
+          // Initial + 3 + 2 = 6 — whitespace counts as empty.
+          expect(recognition.start).toHaveBeenCalledTimes(6)
+        })
+      })
     })
 
     it('stop() calls recognition.stop()', async () => {

--- a/packages/dashboard/src/hooks/useVoiceInput.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.ts
@@ -268,6 +268,18 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
     return () => {
       const rec = recognitionRef.current
       if (rec) {
+        // #4789: per the Web Speech spec, abort() fires `onend`. The
+        // continuous-mode restart branch in onend would otherwise call
+        // recognition.start() on a recogniser whose React owner has already
+        // unmounted — either throwing InvalidStateError or leaving runaway
+        // recognition holding the mic with no UI to stop it. Two defences:
+        //   1. Set userStoppedRef so any fire-before-detach onend exits early.
+        //   2. Null the handlers so the abort()-triggered onend is a no-op.
+        userStoppedRef.current = true
+        rec.onresult = null
+        rec.onerror = null
+        rec.onend = null
+        rec.onstart = null
         try {
           rec.abort()
         } catch {
@@ -282,6 +294,10 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
     setError(null)
     // Fresh user-initiated start: clear the continuous-mode bookkeeping so
     // a prior session's user-stop or restart-counter doesn't carry over.
+    // NOTE: any in-flight web recognition is torn down inside the `web` branch
+    // below — and that teardown re-flips userStoppedRef to true BEFORE calling
+    // abort(), so the OLD onend doesn't re-arm against the NEW recogniser.
+    // We then flip it back to false right before constructing the new one.
     userStoppedRef.current = false
     restartCountRef.current = 0
 
@@ -302,9 +318,21 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
       if (!Ctor) return
 
       // Tear down any prior recognition before starting a fresh one.
+      // #4789: detach the OLD recogniser's handlers BEFORE calling abort().
+      // abort() fires onend, and the continuous-mode branch in onend reads
+      // the shared userStoppedRef/restartCountRef — by the time the old
+      // onend fires the new start() will have already reset both refs to
+      // their "fresh session" values, so the old onend would re-arm itself
+      // and race the new recogniser (dual-mic window). Nulling the handlers
+      // is the only way to guarantee the old session can't re-arm.
       if (recognitionRef.current) {
+        const prior = recognitionRef.current
+        prior.onresult = null
+        prior.onerror = null
+        prior.onend = null
+        prior.onstart = null
         try {
-          recognitionRef.current.abort()
+          prior.abort()
         } catch {
           // ignore
         }
@@ -324,21 +352,27 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
         // interim results is appended live so the UI sees mid-utterance
         // updates.
         let interim = ''
+        let finalDelta = ''
         for (let i = event.resultIndex; i < event.results.length; i++) {
           const r = event.results[i]
           if (!r) continue
           const text = r[0]?.transcript ?? ''
           if (r.isFinal) {
             finalTranscriptRef.current += text
+            finalDelta += text
           } else {
             interim += text
           }
         }
         setTranscript(finalTranscriptRef.current + interim)
-        // Any successful transcript resets the restart counter — proves
-        // recognition is healthy, so a silence-stop after this point should
-        // not count against the budget.
-        restartCountRef.current = 0
+        // #4789: only reset the restart counter when the event actually
+        // delivers non-empty transcript text. A wedged backend can emit
+        // empty/whitespace `onresult` events that would otherwise bypass
+        // MAX_CONTINUOUS_RESTARTS and spin forever. Reset only on real
+        // speech (final or interim).
+        if ((finalDelta + interim).trim().length > 0) {
+          restartCountRef.current = 0
+        }
       }
 
       recognition.onerror = (event) => {

--- a/packages/dashboard/src/hooks/useVoiceInput.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.ts
@@ -295,9 +295,13 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
     // Fresh user-initiated start: clear the continuous-mode bookkeeping so
     // a prior session's user-stop or restart-counter doesn't carry over.
     // NOTE: any in-flight web recognition is torn down inside the `web` branch
-    // below — and that teardown re-flips userStoppedRef to true BEFORE calling
-    // abort(), so the OLD onend doesn't re-arm against the NEW recogniser.
-    // We then flip it back to false right before constructing the new one.
+    // below — and that teardown nulls the OLD recogniser's event handlers
+    // BEFORE calling abort(), so the spec-mandated `abort()`-triggered onend
+    // becomes a no-op and cannot re-arm against the NEW recogniser even
+    // though both refs (userStoppedRef, restartCountRef) have just been
+    // reset to their "fresh session" values here. Handler nulling is the
+    // sole defence on this path; the unmount path adds a second defence
+    // (userStoppedRef = true) for symmetry with onerror's hard-stop branch.
     userStoppedRef.current = false
     restartCountRef.current = 0
 


### PR DESCRIPTION
## Summary

Closes #4789 — audit P0.3 from the Guardian review of #4786 (voice input continuous mode).

Three small fixes to `packages/dashboard/src/hooks/useVoiceInput.ts` that close races introduced when continuous mode landed:

- **Unmount race (bug 1)**: the unmount effect previously called `rec.abort()` without first setting `userStoppedRef.current = true`. Per the W3C Web Speech spec, `abort()` fires `onend`. The continuous-mode branch in `onend` saw `modeRef.current === 'continuous' && !userStoppedRef.current && restartCountRef.current < 5` — all true — and called `recognition.start()` on a recogniser whose React owner had already unmounted. Either threw `InvalidStateError` or left runaway recognition holding the mic permission with no UI to stop it.
- **Dual-recognition window (bug 2)**: `start()` aborted any in-flight prior recognition AFTER clearing `userStoppedRef.current = false`, so the OLD `onend` re-armed the OLD recognition while `recognitionRef.current` already pointed at the NEW one. Two concurrent recognitions on the same mic. Fixed by detaching the prior recogniser's handlers before `abort()`.
- **Restart-cap bypass (bug 3, bonus)**: `restartCountRef.current = 0` previously fired on every `onresult` — a wedged backend emitting one fake/empty `onresult` could bypass `MAX_CONTINUOUS_RESTARTS` and spin forever. Now only resets when the event actually delivers non-empty transcript text.

Both teardown paths (unmount + start-prior-cleanup) null the prior recogniser's event handlers before calling `abort()`, guaranteeing the spec-mandated `onend` cannot re-arm a detached recogniser regardless of the shared-ref state at fire time.

## Test plan

- [x] TDD: 4 new regression tests added under `regression #4789 (audit P0.3)` describe block, covering all three bugs (bug 3 has both empty-string and whitespace-only variants).
- [x] RED confirmed: all 4 new tests fail against pre-fix code.
- [x] GREEN confirmed: 26/26 `useVoiceInput.test.ts` tests pass after fix.
- [x] Full dashboard suite: 2516/2516 tests across 130 files pass.
- [x] `tsc --noEmit` clean.