### PR TITLE
fix(server): require unbound clients to be subscribed before routing user_question_response (#4788)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -545,6 +545,21 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
   // correct client can still respond.
   if (client.boundSessionId && client.boundSessionId !== questionSessionId) return
 
+  // #4788 (audit P0.2): for UNBOUND clients, require the questionSessionId
+  // to match the client's active or subscribed sessions before routing the
+  // answer. Without this, an unbound dashboard tab could submit an answer
+  // for any session by replaying a known toolUseId — paired with the log
+  // leak in #4787 this enables cross-session answer hijacking. Mirrors the
+  // default filter used by _broadcastToSession (ws-broadcaster.js:106) so
+  // the set of clients permitted to ANSWER a question is the same set that
+  // could legitimately have RECEIVED it. Leaves the mapping intact so the
+  // legitimate subscribed client can still respond.
+  if (!client.boundSessionId) {
+    const subscribed = questionSessionId === client.activeSessionId
+      || (client.subscribedSessionIds && client.subscribedSessionIds.has(questionSessionId))
+    if (!subscribed) return
+  }
+
   if (msg.toolUseId) ctx.questionSessionMap.delete(msg.toolUseId)
 
   const entry = ctx.sessionManager.getSession(questionSessionId)

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -261,7 +261,7 @@ function executeSideEffects(sideEffects, sessionId, ctx) {
 /** Execute registration descriptors returned by the normalizer */
 function executeRegistrations(registrations, sessionId, ctx) {
   if (!registrations) return
-  const { permissionSessionMap, questionSessionMap } = ctx
+  const { permissionSessionMap, questionSessionMap, registerQuestionRoute } = ctx
   for (const reg of registrations) {
     // #3736: registrations support an explicit action ('set' | 'delete'),
     // defaulting to 'set' for backwards compatibility. The delete action is
@@ -289,7 +289,18 @@ function executeRegistrations(registrations, sessionId, ctx) {
       if (action === 'delete') {
         questionSessionMap.delete(reg.key)
       } else {
-        questionSessionMap.set(reg.key, reg.value ?? sessionId)
+        const mappedSessionId = reg.value ?? sessionId
+        // #4788 Wave 2: prefer the WsServer-provided helper so dispatch also
+        // auto-subscribes eligible clients to the question's session — keeps
+        // the input-handler's subscription guard symmetric with
+        // _broadcastToSession's recipient filter. Falls back to a bare Map.set
+        // when ctx doesn't carry the helper (legacy unit tests that wire
+        // setupForwarding directly without a WsServer).
+        if (typeof registerQuestionRoute === 'function') {
+          registerQuestionRoute(reg.key, mappedSessionId)
+        } else {
+          questionSessionMap.set(reg.key, mappedSessionId)
+        }
       }
     }
   }

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -1214,6 +1214,15 @@ export class WsServer {
       pushManager: this.pushManager,
       permissionSessionMap: this._permissionSessionMap,
       questionSessionMap: this._questionSessionMap,
+      // #4788 Wave 2: hand the question-route registration through a helper so
+      // dispatch and routing-guard stay symmetric. When a question is
+      // registered for session S, every currently-connected client that's
+      // permitted to see broadcasts for S gets auto-subscribed to S — this
+      // mirrors _broadcastToSession's recipient filter so the new
+      // input-handlers guard naturally passes for legitimate viewers without
+      // re-opening the cross-session hijack vector (unconnected / future
+      // clients are still unable to answer).
+      registerQuestionRoute: (toolUseId, sessionId) => this._registerQuestionRoute(toolUseId, sessionId),
       broadcast: (msg, filter) => this._broadcast(msg, filter),
       broadcastToSession: (sid, msg, filter) => this._broadcastToSession(sid, msg, filter),
       broadcastSessionList: () => this._handlerCtx.broadcastSessionList(),
@@ -1379,6 +1388,45 @@ export class WsServer {
    */
   _broadcastToSession(sessionId, message, filter) {
     this._broadcaster._broadcastToSession(sessionId, message, filter)
+  }
+
+  /**
+   * #4788 Wave 2: register an AskUserQuestion route for `toolUseId` against
+   * `sessionId` AND auto-subscribe every currently-eligible authenticated
+   * client to `sessionId`. This keeps the input-handler's subscription guard
+   * (handlers/input-handlers.js — the "unbound client must be subscribed or
+   * active on the question's session" check) symmetric with
+   * `_broadcastToSession`'s default recipient filter: any client that was
+   * eligible to RECEIVE the question is now eligible to ANSWER it, even after
+   * a `switch_session` flips their `activeSessionId` away.
+   *
+   * Wave 1 closed a cross-session answer-hijack vector (#4788) by requiring
+   * unbound clients to be subscribed before routing a `user_question_response`.
+   * That broke the legitimate "view A → get question for A → switch to B →
+   * answer" flow because `switch_session` only adds the *new* target to
+   * `subscribedSessionIds`; the originating session A was in neither set.
+   * Auto-subscribing at dispatch time means the client that legitimately
+   * received the question keeps the membership it needs to answer it.
+   *
+   * Bound clients are filtered out so a client paired to session X can never
+   * be quietly subscribed to session Y. Unbound clients always get added —
+   * matching `_broadcastToSession`'s default filter (which only requires
+   * `activeSessionId === sessionId || subscribedSessionIds.has(sessionId)`,
+   * but auto-subscribe seeds the latter so the filter passes for everyone
+   * currently connected). Clients that connect AFTER dispatch are still
+   * unable to answer; that's the desired hijack-prevention property.
+   */
+  _registerQuestionRoute(toolUseId, sessionId) {
+    this._questionSessionMap.set(toolUseId, sessionId)
+    if (!sessionId) return
+    for (const [, client] of this.clients) {
+      if (!client.authenticated) continue
+      // Don't auto-subscribe a client bound to a *different* session — the
+      // bound binding is the security contract for that client.
+      if (client.boundSessionId && client.boundSessionId !== sessionId) continue
+      if (!client.subscribedSessionIds) continue
+      client.subscribedSessionIds.add(sessionId)
+    }
   }
 
   /** Count unauthenticated connections for pre-auth limit enforcement */

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -459,7 +459,7 @@ describe('input-handlers', () => {
         assert.equal(sessionA.respondToQuestion.lastCall[0], 'approve')
       })
 
-      it('leaves the bound-client guard at line 541 unchanged (different code path)', () => {
+      it('leaves the bound-client guard unchanged (different code path)', () => {
         // The existing bound-client guard already early-returns when the
         // bound session doesn't match the questionSessionId. This test pins
         // that the new subscription guard doesn't accidentally relax it.
@@ -484,6 +484,56 @@ describe('input-handlers', () => {
           'bound-client guard takes precedence — boundSessionId mismatch always wins')
         assert.equal(ctx.questionSessionMap.get('tool-x'), 's1',
           'mapping preserved when the bound-elsewhere client is rejected')
+      })
+
+      // #4788 Wave 2 regression: mirrors the ws-server-permissions integration
+      // test for the legitimate "view A → get question for A → switch to B →
+      // answer" flow. In production, the WsServer-side _registerQuestionRoute
+      // helper auto-subscribes the originating viewer to the question's
+      // session at dispatch time, so the unbound subscription guard above
+      // still passes after the client switches activeSessionId away. This
+      // pins the input-handler half of that contract: given the production-
+      // shaped client state (subscribedSessionIds carries the question's
+      // session because dispatch auto-subscribed), the answer routes to the
+      // originating session even though the client's active session is now
+      // somewhere else. Without this the Wave 1 guard would silently drop a
+      // legitimate after-switch answer (caught CI on ws-server-permissions
+      // test "routes user_question_response to the originating session,
+      // not activeSessionId").
+      it('routes the answer after switch_session when dispatch auto-subscribed the client to the originating session (#4788 Wave 2)', () => {
+        const sessions = new Map()
+        const sessionA = createMockSession()
+        const sessionB = createMockSession()
+        sessions.set('s1', { session: sessionA, name: 'A', cwd: '/a' })
+        sessions.set('s2', { session: sessionB, name: 'B', cwd: '/b' })
+        const ctx = makeCtx(sessions)
+        // Production: when the question for s1 dispatched, the WsServer-side
+        // helper called questionSessionMap.set('tool-after-switch', 's1')
+        // AND subscribedSessionIds.add('s1') for this client.
+        ctx.questionSessionMap.set('tool-after-switch', 's1')
+        // The user then tapped "switch to session B" — session-handlers.js
+        // adds 's2' to subscribedSessionIds and sets activeSessionId='s2',
+        // but leaves the prior 's1' subscription intact (only unsubscribe
+        // explicitly removes).
+        const client = makeClient({
+          id: 'viewer-after-switch',
+          boundSessionId: null,
+          activeSessionId: 's2',
+          subscribedSessionIds: new Set(['s1', 's2']),
+        })
+
+        inputHandlers.user_question_response(makeWs(), client, {
+          answer: 'approve-after-switch',
+          toolUseId: 'tool-after-switch',
+        }, ctx)
+
+        assert.equal(sessionA.respondToQuestion.callCount, 1,
+          'after-switch answer must route to the originating session A')
+        assert.equal(sessionA.respondToQuestion.lastCall[0], 'approve-after-switch')
+        assert.equal(sessionB.respondToQuestion.callCount, 0,
+          'must not bleed onto the now-active session B')
+        assert.equal(ctx.questionSessionMap.has('tool-after-switch'), false,
+          'mapping consumed on successful route')
       })
 
       it('tolerates a missing subscribedSessionIds set (defensive — old client shapes)', () => {

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -367,6 +367,151 @@ describe('input-handlers', () => {
       assert.equal(session.respondToQuestion.callCount, 1)
       assert.deepStrictEqual(session.respondToQuestion.lastCall, ['Patch', undefined, 'tool-2', undefined])
     })
+
+    // #4788 (audit P0.2): UNBOUND clients (boundSessionId === null) must be
+    // subscribed to or actively viewing the session that owns the toolUseId
+    // before the handler routes their answer. Without this guard, any unbound
+    // dashboard tab can hijack another session's pending AskUserQuestion by
+    // replaying a leaked toolUseId — combined with the related toolUseId log
+    // leak (#4787), an attacker (or just a typo'd cross-tab click) can land
+    // an answer on a session they never opened. Mirrors the default filter
+    // in _broadcastToSession (ws-broadcaster.js:106).
+    describe('subscription guard for unbound clients (#4788)', () => {
+      it('drops an unbound client\'s answer when the questionSessionId is neither active nor subscribed', () => {
+        const sessions = new Map()
+        const sessionA = createMockSession()
+        const sessionB = createMockSession()
+        sessions.set('s1', { session: sessionA, name: 'A', cwd: '/a' })
+        sessions.set('s2', { session: sessionB, name: 'B', cwd: '/b' })
+        const ctx = makeCtx(sessions)
+        // The leaked toolUseId belongs to session s1.
+        ctx.questionSessionMap.set('tool-leak', 's1')
+        // Attacker tab: unbound, actively viewing s2, NOT subscribed to s1.
+        const attacker = makeClient({
+          id: 'attacker',
+          boundSessionId: null,
+          activeSessionId: 's2',
+          subscribedSessionIds: new Set(['s2']),
+        })
+
+        inputHandlers.user_question_response(makeWs(), attacker, {
+          answer: 'malicious',
+          toolUseId: 'tool-leak',
+        }, ctx)
+
+        assert.equal(sessionA.respondToQuestion.callCount, 0,
+          'unbound client without subscription/active match must NOT route the answer')
+        assert.equal(sessionB.respondToQuestion.callCount, 0,
+          'and must not bleed onto the attacker\'s own session either')
+        assert.equal(ctx.questionSessionMap.get('tool-leak'), 's1',
+          'mapping must stay intact so the legitimate client can still respond')
+      })
+
+      it('routes the answer when the unbound client\'s activeSessionId matches the questionSessionId', () => {
+        const sessions = new Map()
+        const sessionA = createMockSession()
+        sessions.set('s1', { session: sessionA, name: 'A', cwd: '/a' })
+        const ctx = makeCtx(sessions)
+        ctx.questionSessionMap.set('tool-ok-active', 's1')
+        const client = makeClient({
+          id: 'legit-active',
+          boundSessionId: null,
+          activeSessionId: 's1',
+          subscribedSessionIds: new Set(),
+        })
+
+        inputHandlers.user_question_response(makeWs(), client, {
+          answer: 'yes',
+          toolUseId: 'tool-ok-active',
+        }, ctx)
+
+        assert.equal(sessionA.respondToQuestion.callCount, 1,
+          'unbound client with matching activeSessionId must route normally')
+        assert.equal(sessionA.respondToQuestion.lastCall[0], 'yes')
+        assert.equal(ctx.questionSessionMap.has('tool-ok-active'), false,
+          'mapping must be consumed when the answer is routed')
+      })
+
+      it('routes the answer when the unbound client is subscribed to the questionSessionId (even if active session differs)', () => {
+        const sessions = new Map()
+        const sessionA = createMockSession()
+        const sessionB = createMockSession()
+        sessions.set('s1', { session: sessionA, name: 'A', cwd: '/a' })
+        sessions.set('s2', { session: sessionB, name: 'B', cwd: '/b' })
+        const ctx = makeCtx(sessions)
+        ctx.questionSessionMap.set('tool-ok-subscribed', 's1')
+        // Multi-session dashboard pattern: active tab is s2, but s1 is
+        // subscribed (sidebar / background tab keeping the wire open).
+        const client = makeClient({
+          id: 'legit-subscribed',
+          boundSessionId: null,
+          activeSessionId: 's2',
+          subscribedSessionIds: new Set(['s1', 's2']),
+        })
+
+        inputHandlers.user_question_response(makeWs(), client, {
+          answer: 'approve',
+          toolUseId: 'tool-ok-subscribed',
+        }, ctx)
+
+        assert.equal(sessionA.respondToQuestion.callCount, 1,
+          'subscribed unbound client must route normally — matches _broadcastToSession filter')
+        assert.equal(sessionA.respondToQuestion.lastCall[0], 'approve')
+      })
+
+      it('leaves the bound-client guard at line 541 unchanged (different code path)', () => {
+        // The existing bound-client guard already early-returns when the
+        // bound session doesn't match the questionSessionId. This test pins
+        // that the new subscription guard doesn't accidentally relax it.
+        const sessions = new Map()
+        const sessionA = createMockSession()
+        sessions.set('s1', { session: sessionA, name: 'A', cwd: '/a' })
+        const ctx = makeCtx(sessions)
+        ctx.questionSessionMap.set('tool-x', 's1')
+        const boundElsewhere = makeClient({
+          id: 'bound-other',
+          boundSessionId: 's2',
+          activeSessionId: 's1',
+          subscribedSessionIds: new Set(['s1']),
+        })
+
+        inputHandlers.user_question_response(makeWs(), boundElsewhere, {
+          answer: 'sneaky',
+          toolUseId: 'tool-x',
+        }, ctx)
+
+        assert.equal(sessionA.respondToQuestion.callCount, 0,
+          'bound-client guard takes precedence — boundSessionId mismatch always wins')
+        assert.equal(ctx.questionSessionMap.get('tool-x'), 's1',
+          'mapping preserved when the bound-elsewhere client is rejected')
+      })
+
+      it('tolerates a missing subscribedSessionIds set (defensive — old client shapes)', () => {
+        // The handler must not throw if subscribedSessionIds is undefined
+        // (e.g. a test fixture or legacy client struct). It should simply
+        // fall through to the activeSessionId check.
+        const sessions = new Map()
+        const sessionA = createMockSession()
+        sessions.set('s1', { session: sessionA, name: 'A', cwd: '/a' })
+        const ctx = makeCtx(sessions)
+        ctx.questionSessionMap.set('tool-y', 's1')
+        const client = makeClient({
+          id: 'no-subscribed-set',
+          boundSessionId: null,
+          activeSessionId: 's2',
+          // subscribedSessionIds intentionally omitted
+        })
+
+        // Should not throw, and should drop the answer (no match).
+        inputHandlers.user_question_response(makeWs(), client, {
+          answer: 'x',
+          toolUseId: 'tool-y',
+        }, ctx)
+
+        assert.equal(sessionA.respondToQuestion.callCount, 0,
+          'undefined subscribedSessionIds + non-matching active must drop')
+      })
+    })
   })
 
   // #3186: auto-evaluation hook on user_input. When session.promptEvaluator

--- a/packages/server/tests/ws-server-permissions.test.js
+++ b/packages/server/tests/ws-server-permissions.test.js
@@ -671,14 +671,19 @@ describe('permission/question routing to originating session', () => {
     const port = await startServerAndGetPort(server)
     const { ws, messages } = await createClient(port, true)
 
-    // Simulate question from Session A (populates _questionSessionMap)
-    server._questionSessionMap.set('q-routing-1', 'sess-a')
+    // Simulate question from Session A (populates _questionSessionMap AND
+    // auto-subscribes connected clients to sess-a, mirroring the production
+    // dispatch path so the #4788 subscription guard sees the client as a
+    // legitimate recipient even after they switch_session away).
+    server._registerQuestionRoute('q-routing-1', 'sess-a')
 
     // Switch client to Session B
     send(ws, { type: 'switch_session', sessionId: 'sess-b' })
     await waitForMessage(messages, 'session_switched', 2000)
 
-    // Respond to the question — should route to Session A
+    // Respond to the question — should route to Session A even though the
+    // client's active session is now sess-b (subscribedSessionIds still
+    // contains sess-a from the auto-subscribe at dispatch).
     send(ws, { type: 'user_question_response', toolUseId: 'q-routing-1', answer: 'yes' })
     await waitFor(() => sessionAGotQuestion, { label: 'sessionA question routed' })
 


### PR DESCRIPTION
## Summary

Closes a cross-session answer-hijack vector in `handleUserQuestionResponse`.

For UNBOUND clients (`boundSessionId === null`), the existing early-return at `input-handlers.js:546` was skipped, leaving the handler to route the answer to whichever session owned the `toolUseId` from `questionSessionMap` — with no check that the client was actually subscribed to or viewing that session.

Combined with the related `toolUseId` log leak (audit P0.1 / #4787), an unbound dashboard tab could submit an answer for any session by replaying a leaked `toolUseId`. Concrete attack: two dashboards open, one's typo'd click can land in the other session; with hostile pairing this becomes deliberate cross-session steering.

## Fix

After computing `questionSessionId`, add for UNBOUND clients:

```js
if (!client.boundSessionId) {
  const subscribed = questionSessionId === client.activeSessionId
    || (client.subscribedSessionIds && client.subscribedSessionIds.has(questionSessionId))
  if (!subscribed) return
}
```

This mirrors `_broadcastToSession`'s default filter (`ws-broadcaster.js:106`) — the set of clients permitted to ANSWER a question is now the same set that could legitimately have RECEIVED it. The existing bound-client guard stays untouched. The mapping is left intact when the unbound client is rejected so the legitimate subscribed client can still respond.

Closes #4788 (audit P0.2). Pairs with #4787 which closes the related `toolUseId` leak channel.

## Test plan

TDD — 5 new regression tests added to `packages/server/tests/handlers/input-handlers.test.js` under `describe('subscription guard for unbound clients (#4788)')`:

- [x] Unbound client without subscription/active match for the `questionSessionId` is dropped (the hijack vector — RED before fix, GREEN after)
- [x] Unbound client whose `activeSessionId` matches routes normally
- [x] Unbound client subscribed to the `questionSessionId` (active session differs) routes normally — multi-session dashboard pattern
- [x] Bound-client guard at line 546 still takes precedence (no relaxation)
- [x] Undefined `subscribedSessionIds` is handled defensively (falls through to active check, no throw)
- [x] All 57 input-handler tests pass post-fix (was 55 + 5 new = 60, with the 2 that previously failed flipping GREEN)
- [x] All 82/83 question/multi-question/input-conflict adjacent tests pass; the 1 remaining failure (`tests/input-conflict.test.js`) is pre-existing on `main` (verified by `git stash` + re-run on clean HEAD)