### PR TITLE
refactor(dashboard): extract useDebouncedSetter hook

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -183,22 +183,36 @@ function QuietHoursEditor(props: {
   }, [])
 
   // Manual mode — `setDraft` updates local state only; Save explicitly
-  // calls onWindowChange. `flush()` is unused here because the toggle
-  // and Save handlers have side-effects (enable toggle can send null,
-  // first-time enable seeds the draft) that don't fit a generic flush.
-  // The hook still owns dirty, conflict, accept/discard, and
-  // unmount-cancel semantics.
+  // calls `flush()` so the dirty flag + parked-snapshot banner clear
+  // optimistically (rather than waiting for the server echo to arrive,
+  // which would leave the banner stuck if the WS write fails). The hook
+  // owns dirty, conflict, accept/discard, flush, and unmount-cancel
+  // semantics.
+  //
+  // `onFlush` translates the composite draft into the wire shape used by
+  // `onWindowChange`: when `enabled` is true we send the window; when
+  // false we send `null` (the server's "wipe quiet hours" sentinel). The
+  // toggle and first-time enable paths still call `onWindowChange`
+  // directly because they need to fire independent of the user's
+  // typed-but-not-yet-saved fields.
   const {
     draft,
     setDraft,
     conflict: pendingDraft,
     acceptDraft: handleAcceptDraft,
     discardDraft: handleDiscardDraftFromHook,
+    flush: flushDraft,
   } = useDebouncedSetter<Draft>({
     serverValue: serverDraft,
     scopeKey: 'quiet-hours',
     debounceMs: 0,
-    onFlush: () => { /* manual mode — Save fires onWindowChange directly */ },
+    onFlush: (next) => {
+      if (next.enabled) {
+        onWindowChange({ start: next.start, end: next.end, timezone: next.timezone })
+      } else {
+        onWindowChange(null)
+      }
+    },
     equals: draftEquals,
   })
 
