### PR TITLE
fix(server): pause replayHistory chunks when bufferedAmount exceeds 256 KB

### DIFF
--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -13,6 +13,51 @@ import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
 
 const log = createLogger('ws')
 
+// #4833 — back-pressure pause for chunked replay/flush loops.
+//
+// Both replayHistory and flushPostAuthQueue emit messages in 20-entry chunks
+// separated by setImmediate yields. On sessions with fat tool_result payloads
+// (200KB+ each), a single chunk can push ws.bufferedAmount past the 1MB
+// EVICT_THRESHOLD in ws-client-sender.js, tripping a post-send 4008 close and
+// surfacing as a "Reconnecting…" loop in the dashboard.
+//
+// Before scheduling the next chunk, the loop now polls bufferedAmount and
+// pauses (via setTimeout, every BACKPRESSURE_POLL_INTERVAL_MS) until it falls
+// back below BACKPRESSURE_PAUSE_THRESHOLD. The threshold (256KB) is well
+// below the 1MB eviction line so the next chunk has headroom even on slow
+// links. The poll interval (20ms) is short enough to keep the replay
+// responsive but long enough to give the socket time to actually flush.
+//
+// Both helpers abort the poll if ws.readyState !== 1 (client disconnected
+// while paused) so we never leak a setTimeout or send to a closed socket.
+const BACKPRESSURE_PAUSE_THRESHOLD = 256 * 1024
+const BACKPRESSURE_POLL_INTERVAL_MS = 20
+
+/**
+ * Schedule `fn` once ws.bufferedAmount falls below BACKPRESSURE_PAUSE_THRESHOLD,
+ * or immediately (via setImmediate) if the buffer is already drained. Polls
+ * with setTimeout(BACKPRESSURE_POLL_INTERVAL_MS) while paused. Bails out
+ * silently if ws.readyState transitions away from OPEN — the caller's first
+ * action in `fn` already re-checks readyState so the bailout is safe.
+ */
+function scheduleAfterDrain(ws, fn) {
+  if (ws.readyState !== 1) return
+  const buffered = ws.bufferedAmount || 0
+  if (buffered <= BACKPRESSURE_PAUSE_THRESHOLD) {
+    setImmediate(fn)
+    return
+  }
+  const poll = () => {
+    if (ws.readyState !== 1) return
+    if ((ws.bufferedAmount || 0) <= BACKPRESSURE_PAUSE_THRESHOLD) {
+      setImmediate(fn)
+      return
+    }
+    setTimeout(poll, BACKPRESSURE_POLL_INTERVAL_MS)
+  }
+  setTimeout(poll, BACKPRESSURE_POLL_INTERVAL_MS)
+}
+
 /**
  * Send all post-authentication info to a newly authenticated client.
  * This includes auth_ok, server mode, session list, model/permission state,
@@ -375,6 +420,7 @@ export function replayHistory(ctx, ws, sessionId) {
   const sendChunk = (offset) => {
     if (ws.readyState !== 1) return
     const end = Math.min(offset + CHUNK_SIZE, history.length)
+    let nextOffset = end
     for (let i = offset; i < end; i++) {
       const entry = history[i]
       send(ws, { ...entry, sessionId })
@@ -393,9 +439,25 @@ export function replayHistory(ctx, ws, sessionId) {
       if (entry && entry.type === 'result') {
         send(ws, { type: 'agent_idle', sessionId })
       }
+      // #4833: break out of the chunk early if bufferedAmount already
+      // crossed the pause threshold mid-burst. The CHUNK_SIZE=20 cap was
+      // designed for short messages; a session with fat tool_result
+      // payloads (200KB+) can blow past the 1MB EVICT_THRESHOLD inside
+      // a single chunk, before the post-chunk scheduleAfterDrain ever
+      // gets to inspect bufferedAmount. Pause + resume from the next
+      // unsent entry instead.
+      if (i + 1 < end && (ws.bufferedAmount || 0) > BACKPRESSURE_PAUSE_THRESHOLD) {
+        nextOffset = i + 1
+        break
+      }
     }
-    if (end < history.length) {
-      setImmediate(() => sendChunk(end))
+    if (nextOffset < history.length) {
+      // #4833: pause if the socket is already congested before scheduling
+      // the next chunk. Without this, every setImmediate fires another
+      // burst regardless of buffer pressure, blowing past the 1MB
+      // EVICT_THRESHOLD in ws-client-sender.js on sessions with fat
+      // tool_result payloads.
+      scheduleAfterDrain(ws, () => sendChunk(nextOffset))
     } else {
       send(ws, { type: 'history_replay_end', sessionId })
     }
@@ -422,12 +484,21 @@ export function flushPostAuthQueue(ctx, ws, queue) {
     }
     const end = Math.min(offset + CHUNK_SIZE, queue.length)
     if (client) client._flushing = false
+    let nextOffset = end
     for (let i = offset; i < end; i++) {
       send(ws, queue[i])
+      // #4833: break early if a fat queued message just tipped bufferedAmount
+      // past the pause threshold — same rationale as replayHistory above.
+      if (i + 1 < end && (ws.bufferedAmount || 0) > BACKPRESSURE_PAUSE_THRESHOLD) {
+        nextOffset = i + 1
+        break
+      }
     }
-    if (end < queue.length) {
+    if (nextOffset < queue.length) {
       if (client) client._flushing = true
-      setImmediate(() => drainChunk(end))
+      // #4833: pause if the socket is already congested before scheduling
+      // the next chunk — same rationale as replayHistory above.
+      scheduleAfterDrain(ws, () => drainChunk(nextOffset))
     } else if (client) {
       if (client._flushOverflow?.length) {
         const overflow = client._flushOverflow

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -28,8 +28,13 @@ const log = createLogger('ws')
 // links. The poll interval (20ms) is short enough to keep the replay
 // responsive but long enough to give the socket time to actually flush.
 //
-// Both helpers abort the poll if ws.readyState !== 1 (client disconnected
-// while paused) so we never leak a setTimeout or send to a closed socket.
+// Both helpers abort the poll once ws.readyState leaves OPEN (client
+// disconnected while paused), so the poll chain terminates on socket close
+// without sending to a closed socket. Note that this is a narrower guarantee
+// than "we never leak a setTimeout" — a dead TCP connection that never moves
+// out of OPEN and never drains would keep polling indefinitely. That is the
+// same liveness window as the existing ws keep-alive ping; if we ever want a
+// hard cap, add a max-wait/backoff here.
 const BACKPRESSURE_PAUSE_THRESHOLD = 256 * 1024
 const BACKPRESSURE_POLL_INTERVAL_MS = 20
 
@@ -419,6 +424,19 @@ export function replayHistory(ctx, ws, sessionId) {
   const CHUNK_SIZE = 20
   const sendChunk = (offset) => {
     if (ws.readyState !== 1) return
+    // #4833 follow-up: gate chunk *entry* on bufferedAmount too, not just
+    // chunk *scheduling*. The recursive setImmediate-via-scheduleAfterDrain
+    // path is already gated, but the very first sendChunk(0) call can land
+    // on a socket that's already congested from the preceding
+    // sendPostAuthInfo / session_switched burst. Without this check, the
+    // first history entry would be sent unconditionally and the mid-chunk
+    // break (which only fires *after* a send) wouldn't trip until i=1 —
+    // meaning we still push one fat tool_result onto an already-congested
+    // socket and can trip the 1MB EVICT_THRESHOLD.
+    if ((ws.bufferedAmount || 0) > BACKPRESSURE_PAUSE_THRESHOLD) {
+      scheduleAfterDrain(ws, () => sendChunk(offset))
+      return
+    }
     const end = Math.min(offset + CHUNK_SIZE, history.length)
     let nextOffset = end
     for (let i = offset; i < end; i++) {
@@ -480,6 +498,19 @@ export function flushPostAuthQueue(ctx, ws, queue) {
         client._flushing = false
         client._flushOverflow = null
       }
+      return
+    }
+    // #4833 follow-up: gate chunk *entry* on bufferedAmount too — same
+    // rationale as replayHistory.sendChunk above. drainChunk(0) is invoked
+    // synchronously from flushPostAuthQueue, so the very first queued
+    // message can land on an already-congested socket (e.g. fat post-auth
+    // payloads that were queued during the encryption handshake) before the
+    // mid-chunk break (which only fires after a send) gets a chance to
+    // pause. Keep _flushing = true so any callers using ws-client-sender's
+    // _flushing buffer still queue overflow instead of blasting past us.
+    if ((ws.bufferedAmount || 0) > BACKPRESSURE_PAUSE_THRESHOLD) {
+      if (client) client._flushing = true
+      scheduleAfterDrain(ws, () => drainChunk(offset))
       return
     }
     const end = Math.min(offset + CHUNK_SIZE, queue.length)

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -1091,6 +1091,282 @@ describe('replayHistory', () => {
   })
 })
 
+// #4833 — replayHistory must pause when ws.bufferedAmount exceeds the
+// backpressure threshold so a session with large tool_result payloads doesn't
+// trip the post-send eviction (1MB) in ws-client-sender.js. Pre-fix, every
+// chunk fires via setImmediate without consulting bufferedAmount; in the
+// reported scenario the per-chunk burst pushes the socket buffer over 1MB
+// and the dashboard sees a 4008 close → "Reconnecting…" loop.
+describe('replayHistory — bufferedAmount backpressure drain (#4833)', () => {
+  /**
+   * Build a fake ws whose `bufferedAmount` mirrors what the real WS would
+   * report between event-loop turns. `send` adds the byte length of the
+   * payload (mimicking the OS-level send queue when the socket is slow),
+   * and tests can call `drain(n)` to subtract bytes as the simulated peer
+   * acknowledges. `readyState` defaults to OPEN.
+   */
+  function makeBackpressuredWs(readyState = 1) {
+    const rawSent = []
+    const ws = {
+      readyState,
+      bufferedAmount: 0,
+      send(data) {
+        // Mirror the real ws.send: bufferedAmount grows by the wire size of
+        // each payload that hasn't yet been flushed to the network.
+        const bytes = Buffer.byteLength(typeof data === 'string' ? data : JSON.stringify(data))
+        ws.bufferedAmount += bytes
+        rawSent.push(data)
+      },
+      close: createSpy(),
+      _rawSent: rawSent,
+      drain(bytes) {
+        ws.bufferedAmount = Math.max(0, ws.bufferedAmount - bytes)
+      },
+      drainAll() {
+        ws.bufferedAmount = 0
+      },
+    }
+    return ws
+  }
+
+  /**
+   * Build a ctx whose `send` writes to the real ws.send so bufferedAmount
+   * tracks the actual byte stream during replay. Mirrors the production
+   * createClientSender path that goes through ws.send, just without the
+   * encryption / post-send eviction logic (those live in ws-client-sender
+   * and are out of scope for the replayHistory loop).
+   */
+  function makeCtxWithRealSend(overrides = {}) {
+    const sends = []
+    const ctx = makeCtx({
+      send: (ws, msg) => {
+        sends.push(msg)
+        if (ws.readyState === 1) ws.send(JSON.stringify(msg))
+      },
+      ...overrides,
+    })
+    // Re-spy nothing: replace the helper sends array with our own tracker.
+    ctx._sends = sends
+    return ctx
+  }
+
+  it('pauses chunk scheduling once bufferedAmount exceeds the 256KB threshold', async () => {
+    // 30 entries × ~200KB payload = 6MB total. Pre-fix, the first
+    // setImmediate-scheduled chunk would push 4MB onto the socket before
+    // yielding, blowing past the 1MB eviction line. Post-fix, we should
+    // stop after the first chunk fills the buffer and wait for drain.
+    const ENTRY_COUNT = 30
+    const PAYLOAD_BYTES = 200 * 1024
+    const bigText = 'x'.repeat(PAYLOAD_BYTES)
+    const history = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
+      type: 'tool_result',
+      toolUseId: `toolu_${i}`,
+      content: bigText,
+    }))
+
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    manager.getHistory = () => history
+    manager.isHistoryTruncated = () => false
+
+    const ws = makeBackpressuredWs()
+    const ctx = makeCtxWithRealSend({ sessionManager: manager })
+    registerClient(ctx, ws)
+
+    replayHistory(ctx, ws, 'sess-1')
+
+    // Yield the loop a few times — without the fix, every setImmediate
+    // would drain another 20-entry chunk and push bufferedAmount well past
+    // 1MB. With the fix, the loop must stall on bufferedAmount > 256KB and
+    // wait for drain (we never drain here, so it never advances).
+    for (let i = 0; i < 5; i++) {
+      await new Promise(r => setImmediate(r))
+    }
+
+    // Sanity: at least the history_replay_start and a partial chunk made it.
+    const startMsg = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.ok(startMsg, 'history_replay_start must always be sent first')
+
+    const replayed = ctx._sends.filter(m => m.type === 'tool_result').length
+    assert.ok(replayed < ENTRY_COUNT,
+      `expected replay to stall before sending all ${ENTRY_COUNT} entries when buffer never drains; got ${replayed}`)
+
+    // The end marker must NOT have been sent yet because the loop is stalled.
+    const endMsg = ctx._sends.find(m => m.type === 'history_replay_end')
+    assert.equal(endMsg, undefined,
+      'history_replay_end should not be sent while bufferedAmount stays above threshold')
+  })
+
+  it('keeps bufferedAmount under the 1MB eviction line during a fat-payload replay', async () => {
+    // Same scenario as above but with a draining peer. The fix should keep
+    // bufferedAmount under 1MB at every observation point throughout the
+    // replay — the 1MB EVICT_THRESHOLD in ws-client-sender.js would 4008
+    // the client otherwise (#4833 reproduction path).
+    const ENTRY_COUNT = 30
+    const PAYLOAD_BYTES = 200 * 1024
+    const EVICT_THRESHOLD = 1024 * 1024
+    const bigText = 'x'.repeat(PAYLOAD_BYTES)
+    const history = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
+      type: 'tool_result',
+      toolUseId: `toolu_${i}`,
+      content: bigText,
+    }))
+
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    manager.getHistory = () => history
+    manager.isHistoryTruncated = () => false
+
+    const ws = makeBackpressuredWs()
+    const ctx = makeCtxWithRealSend({ sessionManager: manager })
+    registerClient(ctx, ws)
+
+    // Background drain: every 5ms, the simulated peer acknowledges 512KB.
+    // That's well under the per-chunk burst the pre-fix code would emit,
+    // so the only way to stay under 1MB is for the replay loop to actually
+    // pause when bufferedAmount climbs.
+    let maxObserved = 0
+    const drainTimer = setInterval(() => {
+      // Snapshot before drain so we measure the peak bufferedAmount, not
+      // the moment-after-drain trough.
+      if (ws.bufferedAmount > maxObserved) maxObserved = ws.bufferedAmount
+      ws.drain(512 * 1024)
+    }, 5)
+
+    try {
+      replayHistory(ctx, ws, 'sess-1')
+
+      // Wait for the replay to finish (history_replay_end) or time out.
+      const deadline = Date.now() + 3000
+      while (Date.now() < deadline) {
+        if (ws.bufferedAmount > maxObserved) maxObserved = ws.bufferedAmount
+        if (ctx._sends.some(m => m.type === 'history_replay_end')) break
+        await new Promise(r => setTimeout(r, 10))
+      }
+
+      const endMsg = ctx._sends.find(m => m.type === 'history_replay_end')
+      assert.ok(endMsg, 'replay must eventually complete when peer drains')
+
+      const replayed = ctx._sends.filter(m => m.type === 'tool_result').length
+      assert.equal(replayed, ENTRY_COUNT, 'every history entry must be replayed')
+
+      assert.ok(maxObserved < EVICT_THRESHOLD,
+        `bufferedAmount peaked at ${maxObserved} bytes; must stay under ${EVICT_THRESHOLD} (1MB) to avoid client eviction`)
+    } finally {
+      clearInterval(drainTimer)
+    }
+  })
+
+  it('bails out gracefully when ws closes while paused on backpressure', async () => {
+    // Edge case: the drain loop must abort if the client disconnects while
+    // we're waiting for bufferedAmount to fall. Otherwise we'd keep polling
+    // and eventually send to a closed socket (or leak a setTimeout).
+    const ENTRY_COUNT = 30
+    const PAYLOAD_BYTES = 200 * 1024
+    const bigText = 'x'.repeat(PAYLOAD_BYTES)
+    const history = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
+      type: 'tool_result',
+      toolUseId: `toolu_${i}`,
+      content: bigText,
+    }))
+
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    manager.getHistory = () => history
+    manager.isHistoryTruncated = () => false
+
+    const ws = makeBackpressuredWs()
+    const ctx = makeCtxWithRealSend({ sessionManager: manager })
+    registerClient(ctx, ws)
+
+    replayHistory(ctx, ws, 'sess-1')
+
+    // Let the first chunk go out and the loop stall on bufferedAmount.
+    await new Promise(r => setImmediate(r))
+    await new Promise(r => setImmediate(r))
+
+    const sentBeforeClose = ctx._sends.length
+    ws.readyState = 3 // CLOSED
+
+    // Drain the buffer so the polled check would otherwise resume the loop,
+    // and wait long enough for the next poll tick (>20ms).
+    ws.drainAll()
+    await new Promise(r => setTimeout(r, 60))
+
+    // The loop must have bailed; no end marker, no extra sends.
+    const endMsg = ctx._sends.find(m => m.type === 'history_replay_end')
+    assert.equal(endMsg, undefined, 'replay must not send end marker after ws closes')
+    assert.equal(ctx._sends.length, sentBeforeClose,
+      'no additional messages should be sent after ws closes while paused')
+  })
+})
+
+// #4833 — flushPostAuthQueue has the same chunking shape and must apply the
+// same drain logic so a large queued burst (e.g. encryption-required handshake
+// stacking auth_ok + session_list + session_switched + history) doesn't trip
+// the same 1MB eviction.
+describe('flushPostAuthQueue — bufferedAmount backpressure drain (#4833)', () => {
+  function makeBackpressuredWs(readyState = 1) {
+    const rawSent = []
+    const ws = {
+      readyState,
+      bufferedAmount: 0,
+      send(data) {
+        const bytes = Buffer.byteLength(typeof data === 'string' ? data : JSON.stringify(data))
+        ws.bufferedAmount += bytes
+        rawSent.push(data)
+      },
+      close: createSpy(),
+      _rawSent: rawSent,
+      drain(bytes) {
+        ws.bufferedAmount = Math.max(0, ws.bufferedAmount - bytes)
+      },
+    }
+    return ws
+  }
+
+  function makeCtxWithRealSend(overrides = {}) {
+    const sends = []
+    const ctx = makeCtx({
+      send: (ws, msg) => {
+        sends.push(msg)
+        if (ws.readyState === 1) ws.send(JSON.stringify(msg))
+      },
+      ...overrides,
+    })
+    ctx._sends = sends
+    return ctx
+  }
+
+  it('pauses queue draining once bufferedAmount exceeds the threshold', async () => {
+    const QUEUE_LEN = 30
+    const PAYLOAD_BYTES = 200 * 1024
+    const bigText = 'x'.repeat(PAYLOAD_BYTES)
+    const queue = Array.from({ length: QUEUE_LEN }, (_, i) => ({
+      type: 'fat_msg',
+      idx: i,
+      data: bigText,
+    }))
+
+    const ws = makeBackpressuredWs()
+    const ctx = makeCtxWithRealSend()
+    registerClient(ctx, ws)
+
+    flushPostAuthQueue(ctx, ws, queue)
+
+    for (let i = 0; i < 5; i++) {
+      await new Promise(r => setImmediate(r))
+    }
+
+    const sent = ctx._sends.filter(m => m.type === 'fat_msg').length
+    assert.ok(sent < QUEUE_LEN,
+      `expected flush to stall before sending all ${QUEUE_LEN} queued messages; got ${sent}`)
+  })
+})
+
 // ── flushPostAuthQueue ─────────────────────────────────────────────────────
 
 describe('flushPostAuthQueue', () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -1196,6 +1196,11 @@ describe('replayHistory — bufferedAmount backpressure drain (#4833)', () => {
     const endMsg = ctx._sends.find(m => m.type === 'history_replay_end')
     assert.equal(endMsg, undefined,
       'history_replay_end should not be sent while bufferedAmount stays above threshold')
+
+    // Mark the ws CLOSED so scheduleAfterDrain's pending 20ms poll exits on
+    // its next tick instead of leaking a setTimeout into later tests in this
+    // file (#4845 review feedback).
+    ws.readyState = 3
   })
 
   it('keeps bufferedAmount under the 1MB eviction line during a fat-payload replay', async () => {
@@ -1257,6 +1262,64 @@ describe('replayHistory — bufferedAmount backpressure drain (#4833)', () => {
     } finally {
       clearInterval(drainTimer)
     }
+  })
+
+  it('pauses on chunk entry when bufferedAmount is already over the threshold', async () => {
+    // #4845 review feedback: even with the mid-chunk break + post-chunk
+    // scheduleAfterDrain, the very first sendChunk(0) call previously sent
+    // its first entry unconditionally — so if the socket was already
+    // congested from the preceding sendPostAuthInfo / session_switched
+    // burst, one fat tool_result still landed on top of a near-eviction
+    // buffer and could tip past 1MB. The chunk-entry gate must defer the
+    // chunk if bufferedAmount > threshold at entry, without sending any
+    // history payload first.
+    const ENTRY_COUNT = 30
+    const PAYLOAD_BYTES = 200 * 1024
+    const bigText = 'x'.repeat(PAYLOAD_BYTES)
+    const history = Array.from({ length: ENTRY_COUNT }, (_, i) => ({
+      type: 'tool_result',
+      toolUseId: `toolu_${i}`,
+      content: bigText,
+    }))
+
+    const { manager } = createMockSessionManager([
+      { id: 'sess-1', name: 'Alpha', cwd: '/alpha' },
+    ])
+    manager.getHistory = () => history
+    manager.isHistoryTruncated = () => false
+
+    const ws = makeBackpressuredWs()
+    const ctx = makeCtxWithRealSend({ sessionManager: manager })
+    registerClient(ctx, ws)
+
+    // Pre-seed the socket buffer well past the 256KB pause threshold to
+    // simulate carry-over from an earlier burst (e.g. post-auth payloads,
+    // session_switched info).
+    ws.bufferedAmount = 512 * 1024
+
+    replayHistory(ctx, ws, 'sess-1')
+
+    // Let the loop turn a few times — without the chunk-entry gate, the
+    // first sendChunk(0) call would still emit at least one history entry
+    // before any drain logic ran. With the gate, only the
+    // history_replay_start (which is sent *before* sendChunk(0)) should
+    // have been emitted.
+    for (let i = 0; i < 5; i++) {
+      await new Promise(r => setImmediate(r))
+    }
+
+    const startMsg = ctx._sends.find(m => m.type === 'history_replay_start')
+    assert.ok(startMsg, 'history_replay_start is always sent before the gate')
+
+    const replayed = ctx._sends.filter(m => m.type === 'tool_result').length
+    assert.equal(replayed, 0,
+      `chunk-entry gate must defer all history sends while bufferedAmount > threshold; got ${replayed} sent`)
+
+    const endMsg = ctx._sends.find(m => m.type === 'history_replay_end')
+    assert.equal(endMsg, undefined, 'replay must not complete while gated')
+
+    // Cleanup: close ws so the polled scheduleAfterDrain exits.
+    ws.readyState = 3
   })
 
   it('bails out gracefully when ws closes while paused on backpressure', async () => {
@@ -1364,6 +1427,51 @@ describe('flushPostAuthQueue — bufferedAmount backpressure drain (#4833)', () 
     const sent = ctx._sends.filter(m => m.type === 'fat_msg').length
     assert.ok(sent < QUEUE_LEN,
       `expected flush to stall before sending all ${QUEUE_LEN} queued messages; got ${sent}`)
+
+    // Mark the ws CLOSED so scheduleAfterDrain's pending 20ms poll exits on
+    // its next tick instead of leaking a setTimeout into later tests in this
+    // file (#4845 review feedback).
+    ws.readyState = 3
+  })
+
+  it('defers chunk entry when bufferedAmount is already over the threshold', async () => {
+    // #4845 review feedback: drainChunk(0) previously sent its first message
+    // unconditionally — so a fat queued message landing on an already-
+    // congested socket could still push past the 1MB eviction line before
+    // the mid-chunk break ran. The chunk-entry gate must defer the chunk
+    // (and keep _flushing = true so ws-client-sender's _flushOverflow keeps
+    // buffering) until bufferedAmount falls below the pause threshold.
+    const QUEUE_LEN = 30
+    const PAYLOAD_BYTES = 200 * 1024
+    const bigText = 'x'.repeat(PAYLOAD_BYTES)
+    const queue = Array.from({ length: QUEUE_LEN }, (_, i) => ({
+      type: 'fat_msg',
+      idx: i,
+      data: bigText,
+    }))
+
+    const ws = makeBackpressuredWs()
+    const ctx = makeCtxWithRealSend()
+    registerClient(ctx, ws)
+
+    // Pre-seed the socket buffer past the pause threshold.
+    ws.bufferedAmount = 512 * 1024
+
+    flushPostAuthQueue(ctx, ws, queue)
+
+    for (let i = 0; i < 5; i++) {
+      await new Promise(r => setImmediate(r))
+    }
+
+    const sent = ctx._sends.filter(m => m.type === 'fat_msg').length
+    assert.equal(sent, 0,
+      `chunk-entry gate must defer all queued sends while bufferedAmount > threshold; got ${sent} sent`)
+
+    const client = ctx.clients.get(ws)
+    assert.equal(client?._flushing, true,
+      'chunk-entry gate must keep _flushing = true so ws-client-sender buffers overflow')
+
+    ws.readyState = 3
   })
 })
 


### PR DESCRIPTION
Closes #4833

## Summary

`replayHistory` and `flushPostAuthQueue` (in `packages/server/src/ws-history.js`) chunked their sends via `setImmediate` without consulting `ws.bufferedAmount`. On sessions with fat `tool_result` payloads (200KB+ each), a single 20-entry chunk could push the socket buffer past the 1MB `EVICT_THRESHOLD` in `ws-client-sender.js`, tripping a post-send 4008 close and surfacing as a "Reconnecting…" loop in the dashboard.

The fix wraps the chunk scheduling in a new `scheduleAfterDrain(ws, fn)` helper that polls `bufferedAmount` (every 20ms) and waits for it to fall below a 256KB pause threshold before scheduling the next chunk. The threshold (256KB) sits well below the 1MB eviction line so the next chunk has headroom even on slow links.

Two layers of defence:

1. **Post-chunk pause** — `scheduleAfterDrain` gates each `setImmediate(() => sendChunk(end))` callback so we never schedule a new burst onto an already-congested socket.
2. **Mid-chunk early break** — inside the 20-entry send loop, if `bufferedAmount` crosses the threshold mid-burst we break out at the current offset and resume from there. Without this, a single 200KB-per-entry chunk could blow past 1MB before the post-chunk drain check ever runs.

Both helpers abort the poll if `ws.readyState !== 1` (client disconnected while paused) so we never leak a `setTimeout` or send to a closed socket.

## Test plan

Added four tests in `packages/server/tests/ws-history.test.js` covering:

- [x] `replayHistory` stalls when buffer never drains — 30×200KB history; replay halts before emitting all entries and never sends `history_replay_end`
- [x] `bufferedAmount` stays under the 1MB eviction line throughout a fat 6MB replay against a peer that drains 512KB every 5ms — peak observed bufferedAmount must be `< 1048576`
- [x] Poll bails out cleanly when `ws.readyState` transitions to CLOSED mid-pause — no additional sends, no leaked timer, no end marker
- [x] `flushPostAuthQueue` applies the same drain logic for queued post-auth bursts

Pre-fix, the 1MB-cap test fails with `bufferedAmount peaked at 6146499 bytes`; post-fix it passes.

- [x] `cd packages/server && PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --import ./tests/_setup.mjs --test --test-force-exit ./tests/ws-history.test.js` → all 80 tests pass
- [x] Full server test suite — only pre-existing env-dependent failures remain (`service.test.js` and `web-task-manager.test.js` rely on absence of a running chroxy daemon / claude CLI; baseline run on `main` shows the same failures)
- [x] `./scripts/lint-tests-state-file-path.sh` → OK
- [x] `./scripts/lint-session-opt-forwarding.sh` → OK