### PR TITLE
refactor(app): factor isFreeformAnswer into a shared typed predicate (#4875)

### DIFF
--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -9,6 +9,12 @@ import {
   LayoutAnimation,
 } from 'react-native';
 import { OTHER_OPTION_VALUE } from '@chroxy/store-core';
+// #4875: `OtherFreeformAnswer` moved to @chroxy/store-core/freeform-answer
+// so the mobile store, the mobile screen, and (eventually) the dashboard
+// can converge on a single declaration paired with the shared
+// `isFreeformAnswer` guard. Re-exported below for the existing call sites
+// (SessionScreen, ChatView, MessageBubble's own onSelectOption signature).
+import type { OtherFreeformAnswer } from '@chroxy/store-core';
 import type { ChatMessage, ToolResultImage } from '../../store/connection';
 import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
@@ -34,10 +40,12 @@ import { StreamStallChip } from '../StreamStallChip';
  * options free-text-only AskUserQuestions (#1245) so older servers that
  * ignore `freeformText` keep working unchanged.
  */
-export interface OtherFreeformAnswer {
-  otherLabel: string;
-  freeformText: string;
-}
+// #4875: the interface itself lives in `@chroxy/store-core/freeform-answer`
+// (single source of truth, paired with the `isFreeformAnswer` guard); re-
+// exported here for downstream importers (ChatView, SessionScreen) that
+// already pull `SelectOptionValue` from this file. Keeping the re-export
+// avoids churning every existing call site for the type alias.
+export type { OtherFreeformAnswer };
 
 export type SelectOptionValue = string | OtherFreeformAnswer;
 

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -20,6 +20,12 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useConnectionStore, selectMessages, selectClaudeReady, selectStreamingMessageId, selectActiveModel, selectPermissionMode, selectContextUsage, selectLastResultCost, selectLastResultDuration, selectIsIdle, stripAnsi, nextMessageId } from '../store/connection';
 import type { ChatMessage, ConnectionPhase, AgentInfo, McpServer, DevPreview } from '../store/connection';
 import type { SessionIntervention } from '@chroxy/store-core';
+// #4875: shared typed predicate for the AskUserQuestion freeform shape.
+// Replaces the looser 2-condition inline check (`'otherLabel' in &&
+// 'freeformText' in`) with the same 5-condition guard the store layer
+// uses, so widening `SelectOptionValue` to a third object shape can't
+// silently misroute it as freeform.
+import { isFreeformAnswer } from '@chroxy/store-core';
 import { useConnectionLifecycleStore } from '../store/connection-lifecycle';
 import { SessionPicker } from '../components/SessionPicker';
 import { CreateSessionModal } from '../components/CreateSessionModal';
@@ -688,25 +694,30 @@ export function SessionScreen() {
     requestId?: string,
     toolUseId?: string,
   ) => {
-    const isFreeformAnswer = typeof value === 'object' && value !== null
-      && 'otherLabel' in value && 'freeformText' in value;
+    // #4875: shared `isFreeformAnswer` guard from @chroxy/store-core
+    // narrows `value` to `OtherFreeformAnswer` in the true branch, so the
+    // string-branch arms can drop the `as string` cast in favour of plain
+    // assignment. The previous inline 2-condition check (`'otherLabel' in
+    // && 'freeformText' in`) was looser than the store-layer detector and
+    // would have silently misrouted a future third object shape; the
+    // shared guard keeps both call sites in lockstep.
+    const freeform = isFreeformAnswer(value);
     let sent: 'sent' | 'queued' | false = false;
     if (toolUseId) {
       sent = sendUserQuestionResponse(value, toolUseId);
     } else if (requestId) {
       // Permission responses are decision strings ('allow' / 'deny' / etc.)
-      // and never carry an Other / freeform payload — coerce to string so
-      // the type stays sound even though this branch isn't reachable for
-      // the freeform shape in practice.
-      sent = sendPermissionResponse(requestId, isFreeformAnswer ? value.freeformText : (value as string));
+      // and never carry an Other / freeform payload — the freeform branch
+      // is defence-in-depth only; in practice this site sees `string`.
+      sent = sendPermissionResponse(requestId, freeform ? value.freeformText : value);
     } else {
-      const literal = isFreeformAnswer ? value.freeformText : (value as string);
+      const literal = freeform ? value.freeformText : value;
       sent = sendInput(hasTerminal ? literal + '\r' : literal);
     }
     if (sent === 'sent') {
       // For the freeform shape, store the typed text (not the label) so
       // the answered-state UI renders the user's actual answer.
-      const summary = isFreeformAnswer ? value.freeformText : (value as string);
+      const summary = freeform ? value.freeformText : value;
       markPromptAnswered(messageId, summary);
     }
   };

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -124,6 +124,11 @@ import { CLIENT_CAPABILITIES } from '@chroxy/protocol';
 import {
   getWsCloseMessage,
   getHealthCheckErrorMessage,
+  // #4875: shared typed predicate for the AskUserQuestion freeform shape.
+  // Replaces the inline 5-condition check that previously diverged from
+  // the looser SessionScreen variant; both call sites now narrow off the
+  // same guard.
+  isFreeformAnswer,
 } from '@chroxy/store-core';
 import { setCallback as setImperativeCallback, getCallback, clearAllCallbacks } from './imperative-callbacks';
 import { useMultiClientStore } from './multi-client';
@@ -1216,24 +1221,22 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     //
     // Freeform shape detection is tight (exactly the two named keys, both
     // strings) so a multi-question Record whose keys happen to be those
-    // names doesn't get misrouted into the freeform branch.
-    const isFreeformAnswer = typeof answer === 'object' && answer !== null
-      && !Array.isArray(answer)
-      && Object.keys(answer).length === 2
-      && 'freeformText' in answer && 'otherLabel' in answer
-      && typeof (answer as Record<string, unknown>).freeformText === 'string'
-      && typeof (answer as Record<string, unknown>).otherLabel === 'string';
-    const isMultiAnswer = !isFreeformAnswer && typeof answer !== 'string';
+    // names doesn't get misrouted into the freeform branch. The guard
+    // lives in `@chroxy/store-core/freeform-answer` so the dashboard
+    // store, the mobile screen layer, and this site all narrow off one
+    // shared predicate (#4875).
+    const freeform = isFreeformAnswer(answer);
+    const isMultiAnswer = !freeform && typeof answer !== 'string';
     const payload: Record<string, unknown> = {
       type: 'user_question_response',
-      answer: isFreeformAnswer
-        ? (answer as { otherLabel: string }).otherLabel
+      answer: freeform
+        ? answer.otherLabel
         : isMultiAnswer
           ? formatQuestionAnswerSummary(answer as Record<string, string | string[]>)
           : (answer as string),
     };
-    if (isFreeformAnswer) {
-      payload.freeformText = (answer as { freeformText: string }).freeformText;
+    if (freeform) {
+      payload.freeformText = answer.freeformText;
     } else if (isMultiAnswer) {
       payload.answers = answer;
     }

--- a/packages/store-core/src/freeform-answer.test.ts
+++ b/packages/store-core/src/freeform-answer.test.ts
@@ -147,6 +147,50 @@ describe('isFreeformAnswer (#4875)', () => {
     })
   })
 
