### PR TITLE
refactor(server): collapse session-state-persistence onto writeFileRestricted

### DIFF
--- a/packages/server/src/session-state-persistence.js
+++ b/packages/server/src/session-state-persistence.js
@@ -45,7 +45,9 @@ export class SessionStatePersistence {
    * #4874 collapsed elsewhere — this file was deferred per the #4874 issue
    * body and audited separately in #4908):
    *   - If we crash AFTER rotate but BEFORE the write completes, `restoreState`
-   *     falls back to `.bak` (line 144) which still holds the prior generation.
+   *     falls back to `.bak` (see {@link restoreState} — when the main file is
+   *     missing or unparseable it reads from `.bak`) which still holds the
+   *     prior generation.
    *   - `writeFileRestricted` is atomic on POSIX (internal rename replaces the
    *     destination), so a partial write of the new generation cannot leave
    *     half-written bytes at `mainPath`.

--- a/packages/server/src/session-state-persistence.js
+++ b/packages/server/src/session-state-persistence.js
@@ -33,41 +33,52 @@ export class SessionStatePersistence {
 
   /**
    * Serialize session state to disk.
+   *
+   * Write order (audited in #4908): rotate the current file to `.bak` FIRST,
+   * then call `writeFileRestricted(mainPath, data)` which atomically writes
+   * via its own internal `.tmp` + rename on POSIX (and direct `writeFileSync`
+   * on Windows — see {@link writeFileRestricted}).
+   *
+   * Why rotate-then-write (not write-then-rotate)? Both orders are crash-safe,
+   * but rotate-first lets us reuse the shared atomic-write helper rather than
+   * hand-rolling a second `.tmp` + rename layer (the bespoke wrapper that
+   * #4874 collapsed elsewhere — this file was deferred per the #4874 issue
+   * body and audited separately in #4908):
+   *   - If we crash AFTER rotate but BEFORE the write completes, `restoreState`
+   *     falls back to `.bak` (line 144) which still holds the prior generation.
+   *   - `writeFileRestricted` is atomic on POSIX (internal rename replaces the
+   *     destination), so a partial write of the new generation cannot leave
+   *     half-written bytes at `mainPath`.
+   *   - On Windows, `writeFileRestricted` does a direct `writeFileSync` — that
+   *     matches the prior behavior (the old code's `.tmp` write was also a
+   *     direct `writeFileSync`; the only "atomic" step on Windows was the
+   *     final `renameSync`, which still depends on the OS).
+   *
+   * `_rotateToBak`'s Windows retry-and-restore-`.bak` flow stays intact under
+   * the new order: the snapshot-and-restore happens before the main write, so
+   * a failed rotation leaves `.bak` holding whichever generation it held
+   * before serialize ran. The Windows `unlinkSync(mainPath)` step (NTFS
+   * EEXIST workaround) is no longer needed — after rotation, `mainPath`
+   * either does not exist (rotate succeeded) or holds the same bytes as
+   * `.bak` (rotate failed). `writeFileSync` on Windows overwrites either way.
+   *
    * @param {object} state - The complete state object to write (version, timestamp, sessions, costs, etc.)
    * @returns {object} The state that was written
    */
   serializeState(state) {
     const dir = dirname(this._stateFilePath)
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-    const tmpPath = this._stateFilePath + '.tmp'
     const bakPath = this._stateFilePath + '.bak'
-    writeFileRestricted(tmpPath, JSON.stringify(state, null, 2))
-    // Rotate the current file to .bak so one generation survives a crash
-    // or partial write during the rename below. Best-effort — a missing
+    // Rotate the current file to .bak BEFORE writing the new generation so
+    // one generation survives a crash mid-write. Best-effort — a missing
     // source file (first write) or rename failure must not block the new write.
     if (fs.existsSync(this._stateFilePath)) {
       this._rotateToBak(this._stateFilePath, bakPath)
     }
-    if (this._isWindows) {
-      try { fs.unlinkSync(this._stateFilePath) } catch (err) {
-        if (err && err.code !== 'ENOENT') {
-          log.error(`Failed to remove existing state file: ${err.message}`)
-        }
-      }
-    }
-    try {
-      fs.renameSync(tmpPath, this._stateFilePath)
-    } catch (err) {
-      // Clean up the orphaned .tmp file so it doesn't leak on disk across
-      // retries. Suppress ENOENT (nothing to clean up) and any secondary
-      // unlink error (we must re-throw the original rename failure).
-      try { fs.unlinkSync(tmpPath) } catch (cleanupErr) {
-        if (cleanupErr && cleanupErr.code !== 'ENOENT') {
-          log.warn(`Failed to remove orphaned ${tmpPath}: ${cleanupErr.message}`)
-        }
-      }
-      throw err
-    }
+    // writeFileRestricted is atomic on POSIX (internal .tmp + rename) and a
+    // direct writeFileSync on Windows. Cleanup of the orphan .tmp on rename
+    // failure is handled inside the helper.
+    writeFileRestricted(this._stateFilePath, JSON.stringify(state, null, 2))
     log.info(`Serialized ${state.sessions?.length ?? 0} session(s) to ${this._stateFilePath}`)
     return state
   }

--- a/packages/server/tests/session-state-persistence.test.js
+++ b/packages/server/tests/session-state-persistence.test.js
@@ -411,6 +411,40 @@ describe('SessionStatePersistence backup rotation (regression: #2906)', () => {
     assert.equal(existsSync(stateFile), false)
     assert.ok(existsSync(stateFile + '.bak'), '.bak preserved for future recovery')
   })
+
+  // #4908 crash-safety pin: serializeState was collapsed onto the shared
+  // writeFileRestricted helper, which requires rotation to happen BEFORE the
+  // new write — otherwise a mid-write crash could replace the main file with
+  // partial bytes and the AFTER-rotation step would then move that partial
+  // copy into .bak, destroying the prior-generation recovery copy. Spy on the
+  // instance's `_rotateToBak` method (instance binding, not an imported one,
+  // so we can replace it directly) and capture filesystem state at the moment
+  // rotation is invoked.
+  it('rotates BEFORE writing the new generation (crash-safety pin for #4908)', () => {
+    const p = new SessionStatePersistence({ stateFilePath: stateFile })
+    p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 'gen1', name: 'Gen1', cwd: '/tmp' }] })
+
+    // Capture main file contents at the moment _rotateToBak runs. Rotate-then-
+    // write means main still holds Gen1 at this point; write-then-rotate would
+    // mean main already holds Gen2.
+    let mainAtRotation = null
+    const originalRotate = p._rotateToBak.bind(p)
+    p._rotateToBak = function spyRotate(mainPath, bakPath) {
+      mainAtRotation = existsSync(mainPath) ? JSON.parse(readFileSync(mainPath, 'utf-8')) : null
+      return originalRotate(mainPath, bakPath)
+    }
+
+    p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 'gen2', name: 'Gen2', cwd: '/tmp' }] })
+
+    assert.ok(mainAtRotation, '_rotateToBak must be called while main still exists (rotate-then-write order)')
+    assert.equal(mainAtRotation.sessions[0].name, 'Gen1',
+      'at rotation time, main must hold the PRIOR generation — proves rotation runs BEFORE the new write')
+
+    const main = JSON.parse(readFileSync(stateFile, 'utf-8'))
+    const bak = JSON.parse(readFileSync(stateFile + '.bak', 'utf-8'))
+    assert.equal(main.sessions[0].name, 'Gen2')
+    assert.equal(bak.sessions[0].name, 'Gen1')
+  })
 })
 
 describe('SessionStatePersistence Windows .bak rotation (regression: #2908)', () => {
@@ -462,8 +496,13 @@ describe('SessionStatePersistence Windows .bak rotation (regression: #2908)', ()
     })
 
     assert.ok(unlinkedBak, 'should unlink the locked .bak before retrying rotation')
-    // Rename called: (1) initial rotate (threw), (2) retry rotate, (3) tmp → main
-    assert.equal(renameCalls, 3, 'should call rename three times: initial rotate + retry + final tmp→main')
+    // Rename called twice via fs.renameSync (rotation path): (1) initial rotate
+    // (threw EPERM), (2) retry rotate (succeeded). The final main-file write is
+    // delegated to writeFileRestricted (#4908 collapse) which imports its rename
+    // binding directly from 'fs' as a named import — that call bypasses
+    // mock.method(fs, 'renameSync', ...) so it is not visible here. The
+    // existsSync post-condition verifies the write happened.
+    assert.equal(renameCalls, 2, 'fs.renameSync called twice in rotation path: initial rotate + retry (final write goes through writeFileRestricted)')
     assert.ok(existsSync(stateFile), 'main state file should exist after serialize')
     assert.ok(existsSync(stateFile + '.bak'), '.bak should exist after successful retry')
     const bak = JSON.parse(readFileSync(stateFile + '.bak', 'utf-8'))
@@ -490,7 +529,11 @@ describe('SessionStatePersistence Windows .bak rotation (regression: #2908)', ()
       p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 'new', name: 'New', cwd: '/tmp' }] })
     })
 
