### PR TITLE
fix(app): wire mobile voice input continuous mode (#4807)

### DIFF
--- a/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
+++ b/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
@@ -429,4 +429,65 @@ describe('useSpeechRecognition', () => {
     });
     expect(MockModule.start).toHaveBeenCalledTimes(startsAfterUnmount);
   });
+
+  // ---- #4813 Copilot finding: error→end must not re-arm in continuous mode ----
+
+  describe('voiceInputMode: continuous error→end restart suppression', () => {
+    it.each([
+      'not-allowed',
+      'service-not-allowed',
+      'audio-capture',
+      'aborted',
+      'interrupted',
+      'language-not-supported',
+    ])('does NOT restart on end after hard error (%s)', async (errCode) => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+      // Hard error fires — should mark stop as user/terminal so the
+      // subsequent `end` event doesn't re-arm a recogniser the UI thinks
+      // is stopped.
+      actSync(() => {
+        eventHandlers['error']?.({ error: errCode, message: errCode });
+      });
+      expect(result.current.isRecognizing).toBe(false);
+
+      // Spec-mandated `end` after error must NOT restart, otherwise the
+      // engine silently holds the mic while the UI shows stopped.
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+      expect(result.current.isRecognizing).toBe(false);
+    });
+
+    it.each([
+      'no-speech',
+      'network',
+      'speech-timeout',
+    ])('DOES restart on end after soft error (%s) in continuous mode', async (errCode) => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+      // Soft error fires — `end` should still re-arm so continuous mode
+      // can recover from transient silence/network blips. (The mic flicker
+      // during the restart blip is a separate cosmetic issue — see #4829.)
+      actSync(() => {
+        eventHandlers['error']?.({ error: errCode, message: errCode });
+      });
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+
+      expect(MockModule.start).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
+++ b/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
@@ -282,4 +282,151 @@ describe('useSpeechRecognition', () => {
 
     expect(MockModule.start).not.toHaveBeenCalled();
   });
+
+  // ---- #4807: voiceInputMode wiring ----
+
+  describe('voiceInputMode: continuous', () => {
+    it('restarts recognition on end event when mode=continuous', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+      // Silence-triggered end should re-arm recognition
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+
+      expect(MockModule.start).toHaveBeenCalledTimes(2);
+      // Mic stays lit during the restart blip
+      expect(result.current.isRecognizing).toBe(true);
+    });
+
+    it('caps restart attempts at MAX_CONTINUOUS_RESTARTS (5)', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+
+      // Initial start = 1 call. Fire `end` repeatedly; each one within the cap
+      // should add a start() call.
+      for (let i = 0; i < 10; i++) {
+        actSync(() => {
+          eventHandlers['end']?.({});
+        });
+      }
+
+      // 1 initial + 5 restart attempts before the cap kicks in = 6 total
+      expect(MockModule.start).toHaveBeenCalledTimes(6);
+      // After the cap, end clears the mic
+      expect(result.current.isRecognizing).toBe(false);
+    });
+
+    it('does NOT restart on end when user explicitly stopped', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+      actSync(() => {
+        result.current.stopListening();
+      });
+
+      // Engine fires onend after stop() — should NOT re-arm
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+      expect(result.current.isRecognizing).toBe(false);
+    });
+
+    it('resets restart counter on a non-empty transcript', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+
+      // Exhaust 3 of 5 restarts
+      for (let i = 0; i < 3; i++) {
+        actSync(() => { eventHandlers['end']?.({}); });
+      }
+      expect(MockModule.start).toHaveBeenCalledTimes(4);
+
+      // Real transcript should reset the counter
+      actSync(() => {
+        eventHandlers['result']?.({ results: [{ transcript: 'hi there' }] });
+      });
+
+      // Now 5 more `end`s should each restart
+      for (let i = 0; i < 5; i++) {
+        actSync(() => { eventHandlers['end']?.({}); });
+      }
+      // 4 (prior) + 5 (post-reset) = 9 total starts
+      expect(MockModule.start).toHaveBeenCalledTimes(9);
+    });
+  });
+
+  describe('voiceInputMode: auto-pause', () => {
+    it('does NOT restart on end when mode=auto-pause', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'auto-pause' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+
+      // No restart, mic clears — pre-#4785 behaviour
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+      expect(result.current.isRecognizing).toBe(false);
+    });
+
+    it('defaults to auto-pause when no mode option supplied', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition());
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+
+      // Backward-compatible default = single-shot behaviour
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+      expect(result.current.isRecognizing).toBe(false);
+    });
+  });
+
+  it('continuous restart does not fire after unmount (#4789 mirror)', async () => {
+    const { result, unmount } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+    await actAsync(async () => {
+      await result.current.startListening();
+    });
+    expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(MockModule.abort).toHaveBeenCalled();
+
+    // Capture call count after unmount; any subsequent `end` from the engine
+    // (e.g. fired by abort()) must NOT trigger restart.
+    const startsAfterUnmount = MockModule.start.mock.calls.length;
+    actSync(() => {
+      eventHandlers['end']?.({});
+    });
+    expect(MockModule.start).toHaveBeenCalledTimes(startsAfterUnmount);
+  });
 });

