### PR TITLE
feat(app): show multi-question intervention counter in session header

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -3506,3 +3506,156 @@ describe('server_error session-scoped routing (#3141)', () => {
     expect(errs[0].message).toContain('pre-session oops');
   });
 });
+
+// #4764 — mobile dispatch for the chroxy multi-question intervention event.
+// Mirrors the dashboard's #4758 handler: append to `interventions`, dedup by
+// toolUseId, push a one-time system ChatMessage on the very first intervention
+// per session so the chat surface narrates what just happened.
+describe('multi_question_intervention handler (#4764)', () => {
+  it('appends to interventions for the targeted session', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'multi_question_intervention',
+      sessionId: 's1',
+      toolUseId: 'toolu_a',
+      questionCount: 3,
+      reason: 'multi_question',
+      timestamp: 1_700_000_000_000,
+    });
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.interventions).toHaveLength(1);
+    expect(ss.interventions[0]).toEqual({
+      kind: 'multi_question',
+      toolUseId: 'toolu_a',
+      count: 3,
+      timestamp: 1_700_000_000_000,
+    });
+  });
+
+  it('pushes a one-time system ChatMessage on the first intervention only', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'multi_question_intervention',
+      sessionId: 's1',
+      toolUseId: 'toolu_a',
+      questionCount: 3,
+      reason: 'multi_question',
+      timestamp: 1,
+    });
+    _testMessageHandler.handle({
+      type: 'multi_question_intervention',
+      sessionId: 's1',
+      toolUseId: 'toolu_b',
+      questionCount: 4,
+      reason: 'multi_question',
+      timestamp: 2,
+    });
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.interventions).toHaveLength(2);
+    const systemMsgs = ss.messages.filter((m) => m.type === 'system');
+    expect(systemMsgs).toHaveLength(1);
+    expect(systemMsgs[0].content).toContain('chroxy intercepted');
+  });
+
+  it('dedups by toolUseId — stuck-model re-emit must not double-count', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    const payload = {
+      type: 'multi_question_intervention' as const,
+      sessionId: 's1',
+      toolUseId: 'toolu_dup',
+      questionCount: 3,
+      reason: 'multi_question' as const,
+      timestamp: 1,
+    };
+    _testMessageHandler.handle(payload);
+    _testMessageHandler.handle(payload);
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.interventions).toHaveLength(1);
+    // System message must still fire exactly once across the duplicate.
+    expect(ss.messages.filter((m) => m.type === 'system')).toHaveLength(1);
+  });
+
+  it('drops malformed payloads (missing toolUseId or questionCount)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'multi_question_intervention',
+      sessionId: 's1',
+      // toolUseId omitted
+      questionCount: 3,
+      reason: 'multi_question',
+    } as any);
+    _testMessageHandler.handle({
+      type: 'multi_question_intervention',
+      sessionId: 's1',
+      toolUseId: 'toolu_x',
+      // questionCount omitted
+      reason: 'multi_question',
+    } as any);
+
+    const ss = store.getState().sessionStates.s1;
+    expect(ss.interventions).toHaveLength(0);
+    expect(ss.messages.filter((m) => m.type === 'system')).toHaveLength(0);
+  });
+
+  it('routes to the session named on the message when not active', () => {
+    const store = createMockStore({
+      activeSessionId: 'sA',
+      sessions: [
+        { sessionId: 'sA', name: 'A' } as any,
+        { sessionId: 'sB', name: 'B' } as any,
+      ],
+      sessionStates: {
+        sA: createEmptySessionState(),
+        sB: createEmptySessionState(),
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'multi_question_intervention',
+      sessionId: 'sB',
+      toolUseId: 'toolu_b',
+      questionCount: 3,
+      reason: 'multi_question',
+      timestamp: 1,
+    });
+
+    const sA = store.getState().sessionStates.sA;
+    const sB = store.getState().sessionStates.sB;
+    expect(sA.interventions).toHaveLength(0);
+    expect(sB.interventions).toHaveLength(1);
+    expect(sB.interventions[0].toolUseId).toBe('toolu_b');
+  });
+});

