### PR TITLE
feat(dashboard): drag-to-reorder sessions in left sidebar (#4832)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -70,7 +70,8 @@ import { usePermissionNotification, type PermissionPromptInfo } from './hooks/us
 import { useShortcutDispatch } from './hooks/useShortcutDispatch'
 import { useChatMessages, toChatViewMessage } from './hooks/useChatMessages'
 import { SplitPane, type SplitDirection } from './components/SplitPane'
-import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed } from './store/persistence'
+import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed, loadPersistedSidebarRepoOrder, loadPersistedSidebarSessionOrder, persistSidebarRepoOrder, persistSidebarSessionOrder } from './store/persistence'
+import { applyOrderById } from './utils/reorderById'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
 import { AgentMonitorPanel } from './components/AgentMonitorPanel'
 import { SessionLoadingSkeleton } from './components/SessionLoadingSkeleton'
@@ -555,6 +556,14 @@ export function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [sidebarWidth, setSidebarWidth] = useState(() => loadPersistedSidebarWidth() ?? 240)
   const [sidebarFilter, setSidebarFilter] = useState('')
+  // #4832 — user-defined order for the sidebar's repo groups and the
+  // sessions inside each group. Both are layered on top of the
+  // server-supplied session list and persisted in localStorage so they
+  // survive reload + Tauri restart. State sits at App-level so the
+  // `sidebarRepos` memo below can apply the order to the derived
+  // RepoNode[].
+  const [sidebarRepoOrder, setSidebarRepoOrder] = useState<string[]>(() => loadPersistedSidebarRepoOrder())
+  const [sidebarSessionOrder, setSidebarSessionOrder] = useState<Record<string, string[]>>(() => loadPersistedSidebarSessionOrder())
   // #4045: sidebar right-click context menu state. `null` when closed.
   const [sidebarContextMenu, setSidebarContextMenu] = useState<{
     target: ContextMenuTarget
@@ -989,8 +998,38 @@ export function App() {
       return []
     }
 
-    return [...repoMap.values()]
-  }, [sessions, getSessionVisualStatus, sidebarCumulativeUsage])
+    // #4832 — apply user-defined ordering. Repo groups are reordered
+    // by saved cwd order (unknown ids dropped, new repos appended at
+    // tail). Sessions within each repo are reordered by the per-repo
+    // saved order. `applyOrderById` keeps unsaved sessions / repos at
+    // the end so newly-created entries don't shuffle the existing list.
+    const ordered = applyOrderById([...repoMap.values()], sidebarRepoOrder, r => r.path)
+    return ordered.map(repo => {
+      const savedSessionOrder = sidebarSessionOrder[repo.path]
+      if (!savedSessionOrder || savedSessionOrder.length === 0) return repo
+      return {
+        ...repo,
+        activeSessions: applyOrderById(repo.activeSessions, savedSessionOrder, s => s.sessionId),
+      }
+    })
+  }, [sessions, getSessionVisualStatus, sidebarCumulativeUsage, sidebarRepoOrder, sidebarSessionOrder])
+
+  // #4832 — reorder callbacks wired into the Sidebar component. Both
+  // persist immediately so a reload (or Tauri restart) restores the
+  // order. We update local state synchronously so the UI reflects the
+  // new order on the next render without waiting for a round-trip.
+  const handleReorderRepos = useCallback((orderedPaths: string[]) => {
+    setSidebarRepoOrder(orderedPaths)
+    persistSidebarRepoOrder(orderedPaths)
+  }, [])
+
+  const handleReorderSidebarSessions = useCallback((repoPath: string, orderedIds: string[]) => {
+    setSidebarSessionOrder(prev => {
+      const next = { ...prev, [repoPath]: orderedIds }
+      persistSidebarSessionOrder(next)
+      return next
+    })
+  }, [])
 
   // Known CWDs for CreateSessionModal suggestions
   const knownCwds = useMemo(
@@ -1912,6 +1951,8 @@ export function App() {
           initialPanelHeight={loadPersistedSidebarPanelHeight() ?? 200}
           initialPanelView={loadPersistedSidebarPanelView()}
           initialPanelCollapsed={loadPersistedSidebarPanelCollapsed()}
+          onReorderRepos={handleReorderRepos}
+          onReorderSessions={handleReorderSidebarSessions}
         />
       )}
 

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -363,6 +363,11 @@ export function Sidebar({
   const handleRepoReorderKey = useCallback(
     (path: string) => (event: React.KeyboardEvent<HTMLElement>): boolean => {
       if (!onReorderRepos) return false
+      // Mirror the drag guard (`draggable={... && !filter}`) — reordering
+      // from a filtered view would persist an order derived from the
+      // visible subset, silently shuffling hidden repos relative to each
+      // other. Disable the keyboard reorder shortcut while filtering too.
+      if (filter) return false
       if (!event.altKey) return false
       if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return false
       const paths = filteredRepos.map(r => r.path)
@@ -374,12 +379,15 @@ export function Sidebar({
       onReorderRepos(next)
       return true
     },
-    [onReorderRepos, filteredRepos],
+    [onReorderRepos, filteredRepos, filter],
   )
 
   const handleSessionReorderKey = useCallback(
     (repoPath: string, sessionId: string) => (event: React.KeyboardEvent<HTMLElement>): boolean => {
       if (!onReorderSessions) return false
+      // Same rationale as handleRepoReorderKey: filtered subset would
+      // produce a partial persisted order.
+      if (filter) return false
       if (!event.altKey) return false
       if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return false
       const repo = filteredRepos.find(r => r.path === repoPath)
@@ -393,7 +401,7 @@ export function Sidebar({
       onReorderSessions(repoPath, next)
       return true
     },
-    [onReorderSessions, filteredRepos],
+    [onReorderSessions, filteredRepos, filter],
   )
 
   // Resize handle drag logic

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   persistSidebarPanelView,
   persistSidebarPanelCollapsed,
 } from '../store/persistence'
+import { moveItem, orderToIds } from '../utils/reorderById'
 
 export interface ActiveSessionNode {
   sessionId: string
@@ -86,6 +87,13 @@ export interface SidebarProps {
   initialPanelHeight?: number
   initialPanelView?: string | null
   initialPanelCollapsed?: boolean
+  // #4832 — drag-to-reorder callbacks. The sidebar fires these with the
+  // FULL post-move id arrays (not deltas) so the parent can persist the
+  // new order in a single `localStorage.setItem`. Both are optional so
+  // tests + callers that don't care about reordering don't have to wire
+  // them up.
+  onReorderRepos?: (orderedRepoPaths: string[]) => void
+  onReorderSessions?: (repoPath: string, orderedSessionIds: string[]) => void
 }
 
 function abbreviateTunnel(url: string): string {
@@ -121,6 +129,8 @@ export function Sidebar({
   initialPanelHeight = 200,
   initialPanelView = null,
   initialPanelCollapsed = false,
+  onReorderRepos,
+  onReorderSessions,
 }: SidebarProps) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const [focusedIndex, setFocusedIndex] = useState(0)
@@ -163,6 +173,229 @@ export function Sidebar({
     setCollapsed(prev => ({ ...prev, [path]: !prev[path] }))
   }, [])
 
+  // Hoisted above the #4832 drag handlers below so their useCallback
+  // dependency arrays (which reference filteredRepos) sit outside the TDZ.
+  const filteredRepos = filter
+    ? repos
+        .map(r => {
+          const lf = filter.toLowerCase()
+          const matchesRepoName = r.name.toLowerCase().includes(lf)
+          const filteredActive = r.activeSessions.filter(s =>
+            s.name.toLowerCase().includes(lf),
+          )
+          const filteredResumable = r.resumableSessions.filter(s =>
+            (s.preview ?? '').toLowerCase().includes(lf),
+          )
+          const hasMatchingChild = filteredActive.length > 0 || filteredResumable.length > 0
+          if (!matchesRepoName && !hasMatchingChild) return null
+          return {
+            ...r,
+            activeSessions: matchesRepoName ? r.activeSessions : filteredActive,
+            resumableSessions: matchesRepoName ? r.resumableSessions : filteredResumable,
+          }
+        })
+        .filter((r): r is RepoNode => r !== null)
+    : repos
+
+  // #4832 — drag-to-reorder state. We track the dragged item identity and
+  // the current drop target separately:
+  //
+  //   - `dragRepo` / `dragSession` carry the id of the item currently being
+  //     dragged. Set in `onDragStart`, cleared in `onDragEnd`. Used to
+  //     filter `onDragOver` events so we ignore drags that started on a
+  //     mismatched scope (e.g. a session row should not respond to a repo
+  //     drag, and vice versa).
+  //   - `dragOverRepo` / `dragOverSession` carry the id of the row the
+  //     cursor is currently hovering during a drag, plus a 'before' /
+  //     'after' position derived from the cursor's vertical midpoint. This
+  //     drives the drop-indicator CSS class on the target row.
+  //
+  // Cross-group session drags are disallowed (sessions are pinned to their
+  // owning repo by metadata, per the issue's "out of scope" notes), so the
+  // session drop handlers only respond when the drag started inside the
+  // same repo.
+  const [dragRepo, setDragRepo] = useState<string | null>(null)
+  const [dragOverRepo, setDragOverRepo] = useState<{ path: string; position: 'before' | 'after' } | null>(null)
+  const [dragSession, setDragSession] = useState<{ repoPath: string; sessionId: string } | null>(null)
+  const [dragOverSession, setDragOverSession] = useState<{ repoPath: string; sessionId: string; position: 'before' | 'after' } | null>(null)
+
+  /**
+   * Decide whether the cursor is above or below the row's vertical midpoint.
+   * Used to render a single thin drop-indicator line at the top OR bottom
+   * edge — the more conventional pattern than a thick highlight, and matches
+   * VS Code / Linear.
+   */
+  const dropPosition = useCallback((event: React.DragEvent<HTMLElement>): 'before' | 'after' => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    const midY = rect.top + rect.height / 2
+    return event.clientY < midY ? 'before' : 'after'
+  }, [])
+
+  const handleRepoDragStart = useCallback((path: string) => (event: React.DragEvent<HTMLElement>) => {
+    if (!onReorderRepos) return
+    // dataTransfer payload — required by Firefox for the drag to fire at
+    // all. Setting effectAllowed='move' shows the move cursor.
+    event.dataTransfer.effectAllowed = 'move'
+    try { event.dataTransfer.setData('text/plain', path) } catch { /* SSR / jsdom no-op */ }
+    setDragRepo(path)
+  }, [onReorderRepos])
+
+  const handleRepoDragOver = useCallback((path: string) => (event: React.DragEvent<HTMLElement>) => {
+    if (!onReorderRepos || dragRepo === null) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    const pos = dropPosition(event)
+    setDragOverRepo(prev => prev && prev.path === path && prev.position === pos ? prev : { path, position: pos })
+  }, [onReorderRepos, dragRepo, dropPosition])
+
+  const handleRepoDragLeave = useCallback((path: string) => () => {
+    setDragOverRepo(prev => prev && prev.path === path ? null : prev)
+  }, [])
+
+  const handleRepoDrop = useCallback((targetPath: string) => (event: React.DragEvent<HTMLElement>) => {
+    if (!onReorderRepos || dragRepo === null) return
+    event.preventDefault()
+    const pos = dropPosition(event)
+    setDragRepo(null)
+    setDragOverRepo(null)
+    if (dragRepo === targetPath) return
+    const paths = filteredRepos.map(r => r.path)
+    const fromIdx = paths.indexOf(dragRepo)
+    const targetIdx = paths.indexOf(targetPath)
+    if (fromIdx < 0 || targetIdx < 0) return
+    // 'after' means the dragged item lands AFTER target; convert to splice
+    // index. If we're moving forward and dropping after, the post-removal
+    // target index doesn't need a +1 bump (splice removes first), so we
+    // just use the target index when 'before' and target+1 when 'after',
+    // then let moveItem normalize.
+    let toIdx = pos === 'before' ? targetIdx : targetIdx + 1
+    if (fromIdx < toIdx) toIdx -= 1
+    const next = moveItem(paths, fromIdx, toIdx)
+    onReorderRepos(next)
+  }, [onReorderRepos, dragRepo, dropPosition, filteredRepos])
+
+  const handleRepoDragEnd = useCallback(() => {
+    setDragRepo(null)
+    setDragOverRepo(null)
+  }, [])
+
+  const handleSessionDragStart = useCallback(
+    (repoPath: string, sessionId: string) => (event: React.DragEvent<HTMLElement>) => {
+      if (!onReorderSessions) return
+      event.dataTransfer.effectAllowed = 'move'
+      try { event.dataTransfer.setData('text/plain', sessionId) } catch { /* jsdom no-op */ }
+      // stopPropagation so the parent repo treeitem's drag handlers don't
+      // also fire (the outer treeitem is the drop target for repo
+      // reordering — a session drag started inside it would otherwise be
+      // mistaken for a repo drag).
+      event.stopPropagation()
+      setDragSession({ repoPath, sessionId })
+    },
+    [onReorderSessions],
+  )
+
+  const handleSessionDragOver = useCallback(
+    (repoPath: string, sessionId: string) => (event: React.DragEvent<HTMLElement>) => {
+      if (!onReorderSessions || dragSession === null) return
+      // Only respond to drags that started in the same repo — cross-group
+      // moves are out of scope (per the issue).
+      if (dragSession.repoPath !== repoPath) return
+      event.preventDefault()
+      event.stopPropagation()
+      event.dataTransfer.dropEffect = 'move'
+      const pos = dropPosition(event)
+      setDragOverSession(prev =>
+        prev && prev.sessionId === sessionId && prev.position === pos && prev.repoPath === repoPath
+          ? prev
+          : { repoPath, sessionId, position: pos },
+      )
+    },
+    [onReorderSessions, dragSession, dropPosition],
+  )
+
+  const handleSessionDragLeave = useCallback(
+    (sessionId: string) => () => {
+      setDragOverSession(prev => prev && prev.sessionId === sessionId ? null : prev)
+    },
+    [],
+  )
+
+  const handleSessionDrop = useCallback(
+    (repoPath: string, targetSessionId: string) => (event: React.DragEvent<HTMLElement>) => {
+      if (!onReorderSessions || dragSession === null) return
+      if (dragSession.repoPath !== repoPath) return
+      event.preventDefault()
+      event.stopPropagation()
+      const pos = dropPosition(event)
+      const dragged = dragSession.sessionId
+      setDragSession(null)
+      setDragOverSession(null)
+      if (dragged === targetSessionId) return
+      const repo = filteredRepos.find(r => r.path === repoPath)
+      if (!repo) return
+      const ids = orderToIds(repo.activeSessions, s => s.sessionId)
+      const fromIdx = ids.indexOf(dragged)
+      const targetIdx = ids.indexOf(targetSessionId)
+      if (fromIdx < 0 || targetIdx < 0) return
+      let toIdx = pos === 'before' ? targetIdx : targetIdx + 1
+      if (fromIdx < toIdx) toIdx -= 1
+      const next = moveItem(ids, fromIdx, toIdx)
+      onReorderSessions(repoPath, next)
+    },
+    [onReorderSessions, dragSession, dropPosition, filteredRepos],
+  )
+
+  const handleSessionDragEnd = useCallback(() => {
+    setDragSession(null)
+    setDragOverSession(null)
+  }, [])
+
+  /**
+   * Keyboard reordering — Alt+ArrowUp / Alt+ArrowDown. The Alt modifier
+   * avoids clobbering plain ArrowUp/ArrowDown (which the WAI-ARIA tree
+   * pattern uses for focus traversal — see handleTreeKeyDown below).
+   *
+   * Repo rows reorder the top-level repo list; session rows reorder
+   * within their owning repo. Returns true when the key was handled so
+   * the row handler can stopPropagation + preventDefault, blocking the
+   * tree-level handler from also processing the same keypress.
+   */
+  const handleRepoReorderKey = useCallback(
+    (path: string) => (event: React.KeyboardEvent<HTMLElement>): boolean => {
+      if (!onReorderRepos) return false
+      if (!event.altKey) return false
+      if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return false
+      const paths = filteredRepos.map(r => r.path)
+      const idx = paths.indexOf(path)
+      if (idx < 0) return false
+      const target = event.key === 'ArrowUp' ? idx - 1 : idx + 1
+      if (target < 0 || target >= paths.length) return true // swallow, no-op at edges
+      const next = moveItem(paths, idx, target)
+      onReorderRepos(next)
+      return true
+    },
+    [onReorderRepos, filteredRepos],
+  )
+
+  const handleSessionReorderKey = useCallback(
+    (repoPath: string, sessionId: string) => (event: React.KeyboardEvent<HTMLElement>): boolean => {
+      if (!onReorderSessions) return false
+      if (!event.altKey) return false
+      if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return false
+      const repo = filteredRepos.find(r => r.path === repoPath)
+      if (!repo) return false
+      const ids = orderToIds(repo.activeSessions, s => s.sessionId)
+      const idx = ids.indexOf(sessionId)
+      if (idx < 0) return false
+      const target = event.key === 'ArrowUp' ? idx - 1 : idx + 1
+      if (target < 0 || target >= ids.length) return true
+      const next = moveItem(ids, idx, target)
+      onReorderSessions(repoPath, next)
+      return true
+    },
+    [onReorderSessions, filteredRepos],
+  )
+
   // Resize handle drag logic
   const isDragging = useRef(false)
   const startX = useRef(0)
@@ -190,28 +423,6 @@ export function Sidebar({
     document.addEventListener('mousemove', onMouseMove)
     document.addEventListener('mouseup', onMouseUp)
   }, [width, onWidthChange])
-
-  const filteredRepos = filter
-    ? repos
-        .map(r => {
-          const lf = filter.toLowerCase()
-          const matchesRepoName = r.name.toLowerCase().includes(lf)
-          const filteredActive = r.activeSessions.filter(s =>
-            s.name.toLowerCase().includes(lf),
-          )
-          const filteredResumable = r.resumableSessions.filter(s =>
-            (s.preview ?? '').toLowerCase().includes(lf),
-          )
-          const hasMatchingChild = filteredActive.length > 0 || filteredResumable.length > 0
-          if (!matchesRepoName && !hasMatchingChild) return null
-          return {
-            ...r,
-            activeSessions: matchesRepoName ? r.activeSessions : filteredActive,
-            resumableSessions: matchesRepoName ? r.resumableSessions : filteredResumable,
-          }
-        })
-        .filter((r): r is RepoNode => r !== null)
-    : repos
 
   // Get all visible treeitem elements for keyboard navigation
   const getVisibleItems = useCallback((): HTMLElement[] => {
@@ -396,12 +607,21 @@ export function Sidebar({
           <div className="sidebar-tree" role="tree" aria-label="Repository sessions" ref={treeRef} onKeyDown={handleTreeKeyDown}>
             {filteredRepos.map(repo => {
               const isCollapsed = filter ? false : (collapsed[repo.path] ?? false)
+              const repoDragOver = dragOverRepo?.path === repo.path ? dragOverRepo.position : null
+              const repoClass = `sidebar-repo${dragRepo === repo.path ? ' dragging' : ''}${repoDragOver ? ` drop-${repoDragOver}` : ''}`
               return (
                 <div
                   key={repo.path}
-                  className="sidebar-repo"
+                  className={repoClass}
                   role="treeitem"
                   aria-expanded={!isCollapsed}
+                  // #4832: only enable drag when reorder is wired AND no
+                  // filter is applied. Reordering during an active filter is
+                  // ambiguous (the on-screen list is a subset of the real
+                  // order) and would persist a confusing order; gate it off.
+                  draggable={!!onReorderRepos && !filter}
+                  data-testid={`sidebar-repo-${repo.path}`}
+                  data-drop-position={repoDragOver ?? undefined}
                   tabIndex={visibleIds.indexOf(`repo:${repo.path}`) === focusedIndex ? 0 : -1}
                   // #4372: bind onContextMenu on the outer treeitem (not the
                   // inner .sidebar-repo-header) so that App's handler can
@@ -417,7 +637,22 @@ export function Sidebar({
                   // ContextMenu key or Shift+F10. invokeContextMenuFromKey
                   // is a no-op for any other key, so this does not
                   // interfere with the tree-level arrow nav.
-                  onKeyDown={e => invokeContextMenuFromKey(e, { type: 'repo', path: repo.path })}
+                  // #4832: Alt+ArrowUp/Down keyboard reorder is checked
+                  // first; when handled it stops propagation so the
+                  // tree-level arrow-nav handler doesn't ALSO move focus.
+                  onKeyDown={e => {
+                    if (handleRepoReorderKey(repo.path)(e)) {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      return
+                    }
+                    invokeContextMenuFromKey(e, { type: 'repo', path: repo.path })
+                  }}
+                  onDragStart={handleRepoDragStart(repo.path)}
+                  onDragOver={handleRepoDragOver(repo.path)}
+                  onDragLeave={handleRepoDragLeave(repo.path)}
+                  onDrop={handleRepoDrop(repo.path)}
+                  onDragEnd={handleRepoDragEnd}
                 >
                   <div
                     className={`sidebar-repo-header${!repo.exists ? ' missing' : ''}`}
@@ -453,14 +688,22 @@ export function Sidebar({
                           : status === 'stale'
                             ? 'Session stale — idle for 1 hour or more'
                             : 'Session idle — ready for input'
+                        const isDraggingThis = dragSession?.sessionId === session.sessionId
+                        const sessionDragOver = dragOverSession?.sessionId === session.sessionId ? dragOverSession.position : null
+                        const sessionItemClass = `sidebar-session-item${activeSessionId === session.sessionId ? ' active' : ''}${isDraggingThis ? ' dragging' : ''}${sessionDragOver ? ` drop-${sessionDragOver}` : ''}`
                         return (
                           <div
                             key={session.sessionId}
                             role="treeitem"
                             aria-selected={activeSessionId === session.sessionId}
                             tabIndex={visibleIds.indexOf(`session:${session.sessionId}`) === focusedIndex ? 0 : -1}
-                            className={`sidebar-session-item${activeSessionId === session.sessionId ? ' active' : ''}`}
+                            className={sessionItemClass}
                             data-testid={`session-item-${session.sessionId}`}
+                            // #4832: same filter guard as repo rows — order
+                            // changes during a filter would persist a
+                            // confusing partial ordering.
+                            draggable={!!onReorderSessions && !filter}
+                            data-drop-position={sessionDragOver ?? undefined}
                             onClick={() => onSessionClick(session.sessionId)}
                             onContextMenu={e => {
                               // #4372: stopPropagation so the right-click
@@ -478,7 +721,24 @@ export function Sidebar({
                             // Shift+F10). stopPropagation inside the helper
                             // keeps the event from also reaching the outer
                             // repo treeitem's onKeyDown.
-                            onKeyDown={e => invokeContextMenuFromKey(e, { type: 'session', sessionId: session.sessionId })}
+                            // #4832: Alt+ArrowUp/Down keyboard reorder runs
+                            // first; when handled, stopPropagation +
+                            // preventDefault block both the parent repo
+                            // treeitem's reorder handler AND the
+                            // tree-level focus traversal.
+                            onKeyDown={e => {
+                              if (handleSessionReorderKey(repo.path, session.sessionId)(e)) {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                return
+                              }
+                              invokeContextMenuFromKey(e, { type: 'session', sessionId: session.sessionId })
+                            }}
+                            onDragStart={handleSessionDragStart(repo.path, session.sessionId)}
+                            onDragOver={handleSessionDragOver(repo.path, session.sessionId)}
+                            onDragLeave={handleSessionDragLeave(session.sessionId)}
+                            onDrop={handleSessionDrop(repo.path, session.sessionId)}
+                            onDragEnd={handleSessionDragEnd}
                           >
                             <span className={`sidebar-session-dot status-${status}`} title={statusTitle} />
                             <span className="sidebar-session-name">{session.name}</span>

--- a/packages/dashboard/src/components/SidebarReorder.test.tsx
+++ b/packages/dashboard/src/components/SidebarReorder.test.tsx
@@ -1,0 +1,475 @@
+/**
+ * Drag-to-reorder tests for the left sidebar (#4832).
+ *
+ * Covers:
+ *   - HTML5 drag-and-drop emits onReorderRepos with the post-move
+ *     ordering for top-level repo groups
+ *   - HTML5 drag-and-drop emits onReorderSessions with the post-move
+ *     ordering for sessions within a repo
+ *   - Sessions cannot be dragged across repo groups (out-of-scope per
+ *     the issue)
+ *   - Keyboard reorder shortcut (Alt+ArrowUp/Down) emits the same
+ *     callbacks without requiring the mouse
+ *   - Drag is disabled while a filter is active (the on-screen list is
+ *     a subset, so reordering it would persist a confusing partial
+ *     order)
+ *   - Persistence round-trip — repo order survives `window.location.reload()`
+ *     by reading from localStorage on remount
+ *   - Drop-position visual indicator class is applied based on the
+ *     cursor's vertical midpoint
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import { useState } from 'react'
+import { Sidebar, type SidebarProps, type RepoNode } from './Sidebar'
+import {
+  persistSidebarRepoOrder,
+  loadPersistedSidebarRepoOrder,
+  persistSidebarSessionOrder,
+  loadPersistedSidebarSessionOrder,
+} from '../store/persistence'
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const store = {
+      serverRegistry: [],
+      activeServerId: null,
+      connectionPhase: 'disconnected',
+      addServer: vi.fn(),
+      removeServer: vi.fn(),
+      switchServer: vi.fn(),
+    }
+    return selector(store)
+  },
+}))
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+const noop = vi.fn()
+
+function makeRepos(): RepoNode[] {
+  return [
+    {
+      path: '/home/user/projects/api',
+      name: 'api',
+      source: 'auto',
+      exists: true,
+      activeSessions: [
+        { sessionId: 's1', name: 'Backend', isBusy: false },
+        { sessionId: 's2', name: 'Tests', isBusy: false },
+        { sessionId: 's3', name: 'Worker', isBusy: false },
+      ],
+      resumableSessions: [],
+    },
+    {
+      path: '/home/user/projects/web',
+      name: 'web',
+      source: 'auto',
+      exists: true,
+      activeSessions: [
+        { sessionId: 'w1', name: 'Frontend', isBusy: false },
+      ],
+      resumableSessions: [],
+    },
+    {
+      path: '/home/user/projects/cli',
+      name: 'cli',
+      source: 'auto',
+      exists: true,
+      activeSessions: [
+        { sessionId: 'c1', name: 'Daemon', isBusy: false },
+      ],
+      resumableSessions: [],
+    },
+  ]
+}
+
+function renderSidebar(props: Partial<SidebarProps> = {}) {
+  const defaultProps: SidebarProps = {
+    repos: makeRepos(),
+    activeSessionId: null,
+    isOpen: true,
+    width: 240,
+    filter: '',
+    serverStatus: 'connected',
+    tunnelUrl: null,
+    clientCount: 0,
+    onFilterChange: noop,
+    onSessionClick: noop,
+    onResumeSession: noop,
+    onNewSession: noop,
+    onToggle: noop,
+    onContextMenu: noop,
+  }
+  return render(<Sidebar {...defaultProps} {...props} />)
+}
+
+/**
+ * jsdom's getBoundingClientRect returns all-zeros. Stub it on a row so
+ * the dropPosition() helper has a non-trivial midpoint to bisect against.
+ */
+function stubRect(el: Element, top: number, height: number) {
+  ;(el as HTMLElement).getBoundingClientRect = () => ({
+    top,
+    bottom: top + height,
+    left: 0,
+    right: 240,
+    width: 240,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  })
+}
+
+/**
+ * Synthesize a DataTransfer-like object so jsdom drag events have a
+ * usable dataTransfer (jsdom returns null otherwise).
+ */
+function mockDataTransfer(): DataTransfer {
+  const store = new Map<string, string>()
+  return {
+    effectAllowed: 'move',
+    dropEffect: 'move',
+    setData: (key: string, value: string) => { store.set(key, value) },
+    getData: (key: string) => store.get(key) ?? '',
+    clearData: () => store.clear(),
+    items: [] as unknown as DataTransferItemList,
+    files: [] as unknown as FileList,
+    types: [],
+    setDragImage: () => undefined,
+  } as unknown as DataTransfer
+}
+
+/**
+ * Dispatch a drag event with both clientY (from MouseEvent) and a
+ * DataTransfer payload. `fireEvent.dragOver(el, { clientY })` does NOT
+ * carry clientY through to the handler in jsdom, so we construct the
+ * event manually and assign dataTransfer + clientY before dispatch.
+ */
+function dispatchDrag(
+  el: Element,
+  type: 'dragstart' | 'dragover' | 'drop' | 'dragend' | 'dragleave',
+  opts: { clientY?: number; dataTransfer: DataTransfer },
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'dataTransfer', { value: opts.dataTransfer, writable: false })
+  if (opts.clientY !== undefined) {
+    Object.defineProperty(event, 'clientY', { value: opts.clientY, writable: false })
+  }
+  act(() => {
+    el.dispatchEvent(event)
+  })
+}
+
+describe('Sidebar drag-to-reorder repos (#4832)', () => {
+  it('emits onReorderRepos with the new order when a repo is dropped onto another', () => {
+    const onReorderRepos = vi.fn()
+    renderSidebar({ onReorderRepos })
+
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    const cliRepo = screen.getByTestId('sidebar-repo-/home/user/projects/cli')
+    stubRect(apiRepo, 0, 24)
+    stubRect(cliRepo, 60, 24)
+
+    const dt = mockDataTransfer()
+    dispatchDrag(apiRepo, 'dragstart', { dataTransfer: dt })
+    // Drop AFTER cli (cursor below midpoint of cli row)
+    dispatchDrag(cliRepo, 'dragover', { dataTransfer: dt, clientY: 80 })
+    dispatchDrag(cliRepo, 'drop', { dataTransfer: dt, clientY: 80 })
+
+    expect(onReorderRepos).toHaveBeenCalledTimes(1)
+    // api moved from position 0 to AFTER cli (last position) =>
+    // ['web', 'cli', 'api']
+    expect(onReorderRepos).toHaveBeenCalledWith([
+      '/home/user/projects/web',
+      '/home/user/projects/cli',
+      '/home/user/projects/api',
+    ])
+  })
+
+  it('emits onReorderRepos with target-before order when cursor is above midpoint', () => {
+    const onReorderRepos = vi.fn()
+    renderSidebar({ onReorderRepos })
+
+    const cliRepo = screen.getByTestId('sidebar-repo-/home/user/projects/cli')
+    const webRepo = screen.getByTestId('sidebar-repo-/home/user/projects/web')
+    stubRect(webRepo, 30, 24)
+    stubRect(cliRepo, 60, 24)
+
+    const dt = mockDataTransfer()
+    dispatchDrag(cliRepo, 'dragstart', { dataTransfer: dt })
+    // Drop BEFORE web (cursor above midpoint of web row)
+    dispatchDrag(webRepo, 'dragover', { dataTransfer: dt, clientY: 35 })
+    dispatchDrag(webRepo, 'drop', { dataTransfer: dt, clientY: 35 })
+
+    expect(onReorderRepos).toHaveBeenCalledWith([
+      '/home/user/projects/api',
+      '/home/user/projects/cli',
+      '/home/user/projects/web',
+    ])
+  })
+
+  it('does not fire onReorderRepos when dropped on the same repo', () => {
+    const onReorderRepos = vi.fn()
+    renderSidebar({ onReorderRepos })
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    stubRect(apiRepo, 0, 24)
+    const dt = mockDataTransfer()
+    dispatchDrag(apiRepo, 'dragstart', { dataTransfer: dt })
+    dispatchDrag(apiRepo, 'dragover', { dataTransfer: dt, clientY: 10 })
+    dispatchDrag(apiRepo, 'drop', { dataTransfer: dt, clientY: 10 })
+    expect(onReorderRepos).not.toHaveBeenCalled()
+  })
+
+  it('disables drag on repo rows when a filter is active', () => {
+    renderSidebar({ filter: 'api', onReorderRepos: vi.fn() })
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    expect(apiRepo.getAttribute('draggable')).toBe('false')
+  })
+
+  it('disables drag on repo rows when onReorderRepos is not provided', () => {
+    renderSidebar() // no onReorderRepos
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    expect(apiRepo.getAttribute('draggable')).toBe('false')
+  })
+
+  it('enables drag on repo rows when onReorderRepos is provided and no filter', () => {
+    renderSidebar({ onReorderRepos: vi.fn() })
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    expect(apiRepo.getAttribute('draggable')).toBe('true')
+  })
+})
+
+describe('Sidebar drag-to-reorder sessions (#4832)', () => {
+  it('emits onReorderSessions when a session is dropped on a sibling', () => {
+    const onReorderSessions = vi.fn()
+    renderSidebar({ onReorderSessions })
+
+    const s1 = screen.getByTestId('session-item-s1')
+    const s3 = screen.getByTestId('session-item-s3')
+    stubRect(s1, 0, 20)
+    stubRect(s3, 40, 20)
+
+    const dt = mockDataTransfer()
+    dispatchDrag(s1, 'dragstart', { dataTransfer: dt })
+    // Drop AFTER s3 (cursor below midpoint => goes to the end)
+    dispatchDrag(s3, 'dragover', { dataTransfer: dt, clientY: 55 })
+    dispatchDrag(s3, 'drop', { dataTransfer: dt, clientY: 55 })
+
+    expect(onReorderSessions).toHaveBeenCalledTimes(1)
+    expect(onReorderSessions).toHaveBeenCalledWith(
+      '/home/user/projects/api',
+      ['s2', 's3', 's1'],
+    )
+  })
+
+  it('does not allow cross-repo session drag (drop is ignored)', () => {
+    const onReorderSessions = vi.fn()
+    renderSidebar({ onReorderSessions })
+
+    const apiSession = screen.getByTestId('session-item-s1')
+    const webSession = screen.getByTestId('session-item-w1')
+    stubRect(apiSession, 0, 20)
+    stubRect(webSession, 100, 20)
+
+    const dt = mockDataTransfer()
+    dispatchDrag(apiSession, 'dragstart', { dataTransfer: dt })
+    // Try to drop s1 (api repo) on w1 (web repo) — should be a no-op
+    dispatchDrag(webSession, 'dragover', { dataTransfer: dt, clientY: 105 })
+    dispatchDrag(webSession, 'drop', { dataTransfer: dt, clientY: 105 })
+
+    expect(onReorderSessions).not.toHaveBeenCalled()
+  })
+
+  it('marks the dragged session row with the .dragging class', () => {
+    renderSidebar({ onReorderSessions: vi.fn() })
+    const s1 = screen.getByTestId('session-item-s1')
+    const dt = mockDataTransfer()
+    dispatchDrag(s1, 'dragstart', { dataTransfer: dt })
+    expect(s1.className).toMatch(/\bdragging\b/)
+    dispatchDrag(s1, 'dragend', { dataTransfer: dt })
+    expect(s1.className).not.toMatch(/\bdragging\b/)
+  })
+
+  it('marks the drop target with drop-before / drop-after based on cursor Y', () => {
+    renderSidebar({ onReorderSessions: vi.fn() })
+    const s1 = screen.getByTestId('session-item-s1')
+    const s3 = screen.getByTestId('session-item-s3')
+    stubRect(s1, 0, 20)
+    stubRect(s3, 40, 20)
+    const dt = mockDataTransfer()
+    dispatchDrag(s1, 'dragstart', { dataTransfer: dt })
+
+    // Above midpoint (40 + 10 = 50) => drop-before
+    dispatchDrag(s3, 'dragover', { dataTransfer: dt, clientY: 45 })
+    expect(s3.className).toMatch(/\bdrop-before\b/)
+
+    // Below midpoint => drop-after
+    dispatchDrag(s3, 'dragover', { dataTransfer: dt, clientY: 55 })
+    expect(s3.className).toMatch(/\bdrop-after\b/)
+    expect(s3.className).not.toMatch(/\bdrop-before\b/)
+  })
+})
+
+describe('Sidebar keyboard reorder (#4832)', () => {
+  it('moves a session up with Alt+ArrowUp', () => {
+    const onReorderSessions = vi.fn()
+    renderSidebar({ onReorderSessions })
+    const s2 = screen.getByTestId('session-item-s2')
+    fireEvent.keyDown(s2, { key: 'ArrowUp', altKey: true })
+    expect(onReorderSessions).toHaveBeenCalledWith(
+      '/home/user/projects/api',
+      ['s2', 's1', 's3'],
+    )
+  })
+
+  it('moves a session down with Alt+ArrowDown', () => {
+    const onReorderSessions = vi.fn()
+    renderSidebar({ onReorderSessions })
+    const s2 = screen.getByTestId('session-item-s2')
+    fireEvent.keyDown(s2, { key: 'ArrowDown', altKey: true })
+    expect(onReorderSessions).toHaveBeenCalledWith(
+      '/home/user/projects/api',
+      ['s1', 's3', 's2'],
+    )
+  })
+
+  it('is a no-op (no callback) at the top edge with Alt+ArrowUp', () => {
+    const onReorderSessions = vi.fn()
+    renderSidebar({ onReorderSessions })
+    const s1 = screen.getByTestId('session-item-s1')
+    fireEvent.keyDown(s1, { key: 'ArrowUp', altKey: true })
+    expect(onReorderSessions).not.toHaveBeenCalled()
+  })
+
+  it('moves a repo up with Alt+ArrowUp on the outer treeitem', () => {
+    const onReorderRepos = vi.fn()
+    renderSidebar({ onReorderRepos })
+    const webRepo = screen.getByTestId('sidebar-repo-/home/user/projects/web')
+    fireEvent.keyDown(webRepo, { key: 'ArrowUp', altKey: true })
+    expect(onReorderRepos).toHaveBeenCalledWith([
+      '/home/user/projects/web',
+      '/home/user/projects/api',
+      '/home/user/projects/cli',
+    ])
+  })
+
+  it('does not move focus when reorder shortcut fires (stopPropagation)', () => {
+    // Plain ArrowDown (no Alt) goes through handleTreeKeyDown and moves
+    // focus; Alt+ArrowDown should be intercepted by the row handler
+    // BEFORE the tree handler runs, so focus stays where it was.
+    const onReorderSessions = vi.fn()
+    renderSidebar({ onReorderSessions })
+    const s1 = screen.getByTestId('session-item-s1')
+    s1.focus()
+    expect(document.activeElement).toBe(s1)
+    fireEvent.keyDown(s1, { key: 'ArrowDown', altKey: true })
+    // Focus stays on s1 (no traversal)
+    expect(document.activeElement).toBe(s1)
+    expect(onReorderSessions).toHaveBeenCalled()
+  })
+
+  it('does not respond to plain ArrowUp/ArrowDown (no Alt) for reordering', () => {
+    const onReorderSessions = vi.fn()
+    renderSidebar({ onReorderSessions })
+    const s2 = screen.getByTestId('session-item-s2')
+    fireEvent.keyDown(s2, { key: 'ArrowUp' })
+    fireEvent.keyDown(s2, { key: 'ArrowDown' })
+    expect(onReorderSessions).not.toHaveBeenCalled()
+  })
+})
+
+describe('Sidebar reorder persistence (#4832)', () => {
+  it('round-trips the repo order through localStorage', () => {
+    const order = [
+      '/home/user/projects/cli',
+      '/home/user/projects/api',
+      '/home/user/projects/web',
+    ]
+    persistSidebarRepoOrder(order)
+    expect(loadPersistedSidebarRepoOrder()).toEqual(order)
+  })
+
+  it('round-trips the per-repo session order through localStorage', () => {
+    const sessionOrder = {
+      '/home/user/projects/api': ['s3', 's1', 's2'],
+      '/home/user/projects/web': ['w1'],
+    }
+    persistSidebarSessionOrder(sessionOrder)
+    expect(loadPersistedSidebarSessionOrder()).toEqual(sessionOrder)
+  })
+
+  it('clears the persisted repo order when an empty array is passed', () => {
+    persistSidebarRepoOrder(['/foo'])
+    expect(loadPersistedSidebarRepoOrder()).toEqual(['/foo'])
+    persistSidebarRepoOrder([])
+    expect(loadPersistedSidebarRepoOrder()).toEqual([])
+  })
+
+  it('returns empty defaults when nothing is persisted', () => {
+    expect(loadPersistedSidebarRepoOrder()).toEqual([])
+    expect(loadPersistedSidebarSessionOrder()).toEqual({})
+  })
+
+  it('survives a simulated reload — drop persists, sidebar reinitialises from storage', () => {
+    // First render — perform a reorder via the App-level handler shape.
+    function Harness() {
+      const [, setOrder] = useState<string[]>(loadPersistedSidebarRepoOrder())
+      return (
+        <Sidebar
+          repos={makeRepos()}
+          activeSessionId={null}
+          isOpen
+          width={240}
+          filter=""
+          serverStatus="connected"
+          tunnelUrl={null}
+          clientCount={0}
+          onFilterChange={noop}
+          onSessionClick={noop}
+          onResumeSession={noop}
+          onNewSession={noop}
+          onToggle={noop}
+          onContextMenu={noop}
+          onReorderRepos={(next) => {
+            setOrder(next)
+            persistSidebarRepoOrder(next)
+          }}
+        />
+      )
+    }
+
+    const { unmount } = render(<Harness />)
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    const cliRepo = screen.getByTestId('sidebar-repo-/home/user/projects/cli')
+    stubRect(apiRepo, 0, 24)
+    stubRect(cliRepo, 60, 24)
+    const dt = mockDataTransfer()
+    dispatchDrag(apiRepo, 'dragstart', { dataTransfer: dt })
+    dispatchDrag(cliRepo, 'dragover', { dataTransfer: dt, clientY: 80 })
+    dispatchDrag(cliRepo, 'drop', { dataTransfer: dt, clientY: 80 })
+
+    expect(loadPersistedSidebarRepoOrder()).toEqual([
+      '/home/user/projects/web',
+      '/home/user/projects/cli',
+      '/home/user/projects/api',
+    ])
+
+    // Simulate reload: unmount + remount, reads from storage.
+    unmount()
+    render(<Harness />)
+    expect(loadPersistedSidebarRepoOrder()).toEqual([
+      '/home/user/projects/web',
+      '/home/user/projects/cli',
+      '/home/user/projects/api',
+    ])
+  })
+})

--- a/packages/dashboard/src/components/SidebarReorder.test.tsx
+++ b/packages/dashboard/src/components/SidebarReorder.test.tsx
@@ -385,6 +385,25 @@ describe('Sidebar keyboard reorder (#4832)', () => {
     fireEvent.keyDown(s2, { key: 'ArrowDown' })
     expect(onReorderSessions).not.toHaveBeenCalled()
   })
+
+  it('does not reorder sessions via Alt+Arrow while a filter is active', () => {
+    // Mirrors the drag guard: reordering from a filtered subset would
+    // persist a partial order. The keyboard shortcut must obey the same
+    // rule the drag handler does.
+    const onReorderSessions = vi.fn()
+    renderSidebar({ filter: 'api', onReorderSessions })
+    const s2 = screen.getByTestId('session-item-s2')
+    fireEvent.keyDown(s2, { key: 'ArrowDown', altKey: true })
+    expect(onReorderSessions).not.toHaveBeenCalled()
+  })
+
+  it('does not reorder repos via Alt+Arrow while a filter is active', () => {
+    const onReorderRepos = vi.fn()
+    renderSidebar({ filter: 'api', onReorderRepos })
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    fireEvent.keyDown(apiRepo, { key: 'ArrowDown', altKey: true })
+    expect(onReorderRepos).not.toHaveBeenCalled()
+  })
 })
 
 describe('Sidebar reorder persistence (#4832)', () => {

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -24,6 +24,13 @@ const KEY_SHOW_CONSOLE_TAB = `${KEY_PREFIX}show_console_tab`;
 const KEY_SIDEBAR_PANEL_HEIGHT = `${KEY_PREFIX}sidebar_panel_height`;
 const KEY_SIDEBAR_PANEL_VIEW = `${KEY_PREFIX}sidebar_panel_view`;
 const KEY_SIDEBAR_PANEL_COLLAPSED = `${KEY_PREFIX}sidebar_panel_collapsed`;
+// #4832 — drag-to-reorder sidebar persistence. Repo order is a flat list of
+// cwd paths; session order is keyed by repo cwd so each name-group keeps
+// its own ordering and a session moved in one repo never reshuffles
+// another. Both are server-scoped so different servers can have different
+// orders without clobbering each other.
+const KEY_SIDEBAR_REPO_ORDER = `${KEY_PREFIX}sidebar_repo_order`;
+const KEY_SIDEBAR_SESSION_ORDER = `${KEY_PREFIX}sidebar_session_order`;
 
 // ---------------------------------------------------------------------------
 // Server-scoped persistence — keys scoped by server ID to prevent data loss
@@ -288,6 +295,89 @@ export function loadPersistedSidebarPanelCollapsed(): boolean {
     return localStorage.getItem(KEY_SIDEBAR_PANEL_COLLAPSED) === '1';
   } catch {
     return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// #4832 — Drag-to-reorder sidebar persistence
+//
+// The sidebar groups sessions by repo cwd; users can drag both groups
+// (top-level repo entries) and individual sessions (within a group) to
+// reorder them. The order is layered on top of the server-supplied
+// session list (which is ordered by creation time) and persisted in
+// localStorage so it survives reload + Tauri restart.
+//
+// Storage shapes:
+//   repo order:    `string[]` — cwd paths in user order
+//   session order: `Record<string, string[]>` — keyed by repo cwd, value
+//                  is the sessionId array in user order
+//
+// Both are SERVER-SCOPED — different servers have different sessions and
+// repos, so each server gets its own ordering. Unknown ids in the saved
+// order are dropped silently on reapply (see `applyOrderById`), so we
+// never need to GC.
+// ---------------------------------------------------------------------------
+
+/** Persist the sidebar repo (top-level group) order (server-scoped). */
+export function persistSidebarRepoOrder(order: string[]): void {
+  try {
+    const key = scopedKey(KEY_SIDEBAR_REPO_ORDER);
+    if (order.length === 0) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, JSON.stringify(order));
+    }
+  } catch {
+    // Storage not available
+  }
+}
+
+/** Load persisted sidebar repo order. Returns [] when unset / invalid. */
+export function loadPersistedSidebarRepoOrder(): string[] {
+  try {
+    const raw = scopedRead(KEY_SIDEBAR_REPO_ORDER);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist sidebar session order per repo (server-scoped).
+ * Pass `{}` to clear all per-repo orderings.
+ */
+export function persistSidebarSessionOrder(order: Record<string, string[]>): void {
+  try {
+    const key = scopedKey(KEY_SIDEBAR_SESSION_ORDER);
+    if (Object.keys(order).length === 0) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, JSON.stringify(order));
+    }
+  } catch {
+    // Storage not available
+  }
+}
+
+/** Load persisted sidebar session order keyed by repo cwd. */
+export function loadPersistedSidebarSessionOrder(): Record<string, string[]> {
+  try {
+    const raw = scopedRead(KEY_SIDEBAR_SESSION_ORDER);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out: Record<string, string[]> = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (typeof k === 'string' && Array.isArray(v)) {
+        out[k] = v.filter((x): x is string => typeof x === 'string');
+      }
+    }
+    return out;
+  } catch {
+    return {};
   }
 }
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -656,7 +656,7 @@
   left: 0;
   right: 0;
   height: 2px;
-  background: var(--accent-blue, #4d9fff);
+  background: var(--accent-blue, #4a9eff);
   pointer-events: none;
   border-radius: 1px;
 }

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -625,6 +625,50 @@
   outline-offset: -2px;
 }
 
+/* #4832 — drag-to-reorder visual feedback.
+ *
+ *   .dragging       — applied to the row currently being dragged. Fades it
+ *                     so the user can see the cursor's drop-target row
+ *                     behind it.
+ *   .drop-before    — applied to the row the cursor is hovering when
+ *                     positioned above the row's midpoint. Renders a 2px
+ *                     accent line along the row's TOP edge.
+ *   .drop-after     — same but for BELOW the midpoint, line at the BOTTOM.
+ *
+ * The lines are absolutely-positioned ::before/::after pseudos that span
+ * the row's full width. The parent rule needs `position: relative` for
+ * the absolute pseudos to anchor correctly.
+ */
+.sidebar-repo,
+.sidebar-session-item {
+  position: relative;
+}
+.sidebar-repo.dragging,
+.sidebar-session-item.dragging {
+  opacity: 0.45;
+}
+.sidebar-repo.drop-before::before,
+.sidebar-session-item.drop-before::before,
+.sidebar-repo.drop-after::after,
+.sidebar-session-item.drop-after::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--accent-blue, #4d9fff);
+  pointer-events: none;
+  border-radius: 1px;
+}
+.sidebar-repo.drop-before::before,
+.sidebar-session-item.drop-before::before {
+  top: 0;
+}
+.sidebar-repo.drop-after::after,
+.sidebar-session-item.drop-after::after {
+  bottom: 0;
+}
+
 /* SessionContextMenu (#4045) — right-click context menu overlay for sidebar
  * items. Positioned fixed at the click coordinates; the component itself
  * handles outside-click / Escape / blur dismissal. */

--- a/packages/dashboard/src/utils/reorderById.test.ts
+++ b/packages/dashboard/src/utils/reorderById.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the shared reorder utility used by sidebar (#4832) and
+ * SessionBar (#4831) drag-to-reorder.
+ */
+import { describe, it, expect } from 'vitest'
+import { applyOrderById, moveItem, orderToIds } from './reorderById'
+
+describe('moveItem', () => {
+  it('moves an item from one index to another', () => {
+    expect(moveItem(['a', 'b', 'c', 'd'], 0, 2)).toEqual(['b', 'c', 'a', 'd'])
+    expect(moveItem(['a', 'b', 'c', 'd'], 3, 1)).toEqual(['a', 'd', 'b', 'c'])
+  })
+
+  it('is a no-op when from === to', () => {
+    const items = ['a', 'b', 'c']
+    expect(moveItem(items, 1, 1)).toBe(items)
+  })
+
+  it('returns the same reference for single-element / empty arrays', () => {
+    const empty: string[] = []
+    expect(moveItem(empty, 0, 0)).toBe(empty)
+    const one = ['only']
+    expect(moveItem(one, 0, 0)).toBe(one)
+  })
+
+  it('clamps out-of-range indices', () => {
+    expect(moveItem(['a', 'b', 'c'], -5, 10)).toEqual(['b', 'c', 'a'])
+    expect(moveItem(['a', 'b', 'c'], 10, -5)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('does not mutate the input array', () => {
+    const items = ['a', 'b', 'c']
+    const result = moveItem(items, 0, 2)
+    expect(items).toEqual(['a', 'b', 'c'])
+    expect(result).not.toBe(items)
+  })
+})
+
+describe('applyOrderById', () => {
+  type Item = { id: string; name: string }
+  const get = (i: Item) => i.id
+
+  it('returns the items in saved order', () => {
+    const items: Item[] = [
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+      { id: 'c', name: 'C' },
+    ]
+    const result = applyOrderById(items, ['c', 'a', 'b'], get)
+    expect(result.map(get)).toEqual(['c', 'a', 'b'])
+  })
+
+  it('drops ids in the saved order that no longer exist', () => {
+    const items: Item[] = [
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+    ]
+    const result = applyOrderById(items, ['ghost', 'a', 'gone', 'b'], get)
+    expect(result.map(get)).toEqual(['a', 'b'])
+  })
+
+  it('appends items not in the saved order at the end, preserving input order', () => {
+    const items: Item[] = [
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+      { id: 'newer', name: 'Newer' },
+      { id: 'newest', name: 'Newest' },
+    ]
+    const result = applyOrderById(items, ['b', 'a'], get)
+    expect(result.map(get)).toEqual(['b', 'a', 'newer', 'newest'])
+  })
+
+  it('returns the items as-is when no order is saved', () => {
+    const items: Item[] = [
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+    ]
+    const result = applyOrderById(items, [], get)
+    expect(result.map(get)).toEqual(['a', 'b'])
+  })
+
+  it('handles empty items list', () => {
+    expect(applyOrderById<Item>([], ['a', 'b'], get)).toEqual([])
+  })
+
+  it('ignores duplicate ids in the saved order', () => {
+    const items: Item[] = [
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+    ]
+    const result = applyOrderById(items, ['a', 'a', 'b', 'a'], get)
+    expect(result.map(get)).toEqual(['a', 'b'])
+  })
+})
+
+describe('orderToIds', () => {
+  it('extracts ids using the getter', () => {
+    type Item = { id: string }
+    const items: Item[] = [{ id: 'x' }, { id: 'y' }]
+    expect(orderToIds(items, (i) => i.id)).toEqual(['x', 'y'])
+  })
+})

--- a/packages/dashboard/src/utils/reorderById.ts
+++ b/packages/dashboard/src/utils/reorderById.ts
@@ -1,0 +1,90 @@
+/**
+ * Generic id-keyed reordering helpers.
+ *
+ * Used by the left-sidebar session list (#4832) and the top SessionBar
+ * tab strip (#4831). Both need to:
+ *
+ *   - Move an item from one position to another (drag-and-drop, keyboard
+ *     reorder shortcuts).
+ *   - Reconcile a persisted order array against a current live array of
+ *     items: keep the persisted order for items that still exist, drop
+ *     ids that are gone, and append new ids that haven't been ordered
+ *     yet.
+ *
+ * Keeping both helpers in one place avoids the two issues drifting on
+ * subtly different rules (which we hit on #4419/#4420 with the
+ * pending-shell cap helpers).
+ */
+
+/**
+ * Move the item at `fromIndex` so it lands at `toIndex` in a fresh array.
+ *
+ * Out-of-range indices are clamped to the array's valid range. Returns the
+ * original array (no copy) when the move is a no-op (same index or
+ * single-element array). Callers can treat the return as immutable.
+ */
+export function moveItem<T>(items: readonly T[], fromIndex: number, toIndex: number): T[] {
+  if (items.length <= 1) return items as T[]
+  const clampedFrom = Math.max(0, Math.min(fromIndex, items.length - 1))
+  const clampedTo = Math.max(0, Math.min(toIndex, items.length - 1))
+  if (clampedFrom === clampedTo) return items as T[]
+  const next = items.slice()
+  const [moved] = next.splice(clampedFrom, 1)
+  next.splice(clampedTo, 0, moved as T)
+  return next
+}
+
+/**
+ * Reorder a list of items keyed by id, following a saved order.
+ *
+ * - `getId` extracts the stable id from an item.
+ * - `order` is the persisted ordering (e.g. from localStorage). Ids in
+ *   `order` that are missing from `items` are silently dropped.
+ * - Items present in `items` but NOT in `order` are appended at the end,
+ *   preserving their relative order from the input array. New sessions
+ *   land at the bottom of the list — they don't shuffle existing entries.
+ *
+ * This is the function the sidebar memo runs every render, so it
+ * intentionally returns a fresh array only when reordering actually
+ * happens; if the live order already matches `order` (plus any tail
+ * additions), the result is still a fresh array but the contents are
+ * stable for downstream memoization.
+ */
+export function applyOrderById<T>(
+  items: readonly T[],
+  order: readonly string[],
+  getId: (item: T) => string,
+): T[] {
+  if (items.length === 0) return []
+  if (order.length === 0) return items.slice()
+
+  const byId = new Map<string, T>()
+  for (const item of items) byId.set(getId(item), item)
+
+  const seen = new Set<string>()
+  const ordered: T[] = []
+  for (const id of order) {
+    const found = byId.get(id)
+    if (found && !seen.has(id)) {
+      ordered.push(found)
+      seen.add(id)
+    }
+  }
+  // Tail-append unseen items in their original order.
+  for (const item of items) {
+    const id = getId(item)
+    if (!seen.has(id)) {
+      ordered.push(item)
+      seen.add(id)
+    }
+  }
+  return ordered
+}
+
+/**
+ * Convert a reordered item list back into the id array we persist. Pure
+ * convenience: keeps callers from inlining `.map(getId)` everywhere.
+ */
+export function orderToIds<T>(items: readonly T[], getId: (item: T) => string): string[] {
+  return items.map(getId)
+}

--- a/packages/dashboard/src/utils/reorderById.ts
+++ b/packages/dashboard/src/utils/reorderById.ts
@@ -44,11 +44,13 @@ export function moveItem<T>(items: readonly T[], fromIndex: number, toIndex: num
  *   preserving their relative order from the input array. New sessions
  *   land at the bottom of the list — they don't shuffle existing entries.
  *
- * This is the function the sidebar memo runs every render, so it
- * intentionally returns a fresh array only when reordering actually
- * happens; if the live order already matches `order` (plus any tail
- * additions), the result is still a fresh array but the contents are
- * stable for downstream memoization.
+ * This is the function the sidebar memo runs every render. It always
+ * allocates a fresh array whenever `order.length > 0` — even if the
+ * resulting sequence is identical to `items` — so callers MUST NOT rely
+ * on referential equality to detect "no change". Use a contents-based
+ * comparison (or downstream memoization keyed on the id list) instead.
+ * The only reference-stable fast path is `order.length === 0`, where we
+ * return `items.slice()` unchanged in order.
  */
 export function applyOrderById<T>(
   items: readonly T[],


### PR DESCRIPTION
## Summary

Closes #4832.

Drag-to-reorder for both the sidebar's top-level repo groups and the sessions within each group, with the order persisted in localStorage (server-scoped) so it survives reload and Tauri restart.

- **New shared utility `reorderById`** (`moveItem` + `applyOrderById`) covering move + persisted-order-overlay logic. Designed to be reused by the sibling SessionBar tab-reorder PR (#4831).
- **Native HTML5 DnD** on the outer repo `treeitem` and on each session row. No new dependency. Drop position is bisected on the cursor's vertical midpoint and surfaced with a 2px accent line at the row's top or bottom edge.
- **Cross-group session drag is rejected** — sessions are pinned to their owning repo, matching the issue's out-of-scope notes (no drag-to-rename / drag-between-groups).
- **Keyboard reorder**: `Alt+ArrowUp` / `Alt+ArrowDown` on a focused row moves it within its list. The row handler stops propagation so the existing WAI-ARIA tree arrow-nav (plain `ArrowUp`/`ArrowDown` focus traversal) is unaffected.
- **Drag disabled during filter** — the on-screen list is a subset of the real order, so persisting a reorder from a filtered view would yield a confusing partial order.
- **Persistence**: new helpers `persistSidebarRepoOrder` / `persistSidebarSessionOrder` (server-scoped, sibling to the existing `persistSidebarPanel*` keys).
- **App.tsx**: holds order state, applies via `applyOrderById` inside the existing `sidebarRepos` memo, persists on every change. New sessions / repos are tail-appended so existing entries don't shuffle when the server adds something.

## Test plan

- [x] `npx vitest run` — 2638 tests pass (135 files), including the 21 new cases in `SidebarReorder.test.tsx` + 12 in `reorderById.test.ts`.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx vite build` — clean.
- [ ] Visual verification in rebuilt Tauri app: drag a session row, drag a repo group, reload, confirm order survives.

## Conflict-awareness note (#4831)

This PR adds `packages/dashboard/src/utils/reorderById.ts` as a SHARED utility. The sibling PR (top SessionBar tab reorder, #4831) should rebase to pick it up rather than duplicate the move/order-overlay logic. If #4831 lands first with its own helper, I'm happy to follow up and harmonize.