### PR TITLE
refactor(app): gate mobile voiceInputMode rehydrate behind isVoiceInputMode (#4872)

### DIFF
--- a/packages/app/src/__tests__/store/connection-rehydrate-input-settings.test.ts
+++ b/packages/app/src/__tests__/store/connection-rehydrate-input-settings.test.ts
@@ -1,0 +1,225 @@
+/**
+ * #4872 — Tests for `loadSavedConnection`'s SecureStore-backed
+ * `inputSettings` rehydrate path in `packages/app/src/store/connection.ts`.
+ *
+ * Mirrors the dashboard coverage shipped with #4853 / #4858 (which migrated
+ * the localStorage rehydrate path to the shared `isVoiceInputMode` guard).
+ * The mobile rehydrate path used to spread the SecureStore blob in
+ * unchecked, gated only on `chatEnterToSend` / `terminalEnterToSend` being
+ * booleans, so a stale or tampered `voiceInputMode` (`'push-to-talk'`,
+ * `null`, `42`) flowed through to `useSpeechRecognition({ mode })`.
+ *
+ * These tests pin the new guarded behaviour: known modes round-trip,
+ * unknown / non-string / object values drop on rehydrate, and the existing
+ * boolean toggles continue to be gated by `typeof === 'boolean'`.
+ *
+ * jest.mock() is hoisted above imports, so the SecureStore + AsyncStorage
+ * + persistence mocks here apply for every test below — the store under
+ * test then sees a fully in-memory SecureStore, no native module touched.
+ */
+
+// SecureStore mock — tests overwrite `getItemAsync`'s resolved value to
+// drive each scenario. `setItemAsync` / `deleteItemAsync` are stubs so the
+// store's persist path doesn't throw if exercised incidentally.
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+  deleteItemAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+// Persistence is async + debounced — stub the load helpers so the rehydrate
+// path under test isn't entangled with session-state / session-list
+// loading, both of which have their own dedicated test files.
+jest.mock('../../store/persistence', () => ({
+  loadPersistedState: jest.fn().mockResolvedValue({}),
+  loadSessionMessages: jest.fn().mockResolvedValue([]),
+  loadSessionList: jest.fn().mockResolvedValue([]),
+  loadAllSessionMessages: jest.fn().mockResolvedValue({}),
+  persistSessionMessages: jest.fn(),
+  persistViewMode: jest.fn().mockResolvedValue(undefined),
+  persistActiveSession: jest.fn().mockResolvedValue(undefined),
+  persistTerminalBuffer: jest.fn(),
+  persistSessionList: jest.fn(),
+  clearPersistedState: jest.fn().mockResolvedValue(undefined),
+}));
+
+import * as SecureStore from 'expo-secure-store';
+import { useConnectionStore } from '../../store/connection';
+import { useConnectionLifecycleStore } from '../../store/connection-lifecycle';
+
+const STORAGE_KEY_INPUT_SETTINGS = 'chroxy_input_settings';
+
+const DEFAULT_INPUT_SETTINGS = {
+  chatEnterToSend: true,
+  terminalEnterToSend: false,
+  voiceInputMode: 'continuous' as const,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Reset the rehydrate slice we care about back to defaults so each test
+  // starts from a known baseline.
+  useConnectionStore.setState({ inputSettings: { ...DEFAULT_INPUT_SETTINGS } });
+  useConnectionLifecycleStore.setState({
+    savedConnection: null,
+  });
+  // Default: SecureStore returns null for every key (no persisted blob).
+  (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+});
+
+/**
+ * Wire the SecureStore mock so that the `chroxy_input_settings` key
+ * returns the given serialized blob and every other key returns `null`
+ * (default). Lets each test focus on a single rehydrate scenario without
+ * leaking state into unrelated keys (saved connection URL/token, device
+ * id, etc.).
+ */
+function seedInputSettingsBlob(blob: unknown): void {
+  const serialized = blob === undefined ? null : JSON.stringify(blob);
+  (SecureStore.getItemAsync as jest.Mock).mockImplementation((key: string) => {
+    if (key === STORAGE_KEY_INPUT_SETTINGS) return Promise.resolve(serialized);
+    return Promise.resolve(null);
+  });
+}
+
+describe('loadSavedConnection() — inputSettings rehydrate (#4872)', () => {
+  describe('voiceInputMode validation', () => {
+    it('accepts the canonical "continuous" mode', async () => {
+      seedInputSettingsBlob({ voiceInputMode: 'continuous' });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('continuous');
+    });
+
+    it('accepts the canonical "auto-pause" mode', async () => {
+      seedInputSettingsBlob({ voiceInputMode: 'auto-pause' });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('auto-pause');
+    });
+
+    it('drops an unknown string mode and preserves the default', async () => {
+      seedInputSettingsBlob({ voiceInputMode: 'push-to-talk' });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('continuous');
+    });
+
+    it('drops a `null` voiceInputMode and preserves the default', async () => {
+      seedInputSettingsBlob({ voiceInputMode: null });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('continuous');
+    });
+
+    it('drops a numeric voiceInputMode and preserves the default', async () => {
+      seedInputSettingsBlob({ voiceInputMode: 42 });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('continuous');
+    });
+
+    it('drops an object voiceInputMode and preserves the default', async () => {
+      seedInputSettingsBlob({ voiceInputMode: { mode: 'continuous' } });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('continuous');
+    });
+
+    it('drops an array voiceInputMode and preserves the default', async () => {
+      seedInputSettingsBlob({ voiceInputMode: ['continuous'] });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('continuous');
+    });
+
+    it('drops a case-mismatched mode (guard is exact-match)', async () => {
+      seedInputSettingsBlob({ voiceInputMode: 'Continuous' });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('continuous');
+    });
+
+    it('drops an empty-string mode', async () => {
+      seedInputSettingsBlob({ voiceInputMode: '' });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('continuous');
+    });
+
+    it('drops a prototype-method name (hasOwnProperty defends against this)', async () => {
+      seedInputSettingsBlob({ voiceInputMode: 'toString' });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.voiceInputMode).toBe('continuous');
+    });
+  });
+
+  describe('boolean toggle gating', () => {
+    it('round-trips chatEnterToSend = false', async () => {
+      seedInputSettingsBlob({ chatEnterToSend: false });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.chatEnterToSend).toBe(false);
+    });
+
+    it('round-trips terminalEnterToSend = true', async () => {
+      seedInputSettingsBlob({ terminalEnterToSend: true });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.terminalEnterToSend).toBe(true);
+    });
+
+    it('drops a string chatEnterToSend and preserves the default (true)', async () => {
+      seedInputSettingsBlob({ chatEnterToSend: 'yes' });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.chatEnterToSend).toBe(true);
+    });
+
+    it('drops a numeric terminalEnterToSend and preserves the default (false)', async () => {
+      seedInputSettingsBlob({ terminalEnterToSend: 1 });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings.terminalEnterToSend).toBe(false);
+    });
+  });
+
+  describe('mixed / extraneous payloads', () => {
+    it('rehydrates valid fields while dropping a sibling unknown mode', async () => {
+      seedInputSettingsBlob({
+        chatEnterToSend: false,
+        terminalEnterToSend: true,
+        voiceInputMode: 'push-to-talk',
+      });
+      await useConnectionStore.getState().loadSavedConnection();
+      const s = useConnectionStore.getState().inputSettings;
+      expect(s.chatEnterToSend).toBe(false);
+      expect(s.terminalEnterToSend).toBe(true);
+      // unknown mode dropped — default preserved
+      expect(s.voiceInputMode).toBe('continuous');
+    });
+
+    it('ignores extra keys in the persisted blob (no shoehorned state)', async () => {
+      seedInputSettingsBlob({
+        chatEnterToSend: false,
+        somethingElseEntirely: 'should-not-land',
+        nestedAttack: { a: 1 },
+      });
+      await useConnectionStore.getState().loadSavedConnection();
+      const s = useConnectionStore.getState().inputSettings;
+      expect(s.chatEnterToSend).toBe(false);
+      // Spread did NOT pull in unknown keys
+      expect((s as unknown as Record<string, unknown>).somethingElseEntirely).toBeUndefined();
+      expect((s as unknown as Record<string, unknown>).nestedAttack).toBeUndefined();
+    });
+
+    it('preserves all defaults when the blob has no recognised fields', async () => {
+      seedInputSettingsBlob({ foo: 'bar' });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings).toEqual(DEFAULT_INPUT_SETTINGS);
+    });
+
+    it('preserves all defaults when no blob is persisted', async () => {
+      seedInputSettingsBlob(undefined);
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings).toEqual(DEFAULT_INPUT_SETTINGS);
+    });
+
+    it('preserves all defaults when the persisted blob is malformed JSON', async () => {
+      // raw return — JSON.parse throws, handler swallows it
+      (SecureStore.getItemAsync as jest.Mock).mockImplementation((key: string) => {
+        if (key === STORAGE_KEY_INPUT_SETTINGS) return Promise.resolve('{not-json');
+        return Promise.resolve(null);
+      });
+      await useConnectionStore.getState().loadSavedConnection();
+      expect(useConnectionStore.getState().inputSettings).toEqual(DEFAULT_INPUT_SETTINGS);
+    });
+  });
+});

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -129,7 +129,16 @@ import {
   // the looser SessionScreen variant; both call sites now narrow off the
   // same guard.
   isFreeformAnswer,
+  // #4872: shared runtime type-guard for `VoiceInputMode`. The mobile
+  // rehydrate path below (`loadSavedConnection`) used to spread the
+  // SecureStore blob in unchecked, gated only on `chatEnterToSend` /
+  // `terminalEnterToSend` being booleans, so a stale or tampered
+  // `voiceInputMode` (`'push-to-talk'`, `null`, `42`) flowed through
+  // to `useSpeechRecognition({ mode })`. Now gated by the same guard
+  // the dashboard uses (#4853).
+  isVoiceInputMode,
 } from '@chroxy/store-core';