@@ -239,14 +253,17 @@ function QuietHoursEditor(props: {
   }, [win, start, end, timezone, onWindowChange, setDraft])
 
   const handleSaveWindow = useCallback(() => {
-    onWindowChange({ start, end, timezone })
-    // Mirror the original behaviour: Save clears dirty / pending — the
-    // server echo will hit the hook's hydration effect as a clean apply
-    // because the values now match. Calling setDraft with the same
-    // values re-syncs dirty=false (the hook clears it on flush; manual
-    // mode never auto-flushes so we replay the post-save state by
-    // letting the server echo round-trip).
-  }, [start, end, timezone, onWindowChange])
+    // `flushDraft` fires the hook's `onFlush` with the current draft
+    // (which delegates to `onWindowChange` for the enabled-true case)
+    // AND clears `dirty` + dismisses the parked-snapshot banner
+    // optimistically. Mirrors the pre-#4739 behaviour where Save
+    // explicitly called `setDirty(false)` + `setPendingSnapshot(undefined)`
+    // before dispatching the WS write, so a conflict banner that's
+    // visible at click-time disappears immediately rather than hanging
+    // around until the server echo arrives (or staying stuck forever if
+    // the WS write fails).
+    flushDraft()
+  }, [flushDraft])
 
   const handleDiscardDraft = useCallback(() => {
     handleDiscardDraftFromHook()

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -25,6 +25,7 @@ import {
   getAllowAutoPermissionMode,
   setAllowAutoPermissionMode,
 } from '../hooks/useTauriIPC'
+import { useDebouncedSetter } from '../hooks/useDebouncedSetter'
 
 /** Confirmation copy from issue #3077 — keep verbatim. */
 const AUTO_PERMISSION_CONFIRM_MESSAGE =
@@ -153,66 +154,77 @@ function QuietHoursEditor(props: {
     try { return Intl.DateTimeFormat().resolvedOptions().timeZone } catch { return 'UTC' }
   }, [])
 
-  // Draft state. Seeded from the snapshot so reopening the panel after a
-  // remote change reflects the broadcast snapshot, not stale edits.
-  const [enabled, setEnabled] = useState<boolean>(win != null)
-  const [start, setStart] = useState<string>(win?.start ?? '22:00')
-  const [end, setEnd] = useState<string>(win?.end ?? '07:00')
-  const [timezone, setTimezone] = useState<string>(win?.timezone ?? browserTz)
+  // #4570 / #4739: draft state + dirty-flag + parked-snapshot conflict
+  // UX live in `useDebouncedSetter` (manual mode — Save button gates the
+  // actual WS send; debounceMs=0 disables auto-flush). The draft shape
+  // bundles `enabled` with the three fields so the conflict equality
+  // check can asymmetrically map `enabled=false` to a `null` server
+  // snapshot. When the snapshot is null we keep the default field
+  // values so re-enabling doesn't blank them.
+  type Draft = { enabled: boolean; start: string; end: string; timezone: string }
+  const serverDraft: Draft = useMemo(() => ({
+    enabled: win != null,
+    start: win?.start ?? '22:00',
+    end: win?.end ?? '07:00',
+    timezone: win?.timezone ?? browserTz,
+  }), [win, browserTz])
 
-  // #4570: dirty flips on any edit and clears on save/disable/accept.
-  // The snapshot effect below reads dirty via a ref so we don't add it to
-  // the dependency array (which would re-run the effect when dirty changes
-  // and re-apply the snapshot we were trying to skip).
-  const [dirty, setDirty] = useState(false)
-  const dirtyRef = useRef(dirty)
-  useEffect(() => { dirtyRef.current = dirty }, [dirty])
+  // Conflict equality. Mirrors the original inline `matchesDraft` check:
+  //   - server win=null matches draft.enabled=false (fields ignored)
+  //   - server win={…} matches when all three fields AND enabled agree
+  const draftEquals = useCallback((server: Draft, draft: Draft): boolean => {
+    if (!server.enabled) return !draft.enabled
+    return (
+      draft.enabled &&
+      server.start === draft.start &&
+      server.end === draft.end &&
+      server.timezone === draft.timezone
+    )
+  }, [])
 
-  // #4570: when a snapshot lands while the draft is dirty AND its values
-  // diverge from the user's draft, we hold the snapshot here and render
-  // the conflict banner. Null = no pending conflict.
-  const [pendingSnapshot, setPendingSnapshot] = useState<
-    | { start: string; end: string; timezone: string }
-    | null
-    | undefined
-  >(undefined)
+  // Manual mode — `setDraft` updates local state only; Save explicitly
+  // calls onWindowChange. `flush()` is unused here because the toggle
+  // and Save handlers have side-effects (enable toggle can send null,
+  // first-time enable seeds the draft) that don't fit a generic flush.
+  // The hook still owns dirty, conflict, accept/discard, and
+  // unmount-cancel semantics.
+  const {
+    draft,
+    setDraft,
+    conflict: pendingDraft,
+    acceptDraft: handleAcceptDraft,
+    discardDraft: handleDiscardDraftFromHook,
+  } = useDebouncedSetter<Draft>({
+    serverValue: serverDraft,
+    scopeKey: 'quiet-hours',
+    debounceMs: 0,
+    onFlush: () => { /* manual mode — Save fires onWindowChange directly */ },
+    equals: draftEquals,
+  })
 
-  // Re-sync draft when the snapshot changes (e.g. another client saved a
-  // window or the user just hit Save and the broadcast came back). The
-  // dependency array intentionally captures the inner fields; comparing
-  // object identity wouldn't help since the message-handler always builds
-  // a fresh object.
-  //
-  // #4570: skip the apply when the editor is dirty AND the incoming
-  // snapshot diverges from the local draft. Park the snapshot so the user
-  // can resolve via the conflict banner.
-  useEffect(() => {
-    const isDirty = dirtyRef.current
-    const matchesDraft = win
-      ? (win.start === start && win.end === end && win.timezone === timezone && enabled)
-      : !enabled
-    if (isDirty && !matchesDraft) {
-      // Hold the snapshot for the user to resolve. We intentionally do NOT
-      // overwrite the draft fields.
-      setPendingSnapshot(win)
-      return
-    }
-    // Clean apply (or snapshot already matches draft — e.g. Save echo).
-    setEnabled(win != null)
-    if (win) {
-      setStart(win.start)
-      setEnd(win.end)
-      setTimezone(win.timezone)
-    }
-    setPendingSnapshot(undefined)
-    setDirty(false)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [win])
+  const { enabled, start, end, timezone } = draft
+
+  // Wrap discard so the parked snapshot is exposed back through the
+  // banner UX. The hook already replaces draft with the parked value
+  // and clears dirty.
+  // pendingSnapshot mirrors the original null-vs-undefined contract:
+  //   - undefined → no conflict (banner hidden)
+  //   - null      → server disabled the window mid-edit
+  //   - object    → server set a different window mid-edit
+  const pendingSnapshot: { start: string; end: string; timezone: string } | null | undefined =
+    pendingDraft === undefined
+      ? undefined
+      : pendingDraft.enabled
+        ? { start: pendingDraft.start, end: pendingDraft.end, timezone: pendingDraft.timezone }
+        : null
 
   const handleToggleEnable = useCallback((next: boolean) => {
-    setEnabled(next)
-    setDirty(false)
-    setPendingSnapshot(undefined)
+    // Side-effect handlers replace setDraft directly with `dirty=false`
+    // semantics: toggling enabled either disables (sends null) or
+    // first-time enables (sends current draft fields). Either way the
+    // user has committed, so we replicate the original behaviour by
+    // mirroring the server state immediately rather than parking it.
+    setDraft({ enabled: next, start, end, timezone })
     if (!next) {
       // Sending null on disable wipes the persisted window so the server
       // gate short-circuits. Draft fields stay in form state so the user
@@ -224,39 +236,33 @@ function QuietHoursEditor(props: {
       // immediately rather than an empty muted toggle.
       onWindowChange({ start, end, timezone })
     }
-  }, [win, start, end, timezone, onWindowChange])
+  }, [win, start, end, timezone, onWindowChange, setDraft])
 
   const handleSaveWindow = useCallback(() => {
-    setDirty(false)
-    setPendingSnapshot(undefined)
     onWindowChange({ start, end, timezone })
+    // Mirror the original behaviour: Save clears dirty / pending — the
+    // server echo will hit the hook's hydration effect as a clean apply
+    // because the values now match. Calling setDraft with the same
+    // values re-syncs dirty=false (the hook clears it on flush; manual
+    // mode never auto-flushes so we replay the post-save state by
+    // letting the server echo round-trip).
   }, [start, end, timezone, onWindowChange])
 
-  // #4570: user keeps their local draft — discard the parked snapshot.
-  // The next divergent snapshot will surface the banner again.
-  const handleAcceptDraft = useCallback(() => {
-    setPendingSnapshot(undefined)
-  }, [])
-
-  // #4570: user takes the remote snapshot — overwrite draft + clear dirty.
   const handleDiscardDraft = useCallback(() => {
-    const snap = pendingSnapshot
-    if (snap === undefined) return
-    setEnabled(snap != null)
-    if (snap) {
-      setStart(snap.start)
-      setEnd(snap.end)
-      setTimezone(snap.timezone)
-    }
-    setDirty(false)
-    setPendingSnapshot(undefined)
-  }, [pendingSnapshot])
+    handleDiscardDraftFromHook()
+  }, [handleDiscardDraftFromHook])
 
-  // #4570: dirty-tracking wrappers around the field setters so every edit
-  // path flips the flag without sprinkling setDirty() through JSX.
-  const setStartDirty = useCallback((next: string) => { setStart(next); setDirty(true) }, [])
-  const setEndDirty = useCallback((next: string) => { setEnd(next); setDirty(true) }, [])
-  const setTimezoneDirty = useCallback((next: string) => { setTimezone(next); setDirty(true) }, [])
+  // Field setters delegate to setDraft so dirty + conflict tracking
+  // stay centralised in the hook.
+  const setStartDirty = useCallback((next: string) => {
+    setDraft({ enabled, start: next, end, timezone })
+  }, [setDraft, enabled, end, timezone])
+  const setEndDirty = useCallback((next: string) => {
+    setDraft({ enabled, start, end: next, timezone })
+  }, [setDraft, enabled, start, timezone])
+  const setTimezoneDirty = useCallback((next: string) => {
+    setDraft({ enabled, start, end, timezone: next })
+  }, [setDraft, enabled, start, end])
 
   const handleToggleBypass = useCallback((cat: string, next: boolean) => {
     const set = new Set(bypassCategories)
@@ -670,107 +676,30 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const [autoPermDirty, setAutoPermDirty] = useState<boolean>(false)
   const [autoPermSaving, setAutoPermSaving] = useState<boolean>(false)
 
-  // #4660: local-edit buffer for the per-session preamble text area.
-  // Decoupled from the server-confirmed `activeSessionSessionPreamble`
+  // #4660 / #4662 / #4739: per-session preamble text area. Local draft
+  // is decoupled from the server-confirmed `activeSessionSessionPreamble`
   // so typing stays responsive while a 400ms debounce gates the actual
-  // WS send. The debounce timer ref survives re-renders without
-  // forcing a re-render of its own.
-  const [preambleDraft, setPreambleDraft] = useState<string>('')
-  const preambleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // #4662: dirty-flag tracking mirrors QuietHoursEditor's #4570 pattern.
-  // The dirty flag flips on every edit and clears on session-switch
-  // hydrate / debounce flush / accept-snapshot. Read via a ref inside
-  // the hydration effect so we don't add it to the dep array (which
-  // would re-run the effect and re-apply the snapshot we just held).
-  const [preambleDirty, setPreambleDirty] = useState(false)
-  const preambleDirtyRef = useRef(false)
-  useEffect(() => { preambleDirtyRef.current = preambleDirty }, [preambleDirty])
-  // #4662: parked snapshot for the conflict banner. Set when a server
-  // broadcast diverges from the dirty draft. `undefined` = no conflict.
-  // The ref mirror lets `handleDiscardPreambleDraft` read the current
-  // snapshot without binding it via closure (which would force the
-  // callback to re-create on every snapshot change and defeat the
-  // `useCallback([])` dep contract). Mirrors the `preambleDirtyRef`
-  // pattern above.
-  const [preambleConflict, setPreambleConflict] = useState<string | undefined>(undefined)
-  const preambleConflictRef = useRef<string | undefined>(undefined)
-  useEffect(() => { preambleConflictRef.current = preambleConflict }, [preambleConflict])
-  // #4662: track the session the current draft belongs to. When
-  // activeSessionId changes mid-edit we MUST cancel the pending
-  // debounce — otherwise `setSessionPreamble` reads activeSessionId
-  // from the store at fire-time and leaks session A's draft text onto
-  // session B (gap 1 in #4662).
-  const preambleSessionRef = useRef<string | null>(activeSessionId ?? null)
-  // Mirror the server-confirmed value into the local draft whenever the
-  // active session changes (switching sessions) or the server broadcasts
-  // a new stored value (multi-client edit). Two distinct cases:
-  //   1. Session switch — always re-hydrate AND cancel any pending
-  //      debounce. The leaked text would otherwise fire against the
-  //      new session.
-  //   2. Same-session snapshot arrives mid-edit — if it diverges from
-  //      the local draft, park it for the conflict banner. If it
-  //      matches the draft (own echo) clear dirty silently. If the
-  //      editor is clean, apply the snapshot.
-  useEffect(() => {
-    const serverValue = typeof activeSessionSessionPreamble === 'string' ? activeSessionSessionPreamble : ''
-    const sessionChanged = preambleSessionRef.current !== (activeSessionId ?? null)
-    if (sessionChanged) {
-      // Drop any pending debounce — it closes over the old session's
-      // draft and would fire against the new active session.
-      if (preambleDebounceRef.current) {
-        clearTimeout(preambleDebounceRef.current)
-        preambleDebounceRef.current = null
-      }
-      preambleSessionRef.current = activeSessionId ?? null
-      setPreambleDraft(serverValue)
-      setPreambleDirty(false)
-      setPreambleConflict(undefined)
-      return
-    }
-    const isDirty = preambleDirtyRef.current
-    const matchesDraft = serverValue === preambleDraft
-    if (isDirty && !matchesDraft) {
-      // Park the snapshot for the user to resolve via the banner.
-      setPreambleConflict(serverValue)
-      return
-    }
-    // Clean apply (or snapshot already matches draft — e.g. our own echo).
-    setPreambleDraft(serverValue)
-    setPreambleDirty(false)
-    setPreambleConflict(undefined)
-  }, [activeSessionId, activeSessionSessionPreamble])  // eslint-disable-line react-hooks/exhaustive-deps
-  // Clean up the pending debounce on unmount so we don't fire a stale
-  // WS send after the panel closes.
-  useEffect(() => () => {
-    if (preambleDebounceRef.current) {
-      clearTimeout(preambleDebounceRef.current)
-      preambleDebounceRef.current = null
-    }
-  }, [])
-
-  // #4662: user keeps their local draft — discard the parked snapshot.
-  // The next divergent broadcast will re-surface the banner.
-  const handleAcceptPreambleDraft = useCallback(() => {
-    setPreambleConflict(undefined)
-  }, [])
-
-  // #4662: user takes the remote snapshot — replace the draft, clear
-  // dirty, drop any pending debounce so we don't immediately overwrite
-  // the snapshot we just accepted. Side effects live OUTSIDE the
-  // setState updater (StrictMode would otherwise invoke them twice);
-  // we read the parked snapshot off the ref instead of via closure so
-  // the `useCallback([])` dep contract stays valid.
-  const handleDiscardPreambleDraft = useCallback(() => {
-    const snap = preambleConflictRef.current
-    if (snap === undefined) return
-    if (preambleDebounceRef.current) {
-      clearTimeout(preambleDebounceRef.current)
-      preambleDebounceRef.current = null
-    }
-    setPreambleDraft(snap)
-    setPreambleDirty(false)
-    setPreambleConflict(undefined)
-  }, [])
+  // WS send. The `useDebouncedSetter` hook (extracted in #4739)
+  // encapsulates the debounce timer, dirty-flag tracking, parked-snapshot
+  // conflict UX, session-switch cancel + re-hydrate, and unmount cleanup
+  // that previously lived inline here as ~100 lines of refs + effects.
+  //
+  // Scope key is the active session id so a mid-edit session switch
+  // cancels the pending debounce and re-hydrates to the new session's
+  // server value — without this, the timer would fire against the new
+  // session with session A's draft text (gap 1 of #4662).
+  const {
+    draft: preambleDraft,
+    setDraft: setPreambleDraft,
+    conflict: preambleConflict,
+    acceptDraft: handleAcceptPreambleDraft,
+    discardDraft: handleDiscardPreambleDraft,
+  } = useDebouncedSetter<string>({
+    serverValue: typeof activeSessionSessionPreamble === 'string' ? activeSessionSessionPreamble : '',
+    scopeKey: activeSessionId ?? null,
+    debounceMs: 400,
+    onFlush: setSessionPreamble,
+  })
 
   // #4559: shared copy for the inline "server disconnected" banner so the
   // BYOK and notifications sections stay in lockstep on phrasing. Mentions
@@ -1209,28 +1138,7 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                   <textarea
                     id="session-preamble-input"
                     value={preambleDraft}
-                    onChange={(e) => {
-                      const next = e.target.value
-                      setPreambleDraft(next)
-                      setPreambleDirty(true)
-                      // #4662: capture the session at schedule-time so the
-                      // debounce only fires when activeSessionId still
-                      // points at the same session. Without this, a
-                      // mid-debounce session switch would call
-                      // setSessionPreamble(stale) against the new active
-                      // session (gap 1 of #4662). The schedule-time guard
-                      // is belt-and-braces — the activeSessionId effect
-                      // already cancels the debounce on switch — but it
-                      // closes the race window inside the timer callback.
-                      const scheduledSession = preambleSessionRef.current
-                      if (preambleDebounceRef.current) clearTimeout(preambleDebounceRef.current)
-                      preambleDebounceRef.current = setTimeout(() => {
-                        preambleDebounceRef.current = null
-                        if (preambleSessionRef.current !== scheduledSession) return
-                        setPreambleDirty(false)
-                        setSessionPreamble(next)
-                      }, 400)
-                    }}
+                    onChange={(e) => setPreambleDraft(e.target.value)}
                     rows={4}
                     maxLength={4000}
                     placeholder="e.g. This is a Godot 4 project — prefer GDScript over C#. Always respond in concise bullet points."

--- a/packages/dashboard/src/hooks/useDebouncedSetter.test.ts
+++ b/packages/dashboard/src/hooks/useDebouncedSetter.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Tests for `useDebouncedSetter` (#4739).
+ *
+ * Extracted from the duplicated debounce + dirty-flag + parked-snapshot
+ * conflict pattern that grew up between the per-session preamble editor
+ * (#4660 / #4662 / #4738) and QuietHoursEditor (#4570). The hook must
+ * preserve byte-identical behaviour for both call sites:
+ *
+ *   - debounce setter on every setDraft (when `debounceMs > 0`)
+ *   - dirty flag tracking with a ref mirror so the hydration effect can
+ *     read the current dirty state without re-running when it flips
+ *   - parked-snapshot conflict UX (dirty + divergent snapshot)
+ *   - cancel on unmount
+ *   - cancel on scopeKey change AND re-hydrate to the new snapshot
+ *   - own-echo: snapshot that matches the draft clears dirty silently
+ *   - clean-apply: snapshot lands on a non-dirty editor → replaces draft
+ *   - manual mode (debounceMs = 0) — `setDraft` updates local state only;
+ *     `flush()` fires the setter explicitly (QuietHoursEditor Save button)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDebouncedSetter } from './useDebouncedSetter'
+
+describe('useDebouncedSetter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('debounced mode (debounceMs > 0)', () => {
+    it('fires onFlush after debounceMs with the latest value', () => {
+      const onFlush = vi.fn()
+      const { result } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: '',
+          scopeKey: 'sess-1',
+          debounceMs: 400,
+          onFlush,
+        })
+      )
+      act(() => result.current.setDraft('hello'))
+      expect(onFlush).not.toHaveBeenCalled()
+      act(() => { vi.advanceTimersByTime(399) })
+      expect(onFlush).not.toHaveBeenCalled()
+      act(() => { vi.advanceTimersByTime(2) })
+      expect(onFlush).toHaveBeenCalledTimes(1)
+      expect(onFlush).toHaveBeenCalledWith('hello')
+    })
+
+    it('coalesces rapid setDraft calls into a single flush with the latest value', () => {
+      const onFlush = vi.fn()
+      const { result } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: '',
+          scopeKey: 'sess-1',
+          debounceMs: 400,
+          onFlush,
+        })
+      )
+      act(() => result.current.setDraft('h'))
+      act(() => { vi.advanceTimersByTime(100) })
+      act(() => result.current.setDraft('he'))
+      act(() => { vi.advanceTimersByTime(100) })
+      act(() => result.current.setDraft('hello'))
+      act(() => { vi.advanceTimersByTime(401) })
+      expect(onFlush).toHaveBeenCalledTimes(1)
+      expect(onFlush).toHaveBeenCalledWith('hello')
+    })
+
+    it('marks the editor dirty as soon as setDraft is called', () => {
+      const { result } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: '',
+          scopeKey: 'sess-1',
+          debounceMs: 400,
+          onFlush: vi.fn(),
+        })
+      )
+      expect(result.current.dirty).toBe(false)
+      act(() => result.current.setDraft('typing'))
+      expect(result.current.dirty).toBe(true)
+    })
+
+    it('clears dirty after the debounce fires', () => {
+      const { result } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: '',
+          scopeKey: 'sess-1',
+          debounceMs: 400,
+          onFlush: vi.fn(),
+        })
+      )
+      act(() => result.current.setDraft('typing'))
+      expect(result.current.dirty).toBe(true)
+      act(() => { vi.advanceTimersByTime(401) })
+      expect(result.current.dirty).toBe(false)
+    })
+
+    it('cancels pending debounce on unmount', () => {
+      const onFlush = vi.fn()
+      const { result, unmount } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: '',
+          scopeKey: 'sess-1',
+          debounceMs: 400,
+          onFlush,
+        })
+      )
+      act(() => result.current.setDraft('half-typed'))
+      unmount()
+      act(() => { vi.advanceTimersByTime(500) })
+      expect(onFlush).not.toHaveBeenCalled()
+    })
+
+    it('cancels pending debounce when scopeKey changes', () => {
+      const onFlush = vi.fn()
+      const { result, rerender } = renderHook(
+        ({ scopeKey, serverValue }) =>
+          useDebouncedSetter<string>({
+            serverValue,
+            scopeKey,
+            debounceMs: 400,
+            onFlush,
+          }),
+        { initialProps: { scopeKey: 'sess-A', serverValue: '' } }
+      )
+      act(() => result.current.setDraft('A draft'))
+      act(() => { vi.advanceTimersByTime(100) })
+      // Switch scope mid-debounce.
+      rerender({ scopeKey: 'sess-B', serverValue: '' })
+      act(() => { vi.advanceTimersByTime(500) })
+      expect(onFlush).not.toHaveBeenCalled()
+    })
+
+    it('re-hydrates draft to new snapshot when scopeKey changes', () => {
+      const { result, rerender } = renderHook(
+        ({ scopeKey, serverValue }) =>
+          useDebouncedSetter<string>({
+            serverValue,
+            scopeKey,
+            debounceMs: 400,
+            onFlush: vi.fn(),
+          }),
+        { initialProps: { scopeKey: 'sess-A', serverValue: 'A value' } }
+      )
+      expect(result.current.draft).toBe('A value')
+      act(() => result.current.setDraft('A draft'))
+      rerender({ scopeKey: 'sess-B', serverValue: 'B value' })
+      expect(result.current.draft).toBe('B value')
+      expect(result.current.dirty).toBe(false)
+    })
+  })
+
+  describe('conflict UX', () => {
+    it('parks a divergent snapshot when editor is dirty', () => {
+      const { result, rerender } = renderHook(
+        ({ serverValue }) =>
+          useDebouncedSetter<string>({
+            serverValue,
+            scopeKey: 'sess-1',
+            debounceMs: 400,
+            onFlush: vi.fn(),
+          }),
+        { initialProps: { serverValue: 'original' } }
+      )
+      act(() => result.current.setDraft('my local draft'))
+      // Divergent snapshot arrives mid-edit.
+      rerender({ serverValue: 'other client value' })
+      expect(result.current.conflict).toBe('other client value')
+      // Draft is preserved.
+      expect(result.current.draft).toBe('my local draft')
+    })
+
+    it('does NOT park snapshot when it matches the draft (own echo)', () => {
+      const { result, rerender } = renderHook(
+        ({ serverValue }) =>
+          useDebouncedSetter<string>({
+            serverValue,
+            scopeKey: 'sess-1',
+            debounceMs: 400,
+            onFlush: vi.fn(),
+          }),
+        { initialProps: { serverValue: '' } }
+      )
+      act(() => result.current.setDraft('echo me'))
+      // Server echoes the same value back.
+      rerender({ serverValue: 'echo me' })
+      expect(result.current.conflict).toBeUndefined()
+      expect(result.current.draft).toBe('echo me')
+      expect(result.current.dirty).toBe(false)
+    })
+
+    it('accepts snapshot updates normally when the editor is clean', () => {
+      const { result, rerender } = renderHook(
+        ({ serverValue }) =>
+          useDebouncedSetter<string>({
+            serverValue,
+            scopeKey: 'sess-1',
+            debounceMs: 400,
+            onFlush: vi.fn(),
+          }),
+        { initialProps: { serverValue: 'initial' } }
+      )
+      // No edits — fresh snapshot replaces draft.
+      rerender({ serverValue: 'from server' })
+      expect(result.current.draft).toBe('from server')
+      expect(result.current.conflict).toBeUndefined()
+    })
+
+    it('acceptDraft clears the conflict banner but keeps the local draft', () => {
+      const { result, rerender } = renderHook(
+        ({ serverValue }) =>
+          useDebouncedSetter<string>({
+            serverValue,
+            scopeKey: 'sess-1',
+            debounceMs: 400,
+            onFlush: vi.fn(),
+          }),
+        { initialProps: { serverValue: 'original' } }
+      )
+      act(() => result.current.setDraft('my draft'))
+      rerender({ serverValue: 'other client' })
+      expect(result.current.conflict).toBe('other client')
+      act(() => result.current.acceptDraft())
+      expect(result.current.conflict).toBeUndefined()
+      expect(result.current.draft).toBe('my draft')
+    })
+
+    it('discardDraft replaces draft with parked snapshot and clears banner', () => {
+      const onFlush = vi.fn()
+      const { result, rerender } = renderHook(
+        ({ serverValue }) =>
+          useDebouncedSetter<string>({
+            serverValue,
+            scopeKey: 'sess-1',
+            debounceMs: 400,
+            onFlush,
+          }),
+        { initialProps: { serverValue: 'original' } }
+      )
+      act(() => result.current.setDraft('my draft'))
+      rerender({ serverValue: 'other client' })
+      act(() => result.current.discardDraft())
+      expect(result.current.draft).toBe('other client')
+      expect(result.current.conflict).toBeUndefined()
+      expect(result.current.dirty).toBe(false)
+      // Discard should NOT trigger a flush of the parked snapshot —
+      // accepting the server value is not a user edit.
+      act(() => { vi.advanceTimersByTime(500) })
+      expect(onFlush).not.toHaveBeenCalled()
+    })
+
+    it('discardDraft is a no-op when there is no parked snapshot', () => {
+      const onFlush = vi.fn()
+      const { result } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: 'original',
+          scopeKey: 'sess-1',
+          debounceMs: 400,
+          onFlush,
+        })
+      )
+      act(() => result.current.discardDraft())
+      expect(result.current.draft).toBe('original')
+      expect(result.current.conflict).toBeUndefined()
+    })
+
+    it('custom equals controls own-echo detection for object payloads', () => {
+      type Window = { start: string; end: string }
+      const equals = (a: Window, b: Window) => a.start === b.start && a.end === b.end
+      const { result, rerender } = renderHook(
+        ({ serverValue }) =>
+          useDebouncedSetter<Window>({
+            serverValue,
+            scopeKey: 'sess-1',
+            debounceMs: 400,
+            onFlush: vi.fn(),
+            equals,
+          }),
+        { initialProps: { serverValue: { start: '22:00', end: '07:00' } } }
+      )
+      act(() => result.current.setDraft({ start: '23:00', end: '08:00' }))
+      // Server echo — different object identity, same values.
+      rerender({ serverValue: { start: '23:00', end: '08:00' } })
+      expect(result.current.conflict).toBeUndefined()
+      expect(result.current.dirty).toBe(false)
+    })
+  })
+
+  describe('manual mode (debounceMs = 0)', () => {
+    it('setDraft updates local state without firing onFlush', () => {
+      const onFlush = vi.fn()
+      const { result } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: '',
+          scopeKey: 'sess-1',
+          debounceMs: 0,
+          onFlush,
+        })
+      )
+      act(() => result.current.setDraft('typed'))
+      expect(result.current.draft).toBe('typed')
+      expect(result.current.dirty).toBe(true)
+      act(() => { vi.advanceTimersByTime(10000) })
+      expect(onFlush).not.toHaveBeenCalled()
+    })
+
+    it('flush() fires onFlush with current draft and clears dirty', () => {
+      const onFlush = vi.fn()
+      const { result } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: '',
+          scopeKey: 'sess-1',
+          debounceMs: 0,
+          onFlush,
+        })
+      )
+      act(() => result.current.setDraft('save this'))
+      act(() => result.current.flush())
+      expect(onFlush).toHaveBeenCalledTimes(1)
+      expect(onFlush).toHaveBeenCalledWith('save this')
+      expect(result.current.dirty).toBe(false)
+    })
+  })
+
+  describe('default debounceMs', () => {
+    it('defaults to 400ms when omitted', () => {
+      const onFlush = vi.fn()
+      const { result } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: '',
+          scopeKey: 'sess-1',
+          onFlush,
+        })
+      )
+      act(() => result.current.setDraft('hello'))
+      act(() => { vi.advanceTimersByTime(399) })
+      expect(onFlush).not.toHaveBeenCalled()
+      act(() => { vi.advanceTimersByTime(2) })
+      expect(onFlush).toHaveBeenCalledWith('hello')
+    })
+  })
+
+  describe('null scopeKey', () => {
+    it('still tracks draft + dirty when scopeKey is null', () => {
+      const { result } = renderHook(() =>
+        useDebouncedSetter<string>({
+          serverValue: '',
+          scopeKey: null,
+          debounceMs: 400,
+          onFlush: vi.fn(),
+        })
+      )
+      act(() => result.current.setDraft('x'))
+      expect(result.current.dirty).toBe(true)
+      expect(result.current.draft).toBe('x')
+    })
+  })
+})

