### PR TITLE
chore(release): cut v0.9.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.36] - 2026-06-02
+
+Backlog-sweep release: 16 from-review issues landed in a single overnight marathon, plus one cross-PR fix-CI commit (#4886) when #4867's settle delay broke #4866's freshly-merged arrow-nav tests. All sourced from prior agent-review deferrals (#4823 / v0.9.34 / v0.9.35 follow-ups).
+
+### Added
+
+- **>9-option AskUserQuestion native drive (#4848 → #4866):** single-question and multi-question paths with `idx >= 9` now navigate via arrow-key sequence (`\x1b[?2004l` + N× `\x1b[B` + `\r`) instead of teardown-with-error. Multi-select still bails with `ASK_USER_QUESTION_TOO_MANY_OPTIONS` (deliberate scope per #4848). Arrow-nav byte sequence is conservative — empirical recorder verification deferred per the PR body; revisit if user reports misfires.
+- **Wire `stopped` event end-to-end (#4756 → #4868):** `CliSession.emit('stopped')` (added in #4750) now propagates through `SessionManager._wireSessionEvents` → `ws-forwarding` → `event-normalizer` → `ServerSessionStoppedSchema` → wire `{type: 'session_stopped', sessionId?, code?}`. Client UX surfacing deferred to per-platform follow-ups (#4878 dashboard, #4879 mobile).
+- **Prune stale device-preferences entries on startup (#4849 → #4863):** `~/.chroxy/device-preferences.json` now drops entries whose `activeSessionId` no longer exists (after `restoreState` lands), so the file doesn't accumulate stale device→session refs.
+- **`isVoiceInputMode` runtime type-guard helper (#4853 → #4858):** new exported guard in `@chroxy/store-core/types`. Migrated dashboard `connection.ts:805` rehydrate path + `SettingsPanel` inline literal. Mobile rehydrate has the same latent bug — tracked in #4872.
+- **Mobile single-question Other/freeform parity (#4755 → #4864):** mobile `useUserQuestion` now supports the `{otherLabel, freeformText}` answer shape, matching dashboard #4651. Wire payload: `{answer: <otherLabel>, freeformText: <typed text>}`.
+- **Mobile multi-question intervention counter (#4764 → #4862):** new tappable header badge in `SettingsBar` showing intervention count, opens a newest-first sheet. Touch target sweep across all header badges deferred (#4876).
+- **Mobile `sendUserQuestionResponse` per-question Record support (#4761 → #4859):** widened to accept `string | Record<string, string | string[]> | { otherLabel: string; freeformText: string }`. Three shapes covered: legacy single-answer, multi-question form, Other/freeform.
+- **`end`-handler `inFlightRef` gate (#4851 → #4855):** defence-in-depth for the #4826 abort-end async race. End-handler continuous re-arm now requires `inFlightRef.current` true, so a queued `end` event after `abort()` can't re-arm a torn-down session.
+
+### Changed
+
+- **Multi-question all-single-select form submit (#4635 → #4867):** added 150ms settle + defensive trailing `\r` after the last-question single-select auto-advance so the Submit screen reliably commits. Empirical recorder verification of the all-single-select shape deferred (#4882, #4883, #4884).
+- **Second-wave `loggerForSession` migration sweep (#4828 → #4869):** 50+ post-session-init log call sites in `claude-tui-session.js` / `sdk-session.js` / `cli-session.js` / 4 handler files migrated to session-scoped loggers. Cached `this._log` in sdk/cli sessions for early-path safety. Added 5 lint fixture tests + tightened the lint script.
+- **Removed `VoiceInputMode` re-export shims (#4852 → #4856):** all callers now import directly from `@chroxy/store-core` (no migration needed — confirmed via caller audit). Hooks `useSpeechRecognition.ts` + `useVoiceInput.ts` drop their `export type { VoiceInputMode }` lines.
+
+### Fixed
+
+- **🚨 Hide AskUserQuestion content until permission granted (#4685 → #4860):** dashboard rendered question prompt + options before user clicked Allow. Now `QuestionPrompt` accepts `pendingPermission` prop and shows a placeholder; `App.tsx` derives the gate from `resolvedPermissions + messages`. Deny correctly keeps the gate up.
+- **`writeFileRestricted` is now atomic (#4850 → #4865):** `connection.json` + `device-preferences.json` writes go through write-temp + rename so a killed writer can't leave a half-written file. 0o600 mode preserved by rename. Subprocess-based test exercises the simulated-crash invariant.
+- **Header buttons in desktop dashboard now expose both `title` and `aria-label` (#4630 → #4861):** audited App header + FooterBar + SessionBar; paired both attributes on 9 controls that were missing one half. 13 new tests pin the contract.
+- **Copy-transcript clipboard failure now surfaces a toast in Tauri (#4629 → #4857):** the underlying clipboard helper was already Tauri-aware (#4676); this PR ships the remaining AC — an `addServerError` toast when the helper reports failure instead of silently no-op. Sibling sidebar callsite has the same gap, tracked in #4871.
+- **`ctx.currentToolUseId` aligned with synthesized fallback `toolId` (#4778 → #4885):** when upstream events omit `content_block.id`, the synthesized id (`msg-N-tool`) now also writes to `ctx.currentToolUseId` (cli path) and `_activeAgents` key (sdk path), so downstream `tool_result` events correlate.
+
+### Internal (CI hotfix)
+
+- **#4886 (no issue) — cross-PR test breakage:** #4867's 150ms settle + trailing `\r` broke #4866's arrow-nav tests (12-option waited 100ms, both expected arrays omitted the `\r`). Fix bumps waits to 300ms and adds the trailer to expected. Caught after merge; main was red for ~20 minutes.
+
+### Follow-up issues filed during this marathon
+
+- #4870 — Clipboard-failure toast should use `'warning'` severity per #4148 convention.
+- #4871 — Sidebar `copyToClipboard` callsite still silently no-ops on Tauri/WKWebView failure.
+- #4872 — Mobile app rehydrate has the same latent `VoiceInputMode` validation gap #4853 closed on dashboard.
+- #4873 — Header status-dot `role="status"` live-region polish (cosmetic).
+- #4874 — Audit three `writeFileRestricted` callers (models / env-mgr / session-state-persistence) for now-redundant double `.tmp+rename`.
+- #4875 — Factor `isFreeformAnswer` into a shared typed predicate.
+- #4876 — Mobile session-header badges below 44pt touch target.
+- #4877 — Maestro flow for Other → freeform answer (third AC of #4755).
+- #4878 — Dashboard quiet "Session stopped." toast on `session_stopped` event.
+- #4879 — Mobile app quiet status confirmation on `session_stopped` event.
+- #4881 — Provider parity: SDK / Codex / Gemini sessions should also emit `stopped`.
+- #4882 — Empirically re-record all-single-select multi-question form bytes.
+- #4883 — Tighten `lastIsSingleSelect` detection to surface unexpected question shapes.
+- #4884 — Live-verify trailing `\r` on mixed multi-question forms.
+
 ## [0.9.35] - 2026-06-02
 
 Bug-fix release driven by a live two-session reproduction: clicking a large-history CLI session tab in the dashboard reliably triggered a "Reconnecting…" loop and bounced the user back to the first session, making the offending session unreachable. Diagnosis traced this to a P0 trap composed of two server bugs (#4833 backpressure-eviction during chunked history replay + #4835 active-session-reset on every reconnect) plus a long-tail of voice-input + question-flow + docker auth polish from prior audits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.35",
+      "version": "0.9.36",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.35",
+      "version": "0.9.36",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.35",
+      "version": "0.9.36",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.35"
+      "version": "0.9.36"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.35",
+      "version": "0.9.36",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.35",
+      "version": "0.9.36",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.35",
+      "version": "0.9.36",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.35",
+    "version": "0.9.36",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.35</string>
+    <string>0.9.36</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.35"
+version = "0.9.36"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.35"
+version = "0.9.36"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.35",
+      "version": "0.9.36",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Backlog-sweep release — 16 from-review issues landed in a single overnight marathon, plus 1 fix-CI commit (#4886) when #4867's settle delay collided with #4866's freshly-merged arrow-nav tests.

### PRs landed in this release (sorted by area)

**Server (8):** #4867 (multi-question all-single-select), #4869 (logger sweep), #4866 (arrow-nav >9 options), #4868 (stopped event wiring), #4863 (device-prefs prune), #4865 (atomic file writes), #4885 (toolUseId fallback), #4886 (cross-PR test timing fix)

**Dashboard (3):** #4861 (header tooltips), #4860 (AskUserQuestion gate), #4857 (Tauri clipboard toast)

**Mobile app (4):** #4864 (Other/freeform parity), #4862 (intervention counter), #4859 (sendQuestionResponse Record), #4855 (inFlightRef gate)

**Cross-package (2):** #4858 (isVoiceInputMode guard), #4856 (VoiceInputMode shim removal)

### Follow-up issues filed during the marathon

14 new from-review issues queued for a future marathon (cosmetic polish, defence-in-depth, parity gaps): #4870, #4871, #4872, #4873, #4874, #4875, #4876, #4877, #4878, #4879, #4881, #4882, #4883, #4884.

## Test plan
- [x] All 17 source PRs CI-green before merge
- [x] CHANGELOG covers every PR with issue cross-refs
- [x] Version bumped via `scripts/bump-version.sh`
- [x] Cross-PR test breakage fixed in #4886; tests green on tip
- [ ] Tauri rebuild + install after this lands (separate step)