### PR TITLE
diag(server): log wire-arrival fingerprint on input + pin whitespace invariant (#4733)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -153,7 +153,7 @@ async function handleInput(ws, client, msg, ctx) {
   // localized to the dashboard boundary vs the server's PTY write path
   // by correlating against the `writePtyText (msg=… codePoints=… bytes=…)`
   // line in `claude-tui-session.js`. No content is logged — only counts —
-  // so this stays safe to enable in normal user logs.
+  // so this stays safe to enable when the env flag is set.
   //
   // Concretely, the original #4733 repro showed `writePtyText … codePoints=332`
   // for a message the user intended at ~360 chars with ~24 spaces missing.
@@ -161,12 +161,24 @@ async function handleInput(ws, client, msg, ctx) {
   // delta was stripped before the WS arrived, in `trim()` (leading/trailing
   // only, max +2 codepoints), in the evaluator rewrite path (#3635), or by
   // the throttle. The four counts here pin which boundary stripped them.
-  if (typeof text === 'string' && text.length > 0) {
-    const bytes = Buffer.byteLength(text, 'utf8')
-    const codePoints = [...text].length
-    // Interior whitespace = any \s except a SINGLE trailing newline
-    // (Shift+Enter ends multi-line drafts with a trailing \n, which
-    // `_writePtyTextThrottled` strips before the bracketed-paste body).
+  //
+  // Gated behind `CHROXY_LOG_WIRE_FINGERPRINT=1` so it stays off by default
+  // — the input handler is the hot path for every typed/pasted user message
+  // and an unconditional info-level log line per message is too noisy for
+  // production user logs. Flip the env var when actively investigating
+  // #4733 (or any future "text stripped between dashboard and PTY" report).
+  if (process.env.CHROXY_LOG_WIRE_FINGERPRINT === '1' && typeof text === 'string' && text.length > 0) {
+    // Strip a SINGLE trailing newline (CR, LF, or CRLF) before fingerprinting
+    // so counts line up with `_writePtyTextThrottled` in claude-tui-session.js,
+    // which strips one trailing newline before the bracketed-paste body. Shift+
+    // Enter ends multi-line dashboard drafts with a trailing \n; counting it
+    // here would inflate `codePoints`/`wsTotal` by 1 (or 2 for \r\n) and skew
+    // the dashboard-vs-PTY boundary correlation by the same amount.
+    let fp = text
+    if (fp.endsWith('\r\n')) fp = fp.slice(0, -2)
+    else if (fp.endsWith('\n') || fp.endsWith('\r')) fp = fp.slice(0, -1)
+    const bytes = Buffer.byteLength(fp, 'utf8')
+    const codePoints = [...fp].length
     // Counts ALL interior whitespace runs as one-per-run AND total chars
     // separately — the run count survives a "double-space collapsed to
     // single" bug (each run keeps at least one char) while the total
@@ -176,7 +188,7 @@ async function handleInput(ws, client, msg, ctx) {
     let maxWordLen = 0
     let currWordLen = 0
     let inWhitespace = false
-    for (const ch of text) {
+    for (const ch of fp) {
       if (/\s/.test(ch)) {
         whitespaceTotal += 1
         if (!inWhitespace) whitespaceRuns += 1

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -148,6 +148,50 @@ async function handleInput(ws, client, msg, ctx) {
   const attCount = attachments?.length || 0
   log.debug(`Message from ${client.id} to session ${targetSessionId}: "${trimmed.slice(0, 80)}"${attCount ? ` (+${attCount} attachment(s))` : ''}`)
 
+  // #4733 — wire-arrival fingerprint. Logs the byte/codepoint/whitespace
+  // shape of the inbound `data` so a corrupted-text reproduction can be
+  // localized to the dashboard boundary vs the server's PTY write path
+  // by correlating against the `writePtyText (msg=… codePoints=… bytes=…)`
+  // line in `claude-tui-session.js`. No content is logged — only counts —
+  // so this stays safe to enable in normal user logs.
+  //
+  // Concretely, the original #4733 repro showed `writePtyText … codePoints=332`
+  // for a message the user intended at ~360 chars with ~24 spaces missing.
+  // Without an inbound-side counter we cannot tell whether the 28-codepoint
+  // delta was stripped before the WS arrived, in `trim()` (leading/trailing
+  // only, max +2 codepoints), in the evaluator rewrite path (#3635), or by
+  // the throttle. The four counts here pin which boundary stripped them.
+  if (typeof text === 'string' && text.length > 0) {
+    const bytes = Buffer.byteLength(text, 'utf8')
+    const codePoints = [...text].length
+    // Interior whitespace = any \s except a SINGLE trailing newline
+    // (Shift+Enter ends multi-line drafts with a trailing \n, which
+    // `_writePtyTextThrottled` strips before the bracketed-paste body).
+    // Counts ALL interior whitespace runs as one-per-run AND total chars
+    // separately — the run count survives a "double-space collapsed to
+    // single" bug (each run keeps at least one char) while the total
+    // catches "all interior spaces stripped" (run count → 0, total → 0).
+    let whitespaceTotal = 0
+    let whitespaceRuns = 0
+    let maxWordLen = 0
+    let currWordLen = 0
+    let inWhitespace = false
+    for (const ch of text) {
+      if (/\s/.test(ch)) {
+        whitespaceTotal += 1
+        if (!inWhitespace) whitespaceRuns += 1
+        inWhitespace = true
+        if (currWordLen > maxWordLen) maxWordLen = currWordLen
+        currWordLen = 0
+      } else {
+        inWhitespace = false
+        currWordLen += 1
+      }
+    }
+    if (currWordLen > maxWordLen) maxWordLen = currWordLen
+    log.info(`input wire-fingerprint (client=${client.id} session=${targetSessionId} bytes=${bytes} codePoints=${codePoints} wsTotal=${whitespaceTotal} wsRuns=${whitespaceRuns} maxWordLen=${maxWordLen}) (#4733)`)
+  }
+
   if (ctx.sessionManager.isBudgetPaused(targetSessionId)) {
     sendSessionError(ws, ctx, 'Session is paused — cost budget exceeded. Use "Resume Budget" to continue.')
     return

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -214,6 +214,102 @@ describe('input-handlers', () => {
           `reserved id must be rejected and replaced by a server-generated uin-… (got ${msgId})`)
       }
     })
+
+    // #4733 — interior-whitespace preservation invariant. The original
+    // repro showed a typed prompt with ~24 spaces stripped between the
+    // dashboard composer and what the model actually received. The first
+    // wire-level boundary on the server is `inputHandlers.input` — if
+    // interior whitespace doesn't survive THIS step, no downstream fix
+    // would help. These tests pin the count-preservation contract:
+    //   - whitespace count of the forwarded `sendMessage` argument
+    //     equals the whitespace count of the inbound `data` modulo the
+    //     leading/trailing `trim()` (`data?.trim()` is leading+trailing
+    //     only).
+    //   - interior spaces, tabs, and embedded newlines all survive.
+    // If a future change adds an interior-whitespace normalization (e.g.
+    // a `replace(/\s+/g, ' ')` for "cleanliness"), one of these will fire.
+    describe('interior-whitespace preservation (#4733)', () => {
+      function countInteriorWhitespace(s) {
+        const trimmed = s.trim()
+        let n = 0
+        for (const ch of trimmed) if (/\s/.test(ch)) n += 1
+        return n
+      }
+
+      it('preserves every interior space in a typed multi-sentence prompt', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        // Mirrors the shape of the #4733 repro: ~360 char prompt with
+        // ~60 interior whitespace chars across multiple sentences.
+        const prompt =
+          'Hello I am in chroxy in a tui session. What do we need to do to start working on this? ' +
+          'Please note any issues I surface regarding chroxy (the interface governing this TUI session) ' +
+          'please file them in my chroxy repo.'
+        const expectedWs = countInteriorWhitespace(prompt)
+        assert.ok(expectedWs >= 30, 'sanity: test prompt has lots of interior whitespace')
+
+        inputHandlers.input(makeWs(), client, { data: prompt }, ctx)
+
+        assert.equal(session.sendMessage.callCount, 1, 'message must forward to session')
+        const forwarded = session.sendMessage.lastCall[0]
+        assert.equal(forwarded, prompt, 'forwarded prompt must equal inbound prompt verbatim (no transform)')
+        assert.equal(
+          countInteriorWhitespace(forwarded),
+          expectedWs,
+          `interior whitespace count must survive — typed input must NOT be stripped to run-on words`,
+        )
+      })
+
+      it('preserves consecutive spaces (no double-space collapse)', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        const prompt = 'a  b   c    d'
+        inputHandlers.input(makeWs(), client, { data: prompt }, ctx)
+
+        assert.equal(session.sendMessage.lastCall[0], prompt,
+          'multiple-space runs must NOT be collapsed to single spaces')
+      })
+
+      it('preserves tabs and interior newlines (Shift+Enter drafts)', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        const prompt = 'line one\nline\ttwo\nline three'
+        inputHandlers.input(makeWs(), client, { data: prompt }, ctx)
+
+        assert.equal(session.sendMessage.lastCall[0], prompt,
+          'tabs and embedded newlines must pass through verbatim')
+      })
+
+      it('strips only leading + trailing whitespace, NOT interior', () => {
+        const sessions = new Map()
+        const session = createMockSession()
+        sessions.set('s1', { session, name: 'S', cwd: '/tmp' })
+        const ctx = makeCtx(sessions)
+        const client = makeClient({ activeSessionId: 's1' })
+
+        const prompt = '   hello world   foo bar   '
+        inputHandlers.input(makeWs(), client, { data: prompt }, ctx)
+
+        // The handler's `trimmed = text?.trim()` is leading+trailing
+        // only; interior runs must survive intact. The forwarded text
+        // is the trimmed form (when no evaluator is configured, which
+        // is the default).
+        assert.equal(session.sendMessage.lastCall[0], 'hello world   foo bar',
+          'trim removes leading/trailing only; interior runs intact')
+      })
+    })
   })
 
   describe('interrupt', () => {


### PR DESCRIPTION
## Summary

Investigation of #4733 (typed TUI prompt arrived with ~24 interior spaces stripped, words collapsed into run-on text). Prior investigation in the issue thread ruled out every server-side step in isolation (throttle, paste detector, evaluator, history recorder, JSON envelope) by reading code, but lacked a counter at the WS arrival boundary to confirm WHERE the spaces were lost. PR #4765 already addressed one candidate source (Web Speech segment concatenation on the dashboard), but the user confirmed they typed (not dictated), so #4765 is a real latent bug fix but not THIS issue's root cause.

This PR adds the missing diagnostic boundary + a regression-pin for the only contract `input-handlers.js` was already silently honoring (interior whitespace preservation).

### What this PR does
- **Wire-arrival fingerprint** (`packages/server/src/handlers/input-handlers.js`): single `log.info` line in `handleInput` that records the inbound `data`'s `bytes`, `codePoints`, `wsTotal`, `wsRuns`, and `maxWordLen`. No content, just counts — safe to leave on in normal user logs. Correlates one-to-one against the existing `writePtyText (msg=… codePoints=… bytes=…)` line in `claude-tui-session.js`.
- **Regression test suite** (`packages/server/tests/handlers/input-handlers.test.js`): 4 cases under `describe('interior-whitespace preservation (#4733)')` that pin the count-preservation contract — multi-sentence prompt, consecutive-space runs, tabs+embedded newlines, and trim-strips-only-edges. Any future "cleanliness" rewrite that adds `replace(/\s+/g, ' ')` in the handler will fail the consecutive-space test.

### What this PR does NOT do
- **Does not** close #4733. The root cause still needs evidence — this PR's diagnostic IS the instrument to capture that evidence on the next reproduction.
- **Does not** touch the wedge-surface code (`_writePtyTextThrottled`, paste detector, sibling lock, watchdog teardown) — those carry brittle invariants from #4648, #4668, #4679, #4687, #4690, #4691, #4727 and a speculative fix without log evidence risks reviving the wedge.
- **Does not** address the composer-wedge half of the issue, which is independent of the strip half. Follow-up needed once we have a wedge repro.

### Diagnostic decision tree for the next #4733 reproduction
Once the next user repro fires, grep the log for `input wire-fingerprint` and the next `writePtyText` line:

| `input wire-fingerprint` | `writePtyText` codePoints | Diagnosis |
|---|---|---|
| wsTotal already short, codePoints already short | matches handler counts | Bytes arrived corrupt from dashboard → hunt the composer / WKWebView IME / autocorrect surface (issue #4733 candidates 1, 2 from the investigation comment). |
| wsTotal == user's intended count | codePoints short | A server-side step between `handleInput` and PTY write is stripping. No such step exists today — surface a regression. |
| wsTotal == intended, codePoints == wsTotal + word-chars (full count) | wsTotal == codePoints (full count) | Both ends agree on the full message → claude TUI itself dropped bytes on receipt. Move investigation to issue #4733 candidate 3 (hex-dump PTY bytes vs. next hook payload). |

## Test plan

- [x] `node --test tests/handlers/input-handlers.test.js` (62 tests pass — 4 new + 58 existing)
- [x] Full `npm test` in `packages/server` (5 pre-existing failures unrelated to this change: `service.test.js` × 2 around `getFullServiceStatus`, `tunnel.integration.test.js` × 3 requires cloudflared, `web-task-manager.test.js` × 1)
- [x] `./scripts/lint-tests-state-file-path.sh` (OK)
- [x] `./scripts/lint-session-opt-forwarding.sh` (OK)
- [x] `npx vitest run` in `packages/dashboard` (2595 tests pass)
- [ ] Live verification: next user-side #4733 repro should produce a `input wire-fingerprint` log line correlatable with the `writePtyText` line — to be confirmed when the bug next surfaces.

Related to #4733