--- a/packages/app/src/hooks/useSpeechRecognition.ts
+++ b/packages/app/src/hooks/useSpeechRecognition.ts
@@ -77,6 +77,35 @@ export interface UseSpeechRecognitionReturn {
  */
 const MAX_CONTINUOUS_RESTARTS = 5;
 
+/**
+ * Errors that hard-stop continuous mode rather than letting the `end`
+ * handler re-arm recognition. Mirrors `HARD_STOP_ERRORS` in the dashboard's
+ * `useVoiceInput`. Without this set, an error event followed by an `end`
+ * event would re-arm recognition while the UI state shows stopped — the
+ * engine keeps the mic open silently with no UI feedback (Copilot finding
+ * on #4813).
+ *
+ * - `'not-allowed'` / `'service-not-allowed'`: permission/availability —
+ *   retrying would re-fail.
+ * - `'audio-capture'`: mic hardware gone.
+ * - `'aborted'`: user/system invoked `abort()`; restarting would race the
+ *   teardown.
+ * - `'interrupted'` (iOS): audio session interrupted by phone call/Siri;
+ *   honour the system event and stop.
+ * - `'language-not-supported'`: locale invalid — retrying re-throws.
+ *
+ * Soft errors (`no-speech`, `network`, `speech-timeout`, etc.) are left for
+ * the `end` handler so continuous mode can re-arm across normal silence gaps.
+ */
+const HARD_STOP_ERRORS: ReadonlySet<string> = new Set([
+  'not-allowed',
+  'service-not-allowed',
+  'audio-capture',
+  'aborted',
+  'interrupted',
+  'language-not-supported',
+]);
+
 export function useSpeechRecognition(
   options: UseSpeechRecognitionOptions = {},
 ): UseSpeechRecognitionReturn {
@@ -160,6 +189,17 @@ export function useSpeechRecognition(
     // Don't treat abort as a user-visible error
     if (event.error !== 'aborted') {
       setError(event.message || event.error);
+    }
+    // Hard errors must suppress the continuous-mode `end` restart branch.
+    // Without flipping `userStoppedRef`, an error event followed by an
+    // `end` event (the spec-mandated sequence) would let the restart path
+    // re-arm recognition while the UI shows stopped (`isRecognizing` is
+    // cleared below) — the engine would silently hold the mic with no UI
+    // to release it. Soft errors (no-speech, network, speech-timeout) fall
+    // through so continuous mode can re-arm across normal silence gaps.
+    // Mirrors the dashboard's `onerror` hard-stop branch.
+    if (HARD_STOP_ERRORS.has(event.error)) {
+      userStoppedRef.current = true;
     }
     setIsRecognizing(false);
   });

--- a/packages/app/src/hooks/useSpeechRecognition.ts
+++ b/packages/app/src/hooks/useSpeechRecognition.ts
@@ -43,6 +43,24 @@ export async function setSpeechLang(lang: string): Promise<void> {
   }
 }
 
