### PR TITLE
chore(server): second-wave loggerForSession sweep (#4823 follow-up)

### DIFF
--- a/packages/server/scripts/lint-logger-session-scoping.mjs
+++ b/packages/server/scripts/lint-logger-session-scoping.mjs
@@ -61,6 +61,21 @@ const REQUIRES_FACTORY_IMPORT = new Set([
   // migration list and the deferred-sweep follow-up issue for the rest.
   'claude-tui-session.js',
   'handlers/input-handlers.js',
+  // #4828 second wave — sweep across the remaining per-session
+  // surfaces. claude-tui-session.js stays from the first wave; sdk-session
+  // and cli-session now bind `this._log` on the init message (where the
+  // session id becomes known) and route every post-init log line through
+  // it. The handler files migrated every session-aware call site to
+  // `loggerForSession('ws', sessionId)`. None of these can promote into
+  // FORBIDS_BARE_CREATELOGGER yet because each one keeps a module-level
+  // `createLogger('...')` for the pre-session-id / cross-session
+  // fallback paths.
+  'sdk-session.js',
+  'cli-session.js',
+  'handlers/conversation-handlers.js',
+  'handlers/feature-handlers.js',
+  'handlers/session-handlers.js',
+  'handlers/settings-handlers.js',
 ])
 
 /**

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1638,7 +1638,9 @@ export class ClaudeTuiSession extends BaseSession {
         // multi-question wedge condition is greppable. The bug was
         // diagnosed via /tmp/.../pre-*.json spelunking — never again.
         const questionCount = questions.length
-        log.info(`AskUserQuestion pending: tool=${toolUseId} questions=${questionCount} options.q1=${options.length}`)
+        // #4828: session-scoped — runs strictly post-start when `this._log`
+        // is cached. Falls back to module-level `log` only defensively.
+        ;(this._log || log).info(`AskUserQuestion pending: tool=${toolUseId} questions=${questionCount} options.q1=${options.length}`)
         if (questionCount > 1) {
           // #4604 Chunk B note: kept the historical "not yet supported"
           // wording so existing test guards (regex on this string) keep
@@ -1648,7 +1650,8 @@ export class ClaudeTuiSession extends BaseSession {
           // back-compat default-to-option-1 fallback in respondToQuestion
           // means even old dashboards no longer wedge the session, just
           // pick defaults the user can re-prompt past.
-          log.warn(`AskUserQuestion has ${questionCount} questions — multi-question forms are not yet supported (see #4604). Only question 1 will be answered.`)
+          // #4828: session-scoped.
+          ;(this._log || log).warn(`AskUserQuestion has ${questionCount} questions — multi-question forms are not yet supported (see #4604). Only question 1 will be answered.`)
           // #4653: surface the deny to the user. The bash permission-hook
           // returns `permissionDecision: deny` for this exact payload
           // shape (questions.length > 1), so this server-side mirror
@@ -2386,7 +2389,8 @@ export class ClaudeTuiSession extends BaseSession {
       // cleared the Map (watchdog fire, user gave up + the late answer
       // came in). Log + drop rather than write keystrokes into whatever
       // form happens to be currently rendered.
-      log.warn(`respondToQuestion: dashboard sent toolUseId=${toolUseId} but no matching pending entry (Map.size=${this._pendingUserAnswers.size} keys=${[...this._pendingUserAnswers.keys()].join(',')}) — dropping`)
+      // #4828: session-scoped — respondToQuestion runs strictly post-start.
+      ;(this._log || log).warn(`respondToQuestion: dashboard sent toolUseId=${toolUseId} but no matching pending entry (Map.size=${this._pendingUserAnswers.size} keys=${[...this._pendingUserAnswers.keys()].join(',')}) — dropping`)
       return
     } else {
       // Legacy / unidentified path: route to the most-recent entry via
@@ -2399,14 +2403,16 @@ export class ClaudeTuiSession extends BaseSession {
       // most-recent entry by insertion order, which may not be what
       // the user intended. Loud log so the wedge symptom is greppable.
       if (!toolUseId && this._pendingUserAnswers.size > 1) {
-        log.warn(`respondToQuestion: dashboard omitted toolUseId but ${this._pendingUserAnswers.size} pending entries exist (keys=${[...this._pendingUserAnswers.keys()].join(',')}) — falling back to most-recent which may misroute`)
+        // #4828: session-scoped.
+        ;(this._log || log).warn(`respondToQuestion: dashboard omitted toolUseId but ${this._pendingUserAnswers.size} pending entries exist (keys=${[...this._pendingUserAnswers.keys()].join(',')}) — falling back to most-recent which may misroute`)
       }
       entry = this._pendingUserAnswer
     }
     const prevToolUseId = entry?.toolUseId || null
     const pendingQuestions = entry?.questions || []
     const answersMapKeyCount = answersMap && typeof answersMap === 'object' ? Object.keys(answersMap).length : 0
-    log.info(`respondToQuestion: tool=${prevToolUseId || '?'} dashboardToolUseId=${toolUseId || 'none'} text.length=${(text || '').length} answersMap.keys=${answersMapKeyCount} questions=${pendingQuestions.length} options=${entry?.options?.length || 0} pendingMapSize=${this._pendingUserAnswers.size}`)
+    // #4828: session-scoped.
+    ;(this._log || log).info(`respondToQuestion: tool=${prevToolUseId || '?'} dashboardToolUseId=${toolUseId || 'none'} text.length=${(text || '').length} answersMap.keys=${answersMapKeyCount} questions=${pendingQuestions.length} options=${entry?.options?.length || 0} pendingMapSize=${this._pendingUserAnswers.size}`)
     if (!entry) return
     // Single-question / free-text path requires a non-empty `text`. The
     // multi-question path is driven from answersMap (text is ignored when
@@ -2492,12 +2498,14 @@ export class ClaudeTuiSession extends BaseSession {
       // AskUserQuestion without an Other option in the first place.
       if (freeformText) {
         if (!Array.isArray(options) || options.length === 0) {
-          log.warn(`respondToQuestion: freeformText supplied for question with no options (tool=${prevToolUseId || '?'}) — dropping`)
+          // #4828: session-scoped.
+          ;(this._log || log).warn(`respondToQuestion: freeformText supplied for question with no options (tool=${prevToolUseId || '?'}) — dropping`)
           return
         }
         const otherIdx = options.findIndex((o) => o && o.label === text)
         if (otherIdx < 0 || otherIdx >= 9) {
-          log.warn(`respondToQuestion: freeformText supplied but chosen option "${text}" not found (or beyond single-digit hotkey range) in pending options for tool=${prevToolUseId || '?'} — dropping`)
+          // #4828: session-scoped.
+          ;(this._log || log).warn(`respondToQuestion: freeformText supplied but chosen option "${text}" not found (or beyond single-digit hotkey range) in pending options for tool=${prevToolUseId || '?'} — dropping`)
           return
         }
         const otherDigit = String(otherIdx + 1)
@@ -2522,7 +2530,8 @@ export class ClaudeTuiSession extends BaseSession {
           //     the inner write loop
           // Bail out at every await boundary instead.
           const stage1ok = await this._writePtyTextThrottled(otherDigit).catch((err) => {
-            log.warn(`respondToQuestion Other-digit PTY write failed: ${err.message} (tool=${tag})`)
+            // #4828: session-scoped.
+            ;(this._log || log).warn(`respondToQuestion Other-digit PTY write failed: ${err.message} (tool=${tag})`)
             return false
           })
           if (this._destroying) return
@@ -2547,7 +2556,8 @@ export class ClaudeTuiSession extends BaseSession {
             this._onAskUserQuestionStall(prevToolUseId)
           }, OTHER_FREEFORM_WATCHDOG_MS)
           await this._writePtyTextThrottled(freeformText).catch((err) => {
-            log.warn(`respondToQuestion Other-freeform PTY write failed: ${err.message} (tool=${tag})`)
+            // #4828: session-scoped.
+            ;(this._log || log).warn(`respondToQuestion Other-freeform PTY write failed: ${err.message} (tool=${tag})`)
           })
         })()
         armWatchdog()
@@ -2591,9 +2601,9 @@ export class ClaudeTuiSession extends BaseSession {
         // path) so the Other / freeform back-compat case is preserved.
         if (matchIdx >= 9) {
           const total = options.length
-          log.info(`AskUserQuestion single-question: question has ${total} options and the user picked option ${matchIdx + 1} ("${(text || '').slice(0, 40)}") — driving via arrow-key navigation (#4848) (tool=${prevToolUseId || '?'})`)
+          ;(this._log || log).info(`AskUserQuestion single-question: question has ${total} options and the user picked option ${matchIdx + 1} ("${(text || '').slice(0, 40)}") — driving via arrow-key navigation (#4848) (tool=${prevToolUseId || '?'})`)
           this._writePtyArrowNavSequence(matchIdx).catch((err) => {
-            log.warn(`respondToQuestion arrow-nav PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
+            ;(this._log || log).warn(`respondToQuestion arrow-nav PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
           })
           armWatchdog()
           return
@@ -2606,7 +2616,8 @@ export class ClaudeTuiSession extends BaseSession {
       // but the caller (handleUserQuestionResponse) is sync. Errors here
       // are non-fatal; worst case the user re-sends the answer.
       this._writePtyTextThrottled(writeText).catch((err) => {
-        log.warn(`respondToQuestion PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
+        // #4828: session-scoped.
+        ;(this._log || log).warn(`respondToQuestion PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
       })
       armWatchdog()
       return
@@ -2619,7 +2630,8 @@ export class ClaudeTuiSession extends BaseSession {
     const map = (answersMap && typeof answersMap === 'object') ? answersMap : {}
     const haveMap = Object.keys(map).length > 0
     if (!haveMap) {
-      log.warn(`AskUserQuestion multi-question: dashboard didn't send answersMap (tool=${prevToolUseId || '?'}, questions=${questions.length}) — defaulting every question to option 1. Update the client to populate the per-question answers map.`)
+      // #4828: session-scoped.
+      ;(this._log || log).warn(`AskUserQuestion multi-question: dashboard didn't send answersMap (tool=${prevToolUseId || '?'}, questions=${questions.length}) — defaulting every question to option 1. Update the client to populate the per-question answers map.`)
     }
 
     // #4625 + #4848 — claude TUI's single-digit hotkey alphabet ('1'..'9')
@@ -2679,7 +2691,7 @@ export class ClaudeTuiSession extends BaseSession {
       }
       if (unrepresentableMultiSelect.length > 0) {
         const first = unrepresentableMultiSelect[0]
-        log.warn(`AskUserQuestion multi-question: multi-select question has ${first.total} options and the user toggled option ${first.index + 1} ("${(first.label || '').slice(0, 40)}") which is outside claude TUI's 1..9 hotkey alphabet AND beyond the arrow-nav single-select fallback (#4848 deliberately scopes arrow-nav to single-select only) — surfacing ASK_USER_QUESTION_TOO_MANY_OPTIONS (tool=${prevToolUseId || '?'})`)
+        ;(this._log || log).warn(`AskUserQuestion multi-question: multi-select question has ${first.total} options and the user toggled option ${first.index + 1} ("${(first.label || '').slice(0, 40)}") which is outside claude TUI's 1..9 hotkey alphabet AND beyond the arrow-nav single-select fallback (#4848 deliberately scopes arrow-nav to single-select only) — surfacing ASK_USER_QUESTION_TOO_MANY_OPTIONS (tool=${prevToolUseId || '?'})`)
         // Full AskUserQuestion teardown: synth tool_result + Ctrl-C the
         // TUI + clear inactivity timers + stream_end + _emitResult +
         // error (in that order). Without the full teardown the dashboard
@@ -2750,7 +2762,8 @@ export class ClaudeTuiSession extends BaseSession {
           // couldn't match (defaulted handling below).
         }
         if (digits.length === 0 && defaultDigit) {
-          log.warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (multi-select) — defaulting to option 1`)
+          // #4828: session-scoped (closure runs inside respondToQuestion, post-start).
+          ;(this._log || log).warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (multi-select) — defaulting to option 1`)
           digits.push(defaultDigit)
         }
         return digits
@@ -2784,7 +2797,8 @@ export class ClaudeTuiSession extends BaseSession {
         }
       }
       if (defaultDigit) {
-        if (haveMap) log.warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (single-select) — defaulting to option 1`)
+        // #4828: session-scoped (closure runs inside respondToQuestion, post-start).
+        if (haveMap) (this._log || log).warn(`AskUserQuestion multi-question: no resolvable answer for q="${(q.question || '').slice(0, 40)}" (single-select) — defaulting to option 1`)
         return [defaultDigit]
       }
       return []
@@ -2833,10 +2847,11 @@ export class ClaudeTuiSession extends BaseSession {
     sequence.push('\r')
 
     const keystrokeCount = sequence.filter((x) => typeof x === 'string').length
-    log.info(`AskUserQuestion multi-question: tool=${prevToolUseId || '?'} questions=${questions.length} keystrokes=${keystrokeCount} haveAnswersMap=${haveMap}`)
+    ;(this._log || log).info(`AskUserQuestion multi-question: tool=${prevToolUseId || '?'} questions=${questions.length} keystrokes=${keystrokeCount} haveAnswersMap=${haveMap}`)
 
     this._writePtyMultiQuestionSequence(sequence).catch((err) => {
-      log.warn(`respondToQuestion multi-question PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
+      // #4828: session-scoped.
+      ;(this._log || log).warn(`respondToQuestion multi-question PTY write failed: ${err.message} (tool=${prevToolUseId || '?'})`)
     })
     armWatchdog()
   }
@@ -2975,7 +2990,8 @@ export class ClaudeTuiSession extends BaseSession {
     if (!this._pendingUserAnswer && !this._isBusy) return
 
     this._assertBusyHasMessageId('_onAskUserQuestionStall')
-    log.warn(`AskUserQuestion stall: tool=${toolUseId} — claude TUI never emitted PostToolUse after answer write (${ASK_USER_QUESTION_WATCHDOG_MS}ms). Likely a multi-question form (#4604). Tearing down turn so the session is recoverable.`)
+    // #4828: session-scoped — stall watchdog fires strictly post-start.
+    ;(this._log || log).warn(`AskUserQuestion stall: tool=${toolUseId} — claude TUI never emitted PostToolUse after answer write (${ASK_USER_QUESTION_WATCHDOG_MS}ms). Likely a multi-question form (#4604). Tearing down turn so the session is recoverable.`)
 
     this._teardownAskUserQuestion(toolUseId, {
       synthResult: 'AskUserQuestion stalled — no response from claude TUI within 30s. Likely a multi-question form (#4604).',

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -13,7 +13,7 @@ import { emitToolResults } from './tool-result.js'
 import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
-import { createLogger } from './logger.js'
+import { createLogger, loggerForSession } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 
 const log = createLogger('cli-session')
@@ -194,6 +194,11 @@ export class CliSession extends BaseSession {
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sessionId = null
+    // #4828: session-scoped logger, lazily bound when the CLI emits its
+    // `init` message (where session_id becomes known). Pre-init log lines
+    // stay on the module-level `log` — same fallback pattern as SdkSession
+    // / ClaudeTuiSession.
+    this._log = null
     this._child = null
     this._rl = null
     this._stderrRL = null
@@ -543,7 +548,8 @@ export class CliSession extends BaseSession {
     if (!this._isBusy) return
     const idleMs = this._resultTimeoutMs
     const friendly = formatIdleDuration(idleMs)
-    log.info(`Inactivity warning (${friendly}) — session alive, prompting check-in`)
+    // #4828: session-scoped (inactivity warning fires from active turn).
+    ;(this._log || log).info(`Inactivity warning (${friendly}) — session alive, prompting check-in`)
     this.emit('inactivity_warning', {
       messageId: this._currentMessageId,
       idleMs,
@@ -562,7 +568,8 @@ export class CliSession extends BaseSession {
   _handleHardTimeout() {
     if (!this._isBusy) return
     const friendly = formatIdleDuration(this._hardTimeoutMs)
-    log.warn(`Hard-cap timeout (${friendly}) — force-clearing busy state`)
+    // #4828: session-scoped (hard-cap fires from active turn).
+    ;(this._log || log).warn(`Hard-cap timeout (${friendly}) — force-clearing busy state`)
     // Fire permission_expired for every pending permission we know about
     // so the client clears the stale prompt.
     for (const requestId of this._pendingPermissionIds) {
@@ -585,7 +592,8 @@ export class CliSession extends BaseSession {
   _handleStreamStall() {
     if (!this._isBusy) return
     const friendly = formatIdleDuration(this._streamStallTimeoutMs)
-    log.warn(
+    // #4828: session-scoped (stall fires from active turn).
+    ;(this._log || log).warn(
       `Stream stalled (${friendly}, messageId=${this._currentMessageId}) — clearing busy state for retry`,
     )
     this._emitInterruptedTurnResult(this._streamStallTimeoutMs)
@@ -682,13 +690,17 @@ export class CliSession extends BaseSession {
         if (data.subtype === 'init') {
           this._sessionId = data.session_id
           this._respawnCount = 0
+          // #4828: bind the session-scoped logger now that session_id is
+          // known. Subsequent log lines route through the WsServer log
+          // fan-out (#4787) to dashboards bound to this session.
+          this._log = loggerForSession('cli-session', data.session_id)
           // #3687: persist the actual model the CLI booted with so
           // sendSessionInfo (replay on reconnect / tab switch) reports the
           // truth instead of `null` when the user didn't specify a model.
           if (typeof data.model === 'string' && data.model) {
             this.bootedModel = data.model
           }
-          log.info(`Session initialized: ${data.session_id}`)
+          ;(this._log || log).info(`Session initialized: ${data.session_id}`)
           this.emit('ready', {
             sessionId: data.session_id,
             model: data.model,
@@ -697,7 +709,8 @@ export class CliSession extends BaseSession {
           // Emit MCP server status if present (including empty list to clear stale state)
           if (Array.isArray(data.mcp_servers)) {
             if (data.mcp_servers.length > 0) {
-              log.info(`MCP servers: ${data.mcp_servers.map(s => `${s.name}(${s.status})`).join(', ')}`)
+              // #4828: session-scoped (post-init).
+              ;(this._log || log).info(`MCP servers: ${data.mcp_servers.map(s => `${s.name}(${s.status})`).join(', ')}`)
             }
             this.emit('mcp_servers', { servers: data.mcp_servers })
           }
@@ -705,7 +718,8 @@ export class CliSession extends BaseSession {
           // Forward non-init system events (e.g. usage limits, sub-agent
           // notifications) as system messages to the client
           const text = data.message || data.text || data.subtype || 'System event'
-          log.info(`System event (${data.subtype || 'unknown'}): ${text}`)
+          // #4828: session-scoped (non-init system event arrives after init).
+          ;(this._log || log).info(`System event (${data.subtype || 'unknown'}): ${text}`)
           this.emit('message', {
             type: 'system',
             content: text,
@@ -768,7 +782,8 @@ export class CliSession extends BaseSession {
                 if (ctx.toolInputBytes + chunkBytes > this._maxToolInput) {
                   ctx.toolInputChunks = ''
                   ctx.toolInputOverflow = true
-                  log.warn(`toolInputChunks exceeded ${this._maxToolInput} bytes, discarding buffer`)
+                  // #4828: session-scoped (stream_event fires post-init).
+                  ;(this._log || log).warn(`toolInputChunks exceeded ${this._maxToolInput} bytes, discarding buffer`)
                   this.emit('error', {
                     message: `Tool input too large (>${Math.round(this._maxToolInput / 1024)}KB) for ${ctx.currentToolName || 'unknown tool'} — input was truncated`,
                   })
@@ -910,15 +925,16 @@ export class CliSession extends BaseSession {
         // Parse-failure logging matches the per-tool pre-extraction
         // messages so existing log scraping continues to work.
         if (toolName === 'AskUserQuestion') {
-          log.error(`Failed to parse AskUserQuestion input: ${err.message}`)
+          // #4828: session-scoped (tool parsing runs strictly post-init).
+          ;(this._log || log).error(`Failed to parse AskUserQuestion input: ${err.message}`)
           return
         }
         if (toolName === 'Task') {
-          log.warn(`Failed to parse Task tool input: ${err.message}`)
+          ;(this._log || log).warn(`Failed to parse Task tool input: ${err.message}`)
           return
         }
         if (toolName === 'ExitPlanMode') {
-          log.warn(`Failed to parse ExitPlanMode input: ${err.message}`)
+          ;(this._log || log).warn(`Failed to parse ExitPlanMode input: ${err.message}`)
           // ExitPlanMode falls through with parseSucceeded=false so the
           // empty allowedPrompts default still applies.
         }
@@ -935,7 +951,8 @@ export class CliSession extends BaseSession {
         // `parseSucceeded` (truthiness of `parsed` would drop legal
         // falsy JSON values).
         if (!parseSucceeded) return
-        log.info(`AskUserQuestion detected (${toolUseId})`)
+        // #4828: session-scoped.
+        ;(this._log || log).info(`AskUserQuestion detected (${toolUseId})`)
         this._waitingForAnswer = true
         this.emit('user_question', {
           toolUseId,
@@ -1001,7 +1018,8 @@ export class CliSession extends BaseSession {
         if (this._destroying) return
         if (!this._processReady || this._pendingQueue.length === 0) return
         const pending = this._pendingQueue.shift()
-        log.info(`Dequeuing next pending message after result (${this._pendingQueue.length} remaining)`)
+        // #4828: session-scoped (post-result, post-init).
+        ;(this._log || log).info(`Dequeuing next pending message after result (${this._pendingQueue.length} remaining)`)
         this.sendMessage(pending.prompt, pending.attachments, pending.options || {})
       })
     }
@@ -1021,6 +1039,9 @@ export class CliSession extends BaseSession {
     this._respawning = true
     this._processReady = false
     this._sessionId = null
+    // #4828: drop the session-scoped logger so the next init re-binds it
+    // to the fresh session_id rather than leaking the stale one.
+    this._log = null
 
     // The new child process has no conversation state — and on Claude CLI
     // the append/system bucket rides on `--append-system-prompt` at spawn,
@@ -1085,7 +1106,8 @@ export class CliSession extends BaseSession {
       // Force-kill after 10s if process doesn't exit cleanly
       const forceKillTimer = setTimeout(() => {
         if (!didClose) {
-          log.warn('Process did not exit after 10s, force-killing')
+          // #4828: session-scoped if init has fired before kill.
+          ;(this._log || log).warn('Process did not exit after 10s, force-killing')
           try {
             forceKill(oldChild)
           } catch (_err) {
@@ -1123,7 +1145,8 @@ export class CliSession extends BaseSession {
    */
   setModel(model) {
     if (!super.setModel(model)) return
-    log.info(`Model changed to ${this.model || 'default'}, restarting process`)
+    // #4828: session-scoped if init has fired before the model change.
+    ;(this._log || log).info(`Model changed to ${this.model || 'default'}, restarting process`)
     this._killAndRespawn()
   }
 
@@ -1134,7 +1157,8 @@ export class CliSession extends BaseSession {
     // the in-flight `claude -p` process is killed and respawned, dropping the
     // current turn. This is by design (parity with SDK auto-resolve of pending
     // prompts); see #3735 for the regression test pinning this behavior.
-    log.info(`Permission mode changed to ${mode}, restarting process`)
+    // #4828: session-scoped if init has fired.
+    ;(this._log || log).info(`Permission mode changed to ${mode}, restarting process`)
     this._killAndRespawn()
   }
 
@@ -1156,7 +1180,8 @@ export class CliSession extends BaseSession {
     try {
       this._child.stdin.write(ndjson + '\n')
     } catch (err) {
-      log.error(`stdin.write failed (respondToQuestion): ${err.message}`)
+      // #4828: session-scoped (respondToQuestion fires strictly post-init).
+      ;(this._log || log).error(`stdin.write failed (respondToQuestion): ${err.message}`)
     }
   }
 
@@ -1198,12 +1223,14 @@ export class CliSession extends BaseSession {
     // exited cleanly as a result — do NOT show "exited unexpectedly" and
     // do NOT auto-respawn the child the user explicitly stopped.
     if (wasIntentionalStop) {
-      log.info(`Process exited (code ${code}) after user stop`)
+      // #4828: session-scoped if init had fired before the stop.
+      ;(this._log || log).info(`Process exited (code ${code}) after user stop`)
       this.emit('stopped', { code })
       return
     }
 
-    log.info(`Process exited (code ${code}), scheduling respawn`)
+    // #4828: session-scoped if init had fired.
+    ;(this._log || log).info(`Process exited (code ${code}), scheduling respawn`)
     this.emit('error', { message: 'Claude process exited unexpectedly, restarting...' })
     this._scheduleRespawn()
   }
@@ -1219,7 +1246,8 @@ export class CliSession extends BaseSession {
     // is cleared in _handleChildClose on whichever exit fires first.
     this._intentionalStop = true
 
-    log.info('Sending SIGINT to claude process')
+    // #4828: session-scoped if init has fired.
+    ;(this._log || log).info('Sending SIGINT to claude process')
     this._child.kill('SIGINT')
 
     // Safety: if still busy after 5s, force-clear state.
@@ -1236,7 +1264,8 @@ export class CliSession extends BaseSession {
       // otherwise the flag stays armed indefinitely and swallows real crashes.
       this._intentionalStop = false
       if (this._isBusy) {
-        log.warn('Interrupt safety timeout — force-clearing busy state')
+        // #4828: session-scoped.
+        ;(this._log || log).warn('Interrupt safety timeout — force-clearing busy state')
         this._emitInterruptedTurnResult()
       }
     }, 5000)

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -323,14 +323,17 @@ export class CliSession extends BaseSession {
     this._stderrRL = stderrRL
     stderrRL.on('line', (line) => {
       if (line.trim()) {
-        log.info(`stderr: ${line}`)
+        // #4828: session-scoped when init has fired (stderr arrives both
+        // pre- and post-init; the fallback covers the pre-init case).
+        ;(this._log || log).info(`stderr: ${line}`)
       }
     })
 
     // Absorb EPIPE and other low-level stdin errors so they don't become
     // unhandled exceptions. Writes are already wrapped in try/catch below.
     child.stdin.on('error', (err) => {
-      log.warn(`stdin error (ignored): ${err.message}`)
+      // #4828: session-scoped when init has fired.
+      ;(this._log || log).warn(`stdin error (ignored): ${err.message}`)
     })
 
     child.on('error', (err) => {
@@ -355,7 +358,9 @@ export class CliSession extends BaseSession {
     // _clearMessageState() after each result.
     while (this._pendingQueue.length > 0 && !this._isBusy) {
       const pending = this._pendingQueue.shift()
-      log.info(`Dequeuing pending message (${this._pendingQueue.length} remaining)`)
+      // #4828: session-scoped when init has fired (dequeue can race with
+      // the very-first init so the fallback is intentional).
+      ;(this._log || log).info(`Dequeuing pending message (${this._pendingQueue.length} remaining)`)
       this.sendMessage(pending.prompt, pending.attachments, pending.options || {})
     }
   }
@@ -404,7 +409,9 @@ export class CliSession extends BaseSession {
         this.emit('error', { message: 'Pending message queue full (max 3) — message discarded' })
         return
       }
-      log.info(`Process not ready, queuing message (queue depth: ${this._pendingQueue.length + 1})`)
+      // #4828: session-scoped when init has fired (queuing typically happens
+      // pre-init or during respawn — both can race with the binding).
+      ;(this._log || log).info(`Process not ready, queuing message (queue depth: ${this._pendingQueue.length + 1})`)
       this._pendingQueue.push({ prompt, attachments, options })
       return
     }
@@ -464,11 +471,16 @@ export class CliSession extends BaseSession {
       },
     })
 
-    log.info(`Sending message ${this._currentMessageId}: "${(prompt || '').slice(0, 60)}"${attachments?.length ? ` (+${attachments.length} attachment(s))` : ''}`)
+    // #4828: session-scoped when init has fired. The very first message
+    // sends pre-init (CLI's `init` arrives in the first response), so the
+    // first turn falls back to module-level `log`; all subsequent sends
+    // route through `this._log`.
+    ;(this._log || log).info(`Sending message ${this._currentMessageId}: "${(prompt || '').slice(0, 60)}"${attachments?.length ? ` (+${attachments.length} attachment(s))` : ''}`)
     try {
       this._child.stdin.write(ndjson + '\n')
     } catch (err) {
-      log.error(`stdin.write failed (sendMessage): ${err.message}`)
+      // #4828: session-scoped when init has fired.
+      ;(this._log || log).error(`stdin.write failed (sendMessage): ${err.message}`)
       this._clearMessageState()
       this.emit('error', { message: `Failed to send message: ${err.message}` })
       return

--- a/packages/server/src/handlers/conversation-handlers.js
+++ b/packages/server/src/handlers/conversation-handlers.js
@@ -8,7 +8,7 @@ import { scanConversations as defaultScanConversations } from '../conversation-s
 import { searchConversations as defaultSearchConversations } from '../conversation-search.js'
 import { validateCwdAllowed, broadcastFocusChanged, resolveSession, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError } from '../handler-utils.js'
 import { scopeConversationsToClient } from '../conversation-scope.js'
-import { createLogger } from '../logger.js'
+import { createLogger, loggerForSession } from '../logger.js'
 
 const log = createLogger('ws')
 
@@ -163,7 +163,11 @@ async function handleRequestSessionContext(ws, client, msg, ctx) {
       sendSessionError(ws, ctx, `Session not found: ${targetId}`)
     }
   } catch (err) {
-    log.warn(`Failed to read session context: ${err.message}`)
+    // #4828: session-scoped — `targetId` is the active session ID in
+    // scope. Legacy single-session callers may surface an empty value,
+    // so fall back to module-level `log` rather than throwing inside
+    // loggerForSession (same pattern as the settings-handlers sites).
+    ;(targetId ? loggerForSession('ws', targetId) : log).warn(`Failed to read session context: ${err.message}`)
     sendSessionError(ws, ctx, `Failed to read session context: ${err.message}`)
   }
 }

