### PR TITLE
docs(server): document writeFileRestricted chmodSync as umask + stale-tmp defense

### DIFF
--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -51,12 +51,18 @@ export function writeFileRestricted(filePath, data, { tmpSuffix = '.tmp' } = {})
   // mode, or another local user pre-created the path under a permissive
   // umask — `writeFileSync` opens with `O_TRUNC` and preserves the
   // existing mode bits. The explicit `chmodSync` afterward guarantees
-  // 0o600 even in that case. These files may carry secrets (session
-  // bearer tokens, push subscriptions, BYOK creds), so the
-  // belt-and-braces is intentional. Same defensive pattern is in
-  // `logger.js` (dir mode), `byok-credentials.js`, `byok-mcp-trust.js`,
-  // and `notification-prefs.js`. See #4907 for the cleanup discussion
-  // that ended in "keep with comment + regression test".
+  // the FINAL file is 0o600, but does NOT eliminate the transient
+  // exposure window between the write and the chmod — during that
+  // window, a pre-existing looser mode means another local user could
+  // read the freshly-written bytes. Full mitigation would require
+  // openSync(O_CREAT|O_EXCL) + fchmodSync before write; the current
+  // belt-and-braces is intentional but only covers the at-rest final
+  // perms, not the in-flight window. These files may carry secrets
+  // (session bearer tokens, push subscriptions, BYOK creds). Same
+  // defensive pattern is in `logger.js` (dir mode),
+  // `byok-credentials.js`, `byok-mcp-trust.js`, and
+  // `notification-prefs.js`. See #4907 for the cleanup discussion that
+  // ended in "keep with comment + regression test".
   writeFileSync(tmpPath, data, { mode: 0o600 })
   chmodSync(tmpPath, 0o600)
   try {

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -45,6 +45,18 @@ export function writeFileRestricted(filePath, data, { tmpSuffix = '.tmp' } = {})
     return
   }
   const tmpPath = `${filePath}${tmpSuffix}`
+  // The `mode: 0o600` arg to `writeFileSync` is ONLY honoured on file
+  // CREATION (`O_CREAT`). When `tmpPath` already exists — e.g. a prior
+  // run crashed before the rename and left a stale sidecar at a looser
+  // mode, or another local user pre-created the path under a permissive
+  // umask — `writeFileSync` opens with `O_TRUNC` and preserves the
+  // existing mode bits. The explicit `chmodSync` afterward guarantees
+  // 0o600 even in that case. These files may carry secrets (session
+  // bearer tokens, push subscriptions, BYOK creds), so the
+  // belt-and-braces is intentional. Same defensive pattern is in
+  // `logger.js` (dir mode), `byok-credentials.js`, `byok-mcp-trust.js`,
+  // and `notification-prefs.js`. See #4907 for the cleanup discussion
+  // that ended in "keep with comment + regression test".
   writeFileSync(tmpPath, data, { mode: 0o600 })
   chmodSync(tmpPath, 0o600)
   try {

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -210,6 +210,29 @@ try {
         const mode = statSync(filePath).mode & 0o777
         assert.strictEqual(mode, 0o600)
       })
+
+      it('tightens perms when a stale tmp sidecar exists at a looser mode (#4907)', async () => {
+        // The `mode: 0o600` arg to `writeFileSync` is ONLY honoured on
+        // file CREATION. If a prior run crashed before rename and left
+        // a `.tmp` sidecar at e.g. 0o644 (an attacker pre-empting the
+        // path with looser perms is the threat model), `writeFileSync`
+        // opens with `O_TRUNC` and silently inherits the stale mode.
+        // The explicit `chmodSync` in `writeFileRestricted` must
+        // restore 0o600 before the rename. This test would fail if
+        // someone "cleaned up" the chmodSync as redundant.
+        const filePath = join(tmpDir, 'sensitive.json')
+        const tmpPath = `${filePath}.tmp`
+        const { writeFileSync, chmodSync } = await import('fs')
+        // Pre-seed the tmp sidecar at a looser mode.
+        writeFileSync(tmpPath, 'stale', { mode: 0o644 })
+        chmodSync(tmpPath, 0o644)
+        assert.strictEqual(statSync(tmpPath).mode & 0o777, 0o644, 'baseline: tmp seeded at 0o644')
+
+        writeFileRestricted(filePath, 'fresh')
+
+        const finalMode = statSync(filePath).mode & 0o777
+        assert.strictEqual(finalMode, 0o600, 'final file must be 0o600 even when tmp was pre-existing at 0o644')
+      })
     }
   })
 

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -212,14 +212,18 @@ try {
       })
 
       it('tightens perms when a stale tmp sidecar exists at a looser mode (#4907)', async () => {
-        // The `mode: 0o600` arg to `writeFileSync` is ONLY honoured on
-        // file CREATION. If a prior run crashed before rename and left
-        // a `.tmp` sidecar at e.g. 0o644 (an attacker pre-empting the
-        // path with looser perms is the threat model), `writeFileSync`
-        // opens with `O_TRUNC` and silently inherits the stale mode.
-        // The explicit `chmodSync` in `writeFileRestricted` must
-        // restore 0o600 before the rename. This test would fail if
-        // someone "cleaned up" the chmodSync as redundant.
+        // Regression for "stale tmp preserves mode unless chmodSync
+        // re-tightens": the `mode: 0o600` arg to `writeFileSync` is
+        // ONLY honoured on file CREATION. If a prior run crashed before
+        // rename and left a `.tmp` sidecar at e.g. 0o644,
+        // `writeFileSync` opens with `O_TRUNC` and silently inherits
+        // the stale mode. The explicit `chmodSync` in
+        // `writeFileRestricted` must restore 0o600 before the rename so
+        // the FINAL file is tight. This test asserts the final mode
+        // bits only — it does NOT cover the transient exposure window
+        // during the write (the bytes are on disk at the stale 0o644
+        // briefly, before chmodSync runs). It would fail if someone
+        // "cleaned up" the chmodSync as redundant.
         const filePath = join(tmpDir, 'sensitive.json')
         const tmpPath = `${filePath}.tmp`
         const { writeFileSync, chmodSync } = await import('fs')


### PR DESCRIPTION
## Summary

- Investigated the #4904-review nitpick that `chmodSync(tmpPath, 0o600)` after `writeFileSync(tmpPath, data, { mode: 0o600 })` in `writeFileRestricted` is redundant. **It is not** — `writeFileSync`'s `mode` arg is only honoured on file CREATION (`O_CREAT`). When the `.tmp` sidecar already exists from a prior crashed run (or pre-empted by another local user under a permissive umask), `writeFileSync` opens with `O_TRUNC` and silently inherits the stale mode bits. The explicit `chmodSync` restores `0o600` before rename.
- Added a comment in `platform.js` explaining the threat model (cross-references the same defensive pattern in `logger.js`, `byok-credentials.js`, `byok-mcp-trust.js`, `notification-prefs.js`).
- Added a regression test that pre-seeds the `.tmp` sidecar at `0o644` and asserts the final file is still `0o600` — this fails if anyone later "cleans up" the `chmodSync` as redundant (verified locally by temporarily removing the `chmodSync` line).

## Test plan

- [x] `packages/server/tests/platform.test.js` — 12/12 pass (including new `tightens perms when a stale tmp sidecar exists at a looser mode (#4907)` regression test)
- [x] Verified regression test catches removal of `chmodSync` — temporarily deleted the line, test failed as expected
- [x] `lint-tests-state-file-path.sh` + `lint-session-opt-forwarding.sh` both pass
- [x] No behaviour change — purely additive (comment + test)

Closes #4907