### PR TITLE
fix(app): widen tappable session-header badge touch targets to 44pt

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -16,7 +16,7 @@ const QUALITY_COLORS = {
 } as const;
 
 // #4876 — shared `hitSlop` for the tappable header badges so each Pressable
-// hits Apple HIG / CLAUDE.md's 44pt minimum touch target even though the
+// hits Apple HIG's 44pt minimum touch target even though the
 // visible badge is kept visually compact (paddingVertical: 2,
 // paddingHorizontal: 6, fontSize: 10 or 11). Numbers chosen so the
 // effective touch area is ≥ 44 × 44pt for even the smallest plausible

--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -15,6 +15,26 @@ const QUALITY_COLORS = {
   poor: { bg: COLORS.accentRedSubtle, fg: COLORS.accentRed },
 } as const;
 
+// #4876 — shared `hitSlop` for the tappable header badges so each Pressable
+// hits Apple HIG / CLAUDE.md's 44pt minimum touch target even though the
+// visible badge is kept visually compact (paddingVertical: 2,
+// paddingHorizontal: 6, fontSize: 10 or 11). Numbers chosen so the
+// effective touch area is ≥ 44 × 44pt for even the smallest plausible
+// content (a single-glyph badge), while still leaving small horizontal
+// gaps between adjacent badges so each one's hitbox doesn't fully overlap
+// its neighbour.
+//
+// Effective hitbox = visible bounds + hitSlop. Worst-case intrinsic vertical
+// extent is fontSize (10pt) + 2pt + 2pt padding = ~14pt, plus 14 + 14 slop
+// = 42pt — bumped to 16 to clear 44pt cleanly. Worst-case horizontal is a
+// single glyph ~6pt + 6pt + 6pt padding = ~18pt, plus 14 + 14 slop = 46pt.
+export const HEADER_BADGE_HIT_SLOP = {
+  top: 16,
+  bottom: 16,
+  left: 14,
+  right: 14,
+} as const;
+
 // -- Props --
 
 export interface SettingsBarProps {
@@ -325,6 +345,9 @@ export function SettingsBar({
           <Pressable
             onPress={() => setInterventionsOpen(true)}
             style={({ pressed }) => [styles.interventionBadge, pressed && styles.interventionBadgePressed]}
+            // #4876 — widen the effective touch target to ≥ 44pt without
+            // resizing the visible badge.
+            hitSlop={HEADER_BADGE_HIT_SLOP}
             accessibilityRole="button"
             accessibilityLabel={`${interventionCount} chroxy ${interventionCount === 1 ? 'intervention' : 'interventions'}. Tap for details.`}
             testID="session-interventions-badge"
@@ -371,6 +394,9 @@ export function SettingsBar({
           <Pressable
             onPress={() => setCostBreakdownOpen(true)}
             style={({ pressed }) => [styles.costBadge, pressed && styles.costBadgePressed]}
+            // #4876 — widen the effective touch target to ≥ 44pt without
+            // resizing the visible badge.
+            hitSlop={HEADER_BADGE_HIT_SLOP}
             accessibilityRole="button"
             accessibilityLabel={`Session cost ${formatCostBadge(cumulativeUsage.costUsd)}. Tap for breakdown.`}
             testID="session-cost-badge"

--- a/packages/app/src/components/__tests__/SettingsBarTouchTargets.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarTouchTargets.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Touch-target tests for the mobile SessionScreen header badges (#4876).
+ *
+ * Apple HIG and CLAUDE.md require interactive elements to have an effective
+ * touch target of at least 44 × 44 logical pixels. The visible header badges
+ * (cost badge from #4074, intervention badge from #4764) intentionally use a
+ * compact look (paddingVertical: 2, paddingHorizontal: 6, fontSize: 10) for
+ * the strip-of-chips header design — so each tappable badge MUST add a
+ * `hitSlop` large enough to bring the effective touch zone above 44pt.
+ *
+ * This test fixes that contract: every tappable header badge has a hitSlop
+ * whose top+bottom and left+right margins are big enough that the smallest
+ * conceivable badge size (a single character) still exceeds 44 × 44pt.
+ *
+ * Non-tappable badges (`deviceBadge`, `agentBadge`, `qualityBadge`) are
+ * informational `accessibilityRole="text"` views and intentionally do NOT
+ * get a hitSlop (they aren't pressable, so the 44pt rule does not apply).
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { SettingsBar, HEADER_BADGE_HIT_SLOP } from '../SettingsBar';
+import type { CumulativeUsage, SessionIntervention } from '@chroxy/store-core';
+
+type HitSlop = { top?: number; bottom?: number; left?: number; right?: number };
+
+/**
+ * Lower-bound estimate of a header badge's intrinsic size given its style.
+ * paddingVertical contributes top+bottom, paddingHorizontal contributes
+ * left+right, and fontSize is the cap-height approximation of the text row.
+ * A single-char "$" badge would be ~fontSize wide, so this models the
+ * smallest plausible visible bounds — the worst case for the 44pt rule.
+ */
+function intrinsicMinSize(style: {
+  paddingVertical: number;
+  paddingHorizontal: number;
+  fontSize: number;
+  borderWidth?: number;
+}) {
+  const border = (style.borderWidth ?? 0) * 2;
+  // Width is dominated by the smallest one-glyph string; ~fontSize × 0.6 is
+  // a conservative approximation of a single-char width at the default font.
+  return {
+    width: Math.ceil(style.fontSize * 0.6) + style.paddingHorizontal * 2 + border,
+    height: style.fontSize + style.paddingVertical * 2 + border,
+  };
+}
+
+function effectiveTouchSize(intrinsic: { width: number; height: number }, hitSlop: HitSlop) {
+  return {
+    width: intrinsic.width + (hitSlop.left ?? 0) + (hitSlop.right ?? 0),
+    height: intrinsic.height + (hitSlop.top ?? 0) + (hitSlop.bottom ?? 0),
+  };
+}
+
+function makeProps(overrides: Partial<{
+  cumulativeUsage: CumulativeUsage | null;
+  interventions: SessionIntervention[];
+}> = {}) {
+  return {
+    expanded: false,
+    onToggle: () => {},
+    activeModel: 'claude-opus-4-7',
+    availableModels: [],
+    permissionMode: null,
+    availablePermissionModes: [],
+    lastResultCost: null,
+    lastResultDuration: null,
+    sessionCost: null,
+    cumulativeUsage: null,
+    costBudget: null,
+    contextUsage: null,
+    sessionCwd: '/tmp',
+    serverMode: 'cli' as const,
+    isIdle: true,
+    activeAgents: [],
+    interventions: [] as SessionIntervention[],
+    connectedClients: [],
+    customAgents: [],
+    mcpServers: [],
+    setModel: () => {},
+    setPermissionMode: () => {},
+    ...overrides,
+  };
+}
+
+const usage: CumulativeUsage = {
+  inputTokens: 100,
+  outputTokens: 50,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+  costUsd: 0.42,
+  turnsBilled: 1,
+};
+
+const oneIntervention: SessionIntervention[] = [
+  { kind: 'multi_question', toolUseId: 'toolu_x', count: 3, timestamp: Date.now() },
+];
+
+describe('SettingsBar header tappable badges hit a 44pt touch target (#4876)', () => {
+  it('exports a shared HEADER_BADGE_HIT_SLOP with all four sides set', () => {
+    expect(HEADER_BADGE_HIT_SLOP).toEqual({ top: 16, bottom: 16, left: 14, right: 14 });
+  });
+
+  it('cost badge has hitSlop large enough for a 44pt effective target', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ cumulativeUsage: usage })} />);
+    });
+    const badge = tree!.root.findByProps({ testID: 'session-cost-badge' });
+    const hitSlop = badge.props.hitSlop as HitSlop;
+    expect(hitSlop).toBeDefined();
+
+    // The cost badge uses paddingVertical 2, paddingHorizontal 6, fontSize 11,
+    // borderWidth 1 (see styles.costBadge / costBadgeText in SettingsBar.tsx).
+    const intrinsic = intrinsicMinSize({
+      paddingVertical: 2,
+      paddingHorizontal: 6,
+      fontSize: 11,
+      borderWidth: 1,
+    });
+    const effective = effectiveTouchSize(intrinsic, hitSlop);
+    expect(effective.width).toBeGreaterThanOrEqual(44);
+    expect(effective.height).toBeGreaterThanOrEqual(44);
+  });
+
+  it('intervention badge has hitSlop large enough for a 44pt effective target', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(<SettingsBar {...makeProps({ interventions: oneIntervention })} />);
+    });
+    const badge = tree!.root.findByProps({ testID: 'session-interventions-badge' });
+    const hitSlop = badge.props.hitSlop as HitSlop;
+    expect(hitSlop).toBeDefined();
+
+    // The intervention badge uses paddingVertical 2, paddingHorizontal 6,
+    // fontSize 10 (see styles.interventionBadge / interventionBadgeText).
+    const intrinsic = intrinsicMinSize({
+      paddingVertical: 2,
+      paddingHorizontal: 6,
+      fontSize: 10,
+    });
+    const effective = effectiveTouchSize(intrinsic, hitSlop);
+    expect(effective.width).toBeGreaterThanOrEqual(44);
+    expect(effective.height).toBeGreaterThanOrEqual(44);
+  });
+
+  it('cost and intervention badges share the same hitSlop constant', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar
+          {...makeProps({ cumulativeUsage: usage, interventions: oneIntervention })}
+        />,
+      );
+    });
+    const costSlop = tree!.root.findByProps({ testID: 'session-cost-badge' }).props.hitSlop;
+    const ivSlop = tree!.root.findByProps({ testID: 'session-interventions-badge' }).props.hitSlop;
+    expect(costSlop).toBe(HEADER_BADGE_HIT_SLOP);
+    expect(ivSlop).toBe(HEADER_BADGE_HIT_SLOP);
+  });
+});

