### PR TITLE
lint(server): detect missing BaseSession opt forwarding in provider sessions (#4797)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,22 @@ jobs:
             exit 1
           fi
 
+      - name: Check session subclasses forward every BaseSession opt
+        run: |
+          # Issue #4797 — every provider session class that extends
+          # BaseSession (or JsonlSubprocessSession) must destructure AND
+          # forward every BaseSession constructor opt via super({ ... }).
+          # The "middle-layer trap" documented in project memory as
+          # feedback_jsonl_subprocess_middle_layer.md has bitten three times
+          # (#3224, #3231, #4790). This lint blocks the next recurrence at
+          # PR time instead of catching it in production.
+          if scripts/lint-session-opt-forwarding.sh; then
+            echo "OK — every session subclass forwards every BaseSession opt"
+          else
+            echo "::error::A provider session class drops a BaseSession opt on its way to super(). See packages/server/scripts/lint-session-opt-forwarding.sh."
+            exit 1
+          fi
+
   dashboard-tests:
     name: Dashboard Tests
     runs-on: ubuntu-24.04

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,14 @@ Two layers of defence are wired up:
 
 If you need to write to the real home for a legitimate reason (no current test does), set `process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'` scoped to the test and restore it after. The sandbox guard MUST stay enabled in `package.json`.
 
+### Provider session constructors must forward every BaseSession opt (#4797)
+
+Every class that extends `BaseSession` (or `JsonlSubprocessSession`, the middle layer above the subprocess providers) **must** destructure every opt accepted by `BaseSession`'s constructor AND forward it via `super({ ... })`. Otherwise the opt is silently dropped on its way down — the "middle-layer trap" that has bitten three times (#3224, #3231, #4790) and is documented in project memory as `feedback_jsonl_subprocess_middle_layer.md`.
+
+The CI lint (`packages/server/scripts/lint-session-opt-forwarding.sh`) parses `base-session.js` for the canonical opt set and diffs it against every subclass's destructure + `super()` block, failing the build with a `file:line` pointer if any opt is missing. Run locally with `cd packages/server && ./scripts/lint-session-opt-forwarding.sh`.
+
+When adding a new BaseSession opt: update every subclass constructor (`cli-session.js`, `sdk-session.js`, `claude-tui-session.js`, `jsonl-subprocess-session.js`, `codex-session.js`, `gemini-session.js`) in the same PR. If an opt deliberately should not propagate to a particular subclass (rare), add `// lint-ignore-opt-forwarding: <key>` immediately above the class declaration and explain why.
+
 ## Architecture
 
 Server streams through `ws-server.js` → Cloudflare tunnel → mobile app / desktop dashboard:

--- a/packages/server/scripts/lint-session-opt-forwarding.mjs
+++ b/packages/server/scripts/lint-session-opt-forwarding.mjs
@@ -1,0 +1,457 @@
+#!/usr/bin/env node
+/**
+ * Lint: every class that extends `BaseSession` (or
+ * `JsonlSubprocessSession`, the middle layer above the subprocess
+ * providers) MUST destructure every constructor opt accepted by
+ * `BaseSession` AND forward it via `super({ ... })`. Otherwise the opt
+ * is silently dropped on its way down — the middle-layer trap
+ * documented in project memory as `feedback_jsonl_subprocess_middle_layer`
+ * and repeated three times historically (#3224, #3231, #4790).
+ *
+ * Detection strategy (regex, intentionally — same style as
+ * `lint-tests-state-file-path.mjs`):
+ *
+ * 1. Parse `base-session.js` to extract the canonical set of opt names
+ *    from the destructure inside the `BaseSession` constructor.
+ * 2. Walk every `*.js` file under `packages/server/src/`.
+ * 3. For each `export class X extends (BaseSession|JsonlSubprocessSession)`,
+ *    locate the constructor's destructure list and the matching
+ *    `super({ ... })` call.
+ * 4. Diff the canonical opt set against the destructure + super forward
+ *    sets. Any opt that is missing from EITHER side is reported.
+ *
+ * Two opt-outs:
+ *
+ *   - `super(opts)` or `super({ ...opts })` style is naturally immune
+ *     because every opt is forwarded by reference; the lint skips these
+ *     classes.
+ *   - A `// lint-ignore-opt-forwarding: <key1>,<key2>` comment placed
+ *     immediately above the class declaration whitelists specific opts
+ *     for that class. Use sparingly — the comment should explain why.
+ *
+ * Issue: #4797. Trap that motivated this lint: #4790 (fixed in #4795).
+ *
+ * Exit codes:
+ *   0 — every subclass forwards every BaseSession opt (or is whitelisted)
+ *   1 — at least one offender found (printed with file:line + missing key)
+ *
+ * Flags:
+ *   --src-dir <path>   Override the src directory (used by tests against
+ *                      fixture trees). Defaults to `../src` relative to
+ *                      this script.
+ *   --dry-run          Print offenders without failing the exit code.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function parseFlags(argv) {
+  const flags = { srcDir: null, dryRun: false }
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--src-dir') flags.srcDir = argv[++i]
+    else if (a === '--dry-run') flags.dryRun = true
+  }
+  return flags
+}
+
+const { srcDir: srcDirOverride, dryRun } = parseFlags(process.argv.slice(2))
+const SRC_DIR = resolve(srcDirOverride || join(__dirname, '..', 'src'))
+
+// ----------------------------------------------------------------------
+// Tiny lexer-aware helpers (lifted in spirit from
+// `lint-tests-state-file-path.mjs`). Regex is fine here because the
+// patterns we care about are stable — destructure-on-one-or-many-lines,
+// super({...}) in the constructor body.
+// ----------------------------------------------------------------------
+
+function findMatchingBracket(src, openIdx, open, close) {
+  let depth = 0
+  let i = openIdx
+  let inStr = null
+  while (i < src.length) {
+    const ch = src[i]
+    const prev = src[i - 1]
+    if (inStr) {
+      if (ch === inStr && prev !== '\\') inStr = null
+    } else if (ch === '"' || ch === "'" || ch === '`') {
+      inStr = ch
+    } else if (ch === '/' && src[i + 1] === '/') {
+      const nl = src.indexOf('\n', i)
+      i = nl === -1 ? src.length : nl
+      continue
+    } else if (ch === '/' && src[i + 1] === '*') {
+      const end = src.indexOf('*/', i + 2)
+      i = end === -1 ? src.length : end + 2
+      continue
+    } else if (ch === open) {
+      depth++
+    } else if (ch === close) {
+      depth--
+      if (depth === 0) return i
+    }
+    i++
+  }
+  return -1
+}
+
+function stripComments(src) {
+  // Strip // line comments and /* block */ comments. Keeps newlines so
+  // line-number math downstream still tracks the original source.
+  let out = ''
+  let i = 0
+  let inStr = null
+  while (i < src.length) {
+    const ch = src[i]
+    const prev = src[i - 1]
+    if (inStr) {
+      out += ch
+      if (ch === inStr && prev !== '\\') inStr = null
+      i++
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      inStr = ch
+      out += ch
+      i++
+      continue
+    }
+    if (ch === '/' && src[i + 1] === '/') {
+      const nl = src.indexOf('\n', i)
+      if (nl === -1) { i = src.length; continue }
+      i = nl
+      continue
+    }
+    if (ch === '/' && src[i + 1] === '*') {
+      const end = src.indexOf('*/', i + 2)
+      if (end === -1) { i = src.length; continue }
+      // Preserve newlines so any downstream line-counting stays sane.
+      const block = src.slice(i, end + 2)
+      for (const c of block) if (c === '\n') out += '\n'
+      i = end + 2
+      continue
+    }
+    out += ch
+    i++
+  }
+  return out
+}
+
+// Extract the set of destructure keys from a `{ ... }` block. Handles
+// trailing commas, default values (`= foo`), rename (`a: b` — rare here),
+// and inline comments (already stripped).
+function extractDestructureKeys(block) {
+  // block includes the surrounding braces. Trim them.
+  const inner = block.slice(1, -1)
+  const keys = new Set()
+  let depth = 0
+  let parenDepth = 0
+  let bracketDepth = 0
+  let inStr = null
+  let buf = ''
+  const flush = () => {
+    let token = buf.trim()
+    buf = ''
+    if (!token) return
+    // Strip default-value clause: `foo = bar` → `foo`
+    const eqIdx = token.indexOf('=')
+    if (eqIdx !== -1) token = token.slice(0, eqIdx).trim()
+    // Strip type annotation (defensive — server is JS, no TS): `foo: bar`
+    const colonIdx = token.indexOf(':')
+    if (colonIdx !== -1) token = token.slice(0, colonIdx).trim()
+    // Strip rest spread: `...rest` — not a forwardable key, skip.
+    if (token.startsWith('...')) return
+    if (/^[A-Za-z_$][\w$]*$/.test(token)) keys.add(token)
+  }
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i]
+    const prev = inner[i - 1]
+    if (inStr) {
+      buf += ch
+      if (ch === inStr && prev !== '\\') inStr = null
+      continue
+    }
+    if (ch === '"' || ch === "'" || ch === '`') { inStr = ch; buf += ch; continue }
+    if (ch === '{') depth++
+    else if (ch === '}') depth--
+    else if (ch === '(') parenDepth++
+    else if (ch === ')') parenDepth--
+    else if (ch === '[') bracketDepth++
+    else if (ch === ']') bracketDepth--
+    if (ch === ',' && depth === 0 && parenDepth === 0 && bracketDepth === 0) {
+      flush()
+      continue
+    }
+    buf += ch
+  }
+  flush()
+  return keys
+}
+
+// Extract the set of keys passed in a `super({ key1, key2: foo, ... })`
+// call. Same parser as the destructure — shorthand `{ a }` and explicit
+// `{ a: b }` both register `a` (which is the key BaseSession sees).
+function extractObjectKeys(block) {
+  return extractDestructureKeys(block)
+}
+
+// ----------------------------------------------------------------------
+// BaseSession opt parsing
+// ----------------------------------------------------------------------
+
+function parseBaseSessionOpts(baseSessionPath) {
+  const src = readFileSync(baseSessionPath, 'utf8')
+  const stripped = stripComments(src)
+  // Anchor on `export class BaseSession` (the class we care about — the
+  // file may export helpers and constants too).
+  const classIdx = stripped.indexOf('export class BaseSession')
+  if (classIdx === -1) {
+    throw new Error(`Could not find "export class BaseSession" in ${baseSessionPath}`)
+  }
+  // Find the `constructor(` after the class declaration.
+  const ctorIdx = stripped.indexOf('constructor(', classIdx)
+  if (ctorIdx === -1) {
+    throw new Error(`Could not find constructor() in BaseSession at ${baseSessionPath}`)
+  }
+  // The constructor takes a single destructured object: `constructor({ ... } = {})`.
+  // Find the `{` that opens the destructure.
+  const parenOpen = stripped.indexOf('(', ctorIdx)
+  const braceOpen = stripped.indexOf('{', parenOpen)
+  if (braceOpen === -1) {
+    throw new Error(`Could not find destructure { in BaseSession constructor`)
+  }
+  const braceClose = findMatchingBracket(stripped, braceOpen, '{', '}')
+  if (braceClose === -1) {
+    throw new Error(`Unbalanced braces in BaseSession constructor`)
+  }
+  const block = stripped.slice(braceOpen, braceClose + 1)
+  return extractDestructureKeys(block)
+}
+
+// ----------------------------------------------------------------------
+// Subclass scanning
+// ----------------------------------------------------------------------
+
+const CLASS_RE = /export\s+class\s+([A-Za-z_$][\w$]*)\s+extends\s+(BaseSession|JsonlSubprocessSession)\b/g
+
+function lineOf(src, idx) {
+  return src.slice(0, idx).split('\n').length
+}
+
+// Find the comment line `// lint-ignore-opt-forwarding: a,b,c` (if any)
+// in the few lines immediately preceding the class declaration. `lineNo`
+// is the 1-indexed line number of the class declaration in the ORIGINAL
+// source (matches strippedSrc's line numbers because stripComments
+// preserves newlines). Returns a Set of allow-listed opt names.
+function findIgnoreList(origSrc, lineNo) {
+  const origLines = origSrc.split('\n')
+  // origLines is 0-indexed; the class declaration is at origLines[lineNo - 1].
+  // Walk backwards starting from the line above.
+  const ignore = new Set()
+  for (let i = lineNo - 2; i >= 0; i--) {
+    const raw = origLines[i]
+    const trimmed = raw.trim()
+    if (trimmed === '') continue
+    if (trimmed.startsWith('//')) {
+      const m = trimmed.match(/lint-ignore-opt-forwarding\s*:\s*(.+)$/)
+      if (m) {
+        for (const k of m[1].split(',')) {
+          const key = k.trim()
+          if (key) ignore.add(key)
+        }
+      }
+      continue
+    }
+    if (trimmed.startsWith('*') || trimmed.startsWith('/*') || trimmed.endsWith('*/')) continue
+    // First non-comment line — stop searching upward.
+    break
+  }
+  return ignore
+}
+
+function findConstructorBlock(strippedSrc, classDeclIdx) {
+  // Locate the `{` opening the class body, then the `constructor(` inside.
+  const classBodyOpen = strippedSrc.indexOf('{', classDeclIdx)
+  if (classBodyOpen === -1) return null
+  const classBodyClose = findMatchingBracket(strippedSrc, classBodyOpen, '{', '}')
+  if (classBodyClose === -1) return null
+  const body = strippedSrc.slice(classBodyOpen, classBodyClose + 1)
+  const ctorOffsetInBody = body.indexOf('constructor(')
+  if (ctorOffsetInBody === -1) return null
+  const ctorAbsIdx = classBodyOpen + ctorOffsetInBody
+  return { ctorAbsIdx, classBodyClose }
+}
+
+function analyzeClass(filePath, origSrc, strippedSrc, classDeclIdx, className) {
+  const block = findConstructorBlock(strippedSrc, classDeclIdx)
+  if (!block) {
+    return { skipped: true, reason: 'no constructor found' }
+  }
+  const { ctorAbsIdx } = block
+  // Find the destructure pattern inside `constructor(`. Two shapes:
+  //   constructor({ a, b } = {}) — destructured
+  //   constructor(opts = {}) — single-arg, naturally immune (rest-spread)
+  const parenOpen = strippedSrc.indexOf('(', ctorAbsIdx)
+  const parenClose = findMatchingBracket(strippedSrc, parenOpen, '(', ')')
+  if (parenClose === -1) return { skipped: true, reason: 'unbalanced ctor parens' }
+  const args = strippedSrc.slice(parenOpen + 1, parenClose).trim()
+  if (!args.startsWith('{')) {
+    // Single positional arg — caller is `super(opts)` or `super({ ...opts })`.
+    // Naturally immune, skip.
+    return { skipped: true, reason: 'single-arg constructor (rest-spread style)' }
+  }
+  // Find the destructure `{ ... }` inside the args.
+  const destructureOpenAbs = strippedSrc.indexOf('{', parenOpen)
+  const destructureCloseAbs = findMatchingBracket(strippedSrc, destructureOpenAbs, '{', '}')
+  if (destructureCloseAbs === -1) return { skipped: true, reason: 'unbalanced destructure' }
+  const destructureBlock = strippedSrc.slice(destructureOpenAbs, destructureCloseAbs + 1)
+  const destructureKeys = extractDestructureKeys(destructureBlock)
+
+  // Find the super({ ... }) call in the constructor body.
+  const ctorBodyOpen = strippedSrc.indexOf('{', parenClose)
+  const ctorBodyClose = findMatchingBracket(strippedSrc, ctorBodyOpen, '{', '}')
+  if (ctorBodyClose === -1) return { skipped: true, reason: 'unbalanced ctor body' }
+  const ctorBody = strippedSrc.slice(ctorBodyOpen, ctorBodyClose + 1)
+
+  // Locate `super(` — there should be exactly one, at the top of the body.
+  const superMatch = ctorBody.match(/super\s*\(/)
+  if (!superMatch) return { skipped: true, reason: 'no super() call' }
+  const superOpenInBody = ctorBody.indexOf(superMatch[0]) + superMatch[0].length - 1
+  const superOpenAbs = ctorBodyOpen + superOpenInBody
+  const superCloseAbs = findMatchingBracket(strippedSrc, superOpenAbs, '(', ')')
+  if (superCloseAbs === -1) return { skipped: true, reason: 'unbalanced super()' }
+  const superArgs = strippedSrc.slice(superOpenAbs + 1, superCloseAbs).trim()
+
+  // super({ ...opts, ... }) or super(opts) — naturally immune.
+  if (superArgs.startsWith('...') || /^[A-Za-z_$][\w$]*$/.test(superArgs)) {
+    return { skipped: true, reason: 'super forwards rest-spread/positional' }
+  }
+  if (!superArgs.startsWith('{')) {
+    return { skipped: true, reason: 'super() call shape not recognised' }
+  }
+
+  // Detect `{ ...opts, ... }` style super calls — also naturally immune.
+  // (Look at the inner content for a leading `...identifier`.)
+  const superBraceOpenAbs = strippedSrc.indexOf('{', superOpenAbs)
+  const superBraceCloseAbs = findMatchingBracket(strippedSrc, superBraceOpenAbs, '{', '}')
+  if (superBraceCloseAbs === -1) return { skipped: true, reason: 'unbalanced super({})' }
+  const superBlock = strippedSrc.slice(superBraceOpenAbs, superBraceCloseAbs + 1)
+  if (/\{\s*\.\.\.[A-Za-z_$]/.test(superBlock)) {
+    return { skipped: true, reason: 'super spreads an identifier' }
+  }
+  const superKeys = extractObjectKeys(superBlock)
+
+  return {
+    className,
+    destructureKeys,
+    superKeys,
+    classDeclLine: lineOf(strippedSrc, classDeclIdx),
+    ctorLine: lineOf(strippedSrc, ctorAbsIdx),
+  }
+}
+
+function walk(dir, acc = []) {
+  for (const ent of readdirSync(dir)) {
+    const p = join(dir, ent)
+    const st = statSync(p)
+    if (st.isDirectory()) walk(p, acc)
+    else if (st.isFile() && p.endsWith('.js')) acc.push(p)
+  }
+  return acc
+}
+
+// ----------------------------------------------------------------------
+// Main
+// ----------------------------------------------------------------------
+
+function main() {
+  const baseSessionPath = join(SRC_DIR, 'base-session.js')
+  let baseOpts
+  try {
+    baseOpts = parseBaseSessionOpts(baseSessionPath)
+  } catch (err) {
+    console.error(`ERROR: failed to parse BaseSession opts from ${baseSessionPath}: ${err.message}`)
+    process.exit(2)
+  }
+  if (baseOpts.size === 0) {
+    console.error(`ERROR: parsed 0 opts from BaseSession at ${baseSessionPath} — parser is broken`)
+    process.exit(2)
+  }
+
+  const files = walk(SRC_DIR).filter(f => !f.endsWith('/base-session.js'))
+  const offenders = []
+  let analyzedCount = 0
+
+  for (const file of files) {
+    const origSrc = readFileSync(file, 'utf8')
+    if (!CLASS_RE.test(origSrc)) continue
+    CLASS_RE.lastIndex = 0
+    const strippedSrc = stripComments(origSrc)
+    let m
+    while ((m = CLASS_RE.exec(strippedSrc)) !== null) {
+      const className = m[1]
+      const classDeclIdx = m.index
+      const declLine = lineOf(strippedSrc, classDeclIdx)
+      const ignore = findIgnoreList(origSrc, declLine)
+      const analysis = analyzeClass(file, origSrc, strippedSrc, classDeclIdx, className)
+      if (analysis.skipped) continue
+      analyzedCount++
+      const { destructureKeys, superKeys } = analysis
+      const missingDestructure = []
+      const missingSuper = []
+      for (const opt of baseOpts) {
+        if (ignore.has(opt)) continue
+        if (!destructureKeys.has(opt)) missingDestructure.push(opt)
+        // Only flag missing-from-super if it's NOT also missing from
+        // destructure (avoids double-reporting; the destructure miss
+        // is the root cause and the super miss is its symptom).
+        else if (!superKeys.has(opt)) missingSuper.push(opt)
+      }
+      if (missingDestructure.length || missingSuper.length) {
+        offenders.push({
+          file,
+          line: declLine,
+          className,
+          missingDestructure,
+          missingSuper,
+        })
+      }
+    }
+    CLASS_RE.lastIndex = 0
+  }
+
+  if (offenders.length) {
+    console.error('ERROR: the following session subclasses drop BaseSession opts on their way to super():')
+    console.error('')
+    for (const o of offenders) {
+      console.error(`  ${o.file}:${o.line}  class ${o.className}`)
+      if (o.missingDestructure.length) {
+        console.error(`    Missing from constructor destructure: ${o.missingDestructure.join(', ')}`)
+      }
+      if (o.missingSuper.length) {
+        console.error(`    Destructured but not forwarded via super(): ${o.missingSuper.join(', ')}`)
+      }
+    }
+    console.error('')
+    console.error('This is the "middle-layer trap" documented in project memory as')
+    console.error('  feedback_jsonl_subprocess_middle_layer.md')
+    console.error('and previously bit #3224, #3231, #4790.')
+    console.error('')
+    console.error('Fix: add the missing key to both the constructor destructure list AND the')
+    console.error('super({ ... }) call. Or, if the omission is deliberate, annotate the class')
+    console.error('with `// lint-ignore-opt-forwarding: <key1>,<key2>` immediately above the')
+    console.error('class declaration and explain why in a comment.')
+    if (dryRun) process.exit(0)
+    process.exit(1)
+  }
+
+  console.log(
+    `OK: ${analyzedCount} session subclass(es) forward all ${baseOpts.size} BaseSession opt(s) ` +
+    `(or are explicitly whitelisted).`,
+  )
+}
+
+main()

--- a/packages/server/scripts/lint-session-opt-forwarding.mjs
+++ b/packages/server/scripts/lint-session-opt-forwarding.mjs
@@ -5,7 +5,7 @@
  * providers) MUST destructure every constructor opt accepted by
  * `BaseSession` AND forward it via `super({ ... })`. Otherwise the opt
  * is silently dropped on its way down — the middle-layer trap
- * documented in project memory as `feedback_jsonl_subprocess_middle_layer`
+ * documented in project memory as `feedback_jsonl_subprocess_middle_layer.md`
  * and repeated three times historically (#3224, #3231, #4790).
  *
  * Detection strategy (regex, intentionally — same style as

--- a/packages/server/scripts/lint-session-opt-forwarding.sh
+++ b/packages/server/scripts/lint-session-opt-forwarding.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Wrapper for the Node-based linter. See `lint-session-opt-forwarding.mjs`
+# for the actual implementation. Kept as a shell entry point so CI can
+# `run: scripts/lint-session-opt-forwarding.sh` without worrying about the
+# Node interpreter path on the runner image.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node ./scripts/lint-session-opt-forwarding.mjs "$@"

--- a/packages/server/tests/lint-session-opt-forwarding.test.js
+++ b/packages/server/tests/lint-session-opt-forwarding.test.js
@@ -1,0 +1,304 @@
+/**
+ * Tests for scripts/lint-session-opt-forwarding.mjs
+ *
+ * The lint guards the "middle-layer trap" documented in project memory as
+ * `feedback_jsonl_subprocess_middle_layer.md`: provider session classes that
+ * extend `BaseSession` (or `JsonlSubprocessSession`) destructure a fixed key
+ * list in their constructor and forward via `super({...})`. When a new
+ * BaseSession opt is added, the middle layers silently drop it unless
+ * updated — see #3224, #3231, #4790.
+ *
+ * Strategy: run the lint as a child process against a temp directory of
+ * fixture files. Each fixture mimics the real provider-session shape so we
+ * can verify the regex parser flags the trap (and accepts the good case).
+ *
+ * Issue: #4797. Trap that motivated this lint: #4790 (fixed in #4795).
+ */
+import { test, describe, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readdirSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const LINT_SCRIPT = resolve(__dirname, '..', 'scripts', 'lint-session-opt-forwarding.mjs')
+
+// Minimal BaseSession fixture that mimics the real signature shape — the
+// lint extracts the opt-name set from the destructure inside the constructor.
+const BASE_SESSION_SRC = `
+import { EventEmitter } from 'events'
+
+export class BaseSession extends EventEmitter {
+  constructor({
+    cwd,
+    model,
+    permissionMode,
+    skillsDir,
+    repoSkillsDir,
+    maxSkillBytes,
+    chroxyContextHint,
+    streamStallTimeoutMs,
+    resultTimeoutMs,
+    hardTimeoutMs,
+  } = {}) {
+    super()
+    this.cwd = cwd
+    this.model = model
+  }
+}
+`
+
+// A "good" middle layer — every BaseSession opt is destructured and
+// forwarded through super(). The real JsonlSubprocessSession looks like
+// this (modulo the much longer key list).
+const GOOD_MIDDLE_LAYER_SRC = `
+import { BaseSession } from './base-session.js'
+
+export class JsonlSubprocessSession extends BaseSession {
+  constructor({
+    cwd,
+    model,
+    permissionMode,
+    skillsDir,
+    repoSkillsDir,
+    maxSkillBytes,
+    chroxyContextHint,
+    streamStallTimeoutMs,
+    resultTimeoutMs,
+    hardTimeoutMs,
+    resumeSessionId,
+  } = {}) {
+    super({
+      cwd,
+      model,
+      permissionMode,
+      skillsDir,
+      repoSkillsDir,
+      maxSkillBytes,
+      chroxyContextHint,
+      streamStallTimeoutMs,
+      resultTimeoutMs,
+      hardTimeoutMs,
+    })
+    this.resumeSessionId = resumeSessionId
+  }
+}
+`
+
+// A "bad" middle layer — drops `streamStallTimeoutMs` from BOTH the
+// destructure and the super() forward. Reproduces the #4790 trap exactly.
+const BAD_MIDDLE_LAYER_SRC = `
+import { BaseSession } from './base-session.js'
+
+export class CodexSession extends BaseSession {
+  constructor({
+    cwd,
+    model,
+    permissionMode,
+    skillsDir,
+    repoSkillsDir,
+    maxSkillBytes,
+    chroxyContextHint,
+    resultTimeoutMs,
+    hardTimeoutMs,
+    resumeSessionId,
+  } = {}) {
+    super({
+      cwd,
+      model,
+      permissionMode,
+      skillsDir,
+      repoSkillsDir,
+      maxSkillBytes,
+      chroxyContextHint,
+      resultTimeoutMs,
+      hardTimeoutMs,
+    })
+    this.resumeSessionId = resumeSessionId
+  }
+}
+`
+
+// A "destructure-only" bad case — the opt is destructured (so it's
+// pulled out of opts) but never forwarded via super(). This is the
+// silent variant of the trap: the key looks plumbed in code review
+// because it's in the destructure list, but it never reaches BaseSession.
+const BAD_FORWARD_ONLY_SRC = `
+import { BaseSession } from './base-session.js'
+
+export class GeminiSession extends BaseSession {
+  constructor({
+    cwd,
+    model,
+    permissionMode,
+    skillsDir,
+    repoSkillsDir,
+    maxSkillBytes,
+    chroxyContextHint,
+    streamStallTimeoutMs,
+    resultTimeoutMs,
+    hardTimeoutMs,
+  } = {}) {
+    super({
+      cwd,
+      model,
+      permissionMode,
+      skillsDir,
+      repoSkillsDir,
+      maxSkillBytes,
+      chroxyContextHint,
+      resultTimeoutMs,
+      hardTimeoutMs,
+    })
+  }
+}
+`
+
+// Rest-spread style — `super({ ...opts, ... })`. Naturally immune to the
+// trap because every opt is forwarded by reference. The lint should
+// accept this without complaint (no enumeration to compare).
+const REST_SPREAD_SRC = `
+import { BaseSession } from './base-session.js'
+
+export class ClaudeByokSession extends BaseSession {
+  constructor(opts = {}) {
+    super({ ...opts, provider: opts.provider || 'claude-byok' })
+  }
+}
+`
+
+function setupFixtureTree(extraFiles = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'chroxy-lint-opt-fwd-'))
+  const srcDir = join(dir, 'src')
+  mkdirSync(srcDir, { recursive: true })
+  writeFileSync(join(srcDir, 'base-session.js'), BASE_SESSION_SRC, 'utf8')
+  for (const [name, src] of Object.entries(extraFiles)) {
+    writeFileSync(join(srcDir, name), src, 'utf8')
+  }
+  return { dir, srcDir }
+}
+
+function runLint(srcDir) {
+  const result = spawnSync(
+    process.execPath,
+    [LINT_SCRIPT, '--src-dir', srcDir],
+    { encoding: 'utf8' },
+  )
+  return {
+    code: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  }
+}
+
+describe('lint-session-opt-forwarding', () => {
+  const cleanups = []
+  after(() => {
+    for (const dir of cleanups) {
+      try { rmSync(dir, { recursive: true, force: true }) } catch {}
+    }
+  })
+
+  test('passes when every BaseSession opt is destructured + forwarded', () => {
+    const { dir, srcDir } = setupFixtureTree({
+      'jsonl-subprocess-session.js': GOOD_MIDDLE_LAYER_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stdout, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `lint should pass on good fixture\nstdout:\n${stdout}\nstderr:\n${stderr}`)
+  })
+
+  test('fails when an opt is dropped from both destructure and super()', () => {
+    const { dir, srcDir } = setupFixtureTree({
+      'codex-session.js': BAD_MIDDLE_LAYER_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'lint should fail when an opt is dropped')
+    assert.match(stderr, /streamStallTimeoutMs/, 'error should name the missing opt')
+    assert.match(stderr, /codex-session\.js/, 'error should name the offending file')
+  })
+
+  test('fails when an opt is destructured but not forwarded via super()', () => {
+    const { dir, srcDir } = setupFixtureTree({
+      'gemini-session.js': BAD_FORWARD_ONLY_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'lint should fail on destructure-only opts')
+    assert.match(stderr, /streamStallTimeoutMs/, 'error should name the missing opt')
+    assert.match(stderr, /gemini-session\.js/, 'error should name the offending file')
+  })
+
+  test('accepts rest-spread super({ ...opts }) without complaint', () => {
+    const { dir, srcDir } = setupFixtureTree({
+      'byok-session.js': REST_SPREAD_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stdout, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `rest-spread is naturally immune\nstdout:\n${stdout}\nstderr:\n${stderr}`)
+  })
+
+  test('passes against the real packages/server/src tree (acceptance criterion)', () => {
+    // No --src-dir override → the lint walks the real source tree. This is
+    // the regression-prevention contract: after #4795, all three middle
+    // layers (jsonl-subprocess, codex, gemini) forward every BaseSession
+    // opt. Future opt additions must come with matching middle-layer plumbing,
+    // or this test will flip red here AND in CI.
+    const result = spawnSync(
+      process.execPath,
+      [LINT_SCRIPT],
+      { encoding: 'utf8' },
+    )
+    assert.equal(
+      result.status,
+      0,
+      `lint must pass on the real tree — middle layers must forward every BaseSession opt.\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    )
+  })
+
+  test('per-key allowlist comment suppresses a specific drop', () => {
+    // Class can opt-out a specific key via a marker comment placed above
+    // the constructor. Use case: a future provider deliberately does not
+    // need a particular opt (e.g. a stub session for testing). The
+    // allowlist is per-key so missing a different opt still fails.
+    const SUPPRESS_SRC = `
+import { BaseSession } from './base-session.js'
+
+// lint-ignore-opt-forwarding: streamStallTimeoutMs
+export class TestStubSession extends BaseSession {
+  constructor({
+    cwd,
+    model,
+    permissionMode,
+    skillsDir,
+    repoSkillsDir,
+    maxSkillBytes,
+    chroxyContextHint,
+    resultTimeoutMs,
+    hardTimeoutMs,
+  } = {}) {
+    super({
+      cwd,
+      model,
+      permissionMode,
+      skillsDir,
+      repoSkillsDir,
+      maxSkillBytes,
+      chroxyContextHint,
+      resultTimeoutMs,
+      hardTimeoutMs,
+    })
+  }
+}
+`
+    const { dir, srcDir } = setupFixtureTree({
+      'test-stub-session.js': SUPPRESS_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stdout, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `allowlist should suppress streamStallTimeoutMs\nstdout:\n${stdout}\nstderr:\n${stderr}`)
+  })
+})

--- a/packages/server/tests/lint-session-opt-forwarding.test.js
+++ b/packages/server/tests/lint-session-opt-forwarding.test.js
@@ -14,9 +14,9 @@
  *
  * Issue: #4797. Trap that motivated this lint: #4790 (fixed in #4795).
  */
-import { test, describe, before, after } from 'node:test'
+import { test, describe, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readdirSync, statSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -260,10 +260,11 @@ describe('lint-session-opt-forwarding', () => {
   })
 
   test('per-key allowlist comment suppresses a specific drop', () => {
-    // Class can opt-out a specific key via a marker comment placed above
-    // the constructor. Use case: a future provider deliberately does not
-    // need a particular opt (e.g. a stub session for testing). The
-    // allowlist is per-key so missing a different opt still fails.
+    // Class can opt-out a specific key via a marker comment placed
+    // immediately above the class declaration. Use case: a future
+    // provider deliberately does not need a particular opt (e.g. a stub
+    // session for testing). The allowlist is per-key so missing a
+    // different opt still fails.
     const SUPPRESS_SRC = `
 import { BaseSession } from './base-session.js'
 


### PR DESCRIPTION
## Summary

Static lint that prevents the next instance of the **middle-layer trap** documented in project memory as `feedback_jsonl_subprocess_middle_layer.md`. The trap: provider session classes (`JsonlSubprocessSession`, `CodexSession`, `GeminiSession`, etc.) destructure a fixed key list in their constructor and forward via `super({ ... })`. When a new `BaseSession` opt is added, the middle layers silently drop it unless updated — which is how #4790 happened (and #3224, and #3231 before it).

Modelled on the existing `packages/server/scripts/lint-tests-state-file-path.{mjs,sh}` — same regex-walk pattern, same shell-wrapper-for-CI convention.

## How the lint works

1. Parses `packages/server/src/base-session.js` to extract the canonical set of constructor opt names from the `BaseSession` destructure (currently 19 opts).
2. Walks every `*.js` under `packages/server/src/` for classes that `extends BaseSession` or `extends JsonlSubprocessSession` (6 classes: cli, sdk, claude-tui, jsonl-subprocess, codex, gemini).
3. For each subclass: extracts the destructure key set + the `super({ ... })` key set, then diffs against the canonical set.
4. Reports any missing opt with `file:line` + class name + a pointer to the project-memory note.

Two opt-outs:
- `super(opts)` / `super({ ...opts })` style is naturally immune (covers `ClaudeByokSession`) and is skipped.
- `// lint-ignore-opt-forwarding: <key1>,<key2>` immediately above the class declaration whitelists specific keys (rare).

## Wiring

- New CI step in the `Server Lint` job (`.github/workflows/ci.yml`) — runs alongside the state-file-path lint.
- Documented in `CLAUDE.md` Testing Conventions section alongside the existing two-layer-defence pattern.

## Verification

- Passes on the current `main` — all 6 subclasses forward all 19 opts after #4795 / #4790.
- Catches the #4790 regression when `streamStallTimeoutMs` is removed from any of the three middle layers (verified locally by temporarily reverting).
- Test suite (`tests/lint-session-opt-forwarding.test.js`) covers happy path, both failure modes (drop-from-destructure and destructured-but-not-forwarded), rest-spread immunity, the real-tree acceptance criterion, and the per-key allowlist comment.

## Test plan

- [x] `cd packages/server && ./scripts/lint-session-opt-forwarding.sh` passes on this branch
- [x] `cd packages/server && node --import ./tests/_setup.mjs --test ./tests/lint-session-opt-forwarding.test.js` — all 6 subtests pass
- [x] Manually dropping `streamStallTimeoutMs` from `codex-session.js` causes the lint to fail with `codex-session.js:292 class CodexSession / Missing from constructor destructure: streamStallTimeoutMs`
- [ ] CI `Server Lint` job picks up the new step and passes

Closes #4797
Related: #4790 (fixed in #4795 — the trap that motivated this lint), #3224, #3231 (earlier instances of the same trap)
Project memory: `feedback_jsonl_subprocess_middle_layer.md`