### PR TITLE
fix(server): make writeFileRestricted atomic on Windows too (#4913)

### DIFF
--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -769,11 +769,12 @@ export class EnvironmentManager extends EventEmitter {
         environments: Array.from(this._environments.values()),
       }
 
-      // writeFileRestricted is atomic on POSIX (#4850) and cleans up
-      // its intermediate `.tmp` on rename failure (#4874) — no manual
-      // tmp+rename wrapper needed here. On Windows it falls through to
-      // a direct writeFileSync which overwrites the destination, so the
-      // pre-#4874 unlinkSync(EEXIST) workaround is no longer required.
+      // writeFileRestricted is atomic on both POSIX (#4850) and Windows
+      // (#4913) and cleans up its intermediate `.tmp` on rename failure
+      // (#4874) — no manual tmp+rename wrapper needed here. The
+      // pre-#4874 unlinkSync(EEXIST) workaround is no longer required
+      // since Node's renameSync uses MoveFileExW(REPLACE_EXISTING) on
+      // Windows.
       writeFileRestricted(this._statePath, JSON.stringify(data, null, 2))
     } catch (err) {
       log.error(`Failed to persist environment state: ${err.message}`)

--- a/packages/server/src/models.js
+++ b/packages/server/src/models.js
@@ -473,15 +473,14 @@ export function createModelsRegistry(hooks = {}) {
 
     try {
       mkdirSync(dirname(path), { recursive: true })
-      // Pass a per-pid `tmpSuffix` so two concurrent POSIX processes
+      // Pass a per-pid `tmpSuffix` so two concurrent processes
       // (test runner + main daemon, or two test workers) writing the
       // same cache do not race on the same intermediate `.tmp` file
-      // (#4874). The suffix is a POSIX-only contract — on Windows
-      // `writeFileRestricted` ignores `tmpSuffix` and writes directly to
-      // the target path (see `platform.js`), so the per-pid hint has no
-      // effect there. writeFileRestricted handles atomic rename +
-      // cleanup internally on POSIX since #4874; no manual rename/unlink
-      // wrapper is needed here.
+      // (#4874). The suffix is honoured on both POSIX and Windows since
+      // #4913 — writeFileRestricted now uses the same temp+rename
+      // pattern on both platforms, so the per-pid hint protects every
+      // host. writeFileRestricted handles atomic rename + cleanup
+      // internally; no manual rename/unlink wrapper is needed here.
       writeFileRestricted(path, JSON.stringify({
         models: activeModels,
         defaultModelId,

--- a/packages/server/src/platform.js
+++ b/packages/server/src/platform.js
@@ -13,27 +13,51 @@ export function defaultShell() {
 }
 
 /**
- * Write `data` to `filePath` atomically on POSIX (write to
- * `<filePath><tmpSuffix>` then `rename` over the target). `rename` is
- * atomic on the same filesystem, so a concurrent reader sees either the
- * previous version or the new one — never a half-written file. This
+ * Write `data` to `filePath` atomically on both POSIX and Windows. The
+ * write goes to a sibling temp file `<filePath><tmpSuffix>` first and is
+ * then `rename`d over the destination. `rename` is atomic on the same
+ * filesystem on both POSIX (POSIX.1 `rename(2)`) and Windows (Node's
+ * `fs.renameSync` calls `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING |
+ * MOVEFILE_WRITE_THROUGH` since v16), so a concurrent reader sees either
+ * the previous version or the new one — never a half-written file. This
  * matters when the process is killed mid-write (SIGKILL / OOM); it is
  * the file-level analogue of the "SIGTERM not SIGKILL for Chroxy"
- * memory note. See #4850, which surfaced this gap for `connection.json`
- * (pre-existing) and `device-preferences.json` (added in #4847).
+ * memory note. See #4850 (the original POSIX gap for `connection.json`
+ * and `device-preferences.json`) and #4913 (extension of the same
+ * crash-safety contract to Windows, after #4874 collapsed manual
+ * tmp+rename wrappers in `environment-manager.js` and `models.js` onto
+ * this helper).
  *
- * On Windows we keep the direct `writeFileSync` path — `rename`
- * semantics differ (it fails when the destination exists unless you
- * use `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`) and there is no ACL
- * machinery here that needs the atomic guarantee yet.
+ * The temp file lives in the same directory as `filePath` (not
+ * `os.tmpdir()`) so the rename always stays within the same filesystem /
+ * volume. A cross-volume rename would fail with EXDEV on POSIX and
+ * ERROR_NOT_SAME_DEVICE on Windows and silently defeat the atomic
+ * guarantee.
  *
- * Options (POSIX only):
+ * On POSIX the temp file is created with `0o600` and `chmod`ed for
+ * defence-in-depth before the rename. On Windows we deliberately do NOT
+ * pass `mode` to `writeFileSync` — Node maps the integer mode argument
+ * through `_open` on Windows where only the write bit (`0o200`) toggles
+ * the read-only attribute; the read / group / other bits are silently
+ * ignored. ACL inheritance from the parent directory is the correct
+ * mechanism on NTFS, and our existing storage paths (`~/.chroxy/`,
+ * `%APPDATA%/Chroxy/`) inherit user-only ACLs from the per-user profile
+ * directory that Chroxy creates them under. See #4913 for the threat
+ * model discussion.
+ *
+ * Options:
  *   - `tmpSuffix` (default `.tmp`): suffix appended to `filePath` for
  *     the intermediate atomic-write file. Callers that may collide on
  *     the same target path from multiple processes (e.g. the models
  *     cache rewritten by both the test runner and the main daemon)
  *     should pass a per-process suffix such as `.tmp-${process.pid}`
- *     so the intermediate files never overwrite each other. See #4874.
+ *     so the intermediate files never overwrite each other. Honoured
+ *     on POSIX since #4874, and on Windows since #4913.
+ *   - `_isWindowsOverride` (test-only): force the Windows branch
+ *     regardless of host platform. Mirrors the same hook in
+ *     `SessionStatePersistence` and lets the cross-platform atomicity
+ *     test exercise the Windows path on a POSIX runner (we cannot rely
+ *     on a Windows CI runner being available — see #4913).
  *
  * On rename failure, the intermediate `<filePath><tmpSuffix>` file is
  * unlinked before the error is rethrown so it does not leak across
@@ -43,32 +67,41 @@ export function defaultShell() {
  * cleanup wrappers in environment-manager.js / session-state-persistence.js
  * had this warn before the hoist in #4874).
  */
-export function writeFileRestricted(filePath, data, { tmpSuffix = '.tmp' } = {}) {
-  if (isWindows) {
-    writeFileSync(filePath, data)
-    return
-  }
+export function writeFileRestricted(
+  filePath,
+  data,
+  { tmpSuffix = '.tmp', _isWindowsOverride } = {},
+) {
+  const onWindows = _isWindowsOverride ?? isWindows
   const tmpPath = `${filePath}${tmpSuffix}`
-  // The `mode: 0o600` arg to `writeFileSync` is ONLY honoured on file
-  // CREATION (`O_CREAT`). When `tmpPath` already exists — e.g. a prior
-  // run crashed before the rename and left a stale sidecar at a looser
-  // mode, or another local user pre-created the path under a permissive
-  // umask — `writeFileSync` opens with `O_TRUNC` and preserves the
-  // existing mode bits. The explicit `chmodSync` afterward guarantees
-  // the FINAL file is 0o600, but does NOT eliminate the transient
-  // exposure window between the write and the chmod — during that
-  // window, a pre-existing looser mode means another local user could
-  // read the freshly-written bytes. Full mitigation would require
-  // openSync(O_CREAT|O_EXCL) + fchmodSync before write; the current
-  // belt-and-braces is intentional but only covers the at-rest final
-  // perms, not the in-flight window. These files may carry secrets
-  // (session bearer tokens, push subscriptions, BYOK creds). Same
-  // defensive pattern is in `logger.js` (dir mode),
+  // POSIX: the `mode: 0o600` arg to `writeFileSync` is ONLY honoured on
+  // file CREATION (`O_CREAT`). When `tmpPath` already exists — e.g. a
+  // prior run crashed before the rename and left a stale sidecar at a
+  // looser mode, or another local user pre-created the path under a
+  // permissive umask — `writeFileSync` opens with `O_TRUNC` and
+  // preserves the existing mode bits. The explicit `chmodSync`
+  // afterward guarantees the FINAL file is 0o600, but does NOT
+  // eliminate the transient exposure window between the write and the
+  // chmod — during that window, a pre-existing looser mode means
+  // another local user could read the freshly-written bytes. Full
+  // mitigation would require openSync(O_CREAT|O_EXCL) + fchmodSync
+  // before write; the current belt-and-braces is intentional but only
+  // covers the at-rest final perms, not the in-flight window. These
+  // files may carry secrets (session bearer tokens, push subscriptions,
+  // BYOK creds). Same defensive pattern is in `logger.js` (dir mode),
   // `byok-credentials.js`, `byok-mcp-trust.js`, and
   // `notification-prefs.js`. See #4907 for the cleanup discussion that
   // ended in "keep with comment + regression test".
-  writeFileSync(tmpPath, data, { mode: 0o600 })
-  chmodSync(tmpPath, 0o600)
+  //
+  // Windows: no POSIX mode bits — ACLs are the correct mechanism and
+  // `writeFileSync`'s `mode` is mostly a no-op on Win32. The temp+rename
+  // pattern still applies for atomicity (#4913).
+  if (onWindows) {
+    writeFileSync(tmpPath, data)
+  } else {
+    writeFileSync(tmpPath, data, { mode: 0o600 })
+    chmodSync(tmpPath, 0o600)
+  }
   try {
     renameSync(tmpPath, filePath)
   } catch (err) {

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -341,6 +341,156 @@ try {
         assert.strictEqual(finalMode, 0o600, 'final file must be 0o600 even when tmp was pre-existing at 0o644')
       })
     }
+
+    describe('Windows branch (cross-platform via _isWindowsOverride) — #4913', () => {
+      // Before #4913 the Windows path of writeFileRestricted was a
+      // direct `writeFileSync` to the destination, which meant a
+      // mid-write SIGKILL / OOM could leave the file truncated and
+      // unparseable. That regression was introduced when #4874 collapsed
+      // the manual tmp+rename wrappers in `environment-manager.js` and
+      // `models.js` onto this helper. The fix is to use the same
+      // temp+rename pattern on Windows as on POSIX (only the chmod step
+      // is skipped — Windows uses ACL inheritance from the parent
+      // directory, not POSIX mode bits).
+      //
+      // We exercise the Windows branch on every host via the
+      // `_isWindowsOverride` option (same hook pattern as
+      // SessionStatePersistence's `isWindowsOverride`). A real Windows
+      // CI runner is not currently available; if Windows-specific
+      // atomicity edge cases (cross-volume rename, AV-held handles,
+      // ACL inheritance) need verification, file a follow-up issue —
+      // these tests cover the core temp+rename contract that the issue
+      // was raised to restore.
+
+      it('writes via <path>.tmp + rename — destination updates atomically (#4913)', () => {
+        // Round-trip: a clean write through the forced-Windows branch
+        // must leave the destination with the new content and clean up
+        // the `.tmp` sidecar. This is the happy-path mirror of the
+        // POSIX "atomic via .tmp + rename" test above.
+        const filePath = join(tmpDir, 'env-state.json')
+        writeFileRestricted(filePath, JSON.stringify({ generation: 1 }), { _isWindowsOverride: true })
+        assert.strictEqual(readFileSync(filePath, 'utf-8'), JSON.stringify({ generation: 1 }))
+        assert.strictEqual(existsSync(`${filePath}.tmp`), false, '.tmp sidecar must be cleaned up after rename')
+
+        writeFileRestricted(filePath, JSON.stringify({ generation: 2 }), { _isWindowsOverride: true })
+        assert.strictEqual(readFileSync(filePath, 'utf-8'), JSON.stringify({ generation: 2 }))
+        assert.strictEqual(existsSync(`${filePath}.tmp`), false)
+      })
+
+      it('honours a custom tmpSuffix on the Windows branch (#4913)', () => {
+        // The per-pid `tmpSuffix` contract used by models.js to avoid
+        // intermediate-file collisions between concurrent writers must
+        // also apply on Windows. Before #4913 the Windows branch
+        // ignored `tmpSuffix` entirely.
+        const filePath = join(tmpDir, 'models-cache.json')
+        writeFileRestricted(filePath, 'payload', {
+          tmpSuffix: '.tmp-12345',
+          _isWindowsOverride: true,
+        })
+        assert.strictEqual(readFileSync(filePath, 'utf-8'), 'payload')
+        assert.strictEqual(existsSync(`${filePath}.tmp-12345`), false, 'custom-suffix sidecar must be cleaned up after rename')
+        assert.strictEqual(existsSync(`${filePath}.tmp`), false, 'default-suffix sidecar must not exist when a custom suffix is used')
+      })
+
+      it('leaves the original destination intact when rename fails mid-write (#4913)', () => {
+        // The crash-safety contract: a `renameSync` failure (or a real
+        // mid-write SIGKILL/OOM, which manifests as the rename never
+        // happening) must leave the previous-generation destination
+        // untouched and parseable. This is the Windows analogue of the
+        // POSIX "atomic via .tmp + rename" test above; on any runner we
+        // force the Windows branch via `_isWindowsOverride` and shim
+        // `fs.renameSync` to throw EIO, replicating the post-crash
+        // filesystem state we would see on Windows.
+        //
+        // Like the POSIX test, this runs in a subprocess because
+        // monkey-patching `fs.renameSync` in-process does not propagate
+        // to `platform.js`'s already-snapshotted ESM-from-CJS import
+        // binding.
+        const filePath = join(tmpDir, 'env-state.json')
+        writeFileRestricted(filePath, JSON.stringify({ generation: 1 }), { _isWindowsOverride: true })
+
+        const shim = join(tmpDir, 'win-throw-on-rename.mjs')
+        const runner = join(tmpDir, 'win-runner.mjs')
+        const shimSrc = `
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+const fs = require('node:fs')
+const orig = fs.renameSync
+fs.renameSync = (oldPath, newPath) => {
+  if (newPath === ${JSON.stringify(filePath)}) {
+    const err = new Error('simulated mid-write crash (windows branch)')
+    err.code = 'EIO'
+    throw err
+  }
+  return orig.call(this, oldPath, newPath)
+}
+`
+        const runnerSrc = `
+import { writeFileRestricted } from ${JSON.stringify(PLATFORM_JS)}
+try {
+  writeFileRestricted(${JSON.stringify(filePath)}, ${JSON.stringify(JSON.stringify({ generation: 2 }))}, { _isWindowsOverride: true })
+  process.exit(0)
+} catch (err) {
+  process.stderr.write(err.message)
+  process.exit(2)
+}
+`
+        writeFileRestricted(shim, shimSrc)
+        writeFileRestricted(runner, runnerSrc)
+        const result = spawnSync(process.execPath, ['--import', shim, runner], { encoding: 'utf-8' })
+        assert.strictEqual(result.status, 2, `expected non-zero exit; stderr=${result.stderr}`)
+        assert.match(result.stderr, /simulated mid-write crash/)
+
+        // The original destination is untouched — still generation 1,
+        // and still parseable JSON. Pre-#4913 the Windows branch wrote
+        // the new payload directly to `filePath`, so a crash mid-write
+        // would have left it truncated and `JSON.parse` would throw.
+        const after = readFileSync(filePath, 'utf-8')
+        assert.strictEqual(after, JSON.stringify({ generation: 1 }))
+        assert.strictEqual(JSON.parse(after).generation, 1)
+
+        // The intermediate `.tmp` is cleaned up on rename failure so it
+        // does not leak across retries — same contract as POSIX.
+        assert.strictEqual(existsSync(`${filePath}.tmp`), false, '.tmp sidecar must be cleaned up on rename failure')
+      })
+
+      it('cleans up the custom-suffix intermediate when rename fails (#4913)', () => {
+        // Without the cleanup, a sequence of failing writes would leak
+        // one sidecar per attempt. This pins the explicit cleanup
+        // contract on the Windows branch — same as POSIX (#4874).
+        const filePath = join(tmpDir, 'env-state.json')
+        const shim = join(tmpDir, 'win-throw-on-rename-cleanup.mjs')
+        const runner = join(tmpDir, 'win-runner-cleanup.mjs')
+        const shimSrc = `
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url)
+const fs = require('node:fs')
+const orig = fs.renameSync
+fs.renameSync = (oldPath, newPath) => {
+  if (newPath === ${JSON.stringify(filePath)}) {
+    const err = new Error('simulated mid-write crash')
+    err.code = 'EIO'
+    throw err
+  }
+  return orig.call(this, oldPath, newPath)
+}
+`
+        const runnerSrc = `
+import { writeFileRestricted } from ${JSON.stringify(PLATFORM_JS)}
+try {
+  writeFileRestricted(${JSON.stringify(filePath)}, 'payload', { tmpSuffix: '.tmp-99999', _isWindowsOverride: true })
+  process.exit(0)
+} catch {
+  process.exit(2)
+}
+`
+        writeFileRestricted(shim, shimSrc)
+        writeFileRestricted(runner, runnerSrc)
+        const result = spawnSync(process.execPath, ['--import', shim, runner], { encoding: 'utf-8' })
+        assert.strictEqual(result.status, 2)
+        assert.strictEqual(existsSync(`${filePath}.tmp-99999`), false, 'custom-suffix sidecar must be cleaned up on rename failure')
+      })
+    })
   })
 
   describe('forceKill()', () => {


### PR DESCRIPTION
## Summary

Restores crash-safety on Windows for the three call-sites (`environment-manager.js`, `models.js`, session state) that depend on `writeFileRestricted`. Before #4874 each of them hand-rolled tmp+rename even on Windows; the helper-hoist regressed Windows behaviour to an in-place `writeFileSync` that could leave files truncated/invalid on mid-write termination.

- Unify the POSIX and Windows paths on `<dest><tmpSuffix>` + `renameSync`. Node's `fs.renameSync` calls `MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH)` on Windows (since v16), so the rename is atomic on both platforms.
- Skip the POSIX `chmod 0o600` step on Windows — the mode bits are mostly a no-op on Win32; ACL inheritance from the per-user `~/.chroxy/` (or `%APPDATA%/Chroxy/`) parent directory is the correct mechanism on NTFS.
- Honour `tmpSuffix` on Windows too (previously silently ignored), so the per-pid suffix `models.js` passes to avoid collisions between concurrent writers now actually protects every host.
- Add a test-only `_isWindowsOverride` option so the new cross-platform atomicity test exercises the Windows code path on POSIX runners (mirrors the same hook in `SessionStatePersistence`).

Closes #4913.

## Test plan

- [x] Existing POSIX `platform.test.js` cases still pass (no regression — same temp+rename logic).
- [x] New Windows-branch tests (4 cases) verify on every host: happy-path rename, custom `tmpSuffix`, original-destination-intact on rename failure, and intermediate-file cleanup on rename failure.
- [x] Caller tests (`environment-manager`, `models-factory`, `session-state-persistence`, `config`, `push`, `connection-info`, `checkpoint-manager`, `permission-hook`, `device-preferences`, `init-cmd`, `tunnel-cmd`) — 403 tests pass.
- [x] Full server test suite — pre-existing failures only (running daemon collision in `service.test.js`, integration tunnel test needing `cloudflared`, and `WebTaskManager` test depending on local claude CLI version). None related to this change.
- [x] Lint scripts (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`) clean.
- [x] ESLint clean (only pre-existing warnings).

## Follow-ups

- Real Windows runner coverage for the edge cases that cannot be simulated on POSIX (AV-held handles producing EPERM/EACCES/EBUSY, cross-volume rename hitting `ERROR_NOT_SAME_DEVICE`, ACL inheritance behaviour on NTFS). The current test covers the core temp+rename + cleanup contract; site-specific Windows quirks would need a dedicated CI runner.