### PR TITLE
fix(dashboard): add hover tooltips + aria-labels to header buttons

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -1906,4 +1906,49 @@ describe('App', () => {
       expect(within(chatPane).getByText('Pick your fighter')).toBeInTheDocument()
     })
   })
+
+  describe('header tooltips (#4630)', () => {
+    const connectedWithSession = {
+      connectionPhase: 'connected' as const,
+      sessions: [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }],
+      activeSessionId: 's1',
+    }
+
+    it('Skills toggle exposes both title and aria-label', () => {
+      stateOverrides = connectedWithSession
+      render(<App />)
+      const btn = screen.getByTestId('btn-toggle-skills-panel')
+      expect(btn.getAttribute('title')).toBeTruthy()
+      expect(btn.getAttribute('aria-label')).toBeTruthy()
+    })
+
+    it('Settings gear button exposes both title and aria-label', () => {
+      stateOverrides = connectedWithSession
+      render(<App />)
+      const btn = screen.getByLabelText('Settings')
+      expect(btn.getAttribute('title')).toMatch(/Settings/)
+      expect(btn.getAttribute('aria-label')).toBe('Settings')
+    })
+
+    it('header status dot exposes both title and aria-label so it is discoverable', () => {
+      stateOverrides = connectedWithSession
+      const { container } = render(<App />)
+      // The header's status-dot is rendered inside #header, distinct from
+      // the per-tab status-dot inside SessionBar.
+      const header = container.querySelector('#header')
+      const dot = header!.querySelector('.status-dot')
+      expect(dot, 'header status-dot must exist').toBeTruthy()
+      expect(dot!.getAttribute('title'), 'status-dot needs title for browser hover').toBeTruthy()
+      expect(dot!.getAttribute('aria-label'), 'status-dot needs aria-label for SR').toBeTruthy()
+    })
+
+    it('version badge exposes both title and aria-label', () => {
+      stateOverrides = connectedWithSession
+      const { container } = render(<App />)
+      const badge = container.querySelector('.version-badge')
+      expect(badge, 'version-badge must exist').toBeTruthy()
+      expect(badge!.getAttribute('title'), 'version-badge needs title').toBeTruthy()
+      expect(badge!.getAttribute('aria-label'), 'version-badge needs aria-label').toBeTruthy()
+    })
+  })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1742,8 +1742,45 @@ export function App() {
       <header id="header">
         <div className="header-left">
           <span className="logo">Chroxy</span>
-          <span className="version-badge">v{serverVersion ?? __APP_VERSION__}</span>
-          <span className={`status-dot ${serverPhase === 'tunnel_warming' || serverPhase === 'tunnel_verifying' || (isConnected && !tunnelReady && serverPhase == null) ? 'connecting' : connectionPhase}`} />
+          {/* #4630 — version + status-dot were bare spans with no
+              discoverable label, leaving Tauri/WKWebView and SR users with
+              nothing on hover. Pair `title` (browser hover tooltip) with
+              `aria-label` (screen-reader announcement) so both surfaces
+              get a label. The status dot also gets `role="status"` so SR
+              tooling treats it as a live region rather than a decorative
+              span. */}
+          {(() => {
+            const versionLabel = `Chroxy server v${serverVersion ?? __APP_VERSION__}`
+            return (
+              <span
+                className="version-badge"
+                title={versionLabel}
+                aria-label={versionLabel}
+              >
+                v{serverVersion ?? __APP_VERSION__}
+              </span>
+            )
+          })()}
+          {(() => {
+            const warming = serverPhase === 'tunnel_warming' || serverPhase === 'tunnel_verifying' || (isConnected && !tunnelReady && serverPhase == null)
+            const phase = warming ? 'connecting' : connectionPhase
+            const STATUS_LABELS: Record<string, string> = {
+              connected: 'Connected to Chroxy server',
+              connecting: warming ? 'Tunnel warming up…' : 'Connecting to Chroxy server…',
+              reconnecting: 'Reconnecting to Chroxy server…',
+              server_restarting: 'Server restarting…',
+              disconnected: 'Disconnected from Chroxy server',
+            }
+            const label = STATUS_LABELS[phase] ?? `Connection status: ${phase}`
+            return (
+              <span
+                className={`status-dot ${phase}`}
+                title={label}
+                aria-label={label}
+                role="status"
+              />
+            )
+          })()}
         </div>
         <div className="header-center">
           <ChatSettingsDropdown

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -224,6 +224,42 @@ describe('FooterBar', () => {
     expect(onShowQr).toHaveBeenCalledOnce()
   })
 
+  // #4630 — every icon/short-label footer control needs a `title` for
+  // browser-native hover tooltips. The QR button only had aria-label;
+  // version + status-dot had neither. Without these, hovering produced
+  // nothing and SR users had no label either.
+  describe('#4630 tooltips on footer chips and buttons', () => {
+    it('QR button exposes both title and aria-label', () => {
+      render(<FooterBar {...baseProps} onShowQr={vi.fn()} />)
+      const btn = screen.getByLabelText('Show QR code')
+      expect(btn.getAttribute('title'), 'QR button needs title').toBeTruthy()
+      expect(btn.getAttribute('aria-label')).toBe('Show QR code')
+    })
+
+    it('Share-session button exposes both title and aria-label', () => {
+      render(<FooterBar {...baseProps} onShareSession={vi.fn()} />)
+      const btn = screen.getByTestId('btn-share-session')
+      expect(btn.getAttribute('title'), 'Share button needs title').toBeTruthy()
+      expect(btn.getAttribute('aria-label')).toBe('Share this session')
+    })
+
+    it('version chip exposes both title and aria-label', () => {
+      const { container } = render(<FooterBar {...baseProps} serverVersion="1.2.3" />)
+      const v = container.querySelector('.footer-version')
+      expect(v, 'footer-version must exist').toBeTruthy()
+      expect(v!.getAttribute('title'), 'version chip needs title').toBeTruthy()
+      expect(v!.getAttribute('aria-label'), 'version chip needs aria-label').toBeTruthy()
+    })
+
+    it('connection status dot exposes both title and aria-label', () => {
+      const { container } = render(<FooterBar {...baseProps} connectionPhase="connected" />)
+      const dot = container.querySelector('.footer-status-dot')
+      expect(dot, 'footer-status-dot must exist').toBeTruthy()
+      expect(dot!.getAttribute('title'), 'status dot needs title').toBeTruthy()
+      expect(dot!.getAttribute('aria-label'), 'status dot needs aria-label').toBeTruthy()
+    })
+  })
+
   // -----------------------------------------------------------------
   // #3857 — high-utilization compact-suggestion chip
   // -----------------------------------------------------------------

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -158,21 +158,49 @@ export function FooterBar({
   const modelTip = modelTooltip({ model, contextWindow })
   const agentTip = agentCountTooltip(agentCount)
 
+  // #4630 — chips and the QR button were missing one half of the
+  // tooltip pair (browser hover OR screen-reader name). Compute the
+  // labels once so the `title` / `aria-label` mirror pair can't drift.
+  const versionLabel = `Chroxy server v${version}`
+  const statusFullLabel = settingUpTunnel
+    ? statusLabel
+    : (STATUS_LABELS[connectionPhase] ?? `Connection status: ${connectionPhase}`)
   return (
     <footer className="footer-bar" data-testid="footer-bar">
       <div className="footer-left">
-        <span className="footer-version">v{version}</span>
-        <span className={`footer-status-dot ${dotClass}`} />
+        <span
+          className="footer-version"
+          title={versionLabel}
+          aria-label={versionLabel}
+        >
+          v{version}
+        </span>
+        <span
+          className={`footer-status-dot ${dotClass}`}
+          title={statusFullLabel}
+          aria-label={statusFullLabel}
+          role="status"
+        />
         <span className="footer-status-label">{statusLabel}</span>
         {cwd && (
-          <span className="footer-cwd" title={cwd}>
+          <span
+            className="footer-cwd"
+            title={cwd}
+            aria-label={`Working directory: ${cwd}`}
+          >
             {abbreviateCwd(cwd)}
           </span>
         )}
       </div>
       <div className="footer-right">
         {onShowQr && (
-          <button className="footer-qr-btn" onClick={onShowQr} type="button" aria-label="Show QR code">
+          <button
+            className="footer-qr-btn"
+            onClick={onShowQr}
+            type="button"
+            aria-label="Show QR code"
+            title="Show QR code — scan with the Chroxy mobile app to pair"
+          >
             QR
           </button>
         )}

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -372,4 +372,70 @@ describe('SessionBar', () => {
       expect(screen.queryByTestId('tab-stdin-disabled-badge')).not.toBeInTheDocument()
     })
   })
+
+  // #4630 — every tab-internal chip/icon needs BOTH `title` (browser
+  // hover tooltip) and `aria-label` (SR announcement). Several chips
+  // had only `title`, leaving SR users with no spoken label. Pinning
+  // the contract so the New-session button + per-tab status dot, cwd,
+  // model, and provider chips all stay discoverable.
+  describe('#4630 tab chips have both title and aria-label', () => {
+    function renderRichTab() {
+      const sessions: SessionTabData[] = [
+        {
+          sessionId: 's1', name: 'Rich', isBusy: false, isActive: true,
+          cwd: '/home/user/projects/api', model: 'claude-opus-4-6', provider: 'claude-sdk',
+        },
+      ]
+      return render(
+        <SessionBar sessions={sessions} onSwitch={vi.fn()} onClose={vi.fn()} onRename={vi.fn()} onNewSession={vi.fn()} />
+      )
+    }
+
+    it('per-tab status dot has both title and aria-label', () => {
+      renderRichTab()
+      const tab = screen.getByTestId('session-tab-s1')
+      const dot = within(tab).getByTestId('status-dot')
+      expect(dot.getAttribute('title'), 'status-dot needs title').toBeTruthy()
+      expect(dot.getAttribute('aria-label'), 'status-dot needs aria-label').toBeTruthy()
+    })
+
+    it('tab cwd chip has both title and aria-label', () => {
+      const { container } = renderRichTab()
+      const cwd = container.querySelector('.tab-cwd')
+      expect(cwd, 'tab-cwd must exist').toBeTruthy()
+      expect(cwd!.getAttribute('title'), 'cwd needs title').toBeTruthy()
+      expect(cwd!.getAttribute('aria-label'), 'cwd needs aria-label').toBeTruthy()
+    })
+
+    it('tab model chip has both title and aria-label', () => {
+      const { container } = renderRichTab()
+      const m = container.querySelector('.tab-model')
+      expect(m, 'tab-model must exist').toBeTruthy()
+      expect(m!.getAttribute('title'), 'model needs title').toBeTruthy()
+      expect(m!.getAttribute('aria-label'), 'model needs aria-label').toBeTruthy()
+    })
+
+    it('tab provider chip has both title and aria-label', () => {
+      const { container } = renderRichTab()
+      const p = container.querySelector('.tab-provider')
+      expect(p, 'tab-provider must exist').toBeTruthy()
+      expect(p!.getAttribute('title'), 'provider needs title').toBeTruthy()
+      expect(p!.getAttribute('aria-label'), 'provider needs aria-label').toBeTruthy()
+    })
+
+    it('new-session button exposes both title and aria-label', () => {
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+        />
+      )
+      const btn = screen.getByTestId('new-session-btn')
+      expect(btn.getAttribute('title'), 'new-session needs title').toBeTruthy()
+      expect(btn.getAttribute('aria-label'), 'new-session needs aria-label').toBeTruthy()
+    })
+  })
 })

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -120,11 +120,17 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
           >
             {(() => {
               const effectiveStatus = session.status ?? (session.isBusy ? 'working' : 'idle')
+              // #4630 — the dot already had `title` for browser hover, but
+              // screen readers ignore `title` on a bare span. `aria-label`
+              // duplicates the same human-readable string so SR users hear
+              // "session working" / "session idle" rather than nothing.
               return (
                 <span
                   className={`tab-status-dot status-${effectiveStatus}`}
                   data-testid="status-dot"
                   title={STATUS_LABELS[effectiveStatus]}
+                  aria-label={STATUS_LABELS[effectiveStatus]}
+                  role="status"
                 />
               )
             })()}
