### PR TITLE
cleanup: remove dead serverMode === 'terminal' branch across 4 packages (#4810)

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -982,12 +982,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // Track this URL as successfully connected
       lastConnectedUrl = ctx.url;
       // #4766: full wire-shape decode lives in the shared parser
-      // (handleAuthOk + parseConnectedClients). The shared handler accepts
-      // both 'cli' and 'terminal' as serverMode; the app has no terminal
-      // view so we narrow 'terminal' to null (matches prior inline
-      // `msg.serverMode === 'cli' ? 'cli' : null` behaviour).
+      // (handleAuthOk + parseConnectedClients). The shared handler narrows
+      // serverMode to `'cli' | null` (#4810: the wire protocol only emits
+      // `'cli'`; the `'terminal'` branch was removed).
       const auth = sharedAuthOk(msg);
-      const authServerMode: 'cli' | null = auth.serverMode === 'cli' ? 'cli' : null;
+      const authServerMode: 'cli' | null = auth.serverMode;
       const clients = sharedParseConnectedClients(msg.connectedClients, auth.myClientId);
 
       // If server provided a sessionToken (via pairing), use it for future auth
@@ -1138,11 +1137,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'server_mode': {
-      // App has no terminal view, so 'terminal' is treated as null (matches
-      // prior inline behaviour `msg.mode === 'cli' ? 'cli' : null`).
+      // #4810: shared handler narrows `mode` to `'cli' | null` (the wire
+      // protocol only ever emits `'cli'`; previously the handler also
+      // accepted `'terminal'` but that branch was unreachable).
       const { mode } = sharedServerMode(msg);
-      const newServerMode: 'cli' | null = mode === 'cli' ? 'cli' : null;
-      useConnectionLifecycleStore.getState().setServerInfo({ serverMode: newServerMode });
+      useConnectionLifecycleStore.getState().setServerInfo({ serverMode: mode });
       // Force chat view in CLI mode (no terminal available)
       if (mode === 'cli' && get().viewMode === 'terminal') {
         set({ viewMode: 'chat' });

--- a/packages/dashboard/src/store/auth-ok-handler.test.ts
+++ b/packages/dashboard/src/store/auth-ok-handler.test.ts
@@ -355,16 +355,18 @@ describe('auth_ok handler', () => {
       expect(store.getState().serverMode).toBe('cli')
     })
 
-    it('sets serverMode to terminal when serverMode is terminal', () => {
-      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
-      handleMessage(createAuthOkMessage({ serverMode: 'terminal' }), ctx as any)
-
-      expect(store.getState().serverMode).toBe('terminal')
-    })
-
     it('sets serverMode to null for unknown mode', () => {
+      // #4810: the wire protocol only emits 'cli'; 'terminal' and other
+      // values are treated as unknown (previously 'terminal' was accepted).
       const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
       handleMessage(createAuthOkMessage({ serverMode: 'unknown_mode' }), ctx as any)
+
+      expect(store.getState().serverMode).toBeNull()
+    })
+
+    it('sets serverMode to null when serverMode is terminal (dead branch, #4810)', () => {
+      const ctx = { url: 'wss://t', token: 'tok', socket: mockSocket, isReconnect: false, silent: false }
+      handleMessage(createAuthOkMessage({ serverMode: 'terminal' }), ctx as any)
 
       expect(store.getState().serverMode).toBeNull()
     })

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -419,8 +419,8 @@ export interface ConnectionState {
   // User explicitly disconnected — prevents auto-reconnect on ConnectScreen mount
   userDisconnected: boolean;
 
-  // Server mode: 'cli' (headless) or 'terminal' (PTY/tmux)
-  serverMode: 'cli' | 'terminal' | null;
+  // Server mode: 'cli' (headless). The wire protocol only emits 'cli' (#4810).
+  serverMode: 'cli' | null;
 
   // Server context (from auth_ok)
   sessionCwd: string | null;

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -419,7 +419,9 @@ export interface ConnectionState {
   // User explicitly disconnected — prevents auto-reconnect on ConnectScreen mount
   userDisconnected: boolean;
 
-  // Server mode: 'cli' (headless). The wire protocol only emits 'cli' (#4810).
+  // Server mode: 'cli' (headless). The wire protocol only emits 'cli' (#4810);
+  // `null` covers pre-`auth_ok` state and any non-`'cli'` value the parser
+  // couldn't validate (degrades to the "Invalid Server Mode" alert path).
   serverMode: 'cli' | null;
 
   // Server context (from auth_ok)

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1215,11 +1215,10 @@ describe('handleAuthOk', () => {
     })
   })
 
-  it('accepts terminal as serverMode', () => {
-    expect(handleAuthOk({ serverMode: 'terminal' }).serverMode).toBe('terminal')
-  })
-
   it('rejects unknown serverMode values', () => {
+    // #4810: 'terminal' was previously accepted but the wire protocol only
+    // emits 'cli'; the unreachable branch is now treated as unknown.
+    expect(handleAuthOk({ serverMode: 'terminal' }).serverMode).toBeNull()
     expect(handleAuthOk({ serverMode: 'bogus' }).serverMode).toBeNull()
     expect(handleAuthOk({ serverMode: 42 }).serverMode).toBeNull()
     expect(handleAuthOk({}).serverMode).toBeNull()
@@ -1583,11 +1582,10 @@ describe('handleServerMode', () => {
     expect(handleServerMode({ mode: 'cli' })).toEqual({ mode: 'cli' })
   })
 
-  it('extracts terminal mode', () => {
-    expect(handleServerMode({ mode: 'terminal' })).toEqual({ mode: 'terminal' })
-  })
-
   it('returns null for unknown mode (caller surfaces an alert)', () => {
+    // #4810: 'terminal' was previously accepted but is now treated as unknown
+    // since the wire protocol only emits 'cli'.
+    expect(handleServerMode({ mode: 'terminal' })).toEqual({ mode: null })
     expect(handleServerMode({ mode: 'bogus' })).toEqual({ mode: null })
     expect(handleServerMode({ mode: 42 })).toEqual({ mode: null })
     expect(handleServerMode({})).toEqual({ mode: null })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -673,16 +673,18 @@ export function handleDevPreviewStopped(
 // ---------------------------------------------------------------------------
 
 /**
- * Server modes the WS protocol can advertise.
+ * Server mode advertised by the WS protocol.
  *
- * Both clients accept `'cli'`; only the dashboard surfaces `'terminal'` (the
- * mobile app currently treats `'terminal'` as null because there is no
- * terminal view). The shared handler returns the validated raw value; the
- * call site decides whether to narrow further.
+ * Historically the server could in principle have run in a `'terminal'`
+ * (PTY/tmux) mode, but the wire protocol only ever emits `'cli'` — the
+ * `ServerAuthOkSchema` is a `z.literal('cli')` and the server hardcodes
+ * `this.serverMode = 'cli'` (see #4810). The shared handler validates the
+ * field and returns null for any non-`'cli'` value so the call site can
+ * surface a hardened "unknown server" branch.
  */
-export type ServerMode = 'cli' | 'terminal'
+export type ServerMode = 'cli'
 
-const VALID_SERVER_MODES: readonly ServerMode[] = ['cli', 'terminal']
+const VALID_SERVER_MODES: readonly ServerMode[] = ['cli']
 
 /**
  * Validated `webFeatures` map advertised by the server. Each flag is a hard
@@ -716,7 +718,7 @@ export interface AuthOkWebFeatures {
  * roster shape doesn't bloat `AuthOkPayload`.
  */
 export interface AuthOkPayload {
-  /** Validated server mode (`'cli'`, `'terminal'`, or null). */
+  /** Validated server mode (`'cli'`, or null when unknown). */
   serverMode: ServerMode | null
   /** Raw `cwd` string (NOT trimmed — empty string preserved). */
   sessionCwd: string | null
@@ -907,9 +909,9 @@ export function handleKeyExchangeOk(msg: Record<string, unknown>): { publicKey: 
  * Extract and validate the mode enum from a `server_mode` message.
  *
  * Returns null for unknown modes; the call site is expected to surface an
- * "Invalid Server Mode" alert (matches dashboard's prior inline behaviour;
- * the app currently ignores `'terminal'` and sets null, which the call site
- * can re-narrow if needed).
+ * "Invalid Server Mode" alert (matches dashboard's prior inline behaviour).
+ * The wire protocol only emits `'cli'` (#4810) — any other value is treated
+ * as null.
  */
 export function handleServerMode(msg: Record<string, unknown>): { mode: ServerMode | null } {
   return { mode: parseEnumField(msg, 'mode', VALID_SERVER_MODES) }


### PR DESCRIPTION
## Summary

Removes the unreachable `serverMode === 'terminal'` branch across 4 packages. The wire enum has only ever taken `'cli'` — the protocol schema is `z.literal('cli')` and `ws-server.js` hardcodes `this.serverMode = 'cli'`. Audit P5.1 finding from `/swarm-audit`.

## Files changed

- `packages/store-core/src/handlers/index.ts` — narrow `ServerMode` type and `VALID_SERVER_MODES` to `['cli']`; refresh doc comments
- `packages/dashboard/src/store/types.ts` — narrow `ConnectionState.serverMode` to `'cli' | null`
- `packages/app/src/store/message-handler.ts` — remove unreachable `auth.serverMode === 'cli' ? 'cli' : null` ternary in the `auth_ok` case; simplify the `server_mode` case the same way
- `packages/store-core/src/handlers/handlers.test.ts` — `'terminal'` now narrows to null (instead of being accepted) for both `handleAuthOk` and `handleServerMode`
- `packages/dashboard/src/store/auth-ok-handler.test.ts` — replace the "sets serverMode to terminal" expectation with a "sets serverMode to null when serverMode is terminal (dead branch)" guard

`packages/protocol/src/schemas/server.ts:44` was already `z.literal('cli')` and `packages/server/src/ws-server.js:759` already hardcoded `'cli'` — no source changes needed in those files.

## Test plan

- [x] `packages/protocol` — 151 / 151 pass
- [x] `packages/store-core` — 982 / 982 pass
- [x] `packages/dashboard` — 2516 / 2516 pass
- [x] `packages/app` — 1429 / 1429 pass
- [x] `packages/server` — 306 / 306 pass for the affected suites (`ws-schemas`, `ws-server-auth`, `ws-history`, `diagnostics`); full suite has 8 pre-existing unrelated flakes (tunnel integration, service network-fetch timeouts, web-task-manager, models_updated broadcast, drain behavior) that also fail on `main`
- [x] `tsc --noEmit` clean in store-core / dashboard / app

Closes #4810