### PR TITLE
fix(dashboard): surface warning toast when sidebar clipboard write fails

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -1649,6 +1649,85 @@ describe('App', () => {
     })
   })
 
+  // #4871 — the sidebar context-menu's copyToClipboard callback (used for
+  // "Copy path" on session/repo rows and "Copy Conversation ID" on
+  // resumable rows) routed through `clipboardWriteText` but explicitly
+  // "fell through quietly" on failure — the same Tauri-WKWebView /
+  // non-secure-context failure modes that motivated #4629 left the user
+  // with zero feedback and a stale paste. PR #4857 fixed the
+  // handleCopyTranscript path; this is the sibling fix. The callback now
+  // surfaces a 'warning'-severity toast (per #4870 — a failed clipboard
+  // write is non-destructive, not red-error-worthy).
+  describe('sidebar copyToClipboard callback failure feedback (#4871)', () => {
+    const connectedWithRepoSession = {
+      connectionPhase: 'connected' as const,
+      sessions: [{
+        sessionId: 's1',
+        name: 'Alpha',
+        cwd: '/tmp/repo',
+        type: 'cli' as const,
+        hasTerminal: true,
+        model: null,
+        permissionMode: null,
+        isBusy: false,
+        createdAt: Date.now(),
+        conversationId: null,
+      }],
+      activeSessionId: 's1',
+    }
+
+    it('surfaces a warning-severity toast when the clipboard helper returns false', async () => {
+      clipboardWriteTextMock.mockResolvedValue(false)
+      stateOverrides = connectedWithRepoSession
+      render(<App />)
+
+      // Right-click the session row to open the sidebar context menu, then
+      // click "Copy path" — the same callback that wires "Copy Conversation
+      // ID" on resumable rows. The session-row path is easier to bootstrap
+      // (no conversationHistory fixture required).
+      const row = screen.getByTestId('session-item-s1')
+      fireEvent.contextMenu(row)
+      const menu = screen.getByRole('menu')
+      expect(menu).toBeInTheDocument()
+
+      const copyPath = within(menu).getByRole('menuitem', { name: /copy path/i })
+      fireEvent.click(copyPath)
+
+      await waitFor(() => {
+        expect(clipboardWriteTextMock).toHaveBeenCalledWith('/tmp/repo')
+      })
+      await waitFor(() => {
+        expect(addServerErrorMock).toHaveBeenCalledTimes(1)
+      })
+      const firstCall = addServerErrorMock.mock.calls[0]
+      expect(firstCall).toBeDefined()
+      const [message, action, severity] = firstCall!
+      expect(message).toMatch(/clipboard/i)
+      // Severity arg pinned to 'warning' (#4870 convention).
+      expect(action).toBeUndefined()
+      expect(severity).toBe('warning')
+    })
+
+    it('does NOT surface a toast on a successful copy (no green confirmation by design)', async () => {
+      clipboardWriteTextMock.mockResolvedValue(true)
+      stateOverrides = connectedWithRepoSession
+      render(<App />)
+
+      const row = screen.getByTestId('session-item-s1')
+      fireEvent.contextMenu(row)
+      const menu = screen.getByRole('menu')
+      const copyPath = within(menu).getByRole('menuitem', { name: /copy path/i })
+      fireEvent.click(copyPath)
+
+      await waitFor(() => {
+        expect(clipboardWriteTextMock).toHaveBeenCalledWith('/tmp/repo')
+      })
+      // Resolve the microtask so the .then() handler runs.
+      await Promise.resolve()
+      expect(addServerErrorMock).not.toHaveBeenCalled()
+    })
+  })
+
   // #4796 — wiring guard for `useVoiceInput({ mode })`. Audit Tester #2
   // flagged that the chain `SettingsPanel.tsx -> updateInputSettings ->
   // inputSettings.voiceInputMode -> App.tsx selector -> useVoiceInput({ mode })`

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -698,10 +698,22 @@ export function App() {
       copyToClipboard: (text) => {
         // #4673: route through the clipboard helper so Tauri builds use the
         // native plugin instead of navigator.clipboard (which silently
-        // no-ops in WKWebView). Failures fall through quietly — the user
-        // can still see the conversation id by hovering or re-running the
-        // search.
-        void clipboardWriteText(text)
+        // no-ops in WKWebView).
+        // #4871: surface a visible warning toast on failure so the user
+        // knows the OS clipboard was NOT written (Tauri plugin rejected,
+        // navigator.clipboard missing in a non-secure context, etc.).
+        // Mirrors the #4857 / #4629 pattern applied to handleCopyTranscript
+        // above. Severity is 'warning' (not the default 'error') per #4870 —
+        // a failed clipboard write is non-destructive, the user just retries.
+        void clipboardWriteText(text).then((ok) => {
+          if (!ok) {
+            useConnectionStore.getState().addServerError(
+              'Failed to copy to clipboard. Please try again.',
+              undefined,
+              'warning',
+            )
+          }
+        })
       },
       openCreateSessionAt: (cwd) => {
         setPendingCwd(cwd)


### PR DESCRIPTION
Closes #4871

## Summary

The sidebar context-menu's `copyToClipboard` callback (used for "Copy path" on session/repo rows and "Copy Conversation ID" on resumable rows) routed through `clipboardWriteText` (#4673) but explicitly "fell through quietly" on failure. The same Tauri-WKWebView / non-secure-context failure modes that motivated #4629 left the user with zero feedback and a stale paste.

PR #4857 fixed the `handleCopyTranscript` path; this is the sibling fix. The callback now surfaces a `'warning'`-severity toast on failure (per the #4870 convention — a failed clipboard write is non-destructive, so yellow is more honest than red).

- `packages/dashboard/src/App.tsx` — `.then(ok => { if (!ok) addServerError('Failed to copy to clipboard. Please try again.', undefined, 'warning') })` on the existing `copyToClipboard` callback at line ~698. No other call sites changed.
- `packages/dashboard/src/App.test.tsx` — two new tests under `describe('sidebar copyToClipboard callback failure feedback (#4871)')`:
  - Failure path: helper returns `false`, right-click session row, click "Copy path" → assert `addServerError` is called once with a clipboard-related message and severity `'warning'`.
  - Success path: helper returns `true`, click "Copy path" → assert `addServerError` is NOT called (guards against future regression that toasts on success).

The session-row "Copy path" path exercises the same callback as the resumable row's "Copy Conversation ID" — easier to bootstrap in tests (no `conversationHistory` fixture required), and the wiring is identical.

## Test plan

- [x] `cd packages/dashboard && npx vitest run src/App.test.tsx -t "sidebar copyToClipboard"` — 2 new tests pass
- [x] Confirmed test fails on origin/main without the App.tsx fix
- [x] `cd packages/dashboard && npx vitest run src/App.test.tsx` — full suite (77 tests) passes
- [ ] CI: typecheck + lint (deferred to CI; my worktree's `@chroxy/store-core` resolves to another agent's WIP via shared symlinks)
- [ ] Manual: trigger clipboard failure in a Tauri desktop build (revoke the `clipboard-manager:allow-write-text` capability), right-click a session row, click "Copy path", confirm a yellow warning toast appears