### PR TITLE
refactor: consolidate VoiceInputMode in store-core

### DIFF
--- a/packages/app/src/hooks/useSpeechRecognition.ts
+++ b/packages/app/src/hooks/useSpeechRecognition.ts
@@ -8,6 +8,10 @@ import type {
   ExpoSpeechRecognitionErrorEvent,
 } from 'expo-speech-recognition';
 
+// #4825: consolidated voice-input mode union lives in store-core so the
+// mobile hook, dashboard hook, and both settings UIs share one declaration.
+import type { VoiceInputMode } from '@chroxy/store-core';
+
 // Dynamically resolve the native module — returns null in Expo Go
 let SpeechModule: typeof import('expo-speech-recognition').ExpoSpeechRecognitionModule | null = null;
 let useSpeechEvent: typeof import('expo-speech-recognition').useSpeechRecognitionEvent = (() => {}) as any;
@@ -44,9 +48,9 @@ export async function setSpeechLang(lang: string): Promise<void> {
 }
 
 /**
- * Voice input behaviour. Mirrors the dashboard `VoiceInputMode` from
- * `packages/dashboard/src/hooks/useVoiceInput.ts` and the shared
- * `InputSettings.voiceInputMode` field in `@chroxy/store-core` (#4785, #4786).
+ * Voice input behaviour. The union itself lives in `@chroxy/store-core`
+ * (#4825) — re-exported here so existing imports of `VoiceInputMode` from
+ * this module keep working without churn.
  *
  * - `'continuous'`: when the engine fires `end` due to silence, the hook
  *   restarts recognition automatically. The mic stays lit until the user
@@ -55,7 +59,7 @@ export async function setSpeechLang(lang: string): Promise<void> {
  * - `'auto-pause'`: original behaviour — `end` ends the session. Default
  *   to keep behaviour stable for callers that don't pass `mode`.
  */
-export type VoiceInputMode = 'continuous' | 'auto-pause';
+export type { VoiceInputMode };
 
 export interface UseSpeechRecognitionOptions {
   mode?: VoiceInputMode;

--- a/packages/app/src/screens/SettingsScreen.tsx
+++ b/packages/app/src/screens/SettingsScreen.tsx
@@ -35,6 +35,7 @@ import {
   formatPlatform,
   formatRelativeTime,
 } from '@chroxy/store-core';
+import type { VoiceInputMode } from '@chroxy/store-core';
 
 const APP_VERSION = Constants.expoConfig?.version ?? 'unknown';
 
@@ -92,9 +93,10 @@ function isValidHHMM(s: string): boolean {
 /**
  * #4807: voice input mode picker options. Mirrors the dashboard
  * `SettingsPanel` select (`packages/dashboard/src/components/SettingsPanel.tsx`)
- * and the shared `InputSettings.voiceInputMode` field.
+ * and the shared `InputSettings.voiceInputMode` field. The mode union
+ * itself is consolidated in `@chroxy/store-core` (#4825).
  */
-const VOICE_INPUT_MODES: { value: 'continuous' | 'auto-pause'; label: string; hint: string }[] = [
+const VOICE_INPUT_MODES: { value: VoiceInputMode; label: string; hint: string }[] = [
   {
     value: 'continuous',
     label: 'Continuous',

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -16,6 +16,7 @@ import {
   formatPlatform,
   formatRelativeTime,
 } from '@chroxy/store-core'
+import type { VoiceInputMode } from '@chroxy/store-core'
 import { isTauri } from '../utils/tauri'
 import {
   getTunnelMode,
@@ -988,9 +989,13 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   }, [updateInputSettings])
 
   const handleVoiceInputModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    // #4825: narrow against the consolidated VoiceInputMode union so adding
+    // a future mode (e.g. 'push-to-talk') to store-core forces this guard
+    // to be updated.
     const next = e.target.value
     if (next === 'continuous' || next === 'auto-pause') {
-      updateInputSettings({ voiceInputMode: next })
+      const mode: VoiceInputMode = next
+      updateInputSettings({ voiceInputMode: mode })
     }
   }, [updateInputSettings])
 

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -989,13 +989,18 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   }, [updateInputSettings])
 
   const handleVoiceInputModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    // #4825: narrow against the consolidated VoiceInputMode union so adding
