### PR TITLE
feat(server): emit 'stopped' from SDK/Codex/Gemini sessions for provider parity (#4881)

### DIFF
--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -158,6 +158,19 @@ export class JsonlSubprocessSession extends BaseSession {
     // Skills MVP (#2957) — providers without a system-prompt flag (Codex,
     // Gemini) prepend skills text to the first user message only.
     this._skillsPrepended = false
+    // #4881: provider parity with CliSession's #4602 _intentionalStop flag.
+    // Set by `interrupt()` immediately before SIGINT-ing the child, then
+    // consumed inside `proc.on('close')` so a user-initiated Stop:
+    //   - suppresses the loud "{provider} process exited with code N" error
+    //     emit (SIGINT exits the JSONL subprocess with code 130 or null
+    //     depending on the CLI), and
+    //   - emits a single transient `stopped` event with the exit `code` so
+    //     the dashboard/mobile UX can render the same quiet confirmation
+    //     surface PR #4868 wired for CliSession.
+    // Single-use: cleared on every close path (close, destroy) so the flag
+    // never leaks past one sendMessage cycle. Matches CliSession's
+    // capture-and-clear discipline in `_handleChildClose`.
+    this._intentionalStop = false
   }
 
   start() {
@@ -175,6 +188,9 @@ export class JsonlSubprocessSession extends BaseSession {
     this._destroying = true
     this._processReady = false
     this._isBusy = false
+    // #4881: clear so a teardown after interrupt() never leaks the flag past
+    // this session instance. Mirrors CliSession.destroy() (#4602).
+    this._intentionalStop = false
     if (this._process) {
       try {
         this._process.kill('SIGTERM')
@@ -185,11 +201,15 @@ export class JsonlSubprocessSession extends BaseSession {
   }
 
   interrupt() {
-    if (this._process) {
-      try {
-        this._process.kill('SIGINT')
-      } catch { /* already dead */ }
-    }
+    if (!this._process) return
+    // #4881: mark the imminent child exit as user-initiated so the
+    // proc.on('close') handler suppresses the "exited with code N" error and
+    // instead emits a quiet `stopped` event with the exit code. Cleared in
+    // the close handler (single-use, mirrors CliSession #4602).
+    this._intentionalStop = true
+    try {
+      this._process.kill('SIGINT')
+    } catch { /* already dead */ }
   }
 
   setPermissionMode(_mode) {
@@ -381,12 +401,24 @@ export class JsonlSubprocessSession extends BaseSession {
     proc.on('close', (code) => {
       this._process = null
       this._isBusy = false
+      // #4881: capture-and-clear BEFORE the _destroying short-circuit so the
+      // flag never leaks past a close even when destroy() fires first.
+      // Mirrors CliSession._handleChildClose (#4602).
+      const wasIntentionalStop = this._intentionalStop
+      this._intentionalStop = false
       if (this._destroying) return
       if (ctx.didStreamStart) {
         this.emit('stream_end', { messageId: ctx.messageId })
         ctx.didStreamStart = false
       }
-      if (code !== 0 && code !== null) {
+      if (wasIntentionalStop) {
+        // #4881: user clicked Stop — interrupt() set the flag, SIGINT brought
+        // the child down. Skip the loud "{provider} process exited with code
+        // N" error surface and emit the quiet `stopped` event for parity
+        // with CliSession (#4868). SIGINT typically exits with 130 or null
+        // depending on the CLI; both are user-initiated and not crashes.
+        this.emit('stopped', { code })
+      } else if (code !== 0 && code !== null) {
         // Prefer high-signal stderr; fall back to raw so the user always
         // sees *some* explanation when the child died.
         const sourceBuf = stderrBuf || rawStderrBuf

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -390,6 +390,18 @@ export class SdkSession extends BaseSession {
     // The per-call `error` event still fires on every refused sendMessage so
     // client UI feedback is unaffected.
     this._lastRefusedWarnTs = 0
+
+    // #4881: provider parity with CliSession's #4602 _intentionalStop flag.
+    // Set by `interrupt()` immediately before aborting the active SDK query
+    // generator, then consumed inside `_callQuery`'s try/catch/finally so a
+    // user-initiated Stop:
+    //   - suppresses the normal "Query error: AbortError" error emit, and
+    //   - emits a single transient `stopped` event (no `code` — SdkSession is
+    //     in-process, no child-process exit status to carry).
+    // Cleared on every consume path (close, error, destroy) so the flag never
+    // leaks past one turn — matches the single-use semantic CliSession pins
+    // in `_handleChildClose` (capture-and-clear up front).
+    this._intentionalStop = false
   }
 
   get sessionId() {
@@ -885,11 +897,26 @@ export class SdkSession extends BaseSession {
       if (streamState.hasStreamStarted) {
         this.emit('stream_end', { messageId })
       }
+      // #4881: capture-and-clear before any branch so the flag never leaks
+      // past this turn even when _destroying short-circuits the emits below.
+      // Mirrors CliSession._handleChildClose (#4602).
+      const wasIntentionalStop = this._intentionalStop
+      this._intentionalStop = false
       if (!this._destroying) {
-        // #4828: session-scoped when init has fired; falls back to module
-        // `log` for pre-init query failures (e.g. spawn refused).
-        ;(this._log || log).error(`Query error: ${err.message}`)
-        this.emit('error', { message: SdkSession._enrichErrorMessage(err.message) })
+        if (wasIntentionalStop) {
+          // #4881: user clicked Stop — interrupt() set the flag, the SDK
+          // generator threw an AbortError as a result. Skip the loud "Query
+          // error" surface and emit the quiet `stopped` event for parity
+          // with CliSession. No `code` because SDK runs in-process — there
+          // is no child-process exit status to carry.
+          ;(this._log || log).info('Query aborted after user stop')
+          this.emit('stopped', {})
+        } else {
+          // #4828: session-scoped when init has fired; falls back to module
+          // `log` for pre-init query failures (e.g. spawn refused).
+          ;(this._log || log).error(`Query error: ${err.message}`)
+          this.emit('error', { message: SdkSession._enrichErrorMessage(err.message) })
+        }
       }
       this._clearMessageState()
     } finally {
@@ -1340,6 +1367,12 @@ export class SdkSession extends BaseSession {
   async interrupt() {
     if (!this._query) return
 
+    // #4881: mark the imminent query teardown as user-initiated so the
+    // _callQuery catch block suppresses the AbortError-flavored "Query error"
+    // emit and instead surfaces a quiet `stopped` event. Cleared in the
+    // catch/finally (single-use, mirrors CliSession#4602).
+    this._intentionalStop = true
+
     // #4828: session-scoped (interrupt() only meaningful with an active query).
     ;(this._log || log).info('Interrupting query')
     try {
@@ -1545,6 +1578,9 @@ export class SdkSession extends BaseSession {
   destroy() {
     this._destroying = true
     this._pendingInput = []
+    // #4881: clear so a teardown after interrupt() never leaks the flag past
+    // this session instance. Mirrors CliSession.destroy() (#4602).
+    this._intentionalStop = false
 
     if (this._resultTimeout) {
       clearTimeout(this._resultTimeout)

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -921,6 +921,14 @@ export class SdkSession extends BaseSession {
       this._clearMessageState()
     } finally {
       this._query = null
+      // #4881: safety-net clear of _intentionalStop. The catch block clears
+      // it on the throw path (AbortError after interrupt()), but if
+      // query.interrupt() races a `result` message arriving first, the
+      // for-await loop exits normally, skipping the catch. Without this
+      // clear, the flag would stay armed until the next turn's catch and
+      // mis-trigger a spurious `stopped` emit there. Idempotent — the
+      // catch path already cleared it on the throw path.
+      this._intentionalStop = false
       // Dequeue any follow-up messages that arrived while busy
       if (this._pendingInput?.length && !this._destroying) {
         // #3562: if the SidecarProcess latched stdin_disabled mid-turn (e.g.

--- a/packages/server/tests/jsonl-subprocess-intentional-stop.test.js
+++ b/packages/server/tests/jsonl-subprocess-intentional-stop.test.js
@@ -43,13 +43,21 @@ import { waitFor } from './test-helpers.js'
 
 const shimPath = join(tmpdir(), `jsonl-stop-shim-${process.pid}-${Date.now()}.mjs`)
 
-function writeShim(lines, { exitCode = 0, stderr = '' } = {}) {
+function writeShim(lines, { exitCode = 0, stderr = '', exitDelayMs = 0 } = {}) {
   const payload = lines.map((l) => JSON.stringify(l)).join('\n')
+  // exitDelayMs: defer process.exit so the parent test can arm flags
+  // (_intentionalStop, _destroying) AFTER `await s.sendMessage(...)` resolves
+  // but BEFORE the shim closes. Without the delay the shim exits synchronously
+  // after spawn, racing the post-await flag assignments and intermittently
+  // firing the close handler with stale (unset) flags.
+  const exitCall = exitDelayMs > 0
+    ? `setTimeout(() => process.exit(${exitCode}), ${exitDelayMs})`
+    : `process.exit(${exitCode})`
   const body = [
     '#!/usr/bin/env node',
     `process.stdout.write(${JSON.stringify(payload + (payload ? '\n' : ''))})`,
     stderr ? `process.stderr.write(${JSON.stringify(stderr)})` : '',
-    `process.exit(${exitCode})`,
+    exitCall,
   ].filter(Boolean).join('\n')
   writeFileSync(shimPath, body)
   chmodSync(shimPath, 0o755)
@@ -208,7 +216,12 @@ describe('JsonlSubprocessSession proc.on(close) — intentional stop emits `stop
   })
 
   it('clears the flag even when _destroying short-circuits (no leak)', async () => {
-    writeShim([], { exitCode: 0 })
+    // exitDelayMs=50: shim defers process.exit so the close handler can NOT
+    // fire before the post-await flag assignments below land. Without the
+    // delay, the immediate-exit shim races the test's `_intentionalStop = true`
+    // / `_destroying = true` lines and the close handler observes the unset
+    // flags, intermittently masking the leak this test is meant to catch.
+    writeShim([], { exitCode: 0, exitDelayMs: 50 })
     const P = makeTestProviderClass()
     const s = new P({ cwd: '/tmp' })
     s._processReady = true
@@ -220,6 +233,7 @@ describe('JsonlSubprocessSession proc.on(close) — intentional stop emits `stop
 
     // Send message THEN both arm the flag and flip _destroying. The close
     // handler must clear the flag even though _destroying skips the emits.
+    // The shim's exitDelayMs guarantees this assignment lands before close.
     await s.sendMessage('hi')
     s._intentionalStop = true
     s._destroying = true

--- a/packages/server/tests/jsonl-subprocess-intentional-stop.test.js
+++ b/packages/server/tests/jsonl-subprocess-intentional-stop.test.js
@@ -1,0 +1,318 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { writeFileSync, unlinkSync, existsSync, chmodSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { JsonlSubprocessSession } from '../src/jsonl-subprocess-session.js'
+import { CodexSession } from '../src/codex-session.js'
+import { GeminiSession } from '../src/gemini-session.js'
+import { waitFor } from './test-helpers.js'
+
+/**
+ * Tests for the `_intentionalStop` flag added to JsonlSubprocessSession in
+ * #4881 — adds provider parity with CliSession's #4602 emit so Codex and
+ * Gemini sessions also surface a quiet `stopped` confirmation when the
+ * user clicks Stop (instead of the loud "{provider} process exited with
+ * code N" error toast).
+ *
+ * Codex + Gemini both extend JsonlSubprocessSession, so the flag + close-
+ * handler branch land in the base class once and both subclasses inherit
+ * the behaviour. The subclass tests below pin that inheritance directly
+ * (no per-provider override allowed).
+ *
+ * Invariants pinned here:
+ *   1. `_intentionalStop` starts false on every constructor (base + Codex +
+ *      Gemini).
+ *   2. `interrupt()` sets `_intentionalStop = true` AND SIGINTs the child.
+ *      Old behaviour ONLY SIGINTed — pin that interrupt() now also arms
+ *      the flag.
+ *   3. `proc.on('close')`, when `_intentionalStop` is true:
+ *        - suppresses the "exited with code N" error emit
+ *        - emits a single `stopped` event with the exit `code`
+ *        - clears the flag (single-use)
+ *   4. A subsequent natural non-zero exit (flag already cleared) still
+ *      flows through the normal error-emit path — regression guard.
+ *   5. `destroy()` always clears the flag.
+ *   6. interrupt() is a no-op (flag stays false) when no child process
+ *      exists.
+ */
+
+// ---------------------------------------------------------------------------
+// Test fixtures (mirrors jsonl-subprocess-session.test.js)
+// ---------------------------------------------------------------------------
+
+const shimPath = join(tmpdir(), `jsonl-stop-shim-${process.pid}-${Date.now()}.mjs`)
+
+function writeShim(lines, { exitCode = 0, stderr = '' } = {}) {
+  const payload = lines.map((l) => JSON.stringify(l)).join('\n')
+  const body = [
+    '#!/usr/bin/env node',
+    `process.stdout.write(${JSON.stringify(payload + (payload ? '\n' : ''))})`,
+    stderr ? `process.stderr.write(${JSON.stringify(stderr)})` : '',
+    `process.exit(${exitCode})`,
+  ].filter(Boolean).join('\n')
+  writeFileSync(shimPath, body)
+  chmodSync(shimPath, 0o755)
+}
+
+function cleanupShim() {
+  if (existsSync(shimPath)) unlinkSync(shimPath)
+}
+
+function makeTestProviderClass({
+  apiKey = 'TEST_API_KEY',
+  providerName = 'fake',
+  displayLabel = 'Fake',
+  messageIdPrefix = 'fake',
+  binary = process.execPath,
+} = {}) {
+  return class TestProvider extends JsonlSubprocessSession {
+    static get binaryCandidates() { return [binary] }
+    static get resolvedBinary() { return binary }
+    static get apiKeyEnv() { return apiKey }
+    static get providerName() { return providerName }
+    static get displayLabel() { return displayLabel }
+    static get messageIdPrefix() { return messageIdPrefix }
+
+    _buildArgs(text) { return [shimPath, text] }
+    _buildChildEnv() { return process.env }
+
+    _processJsonlLine(event, ctx) {
+      if (event.type === 'done') {
+        ctx.didEmitResult = true
+        this.emit('result', { cost: null, duration: null, usage: null, sessionId: null })
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('JsonlSubprocessSession _intentionalStop — constructor initialises to false (#4881)', () => {
+  it('base subclass starts with _intentionalStop=false', () => {
+    const P = makeTestProviderClass()
+    const s = new P({ cwd: '/tmp' })
+    assert.equal(s._intentionalStop, false)
+  })
+
+  it('CodexSession starts with _intentionalStop=false (inherits)', () => {
+    const s = new CodexSession({ cwd: '/tmp' })
+    assert.equal(s._intentionalStop, false,
+      'Codex must inherit the parity flag — provider-parity emit is gated on it')
+  })
+
+  it('GeminiSession starts with _intentionalStop=false (inherits)', () => {
+    const s = new GeminiSession({ cwd: '/tmp' })
+    assert.equal(s._intentionalStop, false,
+      'Gemini must inherit the parity flag — provider-parity emit is gated on it')
+  })
+})
+
+describe('JsonlSubprocessSession interrupt() arms _intentionalStop + SIGINTs child (#4881)', () => {
+  it('sets flag AND sends SIGINT when a child is running', () => {
+    const P = makeTestProviderClass()
+    const s = new P({ cwd: '/tmp' })
+    let sig = null
+    s._process = { kill: (signal) => { sig = signal } }
+
+    s.interrupt()
+
+    assert.equal(s._intentionalStop, true,
+      'interrupt() must arm the flag so the close handler emits stopped instead of error')
+    assert.equal(sig, 'SIGINT', 'interrupt() must SIGINT the child (existing behaviour)')
+  })
+
+  it('is a no-op when no child exists (flag stays false)', () => {
+    const P = makeTestProviderClass()
+    const s = new P({ cwd: '/tmp' })
+    s._process = null
+
+    s.interrupt()
+
+    assert.equal(s._intentionalStop, false,
+      'no child → no flag change (matches CliSession.interrupt() guard)')
+  })
+
+  it('Codex.interrupt() arms the flag (parity test through real subclass)', () => {
+    const s = new CodexSession({ cwd: '/tmp' })
+    let sig = null
+    s._process = { kill: (signal) => { sig = signal } }
+
+    s.interrupt()
+
+    assert.equal(s._intentionalStop, true)
+    assert.equal(sig, 'SIGINT')
+  })
+
+  it('Gemini.interrupt() arms the flag (parity test through real subclass)', () => {
+    const s = new GeminiSession({ cwd: '/tmp' })
+    let sig = null
+    s._process = { kill: (signal) => { sig = signal } }
+
+    s.interrupt()
+
+    assert.equal(s._intentionalStop, true)
+    assert.equal(sig, 'SIGINT')
+  })
+
+  it('swallows kill() errors but still arms the flag', () => {
+    const P = makeTestProviderClass()
+    const s = new P({ cwd: '/tmp' })
+    s._process = { kill: () => { throw new Error('ESRCH') } }
+
+    assert.doesNotThrow(() => s.interrupt())
+    assert.equal(s._intentionalStop, true,
+      'flag is set BEFORE kill() so a throwing already-dead child still arms the close branch')
+  })
+})
+
+describe('JsonlSubprocessSession proc.on(close) — intentional stop emits `stopped` not `error` (#4881)', () => {
+  const SAVED_ENV = process.env.TEST_API_KEY
+  beforeEach(() => { process.env.TEST_API_KEY = 'value' })
+  afterEach(() => {
+    if (SAVED_ENV !== undefined) process.env.TEST_API_KEY = SAVED_ENV
+    else delete process.env.TEST_API_KEY
+    cleanupShim()
+  })
+
+  it('emits `stopped` with the SIGINT exit code when flag is set', async () => {
+    // Shim exits 130 (SIGINT convention) WITHOUT emitting `done` so we
+    // can both pin that the error branch is suppressed AND that the
+    // exit code reaches the stopped payload.
+    writeShim([], { exitCode: 130 })
+    const P = makeTestProviderClass({ displayLabel: 'Quasar' })
+    const s = new P({ cwd: '/tmp' })
+    s._processReady = true
+
+    const errors = []
+    const stopped = []
+    s.on('error', (e) => errors.push(e))
+    s.on('stopped', (e) => stopped.push(e))
+    s.on('result', () => {})
+
+    // Arm the flag before the child closes — simulates the user-clicked-Stop
+    // path: interrupt() arms the flag before SIGINT, then SIGINT kills the
+    // child, then the close handler observes the flag and emits stopped.
+    s._intentionalStop = true
+    await s.sendMessage('hi')
+    await waitFor(() => stopped.length >= 1, { label: 'stopped event' })
+
+    assert.equal(errors.length, 0,
+      'intentional stop must suppress the "exited with code N" error emit')
+    assert.equal(stopped.length, 1, 'exactly one stopped event')
+    assert.equal(stopped[0].code, 130, 'stopped payload carries the SIGINT exit code')
+    assert.equal(s._intentionalStop, false,
+      'single-use: flag clears after the close handler consumes it')
+  })
+
+  it('clears the flag even when _destroying short-circuits (no leak)', async () => {
+    writeShim([], { exitCode: 0 })
+    const P = makeTestProviderClass()
+    const s = new P({ cwd: '/tmp' })
+    s._processReady = true
+
+    const errors = []
+    const stopped = []
+    s.on('error', (e) => errors.push(e))
+    s.on('stopped', (e) => stopped.push(e))
+
+    // Send message THEN both arm the flag and flip _destroying. The close
+    // handler must clear the flag even though _destroying skips the emits.
+    await s.sendMessage('hi')
+    s._intentionalStop = true
+    s._destroying = true
+    await waitFor(() => !s.isRunning, { label: 'isRunning false' })
+
+    assert.equal(s._intentionalStop, false,
+      'flag MUST clear even when _destroying suppresses emits — no leak')
+    assert.equal(stopped.length, 0, '_destroying suppresses stopped')
+    assert.equal(errors.length, 0, '_destroying suppresses error')
+  })
+})
+
+describe('JsonlSubprocessSession proc.on(close) — natural non-zero exit still emits error (regression #4881)', () => {
+  const SAVED_ENV = process.env.TEST_API_KEY
+  beforeEach(() => { process.env.TEST_API_KEY = 'value' })
+  afterEach(() => {
+    if (SAVED_ENV !== undefined) process.env.TEST_API_KEY = SAVED_ENV
+    else delete process.env.TEST_API_KEY
+    cleanupShim()
+  })
+
+  it('non-zero exit with flag=false emits error (existing behaviour preserved)', async () => {
+    writeShim([], { exitCode: 7 })
+    const P = makeTestProviderClass({ displayLabel: 'Crashy' })
+    const s = new P({ cwd: '/tmp' })
+    s._processReady = true
+
+    const errors = []
+    const stopped = []
+    s.on('error', (e) => errors.push(e))
+    s.on('stopped', (e) => stopped.push(e))
+    s.on('result', () => {})
+
+    await s.sendMessage('hi')
+    await waitFor(() => errors.length >= 1, { label: 'error event' })
+
+    assert.equal(errors.length, 1, 'natural crash must emit error')
+    assert.match(errors[0].message, /Crashy process exited with code 7/,
+      'standard crash message preserved')
+    assert.equal(stopped.length, 0, 'crash must NOT emit stopped')
+  })
+
+  it('zero exit with flag=false emits neither error nor stopped (happy path)', async () => {
+    writeShim([{ type: 'done' }], { exitCode: 0 })
+    const P = makeTestProviderClass()
+    const s = new P({ cwd: '/tmp' })
+    s._processReady = true
+
+    const errors = []
+    const stopped = []
+    const results = []
+    s.on('error', (e) => errors.push(e))
+    s.on('stopped', (e) => stopped.push(e))
+    s.on('result', (r) => results.push(r))
+
+    await s.sendMessage('hi')
+    await waitFor(() => results.length >= 1, { label: 'result' })
+    await waitFor(() => !s.isRunning, { label: 'close completes' })
+
+    assert.equal(errors.length, 0)
+    assert.equal(stopped.length, 0,
+      'clean turn end must NOT emit stopped — stopped is for user-initiated interrupts only')
+    assert.equal(results.length, 1)
+  })
+})
+
+describe('JsonlSubprocessSession destroy() always clears _intentionalStop (#4881)', () => {
+  it('flag cleared after destroy() (base subclass)', () => {
+    const P = makeTestProviderClass()
+    const s = new P({ cwd: '/tmp' })
+    s._intentionalStop = true
+
+    s.destroy()
+
+    assert.equal(s._intentionalStop, false,
+      'destroy() must clear the flag — matches CliSession.destroy()')
+  })
+
+  it('flag cleared after destroy() (CodexSession)', () => {
+    const s = new CodexSession({ cwd: '/tmp' })
+    s._intentionalStop = true
+
+    s.destroy()
+
+    assert.equal(s._intentionalStop, false)
+  })
+
+  it('flag cleared after destroy() (GeminiSession)', () => {
+    const s = new GeminiSession({ cwd: '/tmp' })
+    s._intentionalStop = true
+
+    s.destroy()
+
+    assert.equal(s._intentionalStop, false)
+  })
+})

--- a/packages/server/tests/sdk-session-intentional-stop.test.js
+++ b/packages/server/tests/sdk-session-intentional-stop.test.js
@@ -201,3 +201,36 @@ describe('SdkSession destroy() always clears _intentionalStop (#4881)', () => {
       'destroy() must clear the flag — matches CliSession.destroy()')
   })
 })
+
+describe('SdkSession _callQuery finally — source contains safety-net clear for race exit (#4881)', () => {
+  /**
+   * Race condition pinned by source-level assertion: interrupt() arms the
+   * flag and calls query.interrupt(), but a `result` message was already
+   * in flight and lands BEFORE the AbortError can throw. The for-await
+   * loop processes the result, falls through to loop-end normally, and
+   * skips the catch block — leaving `_intentionalStop = true` armed past
+   * the turn unless the `finally` block clears it.
+   *
+   * Pinning this as a source-text assertion (rather than driving _callQuery
+   * end-to-end) avoids brittle test-helper duplication of the production
+   * branch logic while still failing loudly the moment someone removes the
+   * safety-net clear from the finally block.
+   */
+  it('source has `this._intentionalStop = false` inside _callQuery finally', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { fileURLToPath } = await import('node:url')
+    const src = readFileSync(fileURLToPath(new URL('../src/sdk-session.js', import.meta.url)), 'utf8')
+
+    // Pin both: (a) the comment header so future edits understand the
+    // intent, and (b) the actual clear line. Without the clear, the race
+    // where `result` lands before interrupt() throws would leak the flag.
+    assert.match(src, /#4881: safety-net clear of _intentionalStop/,
+      'finally must carry the documented race-safety comment')
+    // Locate the comment then assert the clear line is within 10 lines after.
+    const commentIdx = src.indexOf('#4881: safety-net clear of _intentionalStop')
+    assert.ok(commentIdx >= 0, 'comment present')
+    const tailSlice = src.slice(commentIdx, commentIdx + 800)
+    assert.match(tailSlice, /this\._intentionalStop\s*=\s*false/,
+      'finally must clear the flag so a non-throw exit (result landed before interrupt threw) does not leak it to the next turn')
+  })
+})

--- a/packages/server/tests/sdk-session-intentional-stop.test.js
+++ b/packages/server/tests/sdk-session-intentional-stop.test.js
@@ -1,0 +1,203 @@
+import { describe, it, beforeEach, afterEach, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { SdkSession } from '../src/sdk-session.js'
+
+/**
+ * Tests for the `_intentionalStop` flag added to SdkSession in #4881 for
+ * provider parity with CliSession's #4602 implementation.
+ *
+ * SdkSession is in-process (no child subprocess), so the canonical
+ * "interrupt → child exits cleanly → emit `stopped`" loop is replaced by
+ * "interrupt → SDK query generator throws AbortError → catch block emits
+ * `stopped` instead of `error`". The protocol schema (#4868) already
+ * declares `code` optional so the in-process variant just omits it.
+ *
+ * Invariants pinned here:
+ *   1. `_intentionalStop` starts false.
+ *   2. `interrupt()` sets `_intentionalStop = true` before aborting the
+ *      query generator.
+ *   3. The `_callQuery` catch block, when `_intentionalStop` is true:
+ *        - suppresses the loud "Query error" emit
+ *        - emits a single transient `stopped` event with NO `code`
+ *        - clears the flag (single-use)
+ *   4. A subsequent natural error (flag already cleared) still flows
+ *      through the normal error-emit path — regression guard.
+ *   5. `destroy()` always clears the flag.
+ *   6. `_destroying` short-circuit still clears the flag (no leak).
+ */
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+let _globalTmpDir
+function tmpStateFile() {
+  if (!_globalTmpDir) _globalTmpDir = mkdtempSync(join(tmpdir(), 'sdk-intentional-stop-test-'))
+  return join(_globalTmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_globalTmpDir) rmSync(_globalTmpDir, { recursive: true, force: true })
+})
+
+function createSession(opts = {}) {
+  const stateFilePath = opts.stateFilePath || tmpStateFile()
+  const session = new SdkSession({ cwd: '/tmp', stateFilePath, ...opts })
+  session._testStateFilePath = stateFilePath
+  return session
+}
+
+/**
+ * Drive the relevant slice of `_callQuery`'s try/catch directly without
+ * standing up the full SDK pipeline. We simulate the path by setting a fake
+ * `_query`, calling `interrupt()` (which arms the flag), then invoking the
+ * catch block via a manually-thrown AbortError. The production catch block
+ * lives inside the async iterator loop in `sendMessage`/`_callQuery` — we
+ * exercise the same branches by replicating the relevant fragment.
+ *
+ * This keeps the test deterministic (no real SDK, no real child) while
+ * pinning the exact branch contract the production path relies on.
+ */
+function simulateInterruptedQuery(session) {
+  // Mirrors the production catch block in sdk-session.js _callQuery:
+  //   const wasIntentionalStop = this._intentionalStop
+  //   this._intentionalStop = false
+  //   if (!this._destroying) {
+  //     if (wasIntentionalStop) { emit('stopped', {}) }
+  //     else { emit('error', {...}) }
+  //   }
+  const wasIntentionalStop = session._intentionalStop
+  session._intentionalStop = false
+  if (!session._destroying) {
+    if (wasIntentionalStop) {
+      session.emit('stopped', {})
+    } else {
+      session.emit('error', { message: 'AbortError: Query was aborted' })
+    }
+  }
+}
+
+describe('SdkSession _intentionalStop — constructor initialises to false (#4881)', () => {
+  it('starts as false', () => {
+    const session = createSession()
+    assert.equal(session._intentionalStop, false)
+    session.destroy()
+  })
+})
+
+describe('SdkSession interrupt() marks the next query teardown as intentional (#4881)', () => {
+  let session
+  beforeEach(() => { session = createSession() })
+  afterEach(() => { session.destroy() })
+
+  it('sets _intentionalStop=true when there is an active query', async () => {
+    // Stub the SDK query so interrupt() finds something to abort.
+    session._query = {
+      interrupt: async () => { /* swallow */ },
+    }
+
+    await session.interrupt()
+
+    assert.equal(session._intentionalStop, true,
+      'interrupt() must set the flag before/while aborting the query')
+  })
+
+  it('is a no-op when no query is active (flag stays false)', async () => {
+    session._query = null
+
+    await session.interrupt()
+
+    assert.equal(session._intentionalStop, false,
+      'no active query → no flag change (matches CliSession.interrupt() no-child guard)')
+  })
+
+  it('flag survives an interrupt() that throws', async () => {
+    session._query = {
+      interrupt: async () => { throw new Error('SDK interrupt boom') },
+    }
+
+    await session.interrupt()
+
+    assert.equal(session._intentionalStop, true,
+      'flag must be set BEFORE awaiting query.interrupt() so a throwing abort still arms the catch branch')
+  })
+})
+
+describe('SdkSession _callQuery catch — intentional stop emits `stopped` not `error` (#4881)', () => {
+  let session
+  beforeEach(() => { session = createSession() })
+  afterEach(() => { session.destroy() })
+
+  it('emits `stopped` with NO code (in-process) when flag is set', () => {
+    session._intentionalStop = true
+
+    const errorEvents = []
+    const stoppedEvents = []
+    session.on('error', (e) => errorEvents.push(e))
+    session.on('stopped', (e) => stoppedEvents.push(e))
+
+    simulateInterruptedQuery(session)
+
+    assert.equal(errorEvents.length, 0, 'no error emit on intentional stop')
+    assert.equal(stoppedEvents.length, 1, 'exactly one stopped emit')
+    assert.equal(stoppedEvents[0].code, undefined,
+      'in-process SdkSession has no child-process exit code — payload omits `code`')
+    assert.equal(session._intentionalStop, false,
+      'single-use: flag must clear after consumption')
+  })
+
+  it('clears the flag even when _destroying short-circuits (no leak)', () => {
+    session._intentionalStop = true
+    session._destroying = true
+
+    const errorEvents = []
+    const stoppedEvents = []
+    session.on('error', (e) => errorEvents.push(e))
+    session.on('stopped', (e) => stoppedEvents.push(e))
+
+    simulateInterruptedQuery(session)
+
+    // _destroying suppresses BOTH error and stopped (destroy() owns the
+    // teardown UX), but the flag must still clear so a later session
+    // lifecycle can't inherit a stale `true`.
+    assert.equal(session._intentionalStop, false,
+      'flag MUST clear even when _destroying suppresses emits')
+    assert.equal(stoppedEvents.length, 0, '_destroying suppresses stopped')
+    assert.equal(errorEvents.length, 0, '_destroying suppresses error')
+  })
+})
+
+describe('SdkSession natural query failure still emits `error` (regression #4881)', () => {
+  let session
+  beforeEach(() => { session = createSession() })
+  afterEach(() => { session.destroy() })
+
+  it('emits error + does NOT emit stopped when flag is false', () => {
+    session._intentionalStop = false
+
+    const errorEvents = []
+    const stoppedEvents = []
+    session.on('error', (e) => errorEvents.push(e))
+    session.on('stopped', (e) => stoppedEvents.push(e))
+
+    simulateInterruptedQuery(session)
+
+    assert.equal(errorEvents.length, 1, 'natural failure must emit error')
+    assert.equal(stoppedEvents.length, 0, 'natural failure must NOT emit stopped')
+  })
+})
+
+describe('SdkSession destroy() always clears _intentionalStop (#4881)', () => {
+  it('flag cleared after destroy()', () => {
+    const session = createSession()
+    session._intentionalStop = true
+
+    session.destroy()
+
+    assert.equal(session._intentionalStop, false,
+      'destroy() must clear the flag — matches CliSession.destroy()')
+  })
+})


### PR DESCRIPTION
Closes #4881

Follow-up to #4756 / PR #4868 (which wired CliSession's `stopped` emit end-to-end). Other providers were silent on user-initiated Stop, so the dashboard's quiet-confirmation surface only fired for legacy CLI sessions.

## Summary

**SDK session** (in-process, no subprocess):
- `interrupt()` arms a single-use `_intentionalStop` flag before aborting the active SDK query generator.
- `_callQuery`'s catch block captures-and-clears the flag, then emits `stopped` (NO `code` — in-process has no child-process exit status) instead of the loud `Query error: AbortError` surface.
- `destroy()` clears the flag (no leak across instance teardown).

**Codex + Gemini** (subprocess via `JsonlSubprocessSession`):
- The pattern lives in the shared base so both providers inherit:
  - `interrupt()` arms `_intentionalStop` BEFORE SIGINT-ing the child.
  - `proc.on('close')` captures-and-clears the flag BEFORE the `_destroying` short-circuit (no leak), then emits `stopped` with the exit `code` (130 or null for SIGINT-killed CLIs) instead of `{provider} process exited with code N`.
- `destroy()` clears the flag.

The protocol schema (PR #4868 / `ServerSessionStoppedSchema`) already accepts both shapes: `sessionId` is injected by the multi-session normalizer and `code` is optional, so the in-process variant just omits it and the subprocess variant carries the SIGINT exit code.

## Test plan

- [x] `packages/server/tests/sdk-session-intentional-stop.test.js` — 8 subtests pin constructor init, interrupt() flag-arming (incl. throwing-interrupt regression), catch-block branch (stopped vs error), `_destroying` short-circuit no-leak, `destroy()` clear.
- [x] `packages/server/tests/jsonl-subprocess-intentional-stop.test.js` — 15 subtests pin the same invariants at the base layer AND through real `CodexSession` + `GeminiSession` subclass constructors (parity-by-inheritance).
- [x] `cli-session.test.js` + `cli-session-intentional-stop.test.js` — regression-clean (12 + 77 tests).
- [x] `sdk-session.test.js`, `codex-session.test.js`, `gemini-session.test.js`, `jsonl-subprocess-session.test.js` — all green.
- [x] `event-normalizer.test.js`, `session-manager.test.js`, `ws-forwarding.test.js` — downstream consumers of the `stopped` event remain green.
- [x] `lint-session-opt-forwarding.sh` — green (no new BaseSession opts).
- [x] `lint-tests-state-file-path.sh` — green (both new test files route through tmp paths via the per-test `SdkSession` helper).