### PR TITLE
fix(server): persist active session per deviceId, restore on reconnect

### DIFF
--- a/packages/server/src/device-preferences.js
+++ b/packages/server/src/device-preferences.js
@@ -1,0 +1,161 @@
+/**
+ * Per-device preferences persisted to disk so dashboard reconnects can restore
+ * what the user was actually looking at — not blindly snap them back to
+ * `defaultSessionId || firstSessionId`. See #4835.
+ *
+ * Why this exists separately from `connection.json`:
+ * - `connection.json` describes the running server (pid, tunnel URL, port). It
+ *   is rewritten by the server start-up handshake and removed on shutdown.
+ * - Device preferences are per-deviceId state owned by the *user* and must
+ *   survive server restarts intact. Keeping them in a sibling file keeps the
+ *   two lifecycles independent.
+ *
+ * Storage format (`~/.chroxy/device-preferences.json`):
+ *   {
+ *     "version": 1,
+ *     "devices": {
+ *       "<deviceId>": { "activeSessionId": "<id>", "updatedAt": <ms> },
+ *       ...
+ *     }
+ *   }
+ *
+ * File is written with `0600` perms via `writeFileRestricted` — the active
+ * session is sensitive enough (it leaks which projects a user is working on)
+ * that other local users should not be able to read it.
+ *
+ * The store is intentionally tiny: a single `getActiveSessionId` /
+ * `setActiveSessionId` API. We do not validate that the sessionId still
+ * exists at write time — `sendPostAuthInfo` re-checks against
+ * `sessionManager.getSession()` before consuming it, so a stale entry is
+ * harmless (we fall back to `firstSessionId`).
+ */
+
+import { homedir } from 'os'
+import { join } from 'path'
+import { existsSync, readFileSync, mkdirSync } from 'fs'
+import { writeFileRestricted } from './platform.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('device-prefs')
+
+function getConfigDir() {
+  return process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+}
+
+export function getDevicePreferencesPath() {
+  return join(getConfigDir(), 'device-preferences.json')
+}
+
+/**
+ * Create a device-preferences store. The store loads lazily on first read
+ * and re-writes synchronously on every mutation — preference state is small
+ * (a handful of devices, one line each) so the write cost is negligible
+ * and the simpler synchronous flush avoids losing the most recent switch
+ * if the server is killed mid-write-debounce. See #4835.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.filePath] - override the default path (tests).
+ */
+export function createDevicePreferences({ filePath } = {}) {
+  const path = filePath || getDevicePreferencesPath()
+  let cache = null
+
+  function load() {
+    if (cache) return cache
+    if (!existsSync(path)) {
+      cache = { version: 1, devices: {} }
+      return cache
+    }
+    try {
+      const raw = readFileSync(path, 'utf-8')
+      const parsed = JSON.parse(raw)
+      // Tolerate older / malformed files: any shape that isn't the expected
+      // { devices: {} } resets to empty so the server keeps booting. The
+      // worst case is one user loses their per-device active-session memory,
+      // which is the same as never having set it.
+      if (parsed && typeof parsed === 'object' && parsed.devices && typeof parsed.devices === 'object') {
+        cache = { version: 1, devices: { ...parsed.devices } }
+      } else {
+        cache = { version: 1, devices: {} }
+      }
+    } catch (err) {
+      log.warn(`Failed to read ${path}: ${err.message} — starting fresh`)
+      cache = { version: 1, devices: {} }
+    }
+    return cache
+  }
+
+  function persist() {
+    try {
+      mkdirSync(getConfigDir(), { recursive: true })
+      writeFileRestricted(path, JSON.stringify(cache, null, 2))
+    } catch (err) {
+      // A failed write should never crash the server. The in-memory cache is
+      // still valid, so per-process behavior is unaffected; the user will
+      // simply revert to firstSessionId on the next restart.
+      log.warn(`Failed to persist device preferences to ${path}: ${err.message}`)
+    }
+  }
+
+  return {
+    /**
+     * Return the persisted active sessionId for `deviceId`, or null if no
+     * preference is recorded (or `deviceId` is falsy / not a string).
+     *
+     * Does NOT check whether the session still exists — callers must
+     * re-validate via `sessionManager.getSession()` before using the result.
+     */
+    getActiveSessionId(deviceId) {
+      if (!deviceId || typeof deviceId !== 'string') return null
+      const state = load()
+      const entry = state.devices[deviceId]
+      return entry && typeof entry.activeSessionId === 'string'
+        ? entry.activeSessionId
+        : null
+    },
+
+    /**
+     * Record `sessionId` as the active session for `deviceId`. No-op when
+     * either argument is missing — bound-session clients and pre-deviceId
+     * clients should never hit this path, but we silently ignore rather
+     * than throw so the handler stays infallible.
+     */
+    setActiveSessionId(deviceId, sessionId) {
+      if (!deviceId || typeof deviceId !== 'string') return
+      if (!sessionId || typeof sessionId !== 'string') return
+      const state = load()
+      const existing = state.devices[deviceId]
+      if (existing && existing.activeSessionId === sessionId) {
+        // No-op: avoid touching the file when nothing changed. Tab clicks
+        // can repeat the same target during reconnect flapping.
+        return
+      }
+      state.devices[deviceId] = {
+        activeSessionId: sessionId,
+        updatedAt: Date.now(),
+      }
+      persist()
+    },
+
+    /**
+     * Clear the recorded preference for `deviceId`. Currently unused by
+     * production code, but exposed so future "forget this device" UI
+     * doesn't have to reach into the cache shape.
+     */
+    clear(deviceId) {
+      if (!deviceId || typeof deviceId !== 'string') return
+      const state = load()
+      if (!state.devices[deviceId]) return
+      delete state.devices[deviceId]
+      persist()
+    },
+
+    /**
+     * Test-only escape hatch — drop the in-memory cache so the next read
+     * reloads from disk. Production callers never need this.
+     */
+    _resetCacheForTest() {
+      cache = null
+    },
+  }
+}

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -48,6 +48,16 @@ function handleSwitchSession(ws, client, msg, ctx) {
   }
   client.activeSessionId = targetId
   client.subscribedSessionIds.add(targetId)
