### PR TITLE
refactor(server): make writeFileRestricted atomic (write-temp + rename)

### DIFF
--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -1,4 +1,4 @@
-import { writeFileSync, chmodSync } from 'fs'
+import { writeFileSync, chmodSync, renameSync } from 'fs'
 
 export const isWindows = process.platform === 'win32'
 export const isMac = process.platform === 'darwin'
@@ -9,12 +9,29 @@ export function defaultShell() {
   return process.env.SHELL || '/bin/zsh'
 }
 
+/**
+ * Write `data` to `filePath` atomically on POSIX (write to `<path>.tmp`
+ * then `rename` over the target). `rename` is atomic on the same
+ * filesystem, so a concurrent reader sees either the previous version
+ * or the new one — never a half-written file. This matters when the
+ * process is killed mid-write (SIGKILL / OOM); it is the file-level
+ * analogue of the "SIGTERM not SIGKILL for Chroxy" memory note. See
+ * #4850, which surfaced this gap for `connection.json` (pre-existing)
+ * and `device-preferences.json` (added in #4847).
+ *
+ * On Windows we keep the direct `writeFileSync` path — `rename`
+ * semantics differ (it fails when the destination exists unless you
+ * use `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`) and there is no ACL
+ * machinery here that needs the atomic guarantee yet.
+ */
 export function writeFileRestricted(filePath, data) {
   if (isWindows) {
     writeFileSync(filePath, data)
   } else {
-    writeFileSync(filePath, data, { mode: 0o600 })
-    chmodSync(filePath, 0o600)
+    const tmpPath = `${filePath}.tmp`
+    writeFileSync(tmpPath, data, { mode: 0o600 })
+    chmodSync(tmpPath, 0o600)
+    renameSync(tmpPath, filePath)
   }
 }
 

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -1,9 +1,13 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, readFileSync, rmSync, statSync } from 'fs'
-import { join } from 'path'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, statSync, existsSync } from 'fs'
+import { join, resolve } from 'path'
 import { tmpdir } from 'os'
+import { fileURLToPath } from 'node:url'
 import { defaultShell, writeFileRestricted, forceKill, isWindows } from '../src/platform.js'
