### PR TITLE
feat(app): mobile parity for single-question Other/freeform answer

### DIFF
--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -1919,3 +1919,99 @@ describe('inactivityWarning cleanup (#3899)', () => {
     expect(sessionsRefAfter).toBe(sessionsRefBefore);
   });
 });
+
+// -- sendUserQuestionResponse Other / freeform shape (#4755) --
+//
+// Pins the wire-payload serialization for the single-question Other path,
+// mirroring the dashboard's #4651 store test. When `answer` is the
+// `{otherLabel, freeformText}` object shape, the wire payload must be
+// `{type:'user_question_response', answer:<otherLabel>, freeformText:<typed>,
+// toolUseId?}` so the server can drive the two-stage TUI write (Other digit
+// → text-input prompt → freeform text + Enter). String answers must keep
+// the legacy `{type, answer, toolUseId?}` shape unchanged.
+
+describe('sendUserQuestionResponse Other / freeform shape (#4755)', () => {
+  function makeMockSocket(): { socket: WebSocket; sent: string[] } {
+    const sent: string[] = [];
+    const socket = {
+      readyState: 1,
+      send: (data: string) => sent.push(data),
+      close: () => {},
+      onclose: null,
+    } as unknown as WebSocket;
+    return { socket, sent };
+  }
+
+  afterEach(() => {
+    useConnectionStore.setState({ socket: null });
+  });
+
+  it('emits {answer:<otherLabel>, freeformText, toolUseId} for the freeform object shape', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().sendUserQuestionResponse(
+      { otherLabel: 'Other', freeformText: 'my custom answer' },
+      'toolu_other_freeform',
+    );
+    expect(sent).toHaveLength(1);
+    expect(JSON.parse(sent[0])).toEqual({
+      type: 'user_question_response',
+      answer: 'Other',
+      freeformText: 'my custom answer',
+      toolUseId: 'toolu_other_freeform',
+    });
+  });
+
+  it('preserves a model-supplied custom Other label on the wire', () => {
+    // Defends against a future regression where we forget to thread
+    // `otherLabel` through and instead hard-code the literal "Other"
+    // string — the server's digit-lookup would then resolve to the wrong
+    // hotkey for any custom-label Other option.
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().sendUserQuestionResponse(
+      { otherLabel: 'Something else', freeformText: 'typed' },
+      'toolu-x',
+    );
+    expect(JSON.parse(sent[0])).toEqual({
+      type: 'user_question_response',
+      answer: 'Something else',
+      freeformText: 'typed',
+      toolUseId: 'toolu-x',
+    });
+  });
+
+  it('keeps the legacy {answer:<string>, toolUseId} shape for plain string answers', () => {
+    // Regular option taps + zero-options free-text answers (#1245) must
+    // keep flowing through the legacy string serializer — older servers
+    // that ignore `freeformText` must continue to receive a payload they
+    // understand verbatim.
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().sendUserQuestionResponse('Option A', 'toolu-string');
+    expect(JSON.parse(sent[0])).toEqual({
+      type: 'user_question_response',
+      answer: 'Option A',
+      toolUseId: 'toolu-string',
+    });
+    // Critically, `freeformText` MUST be absent in the legacy shape so
+    // server-side schema validators / handlers don't misclassify a plain
+    // option tap as an Other / freeform send.
+    expect(JSON.parse(sent[0])).not.toHaveProperty('freeformText');
+  });
+
+  it('omits toolUseId from the wire payload when not provided', () => {
+    const { socket, sent } = makeMockSocket();
+    useConnectionStore.setState({ socket });
+    useConnectionStore.getState().sendUserQuestionResponse(
+      { otherLabel: 'Other', freeformText: 'no-tooluse case' },
+    );
+    const payload = JSON.parse(sent[0]);
+    expect(payload).toEqual({
+      type: 'user_question_response',
+      answer: 'Other',
+      freeformText: 'no-tooluse case',
+    });
+    expect(payload).not.toHaveProperty('toolUseId');
+  });
+});

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -19,6 +19,7 @@ import { COLORS } from '../constants/colors';
 import { ActivityGroup } from './chat/ActivityGroup';
 import { ToolDetailModal } from './chat/ToolDetailModal';
 import { MessageBubble } from './chat/MessageBubble';
