### PR TITLE
feat(server): log warn on writeFileRestricted cleanup-unlink failure

### DIFF
--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -1,4 +1,7 @@
 import { writeFileSync, chmodSync, renameSync, unlinkSync } from 'fs'
+import { createLogger } from './logger.js'
+
+const log = createLogger('platform')
 
 export const isWindows = process.platform === 'win32'
 export const isMac = process.platform === 'darwin'
@@ -34,10 +37,11 @@ export function defaultShell() {
  *
  * On rename failure, the intermediate `<filePath><tmpSuffix>` file is
  * unlinked before the error is rethrown so it does not leak across
- * retries. Cleanup errors are suppressed — the original rename error is
- * what the caller needs to surface. See #4874 — environment-manager.js
- * and session-state-persistence.js had identical bespoke cleanup
- * wrappers before this was hoisted into the shared helper.
+ * retries. The rename error is what the caller needs to surface, so it
+ * is always re-thrown; a non-ENOENT cleanup-unlink failure is logged via
+ * `log.warn` so the orphan `.tmp` is not invisible (#4906 — the bespoke
+ * cleanup wrappers in environment-manager.js / session-state-persistence.js
+ * had this warn before the hoist in #4874).
  */
 export function writeFileRestricted(filePath, data, { tmpSuffix = '.tmp' } = {}) {
   if (isWindows) {
@@ -50,7 +54,13 @@ export function writeFileRestricted(filePath, data, { tmpSuffix = '.tmp' } = {})
   try {
     renameSync(tmpPath, filePath)
   } catch (err) {
-    try { unlinkSync(tmpPath) } catch {}
+    try {
+      unlinkSync(tmpPath)
+    } catch (cleanupErr) {
+      if (cleanupErr && cleanupErr.code !== 'ENOENT') {
+        log.warn(`Failed to remove orphaned ${tmpPath}: ${cleanupErr.message}`)
+      }
+    }
     throw err
   }
 }

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -182,6 +182,109 @@ try {
         assert.strictEqual(observed, `${filePath}.tmp-12345`, 'tmpSuffix must drive the intermediate path')
       })
 
+      it('logs a warn when the cleanup-unlink fails with a non-ENOENT error and still re-throws the rename error (#4906)', () => {
+        // Regression: #4904 hoisted the per-caller cleanup into
+        // writeFileRestricted but dropped the warn that environment-manager.js
+        // and session-state-persistence.js emitted on a non-ENOENT unlink
+        // failure. The orphan `.tmp` was left on disk with no diagnostic
+        // trail. This test pins the warn back in place via a subprocess
+        // shim that fails BOTH rename and unlink — we then assert (a) the
+        // rename error is surfaced to the caller, and (b) the
+        // [platform] warn line for the unlink failure shows up on stderr.
+        const filePath = join(tmpDir, 'observability.json')
+        const shim = join(tmpDir, 'throw-on-rename-and-unlink.mjs')
+        const runner = join(tmpDir, 'runner-cleanup-fail.mjs')
+        const shimSrc = `
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+const fs = require('node:fs')
+const origRename = fs.renameSync
+const origUnlink = fs.unlinkSync
+fs.renameSync = (oldPath, newPath) => {
+  if (newPath === ${JSON.stringify(filePath)}) {
+    const err = new Error('simulated mid-write crash')
+    err.code = 'EIO'
+    throw err
+  }
+  return origRename.call(this, oldPath, newPath)
+}
+fs.unlinkSync = (p) => {
+  if (typeof p === 'string' && p === ${JSON.stringify(`${filePath}.tmp`)}) {
+    const err = new Error('simulated cleanup failure')
+    err.code = 'EACCES'
+    throw err
+  }
+  return origUnlink.call(this, p)
+}
+`
+        const runnerSrc = `
+import { writeFileRestricted } from ${JSON.stringify(PLATFORM_JS)}
+try {
+  writeFileRestricted(${JSON.stringify(filePath)}, 'payload')
+  process.exit(0)
+} catch (err) {
+  process.stderr.write('RENAME_ERR=' + err.message + '\\n')
+  process.exit(2)
+}
+`
+        writeFileRestricted(shim, shimSrc)
+        writeFileRestricted(runner, runnerSrc)
+        const result = spawnSync(process.execPath, ['--import', shim, runner], { encoding: 'utf-8' })
+        assert.strictEqual(result.status, 2, `expected non-zero exit; stderr=${result.stderr}`)
+        // (a) Original rename error surfaces to the caller — the
+        //     cleanup-failure log MUST NOT mask it.
+        assert.match(result.stderr, /RENAME_ERR=simulated mid-write crash/)
+        // (b) Warn line for the cleanup unlink is on stderr, scoped to
+        //     the [platform] logger and naming the orphaned tmp path.
+        assert.match(result.stderr, /\[WARN\]\s+\[platform\]\s+Failed to remove orphaned/)
+        assert.match(result.stderr, new RegExp(`${filePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.tmp`))
+        assert.match(result.stderr, /simulated cleanup failure/)
+      })
+
+      it('does NOT log on ENOENT cleanup-unlink — the tmp is already gone (#4906)', () => {
+        // The bespoke cleanup wrappers explicitly suppressed ENOENT
+        // because "tmp is already gone" is the desired post-condition,
+        // not a failure worth a warn. Pin that exemption so we don't
+        // start spamming logs when the tmp never made it to disk (e.g.,
+        // writeFileSync threw before rename was attempted, or another
+        // process unlinked it first).
+        const filePath = join(tmpDir, 'enoent-cleanup.json')
+        const shim = join(tmpDir, 'throw-on-rename-enoent-unlink.mjs')
+        const runner = join(tmpDir, 'runner-enoent-cleanup.mjs')
+        const shimSrc = `
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+const fs = require('node:fs')
+const origRename = fs.renameSync
+const origUnlink = fs.unlinkSync
+fs.renameSync = (oldPath, newPath) => {
+  if (newPath === ${JSON.stringify(filePath)}) {
+    // Pre-emptively unlink so the cleanup path sees ENOENT.
+    try { origUnlink.call(this, oldPath) } catch {}
+    const err = new Error('simulated mid-write crash')
+    err.code = 'EIO'
+    throw err
+  }
+  return origRename.call(this, oldPath, newPath)
+}
+`
+        const runnerSrc = `
+import { writeFileRestricted } from ${JSON.stringify(PLATFORM_JS)}
+try {
+  writeFileRestricted(${JSON.stringify(filePath)}, 'payload')
+  process.exit(0)
+} catch {
+  process.exit(2)
+}
+`
+        writeFileRestricted(shim, shimSrc)
+        writeFileRestricted(runner, runnerSrc)
+        const result = spawnSync(process.execPath, ['--import', shim, runner], { encoding: 'utf-8' })
+        assert.strictEqual(result.status, 2, `expected non-zero exit; stderr=${result.stderr}`)
+        // ENOENT cleanup must stay silent — no platform warn at all.
+        assert.doesNotMatch(result.stderr, /\[WARN\]\s+\[platform\]\s+Failed to remove orphaned/)
+      })
+
       it('cleans up the .tmp sidecar on successful write (#4850)', () => {
         // Once `rename` succeeds the `.tmp` is gone (it WAS the temp,
         // now renamed onto the target). A leftover `.tmp` would mean we


### PR DESCRIPTION
## Summary

Re-adds the cleanup-failure observability hook that `environment-manager.js` and `session-state-persistence.js` had before #4874 hoisted the `.tmp` cleanup into `writeFileRestricted`. After the hoist the cleanup unconditionally swallowed all `unlink` errors:

```js
try { unlinkSync(tmpPath) } catch {}
```

so an orphan `.tmp` left on disk by a locked path or mid-flight perms change had no diagnostic trail — the `rename` error masked it.

## What changes

- `writeFileRestricted` now logs `[platform] warn Failed to remove orphaned <path>: <msg>` when the cleanup `unlinkSync` fails with anything other than `ENOENT`.
- `ENOENT` stays silent — "tmp is already gone" is the desired post-condition.
- The original `rename` error is still re-thrown so the caller surfaces the real failure.

## Tests (TDD)

Two new subtests in `platform.test.js` pin the contract via the same subprocess-shim idiom the existing atomicity tests use (in-process `fs.renameSync` monkey-patch doesn't reach `platform.js`'s already-snapshotted ESM import binding):

1. **non-ENOENT cleanup unlink failure** — both `renameSync` and `unlinkSync` throw; assert the subprocess exits non-zero with the rename error AND `[WARN] [platform] Failed to remove orphaned ...` on stderr.
2. **ENOENT cleanup unlink** — the shim pre-emptively `unlink`s the tmp before throwing in `renameSync`; assert NO warn is logged (avoid log spam on a benign condition).

All 10 `writeFileRestricted()` subtests pass locally. Lints clean (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`, `eslint`).

## Test plan

- [x] `node --test tests/platform.test.js` — 13/13 pass
- [x] `npm run lint` — no new warnings/errors
- [x] State-file and session-opt lint scripts — green
- [ ] CI on PR

Closes #4906