### PR TITLE
refactor(app): extract SpeechModule.start() options into single helper

### DIFF
--- a/packages/app/__tests__/SpeechEventTypes.test.ts
+++ b/packages/app/__tests__/SpeechEventTypes.test.ts
@@ -21,8 +21,11 @@ describe('useSpeechRecognition typed event handlers (#1912)', () => {
   })
 
   test('imports the event types from expo-speech-recognition', () => {
+    // Tolerate additional type imports (e.g. ExpoSpeechRecognitionOptions
+    // added by #4827) as long as both event types are pulled from the
+    // expo-speech-recognition package.
     expect(src).toMatch(
-      /import type \{\s*ExpoSpeechRecognitionResultEvent,\s*ExpoSpeechRecognitionErrorEvent,?\s*\} from 'expo-speech-recognition'/,
+      /import type \{[^}]*\bExpoSpeechRecognitionResultEvent\b[^}]*\bExpoSpeechRecognitionErrorEvent\b[^}]*\} from 'expo-speech-recognition'/,
     )
   })
 })

--- a/packages/app/__tests__/SpeechEventTypes.test.ts
+++ b/packages/app/__tests__/SpeechEventTypes.test.ts
@@ -22,10 +22,11 @@ describe('useSpeechRecognition typed event handlers (#1912)', () => {
 
   test('imports the event types from expo-speech-recognition', () => {
     // Tolerate additional type imports (e.g. ExpoSpeechRecognitionOptions
-    // added by #4827) as long as both event types are pulled from the
-    // expo-speech-recognition package.
+    // added by #4827) AND any ordering of the imported names — lookaheads
+    // assert both event types appear inside the same import block without
+    // pinning their position relative to each other.
     expect(src).toMatch(
-      /import type \{[^}]*\bExpoSpeechRecognitionResultEvent\b[^}]*\bExpoSpeechRecognitionErrorEvent\b[^}]*\} from 'expo-speech-recognition'/,
+      /import type \{(?=[^}]*\bExpoSpeechRecognitionResultEvent\b)(?=[^}]*\bExpoSpeechRecognitionErrorEvent\b)[^}]*\} from 'expo-speech-recognition'/,
     )
   })
 })

--- a/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
+++ b/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
@@ -305,6 +305,40 @@ describe('useSpeechRecognition', () => {
       expect(result.current.isRecognizing).toBe(true);
     });
 