--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert, Modal, Pressable } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { DEFAULT_CONTEXT_WINDOW } from '@chroxy/store-core';
-import type { CumulativeUsage, PendingPermissionConfirm } from '@chroxy/store-core';
+import type { CumulativeUsage, PendingPermissionConfirm, SessionIntervention } from '@chroxy/store-core';
 import { formatCostBadge } from '@chroxy/store-core';
 import type { ModelInfo, ContextUsage, AgentInfo, ConnectedClient, CustomAgent, SessionContext, McpServer, PermissionMode } from '../store/connection';
 import { Icon } from './Icon';
@@ -42,6 +42,11 @@ export interface SettingsBarProps {
   serverMode: 'cli' | null;
   isIdle: boolean;
   activeAgents: AgentInfo[];
+  // #4764: chroxy-side intervention ring for the active session. When
+  // non-empty the session-header renders a counter badge; tapping opens
+  // a sheet listing the recent interventions newest-first (mirrors the
+  // dashboard's FooterBar from #4758).
+  interventions?: SessionIntervention[];
   connectedClients: ConnectedClient[];
   customAgents: CustomAgent[];
   mcpServers: McpServer[];
@@ -58,6 +63,44 @@ export interface SettingsBarProps {
 }
 
 // -- Helpers --
+
+/**
+ * #4764 — humanise an intervention's discriminator into a one-line
+ * operator-facing description. Mirrors the dashboard's `describeIntervention`
+ * helper (FooterBar.tsx) so both surfaces narrate the same intervention with
+ * the same copy. Exported for unit-testing.
+ */
+export function describeIntervention(iv: SessionIntervention): string {
+  switch (iv.kind) {
+    case 'multi_question':
+      return `Multi-question form intercepted (${iv.count} questions) — asked agent to ask one at a time`;
+    default: {
+      // Exhaustive fallback for future discriminator additions. Renders the
+      // raw kind so a forgotten case still gives the operator SOMETHING to
+      // grep on rather than an empty row.
+      const _exhaustive: never = iv.kind;
+      return `chroxy intervention: ${String(_exhaustive)}`;
+    }
+  }
+}
+
+/**
+ * #4764 — format a wall-clock timestamp as a short relative string ("3s ago",
+ * "2m ago", "1h ago"). Falls back to ISO date string for entries older than
+ * 24 hours. Mirrors the dashboard's `formatRelativeTimestamp` helper for
+ * intervention rows.
+ */
+export function formatInterventionTimestamp(ts: number, now: number = Date.now()): string {
+  const elapsedMs = now - ts;
+  if (elapsedMs < 0) return 'just now';
+  const seconds = Math.floor(elapsedMs / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return new Date(ts).toISOString().slice(0, 10);
+}
 
 export function formatElapsed(startedAt: number, now: number): string {
   const seconds = Math.max(0, Math.floor((now - startedAt) / 1000));
@@ -114,6 +157,7 @@ export function SettingsBar({
   serverMode,
   isIdle,
   activeAgents,
+  interventions,
   connectedClients,
   customAgents,
   mcpServers,
@@ -151,6 +195,19 @@ export function SettingsBar({
   // dedicated to the cost details, mirroring the dashboard's hover
   // popover.
   const [costBreakdownOpen, setCostBreakdownOpen] = useState(false);
+  // #4764: tap-to-expand sheet for the chroxy-intervention ring. Distinct
+  // from the SettingsBar's expand/collapse — this is a Modal dedicated to
+  // the recent-interventions list, mirroring the dashboard's
+  // InterventionsPanel from #4758.
+  const [interventionsOpen, setInterventionsOpen] = useState(false);
+  const interventionCount = interventions?.length ?? 0;
+  // Close a stale sheet if the underlying ring drops back to empty (e.g.
+  // session switch / state restore). Same pattern as the cost breakdown
+  // sheet above so the modal can't strand itself on top of a now-hidden
+  // badge.
+  useEffect(() => {
+    if (interventionCount === 0 && interventionsOpen) setInterventionsOpen(false);
+  }, [interventionCount, interventionsOpen]);
   const hasCumulativeCost =
     !!cumulativeUsage && Number.isFinite(cumulativeUsage.costUsd) && cumulativeUsage.costUsd > 0;
   // Close a stale sheet if the cost predicate flips back to false (e.g.
@@ -259,6 +316,23 @@ export function SettingsBar({
               {activeAgents.length} agent{activeAgents.length !== 1 ? 's' : ''}
             </Text>
           </View>
+        )}
+        {/* #4764: chroxy-side intervention counter. Renders only when at
+            least one intervention has fired for the active session. Tap
+            opens a sheet listing the recent interventions newest-first.
+            Mirrors the dashboard's FooterBar counter chip from #4758. */}
+        {interventionCount > 0 && (
+          <Pressable
+            onPress={() => setInterventionsOpen(true)}
+            style={({ pressed }) => [styles.interventionBadge, pressed && styles.interventionBadgePressed]}
+            accessibilityRole="button"
+            accessibilityLabel={`${interventionCount} chroxy ${interventionCount === 1 ? 'intervention' : 'interventions'}. Tap for details.`}
+            testID="session-interventions-badge"
+          >
+            <Text style={styles.interventionBadgeText}>
+              {interventionCount} {interventionCount === 1 ? 'intervention' : 'interventions'}
+            </Text>
+          </Pressable>
         )}
         {connectionQuality && (() => {
           const qc = QUALITY_COLORS[connectionQuality];
@@ -605,6 +679,51 @@ export function SettingsBar({
           </Pressable>
         </Modal>
       )}
+      {/* #4764: interventions sheet — modal listing recent interventions
+          newest-first. Visible only when a tap on the intervention badge
+          has set interventionsOpen. Mirrors the dashboard's
+          InterventionsPanel from #4758 (same six fields, same ordering). */}
+      {interventionCount > 0 && (
+        <Modal
+          visible={interventionsOpen}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setInterventionsOpen(false)}
+        >
+          <Pressable
+            style={styles.costSheetBackdrop}
+            onPress={() => setInterventionsOpen(false)}
+            accessibilityLabel="Dismiss interventions panel"
+            accessibilityRole="button"
+          >
+            <Pressable
+              style={styles.costSheetCard}
+              onPress={() => {}}
+              testID="session-interventions-sheet"
+            >
+              <Text style={styles.costSheetTitle}>Recent chroxy interventions</Text>
+              {[...(interventions ?? [])].reverse().map((iv) => (
+                <View
+                  key={iv.toolUseId}
+                  style={styles.interventionRow}
+                  testID={`session-intervention-${iv.toolUseId}`}
+                >
+                  <Text style={styles.interventionReason}>{describeIntervention(iv)}</Text>
+                  <Text style={styles.interventionMeta}>{formatInterventionTimestamp(iv.timestamp)}</Text>
+                </View>
+              ))}
+              <TouchableOpacity
+                style={styles.costSheetDismiss}
+                onPress={() => setInterventionsOpen(false)}
+                accessibilityRole="button"
+                accessibilityLabel="Close interventions panel"
+              >
+                <Text style={styles.costSheetDismissText}>Close</Text>
+              </TouchableOpacity>
+            </Pressable>
+          </Pressable>
+        </Modal>
+      )}
     </View>
   );
 }
@@ -760,6 +879,39 @@ const styles = StyleSheet.create({
     color: COLORS.accentPurple,
     fontSize: 10,
     fontWeight: '600',
+  },
+  // #4764 — chroxy-intervention header badge. Uses the orange palette to
+  // signal "something the platform intervened on" without veering into
+  // alert-red (the operator may want to acknowledge it, but the deny is
+  // working-as-intended). Tappable target sized comfortably for thumb taps.
+  interventionBadge: {
+    backgroundColor: COLORS.accentOrangeSubtle,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 8,
+    marginRight: 8,
+  },
+  interventionBadgePressed: {
+    opacity: 0.7,
+  },
+  interventionBadgeText: {
+    color: COLORS.accentOrange,
+    fontSize: 10,
+    fontWeight: '600',
+  },
+  interventionRow: {
+    paddingVertical: 6,
+    borderBottomWidth: 1,
+    borderBottomColor: COLORS.borderPrimary,
+  },
+  interventionReason: {
+    color: COLORS.textPrimary,
+    fontSize: 13,
+    marginBottom: 2,
+  },
+  interventionMeta: {
+    color: COLORS.textMuted,
+    fontSize: 11,
   },
   agentSection: {
     gap: 4,

--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert, Modal, Pressable } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Platform, Animated, AccessibilityInfo, Alert, Modal, Pressable, ScrollView } from 'react-native';
 import * as Clipboard from 'expo-clipboard';
 import { DEFAULT_CONTEXT_WINDOW } from '@chroxy/store-core';
 import type { CumulativeUsage, PendingPermissionConfirm, SessionIntervention } from '@chroxy/store-core';
@@ -702,16 +702,29 @@ export function SettingsBar({
               testID="session-interventions-sheet"
             >
               <Text style={styles.costSheetTitle}>Recent chroxy interventions</Text>
-              {[...(interventions ?? [])].reverse().map((iv) => (
-                <View
-                  key={iv.toolUseId}
-                  style={styles.interventionRow}
-                  testID={`session-intervention-${iv.toolUseId}`}
-                >
-                  <Text style={styles.interventionReason}>{describeIntervention(iv)}</Text>
-                  <Text style={styles.interventionMeta}>{formatInterventionTimestamp(iv.timestamp)}</Text>
-                </View>
-              ))}
+              {/* #4862 (Copilot review): the interventions ring is capped at 50
+                  entries (MAX_SESSION_INTERVENTIONS in store-core). Without a
+                  scroll container, on smaller devices a full ring would push
+                  the Close button off-screen and strand the modal. Constrain
+                  the list area and let it scroll; the title + Close button
+                  stay pinned outside the scroll region. */}
+              <ScrollView
+                style={styles.interventionList}
+                contentContainerStyle={styles.interventionListContent}
+                showsVerticalScrollIndicator
+                testID="session-interventions-scroll"
+              >
+                {[...(interventions ?? [])].reverse().map((iv) => (
+                  <View
+                    key={iv.toolUseId}
+                    style={styles.interventionRow}
+                    testID={`session-intervention-${iv.toolUseId}`}
+                  >
+                    <Text style={styles.interventionReason}>{describeIntervention(iv)}</Text>
+                    <Text style={styles.interventionMeta}>{formatInterventionTimestamp(iv.timestamp)}</Text>
+                  </View>
+                ))}
+              </ScrollView>
               <TouchableOpacity
                 style={styles.costSheetDismiss}
                 onPress={() => setInterventionsOpen(false)}
@@ -912,6 +925,18 @@ const styles = StyleSheet.create({
   interventionMeta: {
     color: COLORS.textMuted,
     fontSize: 11,
+  },
+  // #4862 (Copilot review) — scroll container for the recent-interventions
+  // list. maxHeight keeps the modal card bounded on small devices so the
+  // Close button outside the ScrollView is always reachable, even at the
+  // ring's 50-entry cap. marginVertical separates the list from the title
+  // and the Close button.
+  interventionList: {
+    maxHeight: 280,
+    marginVertical: 8,
+  },
+  interventionListContent: {
+    paddingBottom: 4,
   },
   agentSection: {
     gap: 4,

--- a/packages/app/src/components/__tests__/SettingsBarInterventionBadge.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarInterventionBadge.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Render tests for the mobile SessionScreen header intervention badge (#4764).
+ *
+ * Counter visibility + tap-to-open recent-interventions sheet + the two
+ * humanisation helpers. Mirrors the dashboard's #4758 FooterBar test surface
+ * so the same intervention narrates identically on both platforms.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import {
+  SettingsBar,
+  describeIntervention,
+  formatInterventionTimestamp,
+} from '../SettingsBar';
+import type { SessionIntervention } from '@chroxy/store-core';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root.findAllByType(Text).map((node) => {
+    const c = node.props.children;
+    if (typeof c === 'string' || typeof c === 'number') return String(c);
+    if (Array.isArray(c)) {
+      return c.map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : '')).join('');
+    }
+    return '';
+  }).join(' ');
+}
+
+function makeProps(overrides: Partial<{ interventions: SessionIntervention[] }> = {}) {
+  return {
+    expanded: false,
+    onToggle: () => {},
+    activeModel: 'claude-opus-4-7',
+    availableModels: [],
+    permissionMode: null,
+    availablePermissionModes: [],
+    lastResultCost: null,
+    lastResultDuration: null,
+    sessionCost: null,
+    cumulativeUsage: null,
+    costBudget: null,
+    contextUsage: null,
+    sessionCwd: '/tmp',
+    serverMode: 'cli' as const,
+    isIdle: true,
+    activeAgents: [],
+    interventions: [] as SessionIntervention[],
+    connectedClients: [],
+    customAgents: [],
+    mcpServers: [],
+    setModel: () => {},
+    setPermissionMode: () => {},
+    ...overrides,
+  };
+}
+
+describe('describeIntervention (#4764)', () => {
+  it('humanises multi_question with the question count', () => {
+    const iv: SessionIntervention = {
+      kind: 'multi_question',
+      toolUseId: 'toolu_a',
+      count: 4,
+      timestamp: 0,
+    };
+    expect(describeIntervention(iv)).toContain('4 questions');
+    expect(describeIntervention(iv)).toContain('one at a time');
+  });
+});
+
+describe('formatInterventionTimestamp (#4764)', () => {
+  const now = 1_000_000_000_000;
+
+  it('renders sub-minute deltas in seconds', () => {
+    expect(formatInterventionTimestamp(now - 3_000, now)).toBe('3s ago');
+    expect(formatInterventionTimestamp(now - 59_000, now)).toBe('59s ago');
+  });
+
+  it('renders sub-hour deltas in minutes', () => {
+    expect(formatInterventionTimestamp(now - 60_000, now)).toBe('1m ago');
+    expect(formatInterventionTimestamp(now - 59 * 60_000, now)).toBe('59m ago');
+  });
+
+  it('renders sub-day deltas in hours', () => {
+    expect(formatInterventionTimestamp(now - 60 * 60_000, now)).toBe('1h ago');
+    expect(formatInterventionTimestamp(now - 23 * 60 * 60_000, now)).toBe('23h ago');
+  });
+
+  it('falls back to ISO date for entries older than 24h', () => {
+    // 25h ago — should render the YYYY-MM-DD slice of the ISO string.
+    const ts = now - 25 * 60 * 60_000;
+    const out = formatInterventionTimestamp(ts, now);
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('renders "just now" for future timestamps (clock skew defensive)', () => {
+    expect(formatInterventionTimestamp(now + 1000, now)).toBe('just now');
+  });
+});
+
+describe('SettingsBar intervention badge rendering (#4764)', () => {
+  it('hides the badge when interventions is undefined', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ interventions: undefined })} />);
+    });
+    const root = tree!.root;
+    expect(() => root.findByProps({ testID: 'session-interventions-badge' })).toThrow();
+  });
+
+  it('hides the badge when interventions is empty', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ interventions: [] })} />);
+    });
+    const root = tree!.root;
+    expect(() => root.findByProps({ testID: 'session-interventions-badge' })).toThrow();
+  });
+
+  it('renders the badge with the singular noun when count === 1', () => {
+    const interventions: SessionIntervention[] = [
+      { kind: 'multi_question', toolUseId: 'toolu_a', count: 3, timestamp: Date.now() },
+    ];
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ interventions })} />);
+    });
+    const root = tree!.root;
+    const badge = root.findByProps({ testID: 'session-interventions-badge' });
+    expect(collectVisibleText(badge)).toBe('1 intervention');
+  });
+
+  it('renders the badge with the plural noun when count > 1', () => {
+    const interventions: SessionIntervention[] = [
+      { kind: 'multi_question', toolUseId: 'toolu_a', count: 3, timestamp: Date.now() },
+      { kind: 'multi_question', toolUseId: 'toolu_b', count: 2, timestamp: Date.now() },
+    ];
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ interventions })} />);
+    });
+    const root = tree!.root;
+    const badge = root.findByProps({ testID: 'session-interventions-badge' });
+    expect(collectVisibleText(badge)).toBe('2 interventions');
+  });
+
+  it('updates the counter when the interventions prop grows', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar
+          {...makeProps({
+            interventions: [
+              { kind: 'multi_question', toolUseId: 'toolu_a', count: 3, timestamp: Date.now() },
+            ],
+          })}
+        />,
+      );
+    });
+    expect(collectVisibleText(tree!.root.findByProps({ testID: 'session-interventions-badge' }))).toBe(
+      '1 intervention',
+    );
+    act(() => {
+      tree!.update(
+        <SettingsBar
+          {...makeProps({
+            interventions: [
+              { kind: 'multi_question', toolUseId: 'toolu_a', count: 3, timestamp: Date.now() },
+              { kind: 'multi_question', toolUseId: 'toolu_b', count: 5, timestamp: Date.now() },
+              { kind: 'multi_question', toolUseId: 'toolu_c', count: 4, timestamp: Date.now() },
+            ],
+          })}
+        />,
+      );
+    });
+    expect(collectVisibleText(tree!.root.findByProps({ testID: 'session-interventions-badge' }))).toBe(
+      '3 interventions',
+    );
+  });
+
+  it('opens the recent-interventions sheet on tap', () => {
+    const ts = Date.now();
+    const interventions: SessionIntervention[] = [
+      { kind: 'multi_question', toolUseId: 'toolu_a', count: 3, timestamp: ts - 60_000 },
+      { kind: 'multi_question', toolUseId: 'toolu_b', count: 5, timestamp: ts - 5_000 },
+    ];
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ interventions })} />);
+    });
+    const root = tree!.root;
+    const badge = root.findByProps({ testID: 'session-interventions-badge' });
+    act(() => badge.props.onPress());
+    const sheet = root.findByProps({ testID: 'session-interventions-sheet' });
+    const sheetText = collectVisibleText(sheet);
+    expect(sheetText).toContain('Recent chroxy interventions');
+    // Both intervention rows are rendered, and the newest (toolu_b) appears
+    // first because the panel reverses for newest-first ordering.
+    expect(sheetText).toContain('5 questions');
+    expect(sheetText).toContain('3 questions');
+    const newest = root.findByProps({ testID: 'session-intervention-toolu_b' });
+    const oldest = root.findByProps({ testID: 'session-intervention-toolu_a' });
+    expect(newest).toBeTruthy();
+    expect(oldest).toBeTruthy();
+  });
+});

