### PR TITLE
feat(app): mobile session_stopped quiet status strip (#4879)

### DIFF
--- a/packages/app/src/__tests__/screens/SessionScreenStoppedBanner.test.ts
+++ b/packages/app/src/__tests__/screens/SessionScreenStoppedBanner.test.ts
@@ -1,0 +1,99 @@
+/**
+ * #4879 — SessionScreen quiet "Session stopped." status strip.
+ *
+ * The banner renders when the server confirms a user-initiated Stop via
+ * the `session_stopped` wire message (wired in #4868). Intentionally
+ * informational rather than error-styled: positive confirmation that
+ * the Stop tap landed, distinct from the loud red `health: 'crashed'`
+ * banner reserved for unexpected exits.
+ *
+ * No `@testing-library/react-native` in this repo (see
+ * `useSpeechRecognition.test.ts:21` for the same pattern note), so this
+ * suite verifies the wire-up via source-text parsing — same gating
+ * style as `SessionOverview.test.ts`. The runtime behaviour (handler
+ * sets `stoppedAt`/`stoppedCode`; `claude_ready` clears them) is
+ * exercised in `__tests__/store/message-handler.test.ts` against the
+ * real reducer.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SessionScreenSrc = fs.readFileSync(
+  path.resolve(__dirname, '../../screens/SessionScreen.tsx'),
+  'utf-8',
+);
+
+describe('SessionScreen stopped status strip (#4879)', () => {
+  it('subscribes to activeSessionStoppedAt and activeSessionStoppedCode selectors', () => {
+    // Both fields must be selected from the store so the banner re-renders
+    // when the case branch flips them.
+    expect(SessionScreenSrc).toMatch(/const activeSessionStoppedAt = useConnectionStore/);
+    expect(SessionScreenSrc).toMatch(/const activeSessionStoppedCode = useConnectionStore/);
+  });
+
+  it('selectors read stoppedAt / stoppedCode off the active session state', () => {
+    expect(SessionScreenSrc).toMatch(/sessionStates\[id\]\.stoppedAt/);
+    expect(SessionScreenSrc).toMatch(/sessionStates\[id\]\.stoppedCode/);
+  });
+
+  it('renders the banner only when activeSessionStoppedAt is non-null', () => {
+    // The conditional must include the non-null guard — otherwise the
+    // banner would render on every session (`stoppedAt: null` is the
+    // not-stopped state).
+    expect(SessionScreenSrc).toMatch(/activeSessionStoppedAt !== null/);
+  });
+
+  it("suppresses the stopped banner when health === 'crashed' (no double-banner)", () => {
+    // Defensive: the server only emits stopped for clean exits, but if a
+    // race ever surfaces both we want the louder crash banner to win.
+    expect(SessionScreenSrc).toMatch(/activeSessionHealth !== 'crashed' && activeSessionStoppedAt !== null/);
+  });
+
+  it("renders bare 'Session stopped.' when code is 0 or null (clean exit, no decoration)", () => {
+    // The ternary's else branch (code === 0 or code === null) emits the
+    // bare string — keep that in sync with the dashboard's #4878 copy.
+    expect(SessionScreenSrc).toMatch(/'Session stopped\.'/);
+  });
+
+  it("renders 'Session stopped. exit N' suffix for non-zero codes (e.g. 143 = SIGTERM)", () => {
+    expect(SessionScreenSrc).toMatch(/Session stopped\. exit \$\{activeSessionStoppedCode\}/);
+  });
+
+  it('uses informational stoppedBanner style (NOT errorBanner / warningBanner)', () => {
+    // The banner must be visually distinct from session_error's red
+    // strip and from server-error warnings — that's the whole point of
+    // a "quiet" confirmation.
+    expect(SessionScreenSrc).toMatch(/styles\.stoppedBanner/);
+    expect(SessionScreenSrc).toMatch(/styles\.stoppedBannerText/);
+  });
+
+  it('stoppedBanner style is defined with a muted background (greyed out, not accent-coloured)', () => {
+    // backgroundCard is the muted surface used elsewhere for inactive
+    // chrome; explicitly NOT accentRedSubtle / accentOrangeSubtle which
+    // are reserved for crash / warning banners.
+    expect(SessionScreenSrc).toMatch(/stoppedBanner: \{[^}]*backgroundColor: COLORS\.backgroundCard/);
+    expect(SessionScreenSrc).toMatch(/stoppedBannerText: \{[^}]*color: COLORS\.textMuted/);
+  });
+
+  it('exposes testID hooks for Maestro / runtime assertions', () => {
+    expect(SessionScreenSrc).toMatch(/testID="session-stopped-banner"/);
+    expect(SessionScreenSrc).toMatch(/testID="session-stopped-banner-text"/);
+  });
+
+  it('does NOT push a session notification or fire an Alert from the case branch', () => {
+    // The case branch in message-handler.ts must not show modal UI or
+    // push a notification — the inline strip carries the full signal.
+    const msgHandlerSrc = fs.readFileSync(
+      path.resolve(__dirname, '../../store/message-handler.ts'),
+      'utf-8',
+    );
+    // Locate just the case body so we don't trip over unrelated Alert
+    // calls elsewhere in the dispatcher.
+    const caseBlock = msgHandlerSrc.match(/case 'session_stopped':\s*\{([\s\S]*?)\n {4}\}/);
+    expect(caseBlock).not.toBeNull();
+    const body = caseBlock![1];
+    expect(body).not.toMatch(/Alert\.alert/);
+    expect(body).not.toMatch(/pushSessionNotification/);
+    expect(body).not.toMatch(/addServerError/);
+  });
+});

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -163,6 +163,132 @@ describe('session_error SESSION_TOKEN_MISMATCH UX', () => {
   });
 });
 
+// #4879: quiet "user-initiated Stop" confirmation. The wire path (CliSession
+// → SessionManager → ws-forwarding → ServerSessionStoppedSchema) was wired
+// in #4868; this branch surfaces it to the mobile UX as a subtle status
+// strip rather than an Alert.
+describe('session_stopped handler (#4879)', () => {
+  it('sets stoppedAt + stoppedCode on the explicit target session', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [
+        { sessionId: 's1', name: 'S1' } as any,
+        { sessionId: 's2', name: 'S2' } as any,
+      ],
+      sessionStates: {
+        s1: createEmptySessionState(),
+        s2: createEmptySessionState(),
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    const before = Date.now();
+    _testMessageHandler.handle({ type: 'session_stopped', sessionId: 's2', code: 143 });
+    const after = Date.now();
+
+    const state = store.getState();
+    // s1 (active) is untouched — the message targeted s2 explicitly.
+    expect(state.sessionStates.s1.stoppedAt).toBeNull();
+    expect(state.sessionStates.s1.stoppedCode).toBeNull();
+    // s2 carries the marker + the reported exit code.
+    expect(state.sessionStates.s2.stoppedCode).toBe(143);
+    const stoppedAt = state.sessionStates.s2.stoppedAt as number;
+    expect(typeof stoppedAt).toBe('number');
+    expect(stoppedAt).toBeGreaterThanOrEqual(before);
+    expect(stoppedAt).toBeLessThanOrEqual(after);
+  });
+
+  it('falls back to the active session when sessionId is omitted (legacy-cli)', () => {
+    // Legacy-cli broadcasts omit sessionId (ServerSessionStoppedSchema makes
+    // it optional). The handler must still surface the marker on the user's
+    // current session so the inline banner lights up.
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'session_stopped', code: 0 });
+
+    const state = store.getState();
+    expect(state.sessionStates.s1.stoppedCode).toBe(0);
+    expect(state.sessionStates.s1.stoppedAt).not.toBeNull();
+  });
+
+  it('handles missing code (future in-process providers per #4756 follow-up)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'session_stopped' });
+
+    const state = store.getState();
+    expect(state.sessionStates.s1.stoppedAt).not.toBeNull();
+    expect(state.sessionStates.s1.stoppedCode).toBeNull();
+  });
+
+  it('does NOT show an Alert (confirmation is intentionally inline, not modal)', () => {
+    const alertSpy = Alert.alert as jest.Mock;
+    alertSpy.mockClear();
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'session_stopped', sessionId: 's1', code: 0 });
+
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  it('ignores messages targeting an unknown sessionId (defensive — server may race a destroy)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'session_stopped', sessionId: 'unknown-session', code: 0 });
+
+    const state = store.getState();
+    expect(state.sessionStates.s1.stoppedAt).toBeNull();
+    expect(state.sessionStates).not.toHaveProperty('unknown-session');
+  });
+
+  it('claude_ready clears the stopped marker so the inline strip auto-dismisses', () => {
+    // The cleanup path: operator taps Stop, sees the strip, sends another
+    // message, server restarts the child, claude_ready arrives, the strip
+    // disappears. Verifies the handleClaudeReady patch shape — both
+    // fields must collapse to null on the same patch object the case
+    // branch applies, otherwise the strip would linger forever.
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), stoppedAt: 123, stoppedCode: 0 } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'claude_ready' });
+
+    const state = store.getState();
+    expect(state.sessionStates.s1.stoppedAt).toBeNull();
+    expect(state.sessionStates.s1.stoppedCode).toBeNull();
+    expect(state.sessionStates.s1.claudeReady).toBe(true);
+  });
+});
+
 describe('session_timeout handler', () => {
   it('removes timed-out session from sessionStates and sessions list', () => {
     const store = createMockStore({

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -237,6 +237,18 @@ export function SessionScreen() {
     const id = s.activeSessionId;
     return id && s.sessionStates[id] ? s.sessionStates[id].health : 'healthy';
   });
+  // #4879: quiet user-initiated Stop marker. Set by the `session_stopped`
+  // handler (sharedSessionStopped); cleared on next claude_ready. Drives
+  // the subtle "Session stopped." status strip below — distinct from the
+  // loud red crashed banner reserved for unexpected exits.
+  const activeSessionStoppedAt = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? s.sessionStates[id].stoppedAt : null;
+  });
+  const activeSessionStoppedCode = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id && s.sessionStates[id] ? s.sessionStates[id].stoppedCode : null;
+  });
   const isPlanPending = useConnectionStore((s) => {
     const id = s.activeSessionId;
     return id && s.sessionStates[id] ? s.sessionStates[id].isPlanPending : false;
@@ -1160,6 +1172,35 @@ export function SessionScreen() {
         </View>
       )}
 
+      {/* #4879: Quiet stopped status strip for active session — surfaced
+          when the server confirms a user-initiated Stop (session_stopped
+          wire message, wired in #4868). Intentionally informational
+          rather than error-styled: this is positive feedback that the
+          Stop tap landed. Suppressed when health === 'crashed' so the
+          loud red crash banner above isn't doubled up on the unlikely
+          race where both arrive (defensive — the server only emits
+          stopped for clean exits per CliSession._handleChildClose). The
+          strip auto-clears on the next `claude_ready` (typically when
+          the operator sends another message). */}
+      {activeSessionHealth !== 'crashed' && activeSessionStoppedAt !== null && (
+        <View
+          testID="session-stopped-banner"
+          style={[styles.reconnectingBanner, styles.stoppedBanner]}
+        >
+          <View style={styles.errorBannerContent}>
+            <Text
+              testID="session-stopped-banner-text"
+              style={styles.stoppedBannerText}
+              numberOfLines={1}
+            >
+              {activeSessionStoppedCode !== null && activeSessionStoppedCode !== 0
+                ? `Session stopped. exit ${activeSessionStoppedCode}`
+                : 'Session stopped.'}
+            </Text>
+          </View>
+        </View>
+      )}
+
       {/* Server error banners */}
       {serverErrors.map((err) => (
         <View
@@ -1725,6 +1766,18 @@ const styles = StyleSheet.create({
     color: COLORS.accentRed,
     fontSize: 12,
     fontWeight: '600',
+  },
+  // #4879: subtle "Session stopped." status strip. Uses the muted
+  // backgroundCard surface (greyed out, NOT the red/orange accent banners
+  // reserved for crashes / warnings) and textMuted copy so the operator
+  // reads it as a calm confirmation rather than an error.
+  stoppedBanner: {
+    backgroundColor: COLORS.backgroundCard,
+  },
+  stoppedBannerText: {
+    color: COLORS.textMuted,
+    fontSize: 12,
+    fontWeight: '500',
   },
   sheetOverlay: {
     flex: 1,

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -61,6 +61,8 @@ import {
   handleCheckpointRestored as sharedCheckpointRestored,
   handleError as sharedError,
   handleSessionError as sharedSessionError,
+  // #4879: quiet user-initiated Stop confirmation handler
+  handleSessionStopped as sharedSessionStopped,
   handleClientJoined as sharedClientJoined,
   handleClientLeft as sharedClientLeft,
   handlePrimaryChanged as sharedPrimaryChanged,
@@ -1382,6 +1384,34 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         } else {
           Alert.alert('Session Error', parsed.message ?? 'Unknown error');
         }
+      }
+      break;
+    }
+
+    case 'session_stopped': {
+      // #4879: quiet, informational confirmation when CliSession exits
+      // cleanly after a user-initiated Stop. The wire path was wired in
+      // #4868 (CliSession 'stopped' → SessionManager → ws-forwarding →
+      // ServerSessionStoppedSchema). Distinct from `session_error` (which
+      // flips `health: 'crashed'` and surfaces a loud red banner): the
+      // operator tapped Stop, the child process did indeed stop.
+      //
+      // Sets `stoppedAt` + `stoppedCode` on the target session — the
+      // SessionScreen reads those fields to render a subtle, info-styled
+      // status strip ("Session stopped." / "Session stopped. exit N").
+      // Both fields are cleared automatically by `handleClaudeReady`
+      // (which returns `stoppedAt: null, stoppedCode: null`) when the
+      // server restarts the child after the operator's next input.
+      //
+      // NO Alert / push notification — this is intentionally NOT an
+      // error UX. The active session's inline banner carries the full
+      // signal; for inactive sessions the absence of a session_error
+      // already conveys "no crash, clean stop" and adding a notification
+      // here would just be noise.
+      const stoppedPatch = sharedSessionStopped(msg, get().activeSessionId);
+      const stoppedTarget = stoppedPatch.sessionId;
+      if (stoppedTarget && get().sessionStates[stoppedTarget]) {
+        updateSession(stoppedTarget, () => stoppedPatch.patch);
       }
       break;
     }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -761,6 +761,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       isIdle: true,
       lastClientActivityAt: null,
       health: 'healthy' as const,
+      // #4879: parity with the BaseSessionState shape; no Stop has been
+      // confirmed in the flat-state fallback (session_stopped only fires
+      // for known sessions once session_list has populated sessionStates).
+      stoppedAt: null,
+      stoppedCode: null,
       terminalRawBuffer: get().terminalRawBuffer,
       activeAgents: EMPTY_AGENTS,
       // #4308: parity with the BaseSessionState shape; no live tool tracking

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -46,7 +46,7 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
-  // 'session_stopped' moved to PLATFORM_SPECIFIC as 'dashboard' (#4878) — dashboard renders a quiet "Session stopped." info toast (with optional "(exit N)" for non-zero codes); mobile app exposure is a deferred follow-up tracked under the #4756 epic
+  // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
   // app (#4074); no PLATFORM_SPECIFIC entry needed. Coverage test passes
@@ -103,7 +103,6 @@ const PLATFORM_SPECIFIC = {
   // Coverage test passes because each handler has a
   // `case 'multi_question_intervention':` clause.
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
-  'session_stopped': 'dashboard', // user-initiated Stop confirmation (#4878) — dashboard renders a quiet "Session stopped." info toast (with optional "(exit N)" for non-zero codes); mobile app exposure is a deferred follow-up tracked under the #4756 epic
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -1001,15 +1001,20 @@ describe('handleSessionStopped', () => {
     expect(result.patch.stoppedAt).toBe(1_700_000_000_000)
   })
 
-  it('returns stoppedCode: null when code is non-numeric (defensive)', () => {
-    // ServerSessionStoppedSchema enforces integer at the protocol layer,
-    // but the handler is also called from untrusted/test paths — collapse
-    // anything non-numeric to null rather than poisoning stoppedCode with
-    // a string or NaN that the renderer would have to defend against.
+  it('returns stoppedCode: null when code is non-integer (defensive)', () => {
+    // ServerSessionStoppedSchema enforces integer at the protocol layer
+    // (`z.number().int()`), but the handler is also called from
+    // untrusted/test paths — collapse anything non-integer to null
+    // rather than poisoning stoppedCode with a string, NaN, Infinity,
+    // or a fractional value (which would render "exit 1.5" in the UI).
     expect(handleSessionStopped({ code: 'not a number' }, null, fixedNow).patch.stoppedCode).toBeNull()
     expect(handleSessionStopped({ code: null }, null, fixedNow).patch.stoppedCode).toBeNull()
     expect(handleSessionStopped({ code: NaN }, null, fixedNow).patch.stoppedCode).toBeNull()
     expect(handleSessionStopped({ code: Infinity }, null, fixedNow).patch.stoppedCode).toBeNull()
+    // Fractional values get the same treatment — the schema is `int()`,
+    // not `finite()`, so a buggy producer sending 1.5 must NOT render.
+    expect(handleSessionStopped({ code: 1.5 }, null, fixedNow).patch.stoppedCode).toBeNull()
+    expect(handleSessionStopped({ code: -0.1 }, null, fixedNow).patch.stoppedCode).toBeNull()
   })
 
   it('returns sessionId: null when no sessionId on msg AND no active session (broadcast guard semantics handled by caller)', () => {

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -33,6 +33,7 @@ import {
   handleCheckpointRestored,
   handleError,
   handleSessionError,
+  handleSessionStopped,
   handleLogEntry,
   handleClientJoined,
   handleClientLeft,
@@ -356,8 +357,17 @@ describe('handleConfirmPermissionMode', () => {
 // handleClaudeReady
 // ---------------------------------------------------------------------------
 describe('handleClaudeReady', () => {
-  it('returns claudeReady: true', () => {
-    expect(handleClaudeReady()).toEqual({ claudeReady: true })
+  it('returns claudeReady: true and clears stoppedAt/stoppedCode (#4879)', () => {
+    // #4879 — clearing the stopped marker on claude_ready is what makes
+    // the quiet "Session stopped." inline strip auto-dismiss when the
+    // server restarts the child after the operator's next input. Both
+    // new fields collapse to null end-to-end for sessions that were
+    // never stopped, so the patch is safe to broadcast unconditionally.
+    expect(handleClaudeReady()).toEqual({
+      claudeReady: true,
+      stoppedAt: null,
+      stoppedCode: null,
+    })
   })
 })
 
@@ -953,6 +963,68 @@ describe('handleSessionError', () => {
     )
     expect(result.message).toBe('Not authorized')
     expect(result.boundSessionName).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// handleSessionStopped (#4879)
+// ---------------------------------------------------------------------------
+describe('handleSessionStopped', () => {
+  const fixedNow = () => 1_700_000_000_000
+
+  it('builds a patch targeting the explicit sessionId with the stopped marker + code', () => {
+    const result = handleSessionStopped(
+      { sessionId: 'sess-1', code: 143 },
+      'active-1',
+      fixedNow,
+    )
+    expect(result).toEqual({
+      sessionId: 'sess-1',
+      patch: { stoppedAt: 1_700_000_000_000, stoppedCode: 143 },
+    })
+  })
+
+  it('falls back to active session when sessionId is missing', () => {
+    const result = handleSessionStopped({ code: 0 }, 'active-1', fixedNow)
+    expect(result.sessionId).toBe('active-1')
+    expect(result.patch).toEqual({ stoppedAt: 1_700_000_000_000, stoppedCode: 0 })
+  })
+
+  it('preserves code 0 explicitly (clean SIGINT exit is a meaningful signal)', () => {
+    const result = handleSessionStopped({ sessionId: 's', code: 0 }, null, fixedNow)
+    expect(result.patch.stoppedCode).toBe(0)
+  })
+
+  it('returns stoppedCode: null when code is missing on the wire', () => {
+    const result = handleSessionStopped({ sessionId: 's' }, null, fixedNow)
+    expect(result.patch.stoppedCode).toBeNull()
+    expect(result.patch.stoppedAt).toBe(1_700_000_000_000)
+  })
+
+  it('returns stoppedCode: null when code is non-numeric (defensive)', () => {
+    // ServerSessionStoppedSchema enforces integer at the protocol layer,
+    // but the handler is also called from untrusted/test paths — collapse
+    // anything non-numeric to null rather than poisoning stoppedCode with
+    // a string or NaN that the renderer would have to defend against.
+    expect(handleSessionStopped({ code: 'not a number' }, null, fixedNow).patch.stoppedCode).toBeNull()
+    expect(handleSessionStopped({ code: null }, null, fixedNow).patch.stoppedCode).toBeNull()
+    expect(handleSessionStopped({ code: NaN }, null, fixedNow).patch.stoppedCode).toBeNull()
+    expect(handleSessionStopped({ code: Infinity }, null, fixedNow).patch.stoppedCode).toBeNull()
+  })
+
+  it('returns sessionId: null when no sessionId on msg AND no active session (broadcast guard semantics handled by caller)', () => {
+    const result = handleSessionStopped({ code: 0 }, null, fixedNow)
+    expect(result.sessionId).toBeNull()
+  })
+
+  it('defaults `now` to Date.now when not injected', () => {
+    const before = Date.now()
+    const result = handleSessionStopped({ sessionId: 's' }, null)
+    const after = Date.now()
+    const stoppedAt = result.patch.stoppedAt as number
+    expect(typeof stoppedAt).toBe('number')
+    expect(stoppedAt).toBeGreaterThanOrEqual(before)
+    expect(stoppedAt).toBeLessThanOrEqual(after)
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1180,12 +1180,16 @@ export function handleSessionStopped(
   activeSessionId: string | null,
   now: () => number = Date.now,
 ): SessionPatch {
-  // `code` is optional on the wire (ServerSessionStoppedSchema). Preserve
-  // 0 explicitly — it's the common clean-SIGINT-exit case and is a
-  // meaningful signal, not a "missing" value. Non-finite numbers (NaN,
-  // Infinity from a buggy producer) collapse to null so renderers don't
-  // need to defend against them.
-  const code = typeof msg.code === 'number' && Number.isFinite(msg.code) ? msg.code : null
+  // `code` is optional on the wire (ServerSessionStoppedSchema declares it
+  // as `z.number().int()`). Mirror that integer constraint here so a
+  // buggy producer can't poison `stoppedCode` with a fractional value
+  // (e.g. rendering "exit 1.5") or with NaN / Infinity. `Number.isInteger`
+  // already excludes all three failure modes; matches the existing
+  // protocol-int validation pattern used elsewhere in this file (see
+  // `protoRaw` around line 798). Preserve 0 explicitly — it's the common
+  // clean-SIGINT-exit case and is a meaningful signal, not a "missing"
+  // value.
+  const code = typeof msg.code === 'number' && Number.isInteger(msg.code) ? msg.code : null
   return {
     sessionId: resolveSessionId(msg, activeSessionId),
     patch: {

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -226,9 +226,21 @@ export function handleConfirmPermissionMode(
 // claude_ready
 // ---------------------------------------------------------------------------
 
-/** State patch for `claude_ready`. */
-export function handleClaudeReady(): { claudeReady: true } {
-  return { claudeReady: true }
+/**
+ * State patch for `claude_ready`.
+ *
+ * `stoppedAt`/`stoppedCode` are reset to null here so the quiet "Session
+ * stopped." status strip introduced for #4879 clears the moment the
+ * server reports the child is ready again (typically because the user
+ * sent another message after tapping Stop). This is purely additive for
+ * sessions that were never stopped — both fields stay null end-to-end.
+ */
+export function handleClaudeReady(): {
+  claudeReady: true
+  stoppedAt: null
+  stoppedCode: null
+} {
+  return { claudeReady: true, stoppedAt: null, stoppedCode: null }
 }
 
 // ---------------------------------------------------------------------------
@@ -1131,6 +1143,55 @@ export function handleSessionError(
     boundSessionName,
     message,
     sessionPatch: null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// session_stopped (#4879)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a `session_stopped` message into a `SessionPatch` that flips the
+ * target session into the quiet "stopped" UX state.
+ *
+ * The server emits `session_stopped` when `CliSession` exits cleanly after
+ * a user-initiated Stop (wire path wired in #4868 — CliSession `stopped` →
+ * SessionManager → ws-forwarding → ServerSessionStoppedSchema). This is a
+ * positive confirmation distinct from `session_error` (which flips
+ * `health: 'crashed'` and surfaces a loud red banner): the operator
+ * tapped Stop, the child process did indeed stop.
+ *
+ * The patch sets `stoppedAt` to `now()` so renderers can show a calm
+ * informational status strip ("Session stopped." / with optional
+ * "exit N" suffix for non-zero exits). `stoppedCode` carries the child
+ * process exit code when the server reported one — null otherwise. Both
+ * fields are cleared (back to null) by `handleClaudeReady`'s patch when
+ * the server restarts the child after the operator's next input.
+ *
+ * The caller is responsible for applying the patch to its store. No
+ * notification / toast side effects are baked in here; surfaces vary by
+ * platform (dashboard: info toast via `addInfoNotification` per #4878;
+ * mobile app: inline status strip in `SessionScreen` per #4879). The
+ * `now` parameter is injected so tests can pin the timestamp without
+ * touching `Date.now()`.
+ */
+export function handleSessionStopped(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+  now: () => number = Date.now,
+): SessionPatch {
+  // `code` is optional on the wire (ServerSessionStoppedSchema). Preserve
+  // 0 explicitly — it's the common clean-SIGINT-exit case and is a
+  // meaningful signal, not a "missing" value. Non-finite numbers (NaN,
+  // Infinity from a buggy producer) collapse to null so renderers don't
+  // need to defend against them.
+  const code = typeof msg.code === 'number' && Number.isFinite(msg.code) ? msg.code : null
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    patch: {
+      stoppedAt: now(),
+      stoppedCode: code,
+    },
   }
 }
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -367,6 +367,9 @@ export {
   handleCheckpointRestored,
   handleError,
   handleSessionError,
+  // #4879: quiet "user-initiated Stop" confirmation handler — flips
+  // stoppedAt/stoppedCode on the target session for the inline status strip
+  handleSessionStopped,
   handleLogEntry,
   handleClientJoined,
   handleClientLeft,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -662,6 +662,34 @@ export interface BaseSessionState {
    */
   lastClientActivityAt: number | null;
   health: SessionHealth;
+  /**
+   * #4879 — quiet "user-initiated Stop" confirmation marker. Set by the
+   * `session_stopped` handler (which receives the server-broadcast wire
+   * message wired in #4868) to `Date.now()` when the child process exits
+   * cleanly after the user tapped Stop. Null at all other times.
+   *
+   * Distinct from `health: 'crashed'` (loud unexpected-exit error UX) and
+   * from `claudeReady: false` (transient between-turns idle). Renderers
+   * use this to surface a calm, informational status strip ("Session
+   * stopped." / "Session stopped. exit N") that the operator can choose
+   * to act on — typically by sending another message (which clears
+   * `stoppedAt` on the next `claude_ready`) or by deleting the session.
+   *
+   * Cleared when a fresh `claude_ready` arrives for the same session
+   * (server restarted the child after the next user input) — the call
+   * sites in app/dashboard message-handler clear it alongside the
+   * `claudeReady: true` patch returned from `handleClaudeReady`.
+   */
+  stoppedAt: number | null;
+  /**
+   * #4879 — child process exit code reported by the server alongside
+   * `session_stopped`. Null when the wire message omitted it (e.g.
+   * future in-process providers per the #4756 follow-up) or when the
+   * session is not currently in the stopped state (`stoppedAt == null`).
+   * Renderers surface a non-zero code as a small "(exit N)" suffix; code
+   * 0 is the common clean-exit case and renders bare.
+   */
+  stoppedCode: number | null;
   activeAgents: AgentInfo[];
   /**
    * #4308 — in-flight tool calls for this session, in arrival order. See

--- a/packages/store-core/src/utils.test.ts
+++ b/packages/store-core/src/utils.test.ts
@@ -24,6 +24,9 @@ describe('createEmptyBaseSessionState', () => {
       isIdle: true,
       lastClientActivityAt: null,
       health: 'healthy',
+      // #4879: quiet "Stop confirmed" marker — null until session_stopped lands
+      stoppedAt: null,
+      stoppedCode: null,
       activeAgents: [],
       activeTools: [],
       // #4307: empty array on init — populated by background_work_changed

--- a/packages/store-core/src/utils.ts
+++ b/packages/store-core/src/utils.ts
@@ -79,6 +79,10 @@ export function createEmptyBaseSessionState(): BaseSessionState {
     isIdle: true,
     lastClientActivityAt: null,
     health: 'healthy',
+    // #4879: null = session not in stopped state. Set to Date.now() when
+    // session_stopped wire message arrives; cleared on next claude_ready.
+    stoppedAt: null,
+    stoppedCode: null,
     activeAgents: [],
     activeTools: [],
     // #4307: empty until the first background_work_changed event or


### PR DESCRIPTION
Closes #4879

Follow-up to #4756 / PR #4868 (server-side wire path) and pairs with the parallel dashboard PR #4878.

## Summary

- Adds shared `handleSessionStopped` to `@chroxy/store-core` — returns a `SessionPatch` that flips `stoppedAt` (Date.now) and `stoppedCode` (server-reported exit code; null when omitted, 0 preserved as a meaningful clean-SIGINT signal) on the target session.
- `handleClaudeReady` now also returns `stoppedAt: null` / `stoppedCode: null` so the quiet strip auto-dismisses when the server restarts the child after the next user input.
- `BaseSessionState` gains two purely-additive fields (`stoppedAt`, `stoppedCode`); defaults wired through `createEmptyBaseSessionState` + the dashboard's flat-state fallback for parity.
- Mobile `message-handler.ts` adds `case 'session_stopped':` that applies the shared patch. **NO Alert / push notification** — confirmation is intentionally inline, not modal.
- `SessionScreen.tsx` subscribes to the new fields and renders a subtle muted-background status strip ("`Session stopped.`" / "`Session stopped. exit N`" for non-zero codes) positioned alongside the existing crashed banner. Suppressed when `health === 'crashed'` so the louder crash UX wins on the unlikely race where both fire.
- `handler-coverage` contract: `session_stopped` moves from `INTENTIONALLY_UNHANDLED` to `PLATFORM_SPECIFIC: 'app'`. Once #4878 (dashboard parity) merges, both entries can be dropped.

## Why a state field rather than a transient toast

The issue called out "a subtle non-error UI state — e.g. session header shows 'stopped' + greyed out". A persistent muted strip matches that better than a fire-and-forget toast — the operator can glance at the screen long after the Stop click and still see why the session is quiet. The strip clears itself the moment activity resumes (`claude_ready`).

## Test plan

- [x] `store-core/handlers/handlers.test.ts` — 7 new cases for `handleSessionStopped` (explicit sessionId, activeSessionId fallback, code 0 preserved, missing code, non-numeric/NaN/Infinity defensive collapse, sessionId: null when no fallback, default Date.now); updated `handleClaudeReady` shape assertion
- [x] `store-core/utils.test.ts` — `createEmptyBaseSessionState` shape updated
- [x] `app/__tests__/store/message-handler.test.ts` — 5 cases for `case 'session_stopped':` (explicit target, legacy-cli fallback, missing code, NO Alert, unknown sessionId ignored) + `claude_ready` auto-dismiss
- [x] `app/__tests__/screens/SessionScreenStoppedBanner.test.ts` — source-text gate verifying selectors, conditional, copy variants, muted styling, testIDs, and that the case branch never fires an Alert / pushSessionNotification (no `@testing-library/react-native` in repo — same pattern as `SessionOverview.test.ts`)
- [x] `protocol/tests/handler-coverage.test.js` — PLATFORM_SPECIFIC transition validated
- [x] All store-core tests (1018), all app tests (1511), all dashboard tests (2568), all protocol tests (156) — green
- [x] `tsc --noEmit` clean for app, store-core, dashboard