+/**
+ * Voice input behaviour. Mirrors the dashboard `VoiceInputMode` from
+ * `packages/dashboard/src/hooks/useVoiceInput.ts` and the shared
+ * `InputSettings.voiceInputMode` field in `@chroxy/store-core` (#4785, #4786).
+ *
+ * - `'continuous'`: when the engine fires `end` due to silence, the hook
+ *   restarts recognition automatically. The mic stays lit until the user
+ *   explicitly calls `stopListening()`. Bounded by `MAX_CONTINUOUS_RESTARTS`
+ *   so a wedged backend cannot spin forever.
+ * - `'auto-pause'`: original behaviour — `end` ends the session. Default
+ *   to keep behaviour stable for callers that don't pass `mode`.
+ */
+export type VoiceInputMode = 'continuous' | 'auto-pause';
+
+export interface UseSpeechRecognitionOptions {
+  mode?: VoiceInputMode;
+}
+
 export interface UseSpeechRecognitionReturn {
   isRecognizing: boolean;
   transcript: string;
@@ -52,11 +70,38 @@ export interface UseSpeechRecognitionReturn {
   stopListening: () => void;
 }
 
-export function useSpeechRecognition(): UseSpeechRecognitionReturn {
+/**
+ * Maximum consecutive restart attempts before continuous mode gives up.
+ * Mirrors `MAX_CONTINUOUS_RESTARTS` in the dashboard's `useVoiceInput`.
+ * Counter resets on each non-empty `result` event or fresh `startListening`.
+ */
+const MAX_CONTINUOUS_RESTARTS = 5;
+
+export function useSpeechRecognition(
+  options: UseSpeechRecognitionOptions = {},
+): UseSpeechRecognitionReturn {
+  const mode: VoiceInputMode = options.mode ?? 'auto-pause';
+
   const [isRecognizing, setIsRecognizing] = useState(false);
   const [transcript, setTranscript] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isAvailable, setIsAvailable] = useState(false);
+
+  // Continuous-mode restart bookkeeping. `userStoppedRef` flips true when
+  // `stopListening()` or unmount fires so the `end` handler can distinguish a
+  // user-initiated stop from a silence-triggered one. `restartCountRef` bounds
+  // the retry loop — counter resets on a real (non-empty) transcript or on a
+  // fresh `startListening()` call.
+  const userStoppedRef = useRef<boolean>(false);
+  const restartCountRef = useRef<number>(0);
+  const modeRef = useRef<VoiceInputMode>(mode);
+  modeRef.current = mode;
+
+  // Track whether the component is still mounted
+  const mountedRef = useRef(true);
+
+  // Track whether a stop was requested during async permission flow
+  const stopRequestedRef = useRef(false);
 
   useEffect(() => {
     if (SpeechModule) {
@@ -72,10 +117,42 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
     const text = event.results[0]?.transcript;
     if (text) {
       setTranscript(text);
+      // #4789 mirror: only reset the restart counter on real speech so a
+      // wedged engine that emits empty `result` events can't bypass the cap.
+      if (text.trim().length > 0) {
+        restartCountRef.current = 0;
+      }
     }
   });
 
   useSpeechEvent('end', () => {
+    // Continuous mode: silence-triggered end re-arms recognition unless the
+    // user explicitly stopped (or unmounted) and we're still under the
+    // restart cap. The mic stays lit during the restart blip so the UI
+    // doesn't flicker.
+    if (
+      modeRef.current === 'continuous' &&
+      !userStoppedRef.current &&
+      mountedRef.current &&
+      restartCountRef.current < MAX_CONTINUOUS_RESTARTS &&
+      SpeechModule
+    ) {
+      restartCountRef.current += 1;
+      try {
+        // Re-arm the SAME recogniser session — no permission re-prompt, no
+        // lang re-read. `startListening()` is reserved for fresh user-initiated
+        // sessions; this path keeps `isRecognizing` true.
+        SpeechModule.start({
+          lang: lastLangRef.current ?? 'en-US',
+          interimResults: true,
+          contextualStrings: ['Claude', 'Chroxy'],
+        });
+        return;
+      } catch {
+        // Engine may still be in the tail of the previous session; fall
+        // through to clear the mic.
+      }
+    }
     setIsRecognizing(false);
   });
 
@@ -87,20 +164,21 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
     setIsRecognizing(false);
   });
 
-  // Track whether the component is still mounted
-  const mountedRef = useRef(true);
+  // Cache the last resolved language so the silence-restart path doesn't
+  // re-await SecureStore on every silence gap.
+  const lastLangRef = useRef<string | null>(null);
 
-  // Abort on unmount
+  // Abort on unmount — also detach the continuous-mode restart guard so the
+  // engine's post-abort `end` event can't re-arm against an unmounted owner.
+  // Mirrors the #4789 fix pattern from the dashboard.
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      userStoppedRef.current = true;
       SpeechModule?.abort();
     };
   }, []);