+  describe('rejects prototype-pollution-style payloads', () => {
+    it('returns false when otherLabel + freeformText are inherited, not own', () => {
+      // Copilot review of #4900: an object with two unrelated OWN keys
+      // but `otherLabel` / `freeformText` inherited via its prototype
+      // chain MUST be rejected. The guard uses `hasOwnProperty.call`
+      // rather than `'key' in value` so the `in` operator's prototype-
+      // walking behaviour cannot let a tampered payload pass.
+      const proto = { otherLabel: 'tampered', freeformText: 'tampered' }
+      const value = Object.create(proto) as Record<string, unknown>
+      value.foo = 'a'
+      value.bar = 'b'
+      // Sanity: confirm the test fixture actually triggers the unsafe
+      // path the guard is defending against — Object.keys returns only
+      // own keys (length 2 from foo/bar), and `'otherLabel' in value`
+      // returns true via the prototype chain.
+      expect(Object.keys(value).length).toBe(2)
+      expect('otherLabel' in value).toBe(true)
+      expect('freeformText' in value).toBe(true)
+      // Guard must still reject.
+      expect(isFreeformAnswer(value)).toBe(false)
+    })
+
+    it('returns false for an object created with Object.create(null) and the wrong own keys', () => {
+      // Null-prototype objects are the other classic prototype-pollution
+      // shape. Two own keys named anything other than the named pair
+      // must still fail even though there's no prototype to inherit
+      // from.
+      const value = Object.create(null) as Record<string, unknown>
+      value.foo = 'a'
+      value.bar = 'b'
+      expect(isFreeformAnswer(value)).toBe(false)
+    })
+
+    it('returns true for an object created with Object.create(null) and the right own keys', () => {
+      // Conversely, a null-prototype object with the canonical own keys
+      // is still a valid freeform shape — the guard is structural, not
+      // identity-based. Documents the intentional behaviour.
+      const value = Object.create(null) as Record<string, unknown>
+      value.otherLabel = 'Other'
+      value.freeformText = 'typed'
+      expect(isFreeformAnswer(value)).toBe(true)
+    })
+  })
+
   describe('narrows the type for the caller', () => {
     it('narrows `unknown` to `OtherFreeformAnswer` after a passing guard', () => {
       const raw: unknown = { otherLabel: 'Other', freeformText: 'typed' }

--- a/packages/store-core/src/freeform-answer.test.ts
+++ b/packages/store-core/src/freeform-answer.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the `isFreeformAnswer` runtime type-guard (#4875).
+ *
+ * The guard is the single source of truth for runtime detection of the
+ * `OtherFreeformAnswer` payload shape. Boundary sites that accept untrusted
+ * input (store layer in both clients) and UI branching sites
+ * (SessionScreen.handleSelectOption) call this instead of a hand-written
+ * shape check so that:
+ *   - widening `SelectOptionValue` to include a third object shape can't
+ *     silently misroute it as freeform (the original footgun called out in
+ *     review of PR #4864).
+ *   - a multi-question `Record<string, string | string[]>` whose keys
+ *     happen to be literally `"otherLabel"` and `"freeformText"` is
+ *     rejected by the exact-two-keys + both-string constraint, matching
+ *     the dashboard's existing store-layer behaviour.
+ *
+ * Coverage:
+ *   - Canonical happy path returns `true` and narrows the type.
+ *   - Every component of the 5-condition shape (object + non-null + non-
+ *     array + exactly two keys + both string values) has a `false` row.
+ *   - Edge cases: extra keys, missing keys, wrong-typed values, prototype
+ *     pollution keys, empty objects, etc.
+ */
+import { describe, it, expect } from 'vitest'
+import { isFreeformAnswer, type OtherFreeformAnswer } from './freeform-answer'
+
+describe('isFreeformAnswer (#4875)', () => {
+  describe('accepts the canonical shape', () => {
+    it('returns true for the exact two-keys + both-string shape', () => {
+      const value: OtherFreeformAnswer = {
+        otherLabel: 'Other',
+        freeformText: 'some typed text',
+      }
+      expect(isFreeformAnswer(value)).toBe(true)
+    })
+
+    it('returns true even when the strings are empty', () => {
+      // The shape is structural — empty strings are still strings. Callers
+      // that need a non-empty freeformText should validate that separately;
+      // the guard's job is purely shape detection.
+      expect(isFreeformAnswer({ otherLabel: '', freeformText: '' })).toBe(true)
+    })
+
+    it('returns true regardless of key insertion order', () => {
+      // Object.keys order shouldn't matter to the predicate.
+      expect(isFreeformAnswer({ freeformText: 'typed', otherLabel: 'Other' })).toBe(true)
+    })
+  })
+
+  describe('rejects non-object inputs', () => {
+    it('returns false for undefined', () => {
+      expect(isFreeformAnswer(undefined)).toBe(false)
+    })
+
+    it('returns false for null', () => {
+      // `typeof null === 'object'` is the classic JS gotcha — the guard
+      // must explicitly reject it.
+      expect(isFreeformAnswer(null)).toBe(false)
+    })
+
+    it('returns false for a string', () => {
+      // The legacy single-question / free-text answer path passes a bare
+      // string — this MUST stay distinguishable from the freeform shape.
+      expect(isFreeformAnswer('Other')).toBe(false)
+      expect(isFreeformAnswer('')).toBe(false)
+    })
+
+    it('returns false for a number', () => {
+      expect(isFreeformAnswer(0)).toBe(false)
+      expect(isFreeformAnswer(42)).toBe(false)
+    })
+
+    it('returns false for a boolean', () => {
+      expect(isFreeformAnswer(true)).toBe(false)
+      expect(isFreeformAnswer(false)).toBe(false)
+    })
+  })
+
+  describe('rejects arrays', () => {
+    it('returns false for an empty array', () => {
+      expect(isFreeformAnswer([])).toBe(false)
+    })
+
+    it('returns false for an array even with the right "keys"', () => {
+      // `Object.keys(['a', 'b'])` is `['0', '1']` so the length-check would
+      // pass for a two-element array — the explicit `Array.isArray` check
+      // is what rejects it. Defence in depth.
+      expect(isFreeformAnswer(['otherLabel', 'freeformText'])).toBe(false)
+    })
+  })
+
+  describe('rejects objects with the wrong key count', () => {
+    it('returns false for an empty object', () => {
+      expect(isFreeformAnswer({})).toBe(false)
+    })
+
+    it('returns false for an object with only otherLabel', () => {
+      expect(isFreeformAnswer({ otherLabel: 'Other' })).toBe(false)
+    })
+
+    it('returns false for an object with only freeformText', () => {
+      expect(isFreeformAnswer({ freeformText: 'typed' })).toBe(false)
+    })
+
+    it('returns false for an object with EXTRA keys alongside the two', () => {
+      // Critical: this is what made the loose 2-condition variant a
+      // footgun. A multi-question Record whose keys happen to include
+      // `otherLabel` and `freeformText` (plus any third question) MUST
+      // not get misrouted into the freeform branch.
+      expect(isFreeformAnswer({
+        otherLabel: 'Other',
+        freeformText: 'typed',
+        thirdQuestion: 'answer',
+      })).toBe(false)
+    })
+  })
+
+  describe('rejects objects with the right keys but wrong-typed values', () => {
+    it('returns false when otherLabel is not a string', () => {
+      expect(isFreeformAnswer({ otherLabel: 42, freeformText: 'typed' })).toBe(false)
+      expect(isFreeformAnswer({ otherLabel: null, freeformText: 'typed' })).toBe(false)
+      expect(isFreeformAnswer({ otherLabel: ['Other'], freeformText: 'typed' })).toBe(false)
+    })
+
+    it('returns false when freeformText is not a string', () => {
+      expect(isFreeformAnswer({ otherLabel: 'Other', freeformText: 42 })).toBe(false)
+      expect(isFreeformAnswer({ otherLabel: 'Other', freeformText: null })).toBe(false)
+      // Multi-question style: array-valued answer. The store-layer detector
+      // explicitly guards against this by requiring both values to be
+      // `string` (not `string | string[]`).
+      expect(isFreeformAnswer({ otherLabel: 'Other', freeformText: ['typed'] })).toBe(false)
+    })
+
+    it('returns false when both values are wrong-typed', () => {
+      expect(isFreeformAnswer({ otherLabel: 0, freeformText: 0 })).toBe(false)
+    })
+  })
+
+  describe('rejects objects with two keys that are NOT the named pair', () => {
+    it('returns false for two arbitrary keys', () => {
+      expect(isFreeformAnswer({ foo: 'a', bar: 'b' })).toBe(false)
+    })
+
+    it('returns false when one key is right and the other is wrong', () => {
+      expect(isFreeformAnswer({ otherLabel: 'Other', notFreeform: 'typed' })).toBe(false)
+      expect(isFreeformAnswer({ notOther: 'label', freeformText: 'typed' })).toBe(false)
+    })
+  })
+
+  describe('narrows the type for the caller', () => {
+    it('narrows `unknown` to `OtherFreeformAnswer` after a passing guard', () => {
+      const raw: unknown = { otherLabel: 'Other', freeformText: 'typed' }
+      if (isFreeformAnswer(raw)) {
+        // Compile-time check: these assignments would fail to typecheck
+        // without the guard narrowing `raw` from `unknown` to
+        // `OtherFreeformAnswer`. The runtime assertion is just defence
+        // in depth — the real value here is the TS narrowing.
+        const narrowedLabel: string = raw.otherLabel
+        const narrowedText: string = raw.freeformText
+        expect(narrowedLabel).toBe('Other')
+        expect(narrowedText).toBe('typed')
+      } else {
+        throw new Error('guard rejected a canonical-shape value')
+      }
+    })
+
+    it('narrows a `string | OtherFreeformAnswer` union to the string branch when false', () => {
+      // The store + screen call sites take `string | Record<…> |
+      // OtherFreeformAnswer` and need to fall through to the string /
+      // record branch when the freeform guard rejects. Smoke-test the
+      // narrowing direction the call site relies on.
+      const raw: string | OtherFreeformAnswer = 'Other'
+      if (isFreeformAnswer(raw)) {
+        throw new Error('guard accepted a bare string')
+      }
+      const narrowed: string = raw
+      expect(narrowed).toBe('Other')
+    })
+  })
+})

--- a/packages/store-core/src/freeform-answer.ts
+++ b/packages/store-core/src/freeform-answer.ts
@@ -1,0 +1,84 @@
+/**
+ * #4875 — shared typed predicate for the "Other / freeform" answer payload
+ * emitted by AskUserQuestion single-question prompts (mobile #4755 / dashboard
+ * #4651). Previously the same 5-condition shape check was duplicated inline
+ * in both `packages/app/src/store/connection.ts` and
+ * `packages/dashboard/src/store/connection.ts`, plus a *looser* 2-condition
+ * variant in `packages/app/src/screens/SessionScreen.tsx` `handleSelectOption`.
+ *
+ * The divergence was harmless today because the call-site type
+ * (`SelectOptionValue = string | OtherFreeformAnswer`) constrained the input
+ * shape to exactly those two cases. But if `SelectOptionValue` ever grows to
+ * include a third object shape (e.g. mobile multi-question support), the
+ * loose 2-condition check would silently misclassify it as freeform — the
+ * footgun called out in the original review.
+ *
+ * Centralising the type AND the runtime guard here means:
+ *   - Wire-payload boundary sites (store layer in both clients) and UI
+ *     branching sites (screen layer) all narrow the same way.
+ *   - A future widening of `SelectOptionValue` only needs to update this
+ *     guard once.
+ *   - The predicate enforces the tightest possible shape (exactly two named
+ *     keys, both `string` values, no array, no `null`) so a multi-question
+ *     `Record<string, string | string[]>` whose keys happen to literally be
+ *     `"otherLabel"` and `"freeformText"` cannot be misrouted into the
+ *     freeform branch.
+ */
+
+/**
+ * Payload shape emitted when the user picks the synthesized "Other" option
+ * on a single-question AskUserQuestion and types freeform text. The store
+ * forwards this to the server as a two-stage `user_question_response`
+ * (`answer: <otherLabel>, freeformText: <typed>`), so the server can drive
+ * the two-stage TUI write (Other digit → text-input prompt → freeform text
+ * + Enter). Older servers that ignore `freeformText` fall through to the
+ * legacy path and type the label literally — a clean degradation.
+ *
+ * Mirrors the dashboard's `OtherFreeformAnswer` (still re-exported from
+ * `packages/dashboard/src/components/QuestionPrompt.tsx` for backward
+ * compatibility) and the mobile `OtherFreeformAnswer` from
+ * `packages/app/src/components/chat/MessageBubble.tsx`. Both call sites
+ * should converge on this declaration over time.
+ */
+export interface OtherFreeformAnswer {
+  otherLabel: string;
+  freeformText: string;
+}
+
+/**
+ * #4875 — runtime type-guard for {@link OtherFreeformAnswer}. Returns `true`
+ * only for objects that have EXACTLY the two named keys with `string`
+ * values; every other input (`undefined`, `null`, arrays, primitives,
+ * objects with extra/missing keys, objects with non-string values) returns
+ * `false` without throwing.
+ *
+ * The narrowing predicate (`value is OtherFreeformAnswer`) lets callers
+ * drop the `as string` / `as OtherFreeformAnswer` casts at the call site
+ * once the guard passes.
+ *
+ * The tight 5-condition shape (object + non-null + non-array + exactly two
+ * keys + both string values) is deliberate: it mirrors the original store-
+ * layer detector and rejects a multi-question `Record<string, string |
+ * string[]>` whose keys happen to be literally `"otherLabel"` and
+ * `"freeformText"` — a rare but possible misroute if the model phrases a
+ * question that way.
+ *
+ * `unknown` rather than the narrower `SelectOptionValue` union so wire-
+ * payload boundary sites (where the input is untrusted) and UI branching
+ * sites (where the input is already `SelectOptionValue`) can both share
+ * the same guard. The narrowing target (`OtherFreeformAnswer`) is the
+ * same in both cases.
+ */
+export function isFreeformAnswer(value: unknown): value is OtherFreeformAnswer {
+  if (typeof value !== 'object' || value === null) return false;
+  if (Array.isArray(value)) return false;
+  // Use Object.keys to enforce the exact-two-keys constraint; `in` checks
+  // would accept supersets, which is what made the old loose variant a
+  // footgun.
+  const keys = Object.keys(value);
+  if (keys.length !== 2) return false;
+  if (!('otherLabel' in value) || !('freeformText' in value)) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.otherLabel === 'string'
+    && typeof record.freeformText === 'string';
+}

--- a/packages/store-core/src/freeform-answer.ts
+++ b/packages/store-core/src/freeform-answer.ts
@@ -77,7 +77,16 @@ export function isFreeformAnswer(value: unknown): value is OtherFreeformAnswer {
   // footgun.
   const keys = Object.keys(value);
   if (keys.length !== 2) return false;
-  if (!('otherLabel' in value) || !('freeformText' in value)) return false;
+  // `hasOwnProperty.call` rather than `'key' in value` so an object with
+  // two unrelated OWN keys but `otherLabel` / `freeformText` inherited
+  // from its prototype (e.g.
+  // `Object.create({ otherLabel: 'x', freeformText: 'y' })`) cannot slip
+  // through. The `in` operator walks the prototype chain — that breaks
+  // the stated "exactly two named keys" guarantee and would let a
+  // prototype-pollution payload misroute as freeform. Same defence the
+  // `isVoiceInputMode` guard uses (#4853).
+  if (!Object.prototype.hasOwnProperty.call(value, 'otherLabel')) return false;
+  if (!Object.prototype.hasOwnProperty.call(value, 'freeformText')) return false;
   const record = value as Record<string, unknown>;
   return typeof record.otherLabel === 'string'
     && typeof record.freeformText === 'string';

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -17,10 +17,13 @@ export { DEFAULT_CONTEXT_WINDOW } from './types'
 export { isVoiceInputMode } from './types'
 
 // #4875: shared typed predicate + type for the AskUserQuestion "Other /
-// freeform" answer payload. Replaces three duplicate inline shape checks
-// (mobile store, mobile screen, dashboard store) with one source of truth
-// so widening `SelectOptionValue` to a third object shape can't silently
-// misroute it as freeform.
+// freeform" answer payload. Mobile store + mobile screen now narrow off
+// this single guard so widening `SelectOptionValue` to a third object
+// shape can't silently misroute it as freeform. The dashboard store
+// still has its own inline 5-condition detector and its own
+// `OtherFreeformAnswer` declaration; migrating it is tracked in #4901
+// so this export becomes the single source of truth across all three
+// call sites.
 export { isFreeformAnswer } from './freeform-answer'
 export type { OtherFreeformAnswer } from './freeform-answer'
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -16,6 +16,14 @@ export { DEFAULT_CONTEXT_WINDOW } from './types'
 // TS error in the guard, not a silent drop at the call site.
 export { isVoiceInputMode } from './types'
 
+// #4875: shared typed predicate + type for the AskUserQuestion "Other /
+// freeform" answer payload. Replaces three duplicate inline shape checks
+// (mobile store, mobile screen, dashboard store) with one source of truth
+// so widening `SelectOptionValue` to a third object shape can't silently
+// misroute it as freeform.
+export { isFreeformAnswer } from './freeform-answer'
+export type { OtherFreeformAnswer } from './freeform-answer'
+
 export type {
   MessageAttachment,
   ToolResultImage,


### PR DESCRIPTION
## Summary

Extract `isFreeformAnswer` into `@chroxy/store-core/freeform-answer` paired with the `OtherFreeformAnswer` interface so the mobile store, the mobile screen layer, and (eventually) the dashboard store all narrow off one shared predicate.

Closes #4875

## Context

The mobile freeform-answer payload had three independent shape detectors:

- **Store layer** (`packages/app/src/store/connection.ts`) — tight 5-condition check mirroring the dashboard's store-layer detector.
- **Screen layer** (`packages/app/src/screens/SessionScreen.tsx` `handleSelectOption`) — looser 2-condition check (`'otherLabel' in && 'freeformText' in`) that relied on the call-site type to constrain inputs.
- **Dashboard store** (`packages/dashboard/src/store/connection.ts`) — duplicate of the mobile store's tight check.

Today the divergence is harmless because `SelectOptionValue = string | OtherFreeformAnswer` constrains the screen-layer input. But if the union ever grows to include a third object shape (e.g. mobile multi-question support), the loose screen-layer check would silently misroute it as freeform — the footgun called out in review of #4864.

## Changes

- New `packages/store-core/src/freeform-answer.ts`: exports `isFreeformAnswer` (typed predicate) + `OtherFreeformAnswer` (interface). Guard enforces the tightest possible shape (object + non-null + non-array + exactly two named keys + both `string` values).
- Re-exported from `packages/store-core/src/index.ts`.
- Updated `packages/app/src/store/connection.ts` `sendUserQuestionResponse` to use the shared guard; TS now auto-narrows so the inline `as { otherLabel: string }` / `as { freeformText: string }` casts drop out.
- Updated `packages/app/src/screens/SessionScreen.tsx` `handleSelectOption` to use the shared guard; the previous `as string` casts at the string-branch arms drop out.
- Updated `packages/app/src/components/chat/MessageBubble.tsx` to re-export `OtherFreeformAnswer` from store-core (single source of truth) while keeping the type alias for downstream importers (ChatView, SessionScreen).

Dashboard store is **not** touched in this PR — it has its own additional behaviour (`appendTerminalData` echo, `optimisticallyMarkSessionRunning`) entangled with the same shape detector, so a separate follow-up will migrate it cleanly.

## Test plan

- [x] `packages/store-core` typecheck — passes
- [x] `packages/store-core` tests — 1032 passed (21 new in `freeform-answer.test.ts` cover: canonical happy path, key insertion order, every component of the 5-condition shape getting a `false` row — non-object, null, array, wrong key count, missing keys, wrong-typed values, two-but-wrong-named keys — and type narrowing in both branches)
- [x] `packages/app` typecheck — clean
- [x] `packages/app` tests for affected files (`connection`, `SessionScreen`, `MessageBubble`) — 220 passed
- [x] `packages/dashboard` typecheck — clean (no dashboard code changed; verifying the new store-core export doesn't break anything)