### PR TITLE
fix(app): tear down prior speech session in useSpeechRecognition.startListening

### DIFF
--- a/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
+++ b/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
@@ -432,6 +432,129 @@ describe('useSpeechRecognition', () => {
 
   // ---- #4813 Copilot finding: error→end must not re-arm in continuous mode ----
 
+  // ---- #4826: startListening must tear down prior in-flight session ----
+  // Mirrors the #4789 dashboard fix's start-path prior-cleanup. Today the
+  // expo-speech-recognition module-level singleton likely masks this, but the
+  // contract is: a fresh `startListening` cannot land on top of a session that
+  // the engine still considers active. Without this guarantee, a double-tap
+  // (or gesture + voice-command race) could let the prior session's queued
+  // `onend` re-arm in continuous mode against the new session's bookkeeping
+  // refs — the exact dual-mic window #4789 closed on the dashboard.
+
+  describe('startListening prior-session teardown (#4826)', () => {
+    it('aborts prior session when startListening called while already recognizing', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition());
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+      expect(MockModule.abort).not.toHaveBeenCalled();
+      expect(result.current.isRecognizing).toBe(true);
+
+      // Second start while the first is still in-flight.
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+
+      // Must abort the prior session and start a new one.
+      expect(MockModule.abort).toHaveBeenCalledTimes(1);
+      expect(MockModule.start).toHaveBeenCalledTimes(2);
+    });
+
+    it('aborts prior session BEFORE starting the new one', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition());
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+
+      // Track call order across abort/start to assert teardown precedes restart.
+      const callOrder: string[] = [];
+      MockModule.abort.mockImplementation(() => callOrder.push('abort'));
+      const priorStart = MockModule.start.getMockImplementation();
+      MockModule.start.mockImplementation((opts: unknown) => {
+        callOrder.push('start');
+        return priorStart?.(opts);
+      });
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+
+      const abortIdx = callOrder.indexOf('abort');
+      const startIdx = callOrder.indexOf('start');
+      expect(abortIdx).toBeGreaterThanOrEqual(0);
+      expect(startIdx).toBeGreaterThanOrEqual(0);
+      expect(abortIdx).toBeLessThan(startIdx);
+    });
+
+    it('prior-teardown suppresses continuous-mode end re-arm against new bookkeeping', async () => {
+      // Reproduces the #4789 dual-mic window in the start-path:
+      // - first startListening → in-flight continuous session
+      // - second startListening → fresh user-initiated session, must NOT
+      //   leave a queued onend able to re-arm using the new session's
+      //   userStoppedRef (which has just been reset to false)
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+      // Second startListening before the first session has ended. The
+      // start-path teardown must flip userStoppedRef=true BEFORE abort,
+      // then the post-permission fresh-session bookkeeping flips it back
+      // to false — but by then any queued onend from the prior abort has
+      // already been observed and discarded.
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.abort).toHaveBeenCalledTimes(1);
+      expect(MockModule.start).toHaveBeenCalledTimes(2);
+
+      // Now the new session is mounted. A fresh silence-triggered end
+      // belongs to the NEW session and should re-arm normally.
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(3);
+    });
+
+    it('does NOT abort when no prior session is in-flight', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition());
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+
+      expect(MockModule.abort).not.toHaveBeenCalled();
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT abort when prior session has already ended', async () => {
+      const { result } = renderHookSimple(() => useSpeechRecognition());
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+      // Prior session ends naturally (auto-pause mode).
+      actSync(() => {
+        eventHandlers['end']?.({});
+      });
+      expect(result.current.isRecognizing).toBe(false);
+
+      // Fresh start — nothing to tear down.
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.abort).not.toHaveBeenCalled();
+      expect(MockModule.start).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('voiceInputMode: continuous error→end restart suppression', () => {
     it.each([
       'not-allowed',

--- a/packages/app/src/hooks/useSpeechRecognition.ts
+++ b/packages/app/src/hooks/useSpeechRecognition.ts
@@ -132,6 +132,14 @@ export function useSpeechRecognition(
   // Track whether a stop was requested during async permission flow
   const stopRequestedRef = useRef(false);
 
+  // Track whether a recogniser session is currently in-flight. Mirrors
+  // `isRecognizing` state but stays synchronous so the `startListening`
+  // prior-teardown branch (#4826) and the `end` handler don't race against a
+  // pending React state update. Set true when `start()` is called (fresh
+  // start or continuous-mode re-arm), cleared when the session ends or is
+  // explicitly torn down.
+  const inFlightRef = useRef<boolean>(false);
+
   useEffect(() => {
     if (SpeechModule) {
       try {
@@ -176,12 +184,14 @@ export function useSpeechRecognition(
           interimResults: true,
           contextualStrings: ['Claude', 'Chroxy'],
         });
+        inFlightRef.current = true;
         return;
       } catch {
         // Engine may still be in the tail of the previous session; fall
         // through to clear the mic.
       }
     }
+    inFlightRef.current = false;
     setIsRecognizing(false);
   });
 
@@ -201,6 +211,7 @@ export function useSpeechRecognition(
     if (HARD_STOP_ERRORS.has(event.error)) {
       userStoppedRef.current = true;
     }
+    inFlightRef.current = false;
     setIsRecognizing(false);
   });
 
@@ -216,6 +227,7 @@ export function useSpeechRecognition(
     return () => {
       mountedRef.current = false;
       userStoppedRef.current = true;
+      inFlightRef.current = false;
       SpeechModule?.abort();
     };
   }, []);
@@ -226,6 +238,26 @@ export function useSpeechRecognition(
     setError(null);
     setTranscript('');
     stopRequestedRef.current = false;
+
+    // #4826 / #4789 parity: tear down any prior in-flight recogniser BEFORE
+    // resetting the fresh-session bookkeeping. A double-tap on the mic (or
+    // gesture + voice-command racing) can land a second `startListening` on
+    // top of an active session. Without this guard, the prior session's
+    // queued `onend` would arrive after we reset `userStoppedRef = false` /
+    // `restartCountRef = 0` below and re-arm continuous mode against the new
+    // session's bookkeeping — the dual-mic window the dashboard #4789 fix
+    // closed in its start path. `userStoppedRef = true` BEFORE `abort()` so
+    // the prior session's `end` handler sees the stop flag and exits cleanly.
+    if (inFlightRef.current) {
+      userStoppedRef.current = true;
+      try {
+        SpeechModule.abort();
+      } catch {
+        // Engine may already be tearing down; safe to ignore.
+      }
+      inFlightRef.current = false;
+    }
+
     // Fresh user-initiated start: reset continuous bookkeeping so prior
     // session's user-stop or restart-counter doesn't carry over.
     userStoppedRef.current = false;
@@ -255,6 +287,7 @@ export function useSpeechRecognition(
       interimResults: true,
       contextualStrings: ['Claude', 'Chroxy'],
     });
+    inFlightRef.current = true;
     setIsRecognizing(true);
   }, []);
 