-
-  // Track whether a stop was requested during async permission flow
-  const stopRequestedRef = useRef(false);
 
   const startListening = useCallback(async () => {
     if (!SpeechModule) return;
@@ -108,6 +186,10 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
     setError(null);
     setTranscript('');
     stopRequestedRef.current = false;
+    // Fresh user-initiated start: reset continuous bookkeeping so prior
+    // session's user-stop or restart-counter doesn't carry over.
+    userStoppedRef.current = false;
+    restartCountRef.current = 0;
 
     const { granted } = await SpeechModule.requestPermissionsAsync();
 
@@ -127,6 +209,7 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
     // If component unmounted or stop requested while awaiting language, bail out
     if (!mountedRef.current || stopRequestedRef.current) return;
 
+    lastLangRef.current = lang;
     SpeechModule.start({
       lang,
       interimResults: true,
@@ -137,6 +220,10 @@ export function useSpeechRecognition(): UseSpeechRecognitionReturn {
 
   const stopListening = useCallback(() => {
     stopRequestedRef.current = true;
+    // Mark the stop as user-initiated BEFORE invoking engine stop so the
+    // silence-restart path in `end` sees the flag and exits cleanly rather
+    // than re-arming a session the user just cancelled.
+    userStoppedRef.current = true;
     SpeechModule?.stop();
   }, []);
 

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -311,8 +311,12 @@ export function SessionScreen() {
   const searchInputRef = useRef<TextInput>(null);
   const searchFocusTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-  // Speech recognition
-  const { isRecognizing, transcript, isAvailable: speechAvailable, startListening, stopListening, error: speechError } = useSpeechRecognition();
+  // Speech recognition — wire mode from inputSettings.voiceInputMode (#4807).
+  // Mobile defaults to `'continuous'` in the store so users get click-to-stop
+  // semantics matching the dashboard.
+  const { isRecognizing, transcript, isAvailable: speechAvailable, startListening, stopListening, error: speechError } = useSpeechRecognition({
+    mode: inputSettings.voiceInputMode,
+  });
   const dictationStartRef = useRef(inputText.length);
   const usedVoiceRef = useRef(false);
 

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -89,6 +89,24 @@ function isValidHHMM(s: string): boolean {
   return h <= 23 && m <= 59;
 }
 
+/**
+ * #4807: voice input mode picker options. Mirrors the dashboard
+ * `SettingsPanel` select (`packages/dashboard/src/components/SettingsPanel.tsx`)
+ * and the shared `InputSettings.voiceInputMode` field.
+ */
+const VOICE_INPUT_MODES: { value: 'continuous' | 'auto-pause'; label: string; hint: string }[] = [
+  {
+    value: 'continuous',
+    label: 'Continuous',
+    hint: 'Mic stays open until you tap stop.',
+  },
+  {
+    value: 'auto-pause',
+    label: 'Auto-pause',
+    hint: 'Mic stops automatically on silence.',
+  },
+];
+
 const SPEECH_LANGUAGES = [
   { tag: 'en-US', label: 'English (US)' },
   { tag: 'en-GB', label: 'English (UK)' },
@@ -131,6 +149,7 @@ export function SettingsScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const [speechLang, setSpeechLangState] = useState<string>('en-US');
   const [showLangPicker, setShowLangPicker] = useState(false);
+  const [showVoiceModePicker, setShowVoiceModePicker] = useState(false);
   const [biometricAvail, setBiometricAvail] = useState(false);
   const [biometricOn, setBiometricOn] = useState(false);
   // #4559: surfaces "server disconnected" when a notification-prefs Switch
@@ -760,6 +779,14 @@ export function SettingsScreen() {
           <Text style={styles.rowLabel}>Speech Language</Text>
           <Text style={styles.rowValue}>{currentLangLabel}</Text>
         </TouchableOpacity>
+        <View style={styles.separator} />
+        <TouchableOpacity style={styles.row} onPress={() => setShowVoiceModePicker(true)}>
+          <Text style={styles.rowLabel}>Voice Input Mode</Text>
+          <Text style={styles.rowValue}>
+            {VOICE_INPUT_MODES.find((m) => m.value === inputSettings.voiceInputMode)?.label
+              ?? inputSettings.voiceInputMode}
+          </Text>
+        </TouchableOpacity>
       </View>
 
       {/* ABOUT */}
@@ -893,6 +920,49 @@ export function SettingsScreen() {
               ))}
             </ScrollView>
             <TouchableOpacity style={[styles.sheetOption, styles.sheetCancel]} onPress={() => setShowLangPicker(false)}>
+              <Text style={[styles.sheetOptionText, styles.sheetCancelText]}>Cancel</Text>
+            </TouchableOpacity>
+          </Pressable>
+        </Pressable>
+      </Modal>
+
+      {/* Voice input mode picker (#4807) */}
+      <Modal
+        visible={showVoiceModePicker}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowVoiceModePicker(false)}
+      >
+        <Pressable style={styles.sheetOverlay} onPress={() => setShowVoiceModePicker(false)}>
+          <Pressable
+            style={[styles.sheetContent, { paddingBottom: Math.max(insets.bottom, 8) }]}
+            onPress={(e) => e.stopPropagation()}
+          >
+            <Text style={styles.sheetTitle}>Voice Input Mode</Text>
+            <ScrollView style={styles.sheetList} bounces={false}>
+              {VOICE_INPUT_MODES.map((opt) => {
+                const active = opt.value === inputSettings.voiceInputMode;
+                return (
+                  <TouchableOpacity
+                    key={opt.value}
+                    style={[styles.sheetOption, active && styles.sheetOptionActive]}
+                    onPress={() => {
+                      updateInputSettings({ voiceInputMode: opt.value });
+                      setShowVoiceModePicker(false);
+                    }}
+                  >
+                    <Text style={[styles.sheetOptionText, active && styles.sheetOptionTextActive]}>
+                      {opt.label}
+                    </Text>
+                    <Text style={styles.sheetOptionTag}>{opt.hint}</Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </ScrollView>
+            <TouchableOpacity
+              style={[styles.sheetOption, styles.sheetCancel]}
+              onPress={() => setShowVoiceModePicker(false)}
+            >
               <Text style={[styles.sheetOptionText, styles.sheetCancelText]}>Cancel</Text>
             </TouchableOpacity>
           </Pressable>


### PR DESCRIPTION
## Summary

Mobile counterpart to the dashboard's voice-input continuous mode (#4786). The shared `InputSettings.voiceInputMode` field was already plumbed through the mobile store, but `useSpeechRecognition` never read it — so toggling the setting did nothing and the release-note feature was silently missing on phones (audit P1.1 from `/swarm-audit`).

Closes #4807.

Related to #4786 (dashboard precursor that added the shared setting) and #4789 (the unmount race fix whose detach-before-abort pattern this mirrors).

## Changes

**`packages/app/src/hooks/useSpeechRecognition.ts`**
- Accepts optional `{ mode: VoiceInputMode }` option; defaults to `'auto-pause'` so the API stays backward-compatible.
- `'continuous'` mode re-arms recognition in the `end` handler (single recogniser session — no permission re-prompt, no SecureStore re-read) bounded by `MAX_CONTINUOUS_RESTARTS = 5`, mirroring the dashboard.
- Borrows the **#4789 detach-before-abort pattern**: unmount sets `userStoppedRef = true` BEFORE `abort()` so the engine's spec-mandated post-abort `end` event cannot re-arm against an unmounted owner. `end` handler also checks `mountedRef`.
- Restart counter resets only on non-empty transcripts so a wedged engine emitting empty `result` events can't bypass the cap.
- `stopListening` flips `userStoppedRef` before invoking engine stop, same as the dashboard.

**`packages/app/src/screens/SessionScreen.tsx`**
- Wires `useSpeechRecognition({ mode: inputSettings.voiceInputMode })`. Mobile store already defaults to `'continuous'`, so users now get click-to-start / click-to-stop by default.

**`packages/app/src/screens/SettingsScreen.tsx`**
- New `INPUT > Voice Input Mode` picker row modelled on the existing Speech Language picker (TouchableOpacity opening a Modal sheet). Per-option hints mirror the dashboard select.

## Test plan

Test coverage added in `packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts`:

- [x] `continuous` mode restarts recognition on `end` (`.start()` called twice)
- [x] Restart cap enforced at 5 (initial + 5 retries = 6 total `.start()` calls)
- [x] User-initiated `stopListening` blocks restart
- [x] Restart counter resets on real transcript
- [x] `auto-pause` mode does NOT restart on `end`
- [x] Default mode is auto-pause (backward compat)
- [x] Continuous restart does not fire after unmount (#4789 mirror)

Manual:
- [ ] Open Settings on mobile, see new Voice Input Mode row showing "Continuous"
- [ ] Tap row, sheet appears with Continuous + Auto-pause options
- [ ] Switch to Auto-pause, verify mic stops after silence on next dictation
- [ ] Switch back to Continuous, verify mic stays open across silence gaps until manual stop