### PR TITLE
fix(app): mirror dashboard post-tool text chunk split in mobile message handler (#4889 follow-up)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2007,6 +2007,227 @@ describe('stream_delta handler', () => {
   });
 });
 
+// #4922 — mirror of dashboard PR #4919 (#4889) for the mobile message handler.
+// When an assistant turn streams text -> tool -> text -> tool -> text, the
+// server reuses ONE messageId for the entire response. The defensive remap
+// above only fires when the slot is non-response; post-tool text chunks still
+// concatenate into the same response.content with no separator -- producing
+// `...before filing.Filing now.Filed:` and losing paragraph breaks.
+//
+// Fix: when a delta arrives for a non-empty response that already has a
+// tool_use appended after it, materialize a fresh continuation slot at the
+// end of the messages array (suffixed id `-cont-<ts>`). The remap is written
+// against the ORIGINAL incoming messageId (single-hop) so successive splits
+// overwrite the entry instead of building a chain -- `_deltaIdRemaps` stays
+// bounded and `handleStreamEnd`'s `_deltaIdRemaps.delete(originalId)` cleans
+// up completely.
+describe('post-tool text chunks split into continuation slots (#4922 / #4889)', () => {
+  beforeEach(() => {
+    clearDeltaBuffers();
+    clearPermissionSplits();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('creates a new response slot when delta arrives for a response with tool_use appended after it', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // text-A -> tool -> text-B -> tool -> text-C, all sharing messageId 'resp-1'
+    _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'Let me check chroxy before filing.',
+    });
+    jest.runAllTimers();
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'toolu_a',
+      sessionId: 's1',
+      tool: 'Bash',
+      toolUseId: 'toolu_a',
+      input: { command: 'gh issue list' },
+    });
+    _testMessageHandler.handle({
+      type: 'tool_result',
+      sessionId: 's1',
+      toolUseId: 'toolu_a',
+      result: 'ok',
+    });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'Filing now.',
+    });
+    jest.runAllTimers();
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'toolu_b',
+      sessionId: 's1',
+      tool: 'Bash',
+      toolUseId: 'toolu_b',
+      input: { command: 'gh issue create' },
+    });
+    _testMessageHandler.handle({
+      type: 'tool_result',
+      sessionId: 's1',
+      toolUseId: 'toolu_b',
+      result: 'https://...',
+    });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'Filed: https://github.com/...',
+    });
+    jest.runAllTimers();
+
+    const ss = store.getState().sessionStates.s1;
+    const responses = ss.messages.filter((m) => m.type === 'response');
+    const tools = ss.messages.filter((m) => m.type === 'tool_use');
+    expect(responses).toHaveLength(3);
+    expect(tools).toHaveLength(2);
+    expect(responses[0].content).toBe('Let me check chroxy before filing.');
+    expect(responses[1].content).toBe('Filing now.');
+    expect(responses[2].content).toBe('Filed: https://github.com/...');
+    // No `.X` (period followed by capital with no space) across boundaries --
+    // the join in formatTranscript inserts `\n\n` so the concatenation is safe.
+    const joined = responses.map((r) => r.content).join('\n\n');
+    expect(joined).not.toMatch(/\.[A-Z]/);
+  });
+
+  it('places each continuation slot AFTER the preceding tool_use (#4297 ordering preserved)', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'preamble',
+    });
+    jest.runAllTimers();
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'toolu_a',
+      sessionId: 's1',
+      tool: 'Bash',
+      toolUseId: 'toolu_a',
+      input: { command: 'ls' },
+    });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'summary',
+    });
+    jest.runAllTimers();
+
+    const ss = store.getState().sessionStates.s1;
+    // [response('preamble'), tool, response('summary')]
+    expect(ss.messages).toHaveLength(3);
+    expect(ss.messages[0].type).toBe('response');
+    expect(ss.messages[0].content).toBe('preamble');
+    expect(ss.messages[1].type).toBe('tool_use');
+    expect(ss.messages[1].id).toBe('toolu_a');
+    expect(ss.messages[2].type).toBe('response');
+    expect(ss.messages[2].content).toBe('summary');
+  });
+
+  it('does not split when consecutive deltas arrive without an intervening tool', () => {
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'hello ',
+    });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'world',
+    });
+    jest.runAllTimers();
+
+    const ss = store.getState().sessionStates.s1;
+    // No tool ran -- single response slot with concatenated deltas
+    expect(ss.messages).toHaveLength(1);
+    expect(ss.messages[0].type).toBe('response');
+    expect(ss.messages[0].content).toBe('hello world');
+  });
+
+  it('handles three or more post-tool continuation chunks via single-hop remap (no chain)', () => {
+    // Successive continuation splits must overwrite the remap entry against
+    // the ORIGINAL incoming messageId so the map stays bounded. If the remap
+    // were instead chained (A -> A-cont-1 -> A-cont-2 -> A-cont-3), this
+    // case would either drop deltas or require a transitive lookup.
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'A',
+    });
+    jest.runAllTimers();
+    for (let i = 0; i < 3; i++) {
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: `toolu_${i}`,
+        sessionId: 's1',
+        tool: 'Bash',
+        toolUseId: `toolu_${i}`,
+        input: { command: `cmd-${i}` },
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: `cont-${i}`,
+      });
+      jest.runAllTimers();
+    }
+
+    const ss = store.getState().sessionStates.s1;
+    const responses = ss.messages.filter((m) => m.type === 'response');
+    expect(responses).toHaveLength(4);
+    expect(responses.map((r) => r.content)).toEqual(['A', 'cont-0', 'cont-1', 'cont-2']);
+  });
+});
+
 describe('stream_end handler', () => {
   beforeEach(() => {
     clearDeltaBuffers();

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2226,6 +2226,61 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
     expect(responses).toHaveLength(4);
     expect(responses.map((r) => r.content)).toEqual(['A', 'cont-0', 'cont-1', 'cont-2']);
   });
+
+  it('does NOT split during replay -- server-reassembled history must stay intact', () => {
+    // History is reassembled server-side: a single `stream_delta` carries the
+    // entire post-tool tail in one chunk against the original messageId. If
+    // the client split it again, replayed history would gain a phantom
+    // continuation slot that never existed in the live turn. The guard at
+    // `_ctx.replayingSessions.has(...)` skips the split for replaying sessions
+    // -- this test pins that behavior so it can't silently regress.
+    const store = createMockStore({
+      activeSessionId: 's1',
+      sessions: [{ sessionId: 's1', name: 'S1' } as any],
+      sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+    });
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    // Enter replay mode for s1 -- mirrors the live wire sequence: server emits
+    // `history_replay_start` before streaming the cached transcript.
+    _testMessageHandler.handle({ type: 'history_replay_start', sessionId: 's1' });
+
+    // Replay the same shape as the FIX test above (text -> tool -> text),
+    // sharing one messageId. Without the replay guard, the second delta would
+    // create a continuation slot.
+    _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'preamble',
+    });
+    jest.runAllTimers();
+    _testMessageHandler.handle({
+      type: 'tool_start',
+      messageId: 'toolu_a',
+      sessionId: 's1',
+      tool: 'Bash',
+      toolUseId: 'toolu_a',
+      input: { command: 'ls' },
+    });
+    _testMessageHandler.handle({
+      type: 'stream_delta',
+      messageId: 'resp-1',
+      sessionId: 's1',
+      delta: 'summary',
+    });
+    jest.runAllTimers();
+
+    const ss = store.getState().sessionStates.s1;
+    const responses = ss.messages.filter((m) => m.type === 'response');
+    // ONE response slot whose content is both deltas concatenated -- no
+    // continuation slot was created because the session is replaying.
+    expect(responses).toHaveLength(1);
+    expect(responses[0].id).toBe('resp-1');
+    expect(responses[0].content).toBe('preamblesummary');
+  });
 });
 
 describe('stream_end handler', () => {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1556,7 +1556,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'stream_delta': {
-      let deltaId = msg.messageId as string;
+      // Capture the ORIGINAL incoming messageId before any remap resolution.
+      // The post-tool continuation split (#4922 / #4889) writes its remap entry
+      // against this id (not against the resolved `deltaId`) so successive
+      // splits overwrite a single map entry instead of forming a chain --
+      // keeps `_ctx.deltaIdRemaps` bounded and eliminates the need for
+      // chained lookup.
+      const originalMessageId = msg.messageId as string;
+      let deltaId = originalMessageId;
       const capturedSessionId = (msg.sessionId as string) || get().activeSessionId;
 
       // Permission boundary split: first delta after a split creates a new message
@@ -1605,6 +1612,81 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
               }));
             }
             deltaId = suffixed;
