### PR TITLE
feat(server): prune stale device-preferences entries on startup

### DIFF
--- a/packages/server/src/device-preferences.js
+++ b/packages/server/src/device-preferences.js
@@ -168,10 +168,15 @@ export function createDevicePreferences({ filePath } = {}) {
      *   skipped entirely (only the age-based check applies).
      * @param {number} [opts.maxAgeMs]
      *   Drop entries older than this many ms regardless of session
-     *   existence. Default null — no age cap.
+     *   existence. Default null — no age cap. A value of `0` is treated
+     *   as "no cap" (matches the PR description and avoids the foot-gun
+     *   where `now - updatedAt > 0` would evict every entry). Negative
+     *   or non-finite values are coerced to "no cap" as well.
      * @param {number} [opts.staleSessionGraceMs]
      *   Don't drop stale-session entries younger than this many ms.
-     *   Default 0 — drop stale-session entries immediately.
+     *   Default 0 — drop stale-session entries immediately. Negative or
+     *   non-finite values are coerced to 0 so a typo can't defeat the
+     *   grace guard.
      * @returns {number} Number of entries removed.
      */
     prune({ sessionExists, maxAgeMs, staleSessionGraceMs } = {}) {
@@ -179,8 +184,20 @@ export function createDevicePreferences({ filePath } = {}) {
       const deviceIds = Object.keys(state.devices)
       if (deviceIds.length === 0) return 0
 
+      // Clamp inputs to sane non-negative finite numbers. This is now a
+      // public API, so direct callers (and tests) get the same safety
+      // net that parseDevicePrefsDuration provides for the env-var path.
+      // `maxAgeMs === 0` is normalised to null ("no cap") because a
+      // literal-zero cap would evict every entry and the PR description
+      // promises 0 disables the cap.
+      const ageCapMs = (typeof maxAgeMs === 'number' && Number.isFinite(maxAgeMs) && maxAgeMs > 0)
+        ? maxAgeMs
+        : null
+      const grace = (typeof staleSessionGraceMs === 'number' && Number.isFinite(staleSessionGraceMs) && staleSessionGraceMs > 0)
+        ? staleSessionGraceMs
+        : 0
+
       const now = Date.now()
-      const grace = typeof staleSessionGraceMs === 'number' ? staleSessionGraceMs : 0
       let removed = 0
 
       for (const deviceId of deviceIds) {
@@ -199,8 +216,10 @@ export function createDevicePreferences({ filePath } = {}) {
           continue
         }
 
-        // Age-based: hard cap regardless of session existence.
-        if (typeof maxAgeMs === 'number' && now - updatedAt > maxAgeMs) {
+        // Age-based: hard cap regardless of session existence. Skipped
+        // when ageCapMs is null (caller passed 0 / null / undefined /
+        // negative / non-finite).
+        if (ageCapMs != null && now - updatedAt > ageCapMs) {
           delete state.devices[deviceId]
           removed += 1
           continue

--- a/packages/server/src/device-preferences.js
+++ b/packages/server/src/device-preferences.js
@@ -138,6 +138,93 @@ export function createDevicePreferences({ filePath } = {}) {
     },
 
     /**
+     * Drop entries that are no longer useful and persist the result. See
+     * #4849. Two prune criteria are applied in this order:
+     *
+     *   1. Stale-session: `activeSessionId` is not a string OR
+     *      `sessionExists(activeSessionId)` returns false AND the entry's
+     *      `updatedAt` is older than `staleSessionGraceMs` (default `0` —
+     *      remove immediately). The grace window exists so a brief
+     *      restart-induced gap, where the SessionManager has not yet
+     *      restored the session the device was viewing, does not nuke a
+     *      perfectly valid preference. Callers that have a fully-restored
+     *      SessionManager can leave `staleSessionGraceMs` at its default.
+     *
+     *   2. Age-based: `updatedAt` is older than `maxAgeMs`. Skipped when
+     *      `maxAgeMs` is null/undefined.
+     *
+     * Malformed entries (missing or non-string `activeSessionId`, missing
+     * `updatedAt`) are always pruned — they cannot do anything useful and
+     * carrying them forward would propagate the malformation.
+     *
+     * The file is only re-written when at least one entry is removed —
+     * the no-op case is free (no disk I/O), so this method is safe to
+     * call eagerly on startup even when the store is empty.
+     *
+     * @param {object} [opts]
+     * @param {(sessionId: string) => boolean} [opts.sessionExists]
+     *   Predicate that returns true iff the SessionManager still knows
+     *   about `sessionId`. When omitted, the stale-session check is
+     *   skipped entirely (only the age-based check applies).
+     * @param {number} [opts.maxAgeMs]
+     *   Drop entries older than this many ms regardless of session
+     *   existence. Default null — no age cap.
+     * @param {number} [opts.staleSessionGraceMs]
+     *   Don't drop stale-session entries younger than this many ms.
+     *   Default 0 — drop stale-session entries immediately.
+     * @returns {number} Number of entries removed.
+     */
+    prune({ sessionExists, maxAgeMs, staleSessionGraceMs } = {}) {
+      const state = load()
+      const deviceIds = Object.keys(state.devices)
+      if (deviceIds.length === 0) return 0
+
+      const now = Date.now()
+      const grace = typeof staleSessionGraceMs === 'number' ? staleSessionGraceMs : 0
+      let removed = 0
+
+      for (const deviceId of deviceIds) {
+        const entry = state.devices[deviceId]
+        const activeSessionId = entry && typeof entry.activeSessionId === 'string'
+          ? entry.activeSessionId
+          : null
+        const updatedAt = entry && typeof entry.updatedAt === 'number'
+          ? entry.updatedAt
+          : null
+
+        // Malformed: cannot use this entry, evict.
+        if (!activeSessionId || updatedAt == null) {
+          delete state.devices[deviceId]
+          removed += 1
+          continue
+        }
+
+        // Age-based: hard cap regardless of session existence.
+        if (typeof maxAgeMs === 'number' && now - updatedAt > maxAgeMs) {
+          delete state.devices[deviceId]
+          removed += 1
+          continue
+        }
+
+        // Stale-session: drop if the SessionManager no longer knows about
+        // the persisted id AND the entry is older than the grace window.
+        if (typeof sessionExists === 'function' && !sessionExists(activeSessionId)) {
+          if (now - updatedAt >= grace) {
+            delete state.devices[deviceId]
+            removed += 1
+            continue
+          }
+        }
+      }
+
+      if (removed > 0) {
+        log.info(`Pruned ${removed} stale device-preferences entr${removed === 1 ? 'y' : 'ies'}`)
+        persist()
+      }
+      return removed
+    },
+
+    /**
      * Clear the recorded preference for `deviceId`. Currently unused by
      * production code, but exposed so future "forget this device" UI
      * doesn't have to reach into the cache shape.

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -83,8 +83,12 @@ export function resolveDiagnosticsRateLimit(overrideOpts) {
 /**
  * Parse a duration value coming from a `CHROXY_DEVICE_PREFS_*_MS` env var.
  * Accepts:
- *   - a non-negative integer string → that many milliseconds
- *   - "0" → 0 (effectively disables the cap by making everything "older")
+ *   - a non-negative numeric string → that many milliseconds (fractional
+ *     values are floored, e.g. `"1.9"` → 1)
+ *   - `"0"` → 0 (the literal zero; callers decide what 0 means — the
+ *     device-preferences `prune()` treats `maxAgeMs === 0` as "no age
+ *     cap", so setting `CHROXY_DEVICE_PREFS_MAX_AGE_MS=0` disables the
+ *     hard age cap rather than evicting every entry)
  *   - empty / null / non-numeric → fall back to `defaultMs`
  *
  * Negative numbers are silently coerced to the default so a typo can't
@@ -519,11 +523,21 @@ export class WsServer {
           process.env.CHROXY_DEVICE_PREFS_STALE_GRACE_MS,
           30 * 24 * 60 * 60 * 1000,
         )
-        this._devicePreferences.prune({
-          sessionExists: (id) => !!sessionManager.getSession?.(id),
+        // Only enable stale-session pruning when SessionManager actually
+        // exposes getSession. With optional chaining, `getSession?.(id)`
+        // silently returns undefined when the method is missing — every
+        // session would look "stale" and the prune would evict everything
+        // past the grace window. Belt-and-braces: when the predicate is
+        // omitted, prune() skips the stale-session arm and only the
+        // age-based cap (if any) applies.
+        const pruneOpts = {
           maxAgeMs,
           staleSessionGraceMs: staleGraceMs,
-        })
+        }
+        if (typeof sessionManager.getSession === 'function') {
+          pruneOpts.sessionExists = (id) => !!sessionManager.getSession(id)
+        }
+        this._devicePreferences.prune(pruneOpts)
       } catch (err) {
         // A prune failure must never block server startup — the next mutation
         // will reload the file anyway, and the worst case is a slightly

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -79,6 +79,28 @@ export function resolveDiagnosticsRateLimit(overrideOpts) {
   }
   return { windowMs: 60_000, maxMessages: 12, burst: 4 }
 }
+
+/**
+ * Parse a duration value coming from a `CHROXY_DEVICE_PREFS_*_MS` env var.
+ * Accepts:
+ *   - a non-negative integer string → that many milliseconds
+ *   - "0" → 0 (effectively disables the cap by making everything "older")
+ *   - empty / null / non-numeric → fall back to `defaultMs`
+ *
+ * Negative numbers are silently coerced to the default so a typo can't
+ * disable the prune by making `now - updatedAt > -1` always true.
+ *
+ * @param {string|undefined|null} raw
+ * @param {number} defaultMs
+ * @returns {number}
+ */
+export function parseDevicePrefsDuration(raw, defaultMs) {
+  if (raw == null || raw === '') return defaultMs
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n < 0) return defaultMs
+  return Math.floor(n)
+}
+
 const SERVER_VERSION = packageJson.version
 const log = createLogger('ws')
 
@@ -475,6 +497,40 @@ export class WsServer {
     // reconnect and updated by session-handlers.handleSwitchSession after
     // every explicit switch.
     this._devicePreferences = devicePreferences || createDevicePreferences()
+    // #4849: lazy startup prune. server-cli calls sessionManager.restoreState()
+    // before constructing the WsServer, so any device-pref entry whose
+    // activeSessionId is missing here is genuinely orphaned (a session
+    // destroyed in a previous run, or one rotated out by the user). The
+    // grace window guards against the rare path where restoreState
+    // intentionally skipped a session (e.g. corrupted state). prune is a
+    // no-op when the device list is empty, so the disk-I/O cost is zero
+    // for first-run installs and for users who never connected from
+    // ephemeral devices. Threshold env vars:
+    //   - CHROXY_DEVICE_PREFS_MAX_AGE_MS — hard age cap (default 90d)
+    //   - CHROXY_DEVICE_PREFS_STALE_GRACE_MS — stale-session grace (default 30d)
+    // Both can be set to 0 to disable. See #4849.
+    if (sessionManager && typeof this._devicePreferences.prune === 'function') {
+      try {
+        const maxAgeMs = parseDevicePrefsDuration(
+          process.env.CHROXY_DEVICE_PREFS_MAX_AGE_MS,
+          90 * 24 * 60 * 60 * 1000,
+        )
+        const staleGraceMs = parseDevicePrefsDuration(
+          process.env.CHROXY_DEVICE_PREFS_STALE_GRACE_MS,
+          30 * 24 * 60 * 60 * 1000,
+        )
+        this._devicePreferences.prune({
+          sessionExists: (id) => !!sessionManager.getSession?.(id),
+          maxAgeMs,
+          staleSessionGraceMs: staleGraceMs,
+        })
+      } catch (err) {
+        // A prune failure must never block server startup — the next mutation
+        // will reload the file anyway, and the worst case is a slightly
+        // larger preferences file.
+        log.warn(`device-preferences startup prune failed: ${err.message}`)
+      }
+    }
     this.httpServer = null
     this.wss = null
     this._pingInterval = null

--- a/packages/server/tests/device-preferences.test.js
+++ b/packages/server/tests/device-preferences.test.js
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync, existsSync, statSync, readFileSync, writeFileSync 
 import { tmpdir } from 'os'
 import { join, sep } from 'path'
 import { createDevicePreferences } from '../src/device-preferences.js'
+import { WsServer, parseDevicePrefsDuration } from '../src/ws-server.js'
 
 // #4835: device-preferences is a tiny persistence shim used by ws-history.js to
 // remember which session a deviceId was viewing across reconnects. Tests
@@ -161,5 +162,301 @@ describe('device-preferences (#4835)', () => {
   it('test fixture path is under the OS tmp dir', () => {
     assert.ok(filePath.includes(sep + 'chroxy-devprefs-'),
       `expected temp path, got ${filePath}`)
+  })
+
+  // #4849: stale-entry pruning. Devices that ever connected get an entry
+  // that lived forever (no eviction). prune() drops entries whose
+  // activeSessionId points at a session that no longer exists, and
+  // optionally also drops entries older than a configurable max age.
+  describe('prune (#4849)', () => {
+    it('removes entries whose activeSessionId no longer exists in SessionManager', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-live', 'sess-live')
+      prefs.setActiveSessionId('device-dead', 'sess-destroyed')
+
+      // SessionManager only knows about sess-live
+      const liveSessionIds = new Set(['sess-live'])
+      const removed = prefs.prune({ sessionExists: (id) => liveSessionIds.has(id) })
+
+      assert.equal(removed, 1, 'one stale entry should be removed')
+      assert.equal(prefs.getActiveSessionId('device-live'), 'sess-live')
+      assert.equal(prefs.getActiveSessionId('device-dead'), null)
+    })
+
+    it('persists the pruned state to disk', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-live', 'sess-live')
+      prefs.setActiveSessionId('device-dead', 'sess-destroyed')
+
+      prefs.prune({ sessionExists: (id) => id === 'sess-live' })
+
+      // Reload from disk in a fresh instance — pruned entry must be gone
+      const reloaded = createDevicePreferences({ filePath })
+      assert.equal(reloaded.getActiveSessionId('device-live'), 'sess-live')
+      assert.equal(reloaded.getActiveSessionId('device-dead'), null)
+    })
+
+    it('does not write the file when there is nothing to prune (no-op)', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-live', 'sess-live')
+      const beforeMtime = statSync(filePath).mtimeMs
+
+      // Spin briefly so a rewrite would produce a different mtime
+      const start = Date.now()
+      while (Date.now() - start < 20) { /* spin */ }
+
+      const removed = prefs.prune({ sessionExists: () => true })
+      assert.equal(removed, 0)
+      const afterMtime = statSync(filePath).mtimeMs
+      assert.equal(beforeMtime, afterMtime, 'no-op prune should not touch the file')
+    })
+
+    it('is a no-op when devices is empty (no file, no write)', () => {
+      const prefs = createDevicePreferences({ filePath })
+      const removed = prefs.prune({ sessionExists: () => true })
+      assert.equal(removed, 0)
+      assert.equal(existsSync(filePath), false, 'should not create a file with empty devices')
+    })
+
+    it('removes entries older than maxAgeMs regardless of session existence', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-old', 'sess-live')
+      prefs.setActiveSessionId('device-new', 'sess-live')
+
+      // Reach into the file to age one entry past the cutoff
+      const raw = JSON.parse(readFileSync(filePath, 'utf-8'))
+      raw.devices['device-old'].updatedAt = Date.now() - (100 * 24 * 60 * 60 * 1000)
+      writeFileSync(filePath, JSON.stringify(raw, null, 2))
+
+      // Fresh instance so the aged file is reloaded
+      const reloaded = createDevicePreferences({ filePath })
+      const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000
+      const removed = reloaded.prune({
+        sessionExists: () => true,
+        maxAgeMs: ninetyDaysMs,
+      })
+
+      assert.equal(removed, 1)
+      assert.equal(reloaded.getActiveSessionId('device-old'), null)
+      assert.equal(reloaded.getActiveSessionId('device-new'), 'sess-live')
+    })
+
+    it('keeps a recent entry even when its session no longer exists (grace window)', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-A', 'sess-destroyed')
+
+      // Recent updatedAt, stale session — within staleSessionGraceMs
+      const removed = prefs.prune({
+        sessionExists: () => false,
+        staleSessionGraceMs: 30 * 24 * 60 * 60 * 1000, // 30d grace
+      })
+      assert.equal(removed, 0)
+      assert.equal(prefs.getActiveSessionId('device-A'), 'sess-destroyed')
+    })
+
+    it('removes stale-session entries past the grace window', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-A', 'sess-destroyed')
+
+      // Age the entry past the 30-day stale grace
+      const raw = JSON.parse(readFileSync(filePath, 'utf-8'))
+      raw.devices['device-A'].updatedAt = Date.now() - (31 * 24 * 60 * 60 * 1000)
+      writeFileSync(filePath, JSON.stringify(raw, null, 2))
+
+      const reloaded = createDevicePreferences({ filePath })
+      const removed = reloaded.prune({
+        sessionExists: () => false,
+        staleSessionGraceMs: 30 * 24 * 60 * 60 * 1000,
+      })
+      assert.equal(removed, 1)
+      assert.equal(reloaded.getActiveSessionId('device-A'), null)
+    })
+
+    it('defaults: with no opts, removes only entries whose session is missing AND no grace', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-live', 'sess-live')
+      prefs.setActiveSessionId('device-dead', 'sess-gone')
+
+      const removed = prefs.prune({ sessionExists: (id) => id === 'sess-live' })
+      assert.equal(removed, 1)
+      assert.equal(prefs.getActiveSessionId('device-dead'), null)
+    })
+
+    it('treats malformed entries (missing activeSessionId / updatedAt) as prunable', () => {
+      writeFileSync(filePath, JSON.stringify({
+        version: 1,
+        devices: {
+          'device-bad-1': {},
+          'device-bad-2': { activeSessionId: 'sess-1' /* no updatedAt */ },
+          'device-good': { activeSessionId: 'sess-1', updatedAt: Date.now() },
+        },
+      }))
+
+      const prefs = createDevicePreferences({ filePath })
+      const removed = prefs.prune({ sessionExists: (id) => id === 'sess-1' })
+      assert.equal(removed, 2, 'two malformed entries should be removed')
+      assert.equal(prefs.getActiveSessionId('device-good'), 'sess-1')
+    })
+
+    it('tolerates a missing sessionExists callback (treats everything as live)', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-A', 'sess-1')
+      // Without sessionExists, the stale-session check is skipped — only the
+      // age-based check applies. With no maxAgeMs, this should be a no-op.
+      const removed = prefs.prune({})
+      assert.equal(removed, 0)
+      assert.equal(prefs.getActiveSessionId('device-A'), 'sess-1')
+    })
+  })
+
+  // #4849: WsServer must invoke prune at construction time so that the
+  // server starts clean rather than waiting for the next write to evict
+  // stale entries. Validates the full wiring (env-var → constructor →
+  // prune call → file rewrite), not just the helper in isolation.
+  describe('WsServer startup prune (#4849)', () => {
+    let server
+    let savedEnvMaxAge
+    let savedEnvGrace
+
+    beforeEach(() => {
+      savedEnvMaxAge = process.env.CHROXY_DEVICE_PREFS_MAX_AGE_MS
+      savedEnvGrace = process.env.CHROXY_DEVICE_PREFS_STALE_GRACE_MS
+      delete process.env.CHROXY_DEVICE_PREFS_MAX_AGE_MS
+      // Disable the default 30-day stale grace so the test can immediately
+      // observe stale-session eviction. We exercise the grace separately
+      // via parseDevicePrefsDuration unit tests below.
+      process.env.CHROXY_DEVICE_PREFS_STALE_GRACE_MS = '0'
+    })
+
+    afterEach(async () => {
+      if (server) {
+        try { await server.close() } catch {}
+        server = null
+      }
+      if (savedEnvMaxAge === undefined) {
+        delete process.env.CHROXY_DEVICE_PREFS_MAX_AGE_MS
+      } else {
+        process.env.CHROXY_DEVICE_PREFS_MAX_AGE_MS = savedEnvMaxAge
+      }
+      if (savedEnvGrace === undefined) {
+        delete process.env.CHROXY_DEVICE_PREFS_STALE_GRACE_MS
+      } else {
+        process.env.CHROXY_DEVICE_PREFS_STALE_GRACE_MS = savedEnvGrace
+      }
+    })
+
+    it('drops device-prefs entries whose session is gone from SessionManager', () => {
+      // Pre-populate the on-disk store with a live + a destroyed entry.
+      const seed = createDevicePreferences({ filePath })
+      seed.setActiveSessionId('device-live', 'sess-live')
+      seed.setActiveSessionId('device-dead', 'sess-destroyed')
+
+      // Stub SessionManager: only sess-live exists.
+      const sessionManagerStub = {
+        getSession: (id) => (id === 'sess-live' ? { id, name: 'live' } : null),
+      }
+      // Fresh disk-backed store handed to WsServer (cache not warmed).
+      const devicePreferences = createDevicePreferences({ filePath })
+
+      server = new WsServer({
+        port: 0,
+        apiToken: 'test',
+        sessionManager: sessionManagerStub,
+        authRequired: false,
+        devicePreferences,
+      })
+
+      // Verify in-memory state after prune
+      assert.equal(devicePreferences.getActiveSessionId('device-live'), 'sess-live')
+      assert.equal(devicePreferences.getActiveSessionId('device-dead'), null)
+
+      // Verify the prune was persisted to disk (next process boot sees it)
+      const reloaded = createDevicePreferences({ filePath })
+      assert.equal(reloaded.getActiveSessionId('device-dead'), null,
+        'destroyed-session entry must be persisted as removed')
+    })
+
+    it('does not touch the disk when there is nothing to prune', () => {
+      // Pre-populate with a single live entry
+      const seed = createDevicePreferences({ filePath })
+      seed.setActiveSessionId('device-live', 'sess-live')
+      const beforeMtime = statSync(filePath).mtimeMs
+
+      const sessionManagerStub = {
+        getSession: (id) => (id === 'sess-live' ? { id, name: 'live' } : null),
+      }
+      const devicePreferences = createDevicePreferences({ filePath })
+
+      // Spin so a rewrite would produce a measurable mtime delta
+      const start = Date.now()
+      while (Date.now() - start < 20) { /* spin */ }
+
+      server = new WsServer({
+        port: 0,
+        apiToken: 'test',
+        sessionManager: sessionManagerStub,
+        authRequired: false,
+        devicePreferences,
+      })
+
+      const afterMtime = statSync(filePath).mtimeMs
+      assert.equal(beforeMtime, afterMtime,
+        'no stale entries → prune must not rewrite the file')
+    })
+
+    it('is a no-op when devicePreferences has no entries', () => {
+      const sessionManagerStub = { getSession: () => null }
+      const devicePreferences = createDevicePreferences({ filePath })
+
+      assert.doesNotThrow(() => {
+        server = new WsServer({
+          port: 0,
+          apiToken: 'test',
+          sessionManager: sessionManagerStub,
+          authRequired: false,
+          devicePreferences,
+        })
+      })
+
+      // No file should have been created
+      assert.equal(existsSync(filePath), false)
+    })
+
+    it('does not crash when sessionManager is omitted (back-compat)', () => {
+      const devicePreferences = createDevicePreferences({ filePath })
+      assert.doesNotThrow(() => {
+        server = new WsServer({
+          port: 0,
+          apiToken: 'test',
+          authRequired: false,
+          devicePreferences,
+        })
+      })
+    })
+  })
+
+  describe('parseDevicePrefsDuration (#4849)', () => {
+    it('returns the default when raw is null / undefined / empty', () => {
+      assert.equal(parseDevicePrefsDuration(null, 42), 42)
+      assert.equal(parseDevicePrefsDuration(undefined, 42), 42)
+      assert.equal(parseDevicePrefsDuration('', 42), 42)
+    })
+
+    it('parses a positive integer string', () => {
+      assert.equal(parseDevicePrefsDuration('60000', 42), 60000)
+    })
+
+    it('accepts 0 as a valid value (callers can disable a cap)', () => {
+      assert.equal(parseDevicePrefsDuration('0', 42), 0)
+    })
+
+    it('falls back to default on a negative or non-numeric value', () => {
+      assert.equal(parseDevicePrefsDuration('-1', 42), 42)
+      assert.equal(parseDevicePrefsDuration('not-a-number', 42), 42)
+    })
+
+    it('floors fractional values', () => {
+      assert.equal(parseDevicePrefsDuration('1.9', 42), 1)
+    })
   })
 })

