### PR TITLE
feat(app): widen sendQuestionResponse to per-question Record<string, string | string[]>

### DIFF
--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -507,6 +507,115 @@ describe('message queue internals', () => {
   });
 });
 
+// -- sendUserQuestionResponse: widened payload shapes (#4761) --
+
+describe('sendUserQuestionResponse wire payload (#4761)', () => {
+  beforeEach(() => {
+    useConnectionStore.setState({
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+  });
+
+  it('emits the legacy single-question wire shape for a string answer (back-compat)', () => {
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+    useConnectionStore.setState({ socket: mockSocket as unknown as WebSocket });
+
+    const result = useConnectionStore.getState().sendUserQuestionResponse('Option A', 'toolu_single');
+
+    expect(result).toBe('sent');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({
+      type: 'user_question_response',
+      answer: 'Option A',
+      toolUseId: 'toolu_single',
+    });
+    // No `answers` field on the single-question path — that's reserved
+    // for multi-question forms so older servers ignore it cleanly.
+    expect(sent[0]).not.toHaveProperty('answers');
+  });
+
+  it('forwards multi-question Record<string, string | string[]> verbatim and flattens arrays in the answer summary', () => {
+    // #4761 — mirror the dashboard's `sendUserQuestionResponse` widening
+    // (#4760). The widened wire (`UserQuestionResponseSchema`) accepts
+    // `string | string[]` per question. The mobile store should:
+    //   1. Populate `answers` with the map shape unchanged (arrays stay
+    //      arrays — the server normalizes downstream).
+    //   2. Populate the string-only `answer` field with a flattened
+    //      comma-joined summary so older servers reading only `answer`
+    //      still see a human-readable line (no leaked JSON syntax).
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+    useConnectionStore.setState({ socket: mockSocket as unknown as WebSocket });
+
+    const answersMap = {
+      'Which release strategy?': 'Patch',
+      'Which targets?': ['App', 'Tests'],
+      'Confirm?': 'Yes',
+    };
+    const result = useConnectionStore.getState().sendUserQuestionResponse(answersMap, 'toolu_multi');
+
+    expect(result).toBe('sent');
+    expect(sent).toHaveLength(1);
+    const payload = sent[0] as { type: string; answer: string; answers: Record<string, unknown>; toolUseId: string };
+    expect(payload.type).toBe('user_question_response');
+    expect(payload.toolUseId).toBe('toolu_multi');
+    // `answers` passes the map through unchanged — arrays stay arrays.
+    expect(payload.answers).toEqual({
+      'Which release strategy?': 'Patch',
+      'Which targets?': ['App', 'Tests'],
+      'Confirm?': 'Yes',
+    });
+    expect(Array.isArray(payload.answers['Which targets?'])).toBe(true);
+    // Summary flattens arrays as comma-joined labels.
+    expect(payload.answer).toBe(
+      'Which release strategy?: Patch | Which targets?: App, Tests | Confirm?: Yes',
+    );
+  });
+
+  it('flattens legacy JSON-stringified array envelopes in the answer summary (back-compat)', () => {
+    // Pre-#4621 dashboards JSON-stringified multi-select arrays into a
+    // single string. If mixed-version rehydrated state replays such a
+    // payload through the widened store, the `answers` field should
+    // pass through unchanged BUT the `answer` summary should still
+    // flatten the JSON envelope so the terminal echo / older-server
+    // `answer` read stays readable.
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+    useConnectionStore.setState({ socket: mockSocket as unknown as WebSocket });
+
+    const legacyAnswersMap = {
+      'Which targets?': JSON.stringify(['App', 'Tests']),
+      'Confirm?': 'Yes',
+    };
+    useConnectionStore.getState().sendUserQuestionResponse(legacyAnswersMap, 'toolu_legacy');
+
+    expect(sent).toHaveLength(1);
+    const payload = sent[0] as { type: string; answer: string; answers: Record<string, unknown>; toolUseId: string };
+    expect(payload.answers).toEqual(legacyAnswersMap);
+    expect(payload.answer).toBe('Which targets?: App, Tests | Confirm?: Yes');
+    expect(payload.answer).not.toContain('["App"');
+  });
+
+  it('queues the multi-question payload when socket is not connected', () => {
+    useConnectionStore.setState({ socket: null });
+    const result = useConnectionStore
+      .getState()
+      .sendUserQuestionResponse({ 'Q?': ['A', 'B'] }, 'toolu_q');
+    expect(result).toBe('queued');
+  });
+});
+
 // -- Connected clients state --
 
 describe('connectedClients state', () => {

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -81,7 +81,7 @@ import type {
   SessionInfo,
   SessionState,
 } from './types';
-import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, withJitter } from './utils';
+import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, withJitter, formatQuestionAnswerSummary } from './utils';
 import {
   setStore,
   wsSend,
@@ -1197,9 +1197,41 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return result;
   },
 
-  sendUserQuestionResponse: (answer: string, toolUseId?: string) => {
+  sendUserQuestionResponse: (
+    answer: string | Record<string, string | string[]>,
+    toolUseId?: string,
+  ) => {
     const { socket } = get();
-    const payload: Record<string, string> = { type: 'user_question_response', answer };
+    // #4761 — widened to mirror the dashboard's `sendUserQuestionResponse`
+    // (#4760). Split the wire payload by call shape:
+    // - string `answer`: legacy single-question / free-text path. Wire
+    //   shape stays `{ type, answer, toolUseId? }` so older servers
+    //   keep working without schema migration.
+    // - Record `answer`: multi-question form. Populate the `answers`
+    //   field (`UserQuestionResponseSchema` accepts
+    //   `Record<string, string | string[]>` per #4621 / #4735) AND a
+    //   string `answer` summary so a server running an older build that
+    //   only reads `answer` falls through to its default-to-option-1
+    //   path instead of stalling the form.
+    //
+    //   Multi-select values flow through as native arrays — the summary
+    //   helper flattens them to comma-joined labels so the string-only
+    //   `answer` field stays readable. The helper also detects the
+    //   legacy JSON-stringified array envelope (pre-#4621 wire: a
+    //   single value like `'["App","Tests"]'` for multi-select) so
+    //   mixed-version rehydrated state still renders without leaking
+    //   JSON syntax in the `answer` field.
+    const isMultiAnswer = typeof answer !== 'string';
+    const answerSummary = isMultiAnswer
+      ? formatQuestionAnswerSummary(answer)
+      : answer;
+    const payload: Record<string, unknown> = {
+      type: 'user_question_response',
+      answer: answerSummary,
+    };
+    if (isMultiAnswer) {
+      payload.answers = answer;
+    }
     if (toolUseId) payload.toolUseId = toolUseId;
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, payload);

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -419,7 +419,24 @@ export interface MessageInputActions {
   sendInput: (input: string, wireAttachments?: { type: string; mediaType: string; data: string; name: string }[], options?: { isVoice?: boolean; clientMessageId?: string }) => 'sent' | 'queued' | false;
   sendInterrupt: () => 'sent' | 'queued' | false;
   sendPermissionResponse: (requestId: string, decision: string) => 'sent' | 'queued' | false;
-  sendUserQuestionResponse: (answer: string, toolUseId?: string) => 'sent' | 'queued' | false;
+  /**
+   * Send a `user_question_response` answer to the server.
+   *
+   * Accepts two answer shapes:
+   * - `string` — legacy single-question / free-text path. Wire shape stays
+   *   `{ type, answer, toolUseId? }` so older servers keep working.
+   * - `Record<string, string | string[]>` — multi-question form path
+   *   (#4604 / #4621 / #4735). Populates the `answers` field per
+   *   `UserQuestionResponseSchema` (which accepts `string | string[]` per
+   *   question) AND a flattened string `answer` summary so older servers
+   *   reading only `answer` still see a readable line.
+   *
+   * Mirrors `sendUserQuestionResponse` on the dashboard (#4760).
+   */
+  sendUserQuestionResponse: (
+    answer: string | Record<string, string | string[]>,
+    toolUseId?: string,
+  ) => 'sent' | 'queued' | false;
   markPromptAnswered: (messageId: string, answer: string) => void;
   markPromptAnsweredByRequestId: (requestId: string, answer: string) => void;
 }

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -431,7 +431,11 @@ export interface MessageInputActions {
    *   question) AND a flattened string `answer` summary so older servers
    *   reading only `answer` still see a readable line.
    *
-   * Mirrors `sendUserQuestionResponse` on the dashboard (#4760).
+   * Mirrors the `string` and `Record<string, string | string[]>` branches of
+   * `sendUserQuestionResponse` on the dashboard (#4760). The dashboard
+   * additionally accepts a `{ otherLabel, freeformText }` shape for the
+   * single-question Other / freeform path (#4651); mobile parity for that
+   * shape is tracked separately in #4755 and is out of scope here.
    */
   sendUserQuestionResponse: (
     answer: string | Record<string, string | string[]>,

--- a/packages/app/src/store/utils.ts
+++ b/packages/app/src/store/utils.ts
@@ -31,10 +31,13 @@ export function createEmptySessionState(): SessionState {
  *  - `'[...]'`    → parsed as JSON; if it's an array, joined; else returned as-is.
  *  - anything else → returned unchanged.
  *
- * Mirrors the dashboard's helper in
- * `packages/dashboard/src/utils/questionAnswerSummary.ts` (#4622 / #4735)
- * so multi-question answers render consistently across clients in the
- * server-side terminal echo.
+ * Mirrors only the array + legacy JSON-array envelope flattening from the
+ * dashboard's helper in `packages/dashboard/src/utils/questionAnswerSummary.ts`
+ * (#4622 / #4735) so multi-question answers render consistently across
+ * clients in the server-side terminal echo. The dashboard helper additionally
+ * handles the single-question `{ otherLabel, freeformText }` shape (#4651);
+ * mobile parity for that path is tracked separately in #4755 and is out of
+ * scope here.
  */
 function formatAnswerValue(value: string | string[]): string {
   if (Array.isArray(value)) return value.map((item) => String(item)).join(', ');
@@ -52,8 +55,12 @@ function formatAnswerValue(value: string | string[]): string {
 
 /**
  * #4761 — turn a multi-question answers map into a single human-readable
- * line for the wire `answer` summary field. Mirrors the dashboard helper
- * (#4622 / #4735); see `packages/dashboard/src/utils/questionAnswerSummary.ts`.
+ * line for the wire `answer` summary field. Mirrors the multi-question
+ * branch of the dashboard helper (#4622 / #4735); see
+ * `packages/dashboard/src/utils/questionAnswerSummary.ts`. The dashboard
+ * helper additionally handles the single-question `{ otherLabel,
+ * freeformText }` shape (#4651); mobile parity for that path is tracked
+ * separately in #4755 and is out of scope here.
  *
  * Output format: `Q1: A1 | Q2: A2, A3 | Q3: A4`.
  *

--- a/packages/app/src/store/utils.ts
+++ b/packages/app/src/store/utils.ts
@@ -24,3 +24,49 @@ export function createEmptySessionState(): SessionState {
     activityState: { state: 'idle', startedAt: Date.now() },
   };
 }
+
+/**
+ * #4761 — pretty-print a single multi-question answer value:
+ *  - `string[]`   → comma-joined labels (native #4621 path).
+ *  - `'[...]'`    → parsed as JSON; if it's an array, joined; else returned as-is.
+ *  - anything else → returned unchanged.
+ *
+ * Mirrors the dashboard's helper in
+ * `packages/dashboard/src/utils/questionAnswerSummary.ts` (#4622 / #4735)
+ * so multi-question answers render consistently across clients in the
+ * server-side terminal echo.
+ */
+function formatAnswerValue(value: string | string[]): string {
+  if (Array.isArray(value)) return value.map((item) => String(item)).join(', ');
+  // Cheap pre-check to avoid JSON.parse-ing every short-string answer.
+  if (!value.startsWith('[')) return value;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return value;
+  }
+  if (!Array.isArray(parsed)) return value;
+  return parsed.map((item) => String(item)).join(', ');
+}
+
+/**
+ * #4761 — turn a multi-question answers map into a single human-readable
+ * line for the wire `answer` summary field. Mirrors the dashboard helper
+ * (#4622 / #4735); see `packages/dashboard/src/utils/questionAnswerSummary.ts`.
+ *
+ * Output format: `Q1: A1 | Q2: A2, A3 | Q3: A4`.
+ *
+ * The string-only `answer` field is required by `UserQuestionResponseSchema`
+ * so even multi-question payloads must populate it — older servers that
+ * only read `answer` fall through to a default-to-option-1 path if the
+ * field is empty, which stalls the form.
+ */
+export function formatQuestionAnswerSummary(
+  answer: string | Record<string, string | string[]>,
+): string {
+  if (typeof answer === 'string') return answer;
+  return Object.entries(answer)
+    .map(([question, value]) => `${question}: ${formatAnswerValue(value)}`)
+    .join(' | ');
+}


### PR DESCRIPTION
Closes #4761

## Summary

Mirrors the dashboard's `sendUserQuestionResponse` widening (#4760) on the mobile store so the app can submit multi-question form answers once the chat renderer grows multi-question UI.

The widened signature accepts:

- `string` — legacy single-question / free-text path. Wire shape stays `{ type, answer, toolUseId? }` so older servers keep working without schema migration.
- `Record<string, string | string[]>` — multi-question form path (#4604 / #4621 / #4735). Populates the wire `answers` field (`UserQuestionResponseSchema` already accepts `string | string[]` per question) AND a comma-flattened string `answer` summary so older servers reading only `answer` still see a readable line.

## Back-compat

- All existing single-string callers (`SessionScreen.handleSelectOption`) keep working — TypeScript widens, runtime branches on `typeof answer`.
- No behavioural change in the mobile chat today — multi-question UI is still out of scope per the issue. The protocol/server have already been widened in #4760; this PR closes the mobile parity gap so the renderer can be retrofitted without another protocol bump.
- The new `formatQuestionAnswerSummary` helper mirrors the dashboard's (`packages/dashboard/src/utils/questionAnswerSummary.ts`) — also handles the legacy pre-#4621 JSON-stringified array envelope (`'["App","Tests"]'`) for mixed-version rehydrated state.

## Test plan

- [x] `packages/app/src/__tests__/store/connection.test.ts` — added `sendUserQuestionResponse wire payload (#4761)` describe with 4 tests:
  - Legacy single-question string answer emits unchanged wire shape, no `answers` field.
  - Multi-question `Record<string, string | string[]>` forwards verbatim, arrays stay arrays, `answer` summary flattens comma-joined.
  - Legacy JSON-stringified array envelope flattens cleanly in the `answer` summary (no leaked `["App"` syntax).
  - Multi-question payload queues when socket is disconnected.
- [x] All 136 existing tests in `connection.test.ts` still pass.
- [x] `SessionScreen.test.ts` (24 tests) still passes — confirms `handleSelectOption` still type-checks and runs.
- [x] `tsc --noEmit` clean.

## Acceptance Criteria

- [x] Mobile `sendQuestionResponse` types match the dashboard widened signature.
- [x] Test pins a multi-question answersMap (mixed string + string[]) reaching the wire unchanged.
- [x] No regression on the existing single-question happy path.