### PR TITLE
fix(server): guard Other/freeform IIFE against destroy() mid-await (#4808)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2353,8 +2353,8 @@ export class ClaudeTuiSession extends BaseSession {
           //     even though `_onAskUserQuestionStall`'s _destroying
           //     guard silences the eventual emit
           //   - calls `_writePtyTextThrottled(freeformText)` against
-          //     a `_term` that destroy() set to null (line 2792),
-          //     throwing inside the inner write loop
+          //     a `_term` that destroy() set to null, throwing inside
+          //     the inner write loop
           // Bail out at every await boundary instead.
           const stage1ok = await this._writePtyTextThrottled(otherDigit).catch((err) => {
             log.warn(`respondToQuestion Other-digit PTY write failed: ${err.message} (tool=${tag})`)
@@ -2364,8 +2364,11 @@ export class ClaudeTuiSession extends BaseSession {
           if (!stage1ok) return
           await new Promise((resolve) => setTimeout(resolve, OTHER_FREEFORM_SETTLE_MS))
           if (this._destroying) return
-          // Belt-and-braces: even if destroy() raced past the guard
-          // above, a null _term means there's nothing to write to —
+          // Belt-and-braces: destroy() sets _destroying before nulling
+          // _term in the same synchronous frame, so the guard above
+          // already covers the destroy() race. This null-check is
+          // cheap insurance against a future path that releases _term
+          // without flipping _destroying (e.g. a PTY-exit handler) —
           // skip the re-arm AND the stage-2 write together so the
           // watchdog never fires for a session that no longer has a
           // PTY behind it.

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2345,12 +2345,31 @@ export class ClaudeTuiSession extends BaseSession {
         // and the trailing \r submits.
         const tag = prevToolUseId || '?'
         ;(async () => {
+          // #4808: destroy() can run during ANY of the awaits below
+          // (stage-1 write, settle pause, stage-2 write). Without a
+          // guard after each await the IIFE keeps running and:
+          //   - re-arms `_askUserQuestionWatchdog` past destroy(),
+          //     leaking a 30s timer that pins `this` in its closure
+          //     even though `_onAskUserQuestionStall`'s _destroying
+          //     guard silences the eventual emit
+          //   - calls `_writePtyTextThrottled(freeformText)` against
+          //     a `_term` that destroy() set to null (line 2792),
+          //     throwing inside the inner write loop
+          // Bail out at every await boundary instead.
           const stage1ok = await this._writePtyTextThrottled(otherDigit).catch((err) => {
             log.warn(`respondToQuestion Other-digit PTY write failed: ${err.message} (tool=${tag})`)
             return false
           })
+          if (this._destroying) return
           if (!stage1ok) return
           await new Promise((resolve) => setTimeout(resolve, OTHER_FREEFORM_SETTLE_MS))
+          if (this._destroying) return
+          // Belt-and-braces: even if destroy() raced past the guard
+          // above, a null _term means there's nothing to write to —
+          // skip the re-arm AND the stage-2 write together so the
+          // watchdog never fires for a session that no longer has a
+          // PTY behind it.
+          if (!this._term) return
           // Re-arm the watchdog so the freeform write phase has a fresh
           // OTHER_FREEFORM_WATCHDOG_MS window — the stage-1 arm already
           // counted the settle delay against the original 30s budget.

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2940,6 +2940,129 @@ describe('ClaudeTuiSession', () => {
 
         assert.equal(writes.length, 0, `no PTY writes when freeform requested but no Other option exists, got: ${JSON.stringify(writes)}`)
       })
+
+      // #4808 — the Other/freeform path is driven by an async IIFE that
+      // awaits stage-1 write → settle delay → re-arms the watchdog →
+      // awaits stage-2 write. destroy() can run during any of these
+      // awaits but the IIFE keeps going. Pre-#4808 it would:
+      //   1. Re-arm `_askUserQuestionWatchdog` AFTER destroy() already
+      //      cleared it, leaking a 30s timer that holds `this` in its
+      //      closure (the `_onAskUserQuestionStall` guard prevents the
+      //      emit but doesn't release the closure).
+      //   2. Call `_writePtyTextThrottled(freeformText)` on a null
+      //      `_term`, which throws inside the write loop (or worse —
+      //      revives a write path against a torn-down session).
+      // Fix is `if (this._destroying) return` after each `await` and a
+      // null-check on `this._term` before stage 2.
+      describe('destroy() during the two-stage IIFE (#4808)', () => {
+        it('destroy() between stage-1 and stage-2 does NOT re-arm the watchdog', async () => {
+          const writes = []
+          session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+          session._pendingUserAnswer = {
+            toolUseId: 'toolu_aq_destroy_race',
+            options: [
+              { label: 'Patch' },
+              { label: 'Minor' },
+              { label: 'Other' },
+            ],
+          }
+
+          // Kick off the two-stage IIFE.
+          session.respondToQuestion('Other', undefined, 'toolu_aq_destroy_race', {
+            freeformText: 'race text',
+          })
+
+          // Stage 1 (the digit '3') finishes within ~5ms — give it a
+          // beat to land but tear the session down DURING the
+          // OTHER_FREEFORM_SETTLE_MS (150ms) sleep. Targeting 60ms
+          // hits well inside that window on any reasonable machine.
+          await new Promise((resolve) => setTimeout(resolve, 60))
+          await session.destroy()
+          // Null `session` so the afterEach hook does not double-destroy.
+          const torn = session
+          session = null
+
+          // The watchdog was cleared by destroy(). If the IIFE re-arms
+          // it after `await new Promise(setTimeout(SETTLE_MS))` resolves,
+          // a fresh timer appears on `_askUserQuestionWatchdog` —
+          // detectable by sampling the field repeatedly until well past
+          // the settle delay.
+          const samples = []
+          for (let i = 0; i < 4; i++) {
+            await new Promise((resolve) => setTimeout(resolve, 60))
+            samples.push(torn._askUserQuestionWatchdog)
+          }
+
+          // Pre-#4808: at least one sample is a Timeout (re-armed).
+          // Post-fix: every sample stays null.
+          for (const s of samples) {
+            assert.equal(s, null, `_askUserQuestionWatchdog must stay null past destroy(); saw ${s}. samples=${samples.map((x) => x ? 'TIMER' : 'null').join(',')}`)
+          }
+        })
+
+        it('destroy() between stage-1 and stage-2 does NOT attempt to write on a null _term', async () => {
+          // Capture the "Other-freeform PTY write failed" warning — this
+          // is the symptom of the IIFE blindly calling
+          // `_writePtyTextThrottled(freeformText)` against a `_term` that
+          // destroy() set to null. Pre-#4808 the inner `this._term.write`
+          // throws `Cannot read properties of null (reading 'write')`,
+          // the IIFE's .catch logs that warning, and the session has just
+          // demonstrated that it can still execute write logic past
+          // destroy(). Post-fix the IIFE returns early after the
+          // settle-await and the warning never fires.
+          const warnLines = []
+          const captureWarn = (entry) => {
+            if (entry.level === 'warn' && /Other-freeform PTY write failed/.test(entry.message || '')) {
+              warnLines.push(entry.message)
+            }
+          }
+          addLogListener(captureWarn)
+
+          const stage1Writes = []
+          session._term = {
+            write: (data) => { stage1Writes.push(data) },
+            kill: () => {},
+          }
+          session._pendingUserAnswer = {
+            toolUseId: 'toolu_aq_destroy_term',
+            options: [
+              { label: 'Patch' },
+              { label: 'Minor' },
+              { label: 'Other' },
+            ],
+          }
+
+          try {
+            session.respondToQuestion('Other', undefined, 'toolu_aq_destroy_term', {
+              freeformText: 'after destroy',
+            })
+
+            // Let stage-1 (digit '3') land, then destroy during the
+            // OTHER_FREEFORM_SETTLE_MS (150ms) pause.
+            await new Promise((resolve) => setTimeout(resolve, 60))
+            await session.destroy()
+            const torn = session
+            session = null
+            // Sanity: destroy() nulled `_term`.
+            assert.equal(torn._term, null, 'destroy() nulls _term')
+
+            // Wait past the settle (150ms) + per-char throttle time for
+            // stage-2 to run if it's going to. Post-fix the IIFE returns
+            // after `if (this._destroying) return` and never touches
+            // `_term`.
+            await new Promise((resolve) => setTimeout(resolve, 250))
+
+            assert.equal(
+              warnLines.length, 0,
+              `IIFE must not execute stage-2 write into a null _term post-destroy; saw warns: ${JSON.stringify(warnLines)}`,
+            )
+            // Stage-1 digit DID land (it ran before destroy).
+            assert.ok(stage1Writes.some((w) => w === '3'), `stage-1 digit "3" expected to have written before destroy, got: ${JSON.stringify(stage1Writes)}`)
+          } finally {
+            removeLogListener(captureWarn)
+          }
+        })
+      })
     })
 
     it('PostToolUse for AskUserQuestion clears _pendingUserAnswer if it was still set', () => {


### PR DESCRIPTION
## Summary

Audit P1.3 finding — Guardian agent #2 from `/swarm-audit`.

The Other/freeform two-stage writer in `respondToQuestion` is an async IIFE that awaits stage-1 PTY write, then a 150 ms settle, then re-arms `_askUserQuestionWatchdog`, then awaits stage-2 PTY write. `destroy()` can run during any of those awaits — but the IIFE kept going.

Result on the un-fixed path:
- Re-arms a 30 s watchdog timer AFTER `destroy()` cleared it. `_onAskUserQuestionStall`'s `_destroying` guard silences the eventual emit, but the timer closure still holds `this` for the full window past destroy.
- Calls `_writePtyTextThrottled(freeformText)` against the `_term` that destroy nulled at `claude-tui-session.js:2792` — the inner write throws `Cannot read properties of null (reading 'write')`, the IIFE catches and logs `Other-freeform PTY write failed`, and the session has just demonstrated it can still execute write logic past destroy.

## Fix

- `if (this._destroying) return` after `await this._writePtyTextThrottled(otherDigit)`
- `if (this._destroying) return` after `await new Promise(setTimeout(SETTLE_MS))`
- `if (!this._term) return` belt-and-braces before the watchdog re-arm + stage-2 write, so a destroy that races past both guards still can't schedule fresh work.

## Tests

Two regressions added inside the existing `Other / freeform answer (#4651)` describe block under a `destroy() during the two-stage IIFE (#4808)` sub-describe:

1. **No watchdog re-arm post-destroy** — kicks off the IIFE, lets stage-1 land, calls `destroy()` during the 150 ms settle pause, samples `_askUserQuestionWatchdog` four times across 240 ms and asserts every sample is null. Pre-fix the IIFE re-armed a 30 s `setTimeout` past destroy and the assertion failed against the live `TimersList` object.
2. **No stage-2 write on null _term** — same setup, captures `Other-freeform PTY write failed` warns via `addLogListener`, asserts none fire after destroy.

Both tests fail on pre-fix code and pass after.

Closes #4808

## Test plan

- [x] New `destroy() during the two-stage IIFE (#4808)` tests fail before the fix (RED)
- [x] New tests pass after the fix (GREEN)
- [x] Full `claude-tui-session.test.js` suite: 173/173 pass
- [x] Sibling `claude-tui-*.test.js` files: 210/210 pass
- [x] No new failures in the broader server suite (existing failures are pre-existing network-dependent tests in `service.test.js`, `tunnel-manager.test.js`, `webtask-manager.test.js`, `encryption-integration.test.js` — unrelated to this change)