### PR TITLE
fix(server): align ctx.currentToolUseId with synthesized fallback toolId

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -735,7 +735,6 @@ export class CliSession extends BaseSession {
               }
             } else if (blockType === 'tool_use') {
               ctx.currentToolName = event.content_block.name
-              ctx.currentToolUseId = event.content_block.id
               ctx.toolInputChunks = ''
               ctx.toolInputBytes = 0
               ctx.toolInputOverflow = false
@@ -743,6 +742,14 @@ export class CliSession extends BaseSession {
               // emit identical tool_start payloads (see
               // claude-stream-parser.js for the toolId-derivation rules).
               const toolStartData = buildToolStartData(messageId, event.content_block)
+              // #4778: align ctx with the wire-emitted toolUseId so the
+              // synthesized fallback (`${messageId}-tool` when
+              // content_block.id is missing) propagates to
+              // _applyToolInputSemantics → user_question / agent_spawned
+              // and _activeAgents.set(). Without this, ctx.currentToolUseId
+              // stayed undefined on the fallback path and downstream
+              // payloads carried toolUseId=undefined.
+              ctx.currentToolUseId = toolStartData.toolUseId
               this.emit('tool_start', toolStartData)
               // #4628: track so _clearMessageState (or _emitResult) can
               // sweep on turn-end if the API ever drops a tool_result.

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1116,12 +1116,18 @@ export class SdkSession extends BaseSession {
     const semantics = extractToolInputSemantics(block.name, block.input)
     if (!semantics) return
     if (semantics.kind === 'task') {
+      // #4778: when block.id is missing, mirror the synthesized fallback
+      // used by buildToolStartData (`${messageId}-tool`) so the
+      // agent_spawned toolUseId + _activeAgents key match the wire-emitted
+      // tool_start id. Without this, _activeAgents.set(undefined, ...)
+      // collides on undefined for any fallback-path Task spawn.
+      const toolUseId = block.id || `${messageId}-tool`
       const agentInfo = {
-        toolUseId: block.id,
+        toolUseId,
         description: semantics.payload.description,
         startedAt: Date.now(),
       }
-      this._activeAgents.set(block.id, agentInfo)
+      this._activeAgents.set(toolUseId, agentInfo)
       this.emit('agent_spawned', agentInfo)
     }
     // EnterPlanMode / ExitPlanMode are not currently surfaced by SdkSession

--- a/packages/server/tests/cli-session-events.test.js
+++ b/packages/server/tests/cli-session-events.test.js
@@ -273,6 +273,47 @@ describe('CliSession stream-event handling', () => {
       assert.equal(events[0].messageId, 'msg-1-tool')
       assert.equal(events[0].toolUseId, 'msg-1-tool')
     })
+
+    it('aligns ctx.currentToolUseId with synthesized fallback when content_block.id is missing (#4778)', () => {
+      const session = createSession()
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', name: 'Task' },
+        },
+      })
+
+      // Without #4778, ctx.currentToolUseId stays undefined on the fallback
+      // path and downstream emits (user_question / agent_spawned /
+      // _activeAgents.set) propagate toolUseId=undefined while the
+      // tool_start wire event already carries `${messageId}-tool`.
+      assert.equal(session._currentCtx.currentToolUseId, 'msg-1-tool')
+    })
+
+    it('propagates synthesized toolUseId to agent_spawned on Task fallback (#4778)', () => {
+      const session = createSession()
+      const spawned = []
+      session.on('agent_spawned', (info) => spawned.push(info))
+
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'tool_use', name: 'Task' },
+        },
+      })
+      session._handleEvent(inputJsonDelta('{"description":"do thing","prompt":"x"}'))
+      session._handleEvent(contentBlockStop())
+
+      assert.equal(spawned.length, 1)
+      assert.equal(spawned[0].toolUseId, 'msg-1-tool')
+      // _activeAgents key must match the wire-emitted toolUseId so later
+      // lookups (agent_completed, etc.) resolve instead of writing to
+      // _activeAgents.set(undefined, ...).
+      assert.ok(session._activeAgents.has('msg-1-tool'))
+      assert.ok(!session._activeAgents.has(undefined))
+    })
   })
 
   describe('text streaming', () => {

--- a/packages/server/tests/sdk-session.test.js
+++ b/packages/server/tests/sdk-session.test.js
@@ -474,6 +474,25 @@ describe('SdkSession', () => {
       assert.ok(session._activeAgents.has('tool-1'))
     })
 
+    it('aligns toolUseId with synthesized fallback when block.id is missing (#4778)', () => {
+      const events = []
+      session.on('agent_spawned', (data) => events.push(data))
+
+      // Mirrors the defensive fallback path of buildToolStartData when
+      // upstream stream_event omits content_block.id. agent_spawned +
+      // _activeAgents must key off the synthesized `${messageId}-tool`
+      // id, not `undefined`, so they match the wire-emitted tool_start.
+      session._handleToolUseBlock('msg-99', {
+        name: 'Task',
+        input: { description: 'fallback path' },
+      })
+
+      assert.equal(events.length, 1)
+      assert.equal(events[0].toolUseId, 'msg-99-tool')
+      assert.ok(session._activeAgents.has('msg-99-tool'))
+      assert.ok(!session._activeAgents.has(undefined))
+    })
+
     it('truncates long descriptions to 200 chars', () => {
       const events = []
       session.on('agent_spawned', (data) => events.push(data))


### PR DESCRIPTION
Closes #4778

## Summary

- When `content_block.id` is missing from a `content_block_start` stream event, `buildToolStartData` synthesizes `${messageId}-tool` as the toolUseId on the emitted `tool_start` wire event.
- Previously, `CliSession._handleEvent` kept `ctx.currentToolUseId = event.content_block.id` (undefined on the fallback path), and `SdkSession._handleToolUseBlock` used `block.id` directly as the `_activeAgents` key.
- Result: `user_question` / `agent_spawned` payloads emitted `toolUseId: undefined`, and `_activeAgents.set(undefined, ...)` collided across all fallback-path Task spawns.
- Fix: in both sessions, derive the same id as `buildToolStartData` (`block.id || \`${messageId}-tool\``) and store it on `ctx.currentToolUseId` (CliSession) / use it as the agentInfo + `_activeAgents` key (SdkSession). The wire-emitted `tool_start.toolUseId` and the session-internal tracking now match.

## Test plan

- [x] New unit tests in `tests/cli-session-events.test.js` and `tests/sdk-session.test.js` exercise the fallback path and assert (a) `ctx.currentToolUseId` aligns with the synthesized id, (b) `agent_spawned.toolUseId` matches, (c) `_activeAgents` keys off the synthesized id rather than `undefined`. Verified the new tests fail without the fix.
- [x] `tests/cli-session-events.test.js`, `tests/sdk-session.test.js`, `tests/claude-stream-parser.test.js` all pass (198 tests).
- [x] `./scripts/lint-tests-state-file-path.sh` and `./scripts/lint-session-opt-forwarding.sh` pass.

## Scope note

Tightly scoped after a Wave 1 timeout. Only the `currentToolUseId` / `_handleToolUseBlock` ID-derivation lines plus two focused tests. No refactor of adjacent code.