### PR TITLE
refactor(server): harden _broadcastToSession against missing subscribedSessionIds (#4799)

### DIFF
--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -99,8 +99,10 @@ export class WsBroadcaster {
   /**
    * Broadcast a session-scoped message to clients viewing that session.
    * Tags the message with `sessionId` so clients can route it to the correct
-   * session state. By default only delivers to clients whose activeSessionId
-   * matches — prevents cross-session info leakage and bandwidth waste.
+   * session state. By default delivers to clients whose `activeSessionId`
+   * matches OR who have explicitly subscribed via `subscribedSessionIds` —
+   * prevents cross-session info leakage and bandwidth waste while still
+   * supporting multi-session subscribers (e.g. dashboard tabs).
    * Pass a custom filter to override the default recipient selection when needed.
    *
    * #4799: Guards against a client missing `subscribedSessionIds`. Clients
@@ -114,7 +116,7 @@ export class WsBroadcaster {
     if (client.activeSessionId === sessionId) return true
     if (client.subscribedSessionIds) return client.subscribedSessionIds.has(sessionId)
     if (client.authenticated && !client._missingSubscribedSessionIdsWarned) {
-      log.warn(`Client ${client.id} is authenticated but has no subscribedSessionIds Set — falling back to activeSessionId match only`)
+      log.warn(`Client ${client.id} is authenticated but has no subscribedSessionIds Set — falling back to activeSessionId match only (sessionId=${sessionId}, messageType=${message?.type || 'unknown'})`)
       client._missingSubscribedSessionIdsWarned = true
     }
     return false

--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -102,8 +102,23 @@ export class WsBroadcaster {
    * session state. By default only delivers to clients whose activeSessionId
    * matches — prevents cross-session info leakage and bandwidth waste.
    * Pass a custom filter to override the default recipient selection when needed.
+   *
+   * #4799: Guards against a client missing `subscribedSessionIds`. Clients
+   * should always be initialized with `new Set()` (see ws-server.js client
+   * registration), but a missing field would otherwise throw mid-iteration
+   * and abort the broadcast for every later client in the loop. If we
+   * encounter an authenticated client without the Set, log a one-shot
+   * warning to surface the real bug — the broadcast itself stays alive.
    */
-  _broadcastToSession(sessionId, message, filter = (client) => client.activeSessionId === sessionId || client.subscribedSessionIds.has(sessionId)) {
+  _broadcastToSession(sessionId, message, filter = (client) => {
+    if (client.activeSessionId === sessionId) return true
+    if (client.subscribedSessionIds) return client.subscribedSessionIds.has(sessionId)
+    if (client.authenticated && !client._missingSubscribedSessionIdsWarned) {
+      log.warn(`Client ${client.id} is authenticated but has no subscribedSessionIds Set — falling back to activeSessionId match only`)
+      client._missingSubscribedSessionIdsWarned = true
+    }
+    return false
+  }) {
     const tagged = { ...message, sessionId }
     for (const [ws, client] of this._clients) {
       if (client.authenticated && filter(client) && ws.readyState === 1) {

--- a/packages/server/tests/ws-broadcaster.test.js
+++ b/packages/server/tests/ws-broadcaster.test.js
@@ -198,6 +198,39 @@ describe('WsBroadcaster', () => {
       assert.equal(sent.length, 1)
       assert.equal(sent[0].ws, ws2)
     })
+
+    it('does not throw when a client is missing subscribedSessionIds (#4799)', () => {
+      // Defensive: a client could lack `subscribedSessionIds` (legacy fixture,
+      // future refactor, code bug). The default filter must not throw —
+      // otherwise the broadcast loop aborts mid-iteration and other clients
+      // miss the message.
+      const wsBroken = createFakeWs()
+      const wsOk = createFakeWs()
+      const brokenClient = createFakeClient({ id: 'broken', activeSessionId: 'other' })
+      brokenClient.subscribedSessionIds = undefined
+      clients.set(wsBroken, brokenClient)
+      clients.set(wsOk, createFakeClient({ id: 'ok', activeSessionId: 'sess-1' }))
+
+      assert.doesNotThrow(() => {
+        broadcaster._broadcastToSession('sess-1', { type: 'data' })
+      })
+
+      // The healthy client on the matching activeSessionId still receives it.
+      assert.equal(sent.length, 1)
+      assert.equal(sent[0].ws, wsOk)
+    })
+
+    it('still delivers to a client whose activeSessionId matches even with no subscribedSessionIds (#4799)', () => {
+      const ws = createFakeWs()
+      const client = createFakeClient({ id: 'c1', activeSessionId: 'sess-1' })
+      client.subscribedSessionIds = undefined
+      clients.set(ws, client)
+
+      broadcaster._broadcastToSession('sess-1', { type: 'data' })
+
+      assert.equal(sent.length, 1)
+      assert.equal(sent[0].ws, ws)
+    })
   })
 
   describe('_broadcastClientJoined()', () => {


### PR DESCRIPTION
## Summary

- Default filter for `_broadcastToSession` no longer throws when a client lacks `subscribedSessionIds`. Falls back to an `activeSessionId === sessionId` check and logs a one-shot warning so any real upstream bug stays visible.
- Adds regression tests covering both undefined-but-non-matching and undefined-but-matching `activeSessionId` cases.

## Why

Surfaced during `/full-review` of #4794. Every client *should* have `subscribedSessionIds: new Set()` (see `ws-server.js` client registration), but a missing field would otherwise throw `Cannot read properties of undefined (reading 'has')` mid-iteration, aborting the broadcast loop and silently dropping the message for every client later in the loop. `input-handlers.js` already defensively guards the same access — doing it in the default filter costs nothing and prevents the foot-gun.

## Test plan

- [x] `node --test tests/ws-broadcaster.test.js` — new 4799 tests fail before the fix with the exact `Cannot read properties of undefined (reading 'has')` error from the issue; pass after.
- [x] All 90 broadcast-related tests pass (`ws-broadcaster`, `ws-server-broadcast`, `permission-*-broadcast`, `tunnel-warming-broadcast`, `ws-server-log-broadcast`).
- [x] Full server suite run: 6533 pass / 6 fail. The 6 failures are in `base-session.test.js` and `byok-tool-executor.test.js`, unrelated to this change, and pass when run in isolation (test-order flake on main).

Closes #4799