### PR TITLE
feat(dashboard): render quiet 'Session stopped.' toast on session_stopped (#4878)

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -66,6 +66,10 @@ function baseState(overrides: Partial<ConnectionState> = {}): Partial<Connection
   // an actionable INVALID_AUTHOR toast carries a label + click handler.
   // Existing tests still read `serverErrors` as the message-string list.
   const serverErrorActions: Array<unknown> = []
+  // #4878: capture info-level notifications (addInfoNotification) so the
+  // session_stopped dispatch test can assert the toast text without
+  // having to wire the full Zustand store.
+  const infoNotifications: unknown[] = []
   const grantCalls: Array<{ skillName: string; author: string }> = []
   const terminalWrites: string[] = []
   return {
@@ -85,12 +89,16 @@ function baseState(overrides: Partial<ConnectionState> = {}): Partial<Connection
       serverErrors.push(e)
       serverErrorActions.push(action)
     },
+    addInfoNotification: (e: unknown) => {
+      infoNotifications.push(e)
+    },
     grantCommunitySkillTrust: (skillName: string, author: string) => {
       grantCalls.push({ skillName, author })
     },
     appendTerminalData: (d: string) => { terminalWrites.push(d) },
     _terminalWrites: terminalWrites,
     _serverErrorActions: serverErrorActions,
+    _infoNotifications: infoNotifications,
     _grantCalls: grantCalls,
     serverProtocolVersion: null,
     ...overrides,
@@ -493,6 +501,64 @@ describe('dashboard message-handler dispatch', () => {
       expect(state.serverErrors).toEqual([
         'Not authorized: client is bound to a specific session',
       ])
+    })
+  })
+
+  // #4878 — user-initiated Stop confirmation. The wire path was wired by
+  // PR #4868; this is the dashboard UX follow-up. Renders a quiet info
+  // toast (NOT the red `addServerError` reserved for crashes), so the
+  // operator gets a positive "you clicked Stop and the session did indeed
+  // stop" confirmation. Pairs with `session_error` which fires for
+  // unexpected exits / auto-respawn.
+  describe('session_stopped dispatch (#4878)', () => {
+    it('renders a quiet info-level toast on clean exit (code 0)', () => {
+      handleMessage(
+        { type: 'session_stopped', sessionId: 'sess-1', code: 0 },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      // Info notification, not a server error — the red-toast surface is
+      // reserved for genuine error conditions (STREAM_ERROR / ABORT / crash).
+      expect(state._infoNotifications).toEqual(['Session stopped.'])
+      expect(state.serverErrors).toEqual([])
+    })
+
+    it('omits the exit-code suffix when code is missing (future in-process providers)', () => {
+      // Per the #4756 follow-up, providers that don't have a child process
+      // (e.g. in-process SDK session) may emit session_stopped without a
+      // numeric exit code. The bare "Session stopped." carries the signal.
+      handleMessage(
+        { type: 'session_stopped', sessionId: 'sess-1' },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state._infoNotifications).toEqual(['Session stopped.'])
+    })
+
+    it('surfaces a non-zero exit code as a diagnostic suffix (e.g. SIGTERM → 143)', () => {
+      handleMessage(
+        { type: 'session_stopped', sessionId: 'sess-1', code: 143 },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state._infoNotifications).toEqual(['Session stopped. (exit 143)'])
+      // Still NOT a server error — a non-zero exit code from a
+      // user-initiated Stop (SIGTERM = 143) is not a crash. The crash
+      // path stays on session_error.
+      expect(state.serverErrors).toEqual([])
+    })
+
+    it('handles legacy-cli broadcasts (sessionId omitted) the same way', () => {
+      // ws-forwarding's legacy-cli path forwards session_stopped without
+      // a sessionId field (matches the claude_ready / error pattern).
+      // The dashboard toast doesn't depend on sessionId — it's a global
+      // confirmation either way.
+      handleMessage(
+        { type: 'session_stopped', code: 0 },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state._infoNotifications).toEqual(['Session stopped.'])
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2312,6 +2312,29 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       break;
     }
 
+    case 'session_stopped': {
+      // #4878: quiet, informational confirmation when CliSession exits
+      // cleanly after a user-initiated Stop. The wire path was wired in
+      // #4868 (CliSession 'stopped' → SessionManager → ws-forwarding →
+      // ServerSessionStoppedSchema). Routed through `addInfoNotification`
+      // (info-level toast, not the red `addServerError` reserved for
+      // crashes / STREAM_ERROR / ABORT) so the operator gets a positive
+      // "you clicked Stop and the session did indeed stop" confirmation.
+      //
+      // A non-zero exit code is surfaced as a small diagnostic suffix
+      // (e.g. "Session stopped. (exit 143)" for SIGTERM). Code 0 is the
+      // common clean-exit case and gets no decoration — the bare
+      // "Session stopped." carries the full signal there. Missing code
+      // (future in-process providers per the #4756 follow-up) is also
+      // bare; surfacing "(exit undefined)" would be noisier than useful.
+      const stoppedCode = typeof msg.code === 'number' ? msg.code : null;
+      const stoppedMessage = stoppedCode != null && stoppedCode !== 0
+        ? `Session stopped. (exit ${stoppedCode})`
+        : 'Session stopped.';
+      get().addInfoNotification(stoppedMessage);
+      break;
+    }
+
     // --- History replay ---
 
     case 'history_replay_start': {

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -46,7 +46,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
-  'session_stopped', // #4756 user-initiated Stop confirmation — wire path is wired (CliSession → SessionManager → ws-forwarding → ServerSessionStoppedSchema) but client UX (quiet toast / status update) is the follow-up tracked in #4756's issue body item 3; until then the absence of `session_error` already conveys "no crash, clean stop"
+  // 'session_stopped' moved to PLATFORM_SPECIFIC as 'dashboard' (#4878) — dashboard renders a quiet "Session stopped." info toast (with optional "(exit N)" for non-zero codes); mobile app exposure is a deferred follow-up tracked under the #4756 epic
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
@@ -103,6 +103,7 @@ const PLATFORM_SPECIFIC = {
   // Coverage test passes because each handler has a
   // `case 'multi_question_intervention':` clause.
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
+  'session_stopped': 'dashboard', // user-initiated Stop confirmation (#4878) — dashboard renders a quiet "Session stopped." info toast (with optional "(exit N)" for non-zero codes); mobile app exposure is a deferred follow-up tracked under the #4756 epic
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #4878

PR #4868 wired the server-side path end-to-end (`CliSession` → `SessionManager` → `event-normalizer` → `ws-forwarding` → `ServerSessionStoppedSchema`), but the dashboard had no handler — `session_stopped` was sitting in `INTENTIONALLY_UNHANDLED` with a TODO pointing back at this issue.

## Summary

- New `case 'session_stopped'` in `packages/dashboard/src/store/message-handler.ts`. Routes through `addInfoNotification` (info-level toast, `level: 'info'` — **not** the red `addServerError` reserved for `STREAM_ERROR` / `ABORT` / crash), giving the operator a positive *"you clicked Stop and the session did indeed stop"* confirmation. Pairs with `session_error`, which fires on unexpected exits that trigger the auto-respawn path.
- Non-zero exit codes are surfaced as a small diagnostic suffix (`Session stopped. (exit 143)` for SIGTERM). Code `0` (the clean-exit common case) renders bare. Missing `code` (future in-process providers per the #4756 follow-up that drop the child-process exit field) also renders bare — surfacing `(exit undefined)` would be noisier than useful.
- Moves `'session_stopped'` from `INTENTIONALLY_UNHANDLED` to `PLATFORM_SPECIFIC` (`'dashboard'`) in `packages/protocol/tests/handler-coverage.test.js`. Mobile app exposure is a deferred follow-up tracked under the #4756 epic, so the contract test stays happy with single-platform coverage.

## Why addInfoNotification (and not a new addToast)

The dashboard already has the right primitive: `infoNotifications` flow into the same `toastItems` array as `serverErrors`, just with `level: 'info'` instead of `'error' | 'warning'`. This is the same channel that handles `update_available`, the *"Already answered"* race-condition toast (#2839), and clipboard-empty hints — all of which read as quiet, dismissable, non-alarming. Matches the issue's "not styled as an error" acceptance criterion exactly, no new UI affordance needed.

## Acceptance criteria mapping

- [x] **Handler added** — `case 'session_stopped'` in dashboard `message-handler.ts`
- [x] **Quiet toast / status-strip rendering, not styled as an error** — `addInfoNotification` → `level: 'info'` (same channel as update-available toasts)
- [x] **Optional numeric `code` is surfaced as a small diagnostic detail line when non-zero (e.g. "exit 143" for SIGTERM)** — `Session stopped. (exit 143)` for non-zero, bare `Session stopped.` otherwise
- [x] **Remove session_stopped from INTENTIONALLY_UNHANDLED** — moved to `PLATFORM_SPECIFIC` as `'dashboard'`; mobile app exposure deferred per the #4756 epic
- [ ] **Manual smoke** — pending (start a Claude session, click Stop, observe the new toast)

## Test plan

- [x] 4 new dispatch cases in `packages/dashboard/src/store/message-handler.test.ts`:
  - `code: 0` → bare `Session stopped.` into `infoNotifications`, NOT `serverErrors`
  - `code` missing → bare `Session stopped.` (in-process-provider future)
  - `code: 143` (SIGTERM) → `Session stopped. (exit 143)`, still NOT a server error
  - `sessionId` omitted (legacy-cli path) → handled the same way
- [x] Full dashboard suite — 2584/2584 passing (`npx vitest run`)
- [x] Full protocol suite — 156/156 passing (`npm test`), including the 9 `handler-coverage` contract subtests
- [x] `tsc --noEmit` clean
- [ ] Manual smoke (deferred to merge-time)