### PR TITLE
fix(app): keep isRecognizing=true across soft-error restart in continuous mode

### DIFF
--- a/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
+++ b/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
@@ -601,8 +601,7 @@ describe('useSpeechRecognition', () => {
       expect(MockModule.start).toHaveBeenCalledTimes(1);
 
       // Soft error fires — `end` should still re-arm so continuous mode
-      // can recover from transient silence/network blips. (The mic flicker
-      // during the restart blip is a separate cosmetic issue — see #4829.)
+      // can recover from transient silence/network blips.
       actSync(() => {
         eventHandlers['error']?.({ error: errCode, message: errCode });
       });
@@ -611,6 +610,100 @@ describe('useSpeechRecognition', () => {
       });
 
       expect(MockModule.start).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ---- #4829: no isRecognizing flicker on soft-error→restart cycle ----
+
+  describe('#4829: isRecognizing stability across soft-error restart', () => {
+    it.each([
+      'no-speech',
+      'network',
+      'speech-timeout',
+    ])('keeps isRecognizing=true after soft error (%s) in continuous mode (no flicker)', async (errCode) => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(result.current.isRecognizing).toBe(true);
+
+      // Soft error should NOT flip the mic off — from the user's perspective
+      // the engine is still "listening" across the restart blip.
+      actSync(() => {
+        eventHandlers['error']?.({ error: errCode, message: errCode });
+      });
+      expect(result.current.isRecognizing).toBe(true);
+
+      // Spec-mandated `end` after error re-arms recognition; mic stays lit.
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+      expect(result.current.isRecognizing).toBe(true);
+      expect(MockModule.start).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      'not-allowed',
+      'service-not-allowed',
+      'audio-capture',
+      'aborted',
+      'interrupted',
+      'language-not-supported',
+    ])('flips isRecognizing=false on hard error (%s) in continuous mode', async (errCode) => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(result.current.isRecognizing).toBe(true);
+
+      actSync(() => {
+        eventHandlers['error']?.({ error: errCode, message: errCode });
+      });
+
+      // Hard errors are terminal — mic must clear immediately.
+      expect(result.current.isRecognizing).toBe(false);
+    });
+
+    it('flips isRecognizing=false on user-initiated stop in continuous mode', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(result.current.isRecognizing).toBe(true);
+
+      actSync(() => {
+        result.current.stopListening();
+      });
+
+      // Engine fires `end` after stop() — user-initiated stop clears the mic.
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+      expect(result.current.isRecognizing).toBe(false);
+    });
+
+    it.each([
+      'no-speech',
+      'network',
+      'speech-timeout',
+    ])('flips isRecognizing=false on soft error (%s) in auto-pause mode', async (errCode) => {
+      // Auto-pause is the single-shot mode — soft errors should still clear
+      // the mic since there is no continuous-restart loop to ride through.
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'auto-pause' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(result.current.isRecognizing).toBe(true);
+
+      actSync(() => {
+        eventHandlers['error']?.({ error: errCode, message: errCode });
+      });
+
+      expect(result.current.isRecognizing).toBe(false);
     });
   });
 });

--- a/packages/app/src/hooks/useSpeechRecognition.ts
+++ b/packages/app/src/hooks/useSpeechRecognition.ts
@@ -207,15 +207,22 @@ export function useSpeechRecognition(
     // Hard errors must suppress the continuous-mode `end` restart branch.
     // Without flipping `userStoppedRef`, an error event followed by an
     // `end` event (the spec-mandated sequence) would let the restart path
-    // re-arm recognition while the UI shows stopped (`isRecognizing` is
-    // cleared below) — the engine would silently hold the mic with no UI
-    // to release it. Soft errors (no-speech, network, speech-timeout) fall
-    // through so continuous mode can re-arm across normal silence gaps.
-    // Mirrors the dashboard's `onerror` hard-stop branch.
+    // re-arm recognition while the UI shows stopped — the engine would
+    // silently hold the mic with no UI to release it (Copilot finding on
+    // #4813). Mirrors the dashboard's `onerror` hard-stop branch.
     if (HARD_STOP_ERRORS.has(event.error)) {
       userStoppedRef.current = true;
+      inFlightRef.current = false;
+      setIsRecognizing(false);
+      return;
     }
     inFlightRef.current = false;
+    // Soft error in continuous mode (no-speech, network, speech-timeout):
+    // leave `isRecognizing` true and let the subsequent `end` event decide
+    // whether to re-arm. Flipping false here only to have the restart re-set
+    // it true causes a brief mic-icon flicker (#4829). Mirrors the dashboard
+    // `useVoiceInput.onerror` behaviour.
+    if (modeRef.current === 'continuous') return;
     setIsRecognizing(false);
   });
 

--- a/packages/app/src/hooks/useSpeechRecognition.ts
+++ b/packages/app/src/hooks/useSpeechRecognition.ts
@@ -219,9 +219,11 @@ export function useSpeechRecognition(
     inFlightRef.current = false;
     // Soft error in continuous mode (no-speech, network, speech-timeout):
     // leave `isRecognizing` true and let the subsequent `end` event decide
-    // whether to re-arm. Flipping false here only to have the restart re-set
-    // it true causes a brief mic-icon flicker (#4829). Mirrors the dashboard
-    // `useVoiceInput.onerror` behaviour.
+    // whether to re-arm. The restart branch in the `end` handler does NOT
+    // touch `isRecognizing` — it relies on the flag already being true — so
+    // flipping false here would briefly clear the mic icon during the
+    // restart blip with nothing to set it back (#4829). Mirrors the
+    // dashboard `useVoiceInput.onerror` behaviour.
     if (modeRef.current === 'continuous') return;
     setIsRecognizing(false);
   });


### PR DESCRIPTION
Closes #4829

## Summary

In continuous voice-input mode, a soft error (`no-speech`, `network`, `speech-timeout`) followed by the spec-mandated `end` event causes the engine to re-arm recognition. The previous error handler unconditionally called `setIsRecognizing(false)`, and the restart branch in the `end` handler returns early without calling `setIsRecognizing(true)` — producing a brief false-true mic-icon flicker even though recognition continues correctly.

Mirrors the dashboard `useVoiceInput.onerror` pattern: in continuous mode, soft errors leave `isRecognizing` alone and let the `end` handler decide whether to re-arm. Hard errors (`HARD_STOP_ERRORS` set added in #4813) and auto-pause mode still flip the mic off immediately.

## Acceptance Criteria

- [x] Soft error in continuous mode does NOT flip `isRecognizing` to false
- [x] `end` handler restart keeps `isRecognizing` true (existing test verifies)
- [x] Hard error still hard-stops (existing test verifies + new test)
- [x] Auto-pause mode unchanged (existing test verifies + new test)
- [x] Add test asserting `isRecognizing === true` after soft-error -> end restart cycle

## Test plan

- [x] `cd packages/app && npm test` -- all 1458 tests pass (44 in `useSpeechRecognition.test.ts`)
- [x] New `#4829: isRecognizing stability across soft-error restart` describe block adds 13 assertions covering:
  - Soft errors (no-speech, network, speech-timeout) in continuous mode keep `isRecognizing` true across the error-and-restart cycle
  - Hard errors (not-allowed, service-not-allowed, audio-capture, aborted, interrupted, language-not-supported) flip `isRecognizing` false immediately
  - User-initiated stop flips `isRecognizing` false
  - Soft errors in auto-pause mode still flip `isRecognizing` false (no continuous-restart loop to ride through)
- [ ] Manual smoke (out of scope here): trigger network blip on iOS device in continuous mode -- mic icon should stay lit instead of blinking