+    // #4827: fresh-start and silence-restart must hand SpeechModule.start the
+    // identical options shape. They previously constructed the literal twice
+    // and drifted; both call sites now route through a single helper.
+    it('fresh start and continuous restart pass identical start() options', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+
+      // First call: fresh user-initiated start.
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+      const freshOpts = MockModule.start.mock.calls[0][0];
+
+      // Trigger silence-restart branch.
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+
+      expect(MockModule.start).toHaveBeenCalledTimes(2);
+      const restartOpts = MockModule.start.mock.calls[1][0];
+
+      // Byte-identical option shape — guards against future drift like the
+      // pre-#4827 duplicated object literals.
+      expect(restartOpts).toEqual(freshOpts);
+      // And the expected shape itself, so a regression that strips a field
+      // from both sites is still caught.
+      expect(freshOpts).toEqual({
+        lang: 'en-US',
+        interimResults: true,
+        contextualStrings: ['Claude', 'Chroxy'],
+      });
+    });
+
     it('caps restart attempts at MAX_CONTINUOUS_RESTARTS (5)', async () => {
       const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
 

--- a/packages/app/src/hooks/useSpeechRecognition.ts
+++ b/packages/app/src/hooks/useSpeechRecognition.ts
@@ -6,6 +6,7 @@ import { getLocales } from 'expo-localization';
 import type {
   ExpoSpeechRecognitionResultEvent,
   ExpoSpeechRecognitionErrorEvent,
+  ExpoSpeechRecognitionOptions,
 } from 'expo-speech-recognition';
 
 // #4825: consolidated voice-input mode union lives in store-core so the
@@ -110,6 +111,21 @@ const HARD_STOP_ERRORS: ReadonlySet<string> = new Set([
   'language-not-supported',
 ]);
 
+/**
+ * Single source of truth for the option shape passed to
+ * `SpeechModule.start()`. Both the fresh user-initiated start (`startListening`)
+ * and the continuous-mode silence-restart branch in the `end` handler call
+ * this helper so a future option addition (`continuous`, `sampleRate`, etc.)
+ * can't apply to one site and silently miss the other (#4827).
+ */
+export function buildStartOptions(lang: string): ExpoSpeechRecognitionOptions {
+  return {
+    lang,
+    interimResults: true,
+    contextualStrings: ['Claude', 'Chroxy'],
+  };
+}
+
 export function useSpeechRecognition(
   options: UseSpeechRecognitionOptions = {},
 ): UseSpeechRecognitionReturn {
@@ -182,12 +198,10 @@ export function useSpeechRecognition(
       try {
         // Re-arm the SAME recogniser session — no permission re-prompt, no
         // lang re-read. `startListening()` is reserved for fresh user-initiated
-        // sessions; this path keeps `isRecognizing` true.
-        SpeechModule.start({
-          lang: lastLangRef.current ?? 'en-US',
-          interimResults: true,
-          contextualStrings: ['Claude', 'Chroxy'],
-        });
+        // sessions; this path keeps `isRecognizing` true. Options must match
+        // the fresh-start path byte-for-byte (#4827) — both routes call
+        // `buildStartOptions` so a new option can't drift between sites.
+        SpeechModule.start(buildStartOptions(lastLangRef.current ?? 'en-US'));
         inFlightRef.current = true;
         return;
       } catch {
@@ -286,11 +300,7 @@ export function useSpeechRecognition(
     if (!mountedRef.current || stopRequestedRef.current) return;
 
     lastLangRef.current = lang;
-    SpeechModule.start({
-      lang,
-      interimResults: true,
-      contextualStrings: ['Claude', 'Chroxy'],
-    });
+    SpeechModule.start(buildStartOptions(lang));
     inFlightRef.current = true;
     setIsRecognizing(true);
   }, []);


### PR DESCRIPTION
Closes #4827

## Summary

`useSpeechRecognition.ts` was constructing the `SpeechModule.start({...})` options literal at two sites: the fresh user-initiated `startListening` path and the continuous-mode silence-restart branch in the `end` handler. They've matched up to now, but any future option addition (e.g. `continuous`, `sampleRate`, `vadDuration`) at one site would silently miss the other — and restart behaviour would drift from fresh-start behaviour with no failing test to catch it.

This PR extracts a single `buildStartOptions(lang)` helper. Both call sites now route through it. Behaviour is byte-identical: same option shape, same per-call values, same `lastLangRef.current ?? 'en-US'` fallback for the restart path.

## Changes

- `packages/app/src/hooks/useSpeechRecognition.ts`
  - New `buildStartOptions(lang: string): ExpoSpeechRecognitionOptions` exported helper.
  - Both `startListening` and the continuous-restart branch call it instead of inlining the literal.
- `packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts`
  - New test asserts fresh-start and continuous-restart pass identical options to `SpeechModule.start()` (and asserts the exact shape, so a regression that strips a field from both sites is also caught).
- `packages/app/__tests__/SpeechEventTypes.test.ts`
  - Relaxed the `import type { ... }` shape regex (it previously pinned the exact import set) to tolerate the newly added `ExpoSpeechRecognitionOptions` type import. Both event-type assertions remain strict.

## Test plan

- [x] `cd packages/app && npm test` — all 1446 tests pass (104 suites)
- [x] `npx tsc --noEmit` — clean
- [x] New "identical start() options" test passes against the refactored implementation
- [x] All 32 `useSpeechRecognition` tests pass (including continuous-mode, error-suppression, unmount, and stop-during-await branches)