--- a/packages/app/src/components/__tests__/SettingsBarInterventionBadge.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarInterventionBadge.test.tsx
@@ -7,7 +7,7 @@
  */
 import React from 'react';
 import renderer, { act, ReactTestInstance } from 'react-test-renderer';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import {
   SettingsBar,
   describeIntervention,
@@ -201,5 +201,24 @@ describe('SettingsBar intervention badge rendering (#4764)', () => {
     const oldest = root.findByProps({ testID: 'session-intervention-toolu_a' });
     expect(newest).toBeTruthy();
     expect(oldest).toBeTruthy();
+    // #4862 (Copilot review) — explicit ordering assertion so a regression
+    // in the `.reverse()` call is caught. Walk every rendered row testID in
+    // document order and check that newest (toolu_b) comes BEFORE oldest
+    // (toolu_a). `findAll` returns nodes in tree order, so the row testIDs
+    // collected from the sheet subtree are the visible order on screen.
+    // Filter on the View host type to avoid the testID prop being collected
+    // from a child Text that inherits via parent layout (defensive).
+    const renderedRowIds = sheet
+      .findAll(
+        (node) =>
+          node.type === View &&
+          typeof node.props.testID === 'string' &&
+          node.props.testID.startsWith('session-intervention-toolu_'),
+      )
+      .map((node) => node.props.testID as string);
+    expect(renderedRowIds).toEqual([
+      'session-intervention-toolu_b',
+      'session-intervention-toolu_a',
+    ]);
   });
 });

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -19,6 +19,7 @@ import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useConnectionStore, selectMessages, selectClaudeReady, selectStreamingMessageId, selectActiveModel, selectPermissionMode, selectContextUsage, selectLastResultCost, selectLastResultDuration, selectIsIdle, stripAnsi, nextMessageId } from '../store/connection';
 import type { ChatMessage, ConnectionPhase, AgentInfo, McpServer, DevPreview } from '../store/connection';
