### PR TITLE
refactor(store-core): extract isVoiceInputMode runtime type-guard

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -15,8 +15,11 @@ import {
   buildQuietHoursTimezoneList,
   formatPlatform,
   formatRelativeTime,
+  // #4853: shared runtime guard for `VoiceInputMode` — replaces the
+  // inline `Record<VoiceInputMode, true>` literal previously rebuilt
+  // on every change-handler call.
+  isVoiceInputMode,
 } from '@chroxy/store-core'
-import type { VoiceInputMode } from '@chroxy/store-core'
 import { isTauri } from '../utils/tauri'
 import {
   getTunnelMode,
@@ -935,18 +938,15 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   }, [updateInputSettings])
 
   const handleVoiceInputModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
-    // #4825: validate against an exhaustive `Record<VoiceInputMode, true>`
-    // map instead of a hard-coded string-list. Adding a new mode to the
-    // union in store-core makes this object literal a TS error (missing
-    // property), forcing the guard to be updated. The previous `===` chain
-    // would have silently dropped a new mode (#4841 review feedback).
-    const VALID_MODES: Record<VoiceInputMode, true> = {
-      continuous: true,
-      'auto-pause': true,
-    }
-    const next = e.target.value
-    if (Object.prototype.hasOwnProperty.call(VALID_MODES, next)) {
-      updateInputSettings({ voiceInputMode: next as VoiceInputMode })
+    // #4853: validate against the shared `isVoiceInputMode` guard from
+    // store-core. The guard is keyed off an exhaustive
+    // `Record<VoiceInputMode, true>` map, so adding a new mode to the
+    // union without listing it there is a TS error — neither this site
+    // nor any other rehydrate/wire boundary can silently drop a new
+    // mode the way a hand-written `===` chain would (#4841 review
+    // feedback that landed in #4825 inline, now extracted in #4853).
+    if (isVoiceInputMode(e.target.value)) {
+      updateInputSettings({ voiceInputMode: e.target.value })
     }
   }, [updateInputSettings])
 

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -113,6 +113,12 @@ import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
 import {
   getWsCloseMessage,
   getHealthCheckErrorMessage,
+  // #4853: runtime type-guard for `VoiceInputMode`. Used in
+  // `loadSavedConnection` below to validate the persisted
+  // localStorage blob — keyed off an exhaustive
+  // `Record<VoiceInputMode, true>` in store-core, so adding a new mode
+  // to the union cannot silently drop here the way a `===` chain would.
+  isVoiceInputMode,
 } from '@chroxy/store-core';
 import { decrypt, DIRECTION_SERVER, type EncryptedEnvelope } from './crypto';
 import {
@@ -802,7 +808,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         const next: Partial<InputSettings> = {};
         if (typeof parsed.chatEnterToSend === 'boolean') next.chatEnterToSend = parsed.chatEnterToSend;
         if (typeof parsed.terminalEnterToSend === 'boolean') next.terminalEnterToSend = parsed.terminalEnterToSend;
-        if (parsed.voiceInputMode === 'continuous' || parsed.voiceInputMode === 'auto-pause') {
+        // #4853: runtime guard keyed off the same exhaustive
+        // `Record<VoiceInputMode, true>` map the dashboard `SettingsPanel`
+        // change handler uses (#4825). Replaces the previous hand-written
+        // `===` chain that silently dropped any new mode added to the union.
+        if (isVoiceInputMode(parsed.voiceInputMode)) {
           next.voiceInputMode = parsed.voiceInputMode;
         }
         if (Object.keys(next).length > 0) {

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -11,6 +11,11 @@
 
 export { DEFAULT_CONTEXT_WINDOW } from './types'
 
+// #4853: runtime type-guard for `VoiceInputMode` — keyed off an
+// exhaustive `Record<VoiceInputMode, true>` so widening the union is a
+// TS error in the guard, not a silent drop at the call site.
+export { isVoiceInputMode } from './types'
+
 export type {
   MessageAttachment,
   ToolResultImage,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -165,12 +165,48 @@ export interface ContextUsage {
  * that exhaustively key a `Record<VoiceInputMode, …>` (e.g. the dashboard
  * `SettingsPanel` change handler, the mobile `SettingsScreen` picker tuple
  * typed as `{ value: VoiceInputMode; … }[]`) will be flagged by TS when the
- * union widens. Sites that use runtime string guards (e.g. the
- * localStorage-rehydrate path in `packages/dashboard/src/store/connection.ts`
- * line ~805) will silently ignore the new mode until updated — grep for
- * `voiceInputMode ===` before adding a new variant.
+ * union widens. Sites that validate untrusted runtime input (localStorage
+ * rehydrate, wire payloads) MUST use the {@link isVoiceInputMode} guard
+ * below — it is keyed off the same exhaustive `Record<VoiceInputMode, true>`
+ * map, so widening the union to a new mode without updating that map is a
+ * TS error (missing property). See `packages/dashboard/src/store/connection.ts`
+ * `loadSavedConnection` for the canonical rehydrate-path consumer (#4853).
  */
 export type VoiceInputMode = 'continuous' | 'auto-pause';
+
+/**
+ * #4853 — exhaustive `Record<VoiceInputMode, true>` map driving
+ * {@link isVoiceInputMode}. Adding a new variant to the `VoiceInputMode`
+ * union without listing it here is a TS error (missing property), so the
+ * guard cannot silently drop a new mode the way a hand-written `===`
+ * chain would. The same pattern is used inline by the dashboard
+ * `SettingsPanel` change handler (#4825); the guard centralises it for
+ * every other validation site (localStorage rehydrate, wire payload
+ * validation, etc.) so they all share one source of truth.
+ *
+ * Module-scope `const` rather than a closure-local literal so the
+ * underlying object identity is stable and the V8 hidden class doesn't
+ * thrash on hot rehydrate paths.
+ */
+const VOICE_INPUT_MODES: Record<VoiceInputMode, true> = {
+  continuous: true,
+  'auto-pause': true,
+};
+
+/**
+ * #4853 — runtime type-guard for `VoiceInputMode`. Returns `true` only
+ * when `value` is exactly one of the union members declared above; every
+ * non-string input (undefined, null, number, object, array) returns
+ * `false` without throwing. Use at boundary sites that accept untrusted
+ * input — localStorage rehydrate, JSON.parse of a wire payload, etc.
+ *
+ * The narrowing predicate (`value is VoiceInputMode`) lets callers
+ * assign directly without an unsafe cast once the guard passes.
+ */
+export function isVoiceInputMode(value: unknown): value is VoiceInputMode {
+  return typeof value === 'string'
+    && Object.prototype.hasOwnProperty.call(VOICE_INPUT_MODES, value);
+}
 
 export interface InputSettings {
   chatEnterToSend: boolean;

--- a/packages/store-core/src/voice-input-mode.test.ts
+++ b/packages/store-core/src/voice-input-mode.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the `isVoiceInputMode` runtime type-guard (#4853).
+ *
+ * The guard is the single source of truth for runtime validation of the
+ * `VoiceInputMode` union. Boundary sites that accept untrusted input
+ * (localStorage rehydrate in `dashboard/store/connection.ts`, wire
+ * payload validation, etc.) call this instead of a hand-written
+ * `===`-chain so that widening the union in `types.ts` cannot silently
+ * drop a new mode — the underlying `Record<VoiceInputMode, true>` map
+ * makes that a TS error.
+ *
+ * Coverage:
+ *   - Each known mode returns true (so the guard accepts every union
+ *     member; widening the union and updating the map keeps this row
+ *     honest).
+ *   - Unknown strings, undefined, null, numbers, objects, arrays,
+ *     booleans return false (so a stray persisted blob can't shoehorn
+ *     arbitrary state into the store).
+ */
+import { describe, it, expect } from 'vitest'
+import { isVoiceInputMode } from './index'
+import type { VoiceInputMode } from './types'
+
+describe('isVoiceInputMode (#4853)', () => {
+  describe('accepts every union member', () => {
+    // Each row corresponds to one `VoiceInputMode` literal. Adding a
+    // new member to the union without listing it here keeps the test
+    // green by accident, so the table is an explicit checklist rather
+    // than `for (const m of VOICE_INPUT_MODES) …`.
+    const knownModes: VoiceInputMode[] = ['continuous', 'auto-pause']
+
+    for (const mode of knownModes) {
+      it(`returns true for known mode "${mode}"`, () => {
+        expect(isVoiceInputMode(mode)).toBe(true)
+      })
+    }
+  })
+
+  describe('rejects untrusted input', () => {
+    it('returns false for an unknown string', () => {
+      expect(isVoiceInputMode('push-to-talk')).toBe(false)
+      expect(isVoiceInputMode('')).toBe(false)
+      // Case-sensitive: the union uses lowercase only.
+      expect(isVoiceInputMode('Continuous')).toBe(false)
+      expect(isVoiceInputMode('AUTO-PAUSE')).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isVoiceInputMode(undefined)).toBe(false)
+    })
+
+    it('returns false for null', () => {
+      expect(isVoiceInputMode(null)).toBe(false)
+    })
+
+    it('returns false for a number', () => {
+      expect(isVoiceInputMode(0)).toBe(false)
+      expect(isVoiceInputMode(1)).toBe(false)
+      expect(isVoiceInputMode(NaN)).toBe(false)
+    })
+
+    it('returns false for an object', () => {
+      expect(isVoiceInputMode({})).toBe(false)
+      // Even if the object has the right *key* — string-only guard.
+      expect(isVoiceInputMode({ continuous: true })).toBe(false)
+    })
+
+    it('returns false for an array', () => {
+      expect(isVoiceInputMode([])).toBe(false)
+      expect(isVoiceInputMode(['continuous'])).toBe(false)
+    })
+
+    it('returns false for a boolean', () => {
+      expect(isVoiceInputMode(true)).toBe(false)
+      expect(isVoiceInputMode(false)).toBe(false)
+    })
+
+    it('returns false for a prototype-pollution-style key', () => {
+      // The guard uses `Object.prototype.hasOwnProperty.call` rather than
+      // `value in VOICE_INPUT_MODES` so inherited Object.prototype keys
+      // (toString, constructor, __proto__) don't slip through.
+      expect(isVoiceInputMode('toString')).toBe(false)
+      expect(isVoiceInputMode('constructor')).toBe(false)
+      expect(isVoiceInputMode('__proto__')).toBe(false)
+      expect(isVoiceInputMode('hasOwnProperty')).toBe(false)
+    })
+  })
+
+  describe('narrows the type for the caller', () => {
+    it('narrows `unknown` to `VoiceInputMode` after a passing guard', () => {
+      const raw: unknown = 'continuous'
+      if (isVoiceInputMode(raw)) {
+        // Compile-time check: this assignment would fail to typecheck
+        // without the guard narrowing `raw` from `unknown` to
+        // `VoiceInputMode`. The runtime assertion is just defence in
+        // depth — the real value here is the TS narrowing.
+        const narrowed: VoiceInputMode = raw
+        expect(narrowed).toBe('continuous')
+      } else {
+        throw new Error('guard rejected a known mode')
+      }
+    })
+  })
+})


### PR DESCRIPTION
Closes #4853

## Summary

Extracts a runtime type-guard `isVoiceInputMode(value: unknown): value is VoiceInputMode` from `@chroxy/store-core` and migrates the dashboard's localStorage rehydrate path off the ad-hoc string check that drifted from the canonical union.

The guard is backed by a module-scope `Record<VoiceInputMode, true>` map next to the type. Widening the union without listing the new mode in the map is a TS error (missing property), so the guard cannot silently drop a new variant the way a hand-written `===` chain would.

## Helper API

```ts
// packages/store-core/src/types.ts
export function isVoiceInputMode(value: unknown): value is VoiceInputMode
```

Predicate-narrowing return type lets callers assign directly without an unsafe cast after the guard passes. String-only; every non-string input (undefined, null, number, object, array, boolean) returns `false` without throwing. Uses `Object.prototype.hasOwnProperty.call` so inherited prototype keys (`toString`, `constructor`, `__proto__`) don't slip through.

## Migrated sites

- **`packages/dashboard/src/store/connection.ts:805`** (`loadSavedConnection`) — replaces `parsed.voiceInputMode === 'continuous' || parsed.voiceInputMode === 'auto-pause'` with `isVoiceInputMode(parsed.voiceInputMode)`. This was the site the issue called out as silently ignoring any new mode added to the union.
- **`packages/dashboard/src/components/SettingsPanel.tsx`** (`handleVoiceInputModeChange`) — folds the inline `Record<VoiceInputMode, true>` literal that #4825 added (and which the issue cites as the pattern) down to the shared helper. Both validation sites now share one source of truth.

JSDoc on `VoiceInputMode` in `types.ts` is updated to point at the helper instead of recommending grep.

App-side rehydrate: grepped `packages/app/` — no rehydrate path exists for `voiceInputMode`; the only reference is a default value in the store's initial state, so no migration needed.

## Test plan

- [x] Added `packages/store-core/src/voice-input-mode.test.ts` with 11 tests covering every union member, unknown string, empty string, case sensitivity, `undefined`, `null`, numbers (incl. `NaN`), objects, arrays, booleans, prototype-pollution-style keys (`toString`, `constructor`, `__proto__`, `hasOwnProperty`), and a TS narrowing assertion
- [x] `cd packages/store-core && npm test` — 1011 / 1011 pass (20 files)
- [x] `cd packages/store-core && npm run typecheck` — clean
- [x] Dashboard typecheck via worktree-local tsconfig with `paths` override — no new errors introduced in `connection.ts` or `SettingsPanel.tsx` (pre-existing test-file errors are unrelated to this change)
- [ ] CI green