### PR TITLE
fix(server): scope log_entry broadcasts to unbound clients (#4787)

### DIFF
--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1194,13 +1194,13 @@ export class WsServer {
     // fan out to bound clients (mobile pairings into a single per-task
     // session) — pre-fix, server-side logs that lacked withSession() context
     // leaked PTY hex dumps, toolUseIds, prompt sizes and attachment names from
-    // every session to every authenticated WS client. Only 1 of 114
-    // createLogger() call sites uses withSession(), so the fall-through
-    // covered almost the entire log stream. Restrict unscoped entries to
-    // unbound clients (operator dashboards have boundSessionId == null and
-    // legitimately want to see everything). The durable fix is a
-    // loggerForSession factory + lint to force per-call-site scoping —
-    // tracked as a follow-up.
+    // every session to every authenticated WS client. Most server logs are
+    // unscoped today (only a handful of call sites use withSession()), so the
+    // fall-through covered almost the entire log stream. Restrict unscoped
+    // entries to unbound clients (operator dashboards have boundSessionId ==
+    // null and legitimately want to see everything). The durable fix — a
+    // loggerForSession factory + lint to force per-call-site scoping — is
+    // tracked as a follow-up (#4792).
     let inLogBroadcast = false
     this._logListener = (entry) => {
       if (inLogBroadcast) return
@@ -1209,9 +1209,12 @@ export class WsServer {
         if (entry.sessionId) {
           this._broadcastToSession(entry.sessionId, { type: 'log_entry', ...entry })
         } else {
+          // Use loose-equality null check so any non-null/undefined
+          // boundSessionId (including the unlikely empty string) is treated
+          // as bound — matches the comment above and the intent of #4787.
           this._broadcast(
             { type: 'log_entry', ...entry },
-            (client) => !client.boundSessionId
+            (client) => client.boundSessionId == null
           )
         }
       } finally {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1189,6 +1189,18 @@ export class WsServer {
     // Broadcast structured log entries to dashboard clients.
     // Re-entrancy guard prevents infinite recursion when _broadcast() itself
     // logs (e.g. backpressure debug messages) and log level is set to debug.
+    //
+    // #4787 (P0 security): unscoped log entries (no entry.sessionId) MUST NOT
+    // fan out to bound clients (mobile pairings into a single per-task
+    // session) — pre-fix, server-side logs that lacked withSession() context
+    // leaked PTY hex dumps, toolUseIds, prompt sizes and attachment names from
+    // every session to every authenticated WS client. Only 1 of 114
+    // createLogger() call sites uses withSession(), so the fall-through
+    // covered almost the entire log stream. Restrict unscoped entries to
+    // unbound clients (operator dashboards have boundSessionId == null and
+    // legitimately want to see everything). The durable fix is a
+    // loggerForSession factory + lint to force per-call-site scoping —
+    // tracked as a follow-up.
     let inLogBroadcast = false
     this._logListener = (entry) => {
       if (inLogBroadcast) return
@@ -1197,7 +1209,10 @@ export class WsServer {
         if (entry.sessionId) {
           this._broadcastToSession(entry.sessionId, { type: 'log_entry', ...entry })
         } else {
-          this._broadcast({ type: 'log_entry', ...entry })
+          this._broadcast(
+            { type: 'log_entry', ...entry },
+            (client) => !client.boundSessionId
+          )
         }
       } finally {
         inLogBroadcast = false

--- a/packages/server/tests/ws-server-log-broadcast.test.js
+++ b/packages/server/tests/ws-server-log-broadcast.test.js
@@ -1,0 +1,220 @@
+import { describe, it, before, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+/**
+ * Regression test for #4787 — scope log_entry broadcasts to unbound clients.
+ *
+ * Before the fix, the `_logListener` in ws-server.js fell back to
+ * `_broadcast()` for any log entry lacking an `entry.sessionId`, sending
+ * unscoped server logs (PTY hex dumps, toolUseIds, prompt sizes, attachment
+ * names) to EVERY authenticated WS client — including a mobile device paired
+ * to a single per-task session, which would receive log lines from other
+ * sessions running on the same daemon.
+ *
+ * After the fix:
+ *  - Unscoped log entries (no entry.sessionId) are only sent to clients with
+ *    `boundSessionId == null` (operator dashboards) — bound mobile clients no
+ *    longer leak cross-session logs.
+ *  - Scoped log entries (entry.sessionId set) continue to use
+ *    `_broadcastToSession`, which already filters by activeSessionId /
+ *    subscribedSessionIds — so bound clients on a different session still
+ *    don't see them, and an unbound dashboard sees them only if subscribed.
+ */
+describe('WsServer._logListener session scoping (#4787)', () => {
+  let WsServer
+  let server
+
+  before(async () => {
+    ;({ WsServer } = await import('../src/ws-server.js'))
+  })
+
+  afterEach(() => {
+    if (server) {
+      try { server.close() } catch {}
+      server = null
+    }
+  })
+
+  function createServer(opts = {}) {
+    const mockSessionManager = new EventEmitter()
+    mockSessionManager.sessions = new Map()
+    mockSessionManager.getSessions = () => []
+    mockSessionManager.getSession = () => null
+    mockSessionManager.listSessions = () => []
+
+    return new WsServer({
+      port: 0,
+      apiToken: 'test-token',
+      sessionManager: mockSessionManager,
+      authRequired: false,
+      noEncrypt: true,
+      ...opts,
+    })
+  }
+
+  function createMockWs() {
+    return {
+      readyState: 1, // OPEN
+      bufferedAmount: 0,
+      send: mock.fn(),
+      close: mock.fn(),
+    }
+  }
+
+  /**
+   * Build a server, run start() to register the real _logListener, then
+   * stuff fake clients into server.clients. Returns a helper that returns
+   * the list of sent messages keyed by client id.
+   */
+  async function setup(clients) {
+    server = createServer()
+    server.start('127.0.0.1')
+    // Wait briefly for HTTP listen — log listener is registered synchronously
+    // inside start(), so it's already wired by the time start() returns.
+    await new Promise((resolve, reject) => {
+      server.httpServer.once('listening', resolve)
+      server.httpServer.once('error', reject)
+    })
+
+    // Replace _send so we can capture deliveries by client id without going
+    // through the encryption / WS wire path.
+    const delivered = new Map() // clientId -> [messages]
+    server._send = (ws, msg) => {
+      const client = server.clients.get(ws)
+      if (!client) return
+      const list = delivered.get(client.id) || []
+      list.push(msg)
+      delivered.set(client.id, list)
+    }
+
+    for (const c of clients) {
+      const ws = createMockWs()
+      server.clients.set(ws, c)
+    }
+    return delivered
+  }
+
+  it('drops unscoped log entries for bound clients (does not leak across sessions)', async () => {
+    const bound = {
+      id: 'mobile-bound-to-sess-1',
+      authenticated: true,
+      boundSessionId: 'sess-1',
+      activeSessionId: 'sess-1',
+      subscribedSessionIds: new Set(),
+      _backpressureDrops: 0,
+    }
+    const unboundDashboard = {
+      id: 'dashboard-operator',
+      authenticated: true,
+      boundSessionId: null,
+      activeSessionId: null,
+      subscribedSessionIds: new Set(),
+      _backpressureDrops: 0,
+    }
+
+    const delivered = await setup([bound, unboundDashboard])
+
+    // Unscoped entry — no sessionId attached. Pre-fix this fanned out to ALL
+    // clients via _broadcast, leaking PTY hex dumps / toolUseIds to the bound
+    // mobile client. Post-fix it must reach only unbound clients.
+    server._logListener({
+      ts: Date.now(),
+      level: 'info',
+      tag: 'claude-tui-session',
+      message: '[pty-tail] aa55bb66cc77 (raw ANSI sequence)',
+    })
+
+    const boundMsgs = delivered.get(bound.id) || []
+    const dashMsgs = delivered.get(unboundDashboard.id) || []
+
+    const boundLogEntries = boundMsgs.filter((m) => m.type === 'log_entry')
+    const dashLogEntries = dashMsgs.filter((m) => m.type === 'log_entry')
+
+    assert.equal(
+      boundLogEntries.length,
+      0,
+      'bound client must NOT receive unscoped log entries (cross-session leak)'
+    )
+    assert.equal(
+      dashLogEntries.length,
+      1,
+      'unbound dashboard SHOULD still receive unscoped log entries'
+    )
+    assert.equal(dashLogEntries[0].message, '[pty-tail] aa55bb66cc77 (raw ANSI sequence)')
+  })
+
+  it('still routes scoped log entries through _broadcastToSession (session mismatch blocks bound clients on other sessions)', async () => {
+    const boundToSess1 = {
+      id: 'mobile-bound-to-sess-1',
+      authenticated: true,
+      boundSessionId: 'sess-1',
+      activeSessionId: 'sess-1',
+      subscribedSessionIds: new Set(),
+      _backpressureDrops: 0,
+    }
+    const unboundDashboard = {
+      id: 'dashboard-operator',
+      authenticated: true,
+      boundSessionId: null,
+      // dashboard happens to be viewing sess-2 right now
+      activeSessionId: 'sess-2',
+      subscribedSessionIds: new Set(),
+      _backpressureDrops: 0,
+    }
+
+    const delivered = await setup([boundToSess1, unboundDashboard])
+
+    // Scoped log entry FROM sess-2 (e.g. via withSession('sess-2'))
+    server._logListener({
+      ts: Date.now(),
+      level: 'info',
+      tag: 'session-manager',
+      message: 'persisted sess-2 state',
+      sessionId: 'sess-2',
+    })
+
+    const boundMsgs = delivered.get(boundToSess1.id) || []
+    const dashMsgs = delivered.get(unboundDashboard.id) || []
+
+    const boundLogEntries = boundMsgs.filter((m) => m.type === 'log_entry')
+    const dashLogEntries = dashMsgs.filter((m) => m.type === 'log_entry')
+
+    assert.equal(
+      boundLogEntries.length,
+      0,
+      'bound-to-sess-1 client must not see sess-2 scoped log entries'
+    )
+    assert.equal(
+      dashLogEntries.length,
+      1,
+      'dashboard with activeSessionId=sess-2 should receive sess-2 scoped log entries'
+    )
+    assert.equal(dashLogEntries[0].sessionId, 'sess-2')
+  })
+
+  it('delivers scoped log entries to bound clients on the matching session', async () => {
+    const boundToSess1 = {
+      id: 'mobile-bound-to-sess-1',
+      authenticated: true,
+      boundSessionId: 'sess-1',
+      activeSessionId: 'sess-1',
+      subscribedSessionIds: new Set(),
+      _backpressureDrops: 0,
+    }
+
+    const delivered = await setup([boundToSess1])
+
+    server._logListener({
+      ts: Date.now(),
+      level: 'info',
+      tag: 'session-manager',
+      message: 'persisted sess-1 state',
+      sessionId: 'sess-1',
+    })
+
+    const msgs = (delivered.get(boundToSess1.id) || []).filter((m) => m.type === 'log_entry')
+    assert.equal(msgs.length, 1, 'bound client should receive scoped log entries for its own session')
+    assert.equal(msgs[0].sessionId, 'sess-1')
+  })
+})

--- a/packages/server/tests/ws-server-log-broadcast.test.js
+++ b/packages/server/tests/ws-server-log-broadcast.test.js
@@ -1,6 +1,7 @@
 import { describe, it, before, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
+import { removeLogListener } from '../src/logger.js'
 
 /**
  * Regression test for #4787 — scope log_entry broadcasts to unbound clients.
@@ -66,6 +67,12 @@ describe('WsServer._logListener session scoping (#4787)', () => {
    * Build a server, run start() to register the real _logListener, then
    * stuff fake clients into server.clients. Returns a helper that returns
    * the list of sent messages keyed by client id.
+   *
+   * We unregister the global log listener right after start() so that
+   * background async logs (e.g. Claude Code Web feature detection) cannot
+   * race with the test and inflate `delivered`. The test invokes
+   * `server._logListener(...)` directly anyway — the global path is not
+   * needed for the assertions and only introduces flake.
    */
   async function setup(clients) {
     server = createServer()
@@ -76,6 +83,11 @@ describe('WsServer._logListener session scoping (#4787)', () => {
       server.httpServer.once('listening', resolve)
       server.httpServer.once('error', reject)
     })
+
+    // Detach from the global log bus so unrelated async logs cannot bleed
+    // into the captured deliveries. We still hold the reference on
+    // `server._logListener` and call it directly below.
+    removeLogListener(server._logListener)
 
     // Replace _send so we can capture deliveries by client id without going
     // through the encryption / WS wire path.


### PR DESCRIPTION
Closes #4787

## Summary

P0 security fix. Bound WS clients (e.g. mobile devices paired into a single per-task session via `boundSessionId`) were receiving `log_entry` events for any log line that lacked an explicit `entry.sessionId` — i.e. almost the entire server log stream. The leaked content included PTY hex dumps, `toolUseIds`, prompt sizes, freeform-text lengths, and attachment names from **every** session running on the daemon.

The audit (P0.1) identified the root cause: only 1 of 114 `createLogger()` call sites in `packages/server/` uses `.withSession(sid)` to tag its emitted entries. Every other call site falls through to the unscoped path, which previously called `_broadcast()` and fanned out to every authenticated WS client — including mobile clients paired to a single session.

## Fix

Modify `_logListener` in `packages/server/src/ws-server.js` so unscoped log entries (no `entry.sessionId`) are only delivered to clients with `boundSessionId == null` — i.e. operator dashboards. Scoped entries continue to route through `_broadcastToSession`, which already respects `activeSessionId` / `subscribedSessionIds`.

This is **Option A2** from the audit — preserves the operator's "see everything" experience on unbound dashboard tabs while closing the cross-session leak to bound clients. Surgical, single-line change, easy to review and back out if needed.

The durable fix (option B — `loggerForSession` factory + lint to force per-call-site scoping across all 114 sites) is tracked as a follow-up: #4792.

## Tests

New regression test: `packages/server/tests/ws-server-log-broadcast.test.js`

- Bound client (`boundSessionId = 'sess-1'`) MUST NOT receive unscoped log entries
- Unbound dashboard (`boundSessionId = null`) SHOULD still receive unscoped log entries
- Scoped log entries continue to flow through `_broadcastToSession` (bound client on a different session does not receive them; dashboard with matching `activeSessionId` does)
- Bound client on the matching session still receives scoped log entries for its own session

Written TDD-first (RED → GREEN). All 79 tests in the broadcast/log/backpressure suites pass.

## Test plan

- [x] New test fails before the fix (RED)
- [x] New test passes after the fix (GREEN)
- [x] Full broadcast/log/backpressure test suite passes locally (`ws-server-log-broadcast`, `ws-broadcaster`, `ws-server-broadcast`, `log-listener`, `ws-server-backpressure` — 79/79)
- [x] No regressions in full `npm test` — the 4 unrelated failures (`service.test.js`, `tunnel.integration.test.js`, `web-task-manager.test.js`) reproduce on clean main with the same errors (live local server, missing cloudflared, claude CLI `--remote` available)
- [ ] CI green