+  // #4835: persist the chosen session for this device so the next reconnect
+  // restores it instead of snapping back to defaultSessionId. Bound
+  // clients are excluded — their activeSessionId is locked to
+  // boundSessionId, so writing it would just churn the file without
+  // affecting behaviour. devicePreferences is optional on ctx so tests
+  // that don't wire it through (and pre-#4835 callers in general)
+  // continue to work.
+  if (ctx.devicePreferences && !client.boundSessionId && client.deviceInfo?.deviceId) {
+    ctx.devicePreferences.setActiveSessionId(client.deviceInfo.deviceId, targetId)
+  }
   log.info(`Client ${client.id} switched to session ${targetId}`)
   ctx.send(ws, { type: 'session_switched', sessionId: targetId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
   ctx.sendSessionInfo(ws, targetId)

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -29,6 +29,13 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
     protocolVersion, minProtocolVersion, webTaskManager,
     send, broadcast, getConnectedClientList, permissions,
     resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs,
+    // #4835: per-device active-session memory. Consulted below before
+    // falling back to defaultSessionId / firstSessionId so a reconnect
+    // restores whatever session the client was actually viewing instead
+    // of silently snapping them back to "session 1" on every WS drop.
+    // Optional — older callers (and most tests) leave this undefined and
+    // get the legacy default/first behavior.
+    devicePreferences,
   } = ctx
   const client = clients.get(ws)
 
@@ -208,17 +215,47 @@ export function sendPostAuthInfo(ctx, ws, extra = {}) {
       }
     }
 
-    let activeId = defaultSessionId
-    let entry = activeId ? sessionManager.getSession(activeId) : null
+    // #4835: prefer the per-device persisted active session over the server
+    // default. We only consult this for non-bound clients (boundSessionId
+    // remains the security override below). The original snap-to-default
+    // behavior was an infinite trap when combined with #4833's
+    // backpressure eviction: every retry of the user's actually-active
+    // session got bounced back to defaultSessionId.
+    //
+    // Restore order:
+    //   1. devicePreferences[client.deviceInfo.deviceId] — if it still exists
+    //   2. defaultSessionId — config-driven server default
+    //   3. firstSessionId  — last-resort "any session beats no session"
+    //
+    // A stale persisted id (session destroyed between connects) falls
+    // through to step 2 without throwing — see #4835 acceptance criteria.
+    let activeId = null
+    let entry = null
+    const persistedDeviceId = client.deviceInfo?.deviceId
+    if (devicePreferences && persistedDeviceId) {
+      const persistedId = devicePreferences.getActiveSessionId(persistedDeviceId)
+      if (persistedId) {
+        const persistedEntry = sessionManager.getSession(persistedId)
+        if (persistedEntry) {
+          activeId = persistedId
+          entry = persistedEntry
+        }
+      }
+    }
+    if (!entry) {
+      activeId = defaultSessionId
+      entry = activeId ? sessionManager.getSession(activeId) : null
+    }
     if (!entry) {
       activeId = sessionManager.firstSessionId
       entry = activeId ? sessionManager.getSession(activeId) : null
     }
 
     // If the client is bound to a specific session (via session token), enforce