--- a/packages/app/src/components/__tests__/SettingsBarTouchTargets.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarTouchTargets.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Touch-target tests for the mobile SessionScreen header badges (#4876).
  *
- * Apple HIG and CLAUDE.md require interactive elements to have an effective
+ * Apple HIG requires interactive elements to have an effective
  * touch target of at least 44 × 44 logical pixels. The visible header badges
  * (cost badge from #4074, intervention badge from #4764) intentionally use a
  * compact look (paddingVertical: 2, paddingHorizontal: 6, fontSize: 10) for


### PR DESCRIPTION
## Summary

- The mobile `SettingsBar` header badges (cost from #4074, intervention from #4764) use a compact pill style — `paddingVertical: 2`, `paddingHorizontal: 6`, `fontSize: 10-11`. Visually dense, but the intrinsic touch area for the two tappable badges falls well below the 44pt Apple HIG / CLAUDE.md minimum.
- Add a shared `HEADER_BADGE_HIT_SLOP = { top: 16, bottom: 16, left: 14, right: 14 }` constant and apply it to both `Pressable` badges. The visible chip is unchanged; only the hitbox grows so thumbs land cleanly.
- Non-tappable badges (`deviceBadge`, `agentBadge`, `qualityBadge`) stay as informational `accessibilityRole="text"` Views — the 44pt rule doesn't apply since they aren't pressable.

## Acceptance criteria (from #4876)

- [x] Cost badge has 44pt effective touch target (via `hitSlop`)
- [x] Intervention badge has 44pt effective touch target (via `hitSlop`)
- [x] Non-tappable badges (`deviceBadge`, `agentBadge`, `qualityBadge`) remain unchanged
- [ ] Optional stretch — extract a shared `HeaderBadge` / `TappableHeaderBadge` component: not done (shared constant covers the immediate accessibility win; the component extraction is filed-shaped for a follow-up if more tappable badges land)

## Test plan

- [x] `npx jest --testPathPattern="SettingsBar(TouchTargets|InterventionBadge|CostBadge|PermissionModeHint)"` — 28/28 pass
- [x] `npx jest` (full app suite) — 1499/1499 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Maestro E2E coverage: not added here — filed as #4877 for separate work

## Notes on hitSlop sizing

Worst-case intrinsic vertical: `fontSize 10 + paddingVertical 2*2 = 14pt`. With `top/bottom: 16` slop → 46pt vertical hitbox.
Worst-case intrinsic horizontal: single-glyph badge ~6pt + `paddingHorizontal 6*2 = 18pt`. With `left/right: 14` slop → 46pt horizontal hitbox.
Both safely clear 44pt for any plausible content.

Closes #4876