### PR TITLE
fix(server): strip control bytes from single-line PTY freeform input (#4805)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1363,13 +1363,50 @@ export class ClaudeTuiSession extends BaseSession {
       return finish('paste', true)
     }
 
+    // #4805: single-line throttled path used to feed `freeformText`
+    // verbatim into _term.write — no defense against C0 control bytes
+    // or ANSI CSI / OSC sequences embedded in the input. The newline
+    // bracketed-paste branch above (#4678) already strips embedded
+    // `\x1b[201~` markers and explicitly cites attacker-controlled MCP
+    // tool results as the threat model; the single-line branch has the
+    // same input shape and now applies the parallel defense.
+    //
+    // Stripped (in this order, since the first match wins):
+    //   - ANSI CSI: ESC [ <params> <final> (final is A-Z or a-z)
+    //   - OSC: ESC ] <payload> (BEL | ESC \) — title-set + friends
+    //   - Other C0 control bytes \x00-\x08 + \x0b-\x1a + \x1c-\x1f
+    //     + \x7f, plus any leftover lone ESC (\x1b) — excludes \t
+    //     (normal printable whitespace) and \r/\n (which never reach
+    //     this path; the multi-line branch handles them)
+    // Note: the CSI / OSC alternations come BEFORE the C0 range so a
+    // full escape sequence is matched as one unit. If the lone-byte
+    // class came first the regex would peel off the \x1b introducer
+    // and leave the [<final> bytes as printable garbage.
+    // Known damage paths covered:
+    //   - \x03 (Ctrl-C) aborts the active TUI form
+    //   - OSC \x1b]0;...\x07 rewrites the window title on some hosts
+    //   - Long CSI sequences desync the input-mode state machine and
+    //     trigger the recurring wedge symptom class
+    const originalLength = text.length
+    text = text.replace(
+      // eslint-disable-next-line no-control-regex
+      /\x1b\[[\d;]*[A-Za-z]|\x1b\][\s\S]*?(?:\x07|\x1b\\)|[\x00-\x08\x0b-\x1a\x1c-\x1f\x7f]/g,
+      '',
+    )
+    if (text.length !== originalLength) {
+      log.warn(`writePtyText (msg=${this._activeTurn?.messageId ?? 'none'}) stripped ${originalLength - text.length} control/escape bytes from single-line input (#4805)`)
+    }
+    // Re-compute counts now that the body may have shrunk so the bulk-
+    // path threshold check + finish() bookkeeping stay accurate.
+    const sanitizedCodePointCount = [...text].length
+
     this._term.write('\x1b[?2004l')
     try {
       // #4276: huge prompts bypass the throttle. Code-point count
       // (counted once at function entry) keeps the threshold
       // consistent with how the loop iterates — an emoji-only 5000-
       // char string [...].length is 5000, not 10000.
-      if (codePointCount > ClaudeTuiSession.MAX_THROTTLED_CHARS) {
+      if (sanitizedCodePointCount > ClaudeTuiSession.MAX_THROTTLED_CHARS) {
         // Re-check the turn lifecycle exactly once before the bulk
         // write — same shape as the loop's per-iter guards, so a
         // caller that aborted between scheduling and execution doesn't

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1365,36 +1365,69 @@ export class ClaudeTuiSession extends BaseSession {
 
     // #4805: single-line throttled path used to feed `freeformText`
     // verbatim into _term.write — no defense against C0 control bytes
-    // or ANSI CSI / OSC sequences embedded in the input. The newline
+    // or ANSI escape sequences embedded in the input. The newline
     // bracketed-paste branch above (#4678) already strips embedded
     // `\x1b[201~` markers and explicitly cites attacker-controlled MCP
     // tool results as the threat model; the single-line branch has the
-    // same input shape and now applies the parallel defense.
+    // same input shape and applies the parallel defense.
     //
     // Stripped (in this order, since the first match wins):
-    //   - ANSI CSI: ESC [ <params> <final> (final is A-Z or a-z)
-    //   - OSC: ESC ] <payload> (BEL | ESC \) — title-set + friends
-    //   - Other C0 control bytes \x00-\x08 + \x0b-\x1a + \x1c-\x1f
-    //     + \x7f, plus any leftover lone ESC (\x1b) — excludes \t
-    //     (normal printable whitespace) and \r/\n (which never reach
-    //     this path; the multi-line branch handles them)
-    // Note: the CSI / OSC alternations come BEFORE the C0 range so a
-    // full escape sequence is matched as one unit. If the lone-byte
-    // class came first the regex would peel off the \x1b introducer
-    // and leave the [<final> bytes as printable garbage.
+    //   - ANSI CSI: ESC [ <params 0x30-0x3f> <intermediates 0x20-0x2f>
+    //     <final 0x40-0x7e> — the full ECMA-48 grammar including
+    //     DEC-private sequences `?`/`<`/`=`/`>`/`:` (W2 #4805)
+    //   - String controls: ESC ] / P / X / ^ / _ <payload> (BEL | ESC \)
+    //     — covers OSC (title-set), DCS (sixel/ReGIS/termcap),
+    //     SOS / PM / APC (W2 #4805 — original regex covered OSC only)
+    //   - Stray two-byte ESC + final-byte sequences: RIS `\x1b c`,
+    //     DECSC/DECRC `\x1b 7`/`8`, IND/RI/NEL/HTS `\x1b D`/`M`/`E`/`H`,
+    //     keypad-mode `\x1b =`/`>` — `\x1b.?` catch-all (W2 #4805)
+    //   - C0 control bytes \x00-\x08 + \x0b-\x1f + \x7f — the range
+    //     now includes \x1b so any unmatched lone ESC is stripped
+    //     (W2 #4805 closed the 0x1b char-class gap). Excludes \t (a
+    //     normal printable whitespace a user may paste); \r/\n never
+    //     reach this path (the multi-line branch handles them).
+    // Note: the sequence-matching alternations come BEFORE the
+    // C0 class so a full escape is matched as one unit. If the
+    // lone-byte class came first the regex would peel off the \x1b
+    // introducer and leave the [<final> bytes as printable garbage.
     // Known damage paths covered:
     //   - \x03 (Ctrl-C) aborts the active TUI form
     //   - OSC \x1b]0;...\x07 rewrites the window title on some hosts
-    //   - Long CSI sequences desync the input-mode state machine and
-    //     trigger the recurring wedge symptom class
-    const originalLength = text.length
+    //   - DEC-private CSI (\x1b[?25l hide-cursor, \x1b[?1049h alt-
+    //     screen, \x1b[?1000h / \x1b[?1006h mouse-tracking) desync
+    //     the TUI input state machine — the recurring wedge symptom
+    //     class
+    //   - RIS \x1b c full-terminal-reset clears the scrollback
+    //   - APC payloads (iTerm2 proprietary commands)
+    const stripped = []
     text = text.replace(
       // eslint-disable-next-line no-control-regex
-      /\x1b\[[\d;]*[A-Za-z]|\x1b\][\s\S]*?(?:\x07|\x1b\\)|[\x00-\x08\x0b-\x1a\x1c-\x1f\x7f]/g,
-      '',
+      /\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]|\x1b[\]PX^_][\s\S]*?(?:\x07|\x1b\\)|\x1b.?|[\x00-\x08\x0b-\x1f\x7f]/g,
+      (match) => {
+        stripped.push(match)
+        return ''
+      },
     )
-    if (text.length !== originalLength) {
-      log.warn(`writePtyText (msg=${this._activeTurn?.messageId ?? 'none'}) stripped ${originalLength - text.length} control/escape bytes from single-line input (#4805)`)
+    if (stripped.length > 0) {
+      // Bounded hex preview (first 32 stripped bytes total) gives an
+      // incident-response footprint without blowing the log on a
+      // malicious flood. Sequences are concatenated then truncated so
+      // each warn line carries the same payload shape regardless of
+      // how many distinct sequences were stripped.
+      const totalBytes = stripped.reduce((n, s) => n + Buffer.byteLength(s, 'utf8'), 0)
+      const sampleHex = Buffer.from(stripped.join(''), 'utf8').slice(0, 32).toString('hex')
+      const truncated = totalBytes > 32 ? ',…' : ''
+      log.warn(`writePtyText (msg=${this._activeTurn?.messageId ?? 'none'}) stripped ${totalBytes} control/escape bytes from single-line input (sample=${sampleHex}${truncated}) (#4805)`)
+    }
+    // After stripping, an all-control-byte prompt can collapse to an
+    // empty body. Mirror the multi-line branch's `body.length === 0`
+    // guard (:1358): abort the turn cleanly rather than write a bare
+    // \r submit to the TUI — the caller sees a finished turn (no
+    // message ever leaves chroxy) instead of chroxy claiming to have
+    // sent and waiting forever for a reply.
+    if (text.length === 0) {
+      onAbort?.()
+      return finish('throttled-empty', false)
     }
     // Re-compute counts now that the body may have shrunk so the bulk-
     // path threshold check + finish() bookkeeping stay accurate.

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1439,6 +1439,172 @@ describe('ClaudeTuiSession', () => {
       assert.equal(charWrites.join(''), clean,
         'printable + tab + multi-byte text is preserved byte-for-byte')
     })
+
+    // #4805 Wave 2: the original strip regex left three classes of bytes
+    // through (Copilot + agent-review caught these post-merge):
+    //   1. Lone \x1b — char class [\x00-\x08\x0b-\x1a\x1c-\x1f\x7f] has
+    //      a gap at 0x1b (between 0x1a and 0x1c). The comment claimed
+    //      lone ESC was stripped; the code didn't deliver.
+    //   2. CSI parameter bytes 0x30-0x3f — the original `[\d;]*` covers
+    //      only digits + ';', missing DEC-private intro bytes `?`/`<`/
+    //      `=`/`>`/`:`. So `\x1b[?25l`, `\x1b[?1049h`, `\x1b[?1000h`,
+    //      `\x1b[?1006h` all pass through.
+    //   3. String-control introducers other than OSC — DCS `\x1b P`,
+    //      APC `\x1b _`, PM `\x1b ^`, SOS `\x1b X` were not in the
+    //      alternation. Some terminals (iTerm2) execute APC payloads.
+    //
+    // The Wave 2 regex broadens CSI to the full ECMA-48 grammar
+    // (params 0x30-0x3f, intermediates 0x20-0x2f, final 0x40-0x7e),
+    // adds DCS/APC/PM/SOS to the string-control alternation, adds a
+    // `\x1b.?` catch-all for stray two-byte ESC + final-byte sequences
+    // (RIS \x1b c, DECSC/DECRC \x1b 7/8, IND/RI/NEL/HTS \x1b D/M/E/H),
+    // and extends the C0 class to \x1f so a lone ESC is always stripped.
+    it('_writePtyTextThrottled: strips DEC-private CSI sequences (W2 #4805)', async () => {
+      // \x1b[?25l hides the cursor; \x1b[?1049h switches to the alt
+      // screen. Both are CSI sequences with `?` as the first parameter
+      // byte (0x3F, in the 0x30-0x3f param range). The original
+      // `[\d;]*` regex skipped them.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { messageId: 'm-dec', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      const completed = await session._writePtyTextThrottled('a\x1b[?25lb\x1b[?1049hc')
+
+      assert.equal(completed, true)
+      const charWrites = writes.slice(1, writes.indexOf('\r'))
+      const joined = charWrites.join('')
+      assert.equal(joined.includes('\x1b'), false, 'no ESC bytes survive DEC-private strip')
+      assert.equal(joined.includes('?'), false, 'no DEC-private parameter intro bytes survive')
+      assert.equal(joined.includes('25l'), false, 'no DEC sequence tail leaks as printable garbage')
+      assert.equal(joined.includes('1049h'), false, 'no alt-screen sequence tail leaks')
+      assert.equal(joined, 'abc', 'surrounding text preserved with both DEC sequences fully excised')
+    })
+
+    it('_writePtyTextThrottled: strips stray two-byte ESC + final-byte sequences like RIS (W2 #4805)', async () => {
+      // RIS (ESC + 'c', byte sequence `\x1bc`) is the full terminal-
+      // reset escape — clears scrollback, resets colours/attributes.
+      // The original regex matched CSI/OSC only; `\x1bc` passed
+      // through entirely (ESC in the char-class gap, `c` printable).
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { messageId: 'm-ris', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      const completed = await session._writePtyTextThrottled('keep\x1bcmore')
+
+      assert.equal(completed, true)
+      const charWrites = writes.slice(1, writes.indexOf('\r'))
+      const joined = charWrites.join('')
+      assert.equal(joined.includes('\x1b'), false, 'ESC byte stripped')
+      // The \x1b.? alternation consumes ESC + one trailing byte, so the
+      // `c` final byte of RIS goes with it; the surrounding "keep" and
+      // "more" land cleanly with no `c` between them.
+      assert.equal(joined, 'keepmore', 'RIS escape sequence fully excised')
+    })
+
+    it('_writePtyTextThrottled: strips APC payloads terminated by ST (W2 #4805)', async () => {
+      // APC (\x1b _ ... \x1b\\) — iTerm2 interprets these for
+      // proprietary commands. Original regex matched OSC only; APC
+      // body passed through as printable text.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { messageId: 'm-apc', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      const completed = await session._writePtyTextThrottled('pre\x1b_evil\x1b\\post')
+
+      assert.equal(completed, true)
+      const charWrites = writes.slice(1, writes.indexOf('\r'))
+      const joined = charWrites.join('')
+      assert.equal(joined.includes('\x1b'), false, 'no ESC bytes survive')
+      assert.equal(joined.includes('evil'), false, 'APC payload between introducer and ST is dropped')
+      assert.equal(joined, 'prepost', 'APC sequence fully excised with surrounding text preserved')
+    })
+
+    it('_writePtyTextThrottled: strips a lone ESC byte (W2 #4805 regression guard)', async () => {
+      // The original char class [\x00-\x08\x0b-\x1a\x1c-\x1f\x7f] had a
+      // gap at 0x1b. The block comment claimed ESC was stripped; the
+      // code didn't. The Wave 2 regex either matches ESC via the
+      // \x1b.? catch-all OR via the broadened class [\x00-\x08\x0b-\x1f
+      // \x7f]. Either way a bare ESC must not survive.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { messageId: 'm-lone-esc', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      // Trailing ESC at end-of-string — the \x1b.? alternation matches
+      // ESC + optional next byte, so a trailing bare ESC matches with
+      // an empty optional group and is dropped.
+      const completed = await session._writePtyTextThrottled('hello\x1b')
+
+      assert.equal(completed, true)
+      const charWrites = writes.slice(1, writes.indexOf('\r'))
+      const joined = charWrites.join('')
+      assert.equal(joined.includes('\x1b'), false, 'lone trailing ESC stripped')
+      assert.equal(joined, 'hello', 'surrounding text preserved')
+    })
+
+    it('_writePtyTextThrottled: handles all-control-byte input cleanly (W2 #4805 empty-after-strip)', async () => {
+      // Mirror the multi-line branch's `body.length === 0` guard
+      // (:1358): if the post-strip body is empty, abort the turn
+      // cleanly rather than submitting a bare \r to the TUI. Without
+      // the guard the single-line path would still write the bracketed-
+      // paste-disable + zero-iteration loop + \r submit, which is at
+      // best a no-op and at worst an empty prompt the TUI doesn't
+      // expect.
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { messageId: 'm-empty', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      let onAbortCalled = false
+      const completed = await session._writePtyTextThrottled('\x03\x1b[A\x07\x1b]0;t\x07', {
+        onAbort: () => { onAbortCalled = true },
+      })
+
+      assert.equal(completed, false, 'empty-after-strip returns false (no message left chroxy)')
+      assert.equal(onAbortCalled, true, 'onAbort fires so caller surfaces a finished-but-empty turn')
+      assert.equal(writes.includes('\r'), false, 'no bare \\r submit on empty body')
+      // The disable + finally re-enable bookends are fine to emit
+      // (they're idempotent terminal state) — what matters is no body
+      // and no \r reached the PTY.
+    })
+
+    it('_writePtyTextThrottled: audit log includes hex sample of stripped bytes (W2 #4805)', async () => {
+      // The original warn line said only "stripped N bytes" — useless
+      // for forensics on a real attack. The Wave 2 audit log includes
+      // a bounded hex-encoded sample (first 32 bytes) so an operator
+      // can grep for known-bad signatures and an incident-response
+      // run-book has the bytes themselves.
+      const warnLines = []
+      const logSpy = (entry) => {
+        if (entry.level === 'warn' && entry.component === 'claude-tui-session') {
+          warnLines.push(entry.message)
+        }
+      }
+      addLogListener(logSpy)
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._activeTurn = { messageId: 'm-audit', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+        session._term = { write: () => {}, kill: () => {} }
+
+        // \x03 (Ctrl-C) + \x1b[A (CSI cursor-up). Hex-encoded these are
+        // "03" and "1b5b41".
+        await session._writePtyTextThrottled('a\x03b\x1b[Ac')
+
+        const strip = warnLines.find((m) => /stripped \d+ control\/escape bytes/.test(m))
+        assert.ok(strip, `expected strip warn line, got warnLines=${JSON.stringify(warnLines)}`)
+        assert.match(strip, /msg=m-audit/, 'warn carries the active turn messageId')
+        assert.match(strip, /sample=/, 'warn includes a stripped-bytes sample field')
+        // The hex sample must contain the bytes we sent — both \x03
+        // (Ctrl-C) and the full CSI \x1b[A sequence.
+        assert.match(strip, /03/, 'hex sample contains the stripped Ctrl-C byte (0x03)')
+        assert.match(strip, /1b5b41/, 'hex sample contains the stripped CSI cursor-up bytes (\\x1b[A)')
+      } finally {
+        removeLogListener(logSpy)
+      }
+    })
   })
 
   describe('attachment-cap warn lines (#4216)', () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1344,6 +1344,101 @@ describe('ClaudeTuiSession', () => {
       // sent at a stale PTY.
       assert.equal(writes.includes(huge), false, 'large body never reaches a torn-down PTY')
     })
+
+    // #4805: the single-line throttled path fed each code-point verbatim
+    // into _term.write — no defense against C0 control bytes or ANSI
+    // CSI / OSC sequences embedded in the freeform input. The newline
+    // bracketed-paste branch (#4678) already strips embedded `\x1b[201~`
+    // markers and explicitly cites attacker-controlled MCP tool results
+    // as the threat model; the single-line branch has the same input
+    // shape (freeformText from the dashboard, Zod-bounded only to
+    // string + 100KB length) and so needs parallel defense.
+    //
+    // Known damage paths from the audit:
+    //   - `\x03` (Ctrl-C) aborts the active form
+    //   - OSC `\x1b]0;...\x07` → terminal-title injection on some hosts
+    //   - Long ANSI CSI sequences desync the TUI input state machine
+    //     (the recurring wedge symptom class)
+    //
+    // The fix strips C0 control bytes (excluding \t which is whitespace
+    // the user might paste) and ANSI CSI / OSC sequences before the
+    // per-char loop. Tab is kept because it's a normal printable
+    // whitespace; \r and \n never reach this path (the multi-line branch
+    // handles them).
+    it('_writePtyTextThrottled: strips C0 control bytes (Ctrl-C) from single-line input (#4805)', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { messageId: 'm-c0', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      // Ctrl-C embedded mid-prompt. Without the strip the per-char loop
+      // would write \x03 verbatim and abort the TUI form.
+      const completed = await session._writePtyTextThrottled('hello\x03world')
+
+      assert.equal(completed, true)
+      // The combined per-char writes (chars between the disable/enable
+      // bookends and the \r submit) must contain no \x03 byte.
+      const charWrites = writes.slice(1, writes.indexOf('\r'))
+      const joined = charWrites.join('')
+      assert.equal(joined.includes('\x03'), false, 'Ctrl-C byte is stripped from the per-char write stream')
+      assert.equal(joined, 'helloworld', 'surrounding printable text passes through with the control byte excised')
+    })
+
+    it('_writePtyTextThrottled: strips ANSI CSI cursor sequences from single-line input (#4805)', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { messageId: 'm-csi', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      // ANSI CSI cursor-up sequence embedded in the body — drives the
+      // TUI's input cursor in ways the user never typed.
+      const completed = await session._writePtyTextThrottled('foo\x1b[Abar')
+
+      assert.equal(completed, true)
+      const charWrites = writes.slice(1, writes.indexOf('\r'))
+      const joined = charWrites.join('')
+      assert.equal(joined.includes('\x1b'), false, 'ESC byte is stripped (no surviving CSI introducer)')
+      assert.equal(joined.includes('[A'), false, 'CSI tail bytes go with the introducer')
+      assert.equal(joined, 'foobar', 'CSI sequence is fully excised, surrounding text preserved')
+    })
+
+    it('_writePtyTextThrottled: strips OSC title-set sequences from single-line input (#4805)', async () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { messageId: 'm-osc', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      // OSC title-set: ESC ] 0 ; <title> BEL. On terminal hosts that
+      // honour OSC even inside the input box this rewrites the window
+      // title from attacker-controlled bytes.
+      const completed = await session._writePtyTextThrottled('hi\x1b]0;evil\x07there')
+
+      assert.equal(completed, true)
+      const charWrites = writes.slice(1, writes.indexOf('\r'))
+      const joined = charWrites.join('')
+      assert.equal(joined.includes('\x1b'), false, 'OSC ESC is stripped')
+      assert.equal(joined.includes('\x07'), false, 'BEL terminator is stripped')
+      assert.equal(joined.includes('evil'), false, 'OSC payload between ESC ] and BEL is dropped')
+      assert.equal(joined, 'hithere', 'OSC sequence is fully excised, surrounding text preserved')
+    })
+
+    it('_writePtyTextThrottled: passes normal printable text through untouched (#4805)', async () => {
+      // Regression guard for the strip — printable ASCII, tabs, and
+      // multi-byte BMP/non-BMP characters must survive byte-for-byte.
+      // (Newlines are handled by the multi-line branch, not this one.)
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._activeTurn = { messageId: 'm-clean', startedAt: Date.now(), aborted: false, synthSeq: 0 }
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+
+      const clean = 'hello\tworld 你好 🚀 !@#$%^&*()'
+      const completed = await session._writePtyTextThrottled(clean)
+
+      assert.equal(completed, true)
+      const charWrites = writes.slice(1, writes.indexOf('\r'))
+      assert.equal(charWrites.join(''), clean,
+        'printable + tab + multi-byte text is preserved byte-for-byte')
+    })
   })
 
   describe('attachment-cap warn lines (#4216)', () => {


### PR DESCRIPTION
## Summary

Audit P1.4 (swarm-audit adversary finding #3): the single-line path of `_writePtyTextThrottled` in `claude-tui-session.js` fed each code-point verbatim into `_term.write` with no defense against C0 control bytes or ANSI CSI / OSC sequences embedded in the freeform input.

The multi-line bracketed-paste branch (#4678) already strips embedded `\x1b[201~` markers and explicitly cites attacker-controlled MCP tool results as the threat model. The single-line branch had the same input shape (`freeformText` from the dashboard, Zod-bounded only to string + 100KB length) and so needed parallel defense.

## Threat model

Known damage paths from the audit:

- `\x03` (Ctrl-C) aborts the active TUI form
- OSC `\x1b]0;...\x07` rewrites the window title on some terminal hosts
- Long ANSI CSI sequences desync the TUI input-mode state machine, triggering the recurring wedge symptom class

## Fix

At the single-line entry of `_writePtyTextThrottled` (after the multi-line branch returns), apply a strip regex before the per-char loop:

```js
/\x1b\[[\d;]*[A-Za-z]|\x1b\][\s\S]*?(?:\x07|\x1b\\)|[\x00-\x08\x0b-\x1a\x1c-\x1f\x7f]/g
```

Match-order matters: CSI and OSC come BEFORE the lone-byte class so an escape sequence is matched as one unit. If the C0 range came first the regex would peel off the `\x1b` introducer and leave the `[<final>` bytes as printable garbage.

`\t` (HT) is intentionally NOT stripped — it's normal printable whitespace a user might paste. `\r` / `\n` never reach this path; the multi-line branch handles them upstream.

A `log.warn` line fires whenever bytes are stripped so the audit trail captures any real-world injection attempt.

## Parity with the bracketed-paste branch

This mirrors the defense-in-depth pattern at `claude-tui-session.js:1345` where the multi-line path already strips embedded `\x1b[201~` markers from attacker-controlled content. Same threat model, same input shape, now same defense applied.

## Test plan

- [x] New RED tests in `claude-tui-session.test.js` covering each threat:
  - Feed `freeformText` with `\x03` (Ctrl-C) — assert PTY receives no `\x03`
  - Feed with `\x1b[A` (ANSI CSI cursor-up) — assert no ESC, no `[A` tail bytes
  - Feed with `\x1b]0;evil\x07` (OSC title-set) — assert ESC + BEL + payload all stripped
  - Feed with `'hello\tworld 你好 🚀 !@#$%^&*()'` — assert byte-for-byte preservation (regression guard)
- [x] All 175 tests in `claude-tui-session.test.js` pass after the fix (no regression in existing TUI form-driving / bracketed-paste / throttle tests)
- [x] Server suite ran; pre-existing `@anthropic-ai/claude-agent-sdk` `ERR_MODULE_NOT_FOUND` failures are worktree-env artifacts unrelated to this change

Closes #4805