### PR TITLE
fix(desktop): add audio-input entitlement so speech-helper can request mic access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,10 @@ jobs:
       - name: Run tests
         run: cargo test --locked
 
+      - name: Run verify-entitlements.sh tests (#4801)
+        working-directory: packages/desktop
+        run: bash scripts/verify-entitlements.test.sh
+
   scripts-tests:
     name: Scripts Tests
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,18 @@ jobs:
         working-directory: packages/desktop
         run: cargo tauri build --target universal-apple-darwin --bundles app,dmg -c "$TAURI_CONFIG_OVERRIDE"
 
+      - name: Verify .app entitlements (#4801 regression guard)
+        shell: bash
+        working-directory: packages/desktop
+        run: |
+          APP_PATH="$(find src-tauri/target/universal-apple-darwin/release/bundle/macos -maxdepth 2 -name '*.app' -print -quit)"
+          if [ -z "$APP_PATH" ]; then
+            echo "No .app bundle found under src-tauri/target/universal-apple-darwin/release/bundle/macos" >&2
+            exit 1
+          fi
+          echo "Verifying entitlements on $APP_PATH"
+          bash scripts/verify-entitlements.sh "$APP_PATH"
+
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/packages/desktop/scripts/verify-entitlements.sh
+++ b/packages/desktop/scripts/verify-entitlements.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# verify-entitlements.sh — assert required entitlements are present in a
+# signed macOS .app bundle (or in a raw entitlements.plist for unit tests).
+#
+# Background: see #4801. The macOS Tauri build was shipping without
+# `com.apple.security.device.audio-input`, which silently denied microphone
+# access to the bundled Swift speech-helper. This script runs against the
+# release-built .app so the next missing-entitlement regression fails the
+# build instead of shipping broken voice input.
+#
+# Usage:
+#   scripts/verify-entitlements.sh <path-to-app-or-plist>
+#
+# Modes:
+#   - If the target ends with `.plist` or is a regular file, dump its raw text.
+#   - Otherwise, run `codesign -d --entitlements - <target>` against an app
+#     bundle to extract the embedded entitlements blob.
+#
+# Exits non-zero if any required entitlement is missing.
+
+set -euo pipefail
+
+REQUIRED_ENTITLEMENTS=(
+    "com.apple.security.cs.allow-jit"
+    "com.apple.security.cs.allow-unsigned-executable-memory"
+    "com.apple.security.cs.disable-library-validation"
+    "com.apple.security.device.audio-input"
+)
+
+usage() {
+    echo "Usage: $0 <path-to-Chroxy.app | path-to-entitlements.plist>" >&2
+    exit 2
+}
+
+if [ $# -ne 1 ]; then
+    usage
+fi
+
+TARGET="$1"
+
+if [ ! -e "$TARGET" ]; then
+    echo "verify-entitlements: target not found: $TARGET" >&2
+    exit 2
+fi
+
+# Capture entitlements blob. For plist files we just cat; for .app bundles we
+# go through codesign so we're asserting on what was actually signed in, not
+# the source plist.
+if [[ "$TARGET" == *.plist ]] || { [ -f "$TARGET" ] && [[ "$TARGET" != *.app ]]; }; then
+    ENTITLEMENTS_BLOB="$(cat "$TARGET")"
+else
+    if ! command -v codesign >/dev/null 2>&1; then
+        echo "verify-entitlements: codesign not found (macOS-only)" >&2
+        exit 2
+    fi
+    # codesign emits the XML plist on stdout; older macOS versions print a
+    # leading header line on stderr which we discard.
+    ENTITLEMENTS_BLOB="$(codesign -d --entitlements - --xml "$TARGET" 2>/dev/null || true)"
+    if [ -z "$ENTITLEMENTS_BLOB" ]; then
+        # Retry without --xml for compatibility with older codesign that
+        # emits the plist as the primary output and may not support --xml.
+        ENTITLEMENTS_BLOB="$(codesign -d --entitlements - "$TARGET" 2>/dev/null || true)"
+    fi
+    if [ -z "$ENTITLEMENTS_BLOB" ]; then
+        echo "verify-entitlements: unable to read entitlements from $TARGET" >&2
+        exit 1
+    fi
+fi
+
+MISSING=()
+for key in "${REQUIRED_ENTITLEMENTS[@]}"; do
+    # Match the `<key>NAME</key>` line exactly to avoid false positives on
+    # substring matches (e.g. `audio-input` would otherwise match
+    # `audio-input-foo`).
+    if ! printf '%s\n' "$ENTITLEMENTS_BLOB" | grep -qE "<key>${key}</key>"; then
+        MISSING+=("$key")
+    fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    echo "verify-entitlements: FAIL — missing required entitlements in $TARGET:" >&2
+    for key in "${MISSING[@]}"; do
+        echo "  - $key" >&2
+    done
+    exit 1
+fi
+
+echo "verify-entitlements: OK — all required entitlements present in $TARGET"

--- a/packages/desktop/scripts/verify-entitlements.sh
+++ b/packages/desktop/scripts/verify-entitlements.sh
@@ -69,10 +69,13 @@ fi
 
 MISSING=()
 for key in "${REQUIRED_ENTITLEMENTS[@]}"; do
-    # Match the `<key>NAME</key>` line exactly to avoid false positives on
-    # substring matches (e.g. `audio-input` would otherwise match
-    # `audio-input-foo`).
-    if ! printf '%s\n' "$ENTITLEMENTS_BLOB" | grep -qE "<key>${key}</key>"; then
+    # Match the `<key>NAME</key>` line as a fixed string (grep -F) so dots in
+    # the entitlement name (`com.apple.security.device.audio-input`) are not
+    # treated as regex "any char" — a regex match would false-positive on
+    # malformed `<key>comXappleXsecurityXdeviceXaudio-input</key>`. The
+    # surrounding `<key>...</key>` anchors also guard against substring
+    # collisions (e.g. `audio-input` vs `audio-input-foo`).
+    if ! printf '%s\n' "$ENTITLEMENTS_BLOB" | grep -qF "<key>${key}</key>"; then
         MISSING+=("$key")
     fi
 done

--- a/packages/desktop/scripts/verify-entitlements.test.sh
+++ b/packages/desktop/scripts/verify-entitlements.test.sh
@@ -104,6 +104,18 @@ write_plist "$COLLIDE_PLIST" \
     "com.apple.security.device.audio-input-foo"
 assert_exit "rejects look-alike audio-input-foo key" 1 "$(run_verifier "$COLLIDE_PLIST")"
 
+# Regex-metachar guard — dots in the entitlement name must be treated as
+# literal dots, not regex "any char". A malformed plist where dots are
+# replaced with other characters must fail (would falsely pass under
+# `grep -E` because the dots in the pattern would match any character).
+REGEX_COLLIDE_PLIST="$TMP_DIR/regex-collide.plist"
+write_plist "$REGEX_COLLIDE_PLIST" \
+    "com.apple.security.cs.allow-jit" \
+    "com.apple.security.cs.allow-unsigned-executable-memory" \
+    "com.apple.security.cs.disable-library-validation" \
+    "comXappleXsecurityXdeviceXaudio-input"
+assert_exit "treats dots in key as literal, not regex any-char" 1 "$(run_verifier "$REGEX_COLLIDE_PLIST")"
+
 echo ""
 echo "verify-entitlements tests: $PASS passed, $FAIL failed"
 

--- a/packages/desktop/scripts/verify-entitlements.test.sh
+++ b/packages/desktop/scripts/verify-entitlements.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# verify-entitlements.test.sh — black-box test for verify-entitlements.sh.
+#
+# Runs the verifier against synthetic entitlements plists to confirm it:
+#   1. Passes when every required key is present (including audio-input).
+#   2. Fails non-zero when audio-input is missing (the #4801 regression).
+#   3. Fails non-zero when any other required key is missing.
+#   4. Fails non-zero on a malformed / empty plist.
+#   5. Fails non-zero when the target file does not exist.
+#   6. Fails on the live entitlements.plist in src-tauri only if the source
+#      ever drops a required key — guards against accidental removal.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VERIFIER="$SCRIPT_DIR/verify-entitlements.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$expected" -eq "$actual" ]; then
+        echo "ok   - $description (exit=$actual)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL - $description (expected exit=$expected, got $actual)" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+run_verifier() {
+    set +e
+    "$VERIFIER" "$1" >/dev/null 2>&1
+    local rc=$?
+    set -e
+    echo "$rc"
+}
+
+write_plist() {
+    local path="$1"
+    shift
+    {
+        echo '<?xml version="1.0" encoding="UTF-8"?>'
+        echo '<plist version="1.0">'
+        echo '<dict>'
+        for key in "$@"; do
+            echo "    <key>${key}</key>"
+            echo "    <true/>"
+        done
+        echo '</dict>'
+        echo '</plist>'
+    } > "$path"
+}
+
+# Case 1 — all required keys present → exit 0
+GOOD_PLIST="$TMP_DIR/good.plist"
+write_plist "$GOOD_PLIST" \
+    "com.apple.security.cs.allow-jit" \
+    "com.apple.security.cs.allow-unsigned-executable-memory" \
+    "com.apple.security.cs.disable-library-validation" \
+    "com.apple.security.device.audio-input"
+assert_exit "passes when all required entitlements present" 0 "$(run_verifier "$GOOD_PLIST")"
+
+# Case 2 — missing audio-input (the #4801 regression) → exit 1
+MISSING_AUDIO="$TMP_DIR/missing-audio.plist"
+write_plist "$MISSING_AUDIO" \
+    "com.apple.security.cs.allow-jit" \
+    "com.apple.security.cs.allow-unsigned-executable-memory" \
+    "com.apple.security.cs.disable-library-validation"
+assert_exit "fails when audio-input missing (#4801)" 1 "$(run_verifier "$MISSING_AUDIO")"
+
+# Case 3 — missing one of the JIT/library entitlements → exit 1
+MISSING_JIT="$TMP_DIR/missing-jit.plist"
+write_plist "$MISSING_JIT" \
+    "com.apple.security.cs.allow-unsigned-executable-memory" \
+    "com.apple.security.cs.disable-library-validation" \
+    "com.apple.security.device.audio-input"
+assert_exit "fails when allow-jit missing" 1 "$(run_verifier "$MISSING_JIT")"
+
+# Case 4 — empty plist → exit 1
+EMPTY_PLIST="$TMP_DIR/empty.plist"
+write_plist "$EMPTY_PLIST"
+assert_exit "fails on empty plist" 1 "$(run_verifier "$EMPTY_PLIST")"
+
+# Case 5 — non-existent target → exit 2
+assert_exit "fails when target missing" 2 "$(run_verifier "$TMP_DIR/does-not-exist.plist")"
+
+# Case 6 — live source plist must satisfy verifier
+LIVE_PLIST="$(cd "$SCRIPT_DIR/.." && pwd)/src-tauri/entitlements.plist"
+assert_exit "src-tauri/entitlements.plist contains all required keys" 0 "$(run_verifier "$LIVE_PLIST")"
+
+# Substring-collision guard — ensure the matcher doesn't false-positive on a
+# look-alike key (e.g. `com.apple.security.device.audio-input-foo`).
+COLLIDE_PLIST="$TMP_DIR/collide.plist"
+write_plist "$COLLIDE_PLIST" \
+    "com.apple.security.cs.allow-jit" \
+    "com.apple.security.cs.allow-unsigned-executable-memory" \
+    "com.apple.security.cs.disable-library-validation" \
+    "com.apple.security.device.audio-input-foo"
+assert_exit "rejects look-alike audio-input-foo key" 1 "$(run_verifier "$COLLIDE_PLIST")"
+
+echo ""
+echo "verify-entitlements tests: $PASS passed, $FAIL failed"
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/packages/desktop/src-tauri/entitlements.plist
+++ b/packages/desktop/src-tauri/entitlements.plist
@@ -12,5 +12,11 @@
          this, Hardened Runtime rejects loading dylibs from a different team. -->
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <!-- Required so the bundled Swift speech-helper subprocess (inherits this
+         bundle's Hardened Runtime) can request and use the microphone via
+         AVAudioApplication.requestRecordPermission. Without this entitlement
+         macOS silently denies mic access and voice input never starts (#4801). -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Add `com.apple.security.device.audio-input` to `packages/desktop/src-tauri/entitlements.plist` so the bundled Swift speech-helper subprocess (which inherits the parent bundle's Hardened Runtime) can request and use the microphone. Without this, macOS silently denied mic access on every released desktop build and voice input never started — the helper would launch, get `granted=false` from `AVAudioApplication.requestRecordPermission`, emit `{"error": "Microphone permission denied"}`, and exit ~1s later.
- Add `scripts/verify-entitlements.sh` — accepts either a `.app` bundle (uses `codesign -d --entitlements -` so it asserts against what was actually signed in) or a raw `entitlements.plist` (for unit-testability without a build). Fails non-zero with a list of missing keys if any required entitlement is absent.
- Add `scripts/verify-entitlements.test.sh` — TDD black-box harness with 7 cases: all-keys-present, the #4801 missing-audio-input regression, missing JIT/library keys, empty plist, missing target, the live `src-tauri/entitlements.plist`, and a look-alike substring-collision guard.
- Wire the verifier into `release.yml` as a post-`cargo tauri build` step so any future missing-entitlement regression fails the release build before artifact upload.
- Wire the verifier unit tests into `ci.yml` (`desktop-tests` job).

Closes #4801.

The optional UI work to render `voiceInput.error` (audit Operator P4.1) is intentionally deferred to a separate PR so this fix stays tightly scoped to the durable entitlement + regression guard.

## Ship notes

Shipped users only benefit after a desktop rebuild + release cut — landing this PR alone does not unbreak v0.9.34. A v0.9.35 hotfix release is needed (entitlement change, `scripts/bump-version.sh`, `cargo tauri build --bundles app`, tag + push triggers `release.yml`).

## Test plan

- [x] `bash packages/desktop/scripts/verify-entitlements.test.sh` — 7/7 pass locally
- [x] `bash packages/desktop/scripts/verify-entitlements.sh packages/desktop/src-tauri/entitlements.plist` — confirms live source plist satisfies the verifier
- [x] `shellcheck` clean on both scripts
- [ ] CI: `desktop-tests` job (includes new verify-entitlements.test.sh step)
- [ ] On next release: `release.yml` Verify .app entitlements step against the universal-apple-darwin build (will fail if the .app is missing any required key)
- [ ] Manual macOS verification on the rebuilt `.app`: click mic → macOS speech-recognition/mic permission prompt appears on first use → recognition starts and stays running