+
+const PLATFORM_JS = resolve(fileURLToPath(import.meta.url), '../../src/platform.js')
 
 describe('platform', () => {
   describe('isWindows', () => {
@@ -49,6 +53,95 @@ describe('platform', () => {
     if (!isWindows) {
       it('sets 0o600 permissions on Unix', () => {
         const filePath = join(tmpDir, 'restricted.txt')
+        writeFileRestricted(filePath, 'secret')
+        const mode = statSync(filePath).mode & 0o777
+        assert.strictEqual(mode, 0o600)
+      })
+
+      it('writes atomically via <path>.tmp + rename — leaves original intact when rename fails (#4850)', () => {
+        // Simulates the process being killed (SIGKILL / OOM) between the
+        // tmp-write and the rename. The contract is: readers never see a
+        // half-written `filePath` — they see either the previous version
+        // (this test) or the new one. The `.tmp` leftover is acceptable;
+        // a subsequent successful write will overwrite it.
+        //
+        // We run the actual write in a subprocess because monkey-patching
+        // `fs.renameSync` in-process doesn't propagate to `platform.js`'s
+        // already-snapshotted ESM-from-CJS import binding (the same
+        // reason `_setup.mjs` MUST run via `--import` to install the
+        // sandbox guard before any other module loads `node:fs`). The
+        // subprocess loads a tiny patch shim FIRST via `--import`, then
+        // imports `platform.js` fresh, then calls `writeFileRestricted`
+        // and exits non-zero so the parent can assert against the
+        // post-crash filesystem state.
+        const filePath = join(tmpDir, 'connection.json')
+        writeFileRestricted(filePath, JSON.stringify({ generation: 1 }))
+
+        const shim = join(tmpDir, 'throw-on-rename.mjs')
+        const runner = join(tmpDir, 'runner.mjs')
+        const shimSrc = `
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+const fs = require('node:fs')
+const orig = fs.renameSync
+fs.renameSync = (oldPath, newPath) => {
+  if (newPath === ${JSON.stringify(filePath)}) {
+    const err = new Error('simulated mid-write crash')
+    err.code = 'EIO'
+    throw err
+  }
+  return orig.call(this, oldPath, newPath)
+}
+`
+        const runnerSrc = `
+import { writeFileRestricted } from ${JSON.stringify(PLATFORM_JS)}
+try {
+  writeFileRestricted(${JSON.stringify(filePath)}, ${JSON.stringify(JSON.stringify({ generation: 2 }))})
+  process.exit(0)
+} catch (err) {
+  process.stderr.write(err.message)
+  process.exit(2)
+}
+`
+        // Use the same writeFileRestricted to write the shim (atomic
+        // already, which is fine — we're seeding fixtures, not testing
+        // the seeding).
+        writeFileRestricted(shim, shimSrc)
+        writeFileRestricted(runner, runnerSrc)
+
+        const result = spawnSync(process.execPath, ['--import', shim, runner], { encoding: 'utf-8' })
+        assert.strictEqual(result.status, 2, `expected non-zero exit; stderr=${result.stderr}`)
+        assert.match(result.stderr, /simulated mid-write crash/)
+
+        // Original file untouched — still version 1, intact JSON.
+        const after = readFileSync(filePath, 'utf-8')
+        assert.strictEqual(after, JSON.stringify({ generation: 1 }))
+        const parsed = JSON.parse(after) // would throw if half-written
+        assert.strictEqual(parsed.generation, 1)
+
+        // The .tmp sidecar was created (proves we went through the
+        // atomic write path) and contains the new content. Production
+        // readers ignore the `.tmp` suffix — `connection-info.js` and
+        // `device-preferences.js` only read the target path.
+        const tmpPath = `${filePath}.tmp`
+        assert.strictEqual(existsSync(tmpPath), true)
+        assert.strictEqual(readFileSync(tmpPath, 'utf-8'), JSON.stringify({ generation: 2 }))
+      })
+
+      it('cleans up the .tmp sidecar on successful write (#4850)', () => {
+        // Once `rename` succeeds the `.tmp` is gone (it WAS the temp,
+        // now renamed onto the target). A leftover `.tmp` would mean we
+        // were writing to the wrong path.
+        const filePath = join(tmpDir, 'device-preferences.json')
+        writeFileRestricted(filePath, 'final')
+        assert.strictEqual(readFileSync(filePath, 'utf-8'), 'final')
+        assert.strictEqual(existsSync(`${filePath}.tmp`), false)
+      })
+
+      it('preserves 0o600 on the renamed target (#4850)', () => {
+        // chmod applies to the tmp before rename; the perms must
+        // survive the rename onto the final path.
+        const filePath = join(tmpDir, 'sensitive.json')
         writeFileRestricted(filePath, 'secret')
         const mode = statSync(filePath).mode & 0o777
         assert.strictEqual(mode, 0o600)


### PR DESCRIPTION
Closes #4850

## Summary

`platform.writeFileRestricted` previously did `writeFileSync` then `chmodSync` on the target path. If the process was killed mid-write (SIGKILL / OOM, the file-level analogue of the *"SIGTERM not SIGKILL for Chroxy"* memory note), readers could see a truncated file.

Switched to the standard atomic-write idiom on POSIX:

```js
writeFileSync(`${filePath}.tmp`, data, { mode: 0o600 })
chmodSync(`${filePath}.tmp`, 0o600)
renameSync(`${filePath}.tmp`, filePath)
```

`rename(2)` is atomic on the same filesystem, so readers see either the previous version or the new one — never a half-written file. Windows keeps the direct `writeFileSync` path; rename semantics differ there and no caller needs the guarantee yet.

## Behaviour

- `connection.json` (connection-info.js) — pre-existing risk now closed.
- `device-preferences.json` (device-preferences.js, added in #4847) — closed too.
- All other `writeFileRestricted` callers (models cache, push tokens, checkpoints, permission hooks, session-state persistence, environment manager, service state) automatically inherit the atomic guarantee without code changes.
- Sandbox guard in `tests/_setup.mjs` is unaffected — it already patches both `writeFileSync` and `renameSync`, and the `.tmp` path lives under the same protected root as the target, so any test that tries to escape to real `~/.chroxy/` still trips loudly.

## Test plan

- [x] Unit: `writes atomically via <path>.tmp + rename — leaves original intact when rename fails (#4850)` — runs the actual write in a subprocess with a `--import` shim that throws from `renameSync`, then asserts the original file is unchanged and the `.tmp` sidecar contains the new content. Subprocess is needed because ESM-from-CJS named imports snapshot at link time; in-process monkey-patches don't propagate (the same constraint that forces `_setup.mjs` to run via `--import`).
- [x] Unit: `cleans up the .tmp sidecar on successful write (#4850)` — happy path; verifies the `.tmp` is gone after a successful rename.
- [x] Unit: `preserves 0o600 on the renamed target (#4850)` — confirms chmod applied to the tmp survives the rename onto the final path.
- [x] All `packages/server/tests/platform.test.js`, `tests/connection-info.test.js`, `tests/device-preferences.test.js`, `tests/models-factory.test.js` pass locally (80/80).
- [x] All 3 lint scripts pass (`lint-logger-session-scoping.sh`, `lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`).