### PR TITLE
fix(ci): cross-PR test timing for #4848 vs #4867 (main is red)

### DIFF
--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -4640,7 +4640,7 @@ describe('ClaudeTuiSession', () => {
       }
 
       session.respondToQuestion('', answersMap)
-      await new Promise((resolve) => setTimeout(resolve, 200))
+      await new Promise((resolve) => setTimeout(resolve, 300))
 
       const writes = writeEvents.map((e) => e.data)
       assert.deepEqual(
@@ -4744,10 +4744,11 @@ describe('ClaudeTuiSession', () => {
         session.on('error', (e) => errors.push(e))
 
         session.respondToQuestion('', { 'Q1?': 'j', 'Q2?': 'x' })
-        // 200ms wait so the #4867 last-question-single-select settle (150ms)
-        // can fire its trailing Submit before assertions. The 30-option sibling
-        // test below already uses 200ms; this bump matches.
-        await new Promise((resolve) => setTimeout(resolve, 200))
+        // 300ms wait: the #4867 last-question-single-select settle is 150ms;
+        // 300ms leaves comfortable margin under CI load (Copilot review on
+        // #4886 flagged 200ms as too tight). Sibling settle-path tests in
+        // this file use 300ms for the same reason.
+        await new Promise((resolve) => setTimeout(resolve, 300))
 
         // No too-many error — arrow nav drives the form.
         assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
@@ -4778,7 +4779,7 @@ describe('ClaudeTuiSession', () => {
         session.on('error', (e) => errors.push(e))
 
         session.respondToQuestion('', { 'Q1?': 'o-29', 'Q2?': 'y' })
-        await new Promise((resolve) => setTimeout(resolve, 200))
+        await new Promise((resolve) => setTimeout(resolve, 300))
 
         assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
         // Trailing '\r' is the #4867 last-question-single-select defensive Enter.
@@ -4965,7 +4966,7 @@ describe('ClaudeTuiSession', () => {
         session.on('error', (e) => errors.push(e))
 
         session.respondToQuestion('s-29')
-        await new Promise((resolve) => setTimeout(resolve, 200))
+        await new Promise((resolve) => setTimeout(resolve, 300))
 
         assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
         const expected = ['\x1b[?2004l', ...Array(29).fill('\x1b[B'), '\r', '\x1b[?2004h']

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -4744,13 +4744,17 @@ describe('ClaudeTuiSession', () => {
         session.on('error', (e) => errors.push(e))
 
         session.respondToQuestion('', { 'Q1?': 'j', 'Q2?': 'x' })
-        await new Promise((resolve) => setTimeout(resolve, 100))
+        // 200ms wait so the #4867 last-question-single-select settle (150ms)
+        // can fire its trailing Submit before assertions. The 30-option sibling
+        // test below already uses 200ms; this bump matches.
+        await new Promise((resolve) => setTimeout(resolve, 200))
 
         // No too-many error — arrow nav drives the form.
         assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
         // Q1 → 9× Down + Enter (idx 9 nav), Q2 → '1' (single-digit), Submit → '1',
-        // wrapped in paste-disable/enable.
-        const expected = ['\x1b[?2004l', ...Array(9).fill('\x1b[B'), '\r', '1', '1', '\x1b[?2004h']
+        // then defensive trailing '\r' (#4867 — guards against last-question
+        // single-select forms not auto-committing), wrapped in paste-disable/enable.
+        const expected = ['\x1b[?2004l', ...Array(9).fill('\x1b[B'), '\r', '1', '1', '\r', '\x1b[?2004h']
         assert.deepEqual(writes, expected,
           `expected arrow-nav + digits sequence, got ${JSON.stringify(writes)}`)
 
@@ -4777,7 +4781,8 @@ describe('ClaudeTuiSession', () => {
         await new Promise((resolve) => setTimeout(resolve, 200))
 
         assert.equal(errors.length, 0, `expected no errors, got ${JSON.stringify(errors)}`)
-        const expected = ['\x1b[?2004l', ...Array(29).fill('\x1b[B'), '\r', '2', '1', '\x1b[?2004h']
+        // Trailing '\r' is the #4867 last-question-single-select defensive Enter.
+        const expected = ['\x1b[?2004l', ...Array(29).fill('\x1b[B'), '\r', '2', '1', '\r', '\x1b[?2004h']
         assert.deepEqual(writes, expected,
           `expected 29× Down + Enter + Q2 digit + Submit, got ${JSON.stringify(writes)}`)
       })


### PR DESCRIPTION
## Summary

**Main is red right now.** Cross-PR test breakage between two recently-merged PRs:

- #4866 (#4848 arrow-nav driver for >9-option AskUserQuestion) added 2 multi-question tests.
- #4867 (#4635 multi-question all-single-select submit) added a 150ms settle + defensive trailing `\r` to the same code path.

The settle delay + new `\r` byte broke both #4848 tests:
- 12-option test waited only 100ms → didn't observe the final Submit.
- Both 12-option and 30-option tests' expected arrays omitted the new `\r`.

## Fix

- Bump 12-option wait `100 → 200ms` (matches 30-option sibling).
- Add the `\r` defensive trailer to both expected byte sequences.

No production code touched.

## Test plan

- [x] `cd packages/server && PATH=... node --import ./tests/_setup.mjs --test tests/claude-tui-session.test.js` → 193/193 pass locally on this branch.
- [ ] CI green on this PR → unblocks main.

Related: #4848, #4635, #4866, #4867