### PR TITLE
test(dashboard): remove fake ChatMessage markdown overflow coverage (#4803)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Removed fake-coverage ChatMessage markdown overflow tests (#4803, audit P3.3):** the `describe('long markdown content (#4757)')` block in `packages/dashboard/src/components/ChatMessage.test.tsx` was structural-only — every assertion (`code.textContent`, `inlineCodes.length`, "doesn't throw") passed on the pre-PR commit, so removing the CSS fix in `components.css` (`max-width: 100%`, `min-width: 0`, `overflow-wrap: anywhere`) would not fail any test. jsdom doesn't measure layout, so unit tests cannot verify wrapping. The block is deleted with a comment pointing at the CSS rules; #4757 remains manually verified per release. A real visual-regression harness (Playwright screenshot of a narrow viewport with a 220-char fenced line) is tracked as a future enhancement.
+
 ## [0.9.34] - 2026-06-02
 
 P0 hotfix release closing the four highest-severity findings from the v0.9.33 8-agent swarm-audit (`docs/audit-results/code-quality-v0.9.33/`). Two are real cross-session security exposures introduced by the bound-mobile pairing model (log fan-out leaks PTY contents + tool-use IDs to any paired client; unbound clients can hijack another session's pending AskUserQuestion using leaked IDs). Two are correctness regressions from the v0.9.33 work itself (voice-input unmount race introduced by #4786 continuous mode; `streamStallTimeoutMs` per-provider override silently dropped by Codex/Gemini middle-layer destructures — exactly the `feedback_jsonl_subprocess_middle_layer` trap pattern, landing for the 3rd time despite a memory note).

--- a/packages/dashboard/src/components/ChatMessage.test.tsx
+++ b/packages/dashboard/src/components/ChatMessage.test.tsx
@@ -239,72 +239,13 @@ describe('ChatMessage', () => {
     expect(screen.getByTestId('chat-message-msg-error-ok')).toBeInTheDocument()
   })
 
-  /**
-   * #4757 — chat markdown overflow fix. These tests assert the renderer
-   * still emits the <pre> / <code> structure that the CSS rules in
-   * theme/components.css target (`.msg pre`, `.msg pre code`,
-   * `.msg code`). jsdom doesn't measure layout, so the visual cap +
-   * horizontal-scroll behaviour is verified manually in the dashboard;
-   * here we lock in the contract that long content renders without
-   * throwing and lands inside the right elements so the CSS keeps
-   * applying.
-   */
-  describe('long markdown content (#4757)', () => {
-    it('renders a fenced block with a very long single line inside <pre><code>', () => {
-      const longLine = 'a'.repeat(220)
-      render(
-        <ChatMessage
-          id="msg-long-pre"
-          type="response"
-          content={'before\n```\n' + longLine + '\n```\nafter'}
-          timestamp={Date.now()}
-        />
-      )
-      const el = screen.getByTestId('chat-message-msg-long-pre')
-      const pre = el.querySelector('pre')
-      expect(pre).not.toBeNull()
-      const code = pre!.querySelector('code')
-      expect(code).not.toBeNull()
-      expect(code!.textContent).toContain(longLine)
-    })
-
-    it('renders an inline long-token code span inside <code> (no pre ancestor)', () => {
-      const longToken = 'x'.repeat(180)
-      render(
-        <ChatMessage
-          id="msg-long-inline"
-          type="response"
-          content={'see `' + longToken + '` for the path'}
-          timestamp={Date.now()}
-        />
-      )
-      const el = screen.getByTestId('chat-message-msg-long-inline')
-      const inlineCodes = Array.from(el.querySelectorAll('code')).filter(
-        c => !c.closest('pre')
-      )
-      expect(inlineCodes).toHaveLength(1)
-      expect(inlineCodes[0]!.textContent).toBe(longToken)
-    })
-
-    it('renders mixed inline + fenced content in one message without throwing', () => {
-      const longLine = 'z'.repeat(250)
-      const longToken = 'q'.repeat(150)
-      render(
-        <ChatMessage
-          id="msg-mixed"
-          type="response"
-          content={`Use the \`${longToken}\` flag:\n\n\`\`\`\n${longLine}\n\`\`\``}
-          timestamp={Date.now()}
-        />
-      )
-      const el = screen.getByTestId('chat-message-msg-mixed')
-      expect(el.querySelector('pre code')!.textContent).toContain(longLine)
-      const inline = Array.from(el.querySelectorAll('code')).find(
-        c => !c.closest('pre')
-      )
-      expect(inline!.textContent).toBe(longToken)
-    })
-  })
+  // #4757 markdown overflow fix is CSS-only (components.css: max-width, min-width: 0,
+  // overflow-wrap: anywhere). jsdom does not measure layout so unit tests can't
+  // verify wrapping. Manual verification on each release; visual regression
+  // tracked separately as a future enhancement.
+  // Removed structural-only assertions per audit P3.3 (#4803): every assertion
+  // passed on the pre-PR commit, so the suite gave the illusion of regression
+  // protection without exercising the CSS rules that actually fix the bug.
 })
 
 describe('ToolBubble', () => {


### PR DESCRIPTION
## Summary

Closes #4803 (audit P3.3).

The `describe('long markdown content (#4757)')` block in `packages/dashboard/src/components/ChatMessage.test.tsx:242-307` self-acknowledged at line 246 that "jsdom doesn't measure layout, so the visual cap + horizontal-scroll behaviour is verified manually." The actual fix for #4757 is three CSS rules in `packages/dashboard/src/theme/components.css` (`max-width: 100%`, `min-width: 0`, `overflow-wrap: anywhere`).

The block asserted only:
- `code.textContent.toContain(longLine)` — already true pre-PR
- `inlineCodes.toHaveLength(1)` — already true pre-PR
- Renderer doesn't throw — already true pre-PR

Every assertion would PASS on the pre-PR commit. A future CSS regression removing `min-width: 0` from `.msg` would not fail any test. Keeping a fake-coverage test is worse than no test — it creates the illusion of regression protection.

## Choice: Option B (delete + document)

The issue offered:
- **A:** Add a Playwright / Maestro visual regression test (requires new infra — dashboard has no `.maestro/` dir; maestro is mobile-only here)
- **B:** Delete the block + admit the fix is CSS-only / manually verified, note in CHANGELOG

Picked **B**. The dashboard has no visual-regression harness today; standing one up is a separate larger PR. The CSS rules in `components.css` are well-commented at the source (search `#4757` — three blocks, all with explanatory comments), and the manual-verification status is now explicit at both the test site and in CHANGELOG. A real visual-regression harness remains a future enhancement.

## Changes

- Delete `describe('long markdown content (#4757)')` block in `ChatMessage.test.tsx` (-66 LOC)
- Add a comment at the deletion site explaining why (CSS-only fix, jsdom limitation, future visual-regression tracked)
- CHANGELOG.md `[Unreleased]` Changed entry documenting the deletion

## Test plan

- [x] `cd packages/dashboard && npm test -- --run` — all 130 test files, 2513 tests pass (ChatMessage suite drops from 27 to 24 tests, matching the 3 deleted cases)
- [x] No other test references the deleted `describe` (sole `#4757` mention in the test tree was this block)
- [x] CSS rules in `components.css` (lines 1591, 1742, 1760, 1776 — all `#4757` annotated) are unchanged