### PR TITLE
feat(server): wire 'stopped' event through SessionManager + ws-forwarding (#4756)

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -412,6 +412,31 @@ export declare const ServerSessionRestoreFailedSchema: z.ZodObject<{
     originalHistoryPreserved: z.ZodBoolean;
     historyLength: z.ZodOptional<z.ZodNumber>;
 }, z.core.$strip>;
+/**
+ * #4756: user-initiated Stop confirmation broadcast. CliSession emits a
+ * `stopped` event from `_handleChildClose` when the child process exits
+ * cleanly after a Stop click (interrupt() set `_intentionalStop`). The
+ * SessionManager + ws-forwarding paths surface it as this `session_stopped`
+ * wire message so clients can render a quiet "Session stopped." confirmation
+ * — distinct from `session_error` (crash) which fires for unexpected exits
+ * that trigger the auto-respawn path.
+ *
+ * `sessionId` is injected by `_broadcastToSession` on the multi-session
+ * path, so it's optional on the schema for consumers that construct the
+ * message without it pre-broadcast (matches the `cost_update` / `session_usage`
+ * pattern). The legacy-cli path doesn't carry a sessionId at all.
+ *
+ * `code` is the child process exit code (number). Typically 0 on a clean
+ * SIGINT exit, but kept on the wire so clients can render the numeric code
+ * for non-zero exits (e.g. 143 = SIGTERM). Optional because future providers
+ * that adopt the `stopped` event for parity (see #4756 follow-up) may not
+ * have a meaningful exit code (e.g. in-process SDK session).
+ */
+export declare const ServerSessionStoppedSchema: z.ZodObject<{
+    type: z.ZodLiteral<"session_stopped">;
+    sessionId: z.ZodOptional<z.ZodString>;
+    code: z.ZodOptional<z.ZodNumber>;
+}, z.core.$strip>;
 export declare const ServerProviderListSchema: z.ZodObject<{
     type: z.ZodLiteral<"provider_list">;
     providers: z.ZodArray<z.ZodObject<{
@@ -786,6 +811,7 @@ export type ServerErrorEnvelopeMessage = z.infer<typeof ServerErrorEnvelopeSchem
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>;
 export type CumulativeUsage = z.infer<typeof CumulativeUsageSchema>;
 export type ServerSessionUsageMessage = z.infer<typeof ServerSessionUsageSchema>;
+export type ServerSessionStoppedMessage = z.infer<typeof ServerSessionStoppedSchema>;
 export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSessionCostThresholdCrossedSchema>;
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>;
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -514,6 +514,31 @@ export const ServerSessionRestoreFailedSchema = z.object({
     originalHistoryPreserved: z.boolean(),
     historyLength: z.number().optional(),
 });
+/**
+ * #4756: user-initiated Stop confirmation broadcast. CliSession emits a
+ * `stopped` event from `_handleChildClose` when the child process exits
+ * cleanly after a Stop click (interrupt() set `_intentionalStop`). The
+ * SessionManager + ws-forwarding paths surface it as this `session_stopped`
+ * wire message so clients can render a quiet "Session stopped." confirmation
+ * — distinct from `session_error` (crash) which fires for unexpected exits
+ * that trigger the auto-respawn path.
+ *
+ * `sessionId` is injected by `_broadcastToSession` on the multi-session
+ * path, so it's optional on the schema for consumers that construct the
+ * message without it pre-broadcast (matches the `cost_update` / `session_usage`
+ * pattern). The legacy-cli path doesn't carry a sessionId at all.
+ *
+ * `code` is the child process exit code (number). Typically 0 on a clean
+ * SIGINT exit, but kept on the wire so clients can render the numeric code
+ * for non-zero exits (e.g. 143 = SIGTERM). Optional because future providers
+ * that adopt the `stopped` event for parity (see #4756 follow-up) may not
+ * have a meaningful exit code (e.g. in-process SDK session).
+ */
+export const ServerSessionStoppedSchema = z.object({
+    type: z.literal('session_stopped'),
+    sessionId: z.string().optional(),
+    code: z.number().int().optional(),
+});
 // #3404 audit (F1+F5): per-provider auth/billing summary so clients can
 // grey-out unusable providers and surface billing-identity confidence.
 // Optional on the wire so older servers stay parseable.

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -555,6 +555,32 @@ export const ServerSessionRestoreFailedSchema = z.object({
   historyLength: z.number().optional(),
 })
 
+/**
+ * #4756: user-initiated Stop confirmation broadcast. CliSession emits a
+ * `stopped` event from `_handleChildClose` when the child process exits
+ * cleanly after a Stop click (interrupt() set `_intentionalStop`). The
+ * SessionManager + ws-forwarding paths surface it as this `session_stopped`
+ * wire message so clients can render a quiet "Session stopped." confirmation
+ * — distinct from `session_error` (crash) which fires for unexpected exits
+ * that trigger the auto-respawn path.
+ *
+ * `sessionId` is injected by `_broadcastToSession` on the multi-session
+ * path, so it's optional on the schema for consumers that construct the
+ * message without it pre-broadcast (matches the `cost_update` / `session_usage`
+ * pattern). The legacy-cli path doesn't carry a sessionId at all.
+ *
+ * `code` is the child process exit code (number). Typically 0 on a clean
+ * SIGINT exit, but kept on the wire so clients can render the numeric code
+ * for non-zero exits (e.g. 143 = SIGTERM). Optional because future providers
+ * that adopt the `stopped` event for parity (see #4756 follow-up) may not
+ * have a meaningful exit code (e.g. in-process SDK session).
+ */
+export const ServerSessionStoppedSchema = z.object({
+  type: z.literal('session_stopped'),
+  sessionId: z.string().optional(),
+  code: z.number().int().optional(),
+})
+
 // #3404 audit (F1+F5): per-provider auth/billing summary so clients can
 // grey-out unusable providers and surface billing-identity confidence.
 // Optional on the wire so older servers stay parseable.
@@ -1102,6 +1128,8 @@ export type ServerErrorEnvelopeMessage = z.infer<typeof ServerErrorEnvelopeSchem
 export type ServerCostUpdateMessage = z.infer<typeof ServerCostUpdateSchema>
 export type CumulativeUsage = z.infer<typeof CumulativeUsageSchema>
 export type ServerSessionUsageMessage = z.infer<typeof ServerSessionUsageSchema>
+// #4756: typed alias for the user-initiated Stop confirmation broadcast.
+export type ServerSessionStoppedMessage = z.infer<typeof ServerSessionStoppedSchema>
 export type ServerSessionCostThresholdCrossedMessage = z.infer<typeof ServerSessionCostThresholdCrossedSchema>
 export type ServerExtensionMessage = z.infer<typeof ServerExtensionMessageSchema>
 export type ServerSkillsListMessage = z.infer<typeof ServerSkillsListSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -46,6 +46,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
+  'session_stopped', // #4756 user-initiated Stop confirmation — wire path is wired (CliSession → SessionManager → ws-forwarding → ServerSessionStoppedSchema) but client UX (quiet toast / status update) is the follow-up tracked in #4756's issue body item 3; until then the absence of `session_error` already conveys "no crash, clean stop"
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -407,6 +407,52 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(result.success, 'Should accept reason=crash (emitted on uncaughtException)')
   })
 
+  // #4756 — `session_stopped` is the user-initiated Stop confirmation
+  // broadcast. Both the multi-session shape (sessionId + numeric code) and
+  // the legacy-cli shape (no sessionId) must parse. Future provider
+  // adoption (per the issue's #4 follow-up) may also omit `code` when the
+  // provider doesn't have a child-process exit status to report.
+  it('validates session_stopped with multi-session shape (#4756)', async () => {
+    const { ServerSessionStoppedSchema } = await import('../src/schemas/server.ts')
+    const result = ServerSessionStoppedSchema.safeParse({
+      type: 'session_stopped',
+      sessionId: 'sess-abc',
+      code: 0,
+    })
+    assert.ok(result.success, 'Should accept session_stopped with sessionId + code')
+    assert.equal(result.data.sessionId, 'sess-abc')
+    assert.equal(result.data.code, 0)
+  })
+
+  it('accepts session_stopped without sessionId (legacy-cli path)', async () => {
+    const { ServerSessionStoppedSchema } = await import('../src/schemas/server.ts')
+    const result = ServerSessionStoppedSchema.safeParse({
+      type: 'session_stopped',
+      code: 143,
+    })
+    assert.ok(result.success, 'legacy-cli session_stopped omits sessionId')
+    assert.equal(result.data.code, 143)
+  })
+
+  it('accepts session_stopped without code (future provider parity)', async () => {
+    const { ServerSessionStoppedSchema } = await import('../src/schemas/server.ts')
+    const result = ServerSessionStoppedSchema.safeParse({
+      type: 'session_stopped',
+      sessionId: 'sess-abc',
+    })
+    assert.ok(result.success, 'code is optional for providers without an exit status')
+  })
+
+  it('rejects session_stopped with non-integer code', async () => {
+    const { ServerSessionStoppedSchema } = await import('../src/schemas/server.ts')
+    const result = ServerSessionStoppedSchema.safeParse({
+      type: 'session_stopped',
+      sessionId: 'sess-abc',
+      code: 'not-a-number',
+    })
+    assert.equal(result.success, false, 'code must be a number when present')
+  })
+
   it('validates encrypted envelope', async () => {
     const { EncryptedEnvelopeSchema } = await import('../src/schemas/client.ts')
     const result = EncryptedEnvelopeSchema.safeParse({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -443,7 +443,7 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(result.success, 'code is optional for providers without an exit status')
   })
 
-  it('rejects session_stopped with non-integer code', async () => {
+  it('rejects session_stopped with non-numeric code', async () => {
     const { ServerSessionStoppedSchema } = await import('../src/schemas/server.ts')
     const result = ServerSessionStoppedSchema.safeParse({
       type: 'session_stopped',
@@ -451,6 +451,20 @@ describe('@chroxy/protocol schemas', () => {
       code: 'not-a-number',
     })
     assert.equal(result.success, false, 'code must be a number when present')
+  })
+
+  // Distinct from the non-numeric case above: this asserts the `.int()`
+  // constraint specifically. A float (1.5) is a number but not an integer,
+  // so it should fail the integer-only schema and the normalizer's
+  // `Number.isInteger` guard.
+  it('rejects session_stopped with non-integer code (float)', async () => {
+    const { ServerSessionStoppedSchema } = await import('../src/schemas/server.ts')
+    const result = ServerSessionStoppedSchema.safeParse({
+      type: 'session_stopped',
+      sessionId: 'sess-abc',
+      code: 1.5,
+    })
+    assert.equal(result.success, false, 'code must be an integer when present (z.number().int())')
   })
 
   it('validates encrypted envelope', async () => {

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -413,15 +413,23 @@ Object.assign(EVENT_MAP, {
   // Clients should treat it as informational, NOT an error condition.
   // `code` is the exit status from the child; typically 0 on clean SIGINT
   // exit but kept on the wire so clients can render the numeric code for
-  // diagnostic purposes if non-zero (e.g. SIGTERM = 143). `sessionId` is
-  // included for the legacy-cli path where ctx.sessionId is null (per the
-  // `Server -> Client` contract on the multi-session path the field is
-  // injected by `_broadcastToSession`, so omit when ctx.sessionId is null
-  // rather than emitting `sessionId: null`).
+  // diagnostic purposes if non-zero (e.g. SIGTERM = 143). Gated on
+  // `Number.isInteger` (not bare `typeof === 'number'`) so NaN / Infinity
+  // / floats from a defensive provider can't reach the wire — the schema
+  // is `z.number().int()`, so non-integers would fail client-side parsing.
+  // `sessionId` is OMITTED on the legacy-cli path where ctx.sessionId is
+  // null, matching the `claude_ready` / `error` legacy-cli convention so
+  // receivers treat the message as "applies to the connected legacy CLI"
+  // rather than seeing `sessionId: null`. On the multi-session path the
+  // field is also injected by `_broadcastToSession`, so this guard
+  // additionally protects against accidental `sessionId: null` if the
+  // upstream ctx ever degrades.
   stopped: (data, ctx) => {
     const msg = { type: 'session_stopped' }
-    if (ctx.sessionId) msg.sessionId = ctx.sessionId
-    if (typeof data?.code === 'number') msg.code = data.code
+    if (typeof ctx.sessionId === 'string' && ctx.sessionId.length > 0) {
+      msg.sessionId = ctx.sessionId
+    }
+    if (Number.isInteger(data?.code)) msg.code = data.code
     return { messages: [{ msg }] }
   },
 

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -404,6 +404,27 @@ Object.assign(EVENT_MAP, {
     return { messages: [{ msg }] }
   },
 
+  // #4756: user-initiated Stop confirmation. CliSession emits `stopped`
+  // when the child process exits cleanly after `interrupt()` set the
+  // `_intentionalStop` flag (see cli-session.js `_handleChildClose`). This
+  // pairs with `error` — `error` is the louder "crashed unexpectedly,
+  // restarting" toast that the auto-respawn path triggers, while
+  // `session_stopped` is the quiet "you asked, it stopped" confirmation.
+  // Clients should treat it as informational, NOT an error condition.
+  // `code` is the exit status from the child; typically 0 on clean SIGINT
+  // exit but kept on the wire so clients can render the numeric code for
+  // diagnostic purposes if non-zero (e.g. SIGTERM = 143). `sessionId` is
+  // included for the legacy-cli path where ctx.sessionId is null (per the
+  // `Server -> Client` contract on the multi-session path the field is
+  // injected by `_broadcastToSession`, so omit when ctx.sessionId is null
+  // rather than emitting `sessionId: null`).
+  stopped: (data, ctx) => {
+    const msg = { type: 'session_stopped' }
+    if (ctx.sessionId) msg.sessionId = ctx.sessionId
+    if (typeof data?.code === 'number') msg.code = data.code
+    return { messages: [{ msg }] }
+  },
+
   // #3544: surface the cumulative stdin_dropped totals on the wire so
   // dashboards and the mobile app can render a "X bytes lost over N drops"
   // banner / badge for sessions that are silently truncating input at the

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1674,7 +1674,16 @@ export class SessionManager extends EventEmitter {
     // without the event being replayed on every reconnect (the loader re-checks
     // the hash every time skills are scanned, so the latest state is always
     // canonical).
-    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted', 'inactivity_warning', 'background_work_changed']
+    // #4756: `stopped` is a transient signal — CliSession emits it when the
+    // child process exits cleanly after a user-initiated Stop (see
+    // cli-session.js `_handleChildClose`, gated on `_intentionalStop`). It
+    // pairs with `error` (which fires for unexpected crashes that trigger
+    // auto-respawn) so a paired dashboard / mobile client can render a quiet
+    // "Session stopped." confirmation distinct from the louder crash toast.
+    // Transient so it isn't replayed on reconnect — by the time a client
+    // reconnects, either the session was destroyed or the user already saw
+    // the confirmation.
+    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted', 'inactivity_warning', 'background_work_changed', 'stopped']
     const customEvents = Array.isArray(session.constructor.customEvents) ? session.constructor.customEvents : []
     const TRANSIENT_EVENTS = [...new Set([...builtinTransient, ...customEvents])]
     for (const event of TRANSIENT_EVENTS) {

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -146,12 +146,17 @@ function setupCliForwarding(normalizer, ctx) {
   // forwarding loop below — which the schema explicitly allows for this
   // path; #3205's dashboard prompt treats null as "applies to whatever
   // CLI is connected".
+  // #4756: `stopped` mirrors the multi-session forwarding list (see
+  // session-manager.js `_wireSessionEvents` builtinTransient) so the legacy
+  // single-CLI path also surfaces the user-initiated Stop confirmation via
+  // the normalizer's `session_stopped` wire message.
   const FORWARDED_EVENTS = [
     'ready', 'stream_start', 'stream_delta', 'stream_end',
     'message', 'tool_start', 'tool_result', 'result', 'error',
     'user_question', 'agent_spawned', 'agent_completed',
     'plan_started', 'plan_ready', 'mcp_servers',
     'permission_expired', 'skill_changed', 'skill_trust_request', 'skill_trust_granted',
+    'stopped',
   ]
   for (const event of FORWARDED_EVENTS) {
     cliSession.on(event, (data) => {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -298,6 +298,7 @@ function _isSecureRequest(req) {
  *   { type: 'session_switched', sessionId, name, cwd, conversationId? } — switched active session
  *   { type: 'session_created', sessionId, name }      — new session created
  *   { type: 'session_destroyed', sessionId }          — session removed
+ *   { type: 'session_stopped', sessionId?, code? } — user-initiated Stop confirmation (#4756); CliSession emitted `stopped` after a clean SIGINT exit; pairs with the louder `session_error` crash toast
  *   { type: 'session_restore_failed', sessionId, name, provider, cwd?, model?, permissionMode?, errorCode, errorMessage, originalHistoryPreserved, historyLength? }
  *     — session in persisted state could not be restored (e.g. missing env var); history kept on disk for retry
  *   { type: 'session_error', message, category?, sessionId?, recoverable? } — session operation error

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -588,6 +588,61 @@ describe('EventNormalizer', () => {
     })
   })
 
+  // ---- EVENT_MAP: stopped (#4756) ----
+  //
+  // CliSession emits `stopped` after a clean user-initiated SIGINT exit
+  // (cli-session.js `_handleChildClose` gated on `_intentionalStop`). The
+  // normalizer translates it into `session_stopped` so paired clients can
+  // render a quiet confirmation distinct from the louder `session_error`
+  // crash toast.
+
+  describe('stopped event (#4756)', () => {
+    it('maps to a session_stopped wire message in multi mode', () => {
+      const result = normalizer.normalize('stopped', { code: 0 }, makeCtx())
+      assert.equal(result.messages.length, 1)
+      const msg = result.messages[0].msg
+      assert.equal(msg.type, 'session_stopped')
+      assert.equal(msg.sessionId, 'sess-1')
+      assert.equal(msg.code, 0)
+    })
+
+    it('forwards the numeric exit code on the wire', () => {
+      // SIGTERM = 143; clients should see the raw code for non-zero exits
+      // so they can render a diagnostic detail line.
+      const result = normalizer.normalize('stopped', { code: 143 }, makeCtx())
+      assert.equal(result.messages[0].msg.code, 143)
+    })
+
+    it('omits sessionId in legacy-cli mode (ctx.sessionId is null)', () => {
+      const ctx = makeCtx({ sessionId: null, mode: 'legacy-cli' })
+      const result = normalizer.normalize('stopped', { code: 0 }, ctx)
+      const msg = result.messages[0].msg
+      assert.equal(msg.type, 'session_stopped')
+      // Do not emit `sessionId: null` — let the receiver treat absence as
+      // "applies to the connected legacy CLI". Matches the `error` /
+      // `claude_ready` legacy-cli convention.
+      assert.ok(!('sessionId' in msg), 'sessionId should be absent in legacy-cli mode')
+      assert.equal(msg.code, 0)
+    })
+
+    it('omits code when data is missing or non-numeric', () => {
+      // Defensive: future providers that adopt `stopped` for parity may
+      // not carry an exit code (e.g. in-process SDK session). Schema
+      // marks `code` optional.
+      const result = normalizer.normalize('stopped', {}, makeCtx())
+      const msg = result.messages[0].msg
+      assert.equal(msg.type, 'session_stopped')
+      assert.equal(msg.sessionId, 'sess-1')
+      assert.ok(!('code' in msg), 'code should be omitted when not numeric')
+    })
+
+    it('emits no side effects or registrations (informational only)', () => {
+      const result = normalizer.normalize('stopped', { code: 0 }, makeCtx())
+      assert.equal(result.sideEffects, undefined)
+      assert.equal(result.registrations, undefined)
+    })
+  })
+
   // ---- Delta buffering ----
 
   describe('delta buffering', () => {

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -641,6 +641,18 @@ describe('EventNormalizer', () => {
       assert.equal(result.sideEffects, undefined)
       assert.equal(result.registrations, undefined)
     })
+
+    // Per Copilot review on #4868: the protocol schema is z.number().int(),
+    // so the normalizer must reject non-integer numbers (floats, NaN,
+    // Infinity) to prevent client-side schema-validation failures. Bare
+    // `typeof === 'number'` would let any of these through.
+    it('omits code when data.code is a float, NaN, or Infinity', () => {
+      for (const badCode of [1.5, NaN, Infinity, -Infinity]) {
+        const result = normalizer.normalize('stopped', { code: badCode }, makeCtx())
+        const msg = result.messages[0].msg
+        assert.ok(!('code' in msg), `code=${badCode} should be dropped (not a finite integer)`)
+      }
+    })
   })
 
   // ---- Delta buffering ----

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -3540,3 +3540,90 @@ describe('SessionManager operator-timeout MAX_SANE_DURATION_MS ceiling (#4509)',
     })
   }
 })
+
+// #4756 — `stopped` event proxying.
+//
+// CliSession emits `stopped` after `_handleChildClose` confirms a clean
+// SIGINT exit (gated on `_intentionalStop`). PR #4750 added the emit but
+// neither the SessionManager event proxy nor the ws-forwarding broadcaster
+// included it, so no consumer ever saw the confirmation. This block locks
+// in the session-event proxy half of the wiring — the ws-forwarding +
+// normalizer half is covered in ws-forwarding.test.js and
+// event-normalizer.test.js's "stopped event (#4756)" describes.
+describe('_wireSessionEvents — stopped event proxy (#4756)', () => {
+  it('proxies session.emit("stopped") to mgr session_event with event="stopped"', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, name: 'S1', cwd: '/tmp', provider: 'claude-cli' })
+    mgr._wireSessionEvents('s1', session)
+    const events = []
+    mgr.on('session_event', (evt) => events.push(evt))
+
+    session.emit('stopped', { code: 0 })
+
+    const stoppedEvents = events.filter(e => e.event === 'stopped')
+    assert.equal(stoppedEvents.length, 1, 'expected exactly one stopped session_event')
+    assert.equal(stoppedEvents[0].sessionId, 's1')
+    assert.deepEqual(stoppedEvents[0].data, { code: 0 })
+  })
+
+  it('forwards the numeric exit code on the data payload (e.g. 143 = SIGTERM)', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, name: 'S1', cwd: '/tmp', provider: 'claude-cli' })
+    mgr._wireSessionEvents('s1', session)
+    const events = []
+    mgr.on('session_event', (evt) => { if (evt.event === 'stopped') events.push(evt) })
+
+    session.emit('stopped', { code: 143 })
+
+    assert.equal(events.length, 1)
+    assert.equal(events[0].data.code, 143, 'code field must reach the wire layer for diagnostic UX')
+  })
+
+  it('treats stopped as transient — not recorded into history (no replay on reconnect)', () => {
+    // History replay re-fires PROXIED_EVENTS to a reconnecting client.
+    // `stopped` is informational (the user just clicked Stop a moment
+    // ago) — replaying it would surface a misleading "Session stopped."
+    // toast minutes later when the user reconnects. Keep it transient,
+    // mirroring the `permission_request` / `inactivity_warning` policy.
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, name: 'S1', cwd: '/tmp', provider: 'claude-cli' })
+    mgr._wireSessionEvents('s1', session)
+
+    session.emit('stopped', { code: 0 })
+
+    const history = mgr.getHistory('s1') || []
+    const recordedStopped = history.filter(h => h.event === 'stopped')
+    assert.equal(recordedStopped.length, 0, 'stopped must not be persisted to history')
+  })
+
+  it('does not touchActivity for stopped (lifecycle signal, not user input)', () => {
+    // The idle-timeout machinery ticks on `message` / `stream_start` /
+    // `tool_start` / `result` / `user_question` only. A `stopped` event
+    // is the OPPOSITE of activity — the user just ended the turn — so
+    // resetting the idle timer would defer destruction of an already-
+    // stopped session, opposite of the intent.
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const session = new EventEmitter()
+    session.isRunning = false
+    session.destroy = () => {}
+    mgr._sessions.set('s1', { session, name: 'S1', cwd: '/tmp', provider: 'claude-cli' })
+    mgr._wireSessionEvents('s1', session)
+    // Pin lastActivity to a known past timestamp and assert it doesn't move.
+    const beforeTs = Date.now() - 60_000
+    mgr._sessionLastActivityAt.set('s1', beforeTs)
+
+    session.emit('stopped', { code: 0 })
+
+    const after = mgr._sessionLastActivityAt.get('s1')
+    assert.equal(after, beforeTs, 'stopped must not reset lastActivity')
+  })
+})

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -274,6 +274,54 @@ describe('setupForwarding', () => {
     })
   })
 
+  // #4756 — `stopped` event surfaces through the normalizer as a
+  // `session_stopped` broadcast targeted at subscribers of the affected
+  // session (NOT global broadcast). Pairs with the wiring in
+  // session-manager.js's `_wireSessionEvents` (transient list) and the
+  // `stopped` handler in event-normalizer.js.
+  describe('stopped event (#4756)', () => {
+    it('broadcasts session_stopped via broadcastToSession (not global)', () => {
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-stop',
+        event: 'stopped',
+        data: { code: 0 },
+      })
+
+      // Must route per-session — only subscribers of sess-stop should see
+      // the confirmation, not every connected client.
+      assert.equal(ctx.broadcastToSession.mock.calls.length, 1)
+      const [sid, msg] = ctx.broadcastToSession.mock.calls[0].arguments
+      assert.equal(sid, 'sess-stop')
+      assert.equal(msg.type, 'session_stopped')
+      assert.equal(msg.sessionId, 'sess-stop')
+      assert.equal(msg.code, 0)
+      // Must NOT also fire global broadcast for this event.
+      assert.equal(ctx.broadcast.mock.calls.length, 0)
+    })
+
+    it('does not emit session_activity (informational, not busy/idle)', () => {
+      // session_activity is fired on stream_start/result only — `stopped`
+      // is a lifecycle signal, not a busy-state flip, so the sidebar
+      // activity feed should not light up for it.
+      const ctx = makeCtx()
+      setupForwarding(ctx)
+
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-stop',
+        event: 'stopped',
+        data: { code: 0 },
+      })
+
+      const activityCall = ctx.broadcast.mock.calls.find(
+        c => c.arguments[0]?.type === 'session_activity',
+      )
+      assert.equal(activityCall, undefined, 'stopped must not trigger session_activity')
+    })
+  })
+
   describe('setupForwarding with cliSession', () => {
     it('sets up CLI forwarding when cliSession provided (no sessionManager)', () => {
       const cliSession = new EventEmitter()
@@ -401,6 +449,23 @@ describe('setupCliForwarding', () => {
     ctx.cliSession.emit('custom_internal', { foo: 'bar' })
 
     assert.equal(ctx.broadcast.mock.calls.length, 0)
+  })
+
+  // #4756: legacy-cli mode must also forward the `stopped` event so the
+  // single-CLI confirmation reaches connected clients. The legacy path
+  // uses `broadcast` (no per-session routing) since there's only one CLI.
+  it('forwards stopped event as session_stopped broadcast (#4756)', () => {
+    const ctx = makeCliCtx()
+    setupForwarding(ctx)
+
+    ctx.cliSession.emit('stopped', { code: 0 })
+
+    const calls = ctx.broadcast.mock.calls.map(c => c.arguments[0])
+    const stoppedMsg = calls.find(m => m.type === 'session_stopped')
+    assert.ok(stoppedMsg, 'expected session_stopped broadcast from legacy-cli')
+    assert.equal(stoppedMsg.code, 0)
+    // Legacy-cli path: ctx.sessionId is null → normalizer omits sessionId
+    assert.ok(!('sessionId' in stoppedMsg), 'legacy-cli session_stopped should omit sessionId')
   })
 
   // #3240: skill_changed must reach legacy single-CLI users so the trust


### PR DESCRIPTION
Closes #4756

Follow-up to #4602 / PR #4750, which added a `stopped` emit to `CliSession._handleChildClose` so the dashboard could distinguish a user-initiated Stop from an unexpected crash. The event was never wired through the session-event proxy or the ws-forwarding broadcaster, so no consumer ever saw it.

## Summary

End-to-end wire path for the existing `stopped` emit:

- **`session-manager.js`** — `stopped` joins the transient session-event list (alongside `permission_request` / `inactivity_warning`), so `session.emit('stopped', { code })` is re-emitted as a manager-level `session_event`. Transient = not recorded into per-session history, so it isn't replayed on reconnect.
- **`ws-forwarding.js`** — `stopped` added to the legacy single-CLI `FORWARDED_EVENTS` list too, so non-multi-session deployments also surface the confirmation.
- **`event-normalizer.js`** — new `stopped` handler maps the session event into a `{ type: 'session_stopped', sessionId?, code? }` wire message. `sessionId` is injected on the multi-session path and omitted in legacy-cli mode (mirroring `claude_ready` / `error`).
- **`@chroxy/protocol`** — new `ServerSessionStoppedSchema` documents the wire contract. Optional `sessionId` (omitted in legacy-cli), optional integer `code` (omitted for future providers that don't have a child-process exit status).
- **`ws-server.js`** — `Server -> Client` doc-comment lists the new message type so the handler-coverage contract test sees it.
- **`handler-coverage.test.js`** — adds `session_stopped` to `INTENTIONALLY_UNHANDLED`. The wire path is wired; the dashboard / mobile UX (quiet confirmation toast) is the follow-up tracked in the issue body. Until then, absence of `session_error` already conveys *no crash, clean stop*.

## Protocol additions

New server-to-client message:

```ts
{ type: 'session_stopped', sessionId?: string, code?: number }
```

Emitted when `CliSession` exits cleanly after a user-initiated Stop (`interrupt()` set `_intentionalStop`; child exits as a result). Pairs with the louder `session_error` crash toast — `session_stopped` is informational, not an error condition.

Per #3716 (`restoreState fires before WsServer subscribes`), the new proxy hook lives inside `_wireSessionEvents` — which the manager runs for every session at construction time, including restored sessions — so the retroactive-scan pattern is satisfied by construction.

Provider parity (sdk-session / codex-session / gemini-session adopting `stopped` for consistency) is deferred per the issue's explicit non-goal; the schema's optional `code` field already accommodates that future surface area.

## Test plan

- [x] `packages/server/tests/event-normalizer.test.js` — `stopped event (#4756)` describes: multi-session shape, legacy-cli (no sessionId), arbitrary numeric exit codes (e.g. 143), no side effects
- [x] `packages/server/tests/session-manager.test.js` — `_wireSessionEvents — stopped event proxy (#4756)` describes: session_event re-emit, code forwarding, NOT recorded into history, does NOT touch idle-activity timer
- [x] `packages/server/tests/ws-forwarding.test.js` — `stopped event (#4756)` describes: multi-session broadcasts via `broadcastToSession` (not global), does NOT trigger `session_activity`; legacy-cli forwards as `session_stopped` global broadcast with sessionId omitted
- [x] `packages/protocol/tests/schemas.test.js` — `ServerSessionStoppedSchema` accepts multi-session / legacy-cli / no-code shapes; rejects non-integer code
- [x] `packages/protocol/tests/handler-coverage.test.js` — contract test passes with `session_stopped` in `INTENTIONALLY_UNHANDLED`
- [x] Lint scripts: `lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh` — both green