### PR TITLE
fix(server): forward streamStallTimeoutMs through provider middle layers (#4790)

### DIFF
--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -463,7 +463,7 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, resumeSessionId } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, resumeSessionId } = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
@@ -471,7 +471,12 @@ export class CodexSession extends JsonlSubprocessSession {
     // doesn't (yet) split its timer into soft/hard — the config flows
     // through here so when Codex gets the #3899 treatment as a follow-
     // up the plumbing is already in place.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, resumeSessionId })
+    // #4790: streamStallTimeoutMs likewise forwarded so the per-provider
+    // override SessionManager wired in PR #4745 actually reaches
+    // BaseSession's stream-stall timer. Dropping it here silently reverted
+    // operators to the 5min default — the trap documented in
+    // [[feedback_jsonl_subprocess_middle_layer]].
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, resumeSessionId })
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -282,11 +282,15 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, resumeSessionId } = {}) {
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, resumeSessionId } = {}) {
     // #3899: hardTimeoutMs forwarded to BaseSession — same shape as
     // CodexSession. When Gemini gets the soft/hard split as a follow-
     // up, the operator config will already be flowing in.
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, resumeSessionId })
+    // #4790: streamStallTimeoutMs likewise forwarded so the per-provider
+    // override SessionManager wired in PR #4745 actually reaches
+    // BaseSession's stream-stall timer — same middle-layer trap as the
+    // other BaseSession opts above ([[feedback_jsonl_subprocess_middle_layer]]).
+    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, resumeSessionId })
   }
 
   setModel(model) {

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -118,6 +118,12 @@ export class JsonlSubprocessSession extends BaseSession {
     // BaseSession option, plumb it through here too or Codex / Gemini
     // silently fall back to the default.
     hardTimeoutMs,
+    // #4790: per-provider stream-stall recovery timeout. PR #4745 wired
+    // SessionManager → providerOpts.streamStallTimeoutMs but this
+    // destructure dropped it, so Codex / Gemini sessions silently fell
+    // back to BaseSession's 5min default — exactly the trap documented
+    // in [[feedback_jsonl_subprocess_middle_layer]] landing again.
+    streamStallTimeoutMs,
     resumeSessionId,
   } = {}) {
     super({
@@ -139,6 +145,7 @@ export class JsonlSubprocessSession extends BaseSession {
       sessionPreamble,
       resultTimeoutMs,
       hardTimeoutMs,
+      streamStallTimeoutMs,
     })
     // #3865: accept resumeSessionId from constructor so SessionManager's
     // serializeState/restoreState path carries a captured Codex thread_id

--- a/packages/server/tests/codex-session.test.js
+++ b/packages/server/tests/codex-session.test.js
@@ -265,6 +265,28 @@ describe('CodexSession', () => {
       assert.equal(session._resultTimeoutMs, 30 * 60 * 1000)
     })
 
+    // #4790: Leaf constructor must forward streamStallTimeoutMs through every
+    // layer (CodexSession → JsonlSubprocessSession → BaseSession). PR #4745
+    // wired per-provider overrides through SessionManager — Codex was the
+    // motivating case — but each middle layer dropped the key from its
+    // destructure list. The existing CapturingProvider-based test in
+    // session-manager.test.js missed this because CapturingProvider has no
+    // middle layer.
+    it('forwards streamStallTimeoutMs to BaseSession (#4790)', () => {
+      const session = new CodexSession({ cwd: '/tmp', streamStallTimeoutMs: 900_000 })
+      assert.equal(session._streamStallTimeoutMs, 900_000)
+    })
+
+    it('defaults _streamStallTimeoutMs to 5 min when omitted (#4790)', () => {
+      const session = new CodexSession({ cwd: '/tmp' })
+      assert.equal(session._streamStallTimeoutMs, 5 * 60 * 1000)
+    })
+
+    it('forwards streamStallTimeoutMs: 0 (explicit disable) to BaseSession (#4790)', () => {
+      const session = new CodexSession({ cwd: '/tmp', streamStallTimeoutMs: 0 })
+      assert.equal(session._streamStallTimeoutMs, 0)
+    })
+
     // -------------------------------------------------------------------
     // #3225: JsonlSubprocessSession's constructor previously dropped
     // `provider` and `activeManualSkills` (and the budget overrides). The

--- a/packages/server/tests/gemini-session.test.js
+++ b/packages/server/tests/gemini-session.test.js
@@ -92,6 +92,26 @@ describe('GeminiSession', () => {
     assert.equal(session._resultTimeoutMs, 30 * 60 * 1000)
   })
 
+  // #4790: GeminiSession → JsonlSubprocessSession → BaseSession forwarding of
+  // streamStallTimeoutMs. SessionManager (PR #4745) wired per-provider
+  // overrides into providerOpts but each middle layer dropped the key.
+  // The CapturingProvider-based test in session-manager.test.js missed this
+  // because CapturingProvider has no middle layer.
+  it('forwards streamStallTimeoutMs to BaseSession (#4790)', () => {
+    const session = new GeminiSession({ cwd: '/tmp', streamStallTimeoutMs: 900_000 })
+    assert.equal(session._streamStallTimeoutMs, 900_000)
+  })
+
+  it('defaults _streamStallTimeoutMs to 5 min when omitted (#4790)', () => {
+    const session = new GeminiSession({ cwd: '/tmp' })
+    assert.equal(session._streamStallTimeoutMs, 5 * 60 * 1000)
+  })
+
+  it('forwards streamStallTimeoutMs: 0 (explicit disable) to BaseSession (#4790)', () => {
+    const session = new GeminiSession({ cwd: '/tmp', streamStallTimeoutMs: 0 })
+    assert.equal(session._streamStallTimeoutMs, 0)
+  })
+
   // ---------------------------------------------------------------------
   // PR #3231 review (agent-review): JsonlSubprocessSession was the
   // middle layer between GeminiSession and BaseSession and silently

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -190,6 +190,34 @@ describe('JsonlSubprocessSession (base)', () => {
       assert.equal(s2._resultTimeoutMs, 30 * 60 * 1000)
       assert.equal(s3._resultTimeoutMs, 30 * 60 * 1000)
     })
+
+    // #4790: same middle-layer trap as #3755 / #3225 / #3805 / #4660 / #3899 —
+    // SessionManager (PR #4745) wires per-provider streamStallTimeoutMs into
+    // providerOpts but JsonlSubprocessSession dropped the key from its
+    // destructure list, so Codex/Gemini sessions silently fell back to the
+    // BaseSession default. Pin the forwarding at every layer.
+    it('forwards streamStallTimeoutMs to BaseSession (#4790)', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp', streamStallTimeoutMs: 900_000 })
+      assert.equal(s._streamStallTimeoutMs, 900_000,
+        'JsonlSubprocessSession must forward streamStallTimeoutMs so Codex/Gemini honour the per-provider override')
+    })
+
+    it('forwards streamStallTimeoutMs: 0 (explicit disable) to BaseSession (#4790)', () => {
+      // BaseSession honours 0 (allowZero: true) as "disable active recovery".
+      // The middle layer must preserve this — an operator opting out per
+      // provider must not silently re-enable the default 5min timer.
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp', streamStallTimeoutMs: 0 })
+      assert.equal(s._streamStallTimeoutMs, 0)
+    })
+
+    it('defaults _streamStallTimeoutMs to 5 min when omitted (#4790)', () => {
+      const P = makeTestProviderClass()
+      const s = new P({ cwd: '/tmp' })
+      assert.equal(s._streamStallTimeoutMs, 5 * 60 * 1000,
+        'inherits BaseSession default when streamStallTimeoutMs is not provided')
+    })
   })
 
   describe('start()', () => {


### PR DESCRIPTION
## Summary

PR #4745 wired a per-provider `streamStallTimeoutMs` override through `SessionManager` (`packages/server/src/session-manager.js:667-672`), but the wiring stopped at the middle layer — `JsonlSubprocessSession`, `CodexSession`, and `GeminiSession` each destructured a fixed key list in their constructors and silently dropped `streamStallTimeoutMs` before calling `super()`. Net effect: when an operator set `CHROXY_PROVIDER_STREAM_STALL_TIMEOUT_MS={\"codex\":900000}`, the value reached `providerOpts` and was then thrown away by Codex/Gemini constructors — the feature was DOA for the two providers that motivated PR #4745.

This is the exact trap documented in project memory as `feedback_jsonl_subprocess_middle_layer.md` (when adding a `BaseSession` opt, plumb it through every middle layer too) landing again. The existing `session-manager.test.js:3394-3483` test missed it because it uses `CapturingProvider`, which has no middle layer.

Fix:
- Add `streamStallTimeoutMs` to the destructure list AND the `super({...})` call in:
  - `packages/server/src/jsonl-subprocess-session.js`
  - `packages/server/src/codex-session.js`
  - `packages/server/src/gemini-session.js`
- Add integration tests using the REAL provider classes (not `CapturingProvider`) to all three test files — these tests fail before the fix and pass after.

Closes #4790 (audit P0.4).

## Test plan

- [x] New RED tests added to `tests/jsonl-subprocess-session.test.js`, `tests/codex-session.test.js`, `tests/gemini-session.test.js` confirmed failing before the fix.
- [x] After fix: all three test files pass (`node --test tests/jsonl-subprocess-session.test.js tests/codex-session.test.js tests/gemini-session.test.js` → 205/205 green).
- [x] `tests/session-manager.test.js` still passes (181/181) — the CapturingProvider-based per-provider-override tests from #4745 unaffected.
- [x] Full server test suite (`npm test`) — only pre-existing env-dependent failures (cloudflared / claude CLI / port 8765); no new failures introduced by this PR (verified by running the same failing tests against `origin/main`).
- [x] `scripts/lint-tests-state-file-path.sh` passes.