### PR TITLE
fix(server): wire claude CLI --resume to preserve conversation context

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -33,6 +33,69 @@ const CLAUDE = resolveBinary('claude', [
 const DEFAULT_MAX_TOOL_INPUT_LENGTH = 262144
 
 /**
+ * Build the argv passed to `claude -p --input-format stream-json …`.
+ *
+ * Extracted so #4887 has a single, pure place to assert the resume contract.
+ * Mirrors the historical inline build in `start()` exactly — same arg order,
+ * same flag spellings — plus an optional `--resume <id>` segment when a prior
+ * `_sessionId` is known.
+ *
+ * Resume invariants (#4887):
+ *   - A fresh session (no `_sessionId` yet) omits `--resume`. claude CLI
+ *     allocates a brand-new conversation on first init.
+ *   - A respawn (model switch, perm-mode flip, crash) or a server-restart
+ *     restore call MUST include `--resume <id>`. Without it, the new
+ *     subprocess inherits the chroxy-side history ring buffer (replayed to
+ *     the dashboard) but the model itself starts cold mid-conversation —
+ *     the failure mode reported in #4887.
+ *
+ * @param {object} opts
+ * @param {string|null} opts.model
+ * @param {string} opts.permissionMode
+ * @param {string[]} opts.allowedTools
+ * @param {string} opts.skillsText
+ * @param {string|null} opts.resumeSessionId
+ * @returns {string[]}
+ */
+export function buildClaudeCliArgs({ model, permissionMode, allowedTools, skillsText, resumeSessionId } = {}) {
+  const args = [
+    '-p',
+    '--input-format', 'stream-json',
+    '--output-format', 'stream-json',
+    '--verbose',
+    '--include-partial-messages',
+  ]
+
+  if (model) {
+    args.push('--model', model)
+  }
+
+  if (permissionMode === 'auto') {
+    args.push('--permission-mode', 'bypassPermissions')
+  } else if (permissionMode === 'plan') {
+    args.push('--permission-mode', 'plan')
+  }
+
+  if (Array.isArray(allowedTools) && allowedTools.length > 0) {
+    args.push('--allowedTools', allowedTools.join(','))
+  }
+
+  if (skillsText) {
+    args.push('--append-system-prompt', skillsText)
+  }
+
+  // #4887 — wire the prior claude session_id back onto the new subprocess so
+  // the model retains the full prior transcript. Only emitted when a non-empty
+  // string is known; a brand-new session (first start()) leaves this off so
+  // claude CLI mints a fresh conversation id on its `system.init` line.
+  if (typeof resumeSessionId === 'string' && resumeSessionId.length > 0) {
+    args.push('--resume', resumeSessionId)
+  }
+
+  return args
+}
+
+/**
  * Manages a persistent Claude Code CLI session using headless mode.
  *
  * A single `claude -p --input-format stream-json --output-format stream-json`
@@ -85,7 +148,11 @@ export class CliSession extends BaseSession {
       modelSwitch: true,
       permissionModeSwitch: true,
       planMode: true,
-      resume: false,
+      // #4887 — claude CLI supports `--resume <id>`; CliSession now wires
+      // `_sessionId` into the spawn argv on respawn / restore so the model
+      // retains the prior transcript instead of starting cold mid-conversation.
+      // Persistence + UI gating both branch on this flag.
+      resume: true,
       terminal: false,
       thinkingLevel: false,
       // #3932: declared explicitly so the capability matrix matches across
@@ -184,7 +251,7 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs } = {}) {
+  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, resumeSessionId } = {}) {
     super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs })
     this.allowedTools = allowedTools || []
     this._port = port || null
@@ -193,7 +260,14 @@ export class CliSession extends BaseSession {
     this._hookSecret = randomBytes(32).toString('hex')
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
-    this._sessionId = null
+    // #4887 — seed `_sessionId` from the persisted resume id so the very-first
+    // start() (post-restore) passes `--resume <id>` and the new claude
+    // subprocess re-hydrates the prior conversation. Falsy / non-string values
+    // (older state files, missing opt) leave `_sessionId` null exactly as
+    // before, so brand-new sessions still mint a fresh claude conversation.
+    this._sessionId = (typeof resumeSessionId === 'string' && resumeSessionId.length > 0)
+      ? resumeSessionId
+      : null
     // #4828: session-scoped logger, lazily bound when the CLI emits its
     // `init` message (where session_id becomes known). Pre-init log lines
     // stay on the module-level `log` — same fallback pattern as SdkSession
@@ -235,6 +309,23 @@ export class CliSession extends BaseSession {
   }
 
   /**
+   * Public accessor for the claude CLI session id used to resume conversations
+   * via `claude -p --resume <id>` (#4887). SessionManager.serializeState reads
+   * this to persist `sdkSessionId` (the cross-provider name for the resume
+   * token); restoreState forwards it back into the constructor as
+   * `resumeSessionId` so the new chroxy boot re-attaches to the prior
+   * conversation instead of starting cold.
+   *
+   * Returns `null` until the CLI emits its first `system.init` event (or until
+   * the constructor seeds the value from a persisted state file).
+   *
+   * @returns {string|null}
+   */
+  get resumeSessionId() {
+    return this._sessionId || null
+  }
+
+  /**
    * Start the persistent Claude process. Call once after construction.
    */
   start() {
@@ -243,35 +334,25 @@ export class CliSession extends BaseSession {
       this._hookManager.register()
     }
 
-    const args = [
-      '-p',
-      '--input-format', 'stream-json',
-      '--output-format', 'stream-json',
-      '--verbose',
-      '--include-partial-messages',
-    ]
-
-    if (this.model) {
-      args.push('--model', this.model)
-    }
-
-    if (this.permissionMode === 'auto') {
-      args.push('--permission-mode', 'bypassPermissions')
-    } else if (this.permissionMode === 'plan') {
-      args.push('--permission-mode', 'plan')
-    }
-
-    if (this.allowedTools.length > 0) {
-      args.push('--allowedTools', this.allowedTools.join(','))
-    }
-
     // Skills MVP (#2957) — append shared skills to the Claude CLI system prompt.
     const skillsText = this._buildSystemPrompt()
-    if (skillsText) {
-      args.push('--append-system-prompt', skillsText)
-    }
 
-    log.info(`Starting persistent process (model: ${this.model || 'default'}, permission: ${this.permissionMode})`)
+    // #4887 — pass `_sessionId` as `--resume` whenever it's known. This is the
+    // load-bearing flag for the bug: on respawn (crash / model switch / perm-
+    // mode flip) and on server-restart restore, the new claude subprocess
+    // would otherwise lose every prior turn in the model's context window and
+    // the user would see the dashboard transcript replay correctly while the
+    // model itself starts cold mid-conversation.
+    const args = buildClaudeCliArgs({
+      model: this.model,
+      permissionMode: this.permissionMode,
+      allowedTools: this.allowedTools,
+      skillsText,
+      resumeSessionId: this._sessionId,
+    })
+
+    const resumeNote = this._sessionId ? ` (resume ${this._sessionId})` : ''
+    log.info(`Starting persistent process (model: ${this.model || 'default'}, permission: ${this.permissionMode})${resumeNote}`)
     this._spawnPersistentProcess(args)
   }
 
@@ -1057,17 +1138,25 @@ export class CliSession extends BaseSession {
 
     this._respawning = true
     this._processReady = false
-    this._sessionId = null
+    // #4887 — DO NOT null `_sessionId` here. `start()` reads it as the
+    // `--resume` argument; clearing it would force the respawned subprocess
+    // to mint a brand-new conversation and the model would see the new user
+    // message with no prior turns — exactly the cold-start failure in #4887.
+    // The session id is re-confirmed by the next `system.init` (claude CLI
+    // echoes the resumed id back), so the in-process value stays accurate
+    // even on the rare fork case.
     // #4828: drop the session-scoped logger so the next init re-binds it
-    // to the fresh session_id rather than leaking the stale one.
+    // (the underlying session_id is unchanged on a normal resume, but the
+    // logger context is re-created on every init for symmetry with first-
+    // boot — cheap and avoids any stale closure).
     this._log = null
 
-    // The new child process has no conversation state — and on Claude CLI
-    // the append/system bucket rides on `--append-system-prompt` at spawn,
-    // so it's already part of the new argv. The prepend bucket, however,
-    // is concatenated onto the FIRST user message; a respawn means the
-    // next sendMessage() is once again that first message. Reset the
-    // flag so the prepend bucket flows through on the next turn (#3225).
+    // #4887 — the respawned child re-attaches to the prior conversation via
+    // `--resume <_sessionId>`. The append/system bucket still rides on
+    // `--append-system-prompt` at spawn (already in the new argv). The
+    // prepend bucket is concatenated onto the FIRST user message; a respawn
+    // means the next sendMessage() is once again that first message. Reset
+    // the flag so the prepend bucket flows through on the next turn (#3225).
     this._skillsPrepended = false
 
     if (this._interruptTimer) {

--- a/packages/server/tests/cli-session-resume.test.js
+++ b/packages/server/tests/cli-session-resume.test.js
@@ -1,0 +1,194 @@
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { CliSession, buildClaudeCliArgs } from '../src/cli-session.js'
+
+/**
+ * Regression coverage for #4887 — claude CLI session resumes without prior
+ * assistant turn, model starts cold mid-conversation.
+ *
+ * Root cause: the claude `-p --input-format stream-json` subprocess holds the
+ * conversation context entirely in process memory. When chroxy respawns the
+ * subprocess (model switch, permission-mode flip, crash) — or when chroxy
+ * itself restarts and SessionManager rebuilds the session — the new process
+ * starts cold. The user's history is still in the chroxy ring buffer and
+ * replays to the dashboard fine, but the model itself has no idea what the
+ * prior assistant turn said.
+ *
+ * Claude CLI ships `--resume <session-id>` that wires the new subprocess back
+ * onto the previous conversation. This suite pins the resume contract:
+ *
+ *   1. The exposed `resumeSessionId` getter mirrors `_sessionId` so
+ *      SessionManager.serializeState can persist it under `sdkSessionId`.
+ *   2. The CliSession constructor accepts `resumeSessionId` and seeds
+ *      `_sessionId` from it so server-restart restore re-uses it.
+ *   3. `buildClaudeCliArgs` includes `--resume <id>` when a session id is
+ *      known — both on respawn within the same process and on a restored
+ *      session's first spawn.
+ *   4. `capabilities.resume` is true.
+ *   5. `_killAndRespawn` preserves `_sessionId` so the respawned subprocess
+ *      can carry `--resume` forward.
+ */
+
+let _globalTmpDir
+function tmpStateFile() {
+  if (!_globalTmpDir) _globalTmpDir = mkdtempSync(join(tmpdir(), 'cli-session-resume-test-'))
+  return join(_globalTmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+function createSession(opts = {}) {
+  const stateFilePath = opts.stateFilePath || tmpStateFile()
+  const session = new CliSession({ cwd: '/tmp', stateFilePath, ...opts })
+  session._testStateFilePath = stateFilePath
+  return session
+}
+
+describe('CliSession resume — buildClaudeCliArgs (#4887)', () => {
+  it('omits --resume on a brand-new session (no _sessionId yet)', () => {
+    const args = buildClaudeCliArgs({
+      model: null,
+      permissionMode: 'approve',
+      allowedTools: [],
+      skillsText: '',
+      resumeSessionId: null,
+    })
+    assert.ok(!args.includes('--resume'),
+      'fresh session must not carry --resume; CLI starts a new conversation')
+  })
+
+  it('includes --resume <id> when a session id is known (respawn / restore path)', () => {
+    const args = buildClaudeCliArgs({
+      model: null,
+      permissionMode: 'approve',
+      allowedTools: [],
+      skillsText: '',
+      resumeSessionId: 'cli-session-abc-123',
+    })
+    const i = args.indexOf('--resume')
+    assert.ok(i >= 0,
+      'respawned / restored session must carry --resume so the model sees the prior conversation')
+    assert.equal(args[i + 1], 'cli-session-abc-123',
+      'the session id captured from system.init must be the argument to --resume')
+  })
+
+  it('preserves --model / --permission-mode / --allowedTools alongside --resume', () => {
+    const args = buildClaudeCliArgs({
+      model: 'claude-sonnet-4-6',
+      permissionMode: 'auto',
+      allowedTools: ['Read', 'Write'],
+      skillsText: 'extra system prompt',
+      resumeSessionId: 'cli-resume-xyz',
+    })
+    assert.ok(args.includes('--resume'))
+    assert.equal(args[args.indexOf('--resume') + 1], 'cli-resume-xyz')
+    assert.ok(args.includes('--model'))
+    assert.equal(args[args.indexOf('--model') + 1], 'claude-sonnet-4-6')
+    assert.ok(args.includes('--permission-mode'))
+    assert.equal(args[args.indexOf('--permission-mode') + 1], 'bypassPermissions')
+    assert.ok(args.includes('--allowedTools'))
+    assert.equal(args[args.indexOf('--allowedTools') + 1], 'Read,Write')
+    assert.ok(args.includes('--append-system-prompt'))
+    assert.equal(args[args.indexOf('--append-system-prompt') + 1], 'extra system prompt')
+  })
+
+  it('always emits the headless streaming defaults', () => {
+    const args = buildClaudeCliArgs({
+      model: null,
+      permissionMode: 'approve',
+      allowedTools: [],
+      skillsText: '',
+      resumeSessionId: null,
+    })
+    assert.equal(args[0], '-p')
+    assert.ok(args.includes('--input-format'))
+    assert.equal(args[args.indexOf('--input-format') + 1], 'stream-json')
+    assert.ok(args.includes('--output-format'))
+    assert.equal(args[args.indexOf('--output-format') + 1], 'stream-json')
+    assert.ok(args.includes('--verbose'))
+    assert.ok(args.includes('--include-partial-messages'))
+  })
+
+  it('treats empty / non-string resumeSessionId as "no resume"', () => {
+    for (const value of [null, undefined, '', 0, false, {}, []]) {
+      const args = buildClaudeCliArgs({
+        model: null,
+        permissionMode: 'approve',
+        allowedTools: [],
+        skillsText: '',
+        resumeSessionId: value,
+      })
+      assert.ok(!args.includes('--resume'),
+        `non-string / empty resumeSessionId (${JSON.stringify(value)}) must not emit --resume; ` +
+        'a phantom resume id would 404 or fork into a wrong conversation')
+    }
+  })
+})
+
+describe('CliSession resume — capability + constructor (#4887)', () => {
+  afterEach(() => {
+    if (_globalTmpDir) {
+      try { rmSync(_globalTmpDir, { recursive: true, force: true }) } catch {}
+      _globalTmpDir = undefined
+    }
+  })
+
+  it('declares resume: true so SessionManager / UI know the provider supports it', () => {
+    assert.equal(CliSession.capabilities.resume, true,
+      'claude CLI supports --resume; capability must reflect that so the persistence layer round-trips _sessionId')
+  })
+
+  it('exposes resumeSessionId getter wired to _sessionId', () => {
+    const session = createSession()
+    assert.equal(session.resumeSessionId, null, 'no init yet → no resume id')
+    session._sessionId = 'cli-init-uuid'
+    assert.equal(session.resumeSessionId, 'cli-init-uuid',
+      'getter must mirror _sessionId so SessionManager.serializeState can persist it')
+    session.destroy()
+  })
+
+  it('accepts resumeSessionId in the constructor and seeds _sessionId', () => {
+    const session = createSession({ resumeSessionId: 'cli-restored-123' })
+    assert.equal(session._sessionId, 'cli-restored-123',
+      'restore path forwards resumeSessionId; the session must adopt it so start() can pass --resume')
+    assert.equal(session.resumeSessionId, 'cli-restored-123')
+    session.destroy()
+  })
+
+  it('ignores empty / missing resumeSessionId (fresh session, no opt)', () => {
+    const session1 = createSession()
+    assert.equal(session1._sessionId, null)
+    session1.destroy()
+
+    const session2 = createSession({ resumeSessionId: '' })
+    assert.equal(session2._sessionId, null, 'empty string must not pin a phantom resume id')
+    session2.destroy()
+
+    const session3 = createSession({ resumeSessionId: null })
+    assert.equal(session3._sessionId, null)
+    session3.destroy()
+  })
+})
+
+describe('CliSession resume — _killAndRespawn preserves _sessionId so the next start() resumes (#4887)', () => {
+  afterEach(() => {
+    if (_globalTmpDir) {
+      try { rmSync(_globalTmpDir, { recursive: true, force: true }) } catch {}
+      _globalTmpDir = undefined
+    }
+  })
+
+  it('does NOT clear _sessionId on _killAndRespawn — the respawned child must --resume', () => {
+    const session = createSession()
+    session._sessionId = 'cli-init-uuid-from-prior-turn'
+    // Stub start() so we don't actually spawn — we only assert on state.
+    session.start = () => {}
+    session._destroying = true // suppress the closure respawn() so the test is hermetic
+    session._killAndRespawn()
+    assert.equal(session._sessionId, 'cli-init-uuid-from-prior-turn',
+      '_killAndRespawn must NOT null out _sessionId — the next start() needs it to pass --resume so the model retains conversation context')
+    assert.equal(session.resumeSessionId, 'cli-init-uuid-from-prior-turn',
+      'getter mirrors _sessionId; the persistence layer reads this on the next serialize tick')
+  })
+})

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -1410,20 +1410,23 @@ describe('CliSession state-persistence roundtrip (#4700)', () => {
   })
 
   // Snapshot the fields SessionManager.serializeState() would write for a
-  // CliSession entry. Note CliSession has no `resumeSessionId` — claude
-  // -p does not support resume — so `sdkSessionId` always serializes as
-  // null for this provider. Keep in sync with session-manager.test.js.
+  // CliSession entry. As of #4887, CliSession exposes a `resumeSessionId`
+  // getter (mirrored from `_sessionId`) and SessionManager.serializeState
+  // persists it under `sdkSessionId` — the cross-provider name for the
+  // resume token. The restore path forwards it back into the constructor
+  // so the next start() passes `--resume <id>` and the model retains the
+  // prior conversation. Keep in sync with session-manager.test.js.
   function snapshotForPersistence(session, { name, cwd }) {
     return {
       name,
       cwd,
       model: session.model,
       permissionMode: session.permissionMode,
-      sdkSessionId: null,
+      sdkSessionId: session.resumeSessionId,
     }
   }
 
-  it('happy path: create → snapshot → write → read → restore → asserts metadata equality', () => {
+  it('happy path: create → snapshot → write → read → restore → asserts metadata + resume id round-trip (#4887)', () => {
     // Step 1: build a session with non-default metadata so the restore
     // side has to actually hydrate every field.
     const original = createSession({
@@ -1431,8 +1434,8 @@ describe('CliSession state-persistence roundtrip (#4700)', () => {
       permissionMode: 'auto',
     })
     // Simulate the session having booted and recorded a CLI session id.
-    // SessionManager does not persist `_sessionId` for claude-cli (it
-    // can't be resumed), so we don't include it in the snapshot.
+    // #4887 — claude CLI supports `--resume`, so we now persist this id
+    // under `sdkSessionId` and re-seed it on restore.
     original._sessionId = 'cli-session-abc-123'
 
     // Step 2: snapshot + write atomically.
@@ -1447,7 +1450,8 @@ describe('CliSession state-persistence roundtrip (#4700)', () => {
     // Step 3: destroy the original.
     original.destroy()
 
-    // Step 4: read back and reconstruct.
+    // Step 4: read back and reconstruct (mirroring what SessionManager's
+    // restoreState does: forward `sdkSessionId` as `resumeSessionId`).
     const parsed = JSON.parse(readFileSync(stateFile, 'utf-8'))
     assert.equal(parsed.version, 1)
     assert.equal(parsed.sessions.length, 1)
@@ -1456,19 +1460,21 @@ describe('CliSession state-persistence roundtrip (#4700)', () => {
     const restored = createSession({
       model: persisted.model,
       permissionMode: persisted.permissionMode,
+      resumeSessionId: persisted.sdkSessionId,
     })
 
-    // Step 5: every persisted field is back. `sdkSessionId` is null by
-    // design (claude-cli cannot resume), so we DON'T assert that
-    // _sessionId came back — it must start null on a fresh CLI process.
+    // Step 5: every persisted field is back, including the resume id so
+    // the next start() can pass `--resume` and avoid the #4887 cold-start.
     assert.equal(restored.model, 'claude-sonnet-4-6',
       'model must round-trip — dashboard renders this on the session header')
     assert.equal(restored.permissionMode, 'auto',
       'permissionMode must round-trip — controls every permission-hook prompt')
-    assert.equal(restored._sessionId, null,
-      'CliSession cannot resume — restored session must start with a null _sessionId until the new claude -p boots and emits system.init')
-    assert.equal(persisted.sdkSessionId, null,
-      'claude-cli MUST serialize sdkSessionId as null — the provider has no resume capability and persisting a value would mislead the SDK code path')
+    assert.equal(persisted.sdkSessionId, 'cli-session-abc-123',
+      'claude-cli MUST serialize sdkSessionId now that the provider supports --resume; #4887 depends on this id surviving the disk hop')
+    assert.equal(restored._sessionId, 'cli-session-abc-123',
+      'restored session must adopt the persisted resume id so start() passes --resume and the model re-attaches to the prior conversation')
+    assert.equal(restored.resumeSessionId, 'cli-session-abc-123',
+      'getter mirrors _sessionId — same source of truth')
 
     restored.destroy()
   })
@@ -1522,24 +1528,22 @@ describe('CliSession state-persistence roundtrip (#4700)', () => {
     fresh.destroy()
   })
 
-  it('mismatched session id: persisted sessionId is silently ignored because claude-cli cannot resume', () => {
-    // Operator hand-edits the state file (or schema drift): an entry
-    // smuggles a `sdkSessionId` value through for a claude-cli session,
-    // even though the provider declares `resume: false` in capabilities
-    // (cli-session.js:88). The restoration path must NOT plumb it
-    // through to the new session — that would mislead any downstream
-    // code that branches on `sessionId !== null` meaning "resumable".
+  it('persisted resume id flows back into the new CliSession constructor (#4887)', () => {
+    // #4887 — claude CLI supports `--resume <id>`, so when SessionManager
+    // restores a CliSession after a server restart, the persisted
+    // `sdkSessionId` MUST be forwarded as `resumeSessionId` and adopted
+    // by the new instance. Without this, the next start() omits the
+    // `--resume` flag and the model wakes up cold mid-conversation —
+    // the regression #4887 was filed for.
     const state = {
       version: 1,
       timestamp: Date.now(),
       sessions: [{
-        name: 'Stale',
+        name: 'Restored',
         cwd: '/tmp',
         model: null,
         permissionMode: 'approve',
-        // Mismatch: claude-cli does NOT support resume, but this id is in
-        // the state file (operator edit / pre-#3502 schema drift).
-        sdkSessionId: 'cli-stale-9999',
+        sdkSessionId: 'cli-resume-9999',
       }],
     }
     writeFileSync(stateFile, JSON.stringify(state))
@@ -1547,25 +1551,20 @@ describe('CliSession state-persistence roundtrip (#4700)', () => {
     const parsed = JSON.parse(readFileSync(stateFile, 'utf-8'))
     const persisted = parsed.sessions[0]
 
-    // The contract: CliSession constructor must NOT accept any
-    // resume-style option (it has no `resumeSessionId` parameter — see
-    // the constructor signature in cli-session.js). Even if we tried to
-    // forward the id, it would land in destructuring slack and never
-    // touch `_sessionId`.
     const fresh = createSession({
       model: persisted.model,
       permissionMode: persisted.permissionMode,
-      // Defensive: even if a future caller accidentally forwarded this,
-      // the constructor must ignore it.
       resumeSessionId: persisted.sdkSessionId,
     })
 
-    assert.equal(fresh._sessionId, null,
-      'CliSession must not adopt a persisted session id — provider declares resume:false in capabilities')
-    assert.equal(fresh.sessionId, null,
-      'public accessor must also report null — restored sessions wait for the new claude -p to emit system.init')
-    assert.equal(CliSession.capabilities.resume, false,
-      'capability flag must remain false — pins the "no resume" provider contract that this test depends on')
+    assert.equal(fresh._sessionId, 'cli-resume-9999',
+      'CliSession constructor MUST adopt the persisted resume id so start() can pass --resume and recover the prior transcript (#4887)')
+    assert.equal(fresh.sessionId, 'cli-resume-9999',
+      'public accessor reflects the adopted id')
+    assert.equal(fresh.resumeSessionId, 'cli-resume-9999',
+      'resumeSessionId getter mirrors _sessionId — single source of truth used by SessionManager.serializeState on the next persist tick')
+    assert.equal(CliSession.capabilities.resume, true,
+      'capability flag is true now that the provider wires --resume into the spawn argv (#4887)')
 
     fresh.destroy()
   })

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -65,7 +65,10 @@ describe('Provider Registry', () => {
     assert.ok(cliEntry)
     assert.equal(cliEntry.capabilities.permissions, true)
     assert.equal(cliEntry.capabilities.inProcessPermissions, false)
-    assert.equal(cliEntry.capabilities.resume, false)
+    // #4887 — claude CLI supports `--resume <id>`; CliSession now wires
+    // `_sessionId` into the spawn argv on respawn / restore so the model
+    // retains conversation context. Persistence layer round-trips the id.
+    assert.equal(cliEntry.capabilities.resume, true)
 
     const sdkEntry = list.find(p => p.name === 'claude-sdk')
     assert.ok(sdkEntry)
@@ -861,7 +864,10 @@ describe('Provider Capabilities', () => {
     assert.equal(caps.modelSwitch, true)
     assert.equal(caps.permissionModeSwitch, true)
     assert.equal(caps.planMode, true)
-    assert.equal(caps.resume, false)
+    // #4887 — CliSession wires `_sessionId` into the spawn argv as
+    // `--resume <id>` on respawn / restore so the model retains
+    // conversation context. Capability flag flipped from false → true.
+    assert.equal(caps.resume, true)
     assert.equal(caps.terminal, false)
   })
 


### PR DESCRIPTION
## Summary

Closes #4887.

`CliSession` previously declared `resume: false` and never passed `--resume` to the spawned `claude -p` subprocess. On any respawn (model switch, perm-mode flip, crash) — or on server-restart restore — the new subprocess inherited the chroxy-side history ring buffer (replayed to the dashboard fine) but the model itself started cold mid-conversation. The user saw the prior transcript on screen, replied to it, and the model had no idea what they were referring to.

Claude CLI ships `--resume <session-id>` that wires the new subprocess back onto the previous conversation. This PR makes CliSession use it.

## Changes

- Extract the inline arg build into `buildClaudeCliArgs()` so the resume contract has a single, pure place to assert.
- Add a `resumeSessionId` getter on `CliSession` (mirroring `_sessionId`) so `SessionManager.serializeState` persists the id under `sdkSessionId`.
- Add a `resumeSessionId` constructor opt so `SessionManager.restoreState` re-seeds `_sessionId` on the new instance; the first `start()` then passes `--resume <id>`.
- Stop `_killAndRespawn` from nulling `_sessionId` — the respawned child needs it for the `--resume` argument.
- Flip `capabilities.resume` from false → true.
- Add `cli-session-resume.test.js` pinning the arg builder, constructor seed, getter, and `_killAndRespawn` preservation.
- Update the pre-existing "no resume" pinning tests in `cli-session.test.js` + `providers.test.js` to reflect the new contract.

The persistence chain (already in place for SDK) now applies to CLI sessions too:
`CliSession.resumeSessionId` getter → `SessionManager.serializeState` saves under `sdkSessionId` → `restoreState` calls `createSession({ resumeSessionId: saved.sdkSessionId })` → provider opts → `CliSession` constructor seeds `_sessionId` → `start()` passes `--resume`.

`DockerSession extends CliSession` so it inherits the fix automatically.

## Test plan

- [x] `node --test tests/cli-session-resume.test.js` — 10/10 pass (new resume contract suite)
- [x] `node --test tests/providers.test.js` — capability flag flipped, all assertions pass
- [x] `node --test tests/cli-session.test.js` — 79/79 assertions pass (one suite cancellation from a pre-existing force-kill hang unrelated to this change)
- [x] `./scripts/lint-session-opt-forwarding.sh` — green
- [x] `./scripts/lint-tests-state-file-path.sh` — green

## Acceptance criteria from #4887

- [x] After any respawn / server restart, the resumed claude session passes `--resume <id>` so the model retains the full prior transcript
- [x] Regression test: `_killAndRespawn` preserves `_sessionId` (pinned in `cli-session-resume.test.js`)
- [x] If the assistant turn was genuinely never persisted (drop during stream), the existing `_emitInterruptedTurnResult` path still applies — `--resume` doesn't fabricate context the CLI never had