--- a/packages/server/src/handlers/feature-handlers.js
+++ b/packages/server/src/handlers/feature-handlers.js
@@ -9,7 +9,7 @@
  * web-task-handlers.js, and environment-handlers.js. Consolidated here to
  * reduce file fragmentation (each file had 1–4 small functions).
  */
-import { createLogger } from '../logger.js'
+import { createLogger, loggerForSession } from '../logger.js'
 import { validateCwdAllowed, buildSessionTokenMismatchPayload, sendSessionError } from '../handler-utils.js'
 import { validateDockerImage } from '../docker-image-allowlist.js'
 import { WebTaskUnavailableError } from '../web-task-manager.js'
@@ -55,7 +55,11 @@ function handleExtensionMessage(ws, client, msg, ctx) {
   if (typeof entry.session.handleExtensionMessage === 'function') {
     entry.session.handleExtensionMessage({ provider, subtype, data })
   } else {
-    log.debug(`extension_message (${provider}/${subtype}) received; session does not handle it`)
+    // #4828: session-scoped — targetSessionId is in scope and bound.
+    // Legacy single-session callers may surface an empty value, so fall
+    // back to module-level `log` rather than throwing inside
+    // loggerForSession (same pattern as the settings-handlers sites).
+    ;(targetSessionId ? loggerForSession('ws', targetSessionId) : log).debug(`extension_message (${provider}/${subtype}) received; session does not handle it`)
   }
 }
 

