### PR TITLE
refactor: remove VoiceInputMode re-export shims (#4852)

### DIFF
--- a/packages/app/src/hooks/useSpeechRecognition.ts
+++ b/packages/app/src/hooks/useSpeechRecognition.ts
@@ -48,20 +48,6 @@ export async function setSpeechLang(lang: string): Promise<void> {
   }
 }
 
-/**
- * Voice input behaviour. The union itself lives in `@chroxy/store-core`
- * (#4825) — re-exported here so existing imports of `VoiceInputMode` from
- * this module keep working without churn.
- *
- * - `'continuous'`: when the engine fires `end` due to silence, the hook
- *   restarts recognition automatically. The mic stays lit until the user
- *   explicitly calls `stopListening()`. Bounded by `MAX_CONTINUOUS_RESTARTS`
- *   so a wedged backend cannot spin forever.
- * - `'auto-pause'`: original behaviour — `end` ends the session. Default
- *   to keep behaviour stable for callers that don't pass `mode`.
- */
-export type { VoiceInputMode };
-
 export interface UseSpeechRecognitionOptions {
   mode?: VoiceInputMode;
 }

--- a/packages/dashboard/src/hooks/useVoiceInput.ts
+++ b/packages/dashboard/src/hooks/useVoiceInput.ts
@@ -115,27 +115,6 @@ function permissionMessageForError(error: string): string {
   return `Speech recognition error: ${error}`
 }
 
-/**
- * Voice input behaviour. The union itself lives in `@chroxy/store-core`
- * (#4825) — re-exported here so existing imports of `VoiceInputMode` from
- * this module keep working without churn. See `InputSettings.voiceInputMode`
- * in store-core for the persisted setting; this hook accepts it as a runtime
- * option so the caller (App.tsx) reads the store once and the hook stays
- * store-agnostic.
- *
- * - `'continuous'`: when the Web Speech engine fires `onend` due to silence,
- *   the hook restarts recognition automatically. The mic stays lit until the
- *   user explicitly calls `stop()`. This is the click-to-start / click-to-stop
- *   experience #4785 was filed for.
- *
- * - `'auto-pause'`: original behaviour — `onend` ends the session. Kept for
- *   users who prefer the browser's silence-stop semantics.
- *
- * Only the web engine is affected. The native (Tauri) engine has its own
- * end-of-utterance semantics driven by the Swift helper and is out of scope.
- */
-export type { VoiceInputMode }
-
 export interface UseVoiceInputOptions {
   mode?: VoiceInputMode
 }


### PR DESCRIPTION
Closes #4852

## Summary

Follow-up to #4825 / #4841 (consolidated `VoiceInputMode` into `@chroxy/store-core`). The intentional back-compat re-exports in `useSpeechRecognition` (mobile) and `useVoiceInput` (dashboard) have served their purpose — every current caller already imports `VoiceInputMode` from `@chroxy/store-core`, so the shims and their JSDoc rationale paragraphs can be dropped.

## Caller audit

`grep -rn "VoiceInputMode" packages/app packages/dashboard` (excluding the two hook files and store-core itself):

- `packages/app/src/screens/SettingsScreen.tsx` — already `import type { VoiceInputMode } from '@chroxy/store-core'`
- `packages/dashboard/src/components/SettingsPanel.tsx` — already `import type { VoiceInputMode } from '@chroxy/store-core'`

No external caller imports `VoiceInputMode` from the hook modules, so no caller migration was needed.

## Files changed

- `packages/app/src/hooks/useSpeechRecognition.ts` — removed `export type { VoiceInputMode }` and the JSDoc paragraph referencing the shim rationale. Internal `import type { VoiceInputMode } from '@chroxy/store-core'` retained for the hook's own typing.
- `packages/dashboard/src/hooks/useVoiceInput.ts` — same.

## Verification

- `npx tsc --noEmit` in `packages/app` and `packages/dashboard` — clean
- `packages/app` `useSpeechRecognition.test.ts` — 50 passed
- `packages/dashboard` full vitest run — 2541 passed across 131 files