--- a/packages/server/tests/device-preferences.test.js
+++ b/packages/server/tests/device-preferences.test.js
@@ -307,6 +307,72 @@ describe('device-preferences (#4835)', () => {
       assert.equal(removed, 0)
       assert.equal(prefs.getActiveSessionId('device-A'), 'sess-1')
     })
+
+    // Input clamping — pinned per Copilot review on #4863. prune() is part
+    // of the public store API now; direct callers (and tests) must not be
+    // able to silently nuke the file by passing a bogus duration.
+    it('treats maxAgeMs === 0 as "no age cap" (matches PR description)', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-A', 'sess-live')
+      prefs.setActiveSessionId('device-B', 'sess-live')
+
+      // If 0 were taken literally, `now - updatedAt > 0` would evict every
+      // entry on the very next tick. The "disable the cap" contract means
+      // it must be a no-op for the age-based arm.
+      const removed = prefs.prune({
+        sessionExists: () => true,
+        maxAgeMs: 0,
+      })
+      assert.equal(removed, 0, 'maxAgeMs=0 must mean "no cap", not "evict everything"')
+      assert.equal(prefs.getActiveSessionId('device-A'), 'sess-live')
+      assert.equal(prefs.getActiveSessionId('device-B'), 'sess-live')
+    })
+
+    it('coerces a negative maxAgeMs to "no cap" instead of evicting everything', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-A', 'sess-live')
+
+      // Negative cap would be a foot-gun: `now - updatedAt > -1` is true
+      // for every entry. Clamping to "no cap" matches parseDevicePrefsDuration's
+      // env-var behaviour (negatives → default).
+      const removed = prefs.prune({
+        sessionExists: () => true,
+        maxAgeMs: -1,
+      })
+      assert.equal(removed, 0)
+      assert.equal(prefs.getActiveSessionId('device-A'), 'sess-live')
+    })
+
+    it('coerces a negative staleSessionGraceMs to 0 (no grace) instead of skipping the guard', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-A', 'sess-destroyed')
+
+      // The original code took `staleSessionGraceMs` as-is; a negative
+      // value would have left `now - updatedAt >= -1` always true, which
+      // happens to do the right thing here (evict immediately), but only
+      // by accident. Clamping makes the behaviour intentional.
+      const removed = prefs.prune({
+        sessionExists: () => false,
+        staleSessionGraceMs: -1,
+      })
+      assert.equal(removed, 1)
+      assert.equal(prefs.getActiveSessionId('device-A'), null)
+    })
+
+    it('coerces a non-finite maxAgeMs to "no cap"', () => {
+      const prefs = createDevicePreferences({ filePath })
+      prefs.setActiveSessionId('device-A', 'sess-live')
+
+      // NaN comparisons are always false, so historically this would
+      // have been a silent no-op for the age arm anyway, but documenting
+      // it explicitly keeps the clamp guarantee from regressing.
+      const removed = prefs.prune({
+        sessionExists: () => true,
+        maxAgeMs: NaN,
+      })
+      assert.equal(removed, 0)
+      assert.equal(prefs.getActiveSessionId('device-A'), 'sess-live')
+    })
   })
 
   // #4849: WsServer must invoke prune at construction time so that the
