### PR TITLE
fix(dashboard): split post-tool text chunks into continuation slots (#4889)

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -878,7 +878,14 @@ describe('dashboard message-handler dispatch', () => {
 
       it('does not reorder a non-empty (reconnect-replayed) response slot', () => {
         // Simulate reconnect replay where a previous turn's response is
-        // already populated. A subsequent delta on it should NOT reorder.
+        // already populated. A subsequent delta on it must NOT reorder the
+        // existing slot — the #4297 reorder gate is `content === ''`.
+        //
+        // Post-#4889: because a tool_use follows the populated response,
+        // the new delta materializes into a continuation slot at the end
+        // instead of concatenating onto the existing content. The original
+        // response is preserved in place (no reorder), the tool stays at
+        // index 1, and the new text lands in a fresh `-cont-` bubble.
         const replayedResp = {
           id: 'resp-replay',
           type: 'response' as const,
@@ -904,10 +911,17 @@ describe('dashboard message-handler dispatch', () => {
         vi.runAllTimers()
 
         const ss = (store.getState() as any).sessionStates.s1
-        // Response stays at index 0 (the reorder gate is content === '').
+        // Original response stays at index 0 with its replayed content intact
+        // (no reorder, no concatenation).
         expect(ss.messages[0].id).toBe('resp-replay')
-        expect(ss.messages[0].content).toBe('Existing replayed content. more text')
+        expect(ss.messages[0].content).toBe('Existing replayed content. ')
+        // Tool remains at index 1.
         expect(ss.messages[1].id).toBe('toolu_x')
+        // The new delta lands in a continuation slot appended at the end.
+        const last = ss.messages[ss.messages.length - 1]
+        expect(last.type).toBe('response')
+        expect(last.content).toBe('more text')
+        expect(last.id).toMatch(/^resp-replay-cont-/)
       })
 
       it('reorders empty response slot in flat-state branch (legacy/pre-session bootstrap)', () => {
@@ -948,6 +962,221 @@ describe('dashboard message-handler dispatch', () => {
         expect(last.id).toBe('flat-resp')
         expect(last.content).toBe('flat summary')
         expect(flat[0].id).toBe('flat-tool')
+      })
+    })
+
+    // #4889 — when an assistant turn streams text → tool → text → tool → text,
+    // the server reuses ONE messageId for the entire response. The #4297 fix
+    // (reorder empty slot to end) only handles the FIRST delta — subsequent
+    // text chunks (after intervening tool_use messages) concatenate into the
+    // same content field with no separator, producing `…before filing.Filing
+    // now.Filed:` and losing paragraph breaks.
+    //
+    // Fix: when a delta arrives for a non-empty response that already has a
+    // tool_use appended after it, materialize a fresh response continuation
+    // slot at the end of the messages array (suffixed id `-cont-N`). Each
+    // post-tool text chunk becomes its own response bubble — formatTranscript
+    // already separates response messages with `\n\n`.
+    describe('post-tool text chunks split into continuation slots (#4889)', () => {
+      it('creates a new response slot when delta arrives for a response with tool_use appended after it', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        // text-A → tool → text-B → tool → text-C
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-1', sessionId: 's1', delta: 'Let me check chroxy before filing.' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: { command: 'gh issue list' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'tool_result', toolUseId: 'toolu_a', result: 'ok', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-1', sessionId: 's1', delta: 'Filing now.' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_b',
+            tool: 'Bash',
+            toolUseId: 'toolu_b',
+            input: { command: 'gh issue create' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'tool_result', toolUseId: 'toolu_b', result: 'https://...', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-1', sessionId: 's1', delta: 'Filed: https://github.com/...' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        // Three distinct response bubbles, each carrying one chunk
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        const tools = ss.messages.filter((m: any) => m.type === 'tool_use')
+        expect(responses).toHaveLength(3)
+        expect(tools).toHaveLength(2)
+        expect(responses[0].content).toBe('Let me check chroxy before filing.')
+        expect(responses[1].content).toBe('Filing now.')
+        expect(responses[2].content).toBe('Filed: https://github.com/...')
+        // No `.X` (period followed by capital with no space) across boundaries —
+        // the join in formatTranscript inserts `\n\n` so the concatenation is safe.
+        const joined = responses.map((r: any) => r.content).join('\n\n')
+        expect(joined).not.toMatch(/\.[A-Z]/)
+      })
+
+      it('places each continuation slot AFTER the preceding tool_use (#4297 ordering preserved)', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-1', sessionId: 's1', delta: 'preamble' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: { command: 'ls' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-1', sessionId: 's1', delta: 'summary' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        // [response('preamble'), tool, response('summary')]
+        expect(ss.messages).toHaveLength(3)
+        expect(ss.messages[0].type).toBe('response')
+        expect(ss.messages[0].content).toBe('preamble')
+        expect(ss.messages[1].type).toBe('tool_use')
+        expect(ss.messages[1].id).toBe('toolu_a')
+        expect(ss.messages[2].type).toBe('response')
+        expect(ss.messages[2].content).toBe('summary')
+      })
+
+      it('does not split when consecutive deltas arrive without an intervening tool', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-1', sessionId: 's1', delta: 'hello ' },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'resp-1', sessionId: 's1', delta: 'world' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        // No tool ran — single response slot with concatenated deltas
+        expect(ss.messages).toHaveLength(1)
+        expect(ss.messages[0].type).toBe('response')
+        expect(ss.messages[0].content).toBe('hello world')
+      })
+
+      it('splits in the flat-messages branch (legacy/pre-session bootstrap)', () => {
+        const flatBase = baseState({
+          activeSessionId: null,
+          sessions: [],
+          sessionStates: {},
+          messages: [],
+        }) as Record<string, unknown>
+        flatBase.addMessage = (m: unknown) => {
+          const s = store.getState() as { messages: unknown[] }
+          ;(store as { setState: (p: Record<string, unknown>) => void }).setState({
+            messages: [...s.messages, m],
+          })
+        }
+        store = createMockStore(flatBase)
+        setStore(store)
+
+        handleMessage({ type: 'stream_start', messageId: 'flat-resp' }, ctx() as any)
+        handleMessage(
+          { type: 'stream_delta', messageId: 'flat-resp', delta: 'part 1' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'flat-tool',
+            tool: 'Bash',
+            toolUseId: 'flat-tool',
+            input: { command: 'ls' },
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          { type: 'stream_delta', messageId: 'flat-resp', delta: 'part 2' },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const flat = (store.getState() as any).messages
+        const responses = flat.filter((m: any) => m.type === 'response')
+        const tools = flat.filter((m: any) => m.type === 'tool_use')
+        expect(responses).toHaveLength(2)
+        expect(tools).toHaveLength(1)
+        expect(responses[0].content).toBe('part 1')
+        expect(responses[1].content).toBe('part 2')
       })
     })
   })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1398,6 +1398,14 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
     deltaId = newId;
   } else if (_deltaIdRemaps.has(deltaId)) {
     deltaId = _deltaIdRemaps.get(deltaId)!;
+    // Allow chained remaps: when the post-tool continuation split (#4889)
+    // later remaps `deltaId` → `deltaId-cont-...`, the original incoming
+    // id needs to resolve through both hops on subsequent deltas.
+    while (_deltaIdRemaps.has(deltaId)) {
+      const next = _deltaIdRemaps.get(deltaId)!;
+      if (next === deltaId) break;
+      deltaId = next;
+    }
   } else {
     // Defensive: server reuses messageId for tool_start and the post-tool
     // stream_start. If stream_start was dropped or hasn't registered the
@@ -1443,6 +1451,69 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
           }));
         }
         deltaId = suffixed;
