### PR TITLE
fix(server): docker provider auth hint mentions container exec, not host 'claude login'

### DIFF
--- a/packages/server/src/docker-sdk-session.js
+++ b/packages/server/src/docker-sdk-session.js
@@ -40,7 +40,29 @@ export class DockerSdkSession extends SdkSession {
   }
 
   /**
-   * Resolve runtime auth state for the dashboard (#4769).
+   * Preflight credentials block — overrides SdkSession's host-side spec (#4780).
+   *
+   * Mirror of DockerSession.preflight — see that class for the full rationale.
+   * The container has no ~/.claude state and the host Keychain is invisible,
+   * so `claude login` is futile inside the container. Only `ANTHROPIC_API_KEY`
+   * gets forwarded (see `_startContainer` and `DockerBackend.FORWARDED_ENV_KEYS`),
+   * so it is the only env var we advertise here — listing CLAUDE_CODE_OAUTH_TOKEN
+   * would falsely report ready when the container would still be unauthed.
+   */
+  static get preflight() {
+    const parent = SdkSession.preflight
+    return {
+      ...parent,
+      credentials: {
+        envVars: ['ANTHROPIC_API_KEY'],
+        hint: 'set ANTHROPIC_API_KEY on the host so it is forwarded into the container (no OAuth fallback inside the container — the container has no ~/.claude state)',
+        optional: true,
+      },
+    }
+  }
+
+  /**
+   * Resolve runtime auth state for the dashboard (#4769, #4780).
    *
    * Mirror of DockerSession.resolveAuth — overrides SdkSession's OAuth
    * fallback because the container has no ~/.claude state, so env var is
@@ -52,20 +74,17 @@ export class DockerSdkSession extends SdkSession {
   static resolveAuth(env) {
     const credSpec = this.preflight.credentials
     const envVars = credSpec.envVars
-    const hint = credSpec.hint || `set ${envVars.join(' or ')}`
+    const hint = credSpec.hint
 
     const matched = envVars.find(v => env[v])
     if (matched) {
-      const identity = matched === 'CLAUDE_CODE_OAUTH_TOKEN'
-        ? 'Anthropic API (OAuth token forwarded to container)'
-        : 'Anthropic API (forwarded to container)'
       return {
         ready: true,
         source: 'env',
         envVar: matched,
         envVars,
         hint: '',
-        detail: `${identity} (${matched} set)`,
+        detail: `Anthropic API (forwarded to container) (${matched} set)`,
       }
     }
     return {
@@ -73,8 +92,8 @@ export class DockerSdkSession extends SdkSession {
       source: 'none',
       envVar: null,
       envVars,
-      hint: hint || 'set ANTHROPIC_API_KEY (forwarded to the container at run time)',
-      detail: 'Not configured — container providers need ANTHROPIC_API_KEY on the host (no OAuth fallback inside the container)',
+      hint,
+      detail: 'Not configured — set ANTHROPIC_API_KEY on the host (forwarded into the container at run time). No OAuth fallback inside the container — the container has no ~/.claude state.',
     }
   }
 

--- a/packages/server/src/docker-session.js
+++ b/packages/server/src/docker-session.js
@@ -98,7 +98,30 @@ export class DockerSession extends CliSession {
   }
 
   /**
-   * Resolve runtime auth state for the dashboard (#4769).
+   * Preflight credentials block — overrides CliSession's host-side spec (#4780).
+   *
+   * Inside a container `claude login` cannot work: there is no ~/.claude OAuth
+   * state and the host Keychain is invisible. The only valid path is the
+   * `ANTHROPIC_API_KEY` env var, which `_startContainer` forwards via
+   * `docker run --env`. CLAUDE_CODE_OAUTH_TOKEN is intentionally NOT in
+   * `envVars` — _startContainer does not forward it, so claiming the OAuth
+   * token satisfies auth would mislead the dashboard into reporting ready
+   * for a container that would still fail to authenticate.
+   */
+  static get preflight() {
+    const parent = CliSession.preflight
+    return {
+      ...parent,
+      credentials: {
+        envVars: ['ANTHROPIC_API_KEY'],
+        hint: 'set ANTHROPIC_API_KEY on the host so it is forwarded into the container (no OAuth fallback inside the container — the container has no ~/.claude state)',
+        optional: true,
+      },
+    }
+  }
+
+  /**
+   * Resolve runtime auth state for the dashboard (#4769, #4780).
    *
    * Docker container providers forward process.env.ANTHROPIC_API_KEY to
    * the container at `docker run` time (see _startContainer). Inside the
@@ -113,20 +136,17 @@ export class DockerSession extends CliSession {
   static resolveAuth(env) {
     const credSpec = this.preflight.credentials
     const envVars = credSpec.envVars
-    const hint = credSpec.hint || `set ${envVars.join(' or ')}`
+    const hint = credSpec.hint
 
     const matched = envVars.find(v => env[v])
     if (matched) {
-      const identity = matched === 'CLAUDE_CODE_OAUTH_TOKEN'
-        ? 'Anthropic API (OAuth token forwarded to container)'
-        : 'Anthropic API (forwarded to container)'
       return {
         ready: true,
         source: 'env',
         envVar: matched,
         envVars,
         hint: '',
-        detail: `${identity} (${matched} set)`,
+        detail: `Anthropic API (forwarded to container) (${matched} set)`,
       }
     }
     return {
@@ -134,8 +154,8 @@ export class DockerSession extends CliSession {
       source: 'none',
       envVar: null,
       envVars,
-      hint: hint || 'set ANTHROPIC_API_KEY (forwarded to the container at run time)',
-      detail: 'Not configured — container providers need ANTHROPIC_API_KEY on the host (no OAuth fallback inside the container)',
+      hint,
+      detail: 'Not configured — set ANTHROPIC_API_KEY on the host (forwarded into the container at run time). No OAuth fallback inside the container — the container has no ~/.claude state.',
     }
   }
 

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -712,6 +712,145 @@ describe('Docker Provider Naming (#2475)', () => {
     const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
     assert.equal(DockerSdkSession.capabilities.containerized, true)
   })
+
+  // #4780: the docker providers used to inherit the host-CLI preflight
+  // credentials block from their parent, which suggested the user "run
+  // `claude login`". Inside a container that command cannot work — the
+  // container has no ~/.claude state and the host Keychain is invisible.
+  // The only path is forwarding `ANTHROPIC_API_KEY` from the host.
+  describe('container auth hints (#4780)', () => {
+    const ENV_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN']
+    const saved = {}
+    function clearKeys() {
+      for (const k of ENV_KEYS) {
+        saved[k] = process.env[k]
+        delete process.env[k]
+      }
+    }
+    function restoreKeys() {
+      for (const k of ENV_KEYS) {
+        if (saved[k] === undefined) delete process.env[k]
+        else process.env[k] = saved[k]
+      }
+    }
+
+    it('docker-cli preflight hint does NOT mention `claude login`', async () => {
+      const { DockerSession } = await import('../src/docker-session.js')
+      const credSpec = DockerSession.preflight.credentials
+      assert.ok(credSpec, 'docker-cli must declare a preflight credentials block')
+      assert.doesNotMatch(credSpec.hint, /claude login/i,
+        `claude login is futile inside a container — hint was: ${credSpec.hint}`)
+      assert.match(credSpec.hint, /ANTHROPIC_API_KEY/,
+        'hint must point the user at the env var path')
+    })
+
+    it('docker-sdk preflight hint does NOT mention `claude login`', async () => {
+      const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+      const credSpec = DockerSdkSession.preflight.credentials
+      assert.ok(credSpec, 'docker-sdk must declare a preflight credentials block')
+      assert.doesNotMatch(credSpec.hint, /claude login/i,
+        `claude login is futile inside a container — hint was: ${credSpec.hint}`)
+      assert.match(credSpec.hint, /ANTHROPIC_API_KEY/,
+        'hint must point the user at the env var path')
+    })
+
+    it('docker-cli resolveAuth(no env) returns hint without `claude login`', async () => {
+      try {
+        clearKeys()
+        const { DockerSession } = await import('../src/docker-session.js')
+        const auth = DockerSession.resolveAuth(process.env)
+        assert.equal(auth.ready, false)
+        assert.doesNotMatch(auth.hint, /claude login/i,
+          `docker-cli hint must not tell users to claude login — got: ${auth.hint}`)
+        assert.doesNotMatch(auth.detail, /claude login/i,
+          `docker-cli detail must not tell users to claude login — got: ${auth.detail}`)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('docker-sdk resolveAuth(no env) returns hint without `claude login`', async () => {
+      try {
+        clearKeys()
+        const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+        const auth = DockerSdkSession.resolveAuth(process.env, {})
+        assert.equal(auth.ready, false)
+        assert.doesNotMatch(auth.hint, /claude login/i,
+          `docker-sdk hint must not tell users to claude login — got: ${auth.hint}`)
+        assert.doesNotMatch(auth.detail, /claude login/i,
+          `docker-sdk detail must not tell users to claude login — got: ${auth.detail}`)
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('docker-cli envVars match what _startContainer actually forwards (only ANTHROPIC_API_KEY)', async () => {
+      const { DockerSession } = await import('../src/docker-session.js')
+      // _startContainer only pushes --env ANTHROPIC_API_KEY=... — declaring
+      // CLAUDE_CODE_OAUTH_TOKEN here would lie: a user who set only the OAuth
+      // token would see ready=true but the container would still be unauthed.
+      assert.deepEqual(DockerSession.preflight.credentials.envVars, ['ANTHROPIC_API_KEY'])
+    })
+
+    it('docker-sdk envVars match what _startContainer actually forwards (only ANTHROPIC_API_KEY)', async () => {
+      const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+      assert.deepEqual(DockerSdkSession.preflight.credentials.envVars, ['ANTHROPIC_API_KEY'])
+    })
+
+    it('docker-cli resolveAuth ignores CLAUDE_CODE_OAUTH_TOKEN (not forwarded into container)', async () => {
+      try {
+        clearKeys()
+        process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-fake-oauth'
+        const { DockerSession } = await import('../src/docker-session.js')
+        const auth = DockerSession.resolveAuth(process.env)
+        assert.equal(auth.ready, false,
+          'OAuth token alone must not satisfy docker-cli — _startContainer only forwards ANTHROPIC_API_KEY')
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('docker-sdk resolveAuth ignores CLAUDE_CODE_OAUTH_TOKEN (not forwarded into container)', async () => {
+      try {
+        clearKeys()
+        process.env.CLAUDE_CODE_OAUTH_TOKEN = 'sk-fake-oauth'
+        const { DockerSdkSession } = await import('../src/docker-sdk-session.js')
+        const auth = DockerSdkSession.resolveAuth(process.env, {})
+        assert.equal(auth.ready, false,
+          'OAuth token alone must not satisfy docker-sdk — _startContainer only forwards ANTHROPIC_API_KEY')
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('docker-cli resolveAuth is ready when ANTHROPIC_API_KEY is set on the host', async () => {
+      try {
+        clearKeys()
+        process.env.ANTHROPIC_API_KEY = 'sk-test'
+        const { DockerSession } = await import('../src/docker-session.js')
+        const auth = DockerSession.resolveAuth(process.env)
+        assert.equal(auth.ready, true)
+        assert.equal(auth.source, 'env')
+        assert.equal(auth.envVar, 'ANTHROPIC_API_KEY')
+      } finally {
+        restoreKeys()
+      }
+    })
+
+    it('host CliSession still uses the original `claude login` hint (regression guard)', () => {
+      // The fix is scoped to docker providers — the host CLI provider must
+      // keep mentioning `claude login` because on the host that IS the path.
+      const credSpec = CliSession.preflight.credentials
+      assert.match(credSpec.hint, /claude login/,
+        'host CLI provider must still mention claude login — it works on the host')
+    })
+
+    it('host SdkSession still uses the original `claude login` hint (regression guard)', () => {
+      const credSpec = SdkSession.preflight.credentials
+      assert.match(credSpec.hint, /claude login/,
+        'host SDK provider must still mention claude login — it works on the host')
+    })
+  })
 })
 
 describe('Provider Capabilities', () => {


### PR DESCRIPTION
Closes #4780

## Summary

`DockerSession` and `DockerSdkSession` used to inherit the parent CliSession / SdkSession preflight credentials block, which tells the user to "run `claude login`". Inside a Docker container that command cannot work — the container has no `~/.claude` state and the host Keychain is invisible. The only valid auth path is forwarding `ANTHROPIC_API_KEY` from the host at `docker run` time.

This PR overrides the static `preflight` getter on both docker classes (option 1 from the issue — cleaner because the preflight block is the single source of truth for both `chroxy doctor` and the dashboard).

## Changes

- `packages/server/src/docker-session.js`: override `static get preflight()` so `credentials.envVars = ['ANTHROPIC_API_KEY']` and the hint never mentions `claude login`. Refactor `resolveAuth` to use the new spec.
- `packages/server/src/docker-sdk-session.js`: mirror of the same override.
- `packages/server/tests/providers.test.js`: 11 new tests in a `container auth hints (#4780)` describe block.

### Why drop `CLAUDE_CODE_OAUTH_TOKEN` from envVars?

`_startContainer` only pushes `--env ANTHROPIC_API_KEY=...` (see `DockerBackend.FORWARDED_ENV_KEYS = ['ANTHROPIC_API_KEY', 'NODE_ENV']`). Advertising `CLAUDE_CODE_OAUTH_TOKEN` lied to the dashboard: a user with only the OAuth token saw `ready=true` even though the container would still fail to authenticate.

### Host providers unchanged

The override is scoped to the docker classes. `CliSession.preflight` / `SdkSession.preflight` keep their original `claude login` hint — on the host that IS the valid path, so the regression guard tests assert this stays true.

## Test plan

- [x] `node --test --test-name-pattern="container auth" tests/providers.test.js` — 11/11 pass
- [x] `node --test tests/providers.test.js tests/docker-session.test.js tests/docker-sdk-session.test.js` — 206/206 pass
- [x] Full `npm test` — only pre-existing tunnel/service/web-task-manager failures (identical to baseline on `main`)
- [x] `./scripts/lint-tests-state-file-path.sh` — passes
- [x] `./scripts/lint-session-opt-forwarding.sh` — passes