### PR TITLE
fix(dashboard): route copy-transcript through Tauri-aware clipboard helper

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -36,7 +36,16 @@ vi.mock('./hooks/useVoiceInput', () => ({
 // #4673 — control the clipboard helper per-test so we can assert that the
 // "Copied!" check mark only fires when the helper actually wrote. Default
 // to a successful write so the unrelated render-smoke tests stay green.
-const clipboardWriteTextMock = vi.fn<(text: string) => Promise<boolean>>(() => Promise.resolve(true))
+// #4629 — also expose an `addServerErrorMock` so the failure-path test
+// can assert the dashboard surfaces a visible toast when the clipboard
+// write fails (the original bug was a silent no-op + misleading
+// "Copied!" tooltip). Both are declared via `vi.hoisted()` because
+// `vi.mock()` factories are hoisted to the top of the file before any
+// top-level `const`, so a plain const would hit a TDZ ReferenceError.
+const { clipboardWriteTextMock, addServerErrorMock } = vi.hoisted(() => ({
+  clipboardWriteTextMock: vi.fn<(text: string) => Promise<boolean>>(() => Promise.resolve(true)),
+  addServerErrorMock: vi.fn<(message: string, action?: unknown, severity?: unknown) => void>(),
+}))
 vi.mock('./utils/clipboard', () => ({
   writeText: (text: string) => clipboardWriteTextMock(text),
 }))
@@ -135,6 +144,10 @@ vi.mock('./store/connection', () => {
     setModel: vi.fn(),
     setPermissionMode: vi.fn(),
     dismissServerError: vi.fn(),
+    // #4629 — surfaced when the clipboard write fails so the user sees a
+    // visible error instead of a silent no-op. Backed by the top-level
+    // `addServerErrorMock` so tests can assert on the call args directly.
+    addServerError: addServerErrorMock,
     dismissSessionNotification: vi.fn(),
     markPromptAnsweredByRequestId: vi.fn(),
     sessionNotifications: [],
@@ -184,6 +197,9 @@ beforeEach(() => {
   // overrides don't bleed through.
   clipboardWriteTextMock.mockReset()
   clipboardWriteTextMock.mockResolvedValue(true)
+  // #4629 — reset between cases so the failure-path test only sees the
+  // calls it triggered.
+  addServerErrorMock.mockReset()
   // #4432 — reset the shared shortcut registry so per-test rebinds
   // don't bleed between cases. The registry persists overrides to
   // localStorage; clearing the key keeps loadOverrides() returning {}.
@@ -1574,6 +1590,49 @@ describe('App', () => {
       })
       expect(clipboardWriteTextMock).toHaveBeenCalledTimes(1)
       expect(btn.getAttribute('title')).toContain('Copied!')
+    })
+
+    // #4629 — the original bug was that a failed clipboard write would
+    // silently swallow the failure and the "Copied!" tooltip flashed
+    // anyway. PR #4676 (for #4673) fixed the misleading flash but the
+    // user still got zero feedback when the write fell through. The third
+    // acceptance criterion on #4629 explicitly calls this out: "If
+    // clipboard write fails, user sees an error (not a misleading
+    // 'Copied!' tooltip)". Surface a server-error toast so the user knows
+    // the OS clipboard wasn't actually written.
+    it('surfaces a server-error toast when the clipboard helper returns false (#4629)', async () => {
+      clipboardWriteTextMock.mockResolvedValue(false)
+      stateOverrides = connectedWithMessages
+      render(<App />)
+
+      const btn = screen.getByTestId('btn-copy-transcript')
+      fireEvent.click(btn)
+
+      await waitFor(() => {
+        expect(addServerErrorMock).toHaveBeenCalledTimes(1)
+      })
+      const firstCall = addServerErrorMock.mock.calls[0]
+      expect(firstCall).toBeDefined()
+      const [message] = firstCall!
+      expect(message).toMatch(/clipboard/i)
+      // Must NOT also flash the success indicator (that was the #4673 bug;
+      // this test pins the negative too so a future regression on either
+      // axis is caught).
+      expect(btn.textContent).not.toContain('✓')
+    })
+
+    it('does NOT surface a server-error toast on a successful copy (#4629)', async () => {
+      clipboardWriteTextMock.mockResolvedValue(true)
+      stateOverrides = connectedWithMessages
+      render(<App />)
+
+      const btn = screen.getByTestId('btn-copy-transcript')
+      fireEvent.click(btn)
+
+      await waitFor(() => {
+        expect(btn.textContent).toContain('✓')
+      })
+      expect(addServerErrorMock).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -527,7 +527,20 @@ export function App() {
     // WKWebView). Only flash the "Copied!" check mark if the helper actually
     // wrote — otherwise the indicator lies about an empty OS clipboard.
     void clipboardWriteText(text).then((ok) => {
-      if (!ok) return
+      if (!ok) {
+        // #4629: when the helper reports failure (Tauri plugin rejected,
+        // navigator.clipboard missing in a non-secure context, etc.) the
+        // OS clipboard was NOT written. The original bug was that the
+        // dashboard swallowed this silently and the "Copied!" tooltip
+        // still flashed, so the user pasted the wrong content into the
+        // next app. PR #4676 stopped the misleading flash; this surfaces
+        // a visible toast so the user knows to retry instead of being
+        // left guessing why Cmd+V pasted stale data.
+        useConnectionStore.getState().addServerError(
+          'Failed to copy transcript to clipboard. Please try again.',
+        )
+        return
+      }
       setTranscriptCopied(true)
       if (transcriptResetTimerRef.current) clearTimeout(transcriptResetTimerRef.current)
       transcriptResetTimerRef.current = setTimeout(() => setTranscriptCopied(false), 1500)


### PR DESCRIPTION
Closes #4629

## Summary

The Copy transcript button in the desktop app silently no-ops when the OS clipboard write fails — the user gets zero feedback and pastes stale data into the next app. PR #4676 (for #4673) already routed the button through the Tauri-aware `clipboardWriteText` helper so the plugin path is preferred under WKWebView, and stopped the misleading "Copied!" tooltip from flashing on a failed write. The third acceptance criterion on #4629 was still open though: when the helper reports failure (Tauri plugin rejection, `navigator.clipboard` missing in a non-secure context, etc.) the dashboard silently swallowed the failure.

This PR surfaces an `addServerError` toast on the failure branch so the user actually sees that the copy didn't succeed and can retry.

- `packages/dashboard/src/App.tsx` — on the `!ok` branch in `handleCopyTranscript`, call `useConnectionStore.getState().addServerError('Failed to copy transcript to clipboard. Please try again.')` before returning, matching the existing failure-toast pattern used elsewhere in the file (line ~636).
- `packages/dashboard/src/App.test.tsx` — two new tests hanging off the existing `handleCopyTranscript copy indicator` block:
  - Failure path: helper returns `false`, click the button, assert `addServerError` is called once with a clipboard-related message AND the check-mark indicator does not flip.
  - Success path: helper returns `true`, click the button, assert `addServerError` is NOT called (guards against a future regression that spams toasts on success).

The new tests required hoisting both `clipboardWriteTextMock` and a new `addServerErrorMock` via `vi.hoisted()` so the existing `vi.mock('./store/connection')` factory can close over the latter without hitting a TDZ ReferenceError.

## Test plan

- [x] `cd packages/dashboard && npm test` (all 2541 tests pass, including 2 new #4629 tests)
- [x] `cd packages/dashboard && npm run typecheck` (clean)
- [ ] Manual verification on a Tauri desktop build: open a session with messages, click Copy transcript, switch to TextEdit, Cmd+V — transcript pastes. Force a failure (e.g. revoke the `clipboard-manager:allow-write-text` capability) and confirm a visible error toast appears instead of a silent no-op.