### PR TITLE
refactor(dashboard): migrate to shared isFreeformAnswer predicate from store-core

### DIFF
--- a/packages/dashboard/src/components/QuestionPrompt.tsx
+++ b/packages/dashboard/src/components/QuestionPrompt.tsx
@@ -28,7 +28,12 @@
  * suppression.
  */
 import { useId, useState, useRef, useEffect } from 'react'
-import { OTHER_OPTION_VALUE, type ChatMessageQuestion } from '@chroxy/store-core'
+// #4901: `OtherFreeformAnswer` moved to @chroxy/store-core/freeform-answer
+// so the dashboard store, the mobile store, and the mobile screen all
+// converge on a single declaration paired with the shared
+// `isFreeformAnswer` guard. Re-exported below for the existing dashboard
+// call sites that import it from this file.
+import { OTHER_OPTION_VALUE, type ChatMessageQuestion, type OtherFreeformAnswer } from '@chroxy/store-core'
 
 /**
  * #4735 — per-question answer payload emitted by the multi-question form.
@@ -47,11 +52,14 @@ export type MultiQuestionAnswersMap = Record<string, string | string[]>
  * shape to send a two-stage `user_question_response` (server writes the
  * Other digit to claude TUI, waits for the text-input prompt swap, then
  * writes the freeform text + Enter).
+ *
+ * #4901: the interface itself lives in `@chroxy/store-core/freeform-answer`
+ * (single source of truth, paired with the `isFreeformAnswer` guard); re-
+ * exported here so existing dashboard importers (and any downstream
+ * components that pull the type from this file) keep working unchanged.
+ * Mirrors the mobile `MessageBubble.tsx` re-export pattern landed in #4875.
  */