+import type { InputSettings } from '@chroxy/store-core';
 import { setCallback as setImperativeCallback, getCallback, clearAllCallbacks } from './imperative-callbacks';
 import { useMultiClientStore } from './multi-client';
 import { useWebStore } from './web';
@@ -585,8 +594,26 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const raw = await SecureStore.getItemAsync(STORAGE_KEY_INPUT_SETTINGS);
       if (raw) {
         const parsed = JSON.parse(raw);
-        if (typeof parsed.chatEnterToSend === 'boolean' || typeof parsed.terminalEnterToSend === 'boolean') {
-          set((state) => ({ inputSettings: { ...state.inputSettings, ...parsed } }));
+        // #4872: validated, narrowed merge — mirrors the dashboard
+        // rehydrate path (#4853). A stray key in SecureStore (stale blob
+        // from an older mode-name, tampered storage, future variant) can
+        // no longer shoehorn arbitrary state into `inputSettings`. Each
+        // field is checked independently because the persisted blob may
+        // pre-date `voiceInputMode` (#4785) and contain only the boolean
+        // toggles.
+        const next: Partial<InputSettings> = {};
+        if (typeof parsed.chatEnterToSend === 'boolean') next.chatEnterToSend = parsed.chatEnterToSend;
+        if (typeof parsed.terminalEnterToSend === 'boolean') next.terminalEnterToSend = parsed.terminalEnterToSend;
+        // #4872: runtime guard keyed off the same exhaustive
+        // `Record<VoiceInputMode, true>` map the dashboard uses. Adding a
+        // new variant to the `VoiceInputMode` union without listing it
+        // there is a TS error, so the guard cannot silently drop a new
+        // mode the way a hand-written `===` chain would.
+        if (isVoiceInputMode(parsed.voiceInputMode)) {
+          next.voiceInputMode = parsed.voiceInputMode;
+        }
+        if (Object.keys(next).length > 0) {
+          set((state) => ({ inputSettings: { ...state.inputSettings, ...next } }));
         }
       }
     } catch {

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -166,11 +166,13 @@ export interface ContextUsage {
  * `SettingsPanel` change handler, the mobile `SettingsScreen` picker tuple
  * typed as `{ value: VoiceInputMode; … }[]`) will be flagged by TS when the
  * union widens. Sites that validate untrusted runtime input (localStorage
- * rehydrate, wire payloads) MUST use the {@link isVoiceInputMode} guard
- * below — it is keyed off the same exhaustive `Record<VoiceInputMode, true>`
- * map, so widening the union to a new mode without updating that map is a
- * TS error (missing property). See `packages/dashboard/src/store/connection.ts`
- * `loadSavedConnection` for the canonical rehydrate-path consumer (#4853).
+ * rehydrate, SecureStore rehydrate, wire payloads) MUST use the
+ * {@link isVoiceInputMode} guard below — it is keyed off the same exhaustive
+ * `Record<VoiceInputMode, true>` map, so widening the union to a new mode
+ * without updating that map is a TS error (missing property). Canonical
+ * rehydrate-path consumers:
+ * - `packages/dashboard/src/store/connection.ts` — localStorage (#4853)
+ * - `packages/app/src/store/connection.ts` — SecureStore (#4872)
  */
 export type VoiceInputMode = 'continuous' | 'auto-pause';
 


### PR DESCRIPTION
## Summary

`packages/app/src/store/connection.ts:582` persists and rehydrates the full `inputSettings` object (including `voiceInputMode`) via SecureStore, but the rehydrate path validates **nothing** about the mode — the `...parsed` spread takes whatever is on disk straight into store state, gated only on `chatEnterToSend` / `terminalEnterToSend` being booleans. A stale or tampered SecureStore blob with `voiceInputMode: 'push-to-talk'` (or `null`, or `42`) lands directly in the store and is consumed downstream by `useSpeechRecognition({ mode })`.

This is exactly the silent-drop failure mode #4853 was created to prevent — just on the mobile side instead of the dashboard.

## Changes

- **`packages/app/src/store/connection.ts`** — rehydrate now builds a `Partial<InputSettings>` next-object the same way the dashboard does (#4858):
  - `chatEnterToSend` / `terminalEnterToSend` continue to be gated by `typeof === 'boolean'` (each independently — previously a single OR-gate let one valid key drag arbitrary state in via the spread)
  - `voiceInputMode` is now gated by `isVoiceInputMode(parsed.voiceInputMode)` from `@chroxy/store-core`
  - Extra keys in the blob are no longer shoehorned into store state
- **`packages/app/src/__tests__/store/connection-rehydrate-input-settings.test.ts`** — new test file (19 cases) mirroring the dashboard coverage: known modes round-trip; unknown / null / number / object / array / case-mismatched / empty-string / prototype-method values drop on rehydrate; boolean toggles continue to be gated by `typeof === 'boolean'`; defaults preserved when stored blob is missing or malformed.
- **`packages/store-core/src/types.ts`** — JSDoc on `VoiceInputMode` updated to mention both rehydrate consumers (dashboard `connection.ts` AND app `connection.ts`).

## Test plan

- [x] `npm --workspace=@chroxy/app test` — 1514 tests pass (107 suites), including 19 new
- [x] `npx tsc --noEmit` in `packages/app` — clean
- [x] `npx tsc --noEmit` in `packages/store-core` — clean
- [x] `npx tsc --noEmit` in `packages/dashboard` — clean
- [x] `npm test` in `packages/dashboard` — 2568 tests pass (131 suites)
- [x] `npm test` in `packages/store-core` — 1011 tests pass (20 suites)

Closes #4872