### PR TITLE
test(server): pin trailing \r on mixed multi-question forms + forensic timing (#4884)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2871,9 +2871,13 @@ export class ClaudeTuiSession extends BaseSession {
     // Focus lands on `❯ 1. Submit answers / 2. Cancel` after the last
     // question — press 1 to confirm submission.
     // #4884: tag the Submit position with a marker object so
-    // _writePtyMultiQuestionSequence can record the wall-clock at which
-    // Submit-'1' actually hit the PTY (used by _emitToolHookEvent's
-    // PostToolUse handler to log the Submit→PostToolUse delta).
+    // _writePtyMultiQuestionSequence can record the wall-clock at the
+    // point the writer reaches Submit (immediately before the `'1'` is
+    // written to the PTY, after any preceding settle has elapsed). Used
+    // by _emitToolHookEvent's PostToolUse handler to log the
+    // Submit→PostToolUse delta — the marker timestamp is the lower bound
+    // for when '1' actually leaves the writer (within
+    // PROMPT_CHAR_DELAY_MS of the actual write).
     if (prevToolUseId) {
       sequence.push({ type: 'mark', label: 'submit', toolUseId: prevToolUseId })
     }
@@ -2928,7 +2932,7 @@ export class ClaudeTuiSession extends BaseSession {
    * `_multiQuestionSubmitAt`. PostToolUse for that toolUseId logs the
    * delta — forensic evidence the defensive trailing '\r' lands harmlessly.
    *
-   * @param {Array<string|number|object>} sequence — strings to write, numbers to sleep, marker objects to timestamp
+   * @param {Array<string|number|{type:'mark',label:string,toolUseId:string}>} sequence — strings to write, numbers to sleep, marker objects to timestamp
    * @returns {Promise<boolean>} true if completed, false if PTY aborted mid-write
    */
   async _writePtyMultiQuestionSequence(sequence) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -441,6 +441,17 @@ export class ClaudeTuiSession extends BaseSession {
     // _onAskUserQuestionStall clears busy state + emits an error so the
     // session is recoverable. Cleared on PostToolUse + destroy().
     this._askUserQuestionWatchdog = null
+    // #4884: forensic timing for the defensive trailing '\r' added in
+    // #4867 / #4886 — record the wall-clock at which Submit-'1' is written
+    // to the PTY for each multi-question form, keyed by toolUseId. On the
+    // matching PostToolUse we log the delta at INFO so live mixed-form
+    // submissions generate evidence that the trailing '\r' (which lands
+    // ~1ms after Submit-'1' on the mixed path) is harmless. Map (not
+    // single field) to mirror _pendingUserAnswers — parallel AskUserQuestion
+    // tool_use blocks in one turn each get an independent submit-time entry.
+    // Entries are pruned when the matching PostToolUse fires OR when the
+    // teardown / watchdog stall path clears the form.
+    this._multiQuestionSubmitAt = new Map()
     // #4732: effective pre-first-output timeout in ms. Distinct from
     // _streamStallTimeoutMs (#4638) — that watchdog only re-arms BETWEEN
     // hook events, so a turn where claude TUI accepts the prompt write
@@ -516,12 +527,21 @@ export class ClaudeTuiSession extends BaseSession {
   _pendingUserAnswers_clearAll() {
     this._pendingUserAnswers.clear()
     this._lastPendingAnswerToolUseId = null
+    // #4884: parallel cleanup so stale submit-timing entries don't leak
+    // when a teardown path wipes the pending answers (the forensic log
+    // only fires when PostToolUse arrives; if teardown won the race, the
+    // submit-time entry would otherwise sit there until destroy()).
+    if (this._multiQuestionSubmitAt) this._multiQuestionSubmitAt.clear()
   }
 
   /** Internal: drop a specific pending answer entry (PostToolUse cleanup). */
   _clearPendingAnswerByToolUseId(toolUseId) {
     if (!toolUseId) return
     this._pendingUserAnswers.delete(toolUseId)
+    // #4884: parallel cleanup of the submit-timing entry for the same
+    // toolUseId. Idempotent — no-op when the entry was already consumed
+    // by PostToolUse's delta log.
+    if (this._multiQuestionSubmitAt) this._multiQuestionSubmitAt.delete(toolUseId)
     if (this._lastPendingAnswerToolUseId === toolUseId) {
       // Advance the "most recent" pointer to whichever entry was set most
       // recently after the one we just removed (insertion-order via Map
@@ -1692,6 +1712,22 @@ export class ClaudeTuiSession extends BaseSession {
     // above stores the pending entry under THAT synthesized id. Gating
     // cleanup on `payload.tool_use_id` would skip the clear for those
     // builds and leak Map entries indefinitely.
+    // #4884: forensic timing for the defensive trailing '\r' (#4867 / #4886).
+    // If this PostToolUse matches a multi-question form we just drove,
+    // log the wall-clock from Submit-'1' write to PostToolUse arrival at
+    // INFO. The trailing '\r' is sent ~1ms after Submit-'1' (per-char
+    // throttle), so any "spurious empty-prompt activity" theory shows up
+    // as an outlier-large delta. After ~10 captured submissions show
+    // clean numbers, this log line can be downgraded to DEBUG. MUST run
+    // before _clearPendingAnswerByToolUseId below — that helper also
+    // clears _multiQuestionSubmitAt in lockstep with _pendingUserAnswers,
+    // so the timestamp would be gone by the time we read it.
+    if (toolName === 'AskUserQuestion' && toolUseId && this._multiQuestionSubmitAt.has(toolUseId)) {
+      const submitAt = this._multiQuestionSubmitAt.get(toolUseId)
+      this._multiQuestionSubmitAt.delete(toolUseId)
+      const deltaMs = Date.now() - submitAt
+      ;(this._log || log).info(`AskUserQuestion multi-question: Submit→PostToolUse=${deltaMs}ms (tool=${toolUseId}) — forensic for #4884 trailing-'\\r' verification`)
+    }
     if (toolName === 'AskUserQuestion' && toolUseId) {
       this._clearPendingAnswerByToolUseId(toolUseId)
     }
@@ -2834,6 +2870,13 @@ export class ClaudeTuiSession extends BaseSession {
     }
     // Focus lands on `❯ 1. Submit answers / 2. Cancel` after the last
     // question — press 1 to confirm submission.
+    // #4884: tag the Submit position with a marker object so
+    // _writePtyMultiQuestionSequence can record the wall-clock at which
+    // Submit-'1' actually hit the PTY (used by _emitToolHookEvent's
+    // PostToolUse handler to log the Submit→PostToolUse delta).
+    if (prevToolUseId) {
+      sequence.push({ type: 'mark', label: 'submit', toolUseId: prevToolUseId })
+    }
     sequence.push('1')
     // #4635 — defensive trailing Enter. The empirical mixed-form recording
     // pinned `'1'` as immediate-submit (no Enter needed); on the mixed
@@ -2844,6 +2887,11 @@ export class ClaudeTuiSession extends BaseSession {
     // is one of the live-debugged hypotheses for the wedge (Option B in
     // the issue). Costs nothing on the path that already works; potentially
     // saves the path that doesn't.
+    // #4884: per the issue, mixed-form (single + multi mix) live verification
+    // of the trailing `\r` was deferred — the #4290 single-q precedent
+    // applies, but mixed multi-question is a different TUI state. The
+    // Submit-mark above + PostToolUse delta log give forensic evidence
+    // that the trailing `\r` lands harmlessly on every mixed-form submit.
     sequence.push('\r')
 
     const keystrokeCount = sequence.filter((x) => typeof x === 'string').length
@@ -2873,7 +2921,14 @@ export class ClaudeTuiSession extends BaseSession {
    * needs a beat after the last single-select auto-advance — see
    * MULTI_QUESTION_SUBMIT_SETTLE_MS).
    *
-   * @param {Array<string|number>} sequence — strings to write, numbers to sleep
+   * #4884 — sequence entries may also be `{ type: 'mark', label, toolUseId }`
+   * marker objects. Markers are not written to the PTY; they record the
+   * wall-clock at the point the writer reaches them (after any preceding
+   * settle has elapsed but BEFORE the next byte is written) into
+   * `_multiQuestionSubmitAt`. PostToolUse for that toolUseId logs the
+   * delta — forensic evidence the defensive trailing '\r' lands harmlessly.
+   *
+   * @param {Array<string|number|object>} sequence — strings to write, numbers to sleep, marker objects to timestamp
    * @returns {Promise<boolean>} true if completed, false if PTY aborted mid-write
    */
   async _writePtyMultiQuestionSequence(sequence) {
@@ -2884,6 +2939,13 @@ export class ClaudeTuiSession extends BaseSession {
         if (this._activeTurn?.aborted || this._ptyExited) return false
         if (typeof item === 'number') {
           if (item > 0) await new Promise((resolve) => setTimeout(resolve, item))
+          continue
+        }
+        if (item && typeof item === 'object' && item.type === 'mark') {
+          // #4884 — record submit-time marker for the PostToolUse delta log.
+          if (item.label === 'submit' && item.toolUseId) {
+            this._multiQuestionSubmitAt.set(item.toolUseId, Date.now())
+          }
           continue
         }
         this._term.write(item)

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -4715,6 +4715,247 @@ describe('ClaudeTuiSession', () => {
         'options still points at questions[0].options for back-compat')
     })
 
+    // #4884 — extend trailing-`'\r'` coverage to MIXED multi-question forms
+    // (single + multi-select mix). The #4867 fix added a defensive trailing
+    // `'\r'` for ALL multi-question forms; #4886 fixed the cross-PR test
+    // breakage. Live verification ran on the all-single-select shape (the
+    // wedge case). The mixed-form path inherits the trailing `'\r'` based
+    // on the #4290 single-q precedent, but the issue (#4884) calls out that
+    // mixed multi-question is a different TUI state — explicit assertion-
+    // level coverage of every mixed-form last-question shape pins that
+    // shape drift in the driver doesn't silently drop the trailing `'\r'`.
+    describe('trailing \\r on mixed multi-question forms (#4884)', () => {
+      // Shape: S+M (last is multi-select). #4867 sequence ends with
+      // `'\t'` (commit + advance to Submit) + `'1'` (Submit) + `'\r'`
+      // (defensive trailer). No settle — `'\t'` already settles.
+      it('S+M shape: trailing \\r lands immediately after Submit (no settle)', async () => {
+        const writeEvents = []
+        session._term = {
+          write: (data) => { writeEvents.push({ data, t: Date.now() }) },
+          kill: () => {},
+        }
+        const questions = [
+          { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+          { question: 'Q2?', multiSelect: true, options: [{ label: 'p' }, { label: 'q' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_sm', questions, options: questions[0].options }
+
+        session.respondToQuestion('', { 'Q1?': 'a', 'Q2?': ['p', 'q'] })
+        await new Promise((resolve) => setTimeout(resolve, 200))
+
+        const writes = writeEvents.map((e) => e.data)
+        assert.deepEqual(
+          writes,
+          ['\x1b[?2004l', '1', '1', '2', '\t', '1', '\r', '\x1b[?2004h'],
+          `S+M shape must end with Submit '1' + trailing '\\r', got ${JSON.stringify(writes)}`,
+        )
+
+        // The Submit → '\r' gap must be ~per-char throttle (1ms), proving
+        // the trailing '\r' lands AFTER Submit-'1' (the issue's concern
+        // is the inverse — that it'd race ahead and land on the prompt).
+        const submitIdx = writes.lastIndexOf('1')
+        const enterIdx = writes.lastIndexOf('\r')
+        assert.ok(submitIdx >= 0 && enterIdx > submitIdx, 'trailing \\r is after Submit')
+        const gapMs = writeEvents[enterIdx].t - writeEvents[submitIdx].t
+        assert.ok(
+          gapMs < 50,
+          `Submit '1' → trailing '\\r' gap must be ~per-char throttle, got ${gapMs}ms`,
+        )
+      })
+
+      // Shape: M+S+M (multi → single → multi). Last is multi → no settle,
+      // trailing '\r' still pinned. Catches a regression where someone
+      // gates the trailing '\r' on the lastIsSingleSelect branch.
+      it('M+S+M shape: trailing \\r still pinned (no settle)', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        const questions = [
+          { question: 'Q1?', multiSelect: true, options: [{ label: 'a' }, { label: 'b' }] },
+          { question: 'Q2?', options: [{ label: 'p' }, { label: 'q' }] },
+          { question: 'Q3?', multiSelect: true, options: [{ label: 'x' }, { label: 'y' }, { label: 'z' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_msm', questions, options: questions[0].options }
+
+        session.respondToQuestion('', {
+          'Q1?': ['a'],         // → '1' + '\t'
+          'Q2?': 'q',            // → '2' (auto-advances)
+          'Q3?': ['x', 'z'],     // → '1' '3' + '\t'
+        })
+        await new Promise((resolve) => setTimeout(resolve, 200))
+
+        // Last q is multi → no settle. Submit '1' + trailing '\r' still pinned.
+        assert.deepEqual(
+          writes,
+          ['\x1b[?2004l', '1', '\t', '2', '1', '3', '\t', '1', '\r', '\x1b[?2004h'],
+          `M+S+M sequence with trailing '\\r' broke, got ${JSON.stringify(writes)}`,
+        )
+      })
+
+      // Shape: S+M+S (single → multi → single). Last is single → settle
+      // fires AND trailing '\r' still pinned. The settle proves the
+      // last-q-shape decision; the '\r' proves the defensive trailer.
+      it('S+M+S shape: settle fires AND trailing \\r still pinned', async () => {
+        const writeEvents = []
+        session._term = {
+          write: (data) => { writeEvents.push({ data, t: Date.now() }) },
+          kill: () => {},
+        }
+        const questions = [
+          { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+          { question: 'Q2?', multiSelect: true, options: [{ label: 'p' }, { label: 'q' }] },
+          { question: 'Q3?', options: [{ label: 'x' }, { label: 'y' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_sms', questions, options: questions[0].options }
+
+        session.respondToQuestion('', {
+          'Q1?': 'a',           // → '1'
+          'Q2?': ['p', 'q'],    // → '1' '2' + '\t'
+          'Q3?': 'y',           // → '2' (auto-advances; last q so settle fires)
+        })
+        await new Promise((resolve) => setTimeout(resolve, 300))
+
+        const writes = writeEvents.map((e) => e.data)
+        assert.deepEqual(
+          writes,
+          ['\x1b[?2004l', '1', '1', '2', '\t', '2', '1', '\r', '\x1b[?2004h'],
+          `S+M+S sequence with trailing '\\r' broke, got ${JSON.stringify(writes)}`,
+        )
+
+        // Settle present: gap between last single-digit ('2' of Q3) and
+        // Submit '1' >= 140ms.
+        const q3DigitIdx = writes.indexOf('2', writes.indexOf('\t'))
+        const submitIdx = writes.indexOf('1', q3DigitIdx + 1)
+        const settleMs = writeEvents[submitIdx].t - writeEvents[q3DigitIdx].t
+        assert.ok(settleMs >= 140, `expected settle >= 140ms for last-q single-select, got ${settleMs}ms`)
+
+        // Trailing '\r' immediately after Submit (no settle).
+        const enterIdx = writes.lastIndexOf('\r')
+        assert.ok(enterIdx > submitIdx, 'trailing \\r is after Submit')
+        const trailerGapMs = writeEvents[enterIdx].t - writeEvents[submitIdx].t
+        assert.ok(
+          trailerGapMs < 50,
+          `Submit '1' → trailing '\\r' gap must be ~per-char throttle, got ${trailerGapMs}ms`,
+        )
+      })
+
+      // Forensic timing log (#4884 acceptance criterion #1): when PostToolUse
+      // for AskUserQuestion arrives after a multi-question submit, an INFO
+      // line emits the wall-clock delta from Submit-'1' write to PostToolUse
+      // arrival. After ~10 live captures (per the issue's AC#2), the log
+      // line can be downgraded to DEBUG.
+      it('PostToolUse logs Submit→PostToolUse delta at INFO (#4884)', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        // Mixed S+M+S form — last is single so settle path also exercised.
+        const questions = [
+          { question: 'Q1?', options: [{ label: 'a' }, { label: 'b' }] },
+          { question: 'Q2?', multiSelect: true, options: [{ label: 'p' }, { label: 'q' }] },
+          { question: 'Q3?', options: [{ label: 'x' }, { label: 'y' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_forensic', questions, options: questions[0].options }
+
+        session.respondToQuestion('', { 'Q1?': 'a', 'Q2?': ['p'], 'Q3?': 'y' })
+        await new Promise((resolve) => setTimeout(resolve, 300))
+
+        // The Submit marker recorded a timestamp on the session — verify
+        // the writer dispatched the marker BEFORE the Submit byte.
+        assert.ok(
+          session._multiQuestionSubmitAt.has('toolu_forensic'),
+          `expected Submit marker timestamp recorded for the form, got keys=${[...session._multiQuestionSubmitAt.keys()].join(',')}`,
+        )
+
+        // Simulate the matching PostToolUse arriving 50ms later.
+        await new Promise((resolve) => setTimeout(resolve, 50))
+        session._emitToolHookEvent('PostToolUse', {
+          tool_use_id: 'toolu_forensic',
+          tool_name: 'AskUserQuestion',
+          tool_response: '',
+        }, 'msg-post-forensic')
+
+        const forensicInfo = infoLines.find((m) => /Submit.PostToolUse=\d+ms/.test(m) && /toolu_forensic/.test(m))
+        assert.ok(
+          forensicInfo,
+          `expected INFO forensic line for #4884, got infoLines=${JSON.stringify(infoLines)}`,
+        )
+        assert.match(forensicInfo, /#4884/, 'forensic INFO line references the issue for triage')
+
+        // Submit-time entry is consumed on PostToolUse so the Map doesn't
+        // accumulate stale entries across many forms.
+        assert.equal(
+          session._multiQuestionSubmitAt.has('toolu_forensic'),
+          false,
+          'submit-time entry cleared after the forensic log fires',
+        )
+      })
+
+      // Negative: PostToolUse for a non-multi-question AskUserQuestion (the
+      // single-question text-driven path doesn't record a Submit marker)
+      // does NOT emit the forensic log. Pins the scope to multi-question
+      // forms so the log doesn't accidentally fire for single-q happy paths.
+      it('PostToolUse for single-question form does NOT emit forensic log (#4884)', async () => {
+        const writes = []
+        session._term = { write: (data) => { writes.push(data) }, kill: () => {} }
+        const questions = [
+          { question: 'Solo?', options: [{ label: 'a' }, { label: 'b' }] },
+        ]
+        session._pendingUserAnswer = { toolUseId: 'toolu_single_only', questions, options: questions[0].options }
+
+        session.respondToQuestion('a')
+        await new Promise((resolve) => setTimeout(resolve, 50))
+
+        // Single-question path does NOT use _writePtyMultiQuestionSequence,
+        // so no Submit marker is recorded.
+        assert.equal(
+          session._multiQuestionSubmitAt.has('toolu_single_only'),
+          false,
+          'single-question path must not record a Submit marker',
+        )
+
+        session._emitToolHookEvent('PostToolUse', {
+          tool_use_id: 'toolu_single_only',
+          tool_name: 'AskUserQuestion',
+          tool_response: '',
+        }, 'msg-single-post')
+
+        const forensicInfo = infoLines.find((m) => /Submit.PostToolUse=\d+ms/.test(m))
+        assert.equal(
+          forensicInfo,
+          undefined,
+          `single-question path must not emit forensic INFO, got infoLines=${JSON.stringify(infoLines)}`,
+        )
+      })
+
+      // Cleanup: when a teardown path (stall watchdog, _teardownTurn) wipes
+      // _pendingUserAnswers, the parallel _multiQuestionSubmitAt entries
+      // must also be cleared. Otherwise a teardown that wins the race
+      // against PostToolUse leaks the submit-time entry until destroy().
+      it('_pendingUserAnswers_clearAll wipes parallel submit-time entries (#4884)', () => {
+        session._multiQuestionSubmitAt.set('toolu_a', Date.now())
+        session._multiQuestionSubmitAt.set('toolu_b', Date.now())
+        session._pendingUserAnswers.set('toolu_a', { toolUseId: 'toolu_a', questions: [], options: [] })
+
+        session._pendingUserAnswers_clearAll()
+
+        assert.equal(session._multiQuestionSubmitAt.size, 0, 'submit-time map cleared in lockstep')
+      })
+
+      // Per-toolUseId cleanup parity: _clearPendingAnswerByToolUseId
+      // (the PostToolUse cleanup path) also drops the matching submit-time
+      // entry so a late-arriving PostToolUse for a torn-down form doesn't
+      // emit a forensic log with a stale (wall-clock-impossible) delta.
+      it('_clearPendingAnswerByToolUseId drops matching submit-time entry (#4884)', () => {
+        session._multiQuestionSubmitAt.set('toolu_x', Date.now())
+        session._multiQuestionSubmitAt.set('toolu_y', Date.now())
+        session._pendingUserAnswers.set('toolu_x', { toolUseId: 'toolu_x', questions: [], options: [] })
+        session._pendingUserAnswers.set('toolu_y', { toolUseId: 'toolu_y', questions: [], options: [] })
+
+        session._clearPendingAnswerByToolUseId('toolu_x')
+
+        assert.equal(session._multiQuestionSubmitAt.has('toolu_x'), false, 'cleared toolu_x submit time')
+        assert.equal(session._multiQuestionSubmitAt.has('toolu_y'), true, 'kept toolu_y submit time (per-id scope)')
+      })
+    })
+
     // #4625 — 10+ option questions. claude TUI's single-digit hotkey
     // alphabet only covers indices 0..8 (digits '1'..'9'). The pre-#4625
     // driver silently defaulted picks of options 10+ to option 1 (with a


### PR DESCRIPTION
Closes #4884

## Context

#4867 added a defensive trailing `'\r'` after the Submit `'1'` for ALL multi-question AskUserQuestion forms (including mixed forms that previously worked fine without it). Live verification ran on the all-single-select shape (the #4635 wedge case). The justification for mixed forms rests on the #4290 single-q precedent — "trailing Enter is redundant but harmless at the prompt." That precedent was validated on the SINGLE-question codepath, where the TUI is in a different state when the Enter lands.

For mixed multi-question forms, the `'\r'` is sent through `_writePtyMultiQuestionSequence` with only 1ms between the Submit `'1'` and the `'\r'`. The issue documents the risk: if `'1'` immediately submits and returns the TUI to the main prompt before the 1ms throttle ticks, the `'\r'` lands as a bare Enter at the main prompt.

## What this PR does

Adds two layers of evidence the trailing `'\r'` lands harmlessly on mixed-form submissions:

1. **Assertion-level shape coverage** for every mixed-form last-question shape (S+M, M+S+M, S+M+S), pinning the trailing `'\r'` position + verifying it lands ~1ms after Submit `'1'` (not racing ahead). Catches any future regression that gates the trailing `'\r'` on the `lastIsSingleSelect` branch and silently drops it for mixed forms.

2. **Forensic timing log** (the issue's AC#1): a Submit-position marker in the keystroke sequence records wall-clock when the writer reaches it; the PostToolUse handler logs the Submit→PostToolUse delta at INFO with the toolUseId + `#4884` tag. Live mixed-form submissions generate forensic evidence — any outlier-large delta surfaces a "spurious empty-prompt activity" regression in chroxy.log.

The forensic INFO line can be downgraded to DEBUG (or removed) after ~10 live captures show clean numbers, per the issue's AC#2 / AC#3.

## Implementation

- New `_multiQuestionSubmitAt` Map on the session (keyed by toolUseId), mirrors `_pendingUserAnswers` so parallel AskUserQuestion tool_use blocks in one turn each get independent submit-time entries.
- `_pendingUserAnswers_clearAll` + `_clearPendingAnswerByToolUseId` parallel-clear the submit-time map so teardown paths don't leak entries.
- `_writePtyMultiQuestionSequence` accepts a third sequence entry type (`{ type: 'mark', label, toolUseId }`); marker entries record the wall-clock without writing to the PTY.
- PostToolUse handler reads + clears the submit-time entry BEFORE `_clearPendingAnswerByToolUseId` (which would otherwise wipe it in lockstep).

## Test plan

- [x] S+M shape: trailing `'\r'` lands immediately after Submit (no settle)
- [x] M+S+M shape: trailing `'\r'` still pinned when last is multi-select
- [x] S+M+S shape: settle + trailing `'\r'` both fire on last-single-select
- [x] Forensic INFO line emits Submit→PostToolUse delta for multi-question
- [x] Forensic INFO does NOT fire for single-question text-driven path
- [x] `_pendingUserAnswers_clearAll` wipes the parallel submit-time map
- [x] `_clearPendingAnswerByToolUseId` drops the matching entry per-id
- [x] All 200 `claude-tui-session.test.js` tests pass
- [x] `./scripts/lint-tests-state-file-path.sh` OK
- [x] `./scripts/lint-session-opt-forwarding.sh` OK
- [x] `./scripts/lint-logger-session-scoping.sh` OK
- [ ] Live verify: 10 mixed-form submissions to confirm Submit→PostToolUse delta is consistent (~per-char throttle, no outliers)

## Related

- #4867 — added the trailing `'\r'`
- #4886 — cross-PR test breakage fix for #4867 / #4848
- #4290 — single-q trailing-Enter precedent