-export interface OtherFreeformAnswer {
-  otherLabel: string
-  freeformText: string
-}
+export type { OtherFreeformAnswer }
 
 export interface QuestionPromptProps {
   question: string

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -119,6 +119,14 @@ import {
   // `Record<VoiceInputMode, true>` in store-core, so adding a new mode
   // to the union cannot silently drop here the way a `===` chain would.
   isVoiceInputMode,
+  // #4901: shared typed predicate for the AskUserQuestion freeform shape.
+  // Replaces the inline 5-condition check that previously duplicated the
+  // mobile store's detector (mobile migrated in #4875 / PR #4900). All
+  // three call sites (mobile store, mobile screen, dashboard store) now
+  // narrow off the same guard, and the `value is OtherFreeformAnswer`
+  // narrowing lets the post-detection `as { otherLabel, freeformText }`
+  // casts drop out.
+  isFreeformAnswer,
 } from '@chroxy/store-core';
 import { decrypt, DIRECTION_SERVER, type EncryptedEnvelope } from './crypto';
 import {
@@ -1656,17 +1664,17 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // possible if the model phrases a question that way). The freeform
     // shape is an object with EXACTLY those two keys AND both string
     // values — anything else falls through to the multi-question path.
-    const isFreeformAnswer = typeof answer === 'object' && answer !== null
-      && !Array.isArray(answer)
-      && Object.keys(answer).length === 2
-      && 'freeformText' in answer && 'otherLabel' in answer
-      && typeof (answer as Record<string, unknown>).freeformText === 'string'
-      && typeof (answer as Record<string, unknown>).otherLabel === 'string';
-    const isMultiAnswer = !isFreeformAnswer && typeof answer !== 'string';
+    //
+    // #4901: the shape check now lives in `@chroxy/store-core/freeform-answer`
+    // (single source of truth, mobile already migrated in #4875 / PR #4900).
+    // The `value is OtherFreeformAnswer` narrowing means the post-detection
+    // accesses (`answer.otherLabel`, `answer.freeformText`) no longer need
+    // `as { otherLabel: string; freeformText: string }` casts.
+    const freeform = isFreeformAnswer(answer);
+    const isMultiAnswer = !freeform && typeof answer !== 'string';
     let answerSummary: string;
-    if (isFreeformAnswer) {
-      const f = answer as { otherLabel: string; freeformText: string };
-      answerSummary = f.freeformText;
+    if (freeform) {
+      answerSummary = answer.freeformText;
     } else {
       // Delegate to the shared summary helper so multi-question Records
       // (and the legacy JSON-stringified array envelope from #4621) both
@@ -1676,14 +1684,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
         answer as string | Record<string, string | string[]>,
       );
     }
-    const payload: Record<string, unknown> = { type: 'user_question_response', answer: isFreeformAnswer
-      ? (answer as { otherLabel: string; freeformText: string }).otherLabel
+    const payload: Record<string, unknown> = { type: 'user_question_response', answer: freeform
+      ? answer.otherLabel
       : answerSummary };
     if (isMultiAnswer) {
       payload.answers = answer;
     }
-    if (isFreeformAnswer) {
-      payload.freeformText = (answer as { otherLabel: string; freeformText: string }).freeformText;
+    if (freeform) {
+      payload.freeformText = answer.freeformText;
     }
     if (toolUseId) payload.toolUseId = toolUseId;
     // #4296: echo the resolved answer to the terminal buffer so the Output

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1566,6 +1566,197 @@ describe('sendUserQuestionResponse Output-tab echo (#4296)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// #4901 — migration to shared `isFreeformAnswer` predicate from store-core.
+// ---------------------------------------------------------------------------
+// Pin behaviour after replacing the inline 5-condition shape detector in
+// `sendUserQuestionResponse` with the shared `isFreeformAnswer` typed-guard
+// from `@chroxy/store-core/freeform-answer` (mobile counterpart migrated in
+// #4875 / PR #4900). The migration MUST be a behaviour-neutral refactor:
+// the wire payload, the `appendTerminalData` echo, the `runningSince`
+// optimistic bump, and the negative-misroute defence (the original Copilot
+// review concern in #4753) all stay identical. These tests mirror the
+// mobile #4755 block in `packages/app/src/__tests__/store/connection.test.ts`.
+describe('sendUserQuestionResponse Other / freeform shape (#4901 shared-guard migration)', () => {
+  it('preserves a model-supplied custom Other label on the wire', async () => {
+    // Defends against a future regression where we forget to thread
+    // `otherLabel` through and instead hard-code the literal "Other"
+    // string — the server's digit-lookup would then resolve to the wrong
+    // hotkey for any custom-label Other option. Mirrors the mobile
+    // counterpart at app/__tests__/store/connection.test.ts (#4755).
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse(
+      { otherLabel: 'Something else', freeformText: 'typed' },
+      'toolu-custom-other',
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      type: 'user_question_response',
+      answer: 'Something else',
+      freeformText: 'typed',
+      toolUseId: 'toolu-custom-other',
+    });
+  });
+
+  it('omits toolUseId from the wire payload when not provided', async () => {
+    // Mirrors the mobile counterpart (#4755). Zero-options free-text
+    // AskUserQuestions historically lack a tool pairing.
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse(
+      { otherLabel: 'Other', freeformText: 'no-tooluse case' },
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({
+      type: 'user_question_response',
+      answer: 'Other',
+      freeformText: 'no-tooluse case',
+    });
+    expect(sent[0]).not.toHaveProperty('toolUseId');
+  });
+
+  // The Copilot review concern from #4753: a multi-question Record whose
+  // keys happen to literally be `otherLabel` and `freeformText` must NOT
+  // misroute through the freeform branch. The shared guard enforces the
+  // tightest possible shape (exactly two keys AND both string values), so
+  // any non-string value (string[] for a multi-select, etc.) falls
+  // through to the multi-question Record path with `answers` populated
+  // and the freeform `freeformText` field absent.
+  it('does NOT misroute a multi-question Record whose keys happen to be otherLabel + freeformText with non-string values', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    // A model-phrased multi-question form whose question keys happen to
+    // literally be `otherLabel` and `freeformText` AND whose answers are
+    // arrays (multi-select). The shared guard rejects this (array values
+    // fail the `typeof === 'string'` check), so it must serialize as a
+    // multi-question Record on the wire.
+    const adversarial = {
+      otherLabel: ['Patch', 'Minor'],
+      freeformText: ['App', 'Tests'],
+    };
+    useConnectionStore.getState().sendUserQuestionResponse(
+      adversarial as unknown as Record<string, string | string[]>,
+      'toolu-adversarial',
+    );
+
+    expect(sent).toHaveLength(1);
+    const payload = sent[0] as Record<string, unknown>;
+    expect(payload.type).toBe('user_question_response');
+    expect(payload.toolUseId).toBe('toolu-adversarial');
+    // Multi-question path: `answers` carries the verbatim map.
+    expect(payload.answers).toEqual(adversarial);
+    // Freeform-only field MUST be absent — proof we did not misroute.
+    expect(payload).not.toHaveProperty('freeformText');
+  });
+
+  // The acceptance criteria says no behavioural change to the
+  // `appendTerminalData` echo path. This pin defends against an accidental
+  // narrowing or branch reordering during the migration that would skip
+  // the terminal echo for freeform answers (the cyan "User answered:" line
+  // landed in #4296 and gates on `answerSummary` being non-empty).
+  it('still echoes the freeform text into the terminal buffer (#4296 / #4901 acceptance)', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const mockSocket = {
+      readyState: 1,
+      send: () => { /* swallow */ },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse(
+      { otherLabel: 'Other', freeformText: 'typed answer for echo pin' },
+      'toolu-echo',
+    );
+
+    const { terminalBuffer } = useConnectionStore.getState();
+    // ANSI is stripped by the dashboard's terminal-buffer pipeline
+    // (cyan/yellow distinction lives in the rawBuffer / terminal renderer).
+    // The acceptance criteria pin here is just that the cyan-prefixed echo
+    // line still fires for freeform answers under the shared guard — i.e.
+    // the post-detection branch that calls `appendTerminalData` is taken.
+    expect(terminalBuffer).toContain('User answered: typed answer for echo pin');
+    // The "> " prefix is part of the echo template — if it disappears it
+    // means the echo path was bypassed and only the formatQuestionAnswerSummary
+    // fallback wrote into the buffer.
+    expect(terminalBuffer).toContain('> User answered:');
+  });
+
+  // Mirrors mobile #4755 third test: legacy string answers must keep the
+  // back-compat wire shape — `freeformText` MUST be absent so older
+  // servers cannot misclassify a plain option tap as an Other / freeform
+  // send (Zod schema strict-mode would also reject extras here).
+  it('keeps the legacy {answer:<string>, toolUseId} shape for plain string answers and OMITS freeformText', async () => {
+    const { useConnectionStore } = await import('./connection');
+
+    const sent: Record<string, unknown>[] = [];
+    const mockSocket = {
+      readyState: 1,
+      send: (data: string) => { sent.push(JSON.parse(data)); },
+    };
+
+    useConnectionStore.setState({
+      socket: mockSocket as unknown as WebSocket,
+      terminalBuffer: '',
+      terminalRawBuffer: '',
+    });
+
+    useConnectionStore.getState().sendUserQuestionResponse('Option A', 'toolu-string');
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({
+      type: 'user_question_response',
+      answer: 'Option A',
+      toolUseId: 'toolu-string',
+    });
+    expect(sent[0]).not.toHaveProperty('freeformText');
+    expect(sent[0]).not.toHaveProperty('answers');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // #4312 — optimistic busy-state bump on answer send
 // ---------------------------------------------------------------------------
 // sendInput (the regular chat path) implicitly puts the dashboard into a

--- a/packages/store-core/src/freeform-answer.ts
+++ b/packages/store-core/src/freeform-answer.ts
@@ -34,11 +34,11 @@
  * + Enter). Older servers that ignore `freeformText` fall through to the
  * legacy path and type the label literally — a clean degradation.
  *
- * Mirrors the dashboard's `OtherFreeformAnswer` (still re-exported from
- * `packages/dashboard/src/components/QuestionPrompt.tsx` for backward
- * compatibility) and the mobile `OtherFreeformAnswer` from
- * `packages/app/src/components/chat/MessageBubble.tsx`. Both call sites
- * should converge on this declaration over time.
+ * Both `packages/dashboard/src/components/QuestionPrompt.tsx` (#4901) and
+ * `packages/app/src/components/chat/MessageBubble.tsx` (#4875) now re-
+ * export this declaration as a type-only re-export, so all three call
+ * sites (mobile store, mobile screen, dashboard store) converge on the
+ * single source of truth here.
  */
 export interface OtherFreeformAnswer {
   otherLabel: string;

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -16,14 +16,11 @@ export { DEFAULT_CONTEXT_WINDOW } from './types'
 // TS error in the guard, not a silent drop at the call site.
 export { isVoiceInputMode } from './types'
 
-// #4875: shared typed predicate + type for the AskUserQuestion "Other /
-// freeform" answer payload. Mobile store + mobile screen now narrow off
-// this single guard so widening `SelectOptionValue` to a third object
-// shape can't silently misroute it as freeform. The dashboard store
-// still has its own inline 5-condition detector and its own
-// `OtherFreeformAnswer` declaration; migrating it is tracked in #4901
-// so this export becomes the single source of truth across all three
-// call sites.
+// #4875 / #4901: shared typed predicate + type for the AskUserQuestion
+// "Other / freeform" answer payload. Mobile store + mobile screen (#4875)
+// and the dashboard store + `QuestionPrompt.tsx` (#4901) all narrow off
+// this single guard, so widening `SelectOptionValue` to a third object
+// shape can't silently misroute it as freeform on either client.
 export { isFreeformAnswer } from './freeform-answer'
 export type { OtherFreeformAnswer } from './freeform-answer'
 


### PR DESCRIPTION
## Summary

Migrates the dashboard's inline 5-condition `OtherFreeformAnswer` shape detector + duplicate type declaration to the shared `isFreeformAnswer` typed-guard from `@chroxy/store-core/freeform-answer`, mirroring the mobile-side migration in #4875 / PR #4900. With this change, all three call sites (mobile store, mobile screen, dashboard store) converge on a single source of truth, the `value is OtherFreeformAnswer` predicate narrows out the three `as { otherLabel, freeformText }` casts in the dashboard store, and `QuestionPrompt.tsx` becomes a thin type-only re-export the same way the mobile `MessageBubble.tsx` does.

Closes #4901

## Changes

- `packages/dashboard/src/store/connection.ts`: import `isFreeformAnswer` from the existing `@chroxy/store-core` block; replace the inline 5-condition detector with `isFreeformAnswer(answer)`; drop the three post-detection `as { otherLabel: string; freeformText: string }` casts (`:1663`, `:1675`, `:1681` in old numbering) now that the guard narrows.
- `packages/dashboard/src/components/QuestionPrompt.tsx`: replace `export interface OtherFreeformAnswer { ... }` with `import type { OtherFreeformAnswer } from '@chroxy/store-core'` + `export type { OtherFreeformAnswer }`, mirroring the mobile `MessageBubble.tsx` pattern.
- `packages/store-core/src/index.ts` + `freeform-answer.ts`: drop the "migration tracked in #4901" comment now that the dashboard has converged; record both `#4875` (mobile) and `#4901` (dashboard) in the shared module's doc strings.
- `packages/dashboard/src/store/store.test.ts`: add a new `#4901 shared-guard migration` describe block mirroring the mobile `#4755` block in `packages/app/src/__tests__/store/connection.test.ts` - 5 new tests covering:
    - custom Other label preservation,
    - omitted `toolUseId` when not provided,
    - negative-misroute defence (adversarial Record whose keys happen to literally be `otherLabel` + `freeformText` with non-string array values must NOT route as freeform - the original Copilot review concern from #4753),
    - `appendTerminalData` echo still fires (acceptance criteria),
    - legacy string-answer back-compat shape with no `freeformText` leak.

No behavioural change to the wire payload, the `appendTerminalData` echo, or the `runningSince` optimistic activity bump on freeform answers - the migration is a pure refactor.

## Acceptance Criteria

- [x] Replace `packages/dashboard/src/components/QuestionPrompt.tsx:51` `export interface OtherFreeformAnswer { ... }` with a type-only re-export from `@chroxy/store-core`.
- [x] Replace the inline 5-condition shape check in `packages/dashboard/src/store/connection.ts:1654-1659` with `isFreeformAnswer(answer)` imported from `@chroxy/store-core`.
- [x] Drop the `as { otherLabel: string; freeformText: string }` casts at `:1663`, `:1675`, `:1681` now that the guard narrows the type.
- [x] Dashboard typecheck + tests pass.
- [x] No behavioural change to the `appendTerminalData` echo path or the `runningSince` optimistic bump - both still fire on freeform answers exactly as today.

## Test plan

- [x] `packages/store-core` tests - 1060 passed (no new tests; the shared guard was already covered by 24 freeform-answer.test.ts cases from #4875)
- [x] `packages/dashboard` typecheck - clean
- [x] `packages/dashboard` tests - 2600 passed (5 new under `#4901 shared-guard migration`)