### PR TITLE
refactor(server): collapse manual .tmp+rename wrappers onto writeFileRestricted

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -1,10 +1,10 @@
 import { EventEmitter } from 'events'
 import { randomBytes } from 'crypto'
 import { execFile } from 'child_process'
-import { existsSync, readFileSync, mkdirSync, renameSync, unlinkSync } from 'fs'
+import { existsSync, readFileSync, mkdirSync } from 'fs'
 import { dirname, join, resolve } from 'path'
 import { homedir } from 'os'
-import { isWindows, writeFileRestricted } from './platform.js'
+import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
 import { DockerBackend } from './environments/backends/docker.js'
 
@@ -769,26 +769,12 @@ export class EnvironmentManager extends EventEmitter {
         environments: Array.from(this._environments.values()),
       }
 
-      const tmpPath = this._statePath + '.tmp'
-      writeFileRestricted(tmpPath, JSON.stringify(data, null, 2))
-      if (isWindows) {
-        try { unlinkSync(this._statePath) } catch (e) {
-          if (e && e.code !== 'ENOENT') log.error(`Failed to remove existing state file: ${e.message}`)
-        }
-      }
-      try {
-        renameSync(tmpPath, this._statePath)
-      } catch (renameErr) {
-        // Clean up the orphaned .tmp so it doesn't leak across retries.
-        // Suppress ENOENT (nothing to clean up). Log but do not re-throw any
-        // secondary unlink error — the original rename error is what matters.
-        try { unlinkSync(tmpPath) } catch (cleanupErr) {
-          if (cleanupErr && cleanupErr.code !== 'ENOENT') {
-            log.warn(`Failed to remove orphaned ${tmpPath}: ${cleanupErr.message}`)
-          }
-        }
-        throw renameErr
-      }
+      // writeFileRestricted is atomic on POSIX (#4850) and cleans up
+      // its intermediate `.tmp` on rename failure (#4874) — no manual
+      // tmp+rename wrapper needed here. On Windows it falls through to
+      // a direct writeFileSync which overwrites the destination, so the
+      // pre-#4874 unlinkSync(EEXIST) workaround is no longer required.
+      writeFileRestricted(this._statePath, JSON.stringify(data, null, 2))
     } catch (err) {
       log.error(`Failed to persist environment state: ${err.message}`)
     }

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -1,4 +1,4 @@
-import { readFileSync, renameSync, unlinkSync, mkdirSync } from 'fs'
+import { readFileSync, mkdirSync } from 'fs'
 import { homedir } from 'os'
 import { dirname, join } from 'path'
 import { writeFileRestricted } from './platform.js'