@@ -161,14 +167,26 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               </span>
             )}
 
+            {/* #4630 — cwd/model/provider chips had at most a `title` (and
+                tab-model had nothing). Pair each with `aria-label` so the
+                browser hover tooltip and the screen-reader announcement
+                stay in lockstep. */}
             {session.cwd && (
-              <span className="tab-cwd" title={session.cwd}>
+              <span
+                className="tab-cwd"
+                title={session.cwd}
+                aria-label={`Working directory: ${session.cwd}`}
+              >
                 {abbreviateCwd(session.cwd)}
               </span>
             )}
 
             {session.model && (
-              <span className="tab-model">
+              <span
+                className="tab-model"
+                title={`Model: ${session.model}`}
+                aria-label={`Model: ${session.model}`}
+              >
                 {shortenModel(session.model)}
               </span>
             )}
@@ -178,6 +196,7 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
                 className="tab-provider"
                 data-provider={getProviderInfo(session.provider).type}
                 title={getProviderInfo(session.provider).tooltip}
+                aria-label={getProviderInfo(session.provider).tooltip}
               >
                 {shortenProvider(session.provider)}
               </span>


### PR DESCRIPTION
Closes #4630

## Summary
Audit every icon-only / short-label control in the dashboard chrome and ensure each one carries a matching `title` + `aria-label` pair. Tauri WKWebView renders native `title` tooltips inconsistently, but the wider issue surfaced by #4630 is that several controls had no discoverable label at all on either surface (hover or screen reader).

## What changed
- `App.tsx` header — version badge and connection status dot now expose `title` + `aria-label` (previously bare spans). Status dot also gets `role="status"`.
- `FooterBar.tsx` — QR button gained a `title`, version chip + status dot gained `title` + `aria-label`, cwd chip gained `aria-label`.
- `SessionBar.tsx` — per-tab `status-dot`, `tab-cwd`, `tab-model`, and `tab-provider` all gained the missing half of the tooltip pair so hovering and screen-reader navigation announce the same label.
- The Skills / Copy / Settings header buttons + Share-session footer button already had both attributes; new tests pin the contract so a future refactor cannot silently drop either half.

## Test plan
- [x] `cd packages/dashboard && npx vitest run -t "#4630"` — 13 new tests pass
- [x] `cd packages/dashboard && npx vitest run` — full suite (131 files / 2554 tests) green
- [x] `cd packages/dashboard && npx tsc --noEmit` — clean
- [ ] Manual: hover each header / footer / tab icon in the desktop (Tauri) app and confirm a tooltip appears
- [ ] Manual: VoiceOver each control and confirm a human-readable label is announced