### PR TITLE
fix(server): dedupe backpressure eviction log + metric per client

### DIFF
--- a/packages/server/src/ws-broadcaster.js
+++ b/packages/server/src/ws-broadcaster.js
@@ -71,11 +71,21 @@ export class WsBroadcaster {
    * `backpressure.drops` / `backpressure.disconnects` metrics.
    */
   _sendOneWithBackpressure(ws, client, message) {
+    // #4834: short-circuit if this client has already been evicted. ws.close()
+    // is async, so callers iterating the client map in the same tick (e.g.
+    // multiple broadcasts) would otherwise keep re-tripping the close path
+    // and re-incrementing backpressure.disconnects for a single real close.
+    if (client._evicted) {
+      return false
+    }
     if (ws.bufferedAmount > this._backpressureThreshold) {
       client._backpressureDrops = (client._backpressureDrops || 0) + 1
       metrics.inc('backpressure.drops')
       log.warn(`Backpressure: skipping ${message.type || 'unknown'} for client ${client.id} (buffered: ${ws.bufferedAmount}, drops: ${client._backpressureDrops})`)
       if (client._backpressureDrops >= this._backpressureMaxDrops) {
+        // #4834: sticky _evicted flag prevents log spam + metric over-counting
+        // while ws.close() is in flight.
+        client._evicted = true
         log.warn(`Backpressure: closing client ${client.id} after ${client._backpressureDrops} consecutive drops — client will reconnect`)
         metrics.inc('backpressure.disconnects')
         ws.close(4008, 'Backpressure: too many dropped messages')

--- a/packages/server/src/ws-client-sender.js
+++ b/packages/server/src/ws-client-sender.js
@@ -37,6 +37,13 @@ export function createClientSender(log, opts = {}) {
   const warnThrottleMs = opts.warnThrottleMs ?? WARN_THROTTLE_MS
 
   return function send(ws, client, message) {
+    // #4834: short-circuit if this client has already been evicted. ws.close()
+    // is async (CLOSING → CLOSED), so subsequent synchronous sends in the same
+    // chain (e.g. replayHistory / flushPostAuthQueue) would otherwise keep
+    // serializing + encrypting messages that will never leave the buffer.
+    if (client?._evicted) {
+      return
+    }
     // Queue messages while key exchange is pending
     if (client?.encryptionPending && client.postAuthQueue) {
       client.postAuthQueue.push(message)
@@ -65,7 +72,11 @@ export function createClientSender(log, opts = {}) {
 
       // Post-send backpressure monitoring
       const buffered = ws.bufferedAmount
-      if (buffered > evictThreshold && client) {
+      if (buffered > evictThreshold && client && !client._evicted) {
+        // #4834: sticky _evicted flag prevents log spam + metric over-counting
+        // while ws.close() is in flight. Without this, 10+ sends after the
+        // first eviction can each re-log and re-increment for a single close.
+        client._evicted = true
         log.warn(`Backpressure: evicting client ${client.id} — bufferedAmount ${buffered} exceeds ${evictThreshold} bytes`)
         // #4804: unify observability with WsBroadcaster._sendOneWithBackpressure
         // so both backpressure systems feed the same metric. Without this the

--- a/packages/server/tests/ws-broadcaster.test.js
+++ b/packages/server/tests/ws-broadcaster.test.js
@@ -471,6 +471,75 @@ describe('WsBroadcaster', () => {
     })
   })
 
+  describe('backpressure eviction dedupe (#4834)', () => {
+    beforeEach(() => {
+      metrics.reset()
+    })
+
+    it('closes the client EXACTLY ONCE across N broadcasts after maxDrops', () => {
+      // Once a slow client crosses maxDrops, ws.close() is called. ws.close()
+      // is async — subsequent broadcasts in the same synchronous chain still
+      // see bufferedAmount > threshold and would otherwise re-fire close +
+      // re-increment backpressure.disconnects. Dedupe via sticky _evicted.
+      const threshold = 100
+      const maxDrops = 3
+      broadcaster = new WsBroadcaster({ clients, sendFn, backpressureThreshold: threshold, backpressureMaxDrops: maxDrops })
+      const ws1 = createFakeWs({ bufferedAmount: 200 })
+      // Make close() count invocations
+      let closeCount = 0
+      const originalClose = ws1.close
+      ws1.close = (code, reason) => { closeCount++; originalClose.call(ws1, code, reason) }
+      const client1 = createFakeClient({ id: 'c1' })
+      clients.set(ws1, client1)
+
+      // 10 broadcasts. First 3 drop and trigger close. Remaining 7 should
+      // NOT re-call close or re-increment backpressure.disconnects.
+      for (let i = 0; i < 10; i++) {
+        broadcaster._broadcast({ type: 'test', i })
+      }
+
+      assert.equal(closeCount, 1, 'ws.close called exactly once')
+      assert.equal(metrics.get('backpressure.disconnects'), 1, 'disconnect metric incremented exactly once')
+    })
+
+    it('sets sticky client._evicted flag on first eviction', () => {
+      const threshold = 100
+      const maxDrops = 3
+      broadcaster = new WsBroadcaster({ clients, sendFn, backpressureThreshold: threshold, backpressureMaxDrops: maxDrops })
+      const ws1 = createFakeWs({ bufferedAmount: 200 })
+      const client1 = createFakeClient({ id: 'c1' })
+      clients.set(ws1, client1)
+
+      // Trigger maxDrops worth of broadcasts
+      for (let i = 0; i < 5; i++) {
+        broadcaster._broadcast({ type: 'test', i })
+      }
+
+      assert.equal(client1._evicted, true, 'client marked evicted')
+    })
+
+    it('eviction dedupe is per-client (a separate client object still evicts)', () => {
+      const threshold = 100
+      const maxDrops = 3
+      broadcaster = new WsBroadcaster({ clients, sendFn, backpressureThreshold: threshold, backpressureMaxDrops: maxDrops })
+
+      const wsA = createFakeWs({ bufferedAmount: 200 })
+      const clientA = createFakeClient({ id: 'cA' })
+      const wsB = createFakeWs({ bufferedAmount: 200 })
+      const clientB = createFakeClient({ id: 'cB' })
+      clients.set(wsA, clientA)
+      clients.set(wsB, clientB)
+
+      for (let i = 0; i < 10; i++) {
+        broadcaster._broadcast({ type: 'test', i })
+      }
+
+      assert.equal(wsA.closed, true, 'client A closed')
+      assert.equal(wsB.closed, true, 'client B closed')
+      assert.equal(metrics.get('backpressure.disconnects'), 2, 'one disconnect per client')
+    })
+  })
+
   describe('_broadcastClientJoined() backpressure', () => {
     it('skips peers in backpressure and increments their drop counter', () => {
       broadcaster = new WsBroadcaster({ clients, sendFn, backpressureThreshold: 100 })

--- a/packages/server/tests/ws-client-sender.test.js
+++ b/packages/server/tests/ws-client-sender.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { createClientSender } from '../src/ws-client-sender.js'
+import { metrics } from '../src/metrics.js'
 import { createKeyPair, deriveSharedKey, decrypt, DIRECTION_SERVER, DIRECTION_CLIENT } from '@chroxy/store-core/crypto'
 
 describe('createClientSender', () => {
@@ -256,6 +257,122 @@ describe('createClientSender', () => {
 
       send(ws, client, { type: 'test' })
       assert.equal(client._seq, 1)
+    })
+  })
+
+  describe('backpressure eviction dedupe (#4834)', () => {
+    /**
+     * Build a fake ws whose bufferedAmount is set per-call (simulating a
+     * client that's already past the evict threshold and stays that way
+     * because ws.close() is async and CLOSED hasn't taken effect yet).
+     */
+    function createBackpressureWs({ bufferedAmount }) {
+      const ws = {
+        bufferedAmount,
+        closed: false,
+        closeCount: 0,
+        closeCode: null,
+        closeReason: null,
+        sentCount: 0,
+        send() {
+          ws.sentCount++
+          // bufferedAmount stays high — ws.close() hasn't drained yet
+        },
+        close(code, reason) {
+          ws.closed = true
+          ws.closeCount++
+          ws.closeCode = code
+          ws.closeReason = reason
+        },
+      }
+      return ws
+    }
+
+    beforeEach(() => {
+      metrics.reset()
+    })
+
+    it('logs eviction EXACTLY ONCE across N synchronous sends past the evict threshold', () => {
+      const warns = []
+      log.warn = (msg) => warns.push(msg)
+      // Use small thresholds for the test
+      send = createClientSender(log, { warnThreshold: 100, evictThreshold: 1000 })
+
+      const ws = createBackpressureWs({ bufferedAmount: 2000 })
+      const client = { id: 'c1', _seq: 0 }
+
+      // Fire 10 sends in rapid succession on the same client; bufferedAmount
+      // stays above evictThreshold across all of them.
+      for (let i = 0; i < 10; i++) {
+        send(ws, client, { type: 'msg', i })
+      }
+
+      const evictionWarns = warns.filter((w) => /evicting client/.test(w))
+      assert.equal(evictionWarns.length, 1, 'eviction warn logged exactly once')
+    })
+
+    it('increments backpressure.disconnects EXACTLY ONCE across N synchronous sends past the evict threshold', () => {
+      log.warn = () => {}
+      send = createClientSender(log, { warnThreshold: 100, evictThreshold: 1000 })
+
+      const ws = createBackpressureWs({ bufferedAmount: 2000 })
+      const client = { id: 'c1', _seq: 0 }
+
+      for (let i = 0; i < 10; i++) {
+        send(ws, client, { type: 'msg', i })
+      }
+
+      assert.equal(metrics.get('backpressure.disconnects'), 1, 'metric incremented exactly once')
+    })
+
+    it('calls ws.close(4008, ...) EXACTLY ONCE across N synchronous sends past the evict threshold', () => {
+      log.warn = () => {}
+      send = createClientSender(log, { warnThreshold: 100, evictThreshold: 1000 })
+
+      const ws = createBackpressureWs({ bufferedAmount: 2000 })
+      const client = { id: 'c1', _seq: 0 }
+
+      for (let i = 0; i < 10; i++) {
+        send(ws, client, { type: 'msg', i })
+      }
+
+      assert.equal(ws.closeCount, 1, 'ws.close called exactly once')
+      assert.equal(ws.closeCode, 4008)
+    })
+
+    it('sets sticky client._evicted flag on first eviction', () => {
+      log.warn = () => {}
+      send = createClientSender(log, { warnThreshold: 100, evictThreshold: 1000 })
+
+      const ws = createBackpressureWs({ bufferedAmount: 2000 })
+      const client = { id: 'c1', _seq: 0 }
+
+      send(ws, client, { type: 'test' })
+      assert.equal(client._evicted, true, 'client marked evicted')
+    })
+
+    it('eviction dedupe is per-client (a different client object still evicts)', () => {
+      const warns = []
+      log.warn = (msg) => warns.push(msg)
+      send = createClientSender(log, { warnThreshold: 100, evictThreshold: 1000 })
+
+      // Client A — evicts
+      const wsA = createBackpressureWs({ bufferedAmount: 2000 })
+      const clientA = { id: 'cA', _seq: 0 }
+      for (let i = 0; i < 5; i++) send(wsA, clientA, { type: 'a', i })
+
+      // Client B — a brand new object, different ws, also past threshold
+      const wsB = createBackpressureWs({ bufferedAmount: 2000 })
+      const clientB = { id: 'cB', _seq: 0 }
+      for (let i = 0; i < 5; i++) send(wsB, clientB, { type: 'b', i })
+
+      const evictionWarnsA = warns.filter((w) => /evicting client cA/.test(w))
+      const evictionWarnsB = warns.filter((w) => /evicting client cB/.test(w))
+      assert.equal(evictionWarnsA.length, 1, 'client A evicted exactly once')
+      assert.equal(evictionWarnsB.length, 1, 'client B evicted exactly once')
+      assert.equal(metrics.get('backpressure.disconnects'), 2, 'one disconnect per client')
+      assert.equal(wsA.closeCount, 1)
+      assert.equal(wsB.closeCount, 1)
     })
   })
 })


### PR DESCRIPTION
Closes #4834

## Summary

Once a client is evicted with `ws.close(4008)` for backpressure, the same eviction log message and `metrics.inc('backpressure.disconnects')` previously fired 10+ times for a single real close because `ws.close()` is async (CLOSING → CLOSED) and subsequent synchronous sends in the same chain still tripped the eviction check.

Fix: introduce a sticky `client._evicted` flag set on first eviction. Both backpressure paths short-circuit when it's set:

- `ws-client-sender.js` — `send()` returns early; post-send eviction guard adds `!client._evicted`
- `ws-broadcaster.js _sendOneWithBackpressure` — returns false early; close-on-maxDrops path sets the flag

The early return in `createClientSender.send()` also avoids wasted serialization/encryption work for messages that won't drain.

## Test plan
- [x] New tests in `ws-client-sender.test.js` and `ws-broadcaster.test.js` force eviction with a controllable `bufferedAmount`, fire 10 sends, and assert: log warn exactly once, `metrics.inc('backpressure.disconnects')` exactly once, `ws.close(4008, ...)` exactly once
- [x] Per-client sanity test: a separate client object still evicts normally (flag is per-client, not global)
- [x] `cd packages/server && npm test` — new tests pass; remaining failures are pre-existing flakes (tunnel integration, fetch-timeout, web-task-manager feature detection, ws-server multi-client timing race) unrelated to this change
- [x] `./scripts/lint-tests-state-file-path.sh` passes
- [x] `./scripts/lint-session-opt-forwarding.sh` passes