-    // that they can only view that session regardless of the server default.
-    // Fail closed: if the bound session no longer exists, clear the active
-    // session rather than silently falling back to a different session.
+    // that they can only view that session regardless of the server default or
+    // any persisted per-device preference. Fail closed: if the bound session
+    // no longer exists, clear the active session rather than silently falling
+    // back to a different session (or inheriting an unrelated persisted pref).
     if (client.boundSessionId) {
       const boundEntry = sessionManager.getSession(client.boundSessionId)
       if (boundEntry) {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -16,6 +16,7 @@ import { setupForwarding } from './ws-forwarding.js'
 import { handleSessionMessage, handleCliMessage } from './ws-message-handlers.js'
 import { handleAuthMessage, handlePairMessage, handleKeyExchange, BENIGN_PAIR_WINDOW_MS } from './ws-auth.js'
 import { sendPostAuthInfo, replayHistory, flushPostAuthQueue, sendSessionInfo } from './ws-history.js'
+import { createDevicePreferences } from './device-preferences.js'
 import { createHttpHandler } from './http-routes.js'
 import { CheckpointManager } from './checkpoint-manager.js'
 import { DevPreviewManager } from './dev-preview.js'
@@ -434,7 +435,7 @@ function _isSecureRequest(req) {
  *   - A session operation failed in an expected, user-facing way → `session_error`
  */
 export class WsServer {
-  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, maxPendingConnections, backpressureThreshold, environmentManager, config = null, diagnosticsRateLimit = null } = {}) {
+  constructor({ port, apiToken, cliSession, sessionManager, defaultSessionId, authRequired = true, pushManager = null, maxPayload, noEncrypt, keyExchangeTimeoutMs, localhostBypass, tokenManager, pairingManager, maxPendingConnections, backpressureThreshold, environmentManager, config = null, diagnosticsRateLimit = null, devicePreferences = null } = {}) {
     this.port = port
     this.apiToken = apiToken
     this._tokenManager = tokenManager || null
@@ -467,6 +468,13 @@ export class WsServer {
     this._clientSend = createClientSender(log)
     this._clientManager = new WsClientManager()
     this.clients = this._clientManager.clients // back-compat: expose the raw Map for context objects
+    // #4835: per-device active-session memory. Caller can inject a custom
+    // store (tests do this with a tmp file path); otherwise we construct
+    // the default disk-backed store rooted at $CHROXY_CONFIG_DIR /
+    // ~/.chroxy. The store is consumed by ws-history.sendPostAuthInfo on
+    // reconnect and updated by session-handlers.handleSwitchSession after
+    // every explicit switch.
+    this._devicePreferences = devicePreferences || createDevicePreferences()
     this.httpServer = null
     this.wss = null
     this._pingInterval = null
@@ -569,6 +577,10 @@ export class WsServer {
       // provider registrations are reflected without restarting the server.
       get projectsDirs() { return getProviderDataDirs().map(d => join(d, 'projects')) },
       get userAgentsDirs() { return getProviderDataDirs().map(d => join(d, 'agents')) },
+      // #4835: per-device active-session memory. handleSwitchSession writes
+      // here after every successful switch so the next reconnect can
+      // restore the same session.
+      get devicePreferences() { return self._devicePreferences },
     }
 
     // Context objects for extracted modules (ws-auth.js, ws-history.js)
@@ -603,6 +615,11 @@ export class WsServer {
       // the dashboard chip can hide instead of rendering against a
       // disabled timer).
       get streamStallTimeoutMs() { return self.config?.streamStallTimeoutMs ?? null },
+      // #4835: per-device active-session memory consulted during reconnect.
+      // sendPostAuthInfo treats this as optional, but production wiring
+      // always supplies the default disk-backed store from the WsServer
+      // constructor.
+      get devicePreferences() { return self._devicePreferences },
     }
     this._authCtx = {
       get clients() { return self.clients },

--- a/packages/server/tests/device-preferences.test.js
+++ b/packages/server/tests/device-preferences.test.js
@@ -1,0 +1,165 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync, statSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, sep } from 'path'
+import { createDevicePreferences } from '../src/device-preferences.js'
+
+// #4835: device-preferences is a tiny persistence shim used by ws-history.js to
+// remember which session a deviceId was viewing across reconnects. Tests
+// pin (a) the read/write contract, (b) the on-disk format, and (c) the
+// 0600 file mode so other local users can't read which projects a
+// developer has open.
+
+describe('device-preferences (#4835)', () => {
+  let dir
+  let filePath
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-devprefs-'))
+    filePath = join(dir, 'device-preferences.json')
+  })
+
+  afterEach(() => {
+    try { rmSync(dir, { recursive: true, force: true }) } catch {}
+  })
+
+  it('returns null when no preference is set for a deviceId', () => {
+    const prefs = createDevicePreferences({ filePath })
+    assert.equal(prefs.getActiveSessionId('device-A'), null)
+  })
+
+  it('returns null for falsy or non-string deviceIds', () => {
+    const prefs = createDevicePreferences({ filePath })
+    assert.equal(prefs.getActiveSessionId(null), null)
+    assert.equal(prefs.getActiveSessionId(undefined), null)
+    assert.equal(prefs.getActiveSessionId(''), null)
+    assert.equal(prefs.getActiveSessionId(42), null)
+  })
+
+  it('round-trips a set/get within the same process', () => {
+    const prefs = createDevicePreferences({ filePath })
+    prefs.setActiveSessionId('device-A', 'sess-1')
+    assert.equal(prefs.getActiveSessionId('device-A'), 'sess-1')
+  })
+
+  it('persists across new instances pointed at the same file', () => {
+    const a = createDevicePreferences({ filePath })
+    a.setActiveSessionId('device-A', 'sess-77')
+
+    const b = createDevicePreferences({ filePath })
+    assert.equal(b.getActiveSessionId('device-A'), 'sess-77')
+  })
+
+  it('tracks deviceIds independently (laptop A and laptop B do not share)', () => {
+    const prefs = createDevicePreferences({ filePath })
+    prefs.setActiveSessionId('laptop-A', 'sess-alpha')
+    prefs.setActiveSessionId('laptop-B', 'sess-beta')
+    assert.equal(prefs.getActiveSessionId('laptop-A'), 'sess-alpha')
+    assert.equal(prefs.getActiveSessionId('laptop-B'), 'sess-beta')
+  })
+
+  it('overwrites a prior preference for the same deviceId', () => {
+    const prefs = createDevicePreferences({ filePath })
+    prefs.setActiveSessionId('device-A', 'sess-1')
+    prefs.setActiveSessionId('device-A', 'sess-2')
+    assert.equal(prefs.getActiveSessionId('device-A'), 'sess-2')
+  })
+
+  it('silently ignores set() with missing arguments', () => {
+    const prefs = createDevicePreferences({ filePath })
+    prefs.setActiveSessionId(null, 'sess-1')
+    prefs.setActiveSessionId('device-A', null)
+    prefs.setActiveSessionId('', '')
+    assert.equal(prefs.getActiveSessionId('device-A'), null)
+    // File should not have been created — nothing to persist
+    assert.equal(existsSync(filePath), false)
+  })
+
+  it('writes the preferences file with 0600 perms (sensitive — local privacy)', () => {
+    if (process.platform === 'win32') return // Windows has no 0600 equivalent
+    const prefs = createDevicePreferences({ filePath })
+    prefs.setActiveSessionId('device-A', 'sess-1')
+    assert.equal(existsSync(filePath), true)
+    const mode = statSync(filePath).mode & 0o777
+    assert.equal(mode, 0o600, `expected 0600, got ${mode.toString(8)}`)
+  })
+
+  it('stores the expected on-disk shape', () => {
+    const prefs = createDevicePreferences({ filePath })
+    prefs.setActiveSessionId('device-A', 'sess-1')
+    const raw = JSON.parse(readFileSync(filePath, 'utf-8'))
+    assert.equal(raw.version, 1)
+    assert.equal(typeof raw.devices, 'object')
+    assert.equal(raw.devices['device-A'].activeSessionId, 'sess-1')
+    assert.equal(typeof raw.devices['device-A'].updatedAt, 'number')
+  })
+
+  it('handles a malformed file by starting fresh', () => {
+    writeFileSync(filePath, '{not json')
+    const prefs = createDevicePreferences({ filePath })
+    assert.equal(prefs.getActiveSessionId('device-A'), null)
+    // Writing a new pref should not throw
+    prefs.setActiveSessionId('device-A', 'sess-1')
+    assert.equal(prefs.getActiveSessionId('device-A'), 'sess-1')
+  })
+
+  it('handles a JSON file with no `devices` key by starting fresh', () => {
+    writeFileSync(filePath, JSON.stringify({ version: 1 }))
+    const prefs = createDevicePreferences({ filePath })
+    assert.equal(prefs.getActiveSessionId('device-A'), null)
+  })
+
+  it('clear() removes the preference for a deviceId', () => {
+    const prefs = createDevicePreferences({ filePath })
+    prefs.setActiveSessionId('device-A', 'sess-1')
+    prefs.setActiveSessionId('device-B', 'sess-2')
+    prefs.clear('device-A')
+    assert.equal(prefs.getActiveSessionId('device-A'), null)
+    // Other deviceIds untouched
+    assert.equal(prefs.getActiveSessionId('device-B'), 'sess-2')
+  })
+
+  // Defensive — the file path comes from CHROXY_CONFIG_DIR (handled by the
+  // shared test sandbox in tests/_setup.mjs) so a production code path that
+  // forgets to thread `filePath` would still land in a tmp dir during tests.
+  // This test just pins that constructing without an override doesn't blow
+  // up at module-import time.
+  it('constructs with the default path (no override) without throwing', () => {
+    assert.doesNotThrow(() => createDevicePreferences())
+  })
+
+  it('does not rewrite the file when set() is a no-op (same sessionId)', () => {
+    const prefs = createDevicePreferences({ filePath })
+    prefs.setActiveSessionId('device-A', 'sess-1')
+    const firstMtime = statSync(filePath).mtimeMs
+    // Sleep briefly so a re-write would produce a measurably different mtime
+    const start = Date.now()
+    while (Date.now() - start < 20) { /* spin */ }
+    prefs.setActiveSessionId('device-A', 'sess-1')
+    const secondMtime = statSync(filePath).mtimeMs
+    assert.equal(firstMtime, secondMtime, 'no-op set should not touch the file')
+  })
+
+  it('uses CHROXY_CONFIG_DIR for the default path', () => {
+    // The shared test sandbox in tests/_setup.mjs already pins
+    // CHROXY_CONFIG_DIR to a tmp dir, so a default-path construction must
+    // resolve under that dir (not the real ~/.chroxy).
+    const prefs = createDevicePreferences()
+    // Indirect check via the public surface: setting a pref must succeed
+    // (real home is sandbox-blocked, so success implies tmp-dir usage).
+    assert.doesNotThrow(() => prefs.setActiveSessionId('device-sandbox', 'sess-1'))
+    // And it must NOT touch our local `filePath` (different override)
+    assert.equal(existsSync(filePath), false)
+    // Clean up so we don't pollute other tests sharing the tmp config dir
+    prefs.clear('device-sandbox')
+  })
+
+  // Sanity check that our test paths sit under a temp dir, not the real
+  // user's ~/.chroxy. If this fails the sandbox guard in _setup.mjs has
+  // regressed and the test would silently clobber real state.
+  it('test fixture path is under the OS tmp dir', () => {
+    assert.ok(filePath.includes(sep + 'chroxy-devprefs-'),
+      `expected temp path, got ${filePath}`)
+  })
+})

--- a/packages/server/tests/handlers/session-handlers.test.js
+++ b/packages/server/tests/handlers/session-handlers.test.js
@@ -148,6 +148,77 @@ describe('session-handlers', () => {
       assert.equal(sent.boundSessionId, 'sess-a')
       assert.equal(sent.boundSessionName, 'BoundOne')
     })
+
+    // #4835: persist the chosen sessionId per-deviceId so reconnect can
+    // restore it instead of bouncing the client back to defaultSessionId.
+    describe('persists active session for the client deviceId (#4835)', () => {
+      function inMemoryDevicePrefs() {
+        const store = new Map()
+        return {
+          getActiveSessionId: (deviceId) => store.get(deviceId) || null,
+          setActiveSessionId: createSpy((deviceId, sessionId) => { store.set(deviceId, sessionId) }),
+          clear: (deviceId) => { store.delete(deviceId) },
+          _dump: () => Object.fromEntries(store),
+        }
+      }
+
+      it('writes to devicePreferences after a successful switch', () => {
+        const devicePrefs = inMemoryDevicePrefs()
+        const ctx = makeCtx({ devicePreferences: devicePrefs })
+        ctx._sessions.set('sess-target', { session: createMockSession(), name: 'Target', cwd: '/t' })
+
+        const client = makeClient({
+          deviceInfo: { deviceId: 'laptop', deviceName: null, deviceType: 'desktop', platform: 'darwin' },
+        })
+        sessionHandlers.switch_session(makeWs(), client, { sessionId: 'sess-target' }, ctx)
+
+        assert.equal(client.activeSessionId, 'sess-target')
+        assert.equal(devicePrefs.setActiveSessionId.callCount, 1)
+        assert.deepEqual(devicePrefs.setActiveSessionId.lastCall, ['laptop', 'sess-target'])
+      })
+
+      it('does NOT write when the client has no deviceInfo.deviceId', () => {
+        const devicePrefs = inMemoryDevicePrefs()
+        const ctx = makeCtx({ devicePreferences: devicePrefs })
+        ctx._sessions.set('sess-target', { session: createMockSession(), name: 'Target', cwd: '/t' })
+
+        const client = makeClient() // no deviceInfo
+        sessionHandlers.switch_session(makeWs(), client, { sessionId: 'sess-target' }, ctx)
+
+        assert.equal(client.activeSessionId, 'sess-target')
+        assert.equal(devicePrefs.setActiveSessionId.callCount, 0)
+      })
+
+      it('does NOT write when the client is bound (boundSessionId locks them already)', () => {
+        const devicePrefs = inMemoryDevicePrefs()
+        const ctx = makeCtx({ devicePreferences: devicePrefs })
+        ctx._sessions.set('sess-bound', { session: createMockSession(), name: 'Bound', cwd: '/b' })
+
+        const client = makeClient({
+          boundSessionId: 'sess-bound',
+          deviceInfo: { deviceId: 'paired-phone', deviceName: null, deviceType: 'phone', platform: 'ios' },
+        })
+        // Bound clients can only "switch" to their own bound session — that's
+        // the only valid switch, so test that path explicitly.
+        sessionHandlers.switch_session(makeWs(), client, { sessionId: 'sess-bound' }, ctx)
+
+        assert.equal(client.activeSessionId, 'sess-bound')
+        assert.equal(devicePrefs.setActiveSessionId.callCount, 0,
+          'bound clients must not pollute the per-device store')
+      })
+
+      it('does NOT throw when ctx.devicePreferences is absent (backward compat)', () => {
+        const ctx = makeCtx() // no devicePreferences
+        ctx._sessions.set('sess-target', { session: createMockSession(), name: 'T', cwd: '/t' })
+
+        const client = makeClient({
+          deviceInfo: { deviceId: 'laptop', deviceName: null, deviceType: 'desktop', platform: 'darwin' },
+        })
+        assert.doesNotThrow(() =>
+          sessionHandlers.switch_session(makeWs(), client, { sessionId: 'sess-target' }, ctx))
+        assert.equal(client.activeSessionId, 'sess-target')
+      })
+    })
   })
 
   describe('create_session', () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -1317,3 +1317,261 @@ describe('sendPostAuthInfo — provider-scoped available_models (#2956)', () => 
     }
   })
 })
