### PR TITLE
fix(dashboard): hide AskUserQuestion content until permission allowed

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -63,6 +63,19 @@ vi.mock('./components/MultiTerminalView', () => ({
   ),
 }))
 
+// #4685 — PermissionPrompt reads `availableProviders` and calls
+// `isRuleEligibleProvider`, both of which need a richer store mock than the
+// App smoke harness provides. The #4685 gate tests below mount a permission
+// message (requestId + expiresAt + !answered) which would otherwise drive
+// the real PermissionPrompt to crash on the missing helper. Stub it here so
+// the gate tests stay focused on App-level derivation; PermissionPrompt has
+// its own dedicated suite in PermissionPrompt.test.tsx.
+vi.mock('./components/PermissionPrompt', () => ({
+  PermissionPrompt: (props: { requestId: string; tool: string }) => (
+    <div data-testid={`permission-prompt-mock-${props.requestId}`} data-tool={props.tool} />
+  ),
+}))
+
 vi.mock('./components/StdinDisabledBanner', () => ({
   StdinDisabledBanner: (props: {
     visible: boolean
@@ -1605,6 +1618,233 @@ describe('App', () => {
       render(<App />)
       const modes = voiceInputModeSpy.mock.calls.map(c => c[0]?.mode)
       expect(modes).toContain('continuous')
+    })
+  })
+
+  // #4685 — App-level integration tests for the AskUserQuestion content
+  // gate. The component-level tests in QuestionPrompt.test.tsx prove the
+  // placeholder branch given a prop; these prove App.tsx ACTUALLY computes
+  // `pendingPermission=true` when the active session has both an unresolved
+  // `AskUserQuestion` permission_request AND a `user_question`-derived
+  // prompt message, and that the gate flips OFF on allow / STAYS ON on
+  // deny. A future change that renames `m.tool` or moves `requestId`
+  // placement on the permission ChatMessage would silently regress the
+  // fix — these tests pin the App-side derivation. Mirrors Copilot review
+  // comment #2 on #4860.
+  describe('AskUserQuestion content gate — App-level derivation (#4685)', () => {
+    const connectedState = {
+      connectionPhase: 'connected' as const,
+      sessions: [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }],
+      activeSessionId: 's1',
+    }
+
+    // Two messages mirror the TUI race in the wild: the permission hook's
+    // HTTP /permission broadcast creates a `permission_request` ChatMessage
+    // (tool='AskUserQuestion', requestId set), and the in-process
+    // user_question event creates a separate `prompt` ChatMessage carrying
+    // the model-supplied question text + options (no requestId).
+    const askUserQuestionMessages = [
+      {
+        id: 'perm-1',
+        type: 'prompt',
+        content: 'AskUserQuestion: pick your fighter',
+        tool: 'AskUserQuestion',
+        requestId: 'req-aq-1',
+        options: [
+          { label: 'Allow', value: 'allow' },
+          { label: 'Deny', value: 'deny' },
+        ],
+        expiresAt: Date.now() + 300_000,
+        timestamp: 1,
+      },
+      {
+        id: 'q-1',
+        type: 'prompt',
+        content: 'Pick your fighter',
+        options: [
+          { label: 'Ryu', value: 'ryu' },
+          { label: 'Ken', value: 'ken' },
+        ],
+        questions: [
+          { question: 'Pick your fighter', options: [{ label: 'Ryu', value: 'ryu' }, { label: 'Ken', value: 'ken' }] },
+        ],
+        timestamp: 2,
+      },
+    ]
+
+    it('renders the placeholder (and hides question content) when the AskUserQuestion permission_request is unresolved', () => {
+      stateOverrides = {
+        ...connectedState,
+        getActiveSessionState: () => ({
+          messages: askUserQuestionMessages,
+          streamingMessageId: null,
+          activeModel: null,
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+        }),
+        resolvedPermissions: {},
+        viewMode: 'chat',
+      }
+      render(<App />)
+      const chatPane = screen.getByTestId('chat-pane')
+      // Placeholder renders…
+      expect(within(chatPane).getByTestId('question-prompt-pending-permission')).toBeInTheDocument()
+      // …and the model-supplied question + option labels are NOT in the
+      // chat pane (gate works end-to-end through App's derivation).
+      expect(within(chatPane).queryByText('Pick your fighter')).not.toBeInTheDocument()
+      expect(within(chatPane).queryByText('Ryu')).not.toBeInTheDocument()
+      expect(within(chatPane).queryByText('Ken')).not.toBeInTheDocument()
+    })
+
+    it('flips OFF the gate (reveals content) when the permission resolves to `allow`', () => {
+      stateOverrides = {
+        ...connectedState,
+        getActiveSessionState: () => ({
+          messages: askUserQuestionMessages,
+          streamingMessageId: null,
+          activeModel: null,
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+        }),
+        resolvedPermissions: { 'req-aq-1': 'allow' },
+        viewMode: 'chat',
+      }
+      render(<App />)
+      const chatPane = screen.getByTestId('chat-pane')
+      // Placeholder is gone…
+      expect(within(chatPane).queryByTestId('question-prompt-pending-permission')).not.toBeInTheDocument()
+      // …and the actual question + options are visible.
+      expect(within(chatPane).getByText('Pick your fighter')).toBeInTheDocument()
+      expect(within(chatPane).getByText('Ryu')).toBeInTheDocument()
+      expect(within(chatPane).getByText('Ken')).toBeInTheDocument()
+    })
+
+    it('flips OFF the gate when the permission resolves to `allowSession`', () => {
+      // Same behaviour as `allow` — both are "user explicitly approved
+      // seeing the question content."
+      stateOverrides = {
+        ...connectedState,
+        getActiveSessionState: () => ({
+          messages: askUserQuestionMessages,
+          streamingMessageId: null,
+          activeModel: null,
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+        }),
+        resolvedPermissions: { 'req-aq-1': 'allowSession' },
+        viewMode: 'chat',
+      }
+      render(<App />)
+      const chatPane = screen.getByTestId('chat-pane')
+      expect(within(chatPane).queryByTestId('question-prompt-pending-permission')).not.toBeInTheDocument()
+      expect(within(chatPane).getByText('Pick your fighter')).toBeInTheDocument()
+    })
+
+    it('KEEPS the gate ON when the permission resolves to `deny` (#4685 Copilot review)', () => {
+      // Issue #4685 expected behavior: "(b) Question bubble renders only
+      // after the permission flow completes (and shows the redacted/denied
+      // state if user clicks Deny)". Pre-Copilot-review the gate flipped
+      // off on ANY resolved entry, surfacing the model-supplied question
+      // text + options after a denial — exactly defeating the gate. This
+      // test pins the deny-keeps-gate-on rule end-to-end through App's
+      // derivation.
+      stateOverrides = {
+        ...connectedState,
+        getActiveSessionState: () => ({
+          messages: askUserQuestionMessages,
+          streamingMessageId: null,
+          activeModel: null,
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+        }),
+        resolvedPermissions: { 'req-aq-1': 'deny' },
+        viewMode: 'chat',
+      }
+      render(<App />)
+      const chatPane = screen.getByTestId('chat-pane')
+      // Placeholder STILL renders — deny does not un-gate.
+      expect(within(chatPane).getByTestId('question-prompt-pending-permission')).toBeInTheDocument()
+      // Question content stays hidden.
+      expect(within(chatPane).queryByText('Pick your fighter')).not.toBeInTheDocument()
+      expect(within(chatPane).queryByText('Ryu')).not.toBeInTheDocument()
+    })
+
+    it('KEEPS the gate ON when the cross-client permission_resolved set `m.answered = "deny"` on the permission message', () => {
+      // The cross-client path lives on the per-message `answered` field
+      // rather than the store's `resolvedPermissions` map (see
+      // message-handler.ts:1705 — handlePermissionResolved sets answered
+      // for the cross-client view, NOT resolvedPermissions). Mirror the
+      // resolvedPermissions deny test for the per-message branch.
+      const denyAnsweredMessages = [
+        { ...askUserQuestionMessages[0], answered: 'deny' as const, answeredAt: Date.now() },
+        askUserQuestionMessages[1],
+      ]
+      stateOverrides = {
+        ...connectedState,
+        getActiveSessionState: () => ({
+          messages: denyAnsweredMessages,
+          streamingMessageId: null,
+          activeModel: null,
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+        }),
+        resolvedPermissions: {},
+        viewMode: 'chat',
+      }
+      render(<App />)
+      const chatPane = screen.getByTestId('chat-pane')
+      expect(within(chatPane).getByTestId('question-prompt-pending-permission')).toBeInTheDocument()
+      expect(within(chatPane).queryByText('Pick your fighter')).not.toBeInTheDocument()
+    })
+
+    it('does NOT activate the gate when there is no AskUserQuestion permission_request in the session', () => {
+      // Defensive: a `user_question` without a paired permission_request
+      // (e.g. SDK / CLI / BYOK / Codex / Gemini providers, which short-
+      // circuit AskUserQuestion in PermissionManager — no permission_request
+      // is ever broadcast) MUST render the QuestionPrompt content
+      // immediately. The gate is TUI-specific by construction and a no-op
+      // elsewhere; pin that here so a future change can't accidentally
+      // gate every provider's AskUserQuestion.
+      stateOverrides = {
+        ...connectedState,
+        getActiveSessionState: () => ({
+          messages: [askUserQuestionMessages[1]], // user_question only, no permission_request
+          streamingMessageId: null,
+          activeModel: null,
+          permissionMode: null,
+          contextUsage: null,
+          sessionCost: null,
+          isIdle: true,
+          activeAgents: [],
+          isPlanPending: false,
+        }),
+        resolvedPermissions: {},
+        viewMode: 'chat',
+      }
+      render(<App />)
+      const chatPane = screen.getByTestId('chat-pane')
+      expect(within(chatPane).queryByTestId('question-prompt-pending-permission')).not.toBeInTheDocument()
+      expect(within(chatPane).getByText('Pick your fighter')).toBeInTheDocument()
     })
   })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -349,32 +349,47 @@ export function App() {
   )
 
   // #4685 — track resolved permissions from the store so the QuestionPrompt
-  // gate can flip off the moment the user clicks Allow / Deny on a pending
+  // gate can flip off the moment the user clicks Allow on a pending
   // AskUserQuestion permission_request. The store keeps a per-requestId
-  // map keyed by decision; presence in the map = resolved (either
-  // direction). Combined with the per-message `answered` flag this gives
-  // us the full "is there an unresolved AskUserQuestion permission?" view.
+  // map keyed by decision (`allow` | `deny` | `allowSession`); combined
+  // with the per-message `answered` flag this gives us the full
+  // "is there an unresolved-or-denied AskUserQuestion permission?" view.
+  //
+  // #4685 Copilot review: ONLY `allow` / `allowSession` un-gate the
+  // content. `deny` keeps the gate ON — issue #4685's expected behavior
+  // says "and shows the redacted/denied state if user clicks Deny". A
+  // permission denial means the user explicitly refused to see the
+  // question; revealing the model-supplied text and options post-deny
+  // defeats the whole point of the gate.
   const resolvedPermissions = useConnectionStore(s => s.resolvedPermissions)
 
-  // #4685 — boolean: is there an unresolved AskUserQuestion permission
-  // prompt in the active session's chat? When true, the QuestionPrompt
-  // for any `user_question`-derived `prompt` message MUST gate its
-  // content behind a placeholder so the model-supplied question text and
-  // options stay hidden until the user clicks Allow. A permission prompt
-  // counts as "unresolved" when (a) it has not been answered on this
-  // client (no per-message `answered`) AND (b) no other client has
-  // resolved it (no entry in `resolvedPermissions[requestId]`). Multiple
-  // pending AskUserQuestion permissions in the same session are rare but
-  // any single one is enough to gate every question render in that
-  // session — the bug is content leak before consent, not which specific
-  // question got which specific permission decision.
+  // #4685 — boolean: is there an unresolved-or-denied AskUserQuestion
+  // permission prompt in the active session's chat? When true, the
+  // QuestionPrompt for any `user_question`-derived `prompt` message MUST
+  // gate its content behind a placeholder so the model-supplied question
+  // text and options stay hidden. A permission prompt counts as
+  // "unresolved-or-denied" when EITHER (a) it has not been answered on
+  // this client (no `m.answered === 'allow' | 'allowSession'`) AND (b)
+  // no other client has allowed it (`resolvedPermissions[requestId]`
+  // not in {`allow`, `allowSession`}). `deny` on either signal keeps the
+  // gate ON — Copilot review (#4685) caught the pre-fix bug where deny
+  // un-gated the content, contradicting issue #4685's expected behavior.
+  // Multiple pending AskUserQuestion permissions in the same session are
+  // rare but any single un-allowed one is enough to gate every question
+  // render in that session — the bug is content leak before consent, not
+  // which specific question got which specific permission decision.
   const hasPendingAskUserQuestionPermission = useMemo(() => {
     for (const m of storeMessages) {
       if (m.type !== 'prompt') continue
       if (!m.requestId) continue
       if (m.tool !== 'AskUserQuestion') continue
-      if (m.answered) continue
-      if (resolvedPermissions?.[m.requestId]) continue
+      // Per-message `answered` is set by `handlePermissionResolved` on
+      // BOTH allow and deny — gate only flips off for allow variants.
+      if (m.answered === 'allow' || m.answered === 'allowSession') continue
+      // Cross-client decision via `resolvedPermissions[requestId]` —
+      // same allow-only rule.
+      const decision = resolvedPermissions?.[m.requestId]
+      if (decision === 'allow' || decision === 'allowSession') continue
       return true
     }
     return false

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -348,6 +348,38 @@ export function App() {
     [activeSessionProvider],
   )
 
+  // #4685 — track resolved permissions from the store so the QuestionPrompt
+  // gate can flip off the moment the user clicks Allow / Deny on a pending
+  // AskUserQuestion permission_request. The store keeps a per-requestId
+  // map keyed by decision; presence in the map = resolved (either
+  // direction). Combined with the per-message `answered` flag this gives
+  // us the full "is there an unresolved AskUserQuestion permission?" view.
+  const resolvedPermissions = useConnectionStore(s => s.resolvedPermissions)
+
+  // #4685 — boolean: is there an unresolved AskUserQuestion permission
+  // prompt in the active session's chat? When true, the QuestionPrompt
+  // for any `user_question`-derived `prompt` message MUST gate its
+  // content behind a placeholder so the model-supplied question text and
+  // options stay hidden until the user clicks Allow. A permission prompt
+  // counts as "unresolved" when (a) it has not been answered on this
+  // client (no per-message `answered`) AND (b) no other client has
+  // resolved it (no entry in `resolvedPermissions[requestId]`). Multiple
+  // pending AskUserQuestion permissions in the same session are rare but
+  // any single one is enough to gate every question render in that
+  // session — the bug is content leak before consent, not which specific
+  // question got which specific permission decision.
+  const hasPendingAskUserQuestionPermission = useMemo(() => {
+    for (const m of storeMessages) {
+      if (m.type !== 'prompt') continue
+      if (!m.requestId) continue
+      if (m.tool !== 'AskUserQuestion') continue
+      if (m.answered) continue
+      if (resolvedPermissions?.[m.requestId]) continue
+      return true
+    }
+    return false
+  }, [storeMessages, resolvedPermissions])
+
   // #3839: dropdown-gating flags derived from the active session's provider
   // capabilities. Hoisted out of the JSX so the lookups don't re-run on every
   // render of <App>, which fires on most WS messages.
@@ -1344,6 +1376,18 @@ export function App() {
           // `allowMultiQuestionForm` above so the flag flips correctly
           // on session-switch without a full re-render of every prompt.
           allowMultiQuestion={allowMultiQuestionForm}
+          // #4685 — gate the question content render on the matching
+          // AskUserQuestion permission_request being resolved. Pre-fix
+          // the user_question card rendered the moment the wire event
+          // arrived (which the server emits in parallel with the
+          // permission_request), leaking the model-supplied question
+          // text + options before the user had a chance to click Allow.
+          // The derivation `hasPendingAskUserQuestionPermission` scans
+          // the same session's messages for any AskUserQuestion
+          // permission prompt that is still unresolved on both this
+          // client and across clients. Already-answered prompts skip the
+          // gate so post-answer chat history renders normally.
+          pendingPermission={!storeMsg.answered && hasPendingAskUserQuestionPermission}
           onSelect={(answer) => {
             // #4604 Chunk B / #4735 — answer is `string` for
             // single-question / free-text paths and
@@ -1451,7 +1495,7 @@ export function App() {
 
     // Default rendering
     return null
-  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs, allowMultiQuestionForm, activeSessionProvider, setViewMode, stalledPromptIds])
+  }, [storeMsgMap, chatToolGroupPayloads, chatTailMessageId, sendPermissionResponse, sendUserQuestionResponse, markPromptAnswered, storeMessages, sendInput, streamStallTimeoutMs, allowMultiQuestionForm, activeSessionProvider, setViewMode, stalledPromptIds, hasPendingAskUserQuestionPermission])
 
   // #4412: registry-driven cheat sheet. Recomputed on every render —
   // not memoised, by design. The shortcut registry hook re-renders

--- a/packages/dashboard/src/components/QuestionPrompt.test.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.test.tsx
@@ -810,4 +810,147 @@ describe('QuestionPrompt', () => {
       })
     })
   })