+      }
+    }
+  }
+
+  // #4889 — post-tool continuation split. The server reuses ONE messageId for
+  // an entire assistant turn even when text → tool → text → tool → text. The
+  // #4297 reorder only fires on the FIRST delta (gated on content === '');
+  // subsequent text chunks concatenate into the same response.content with no
+  // separator — producing `…before filing.Filing now.Filed:` and losing
+  // paragraph breaks.
+  //
+  // Detect the boundary by checking whether a tool_use was appended AFTER the
+  // currently-resolved response slot. If so, materialize a fresh continuation
+  // slot at the end (`<deltaId>-cont-<ts>`) and chain a remap so subsequent
+  // deltas for the same incoming messageId route to the new slot. The split
+  // mirrors the `-post-` permission-boundary pattern already in this file.
+  // Skipped while the session is replaying — replayed history is reassembled
+  // server-side and must not be re-split on the client.
+  {
+    const splitTargetId = capturedSessionId;
+    const splitEffectiveId = (splitTargetId && get().sessionStates[splitTargetId])
+      ? splitTargetId
+      : get().activeSessionId;
+    const isReplaying = splitEffectiveId ? _replayingSessions.has(splitEffectiveId) : false;
+    if (!isReplaying) {
+      const splitMessages = (splitEffectiveId && get().sessionStates[splitEffectiveId])
+        ? get().sessionStates[splitEffectiveId]!.messages
+        : get().messages;
+      const slotIdx = splitMessages.findIndex((m) => m.id === deltaId);
+      if (slotIdx >= 0) {
+        const slot = splitMessages[slotIdx]!;
+        // Buffered (not-yet-flushed) text counts as content for the split
+        // decision — otherwise a chunk that hasn't hit the 100ms flush yet
+        // would look empty and we'd append onto it.
+        const bufferedContent = pendingDeltas.get(deltaId)?.delta || '';
+        const hasContent = slot.type === 'response'
+          && (slot.content.length > 0 || bufferedContent.length > 0);
+        const toolAfter = hasContent
+          && splitMessages.slice(slotIdx + 1).some((m) => m.type === 'tool_use');
+        if (toolAfter) {
+          const contId = `${deltaId}-cont-${Date.now()}`;
+          // Chain the remap: the next delta for the original incoming id will
+          // resolve through both hops (handled by the while-loop above).
+          _deltaIdRemaps.set(deltaId, contId);
+          const contMsg: ChatMessage = {
+            id: contId,
+            type: 'response',
+            content: '',
+            timestamp: Date.now(),
+          };
+          if (splitEffectiveId && get().sessionStates[splitEffectiveId]) {
+            updateSession(splitEffectiveId, (ss) => ({
+              streamingMessageId: contId,
+              messages: [...ss.messages, contMsg],
+            }));
+          } else {
+            set((state: ConnectionState) => ({
+              streamingMessageId: contId,
+              messages: [...state.messages, contMsg],
+            }));
+          }
+          deltaId = contId;
+        }
       }
     }
   }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1313,7 +1313,13 @@ function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
 }
 
 function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  let deltaId = msg.messageId as string;