@@ -471,15 +471,18 @@ export function createModelsRegistry(hooks = {}) {
     const snapshot = snapshotString()
     if (snapshot === lastSavedSnapshot) return true
 
-    const tmpPath = `${path}.tmp-${process.pid}`
     try {
       mkdirSync(dirname(path), { recursive: true })
-      writeFileRestricted(tmpPath, JSON.stringify({
+      // Pass a per-pid `tmpSuffix` so two concurrent processes (test
+      // runner + main daemon, or two test workers) writing the same
+      // cache do not race on the same intermediate `.tmp` file (#4874).
+      // writeFileRestricted handles atomic rename + cleanup internally
+      // since #4874; no manual rename/unlink wrapper is needed here.
+      writeFileRestricted(path, JSON.stringify({
         models: activeModels,
         defaultModelId,
         savedAt: Date.now(),
-      }, null, 2))
-      renameSync(tmpPath, path)
+      }, null, 2), { tmpSuffix: `.tmp-${process.pid}` })
       lastSavedSnapshot = snapshot
       return true
     } catch (err) {
@@ -488,7 +491,6 @@ export function createModelsRegistry(hooks = {}) {
       // lost on restart — surface at warn level so operators can diagnose
       // from ~/.chroxy/logs/chroxy.log.
       log.warn(`saveCache: failed to persist models cache to ${path}: ${err?.code || ''} ${err?.message || err}`.trim())
-      try { unlinkSync(tmpPath) } catch {}
       return false
     }
   }

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -473,11 +473,15 @@ export function createModelsRegistry(hooks = {}) {
 
     try {
       mkdirSync(dirname(path), { recursive: true })
-      // Pass a per-pid `tmpSuffix` so two concurrent processes (test
-      // runner + main daemon, or two test workers) writing the same
-      // cache do not race on the same intermediate `.tmp` file (#4874).
-      // writeFileRestricted handles atomic rename + cleanup internally
-      // since #4874; no manual rename/unlink wrapper is needed here.
+      // Pass a per-pid `tmpSuffix` so two concurrent POSIX processes
+      // (test runner + main daemon, or two test workers) writing the
+      // same cache do not race on the same intermediate `.tmp` file
+      // (#4874). The suffix is a POSIX-only contract — on Windows
+      // `writeFileRestricted` ignores `tmpSuffix` and writes directly to
+      // the target path (see `platform.js`), so the per-pid hint has no
+      // effect there. writeFileRestricted handles atomic rename +
+      // cleanup internally on POSIX since #4874; no manual rename/unlink
+      // wrapper is needed here.
       writeFileRestricted(path, JSON.stringify({
         models: activeModels,
         defaultModelId,

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -1,4 +1,4 @@
-import { writeFileSync, chmodSync, renameSync } from 'fs'
+import { writeFileSync, chmodSync, renameSync, unlinkSync } from 'fs'
 
 export const isWindows = process.platform === 'win32'
 export const isMac = process.platform === 'darwin'
@@ -10,28 +10,48 @@ export function defaultShell() {
 }
 
 /**
- * Write `data` to `filePath` atomically on POSIX (write to `<path>.tmp`
- * then `rename` over the target). `rename` is atomic on the same
- * filesystem, so a concurrent reader sees either the previous version
- * or the new one — never a half-written file. This matters when the
- * process is killed mid-write (SIGKILL / OOM); it is the file-level
- * analogue of the "SIGTERM not SIGKILL for Chroxy" memory note. See
- * #4850, which surfaced this gap for `connection.json` (pre-existing)
- * and `device-preferences.json` (added in #4847).
+ * Write `data` to `filePath` atomically on POSIX (write to
+ * `<filePath><tmpSuffix>` then `rename` over the target). `rename` is
+ * atomic on the same filesystem, so a concurrent reader sees either the
+ * previous version or the new one — never a half-written file. This
+ * matters when the process is killed mid-write (SIGKILL / OOM); it is
+ * the file-level analogue of the "SIGTERM not SIGKILL for Chroxy"
+ * memory note. See #4850, which surfaced this gap for `connection.json`
+ * (pre-existing) and `device-preferences.json` (added in #4847).
  *
  * On Windows we keep the direct `writeFileSync` path — `rename`
  * semantics differ (it fails when the destination exists unless you
  * use `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`) and there is no ACL
  * machinery here that needs the atomic guarantee yet.
+ *
+ * Options (POSIX only):
+ *   - `tmpSuffix` (default `.tmp`): suffix appended to `filePath` for
+ *     the intermediate atomic-write file. Callers that may collide on
+ *     the same target path from multiple processes (e.g. the models
+ *     cache rewritten by both the test runner and the main daemon)
+ *     should pass a per-process suffix such as `.tmp-${process.pid}`
+ *     so the intermediate files never overwrite each other. See #4874.
+ *
+ * On rename failure, the intermediate `<filePath><tmpSuffix>` file is
+ * unlinked before the error is rethrown so it does not leak across
+ * retries. Cleanup errors are suppressed — the original rename error is
+ * what the caller needs to surface. See #4874 — environment-manager.js
+ * and session-state-persistence.js had identical bespoke cleanup
+ * wrappers before this was hoisted into the shared helper.
  */
-export function writeFileRestricted(filePath, data) {
+export function writeFileRestricted(filePath, data, { tmpSuffix = '.tmp' } = {}) {
   if (isWindows) {
     writeFileSync(filePath, data)
-  } else {
-    const tmpPath = `${filePath}.tmp`
-    writeFileSync(tmpPath, data, { mode: 0o600 })
-    chmodSync(tmpPath, 0o600)
+    return
+  }
+  const tmpPath = `${filePath}${tmpSuffix}`
+  writeFileSync(tmpPath, data, { mode: 0o600 })
+  chmodSync(tmpPath, 0o600)
+  try {
     renameSync(tmpPath, filePath)
+  } catch (err) {
+    try { unlinkSync(tmpPath) } catch {}
+    throw err
   }
 }
 

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -58,12 +58,14 @@ describe('platform', () => {
         assert.strictEqual(mode, 0o600)
       })
 
-      it('writes atomically via <path>.tmp + rename — leaves original intact when rename fails (#4850)', () => {
+      it('writes atomically via <path>.tmp + rename — leaves original intact and cleans up tmp when rename fails (#4850, #4874)', () => {
         // Simulates the process being killed (SIGKILL / OOM) between the
         // tmp-write and the rename. The contract is: readers never see a
         // half-written `filePath` — they see either the previous version
-        // (this test) or the new one. The `.tmp` leftover is acceptable;
-        // a subsequent successful write will overwrite it.
+        // (this test) or the new one. Since #4874 we also clean up the
+        // intermediate `.tmp` on rename failure, so it does not leak on
+        // disk across retries (environment-manager.js and
+        // session-state-persistence.js used to hand-roll this cleanup).
         //
         // We run the actual write in a subprocess because monkey-patching
         // `fs.renameSync` in-process doesn't propagate to `platform.js`'s
@@ -119,13 +121,60 @@ try {
         const parsed = JSON.parse(after) // would throw if half-written
         assert.strictEqual(parsed.generation, 1)
 
-        // The .tmp sidecar was created (proves we went through the
-        // atomic write path) and contains the new content. Production
-        // readers ignore the `.tmp` suffix — `connection-info.js` and
-        // `device-preferences.js` only read the target path.
+        // The intermediate `.tmp` sidecar is cleaned up on rename failure
+        // (#4874) so it does not leak across retries.
         const tmpPath = `${filePath}.tmp`
-        assert.strictEqual(existsSync(tmpPath), true)
-        assert.strictEqual(readFileSync(tmpPath, 'utf-8'), JSON.stringify({ generation: 2 }))
+        assert.strictEqual(existsSync(tmpPath), false, '.tmp sidecar must be cleaned up on rename failure')
+      })
+
+      it('honours a custom tmpSuffix option and routes the intermediate file through it (#4874)', () => {
+        // Two concurrent processes writing the same target with a per-pid
+        // suffix must not race on the same intermediate file. We can't
+        // truly fork here, but we can prove the suffix is honoured by
+        // observing the intermediate path on a rename failure. The shim
+        // also suppresses the cleanup unlink so the post-crash file is
+        // still on disk for inspection.
+        const filePath = join(tmpDir, 'models-cache.json')
+        const shim = join(tmpDir, 'throw-on-rename-suffix.mjs')
+        const runner = join(tmpDir, 'runner-suffix.mjs')
+        const sentinelPath = join(tmpDir, 'observed-tmp-path.txt')
+        const shimSrc = `
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+const fs = require('node:fs')
+const origRename = fs.renameSync
+const origUnlink = fs.unlinkSync
+fs.renameSync = (oldPath, newPath) => {
+  if (newPath === ${JSON.stringify(filePath)}) {
+    fs.writeFileSync(${JSON.stringify(sentinelPath)}, oldPath)
+    const err = new Error('simulated mid-write crash')
+    err.code = 'EIO'
+    throw err
+  }
+  return origRename.call(this, oldPath, newPath)
+}
+// Swallow the cleanup unlink so we can inspect the intermediate path later.
+fs.unlinkSync = (p) => {
+  if (typeof p === 'string' && p.includes('.tmp-')) return
+  return origUnlink.call(this, p)
+}
+`
+        const runnerSrc = `
+import { writeFileRestricted } from ${JSON.stringify(PLATFORM_JS)}
+try {
+  writeFileRestricted(${JSON.stringify(filePath)}, 'payload', { tmpSuffix: '.tmp-12345' })
+  process.exit(0)
+} catch {
+  process.exit(2)
+}
+`
+        writeFileRestricted(shim, shimSrc)
+        writeFileRestricted(runner, runnerSrc)
+        const result = spawnSync(process.execPath, ['--import', shim, runner], { encoding: 'utf-8' })
+        assert.strictEqual(result.status, 2, `expected non-zero exit; stderr=${result.stderr}`)
+
+        const observed = readFileSync(sentinelPath, 'utf-8')
+        assert.strictEqual(observed, `${filePath}.tmp-12345`, 'tmpSuffix must drive the intermediate path')
       })
 
       it('cleans up the .tmp sidecar on successful write (#4850)', () => {
@@ -136,6 +185,16 @@ try {
         writeFileRestricted(filePath, 'final')
         assert.strictEqual(readFileSync(filePath, 'utf-8'), 'final')
         assert.strictEqual(existsSync(`${filePath}.tmp`), false)
+      })
+
+      it('cleans up the custom-suffix sidecar on successful write (#4874)', () => {
+        // Same contract as the default `.tmp` cleanup, exercised via the
+        // models.js `tmpSuffix: \`.tmp-${process.pid}\`` path so the
+        // per-pid intermediate does not leak after a clean save.
+        const filePath = join(tmpDir, 'models-cache.json')
+        writeFileRestricted(filePath, 'final', { tmpSuffix: '.tmp-99999' })
+        assert.strictEqual(readFileSync(filePath, 'utf-8'), 'final')
+        assert.strictEqual(existsSync(`${filePath}.tmp-99999`), false)
       })
 
       it('preserves 0o600 on the renamed target (#4850)', () => {

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -59,13 +59,18 @@ describe('platform', () => {
       })
 
       it('writes atomically via <path>.tmp + rename — leaves original intact and cleans up tmp when rename fails (#4850, #4874)', () => {
-        // Simulates the process being killed (SIGKILL / OOM) between the
-        // tmp-write and the rename. The contract is: readers never see a
-        // half-written `filePath` — they see either the previous version
-        // (this test) or the new one. Since #4874 we also clean up the
-        // intermediate `.tmp` on rename failure, so it does not leak on
-        // disk across retries (environment-manager.js and
+        // Simulates `renameSync` failing AFTER the tmp file is fully
+        // written (EIO from the shim below). The contract under test is
+        // two-part: (1) readers of `filePath` never see a half-written
+        // version — they observe either the previous generation (this
+        // test) or the new one once rename succeeds; (2) since #4874 the
+        // intermediate `.tmp` is unlinked in-process when rename fails so
+        // it does not leak across retries (environment-manager.js and
         // session-state-persistence.js used to hand-roll this cleanup).
+        // The previous-generation guarantee is what protected callers
+        // pre-#4874 when the process was killed mid-write (SIGKILL / OOM)
+        // — same crash-safety contract, exercised here via a synthetic
+        // rename failure rather than a real signal.
         //
         // We run the actual write in a subprocess because monkey-patching
         // `fs.renameSync` in-process doesn't propagate to `platform.js`'s


### PR DESCRIPTION
## Summary

Per the audit acceptance criteria in #4874, collapse the bespoke `<path>.tmp` + `renameSync` wrappers around `writeFileRestricted` now that the helper is itself atomic on POSIX (since #4850 / #4865).

- **environment-manager.js** simplified to a single `writeFileRestricted(statePath, data)` call. The pre-#4874 Windows-EEXIST `unlinkSync(statePath)` workaround is no longer required because `writeFileRestricted` on Windows falls through to a plain `writeFileSync` (overwrite-on-write).
- **models.js** simplified, but with a per-pid `tmpSuffix` so two concurrent processes (test runner + main daemon, or two test workers) writing the same cache file do not race on the same intermediate `.tmp`. `writeFileRestricted` now accepts a `tmpSuffix` option for exactly this case.
- **session-state-persistence.js** left alone. Its `_rotateToBak` recovery flow is wedged between the tmp-write and the final rename and uses the prior-generation `.bak` bytes as a fallback if the Windows EPERM/EACCES/EBUSY/EEXIST retry fails. The issue explicitly flagged this as too risky to collapse without re-thinking the `.bak` recovery path — left out of scope.
- **platform.js** — `writeFileRestricted` now:
  1. Accepts `{ tmpSuffix }` (default `.tmp`) so callers like `models.js` can supply a per-process suffix.
  2. Unlinks the intermediate `<filePath><tmpSuffix>` on rename failure before rethrowing, so it does not leak across retries. This hoisting is what unblocks the environment-manager simplification (which previously duplicated the cleanup).

## Acceptance criteria

- [x] Per-caller decision documented: env-manager simplified, models simplified-with-tmpSuffix, session-state-persistence left alone (issue guidance).
- [x] `writeFileRestricted` grew a `tmpSuffix` option for the models per-pid case.
- [x] Crash-safety regression tests still pass (`environment-manager.test.js` `#2940` block, `session-state-persistence.test.js` `#2909` block, `models-factory.test.js` cache tests, `platform.test.js` atomic-write tests).
- [x] No new CI failures (the only `npm test` fails on this branch are pre-existing flakes — service.test.js `#745`, tunnel.integration.test.js requiring `cloudflared`, web-task-manager feature detection, ws-server encryption nonce — all reproduce on `main`).

## Test plan

- [x] `node --test packages/server/tests/platform.test.js packages/server/tests/environment-manager.test.js packages/server/tests/models-factory.test.js packages/server/tests/session-state-persistence.test.js packages/server/tests/models.test.js packages/server/tests/models-per-provider.test.js` — 284 / 284 pass
- [x] `npm run lint --workspace packages/server` — no new errors (6 pre-existing warnings unchanged)
- [x] `packages/server/scripts/lint-tests-state-file-path.sh` — OK
- [x] `packages/server/scripts/lint-session-opt-forwarding.sh` — OK
- [x] New regression tests added:
  - `platform.test.js` — rename-failure cleanup of the intermediate `.tmp` (was previously asserting the breadcrumb was kept)
  - `platform.test.js` — `tmpSuffix` routes the intermediate path
  - `platform.test.js` — clean-write cleanup of the custom-suffix sidecar

Closes #4874