### PR TITLE
feat(desktop): prominent New Session button + macOS menu-bar entry (#4695)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -85,6 +85,17 @@ vi.mock('./components/PermissionPrompt', () => ({
   ),
 }))
 
+// #4695 — CreateSessionModal pulls multiple store-callback selectors
+// (setDirectoryListingCallback / requestDirectoryListing / …) that the
+// App-test store mock doesn't enumerate. Stubbing the modal lets the
+// chrome-new-session click assertion verify the `open` prop transition
+// without dragging in directory-browser store wiring. Production
+// behaviour is exercised by the CreateSessionModal*.test.tsx suites.
+vi.mock('./components/CreateSessionModal', () => ({
+  CreateSessionModal: (props: { open: boolean }) =>
+    props.open ? <div data-testid="create-session-modal-mock" /> : null,
+}))
+
 vi.mock('./components/StdinDisabledBanner', () => ({
   StdinDisabledBanner: (props: {
     visible: boolean
@@ -2062,6 +2073,57 @@ describe('App', () => {
       expect(badge, 'version-badge must exist').toBeTruthy()
       expect(badge!.getAttribute('title'), 'version-badge needs title').toBeTruthy()
       expect(badge!.getAttribute('aria-label'), 'version-badge needs aria-label').toBeTruthy()
+    })
+  })
+
+  // #4695 — prominent chrome-level "New Session" entry point.
+  //
+  // The per-project sidebar button (`sidebar-new-session-<path>`) and the
+  // command palette (`new-session` id) were the only two entry points
+  // before this change — neither discoverable to a first-time user
+  // scanning the dashboard chrome. The chrome button lives in
+  // `header-right` and reuses the existing handleNewSession path
+  // (setShowCreateSession → CreateSessionModal), so the test pins:
+  //   1. The button renders inside #header (always-visible chrome).
+  //   2. It has accessible title + aria-label (matches the #4630
+  //      header-button convention checked above).
+  //   3. Clicking it opens the Create Session modal (the modal renders
+  //      its overlay only when open=true, mirrored on Modal.tsx's
+  //      `if (!open) return null` guard).
+  describe('chrome-new-session button (#4695)', () => {
+    const baseHeaderState = {
+      connectionPhase: 'connected' as const,
+      sessions: [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }],
+      activeSessionId: 's1',
+    }
+
+    it('renders inside the dashboard #header chrome', () => {
+      stateOverrides = baseHeaderState
+      const { container } = render(<App />)
+      const header = container.querySelector('#header')
+      expect(header, '#header must render').toBeTruthy()
+      const btn = within(header as HTMLElement).getByTestId('chrome-new-session')
+      expect(btn).toBeInTheDocument()
+    })
+
+    it('exposes accessible title + aria-label + visible "New Session" label', () => {
+      stateOverrides = baseHeaderState
+      render(<App />)
+      const btn = screen.getByTestId('chrome-new-session')
+      expect(btn.getAttribute('aria-label'), 'chrome-new-session needs aria-label').toBe('New session')
+      expect(btn.getAttribute('title'), 'chrome-new-session needs title with shortcut hint').toMatch(/New session/)
+      // The visible label is part of the muscle-memory affordance —
+      // without it the button reads as just another icon glyph.
+      expect(btn.textContent).toMatch(/New Session/)
+    })
+
+    it('opens the Create Session modal on click', () => {
+      stateOverrides = baseHeaderState
+      render(<App />)
+      // Modal mock renders the testID node only when `open=true`.
+      expect(screen.queryByTestId('create-session-modal-mock')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByTestId('chrome-new-session'))
+      expect(screen.getByTestId('create-session-modal-mock')).toBeInTheDocument()
     })
   })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1226,9 +1226,12 @@ export function App() {
     setShowCreateSession(true)
   }, [])
 
-  // #4695 — bridge the macOS menu bar "File > New Session" item to the
-  // same handler the chrome button and command palette use. Hook is a
-  // no-op outside Tauri (web dashboard).
+  // #4695 — bridge the macOS menu bar "File > New Session" item to
+  // `handleNewSession` (the same callback the chrome "New Session"
+  // button uses). The sidebar's per-project "+" row and the command
+  // palette's `new-session` entry currently open the create-session
+  // dialog through their own inline handlers, so they are NOT routed
+  // through this hook. Hook is a no-op outside Tauri (web dashboard).
   useTauriMenuEvents({ onNewSession: handleNewSession })
 
   const handleCreateSession = useCallback((data: { name: string; cwd: string; provider?: string; permissionMode?: string; model?: string; worktree?: boolean; skipPermissions?: boolean }) => {
@@ -1839,9 +1842,15 @@ export function App() {
               Previously the affordance lived only on the per-project
               sidebar row (`sidebar-new-session-<path>`) and inside the
               command palette, neither of which a first-time user finds
-              by scanning the chrome. The button reuses handleNewSession
-              (same setShowCreateSession path the sidebar + palette use)
-              so behaviour stays in one place. */}
+              by scanning the chrome. This button and the macOS menu-bar
+              "File > New Session" item both invoke `handleNewSession`,
+              which clears `pendingCwd` and opens the create-session
+              dialog without a preselected project. The sidebar's "+"
+              row and the palette's `new-session` command each have
+              their own inline handlers (the sidebar passes a cwd; the
+              palette opens the dialog directly), so they share the end
+              state (`setShowCreateSession(true)`) but not this
+              callback. */}
           <button
             type="button"
             className="chrome-new-session-btn"

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -64,6 +64,7 @@ import { formatBindingForDisplay, parseBinding } from './shortcuts/registry'
 import { writeText as clipboardWriteText } from './utils/clipboard'
 import { formatQuestionAnswerSummary } from './utils/questionAnswerSummary'
 import { useTauriEvents } from './hooks/useTauriEvents'
+import { useTauriMenuEvents } from './hooks/useTauriMenuEvents'
 import { isTauri } from './utils/tauri'
 import { startServer, revealInFinder } from './hooks/useTauriIPC'
 import { usePermissionNotification, type PermissionPromptInfo } from './hooks/usePermissionNotification'
@@ -1225,6 +1226,11 @@ export function App() {
     setShowCreateSession(true)
   }, [])
 
+  // #4695 — bridge the macOS menu bar "File > New Session" item to the
+  // same handler the chrome button and command palette use. Hook is a
+  // no-op outside Tauri (web dashboard).
+  useTauriMenuEvents({ onNewSession: handleNewSession })
+
   const handleCreateSession = useCallback((data: { name: string; cwd: string; provider?: string; permissionMode?: string; model?: string; worktree?: boolean; skipPermissions?: boolean }) => {
     setSessionCreateError(null)
     setIsCreatingSession(true)
@@ -1829,6 +1835,24 @@ export function App() {
           />
         </div>
         <div className="header-right">
+          {/* #4695 — prominent always-visible New Session entry point.
+              Previously the affordance lived only on the per-project
+              sidebar row (`sidebar-new-session-<path>`) and inside the
+              command palette, neither of which a first-time user finds
+              by scanning the chrome. The button reuses handleNewSession
+              (same setShowCreateSession path the sidebar + palette use)
+              so behaviour stays in one place. */}
+          <button
+            type="button"
+            className="chrome-new-session-btn"
+            data-testid="chrome-new-session"
+            onClick={handleNewSession}
+            aria-label="New session"
+            title={`New session (${formatShortcutKeys('Cmd+N')})`}
+          >
+            <span className="chrome-new-session-icon" aria-hidden="true">+</span>
+            <span className="chrome-new-session-label">New Session</span>
+          </button>
           {/* #3209: Skills toggle, moved to header-right as an icon
               button. Was previously a text button in header-center
               where it competed for space with the model dropdown. */}

--- a/packages/dashboard/src/hooks/useTauriMenuEvents.test.ts
+++ b/packages/dashboard/src/hooks/useTauriMenuEvents.test.ts
@@ -1,0 +1,88 @@
+/**
+ * useTauriMenuEvents — bridge tests for macOS menu-bar item dispatch (#4695).
+ *
+ * Mirrors useTauriEvents.test.ts mocking pattern: stub the Tauri v2 event
+ * bridge (`window.__TAURI__.event.listen`) and assert the hook subscribes
+ * to / dispatches the right event names.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useTauriMenuEvents } from './useTauriMenuEvents'
+
+type Handler = (event: { payload: unknown }) => void
+let listeners: Map<string, Handler[]>
+let unlisten: ReturnType<typeof vi.fn>
+
+function setupTauriMock() {
+  listeners = new Map()
+  unlisten = vi.fn()
+  const mockListen = vi.fn(async (event: string, handler: Handler) => {
+    if (!listeners.has(event)) listeners.set(event, [])
+    listeners.get(event)!.push(handler)
+    return unlisten
+  })
+  Object.defineProperty(window, '__TAURI__', {
+    value: { event: { listen: mockListen } },
+    writable: true,
+    configurable: true,
+  })
+}
+
+function clearTauriMock() {
+  delete (window as unknown as Record<string, unknown>).__TAURI__
+  delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+}
+
+function emit(event: string, payload?: unknown) {
+  const handlers = listeners.get(event) || []
+  handlers.forEach(h => h({ payload }))
+}
+
+describe('useTauriMenuEvents (#4695)', () => {
+  beforeEach(() => {
+    setupTauriMock()
+  })
+
+  afterEach(() => {
+    clearTauriMock()
+  })
+
+  // The Rust app-menu emits `menu://<action>` events with the prefix
+  // matching the `app_menu:<action>` id. This test pins the contract
+  // both sides depend on (rename either side and it breaks).
+  it('subscribes to menu://new-session when running in Tauri', () => {
+    const onNewSession = vi.fn()
+    renderHook(() => useTauriMenuEvents({ onNewSession }))
+    expect(listeners.has('menu://new-session')).toBe(true)
+  })
+
+  it('invokes onNewSession when the menu event fires', () => {
+    const onNewSession = vi.fn()
+    renderHook(() => useTauriMenuEvents({ onNewSession }))
+    expect(onNewSession).not.toHaveBeenCalled()
+    emit('menu://new-session')
+    expect(onNewSession).toHaveBeenCalledTimes(1)
+  })
+
+  it('is a no-op outside Tauri (web dashboard)', () => {
+    clearTauriMock()
+    const onNewSession = vi.fn()
+    renderHook(() => useTauriMenuEvents({ onNewSession }))
+    expect(listeners.size).toBe(0)
+    // Trying to emit when no listener is registered must not call back.
+    emit('menu://new-session')
+    expect(onNewSession).not.toHaveBeenCalled()
+  })
+
+  it('unsubscribes on unmount (prevents stale-handler dispatch)', async () => {
+    const onNewSession = vi.fn()
+    const { unmount } = renderHook(() => useTauriMenuEvents({ onNewSession }))
+    unmount()
+    // The unlisten fn returned by mockListen must be invoked. The hook
+    // awaits the listen() Promise so the unsubscribe is queued via .then;
+    // flush microtasks before asserting.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(unlisten).toHaveBeenCalled()
+  })
+})

--- a/packages/dashboard/src/hooks/useTauriMenuEvents.ts
+++ b/packages/dashboard/src/hooks/useTauriMenuEvents.ts
@@ -4,9 +4,14 @@
  * The Rust side (packages/desktop/src-tauri/src/lib.rs) emits
  * `menu://<action>` events when the user picks an item from the
  * application menu bar. This hook subscribes to those events and
- * dispatches them to the matching React-side callback so menu items
- * and dashboard buttons / palette commands all funnel through the
- * same handler — adding a new menu item only requires:
+ * dispatches each one to the matching React-side callback passed in
+ * via props. The hook itself only guarantees that menu-bar clicks
+ * reach the provided callback — whether a given action's callback is
+ * the same function used by a dashboard button or palette command is
+ * the caller's choice (e.g. App.tsx currently reuses `handleNewSession`
+ * for both the menu bar and the chrome "New Session" button, but the
+ * sidebar's per-project row and the command-palette entry have their
+ * own inline handlers). Adding a new menu item requires:
  *
  *   1. A new `MenuItemBuilder::with_id("app_menu:<action>", …)` entry
  *      in lib.rs's app-menu builder.

--- a/packages/dashboard/src/hooks/useTauriMenuEvents.ts
+++ b/packages/dashboard/src/hooks/useTauriMenuEvents.ts
@@ -1,0 +1,52 @@
+/**
+ * useTauriMenuEvents — bridge macOS menu-bar items to dashboard handlers (#4695).
+ *
+ * The Rust side (packages/desktop/src-tauri/src/lib.rs) emits
+ * `menu://<action>` events when the user picks an item from the
+ * application menu bar. This hook subscribes to those events and
+ * dispatches them to the matching React-side callback so menu items
+ * and dashboard buttons / palette commands all funnel through the
+ * same handler — adding a new menu item only requires:
+ *
+ *   1. A new `MenuItemBuilder::with_id("app_menu:<action>", …)` entry
+ *      in lib.rs's app-menu builder.
+ *   2. A new callback prop on this hook, wired in App.tsx.
+ *
+ * Why a separate hook (vs folding into `useTauriEvents`):
+ *   - `useTauriEvents` mutates the Zustand connection store directly
+ *     (it has no caller-provided callbacks). The menu actions need
+ *     App-local state (`setShowCreateSession`), so they have to flow
+ *     through props. Mixing the two would dilute `useTauriEvents`'s
+ *     "store-only side effects" contract.
+ *
+ * No-op outside Tauri (e.g. plain browser dashboard).
+ */
+import { useEffect } from 'react'
+import { getTauriListen } from '../utils/tauri-bridge'
+
+type UnlistenFn = () => void
+
+export interface TauriMenuHandlers {
+  /** Triggered by `File > New Session` (id `app_menu:new-session`). */
+  onNewSession: () => void
+}
+
+export function useTauriMenuEvents(handlers: TauriMenuHandlers): void {
+  const { onNewSession } = handlers
+  useEffect(() => {
+    const listen = getTauriListen()
+    if (!listen) return
+
+    const unlisteners: Promise<UnlistenFn>[] = []
+
+    unlisteners.push(
+      listen('menu://new-session', () => {
+        onNewSession()
+      }),
+    )
+
+    return () => {
+      unlisteners.forEach(p => p.then(fn => fn()).catch(() => {}))
+    }
+  }, [onNewSession])
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5027,6 +5027,45 @@
   outline-offset: 2px;
 }
 
+/* #4695 — prominent "New Session" chrome button. Lives in header-right
+   ahead of the icon-only buttons (Skills / Copy / Settings) so it is
+   the first affordance a new user spots. Uses the accent color filled
+   in (rather than outlined) to read as the primary chrome action. */
+.chrome-new-session-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--accent-blue);
+  color: #fff;
+  border: 1px solid var(--accent-blue);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+}
+
+.chrome-new-session-btn:hover {
+  opacity: 0.88;
+}
+
+.chrome-new-session-btn:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
+.chrome-new-session-icon {
+  font-size: 16px;
+  line-height: 1;
+  font-weight: 600;
+}
+
+.chrome-new-session-label {
+  white-space: nowrap;
+}
+
 /* --- Settings panel --- */
 
 .settings-backdrop {

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -671,6 +671,29 @@ pub fn run() {
             #[cfg(not(target_os = "macos"))]
             { Mutex::new(()) }
         })
+        .on_menu_event(|app, event| {
+            // #4695 — app-menu (macOS menu bar) item dispatch. Tray menu
+            // events are handled by their own builder-scoped closure
+            // (`on_menu_event` in build_tray_menu). The two surfaces
+            // intentionally use disjoint id namespaces:
+            //   - tray:    "start", "stop", "dashboard", …
+            //   - app-menu: "app_menu:<action>" (this match)
+            // The `app_menu:` prefix means stray cross-fires would
+            // simply no-op rather than accidentally invoke the wrong
+            // tray handler. The actual side effect is event emission —
+            // the dashboard's useTauriMenuEvents listener invokes the
+            // matching command (so menu items and command palette
+            // entries share one handler).
+            let id = event.id().as_ref();
+            if let Some(action) = id.strip_prefix("app_menu:") {
+                let event_name = format!("menu://{}", action);
+                let _ = app.emit(&event_name, ());
+                // Make sure the main window is foregrounded so the user
+                // sees the dashboard react (otherwise a menu click with
+                // the window minimized would silently no-op).
+                window::show_window(app);
+            }
+        })
         .setup(|app| {
             // App menu bar — required for macOS Sequoia window tiling keyboard shortcuts.
             // macOS routes fn+ctrl+arrow through the Window menu's "Move & Resize" items.
@@ -682,6 +705,22 @@ pub fn run() {
                     .about(Some(AboutMetadata::default()))
                     .separator()
                     .quit()
+                    .build()?;
+                // #4695 — File menu. v1 ships with a single item ("New
+                // Session") so the most-used action has a menu-bar entry
+                // matching Terminal.app / iTerm / VS Code muscle memory.
+                // Follow-up issue tracks the rest of the proposed
+                // submenu layout (Shell / View / Tunnel / Help — see
+                // #4695). The accelerator is `Cmd+N`, matching the
+                // dashboard's `session.new` shortcut definition; macOS
+                // routes the chord through the menu bar first when one
+                // is installed, so this entry also serves as the system-
+                // level Cmd+N hint.
+                let new_session_item = MenuItemBuilder::with_id("app_menu:new-session", "New Session")
+                    .accelerator("CmdOrCtrl+N")
+                    .build(app)?;
+                let file_menu = SubmenuBuilder::new(app, "File")
+                    .item(&new_session_item)
                     .build()?;
                 let edit_menu = SubmenuBuilder::new(app, "Edit")
                     .undo()
@@ -698,6 +737,7 @@ pub fn run() {
                     .build()?;
                 let menu = MenuBuilder::new(app)
                     .item(&app_menu)
+                    .item(&file_menu)
                     .item(&edit_menu)
                     .item(&window_menu)
                     .build()?;

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -680,10 +680,13 @@ pub fn run() {
             //   - app-menu: "app_menu:<action>" (this match)
             // The `app_menu:` prefix means stray cross-fires would
             // simply no-op rather than accidentally invoke the wrong
-            // tray handler. The actual side effect is event emission —
-            // the dashboard's useTauriMenuEvents listener invokes the
-            // matching command (so menu items and command palette
-            // entries share one handler).
+            // tray handler. The concrete contract here is: strip the
+            // prefix and emit a `menu://<action>` event for the
+            // dashboard to handle. The dashboard's `useTauriMenuEvents`
+            // hook subscribes to those events and routes each one to a
+            // React-side callback supplied by App.tsx — whether that
+            // callback is shared with another UI affordance (button,
+            // palette entry, etc.) is decided by App.tsx, not here.
             let id = event.id().as_ref();
             if let Some(action) = id.strip_prefix("app_menu:") {
                 let event_name = format!("menu://{}", action);


### PR DESCRIPTION
Closes #4695

## Summary

- **Dashboard:** prominent always-visible "New Session" button in `header-right` (testID `chrome-new-session`). Reuses the existing `handleNewSession` path (`Cmd+N` was already wired via `session.new`), so behaviour stays in one place.
- **macOS menu bar:** new `File > New Session` item (`Cmd+N` accelerator) via Tauri `Builder::on_menu_event`. The handler strips an `app_menu:` id prefix and emits a `menu://<action>` Tauri event the dashboard subscribes to.
- **Bridge plumbing:** new `useTauriMenuEvents` hook subscribes to `menu://*` events and dispatches them to React-side callbacks — adding a future menu item is one `MenuItemBuilder::with_id` entry in `lib.rs` plus one callback prop on the hook.

Why only one menu item: the issue proposes ~15 more items across Shell / View / Tunnel / Help submenus. That is scope-explody for one PR, so this lands the most-used action (`New Session`) plus the dispatch plumbing both surfaces will reuse. Follow-up #4942 tracks the rest now that the bridge exists.

## Files

- `packages/dashboard/src/App.tsx` — new chrome button + hook call
- `packages/dashboard/src/hooks/useTauriMenuEvents.ts` (new) — menu-event bridge
- `packages/dashboard/src/theme/components.css` — `.chrome-new-session-btn` styles
- `packages/desktop/src-tauri/src/lib.rs` — `File` submenu + `on_menu_event` dispatcher

## Tests

- `App.test.tsx > chrome-new-session button (#4695)` — 3 cases: renders inside `#header`, has accessible labels, click opens modal (CreateSessionModal stubbed so the test doesn't pull in the directory-browser store wiring).
- `useTauriMenuEvents.test.ts` — 4 cases: subscribe / dispatch / no-op-outside-Tauri / unmount-cleanup.

All 2611 dashboard tests pass; `cargo check` clean; 126 cargo lib tests pass.

## Manual gap

The menu-bar item firing the correct Tauri event id requires `cargo tauri build` to verify end-to-end (CI doesn't build the Tauri bundle). The dashboard listener and Rust emitter sides are both unit-tested. Suggest verifying via:

```bash
cd packages/desktop && npm run tauri dev
# Click File > New Session in the menu bar — modal should open
```

## Test plan

- [ ] `npx -w packages/dashboard vitest run src/App.test.tsx -t "4695"` — chrome-new-session tests pass
- [ ] `npx -w packages/dashboard vitest run src/hooks/useTauriMenuEvents.test.ts` — hook tests pass
- [ ] `npx -w packages/dashboard tsc --noEmit` — typecheck clean
- [ ] `cd packages/desktop/src-tauri && cargo check` — Rust compiles (warnings unchanged from main)
- [ ] **(manual, requires Tauri build)** `cd packages/desktop && npm run tauri dev`, then File > New Session opens the Create Session modal
- [ ] **(manual)** Confirm the existing per-project sidebar "+" buttons still work (no regression in #4695 AC)