### PR TITLE
fix(app): gate end-handler continuous re-arm on inFlightRef

### DIFF
--- a/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
+++ b/packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts
@@ -555,6 +555,54 @@ describe('useSpeechRecognition', () => {
       expect(MockModule.start).toHaveBeenCalledTimes(3);
     });
 
+    // ---- #4851: end-handler defence-in-depth for the abort-end race ----
+    // Reproduces the residual race the start-path teardown (#4826) cannot
+    // close on the mobile platform: `SpeechModule.abort()` queues `onend`
+    // asynchronously, but the sync block resets `userStoppedRef = false`
+    // BEFORE the queued `onend` fires. Without the `inFlightRef.current`
+    // gate in the end handler, the stale queued end satisfies every re-arm
+    // condition and starts a stale recogniser on top of the new session.
+    it('end-handler ignores stale onend fired between abort and new start (#4851)', async () => {
+      // Simulate the native engine queuing onend asynchronously from abort().
+      // Wire abort() to schedule an `end` on the microtask queue — this is
+      // the race window: the next sync block clears inFlightRef before the
+      // queued end fires.
+      MockModule.abort.mockImplementation(() => {
+        Promise.resolve().then(() => {
+          eventHandlers['end']?.({});
+        });
+      });
+
+      const { result } = renderHookSimple(() => useSpeechRecognition({ mode: 'continuous' }));
+
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+      expect(MockModule.start).toHaveBeenCalledTimes(1);
+
+      // Second startListening triggers the prior-teardown branch:
+      //   1) userStoppedRef = true (sync)
+      //   2) SpeechModule.abort() — queues onend on microtask queue
+      //   3) inFlightRef = false (sync)
+      //   4) userStoppedRef = false (sync, fresh-session bookkeeping)
+      //   5) await permission / lang
+      //   6) SpeechModule.start() — fresh session
+      // Between (4) and (6), the queued onend from step 2 fires. Without
+      // the inFlightRef gate, every other re-arm condition is satisfied
+      // (continuous + !userStoppedRef + mounted + counter<cap) and the
+      // end handler calls SpeechModule.start() against the prior session
+      // BEFORE the fresh session's start() lands — exactly the dual-mic
+      // window the dashboard #4789 closed via handler nulling.
+      await actAsync(async () => {
+        await result.current.startListening();
+      });
+
+      // Two start() calls total: the original and the fresh session.
+      // If the stale queued end re-armed, this would be 3.
+      expect(MockModule.start).toHaveBeenCalledTimes(2);
+      expect(MockModule.abort).toHaveBeenCalledTimes(1);
+    });
+
     it('does NOT abort when no prior session is in-flight', async () => {
       const { result } = renderHookSimple(() => useSpeechRecognition());
 

--- a/packages/app/src/hooks/useSpeechRecognition.ts
+++ b/packages/app/src/hooks/useSpeechRecognition.ts
@@ -187,10 +187,26 @@ export function useSpeechRecognition(
     // user explicitly stopped (or unmounted) and we're still under the
     // restart cap. The mic stays lit during the restart blip so the UI
     // doesn't flicker.
+    //
+    // #4851 defence-in-depth: also gate on `inFlightRef.current`. The
+    // start-path prior-teardown branch (#4826) calls `SpeechModule.abort()`
+    // synchronously, but native engines queue the resulting `onend`
+    // asynchronously. The sync block then resets
+    // `userStoppedRef = false` for the fresh session BEFORE the queued
+    // `onend` fires, so the prior session's late `end` event would
+    // otherwise satisfy every re-arm condition (continuous + !userStopped +
+    // mounted + counter<cap) and start a stale recogniser on top of the
+    // new one — the same dual-mic window the dashboard #4789 fix closed via
+    // handler nulling. The teardown branch clears `inFlightRef.current`
+    // before the new session calls `start()`, so this gate causes the
+    // queued stale `end` to exit cleanly. The fresh session re-arms
+    // `inFlightRef.current = true` after its own `start()`, so subsequent
+    // legitimate silence-triggered ends still re-arm normally.
     if (
       modeRef.current === 'continuous' &&
       !userStoppedRef.current &&
       mountedRef.current &&
+      inFlightRef.current &&
       restartCountRef.current < MAX_CONTINUOUS_RESTARTS &&
       SpeechModule
     ) {
@@ -230,7 +246,6 @@ export function useSpeechRecognition(
       setIsRecognizing(false);
       return;
     }
-    inFlightRef.current = false;
     // Soft error in continuous mode (no-speech, network, speech-timeout):
     // leave `isRecognizing` true and let the subsequent `end` event decide
     // whether to re-arm. The restart branch in the `end` handler does NOT
@@ -238,7 +253,14 @@ export function useSpeechRecognition(
     // flipping false here would briefly clear the mic icon during the
     // restart blip with nothing to set it back (#4829). Mirrors the
     // dashboard `useVoiceInput.onerror` behaviour.
+    //
+    // #4851: also leave `inFlightRef.current = true` in continuous mode so
+    // the subsequent `end` event's new `inFlightRef` gate doesn't suppress
+    // the legitimate soft-error→restart cycle. The session is logically
+    // still in-flight pending the re-arm; only auto-pause / hard-error
+    // paths clear it.
     if (modeRef.current === 'continuous') return;
+    inFlightRef.current = false;
     setIsRecognizing(false);
   });
 


### PR DESCRIPTION
Closes #4851

## Summary

Defence-in-depth for the #4826 abort-end race. Gates the `end` handler's continuous-mode re-arm branch on `inFlightRef.current`, so a queued stale `onend` fired by the prior session's `SpeechModule.abort()` can't re-arm against the new session's freshly-reset bookkeeping.

## Race timing diagram

```
sync   T0  startListening() — fresh user-initiated start
async  T1    └─ SpeechModule.start()                      [session A live]
                inFlightRef = true

sync   T2  startListening() called again (double-tap)
sync   T3    ├─ userStoppedRef = true        (prior-teardown #4826)
sync   T4    ├─ SpeechModule.abort()         (queues onend async)  <─┐
sync   T5    ├─ inFlightRef = false                                   │
sync   T6    ├─ userStoppedRef = false       (fresh-session reset)    │
async  T7    ├─ await SpeechModule.requestPermissionsAsync()          │
async  T8    │   └─ engine fires queued onend HERE  ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
             │      └─ end handler sees:
             │         continuous ✓
             │         !userStoppedRef ✓ (just reset)
             │         mounted ✓
             │         counter<cap ✓
             │
             │     before fix: SpeechModule.start()  ← stale re-arm on session A
             │     after fix:  inFlightRef === false ✗  → bail cleanly
             │
async  T9    └─ SpeechModule.start()                      [session B live, alone]
                inFlightRef = true
```

The mobile expo-speech-recognition API cannot expose handler nulling the way the dashboard `useVoiceInput` #4789 fix does, so `inFlightRef` is the equivalent gate.

## Changes

- `packages/app/src/hooks/useSpeechRecognition.ts`
  - `end` handler: add `inFlightRef.current` to the continuous re-arm condition
  - `error` handler soft-error branch: stop clearing `inFlightRef` when `mode=continuous`, otherwise the legitimate soft-error→end→restart cycle is suppressed by the new gate. Mirrors the existing `isRecognizing` handling for the same reason (#4829).
- `packages/app/src/__tests__/hooks/useSpeechRecognition.test.ts`
  - New test: wires `MockModule.abort()` to fire a queued `end` on the microtask queue between the prior abort and the new `start()`, asserts only ONE re-arm `start()` call (the new session, not the stale queued one).

## Test plan

- [x] Local: `npx jest src/__tests__/hooks/useSpeechRecognition.test.ts` — 51/51 pass
- [x] Verified test exercises the race: reverting only the hook source while keeping the new test causes the new test to fail with `Expected: 2, Received: 3` (the stale queued end re-arms a 3rd `start()`)
- [x] All pre-existing tests still pass:
  - `restarts recognition on end event when mode=continuous` (legitimate silence-restart)
  - `DOES restart on end after soft error (no-speech|network|speech-timeout) in continuous mode`
  - `keeps isRecognizing=true after soft error … in continuous mode (no flicker)` (#4829)
  - `does NOT restart on end after hard error …` (#4813)
  - `prior-teardown suppresses continuous-mode end re-arm against new bookkeeping` (#4826)

## Notes

- Singleton behaviour of `expo-speech-recognition` already serialises `start`/`abort` in practice, so the bare race is unlikely to bite users — this is the matching defence-in-depth for the dashboard #4789 fix.
- Conflicts possible at merge time with #4852 / #4853 (same file area, parallel worktrees).