@@ -264,6 +297,7 @@ export function useSpeechRecognition(
     // silence-restart path in `end` sees the flag and exits cleanly rather
     // than re-arming a session the user just cancelled.
     userStoppedRef.current = true;
+    inFlightRef.current = false;
     SpeechModule?.stop();
   }, []);
 


### PR DESCRIPTION
Closes #4826

## Summary

Mirrors the #4789 dashboard fix's start-path prior-cleanup in the mobile hook. Today `useSpeechRecognition.startListening` calls `SpeechModule.start()` directly without first aborting any prior in-flight session. This is most likely safe today because `expo-speech-recognition` exposes a module-level singleton, but a double-tap on the mic (or gesture + voice-command racing) lands the second `start()` on top of an active session — and the prior session's queued `onend` can re-arm continuous mode against the new session's freshly-reset bookkeeping. That is the exact dual-mic window #4789 closed on the dashboard.

## Changes

- `useSpeechRecognition.ts`: add an `inFlightRef` synchronous tracker for the recogniser state (React state alone lags the teardown check). Set on `start()` (fresh or continuous re-arm), cleared on `end`, error, `stopListening`, unmount, and the new prior-teardown branch.
- `useSpeechRecognition.ts`: in `startListening`, if `inFlightRef.current === true`, flip `userStoppedRef = true` BEFORE invoking `SpeechModule.abort()` so the prior session's `end` handler sees the stop flag and exits cleanly rather than re-arming. Then reset fresh-session bookkeeping as before.
- `useSpeechRecognition.test.ts`: 5 new tests covering the contract:
  - aborts prior session when `startListening` called while already recognizing
  - aborts BEFORE starting the new session (call-order assertion)
  - prior-teardown suppresses continuous-mode `end` re-arm against new bookkeeping
  - does NOT abort when no prior session is in-flight
  - does NOT abort when prior session has already ended

## Test plan

- [x] `npm test` in `packages/app` — 1450/1450 tests pass (36/36 in the speech suite, including 5 new ones)
- [x] `npx tsc --noEmit` clean
- [x] TDD verified: tests added first failed on the unfixed hook, then pass on the fixed hook