### PR TITLE
chore(release): cut v0.9.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.37] - 2026-06-02
+
+Second daytime sweep: 13 from-review follow-ups from v0.9.36 landed alongside two stale prior-cycle PRs (#4655, #4682). Mostly polish + observability with two real surface additions (`session_stopped` UX on both dashboard + mobile, provider-parity `stopped` emit for SDK / Codex / Gemini).
+
+### Added
+
+- **Dashboard `session_stopped` toast (#4878 → #4895):** dashboard now renders a quiet `"Session stopped."` info toast on `session_stopped`, with optional `(exit N)` suffix for non-zero exit codes. Closes the dashboard half of the #4756 epic begun in v0.9.36.
+- **Mobile `session_stopped` status strip (#4879 → #4905):** mobile `SessionScreen` renders an inline quiet status strip on `session_stopped` (with `exit N` for non-zero codes). Closes the mobile half of the #4756 epic. Cross-PR copy alignment with the dashboard ("(exit N)" vs "exit N") tracked in #4910.
+- **Provider-parity `stopped` emit (#4881 → #4912):** SDK, Codex, and Gemini sessions now emit the `stopped` event on natural session-end paths, matching what `cli-session.js` and `claude-tui-session.js` shipped in v0.9.36 (#4868). All five providers now emit the same wire event end-to-end.
+- **`isFreeformAnswer` shared typed predicate (#4875 → #4900):** extracted into `@chroxy/store-core/freeform-answer` as a typed predicate replacing the inline 5-condition shape check that diverged between mobile callsites. Hardened against prototype-pollution via `Object.prototype.hasOwnProperty.call`. Dashboard convergence to the same predicate tracked in #4901.
+
+### Changed
+
+- **`unknown tool_input` shapes now render as compact key:value summaries (#4655 → #4725):** the generic tool-input fallback in `tool-summary.ts` no longer leaks raw JSON for tools whose shape has none of the hardcoded PRIORITY_FIELDS (ToolSearch, MCP tools, custom user tools). The canonical bug fixture was `ToolSearch` rendering `ToolSearch {"matches":[...],"query":"select:..."` during the v0.9.24 dogfood — now renders `ToolSearch query: "select:AskUserQuestion", max_results: 5`. String values JSON-escape; key-count degradation respects the budget; JSDoc + `array` handling tightened.
+- **Per-turn `sendMessage done` summary log on teardown paths (#4682 → #4723):** `_teardownTurn` and the end-to-end hard-timeout / stream-stall handlers all emit the same grep-able `sendMessage done` line with `reason=` tag and per-stage timings (`waitForPromptMs`, `writePath`, `writeMs`, etc.), so every turn ends with a uniform shape regardless of outcome — feeds the #4678 wedge instrumentation.
+- **Clipboard-failure toast uses `warning` severity (#4870 → #4894):** copy-transcript toast no longer trips the red error styling for a recoverable clipboard failure. Aligns with #4148 severity convention.
+- **Sidebar copy-conversation-id surfaces warning toast on failure (#4871 → #4897):** the sidebar's copy-conversation-id callsite no longer silently no-ops on Tauri/WKWebView clipboard write failure — same warning toast as the transcript path.
+- **Status dots drop `role="status"` + add debounced live region (#4873 → #4899):** reconnect / session-state churn no longer floods screen readers. New `ConnectionAnnouncer` with a 1.5s debounce announces the settled phase after the storm; first-paint announcement is delayed (not skipped). Tunnel-warming banner retains `role="status"` intentionally.
+- **Tightened `lastIsSingleSelect` detection (#4883 → #4902):** TUI multi-question driver now surfaces unexpected question shapes (mixed, multi-select, freeform-only, unknown) rather than treating them as single-select by accident. Drift checks promoted to a defensive `'in'` operator; settle-gap measurement now boundary-aware; one new undefined-key drift test.
+- **Mobile `voiceInputMode` rehydrate gated by `isVoiceInputMode` (#4872 → #4903):** mobile `loadSavedConnection` no longer accepts stale or tampered `voiceInputMode` blobs (`'push-to-talk'`, `null`, `42`) — same guard the dashboard adopted in v0.9.36 (#4858). Per-field validation also closed a latent bug where one valid boolean key spread the entire blob into store state.
+- **Collapse manual `.tmp+rename` onto `writeFileRestricted` (#4874 → #4904):** `env-manager` + `models` callers no longer reinvent the temp-write-rename pattern manually now that `writeFileRestricted` is atomic (v0.9.36, #4865). `session-state-persistence` deferred (depends on `.bak` rotation rework — #4908). Three follow-ups filed: #4906 observability, #4907 redundant chmod, #4913 Windows write-atomicity.
+- **Mobile session-header badges widened to 44pt touch targets (#4876 → #4892):** badges now meet Apple HIG minimum tappable area via `hitSlop`. Sibling `conversationIdRow` tap target tracked in #4893.
+
+### Tests / Internal
+
+- **Pin all-single-select 2-question form byte sequence (#4882 → #4898):** test coverage for the multi-question driver's all-single-select shape (Q1 → Q2 → Submit) using distinct keystrokes to disambiguate digit-1 (option) from digit-1 (Submit). Empirical recorder pass on real TUI still outstanding — #4882 stays open.
+- **Pin trailing `\r` on mixed multi-question forms (#4884 → #4911):** 7 new fixtures cover S+M, M+S+M, S+M+S shape variants + forensic Submit→PostToolUse timing log keyed by toolUseId. Extends the #4866/#4886 single-select coverage.
+
+### Process notes
+
+- Two PRs (#4903, #4905) required manual rebase + conflict resolution: #4903 collided with #4900's `isFreeformAnswer` import; #4905 collided with #4895's PLATFORM_SPECIFIC entry for `session_stopped` (the entry got dropped entirely since both handlers now cover it natively). Both rebases hand-resolved + force-pushed; CI green on retry.
+- Two stale PRs (#4725, #4723) needed dedicated triage: #4725 had a brace mismatch in `ToolBubble.test.tsx` from a prior rebase that broke typecheck (fixed in-line); #4723 was 87 commits behind main and its summary-log tests broke after the v0.9.36 logger sweep (wrong listener signature + missing `messageId` on `_activeTurn` stub).
+
+### Follow-up issues filed during this sweep
+
+- #4893 — Mobile `conversationIdRow` tap target below 44pt (sibling to #4876).
+- #4901 — Dashboard `isFreeformAnswer` convergence onto the shared store-core predicate.
+- #4906 — Re-add cleanup-failure observability in `writeFileRestricted` (was lost in the env-manager hoist).
+- #4907 — Drop redundant `chmodSync` after `writeFileSync({ mode: 0o600 })`.
+- #4908 — Re-audit `session-state-persistence.js` for safe simplification once `.bak` rotation is reworked.
+- #4909 — Reconnect-time stale `stoppedAt` in mobile session-stopped strip.
+- #4910 — Align mobile + dashboard `session_stopped` copy (`(exit N)` vs `exit N`).
+- #4913 — Make `writeFileRestricted` atomic on Windows too (the `isWindows` branch in `platform.js` short-circuits to a direct `writeFileSync` with no temp+rename).
+
 ## [0.9.36] - 2026-06-02
 
 Backlog-sweep release: 16 from-review issues landed in a single overnight marathon, plus one cross-PR fix-CI commit (#4886) when #4867's settle delay broke #4866's freshly-merged arrow-nav tests. All sourced from prior agent-review deferrals (#4823 / v0.9.34 / v0.9.35 follow-ups).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.36",
+      "version": "0.9.37",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.36",
+      "version": "0.9.37",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.36",
+      "version": "0.9.37",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.36"
+      "version": "0.9.37"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.36",
+      "version": "0.9.37",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.36",
+      "version": "0.9.37",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.36",
+      "version": "0.9.37",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.36",
+    "version": "0.9.37",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.36</string>
+    <string>0.9.37</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.36"
+version = "0.9.37"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.36"
+version = "0.9.37"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.36",
+      "version": "0.9.37",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
Second daytime sweep — see [CHANGELOG.md](https://github.com/blamechris/chroxy/blob/release/v0.9.37/CHANGELOG.md) for the full v0.9.37 entry.

## Highlights

- **`session_stopped` UX landed end-to-end:** dashboard toast (#4895 / #4878), mobile status strip (#4905 / #4879), provider-parity stopped emit for SDK/Codex/Gemini (#4912 / #4881)
- **Status-dot a11y debounce (#4899 / #4873)** — reconnect churn no longer floods screen readers
- **Shared `isFreeformAnswer` predicate (#4900 / #4875)** — prototype-pollution-hardened
- **Mobile `voiceInputMode` rehydrate guard (#4903 / #4872)** — closes a latent spread bug
- **`writeFileRestricted` callers collapse (#4904 / #4874)** — env-manager + models simplified
- **Mobile 44pt touch targets (#4892 / #4876)** — Apple HIG compliance for session-header badges

Plus two stale prior-cycle PRs landed: unknown tool_input rendering (#4725 / #4655) + per-turn summary log on teardown paths (#4723 / #4682).

## Numbers

- 15 PRs merged across this release window
- 11 issues auto-closed via `Closes #N`; 2 deliberately kept open (#4882 empirical recorder pass, #4879 — wait that closed too)
- 8 new follow-ups filed: #4893, #4901, #4906, #4907, #4908, #4909, #4910, #4913

## Test plan

- [x] All workspace tests + lints pass on each merged PR
- [x] Both rebased PRs (#4903, #4905) re-CI'd green after manual conflict resolution
- [x] No remaining unresolved review threads
- [ ] Smoke-test on Tauri after merge (rebuild from `release/v0.9.37` source)