### PR TITLE
fix(app): align mobile session-stopped strip with dashboard '(exit N)' copy

### DIFF
--- a/packages/app/src/__tests__/screens/SessionScreenStoppedBanner.test.ts
+++ b/packages/app/src/__tests__/screens/SessionScreenStoppedBanner.test.ts
@@ -55,8 +55,13 @@ describe('SessionScreen stopped status strip (#4879)', () => {
     expect(SessionScreenSrc).toMatch(/'Session stopped\.'/);
   });
 
-  it("renders 'Session stopped. exit N' suffix for non-zero codes (e.g. 143 = SIGTERM)", () => {
-    expect(SessionScreenSrc).toMatch(/Session stopped\. exit \$\{activeSessionStoppedCode\}/);
+  it("renders 'Session stopped. (exit N)' suffix for non-zero codes (e.g. 143 = SIGTERM)", () => {
+    // #4910: aligned with the dashboard's parenthesised form ("Session
+    // stopped. (exit N)") so both surfaces speak with one voice. The
+    // protocol doc-comment already uses bare "Session stopped." for the
+    // common case, and parentheses are the conventional wrapper for a
+    // diagnostic suffix.
+    expect(SessionScreenSrc).toMatch(/Session stopped\. \(exit \$\{activeSessionStoppedCode\}\)/);
   });
 
   it('uses informational stoppedBanner style (NOT errorBanner / warningBanner)', () => {

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -1194,7 +1194,7 @@ export function SessionScreen() {
               numberOfLines={1}
             >
               {activeSessionStoppedCode !== null && activeSessionStoppedCode !== 0
-                ? `Session stopped. exit ${activeSessionStoppedCode}`
+                ? `Session stopped. (exit ${activeSessionStoppedCode})`
                 : 'Session stopped.'}
             </Text>
           </View>

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1398,7 +1398,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       //
       // Sets `stoppedAt` + `stoppedCode` on the target session — the
       // SessionScreen reads those fields to render a subtle, info-styled
-      // status strip ("Session stopped." / "Session stopped. exit N").
+      // status strip ("Session stopped." / "Session stopped. (exit N)").
       // Both fields are cleared automatically by `handleClaudeReady`
       // (which returns `stoppedAt: null, stoppedCode: null`) when the
       // server restarts the child after the operator's next input.

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -1163,7 +1163,7 @@ export function handleSessionError(
  *
  * The patch sets `stoppedAt` to `now()` so renderers can show a calm
  * informational status strip ("Session stopped." / with optional
- * "exit N" suffix for non-zero exits). `stoppedCode` carries the child
+ * "(exit N)" suffix for non-zero exits). `stoppedCode` carries the child
  * process exit code when the server reported one — null otherwise. Both
  * fields are cleared (back to null) by `handleClaudeReady`'s patch when
  * the server restarts the child after the operator's next input.

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -673,7 +673,7 @@ export interface BaseSessionState {
    * Distinct from `health: 'crashed'` (loud unexpected-exit error UX) and
    * from `claudeReady: false` (transient between-turns idle). Renderers
    * use this to surface a calm, informational status strip ("Session
-   * stopped." / "Session stopped. exit N") that the operator can choose
+   * stopped." / "Session stopped. (exit N)") that the operator can choose
    * to act on — typically by sending another message (which clears
    * `stoppedAt` on the next `claude_ready`) or by deleting the session.
    *


### PR DESCRIPTION
## Summary

- Mobile #4879 strip rendered `Session stopped. exit 143`; dashboard #4878 toast rendered `Session stopped. (exit 143)`. Aligned mobile on the dashboard's parenthesised form so both surfaces speak with one voice.
- Updated the wire-up assertion in `SessionScreenStoppedBanner.test.ts` to match the new copy.
- Refreshed three nearby doc-comments (`packages/app/src/store/message-handler.ts`, `packages/store-core/src/types.ts`, `packages/store-core/src/handlers/index.ts`) that quoted the old `exit N` example string.

## Why parens (not bare)

- Dashboard already shipped with parens — flipping the dashboard would mean changing the more user-visible toast on stable.
- Parentheses are the conventional wrapper for a diagnostic / parenthetical suffix.
- The protocol's `ServerSessionStoppedSchema` doc-comment uses bare `"Session stopped."` for the common case, so the parens marker reinforces "this is a decoration on top of the canonical message".

## Test plan

- [x] `cd packages/app && npx jest` — 109 suites, 1537 tests passing (includes the updated `SessionScreenStoppedBanner.test.ts` assertion)
- [x] `cd packages/dashboard && npx vitest run src/store/message-handler.test.ts` — 168 tests passing (dashboard copy already canonical)
- [x] `tsc --noEmit` in `packages/app`, `packages/dashboard`, `packages/store-core` — all clean
- [ ] Spot-check on simulator that a SIGTERM (`pkill -TERM`) surfaces `Session stopped. (exit 143)` in the strip — easy follow-up if anyone wants to eyeball it; the source-text test gates the wire-up.

Closes #4910