### PR TITLE
feat(server): native drive of >9-option AskUserQuestion via arrow-key nav

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2548,34 +2548,35 @@ export class ClaudeTuiSession extends BaseSession {
       let writeText = text
       if (Array.isArray(options) && options.length > 0) {
         const matchIdx = options.findIndex((o) => o && o.label === text)
-        // #4292 + #4746: single-digit guard (1..9). Multi-digit hotkeys
-        // (10+) are NOT assumed to work on claude TUI's prompt — most
-        // single-keystroke menus commit on the first digit and the second
-        // char would either be a spurious next-prompt input or get
-        // dropped. Pre-#4746 the driver fell through to writing the
-        // label text verbatim when the picked label landed at idx >= 9
-        // (silent-drop path): claude TUI's prompt parser single-
-        // character-jump-navigated through the menu and landed on
-        // whichever option's label started with the same first character
-        // (#4288 jump-nav footgun), NOT necessarily the option the user
-        // picked. No error fired. The multi-question path solved this
-        // in #4625 by surfacing a structured ASK_USER_QUESTION_TOO_MANY_OPTIONS
-        // error before any PTY write; #4746 mirrors that fix for the
-        // single-question path so the same dashboard toast prompts the
-        // user to re-prompt the agent with fewer options. Scoped to
-        // MATCHED picks at idx >= 9 only — an unmatched label still
-        // falls through to the label-text path so the Other / freeform
-        // back-compat case (old clients without `freeformText`) is
-        // preserved.
+        // #4292 + #4746 + #4848: single-digit hotkey covers indices 0..8.
+        // For matched picks at idx >= 9 we drive the form via arrow-key
+        // navigation instead of the hotkey alphabet — Down arrow (`\x1b[B`)
+        // N times moves the cursor from the top option (idx 0) to the
+        // target idx, and Enter (`\r`) commits the highlighted option
+        // (#4848). Pre-#4848 this path tore the turn down with a
+        // structured ASK_USER_QUESTION_TOO_MANY_OPTIONS error (#4746)
+        // because the empirical multi-digit keystroke for option 10+
+        // was unrecorded; arrow-key navigation was always one of the two
+        // candidate paths the recorder script (scripts/tui-form-recorder.mjs)
+        // called out and is the more conservative bet (single-keystroke
+        // menus that auto-commit on the first digit can't be driven via
+        // multi-digit chord like '1','0'; arrow keys are the standard
+        // claude TUI navigation primitive used elsewhere in its form
+        // pickers). The recorder script's authoritative note is preserved
+        // as the open assumption — re-run the recorder pass against a
+        // 10+ option AskUserQuestion to confirm arrow nav is the right
+        // path; if not, switch to whichever empirical sequence pins.
+        //
+        // Scoped to MATCHED picks at idx >= 9. An unmatched label still
+        // falls through to typing the literal text (the v0.9.3 / pre-#4292
+        // path) so the Other / freeform back-compat case is preserved.
         if (matchIdx >= 9) {
           const total = options.length
-          log.warn(`AskUserQuestion single-question: question has ${total} options and the user picked option ${matchIdx + 1} ("${(text || '').slice(0, 40)}") which is outside claude TUI's 1..9 hotkey alphabet — surfacing ASK_USER_QUESTION_TOO_MANY_OPTIONS instead of silently falling through to label-text typing (#4288 jump-nav footgun) (tool=${prevToolUseId || '?'})`)
-          this._teardownAskUserQuestion(prevToolUseId, {
-            synthResult: `AskUserQuestion failed: question has ${total} options and you picked option ${matchIdx + 1}, beyond the 9 the claude TUI form can drive (#4746).`,
-            emitResultReason: 'ask_user_question_too_many_options',
-            errorCode: 'ASK_USER_QUESTION_TOO_MANY_OPTIONS',
-            errorMessage: `Couldn't answer: a question has ${total} options and you picked option ${matchIdx + 1}, which is beyond the 9 the claude TUI form can drive. Re-prompt the agent to ask with 9 or fewer options.`,
+          log.info(`AskUserQuestion single-question: question has ${total} options and the user picked option ${matchIdx + 1} ("${(text || '').slice(0, 40)}") — driving via arrow-key navigation (#4848) (tool=${prevToolUseId || '?'})`)
+          this._writePtyArrowNavSequence(matchIdx).catch((err) => {
+            log.warn(`respondToQuestion arrow-nav PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
           })
+          armWatchdog()
           return
         }
         if (matchIdx >= 0 && matchIdx < 9) {
@@ -2602,60 +2603,64 @@ export class ClaudeTuiSession extends BaseSession {
       log.warn(`AskUserQuestion multi-question: dashboard didn't send answersMap (tool=${prevToolUseId || '?'}, questions=${questions.length}) — defaulting every question to option 1. Update the client to populate the per-question answers map.`)
     }
 
-    // #4625 — claude TUI's hotkey alphabet is single-digit '1'..'9' only,
-    // which covers options at indices 0..8. When a question has 10+ options
+    // #4625 + #4848 — claude TUI's single-digit hotkey alphabet ('1'..'9')
+    // covers options at indices 0..8 only. When a question has 10+ options
     // AND the user explicitly picked one at index ≥ 9, we have no
-    // representable keystroke. Pre-#4625 the driver silently defaulted
-    // such picks to option 1 (with only a buried WARN in chroxy.log),
-    // dropping the user's explicit pick without UI feedback. Detect the
-    // condition up-front and surface a structured
-    // ASK_USER_QUESTION_TOO_MANY_OPTIONS error so the dashboard can
-    // render a toast prompting the user to re-prompt the agent for fewer
-    // options. Bails BEFORE any PTY write so the form stays in its
-    // initial state — claude TUI's watchdog or the user's Ctrl-C unsticks
-    // it. We deliberately scope the check to explicit user picks: a
-    // 10+ option question with no per-question answer still falls back
-    // to option 1 (back-compat for old clients), which is acceptable
-    // because nothing was silently dropped.
+    // representable digit keystroke. Pre-#4625 the driver silently
+    // defaulted such picks to option 1; #4625 surfaced a structured
+    // ASK_USER_QUESTION_TOO_MANY_OPTIONS error before any PTY write so
+    // the dashboard could prompt for a re-ask. #4848 splits this by
+    // question kind:
+    //   - single-select questions with an explicit pick at idx >= 9:
+    //     driven natively via arrow-key navigation in the assembled
+    //     sequence below (each Down arrow lands the cursor on the next
+    //     option, Enter commits + advances to the next question — same
+    //     mechanism the single-question path now uses).
+    //   - multi-select questions with a toggle at idx >= 9: KEEP the
+    //     structured ASK_USER_QUESTION_TOO_MANY_OPTIONS error. multi-
+    //     select form navigation (arrow + Space to toggle + return-to-
+    //     start) is empirically unrecorded; mixing arrow nav with the
+    //     digit hotkeys for in-range toggles in the same question would
+    //     leave the cursor in an unknown state without a tested return-
+    //     to-anchor primitive. Reserve the too-many error for this case.
+    //
+    // Bail BEFORE any PTY write so the form stays in its initial state
+    // when the error fires (claude TUI's watchdog or the user's Ctrl-C
+    // unsticks it). 10+ option questions with no per-question answer
+    // still fall back to option 1 (back-compat for old clients).
     if (haveMap) {
-      const unrepresentable = []
+      const unrepresentableMultiSelect = []
       for (const q of questions) {
         const opts = Array.isArray(q.options) ? q.options : []
         if (opts.length <= 9) continue
+        if (!q.multiSelect) continue // single-select 10+ now driven via arrow nav
         const raw = map[q.question]
-        // Gather every label the user picked for this question (single- or
-        // multi-select). MUST mirror resolveQuestionDigits' multi-select
-        // parsing — array → JSON-encoded array → comma-joined list — so
-        // an unrepresentable pick sent via the comma-joined fallback
+        // Gather every label the user toggled for this multi-select.
+        // MUST mirror resolveQuestionDigits' multi-select parsing —
+        // array → JSON-encoded array → comma-joined list — so an
+        // unrepresentable toggle sent via the comma-joined fallback
         // (e.g. "a,k") isn't accidentally treated as a single 3-char
-        // label and missed (Copilot review feedback). For single-select
-        // we don't split on comma because option labels may legitimately
-        // contain commas; the multi-select code path is the only one
-        // that defined comma-joining as a wire encoding.
+        // label and missed (Copilot review feedback on #4625).
         let labels = []
         if (Array.isArray(raw)) {
           labels = raw.filter((s) => typeof s === 'string')
         } else if (typeof raw === 'string' && raw.length > 0) {
-          if (q.multiSelect) {
-            let parsed = null
-            try { parsed = JSON.parse(raw) } catch { parsed = null }
-            if (Array.isArray(parsed)) {
-              labels = parsed.filter((s) => typeof s === 'string')
-            } else {
-              labels = raw.split(',').map((s) => s.trim()).filter(Boolean)
-            }
+          let parsed = null
+          try { parsed = JSON.parse(raw) } catch { parsed = null }
+          if (Array.isArray(parsed)) {
+            labels = parsed.filter((s) => typeof s === 'string')
           } else {
-            labels = [raw]
+            labels = raw.split(',').map((s) => s.trim()).filter(Boolean)
           }
         }
         for (const label of labels) {
           const idx = opts.findIndex((o) => o && o.label === label)
-          if (idx >= 9) unrepresentable.push({ question: q.question, label, index: idx, total: opts.length })
+          if (idx >= 9) unrepresentableMultiSelect.push({ question: q.question, label, index: idx, total: opts.length })
         }
       }
-      if (unrepresentable.length > 0) {
-        const first = unrepresentable[0]
-        log.warn(`AskUserQuestion multi-question: question has ${first.total} options and the user picked option ${first.index + 1} ("${(first.label || '').slice(0, 40)}") which is outside claude TUI's 1..9 hotkey alphabet — surfacing ASK_USER_QUESTION_TOO_MANY_OPTIONS instead of silently defaulting to option 1 (tool=${prevToolUseId || '?'})`)
+      if (unrepresentableMultiSelect.length > 0) {
+        const first = unrepresentableMultiSelect[0]
+        log.warn(`AskUserQuestion multi-question: multi-select question has ${first.total} options and the user toggled option ${first.index + 1} ("${(first.label || '').slice(0, 40)}") which is outside claude TUI's 1..9 hotkey alphabet AND beyond the arrow-nav single-select fallback (#4848 deliberately scopes arrow-nav to single-select only) — surfacing ASK_USER_QUESTION_TOO_MANY_OPTIONS (tool=${prevToolUseId || '?'})`)
         // Full AskUserQuestion teardown: synth tool_result + Ctrl-C the
         // TUI + clear inactivity timers + stream_end + _emitResult +
         // error (in that order). Without the full teardown the dashboard
@@ -2664,10 +2669,10 @@ export class ClaudeTuiSession extends BaseSession {
         // chroxy gave up before writing any keystrokes (#4625 hands the
         // form's resolution back to the user via the error toast).
         this._teardownAskUserQuestion(prevToolUseId, {
-          synthResult: `AskUserQuestion failed: question has ${first.total} options and you picked option ${first.index + 1}, beyond the 9 the claude TUI form can drive (#4625).`,
+          synthResult: `AskUserQuestion failed: multi-select question has ${first.total} options and you toggled option ${first.index + 1}, beyond the 9 the claude TUI multi-select form can drive (#4848).`,
           emitResultReason: 'ask_user_question_too_many_options',
           errorCode: 'ASK_USER_QUESTION_TOO_MANY_OPTIONS',
-          errorMessage: `Couldn't answer: a question has ${first.total} options and you picked option ${first.index + 1}, which is beyond the 9 the claude TUI form can drive. Re-prompt the agent to ask with 9 or fewer options.`,
+          errorMessage: `Couldn't answer: a multi-select question has ${first.total} options and you toggled option ${first.index + 1}, which is beyond the 9 the claude TUI form can drive for multi-select. Re-prompt the agent to ask with 9 or fewer options for that question.`,
         })
         return
       }
@@ -2681,8 +2686,16 @@ export class ClaudeTuiSession extends BaseSession {
       return null
     }
 
-    /** Resolve a single question's answer entry to an array of digits to write. */
-    const resolveQuestionDigits = (q, rawAnswer) => {
+    /**
+     * Resolve a single question's answer entry to an array of keystroke
+     * tokens to write. Tokens are arbitrary-length strings — usually a
+     * single digit ('1'..'9') or Tab/Enter, but for #4848 a single-select
+     * answer at idx >= 9 expands to a multi-token arrow-nav sequence
+     * (`'\x1b[B'` × idx + `'\r'`). The writer (`_writePtyMultiQuestionSequence`)
+     * doesn't care about token length — it writes each entry as one
+     * `term.write` call with a throttle pause after.
+     */
+    const resolveQuestionKeystrokes = (q, rawAnswer) => {
       const opts = Array.isArray(q.options) ? q.options : []
       const defaultDigit = opts.length > 0 ? '1' : null
 
@@ -2712,6 +2725,10 @@ export class ClaudeTuiSession extends BaseSession {
         for (const label of labels) {
           const d = labelToDigit(q, label)
           if (d) digits.push(d)
+          // Multi-select 10+ toggles already pre-screened above and
+          // surfaced as ASK_USER_QUESTION_TOO_MANY_OPTIONS — anything
+          // unrepresentable here means the dashboard sent something we
+          // couldn't match (defaulted handling below).
         }
         if (digits.length === 0 && defaultDigit) {
           log.warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (multi-select) — defaulting to option 1`)
@@ -2720,13 +2737,32 @@ export class ClaudeTuiSession extends BaseSession {
         return digits
       }
 
-      // single-select — exactly one digit
+      // single-select — exactly one keystroke token.
+      let pickedLabel = null
       if (typeof rawAnswer === 'string' && rawAnswer.length > 0) {
-        const d = labelToDigit(q, rawAnswer)
-        if (d) return [d]
+        pickedLabel = rawAnswer
       } else if (Array.isArray(rawAnswer) && typeof rawAnswer[0] === 'string') {
-        const d = labelToDigit(q, rawAnswer[0])
-        if (d) return [d]
+        pickedLabel = rawAnswer[0]
+      }
+      if (pickedLabel !== null) {
+        const idx = opts.findIndex((o) => o && o.label === pickedLabel)
+        if (idx >= 0 && idx < 9) return [String(idx + 1)]
+        if (idx >= 9) {
+          // #4848 — option at idx >= 9 in a single-select question.
+          // Drive via arrow-key navigation: idx Down arrows from the
+          // top option (cursor starts at idx 0) followed by Enter to
+          // commit + advance to the next question. The arrow sequence
+          // and the Enter are emitted as two distinct keystroke tokens
+          // so the throttle pauses BETWEEN them (claude TUI's paste
+          // detector treats a single 11-byte burst as a paste). Each
+          // arrow is 3 bytes ('\x1b[B'); 10 arrows = 30 bytes is still
+          // well under any reasonable paste threshold, but stay safe.
+          log.info(`AskUserQuestion multi-question: single-select pick at idx=${idx} (option ${idx + 1}) in q="${(q.question || '').slice(0, 40)}" → arrow-nav (#4848)`)
+          const tokens = []
+          for (let i = 0; i < idx; i++) tokens.push('\x1b[B')
+          tokens.push('\r')
+          return tokens
+        }
       }
       if (defaultDigit) {
         if (haveMap) log.warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (single-select) — defaulting to option 1`)
@@ -2740,11 +2776,12 @@ export class ClaudeTuiSession extends BaseSession {
     const sequence = []
     for (const q of questions) {
       const rawAnswer = map[q.question]
-      const digits = resolveQuestionDigits(q, rawAnswer)
-      for (const d of digits) sequence.push(d)
+      const keystrokes = resolveQuestionKeystrokes(q, rawAnswer)
+      for (const k of keystrokes) sequence.push(k)
       if (q.multiSelect) {
         // Multi-select needs an explicit advance keystroke; single-select
-        // auto-advances on digit (verified empirically).
+        // auto-advances on digit OR on Enter after arrow-nav (verified
+        // empirically for digit; arrow-nav variant pinned by #4848).
         sequence.push('\t')
       }
     }
@@ -2785,6 +2822,54 @@ export class ClaudeTuiSession extends BaseSession {
           await new Promise((resolve) => setTimeout(resolve, ClaudeTuiSession.PROMPT_CHAR_DELAY_MS))
         }
       }
+      return true
+    } finally {
+      try { this._term.write('\x1b[?2004h') } catch {}
+    }
+  }
+
+  /**
+   * Write an arrow-key navigation sequence for the single-question
+   * AskUserQuestion form when the user picked an option beyond the
+   * single-digit hotkey range (idx >= 9). Emits `targetIdx` Down arrow
+   * keystrokes (`\x1b[B`, 3 bytes each) — claude TUI's form cursor
+   * starts at idx 0, so `targetIdx` downs land on the picked option —
+   * followed by Enter (`\r`) to commit (#4848).
+   *
+   * Wrapped in bracketed-paste-disable / re-enable exactly once (same
+   * defense as _writePtyTextThrottled and _writePtyMultiQuestionSequence)
+   * and each keystroke is throttled by PROMPT_CHAR_DELAY_MS so claude TUI's
+   * paste detector doesn't reject the burst. Each arrow is one
+   * `_term.write` call (3 bytes); the throttle pauses BETWEEN tokens so
+   * the cumulative arrival rate stays well under any reasonable paste
+   * threshold.
+   *
+   * **Open assumption (#4848):** the empirical recorder pass against a
+   * 10+ option AskUserQuestion was not run before this PR — arrow-key
+   * navigation is the conservative bet (recorder script
+   * scripts/tui-form-recorder.mjs called it out as the most likely
+   * working path; multi-digit chord '1','0' was ruled out because the
+   * digit hotkey auto-commits on the first keystroke). Re-run the
+   * recorder against a 12-option AskUserQuestion and pick option 11 to
+   * confirm; if the working sequence differs, replace this writer.
+   *
+   * @param {number} targetIdx — 0-indexed option to land on
+   * @returns {Promise<boolean>} true if completed, false if PTY aborted mid-write
+   */
+  async _writePtyArrowNavSequence(targetIdx) {
+    if (!this._term) return false
+    if (typeof targetIdx !== 'number' || targetIdx < 0) return false
+    this._term.write('\x1b[?2004l')
+    try {
+      for (let i = 0; i < targetIdx; i++) {
+        if (this._activeTurn?.aborted || this._ptyExited) return false
+        this._term.write('\x1b[B')
+        if (ClaudeTuiSession.PROMPT_CHAR_DELAY_MS > 0) {
+          await new Promise((resolve) => setTimeout(resolve, ClaudeTuiSession.PROMPT_CHAR_DELAY_MS))
+        }
+      }
+      if (this._activeTurn?.aborted || this._ptyExited) return false
+      this._term.write('\r')
       return true
     } finally {
       try { this._term.write('\x1b[?2004h') } catch {}

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2636,7 +2636,7 @@ export class ClaudeTuiSession extends BaseSession {
         if (!q.multiSelect) continue // single-select 10+ now driven via arrow nav
         const raw = map[q.question]
         // Gather every label the user toggled for this multi-select.
-        // MUST mirror resolveQuestionDigits' multi-select parsing —
+        // MUST mirror resolveQuestionKeystrokes' multi-select parsing —
         // array → JSON-encoded array → comma-joined list — so an
         // unrepresentable toggle sent via the comma-joined fallback
         // (e.g. "a,k") isn't accidentally treated as a single 3-char
@@ -2837,12 +2837,14 @@ export class ClaudeTuiSession extends BaseSession {
    * followed by Enter (`\r`) to commit (#4848).
    *
    * Wrapped in bracketed-paste-disable / re-enable exactly once (same
-   * defense as _writePtyTextThrottled and _writePtyMultiQuestionSequence)
-   * and each keystroke is throttled by PROMPT_CHAR_DELAY_MS so claude TUI's
-   * paste detector doesn't reject the burst. Each arrow is one
-   * `_term.write` call (3 bytes); the throttle pauses BETWEEN tokens so
-   * the cumulative arrival rate stays well under any reasonable paste
-   * threshold.
+   * defense as _writePtyTextThrottled and _writePtyMultiQuestionSequence).
+   * A PROMPT_CHAR_DELAY_MS pause runs BETWEEN each Down-arrow write so
+   * claude TUI's paste detector doesn't reject the burst. The trailing
+   * Enter (`\r`) and the bracketed-paste re-enable write fire
+   * immediately after the final delay — no extra pause separates them
+   * from the last arrow (the arrival rate at that point is already well
+   * under any reasonable paste threshold). Each arrow is one `_term.write`
+   * call (3 bytes); 10 arrows ≈ 30 bytes total form-byte payload.
    *
    * **Open assumption (#4848):** the empirical recorder pass against a
    * 10+ option AskUserQuestion was not run before this PR — arrow-key

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3078,35 +3078,58 @@ describe('ClaudeTuiSession', () => {
       }
     })
 
-    it('respondToQuestion surfaces ASK_USER_QUESTION_TOO_MANY_OPTIONS when matchIdx >= 9 (#4746)', async () => {
+    it('respondToQuestion drives matchIdx >= 9 via arrow-key navigation (#4848)', async () => {
       // #4292 originally fell through to writing the label text verbatim
       // when matchIdx >= 9, which #4288 showed lands on whichever option's
       // label starts with the same first character (jump-nav footgun).
-      // #4746 replaces the silent label-text fallback with the same
-      // structured ASK_USER_QUESTION_TOO_MANY_OPTIONS error the multi-
-      // question path emits (see #4625) so the dashboard can render a
-      // toast asking the user to re-prompt with fewer options.
+      // #4746 replaced the silent label-text fallback with a structured
+      // ASK_USER_QUESTION_TOO_MANY_OPTIONS error. #4848 takes the
+      // remaining step: drive the form natively via arrow-key navigation
+      // (Down arrow × matchIdx + Enter) so the user's explicit pick of
+      // option 10/11/12 actually lands on the right option instead of
+      // tearing the turn down.
       const writes = []
       session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
       session._isBusy = true
-      session._currentMessageId = 'msg-toomany'
-      session._activeTurn = { uuid: 'turn-toomany', synthSeq: 0, startedAt: Date.now() }
+      session._currentMessageId = 'msg-arrownav'
+      session._activeTurn = { uuid: 'turn-arrownav', synthSeq: 0, startedAt: Date.now() }
       const options = Array.from({ length: 12 }, (_, i) => ({ label: `opt-${i}` }))
-      session._pendingUserAnswer = { toolUseId: 'toolu-10', options }
+      session._pendingUserAnswer = { toolUseId: 'toolu-arrownav', options }
 
       const errors = []
       session.on('error', (e) => errors.push(e))
 
-      // opt-9 is index 9 → unrepresentable in claude TUI's 1..9 hotkey alphabet.
+      // opt-9 is index 9 → drive via 9 Down arrows + Enter.
       session.respondToQuestion('opt-9')
       await new Promise((resolve) => setTimeout(resolve, 50))
 
-      // No label-text writes — only the teardown Ctrl-C is present.
-      assert.deepEqual(writes, ['\x03'],
-        `expected only Ctrl-C teardown write, got ${JSON.stringify(writes)}`)
-      assert.equal(errors.length, 1, 'one error emitted')
-      assert.equal(errors[0].code, 'ASK_USER_QUESTION_TOO_MANY_OPTIONS')
-      assert.equal(errors[0].toolUseId, 'toolu-10')
+      // No too-many error — arrow-nav drives the form natively.
+      assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
+      // disable + 9× Down arrow + Enter + enable.
+      const expected = ['\x1b[?2004l', ...Array(9).fill('\x1b[B'), '\r', '\x1b[?2004h']
+      assert.deepEqual(writes, expected,
+        `expected 9× Down + Enter sequence, got ${JSON.stringify(writes)}`)
+    })
+
+    // #4848 boundary: opt-11 (idx 11) in a 12-option question — pin the
+    // larger-N arrow-nav case so the loop count tracks idx exactly.
+    it('respondToQuestion drives matchIdx=11 via 11× Down + Enter (#4848 boundary)', async () => {
+      const writes = []
+      session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+      const options = Array.from({ length: 12 }, (_, i) => ({ label: `opt-${i}` }))
+      session._pendingUserAnswer = { toolUseId: 'toolu-arrownav-11', options }
+
+      const errors = []
+      session.on('error', (e) => errors.push(e))
+
+      // opt-11 is the LAST option (idx 11) → 11 Down arrows + Enter.
+      session.respondToQuestion('opt-11')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
+      const expected = ['\x1b[?2004l', ...Array(11).fill('\x1b[B'), '\r', '\x1b[?2004h']
+      assert.deepEqual(writes, expected,
+        `expected 11× Down + Enter sequence, got ${JSON.stringify(writes)}`)
     })
 
     it('respondToQuestion writes the text when options array is missing or empty (free-text-only AskUserQuestion)', async () => {
@@ -4544,22 +4567,16 @@ describe('ClaudeTuiSession', () => {
     // dropped without any UI feedback. The fix surfaces a structured
     // error before any keystroke is written so the dashboard can prompt
     // the user to re-ask with fewer options.
-    describe('10+ option support (#4625)', () => {
-      // The 10-option case: user picked option 10 (index 9). The driver
-      // can't express index 9 in single-digit hotkey land, so it MUST
-      // emit ASK_USER_QUESTION_TOO_MANY_OPTIONS and tear down the turn
-      // instead of writing keystrokes that would silently land on option 1.
-      it('multi-question: pick of option 10+ surfaces ASK_USER_QUESTION_TOO_MANY_OPTIONS error + no PTY writes', async () => {
+    describe('10+ option support (#4625 + #4848)', () => {
+      // #4848 — single-select question with a 10+ option pick: drive
+      // natively via arrow-key navigation (Down arrow × idx + Enter)
+      // instead of bailing with the too-many error. Pre-#4848 this
+      // teardown fired (see #4625 history); the user's explicit pick of
+      // option 10+ would never reach claude TUI.
+      it('multi-question: single-select pick of option 10+ drives via arrow-nav (#4848)', async () => {
         const writes = []
-        // The teardown writes Ctrl-C ('\x03') to unstick the TUI form,
-        // matching _onAskUserQuestionStall. Captured so we can assert
-        // the form bytes are NOT written (driver bailed before any digit
-        // keystroke), and the Ctrl-C IS written (recoverable teardown).
         session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
-        session._isBusy = true
-        session._currentMessageId = 'msg_big'
-        session._activeTurn = { uuid: 'turn_big', synthSeq: 0, startedAt: Date.now() }
-        // Q1 has 12 options; user picked option 10 (label 'j').
+        // Q1 has 12 options; user picked option 10 (label 'j', idx 9).
         const tenPlusOptions = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l']
           .map((label) => ({ label }))
         const questions = [
@@ -4569,51 +4586,45 @@ describe('ClaudeTuiSession', () => {
         session._pendingUserAnswer = { toolUseId: 'toolu_big', questions, options: questions[0].options }
 
         const errors = []
-        const toolResults = []
-        const streamEnds = []
-        const results = []
         session.on('error', (e) => errors.push(e))
-        session.on('tool_result', (tr) => toolResults.push(tr))
-        session.on('stream_end', (se) => streamEnds.push(se))
-        session.on('result', (r) => results.push(r))
 
         session.respondToQuestion('', { 'Q1?': 'j', 'Q2?': 'x' })
-        await new Promise((resolve) => setTimeout(resolve, 50))
+        await new Promise((resolve) => setTimeout(resolve, 100))
 
-        // No FORM keystrokes written — bailed out before the PTY write
-        // path. The teardown's Ctrl-C ('\x03') IS expected so claude TUI
-        // unsticks from the form screen for the next turn.
-        assert.deepEqual(writes, ['\x03'],
-          `expected only Ctrl-C teardown write, got ${JSON.stringify(writes)}`)
+        // No too-many error — arrow nav drives the form.
+        assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
+        // Q1 → 9× Down + Enter (idx 9 nav), Q2 → '1' (single-digit), Submit → '1',
+        // wrapped in paste-disable/enable.
+        const expected = ['\x1b[?2004l', ...Array(9).fill('\x1b[B'), '\r', '1', '1', '\x1b[?2004h']
+        assert.deepEqual(writes, expected,
+          `expected arrow-nav + digits sequence, got ${JSON.stringify(writes)}`)
 
-        // Structured error surfaced so the dashboard can render a toast.
-        assert.equal(errors.length, 1, 'exactly one error emitted')
-        assert.equal(errors[0].code, 'ASK_USER_QUESTION_TOO_MANY_OPTIONS')
-        assert.equal(errors[0].toolUseId, 'toolu_big')
-        assert.match(errors[0].message, /option/i,
-          `error message mentions the option-count limitation, got ${errors[0].message}`)
+        // Pending cleared on the happy path.
+        assert.equal(session._pendingUserAnswer, null, 'pending cleared after answer write')
+      })
 
-        // Full teardown so the dashboard's Working banner + Stop button +
-        // activeTools entry all clear (mirrors _onAskUserQuestionStall).
-        assert.equal(toolResults.length, 1, 'synthetic tool_result for activeTools clear')
-        assert.equal(toolResults[0].toolUseId, 'toolu_big')
-        assert.equal(streamEnds.length, 1, 'stream_end emitted to clear streamingMessageId')
-        assert.equal(streamEnds[0].messageId, 'msg_big')
-        assert.equal(results.length, 1, '_emitResult fanned for agent_idle')
-        assert.equal(session._isBusy, false, '_isBusy cleared')
-        assert.equal(session._currentMessageId, null, '_currentMessageId cleared')
-        assert.equal(session._activeTurn, null, '_activeTurn cleared')
+      // #4848 boundary: option 30 in a 30-option single-select question.
+      // Pin the larger-N case to make sure the arrow count tracks idx exactly.
+      it('multi-question: single-select pick of option 30 (idx 29) drives via 29× Down + Enter (#4848)', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        const thirtyOptions = Array.from({ length: 30 }, (_, i) => ({ label: `o-${i}` }))
+        const questions = [
+          { question: 'Q1?', options: thirtyOptions },
+          { question: 'Q2?', options: [{ label: 'x' }, { label: 'y' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_30', questions, options: questions[0].options }
 
-        // Pending cleared so subsequent answers don't write into a
-        // resolved-but-now-torn-down turn.
-        assert.equal(session._pendingUserAnswer, null, 'pending cleared after too-many error')
+        const errors = []
+        session.on('error', (e) => errors.push(e))
 
-        // No stall watchdog armed — the error is the resolution.
-        assert.equal(session._askUserQuestionWatchdog, null, 'watchdog NOT armed (error is the resolution)')
+        session.respondToQuestion('', { 'Q1?': 'o-29', 'Q2?': 'y' })
+        await new Promise((resolve) => setTimeout(resolve, 200))
 
-        // WARN in chroxy.log so the wedge is greppable.
-        const warn = warnLines.find((m) => /AskUserQuestion multi-question: question has \d+ options/.test(m))
-        assert.ok(warn, `expected too-many-options WARN, got ${JSON.stringify(warnLines)}`)
+        assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
+        const expected = ['\x1b[?2004l', ...Array(29).fill('\x1b[B'), '\r', '2', '1', '\x1b[?2004h']
+        assert.deepEqual(writes, expected,
+          `expected 29× Down + Enter + Q2 digit + Submit, got ${JSON.stringify(writes)}`)
       })
 
       // Boundary: a 10-option question where the user picked option 9 (the
@@ -4745,79 +4756,59 @@ describe('ClaudeTuiSession', () => {
           `expected default-to-1 sequence even with 10+ options, got ${JSON.stringify(writes)}`)
       })
 
-      // #4746 — single-question parity with the multi-question fix above.
-      // Pre-#4746 the single-question path (questions.length <= 1) had the
-      // SAME limitation but a different failure mode: per the #4292 guard,
-      // a match at index >= 9 fell through to typing the label text
-      // verbatim. claude TUI's single-character jump-nav then landed on
-      // whichever option's label started with the same first character
-      // (#4288) — could be the picked option, could be any other option
-      // with a matching prefix. No error fired. The fix surfaces the same
-      // ASK_USER_QUESTION_TOO_MANY_OPTIONS error the multi-question path
-      // emits, with full teardown so the dashboard's Working banner clears.
-      it('single-question: pick of option 10+ surfaces ASK_USER_QUESTION_TOO_MANY_OPTIONS error + no PTY writes', async () => {
+      // #4848 — single-question pick of option 10+: drive natively via
+      // arrow-key navigation instead of the too-many teardown. Pre-#4848
+      // (#4746) this fired ASK_USER_QUESTION_TOO_MANY_OPTIONS with full
+      // turn teardown; #4848 takes the next step and actually drives the
+      // form by sending matchIdx Down arrows + Enter.
+      it('single-question: pick of option 10+ drives via arrow-nav (#4848)', async () => {
         const writes = []
-        // The teardown writes Ctrl-C ('\x03') to unstick the TUI form,
-        // matching _onAskUserQuestionStall. Assert form bytes are NOT
-        // written (driver bailed before any keystroke) and the Ctrl-C IS
-        // written (recoverable teardown).
         session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
-        session._isBusy = true
-        session._currentMessageId = 'msg_single_big'
-        session._activeTurn = { uuid: 'turn_single_big', synthSeq: 0, startedAt: Date.now() }
-        // Single question with 12 options; user picked option 11 ('k', index 10).
-        // Index 10 is unrepresentable in claude TUI's 1..9 hotkey alphabet.
+        // Single question with 12 options; user picked option 11 ('k', idx 10).
         const tenPlusOptions = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l']
           .map((label) => ({ label }))
         const questions = [{ question: 'Pick one?', options: tenPlusOptions }]
         session._pendingUserAnswer = { toolUseId: 'toolu_single_big', questions, options: tenPlusOptions }
 
         const errors = []
-        const toolResults = []
-        const streamEnds = []
-        const results = []
         session.on('error', (e) => errors.push(e))
-        session.on('tool_result', (tr) => toolResults.push(tr))
-        session.on('stream_end', (se) => streamEnds.push(se))
-        session.on('result', (r) => results.push(r))
 
-        // Single-question is text-driven (no answersMap) — user picked 'k'.
+        // Single-question is text-driven (no answersMap) — user picked 'k' (idx 10).
         session.respondToQuestion('k')
-        await new Promise((resolve) => setTimeout(resolve, 50))
+        await new Promise((resolve) => setTimeout(resolve, 100))
 
-        // No FORM keystrokes written — bailed out before the PTY write
-        // path. The teardown's Ctrl-C ('\x03') IS expected so claude TUI
-        // unsticks from the form screen for the next turn.
-        assert.deepEqual(writes, ['\x03'],
-          `expected only Ctrl-C teardown write, got ${JSON.stringify(writes)}`)
+        // No too-many error — arrow nav drives the form natively.
+        assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
+        // 10× Down arrow + Enter (cursor starts at idx 0, lands at idx 10),
+        // wrapped in paste-disable/enable.
+        const expected = ['\x1b[?2004l', ...Array(10).fill('\x1b[B'), '\r', '\x1b[?2004h']
+        assert.deepEqual(writes, expected,
+          `expected 10× Down + Enter sequence, got ${JSON.stringify(writes)}`)
 
-        // Structured error surfaced so the dashboard can render a toast.
-        assert.equal(errors.length, 1, 'exactly one error emitted')
-        assert.equal(errors[0].code, 'ASK_USER_QUESTION_TOO_MANY_OPTIONS')
-        assert.equal(errors[0].toolUseId, 'toolu_single_big')
-        assert.match(errors[0].message, /option/i,
-          `error message mentions the option-count limitation, got ${errors[0].message}`)
+        // Pending cleared on the happy path.
+        assert.equal(session._pendingUserAnswer, null, 'pending cleared after answer write')
+      })
 
-        // Full teardown so the dashboard's Working banner + Stop button +
-        // activeTools entry all clear (mirrors the multi-question case).
-        assert.equal(toolResults.length, 1, 'synthetic tool_result for activeTools clear')
-        assert.equal(toolResults[0].toolUseId, 'toolu_single_big')
-        assert.equal(streamEnds.length, 1, 'stream_end emitted to clear streamingMessageId')
-        assert.equal(streamEnds[0].messageId, 'msg_single_big')
-        assert.equal(results.length, 1, '_emitResult fanned for agent_idle')
-        assert.equal(session._isBusy, false, '_isBusy cleared')
-        assert.equal(session._currentMessageId, null, '_currentMessageId cleared')
-        assert.equal(session._activeTurn, null, '_activeTurn cleared')
+      // #4848 — single-question last option (idx N-1) in a 30-option
+      // prompt. Pin the larger-N case to make sure arrow count tracks
+      // idx exactly across larger forms.
+      it('single-question: last option in a 30-option question drives via 29× Down + Enter (#4848)', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        const thirtyOptions = Array.from({ length: 30 }, (_, i) => ({ label: `s-${i}` }))
+        const questions = [{ question: 'Pick one?', options: thirtyOptions }]
+        session._pendingUserAnswer = { toolUseId: 'toolu_single_30', questions, options: thirtyOptions }
 
-        // Pending cleared so a stale answer can't write into a torn-down turn.
-        assert.equal(session._pendingUserAnswer, null, 'pending cleared after too-many error')
+        const errors = []
+        session.on('error', (e) => errors.push(e))
 
-        // No stall watchdog armed — the error IS the resolution.
-        assert.equal(session._askUserQuestionWatchdog, null, 'watchdog NOT armed (error is the resolution)')
+        session.respondToQuestion('s-29')
+        await new Promise((resolve) => setTimeout(resolve, 200))
 
-        // WARN in chroxy.log so the wedge is greppable.
-        const warn = warnLines.find((m) => /AskUserQuestion single-question: question has \d+ options/.test(m))
-        assert.ok(warn, `expected too-many-options WARN, got ${JSON.stringify(warnLines)}`)
+        assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
+        const expected = ['\x1b[?2004l', ...Array(29).fill('\x1b[B'), '\r', '\x1b[?2004h']
+        assert.deepEqual(writes, expected,
+          `expected 29× Down + Enter sequence, got ${JSON.stringify(writes)}`)
       })
 
       // Boundary: a 10-option single-question where the user picked option 9

--- a/scripts/tui-form-recorder.mjs
+++ b/scripts/tui-form-recorder.mjs
@@ -23,26 +23,30 @@
  * Analysis: tail the JSONL file to find the keystroke patterns that
  * advance between questions, toggle multiSelect, and reach Submit.
  *
- * 10+ option questions (#4625):
+ * 10+ option questions (#4625 + #4848):
  *   The 2026-05-30 empirical recording only covered questions with ≤9
- *   options (single-digit hotkeys '1'..'9'). For questions with 10+
- *   options, two TUI keystroke paths are theoretically possible — neither
- *   has been verified live:
- *     - Arrow-key navigation: '\x1b[B' (down) N-1 times + '\r' (Enter)
- *       to commit. Risk: claude TUI's multi-question form layout may not
- *       accept arrow keys (no empirical recording exists).
- *     - Multi-digit hotkey (e.g. '10', '11'): the v0.9.x single-digit
- *       commit-on-keystroke behaviour pinned in #4292 makes this
- *       unlikely to work; the second digit would either be dropped or
- *       parsed as the next question's input.
- *   Until a recorder pass exists for either path, the chroxy driver
- *   (claude-tui-session.js) bails with ASK_USER_QUESTION_TOO_MANY_OPTIONS
- *   when the user picks an option at index ≥9 — the dashboard surfaces a
- *   toast asking the user to re-prompt with fewer options. To extend the
- *   driver, record a session against a 10+ option question and pick
- *   options 10, 11, etc. with whichever keystroke pattern works, then
- *   add the supported keys to the multi-question driver and remove the
- *   too-many-options guard.
+ *   options (single-digit hotkeys '1'..'9'). #4848 added native drive
+ *   for single-select 10+ option picks via arrow-key navigation:
+ *   '\x1b[B' (down) × matchIdx + '\r' (Enter) to commit. This is the
+ *   conservative bet of the two theoretically-possible paths (the
+ *   multi-digit hotkey path was ruled out — claude TUI's single-digit
+ *   commit-on-keystroke behaviour pinned in #4292 means a '1' would
+ *   commit option 1 before the '0' arrived).
+ *
+ *   **Open assumption (#4848):** the arrow-nav sequence is implemented
+ *   under the assumption it works against claude TUI's AskUserQuestion
+ *   form, but the empirical recorder pass against a 10+ option form
+ *   was NOT run before the PR landed. If the sequence misfires in
+ *   dogfood, re-run this recorder against a 12-option AskUserQuestion
+ *   form, pick option 11 manually with whichever keystroke works, and
+ *   replace `_writePtyArrowNavSequence` in claude-tui-session.js with
+ *   the empirically-pinned bytes.
+ *
+ *   Multi-select 10+ toggles STILL bail with ASK_USER_QUESTION_TOO_MANY_OPTIONS
+ *   because the multi-select arrow-nav pattern (arrow + Space toggle +
+ *   return-to-anchor) is more complex and was deliberately scoped out
+ *   of #4848 — record a multi-select form pick to extend driver
+ *   coverage there too.
  *
  * Exit:
  *   Ctrl+D — clean exit (closes recording file)


### PR DESCRIPTION
Closes #4848

## Summary

claude TUI's single-digit hotkey alphabet (`'1'..'9'`) only covers options at indices 0..8. Pre-this-PR, picking option 10+ tore the turn down with `ASK_USER_QUESTION_TOO_MANY_OPTIONS` (#4625 multi-question, #4746 single-question parity). This PR drives those picks natively via arrow-key navigation instead.

## What changed

- **Single-question (`respondToQuestion` text-driven path):** matched pick at `matchIdx >= 9` now writes `matchIdx` Down arrows + Enter via the new `_writePtyArrowNavSequence` helper. Unmatched labels still fall through to the freeform label-text path so the Other / freeform back-compat is preserved.
- **Multi-question (`respondToQuestion` answersMap path):** single-select questions with a pick at `idx >= 9` expand to a multi-token arrow-nav sequence inside the assembled keystroke array (Down arrow tokens + Enter), driven through the existing `_writePtyMultiQuestionSequence` writer with the per-token throttle keeping arrival rate under claude TUI's paste-detector threshold.
- **Multi-select toggles at `idx >= 9` KEEP `ASK_USER_QUESTION_TOO_MANY_OPTIONS`.** multi-select form navigation (arrow + Space toggle + return-to-anchor) is empirically unrecorded and mixing arrow nav with the digit hotkeys for in-range toggles in the same question would leave the cursor in an unknown state without a tested return-to-start primitive. The error scope narrows from "any 10+ option question" to "multi-select toggle at 10+ idx only".

## Recorder findings

The empirical recorder pass against a 12-option AskUserQuestion was **NOT** run before this PR — a worktree agent cannot drive the interactive TUI required for the recording. Implementation chose arrow-key navigation as the conservative bet based on the two theoretically-possible paths the recorder script itself called out:

| Path | Verdict | Reasoning |
|---|---|---|
| Arrow-nav: `\x1b[B` × N + `\r` | Implemented | Standard claude TUI nav primitive used elsewhere in its form pickers. The recorder script's authoritative comment (`scripts/tui-form-recorder.mjs` lines 26-37 pre-PR) called this out as the most likely working path. |
| Multi-digit chord: `'1','0'` for option 10 | Ruled out | claude TUI single-digit `commit-on-keystroke` behaviour pinned in #4292 means `'1'` would commit option 1 before the `'0'` arrived. The recorder script noted "unlikely to work". |

## Open assumption / verification path

If the arrow-nav sequence misfires in dogfood (claude TUI doesn't accept arrow keys at the AskUserQuestion form), re-run the recorder against a 12-option AskUserQuestion form, pick option 11 manually with whichever keystroke works, and replace `_writePtyArrowNavSequence` in `claude-tui-session.js` with the empirically-pinned bytes. The recorder script docstring (lines 26-50 post-PR) carries this verification recipe.

## Test plan

Assertion-based unit tests pin the exact byte sequence at every supported boundary:

- [x] `respondToQuestion drives matchIdx >= 9 via arrow-key navigation (#4848)` — single-question, 12 options, pick idx 9 → `[disable, 9× '\x1b[B', '\r', enable]`
- [x] `respondToQuestion drives matchIdx=11 via 11× Down + Enter (#4848 boundary)` — single-question, 12 options, pick last
- [x] `multi-question: single-select pick of option 10+ drives via arrow-nav (#4848)` — multi-question, Q1 12-opt + Q2 2-opt, pick idx 9 → `[disable, 9× '\x1b[B', '\r', '1', '1', enable]`
- [x] `multi-question: single-select pick of option 30 (idx 29) drives via 29× Down + Enter (#4848)` — 30-option last-pick (the largest case the acceptance criteria call out)
- [x] `single-question: pick of option 10+ drives via arrow-nav (#4848)` — single-question parity at idx 10
- [x] `single-question: last option in a 30-option question drives via 29× Down + Enter (#4848)` — single-question 30-option boundary
- [x] Existing multi-select 10+ tests still pass — they continue to surface `ASK_USER_QUESTION_TOO_MANY_OPTIONS` (scope narrowed but case preserved)
- [x] Existing in-range tests (idx 0..8) untouched
- [x] Existing back-compat tests (no `answersMap`, unmatched label fallback) untouched
- [x] `packages/server` lint scripts green: `lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`, `lint-logger-session-scoping.sh`
- [x] Full `claude-tui-session.test.js` suite: 190 tests pass, 0 fail
- [ ] Dogfood verification on a real `>9-option` AskUserQuestion (the recorder pass) — see "Open assumption" above