+  // Capture the ORIGINAL incoming messageId before any remap resolution.
+  // The post-tool continuation split (#4889) writes its remap entry against
+  // this id (not against the resolved `deltaId`) so successive splits
+  // overwrite a single map entry instead of forming a chain — keeps
+  // `_deltaIdRemaps` bounded and eliminates the need for chained lookup.
+  const originalMessageId = msg.messageId as string;
+  let deltaId = originalMessageId;
   const capturedSessionId = (msg.sessionId as string) || get().activeSessionId;
 
   // Forward delta text to terminal view (synthesize raw output in CLI mode)
@@ -1398,14 +1404,6 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
     deltaId = newId;
   } else if (_deltaIdRemaps.has(deltaId)) {
     deltaId = _deltaIdRemaps.get(deltaId)!;
-    // Allow chained remaps: when the post-tool continuation split (#4889)
-    // later remaps `deltaId` → `deltaId-cont-...`, the original incoming
-    // id needs to resolve through both hops on subsequent deltas.
-    while (_deltaIdRemaps.has(deltaId)) {
-      const next = _deltaIdRemaps.get(deltaId)!;
-      if (next === deltaId) break;
-      deltaId = next;
-    }
   } else {
     // Defensive: server reuses messageId for tool_start and the post-tool
     // stream_start. If stream_start was dropped or hasn't registered the
@@ -1464,11 +1462,13 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
   //
   // Detect the boundary by checking whether a tool_use was appended AFTER the
   // currently-resolved response slot. If so, materialize a fresh continuation
-  // slot at the end (`<deltaId>-cont-<ts>`) and chain a remap so subsequent
-  // deltas for the same incoming messageId route to the new slot. The split
-  // mirrors the `-post-` permission-boundary pattern already in this file.
-  // Skipped while the session is replaying — replayed history is reassembled
-  // server-side and must not be re-split on the client.
+  // slot at the end (`<deltaId>-cont-<ts>`) and remap the ORIGINAL incoming
+  // messageId directly to the new slot (single-hop, never chained — successive
+  // splits overwrite the existing entry so `_deltaIdRemaps` stays bounded and
+  // `handleStreamEnd`'s `_deltaIdRemaps.delete(out.messageId)` cleans up
+  // completely). The split mirrors the `-post-` permission-boundary pattern
+  // already in this file. Skipped while the session is replaying — replayed
+  // history is reassembled server-side and must not be re-split on the client.
   {
     const splitTargetId = capturedSessionId;
     const splitEffectiveId = (splitTargetId && get().sessionStates[splitTargetId])
@@ -1488,13 +1488,28 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
         const bufferedContent = pendingDeltas.get(deltaId)?.delta || '';
         const hasContent = slot.type === 'response'
           && (slot.content.length > 0 || bufferedContent.length > 0);
-        const toolAfter = hasContent
-          && splitMessages.slice(slotIdx + 1).some((m) => m.type === 'tool_use');
+        // Index-based scan instead of slice().some() — avoids allocating a
+        // tail array on every delta. handleStreamDelta is called many times
+        // per turn and sessions can carry long histories, so this stays on
+        // the hot path lean.
+        let toolAfter = false;
+        if (hasContent) {
+          for (let i = slotIdx + 1; i < splitMessages.length; i++) {
+            if (splitMessages[i]!.type === 'tool_use') {
+              toolAfter = true;
+              break;
+            }
+          }
+        }
         if (toolAfter) {
           const contId = `${deltaId}-cont-${Date.now()}`;
-          // Chain the remap: the next delta for the original incoming id will
-          // resolve through both hops (handled by the while-loop above).
-          _deltaIdRemaps.set(deltaId, contId);
+          // Single-hop remap: write against the ORIGINAL incoming messageId
+          // so successive continuation splits overwrite this entry rather
+          // than building a chain. Keeps `_deltaIdRemaps` size bounded by
+          // the count of distinct in-flight turn ids, and lets
+          // `handleStreamEnd`'s `_deltaIdRemaps.delete(out.messageId)` clean
+          // up completely.
+          _deltaIdRemaps.set(originalMessageId, contId);
           const contMsg: ChatMessage = {
             id: contId,
             type: 'response',


### PR DESCRIPTION
## Summary

Fix dashboard text-chunk concatenation across tool boundaries. When an assistant turn streams text → tool → text → tool → text, the server reuses ONE `messageId` for the entire response, so all post-tool text chunks land in the same response slot and concatenate without separator — producing `…before filing.Filing now.Filed:` and losing paragraph breaks.

- `handleStreamDelta` now detects the post-tool boundary by checking whether a `tool_use` was appended after the currently-resolved response slot. When yes, it materializes a fresh continuation slot (`<deltaId>-cont-<ts>`) at the end of the messages array and chains a remap so subsequent deltas for the same incoming `messageId` route to the new slot.
- Mirrors the existing `-post-` permission-boundary split pattern in the same file.
- Chained remaps resolved by extending the lookup with a small `while`-loop so `A → A-cont-1 → A-cont-2` resolves transitively on the next delta.
- Split is skipped while `_replayingSessions` includes the session — replayed history is reassembled server-side and must not be re-split on the client.

`formatTranscript` already separates response messages with `\n\n`, so post-tool text chunks now render as distinct paragraphs in the chat bubble and in the copied transcript. No spurious whitespace is injected; #4297 ordering invariant is preserved (each new slot appends at the current end); single-chunk turns are untouched.

Closes #4889

## Test plan

- [x] New `post-tool text chunks split into continuation slots (#4889)` describe block with four tests:
  - text → tool → text → tool → text yields three distinct response bubbles, no `.[A-Z]` across boundaries
  - continuation slot lands AFTER the preceding tool_use (#4297 ordering preserved)
  - consecutive deltas without intervening tool do NOT split
  - flat-state branch (legacy/pre-session bootstrap) also splits
- [x] Existing `does not reorder a non-empty (reconnect-replayed) response slot` updated to reflect the new continuation behaviour — the original response stays at index 0 with its replayed content intact; the new delta lands in a `-cont-` bubble at the end.
- [x] `npm run test -w @chroxy/dashboard` — 2599 passed (132 files)
- [x] `npm run test -w @chroxy/store-core` — 1060 passed (21 files)
- [x] `npm run typecheck -w @chroxy/dashboard` — clean
- [x] `npm run build -w @chroxy/dashboard` — clean