### PR TITLE
fix(app): clear stale session_stopped marker on reconnect (#4909)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -289,6 +289,100 @@ describe('session_stopped handler (#4879)', () => {
   });
 });
 
+// #4909: the `session_stopped` event is transient and NOT recorded into
+// per-session history (#4868 wire path), so it isn't replayed on reconnect.
+// However, the client-side `stoppedAt`/`stoppedCode` derived state survives
+// the WebSocket teardown in Zustand store memory — the strip flashes back
+// into view until activity resumes. `history_replay_start` is the canonical
+// "reconnect handshake" event and clears the stale marker for the same
+// reason it clears `activeAgents`/`isPlanPending`.
+describe('history_replay_start clears stale session_stopped marker (#4909)', () => {
+  afterEach(() => {
+    resetReplayFlags();
+  });
+
+  it('clears stoppedAt + stoppedCode on history_replay_start for the target session', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: {
+        s1: { ...createEmptySessionState(), stoppedAt: 1700000000000, stoppedCode: 143 },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
+
+    const state = store.getState();
+    expect(state.sessionStates.s1.stoppedAt).toBeNull();
+    expect(state.sessionStates.s1.stoppedCode).toBeNull();
+  });
+
+  it('clears stoppedAt for a background (non-active) session reconnecting', () => {
+    // The strip can flash on an inactive session too — `history_replay_start`
+    // targets `replayTargetId` (per-session) rather than activeSessionId so
+    // a background session reconnecting also sheds its stale marker.
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [
+        { sessionId: 's1', name: 'S1' } as any,
+        { sessionId: 's2', name: 'S2' } as any,
+      ],
+      sessionStates: {
+        s1: createEmptySessionState(),
+        s2: { ...createEmptySessionState(), stoppedAt: 1700000000000, stoppedCode: 0 },
+      },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's2' });
+
+    const state = store.getState();
+    expect(state.sessionStates.s2.stoppedAt).toBeNull();
+    expect(state.sessionStates.s2.stoppedCode).toBeNull();
+    // s1 (active, not the replay target) is untouched.
+    expect(state.sessionStates.s1.stoppedAt).toBeNull();
+  });
+
+  it('no-op when neither field is set (avoids unnecessary state churn)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    const sessionStatesBefore = store.getState().sessionStates;
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
+    const sessionStatesAfter = store.getState().sessionStates;
+
+    // The empty patch optimization in updateSession should leave the
+    // sessionStates map reference unchanged when there's nothing to clear.
+    expect(sessionStatesAfter.s1.stoppedAt).toBeNull();
+    expect(sessionStatesAfter.s1.stoppedCode).toBeNull();
+    expect(sessionStatesAfter).toBe(sessionStatesBefore);
+  });
+
+  it('handles unknown session id without throwing (defensive — server may race)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: createEmptySessionState() },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    expect(() =>
+      _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 'unknown-id' }),
+    ).not.toThrow();
+
+    expect(store.getState().sessionStates).not.toHaveProperty('unknown-id');
+  });
+});
+
 describe('session_timeout handler', () => {
   it('removes timed-out session from sessionStates and sessions list', () => {
     const store = createMockStore({

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1446,6 +1446,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
         return Object.keys(patch).length > 0 ? patch : {};
       });
+      // #4909 — `session_stopped` is a transient event NOT recorded into
+      // per-session history (#4868 wire path), so it isn't replayed on
+      // reconnect. But the client-side `stoppedAt`/`stoppedCode` derived
+      // state survives the WebSocket teardown in Zustand store memory and
+      // the strip flashes back into view until activity resumes. Clear
+      // it on history replay (the canonical "reconnect handshake" event)
+      // for the same reason the transient `activeAgents`/`isPlanPending`
+      // are cleared above. Targets `replayTargetId` (per-session) rather
+      // than activeSessionId so a background session reconnecting also
+      // sheds its stale marker.
+      if (replayTargetId && get().sessionStates[replayTargetId]) {
+        updateSession(replayTargetId, (ss) => {
+          if (ss.stoppedAt == null && ss.stoppedCode == null) return {};
+          return { stoppedAt: null, stoppedCode: null };
+        });
+      }
       break;
     }
 


### PR DESCRIPTION
Closes #4909

Follow-up to #4879 / PR #4905.

## Summary

The `session_stopped` event (wired in #4868) is transient and not recorded into per-session history, so it isn't replayed on reconnect. The client-side `stoppedAt` / `stoppedCode` derived state, however, survives WebSocket teardown in Zustand store memory — when the operator taps Stop and then disconnects (backgrounding the app, swapping networks, etc.) without sending another message, the quiet \"Session stopped.\" strip flashes back into view on reconnect until activity resumes.

This adds the field-pair to the existing transient-state sweep in the `history_replay_start` handler — the same canonical reconnect-handshake event that already clears `activeAgents` and `isPlanPending` for the identical \"stale pre-disconnect snapshot\" reason.

## Why `history_replay_start` (vs the disconnect handler)

- Symmetry: `activeAgents` and `isPlanPending` are already cleared here for the exact same reason (client-side derived transient state that the server doesn't replay). Routing `stoppedAt`/`stoppedCode` through the same gate keeps the cleanup policy consolidated rather than scattered across both lifecycle ends.
- Per-session targeting: the handler uses `replayTargetId` so a background session reconnecting also sheds its stale marker — not just the active one.
- Cheap: no-op early-return when both fields are already null avoids unnecessary state churn for the (overwhelmingly common) case where no Stop happened pre-disconnect.

## Test plan

- [x] `packages/app/src/__tests__/store/message-handler.test.ts` — 4 new cases under `history_replay_start clears stale session_stopped marker (#4909)`:
  - clears `stoppedAt` + `stoppedCode` for the explicit target session
  - clears for a background (non-active) session reconnecting
  - no-op preserves the `sessionStates` reference when neither field is set
  - unknown session id is handled without throwing
- [x] All 144 message-handler tests green; all 1541 app tests green
- [x] `tsc --noEmit` clean