### PR TITLE
fix(server): make _pendingUserAnswers clear-all intent explicit at each callsite (#4802)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -448,22 +448,48 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
-   * Back-compat setter: writing `_pendingUserAnswer = null` (the pattern
-   * used at every turn-teardown site) clears the entire Map. Writing an
-   * entry sets it in the Map keyed by its toolUseId AND updates the
-   * "most recent" pointer. Pre-#4668 callers don't need to change.
+   * Back-compat setter: writing an entry sets it in the Map keyed by its
+   * toolUseId AND updates the "most recent" pointer. Pre-#4668 callers
+   * that wrote `_pendingUserAnswer = { ... }` don't need to change.
+   *
+   * #4802: the previous null-branch behaviour (`= null` → Map.clear()) is
+   * removed. Implicit clear-all at every teardown site silently wiped
+   * sibling AskUserQuestion entries that still had answers in flight
+   * (see `_pendingUserAnswers_clearAll` for the audit + the per-callsite
+   * rationale). Writing null now throws so the regression is loud — each
+   * callsite must pick `_pendingUserAnswers_clearAll()` (intentional
+   * turn-level wipe with documented reason) or
+   * `_clearPendingAnswerByToolUseId(tid)` (surgical, the watchdog path)
+   * explicitly.
    */
   set _pendingUserAnswer(entry) {
     if (entry === null || entry === undefined) {
-      this._pendingUserAnswers.clear()
-      this._lastPendingAnswerToolUseId = null
-      return
+      throw new Error('_pendingUserAnswer = null forbidden (#4802) — use _pendingUserAnswers_clearAll() or _clearPendingAnswerByToolUseId(tid) so the destructive intent is visible at the call site')
     }
     const toolUseId = entry.toolUseId
     if (toolUseId) {
       this._pendingUserAnswers.set(toolUseId, entry)
       this._lastPendingAnswerToolUseId = toolUseId
     }
+  }
+
+  /**
+   * #4802: explicit clear-all for the turn-level teardown sites that
+   * unambiguously kill the PTY for the current turn (Ctrl-C via
+   * `_teardownTurn` / `interrupt()`, or SIGTERM via `destroy()`). After
+   * any of those, even a surviving Map entry can't be served — claude
+   * TUI is no longer waiting on its prompt — so wiping the slot keeps
+   * a late `respondToQuestion` from writing into a torn-down form.
+   *
+   * NOT used by `_finishTurnError` (no Ctrl-C, sibling answers may still
+   * be valid for the brief race window — see audit P1.2) nor by the
+   * AskUserQuestion stall watchdog (knows the exact `toolUseId` that
+   * stalled, so it calls `_clearPendingAnswerByToolUseId` instead per
+   * #4691).
+   */
+  _pendingUserAnswers_clearAll() {
+    this._pendingUserAnswers.clear()
+    this._lastPendingAnswerToolUseId = null
   }
 
   /** Internal: drop a specific pending answer entry (PostToolUse cleanup). */
@@ -1709,12 +1735,23 @@ export class ClaudeTuiSession extends BaseSession {
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
-    // #4286: symmetry with interrupt() / destroy(). A turn failing or
-    // timing out while AskUserQuestion is pending must clear the answer
-    // slot — otherwise a late user_question_response (e.g. the user
-    // clicked the QuestionPrompt right as the hard timeout fired) would
-    // attempt a PTY write that no longer matches a live turn.
-    this._pendingUserAnswer = null
+    // #4286 / #4802: deliberately do NOT call
+    // `_pendingUserAnswers_clearAll()` here. The original #4286 fix
+    // wiped the single-field slot to keep late user_question_response
+    // events from writing into a dead turn — but post-#4668 the field is
+    // a Map, and the audit (P1.2 #4802) flagged that the implicit wipe
+    // collapsed sibling AskUserQuestion entries that still had legitimate
+    // answers in flight. `_finishTurnError` runs on PTY-exit / Stop-hook
+    // timeout / prompt-write failure paths that do NOT issue Ctrl-C, so
+    // a parallel sibling's response that's already on the wire (#4668
+    // retry-as-singles shape) can still validly consume its entry. Late
+    // arrivals after the PTY has truly stopped responding will no-op in
+    // `respondToQuestion` (write throws / TUI ignores) — far better than
+    // silently dropping the legitimate response and re-creating the
+    // #4668 wedge. The other turn-ending sites
+    // (`_teardownTurn` / `interrupt()` / `destroy()`) still call
+    // `_pendingUserAnswers_clearAll()` because they DO issue Ctrl-C or
+    // kill the PTY outright.
     this._clearAskUserQuestionLock()
     // #4604: same symmetry for the stall watchdog. The guard in
     // _onAskUserQuestionStall (`!_pendingUserAnswer && !_isBusy`) would
@@ -2041,8 +2078,15 @@ export class ClaudeTuiSession extends BaseSession {
     this._activeTurn = null
     this._isBusy = false
     this._currentMessageId = null
-    // 4. AskUserQuestion-related slot/lock/watchdog symmetry.
-    this._pendingUserAnswer = null
+    // 4. AskUserQuestion-related slot/lock/watchdog symmetry. #4802:
+    //    explicit `_pendingUserAnswers_clearAll()` (was an implicit
+    //    `_pendingUserAnswer = null` via the back-compat setter). Safe
+    //    here because _teardownTurn always issues Ctrl-C above
+    //    (step 1), so the TUI has dropped its current AskUserQuestion
+    //    form — any sibling pending entry can no longer be served and
+    //    leaving it would just risk a late respondToQuestion writing
+    //    stale keystrokes into whatever form the next turn brings up.
+    this._pendingUserAnswers_clearAll()
     this._clearAskUserQuestionLock()
     if (this._askUserQuestionWatchdog) {
       clearTimeout(this._askUserQuestionWatchdog)
@@ -2128,9 +2172,14 @@ export class ClaudeTuiSession extends BaseSession {
       // sendMessage() works normally. Matches _handleHardTimeout.
       try { this._term.write('\x03') } catch { /* ignore */ }
     }
-    // #4278: also drop any pending AskUserQuestion so a subsequent
+    // #4278 / #4802: drop any pending AskUserQuestion so a subsequent
     // user_question_response can't write into a torn-down context.
-    this._pendingUserAnswer = null
+    // Explicit `_pendingUserAnswers_clearAll()` (was an implicit
+    // `_pendingUserAnswer = null` → Map.clear() via the back-compat
+    // setter). Safe here: interrupt() writes Ctrl-C to the PTY above,
+    // so the TUI is no longer waiting on any AskUserQuestion form —
+    // every sibling pending entry is now equally stale.
+    this._pendingUserAnswers_clearAll()
     this._clearAskUserQuestionLock()
     // #4604: cancel the stall watchdog too. interrupt() does NOT clear
     // _isBusy directly (Ctrl-C surfaces async via _finishTurn*), so without
@@ -2767,9 +2816,13 @@ export class ClaudeTuiSession extends BaseSession {
     this._processReady = false
     this._isBusy = false
     this._activeTurn = null
-    // #4278: drop any pending AskUserQuestion so a late
-    // user_question_response can't write into a dead PTY.
-    this._pendingUserAnswer = null
+    // #4278 / #4802: drop any pending AskUserQuestion so a late
+    // user_question_response can't write into a dead PTY. Explicit
+    // `_pendingUserAnswers_clearAll()` (was an implicit
+    // `_pendingUserAnswer = null` → Map.clear() via the back-compat
+    // setter). Unambiguous here: destroy() SIGTERMs the PTY below and
+    // nulls `_term`, so every pending entry is permanently unservable.
+    this._pendingUserAnswers_clearAll()
     this._clearAskUserQuestionLock()
     if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
     if (this._hardTimeout) { clearTimeout(this._hardTimeout); this._hardTimeout = null }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -464,7 +464,7 @@ export class ClaudeTuiSession extends BaseSession {
    */
   set _pendingUserAnswer(entry) {
     if (entry === null || entry === undefined) {
-      throw new Error('_pendingUserAnswer = null forbidden (#4802) — use _pendingUserAnswers_clearAll() or _clearPendingAnswerByToolUseId(tid) so the destructive intent is visible at the call site')
+      throw new Error('_pendingUserAnswer = null/undefined forbidden (#4802) — use _pendingUserAnswers_clearAll() or _clearPendingAnswerByToolUseId(tid) so the destructive intent is visible at the call site')
     }
     const toolUseId = entry.toolUseId
     if (toolUseId) {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2851,7 +2851,11 @@ describe('ClaudeTuiSession', () => {
     it('respondToQuestion is a no-op when no pending answer (defensive)', () => {
       const writes = []
       session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
-      session._pendingUserAnswer = null
+      // #4802: explicit clear-all replaces the old `_pendingUserAnswer = null`
+      // back-compat setter (the implicit-clear pattern is now forbidden — it
+      // silently wiped sibling AskUserQuestion entries that still had answers
+      // in flight on the wire, per the audit P1.2 root cause).
+      session._pendingUserAnswers_clearAll()
 
       session.respondToQuestion('whatever')
       assert.equal(writes.length, 0, 'no PTY writes when there is no pending answer')
@@ -3045,21 +3049,28 @@ describe('ClaudeTuiSession', () => {
       )
     })
 
-    // #4286 (review-caught): _finishTurnError and _handleHardTimeout
-    // were the two asymmetric exits that left the answer slot dirty
-    // (interrupt/destroy already clear it). Pin both so a regression
-    // doesn't re-introduce a late user_question_response writing into
-    // a dead turn.
-    it('_finishTurnError clears _pendingUserAnswer (symmetry with interrupt/destroy)', () => {
+    // #4286 + #4802 (audit P1.2): _finishTurnError's original #4286 fix
+    // wiped the pending-answer slot for symmetry with interrupt/destroy,
+    // but the audit re-evaluated that decision once `_pendingUserAnswer`
+    // became a Map (#4668). `_finishTurnError` runs on paths that do NOT
+    // issue Ctrl-C (PTY exit / Stop hook timeout / prompt-write failure),
+    // so a parallel sibling AskUserQuestion's late answer may still be
+    // legitimately consumable. Post-#4802 `_finishTurnError` PRESERVES
+    // the Map; `_handleHardTimeout` (which DOES Ctrl-C via _teardownTurn)
+    // still wipes — see the #4691 + #4802 audit tests further down for
+    // the per-callsite intent matrix.
+    it('_finishTurnError preserves _pendingUserAnswer (audit P1.2 #4802)', () => {
       session._pendingUserAnswer = { toolUseId: 'toolu_aq_finish' }
       session.on('error', () => {})  // swallow
       session._currentMessageId = 'msg-x'
       session._activeTurn = { startedAt: Date.now(), aborted: false }
       session._finishTurnError('test-error', 'msg-x')
-      assert.equal(session._pendingUserAnswer, null, 'finishTurnError clears pending answer')
+      assert.ok(session._pendingUserAnswer, 'finishTurnError preserves pending answer (#4802)')
+      assert.equal(session._pendingUserAnswer.toolUseId, 'toolu_aq_finish',
+        'entry survives so a late respondToQuestion can still consume it')
     })
 
-    it('_handleHardTimeout clears _pendingUserAnswer (symmetry with interrupt/destroy)', () => {
+    it('_handleHardTimeout clears _pendingUserAnswer (symmetry with interrupt/destroy via Ctrl-C)', () => {
       session._pendingUserAnswer = { toolUseId: 'toolu_aq_hard' }
       session.on('error', () => {})
       session._isBusy = true
@@ -3632,16 +3643,25 @@ describe('ClaudeTuiSession', () => {
       }
     })
 
-    // #4691 — pin all-or-nothing semantics for the OTHER teardown sites
-    // (_finishTurnError / _handleHardTimeout / interrupt / destroy). The
-    // surgical-by-toolUseId fix only applies to the watchdog because it
-    // knows which tool stalled. The other paths end the whole turn —
-    // no sibling can survive a turn ending — so wiping the Map is the
-    // correct semantic. If a future refactor accidentally introduces a
-    // per-toolUseId clear at one of these sites, a stale entry could
-    // outlive the turn and misroute a late user_question_response into
-    // a dead PTY.
-    it('_finishTurnError wipes ALL pending entries (turn-level teardown, #4691)', () => {
+    // #4802 — per-callsite intent audit. Each teardown site now picks an
+    // explicit method (`_pendingUserAnswers_clearAll()` or
+    // `_clearPendingAnswerByToolUseId(tid)`) instead of routing through
+    // a back-compat `_pendingUserAnswer = null` setter that implicitly
+    // wiped the entire Map. The audit flagged `_finishTurnError` in
+    // particular: it does NOT issue Ctrl-C and is invoked for several
+    // "turn ended unexpectedly" reasons (PTY exit, Stop hook timeout,
+    // prompt-write failure) where a sibling AskUserQuestion's answer can
+    // still be in flight on the wire. Wiping the sibling there hits the
+    // "no matching pending entry — dropping" path in respondToQuestion
+    // and produces the silent #4668-class wedge described in #4802.
+    //
+    // Post-#4802: `_finishTurnError` PRESERVES the Map (no clear-all);
+    // late respondToQuestion calls still find their entry. The other
+    // turn-ending sites (`_teardownTurn` via hard timeout / stream stall /
+    // first-output timeout, `interrupt()`, `destroy()`) keep clear-all
+    // because they all issue Ctrl-C (or kill the PTY outright), so any
+    // late keystroke would be writing into a torn-down TUI anyway.
+    it('_finishTurnError preserves pending entries (surgical, audit P1.2 #4802)', () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       session._pendingUserAnswers.set('toolu_one', { toolUseId: 'toolu_one', options: [] })
       session._pendingUserAnswers.set('toolu_two', { toolUseId: 'toolu_two', options: [] })
@@ -3651,8 +3671,10 @@ describe('ClaudeTuiSession', () => {
       session._currentMessageId = 'msg-finish'
       session._activeTurn = { startedAt: Date.now(), aborted: false }
       session._finishTurnError('test-error', 'msg-finish')
-      assert.equal(session._pendingUserAnswers.size, 0,
-        '_finishTurnError ends the turn — every pending answer is now stale')
+      assert.equal(session._pendingUserAnswers.size, 2,
+        '_finishTurnError must NOT wipe pending entries — siblings can have answers in flight (#4802)')
+      assert.ok(session._pendingUserAnswers.has('toolu_one'), 'sibling one preserved')
+      assert.ok(session._pendingUserAnswers.has('toolu_two'), 'sibling two preserved')
     })
 
     it('_handleHardTimeout wipes ALL pending entries (turn-level teardown, #4691)', () => {
@@ -3668,7 +3690,7 @@ describe('ClaudeTuiSession', () => {
       session._hardTimeoutMs = 1000
       session._handleHardTimeout()
       assert.equal(session._pendingUserAnswers.size, 0,
-        'hard timeout ends the turn — every pending answer is now stale')
+        'hard timeout ends the turn with Ctrl-C — every pending answer is now stale')
     })
 
     it('interrupt() wipes ALL pending entries (turn-level teardown, #4691)', () => {
@@ -3680,7 +3702,64 @@ describe('ClaudeTuiSession', () => {
       session._term = { write: () => {}, kill: () => {} }
       session.interrupt()
       assert.equal(session._pendingUserAnswers.size, 0,
-        'interrupt ends the turn — every pending answer is now stale')
+        'interrupt ends the turn with Ctrl-C — every pending answer is now stale')
+    })
+
+    // #4802 — pin the parallel-questions-with-mid-flight-stall regression
+    // scenario from the audit verbatim. The audit's failure mode:
+    //
+    //   1. Turn emits AskUserQuestion A + B in parallel (post-#4668 deny
+    //      retry-as-singles shape).
+    //   2. PostToolUse for A arrives → A's entry is cleared surgically.
+    //   3. Stream stalls for an UNRELATED reason (Stop hook timeout, PTY
+    //      exit, etc.) → `_finishTurnError` runs.
+    //   4. Pre-#4802 the back-compat `_pendingUserAnswer = null` setter
+    //      called `_pendingUserAnswers.clear()` and wiped B.
+    //   5. B's answer arrives microseconds later from the dashboard,
+    //      finds the Map empty, hits the "no matching pending entry —
+    //      dropping" path, and silently wedges.
+    //
+    // Post-#4802: `_finishTurnError` does NOT wipe — B survives so the
+    // late response can still consume it.
+    it('parallel A+B with mid-flight _finishTurnError preserves sibling B (audit P1.2 #4802)', () => {
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      session._term = { write: () => {}, kill: () => {} }
+      session.on('error', () => {})
+      session._isBusy = true
+      session._currentMessageId = 'msg-parallel-stall'
+      session._activeTurn = { startedAt: Date.now(), aborted: false, uuid: 'test-4802' }
+
+      // (1) Two parallel AskUserQuestion tool_uses arrive in one turn.
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_A',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'QA?', options: [{ label: 'a1' }, { label: 'a2' }] }] },
+      }, 'msg-parallel-stall')
+      session._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_B',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'QB?', options: [{ label: 'b1' }, { label: 'b2' }] }] },
+      }, 'msg-parallel-stall')
+      assert.equal(session._pendingUserAnswers.size, 2, 'precondition: A and B armed')
+
+      // (2) PostToolUse for A only — A cleared, B still pending.
+      session._emitToolHookEvent('PostToolUse', {
+        tool_use_id: 'toolu_A',
+        tool_name: 'AskUserQuestion',
+        tool_response: { selectedLabel: 'a1' },
+      }, 'msg-parallel-stall')
+      assert.ok(!session._pendingUserAnswers.has('toolu_A'), 'A cleared by its own PostToolUse')
+      assert.ok(session._pendingUserAnswers.has('toolu_B'), 'B still pending pre-stall')
+
+      // (3) Stream stalls for an unrelated reason → _finishTurnError fires.
+      session._finishTurnError('Stop hook timeout', 'msg-parallel-stall')
+
+      // (4) Pre-#4802: B was wiped by the back-compat null setter →
+      //     `_pendingUserAnswers.clear()`. Post-#4802: B SURVIVES — a
+      //     late response from the dashboard can still consume it.
+      assert.ok(session._pendingUserAnswers.has('toolu_B'),
+        'B\'s pending answer SURVIVES the unrelated turn teardown — late dashboard response must still find its entry (#4802)')
+      assert.equal(session._pendingUserAnswers.size, 1, 'only B remains (A already consumed)')
     })
 
     it('watchdog is cleared on destroy() (clean teardown)', async () => {


### PR DESCRIPTION
## Summary

Closes #4802. Completes the partial fix from #4752 (which surgically fixed only the watchdog callsite).

The pre-#4668 back-compat setter `_pendingUserAnswer = null` was hidden at four turn-teardown sites and silently called `_pendingUserAnswers.clear()` under the hood, wiping sibling AskUserQuestion entries that still had legitimate answers in flight. The audit (guardian P1 finding #3) flagged this as the same shape as the #4668 chain — the Map exists precisely because parallel AskUserQuestion tool_uses can coexist.

## Failure mode (the wedge this prevents)

1. Turn emits AskUserQuestion `A` + `B` in parallel (post-#4648 deny → retry-as-singles shape).
2. PostToolUse for `A` arrives → A's entry is surgically cleared.
3. Stream stalls for an unrelated reason (Stop-hook timeout, PTY exit, prompt-write failure) → `_finishTurnError` runs.
4. Pre-#4802: implicit `_pendingUserAnswer = null` setter → `Map.clear()` wipes `B`.
5. `B`'s answer arrives microseconds later from the dashboard, finds the Map empty, hits the "no matching pending entry — dropping" path, and silently wedges the form.

## Changes

- **Replace** the implicit `set _pendingUserAnswer = null` branch with a `throw` so the regression is loud at any future callsite.
- **Add** `_pendingUserAnswers_clearAll()` for turn-level teardowns that issue Ctrl-C or SIGTERM.
- **Per-callsite audit** (each call now picks an explicit method with a documented reason):
  - `_finishTurnError`: **PRESERVES** the Map. No Ctrl-C → sibling answers may still be validly served.
  - `_teardownTurn` (hard timeout, stream stall, first-output timeout): `_pendingUserAnswers_clearAll()` — Ctrl-C above means the TUI dropped its form.
  - `interrupt()`: `_pendingUserAnswers_clearAll()` — Ctrl-C semantics.
  - `destroy()`: `_pendingUserAnswers_clearAll()` — SIGTERMs the PTY.

## Test plan

- [x] New regression test (RED → GREEN): parallel A+B with mid-flight `_finishTurnError` asserts sibling B survives. Confirmed it fails on the pre-fix setter.
- [x] Updated existing #4691 "_finishTurnError wipes ALL" pinning test to assert preserve-siblings (the new behaviour); `_handleHardTimeout` and `interrupt()` pins keep the clear-all assertion because those paths issue Ctrl-C.
- [x] Updated #4286 "symmetry" test (line 3057) with the same flip + a comment pointing at the audit.
- [x] Updated the "respondToQuestion is a no-op when no pending answer" defensive test to use `_pendingUserAnswers_clearAll()` instead of the now-forbidden implicit setter.
- [x] Full `claude-tui-session.test.js`: 172/172 pass.
- [x] Related suites (`claude-tui-multi-question-intervention`, `claude-tui-attachments`, `claude-tui-session-paste-heuristic`, `permission-hook-multi-question`, `permission-hook-sibling-deny`): 227/227 pass.
- [x] Full server suite: 6532/6544 pass. The 6 remaining failures are environmental (live server on :8765, missing `cloudflared`, real claude CLI installed) and unrelated to this change.

## Related

- Closes #4802
- Completes #4752 (the partial watchdog-only fix this PR generalises across the remaining four callsites)