+
+// #4835: per-deviceId active-session restore on reconnect.
+//
+// Before this fix, every reconnect snapped the client back to
+// `defaultSessionId || firstSessionId` — meaning a tunnel hiccup, eviction,
+// or restart silently lost the user's currently-viewed session. Combined
+// with #4833 (backpressure eviction on large-history sessions) it created
+// an unbreakable trap: every attempt to view the big session got bounced
+// back to the small session, with no way out short of restarting chroxy.
+//
+// The fix wires an injectable `devicePreferences` store through ctx that
+// `sendPostAuthInfo` consults BEFORE falling back to defaultSessionId.
+// `boundSessionId` clients (paired with a specific session) continue to
+// fail-closed — the preference is ignored when the client is bound.
+describe('sendPostAuthInfo — per-device active session restore (#4835)', () => {
+  function inMemoryDevicePrefs(initial = {}) {
+    // Test-double: same shape as the production createDevicePreferences()
+    // store but no disk I/O. Real disk-backed version is exercised in
+    // tests/device-preferences.test.js.
+    const store = new Map(Object.entries(initial))
+    return {
+      getActiveSessionId: (deviceId) => store.get(deviceId) || null,
+      setActiveSessionId: (deviceId, sessionId) => { store.set(deviceId, sessionId) },
+      clear: (deviceId) => { store.delete(deviceId) },
+      _dump: () => Object.fromEntries(store),
+    }
+  }
+
+  it('restores the persisted active session over defaultSessionId / firstSessionId', () => {
+    // Three sessions; defaultSessionId points at sess-default. Device "laptop"
+    // previously switched to sess-big and we want that restored on reconnect.
+    const { manager } = createMockSessionManager([
+      { id: 'sess-default', name: 'Default', cwd: '/d' },
+      { id: 'sess-big', name: 'Ltl', cwd: '/big' },
+      { id: 'sess-other', name: 'Other', cwd: '/o' },
+    ])
+    const devicePrefs = inMemoryDevicePrefs({ 'laptop': 'sess-big' })
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: 'sess-default',
+      devicePreferences: devicePrefs,
+    })
+    const client = registerClient(ctx, ws, {
+      deviceInfo: { deviceId: 'laptop', deviceName: 'Laptop', deviceType: 'desktop', platform: 'darwin' },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+
+    assert.equal(client.activeSessionId, 'sess-big',
+      'persisted preference must win over defaultSessionId')
+    const switchMsg = ctx._sends.find(m => m.type === 'session_switched')
+    assert.ok(switchMsg, 'session_switched not sent')
+    assert.equal(switchMsg.sessionId, 'sess-big')
+    assert.equal(switchMsg.name, 'Ltl')
+  })
+
+  it('falls back to firstSessionId when the deviceId has no recorded preference', () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-first', name: 'First', cwd: '/first' },
+      { id: 'sess-other', name: 'Other', cwd: '/other' },
+    ])
+    const devicePrefs = inMemoryDevicePrefs() // empty
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: null, // exercise the firstSessionId fallback
+      devicePreferences: devicePrefs,
+    })
+    const client = registerClient(ctx, ws, {
+      deviceInfo: { deviceId: 'unknown-device', deviceName: null, deviceType: 'unknown', platform: 'unknown' },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+    assert.equal(client.activeSessionId, 'sess-first',
+      'unknown device must fall back to firstSessionId, not null')
+  })
+
+  it('falls back to firstSessionId when the persisted session no longer exists', () => {
+    // Persisted preference points at sess-deleted, which is not in the
+    // manager (session was destroyed between connects). Must NOT throw,
+    // must fall back cleanly to firstSessionId.
+    const { manager } = createMockSessionManager([
+      { id: 'sess-alive', name: 'Alive', cwd: '/alive' },
+    ])
+    const devicePrefs = inMemoryDevicePrefs({ 'laptop': 'sess-deleted' })
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: null,
+      devicePreferences: devicePrefs,
+    })
+    const client = registerClient(ctx, ws, {
+      deviceInfo: { deviceId: 'laptop', deviceName: null, deviceType: 'desktop', platform: 'linux' },
+    })
+
+    assert.doesNotThrow(() => sendPostAuthInfo(ctx, ws))
+    assert.equal(client.activeSessionId, 'sess-alive',
+      'stale preference must fall back to firstSessionId without throwing')
+  })
+
+  it('falls back to defaultSessionId when the persisted session no longer exists', () => {
+    // Same as above but with a defaultSessionId set — the defaultSessionId
+    // should win over firstSessionId when the stale persisted pref is
+    // discarded.
+    const { manager } = createMockSessionManager([
+      { id: 'sess-first', name: 'First', cwd: '/first' },
+      { id: 'sess-default', name: 'Default', cwd: '/default' },
+    ])
+    const devicePrefs = inMemoryDevicePrefs({ 'laptop': 'sess-gone' })
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: 'sess-default',
+      devicePreferences: devicePrefs,
+    })
+    const client = registerClient(ctx, ws, {
+      deviceInfo: { deviceId: 'laptop', deviceName: null, deviceType: 'desktop', platform: 'linux' },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+    assert.equal(client.activeSessionId, 'sess-default',
+      'stale persisted pref must yield to defaultSessionId')
+  })
+
+  it('bound clients ignore the persisted preference (fail-closed wins)', () => {
+    // boundSessionId clients must only ever see their bound session, even
+    // if a stale per-device preference exists. This is the security
+    // invariant from the original ws-history.js bound-session branch.
+    const { manager } = createMockSessionManager([
+      { id: 'sess-bound', name: 'Bound', cwd: '/bound' },
+      { id: 'sess-other', name: 'Other', cwd: '/other' },
+    ])
+    const devicePrefs = inMemoryDevicePrefs({ 'paired-phone': 'sess-other' })
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: null,
+      devicePreferences: devicePrefs,
+    })
+    const client = registerClient(ctx, ws, {
+      boundSessionId: 'sess-bound',
+      deviceInfo: { deviceId: 'paired-phone', deviceName: null, deviceType: 'phone', platform: 'ios' },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+    assert.equal(client.activeSessionId, 'sess-bound',
+      'bound clients must ignore the per-device preference')
+  })
+
+  it('bound clients fail closed when bound session is gone (preference is ignored)', () => {
+    // Even more pointed: bound session no longer exists, but a valid
+    // per-device pref points at a still-existing session. The bound
+    // client must NOT inherit that preference — it must clear active
+    // session to null (existing fail-closed behavior).
+    const { manager } = createMockSessionManager([
+      { id: 'sess-still-there', name: 'Still', cwd: '/s' },
+    ])
+    const devicePrefs = inMemoryDevicePrefs({ 'paired-phone': 'sess-still-there' })
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: 'sess-still-there',
+      devicePreferences: devicePrefs,
+    })
+    const client = registerClient(ctx, ws, {
+      boundSessionId: 'sess-bound-but-gone',
+      deviceInfo: { deviceId: 'paired-phone', deviceName: null, deviceType: 'phone', platform: 'ios' },
+    })
+
+    sendPostAuthInfo(ctx, ws)
+    assert.equal(client.activeSessionId, null,
+      'missing bound session must clear active session even when a valid preference exists')
+  })
+
+  it('two deviceIds maintain independent active sessions (laptop + phone do not share)', () => {
+    const { manager } = createMockSessionManager([
+      { id: 'sess-A', name: 'Alpha', cwd: '/a' },
+      { id: 'sess-B', name: 'Beta', cwd: '/b' },
+    ])
+    const devicePrefs = inMemoryDevicePrefs({
+      'laptop': 'sess-A',
+      'phone': 'sess-B',
+    })
+
+    // Connect laptop
+    const laptopWs = makeFakeWs()
+    const laptopCtx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: null,
+      devicePreferences: devicePrefs,
+    })
+    const laptop = registerClient(laptopCtx, laptopWs, {
+      id: 'laptop-client',
+      deviceInfo: { deviceId: 'laptop', deviceName: null, deviceType: 'desktop', platform: 'darwin' },
+    })
+    sendPostAuthInfo(laptopCtx, laptopWs)
+    assert.equal(laptop.activeSessionId, 'sess-A')
+
+    // Connect phone (same in-memory devicePrefs store)
+    const phoneWs = makeFakeWs()
+    const phoneCtx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: null,
+      devicePreferences: devicePrefs,
+    })
+    const phone = registerClient(phoneCtx, phoneWs, {
+      id: 'phone-client',
+      deviceInfo: { deviceId: 'phone', deviceName: null, deviceType: 'phone', platform: 'ios' },
+    })
+    sendPostAuthInfo(phoneCtx, phoneWs)
+    assert.equal(phone.activeSessionId, 'sess-B')
+  })
+
+  it('clients with no deviceInfo (older clients) keep the legacy defaultSessionId behavior', () => {
+    // Backward compat: pre-deviceId clients shouldn't crash or stall — they
+    // should land on defaultSessionId / firstSessionId, exactly as today.
+    const { manager } = createMockSessionManager([
+      { id: 'sess-default', name: 'Default', cwd: '/d' },
+      { id: 'sess-other', name: 'Other', cwd: '/o' },
+    ])
+    const devicePrefs = inMemoryDevicePrefs({ 'some-device': 'sess-other' })
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: 'sess-default',
+      devicePreferences: devicePrefs,
+    })
+    // No deviceInfo on the client
+    const client = registerClient(ctx, ws)
+
+    sendPostAuthInfo(ctx, ws)
+    assert.equal(client.activeSessionId, 'sess-default',
+      'a deviceId-less client must not inherit anyone else\'s preference')
+  })
+
+  it('works without devicePreferences on ctx (backward compat with older callers)', () => {
+    // ctx.devicePreferences is optional — older wirings (e.g. in-progress
+    // refactors, test harnesses) that don't supply it must keep the
+    // existing default/first behavior, not crash.
+    const { manager } = createMockSessionManager([
+      { id: 'sess-default', name: 'Default', cwd: '/d' },
+    ])
+    const ws = makeFakeWs()
+    const ctx = makeCtx({
+      sessionManager: manager,
+      defaultSessionId: 'sess-default',
+      // devicePreferences deliberately absent
+    })
+    const client = registerClient(ctx, ws, {
+      deviceInfo: { deviceId: 'laptop', deviceName: null, deviceType: 'desktop', platform: 'darwin' },
+    })
+
+    assert.doesNotThrow(() => sendPostAuthInfo(ctx, ws))
+    assert.equal(client.activeSessionId, 'sess-default')
+  })
+})
+