+import type { SelectOptionValue } from './chat/MessageBubble';
 import { buildChatViewMessages } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
 
@@ -28,7 +29,16 @@ export interface ChatViewProps {
   messages: ChatMessage[];
   scrollViewRef: React.RefObject<ScrollView | null>;
   claudeReady: boolean;
-  onSelectOption: (value: string, messageId: string, requestId?: string, toolUseId?: string) => void;
+  /**
+   * #4755 — `value` is `string` for regular option taps + zero-options
+   * free-text answers, or `{otherLabel, freeformText}` (`OtherFreeformAnswer`)
+   * when the user picked the synthesized "Other" option and typed
+   * freeform text. The widened shape rides through to
+   * `sendUserQuestionResponse`, which serializes the wire payload
+   * (`answer: <otherLabel>, freeformText`). See
+   * `MessageBubble.SelectOptionValue` for the union type.
+   */
+  onSelectOption: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
   isCliMode: boolean;
   selectedIds: Set<string>;
   isSelecting: boolean;

--- a/packages/app/src/components/__tests__/MessageBubble.otherFreeform.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.otherFreeform.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * MessageBubble Other / freeform answer integration — #4755
+ *
+ * Mobile parity with the dashboard's #4651 freeform Other support.
+ * Asserts that when the user picks the synthesized "Other" option on a
+ * single-question AskUserQuestion prompt, MessageBubble:
+ *
+ *   1. Swaps the option buttons for a freeform `TextInput` + Send button.
+ *   2. On Send / Enter, emits `{otherLabel, freeformText}` (not the typed
+ *      string) so SessionScreen can forward the structured shape to
+ *      `sendUserQuestionResponse` — which serializes the two-stage TUI
+ *      wire payload (`answer: <otherLabel>, freeformText: <typed>`).
+ *   3. Preserves the legacy string `onSelectOption` payload for regular
+ *      option taps (no behaviour change there).
+ *
+ * Without the freeform shape the typed text would be written directly at
+ * claude TUI's digit-select menu, where the first char would jump-nav
+ * the menu (#4288 footgun) and wedge or mis-resolve the answer.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { OTHER_OPTION_VALUE } from '@chroxy/store-core';
+import { MessageBubble } from '../chat/MessageBubble';
+import type { ChatMessage } from '../../store/types';
+
+function makePromptWithOther(): ChatMessage {
+  return {
+    id: 'q-1',
+    type: 'prompt',
+    content: 'Pick one',
+    timestamp: Date.now(),
+    toolUseId: 'toolu_other_freeform',
+    tool: 'AskUserQuestion',
+    options: [
+      { label: 'Option A', value: 'a' },
+      { label: 'Option B', value: 'b' },
+      // Synthesized sentinel — #3746 inserts this so users can always
+      // type a custom answer alongside the model-supplied options.
+      { label: 'Other', value: OTHER_OPTION_VALUE },
+    ],
+  } as ChatMessage;
+}
+
+function render(message: ChatMessage, onSelectOption: jest.Mock) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(
+      <MessageBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onLongPress={() => {}}
+        onPress={() => {}}
+        onOpenDetail={() => {}}
+        onSelectOption={onSelectOption}
+      />,
+    );
+  });
+  return tree;
+}
+
+describe('MessageBubble Other / freeform answer (#4755)', () => {
+  it('shows the freeform input when the user picks the Other option', () => {
+    // Step 1 of the freeform flow: tapping Other must hide the option
+    // buttons and surface the text input keyed by `approval-freetext-input`.
+    const onSelectOption = jest.fn();
+    const tree = render(makePromptWithOther(), onSelectOption);
+    // Before tapping Other, no freeform input exists.
+    expect(tree.root.findAllByProps({ testID: 'approval-freetext-input' })).toHaveLength(0);
+    const otherBtn = tree.root.findByProps({ testID: `approval-button-${OTHER_OPTION_VALUE}` });
+    act(() => {
+      otherBtn.props.onPress?.();
+    });
+    // After tapping Other, the freeform input renders (RN's TextInput
+    // forwards `testID` onto both the composite + the underlying host
+    // node, so `findAllByProps` returns 2 entries — assert presence with
+    // `>= 1`). onSelectOption has NOT been called yet (we're waiting for
+    // the user to type + send).
+    expect(
+      tree.root.findAllByProps({ testID: 'approval-freetext-input' }).length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(onSelectOption).not.toHaveBeenCalled();
+  });
+
+  it('emits {otherLabel, freeformText} when Send is tapped from Other mode', () => {
+    // The wire-payload shape change is the whole point of #4755 — assert
+    // the object payload so SessionScreen / connection.ts wire layer
+    // can serialize `{answer: <otherLabel>, freeformText}` on the wire.
+    const onSelectOption = jest.fn();
+    const tree = render(makePromptWithOther(), onSelectOption);
+    const otherBtn = tree.root.findByProps({ testID: `approval-button-${OTHER_OPTION_VALUE}` });
+    act(() => {
+      otherBtn.props.onPress?.();
+    });
+    // findAllByProps + first entry: see Enter-key test for why.
+    const inputs = tree.root.findAllByProps({ testID: 'approval-freetext-input' });
+    act(() => {
+      inputs[0].props.onChangeText?.('my custom answer');
+    });
+    const sendBtn = tree.root.findByProps({ testID: 'approval-freetext-send' });
+    act(() => {
+      sendBtn.props.onPress?.();
+    });
+    expect(onSelectOption).toHaveBeenCalledTimes(1);
+    expect(onSelectOption).toHaveBeenCalledWith(
+      { otherLabel: 'Other', freeformText: 'my custom answer' },
+      'q-1',
+      undefined,
+      'toolu_other_freeform',
+    );
+  });
+
+  it('emits {otherLabel, freeformText} when Enter (onSubmitEditing) is fired from Other mode', () => {
+    // The onSubmitEditing path (return key on the keyboard) must emit
+    // the same shape as the Send button — otherwise Enter on iOS / hardware
+    // keyboards would silently regress to the legacy string write path.
+    const onSelectOption = jest.fn();
+    const tree = render(makePromptWithOther(), onSelectOption);
+    const otherBtn = tree.root.findByProps({ testID: `approval-button-${OTHER_OPTION_VALUE}` });
+    act(() => {
+      otherBtn.props.onPress?.();
+    });
+    // findAllByProps + first match: the underlying TextInput host node
+    // mirrors the composite's testID, so both findByProps would throw
+    // ambiguously — use the composite (first entry) which carries the
+    // freshly-rendered onChangeText / onSubmitEditing handlers.
+    const inputs = tree.root.findAllByProps({ testID: 'approval-freetext-input' });
+    act(() => {
+      inputs[0].props.onChangeText?.('enter-sent answer');
+    });
+    // State update must commit before onSubmitEditing fires, otherwise
+    // the closure reads stale `otherText` (=== '') and the submit
+    // bails on the empty-string guard. Mirrors the Send-button test
+    // pattern — both invocations live in their own act() block.
+    const inputsAfter = tree.root.findAllByProps({ testID: 'approval-freetext-input' });
+    act(() => {
+      inputsAfter[0].props.onSubmitEditing?.();
+    });
+    expect(onSelectOption).toHaveBeenCalledWith(
+      { otherLabel: 'Other', freeformText: 'enter-sent answer' },
+      'q-1',
+      undefined,
+      'toolu_other_freeform',
+    );
+  });
+
+  it('preserves a custom Other-option label in the emitted payload', () => {
+    // If the model supplies a custom label for the OTHER_OPTION_VALUE
+    // sentinel (rare — mostly the synthesized `'Other'` case) the
+    // payload must echo that label so the server's digit-lookup resolves
+    // to the right TUI hotkey.
+    const onSelectOption = jest.fn();
+    const customMsg = {
+      ...makePromptWithOther(),
+      options: [
+        { label: 'Option A', value: 'a' },
+        { label: 'Something else', value: OTHER_OPTION_VALUE },
+      ],
+    } as ChatMessage;
+    const tree = render(customMsg, onSelectOption);
+    const otherBtn = tree.root.findByProps({ testID: `approval-button-${OTHER_OPTION_VALUE}` });
+    act(() => {
+      otherBtn.props.onPress?.();
+    });
+    const inputs = tree.root.findAllByProps({ testID: 'approval-freetext-input' });
+    act(() => {
+      inputs[0].props.onChangeText?.('typed');
+    });
+    const sendBtn = tree.root.findByProps({ testID: 'approval-freetext-send' });
+    act(() => {
+      sendBtn.props.onPress?.();
+    });
+    expect(onSelectOption).toHaveBeenCalledWith(
+      { otherLabel: 'Something else', freeformText: 'typed' },
+      'q-1',
+      undefined,
+      'toolu_other_freeform',
+    );
+  });
+
+  it('still emits a plain string when a regular option is tapped (no behaviour change)', () => {
+    // Belt-and-braces back-compat assertion. The freeform shape is
+    // reserved for the Other path; regular option taps must keep the
+    // legacy string payload so SessionScreen / connection.ts continue
+    // through their existing string-only code paths.
+    const onSelectOption = jest.fn();
+    const tree = render(makePromptWithOther(), onSelectOption);
+    const optionABtn = tree.root.findByProps({ testID: 'approval-button-a' });
+    act(() => {
+      optionABtn.props.onPress?.();
+    });
+    expect(onSelectOption).toHaveBeenCalledTimes(1);
+    expect(onSelectOption).toHaveBeenCalledWith(
+      'a',
+      'q-1',
+      undefined,
+      'toolu_other_freeform',
+    );
+  });
+});

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -18,9 +18,32 @@ import { ThinkingIndicator } from './ThinkingIndicator';
 import { ToolBubble } from './ToolBubble';
 import { StreamStallChip } from '../StreamStallChip';
 
+/**
+ * #4755 — single-question Other / freeform answer payload (mobile parity
+ * with the dashboard's `OtherFreeformAnswer`, see #4651 / PR #4753).
+ *
+ * When the user picks the synthesized "Other" option (`OTHER_OPTION_VALUE`)
+ * and types freeform text, the bubble emits this object shape instead of
+ * the typed string. SessionScreen forwards it to `sendUserQuestionResponse`,
+ * which serializes `{answer: <otherLabel>, freeformText: <typed>}` on the
+ * wire so the server can drive a two-stage TUI write (Other digit → text-
+ * input prompt → freeform text + Enter) — sidestepping claude TUI's
+ * single-character jump-nav (#4288) that would otherwise wedge the menu.
+ *
+ * The legacy string path is preserved for regular option taps and zero-
+ * options free-text-only AskUserQuestions (#1245) so older servers that
+ * ignore `freeformText` keep working unchanged.
+ */
+export interface OtherFreeformAnswer {
+  otherLabel: string;
+  freeformText: string;
+}
+
+export type SelectOptionValue = string | OtherFreeformAnswer;
+
 export function MessageBubble({ message, onSelectOption, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall }: {
   message: ChatMessage;
-  onSelectOption?: (value: string, messageId: string, requestId?: string, toolUseId?: string) => void;
+  onSelectOption?: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
   isSelected: boolean;
   isSelecting: boolean;
   onLongPress: () => void;
@@ -43,6 +66,14 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
   // #3746: free-text mode when user picks the synthetic "Other" option
   const [otherActive, setOtherActive] = useState(false);
   const [otherText, setOtherText] = useState('');
+  // #4755 — when the user clicks the Other option button, stash the option's
+  // label so we can emit it alongside the freeform text. The server resolves
+  // the label to its 1-indexed TUI digit, writes that digit BEFORE the
+  // freeform text so the TUI's text-input prompt is open when the text
+  // lands. Default 'Other' covers the synthesized-sentinel case (#3746)
+  // where options[*].value === OTHER_OPTION_VALUE but no real option
+  // carries that label. Mirrors `QuestionPrompt` in the dashboard (#4651).
+  const [otherLabel, setOtherLabel] = useState<string>('Other');
   // #3753: mirror the dashboard's submittedRef — guarantee one-shot send
   // even if the user rapid-taps Send / hits Enter before the store
   // round-trip flips `message.answered`. Reset when the prompt is
@@ -221,6 +252,13 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
                 disabled={isDisabled}
                 onPress={() => {
                   if (opt.value === OTHER_OPTION_VALUE) {
+                    // #4755 — capture the label of the option the user
+                    // actually clicked so the freeform payload carries the
+                    // right label for the server's digit lookup. Synthetic
+                    // sentinel options use the label 'Other'; model-supplied
+                    // custom labels (rare) preserve their text. Mirrors the
+                    // dashboard's QuestionPrompt (#4651).
+                    setOtherLabel(opt.label || 'Other');
                     setOtherActive(true);
                     return;
                   }
@@ -252,23 +290,45 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
             placeholder="Type your response…"
             placeholderTextColor={COLORS.textSecondary}
             style={styles.promptFreetextInput}
+            // #4755 — testID anchors the freeform input for both unit
+            // tests and Maestro flows. Pairs with `approval-freetext-send`
+            // on the Send button so flows can drive Other-mode end-to-end.
+            testID="approval-freetext-input"
             autoFocus
             onSubmitEditing={() => {
               const trimmed = otherText.trim();
               if (!trimmed || submittedRef.current) return;
               submittedRef.current = true;
-              onSelectOption?.(trimmed, message.id, message.requestId, message.toolUseId);
+              // #4755 — when the user reached this input by clicking the
+              // synthesized "Other" option (otherActive true), emit the
+              // structured `{otherLabel, freeformText}` payload so the
+              // server can drive the two-stage TUI write. When otherActive
+              // is false the user is in the zero-options free-text-only
+              // path (#1245) — keep emitting a plain string so the
+              // server's existing free-text handler continues to work
+              // unchanged. Mirrors dashboard handleSubmit (#4651).
+              const payload: SelectOptionValue = otherActive
+                ? { otherLabel, freeformText: trimmed }
+                : trimmed;
+              onSelectOption?.(payload, message.id, message.requestId, message.toolUseId);
             }}
             returnKeyType="send"
           />
           <TouchableOpacity
             style={[styles.promptFreetextSend, !otherText.trim() && styles.promptOptionDisabled]}
             disabled={!otherText.trim()}
+            // #4755 — see input testID comment above.
+            testID="approval-freetext-send"
             onPress={() => {
               const trimmed = otherText.trim();
               if (!trimmed || submittedRef.current) return;
               submittedRef.current = true;
-              onSelectOption?.(trimmed, message.id, message.requestId, message.toolUseId);
+              // #4755 — see onSubmitEditing comment above. Both paths
+              // (Enter key + Send button tap) must emit the same shape.
+              const payload: SelectOptionValue = otherActive
+                ? { otherLabel, freeformText: trimmed }
+                : trimmed;
+              onSelectOption?.(payload, message.id, message.requestId, message.toolUseId);
             }}
           >
             <Text style={styles.promptFreetextSendText}>Send</Text>

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -24,6 +24,7 @@ import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { SessionPicker } from '../components/SessionPicker';
 import { CreateSessionModal } from '../components/CreateSessionModal';
 import { ChatView } from '../components/ChatView';
+import type { SelectOptionValue } from '../components/chat/MessageBubble';
 import { TerminalView, TerminalHandle } from '../components/TerminalView';
 import { SettingsBar } from '../components/SettingsBar';
 import { WebTasksPanel } from '../components/WebTasksPanel';
@@ -671,17 +672,42 @@ export function SessionScreen() {
   };
 
   // Handle tapping a prompt option
-  const handleSelectOption = (value: string, messageId: string, requestId?: string, toolUseId?: string) => {
+  // #4755 — `value` widened to `SelectOptionValue` to carry the
+  // single-question Other / freeform payload (`{otherLabel, freeformText}`).
+  // We forward the object shape directly to `sendUserQuestionResponse` so
+  // the wire layer can emit `{answer: <otherLabel>, freeformText}` for the
+  // server's two-stage TUI write (Other digit → text-input prompt →
+  // freeform text + Enter). The local `markPromptAnswered` summary stores
+  // the typed text — not the literal "Other" label — matching the
+  // post-answer UX of the free-text-only path (#1245) so the chat bubble
+  // shows what the user actually wrote. Mirrors dashboard App.tsx +
+  // `formatQuestionAnswerSummary` for the freeform shape (#4651).
+  const handleSelectOption = (
+    value: SelectOptionValue,
+    messageId: string,
+    requestId?: string,
+    toolUseId?: string,
+  ) => {
+    const isFreeformAnswer = typeof value === 'object' && value !== null
+      && 'otherLabel' in value && 'freeformText' in value;
     let sent: 'sent' | 'queued' | false = false;
     if (toolUseId) {
       sent = sendUserQuestionResponse(value, toolUseId);
     } else if (requestId) {
-      sent = sendPermissionResponse(requestId, value);
+      // Permission responses are decision strings ('allow' / 'deny' / etc.)
+      // and never carry an Other / freeform payload — coerce to string so
+      // the type stays sound even though this branch isn't reachable for
+      // the freeform shape in practice.
+      sent = sendPermissionResponse(requestId, isFreeformAnswer ? value.freeformText : (value as string));
     } else {
-      sent = sendInput(hasTerminal ? value + '\r' : value);
+      const literal = isFreeformAnswer ? value.freeformText : (value as string);
+      sent = sendInput(hasTerminal ? literal + '\r' : literal);
     }
     if (sent === 'sent') {
-      markPromptAnswered(messageId, value);
+      // For the freeform shape, store the typed text (not the label) so
+      // the answered-state UI renders the user's actual answer.
+      const summary = isFreeformAnswer ? value.freeformText : (value as string);
+      markPromptAnswered(messageId, summary);
     }
   };
 

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1198,38 +1198,43 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   sendUserQuestionResponse: (
-    answer: string | Record<string, string | string[]>,
+    answer: string | Record<string, string | string[]> | { otherLabel: string; freeformText: string },
     toolUseId?: string,
   ) => {
     const { socket } = get();
-    // #4761 — widened to mirror the dashboard's `sendUserQuestionResponse`
-    // (#4760). Split the wire payload by call shape:
-    // - string `answer`: legacy single-question / free-text path. Wire
-    //   shape stays `{ type, answer, toolUseId? }` so older servers
-    //   keep working without schema migration.
-    // - Record `answer`: multi-question form. Populate the `answers`
-    //   field (`UserQuestionResponseSchema` accepts
-    //   `Record<string, string | string[]>` per #4621 / #4735) AND a
-    //   string `answer` summary so a server running an older build that
-    //   only reads `answer` falls through to its default-to-option-1
-    //   path instead of stalling the form.
+    // Three shapes (#4761 multi-question + #4755 Other/freeform parity):
+    // - string: legacy single-question / free-text. Wire shape stays
+    //   `{ type, answer, toolUseId? }` so older servers keep working.
+    // - { otherLabel, freeformText }: single-question Other freeform
+    //   path (#4755, mirrors dashboard #4651). Wire `{answer: otherLabel,
+    //   freeformText: typedText}` so the server can drive the two-stage
+    //   TUI write (Other digit → text-input prompt → freeform text + Enter).
+    // - Record<string, string | string[]>: multi-question form (#4761,
+    //   mirrors dashboard #4760). Populate `answers` per
+    //   UserQuestionResponseSchema AND a string `answer` summary so older
+    //   servers reading only `answer` fall through readably.
     //
-    //   Multi-select values flow through as native arrays — the summary
-    //   helper flattens them to comma-joined labels so the string-only
-    //   `answer` field stays readable. The helper also detects the
-    //   legacy JSON-stringified array envelope (pre-#4621 wire: a
-    //   single value like `'["App","Tests"]'` for multi-select) so
-    //   mixed-version rehydrated state still renders without leaking
-    //   JSON syntax in the `answer` field.
-    const isMultiAnswer = typeof answer !== 'string';
-    const answerSummary = isMultiAnswer
-      ? formatQuestionAnswerSummary(answer)
-      : answer;
+    // Freeform shape detection is tight (exactly the two named keys, both
+    // strings) so a multi-question Record whose keys happen to be those
+    // names doesn't get misrouted into the freeform branch.
+    const isFreeformAnswer = typeof answer === 'object' && answer !== null
+      && !Array.isArray(answer)
+      && Object.keys(answer).length === 2
+      && 'freeformText' in answer && 'otherLabel' in answer
+      && typeof (answer as Record<string, unknown>).freeformText === 'string'
+      && typeof (answer as Record<string, unknown>).otherLabel === 'string';
+    const isMultiAnswer = !isFreeformAnswer && typeof answer !== 'string';
     const payload: Record<string, unknown> = {
       type: 'user_question_response',
-      answer: answerSummary,
+      answer: isFreeformAnswer
+        ? (answer as { otherLabel: string }).otherLabel
+        : isMultiAnswer
+          ? formatQuestionAnswerSummary(answer as Record<string, string | string[]>)
+          : (answer as string),
     };
-    if (isMultiAnswer) {
+    if (isFreeformAnswer) {
+      payload.freeformText = (answer as { freeformText: string }).freeformText;
+    } else if (isMultiAnswer) {
       payload.answers = answer;
     }
     if (toolUseId) payload.toolUseId = toolUseId;

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -422,23 +422,20 @@ export interface MessageInputActions {
   /**
    * Send a `user_question_response` answer to the server.
    *
-   * Accepts two answer shapes:
+   * Accepts three answer shapes:
    * - `string` — legacy single-question / free-text path. Wire shape stays
    *   `{ type, answer, toolUseId? }` so older servers keep working.
    * - `Record<string, string | string[]>` — multi-question form path
-   *   (#4604 / #4621 / #4735). Populates the `answers` field per
-   *   `UserQuestionResponseSchema` (which accepts `string | string[]` per
-   *   question) AND a flattened string `answer` summary so older servers
-   *   reading only `answer` still see a readable line.
-   *
-   * Mirrors the `string` and `Record<string, string | string[]>` branches of
-   * `sendUserQuestionResponse` on the dashboard (#4760). The dashboard
-   * additionally accepts a `{ otherLabel, freeformText }` shape for the
-   * single-question Other / freeform path (#4651); mobile parity for that
-   * shape is tracked separately in #4755 and is out of scope here.
+   *   (#4604 / #4621 / #4735 / #4761). Populates the `answers` field per
+   *   `UserQuestionResponseSchema` and a flattened string `answer` summary.
+   * - `{ otherLabel, freeformText }` — single-question Other / freeform
+   *   path (#4755, mobile parity with dashboard #4651). Wire payload is
+   *   `{answer: <otherLabel>, freeformText: <typed text>}` so the server
+   *   drives the two-stage TUI write (Other digit → text-input prompt →
+   *   freeform text + Enter).
    */
   sendUserQuestionResponse: (
-    answer: string | Record<string, string | string[]>,
+    answer: string | Record<string, string | string[]> | { otherLabel: string; freeformText: string },
     toolUseId?: string,
   ) => 'sent' | 'queued' | false;
   markPromptAnswered: (messageId: string, answer: string) => void;


### PR DESCRIPTION
Closes #4755

## Summary

Follow-up to #4651 (PR #4753) which landed the dashboard + server chain for the single-question Other / freeform answer path. The mobile `MessageBubble` already rendered the freetext input when the user picked the synthesized "Other" option, but it sent only the typed string as a plain `answer` — meaning mobile users still hit the #4288 jump-nav footgun (first char selects a menu hotkey) on claude TUI sessions when picking Other.

When the user now picks Other + types text, the mobile app emits the same `{answer: <otherLabel>, freeformText, toolUseId}` payload as the dashboard. The server's existing #4651 handler resolves the Other label to its 1-indexed TUI digit, writes the digit to swap the menu into text-input mode, waits 150 ms, then writes the freeform text + Enter. Older servers that ignore `freeformText` fall through to the legacy literal-text write (clean degradation).

## Scope

- `MessageBubble.tsx`: exports `OtherFreeformAnswer` + `SelectOptionValue` union; tracks the Other option's label so the freeform payload carries the right label for the server's digit lookup; adds `approval-freetext-input` / `approval-freetext-send` testIDs so Maestro + unit tests can pin the input + Send button.
- `ChatView.tsx` + `SessionScreen.tsx`: widen `onSelectOption` / `handleSelectOption` signatures to the `SelectOptionValue` union; `markPromptAnswered` stores the typed text (not the literal "Other" label) so the post-answer bubble shows the user's actual answer — matches dashboard `formatQuestionAnswerSummary` behaviour.
- `connection.ts` + `store/types.ts`: `sendUserQuestionResponse` accepts the `{otherLabel, freeformText}` shape and serializes the wire payload identically to the dashboard (tight 2-key shape detection guards against a hypothetical multi-question Record collision).

Acceptance criteria from #4755:

- [x] Mobile sends `{answer: <Other-label>, freeformText, toolUseId}` when the user picks Other and types text.
- [x] Existing mobile string path (regular option taps) unchanged.
- [ ] Maestro flow covers the Other → freeform send-path (optional per issue — deferred; mock-server fixture would need a new trigger-phrase branch in `mock-server.mjs`).

## Test plan

- [x] `packages/app/src/components/__tests__/MessageBubble.otherFreeform.test.tsx` (new, 5 tests): freetext input appears after Other tap; Send button + Enter (onSubmitEditing) both emit the `{otherLabel, freeformText}` object shape; custom Other-option labels (model-supplied) are preserved on the wire; regular option taps still emit the legacy string payload.
- [x] `packages/app/src/__tests__/store/connection.test.ts` (4 new tests in a new `sendUserQuestionResponse Other / freeform shape (#4755)` describe block): wire payload pinning for the freeform shape; custom-label preservation; legacy string shape back-compat (asserts `freeformText` is absent); optional `toolUseId` omission.
- [x] Full app jest suite green: 1473 passed.
- [x] TypeScript clean across the changed files (pre-existing missing-module noise from `expo-*` deps in unrelated files only).
- [ ] Dogfood: trigger a real `AskUserQuestion` with an Other option on the mobile app, pick Other, type a freeform answer, confirm claude TUI receives it without wedge (server side already covered by PR #4753 server tests).