### PR TITLE
fix(app): grow mobile conversationIdRow tap target to 44pt

### DIFF
--- a/packages/app/src/components/SettingsBar.tsx
+++ b/packages/app/src/components/SettingsBar.tsx
@@ -553,6 +553,7 @@ export function SettingsBar({
               }}
               accessibilityRole="button"
               accessibilityLabel="Copy conversation ID"
+              testID="conversation-id-row"
             >
               <Text style={styles.conversationIdLabel}>Conversation ID</Text>
               <Text style={styles.conversationIdValue} numberOfLines={1}>
@@ -1032,12 +1033,17 @@ const styles = StyleSheet.create({
     borderRadius: 3,
     overflow: 'hidden',
   },
+  // #4893 — bump minHeight from 32 → 44 so the copy-to-clipboard row clears
+  // the Apple HIG / CLAUDE.md 44pt minimum tappable target. Sibling fix to
+  // #4892 (which used hitSlop for the compact header badges); here the row
+  // already has horizontal whitespace in the expanded panel, so growing the
+  // visible row by 12pt is preferable to a hitSlop hack.
   conversationIdRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
     paddingVertical: 4,
-    minHeight: 32,
+    minHeight: 44,
   },
   conversationIdLabel: {
     color: COLORS.textMuted,

--- a/packages/app/src/components/__tests__/SettingsBarTouchTargets.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarTouchTargets.test.tsx
@@ -168,10 +168,13 @@ describe('SettingsBar header tappable badges hit a 44pt touch target (#4876)', (
  * plenty of horizontal whitespace, so the chosen fix grows the visible row to
  * 44pt (Option 1 from the issue) rather than adding `hitSlop`.
  *
- * This test asserts the row's effective tap target is at least 44 × 44pt,
- * computed as `style.minHeight + 2 * paddingVertical + hitSlop`. The row's
- * width spans the parent's flex space, so we only assert on the height
- * dimension that the original bug was about.
+ * This test asserts the row's effective tap target is at least 44pt tall,
+ * computed as `max(style.minHeight, style.paddingVertical * 2)` plus the
+ * top + bottom `hitSlop` (defaulting to 0 when unset). `minHeight` in RN
+ * already accounts for padding + content, so we take the larger of the two
+ * lower bounds rather than summing them. The row's width spans the parent's
+ * flex space, so we only assert on the height dimension that the original
+ * bug was about.
  */
 describe('SettingsBar conversationIdRow hits a 44pt touch target (#4893)', () => {
   it('row is rendered (expanded, with a conversationId)', () => {
@@ -209,9 +212,11 @@ describe('SettingsBar conversationIdRow hits a 44pt touch target (#4893)', () =>
     const hitSlop: HitSlop = (row.props.hitSlop as HitSlop) ?? {};
     const paddingVertical = style.paddingVertical ?? 0;
     const minHeight = style.minHeight ?? 0;
-    // Effective tap-target height is the larger of minHeight or (paddingVertical*2 + content)
-    // — minHeight wins here because it is set explicitly. Add hitSlop top/bottom in case a
-    // future change keeps minHeight low but compensates with slop.
+    // Effective tap-target height is the larger of minHeight or paddingVertical*2
+    // (a conservative lower bound — actual content height is not measured here),
+    // plus any top/bottom hitSlop. minHeight wins for this row because it is set
+    // explicitly to 44; the paddingVertical fallback only matters if a future
+    // change drops minHeight and relies on padding alone.
     const effectiveHeight = Math.max(minHeight, paddingVertical * 2)
       + (hitSlop.top ?? 0)
       + (hitSlop.bottom ?? 0);

--- a/packages/app/src/components/__tests__/SettingsBarTouchTargets.test.tsx
+++ b/packages/app/src/components/__tests__/SettingsBarTouchTargets.test.tsx
@@ -159,3 +159,62 @@ describe('SettingsBar header tappable badges hit a 44pt touch target (#4876)', (
     expect(ivSlop).toBe(HEADER_BADGE_HIT_SLOP);
   });
 });
+
+/**
+ * #4893 — the same SettingsBar exposes a `conversationIdRow` in the expanded
+ * panel that copies the conversation ID to the clipboard on tap. It is the
+ * sibling of the header-badge fix above and was originally under-sized at
+ * `minHeight: 32` (below Apple HIG's 44pt minimum). The expanded panel has
+ * plenty of horizontal whitespace, so the chosen fix grows the visible row to
+ * 44pt (Option 1 from the issue) rather than adding `hitSlop`.
+ *
+ * This test asserts the row's effective tap target is at least 44 × 44pt,
+ * computed as `style.minHeight + 2 * paddingVertical + hitSlop`. The row's
+ * width spans the parent's flex space, so we only assert on the height
+ * dimension that the original bug was about.
+ */
+describe('SettingsBar conversationIdRow hits a 44pt touch target (#4893)', () => {
+  it('row is rendered (expanded, with a conversationId)', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar
+          {...makeProps()}
+          expanded
+          conversationId="abc12345-deadbeef-0000-1111-222233334444"
+        />,
+      );
+    });
+    const row = tree!.root.findByProps({ testID: 'conversation-id-row' });
+    expect(row).toBeDefined();
+  });
+
+  it('row style has minHeight ≥ 44 so the visible target clears Apple HIG', () => {
+    let tree: renderer.ReactTestRenderer | null = null;
+    act(() => {
+      tree = renderer.create(
+        <SettingsBar
+          {...makeProps()}
+          expanded
+          conversationId="abc12345-deadbeef-0000-1111-222233334444"
+        />,
+      );
+    });
+    const row = tree!.root.findByProps({ testID: 'conversation-id-row' });
+    // RN TouchableOpacity merges style arrays/objects; flatten by reading
+    // the style prop and pulling minHeight off the resolved object.
+    const style = Array.isArray(row.props.style)
+      ? Object.assign({}, ...row.props.style)
+      : row.props.style;
+    const hitSlop: HitSlop = (row.props.hitSlop as HitSlop) ?? {};
+    const paddingVertical = style.paddingVertical ?? 0;
+    const minHeight = style.minHeight ?? 0;
+    // Effective tap-target height is the larger of minHeight or (paddingVertical*2 + content)
+    // — minHeight wins here because it is set explicitly. Add hitSlop top/bottom in case a
+    // future change keeps minHeight low but compensates with slop.
+    const effectiveHeight = Math.max(minHeight, paddingVertical * 2)
+      + (hitSlop.top ?? 0)
+      + (hitSlop.bottom ?? 0);
+    expect(effectiveHeight).toBeGreaterThanOrEqual(44);
+  });
+});


### PR DESCRIPTION
## Summary

The mobile `SettingsBar` exposes a copy-to-clipboard `conversationIdRow` in its expanded panel. Its style block sets `minHeight: 32` — below the 44pt Apple HIG / CLAUDE.md minimum tappable target. Sibling to PR #4892 (which fixed the two compact header badges with `hitSlop`); the row was identified there as the next obvious follow-up.

Fix follows Option 1 from the issue: bump `minHeight: 32` -> `minHeight: 44`. The expanded panel has plenty of horizontal whitespace, so growing the visible row by 12pt is cleaner than the `hitSlop` hack used for the compact header badges.

## Changes

- `SettingsBar.tsx` — bump `conversationIdRow.minHeight` to 44, add `testID="conversation-id-row"`, add comment explaining the choice
- `SettingsBarTouchTargets.test.tsx` — new describe block `SettingsBar conversationIdRow hits a 44pt touch target (#4893)` with two tests:
  - row renders when expanded with a conversationId
  - effective tap-target height (`max(minHeight, paddingVertical*2) + hitSlop top/bottom`) is >= 44pt

## Acceptance criteria

- [x] `conversationIdRow` tap target effectively >= 44 x 44pt (height covered; width spans the parent's flex space so the test asserts on height only)
- [x] No regression in the chip-strip header layout (visible badges unchanged; only the expanded-panel row grew)
- [x] Test asserts the effective tap target size (mirrors the pattern from `SettingsBarTouchTargets.test.tsx`)

## Test plan

- [x] `npx jest --testPathPattern="SettingsBar"` -> 30/30 pass (4 suites)
- [x] `npx tsc --noEmit` clean on main worktree

Closes #4893