+          }
+        }
+      }
+
+      // #4922 / #4889 -- post-tool continuation split. The server reuses ONE
+      // messageId for an entire assistant turn even when text -> tool -> text
+      // -> tool -> text. The defensive remap above only fires when the slot
+      // at deltaId is non-response; subsequent text chunks otherwise
+      // concatenate into the same response.content with no separator --
+      // producing `...before filing.Filing now.Filed:` and losing paragraph
+      // breaks.
+      //
+      // Detect the boundary by checking whether a tool_use was appended AFTER
+      // the currently-resolved response slot. If so, materialize a fresh
+      // continuation slot at the end (`<deltaId>-cont-<ts>`) and remap the
+      // ORIGINAL incoming messageId directly to the new slot (single-hop,
+      // never chained -- successive splits overwrite the existing entry so
+      // `_ctx.deltaIdRemaps` stays bounded and `stream_end`'s
+      // `_ctx.deltaIdRemaps.delete(out.messageId)` cleans up completely).
+      // The split mirrors the `-post-` permission-boundary pattern already
+      // in this file. Skipped while the session is replaying -- replayed
+      // history is reassembled server-side and must not be re-split on the
+      // client.
+      {
+        const splitTargetId = capturedSessionId;
+        const splitEffectiveId = (splitTargetId && get().sessionStates[splitTargetId])
+          ? splitTargetId
+          : get().activeSessionId;
+        const isReplaying = splitEffectiveId ? _ctx.replayingSessions.has(splitEffectiveId) : false;
+        if (!isReplaying && splitEffectiveId && get().sessionStates[splitEffectiveId]) {
+          const splitMessages = get().sessionStates[splitEffectiveId].messages;
+          const slotIdx = splitMessages.findIndex((m) => m.id === deltaId);
+          if (slotIdx >= 0) {
+            const slot = splitMessages[slotIdx];
+            // Buffered (not-yet-flushed) text counts as content for the
+            // split decision -- otherwise a chunk that hasn't hit the 100ms
+            // flush yet would look empty and we'd append onto it.
+            const bufferedContent = _ctx.pendingDeltas.get(deltaId)?.delta || '';
+            const hasContent = slot.type === 'response'
+              && (slot.content.length > 0 || bufferedContent.length > 0);
+            // Index-based scan instead of slice().some() -- avoids allocating
+            // a tail array on every delta. stream_delta is called many times
+            // per turn and sessions can carry long histories, so this stays
+            // on the hot path lean.
+            let toolAfter = false;
+            if (hasContent) {
+              for (let i = slotIdx + 1; i < splitMessages.length; i++) {
+                if (splitMessages[i].type === 'tool_use') {
+                  toolAfter = true;
+                  break;
+                }
+              }
+            }
+            if (toolAfter) {
+              const contId = `${deltaId}-cont-${Date.now()}`;
+              // Single-hop remap: write against the ORIGINAL incoming
+              // messageId so successive continuation splits overwrite this
+              // entry rather than building a chain. Keeps
+              // `_ctx.deltaIdRemaps` size bounded by the count of distinct
+              // in-flight turn ids, and lets `stream_end`'s
+              // `_ctx.deltaIdRemaps.delete(out.messageId)` clean up
+              // completely.
+              _ctx.deltaIdRemaps.set(originalMessageId, contId);
+              const contMsg: ChatMessage = {
+                id: contId,
+                type: 'response',
+                content: '',
+                timestamp: Date.now(),
+              };
+              updateSession(splitEffectiveId, (ss) => ({
+                streamingMessageId: contId,
+                messages: [...ss.messages, contMsg],
+              }));
+              deltaId = contId;
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

Mirror of dashboard PR #4919 for the mobile message handler. The mobile app receives the same wire protocol as the dashboard (one `messageId` per assistant turn even when text streams as text → tool → text → tool → text) and concatenated post-tool deltas onto the same response slot with no separator -- producing `…before filing.Filing now.Filed:` and losing paragraph breaks.

- `packages/app/src/store/message-handler.ts` `handleStreamDelta` now materializes a fresh continuation slot (`<deltaId>-cont-<ts>`) at the end of the messages array when a delta arrives for a non-empty response that already has a `tool_use` appended after it.
- Single-hop remap pattern: the new `_ctx.deltaIdRemaps` entry is written against the ORIGINAL incoming `messageId` so successive continuation splits overwrite a single map entry instead of building a chain. `_ctx.deltaIdRemaps` stays bounded and `stream_end`'s `_ctx.deltaIdRemaps.delete(out.messageId)` cleans up completely.
- Index-based scan over later messages (no `slice().some()` allocation on the hot path).
- Skipped while the session is replaying -- replayed history is reassembled server-side and must not be re-split on the client.
- Buffered (not-yet-flushed) text counts as content for the split decision so a chunk that hasn't hit the 100ms flush yet doesn't look empty.

App has no top-level `messages` array (always uses `sessionStates`), so the dashboard's flat-fallback branch is omitted.

Closes #4922

## Test plan

- [x] New `post-tool text chunks split into continuation slots (#4922 / #4889)` describe block with four tests:
  - text → tool → text → tool → text yields three distinct response bubbles, no `.[A-Z]` across boundaries
  - continuation slot lands AFTER the preceding `tool_use` (#4297 ordering preserved)
  - consecutive deltas without intervening tool do NOT split
  - 3+ post-tool continuation chunks: single-hop remap stays bounded, no chained lookup
- [x] `cd packages/app && npx jest` -- 1547 passed (109 files)
- [x] `npm run test -w @chroxy/store-core` -- 1060 passed (21 files)
- [x] `cd packages/app && npx tsc --noEmit` -- clean
- [x] `cd packages/store-core && npx tsc --noEmit` -- clean