### PR DESCRIPTION
Closes #4835

## Summary

Before this fix, every dashboard reconnect snapped the client back to `defaultSessionId || firstSessionId` in `sendPostAuthInfo`. Combined with the backpressure eviction in #4833 this was an unbreakable trap: every attempt to view a large-history session got bounced back to a small-history session, with no way out short of restarting chroxy.

## Approach

- New tiny per-device store at `~/.chroxy/device-preferences.json` (0600 perms), keyed by `client.deviceInfo.deviceId`. Lives next to `connection.json` but has independent lifecycle (survives server restart; not rewritten on tunnel handshake).
- `handleSwitchSession` writes the chosen session after every successful switch.
- `sendPostAuthInfo` consults the store on reconnect BEFORE the existing `defaultSessionId` / `firstSessionId` fallback chain.
- `boundSessionId` clients keep their existing fail-closed behaviour — the per-device preference is ignored when the client is paired to a specific session.
- Stale persisted id (session destroyed between connects) falls through to `defaultSessionId` / `firstSessionId` without erroring.
- `devicePreferences` is constructor-injectable on `WsServer` so tests can supply a tmp-file-backed store (or an in-memory double for unit tests).

## Files

- `packages/server/src/device-preferences.js` — new disk-backed store with `getActiveSessionId` / `setActiveSessionId` / `clear`. Tolerates malformed files, no-ops on duplicate writes.
- `packages/server/src/ws-history.js` — consult devicePrefs in `sendPostAuthInfo` before defaultSessionId fallback.
- `packages/server/src/handlers/session-handlers.js` — write to devicePrefs after a successful `switch_session`.
- `packages/server/src/ws-server.js` — wire `devicePreferences` into the WsServer constructor + `_historyCtx` / `_handlerCtx`.

## Test plan

- [x] `packages/server/tests/device-preferences.test.js` — 16 tests covering CRUD, malformed-file recovery, 0600 perms, no-op write skipping, on-disk shape.
- [x] `packages/server/tests/ws-history.test.js` — 9 new `#4835` tests: persisted-restore wins over defaultSessionId, falls back to firstSessionId on stale id, bound clients ignore the preference, two deviceIds tracked independently, backward compat without `devicePreferences` on ctx.
- [x] `packages/server/tests/handlers/session-handlers.test.js` — 4 new `#4835` tests: writes on successful switch, no-write without deviceId, no-write for bound clients, no-throw without devicePrefs.
- [x] `./scripts/lint-tests-state-file-path.sh` passes.
- [x] `./scripts/lint-session-opt-forwarding.sh` passes.
- [x] Full `npm test` suite — only the pre-existing flakes in `service.test.js` / `tunnel.integration.test.js` / `web-task-manager.test.js` / `ws-server-broadcast.test.js` fail (also fail on `main`); no new failures from this change.