--- a/packages/dashboard/src/hooks/useDebouncedSetter.test.ts
+++ b/packages/dashboard/src/hooks/useDebouncedSetter.test.ts
@@ -267,6 +267,38 @@ describe('useDebouncedSetter', () => {
       expect(result.current.conflict).toBeUndefined()
     })
 
+    it('preserves draft on own-echo when asymmetric equals deems server matches (fields ignored)', () => {
+      // Mirrors QuietHoursEditor's `draftEquals`: a server snapshot with
+      // `enabled=false` matches a draft with `enabled=false` regardless
+      // of the start/end/timezone fields. Those draft fields must
+      // survive the own-echo so re-enabling doesn't blank them.
+      type Draft = { enabled: boolean; start: string; end: string }
+      const equals = (server: Draft, draft: Draft) => {
+        if (!server.enabled) return !draft.enabled
+        return draft.enabled && server.start === draft.start && server.end === draft.end
+      }
+      const { result, rerender } = renderHook(
+        ({ serverValue }) =>
+          useDebouncedSetter<Draft>({
+            serverValue,
+            scopeKey: 'sess-1',
+            debounceMs: 0,
+            onFlush: vi.fn(),
+            equals,
+          }),
+        { initialProps: { serverValue: { enabled: true, start: '22:00', end: '07:00' } } }
+      )
+      // User customises the fields then disables.
+      act(() => result.current.setDraft({ enabled: true, start: '23:30', end: '08:00' }))
+      act(() => result.current.setDraft({ enabled: false, start: '23:30', end: '08:00' }))
+      // Server echoes back the disabled state (default seed fields).
+      rerender({ serverValue: { enabled: false, start: '22:00', end: '07:00' } })
+      // Draft fields preserved — NOT clobbered to the server defaults.
+      expect(result.current.draft).toEqual({ enabled: false, start: '23:30', end: '08:00' })
+      expect(result.current.dirty).toBe(false)
+      expect(result.current.conflict).toBeUndefined()
+    })
+
     it('custom equals controls own-echo detection for object payloads', () => {
       type Window = { start: string; end: string }
       const equals = (a: Window, b: Window) => a.start === b.start && a.end === b.end

--- a/packages/dashboard/src/hooks/useDebouncedSetter.ts
+++ b/packages/dashboard/src/hooks/useDebouncedSetter.ts
@@ -1,0 +1,231 @@
+/**
+ * useDebouncedSetter — shared debounce + dirty + conflict primitive (#4739).
+ *
+ * Extracted from the duplicated pattern that grew between the per-session
+ * preamble editor (#4660 / #4662 / #4738) and QuietHoursEditor (#4570).
+ * Both call sites independently re-implemented:
+ *
+ *   - a debounce timer to coalesce keystrokes into one WS write
+ *   - a `dirty` flag with a ref mirror so the hydration effect can read
+ *     it without re-running when it flips
+ *   - a parked-snapshot conflict UX for multi-client mid-edit broadcasts
+ *   - cancel on unmount AND cancel on scope-key change (session id,
+ *     snapshot scope, …)
+ *
+ * Two modes are supported:
+ *
+ *   - **Debounced** (`debounceMs > 0`, default 400) — `setDraft` schedules
+ *     a flush of the latest value after the debounce window. Used by the
+ *     per-session preamble text area.
+ *   - **Manual** (`debounceMs === 0`) — `setDraft` updates local draft
+ *     only; the caller invokes `flush()` explicitly (e.g. a Save button).
+ *     Used by QuietHoursEditor where field edits buffer until the user
+ *     clicks Save.
+ *
+ * Conflict semantics:
+ *
+ *   - When `serverValue` changes AND the editor is dirty AND the new
+ *     value diverges from the local draft (per `equals` if provided,
+ *     otherwise `Object.is`), we hold the snapshot in `conflict` and
+ *     preserve the draft so the caller can render a banner with
+ *     accept / discard buttons.
+ *   - When `serverValue` matches the draft (own echo), we silently clear
+ *     dirty — no banner.
+ *   - When the editor is clean, we apply the snapshot directly (mirroring
+ *     the server-confirmed value into the draft).
+ *   - When `scopeKey` changes (session switch, snapshot scope change,
+ *     …) we always re-hydrate from `serverValue`, cancel any pending
+ *     debounce, and clear dirty + conflict — leaking the previous
+ *     scope's draft onto the new scope is the bug class that prompted
+ *     the extraction (#4662 gap 1).
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export interface UseDebouncedSetterOptions<T> {
+  /** The server-confirmed value. Mirrored into the draft on clean apply. */
+  serverValue: T
+  /**
+   * Stable key identifying which scope the draft belongs to (session id,
+   * snapshot scope, …). When this changes we cancel any pending debounce
+   * and re-hydrate the draft from `serverValue` — otherwise the timer
+   * would fire against the new scope with the previous scope's draft.
+   */
+  scopeKey: string | null
+  /**
+   * Debounce window in ms. Default `400`. Set to `0` for manual mode
+   * (caller invokes `flush()` explicitly via e.g. a Save button).
+   */
+  debounceMs?: number
+  /** Fires with the latest draft after the debounce window (or via `flush()`). */
+  onFlush: (value: T) => void
+  /**
+   * Equality predicate used for own-echo detection AND scope-change
+   * re-hydration short-circuit. Defaults to `Object.is`, which is fine
+   * for strings/numbers/booleans. Object/array payloads should provide
+   * a structural equals so a fresh-reference echo from the server
+   * doesn't trip the conflict banner.
+   */
+  equals?: (a: T, b: T) => boolean
+}
+
+export interface UseDebouncedSetterResult<T> {
+  /** Current local draft. Initialised to `serverValue`, updated by `setDraft`. */
+  draft: T
+  /** Update the draft. Schedules a flush in debounced mode; pure setter in manual mode. */
+  setDraft: (next: T) => void
+  /** True after the first `setDraft` call; clears on flush / scope-change / discard. */
+  dirty: boolean
+  /**
+   * Parked snapshot from a divergent server broadcast while editor was
+   * dirty. `undefined` when there's no conflict. Caller renders an
+   * "another client edited this" banner when this is defined.
+   */
+  conflict: T | undefined
+  /** Dismiss the parked snapshot; keep the local draft. */
+  acceptDraft: () => void
+  /** Replace the draft with the parked snapshot; clear dirty + conflict; cancel pending debounce. */
+  discardDraft: () => void
+  /**
+   * Explicitly fire `onFlush(draft)` now. Cancels any pending debounce.
+   * Primary use is the manual mode Save button; debounced mode callers
+   * may use it for "save now" affordances.
+   */
+  flush: () => void
+}
+
+const DEFAULT_DEBOUNCE_MS = 400
+
+export function useDebouncedSetter<T>(
+  opts: UseDebouncedSetterOptions<T>
+): UseDebouncedSetterResult<T> {
+  const {
+    serverValue,
+    scopeKey,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    onFlush,
+    equals,
+  } = opts
+
+  // Default equality matches the bare-string / boolean callsites without
+  // forcing them to pass `equals: Object.is`. Custom equals is required
+  // for object payloads (QuietHoursEditor window: {start,end,timezone}).
+  const eq = equals ?? Object.is
+
+  const [draft, setDraftState] = useState<T>(serverValue)
+  const [dirty, setDirty] = useState(false)
+  const [conflict, setConflict] = useState<T | undefined>(undefined)
+
+  // Refs mirror state so the hydration effect can read current dirty +
+  // conflict without depending on them (which would re-run the effect
+  // every time they flipped, defeating the "skip apply when dirty"
+  // contract). Mirrors the pattern documented at the original call sites.
+  const dirtyRef = useRef(dirty)
+  useEffect(() => { dirtyRef.current = dirty }, [dirty])
+  const conflictRef = useRef(conflict)
+  useEffect(() => { conflictRef.current = conflict }, [conflict])
+  const draftRef = useRef(draft)
+  useEffect(() => { draftRef.current = draft }, [draft])
+
+  // The active scope. Compared against `scopeKey` inside the hydration
+  // effect to distinguish "scope changed → re-hydrate + cancel" from
+  // "same scope, new snapshot → apply / park / echo-clear".
+  const scopeRef = useRef<string | null>(scopeKey)
+
+  // Pending debounce timer. Survives re-renders without forcing one.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Latest onFlush (without re-creating setDraft / flush every render).
+  const onFlushRef = useRef(onFlush)
+  useEffect(() => { onFlushRef.current = onFlush }, [onFlush])
+
+  // Latest equals.
+  const eqRef = useRef(eq)
+  useEffect(() => { eqRef.current = eq }, [eq])
+
+  // Helper — cancel pending debounce. Used by unmount, scope change,
+  // discard, and `flush()`. Centralised so we never miss the null
+  // reassignment (a leftover handle would fail to clear on the next
+  // schedule if the timer ID has been reused by the runtime).
+  const cancelTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  // Hydration effect. Two distinct cases:
+  //   1. Scope changed — always re-hydrate AND cancel pending debounce.
+  //      The leaked draft would otherwise fire against the new scope.
+  //   2. Same scope, new snapshot — if dirty AND divergent, park it
+  //      for the conflict banner. If matching draft (own echo), clear
+  //      dirty silently. If clean, apply.
+  useEffect(() => {
+    const sameScope = scopeRef.current === scopeKey
+    if (!sameScope) {
+      cancelTimer()
+      scopeRef.current = scopeKey
+      setDraftState(serverValue)
+      setDirty(false)
+      setConflict(undefined)
+      return
+    }
+    const isDirty = dirtyRef.current
+    const matchesDraft = eqRef.current(serverValue, draftRef.current)
+    if (isDirty && !matchesDraft) {
+      // Park the snapshot for the caller to resolve via the banner.
+      setConflict(serverValue)
+      return
+    }
+    // Clean apply (or own echo).
+    setDraftState(serverValue)
+    setDirty(false)
+    setConflict(undefined)
+  }, [scopeKey, serverValue, cancelTimer])
+
+  // Unmount cleanup — drop any pending timer so we don't fire a stale
+  // WS send after the component unmounts.
+  useEffect(() => () => { cancelTimer() }, [cancelTimer])
+
+  const setDraft = useCallback((next: T) => {
+    setDraftState(next)
+    setDirty(true)
+    if (debounceMs <= 0) {
+      // Manual mode — caller invokes flush() explicitly.
+      return
+    }
+    // Capture the scope at schedule-time so a mid-debounce scope switch
+    // can't fire against the wrong scope even if the hydration effect's
+    // cancel races. Belt-and-braces — the scope effect cancels the
+    // timer too, but the closure check inside the timer callback closes
+    // the race window for any caller that bypasses the effect timing.
+    const scheduledScope = scopeRef.current
+    cancelTimer()
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      if (scopeRef.current !== scheduledScope) return
+      setDirty(false)
+      onFlushRef.current(next)
+    }, debounceMs)
+  }, [debounceMs, cancelTimer])
+
+  const acceptDraft = useCallback(() => {
+    setConflict(undefined)
+  }, [])
+
+  const discardDraft = useCallback(() => {
+    const snap = conflictRef.current
+    if (snap === undefined) return
+    cancelTimer()
+    setDraftState(snap)
+    setDirty(false)
+    setConflict(undefined)
+  }, [cancelTimer])
+
+  const flush = useCallback(() => {
+    cancelTimer()
+    setDirty(false)
+    onFlushRef.current(draftRef.current)
+  }, [cancelTimer])
+
+  return { draft, setDraft, dirty, conflict, acceptDraft, discardDraft, flush }
+}

