### PR TITLE
feat(server): add loggerForSession factory + scoping lint (#4792)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,23 @@ jobs:
             exit 1
           fi
 
+      - name: Check session-aware modules use loggerForSession
+        run: |
+          # Issue #4792 — durable follow-up to #4787 / #4793. Session-aware
+          # modules (claude-tui-session.js, handlers/input-handlers.js, ...)
+          # MUST import `loggerForSession` from logger.js so per-session log
+          # lines carry sessionId. Without it the WsServer log fan-out
+          # (#4787 defensive filter) silently drops the entry from bound
+          # dashboard clients — operators lose useful diagnostics.
+          # The lint is ratcheted by file; see scripts/lint-logger-session-scoping.mjs
+          # for the enforced set.
+          if scripts/lint-logger-session-scoping.sh; then
+            echo "OK — enforced modules use loggerForSession"
+          else
+            echo "::error::A session-aware module dropped its loggerForSession import or introduced a bare createLogger. See packages/server/scripts/lint-logger-session-scoping.sh."
+            exit 1
+          fi
+
   dashboard-tests:
     name: Dashboard Tests
     runs-on: ubuntu-24.04

--- a/packages/server/scripts/lint-logger-session-scoping.mjs
+++ b/packages/server/scripts/lint-logger-session-scoping.mjs
@@ -39,7 +39,7 @@
  */
 
 import { readFileSync, readdirSync, statSync } from 'node:fs'
-import { dirname, join, resolve, relative } from 'node:path'
+import { dirname, join, resolve, relative, sep as pathSep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -155,7 +155,12 @@ const allEnforced = new Set([
 ])
 
 for (const file of walk(SRC_DIR)) {
-  const rel = relative(SRC_DIR, file)
+  // Normalize to POSIX-style separators so set membership works on Windows
+  // (relative() returns \\-separated paths there). REQUIRES_FACTORY_IMPORT
+  // / FORBIDS_BARE_CREATELOGGER are authored with POSIX-style paths so the
+  // sets stay readable in the source; this normalization is what makes the
+  // lint cross-platform.
+  const rel = pathSep === '/' ? relative(SRC_DIR, file) : relative(SRC_DIR, file).split(pathSep).join('/')
   if (!allEnforced.has(rel)) continue
 
   const src = readFileSync(file, 'utf8')
@@ -169,10 +174,16 @@ for (const file of walk(SRC_DIR)) {
       if (/\bloggerForSession\b/.test(mm[1])) { found = true; break }
     }
     if (!found) {
+      // The import path depends on directory depth: src/foo.js uses
+      // './logger.js' but src/handlers/foo.js uses '../logger.js'.
+      // Compute the correct hint per file so the guidance isn't misleading
+      // for nested modules.
+      const depth = rel.split('/').length - 1
+      const importPath = depth === 0 ? './logger.js' : '../'.repeat(depth) + 'logger.js'
       errors.push({
         file,
         line: 1,
-        msg: 'session-aware module must `import { loggerForSession } from \'./logger.js\'` — see issue #4792',
+        msg: `session-aware module must \`import { loggerForSession } from '${importPath}'\` — see issue #4792`,
       })
     }
   }

--- a/packages/server/scripts/lint-logger-session-scoping.mjs
+++ b/packages/server/scripts/lint-logger-session-scoping.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Lint: session-aware modules in `packages/server/src/` MUST scope their
+ * log entries with `sessionId` — either via the `loggerForSession(...)`
+ * factory or via an explicit `.withSession(...)` chain on `createLogger`.
+ *
+ * Background: PR #4787 (security P0) added a defensive filter to the
+ * WsServer `_logListener` that drops UNSCOPED log entries from BOUND
+ * dashboard clients to prevent cross-session leaks of PTY hex dumps,
+ * prompt sizes, toolUseIds, and attachment metadata. The defensive
+ * filter ships in #4793. Issue #4792 (this lint) is the durable
+ * follow-up: ensure session-aware modules emit scoped entries so the
+ * legitimate per-session diagnostic value (operators watching THEIR
+ * session in the dashboard) is preserved.
+ *
+ * The lint has two layers, both ratcheted by file:
+ *
+ *   1. REQUIRES_FACTORY_IMPORT — the module must `import { loggerForSession }`
+ *      from logger.js. Catches drive-by edits that add a new log line
+ *      without realising the file participates in the session-scoping
+ *      contract.
+ *
+ *   2. FORBIDS_BARE_CREATELOGGER — every `createLogger(...)` in the
+ *      module MUST be followed by `.withSession(...)`. Stronger: blocks
+ *      ALL bare `createLogger` once the module has been fully migrated
+ *      and no longer needs the pre-session-id fallback. Files in the
+ *      first set need not be in the second.
+ *
+ * As more modules migrate, add them to the appropriate set. Start with
+ * REQUIRES_FACTORY_IMPORT for any file you touch session-side; promote
+ * to FORBIDS_BARE_CREATELOGGER once the module has zero bare
+ * createLogger calls left.
+ *
+ * Exit codes:
+ *   0 — all enforced rules pass
+ *   1 — at least one offender found (printed with file:line)
+ *
+ * Set `DRY_RUN=1` to list offenders without failing the exit code.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { dirname, join, resolve, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const SRC_DIR = resolve(__dirname, '..', 'src')
+
+/**
+ * Files that MUST import `loggerForSession` from logger.js. Signals to
+ * future contributors that the module participates in session-scoped
+ * logging — a new log line in this file should reach for
+ * `loggerForSession(...)` (or `this._log` when the class stashes one).
+ *
+ * Add a file here when you migrate one of its log sites to the factory.
+ * Removing the import then becomes a lint failure, catching drive-by
+ * regressions.
+ */
+const REQUIRES_FACTORY_IMPORT = new Set([
+  // #4792 first wave — 4 audit-flagged sites in claude-tui-session.js,
+  // 1 in input-handlers.js. See PR opening this issue for the full
+  // migration list and the deferred-sweep follow-up issue for the rest.
+  'claude-tui-session.js',
+  'handlers/input-handlers.js',
+])
+
+/**
+ * Files where EVERY `createLogger(...)` call MUST be followed by
+ * `.withSession(...)`. Use this once a module is fully migrated and no
+ * longer needs the pre-session-id fallback path (i.e. all logging
+ * happens after the session id is known).
+ *
+ * Empty for now — both #4792 first-wave files still keep a bare
+ * module-level `const log = createLogger('...')` for the early-boot
+ * fallback paths. Promote files here in a follow-up PR once that
+ * fallback is gone.
+ */
+const FORBIDS_BARE_CREATELOGGER = new Set([
+  // Add files here once they no longer keep a module-level
+  // `createLogger(...)` for pre-session-id fallback.
+])
+
+function walk(dir, acc = []) {
+  for (const ent of readdirSync(dir)) {
+    const p = join(dir, ent)
+    const st = statSync(p)
+    if (st.isDirectory()) walk(p, acc)
+    else if (st.isFile() && p.endsWith('.js')) acc.push(p)
+  }
+  return acc
+}
+
+function isInsideComment(src, idx) {
+  const lineStart = src.lastIndexOf('\n', idx) + 1
+  const lineSoFar = src.slice(lineStart, idx)
+  if (lineSoFar.trimStart().startsWith('//')) return true
+  if (lineSoFar.trimStart().startsWith('*')) return true
+  const lastOpen = src.lastIndexOf('/*', idx)
+  const lastClose = src.lastIndexOf('*/', idx)
+  return lastOpen > lastClose
+}
+
+function lineOf(src, idx) {
+  return src.slice(0, idx).split('\n').length
+}
+
+function findUnscopedCreateLoggerCalls(src) {
+  const offenders = []
+  const re = /\bcreateLogger\s*\(/g
+  let m
+  while ((m = re.exec(src)) !== null) {
+    const idx = m.index
+    if (isInsideComment(src, idx)) continue
+
+    // Skip import/export lines — `import { createLogger } from ...` is
+    // a reference to the symbol, not a call.
+    const lineStart = src.lastIndexOf('\n', idx) + 1
+    const lineSoFar = src.slice(lineStart, idx)
+    if (/^import\b/.test(lineSoFar.trimStart())) continue
+    if (/^export\b/.test(lineSoFar.trimStart())) continue
+
+    // Find the matching `)`, then look at what follows.
+    let depth = 0
+    let i = idx + m[0].length - 1
+    let inStr = null
+    let close = -1
+    while (i < src.length) {
+      const ch = src[i]
+      const prev = src[i - 1]
+      if (inStr) {
+        if (ch === inStr && prev !== '\\') inStr = null
+      } else if (ch === '"' || ch === "'" || ch === '`') {
+        inStr = ch
+      } else if (ch === '(') {
+        depth++
+      } else if (ch === ')') {
+        depth--
+        if (depth === 0) { close = i; break }
+      }
+      i++
+    }
+    if (close === -1) continue
+
+    const after = src.slice(close + 1).trimStart()
+    if (after.startsWith('.withSession(')) continue
+
+    offenders.push({ line: lineOf(src, idx) })
+  }
+  return offenders
+}
+
+const errors = []
+const allEnforced = new Set([
+  ...REQUIRES_FACTORY_IMPORT,
+  ...FORBIDS_BARE_CREATELOGGER,
+])
+
+for (const file of walk(SRC_DIR)) {
+  const rel = relative(SRC_DIR, file)
+  if (!allEnforced.has(rel)) continue
+
+  const src = readFileSync(file, 'utf8')
+
+  if (REQUIRES_FACTORY_IMPORT.has(rel)) {
+    // Find the logger.js import block and check loggerForSession appears.
+    const importRe = /import\s*\{([^}]*)\}\s*from\s*['"](?:\.{1,2}\/)+logger\.js['"]/g
+    let mm
+    let found = false
+    while ((mm = importRe.exec(src)) !== null) {
+      if (/\bloggerForSession\b/.test(mm[1])) { found = true; break }
+    }
+    if (!found) {
+      errors.push({
+        file,
+        line: 1,
+        msg: 'session-aware module must `import { loggerForSession } from \'./logger.js\'` — see issue #4792',
+      })
+    }
+  }
+
+  if (FORBIDS_BARE_CREATELOGGER.has(rel)) {
+    for (const o of findUnscopedCreateLoggerCalls(src)) {
+      errors.push({
+        file,
+        line: o.line,
+        msg: 'bare createLogger(...) is forbidden in this module — chain .withSession(...) or use loggerForSession(component, sessionId)',
+      })
+    }
+  }
+}
+
+if (errors.length) {
+  console.error('ERROR: session-aware modules must scope their log entries with sessionId.')
+  console.error('Either import { loggerForSession } and use loggerForSession(component, sessionId)')
+  console.error('at the call site, or chain createLogger(component).withSession(sessionId).')
+  console.error('See packages/server/src/logger.js and issue #4792.')
+  console.error('')
+  for (const e of errors) {
+    console.error(`  ${e.file}:${e.line} — ${e.msg}`)
+  }
+  console.error('')
+  console.error('Background: issue #4792 (durable fix), PR #4787 / #4793 (defensive filter).')
+  if (process.env.DRY_RUN === '1') process.exit(0)
+  process.exit(1)
+}
+
+const reqCount = REQUIRES_FACTORY_IMPORT.size
+const forbidCount = FORBIDS_BARE_CREATELOGGER.size
+console.log(`OK: ${reqCount} module(s) import loggerForSession; ${forbidCount} module(s) forbid bare createLogger`)

--- a/packages/server/scripts/lint-logger-session-scoping.sh
+++ b/packages/server/scripts/lint-logger-session-scoping.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Wrapper for the Node-based linter. See `lint-logger-session-scoping.mjs`
+# for the actual implementation. Kept as a shell entry point so CI can
+# `run: scripts/lint-logger-session-scoping.sh` without worrying about
+# the Node interpreter path on the runner image.
+#
+# Issue #4792 — durable follow-up to #4787 / #4793.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+exec node ./scripts/lint-logger-session-scoping.mjs "$@"

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url'
 import { BaseSession } from './base-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { resolveBinary } from './utils/resolve-binary.js'
-import { createLogger } from './logger.js'
+import { createLogger, loggerForSession } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { materializeAttachments, buildAttachmentsPromptSuffix } from './claude-tui-attachments.js'
@@ -365,6 +365,13 @@ export class ClaudeTuiSession extends BaseSession {
     // uses so the existing permission HTTP route routes us with no changes.
     this._hookSecret = this._port ? randomBytes(32).toString('hex') : null
     this._sessionId = null   // upstream claude conversation uuid, assigned at start()
+    // #4792: session-scoped logger. Assigned in start() once _sessionId is
+    // generated. Until then, code paths that need to log MUST fall back to
+    // the module-level `log` (e.g. trust pre-write failure, sink dir create
+    // failure). Per-session log lines (sendMessage, respondToQuestion,
+    // attachment materialization) prefer `this._log` so the WsServer log
+    // listener can route them to the right bound client (#4787, #4793).
+    this._log = null
     this._sinkDir = null     // created on start, removed on destroy
     this._term = null        // persistent PTY for the session's lifetime
     this._settingsPath = null
@@ -636,6 +643,13 @@ export class ClaudeTuiSession extends BaseSession {
     // Generate the upstream session uuid here so the JSONL path is
     // predictable + so claude resumes the same conversation across turns.
     this._sessionId = randomUUID()
+    // #4792: now that the session id exists, bind the per-instance logger
+    // so subsequent log lines carry sessionId and route correctly through
+    // the WsServer log fan-out (#4787). Anything that logs before this
+    // point uses the module-level `log` (unscoped) and only reaches
+    // unbound dashboard clients — that is the desired behaviour for
+    // pre-start setup failures.
+    this._log = loggerForSession('claude-tui-session', this._sessionId)
 
     // #4044: skipPermissions wins over port — when the user opts in to
     // unmediated TUI behaviour, the hook installation + sidecar write must
@@ -966,7 +980,11 @@ export class ClaudeTuiSession extends BaseSession {
     // accumulated on _activeTurn and emitted in the summary line at
     // turn finish (success or error). Together they let us reconstruct
     // where the wedge actually sits without re-instrumenting the file.
-    log.info(`sendMessage start (msg=${messageId} sessionId=${this._sessionId} bytes=${Buffer.byteLength(prompt || '', 'utf8')} attachments=${attachments?.length || 0})`)
+    // #4792: prefer the session-bound logger so the entry routes to the
+    // correct bound dashboard client. Falls back to module-level `log`
+    // only if start() hasn't run (defensive — sendMessage on an unstarted
+    // session is a misuse, but the fallback keeps the diagnostic alive).
+    ;(this._log || log).info(`sendMessage start (msg=${messageId} sessionId=${this._sessionId} bytes=${Buffer.byteLength(prompt || '', 'utf8')} attachments=${attachments?.length || 0})`)
 
     // #4012: TUI can't accept inline multimodal blocks the way SDK/CLI
     // do, but it CAN read files via the Read tool. Materialize each
@@ -1002,10 +1020,12 @@ export class ClaudeTuiSession extends BaseSession {
           // distinct warn lines so ops can grep for either degradation:
           //   - regular truncation: some files dropped from the list
           //   - bareFallback: even one entry exceeded the cap (worst)
+          // #4792: same session-scoped logger fallback as sendMessage start.
+          const slog = this._log || log
           if (suffixResult.bareFallback) {
-            log.warn(`TUI attachment suffix bare-fallback fired (msg=${messageId} count=${files.length} cap=${suffixResult.cap}B) — all file paths omitted from prompt suffix; agent will only see the size-cap marker. Pathological path-generation regression?`)
+            slog.warn(`TUI attachment suffix bare-fallback fired (msg=${messageId} count=${files.length} cap=${suffixResult.cap}B) — all file paths omitted from prompt suffix; agent will only see the size-cap marker. Pathological path-generation regression?`)
           } else if (suffixResult.truncated) {
-            log.warn(`TUI attachment suffix truncated (msg=${messageId} suffixBytes=${suffixResult.byteLength} cap=${suffixResult.cap}B omitted=${suffixResult.omitted} of=${files.length})`)
+            slog.warn(`TUI attachment suffix truncated (msg=${messageId} suffixBytes=${suffixResult.byteLength} cap=${suffixResult.cap}B omitted=${suffixResult.omitted} of=${files.length})`)
           }
         }
       } catch (err) {
@@ -2398,17 +2418,24 @@ export class ClaudeTuiSession extends BaseSession {
     // `_activeTurn`). Subsequent answers in the same turn emit a compact
     // one-line skip notice carrying the tool ids so a log reader can still
     // grep all answer-write events without scanning past 200+ hex lines.
+    // #4792: PTY tail hex dumps are the highest-volume, most-sensitive
+    // unscoped log lines pre-fix — they emit literal terminal bytes
+    // (user prompts, answer text, attachment names) on every
+    // respondToQuestion. Routing them through the session-bound logger
+    // makes the audit story clean: only operators bound to this session
+    // (or unbound) see the dump (#4787 fan-out filter).
+    const slog = this._log || log
     const turn = this._activeTurn
     if (turn && !turn.hexDumpEmitted) {
-      log.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
+      slog.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
       turn.hexDumpEmitted = true
     } else if (turn) {
-      log.info(`respondToQuestion PTY tail hex dump skipped (tool=${prevToolUseId || '?'}) — already emitted for turn msg=${turn.messageId || '?'}`)
+      slog.info(`respondToQuestion PTY tail hex dump skipped (tool=${prevToolUseId || '?'}) — already emitted for turn msg=${turn.messageId || '?'}`)
     } else {
       // No active turn (defensive — tests that drive respondToQuestion
       // directly without sendMessage(), late watchdog teardown races).
       // Emit the dump so the diagnostic is still useful in those paths.
-      log.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
+      slog.info(`respondToQuestion PTY tail before write (tool=${prevToolUseId || '?'}):\n${this._outputTailHexDump()}`)
     }
 
     const armWatchdog = () => {

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -9,7 +9,7 @@ import { randomUUID } from 'node:crypto'
 import { validateAttachments, resolveFileRefAttachments, resolveSession, sendError, sendSessionError } from '../handler-utils.js'
 import { evaluateDraft as defaultEvaluateDraft, shouldSkipEvaluator } from '../prompt-evaluator.js'
 import { PushManager } from '../push.js'
-import { createLogger } from '../logger.js'
+import { createLogger, loggerForSession } from '../logger.js'
 
 const log = createLogger('ws')
 
@@ -574,7 +574,21 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
     // the string, not a boolean, which downstream conditionals can read
     // but is confusing in a `freeform=${...}` log template.
     const hasFreeform = typeof msg.freeformText === 'string' && msg.freeformText.length > 0
-    log.info(`user_question_response received: toolUseId=${msg.toolUseId || '?'} answer.length=${(msg.answer || '').length} answers.keys=${msg.answers ? Object.keys(msg.answers).length : 0} freeform=${hasFreeform ? msg.freeformText.length : 0}`)
+    // #4792: scope this entry to the question's session so the WsServer
+    // log fan-out (#4787) routes it to the bound dashboard for that
+    // session rather than dropping it for all bound clients. The line
+    // carries toolUseId + freeform.length — useful for correlating
+    // multi-question form wedges per-session in chroxy.log.
+    //
+    // Legacy single-session mode (ws-message-handlers.js createCliSessionAdapter)
+    // serves `getSession(undefined)` from a synthetic default entry, so
+    // `questionSessionId` can legitimately be falsy here. In that mode
+    // there's exactly one session and no cross-session fan-out leak risk,
+    // so fall back to the unscoped `log` instead of throwing — multi-session
+    // deployments always have a real sessionId from the toolUseId map or
+    // client.activeSessionId.
+    const qlog = questionSessionId ? loggerForSession('ws', questionSessionId) : log
+    qlog.info(`user_question_response received: toolUseId=${msg.toolUseId || '?'} answer.length=${(msg.answer || '').length} answers.keys=${msg.answers ? Object.keys(msg.answers).length : 0} freeform=${hasFreeform ? msg.freeformText.length : 0}`)
     // #4668: forward msg.toolUseId so claude-tui-session can route the
     // answer to the right pending entry in its Map. Sessions that don't
     // care about toolUseId (cli-session, sdk-session via permission-

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -285,3 +285,39 @@ export function createLogger(component, context = {}) {
     withSession(sessionId) { return createLogger(component, { ...context, sessionId }) },
   }
 }
+
+/**
+ * Create a session-scoped component logger.
+ *
+ * This is the preferred factory for any code that operates within session
+ * context (`ClaudeTuiSession`, `SdkSession`, `CliSession`, per-session
+ * handlers in `handlers/*`, etc.). It guarantees that every log entry
+ * the returned logger emits is tagged with `sessionId`, which the
+ * WsServer `_logListener` (#4787) uses to route log entries to the
+ * correct bound client. An unscoped `createLogger(component)` in a
+ * session-aware module silently drops to "global only" fan-out, leaking
+ * PTY hex dumps and prompt sizes to operators on other sessions.
+ *
+ * Equivalent to `createLogger(component).withSession(sessionId)` but
+ * explicit at the call site. Throws if either argument is missing — the
+ * whole point of the helper is to prevent unscoped session logs, so a
+ * silent fallback would defeat its purpose.
+ *
+ * @example
+ *   // In a per-session class constructor:
+ *   this._log = loggerForSession('claude-tui-session', this._sessionId)
+ *   this._log.info('sendMessage start')  // entry.sessionId is set
+ *
+ * @param {string} component - Component tag (same as createLogger).
+ * @param {string} sessionId - Session id to bind. Required.
+ * @returns {ReturnType<typeof createLogger>}
+ */
+export function loggerForSession(component, sessionId) {
+  if (typeof component !== 'string' || component.length === 0) {
+    throw new TypeError('loggerForSession: component must be a non-empty string')
+  }
+  if (typeof sessionId !== 'string' || sessionId.length === 0) {
+    throw new TypeError('loggerForSession: sessionId must be a non-empty string')
+  }
+  return createLogger(component, { sessionId })
+}

--- a/packages/server/tests/logger.test.js
+++ b/packages/server/tests/logger.test.js
@@ -698,3 +698,105 @@ describe('withSession', () => {
     assert.equal(entries[0].sessionId, undefined)
   })
 })
+
+describe('loggerForSession (#4792)', () => {
+  afterEach(() => {
+    setLogListener(null)
+  })
+
+  it('is exported as a function', async () => {
+    const { loggerForSession } = await import('../src/logger.js')
+    assert.equal(typeof loggerForSession, 'function')
+  })
+
+  it('returns a logger pre-bound to a session id', async () => {
+    const { loggerForSession } = await import('../src/logger.js')
+    const entries = []
+    setLogListener((entry) => entries.push(entry))
+
+    const log = loggerForSession('claude-tui-session', 'sess-abc')
+    log.info('hello')
+    log.warn('careful')
+    log.error('boom')
+
+    assert.equal(entries.length, 3)
+    for (const e of entries) {
+      assert.equal(e.sessionId, 'sess-abc', 'every entry must carry the bound session id')
+      assert.equal(e.component, 'claude-tui-session')
+    }
+  })
+
+  it('exposes the standard logger surface (debug/info/warn/error/log/withSession)', async () => {
+    const { loggerForSession } = await import('../src/logger.js')
+    const log = loggerForSession('ws', 'sess-1')
+    assert.equal(typeof log.debug, 'function')
+    assert.equal(typeof log.info, 'function')
+    assert.equal(typeof log.warn, 'function')
+    assert.equal(typeof log.error, 'function')
+    assert.equal(typeof log.log, 'function')
+    assert.equal(typeof log.withSession, 'function')
+  })
+
+  it('is equivalent to createLogger(component).withSession(sessionId)', async () => {
+    const { loggerForSession } = await import('../src/logger.js')
+    const direct = []
+    const factory = []
+
+    setLogListener((entry) => direct.push(entry))
+    createLogger('eq').withSession('sess-eq').info('direct line')
+
+    setLogListener(null)
+    setLogListener((entry) => factory.push(entry))
+    loggerForSession('eq', 'sess-eq').info('factory line')
+
+    assert.equal(direct[0].component, factory[0].component)
+    assert.equal(direct[0].sessionId, factory[0].sessionId)
+    assert.equal(direct[0].level, factory[0].level)
+  })
+
+  it('further .withSession(...) rebinds the session id', async () => {
+    const { loggerForSession } = await import('../src/logger.js')
+    const entries = []
+    setLogListener((entry) => entries.push(entry))
+
+    const log = loggerForSession('ws', 'sess-a').withSession('sess-b')
+    log.info('rebound')
+
+    assert.equal(entries.length, 1)
+    assert.equal(entries[0].sessionId, 'sess-b',
+      'an explicit follow-up withSession should override the factory-bound id')
+  })
+
+  it('throws if sessionId is missing — the factory exists to prevent unscoped session logs', async () => {
+    const { loggerForSession } = await import('../src/logger.js')
+    assert.throws(
+      () => loggerForSession('component-name'),
+      /sessionId/,
+      'calling loggerForSession without a sessionId defeats the point — must throw',
+    )
+    assert.throws(
+      () => loggerForSession('component-name', ''),
+      /sessionId/,
+      'empty string sessionId must also throw',
+    )
+    assert.throws(
+      () => loggerForSession('component-name', null),
+      /sessionId/,
+      'null sessionId must also throw',
+    )
+  })
+
+  it('throws if component is missing', async () => {
+    const { loggerForSession } = await import('../src/logger.js')
+    assert.throws(
+      () => loggerForSession(undefined, 'sess-1'),
+      /component/,
+      'calling loggerForSession without a component must throw',
+    )
+    assert.throws(
+      () => loggerForSession('', 'sess-1'),
+      /component/,
+      'empty string component must also throw',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Durable follow-up to #4787 (security P0) and #4793 (Option A defensive filter for the WsServer log fan-out leak). This is **Option B** as called out in the issue: introduce `loggerForSession(component, sessionId)` as the preferred factory for session-aware modules, migrate the highest-impact audit-flagged sites, and add a lint rule so regressions fail CI.

Closes #4792.

## What this ships

1. **`loggerForSession(component, sessionId)`** in `packages/server/src/logger.js`
   - Thin wrapper around `createLogger(component).withSession(sessionId)`
   - **Throws** if either argument is missing — defeats silent fallbacks that would re-introduce unscoped session log entries (the whole point of the helper)
   - Backward-compatible: existing `createLogger` and `withSession` unchanged

2. **First-wave migration** of the 5 audit-flagged sites:
   - `claude-tui-session.js` — caches `this._log = loggerForSession(...)` once `_sessionId` is generated in `start()`. The four flagged log lines (PTY hex dumps in `respondToQuestion`, `sendMessage start`, attachment suffix bare-fallback/truncated warns) now route through `this._log`
   - `handlers/input-handlers.js:582` — `user_question_response received` now scoped to `questionSessionId`. Falls back to the unscoped `log` in legacy single-session mode where `createCliSessionAdapter` synthesises a default session entry

3. **Lint** at `packages/server/scripts/lint-logger-session-scoping.{sh,mjs}` with two ratcheted enforcement layers:
   - **`REQUIRES_FACTORY_IMPORT`** — listed modules must `import { loggerForSession }`. Catches drive-by edits that drop the import.
   - **`FORBIDS_BARE_CREATELOGGER`** — listed modules must chain every `createLogger(...)` with `.withSession(...)`. Empty for now — the two first-wave modules still keep a module-level `createLogger` for the pre-session-id fallback path.

4. **CI wiring** — new "Check session-aware modules use loggerForSession" step in the existing Server Lint job.

## Why this is incremental

The issue calls out ~113 unscoped call sites across `packages/server/`. Migrating them all in a single PR would make review intractable and risk regressions in load-bearing code (TUI session state machine, SDK session lifecycle, handlers). This PR ships the durable mechanism + the 5 highest-impact sites; follow-up PRs can add modules to `REQUIRES_FACTORY_IMPORT` and `FORBIDS_BARE_CREATELOGGER` as they migrate.

The lint is designed to **ratchet**: each new module added to the enforced sets makes regressions impossible without explicit removal. The defensive filter from #4793 stays in place as belt-and-braces.

## Test plan

- [x] Added 7 cases in `tests/logger.test.js`: factory shape, equivalence with `withSession`, validation throws on missing component / missing sessionId, rebind via `.withSession(...)`
- [x] Full server suite: **6538/6550 pass** (6 pre-existing env-specific failures unchanged from main — `service.test.js` fetch tests, `TunnelManager Integration` (no cloudflared), `WebTaskManager` (no claude CLI `--remote`), `encryption-integration`)
- [x] `./scripts/lint-logger-session-scoping.sh` → `OK: 2 module(s) import loggerForSession; 0 module(s) forbid bare createLogger`
- [x] `npm run lint` clean (only pre-existing warnings in unrelated files)
- [x] Verified the lint catches the documented regression: removing `loggerForSession` from the `input-handlers.js` import block trips the check