### PR TITLE
fix(server): tighten lastIsSingleSelect detection in multi-question driver

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2827,8 +2827,17 @@ export class ClaudeTuiSession extends BaseSession {
     // rendering last-question screen and gets swallowed (the wedge the
     // issue documents). Mixed forms ending in multi-select don't need
     // this — the explicit '\t' already settles the form.
+    // #4883 — tighten the lastIsSingleSelect detection so an unexpected TUI
+    // question shape surfaces in logs instead of silently picking a branch.
+    // Today's TUI omits `multiSelect` on single-select questions and sets it
+    // to `true` on multi-select; any other shape (string, null, number, a
+    // hypothetical future field rename) is treated as "assume single-select
+    // for settle purposes" — but we log a WARN so the shape drift is visible.
     const lastQuestion = questions.length > 0 ? questions[questions.length - 1] : null
-    const lastIsSingleSelect = !!(lastQuestion && !lastQuestion.multiSelect)
+    if (lastQuestion && lastQuestion.multiSelect !== undefined && typeof lastQuestion.multiSelect !== 'boolean') {
+      ;(this._log || log).warn(`AskUserQuestion multi-question: last question has non-boolean multiSelect=${JSON.stringify(lastQuestion.multiSelect)} (q="${(lastQuestion.question || '').slice(0, 40)}") — assuming single-select for settle (#4883)`)
+    }
+    const lastIsSingleSelect = !!(lastQuestion && lastQuestion.multiSelect !== true)
     if (lastIsSingleSelect) {
       sequence.push(MULTI_QUESTION_SUBMIT_SETTLE_MS)
     }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2833,8 +2833,15 @@ export class ClaudeTuiSession extends BaseSession {
     // to `true` on multi-select; any other shape (string, null, number, a
     // hypothetical future field rename) is treated as "assume single-select
     // for settle purposes" — but we log a WARN so the shape drift is visible.
+    //
+    // The "drift" check uses `'multiSelect' in lastQuestion` rather than
+    // `!== undefined` so it also catches the in-code pathological case
+    // `{ multiSelect: undefined }` (Copilot review on #4902): the key is
+    // present but the value isn't boolean — that's still drift worth
+    // surfacing, since wire-deserialized shapes can't produce that pattern
+    // (JSON.stringify drops undefined-valued keys) but in-code shapes can.
     const lastQuestion = questions.length > 0 ? questions[questions.length - 1] : null
-    if (lastQuestion && lastQuestion.multiSelect !== undefined && typeof lastQuestion.multiSelect !== 'boolean') {
+    if (lastQuestion && 'multiSelect' in lastQuestion && typeof lastQuestion.multiSelect !== 'boolean') {
       ;(this._log || log).warn(`AskUserQuestion multi-question: last question has non-boolean multiSelect=${JSON.stringify(lastQuestion.multiSelect)} (q="${(lastQuestion.question || '').slice(0, 40)}") — assuming single-select for settle (#4883)`)
     }
     const lastIsSingleSelect = !!(lastQuestion && lastQuestion.multiSelect !== true)

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -4686,13 +4686,20 @@ describe('ClaudeTuiSession', () => {
       await new Promise((resolve) => setTimeout(resolve, 300))
 
       // Settle MUST fire — back-compat with the pre-tightening behaviour.
+      // Measure the gap from the LAST QUESTION's digit (Q2's '2') to the
+      // Submit '1', not from Q1's '\t'. The settle is inserted at that
+      // specific boundary; measuring across Q1's Tab would mask a
+      // regression where the last-q keystroke changes (Copilot #4902).
       const writes = writeEvents.map((e) => e.data)
-      const q1TabIdx = writes.indexOf('\t')
-      const submitIdx = writes.indexOf('1', q1TabIdx + 1)
-      const gapMs = writeEvents[submitIdx].t - writeEvents[q1TabIdx].t
+      // Bytes: paste-disable, Q1 '1' '2' '\t', Q2 '2', [settle], Submit '1', '\r', paste-enable.
+      const tabIdx = writes.indexOf('\t')
+      const lastDigitIdx = writes.indexOf('2', tabIdx + 1) // Q2's '2' after the Tab
+      const submitIdx = writes.indexOf('1', lastDigitIdx + 1)
+      assert.ok(lastDigitIdx > tabIdx && submitIdx > lastDigitIdx, 'found Q2 digit + submit')
+      const gapMs = writeEvents[submitIdx].t - writeEvents[lastDigitIdx].t
       assert.ok(
         gapMs >= 140,
-        `omitted-multiSelect last q is single-select: expected settle gap >= 140ms, got ${gapMs}ms`,
+        `omitted-multiSelect last q is single-select: expected settle gap >= 140ms between last digit and Submit, got ${gapMs}ms`,
       )
 
       // And the WARN must NOT fire on this canonical shape.
@@ -4720,13 +4727,19 @@ describe('ClaudeTuiSession', () => {
       session.respondToQuestion('', { 'Q1?': ['a', 'b'], 'Q2?': 'q' })
       await new Promise((resolve) => setTimeout(resolve, 300))
 
+      // Measure the gap at the actual settle boundary: Q2's digit ('2')
+      // → Submit '1'. Measuring across Q1's '\t' would mask a regression
+      // where the last-q keystroke changes (Copilot #4902).
       const writes = writeEvents.map((e) => e.data)
+      // Bytes: paste-disable, Q1 '1' '2' '\t', Q2 '2', [settle], Submit '1', '\r', paste-enable.
       const tabIdx = writes.indexOf('\t')
-      const submitIdx = writes.indexOf('1', tabIdx + 1)
-      const gapMs = writeEvents[submitIdx].t - writeEvents[tabIdx].t
+      const lastDigitIdx = writes.indexOf('2', tabIdx + 1) // Q2's '2' after the Tab
+      const submitIdx = writes.indexOf('1', lastDigitIdx + 1)
+      assert.ok(lastDigitIdx > tabIdx && submitIdx > lastDigitIdx, 'found Q2 digit + submit')
+      const gapMs = writeEvents[submitIdx].t - writeEvents[lastDigitIdx].t
       assert.ok(
         gapMs >= 140,
-        `explicit multiSelect:false is single-select: expected settle gap >= 140ms, got ${gapMs}ms`,
+        `explicit multiSelect:false is single-select: expected settle gap >= 140ms between last digit and Submit, got ${gapMs}ms`,
       )
 
       const drift = warnLines.find((m) => /non-boolean multiSelect/.test(m))
@@ -4752,6 +4765,32 @@ describe('ClaudeTuiSession', () => {
         `expected drift WARN for non-boolean multiSelect, got warns=${JSON.stringify(warnLines)}`,
       )
       assert.match(drift, /Q2\?/, 'warn includes the offending question text')
+    })
+
+    // Drift: pathological in-code `{ multiSelect: undefined }`. JSON.stringify
+    // drops undefined-valued keys, so wire-deserialized shapes can't produce
+    // this — but in-code construction can. The tightened check uses
+    // `'multiSelect' in lastQuestion` precisely to catch this case
+    // (Copilot review on #4902): key present, value not boolean = drift.
+    it('explicit multiSelect:undefined on last q: WARN fires (Copilot #4902)', async () => {
+      session._term = { write: () => {}, kill: () => {} }
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }] },
+        { question: 'Q2?', multiSelect: undefined, options: [{ label: 'p' }, { label: 'q' }] },
+      ]
+      // Sanity: the key IS present (otherwise this test would be checking the
+      // omitted-multiSelect path, which has its own test above).
+      assert.ok('multiSelect' in questions[1], 'multiSelect key present on Q2')
+      session._pendingUserAnswer = { toolUseId: 'toolu_undef_drift', questions, options: questions[0].options }
+
+      session.respondToQuestion('', { 'Q1?': 'a', 'Q2?': 'q' })
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      const drift = warnLines.find((m) => /non-boolean multiSelect/.test(m))
+      assert.ok(
+        drift,
+        `expected drift WARN for explicit undefined multiSelect, got warns=${JSON.stringify(warnLines)}`,
+      )
     })
 
     // Drift: `multiSelect: null`. Same surfacing requirement as the string case.

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -4659,6 +4659,144 @@ describe('ClaudeTuiSession', () => {
       )
     })
 
+    // #4883 — tighten lastIsSingleSelect detection. Pre-fix logic was
+    // `!!(lastQuestion && !lastQuestion.multiSelect)`, which treated *any*
+    // non-truthy `multiSelect` (undefined, null, 0, '') as single-select
+    // silently. That's correct for today's TUI shape (single-select omits
+    // the field) but masks any future TUI shape drift. The tightened logic
+    // is `multiSelect !== true`, plus a WARN whenever the field is present
+    // but non-boolean so the drift surfaces in logs.
+
+    // The canonical single-select shape today is `multiSelect` absent. That
+    // path must STILL produce the settle (back-compat) AND must NOT warn,
+    // otherwise every multi-question form spams the log.
+    it('omitted multiSelect on last q: settle fires + NO warn (back-compat #4883)', async () => {
+      const writeEvents = []
+      session._term = {
+        write: (data) => { writeEvents.push({ data, t: Date.now() }) },
+        kill: () => {},
+      }
+      const questions = [
+        { question: 'Q1?', multiSelect: true, options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', options: [{ label: 'p' }, { label: 'q' }] }, // multiSelect omitted
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_omit_multiselect', questions, options: questions[0].options }
+
+      session.respondToQuestion('', { 'Q1?': ['a', 'b'], 'Q2?': 'q' })
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      // Settle MUST fire — back-compat with the pre-tightening behaviour.
+      const writes = writeEvents.map((e) => e.data)
+      const q1TabIdx = writes.indexOf('\t')
+      const submitIdx = writes.indexOf('1', q1TabIdx + 1)
+      const gapMs = writeEvents[submitIdx].t - writeEvents[q1TabIdx].t
+      assert.ok(
+        gapMs >= 140,
+        `omitted-multiSelect last q is single-select: expected settle gap >= 140ms, got ${gapMs}ms`,
+      )
+
+      // And the WARN must NOT fire on this canonical shape.
+      const drift = warnLines.find((m) => /non-boolean multiSelect/.test(m))
+      assert.equal(
+        drift,
+        undefined,
+        `canonical single-select shape (multiSelect omitted) must NOT warn, got warns=${JSON.stringify(warnLines)}`,
+      )
+    })
+
+    // Explicit `multiSelect: false` on the last q: still single-select, no warn.
+    it('explicit multiSelect:false on last q: settle fires + NO warn (#4883)', async () => {
+      const writeEvents = []
+      session._term = {
+        write: (data) => { writeEvents.push({ data, t: Date.now() }) },
+        kill: () => {},
+      }
+      const questions = [
+        { question: 'Q1?', multiSelect: true, options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', multiSelect: false, options: [{ label: 'p' }, { label: 'q' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_explicit_false', questions, options: questions[0].options }
+
+      session.respondToQuestion('', { 'Q1?': ['a', 'b'], 'Q2?': 'q' })
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      const writes = writeEvents.map((e) => e.data)
+      const tabIdx = writes.indexOf('\t')
+      const submitIdx = writes.indexOf('1', tabIdx + 1)
+      const gapMs = writeEvents[submitIdx].t - writeEvents[tabIdx].t
+      assert.ok(
+        gapMs >= 140,
+        `explicit multiSelect:false is single-select: expected settle gap >= 140ms, got ${gapMs}ms`,
+      )
+
+      const drift = warnLines.find((m) => /non-boolean multiSelect/.test(m))
+      assert.equal(drift, undefined, `explicit boolean must NOT warn, got warns=${JSON.stringify(warnLines)}`)
+    })
+
+    // Drift: `multiSelect` present but a STRING (e.g. a future TUI ships
+    // `multiSelect: "true"` accidentally). Warn fires + settle assumed.
+    it('non-boolean multiSelect (string) on last q: WARN fires + still settles (#4883)', async () => {
+      session._term = { write: () => {}, kill: () => {} }
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+        { question: 'Q2?', multiSelect: 'true', options: [{ label: 'p' }, { label: 'q' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_string_drift', questions, options: questions[0].options }
+
+      session.respondToQuestion('', { 'Q1?': 'a', 'Q2?': 'q' })
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      const drift = warnLines.find((m) => /non-boolean multiSelect/.test(m))
+      assert.ok(
+        drift,
+        `expected drift WARN for non-boolean multiSelect, got warns=${JSON.stringify(warnLines)}`,
+      )
+      assert.match(drift, /Q2\?/, 'warn includes the offending question text')
+    })
+
+    // Drift: `multiSelect: null`. Same surfacing requirement as the string case.
+    it('null multiSelect on last q: WARN fires (#4883)', async () => {
+      session._term = { write: () => {}, kill: () => {} }
+      const questions = [
+        { question: 'Q1?', options: [{ label: 'a' }] },
+        { question: 'Q2?', multiSelect: null, options: [{ label: 'p' }, { label: 'q' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_null_drift', questions, options: questions[0].options }
+
+      session.respondToQuestion('', { 'Q1?': 'a', 'Q2?': 'q' })
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      const drift = warnLines.find((m) => /non-boolean multiSelect/.test(m))
+      assert.ok(
+        drift,
+        `expected drift WARN for null multiSelect, got warns=${JSON.stringify(warnLines)}`,
+      )
+    })
+
+    // Drift on a NON-last question must NOT trigger the warn — the settle
+    // decision is driven by the LAST question's shape only, so the warn is
+    // scoped to that one. (Keeps log noise bounded for forms that mix shapes
+    // and ensures the warn pinpoints the question that actually drove the
+    // settle branch.)
+    it('non-boolean multiSelect on a non-last q does NOT warn (#4883)', async () => {
+      session._term = { write: () => {}, kill: () => {} }
+      const questions = [
+        { question: 'Q1?', multiSelect: 'true', options: [{ label: 'a' }, { label: 'b' }] }, // drifty but NOT last
+        { question: 'Q2?', multiSelect: true, options: [{ label: 'p' }, { label: 'q' }] },
+      ]
+      session._pendingUserAnswer = { toolUseId: 'toolu_drift_not_last', questions, options: questions[0].options }
+
+      session.respondToQuestion('', { 'Q1?': ['a'], 'Q2?': ['p'] })
+      await new Promise((resolve) => setTimeout(resolve, 300))
+
+      const drift = warnLines.find((m) => /non-boolean multiSelect/.test(m))
+      assert.equal(
+        drift,
+        undefined,
+        `drift on non-last question must NOT warn, got warns=${JSON.stringify(warnLines)}`,
+      )
+    })
+
     // Pre-Chunk-B watchdog still arms for multi-question forms — if claude
     // TUI's actual form differs from the empirical spec (a future TUI
     // version, edge-case shape), the stall watchdog still surfaces the


### PR DESCRIPTION
## Summary

The `lastIsSingleSelect` detection in `claude-tui-session.js` used
`!!(lastQuestion && !lastQuestion.multiSelect)`, treating any
non-truthy `multiSelect` (undefined, null, 0, '', etc.) as single-select.
That's correct for today's TUI shape but silently subsumes any future
TUI question shape that omits `multiSelect` deliberately (a
freeform-only step, a field rename in a TUI v3, etc.).

Tighten the check to compare explicitly against `true` and emit a
WARN whenever the last question's `multiSelect` is present but
non-boolean. The settle decision still defaults to single-select for
safety, but a shape drift now surfaces in logs instead of quietly
changing the driver's settle behaviour.

## Changes

- `packages/server/src/claude-tui-session.js`: detection uses
  `multiSelect !== true`; WARN fires when the field is present but
  non-boolean. Scoped to the LAST question only — the only one that
  drives the settle branch.
- `packages/server/tests/claude-tui-session.test.js`: 5 new subtests
  pinning the new behaviour and back-compat:
  - omitted `multiSelect` on last q → settle fires, NO warn
  - explicit `multiSelect: false` → settle fires, NO warn
  - `multiSelect: 'true'` (string drift) → WARN + still settles
  - `multiSelect: null` → WARN fires
  - non-boolean `multiSelect` on a NON-last q → NO warn (scoped to
    the question that drove the settle decision)

## Test plan

- [x] `node --import ./tests/_setup.mjs --test packages/server/tests/claude-tui-session.test.js` — all 198 pass
- [x] `node --import ./tests/_setup.mjs --test --test-name-pattern="#4883" ...` — all 5 new pass
- [x] `./scripts/lint-tests-state-file-path.sh` — clean
- [x] `./scripts/lint-session-opt-forwarding.sh` — clean

Closes #4883