-    assert.ok(renameCalls >= 3, 'rotate attempted twice, then final tmp → main')
+    // fs.renameSync called twice (rotation initial + retry, both threw EBUSY).
+    // The main write goes through writeFileRestricted whose internal rename
+    // bypasses mock.method(fs, ...) — see the EPERM test above. The existsSync
+    // post-condition verifies the new generation was still written.
+    assert.ok(renameCalls >= 2, 'rotate attempted twice (initial + retry)')
     assert.ok(existsSync(stateFile), 'main state file must still be written when rotation fails')
     const main = JSON.parse(readFileSync(stateFile, 'utf-8'))
     assert.equal(main.sessions[0].name, 'New', 'new state should be persisted even if .bak rotation failed')

--- a/packages/server/tests/session-state-persistence.test.js
+++ b/packages/server/tests/session-state-persistence.test.js
@@ -413,13 +413,15 @@ describe('SessionStatePersistence backup rotation (regression: #2906)', () => {
   })
 
   // #4908 crash-safety pin: serializeState was collapsed onto the shared
-  // writeFileRestricted helper, which requires rotation to happen BEFORE the
-  // new write — otherwise a mid-write crash could replace the main file with
-  // partial bytes and the AFTER-rotation step would then move that partial
-  // copy into .bak, destroying the prior-generation recovery copy. Spy on the
-  // instance's `_rotateToBak` method (instance binding, not an imported one,
-  // so we can replace it directly) and capture filesystem state at the moment
-  // rotation is invoked.
+  // writeFileRestricted helper. The key invariant pinned here is that rotation
+  // must happen BEFORE the main-path write so `.bak` always captures the prior
+  // generation — without reintroducing a bespoke tmp+rename layer on top of
+  // the shared helper. Reversing the order (write-then-rotate) would mean a
+  // successful write followed by rotation would copy the NEW generation into
+  // `.bak`, overwriting the recoverable prior generation. Spy on the instance's
+  // `_rotateToBak` method (instance binding, not an imported one, so we can
+  // replace it directly) and capture filesystem state at the moment rotation
+  // is invoked.
   it('rotates BEFORE writing the new generation (crash-safety pin for #4908)', () => {
     const p = new SessionStatePersistence({ stateFilePath: stateFile })
     p.serializeState({ version: 1, timestamp: Date.now(), sessions: [{ id: 'gen1', name: 'Gen1', cwd: '/tmp' }] })


### PR DESCRIPTION
## Summary

Closes #4908.

Audit verdict: **collapse is safe**. The hand-rolled `.tmp` + rename layer in `serializeState` predated `writeFileRestricted`'s atomic guarantee (added in #4874). Move rotation to BEFORE the write so the shared helper can do the atomic write, and delete the duplicate `.tmp` + rename + cleanup logic.

### Audit conclusion

`writeFileRestricted` now provides atomic semantics on POSIX (internal `.tmp` + rename) and a direct `writeFileSync` on Windows. The previous `serializeState` was double-buffering: it wrote to `<state>.tmp` via the helper (which on POSIX wrote to `<state>.tmp.tmp` and renamed to `<state>.tmp`), then renamed `<state>.tmp` to `<state>`. Pointless on POSIX.

The audit found rotation can move BEFORE the write without losing crash safety:
- If a crash happens after rotation but before the write completes, `restoreState` already falls back to `.bak` (existing code at line 144).
- `writeFileRestricted` on POSIX is atomic — partial bytes cannot end up at `mainPath`.
- On Windows the prior code's `.tmp` write was a direct `writeFileSync` too; the only "atomic" step was the final `renameSync`. The new code's behavior matches.

`_rotateToBak`'s Windows EPERM/EACCES/EBUSY/EEXIST retry-and-restore-`.bak` flow is unchanged. The Windows `unlinkSync(mainPath)` NTFS workaround is no longer needed — after rotation, `mainPath` either doesn't exist (rotate succeeded) or holds the same bytes as `.bak` (rotate failed); `writeFileSync` overwrites either way.

### Changes

- `packages/server/src/session-state-persistence.js`: collapse `serializeState` from ~35 lines to ~5 lines (rotate-then-write). Add a long-form docstring documenting the audit conclusion so the next refactor doesn't redo the analysis.
- `packages/server/tests/session-state-persistence.test.js`:
  - Two #2908 assertions on `fs.renameSync` call counts updated from 3 to 2 — `writeFileRestricted` uses a named-import rename binding that `mock.method(fs, ...)` does not observe. The existing `existsSync` post-conditions still verify the main write happened.
  - New rotate-then-write pin test spies on `_rotateToBak` to assert main still holds the prior generation at rotation time. Locks the order so a future refactor can't accidentally invert it (which would destroy the `.bak` recovery copy on a mid-write crash).

## Test plan

- [x] `node --test tests/session-state-persistence.test.js` — 38 pass, 0 fail (37 existing + 1 new pin test)
- [x] Existing #2906 rotation, #2908 Windows retry, #2909 rename-failure cleanup blocks pass unchanged in behavior
- [x] `./scripts/lint-tests-state-file-path.sh` — clean
- [x] `./scripts/lint-session-opt-forwarding.sh` — clean
- [x] Full `npm test` shows no NEW failures from this change (only pre-existing tunnel/encryption integration test failures unrelated to persistence)