### PR TITLE
refactor(server): unify ws-client-sender backpressure with ws-broadcaster (#4804)

### DIFF
--- a/packages/server/src/ws-client-sender.js
+++ b/packages/server/src/ws-client-sender.js
@@ -1,4 +1,5 @@
 import { encrypt, DIRECTION_SERVER } from '@chroxy/store-core/crypto'
+import { metrics } from './metrics.js'
 
 /** Backpressure thresholds (bytes) */
 const WARN_THRESHOLD = 64 * 1024    // 64KB — log warning
@@ -12,6 +13,16 @@ const WARN_THROTTLE_MS = 30_000
  * Handles JSON serialization, optional encryption, sequence numbering,
  * post-auth queue buffering, flush-overflow buffering, and post-send
  * backpressure monitoring.
+ *
+ * Post-send backpressure is intentionally distinct from the pre-send
+ * check in `WsBroadcaster._sendOneWithBackpressure` (#4775). The
+ * broadcaster only protects multi-recipient broadcast paths; single-
+ * recipient sends from `WsServer._send` (pong, token_rotated,
+ * auth_fail, rate_limited, server_status, error, etc.) bypass the
+ * broadcaster entirely, so this post-send path is the only thing that
+ * evicts a slow client on those code paths. Per #4804 both paths must
+ * emit `backpressure.disconnects` so alerting catches either eviction
+ * source — see `metrics.inc('backpressure.disconnects')` below.
  *
  * @param {object} log - Logger with .error() and .warn() methods
  * @param {object} [opts] - Optional overrides (for testing)
@@ -56,6 +67,10 @@ export function createClientSender(log, opts = {}) {
       const buffered = ws.bufferedAmount
       if (buffered > evictThreshold && client) {
         log.warn(`Backpressure: evicting client ${client.id} — bufferedAmount ${buffered} exceeds ${evictThreshold} bytes`)
+        // #4804: unify observability with WsBroadcaster._sendOneWithBackpressure
+        // so both backpressure systems feed the same metric. Without this the
+        // single-recipient eviction path silently bypasses alerting.
+        metrics.inc('backpressure.disconnects')
         ws.close(4008, 'Backpressure: slow client evicted')
       } else if (buffered > warnThreshold && client) {
         const now = Date.now()

--- a/packages/server/tests/ws-backpressure-monitoring.test.js
+++ b/packages/server/tests/ws-backpressure-monitoring.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { createClientSender } from '../src/ws-client-sender.js'
+import { metrics } from '../src/metrics.js'
 
 describe('ws-client-sender backpressure monitoring (#2205)', () => {
   let warnings
@@ -185,6 +186,61 @@ describe('ws-client-sender backpressure monitoring (#2205)', () => {
       assert.equal(warnings.length, 1)
       assert.match(warnings[0], /warning threshold/)
       assert.equal(ws._closed, false)
+    })
+  })
+
+  // #4804: the post-send path in ws-client-sender is a second, semantically
+  // distinct backpressure system from WsBroadcaster._sendOneWithBackpressure
+  // (which is pre-send). It catches slow clients on single-recipient sends
+  // that bypass the broadcaster entirely (pong, token_rotated, auth_fail,
+  // rate_limited, server_status, error, etc. — see ws-server.js _send call
+  // sites). Without metrics, evictions on those paths silently bypass the
+  // observability that #4775 was specifically trying to add.
+  describe('observability metrics (#4804)', () => {
+    beforeEach(() => {
+      metrics.reset()
+    })
+
+    it('increments backpressure.disconnects when evicting a slow client', () => {
+      send = createClientSender(log, { warnThreshold: 100, evictThreshold: 500, warnThrottleMs: 0 })
+      const ws = makeWs(600) // above evict threshold
+      const client = makeClient()
+
+      send(ws, client, { type: 'test' })
+
+      assert.equal(ws._closed, true, 'sanity: client should be evicted')
+      assert.equal(metrics.get('backpressure.disconnects'), 1, 'eviction must fire the disconnects metric')
+    })
+
+    it('does not increment backpressure.disconnects on warn-only events', () => {
+      send = createClientSender(log, { warnThreshold: 100, evictThreshold: 10000, warnThrottleMs: 0 })
+      const ws = makeWs(200) // above warn, below evict
+      const client = makeClient()
+
+      send(ws, client, { type: 'test' })
+
+      assert.equal(ws._closed, false, 'sanity: warn-only, no close')
+      assert.equal(metrics.get('backpressure.disconnects'), 0)
+    })
+
+    it('does not increment backpressure.disconnects when client is undefined', () => {
+      send = createClientSender(log, { warnThreshold: 100, evictThreshold: 500, warnThrottleMs: 0 })
+      const ws = makeWs(600)
+
+      // No client to evict — should be a no-op for metrics too
+      send(ws, undefined, { type: 'test' })
+
+      assert.equal(metrics.get('backpressure.disconnects'), 0)
+    })
+
+    it('does not increment on successful sends below warn threshold', () => {
+      send = createClientSender(log, { warnThreshold: 100, evictThreshold: 500, warnThrottleMs: 0 })
+      const ws = makeWs(50)
+      const client = makeClient()
+
+      send(ws, client, { type: 'test' })
+
+      assert.equal(metrics.get('backpressure.disconnects'), 0)
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes #4804. Related to #4775 (the partial unification that left this gap).

`ws-broadcaster.js _sendOneWithBackpressure` (pre-send, #4775) and
`ws-client-sender.js` (post-send, #2205) are **two distinct backpressure
systems** with different thresholds, different trigger conditions, and —
until this PR — different observability:

| | pre-send (broadcaster) | post-send (client-sender) |
|---|---|---|
| Threshold | 1MB (pre-write) | 64KB warn / 1MB evict (post-write) |
| Drop counter | yes (10-deep) | n/a (instant evict at 1MB) |
| `backpressure.drops` | yes | n/a |
| `backpressure.disconnects` | yes | **no** (silent eviction) |

## Why keep the post-send path

The audit's first option ("delete it, rely on pre-send") loses coverage
for every single-recipient `WsServer._send` call site — `pong`,
`token_rotated`, `auth_fail`, `rate_limited`, `server_status`, `error`,
`server_error`. Those don't iterate through `_sendOneWithBackpressure`,
so deleting the post-send path would leave them unprotected against slow
clients. Audit option B (route the eviction through the metric) is
strictly additive and closes the observability gap without losing
coverage.

## Changes

- `packages/server/src/ws-client-sender.js`: call
  `metrics.inc('backpressure.disconnects')` from the post-send eviction
  branch; add JSDoc explaining why both backpressure paths coexist so
  the next reader doesn't repeat this audit.
- `packages/server/tests/ws-backpressure-monitoring.test.js`: new
  `observability metrics (#4804)` describe block — asserts the metric
  fires on eviction, doesn't fire on warn-only / no-client / healthy
  sends.

## Test plan

- [x] `node --test tests/ws-backpressure-monitoring.test.js` — new
  observability suite passes (4/4)
- [x] `node --test tests/ws-client-sender.test.js tests/ws-broadcaster.test.js tests/ws-server-backpressure.test.js tests/ws-server-broadcast.test.js tests/ws-server-log-broadcast.test.js` — 103/103
- [x] Full server suite: only pre-existing env-dependent failures
  (service port test, TunnelManager Integration "requires cloudflared",
  WebTaskManager feature detection) — confirmed identical on `main`