+import type { SessionIntervention } from '@chroxy/store-core';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { SessionPicker } from '../components/SessionPicker';
 import { CreateSessionModal } from '../components/CreateSessionModal';
@@ -60,6 +61,7 @@ const EMPTY_AGENTS: AgentInfo[] = [];
 const EMPTY_MCP_SERVERS: McpServer[] = [];
 const EMPTY_DEV_PREVIEWS: DevPreview[] = [];
 const EMPTY_PROMPTS: { tool: string; prompt: string }[] = [];
+const EMPTY_INTERVENTIONS: SessionIntervention[] = [];
 
 // Message sent when user taps "Approve" on a plan approval card
 const PLAN_APPROVAL_MESSAGE = 'Go ahead with the plan';
@@ -269,6 +271,13 @@ export function SessionScreen() {
     return id && s.sessionStates[id] ? s.sessionStates[id].costThresholdWarning : null;
   });
   const costBudget = useConnectionStore((s) => s.costBudget);
+  // #4764 — chroxy-side intervention ring for the active session. Drives the
+  // session-header counter badge and the tap-to-expand recent-interventions
+  // sheet (mirrors the dashboard's FooterBar surface from #4758).
+  const interventions = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? s.sessionStates[id].interventions : EMPTY_INTERVENTIONS;
+  });
   const devPreviews = useConnectionStore((s) => {
     const id = s.activeSessionId;
     return id && s.sessionStates[id] ? s.sessionStates[id].devPreviews : EMPTY_DEV_PREVIEWS;
@@ -992,6 +1001,7 @@ export function SessionScreen() {
           serverMode={serverMode}
           isIdle={isIdle}
           activeAgents={activeAgents}
+          interventions={interventions}
           connectedClients={connectedClients}
           customAgents={customAgents}
           mcpServers={mcpServers}

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -42,6 +42,8 @@ import {
   handlePlanStarted as sharedPlanStarted,
   handlePlanReady as sharedPlanReady,
   handleInactivityWarning as sharedInactivityWarning,
+  handleMultiQuestionIntervention as sharedMultiQuestionIntervention,
+  applyInterventionBuilder,
   handleDevPreview as sharedDevPreview,
   handleDevPreviewStopped as sharedDevPreviewStopped,
   handleToolStart as sharedToolStart,
@@ -1886,6 +1888,51 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (warning && warning.sessionId && get().sessionStates[warning.sessionId]) {
         updateSession(warning.sessionId, () => warning.patch);
       }
+      break;
+    }
+
+    case 'multi_question_intervention': {
+      // #4764 — chroxy's permission-hook (#4648) just denied a multi-question
+      // AskUserQuestion. Mirrors the dashboard's #4758 handler: append a
+      // SessionIntervention entry so the session-header counter ticks, and on
+      // the FIRST such intervention per session push a one-time system
+      // ChatMessage explaining what happened (without it the deny is invisible
+      // on the chat surface).
+      //
+      // applyInterventionBuilder dedups by toolUseId (a stuck model re-emitting
+      // the same payload won't double-count) and tells us whether this was the
+      // session's first intervention so the inline notice only fires once.
+      const builder = sharedMultiQuestionIntervention(msg, get().activeSessionId);
+      if (!builder) break;
+      const interventionTargetId = builder.sessionId;
+      if (!interventionTargetId) break;
+      const targetState = get().sessionStates[interventionTargetId];
+      if (!targetState) break;
+      const { interventions: nextInterventions, isFirst } = applyInterventionBuilder(
+        builder,
+        targetState.interventions,
+      );
+      // Skip the state mutation if nothing changed (dedup'd repeat) so React
+      // doesn't re-render the header counter on every stuck-model re-emit.
+      if (nextInterventions === targetState.interventions) break;
+      updateSession(interventionTargetId, (ss) => {
+        if (isFirst) {
+          return {
+            interventions: nextInterventions,
+            messages: [
+              ...ss.messages,
+              {
+                id: nextMessageId('system'),
+                type: 'system',
+                content:
+                  "chroxy intercepted a multi-question form and asked the agent to break it into single questions.",
+                timestamp: Date.now(),
+              },
+            ],
+          };
+        }
+        return { interventions: nextInterventions };
+      });
       break;
     }
 

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -97,7 +97,10 @@ const PLATFORM_SPECIFIC = {
   'skill_trust_granted': 'dashboard',  // community trust granted broadcast (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'skill_trust_grant_ok': 'dashboard', // ack for skill_trust_grant handler (#3297) — dashboard-only for v1; mobile app exposure tracked under parent epic #2959
   'byok_credentials_status': 'dashboard', // paste-API-key form is dashboard-only (#4052); mobile app exposure tracked under the BYOK epic #4047
-  'multi_question_intervention': 'dashboard', // chroxy permission-hook deny surface (#4653) — dashboard renders a FooterBar counter chip + InterventionsPanel; mobile app exposure tracked as a follow-up since the app has no FooterBar equivalent
+  // 'multi_question_intervention' is now handled by both dashboard (#4758)
+  // and mobile app (#4764 / PR #4862); no PLATFORM_SPECIFIC entry needed.
+  // Coverage test passes because each handler has a
+  // `case 'multi_question_intervention':` clause.
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
 }
 


### PR DESCRIPTION
Closes #4764

## Summary
- Wires the `multi_question_intervention` event into the mobile app message-handler (it was previously falling through to the default-case logger) — appends to `BaseSessionState.interventions`, dedups by `toolUseId`, and pushes a one-time system `ChatMessage` on the very first intervention per session so the chat surface narrates the deny.
- Adds a tappable intervention counter badge to the `SettingsBar` summary row (the natural session-header surface on mobile). Tap opens a Modal listing recent interventions newest-first, mirroring the dashboard's `InterventionsPanel` from #4758.
- Wires `interventions` through `SessionScreen` -> `SettingsBar` via a per-session Zustand selector with a stable empty-array sentinel.

## UI behaviour
- **Hidden by default.** Badge renders only when at least one intervention has fired for the active session.
- **Copy parity with dashboard #4758.** "1 intervention" / "N interventions" in the badge; the sheet header reads "Recent chroxy interventions" and each row uses the same humanised reason + relative timestamp as the desktop counterpart.
- **Orange palette** (`accentOrangeSubtle` + `accentOrange`) so the badge reads as "platform intervened" without veering into alert-red — the deny is working-as-intended.
- **Sheet auto-closes** when the ring drops back to empty (e.g. session switch resets state) so the modal can't strand itself on top of a now-hidden badge.

## Test plan
- [x] `SettingsBarInterventionBadge.test.tsx` — 12 specs covering: `describeIntervention` copy, `formatInterventionTimestamp` for the four bucket boundaries + future timestamps, badge hidden when prop is undefined/empty, singular vs plural noun, prop-update reflection, tap-to-open sheet with newest-first ordering verified via `testID`.
- [x] `message-handler.test.ts` — 5 new specs for the `multi_question_intervention` dispatch: append, one-time system ChatMessage gate, `toolUseId` dedup (stuck-model re-emit), malformed-payload drop, cross-session routing.
- [x] `npx tsc --noEmit` clean.
- [x] All existing SettingsBar tests still pass (24 / 24 across 3 suites).

## Wire-protocol / shared-store
No protocol or store-core changes — `SessionIntervention`, `handleMultiQuestionIntervention`, `applyInterventionBuilder`, and the `interventions: SessionIntervention[]` field on `BaseSessionState` all landed in #4758. This PR only adds the mobile-side dispatch + UI surface.