-    // a future mode (e.g. 'push-to-talk') to store-core forces this guard
-    // to be updated.
+    // #4825: validate against an exhaustive `Record<VoiceInputMode, true>`
+    // map instead of a hard-coded string-list. Adding a new mode to the
+    // union in store-core makes this object literal a TS error (missing
+    // property), forcing the guard to be updated. The previous `===` chain
+    // would have silently dropped a new mode (#4841 review feedback).
+    const VALID_MODES: Record<VoiceInputMode, true> = {
+      continuous: true,
+      'auto-pause': true,
+    }
     const next = e.target.value
-    if (next === 'continuous' || next === 'auto-pause') {
-      const mode: VoiceInputMode = next
-      updateInputSettings({ voiceInputMode: mode })
+    if (Object.prototype.hasOwnProperty.call(VALID_MODES, next)) {
+      updateInputSettings({ voiceInputMode: next as VoiceInputMode })
     }
   }, [updateInputSettings])
 

--- a/packages/dashboard/src/hooks/useVoiceInput.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.ts
@@ -26,6 +26,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { getTauriInvoke, getTauriListen } from '../utils/tauri-bridge'
 
+// #4825: consolidated voice-input mode union lives in store-core so both
+// the dashboard and the mobile hook share one declaration.
+import type { VoiceInputMode } from '@chroxy/store-core'
+
 interface TranscriptionPayload {
   text: string
   is_final: boolean
@@ -112,9 +116,12 @@ function permissionMessageForError(error: string): string {
 }
 
 /**
- * Voice input behaviour. See `InputSettings.voiceInputMode` in store-core for
- * the persisted setting; this hook accepts it as a runtime option so the
- * caller (App.tsx) reads the store once and the hook stays store-agnostic.
+ * Voice input behaviour. The union itself lives in `@chroxy/store-core`
+ * (#4825) — re-exported here so existing imports of `VoiceInputMode` from
+ * this module keep working without churn. See `InputSettings.voiceInputMode`
+ * in store-core for the persisted setting; this hook accepts it as a runtime
+ * option so the caller (App.tsx) reads the store once and the hook stays
+ * store-agnostic.
  *
  * - `'continuous'`: when the Web Speech engine fires `onend` due to silence,
  *   the hook restarts recognition automatically. The mic stays lit until the
@@ -127,7 +134,7 @@ function permissionMessageForError(error: string): string {
  * Only the web engine is affected. The native (Tauri) engine has its own
  * end-of-utterance semantics driven by the Swift helper and is out of scope.
  */
-export type VoiceInputMode = 'continuous' | 'auto-pause'
+export type { VoiceInputMode }
 
 export interface UseVoiceInputOptions {
   mode?: VoiceInputMode

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -23,6 +23,10 @@ export type {
   ContextUsage,
   CumulativeUsage,
   InputSettings,
+  // #4825: consolidated VoiceInputMode union previously declared in
+  // packages/app/src/hooks/useSpeechRecognition.ts and
+  // packages/dashboard/src/hooks/useVoiceInput.ts.
+  VoiceInputMode,
   ModelInfo,
   SessionInfo,
   AgentInfo,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -149,18 +149,26 @@ export interface ContextUsage {
   cacheRead: number;
 }
 
+/**
+ * Voice input behaviour. `'continuous'` keeps the mic open across silence
+ * gaps until the user explicitly clicks stop (the hook restarts Web Speech
+ * recognition on each silence-triggered `onend`). `'auto-pause'` lets the
+ * browser auto-stop on silence — the previous behaviour, kept for users who
+ * prefer it (#4785). Defaults to `'continuous'` so new users get the
+ * click-to-start / click-to-stop experience by default.
+ *
+ * #4825: consolidated here so the mobile `useSpeechRecognition` hook, the
+ * dashboard `useVoiceInput` hook, the dashboard `SettingsPanel` change
+ * handler, and the mobile `SettingsScreen` picker all share one declaration.
+ * Add a new mode (e.g. `'push-to-talk'`) once here and the type-checker will
+ * flag every site that needs to handle it.
+ */
+export type VoiceInputMode = 'continuous' | 'auto-pause';
+
 export interface InputSettings {
   chatEnterToSend: boolean;
   terminalEnterToSend: boolean;
-  /**
-   * Voice input behaviour. `'continuous'` keeps the mic open across silence
-   * gaps until the user explicitly clicks stop (the hook restarts Web Speech
-   * recognition on each silence-triggered `onend`). `'auto-pause'` lets the
-   * browser auto-stop on silence — the previous behaviour, kept for users who
-   * prefer it (#4785). Defaults to `'continuous'` so new users get the
-   * click-to-start / click-to-stop experience by default.
-   */
-  voiceInputMode: 'continuous' | 'auto-pause';
+  voiceInputMode: VoiceInputMode;
 }
 
 /** Default context window size (tokens) used when model metadata doesn't specify one. */

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -160,8 +160,15 @@ export interface ContextUsage {
  * #4825: consolidated here so the mobile `useSpeechRecognition` hook, the
  * dashboard `useVoiceInput` hook, the dashboard `SettingsPanel` change
  * handler, and the mobile `SettingsScreen` picker all share one declaration.
- * Add a new mode (e.g. `'push-to-talk'`) once here and the type-checker will
- * flag every site that needs to handle it.
+ *
+ * Compile-time enforcement is only as strong as the consuming pattern: sites
+ * that exhaustively key a `Record<VoiceInputMode, …>` (e.g. the dashboard
+ * `SettingsPanel` change handler, the mobile `SettingsScreen` picker tuple
+ * typed as `{ value: VoiceInputMode; … }[]`) will be flagged by TS when the
+ * union widens. Sites that use runtime string guards (e.g. the
+ * localStorage-rehydrate path in `packages/dashboard/src/store/connection.ts`
+ * line ~805) will silently ignore the new mode until updated — grep for
+ * `voiceInputMode ===` before adding a new variant.
  */
 export type VoiceInputMode = 'continuous' | 'auto-pause';
 


### PR DESCRIPTION
Closes #4825

## Summary

The `'continuous' | 'auto-pause'` voice-input-mode union was declared in three places (`packages/store-core/src/types.ts` inline on `InputSettings.voiceInputMode`, `packages/dashboard/src/hooks/useVoiceInput.ts`, and `packages/app/src/hooks/useSpeechRecognition.ts`) plus a fourth site (`packages/app/src/screens/SettingsScreen.tsx`) that repeated the literal in a tuple type. Adding a future mode (e.g. `'push-to-talk'`) required updating each site in lockstep.

This PR extracts a single `VoiceInputMode` type alias in `@chroxy/store-core` and has every consumer import it.

## Files changed

- `packages/store-core/src/types.ts` — extract `VoiceInputMode` alias, reference it from `InputSettings.voiceInputMode`.
- `packages/store-core/src/index.ts` — export the new type alias.
- `packages/app/src/hooks/useSpeechRecognition.ts` — import + re-export (preserves existing `import { VoiceInputMode } from '../hooks/useSpeechRecognition'` callers).
- `packages/dashboard/src/hooks/useVoiceInput.ts` — same pattern.
- `packages/app/src/screens/SettingsScreen.tsx` — use the shared type for the `VOICE_INPUT_MODES` tuple instead of the inline literal.
- `packages/dashboard/src/components/SettingsPanel.tsx` — narrow the select-change handler against `VoiceInputMode` so adding a future mode forces the guard to be updated.

## Behaviour

Pure refactor — no type widening, no runtime change. All three sites previously declared the identical union; the consolidated alias is byte-equivalent.

## Test plan

- [x] `packages/store-core` test suite — 1000 tests pass (before and after).
- [x] Type-check after pointing `node_modules/@chroxy/store-core` at the worktree's source: no `VoiceInputMode`-related errors in `packages/dashboard` or `packages/app`. Remaining errors are pre-existing worktree environment issues (missing `@testing-library/react`, `expo-localization`, etc. that aren't in the hoisted node_modules) and reproduce on `main`.
- [ ] CI: dashboard + app + store-core jobs pass on the PR build (clean install resolves the worktree-only environment gaps).