### PR TITLE
fix(dashboard): drop role=status from status dots, add debounced live region (#4873)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -1942,6 +1942,32 @@ describe('App', () => {
       expect(dot!.getAttribute('aria-label'), 'status-dot needs aria-label for SR').toBeTruthy()
     })
 
+    // #4873 — header status dot must NOT carry role="status" / aria-live.
+    // The per-element live region announced every reconnect intermediate
+    // (connecting → reconnecting → connected → reconnecting…), spamming
+    // SR users. The page-level ConnectionAnnouncer (mounted in App)
+    // handles settled-state announcements instead.
+    it('header status dot does NOT carry role="status" (#4873)', () => {
+      stateOverrides = connectedWithSession
+      const { container } = render(<App />)
+      const header = container.querySelector('#header')
+      const dot = header!.querySelector('.status-dot')
+      expect(dot, 'header status-dot must exist').toBeTruthy()
+      expect(dot!.getAttribute('role'), 'status-dot must NOT be role=status').not.toBe('status')
+      expect(dot!.getAttribute('aria-live'), 'status-dot must not be a live region').toBeNull()
+    })
+
+    // #4873 — the page-level live region IS rendered, so SR users still
+    // get a settled-state announcement after the debounce window.
+    it('renders a page-level ConnectionAnnouncer live region (#4873)', () => {
+      stateOverrides = connectedWithSession
+      const { container } = render(<App />)
+      const announcer = container.querySelector('[data-testid="connection-announcer"]')
+      expect(announcer, 'page-level connection announcer must exist').toBeTruthy()
+      expect(announcer!.getAttribute('role')).toBe('status')
+      expect(announcer!.getAttribute('aria-live')).toBe('polite')
+    })
+
     it('version badge exposes both title and aria-label', () => {
       stateOverrides = connectedWithSession
       const { container } = render(<App />)

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -46,6 +46,7 @@ import { StreamStallChip } from './components/StreamStallChip'
 import { AskUserQuestionStallChip } from './components/AskUserQuestionStallChip'
 import { PlanApproval } from './components/PlanApproval'
 import { ReconnectBanner } from './components/ReconnectBanner'
+import { ConnectionAnnouncer } from './components/ConnectionAnnouncer'
 import { StdinDisabledBanner } from './components/StdinDisabledBanner'
 import { WelcomeScreen } from './components/WelcomeScreen'
 import { CreateSessionModal } from './components/CreateSessionModal'
@@ -1708,6 +1709,11 @@ export function App() {
 
   return (
     <div id="app" className={sidebarRepos.length > 0 ? 'with-sidebar' : ''}>
+      {/* #4873 — single page-level live region that announces only the
+          SETTLED connection phase after a debounce. Replaces the
+          per-status-dot role=status announcements that flooded SR
+          users during reconnect storms. */}
+      <ConnectionAnnouncer phase={connectionPhase} />
       {/* Reconnect banner */}
       <ReconnectBanner
         visible={isReconnecting}
@@ -1746,9 +1752,15 @@ export function App() {
               discoverable label, leaving Tauri/WKWebView and SR users with
               nothing on hover. Pair `title` (browser hover tooltip) with
               `aria-label` (screen-reader announcement) so both surfaces
-              get a label. The status dot also gets `role="status"` so SR
-              tooling treats it as a live region rather than a decorative
-              span. */}
+              get a label.
+              #4873 — the status dot intentionally does NOT carry
+              `role="status"`. role=status implies aria-live=polite,
+              which made reconnect-storm churn (connecting →
+              reconnecting → connected → reconnecting…) verbally hammer
+              SR users with every intermediate transition. aria-label
+              alone keeps the dot discoverable on focus/hover, and the
+              page-level debounced ConnectionAnnouncer (mounted above)
+              announces only the settled phase. */}
           {(() => {
             const versionLabel = `Chroxy server v${serverVersion ?? __APP_VERSION__}`
             return (
@@ -1777,7 +1789,6 @@ export function App() {
                 className={`status-dot ${phase}`}
                 title={label}
                 aria-label={label}
-                role="status"
               />
             )
           })()}

--- a/packages/dashboard/src/components/ConnectionAnnouncer.test.tsx
+++ b/packages/dashboard/src/components/ConnectionAnnouncer.test.tsx
@@ -5,7 +5,9 @@
  *   - has role=status + aria-live=polite (so SR announces)
  *   - debounces phase churn (reconnect storm = one announcement)
  *   - announces only SETTLED phase after debounce
- *   - does not announce on first paint (initial empty)
+ *   - does not announce SYNCHRONOUSLY on first paint (initial empty)
+ *     — the initial phase IS announced, but only after the debounce
+ *     window settles
  *   - re-announces when a NEW settled phase arrives
  *   - cancels stale timers on unmount (no setState-after-unmount)
  */
@@ -37,17 +39,19 @@ describe('ConnectionAnnouncer (#4873)', () => {
     expect(region.style.position).toBe('absolute')
   })
 
-  it('does not announce anything on first paint', () => {
+  it('delays the initial-phase announcement until after the debounce window', () => {
     const { getByTestId } = render(<ConnectionAnnouncer phase="connecting" debounceMs={50} />)
     const region = getByTestId('connection-announcer')
-    // Region exists but is empty until the debounce timer fires for
-    // the first NEW phase value (initial paint is not a transition).
+    // Region exists but is empty SYNCHRONOUSLY on first paint — the
+    // mount effect has scheduled a timer but it hasn't fired yet, so
+    // SR hears nothing immediately.
     expect(region.textContent).toBe('')
     act(() => {
       vi.advanceTimersByTime(50)
     })
-    // After the debounce, the initial phase IS announced — but only
-    // once, and only after settling.
+    // After the debounce window the initial phase IS announced (once,
+    // and only after settling). The delay coalesces a fast initial
+    // flap into a single announcement of the settled state.
     expect(region.textContent).toBe('Connecting to Chroxy server')
   })
 

--- a/packages/dashboard/src/components/ConnectionAnnouncer.test.tsx
+++ b/packages/dashboard/src/components/ConnectionAnnouncer.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * ConnectionAnnouncer (#4873)
+ *
+ * Verifies the page-level debounced live region:
+ *   - has role=status + aria-live=polite (so SR announces)
+ *   - debounces phase churn (reconnect storm = one announcement)
+ *   - announces only SETTLED phase after debounce
+ *   - does not announce on first paint (initial empty)
+ *   - re-announces when a NEW settled phase arrives
+ *   - cancels stale timers on unmount (no setState-after-unmount)
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, cleanup, act } from '@testing-library/react'
+import { ConnectionAnnouncer } from './ConnectionAnnouncer'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  cleanup()
+})
+
+describe('ConnectionAnnouncer (#4873)', () => {
+  it('renders an off-screen polite live region with role=status', () => {
+    const { getByTestId } = render(<ConnectionAnnouncer phase="connecting" />)
+    const region = getByTestId('connection-announcer')
+    expect(region.getAttribute('role')).toBe('status')
+    expect(region.getAttribute('aria-live')).toBe('polite')
+    expect(region.getAttribute('aria-atomic')).toBe('true')
+    // Must NOT be display:none / visibility:hidden — SR ignores both.
+    expect(region.style.display).not.toBe('none')
+    expect(region.style.visibility).not.toBe('hidden')
+    // Off-screen clip recipe — keeps it out of the visual viewport
+    // while remaining in the a11y tree.
+    expect(region.style.position).toBe('absolute')
+  })
+
+  it('does not announce anything on first paint', () => {
+    const { getByTestId } = render(<ConnectionAnnouncer phase="connecting" debounceMs={50} />)
+    const region = getByTestId('connection-announcer')
+    // Region exists but is empty until the debounce timer fires for
+    // the first NEW phase value (initial paint is not a transition).
+    expect(region.textContent).toBe('')
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+    // After the debounce, the initial phase IS announced — but only
+    // once, and only after settling.
+    expect(region.textContent).toBe('Connecting to Chroxy server')
+  })
+
+  it('debounces a reconnect-storm into a single announcement', () => {
+    const { getByTestId, rerender } = render(
+      <ConnectionAnnouncer phase="connecting" debounceMs={100} />,
+    )
+    const region = getByTestId('connection-announcer')
+
+    // Storm: flap through 4 phase changes inside the debounce window.
+    act(() => {
+      vi.advanceTimersByTime(30)
+    })
+    rerender(<ConnectionAnnouncer phase="reconnecting" debounceMs={100} />)
+    act(() => {
+      vi.advanceTimersByTime(30)
+    })
+    rerender(<ConnectionAnnouncer phase="connecting" debounceMs={100} />)
+    act(() => {
+      vi.advanceTimersByTime(30)
+    })
+    rerender(<ConnectionAnnouncer phase="reconnecting" debounceMs={100} />)
+    act(() => {
+      vi.advanceTimersByTime(30)
+    })
+    rerender(<ConnectionAnnouncer phase="connected" debounceMs={100} />)
+
+    // Mid-storm the region is still empty — no intermediates have
+    // been announced.
+    expect(region.textContent).toBe('')
+
+    // Now let the debounce settle.
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(region.textContent).toBe('Connected to Chroxy server')
+  })
+
+  it('does not re-announce the same settled phase', () => {
+    const { getByTestId, rerender } = render(
+      <ConnectionAnnouncer phase="connected" debounceMs={50} />,
+    )
+    const region = getByTestId('connection-announcer')
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+    expect(region.textContent).toBe('Connected to Chroxy server')
+
+    // Rerender with the same phase — no new timer should fire because
+    // the phase didn't change.
+    rerender(<ConnectionAnnouncer phase="connected" debounceMs={50} />)
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    // Still the same text; no churn.
+    expect(region.textContent).toBe('Connected to Chroxy server')
+  })
+
+  it('announces a NEW settled phase after the previous one was already announced', () => {
+    const { getByTestId, rerender } = render(
+      <ConnectionAnnouncer phase="connected" debounceMs={50} />,
+    )
+    const region = getByTestId('connection-announcer')
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+    expect(region.textContent).toBe('Connected to Chroxy server')
+
+    // Real wire drop — phase moves to disconnected. After the debounce
+    // window the SR should hear the new state.
+    rerender(<ConnectionAnnouncer phase="disconnected" debounceMs={50} />)
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+    expect(region.textContent).toBe('Disconnected from Chroxy server')
+  })
+
+  it('skips announcement if phase flaps BACK to the previously-announced value mid-debounce', () => {
+    const { getByTestId, rerender } = render(
+      <ConnectionAnnouncer phase="connected" debounceMs={100} />,
+    )
+    const region = getByTestId('connection-announcer')
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(region.textContent).toBe('Connected to Chroxy server')
+
+    // Brief flap: reconnecting → connected. The timer is started on
+    // the reconnecting change but by the time it fires the phase is
+    // back to connected, so nothing new is announced (no churn).
+    rerender(<ConnectionAnnouncer phase="reconnecting" debounceMs={100} />)
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+    rerender(<ConnectionAnnouncer phase="connected" debounceMs={100} />)
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    // Text didn't change — no double announcement of "Connected".
+    expect(region.textContent).toBe('Connected to Chroxy server')
+  })
+
+  it('cleans up the pending timer on unmount', () => {
+    const { unmount } = render(
+      <ConnectionAnnouncer phase="connecting" debounceMs={500} />,
+    )
+    // Unmount before the timer fires. If we didn't clean up, the
+    // pending setState would warn about updating an unmounted
+    // component — vi.useFakeTimers + advance lets us prove the timer
+    // is gone.
+    unmount()
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+    }).not.toThrow()
+  })
+
+  it('falls back to a generic label for unknown phases', () => {
+    const { getByTestId } = render(
+      <ConnectionAnnouncer phase="some-future-phase" debounceMs={10} />,
+    )
+    act(() => {
+      vi.advanceTimersByTime(10)
+    })
+    expect(getByTestId('connection-announcer').textContent).toBe(
+      'Connection status: some-future-phase',
+    )
+  })
+})

--- a/packages/dashboard/src/components/ConnectionAnnouncer.tsx
+++ b/packages/dashboard/src/components/ConnectionAnnouncer.tsx
@@ -1,0 +1,128 @@
+/**
+ * ConnectionAnnouncer (#4873) — single page-level live region that
+ * announces SETTLED connection-phase transitions to assistive tech.
+ *
+ * Background — #4861 added `role="status"` to the header, footer, and
+ * per-tab status dots. role=status implies aria-live=polite, so every
+ * aria-label change announced. During reconnect storms the phase flips
+ * `connecting → reconnecting → connected → reconnecting…` many times
+ * per second, and SR users heard every intermediate state. With N tabs,
+ * background-agent busy/idle churn made the chat unusable on a screen
+ * reader (#4873).
+ *
+ * Fix shape:
+ *   - The three status dots dropped `role="status"` — `aria-label` alone
+ *     keeps them discoverable on focus/hover.
+ *   - This component renders ONE off-screen live region that announces
+ *     only the final SETTLED phase after a debounce window. Transient
+ *     intermediates during a reconnect cycle are coalesced into a single
+ *     polite announcement of the resting state.
+ *
+ * Why debounce instead of "announce on transition to error":
+ *   - SR users still need to know when the connection has settled into
+ *     a degraded state (disconnected / server_restarting). Picking only
+ *     "error" would miss the "we recovered" announcement that closes
+ *     the loop after a reconnect.
+ *   - The debounce window (default 1.5s) is long enough to absorb the
+ *     fastest reconnect-storm cycles observed in practice (#4630
+ *     telemetry), but short enough that the user hears the settled
+ *     state within ~2s of the wire actually settling.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+
+export interface ConnectionAnnouncerProps {
+  /** Current connection phase from the store. */
+  phase: string
+  /**
+   * Debounce window in ms. Phase changes within this window are
+   * coalesced — only the final phase is announced. Exposed for tests
+   * to set very short windows (the production default is 1500ms).
+   */
+  debounceMs?: number
+}
+
+const SETTLED_LABELS: Record<string, string> = {
+  connected: 'Connected to Chroxy server',
+  connecting: 'Connecting to Chroxy server',
+  reconnecting: 'Reconnecting to Chroxy server',
+  server_restarting: 'Chroxy server restarting',
+  disconnected: 'Disconnected from Chroxy server',
+}
+
+function settledLabelFor(phase: string): string {
+  return SETTLED_LABELS[phase] ?? `Connection status: ${phase}`
+}
+
+/**
+ * Off-screen visually-hidden styles. Avoids `display: none` (SR ignores
+ * it) and `visibility: hidden` (cancels announcements). The "1px box
+ * clipped to nothing" recipe is the standard SR-only pattern.
+ */
+const SR_ONLY_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+}
+
+export function ConnectionAnnouncer({
+  phase,
+  debounceMs = 1500,
+}: ConnectionAnnouncerProps) {
+  // The text currently in the live region. Initially empty so SR does
+  // not announce on first mount (the dashboard's first paint is not a
+  // state change worth narrating).
+  const [announced, setAnnounced] = useState('')
+  // Track the last phase we actually announced so we don't re-announce
+  // the same settled state if the debounce timer trips on a no-op
+  // change (e.g. React re-render with the same phase string).
+  const lastAnnouncedRef = useRef<string>('')
+  // Pending timer id so successive phase changes within the debounce
+  // window cancel the prior one.
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    // Clear any pending timer — we want only the LAST phase change in
+    // a churn window to fire.
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    // If the phase hasn't actually changed from the last announced
+    // value, skip the timer entirely — re-renders are free.
+    if (phase === lastAnnouncedRef.current) return
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      // Re-check inside the timer — by the time it fires, the phase
+      // may have flapped back to the previously-announced value, in
+      // which case there's nothing to say.
+      if (phase === lastAnnouncedRef.current) return
+      lastAnnouncedRef.current = phase
+      setAnnounced(settledLabelFor(phase))
+    }, debounceMs)
+    return () => {
+      if (timerRef.current != null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [phase, debounceMs])
+
+  return (
+    <div
+      data-testid="connection-announcer"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      style={SR_ONLY_STYLE}
+    >
+      {announced}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ConnectionAnnouncer.tsx
+++ b/packages/dashboard/src/components/ConnectionAnnouncer.tsx
@@ -75,9 +75,14 @@ export function ConnectionAnnouncer({
   phase,
   debounceMs = 1500,
 }: ConnectionAnnouncerProps) {
-  // The text currently in the live region. Initially empty so SR does
-  // not announce on first mount (the dashboard's first paint is not a
-  // state change worth narrating).
+  // The text currently in the live region. Initially empty so the
+  // first paint does not announce SYNCHRONOUSLY. The mount effect
+  // still schedules a debounced timer for the initial phase, so SR
+  // will hear that phase after `debounceMs` (e.g. dashboard mounting
+  // in `connecting` → "Connecting to Chroxy server" ~1.5s later).
+  // This delay is intentional: it coalesces a fast initial flap
+  // (connecting → connected within the debounce window) into a
+  // single announcement of the settled state.
   const [announced, setAnnounced] = useState('')
   // Track the last phase we actually announced so we don't re-announce
   // the same settled state if the debounce timer trips on a no-op

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -261,6 +261,42 @@ describe('FooterBar', () => {
   })
 
   // -----------------------------------------------------------------
+  // #4873 — the footer status dot must NOT carry role="status" /
+  // aria-live, because reconnect-storm churn (connecting →
+  // reconnecting → connected → reconnecting…) would announce every
+  // intermediate state to SR users. The dot is still discoverable on
+  // focus/hover via aria-label; settled-state announcements are
+  // handled by the page-level ConnectionAnnouncer.
+  // Also: avoid duplicate SR announcement between the dot and the
+  // adjacent visible status-label.
+  // -----------------------------------------------------------------
+  describe('#4873 footer status dot avoids polite live-region churn', () => {
+    it('connection status dot does NOT carry role="status"', () => {
+      const { container } = render(<FooterBar {...baseProps} connectionPhase="reconnecting" />)
+      const dot = container.querySelector('.footer-status-dot')
+      expect(dot, 'footer-status-dot must exist').toBeTruthy()
+      expect(dot!.getAttribute('role'), 'status dot must NOT be role=status').not.toBe('status')
+    })
+
+    it('connection status dot does NOT carry aria-live', () => {
+      const { container } = render(<FooterBar {...baseProps} connectionPhase="reconnecting" />)
+      const dot = container.querySelector('.footer-status-dot')
+      expect(dot!.getAttribute('aria-live'), 'status dot must not be a live region').toBeNull()
+    })
+
+    it('footer-status-label is aria-hidden to avoid duplicate SR announcement with the dot', () => {
+      // The dot already carries the spoken label via aria-label, so
+      // the adjacent visible text would be announced twice if both
+      // were exposed. Hide the visible label from SR while keeping
+      // the dot's aria-label as the spoken name.
+      const { container } = render(<FooterBar {...baseProps} connectionPhase="connected" />)
+      const label = container.querySelector('.footer-status-label')
+      expect(label, 'footer-status-label must exist').toBeTruthy()
+      expect(label!.getAttribute('aria-hidden')).toBe('true')
+    })
+  })
+
+  // -----------------------------------------------------------------
   // #3857 — high-utilization compact-suggestion chip
   // -----------------------------------------------------------------
   describe('#3857 compact suggestion at high context utilization', () => {

--- a/packages/dashboard/src/components/FooterBar.tsx
+++ b/packages/dashboard/src/components/FooterBar.tsx
@@ -175,13 +175,23 @@ export function FooterBar({
         >
           v{version}
         </span>
+        {/* #4873 — dot no longer carries `role="status"`. The polite
+            live region used to announce every reconnect intermediate
+            (connecting → reconnecting → connected → reconnecting…),
+            spamming SR users. The aria-label still gives the dot a
+            spoken name on focus/hover. The page-level
+            ConnectionAnnouncer (App.tsx) handles debounced settled-state
+            announcements. */}
         <span
           className={`footer-status-dot ${dotClass}`}
           title={statusFullLabel}
           aria-label={statusFullLabel}
-          role="status"
         />
-        <span className="footer-status-label">{statusLabel}</span>
+        {/* #4873 — visible label is aria-hidden to avoid a duplicate
+            SR announcement next to the dot (which already carries the
+            full spoken label via aria-label). Sighted users still see
+            the text. */}
+        <span className="footer-status-label" aria-hidden="true">{statusLabel}</span>
         {cwd && (
           <span
             className="footer-cwd"

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -399,6 +399,19 @@ describe('SessionBar', () => {
       expect(dot.getAttribute('aria-label'), 'status-dot needs aria-label').toBeTruthy()
     })
 
+    // #4873 — the per-tab status dot must NOT carry role="status".
+    // With N tabs and frequent busy/idle churn from background agents,
+    // a polite live region on each dot would make the chat unusable
+    // on a screen reader. aria-label keeps the dot discoverable on
+    // focus/hover without flooding the SR queue.
+    it('per-tab status dot does NOT carry role="status" (#4873)', () => {
+      renderRichTab()
+      const tab = screen.getByTestId('session-tab-s1')
+      const dot = within(tab).getByTestId('status-dot')
+      expect(dot.getAttribute('role'), 'status-dot must NOT be role=status').not.toBe('status')
+      expect(dot.getAttribute('aria-live'), 'status-dot must not be a live region').toBeNull()
+    })
+
     it('tab cwd chip has both title and aria-label', () => {
       const { container } = renderRichTab()
       const cwd = container.querySelector('.tab-cwd')

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -124,13 +124,18 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               // screen readers ignore `title` on a bare span. `aria-label`
               // duplicates the same human-readable string so SR users hear
               // "session working" / "session idle" rather than nothing.
+              // #4873 — the dot intentionally does NOT carry
+              // `role="status"`. With N tabs and frequent busy/idle
+              // churn from background agents, a polite live region per
+              // tab would make the chat unusable on a screen reader.
+              // aria-label keeps the dot discoverable on focus/hover
+              // without flooding the SR queue.
               return (
                 <span
                   className={`tab-status-dot status-${effectiveStatus}`}
                   data-testid="status-dot"
                   title={STATUS_LABELS[effectiveStatus]}
                   aria-label={STATUS_LABELS[effectiveStatus]}
-                  role="status"
                 />
               )
             })()}


### PR DESCRIPTION
## Summary

#4861 added `role="status"` to the connection status dots to give SR users a discoverable name. role=status implies aria-live=polite, so every aria-label update was announced — which made three things ugly on a screen reader:

1. **Reconnect storms** — phase flips `connecting → reconnecting → connected → reconnecting…` during tunnel warming. SR users heard every intermediate transition.
2. **Duplicate footer announcement** — `footer-status-dot` (aria-label) sat next to `footer-status-label` (visible text), announcing the same state twice.
3. **N tabs = N live regions** — every busy/idle flip on every background-agent tab announced. With 5 agents flipping state the chat was unusable on a screen reader.

## Fix

- Drop `role="status"` from the three status dots (App header, FooterBar, SessionBar). `aria-label` alone keeps each dot discoverable on focus/hover without flooding the SR queue.
- Mark `footer-status-label` `aria-hidden="true"` so the visible text doesn't double-announce alongside the dot's aria-label.
- Add a single page-level **`ConnectionAnnouncer`** (role=status + aria-live=polite, off-screen visually-hidden) that **debounces phase changes (1.5s default)**. Reconnect-storm intermediates are coalesced into one announcement of the final settled phase. Same-phase re-renders and short flaps that resolve to the previously-announced phase don't re-announce.

## Why debounce instead of "only announce on transition to error"

SR users still need to know when the connection has settled into a degraded state (disconnected / server_restarting) AND when it recovers. Picking only "error" would miss the "we recovered" announcement that closes the loop after a reconnect cycle. The 1.5s window absorbs the fastest reconnect-storm cycles observed in practice while announcing the settled state within ~2s.

## Acceptance (from #4873)

- [x] Status dots use only `aria-label` (no `role="status"` / `aria-live`)
- [x] No duplicate announcement between `footer-status-dot` and `footer-status-label` (label is `aria-hidden`)
- [x] Page-level debounced live region announces settled-state transitions
- [x] Tests assert dots do NOT have role="status"

## Test plan

- [x] `ConnectionAnnouncer.test.tsx` — 8 tests covering: live-region shape, no first-paint announce spam, reconnect-storm coalescing, no re-announce on same phase, NEW phase after settled, flap-back skip, unmount cleanup, unknown-phase fallback.
- [x] Regression tests on App / FooterBar / SessionBar assert the dots explicitly do NOT carry role=status / aria-live, and App renders the page-level announcer.
- [x] Full dashboard suite: 2582 tests pass, typecheck clean.

Closes #4873