### PR TITLE
test(server): pin all-single-select 2-question form byte sequence (#4882)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -138,15 +138,15 @@ const OTHER_FREEFORM_WATCHDOG_MS = 30 * 1000
 //
 // #4882 (open) — this constant + the trailing `\r` below are still
 // "best-effort defensive" rather than empirically confirmed. The recorder
-// script `scripts/tui-form-recorder.mjs` was originally only run against a
-// MIXED multi-question form (#4604 Chunk B). A fresh recorder pass against
-// a pure all-single-select N-question prompt is needed to:
+// script `scripts/tui-form-recorder.mjs` (repo root) was originally only run
+// against a MIXED multi-question form (#4604 Chunk B). A fresh recorder pass
+// against a pure all-single-select N-question prompt is needed to:
 //   - confirm 150ms is the right magnitude (or tune down/up)
 //   - confirm the Submit screen accepts `'1'` (vs needing `'\r'`, vs auto-
 //     submitting after the last digit with NO Submit screen)
 // Until that happens, the 30s ASK_USER_QUESTION watchdog is the safety net
-// for any remaining wedge. See `tui_multi_question_form_keys.md` memory note
-// for the empirical findings to date.
+// for any remaining wedge. See issue #4882 for the empirical reconcile
+// tracking and the prior all-single-select wedge analysis (#4635, #4867).
 const MULTI_QUESTION_SUBMIT_SETTLE_MS = 150
 
 // Pre-trust the cwd in ~/.claude.json so the workspace-trust dialog doesn't

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -135,6 +135,18 @@ const OTHER_FREEFORM_WATCHDOG_MS = 30 * 1000
 // final question in the sequence is single-select; mixed forms keep the
 // pre-#4635 timing-free path (Tab's commit signal makes Submit settle
 // naturally and the existing empirical recording pins the Tab + '1' run).
+//
+// #4882 (open) — this constant + the trailing `\r` below are still
+// "best-effort defensive" rather than empirically confirmed. The recorder
+// script `scripts/tui-form-recorder.mjs` was originally only run against a
+// MIXED multi-question form (#4604 Chunk B). A fresh recorder pass against
+// a pure all-single-select N-question prompt is needed to:
+//   - confirm 150ms is the right magnitude (or tune down/up)
+//   - confirm the Submit screen accepts `'1'` (vs needing `'\r'`, vs auto-
+//     submitting after the last digit with NO Submit screen)
+// Until that happens, the 30s ASK_USER_QUESTION watchdog is the safety net
+// for any remaining wedge. See `tui_multi_question_form_keys.md` memory note
+// for the empirical findings to date.
 const MULTI_QUESTION_SUBMIT_SETTLE_MS = 150
 
 // Pre-trust the cwd in ~/.claude.json so the workspace-trust dialog doesn't

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -4586,13 +4586,19 @@ describe('ClaudeTuiSession', () => {
     // breaks the smallest-N case can't slip past tests that only assert
     // against larger forms.
     //
+    // Q2 picks option 2 ('q' → '2') rather than option 1 so the last
+    // single-select digit is DISTINCT from the Submit screen's '1' — that
+    // way a future reorder bug that swapped the Q2 digit and the Submit
+    // digit would change the pinned byte sequence (currently `'2','2','1'`)
+    // instead of being invisible inside `'1','1','1'`.
+    //
     // NOTE: this pins the bytes the DRIVER writes per the #4867 fix; the
     // upstream empirical recorder pass against a live claude TUI is still
     // outstanding (tracked under #4882) — until that runs, the trailing
     // `\r` and the 150ms settle remain "best-effort defensive" not
     // "empirically confirmed". Driver shape pinned here so any reconciliation
-    // PR after the recorder pass updates this test alongside
-    // `tui_multi_question_form_keys.md`.
+    // PR after the recorder pass updates this test alongside the empirical
+    // findings recorded under #4882.
     it('drives a pure all-single-select 2-question form with settle + trailing Enter (#4882)', async () => {
       const writeEvents = []
       session._term = {
@@ -4606,7 +4612,7 @@ describe('ClaudeTuiSession', () => {
       session._pendingUserAnswer = { toolUseId: 'toolu_all_single_2q', questions, options: questions[0].options }
       const answersMap = {
         'Q1?': 'b',  // → '2' (auto-advances)
-        'Q2?': 'p',  // → '1' (auto-advances to Submit screen)
+        'Q2?': 'q',  // → '2' (auto-advances to Submit screen) — distinct from Submit's '1'
       }
 
       session.respondToQuestion('', answersMap)
@@ -4615,21 +4621,23 @@ describe('ClaudeTuiSession', () => {
 
       const writes = writeEvents.map((e) => e.data)
       // Byte sequence (pinned by #4867 driver fix; empirical confirmation
-      // outstanding under #4882): paste-disable, Q1 → '2', Q2 → '1',
+      // outstanding under #4882): paste-disable, Q1 → '2', Q2 → '2',
       // [settle 150ms], Submit '1', trailing Enter '\r', paste-enable.
+      // Q2's '2' is intentionally distinct from Submit's '1' so a reorder
+      // regression would mutate the pinned sequence (see test comment above).
       assert.deepEqual(
         writes,
-        ['\x1b[?2004l', '2', '1', '1', '\r', '\x1b[?2004h'],
+        ['\x1b[?2004l', '2', '2', '1', '\r', '\x1b[?2004h'],
         `expected all-single-select 2-q sequence with trailing \\r, got ${JSON.stringify(writes)}`,
       )
 
-      // The settle MUST land between the last single-select digit (Q2's '1')
+      // The settle MUST land between the last single-select digit (Q2's '2')
       // and the Submit '1'. After paste-disable (idx 0), Q1 writes '2' (idx 1),
-      // Q2 writes '1' (idx 2), then the 150ms settle fires, then Submit '1'
+      // Q2 writes '2' (idx 2), then the 150ms settle fires, then Submit '1'
       // (idx 3). Measure the gap between idx 2 and idx 3.
       const q2DigitWriteIdx = 2
       const submitWriteIdx = 3
-      assert.equal(writes[q2DigitWriteIdx], '1', 'Q2 single-select pick at index 2')
+      assert.equal(writes[q2DigitWriteIdx], '2', 'Q2 single-select pick at index 2')
       assert.equal(writes[submitWriteIdx], '1', 'Submit at index 3')
       const gapMs = writeEvents[submitWriteIdx].t - writeEvents[q2DigitWriteIdx].t
       assert.ok(

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -4578,6 +4578,68 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._pendingUserAnswer, null, 'pending cleared')
     })
 
+    // #4882 — minimal reproduction of the all-single-select wedge: a TWO-
+    // question pure-single-select form. The #4882 issue body specifically
+    // calls out "a 2+ question all-single-select prompt" as the empirical
+    // target; pinning the 2-q variant alongside the 3-q variant above makes
+    // the minimum failing shape explicit so a future regression that subtly
+    // breaks the smallest-N case can't slip past tests that only assert
+    // against larger forms.
+    //
+    // NOTE: this pins the bytes the DRIVER writes per the #4867 fix; the
+    // upstream empirical recorder pass against a live claude TUI is still
+    // outstanding (tracked under #4882) — until that runs, the trailing
+    // `\r` and the 150ms settle remain "best-effort defensive" not
+    // "empirically confirmed". Driver shape pinned here so any reconciliation
+    // PR after the recorder pass updates this test alongside
+    // `tui_multi_question_form_keys.md`.
+    it('drives a pure all-single-select 2-question form with settle + trailing Enter (#4882)', async () => {
+      const writeEvents = []
+      session._term = {
+        write: (data) => { writeEvents.push({ data, t: Date.now() }) },
+        kill: () => {},
+      }
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', options: [{ label: 'p' }, { label: 'q' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_all_single_2q', questions, options: questions[0].options }
+      const answersMap = {
+        'Q1?': 'b',  // → '2' (auto-advances)
+        'Q2?': 'p',  // → '1' (auto-advances to Submit screen)
+      }
+
+      session.respondToQuestion('', answersMap)
+      // Wait past the 150ms settle + per-char throttle + Enter.
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      const writes = writeEvents.map((e) => e.data)
+      // Byte sequence (pinned by #4867 driver fix; empirical confirmation
+      // outstanding under #4882): paste-disable, Q1 → '2', Q2 → '1',
+      // [settle 150ms], Submit '1', trailing Enter '\r', paste-enable.
+      assert.deepEqual(
+        writes,
+        ['\x1b[?2004l', '2', '1', '1', '\r', '\x1b[?2004h'],
+        `expected all-single-select 2-q sequence with trailing \\r, got ${JSON.stringify(writes)}`,
+      )
+
+      // The settle MUST land between the last single-select digit (Q2's '1')
+      // and the Submit '1'. After paste-disable (idx 0), Q1 writes '2' (idx 1),
+      // Q2 writes '1' (idx 2), then the 150ms settle fires, then Submit '1'
+      // (idx 3). Measure the gap between idx 2 and idx 3.
+      const q2DigitWriteIdx = 2
+      const submitWriteIdx = 3
+      assert.equal(writes[q2DigitWriteIdx], '1', 'Q2 single-select pick at index 2')
+      assert.equal(writes[submitWriteIdx], '1', 'Submit at index 3')
+      const gapMs = writeEvents[submitWriteIdx].t - writeEvents[q2DigitWriteIdx].t
+      assert.ok(
+        gapMs >= 140,
+        `expected settle gap >= 140ms between Q2 digit and Submit, got ${gapMs}ms`,
+      )
+
+      assert.equal(session._pendingUserAnswer, null, 'pending cleared')
+    })
+
     // #4635 — when ONLY the last question is single-select (e.g. multi
     // then single), still need the settle. Mirror of the all-single-select
     // case but with a leading multi-select to confirm the settle decision


### PR DESCRIPTION
Partial scoping of #4882. Adds the minimum-reproduction test variant and surfaces the empirical-confirmation status more loudly; the human-driven recorder pass against a live claude TUI is still outstanding.

## Summary

- **New test** (`packages/server/tests/claude-tui-session.test.js`): pin the all-single-select **2-question** form's byte sequence (`['\x1b[?2004l', '2', '1', '1', '\r', '\x1b[?2004h']`) + assert the 150ms settle gap. The 3-question variant was already pinned (#4635); the 2-q minimum is the smallest shape called out in the #4882 issue body and is now equally covered.
- **Docstring expansion** (`packages/server/src/claude-tui-session.js`): the `MULTI_QUESTION_SUBMIT_SETTLE_MS` constant comment now explicitly flags that the 150ms magnitude AND the trailing `\r` are **best-effort defensive** rather than empirically pinned, pointing readers to the recorder script + memory note for the open empirical question.
- **Memory note** (`tui_multi_question_form_keys.md`): appended a 2026-06-02 update summarising #4867's defensive layers, the test coverage in place, and the precise empirical questions that remain unanswered (settle magnitude, Submit screen contract, trailing-Enter necessity).

## What this PR does NOT do

The acceptance criterion **"Fresh `tui-form-recorder.mjs` run against an all-single-select prompt is captured"** requires:

1. A live, interactive `claude` TUI session under node-pty (the recorder spawns it).
2. A human typing a prompt that triggers a pure all-single-select multi-question AskUserQuestion.
3. A human answering it manually and observing whether Submit succeeds.
4. Tailing `/tmp/tui-form-recording-<ts>.jsonl` to extract the actually-accepted byte sequence.

None of those steps can be automated in this PR. Once the recorder pass is run, the follow-up reconciliation work is:
- If `\r` is load-bearing → rename "defensive" → "required" in `claude-tui-session.js` comments + keep the test pin as-is.
- If `\r` is harmful → drop the `'\r'` from the assembled sequence + update both 2-q and 3-q test pins.
- If 150ms is wrong → tune `MULTI_QUESTION_SUBMIT_SETTLE_MS` to whatever the recording shows is the actual required gap.

That reconciliation is the second half of #4882; this PR scopes the test/docs half so the empirical status is loud in code, comments, and project memory.

## Test plan

- [x] `node --test packages/server/tests/claude-tui-session.test.js` — 194 tests pass (193 baseline + 1 new)
- [x] `packages/server/scripts/lint-tests-state-file-path.sh` — OK
- [x] `packages/server/scripts/lint-session-opt-forwarding.sh` — OK
- [ ] Empirical recorder pass (outstanding — see #4882)

Related: #4867 (defensive fix), #4635 (root issue), #4848 (arrow-nav for 10+ option).

Related to #4882 (test/docs half only — empirical recorder pass outstanding)