@@ -432,6 +498,41 @@ describe('device-preferences (#4835)', () => {
           devicePreferences,
         })
       })
+    })
+
+    // Pinned per Copilot review on #4863. If sessionManager exists but
+    // doesn't expose getSession (older mock objects, partially-built test
+    // doubles), the previous wiring used optional chaining and silently
+    // marked every session as "stale" — past the grace window the prune
+    // would evict everything. The guard now skips the stale-session arm
+    // when getSession is missing, so prune is reduced to the age cap.
+    it('does not evict fresh entries when sessionManager is missing getSession', () => {
+      // Override the test's default `staleSessionGraceMs = 0` so the
+      // stale-session arm WOULD fire instantly if it were enabled. With
+      // the bug fix the arm is skipped entirely; without the fix the
+      // fresh entry would be evicted on construction.
+      const seed = createDevicePreferences({ filePath })
+      seed.setActiveSessionId('device-A', 'sess-mystery')
+
+      // Stub WITHOUT getSession (partial mock — common in older tests).
+      const sessionManagerWithoutGetSession = { /* deliberately empty */ }
+      const devicePreferences = createDevicePreferences({ filePath })
+
+      server = new WsServer({
+        port: 0,
+        apiToken: 'test',
+        sessionManager: sessionManagerWithoutGetSession,
+        authRequired: false,
+        devicePreferences,
+      })
+
+      // Without the guard, sessionExists would have returned `!!undefined`
+      // → false for every id, and the entry would have been evicted past
+      // the (0 ms) grace. With the guard, the stale-session arm is skipped
+      // and the entry survives — only the age cap (90d default, not
+      // reached) could remove it.
+      assert.equal(devicePreferences.getActiveSessionId('device-A'), 'sess-mystery',
+        'entry must survive when getSession is missing — stale arm is skipped')
     })
   })
 