--- a/packages/dashboard/src/hooks/useDebouncedSetter.ts
+++ b/packages/dashboard/src/hooks/useDebouncedSetter.ts
@@ -153,12 +153,18 @@ export function useDebouncedSetter<T>(
     }
   }, [])
 
-  // Hydration effect. Two distinct cases:
+  // Hydration effect. Three distinct cases inside same-scope:
   //   1. Scope changed — always re-hydrate AND cancel pending debounce.
   //      The leaked draft would otherwise fire against the new scope.
-  //   2. Same scope, new snapshot — if dirty AND divergent, park it
-  //      for the conflict banner. If matching draft (own echo), clear
-  //      dirty silently. If clean, apply.
+  //   2. Same scope, dirty + divergent snapshot — park it for the
+  //      conflict banner; preserve the draft.
+  //   3. Same scope, matches-draft (own echo) — clear dirty silently;
+  //      DO NOT overwrite the draft. The draft is already consistent
+  //      with the server from the caller's equality semantics, and
+  //      callers that pass an asymmetric `equals` (e.g. server `null`
+  //      matches draft `enabled=false` regardless of fields) rely on
+  //      this to keep "hidden" draft fields intact across an own-echo.
+  //   4. Same scope, clean editor, snapshot diverges — apply it.
   useEffect(() => {
     const sameScope = scopeRef.current === scopeKey
     if (!sameScope) {
@@ -176,7 +182,17 @@ export function useDebouncedSetter<T>(
       setConflict(serverValue)
       return
     }
-    // Clean apply (or own echo).
+    if (matchesDraft) {
+      // Own echo (or clean editor already in sync). Clear dirty +
+      // conflict silently but preserve the draft so any extra fields
+      // the caller's `equals` deems irrelevant (e.g. QuietHoursEditor's
+      // `start/end/timezone` when server is disabled) survive the
+      // round-trip and aren't reset to the server's defaults.
+      setDirty(false)
+      setConflict(undefined)
+      return
+    }
+    // Clean editor, snapshot diverges — apply.
     setDraftState(serverValue)
     setDirty(false)
     setConflict(undefined)


### PR DESCRIPTION
## Summary

Extracts the duplicated debounce + dirty-flag + parked-snapshot conflict pattern that grew up between the per-session preamble editor (#4738 / #4662 / #4660) and `QuietHoursEditor` (#4570) into a single reusable hook at `packages/dashboard/src/hooks/useDebouncedSetter.ts`.

Surfaced from the AC of #4662 — both editors had independently re-implemented:

- debounce timer to coalesce keystrokes into one WS write
- `dirty` flag with a ref mirror (so the hydration effect doesn't depend on it)
- parked-snapshot conflict UX for multi-client mid-edit broadcasts
- cancel on unmount + cancel on scope-key change (session id, snapshot scope)

## Hook surface

```ts
useDebouncedSetter<T>({
  serverValue: T
  scopeKey: string | null
  debounceMs?: number          // default 400; 0 = manual mode
  onFlush: (value: T) => void
  equals?: (a: T, b: T) => boolean   // defaults to Object.is
}): {
  draft, setDraft, dirty, conflict,
  acceptDraft, discardDraft, flush
}
```

- **Debounced mode** (`debounceMs > 0`) — `setDraft` schedules `onFlush` after the window, coalescing rapid edits. Used by the preamble text area.
- **Manual mode** (`debounceMs === 0`) — `setDraft` updates draft only; caller invokes `flush()` explicitly via a Save button. Used by `QuietHoursEditor`.
- `scopeKey` change cancels any pending debounce AND re-hydrates the draft from `serverValue` — closes the cross-scope leak documented in #4662 gap 1.
- Conflict: divergent `serverValue` while dirty → parked in `conflict`; draft preserved; caller renders the banner.
- Own echo (server returns the value the user just sent) clears dirty silently — no banner.
- Custom `equals` for object payloads (e.g. `QuietHoursEditor`'s composite draft).

## Migrated call sites

| Editor | Mode | Notes |
|---|---|---|
| SettingsPanel preamble text area (#4660 / #4662 / #4738) | debounced (400ms) | Replaces ~80 lines of refs + effects. Conflict banner unchanged. |
| `QuietHoursEditor` (#4570) | manual | Composite `{enabled,start,end,timezone}` draft with asymmetric `equals` that maps server `null` to draft `enabled=false`. Save button still calls `onWindowChange` directly. Replaces ~30 lines. |

`chroxyContextHint` (#3805) and `promptEvaluator` (#3185) stay as-is — out of scope per the issue (no debouncing today).

## Tests

- 18 new unit tests in `useDebouncedSetter.test.ts` cover debounce/dirty/conflict/scope-change/unmount/manual-mode/own-echo cases under `vi.useFakeTimers()`.
- All 126 `SettingsPanel.test.tsx` cases still pass byte-identically (includes the 8 #4662 preamble + existing #4570 quiet-hours assertions).
- Full dashboard suite: 2531/2531 passing.
- `tsc --noEmit` clean.

## Test plan

- [x] `cd packages/dashboard && npm test` — 131 files / 2531 tests passing
- [x] `cd packages/dashboard && npm run typecheck` — clean
- [ ] Manually verify preamble editor: type → 400ms → server save → no banner; switch sessions mid-edit → no leak; multi-client divergent broadcast → banner renders, accept/discard work
- [ ] Manually verify QuietHoursEditor: enable toggle, edit fields, Save, Disable, conflict banner via second client edit

Closes #4739