### PR TITLE
refactor(store-core,app): lift ChatView message pipeline into store-core (#4806)

### DIFF
--- a/packages/app/__tests__/ComponentRendering.test.ts
+++ b/packages/app/__tests__/ComponentRendering.test.ts
@@ -147,9 +147,12 @@ describe('ChatView component', () => {
     expect(chatViewSrc).toMatch(/Starting Claude Code\.\.\./)
   })
 
-  test('imports groupMessages from the shared store-core selector', () => {
-    expect(chatViewSrc).toMatch(/import\s*\{[^}]*groupMessages[^}]*\}\s*from\s*'@chroxy\/store-core'/)
-    expect(chatViewSrc).toMatch(/import\s*\{[^}]*applyStreamingOverlay[^}]*\}\s*from\s*'@chroxy\/store-core'/)
+  test('imports buildChatViewMessages from the shared store-core pipeline (#4806)', () => {
+    // Previously imported groupMessages + applyStreamingOverlay directly;
+    // now delegates to the shared buildChatViewMessages pure function
+    // (single source of truth for filter + group + overlay + tail-id +
+    // stalledPromptIds across dashboard + mobile).
+    expect(chatViewSrc).toMatch(/import\s*\{[^}]*buildChatViewMessages[^}]*\}\s*from\s*'@chroxy\/store-core'/)
   })
 
   test('listens for reduce motion accessibility setting', () => {

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -19,7 +19,7 @@ import { COLORS } from '../constants/colors';
 import { ActivityGroup } from './chat/ActivityGroup';
 import { ToolDetailModal } from './chat/ToolDetailModal';
 import { MessageBubble } from './chat/MessageBubble';
-import { groupMessages, applyStreamingOverlay } from '@chroxy/store-core';
+import { buildChatViewMessages } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
 
 // -- Props --
@@ -194,25 +194,28 @@ export function ChatView({
     setToolDetail({ toolName, content, toolResult, toolResultTruncated, toolResultImages, serverName });
   };
 
-  // Structural grouping — only re-runs when messages change (not on streaming deltas)
-  const baseGroups = useMemo(() => groupMessages(messages), [messages]);
-
-  // Overlay streaming isActive flag — cheap to recompute on every delta
-  const displayGroups = useMemo(
-    () => applyStreamingOverlay(baseGroups, messages, streamingMessageId),
-    [baseGroups, streamingMessageId, messages],
+  // #4806: shared ChatView message pipeline (lifted from dashboard's
+  // `useChatMessages`). Single source of truth for filter + group +
+  // overlay + tail-id + stalledPromptIds — both dashboard and mobile
+  // derive identically. The mobile renderer below consumes
+  // `displayGroups` (groups, not flattened rows) so it can keep using
+  // ActivityGroup / MessageBubble; `chatTailMessageId` and
+  // `stalledPromptIds` (#4615) flow straight through.
+  const {
+    displayGroups,
+    chatTailMessageId,
+    stalledPromptIds,
+  } = useMemo(
+    () => buildChatViewMessages(messages, streamingMessageId),
+    [messages, streamingMessageId],
   );
 
-  // #4496: tail message id + last user input — used to gate the
-  // stream-stall chip's Retry button. Mirrors the dashboard's `isTail`
-  // check (only the most recent stall retry-button-wires; historical
-  // replayed stalls render chip text only). Walking messages once here
-  // is cheaper than recomputing per bubble.
+  // #4496: last user input — used to gate the stream-stall chip's Retry
+  // button. Mirrors the dashboard's `isTail` check (only the most recent
+  // stall retry-button-wires; historical replayed stalls render chip
+  // text only). Walking messages once here is cheaper than recomputing
+  // per bubble.
   const sendInput = useConnectionStore((s) => s.sendInput);
-  const chatTailMessageId = useMemo(
-    () => (messages.length > 0 ? messages[messages.length - 1].id : null),
-    [messages],
-  );
   const lastUserInputContent = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i].type === 'user_input') return messages[i].content;
@@ -299,6 +302,20 @@ export function ChatView({
             );
           }
           const msg = group.message;
+          // #4615 (mobile parity via #4806): suppress unanswered prompts
+          // invalidated by a subsequent ASK_USER_QUESTION_STALL. The
+          // pending prompt has already been discarded server-side; the
+          // stall-chip rendered for the error bubble below carries the
+          // retry affordance. Mirrors the dashboard App.tsx renderMessage
+          // gating that has been live since #4615.
+          if (
+            msg.type === 'prompt' &&
+            msg.options &&
+            !msg.requestId &&
+            stalledPromptIds.has(msg.id)
+          ) {
+            return null;
+          }
           const isSearchMatch = searchMatchIds?.has(msg.id) ?? false;
           const isCurrentMatch = currentMatchId === msg.id;
           return (

--- a/packages/dashboard/src/hooks/useChatMessages.ts
+++ b/packages/dashboard/src/hooks/useChatMessages.ts
@@ -1,7 +1,12 @@
 /**
  * useChatMessages — derive the chat-view message list from store messages (#4770).
  *
- * Pipeline (extracted from App.tsx):
+ * Thin React-memo wrapper around the pure `buildChatViewMessages` function
+ * in `@chroxy/store-core` (#4806). The mobile `ChatView` consumes the same
+ * pure function inline so both surfaces share the filter + group + overlay +
+ * tail-id + storeMsgMap + stalled-prompt derivations.
+ *
+ * Pipeline (see `buildChatViewMessages` for the canonical doc):
  *   storeMessages
  *     -> filter(m => m.type !== 'system')   // System events render on the
  *                                           //   System tab, not in chat.
@@ -12,30 +17,32 @@
  *                                           //   as active during streaming.
  *     -> ChatViewMessage[]                  // flatten to chat-view rows.
  *
- * Singleton activity groups (1 message) pass through as the original
- * `tool_use` / `thinking` row so the existing ToolBubble path stays
- * reachable. Runs of 2+ messages collapse to a synthetic `tool_group`
- * row whose `id` is the group key `activity-<firstId>`. The full payload
- * is exposed via `chatToolGroupPayloads: Map<groupId, { messages, isActive }>`
- * so the renderer can look it up when emitting `<ToolGroup>`.
- *
- * `chatTailMessageId` is provided so renderers can detect the trailing
- * row without re-deriving it (used by ToolBubble / StreamStallChip /
- * AskUserQuestionStallChip).
- *
  * Memoisation
  * -----------
- * Each derivation step is `useMemo`-wrapped on its true input deps —
- * passing the same `storeMessages` reference + same `streamingMessageId`
- * across renders yields the same output references.
+ * The pure function is `useMemo`-wrapped on `storeMessages` and
+ * `streamingMessageId`. Passing the same references yields a stable
+ * `UseChatMessagesResult` reference across renders.
  */
 import { useMemo } from 'react'
 import {
-  groupMessages,
-  applyStreamingOverlay,
+  buildChatViewMessages,
+  toChatViewMessage,
   type ChatMessage,
+  type ChatViewMessage as StoreChatViewMessage,
 } from '@chroxy/store-core'
 import type { ChatViewMessage } from '../components/ChatView'
+
+// The dashboard re-exports its own `ChatViewMessage` for component prop
+// typing; the store-core type is structurally identical (same fields,
+// same discriminator). This static assertion catches drift if either
+// definition changes without the other.
+type _AssertCompatible = ChatViewMessage extends StoreChatViewMessage
+  ? StoreChatViewMessage extends ChatViewMessage
+    ? true
+    : false
+  : false
+const _assert: _AssertCompatible = true
+void _assert
 
 export interface UseChatMessagesProps {
   storeMessages: ChatMessage[]
@@ -59,114 +66,28 @@ export interface UseChatMessagesResult {
   stalledPromptIds: Set<string>
 }
 
-/** Map store ChatMessage to ChatViewMessage. Exported so callers can map
- *  derived lists (e.g. systemMessages on the System tab) using the same
- *  conversion as the chat pipeline. */
-export function toChatViewMessage(msg: ChatMessage): ChatViewMessage {
-  return {
-    id: msg.id,
-    type: msg.type === 'prompt' ? 'response' : msg.type,
-    content: msg.content,
-    timestamp: msg.timestamp,
-    // #4476: propagate the structured error code so the chat-view
-    // renderMessage path can switch error bubbles into the
-    // StreamStallChip variant.
-    ...(msg.code ? { code: msg.code } : {}),
-  }
-}
+// Re-export so existing dashboard call sites (App.tsx imports
+// `toChatViewMessage` from this module for the System-tab mapping) keep
+// compiling without a churn diff.
+export { toChatViewMessage }
 
 export function useChatMessages(props: UseChatMessagesProps): UseChatMessagesResult {
   const { storeMessages, streamingMessageId } = props
 
-  // Filter out `system` events — they belong on the System tab.
-  const chatFilteredMessages = useMemo(
-    () => storeMessages.filter(m => m.type !== 'system'),
-    [storeMessages],
+  const result = useMemo(
+    () => buildChatViewMessages(storeMessages, streamingMessageId),
+    [storeMessages, streamingMessageId],
   )
 
-  // Group contiguous tool_use / thinking runs into ActivityGroups, then
-  // apply the streaming overlay so the trailing group flips to isActive
-  // while streaming is in progress.
-  const chatDisplayGroups = useMemo(() => {
-    const base = groupMessages(chatFilteredMessages)
-    return applyStreamingOverlay(base, chatFilteredMessages, streamingMessageId ?? null)
-  }, [chatFilteredMessages, streamingMessageId])
-
-  // Map of synthetic group id -> original messages + isActive. Only
-  // populated for runs of 2+ messages (#3794 review) — singleton
-  // activity groups render as the original `tool_use` / `thinking` row
-  // through ToolBubble, so they don't need a payload lookup.
-  const chatToolGroupPayloads = useMemo(() => {
-    const map = new Map<string, { messages: ChatMessage[]; isActive: boolean }>()
-    for (const g of chatDisplayGroups) {
-      if (g.type === 'activity' && g.messages.length >= 2) {
-        map.set(g.key, { messages: g.messages, isActive: g.isActive })
-      }
-    }
-    return map
-  }, [chatDisplayGroups])
-
-  // Flatten to ChatViewMessage[] — singleton activity groups (1 msg)
-  // pass through as `tool_use` / `thinking`; runs of 2+ collapse to a
-  // single synthetic `tool_group` row keyed by the group key.
-  const chatMessages = useMemo<ChatViewMessage[]>(
-    () =>
-      chatDisplayGroups.map((g) => {
-        if (g.type === 'single') return toChatViewMessage(g.message)
-        if (g.messages.length < 2) {
-          // Singleton — emit as the original tool_use / thinking row.
-          return toChatViewMessage(g.messages[0]!)
-        }
-        const last = g.messages[g.messages.length - 1]
-        return {
-          id: g.key,
-          type: 'tool_group',
-          content: '',
-          timestamp: last?.timestamp ?? 0,
-        }
-      }),
-    [chatDisplayGroups],
-  )
-
-  const chatTailMessageId = chatMessages.length > 0
-    ? chatMessages[chatMessages.length - 1]!.id
-    : null
-
-  // O(1) lookup map for renderMessage — keyed by store id, value is
-  // the original ChatMessage so the renderer can inspect fields the
-  // ChatViewMessage shape doesn't carry (toolInput, requestId,
-  // questions, etc.).
-  const storeMsgMap = useMemo(
-    () => new Map(storeMessages.map(m => [m.id, m])),
-    [storeMessages],
-  )
-
-  // #4615: track which `type: 'prompt'` bubbles have been invalidated by a
-  // subsequent ASK_USER_QUESTION_STALL error. The server emits the error
-  // when the Claude TUI never acknowledges an AskUserQuestion answer —
-  // typically a multi-question form wedge. The pending QuestionPrompt is
-  // now dead, so submitting it would fire keystrokes into a session that
-  // already discarded the prompt context. We suppress the interactive
-  // prompt render (the AskUserQuestionStallChip rendered for the error
-  // bubble below it carries the retry affordance).
-  const stalledPromptIds = useMemo(() => {
-    const stalled = new Set<string>()
-    let lastStallIndex = -1
-    for (let i = storeMessages.length - 1; i >= 0; i -= 1) {
-      const m = storeMessages[i]!
-      if (m.type === 'error' && m.code === 'ASK_USER_QUESTION_STALL') {
-        lastStallIndex = i
-        break
-      }
-    }
-    if (lastStallIndex >= 0) {
-      for (let i = 0; i < lastStallIndex; i += 1) {
-        const m = storeMessages[i]!
-        if (m.type === 'prompt' && !m.answered) stalled.add(m.id)
-      }
-    }
-    return stalled
-  }, [storeMessages])
+  // Destructure to drop `displayGroups` (dashboard uses the flattened
+  // `chatMessages` path; only mobile consumes displayGroups directly).
+  const {
+    chatMessages,
+    chatToolGroupPayloads,
+    chatTailMessageId,
+    storeMsgMap,
+    stalledPromptIds,
+  } = result
 
   return {
     chatMessages,

--- a/packages/store-core/src/buildChatViewMessages.test.ts
+++ b/packages/store-core/src/buildChatViewMessages.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for the shared ChatView message pipeline (#4806).
+ *
+ * Pipeline shape under test:
+ *   storeMessages -> filter(system) -> groupMessages -> applyStreamingOverlay
+ *     -> { chatMessages, displayGroups, chatToolGroupPayloads, chatTailMessageId,
+ *          storeMsgMap, stalledPromptIds }
+ *
+ * This is the platform-agnostic core that both the dashboard's
+ * `useChatMessages` hook and the mobile `ChatView` consume. Same coverage
+ * the dashboard hook test had, run directly against the pure function.
+ */
+import { describe, it, expect } from 'vitest'
+import { buildChatViewMessages, toChatViewMessage } from './buildChatViewMessages'
+import type { ChatMessage } from './types'
+
+function msg(partial: Partial<ChatMessage> & { id: string; type: ChatMessage['type'] }): ChatMessage {
+  return {
+    content: '',
+    timestamp: 0,
+    ...partial,
+  } as ChatMessage
+}
+
+describe('buildChatViewMessages', () => {
+  it('returns empty derivations for empty input', () => {
+    const out = buildChatViewMessages([], null)
+    expect(out.chatMessages).toEqual([])
+    expect(out.displayGroups).toEqual([])
+    expect(out.chatToolGroupPayloads.size).toBe(0)
+    expect(out.chatTailMessageId).toBeNull()
+    expect(out.storeMsgMap.size).toBe(0)
+    expect(out.stalledPromptIds.size).toBe(0)
+  })
+
+  it('filters out `system` events (they belong on the System tab)', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'hi' }),
+      msg({ id: 's1', type: 'system', content: 'connected' }),
+      msg({ id: 'r1', type: 'response', content: 'hello' }),
+    ]
+    const out = buildChatViewMessages(messages, null)
+    const ids = out.chatMessages.map(m => m.id)
+    expect(ids).toEqual(['u1', 'r1'])
+    // displayGroups also reflects the filtered list (system row excluded).
+    const groupIds = out.displayGroups.flatMap(g =>
+      g.type === 'single' ? [g.message.id] : g.messages.map(m => m.id),
+    )
+    expect(groupIds).toEqual(['u1', 'r1'])
+  })
+
+  it('passes singleton tool_use through as `tool_use`, not collapsed', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'do a thing' }),
+      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+      msg({ id: 'r1', type: 'response', content: 'done' }),
+    ]
+    const out = buildChatViewMessages(messages, null)
+    const types = out.chatMessages.map(m => m.type)
+    expect(types).toEqual(['user_input', 'tool_use', 'response'])
+    expect(out.chatToolGroupPayloads.size).toBe(0)
+  })
+
+  it('collapses a run of 2+ tool_use/thinking into a single tool_group row', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'do many things' }),
+      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+      msg({ id: 'th1', type: 'thinking', content: 'planning' }),
+      msg({ id: 't2', type: 'tool_use', content: '', tool: 'Read' }),
+      msg({ id: 'r1', type: 'response', content: 'done' }),
+    ]
+    const out = buildChatViewMessages(messages, null)
+    const types = out.chatMessages.map(m => m.type)
+    expect(types).toEqual(['user_input', 'tool_group', 'response'])
+
+    const groupRow = out.chatMessages.find(m => m.type === 'tool_group')!
+    expect(groupRow.id).toBe('activity-t1')
+
+    const payload = out.chatToolGroupPayloads.get('activity-t1')
+    expect(payload).toBeDefined()
+    expect(payload!.messages.map(m => m.id)).toEqual(['t1', 'th1', 't2'])
+    expect(payload!.isActive).toBe(false)
+  })
+
+  it('sets chatTailMessageId to the last entry id', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'a' }),
+      msg({ id: 'r1', type: 'response', content: 'b' }),
+    ]
+    const out = buildChatViewMessages(messages, null)
+    expect(out.chatTailMessageId).toBe('r1')
+  })
+
+  it('chatTailMessageId reflects synthetic group id when tail is a tool_group', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'go' }),
+      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+      msg({ id: 't2', type: 'tool_use', content: '', tool: 'Bash' }),
+    ]
+    const out = buildChatViewMessages(messages, null)
+    expect(out.chatTailMessageId).toBe('activity-t1')
+  })
+
+  it('marks the trailing activity group active when streamingMessageId matches last msg', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'go' }),
+      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+      msg({ id: 't2', type: 'tool_use', content: '', tool: 'Bash' }),
+    ]
+    const out = buildChatViewMessages(messages, 't2')
+    const payload = out.chatToolGroupPayloads.get('activity-t1')
+    expect(payload?.isActive).toBe(true)
+
+    // displayGroups overlay also reflects active state on the trailing group.
+    const lastGroup = out.displayGroups[out.displayGroups.length - 1]
+    expect(lastGroup.type).toBe('activity')
+    if (lastGroup.type === 'activity') {
+      expect(lastGroup.isActive).toBe(true)
+    }
+  })
+
+  it('does not include singleton activity groups in the payload map', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'go' }),
+      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+      msg({ id: 'r1', type: 'response', content: 'done' }),
+      msg({ id: 't2', type: 'tool_use', content: '', tool: 'Read' }),
+    ]
+    const out = buildChatViewMessages(messages, null)
+    expect(out.chatToolGroupPayloads.size).toBe(0)
+  })
+
+  it('storeMsgMap keys by message id and preserves the original ChatMessage shape', () => {
+    const messages = [
+      msg({ id: 'u1', type: 'user_input', content: 'hi' }),
+      msg({ id: 't1', type: 'tool_use', content: '', tool: 'Bash' }),
+    ]
+    const out = buildChatViewMessages(messages, null)
+    expect(out.storeMsgMap.size).toBe(2)
+    expect(out.storeMsgMap.get('t1')?.tool).toBe('Bash')
+    // Map values are the original ChatMessage references, not copies.
+    expect(out.storeMsgMap.get('u1')).toBe(messages[0])
+  })
+
+  it('storeMsgMap includes system events too (renderMessage may inspect them)', () => {
+    const messages = [
+      msg({ id: 's1', type: 'system', content: 'connected' }),
+      msg({ id: 'r1', type: 'response', content: 'hi' }),
+    ]
+    const out = buildChatViewMessages(messages, null)
+    expect(out.storeMsgMap.get('s1')).toBeDefined()
+  })
+
+  describe('stalledPromptIds (#4615)', () => {
+    it('is empty when no ASK_USER_QUESTION_STALL error is present', () => {
+      const messages = [
+        msg({ id: 'p1', type: 'prompt', content: 'pick one' }),
+      ]
+      const out = buildChatViewMessages(messages, null)
+      expect(out.stalledPromptIds.size).toBe(0)
+    })
+
+    it('marks all unanswered prompts BEFORE the stall error as stalled', () => {
+      const messages: ChatMessage[] = [
+        msg({ id: 'p1', type: 'prompt', content: 'q1' }),
+        msg({ id: 'p2', type: 'prompt', content: 'q2' }),
+        msg({ id: 'e1', type: 'error', content: 'stalled', code: 'ASK_USER_QUESTION_STALL' }),
+      ]
+      const out = buildChatViewMessages(messages, null)
+      expect(out.stalledPromptIds.has('p1')).toBe(true)
+      expect(out.stalledPromptIds.has('p2')).toBe(true)
+    })
+
+    it('does NOT mark already-answered prompts as stalled (their answer is part of history)', () => {
+      const messages: ChatMessage[] = [
+        msg({ id: 'p1', type: 'prompt', content: 'q1', answered: 'yes' }),
+        msg({ id: 'p2', type: 'prompt', content: 'q2' }),
+        msg({ id: 'e1', type: 'error', content: 'stalled', code: 'ASK_USER_QUESTION_STALL' }),
+      ]
+      const out = buildChatViewMessages(messages, null)
+      expect(out.stalledPromptIds.has('p1')).toBe(false)
+      expect(out.stalledPromptIds.has('p2')).toBe(true)
+    })
+
+    it('uses the LAST stall as the boundary (later prompts are not stalled)', () => {
+      const messages: ChatMessage[] = [
+        msg({ id: 'p1', type: 'prompt', content: 'q1' }),
+        msg({ id: 'e1', type: 'error', content: 'stalled', code: 'ASK_USER_QUESTION_STALL' }),
+        msg({ id: 'p2', type: 'prompt', content: 'q2 — retry' }),
+      ]
+      const out = buildChatViewMessages(messages, null)
+      expect(out.stalledPromptIds.has('p1')).toBe(true)
+      // p2 is AFTER the stall error, so it's a fresh retry prompt — not stalled.
+      expect(out.stalledPromptIds.has('p2')).toBe(false)
+    })
+
+    it('ignores error bubbles with a different code', () => {
+      const messages: ChatMessage[] = [
+        msg({ id: 'p1', type: 'prompt', content: 'q1' }),
+        msg({ id: 'e1', type: 'error', content: 'other', code: 'stream_stall' }),
+      ]
+      const out = buildChatViewMessages(messages, null)
+      expect(out.stalledPromptIds.size).toBe(0)
+    })
+  })
+
+  describe('toChatViewMessage', () => {
+    it('maps `prompt` → `response` (legacy ChatViewMessage discriminator)', () => {
+      const m = msg({ id: 'p1', type: 'prompt', content: 'pick one' })
+      const v = toChatViewMessage(m)
+      expect(v.type).toBe('response')
+      expect(v.id).toBe('p1')
+    })
+
+    it('propagates the structured `code` for error bubbles (#4476)', () => {
+      const m = msg({
+        id: 'e1',
+        type: 'error',
+        content: 'oops',
+        code: 'stream_stall',
+      })
+      const v = toChatViewMessage(m)
+      expect(v.code).toBe('stream_stall')
+    })
+
+    it('omits `code` when undefined (keeps test snapshots clean)', () => {
+      const m = msg({ id: 'r1', type: 'response', content: 'hi' })
+      const v = toChatViewMessage(m)
+      expect('code' in v).toBe(false)
+    })
+  })
+})