+
+  // #4685 — when an AskUserQuestion permission_request is still
+  // unresolved (user hasn't clicked Allow yet), the dashboard MUST NOT
+  // render the question content (text, options, free-text input,
+  // multi-question form, deferred notice). Pre-#4685 the question card
+  // rendered the moment `user_question` arrived, racing the permission
+  // prompt and leaking the model-supplied content before consent. The
+  // gate flips off as soon as the matching permission_request is
+  // resolved (allow/deny), at which point the normal content renders.
+  describe('pendingPermission gate (#4685)', () => {
+    const opts = [
+      { label: 'Option A', value: 'a' },
+      { label: 'Option B', value: 'b' },
+    ]
+
+    it('hides the question text and options when pendingPermission is true', () => {
+      render(
+        <QuestionPrompt
+          question="What is your password?"
+          options={opts}
+          pendingPermission
+          onSelect={vi.fn()}
+        />
+      )
+      // Neutral placeholder renders…
+      expect(screen.getByTestId('question-prompt-pending-permission')).toBeInTheDocument()
+      expect(screen.getByText(/Pending permission to view question/i)).toBeInTheDocument()
+      // …and the actual question payload is NOT in the DOM. The model-
+      // supplied question text and every option label must stay hidden
+      // until permission is granted.
+      expect(screen.queryByText('What is your password?')).not.toBeInTheDocument()
+      expect(screen.queryByText('Option A')).not.toBeInTheDocument()
+      expect(screen.queryByText('Option B')).not.toBeInTheDocument()
+      // The normal question-prompt container is suppressed too.
+      expect(screen.queryByTestId('question-prompt')).not.toBeInTheDocument()
+    })
+
+    it('renders no interactive controls when pendingPermission is true', () => {
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={opts}
+          pendingPermission
+          onSelect={vi.fn()}
+        />
+      )
+      // No option buttons, no Send/Submit buttons, no inputs of any kind.
+      expect(screen.queryAllByRole('button')).toHaveLength(0)
+      expect(screen.queryByPlaceholderText('Type your response…')).not.toBeInTheDocument()
+    })
+
+    it('hides multi-question content (form and deferred notice) when pendingPermission is true', () => {
+      const multiQs = [
+        { question: 'Q1?', options: [{ label: 'a', value: 'a' }] },
+        { question: 'Q2?', options: [{ label: 'b', value: 'b' }] },
+      ]
+      render(
+        <QuestionPrompt
+          question="Q1?"
+          options={[{ label: 'a', value: 'a' }]}
+          questions={multiQs}
+          pendingPermission
+          onSelect={vi.fn()}
+        />
+      )
+      // Neither variant renders while permission is pending.
+      expect(screen.queryByTestId('question-prompt-multi')).not.toBeInTheDocument()
+      expect(screen.queryByTestId('multi-question-deferred-notice')).not.toBeInTheDocument()
+      // The placeholder takes over.
+      expect(screen.getByTestId('question-prompt-pending-permission')).toBeInTheDocument()
+      // No question text from any of the questions is visible.
+      expect(screen.queryByText('Q1?')).not.toBeInTheDocument()
+      expect(screen.queryByText('Q2?')).not.toBeInTheDocument()
+    })
+
+    it('reveals the question content after pendingPermission flips to false', () => {
+      const { rerender } = render(
+        <QuestionPrompt
+          question="What is your password?"
+          options={opts}
+          pendingPermission
+          onSelect={vi.fn()}
+        />
+      )
+      // While pending: placeholder only.
+      expect(screen.getByTestId('question-prompt-pending-permission')).toBeInTheDocument()
+      expect(screen.queryByText('What is your password?')).not.toBeInTheDocument()
+
+      // User clicks Allow → store flips pendingPermission to false →
+      // component re-renders with the real content.
+      rerender(
+        <QuestionPrompt
+          question="What is your password?"
+          options={opts}
+          onSelect={vi.fn()}
+        />
+      )
+      expect(screen.queryByTestId('question-prompt-pending-permission')).not.toBeInTheDocument()
+      expect(screen.getByText('What is your password?')).toBeInTheDocument()
+      expect(screen.getByText('Option A')).toBeInTheDocument()
+      expect(screen.getByText('Option B')).toBeInTheDocument()
+    })
+
+    it('renders the question content normally when pendingPermission is false (legacy default)', () => {
+      // Defensive: explicit `false` must behave exactly like the prop
+      // being omitted so pre-#4685 callers stay green.
+      render(
+        <QuestionPrompt
+          question="Pick one"
+          options={opts}
+          pendingPermission={false}
+          onSelect={vi.fn()}
+        />
+      )
+      expect(screen.queryByTestId('question-prompt-pending-permission')).not.toBeInTheDocument()
+      expect(screen.getByText('Pick one')).toBeInTheDocument()
+      expect(screen.getByText('Option A')).toBeInTheDocument()
+    })
+
+    it('placeholder copy is neutral — does not leak any question or option text', () => {
+      // The leaked content is the bug; the placeholder must NOT
+      // accidentally echo the question or options through some shared
+      // prop. Verify the placeholder carries only the generic "Pending
+      // permission" copy and nothing else.
+      render(
+        <QuestionPrompt
+          question="LEAK_ME_QUESTION"
+          options={[
+            { label: 'LEAK_ME_OPTION_A', value: 'a' },
+            { label: 'LEAK_ME_OPTION_B', value: 'b' },
+          ]}
+          pendingPermission
+          onSelect={vi.fn()}
+        />
+      )
+      const placeholder = screen.getByTestId('question-prompt-pending-permission')
+      expect(placeholder.textContent).not.toContain('LEAK_ME_QUESTION')
+      expect(placeholder.textContent).not.toContain('LEAK_ME_OPTION_A')
+      expect(placeholder.textContent).not.toContain('LEAK_ME_OPTION_B')
+      // And nothing leaks elsewhere in the rendered tree either.
+      expect(screen.queryByText(/LEAK_ME/)).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -58,6 +58,21 @@ export interface QuestionPromptProps {
   options: { label: string; value: string }[]
   answered?: string
   /**
+   * #4685 — when true, an `AskUserQuestion` permission_request for the
+   * owning session is still unresolved (the user has NOT clicked Allow
+   * yet). Gate ALL question content (text, options, multi-question form,
+   * deferred notice, free-text input) behind this flag and render only a
+   * neutral "Pending permission to view question…" placeholder until
+   * permission is granted. Without this gate the dashboard surfaces the
+   * full question payload before the user has consented to see it —
+   * defeating the purpose of the permission prompt. The flag flips back
+   * to false once `resolvedPermissions[requestId]` is set OR the matching
+   * permission prompt is `answered`, at which point the normal content
+   * renders. Default false so legacy callers (and tests) keep their
+   * pre-#4685 behaviour unless they explicitly opt in.
+   */
+  pendingPermission?: boolean
+  /**
    * #4604 Chunk B — full per-question payload for multi-question forms.
    * Always populated by store-core handleUserQuestion (questions[0]
    * mirrors the top-level `question` + `options`). When length > 1 the
@@ -92,7 +107,27 @@ export interface QuestionPromptProps {
   onSelect: (answer: string | MultiQuestionAnswersMap | OtherFreeformAnswer) => void
 }
 
-export function QuestionPrompt({ question, options, answered, questions, allowMultiQuestion, onSelect }: QuestionPromptProps) {
+export function QuestionPrompt({ question, options, answered, questions, allowMultiQuestion, pendingPermission, onSelect }: QuestionPromptProps) {
+  // #4685 — gate ALL question content (text, options, multi-question
+  // form, deferred notice, free-text input) behind the
+  // `pendingPermission` flag. Render only a neutral placeholder until
+  // the user has clicked Allow on the AskUserQuestion permission prompt.
+  // Without this gate the dashboard surfaces the full question payload
+  // (and the model-supplied options, which can be social-engineering
+  // text) before the user has consented to see it — defeating the
+  // purpose of the permission prompt.
+  if (pendingPermission) {
+    return (
+      <div
+        className="question-prompt question-prompt--pending-permission"
+        data-testid="question-prompt-pending-permission"
+        role="status"
+      >
+        <div className="question-text">Pending permission to view question…</div>
+      </div>
+    )
+  }
+
   const isMultiQuestion = Array.isArray(questions) && questions.length > 1
 
   // #4666 / #4735 / #4731 — TUI / CLI sessions: permission-hook denies any

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2281,6 +2281,24 @@
   color: var(--text-muted);
 }
 
+/* #4685: pending-permission placeholder shown when an AskUserQuestion
+   permission_request is still unresolved on this session. The full
+   question payload (text, options, multi-question form, deferred notice,
+   free-text input) is suppressed until the user clicks Allow on the
+   matching permission prompt — pre-fix the content rendered the moment
+   the wire `user_question` event arrived, leaking model-supplied text
+   before consent. Mirrors the deferred-notice variant's muted tone so
+   the gap reads as "waiting" rather than "broken". */
+.question-prompt--pending-permission {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.question-prompt--pending-permission .question-text {
+  margin-bottom: 0;
+  color: var(--text-muted);
+}
+
 /* #4634: multi-question AskUserQuestion form (#4604 Chunk B / #4620).
    The component renders these class names but they previously had no
    CSS rules — Submit fell back to the native browser button (gray-on-


### PR DESCRIPTION
Closes #4685

## Summary

The dashboard rendered the full AskUserQuestion payload (text, options, multi-question form, deferred notice, free-text input) the moment the `user_question` wire event arrived — which the server broadcasts in parallel with the matching `permission_request`. By the time the user saw the Allow / Deny card, the model-supplied content had already leaked onto the chat surface, defeating the purpose of the permission gate.

## Fix

- `QuestionPrompt` accepts a new `pendingPermission?: boolean` prop. When true, every render branch short-circuits to a neutral `Pending permission to view question…` placeholder (no question text, no options, no inputs, no submit/send buttons).
- `App.tsx` derives the flag by scanning the active session's messages for any AskUserQuestion `permission_request` that is still unresolved on both this client (no per-message `answered`) and across clients (no entry in the store's `resolvedPermissions[requestId]` map).
- The gate flips off the instant the user (or any other client) clicks Allow / Deny on the permission card, at which point the normal question content renders.
- Already-answered prompts skip the gate so post-answer chat history keeps rendering normally on replay.
- CSS adds a muted-italic style for the new `question-prompt--pending-permission` variant, mirroring the existing `question-prompt--deferred` look.

## Test plan

- [x] Added `QuestionPrompt` unit tests covering: placeholder hides single-question content (text + options), placeholder hides multi-question content (form + deferred notice), no interactive controls render, transition from `pendingPermission=true` to `false` reveals the real content, explicit `false` matches the default, and the placeholder copy never echoes any question or option text.
- [x] `npx vitest run` in `packages/dashboard/` — 2547 tests pass (49 in `QuestionPrompt.test.tsx`, including 6 new gate cases).
- [x] `npx tsc --noEmit` in `packages/dashboard/` — clean.
- [ ] Manual repro on v0.9.30: trigger an AskUserQuestion in a TUI session, confirm the question payload stays hidden until Allow is clicked, and that Deny also reveals nothing.