--- a/packages/server/src/handlers/session-handlers.js
+++ b/packages/server/src/handlers/session-handlers.js
@@ -6,7 +6,7 @@
  */
 import { validateCwdAllowed, broadcastFocusChanged, autoSubscribeOtherClients, buildSessionTokenMismatchPayload, sendSessionError } from '../handler-utils.js'
 import { getRegistryForProvider } from '../models.js'
-import { createLogger } from '../logger.js'
+import { createLogger, loggerForSession } from '../logger.js'
 
 const log = createLogger('ws')
 
@@ -30,7 +30,9 @@ function handleSwitchSession(ws, client, msg, ctx) {
   // pairing-issued session token that was bound to a specific session,
   // prevent them from switching to any other session.
   if (client.boundSessionId && client.boundSessionId !== targetId) {
-    log.warn(`Client ${client.id} attempted to switch to session ${targetId} but is bound to ${client.boundSessionId}`)
+    // #4828: session-scoped to the bound session — the binding-mismatch
+    // warn belongs to the OWNER of `boundSessionId`, not the request target.
+    loggerForSession('ws', client.boundSessionId).warn(`Client ${client.id} attempted to switch to session ${targetId} but is bound to ${client.boundSessionId}`)
     ctx.send(ws, {
       type: 'session_error',
       ...buildSessionTokenMismatchPayload({
@@ -58,7 +60,8 @@ function handleSwitchSession(ws, client, msg, ctx) {
   if (ctx.devicePreferences && !client.boundSessionId && client.deviceInfo?.deviceId) {
     ctx.devicePreferences.setActiveSessionId(client.deviceInfo.deviceId, targetId)
   }
-  log.info(`Client ${client.id} switched to session ${targetId}`)
+  // #4828: session-scoped — the switch is into `targetId`.
+  loggerForSession('ws', targetId).info(`Client ${client.id} switched to session ${targetId}`)
   ctx.send(ws, { type: 'session_switched', sessionId: targetId, name: entry.name, cwd: entry.cwd, conversationId: entry.session.resumeSessionId || null })
   ctx.sendSessionInfo(ws, targetId)
   ctx.replayHistory(ws, targetId)

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -22,7 +22,7 @@ import {
 } from '../byok-credentials.js'
 import { loadActiveSkillsLayered, findRepoSkillsDir, findSkillForRetrust, DEFAULT_SKILLS_DIR, _isCommunityNamespace } from '../skills-loader.js'
 import { realpathSync, readdirSync, statSync } from 'fs'
-import { createLogger } from '../logger.js'
+import { createLogger, loggerForSession } from '../logger.js'
 import {
   PER_SESSION_SETTINGS,
   buildPerSessionSettingHandler,
@@ -99,7 +99,12 @@ function handleSetModel(ws, client, msg, ctx) {
     const providerAllowed = getProviderAllowedModels(entry.provider)
     if (providerAllowed) {
       if (!providerAllowed.includes(msg.model)) {
-        log.warn(`Rejected model '${msg.model}' on ${entry.provider} session ${modelSessionId} from ${client.id}`)
+        // #4828: session-scoped — modelSessionId identifies the affected
+        // session. Legacy single-session adapters may surface an empty
+        // sessionId, so fall back to the module-level `log` rather than
+        // throwing inside loggerForSession (matches the input-handlers
+        // pattern from #4823).
+        ;(modelSessionId ? loggerForSession('ws', modelSessionId) : log).warn(`Rejected model '${msg.model}' on ${entry.provider} session ${modelSessionId} from ${client.id}`)
         sendError(
           ws,
           msg?.requestId,
@@ -108,7 +113,8 @@ function handleSetModel(ws, client, msg, ctx) {
         )
         return
       }
-      log.info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
+      // #4828: session-scoped (single-session fallback as above).
+      ;(modelSessionId ? loggerForSession('ws', modelSessionId) : log).info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
       entry.session.setModel(msg.model)
       // Non-Claude providers use opaque model IDs (e.g. 'gemini-2.5-pro') —
       // broadcast them verbatim. toShortModelId() is a Claude-specific
@@ -123,7 +129,8 @@ function handleSetModel(ws, client, msg, ctx) {
 
   if (ALLOWED_MODEL_IDS.has(msg.model)) {
     if (entry) {
-      log.info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
+      // #4828: session-scoped (single-session fallback).
+      ;(modelSessionId ? loggerForSession('ws', modelSessionId) : log).info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
       entry.session.setModel(msg.model)
       ctx.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(msg.model) })
     }
@@ -154,7 +161,8 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
           // Unknown provider — allow through (fail open for forward-compat).
         }
         if (ProviderClass && ProviderClass.capabilities?.permissionModeSwitch === false) {
-          log.warn(`Rejected set_permission_mode on ${entry.provider} session ${permModeSessionId} from ${client.id}: provider does not support permissionModeSwitch`)
+          // #4828: session-scoped (single-session fallback).
+          ;(permModeSessionId ? loggerForSession('ws', permModeSessionId) : log).warn(`Rejected set_permission_mode on ${entry.provider} session ${permModeSessionId} from ${client.id}: provider does not support permissionModeSwitch`)
           sendError(
             ws,
             msg?.requestId,
@@ -197,20 +205,24 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
       //    escalate. Only the primary API token can flip to auto.
       if (msg.mode === 'auto') {
         if (client.boundSessionId) {
-          log.warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to flip to auto permission mode — rejected`)
+          // #4828: session-scoped to the bound session — that's the
+          // session the rejection belongs to.
+          loggerForSession('ws', client.boundSessionId).warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to flip to auto permission mode — rejected`)
           sendError(ws, msg?.requestId, 'AUTO_MODE_FORBIDDEN_BOUND_CLIENT',
             'Pairing-issued session tokens cannot enable auto permission mode. Use the primary API token from a device with physical access to this machine.')
           return
         }
         if (ctx.config?.allowAutoPermissionMode !== true) {
-          log.warn(`Client ${client.id} attempted to flip to auto permission mode but allowAutoPermissionMode is not enabled in server config`)
+          // #4828: session-scoped (single-session fallback).
+          ;(permModeSessionId ? loggerForSession('ws', permModeSessionId) : log).warn(`Client ${client.id} attempted to flip to auto permission mode but allowAutoPermissionMode is not enabled in server config`)
           sendError(ws, msg?.requestId, 'AUTO_MODE_DISABLED_BY_CONFIG',
             'Auto permission mode is disabled on this server. To enable, set allowAutoPermissionMode:true in the server config file (requires local filesystem access). Default is disabled for security.')
           return
         }
       }
       if (msg.mode === 'auto' && !msg.confirmed) {
-        log.info(`Auto mode requested by ${client.id}, awaiting confirmation`)
+        // #4828: session-scoped (single-session fallback).
+        ;(permModeSessionId ? loggerForSession('ws', permModeSessionId) : log).info(`Auto mode requested by ${client.id}, awaiting confirmation`)
         ctx.send(ws, {
           type: 'confirm_permission_mode',
           mode: 'auto',
@@ -218,10 +230,12 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
         })
       } else {
         const previousMode = entry.session.permissionMode || 'unknown'
+        // #4828: session-scoped (single-session fallback).
+        const _pmLog = permModeSessionId ? loggerForSession('ws', permModeSessionId) : log
         if (msg.mode === 'auto') {
-          log.info(`Auto permission mode CONFIRMED by ${client.id} at ${new Date().toISOString()} (was: ${previousMode})`)
+          _pmLog.info(`Auto permission mode CONFIRMED by ${client.id} at ${new Date().toISOString()} (was: ${previousMode})`)
         } else {
-          log.info(`Permission mode change from ${client.id} on session ${permModeSessionId}: ${previousMode} → ${msg.mode} at ${new Date().toISOString()}`)
+          _pmLog.info(`Permission mode change from ${client.id} on session ${permModeSessionId}: ${previousMode} → ${msg.mode} at ${new Date().toISOString()}`)
         }
         // BaseSession exposes the mode on the public `permissionMode` field.
         // The earlier `_permissionMode` read was a typo that always resolved
@@ -238,7 +252,8 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
         // leaving the user staring at fresh prompts in supposed bypass mode.
         const actualMode = entry.session.permissionMode
         if (actualMode !== msg.mode) {
-          log.warn(`set_permission_mode rejected (session busy or no-op): requested ${msg.mode}, still ${actualMode}`)
+          // #4828: session-scoped (single-session fallback).
+          ;(permModeSessionId ? loggerForSession('ws', permModeSessionId) : log).warn(`set_permission_mode rejected (session busy or no-op): requested ${msg.mode}, still ${actualMode}`)
           sendError(ws, msg?.requestId, 'PERMISSION_MODE_NOT_APPLIED',
             `Permission mode change to '${msg.mode}' was not applied (session busy or already in that mode).`)
           return
@@ -306,7 +321,9 @@ function handlePermissionResponse(ws, client, msg, ctx) {
         (ageMs !== null && ageMs > 30_000) ||
         (createdAt && clientConnectedAt && clientConnectedAt > createdAt)
       )
-      log.warn(`[session-binding-reject] permission_response rejected ${JSON.stringify({
+      // #4828: session-scoped to the bound session — the reject belongs
+      // to the OWNER of `boundSessionId`, not the mismatched `originSessionId`.
+      loggerForSession('ws', client.boundSessionId).warn(`[session-binding-reject] permission_response rejected ${JSON.stringify({
         requestId,
         decision,
         clientId: client.id,
@@ -356,7 +373,10 @@ function handlePermissionResponse(ws, client, msg, ctx) {
     const subscribed = originSessionId === client.activeSessionId
       || (client.subscribedSessionIds && client.subscribedSessionIds.has(originSessionId))
     if (!subscribed) {
-      log.warn(`[permission-response-reject] unbound client ${client.id} attempted to respond to ${requestId} (originSessionId=${originSessionId}, activeSessionId=${client.activeSessionId ?? 'none'}, subscribed=false) — dropped`)
+      // #4828: session-scoped — the permission belongs to `originSessionId`
+      // when known. Fall back to module-level `log` when the request had
+      // no mapping AND the client isn't bound (legacy / unknown route).
+      ;(originSessionId ? loggerForSession('ws', originSessionId) : log).warn(`[permission-response-reject] unbound client ${client.id} attempted to respond to ${requestId} (originSessionId=${originSessionId}, activeSessionId=${client.activeSessionId ?? 'none'}, subscribed=false) — dropped`)
       return
     }
   }
@@ -832,7 +852,8 @@ function handleSkillTrustAccept(ws, client, msg, ctx) {
     try {
       trustStore.flush()
     } catch (err) {
-      log.warn(`skill_trust_accept: flush failed (${err && err.message ? err.message : err})`)
+      // #4828: session-scoped — `sessionId` is in scope (L772 above).
+      loggerForSession('ws', sessionId).warn(`skill_trust_accept: flush failed (${err && err.message ? err.message : err})`)
       sendError(
         ws,
         msg?.requestId,
@@ -1071,7 +1092,8 @@ function handleSkillTrustGrant(ws, client, msg, ctx) {
   try {
     trustStore.grantCommunityTrust(msg.author, { realPath: resolvedPath })
   } catch (err) {
-    log.warn(`skill_trust_grant: flush failed (${err && err.message ? err.message : err})`)
+    // #4828: session-scoped — `sessionId` is in scope earlier in the handler.
+    loggerForSession('ws', sessionId).warn(`skill_trust_grant: flush failed (${err && err.message ? err.message : err})`)
     sendError(
       ws,
       msg?.requestId,
@@ -1194,7 +1216,8 @@ function handleSetPromptEvaluatorSkipPattern(ws, client, msg, ctx) {
   try {
     ctx.sessionManager?.serializeState?.()
   } catch (err) {
-    log.warn(`Failed to persist promptEvaluatorSkipPattern for ${sessionId}: ${err?.message || err}`)
+    // #4828: session-scoped.
+    loggerForSession('ws', sessionId).warn(`Failed to persist promptEvaluatorSkipPattern for ${sessionId}: ${err?.message || err}`)
   }
 }
 
@@ -1255,7 +1278,8 @@ function handleSetPermissionRules(ws, client, msg, ctx) {
   // Broadcast updated rules to all session clients
   const currentRules = entry.session.getPermissionRules ? entry.session.getPermissionRules() : rules
   ctx.broadcastToSession(sessionId, { type: 'permission_rules_updated', rules: currentRules, sessionId })
-  log.info(`Permission rules updated by ${client.id} on session ${sessionId}: ${rules.length} rule(s)`)
+  // #4828: session-scoped.
+  loggerForSession('ws', sessionId).info(`Permission rules updated by ${client.id} on session ${sessionId}: ${rules.length} rule(s)`)
 }
 
 // #4664: assemble the per-session-setting WS handlers from the registry.

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -12,7 +12,7 @@ import {
   parseBashOutputShellId,
 } from './background-shells.js'
 import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
-import { createLogger } from './logger.js'
+import { createLogger, loggerForSession } from './logger.js'
 import { PermissionManager } from './permission-manager.js'
 import { formatBytes } from './utils/format-bytes.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
@@ -307,6 +307,10 @@ export class SdkSession extends BaseSession {
 
     this._sdkSessionId = resumeSessionId || null
     this._sessionId = null
+    // #4828: session-scoped logger, lazily bound on the SDK's first `init`
+    // message (where session_id becomes known). Pre-init log lines stay on
+    // the module-level `log` — same fallback pattern as ClaudeTuiSession.
+    this._log = null
     this._query = null
     this._thinkingLevel = null
     this._pendingInput = []
@@ -682,6 +686,10 @@ export class SdkSession extends BaseSession {
             if (msg.subtype === 'init') {
               this._sdkSessionId = msg.session_id
               this._sessionId = msg.session_id
+              // #4828: bind the session-scoped logger now that session_id
+              // is known. Subsequent log lines route through the WsServer
+              // log fan-out (#4787) to dashboards bound to this session.
+              this._log = loggerForSession('sdk', msg.session_id)
               // #3687: persist the actual model the SDK booted with so
               // sendSessionInfo (replay on reconnect / tab switch) reports
               // the truth instead of `null` when the user didn't specify a
@@ -689,7 +697,7 @@ export class SdkSession extends BaseSession {
               if (typeof msg.model === 'string' && msg.model) {
                 this.bootedModel = msg.model
               }
-              log.info(`Session initialized: ${msg.session_id} (model: ${msg.model})`)
+              ;(this._log || log).info(`Session initialized: ${msg.session_id} (model: ${msg.model})`)
               this.emit('ready', {
                 sessionId: msg.session_id,
                 model: msg.model,
@@ -698,7 +706,8 @@ export class SdkSession extends BaseSession {
               // Emit MCP server status if present (including empty list to clear stale state)
               if (Array.isArray(msg.mcp_servers)) {
                 if (msg.mcp_servers.length > 0) {
-                  log.info(`MCP servers: ${msg.mcp_servers.map(s => `${s.name}(${s.status})`).join(', ')}`)
+                  // #4828: session-scoped (post-init).
+                  ;(this._log || log).info(`MCP servers: ${msg.mcp_servers.map(s => `${s.name}(${s.status})`).join(', ')}`)
                 }
                 this.emit('mcp_servers', { servers: msg.mcp_servers })
               }
@@ -708,7 +717,8 @@ export class SdkSession extends BaseSession {
               // Forward non-init system events (e.g. /usage, /cost, other
               // slash command responses) as system messages to the client
               const text = msg.message || msg.text || msg.subtype || 'System event'
-              log.info(`System event (${msg.subtype || 'unknown'}): ${typeof text === 'string' ? text.slice(0, 120) : text}`)
+              // #4828: session-scoped (non-init system event arrives after init).
+              ;(this._log || log).info(`System event (${msg.subtype || 'unknown'}): ${typeof text === 'string' ? text.slice(0, 120) : text}`)
               this.emit('message', {
                 type: 'system',
                 content: text,
@@ -832,7 +842,8 @@ export class SdkSession extends BaseSession {
               if (missingIds.length > 0) {
                 const sampleId = missingIds[0]
                 const sampleKeys = Object.keys(msg.modelUsage[sampleId] || {})
-                log.debug(
+                // #4828: session-scoped (result handler runs strictly post-init).
+                ;(this._log || log).debug(
                   `modelUsage partial drift: contextWindow missing for modelIds=${JSON.stringify(missingIds)} sampleKeys=${JSON.stringify(sampleKeys)}`
                 )
               }
@@ -866,7 +877,9 @@ export class SdkSession extends BaseSession {
         this.emit('stream_end', { messageId })
       }
       if (!this._destroying) {
-        log.error(`Query error: ${err.message}`)
+        // #4828: session-scoped when init has fired; falls back to module
+        // `log` for pre-init query failures (e.g. spawn refused).
+        ;(this._log || log).error(`Query error: ${err.message}`)
         this.emit('error', { message: SdkSession._enrichErrorMessage(err.message) })
       }
       this._clearMessageState()
@@ -884,7 +897,8 @@ export class SdkSession extends BaseSession {
         // the entry-gate drain (#3539/PR #3560), log a single warn, and
         // skip the recursion entirely.
         if (this._stdinForwardingDisabled) {
-          log.warn(
+          // #4828: session-scoped (finally block runs strictly post-init).
+          ;(this._log || log).warn(
             `Discarding ${this._pendingInput.length} queued follow-up message(s) after turn finish — ` +
             'stdin forwarding is disabled'
           )
@@ -892,7 +906,8 @@ export class SdkSession extends BaseSession {
           return
         }
         const next = this._pendingInput.shift()
-        log.info(`Dequeuing follow-up message (${this._pendingInput.length} remaining)`)
+        // #4828: session-scoped.
+        ;(this._log || log).info(`Dequeuing follow-up message (${this._pendingInput.length} remaining)`)
         // Use setImmediate/nextTick to avoid stack depth issues
         process.nextTick(() => {
           if (!this._destroying) {
@@ -1007,10 +1022,13 @@ export class SdkSession extends BaseSession {
         `cumulative=${cumulative} bytes (${cumulativeHuman}) over ${dropCount} drops) — ` +
         'turn input was truncated; consumer may need to retry'
 
+      // #4828: session-scoped when init has fired; falls back to module
+      // `log` for stdin drops that occur pre-init (rare — SidecarProcess
+      // listener attach happens after spawn, before init normally arrives).
       if (escalate) {
-        log.error(message)
+        ;(this._log || log).error(message)
       } else {
-        log.warn(message)
+        ;(this._log || log).warn(message)
       }
 
       // #3544: surface the cumulative totals as a session-level event so
@@ -1054,7 +1072,9 @@ export class SdkSession extends BaseSession {
       // that cannot work.
       const message = 'Sidecar stdin forwarding is disabled — further writes will be ' +
         'silently dropped; restart this session to recover'
-      log.warn(message)
+      // #4828: session-scoped when known; falls back to module `log` for
+      // the rare pre-init case (same rationale as the stdin_dropped path).
+      ;(this._log || log).warn(message)
       // #3502: surface the disabled flag to paired clients via the session
       // `error` channel.  SessionManager._wireSessionEvents proxies `error`
       // into the unified `session_event` envelope, so dashboards and the
@@ -1082,7 +1102,8 @@ export class SdkSession extends BaseSession {
     // Guard against oversized tool inputs
     const inputStr = JSON.stringify(block.input || {})
     if (Buffer.byteLength(inputStr, 'utf8') > this._maxToolInput) {
-      log.warn(`Tool input for ${block.name} exceeded ${this._maxToolInput} bytes, skipping`)
+      // #4828: session-scoped (tool_use only arrives after init).
+      ;(this._log || log).warn(`Tool input for ${block.name} exceeded ${this._maxToolInput} bytes, skipping`)
       this.emit('error', {
         message: `Tool input too large (>${Math.round(this._maxToolInput / 1024)}KB) for ${block.name} — tool use was skipped`,
       })
@@ -1195,7 +1216,8 @@ export class SdkSession extends BaseSession {
    */
   setModel(model) {
     if (!super.setModel(model)) return
-    log.info(`Model changed to ${this.model || 'default'}`)
+    // #4828: session-scoped when init has fired.
+    ;(this._log || log).info(`Model changed to ${this.model || 'default'}`)
   }
 
   setPermissionMode(mode) {
@@ -1209,7 +1231,8 @@ export class SdkSession extends BaseSession {
     if (mode === 'auto') {
       this._permissions.autoAllowPending()
     }
-    log.info(`Permission mode changed to ${mode}`)
+    // #4828: session-scoped when init has fired.
+    ;(this._log || log).info(`Permission mode changed to ${mode}`)
   }
 
   /**
@@ -1253,9 +1276,11 @@ export class SdkSession extends BaseSession {
     if (this._query && typeof this._query.setMaxThinkingTokens === 'function') {
       try {
         await this._query.setMaxThinkingTokens(budget)
-        log.info(`Thinking level set to ${level} (${budget ?? 'adaptive'} tokens)`)
+        // #4828: session-scoped (setThinkingLevel only takes effect with
+        // an active query — strictly post-init).
+        ;(this._log || log).info(`Thinking level set to ${level} (${budget ?? 'adaptive'} tokens)`)
       } catch (err) {
-        log.warn(`Failed to set thinking level: ${err.message}`)
+        ;(this._log || log).warn(`Failed to set thinking level: ${err.message}`)
       }
     }
 
@@ -1284,12 +1309,13 @@ export class SdkSession extends BaseSession {
       const sdkModels = await this._query.supportedModels()
       const converted = updateModels(sdkModels)
       if (converted && converted.length > 0) {
-        log.info(`Dynamic model list: ${converted.map(m => m.id).join(', ')}`)
+        // #4828: session-scoped (called from init handler so _log is set).
+        ;(this._log || log).info(`Dynamic model list: ${converted.map(m => m.id).join(', ')}`)
         saveModelsCache()
         this.emit('models_updated', { models: converted })
       }
     } catch (err) {
-      log.warn(`Failed to fetch supported models: ${err.message}`)
+      ;(this._log || log).warn(`Failed to fetch supported models: ${err.message}`)
     }
   }
 
@@ -1299,11 +1325,12 @@ export class SdkSession extends BaseSession {
   async interrupt() {
     if (!this._query) return
 
-    log.info('Interrupting query')
+    // #4828: session-scoped (interrupt() only meaningful with an active query).
+    ;(this._log || log).info('Interrupting query')
     try {
       await this._query.interrupt()
     } catch (err) {
-      log.warn(`Interrupt error: ${err.message}`)
+      ;(this._log || log).warn(`Interrupt error: ${err.message}`)
     }
   }
 
@@ -1326,7 +1353,8 @@ export class SdkSession extends BaseSession {
     if (!this._isBusy) return
     const idleMs = this._resultTimeoutMs
     const friendly = formatIdleDuration(idleMs)
-    log.info(`Inactivity warning (${friendly}) — session alive, prompting check-in`)
+    // #4828: session-scoped (inactivity warning fires from active turn).
+    ;(this._log || log).info(`Inactivity warning (${friendly}) — session alive, prompting check-in`)
     this.emit('inactivity_warning', {
       messageId,
       idleMs,
@@ -1347,7 +1375,8 @@ export class SdkSession extends BaseSession {
   _handleHardTimeout(messageId, hasStreamStarted) {
     if (!this._isBusy) return
     const friendly = formatIdleDuration(this._hardTimeoutMs)
-    log.warn(`Hard-cap timeout (${friendly} inactivity) — force-clearing busy state`)
+    // #4828: session-scoped (hard-cap fires from active turn).
+    ;(this._log || log).warn(`Hard-cap timeout (${friendly} inactivity) — force-clearing busy state`)
     if (hasStreamStarted) {
       this.emit('stream_end', { messageId })
     }
@@ -1387,7 +1416,8 @@ export class SdkSession extends BaseSession {
   _handleStreamStall(messageId, hasStreamStarted) {
     if (!this._isBusy) return
     const friendly = formatIdleDuration(this._streamStallTimeoutMs)
-    log.warn(
+    // #4828: session-scoped (stall fires from active turn).
+    ;(this._log || log).warn(
       `Stream stalled (${friendly}, messageId=${messageId}) — clearing busy state for retry`,
     )
     if (hasStreamStarted) {
@@ -1426,13 +1456,15 @@ export class SdkSession extends BaseSession {
       if (typeof q.interrupt === 'function') {
         const p = q.interrupt()
         if (p && typeof p.catch === 'function') {
-          p.catch((err) => log.warn(`Query interrupt (timeout) failed: ${err.message}`))
+          // #4828: session-scoped (abort runs strictly post-init).
+          p.catch((err) => (this._log || log).warn(`Query interrupt (timeout) failed: ${err.message}`))
         }
       } else if (typeof q.return === 'function') {
         q.return()
       }
     } catch (err) {
-      log.warn(`Query abort (timeout) failed: ${err.message}`)
+      // #4828: session-scoped.
+      ;(this._log || log).warn(`Query abort (timeout) failed: ${err.message}`)
     }
   }
 
@@ -1517,7 +1549,8 @@ export class SdkSession extends BaseSession {
     // Interrupt active query
     if (this._query) {
       this._query.interrupt().catch((err) => {
-        log.warn(`Failed to interrupt active query: ${err.message} (non-critical, session destroying)`)
+        // #4828: session-scoped when init has fired.
+        ;(this._log || log).warn(`Failed to interrupt active query: ${err.message} (non-critical, session destroying)`)
       })
       this._query = null
     }

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -310,6 +310,9 @@ export class SdkSession extends BaseSession {
     // #4828: session-scoped logger, lazily bound on the SDK's first `init`
     // message (where session_id becomes known). Pre-init log lines stay on
     // the module-level `log` — same fallback pattern as ClaudeTuiSession.
+    // No reset on destroy/respawn (unlike CliSession): SdkSession lacks a
+    // _killAndRespawn path so session_id is stable for the instance
+    // lifetime; the binding stays valid until destroy() drops the instance.
     this._log = null
     this._query = null
     this._thinkingLevel = null
@@ -450,7 +453,9 @@ export class SdkSession extends BaseSession {
       const now = Date.now()
       const warnSuppressed = (now - this._lastRefusedWarnTs) < REFUSED_SENDMESSAGE_WARN_INTERVAL_MS
       if (!warnSuppressed) {
-        log.warn(
+        // #4828: session-scoped when init has fired (sendMessage typically
+        // arrives after init; first-message pre-init path falls back to `log`).
+        ;(this._log || log).warn(
           'Refusing sendMessage — stdin forwarding is disabled for this session; ' +
           'restart the session to recover'
         )
@@ -462,7 +467,8 @@ export class SdkSession extends BaseSession {
       // noisy, and pointless because none of them can be sent.
       if (this._pendingInput?.length) {
         if (!warnSuppressed) {
-          log.warn(
+          // #4828: session-scoped when init has fired.
+          ;(this._log || log).warn(
             `Discarding ${this._pendingInput.length} queued follow-up message(s) — ` +
             'stdin forwarding is disabled'
           )
@@ -481,7 +487,9 @@ export class SdkSession extends BaseSession {
       // Queue the message — it will be sent after the current turn completes
       if (!this._pendingInput) this._pendingInput = []
       this._pendingInput.push({ prompt, attachments, sendOptions })
-      log.info(`Queued follow-up message (${this._pendingInput.length} pending)`)
+      // #4828: session-scoped when init has fired (queue path requires an
+      // in-flight turn, so init is normally already in by this point).
+      ;(this._log || log).info(`Queued follow-up message (${this._pendingInput.length} pending)`)
       return
     }
 
@@ -580,9 +588,10 @@ export class SdkSession extends BaseSession {
       const existing = options.maxThinkingTokens ?? 0
       if (detectedKeyword.budget > existing) {
         options.maxThinkingTokens = detectedKeyword.budget
-        log.info(`Thinking keyword "${detectedKeyword.keyword}" detected — escalating maxThinkingTokens to ${detectedKeyword.budget} for this turn`)
+        // #4828: session-scoped when init has fired.
+        ;(this._log || log).info(`Thinking keyword "${detectedKeyword.keyword}" detected — escalating maxThinkingTokens to ${detectedKeyword.budget} for this turn`)
       } else {
-        log.debug(`Thinking keyword "${detectedKeyword.keyword}" detected but session already at higher budget (${existing}) — leaving unchanged`)
+        ;(this._log || log).debug(`Thinking keyword "${detectedKeyword.keyword}" detected but session already at higher budget (${existing}) — leaving unchanged`)
       }
     }
 

--- a/packages/server/tests/lint-logger-session-scoping.test.js
+++ b/packages/server/tests/lint-logger-session-scoping.test.js
@@ -22,7 +22,7 @@
  */
 import { test, describe, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, cpSync, readFileSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -52,13 +52,26 @@ function buildFixtureTree({ requiresFactoryImport, forbidsBareCreateLogger, srcF
 
   let patched = REAL_LINT_SOURCE
   // Swap the REQUIRES_FACTORY_IMPORT Set body for the test-supplied list.
+  // #4828 (Copilot review): if the production Set's surface shape changes
+  // (multi-line keys, trailing comma stylistics, rename) the regex would
+  // silently no-op and every test would become vacuous — the fixture
+  // filenames would not appear in the real sets, lint would skip them, and
+  // assertions on offender lists would still pass. Assert the patch ran.
+  const reqRe = /const REQUIRES_FACTORY_IMPORT = new Set\(\[[\s\S]*?\]\)/
+  const forbidRe = /const FORBIDS_BARE_CREATELOGGER = new Set\(\[[\s\S]*?\]\)/
+  if (!reqRe.test(patched)) {
+    throw new Error('lint script no longer matches REQUIRES_FACTORY_IMPORT regex — fixture builder needs updating')
+  }
+  if (!forbidRe.test(patched)) {
+    throw new Error('lint script no longer matches FORBIDS_BARE_CREATELOGGER regex — fixture builder needs updating')
+  }
   patched = patched.replace(
-    /const REQUIRES_FACTORY_IMPORT = new Set\(\[[\s\S]*?\]\)/,
+    reqRe,
     `const REQUIRES_FACTORY_IMPORT = new Set([${requiresFactoryImport.map((f) => JSON.stringify(f)).join(', ')}])`,
   )
   // Same for FORBIDS_BARE_CREATELOGGER.
   patched = patched.replace(
-    /const FORBIDS_BARE_CREATELOGGER = new Set\(\[[\s\S]*?\]\)/,
+    forbidRe,
     `const FORBIDS_BARE_CREATELOGGER = new Set([${forbidsBareCreateLogger.map((f) => JSON.stringify(f)).join(', ')}])`,
   )
 

--- a/packages/server/tests/lint-logger-session-scoping.test.js
+++ b/packages/server/tests/lint-logger-session-scoping.test.js
@@ -1,0 +1,207 @@
+/**
+ * Tests for scripts/lint-logger-session-scoping.mjs
+ *
+ * The lint exists so session-aware modules cannot regress to unscoped log
+ * lines — those would leak across sessions on the WsServer log fan-out
+ * (#4787). Two layers of enforcement:
+ *
+ *   1. REQUIRES_FACTORY_IMPORT — file must `import { loggerForSession }`
+ *      from logger.js.
+ *   2. FORBIDS_BARE_CREATELOGGER — every `createLogger(...)` call in the
+ *      file must be followed by `.withSession(...)`. Stronger guard
+ *      reserved for files that no longer need a pre-session-id fallback.
+ *
+ * Issue: #4828 follow-up to #4823. The FORBIDS_BARE_CREATELOGGER set was
+ * empty in #4823 (no files migrated far enough yet), so without these
+ * tests a regression in the parser's parenthesis-depth / string-state
+ * tracking could land silently — no real file exercises that code path.
+ *
+ * Strategy: build a tiny temp `src/` tree, point the lint at it via the
+ * resolution path it already uses (relative `../src/`), and assert the
+ * exit code + offender list match the fixture's shape.
+ */
+import { test, describe, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, cpSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REAL_LINT_SCRIPT = resolve(__dirname, '..', 'scripts', 'lint-logger-session-scoping.mjs')
+const REAL_LINT_SOURCE = readFileSync(REAL_LINT_SCRIPT, 'utf8')
+
+/**
+ * Build an isolated scratch tree of the form:
+ *   tmpDir/
+ *     scripts/lint-logger-session-scoping.mjs   (rewritten with the test sets)
+ *     src/                                      (fixture .js files supplied by caller)
+ *
+ * The real lint resolves `SRC_DIR = resolve(__dirname, '..', 'src')`, so
+ * dropping the script under `scripts/` makes that resolve to our fixture
+ * `src/`. We splice in the caller's `REQUIRES_FACTORY_IMPORT` and
+ * `FORBIDS_BARE_CREATELOGGER` set bodies via a literal regex replace —
+ * the real source defines each Set in the same shape, so swapping the
+ * Set bodies is unambiguous.
+ */
+function buildFixtureTree({ requiresFactoryImport, forbidsBareCreateLogger, srcFiles }) {
+  const root = mkdtempSync(join(tmpdir(), 'chroxy-lint-logger-'))
+  mkdirSync(join(root, 'scripts'), { recursive: true })
+  mkdirSync(join(root, 'src'), { recursive: true })
+
+  let patched = REAL_LINT_SOURCE
+  // Swap the REQUIRES_FACTORY_IMPORT Set body for the test-supplied list.
+  patched = patched.replace(
+    /const REQUIRES_FACTORY_IMPORT = new Set\(\[[\s\S]*?\]\)/,
+    `const REQUIRES_FACTORY_IMPORT = new Set([${requiresFactoryImport.map((f) => JSON.stringify(f)).join(', ')}])`,
+  )
+  // Same for FORBIDS_BARE_CREATELOGGER.
+  patched = patched.replace(
+    /const FORBIDS_BARE_CREATELOGGER = new Set\(\[[\s\S]*?\]\)/,
+    `const FORBIDS_BARE_CREATELOGGER = new Set([${forbidsBareCreateLogger.map((f) => JSON.stringify(f)).join(', ')}])`,
+  )
+
+  writeFileSync(join(root, 'scripts', 'lint-logger-session-scoping.mjs'), patched)
+
+  for (const [relPath, contents] of Object.entries(srcFiles)) {
+    const fullPath = join(root, 'src', relPath)
+    mkdirSync(dirname(fullPath), { recursive: true })
+    writeFileSync(fullPath, contents)
+  }
+
+  return root
+}
+
+function runLint(root) {
+  return spawnSync(process.execPath, [join(root, 'scripts', 'lint-logger-session-scoping.mjs')], {
+    encoding: 'utf8',
+  })
+}
+
+const cleanups = []
+after(() => {
+  for (const root of cleanups) {
+    try { rmSync(root, { recursive: true, force: true }) } catch { /* ignore */ }
+  }
+})
+
+describe('lint-logger-session-scoping', () => {
+  test('REQUIRES_FACTORY_IMPORT: passes when loggerForSession is imported', () => {
+    const root = buildFixtureTree({
+      requiresFactoryImport: ['session-good.js'],
+      forbidsBareCreateLogger: [],
+      srcFiles: {
+        'session-good.js': `
+import { createLogger, loggerForSession } from './logger.js'
+
+const log = createLogger('test')
+export function withLogger(sid) {
+  return loggerForSession('test', sid)
+}
+`,
+      },
+    })
+    cleanups.push(root)
+
+    const res = runLint(root)
+    assert.equal(res.status, 0, `expected exit 0, got ${res.status}; stderr:\n${res.stderr}`)
+    assert.match(res.stdout, /OK: 1 module\(s\) import loggerForSession/)
+  })
+
+  test('REQUIRES_FACTORY_IMPORT: fails when only createLogger is imported', () => {
+    const root = buildFixtureTree({
+      requiresFactoryImport: ['session-missing-import.js'],
+      forbidsBareCreateLogger: [],
+      srcFiles: {
+        'session-missing-import.js': `
+import { createLogger } from './logger.js'
+
+const log = createLogger('test')
+`,
+      },
+    })
+    cleanups.push(root)
+
+    const res = runLint(root)
+    assert.equal(res.status, 1, `expected exit 1, got ${res.status}; stdout:\n${res.stdout}`)
+    assert.match(res.stderr, /session-aware module must `import \{ loggerForSession \} from/)
+  })
+
+  test('FORBIDS_BARE_CREATELOGGER: passes when every createLogger is chained with .withSession', () => {
+    const root = buildFixtureTree({
+      requiresFactoryImport: ['session-forbid-good.js'],
+      forbidsBareCreateLogger: ['session-forbid-good.js'],
+      srcFiles: {
+        'session-forbid-good.js': `
+import { createLogger, loggerForSession } from './logger.js'
+
+export function build(sid) {
+  const a = createLogger('test').withSession(sid)
+  const b = loggerForSession('test', sid)
+  return [a, b]
+}
+`,
+      },
+    })
+    cleanups.push(root)
+
+    const res = runLint(root)
+    assert.equal(res.status, 0, `expected exit 0, got ${res.status}; stderr:\n${res.stderr}`)
+    assert.match(res.stdout, /1 module\(s\) forbid bare createLogger/)
+  })
+
+  test('FORBIDS_BARE_CREATELOGGER: fails on a bare module-level createLogger', () => {
+    const root = buildFixtureTree({
+      requiresFactoryImport: ['session-forbid-bad.js'],
+      forbidsBareCreateLogger: ['session-forbid-bad.js'],
+      srcFiles: {
+        'session-forbid-bad.js': `
+import { createLogger, loggerForSession } from './logger.js'
+
+// Bare createLogger() with no trailing .withSession — the forbid rule
+// must flag this as the regression the lint exists to catch.
+const log = createLogger('test')
+export function go(sid) { return loggerForSession('test', sid) }
+`,
+      },
+    })
+    cleanups.push(root)
+
+    const res = runLint(root)
+    assert.equal(res.status, 1, `expected exit 1, got ${res.status}; stdout:\n${res.stdout}`)
+    assert.match(res.stderr, /bare createLogger\(\.\.\.\) is forbidden/)
+  })
+
+  test('FORBIDS_BARE_CREATELOGGER: parser tolerates string args containing parens', () => {
+    // Regression guard for the parenthesis-depth tracker in
+    // findUnscopedCreateLoggerCalls: the close-paren scanner must not
+    // count `(` / `)` that appear INSIDE a string literal as call-depth
+    // changes. Without correct string-state tracking, a `createLogger`
+    // with a complex string argument would either close too early
+    // (false positive — sees a `.withSession` that's actually after a
+    // different call) or never close (silent skip — never flags real
+    // bare calls). Both regressions would land silently because the
+    // production source does not exercise the corner case.
+    const root = buildFixtureTree({
+      requiresFactoryImport: ['session-parens.js'],
+      forbidsBareCreateLogger: ['session-parens.js'],
+      srcFiles: {
+        'session-parens.js': `
+import { createLogger } from './logger.js'
+
+// Bare call with a paren-bearing string. After the string-aware scanner
+// finds the matching close-paren, the next non-whitespace token is the
+// statement terminator — there is NO .withSession to satisfy the rule.
+const log = createLogger('component (with parens)')
+export const logRef = log
+`,
+      },
+    })
+    cleanups.push(root)
+
+    const res = runLint(root)
+    assert.equal(res.status, 1, `expected exit 1, got ${res.status}; stderr:\n${res.stderr}`)
+    assert.match(res.stderr, /bare createLogger\(\.\.\.\) is forbidden/)
+  })
+})


### PR DESCRIPTION
Closes #4828

Follow-up to #4823 / #4792 — completes the deferred migration sweep so every per-session log site that fires after the session id is known routes through `loggerForSession(...)` and gets fan-out-filtered by `WsServer._logListener` (#4787).

## Migrated sites

**`packages/server/src/claude-tui-session.js`** — uses cached `this._log` (set in `start()` per #4823):
- `AskUserQuestion pending` + `has N questions` warn (multi-question intervention)
- `respondToQuestion` map-routing warns + main info line
- single-question freeform/Other-path PTY write failures + `TOO_MANY_OPTIONS` warn
- multi-question driver: missing-answersMap, unrepresentable picks, single-/multi-select default-fallback warns, info summary, PTY write failure
- `_onAskUserQuestionStall` watchdog warn

**`packages/server/src/sdk-session.js`** — caches `this._log = loggerForSession('sdk', msg.session_id)` on the SDK's `init` message:
- `Session initialized`, `MCP servers`, `System event`
- `modelUsage` partial drift debug
- Query error/abort/interrupt error
- Follow-up message dequeue/discard
- SidecarProcess `stdin_dropped` + `stdin_disabled` (with pre-init fallback)
- Tool input over-size warn
- `setModel` / `setPermissionMode` / `setThinkingLevel`
- `_fetchSupportedModels` dynamic-list info + failure warn
- `interrupt()` info + error
- Inactivity warning / hard-cap / stream-stall
- `destroy()` interrupt warn

**`packages/server/src/cli-session.js`** — caches `this._log = loggerForSession('cli-session', data.session_id)` on the CLI's `init` message, drops it on `_killAndRespawn` so the next init re-binds:
- `Session initialized`, `MCP servers`, `System event`
- `toolInputChunks` overflow warn
- AskUserQuestion / Task / ExitPlanMode parse failures + `AskUserQuestion detected`
- Pending-queue dequeue after result
- Process force-kill + `setModel` / `setPermissionMode` / `respondToQuestion` stdin write failure
- Process-exit info (intentional stop + scheduled respawn)
- `interrupt()` SIGINT + safety-timeout warn
- Inactivity warning / hard-cap / stream-stall

**`packages/server/src/handlers/*.js`** — every session-aware call site now uses `loggerForSession('ws', sessionId)`, with a single-session fallback to module-level `log` when the legacy CLI-session adapter surfaces an empty `sessionId` (the same pattern `input-handlers.js` adopted in #4823):
- `conversation-handlers.js`: `Failed to read session context`
- `feature-handlers.js`: `extension_message` unhandled debug
- `session-handlers.js`: switch-attempt-rejection + switch-success info
- `settings-handlers.js`: `set_model` (3 sites), `set_permission_mode` (7 sites incl. auto-mode handshake + audit), `permission_response` reject paths, `skill_trust_{accept,grant}` flush failures, `Failed to persist promptEvaluatorSkipPattern`, `Permission rules updated`

## Lint promotion

All 6 newly-migrated modules go into `REQUIRES_FACTORY_IMPORT` in `scripts/lint-logger-session-scoping.mjs`. None can promote into `FORBIDS_BARE_CREATELOGGER` yet — each one keeps a module-level `createLogger('...')` for the pre-session-id (sdk/cli/tui) or legacy-fallback (handlers) paths.

## Test coverage for the ratchet

Adds `tests/lint-logger-session-scoping.test.js` — 5 fixture tests covering:
- `REQUIRES_FACTORY_IMPORT` pass + fail
- `FORBIDS_BARE_CREATELOGGER` pass + fail
- Parser regression guard: string-aware parenthesis-depth tracker correctly handles `createLogger('label (with parens)')`

The ratchet `FORBIDS_BARE_CREATELOGGER` set is still empty in production, but the parser is now exercised — closes the "silent regression in the lint's own parser" gap called out in the issue.

## Verification

```
$ cd packages/server && ./scripts/lint-logger-session-scoping.sh
OK: 8 module(s) import loggerForSession; 0 module(s) forbid bare createLogger

$ ./scripts/lint-session-opt-forwarding.sh
OK: 6 session subclass(es) forward all 19 BaseSession opt(s) (or are explicitly whitelisted).

$ ./scripts/lint-tests-state-file-path.sh
OK: every new SessionManager(...) / new CheckpointManager(...) in tests includes its required tmp-path option
```

Server test suite: 6635/6647 pass; the 6 remaining failures (`service.test.js` fetch timeout, `TunnelManager Integration` cloudflared requirement, `WebTaskManager` writeFile) reproduce on a clean `main` checkout and are pre-existing flakes unrelated to this PR.