--- a/packages/store-core/src/buildChatViewMessages.ts
+++ b/packages/store-core/src/buildChatViewMessages.ts
@@ -1,0 +1,210 @@
+/**
+ * Shared ChatView message pipeline (#4806).
+ *
+ * Pure function lifted from dashboard's `useChatMessages` hook so both the
+ * web dashboard and the mobile app derive the chat-view representation
+ * from the same code. Eliminates the silent #4615 mobile gap where the
+ * inline mobile pipeline never computed `stalledPromptIds` and rendered
+ * interactive QuestionPrompt for ASK_USER_QUESTION_STALL-invalidated
+ * prompts.
+ *
+ * Pipeline:
+ *   storeMessages
+ *     -> filter(m => m.type !== 'system')   // System events render on
+ *                                           //   the System tab.
+ *     -> groupMessages                      // (#3747) collapse contiguous
+ *                                           //   tool_use / thinking runs
+ *                                           //   into ActivityGroups.
+ *     -> applyStreamingOverlay              // mark trailing activity group
+ *                                           //   as active during streaming.
+ *     -> ChatViewMessage[]                  // flatten to chat-view rows.
+ *
+ * Singleton activity groups (1 message) pass through as the original
+ * `tool_use` / `thinking` row so the existing ToolBubble path stays
+ * reachable. Runs of 2+ messages collapse to a synthetic `tool_group`
+ * row whose `id` is the group key `activity-<firstId>`. The full payload
+ * is exposed via `chatToolGroupPayloads: Map<groupId, { messages, isActive }>`
+ * so the renderer can look it up when emitting `<ToolGroup>`.
+ *
+ * `chatTailMessageId` is provided so renderers can detect the trailing
+ * row without re-deriving it.
+ *
+ * `displayGroups` is exposed too — the mobile ChatView renders groups
+ * directly (no flatten) while the dashboard consumes `chatMessages`. Both
+ * surfaces get derivation parity from a single call.
+ *
+ * `stalledPromptIds` (#4615) carries the set of `type: 'prompt'` message
+ * ids that have been invalidated by a subsequent ASK_USER_QUESTION_STALL
+ * error so renderers can suppress the interactive prompt UI.
+ *
+ * This function is intentionally pure (no hooks, no refs, no I/O) — React
+ * memoisation lives in the calling hook / component.
+ */
+import {
+  groupMessages,
+  applyStreamingOverlay,
+  type DisplayGroup,
+} from './group-messages'
+import type { ChatMessage } from './types'
+
+/**
+ * Flattened chat-view row.
+ *
+ * `tool_group` is a synthetic discriminator emitted by the grouping pass —
+ * it has no store-side equivalent and consumers always render it via a
+ * custom renderer that looks the payload up in `chatToolGroupPayloads`.
+ */
+export interface ChatViewMessage {
+  id: string
+  type: 'response' | 'user_input' | 'system' | 'error' | 'thinking' | 'tool_use' | 'tool_group'
+  content: string
+  timestamp: number
+  isStreaming?: boolean
+  /**
+   * #4476 — structured error code mirrored from the store ChatMessage so
+   * renderers can switch on it (e.g. `'stream_stall'` → chip + retry).
+   */
+  code?: string
+}
+
+export interface ChatViewPipelineResult {
+  /** Chat-view rows with contiguous tool runs collapsed to `tool_group`. */
+  chatMessages: ChatViewMessage[]
+  /**
+   * Display groups after filter + group + streaming overlay. Mobile
+   * renders these directly; dashboard consumes `chatMessages` instead.
+   * Both come from the same source pass.
+   */
+  displayGroups: DisplayGroup[]
+  /** Group key -> original messages + isActive overlay, for `<ToolGroup>`. */
+  chatToolGroupPayloads: Map<string, { messages: ChatMessage[]; isActive: boolean }>
+  /** Id of the last chat row, or null when empty. */
+  chatTailMessageId: string | null
+  /** O(1) lookup map `id -> storeMessage` for renderMessage. */
+  storeMsgMap: Map<string, ChatMessage>
+  /**
+   * #4615 — set of `type: 'prompt'` message ids invalidated by a
+   * subsequent ASK_USER_QUESTION_STALL error. Renderers suppress these
+   * prompts; the stall chip carries the retry affordance instead.
+   */
+  stalledPromptIds: Set<string>
+}
+
+/** Map store ChatMessage to ChatViewMessage. Exported so callers can map
+ *  derived lists (e.g. systemMessages on the System tab) using the same
+ *  conversion as the chat pipeline. */
+export function toChatViewMessage(msg: ChatMessage): ChatViewMessage {
+  return {
+    id: msg.id,
+    type: msg.type === 'prompt' ? 'response' : msg.type,
+    content: msg.content,
+    timestamp: msg.timestamp,
+    // #4476: propagate the structured error code so the chat-view
+    // renderMessage path can switch error bubbles into the
+    // StreamStallChip variant.
+    ...(msg.code ? { code: msg.code } : {}),
+  }
+}
+
+/**
+ * Build the full chat-view derivation set from a list of store messages.
+ *
+ * Pure — same inputs yield identical outputs. Callers wrap this in
+ * `useMemo` (or equivalent) to avoid recomputation on unrelated renders.
+ *
+ * @param storeMessages full message list from BaseSessionState.messages
+ * @param streamingMessageId currently-streaming message id (drives the
+ *   trailing activity group's `isActive` overlay); `null` when idle.
+ */
+export function buildChatViewMessages(
+  storeMessages: ChatMessage[],
+  streamingMessageId: string | null,
+): ChatViewPipelineResult {
+  // Filter out `system` events — they belong on the System tab.
+  const chatFilteredMessages = storeMessages.filter(m => m.type !== 'system')
+
+  // Group contiguous tool_use / thinking runs, then apply the streaming
+  // overlay so the trailing group flips to isActive while streaming.
+  const baseGroups = groupMessages(chatFilteredMessages)
+  const displayGroups = applyStreamingOverlay(
+    baseGroups,
+    chatFilteredMessages,
+    streamingMessageId ?? null,
+  )
+
+  // Map of synthetic group id -> original messages + isActive. Only
+  // populated for runs of 2+ messages (#3794 review) — singleton activity
+  // groups render as the original `tool_use` / `thinking` row through
+  // ToolBubble, so they don't need a payload lookup.
+  const chatToolGroupPayloads = new Map<
+    string,
+    { messages: ChatMessage[]; isActive: boolean }
+  >()
+  for (const g of displayGroups) {
+    if (g.type === 'activity' && g.messages.length >= 2) {
+      chatToolGroupPayloads.set(g.key, { messages: g.messages, isActive: g.isActive })
+    }
+  }
+
+  // Flatten to ChatViewMessage[] — singleton activity groups (1 msg)
+  // pass through as `tool_use` / `thinking`; runs of 2+ collapse to a
+  // single synthetic `tool_group` row keyed by the group key.
+  const chatMessages: ChatViewMessage[] = displayGroups.map((g) => {
+    if (g.type === 'single') return toChatViewMessage(g.message)
+    if (g.messages.length < 2) {
+      // Singleton — emit as the original tool_use / thinking row.
+      return toChatViewMessage(g.messages[0]!)
+    }
+    const last = g.messages[g.messages.length - 1]
+    return {
+      id: g.key,
+      type: 'tool_group',
+      content: '',
+      timestamp: last?.timestamp ?? 0,
+    }
+  })
+
+  const chatTailMessageId = chatMessages.length > 0
+    ? chatMessages[chatMessages.length - 1]!.id
+    : null
+
+  // O(1) lookup map for renderMessage — keyed by store id, value is the
+  // original ChatMessage so the renderer can inspect fields the
+  // ChatViewMessage shape doesn't carry (toolInput, requestId,
+  // questions, etc.). Built from the unfiltered storeMessages so callers
+  // can look up system events too.
+  const storeMsgMap = new Map(storeMessages.map(m => [m.id, m]))
+
+  // #4615: track which `type: 'prompt'` bubbles have been invalidated by
+  // a subsequent ASK_USER_QUESTION_STALL error. The server emits the
+  // error when the Claude TUI never acknowledges an AskUserQuestion
+  // answer — typically a multi-question form wedge. The pending
+  // QuestionPrompt is now dead, so submitting it would fire keystrokes
+  // into a session that already discarded the prompt context. We
+  // suppress the interactive prompt render (the AskUserQuestionStallChip
+  // rendered for the error bubble below it carries the retry affordance).
+  const stalledPromptIds = new Set<string>()
+  let lastStallIndex = -1
+  for (let i = storeMessages.length - 1; i >= 0; i -= 1) {
+    const m = storeMessages[i]!
+    if (m.type === 'error' && m.code === 'ASK_USER_QUESTION_STALL') {
+      lastStallIndex = i
+      break
+    }
+  }
+  if (lastStallIndex >= 0) {
+    for (let i = 0; i < lastStallIndex; i += 1) {
+      const m = storeMessages[i]!
+      if (m.type === 'prompt' && !m.answered) stalledPromptIds.add(m.id)
+    }
+  }
+
+  return {
+    chatMessages,
+    displayGroups,
+    chatToolGroupPayloads,
+    chatTailMessageId,
+    storeMsgMap,
+    stalledPromptIds,
+  }
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -195,6 +195,20 @@ export {
   formatToolName,
 } from './group-messages'
 
+// #4806: shared ChatView message pipeline — lifted from dashboard's
+// `useChatMessages` hook so both dashboard and mobile derive the same
+// chat-view representation (closes the silent #4615 stalled-prompt gap
+// on mobile as a side effect).
+export type {
+  ChatViewMessage,
+  ChatViewPipelineResult,
+} from './buildChatViewMessages'
+
+export {
+  buildChatViewMessages,
+  toChatViewMessage,
+} from './buildChatViewMessages'
+
 // #4243: shared tool-input summary helpers — both dashboard and mobile
 // ToolBubble derive the collapsed-preview string from the same
 // field-priority extraction (`command` → `file_path` → `path` →


### PR DESCRIPTION
## Summary

Extract the pure portions of dashboard's `useChatMessages` hook into a shared `buildChatViewMessages` pure function in `@chroxy/store-core`. Dashboard hook becomes a thin React-memo wrapper; mobile `ChatView` consumes the same function inline.

Closes #4806.

## Why

Builder-agent audit finding #5 (P1): #4776 extracted `useChatMessages` from `App.tsx` for the dashboard, but `packages/app/src/components/ChatView.tsx` re-implemented the same filter + group + overlay + tail-id pipeline inline. The mobile version was missing `stalledPromptIds` entirely (the #4615 invariant added to the dashboard), so an `ASK_USER_QUESTION_STALL` would leave the now-dead interactive QuestionPrompt visible on mobile. Submitting it would fire keystrokes into a session that already discarded the prompt context.

## What

- `packages/store-core/src/buildChatViewMessages.ts` — pure function returning `{ chatMessages, displayGroups, chatToolGroupPayloads, chatTailMessageId, storeMsgMap, stalledPromptIds }`. `displayGroups` is exposed alongside `chatMessages` so the mobile renderer (which renders groups directly with `ActivityGroup`) and the dashboard renderer (which renders flattened rows via `renderMessage`) share the same source pass.
- `packages/store-core/src/buildChatViewMessages.test.ts` — 19 cases covering empty input, system filtering, singleton tool_use passthrough, 2+ collapse, tail-id derivation (incl. synthetic group id), streaming overlay, payload-map population gating, `storeMsgMap` shape, all five `stalledPromptIds` scenarios, and `toChatViewMessage` mapping.
- `packages/dashboard/src/hooks/useChatMessages.ts` — thin `useMemo` wrapper around the shared call. Same public API; existing 16 hook tests still pass unchanged.
- `packages/app/src/components/ChatView.tsx` — consumes `buildChatViewMessages`. Stalled prompts (`prompt` + `options` + no `requestId` + in `stalledPromptIds`) now skip `MessageBubble` rendering, mirroring `App.tsx:1333` in the dashboard.

## Mobile parity side effect

Mobile `ChatView` now suppresses interactive QuestionPrompt for ASK_USER_QUESTION_STALL-invalidated prompts, closing the #4615 gap that was previously dashboard-only.

## Test plan

- [x] `cd packages/store-core && npm test` — 1002/1002 pass (19 new in `buildChatViewMessages.test.ts`)
- [x] `cd packages/dashboard && npm test` — 2516/2516 pass (16 `useChatMessages` hook tests unchanged)
- [x] `cd packages/app && npm test` — 1429/1429 pass (updated `ComponentRendering.test.ts` static-source assertion to match the new `buildChatViewMessages` import)
- [x] `tsc --noEmit` clean across store-core, dashboard, app