### PR TITLE
fix(dashboard): use warning severity for clipboard-failure toast

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -1626,8 +1626,16 @@ describe('App', () => {
       })
       const firstCall = addServerErrorMock.mock.calls[0]
       expect(firstCall).toBeDefined()
-      const [message] = firstCall!
+      const [message, action, severity] = firstCall!
       expect(message).toMatch(/clipboard/i)
+      // #4870 — a failed clipboard write is non-destructive (the user just
+      // needs to retry). Match the #4148 convention by tagging the toast
+      // as a 'warning' so it renders yellow rather than the red 'error'
+      // reserved for STREAM_ERROR / ABORT. The recovery `action` slot
+      // stays undefined because we have nothing meaningful to wire a
+      // one-click retry to from this call site.
+      expect(action).toBeUndefined()
+      expect(severity).toBe('warning')
       // Must NOT also flash the success indicator (that was the #4673 bug;
       // this test pins the negative too so a future regression on either
       // axis is caught).

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -583,8 +583,15 @@ export function App() {
         // next app. PR #4676 stopped the misleading flash; this surfaces
         // a visible toast so the user knows to retry instead of being
         // left guessing why Cmd+V pasted stale data.
+        // #4870: tag as 'warning' (yellow) rather than the default
+        // 'error' (red). Per the #4148 convention, red is reserved
+        // for destructive failures like STREAM_ERROR / ABORT; a
+        // failed clipboard write is non-destructive — the user just
+        // needs to retry — so warning is the visually honest level.
         useConnectionStore.getState().addServerError(
           'Failed to copy transcript to clipboard. Please try again.',
+          undefined,
+          'warning',
         )
         return
       }


### PR DESCRIPTION
## Summary

The `handleCopyTranscript` failure-path toast added in #4857 (which closed #4629) currently calls `addServerError(...)` with only the message argument, so the toast renders with the default `'error'` severity (red).

Per the #4148 convention, red is reserved for **destructive** failures like `STREAM_ERROR` and `ABORT`. A failed clipboard write is non-destructive — the user just needs to retry — so a yellow `'warning'` toast is the visually honest level and matches other non-fatal warnings like `MAX_TOOL_ROUNDS_REACHED`.

This is the M2 follow-up explicitly deferred from the #4857 review.

## Changes

- `packages/dashboard/src/App.tsx` — pass `undefined, 'warning'` as the 2nd/3rd args to `addServerError` in the `handleCopyTranscript` failure branch. Inline comment explains the #4148 severity convention and why warning beats error here.
- `packages/dashboard/src/App.test.tsx` — extend the existing `'surfaces a server-error toast when the clipboard helper returns false (#4629)'` test to destructure all three call args and assert `action === undefined` and `severity === 'warning'`. Locks in both the severity and the no-action contract so a future regression on either axis is caught.

## Test plan

- [x] Failing test demonstrates the bug (severity was `undefined`)
- [x] Updated test passes after the fix
- [x] `npm --workspace=@chroxy/dashboard run typecheck` clean
- [x] `npm --workspace=@chroxy/dashboard test` — all 2568 tests pass
- [ ] Manual verification: trigger clipboard failure (e.g. Tauri build where plugin rejects), confirm yellow toast renders instead of red

Closes #4870