### PR DESCRIPTION
Closes #4849

## Summary

The per-device-preferences store added in #4847 was append-mostly — every distinct `deviceId` that ever connected got an entry that lived forever. A user who rotates through dev VMs, ephemeral codespaces, or guest devices steadily accumulated orphaned entries pointing at long-destroyed sessions. The disk cost is small (~80 bytes per entry) so this is not urgent, but it adds up.

This adds a lazy startup prune that runs once when `WsServer` is constructed — after `server-cli.js` has called `sessionManager.restoreState()`, so the SessionManager is the authoritative source for "still exists".

## Behaviour

- `prune({ sessionExists, maxAgeMs, staleSessionGraceMs })` on the device-preferences store drops entries when EITHER:
  - `activeSessionId` is no longer known to the SessionManager AND the entry is older than `staleSessionGraceMs` (default 30d grace), OR
  - `updatedAt` is older than `maxAgeMs` (default 90d hard cap), OR
  - the entry is malformed (missing `activeSessionId` / `updatedAt`).
- No-op when `devices` is empty (zero disk I/O on first-run installs).
- The file is only re-written when at least one entry is removed — repeated startups against a clean store touch nothing.
- Tunable via env vars (set `0` to disable, negative/non-numeric falls back to default):
  - `CHROXY_DEVICE_PREFS_MAX_AGE_MS`
  - `CHROXY_DEVICE_PREFS_STALE_GRACE_MS`
- Prune failures are logged at `warn` and swallowed — they must never block server startup.

Atomicity for the underlying write continues to be handled by `writeFileRestricted` in `platform.js`. Issue #4850 will harden that helper separately; this PR does not reimplement the atomic path.

## Files

- `packages/server/src/device-preferences.js` — new `prune()` method.
- `packages/server/src/ws-server.js` — exported `parseDevicePrefsDuration()` env-var helper + startup prune call inside the constructor.
- `packages/server/tests/device-preferences.test.js` — 19 new tests covering the prune logic, the WsServer wiring, and the env-var parser.

## Test plan

- [x] `device-preferences.test.js` — 19 new prune tests cover: stale-session eviction, age-based eviction, grace window, malformed entries, no-op on empty, no-op on no-changes, persistence to disk, env-var defaults, env-var overrides, missing `sessionExists` callback.
- [x] WsServer startup-prune integration tests pin: destroyed-session entry removed on construction, live entry retained, file not touched when nothing to prune, no-op on empty store, back-compat when `sessionManager` is omitted.
- [x] `./scripts/lint-tests-state-file-path.sh` passes.
- [x] `./scripts/lint-session-opt-forwarding.sh` passes.
- [x] `./scripts/lint-logger-session-scoping.sh` passes.
- [x] Full `npm test` suite — only the pre-existing flakes from PR #4847's test plan fail (`service.test.js`, `tunnel.integration.test.js`, `web-task-manager.test.js`, `ws-server-broadcast.test.js`); no new failures from this change.