### PR TITLE
feat(dashboard): drag-to-reorder session tabs in SessionBar

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -922,6 +922,16 @@ export function App() {
   // server is still authoritative for which sessions EXIST; this slice
   // controls only the visual order in the top tab strip (issue #4831).
   const [tabOrder, setTabOrder] = useState<string[]>(() => loadPersistedSessionTabOrder())
+  // #4831 — `loadPersistedSessionTabOrder` reads under the *current*
+  // server scope (set by `setServerScope` on server-switch). The initial
+  // `useState` only fires once on mount, so without this effect a server
+  // switch in the same browser tab would leave SessionBar showing the
+  // previous server's tabOrder until a full page refresh. Re-load whenever
+  // the active server changes so each server gets its own persisted order.
+  const activeServerId = useConnectionStore(s => s.activeServerId)
+  useEffect(() => {
+    setTabOrder(loadPersistedSessionTabOrder())
+  }, [activeServerId])
   const handleReorderTabs = useCallback((nextOrder: string[]) => {
     setTabOrder(nextOrder)
     persistSessionTabOrder(nextOrder)

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -71,7 +71,7 @@ import { usePermissionNotification, type PermissionPromptInfo } from './hooks/us
 import { useShortcutDispatch } from './hooks/useShortcutDispatch'
 import { useChatMessages, toChatViewMessage } from './hooks/useChatMessages'
 import { SplitPane, type SplitDirection } from './components/SplitPane'
-import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed, loadPersistedSidebarRepoOrder, loadPersistedSidebarSessionOrder, persistSidebarRepoOrder, persistSidebarSessionOrder } from './store/persistence'
+import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed, loadPersistedSidebarRepoOrder, loadPersistedSidebarSessionOrder, persistSidebarRepoOrder, persistSidebarSessionOrder, persistSessionTabOrder, loadPersistedSessionTabOrder } from './store/persistence'
 import { applyOrderById } from './utils/reorderById'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
 import { AgentMonitorPanel } from './components/AgentMonitorPanel'
@@ -916,10 +916,41 @@ export function App() {
     })
   }, [sessionStates, sessionActivityNow])
 
+  // #4831 — user-defined SessionBar tab order (overlay on the server's
+  // `sessions[]` membership). Loaded lazily from localStorage on mount and
+  // re-persisted whenever the user drags / keyboard-reorders a tab. The
+  // server is still authoritative for which sessions EXIST; this slice
+  // controls only the visual order in the top tab strip (issue #4831).
+  const [tabOrder, setTabOrder] = useState<string[]>(() => loadPersistedSessionTabOrder())
+  const handleReorderTabs = useCallback((nextOrder: string[]) => {
+    setTabOrder(nextOrder)
+    persistSessionTabOrder(nextOrder)
+  }, [])
+
   // Map sessions to SessionTabData[] with unified status indicators.
+  //
+  // #4831: apply the persisted `tabOrder` overlay. Sessions present in
+  // `tabOrder` render in that order; sessions added by the server since
+  // the last reorder (new tabs, restored conversations) fall through to
+  // the server's natural order at the end. Stale ids in `tabOrder` (server
+  // removed the session) are harmlessly ignored because we filter against
+  // the live `sessions` list.
   const sessionTabs: SessionTabData[] = useMemo(
-    () => sessions.map(s => {
-      return {
+    () => {
+      const byId = new Map(sessions.map(s => [s.sessionId, s]))
+      const ordered: SessionInfo[] = []
+      const seen = new Set<string>()
+      for (const id of tabOrder) {
+        const s = byId.get(id)
+        if (s && !seen.has(id)) {
+          ordered.push(s)
+          seen.add(id)
+        }
+      }
+      for (const s of sessions) {
+        if (!seen.has(s.sessionId)) ordered.push(s)
+      }
+      return ordered.map(s => ({
         sessionId: s.sessionId,
         name: s.name,
         isBusy: s.isBusy,
@@ -930,9 +961,9 @@ export function App() {
         status: getSessionVisualStatus(s),
         // #3567: surface latched stdin-disabled flag from session_list.
         stdinForwardingDisabled: s.stdinForwardingDisabled,
-      }
-    }),
-    [sessions, activeSessionId, getSessionVisualStatus],
+      }))
+    },
+    [sessions, activeSessionId, getSessionVisualStatus, tabOrder],
   )
 
   // Derive sidebar repo tree from sessions
@@ -1999,6 +2030,7 @@ export function App() {
             onClose={handleCloseSession}
             onRename={renameSession}
             onNewSession={handleNewSession}
+            onReorder={handleReorderTabs}
           />
         )}
 

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup, within } from '@testing-library/react'
-import { SessionBar, type SessionTabData } from './SessionBar'
+import { SessionBar, reorderTabs, type SessionTabData } from './SessionBar'
 
 afterEach(cleanup)
 
@@ -449,6 +449,197 @@ describe('SessionBar', () => {
       const btn = screen.getByTestId('new-session-btn')
       expect(btn.getAttribute('title'), 'new-session needs title').toBeTruthy()
       expect(btn.getAttribute('aria-label'), 'new-session needs aria-label').toBeTruthy()
+    })
+  })
+
+  // #4831 — drag-to-reorder. Users want to drag tabs in the top SessionBar
+  // strip to reorder them; the new order persists across reload. These
+  // tests cover the pure reorder helper, the drag-emit path, the keyboard
+  // reorder ladder, the anchored `+` button, and click-to-activate left
+  // intact under the new draggable attribute.
+  describe('#4831 drag-to-reorder', () => {
+    function makeThree(): SessionTabData[] {
+      return [
+        { sessionId: 'a', name: 'Alpha', isBusy: false, isActive: true },
+        { sessionId: 'b', name: 'Beta', isBusy: false, isActive: false },
+        { sessionId: 'c', name: 'Charlie', isBusy: false, isActive: false },
+      ]
+    }
+
+    describe('reorderTabs helper', () => {
+      it('moves forward (insert-before semantics)', () => {
+        // Move index 0 ("a") onto index 2 ("c"): "a" should land at the
+        // position "c" used to occupy after "c" shifts left.
+        expect(reorderTabs(['a', 'b', 'c'], 0, 2)).toEqual(['b', 'a', 'c'])
+      })
+      it('moves backward', () => {
+        // Move index 2 ("c") onto index 0 ("a"): "c" takes slot 0.
+        expect(reorderTabs(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b'])
+      })
+      it('returns the same array reference when no-op', () => {
+        const arr = ['a', 'b', 'c']
+        expect(reorderTabs(arr, 1, 1)).toBe(arr)
+      })
+      it('ignores out-of-range indices', () => {
+        const arr = ['a', 'b']
+        expect(reorderTabs(arr, -1, 0)).toBe(arr)
+        expect(reorderTabs(arr, 0, -1)).toBe(arr)
+        expect(reorderTabs(arr, 5, 0)).toBe(arr)
+      })
+    })
+
+    it('marks tabs as draggable when onReorder is wired', () => {
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={vi.fn()}
+        />
+      )
+      const tab = screen.getByTestId('session-tab-a')
+      expect(tab.getAttribute('draggable')).toBe('true')
+    })
+
+    it('does NOT mark tabs as draggable when onReorder is missing', () => {
+      // Back-compat: existing callers (and tests above) didn't pass onReorder
+      // and shouldn't suddenly get drag behavior they didn't opt into.
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+        />
+      )
+      const tab = screen.getByTestId('session-tab-a')
+      expect(tab.getAttribute('draggable')).toBe('false')
+    })
+
+    it('emits onReorder with the new id order on drop', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      const tabC = screen.getByTestId('session-tab-c')
+      // Minimal DataTransfer stub for jsdom (the component calls setData
+      // and reads dropEffect / effectAllowed in defensive try/catch).
+      const dataTransfer = {
+        data: {} as Record<string, string>,
+        setData(format: string, val: string) { this.data[format] = val },
+        getData(format: string) { return this.data[format] ?? '' },
+        effectAllowed: 'all',
+        dropEffect: 'none',
+        types: [] as string[],
+      }
+      fireEvent.dragStart(tabA, { dataTransfer })
+      fireEvent.dragOver(tabC, { dataTransfer })
+      fireEvent.drop(tabC, { dataTransfer })
+      expect(onReorder).toHaveBeenCalledTimes(1)
+      // Insert-before semantics: dropping "a" onto "c" inserts "a" at "c"'s
+      // original slot; "c" had already shifted left by one when "a" was
+      // removed, so the final ordering is ["b", "a", "c"].
+      expect(onReorder).toHaveBeenCalledWith(['b', 'a', 'c'])
+    })
+
+    it('does not emit onReorder when dropping a tab onto itself', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      const dataTransfer = {
+        data: {} as Record<string, string>,
+        setData(format: string, val: string) { this.data[format] = val },
+        getData(format: string) { return this.data[format] ?? '' },
+        effectAllowed: 'all',
+        dropEffect: 'none',
+        types: [] as string[],
+      }
+      fireEvent.dragStart(tabA, { dataTransfer })
+      fireEvent.drop(tabA, { dataTransfer })
+      expect(onReorder).not.toHaveBeenCalled()
+    })
+
+    it('+ (new session) button is NOT draggable and stays after the tabs', () => {
+      const { container } = render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={vi.fn()}
+        />
+      )
+      const newBtn = screen.getByTestId('new-session-btn')
+      // The + button is rendered outside the tablist, so it has no draggable
+      // attribute and no role="tab".
+      expect(newBtn.getAttribute('draggable')).toBe(null)
+      expect(newBtn.getAttribute('role')).not.toBe('tab')
+      // DOM order: the tablist comes before the new-session button.
+      const tablist = container.querySelector('[role="tablist"]')!
+      const tablistPos = Array.from(container.firstChild!.childNodes).indexOf(tablist)
+      const btnPos = Array.from(container.firstChild!.childNodes).indexOf(newBtn)
+      expect(btnPos).toBeGreaterThan(tablistPos)
+    })
+
+    it('keyboard reorder: Shift+Space lifts, ArrowRight moves, Escape cancels lift', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      // Lift "a" into reorder mode
+      fireEvent.keyDown(tabA, { key: ' ', shiftKey: true })
+      expect(tabA.getAttribute('aria-grabbed')).toBe('true')
+      // Move "a" one slot right — should land in position 1 of ['b','a','c']
+      fireEvent.keyDown(tabA, { key: 'ArrowRight' })
+      expect(onReorder).toHaveBeenCalledWith(['b', 'a', 'c'])
+      // Escape clears the lift state (no further reorder)
+      fireEvent.keyDown(tabA, { key: 'Escape' })
+      expect(tabA.getAttribute('aria-grabbed')).toBe(null)
+    })
+
+    it('click-to-activate still works when reorder is wired', () => {
+      const onSwitch = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={onSwitch}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={vi.fn()}
+        />
+      )
+      fireEvent.click(screen.getByTestId('session-tab-b'))
+      expect(onSwitch).toHaveBeenCalledWith('b')
     })
   })
 })

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -602,7 +602,7 @@ describe('SessionBar', () => {
       expect(btnPos).toBeGreaterThan(tablistPos)
     })
 
-    it('keyboard reorder: Shift+Space lifts, ArrowRight moves, Escape cancels lift', () => {
+    it('keyboard reorder: Space lifts, ArrowRight moves, Escape cancels lift', () => {
       const onReorder = vi.fn()
       render(
         <SessionBar
@@ -615,8 +615,8 @@ describe('SessionBar', () => {
         />
       )
       const tabA = screen.getByTestId('session-tab-a')
-      // Lift "a" into reorder mode
-      fireEvent.keyDown(tabA, { key: ' ', shiftKey: true })
+      // Lift "a" into reorder mode (plain Space matches #4831 AC)
+      fireEvent.keyDown(tabA, { key: ' ' })
       expect(tabA.getAttribute('aria-grabbed')).toBe('true')
       // Move "a" one slot right — should land in position 1 of ['b','a','c']
       fireEvent.keyDown(tabA, { key: 'ArrowRight' })
@@ -624,6 +624,25 @@ describe('SessionBar', () => {
       // Escape clears the lift state (no further reorder)
       fireEvent.keyDown(tabA, { key: 'Escape' })
       expect(tabA.getAttribute('aria-grabbed')).toBe(null)
+    })
+
+    it('keyboard reorder: Shift+Space alias also lifts', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      fireEvent.keyDown(tabA, { key: ' ', shiftKey: true })
+      expect(tabA.getAttribute('aria-grabbed')).toBe('true')
+      fireEvent.keyDown(tabA, { key: 'ArrowRight' })
+      expect(onReorder).toHaveBeenCalledWith(['b', 'a', 'c'])
     })
 
     it('click-to-activate still works when reorder is wired', () => {

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -2,6 +2,12 @@
  * SessionBar — horizontal tab strip for session management.
  *
  * Features: active highlight, status dot, close/rename, cwd badge, model badge, provider badge.
+ *
+ * #4831 — tabs are drag-and-drop reorderable. Native HTML5 DnD (no new deps).
+ * Reordering also supports keyboard: focus a tab, press Shift+Space to "lift"
+ * it into reorder mode, then Arrow Left / Right to move it, then Space /
+ * Enter / Escape to drop. The `+` (new session) button is anchored at the
+ * right edge and is NOT draggable / not a drop target.
  */
 import { useState, useCallback, useRef, useEffect } from 'react'
 import type { SessionVisualStatus } from '@chroxy/store-core'
@@ -37,6 +43,13 @@ export interface SessionBarProps {
   onClose: (sessionId: string) => void
   onRename: (sessionId: string, newName: string) => void
   onNewSession: () => void
+  /**
+   * #4831 — invoked when the user drops a tab in a new position.
+   * `nextOrder` is the full array of sessionIds in the new visual order
+   * (same membership as `sessions`, just permuted). Optional so existing
+   * callers continue to compile without reorder support.
+   */
+  onReorder?: (nextOrder: string[]) => void
 }
 
 function shortenModel(model: string): string {
@@ -52,12 +65,43 @@ function shortenProvider(provider: string): string {
   return getProviderInfo(provider).short
 }
 
-export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession }: SessionBarProps) {
+/**
+ * #4831 — pure reorder helper, exported for tests. Moves the entry at
+ * `fromIndex` to `toIndex` (insert-before semantics; matches typical drop
+ * UX where the dragged tab takes the dropped-on tab's slot and pushes it
+ * one over). Returns a NEW array; never mutates the input.
+ */
+export function reorderTabs(ids: string[], fromIndex: number, toIndex: number): string[] {
+  if (fromIndex === toIndex) return ids
+  if (fromIndex < 0 || fromIndex >= ids.length) return ids
+  if (toIndex < 0 || toIndex > ids.length) return ids
+  const next = ids.slice()
+  const [moved] = next.splice(fromIndex, 1)
+  if (moved === undefined) return ids
+  // After removal the indices to the right shift left by one; clamp the
+  // insertion point so a drop on the far right lands at the new array's end.
+  const adjusted = toIndex > fromIndex ? toIndex - 1 : toIndex
+  next.splice(adjusted, 0, moved)
+  return next
+}
+
+export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession, onReorder }: SessionBarProps) {
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
   const cancelledRef = useRef(false)
   const showClose = sessions.length > 1
+
+  // #4831 — drag state. `draggingId` is the sessionId of the tab being
+  // dragged (set on dragstart, cleared on dragend); `dragOverId` is the
+  // sessionId of the tab currently under the cursor (set on dragover,
+  // cleared on dragleave / drop). Both are used purely for visual
+  // affordance — the actual reorder is computed on drop from index lookups.
+  const [draggingId, setDraggingId] = useState<string | null>(null)
+  const [dragOverId, setDragOverId] = useState<string | null>(null)
+  // #4831 — keyboard reorder. When non-null, arrows move the tab without
+  // a pointer; Space / Enter commits, Escape cancels.
+  const [keyboardLiftId, setKeyboardLiftId] = useState<string | null>(null)
 
   useEffect(() => {
     if (renamingId && inputRef.current) {
@@ -87,22 +131,133 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
     setRenamingId(null)
   }, [])
 
+  // #4831 — emit a reorder. `from` and `to` are sessionIds, not indices,
+  // so we look up indices from the live `sessions` array (which already
+  // reflects the user's current order, since App.tsx feeds it back in via
+  // `onReorder`). No-ops when `onReorder` isn't wired.
+  const emitReorder = useCallback((from: string, to: string) => {
+    if (!onReorder) return
+    if (from === to) return
+    const ids = sessions.map(s => s.sessionId)
+    const fromIdx = ids.indexOf(from)
+    const toIdx = ids.indexOf(to)
+    if (fromIdx === -1 || toIdx === -1) return
+    const next = reorderTabs(ids, fromIdx, toIdx)
+    onReorder(next)
+  }, [sessions, onReorder])
+
+  // #4831 — keyboard step. `dir` is +1 (right) / -1 (left). Mutates via
+  // `emitReorder` (insert-before semantics: stepping right swaps with the
+  // next neighbor by inserting after it).
+  const stepKeyboard = useCallback((sessionId: string, dir: 1 | -1) => {
+    if (!onReorder) return
+    const ids = sessions.map(s => s.sessionId)
+    const idx = ids.indexOf(sessionId)
+    if (idx === -1) return
+    const target = idx + dir
+    if (target < 0 || target >= ids.length) return
+    // For insert-before semantics, swapping with the right neighbor means
+    // inserting at (idx+2) so the dragged tab lands after the neighbor.
+    const insertAt = dir > 0 ? idx + 2 : idx - 1
+    const next = reorderTabs(ids, idx, insertAt)
+    onReorder(next)
+  }, [sessions, onReorder])
+
   return (
     <div className="session-bar" data-testid="session-bar">
       <div className="session-tabs" role="tablist">
-        {sessions.map(session => (
+        {sessions.map(session => {
+          const isDragging = draggingId === session.sessionId
+          const isDragOver = dragOverId === session.sessionId && draggingId !== null && draggingId !== session.sessionId
+          const isLifted = keyboardLiftId === session.sessionId
+          const reorderDisabled = !onReorder
+          return (
           <div
             key={session.sessionId}
-            className={`session-tab${session.isActive ? ' active' : ''}`}
+            className={
+              `session-tab${session.isActive ? ' active' : ''}` +
+              `${isDragging ? ' dragging' : ''}` +
+              `${isDragOver ? ' drag-over' : ''}` +
+              `${isLifted ? ' lifted' : ''}`
+            }
             data-testid={`session-tab-${session.sessionId}`}
             role="tab"
             aria-selected={session.isActive}
+            aria-grabbed={isLifted || isDragging ? true : undefined}
             tabIndex={0}
+            // #4831 — native HTML5 DnD attributes. `draggable` is only enabled
+            // when a reorder callback is wired (so consumers that don't opt
+            // in don't get an unexpected interaction). Rename mode suppresses
+            // dragging so the user can select text inside the input.
+            draggable={!reorderDisabled && renamingId !== session.sessionId}
+            onDragStart={e => {
+              if (reorderDisabled) return
+              setDraggingId(session.sessionId)
+              // setData is required for Firefox to actually start the drag;
+              // the payload isn't read on drop (we resolve from state).
+              try { e.dataTransfer.setData('text/plain', session.sessionId) } catch { /* jsdom */ }
+              if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move'
+            }}
+            onDragEnd={() => {
+              setDraggingId(null)
+              setDragOverId(null)
+            }}
+            onDragOver={e => {
+              if (reorderDisabled || !draggingId || draggingId === session.sessionId) return
+              // Calling preventDefault is what makes this element a valid
+              // drop target — without it the drop event never fires.
+              e.preventDefault()
+              if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+              if (dragOverId !== session.sessionId) setDragOverId(session.sessionId)
+            }}
+            onDragLeave={() => {
+              if (dragOverId === session.sessionId) setDragOverId(null)
+            }}
+            onDrop={e => {
+              if (reorderDisabled || !draggingId) return
+              e.preventDefault()
+              emitReorder(draggingId, session.sessionId)
+              setDraggingId(null)
+              setDragOverId(null)
+            }}
             onClick={() => {
               if (!session.isActive) onSwitch(session.sessionId)
             }}
             onKeyDown={e => {
               if (renamingId === session.sessionId) return
+              // #4831 — keyboard reorder ladder. Shift+Space toggles "lift"
+              // mode. While lifted, ArrowLeft / ArrowRight step the tab,
+              // and Enter / Space / Escape commit / cancel the lift.
+              // Plain Space / Enter retain their existing tab-activate
+              // behaviour so we don't break established UX for users who
+              // never engage reorder mode.
+              if (e.key === ' ' && e.shiftKey && !reorderDisabled) {
+                e.preventDefault()
+                setKeyboardLiftId(prev => prev === session.sessionId ? null : session.sessionId)
+                return
+              }
+              if (keyboardLiftId === session.sessionId) {
+                if (e.key === 'Escape') {
+                  e.preventDefault()
+                  setKeyboardLiftId(null)
+                  return
+                }
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  setKeyboardLiftId(null)
+                  return
+                }
+                if (e.key === 'ArrowRight') {
+                  e.preventDefault()
+                  stepKeyboard(session.sessionId, 1)
+                  return
+                }
+                if (e.key === 'ArrowLeft') {
+                  e.preventDefault()
+                  stepKeyboard(session.sessionId, -1)
+                  return
+                }
+              }
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault()
                 if (!session.isActive) onSwitch(session.sessionId)
@@ -233,7 +388,8 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               </button>
             )}
           </div>
-        ))}
+          )
+        })}
       </div>
 
       <button

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -4,10 +4,12 @@
  * Features: active highlight, status dot, close/rename, cwd badge, model badge, provider badge.
  *
  * #4831 — tabs are drag-and-drop reorderable. Native HTML5 DnD (no new deps).
- * Reordering also supports keyboard: focus a tab, press Shift+Space to "lift"
- * it into reorder mode, then Arrow Left / Right to move it, then Space /
- * Enter / Escape to drop. The `+` (new session) button is anchored at the
- * right edge and is NOT draggable / not a drop target.
+ * Reordering also supports keyboard: focus a tab, press Space (or Shift+Space)
+ * to "lift" it into reorder mode, then Arrow Left / Right to move it, then
+ * Space / Enter / Escape to drop. Plain Space is the WAI-ARIA grid pattern
+ * and matches the #4831 acceptance criteria; Shift+Space is retained as an
+ * alias. The `+` (new session) button is anchored at the right edge and is
+ * NOT draggable / not a drop target.
  */
 import { useState, useCallback, useRef, useEffect } from 'react'
 import type { SessionVisualStatus } from '@chroxy/store-core'
@@ -69,7 +71,15 @@ function shortenProvider(provider: string): string {
  * #4831 — pure reorder helper, exported for tests. Moves the entry at
  * `fromIndex` to `toIndex` (insert-before semantics; matches typical drop
  * UX where the dragged tab takes the dropped-on tab's slot and pushes it
- * one over). Returns a NEW array; never mutates the input.
+ * one over). Never mutates the input.
+ *
+ * Return-reference contract:
+ * - On a successful move (the indices are in range and not a no-op), returns
+ *   a NEW array (the result of `slice() + splice()`).
+ * - On a no-op (`fromIndex === toIndex`) or out-of-range indices, returns the
+ *   ORIGINAL `ids` reference unchanged. Callers using referential equality to
+ *   detect "nothing changed" can rely on this; callers that always want a new
+ *   reference must clone explicitly.
  */
 export function reorderTabs(ids: string[], fromIndex: number, toIndex: number): string[] {
   if (fromIndex === toIndex) return ids
@@ -225,13 +235,15 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
             }}
             onKeyDown={e => {
               if (renamingId === session.sessionId) return
-              // #4831 — keyboard reorder ladder. Shift+Space toggles "lift"
-              // mode. While lifted, ArrowLeft / ArrowRight step the tab,
-              // and Enter / Space / Escape commit / cancel the lift.
-              // Plain Space / Enter retain their existing tab-activate
-              // behaviour so we don't break established UX for users who
-              // never engage reorder mode.
-              if (e.key === ' ' && e.shiftKey && !reorderDisabled) {
+              // #4831 — keyboard reorder ladder. Both Space (matches the
+              // #4831 acceptance criteria + WAI-ARIA grid pattern) and
+              // Shift+Space toggle "lift" mode when reorder is wired.
+              // While lifted, ArrowLeft / ArrowRight step the tab, and
+              // Enter / Space / Escape commit / cancel the lift.
+              // When reorder is NOT wired (or while not lifted), plain
+              // Space falls through to the tab-activate handler below so
+              // role="tab" semantics are preserved; Enter always activates.
+              if (e.key === ' ' && !reorderDisabled) {
                 e.preventDefault()
                 setKeyboardLiftId(prev => prev === session.sessionId ? null : session.sessionId)
                 return
@@ -242,7 +254,7 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
                   setKeyboardLiftId(null)
                   return
                 }
-                if (e.key === 'Enter' || e.key === ' ') {
+                if (e.key === 'Enter') {
                   e.preventDefault()
                   setKeyboardLiftId(null)
                   return

--- a/packages/dashboard/src/components/SessionBarReorderPersist.test.tsx
+++ b/packages/dashboard/src/components/SessionBarReorderPersist.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * SessionBar drag-reorder + persistence integration test (#4831)
+ *
+ * Acceptance criterion from #4831: "Regression test: tab order survives a
+ * `window.location.reload()` in a vitest jsdom test." This test pairs the
+ * SessionBar drop handler with the persistence helper and `unmount` →
+ * remount to simulate a reload, asserting the dragged order is reapplied.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
+import { render, fireEvent, cleanup, screen } from '@testing-library/react'
+import { useState, useMemo } from 'react'
+import { SessionBar, type SessionTabData } from './SessionBar'
+import {
+  loadPersistedSessionTabOrder,
+  persistSessionTabOrder,
+  setServerScope,
+  _resetForTesting,
+} from '../store/persistence'
+
+beforeEach(() => {
+  localStorage.clear()
+  _resetForTesting()
+  setServerScope(null)
+})
+afterEach(cleanup)
+
+// Minimal harness that mirrors the App.tsx wiring: load persisted order on
+// mount, apply it as an overlay on the server-supplied `sessions`, and
+// persist on every reorder. Lives inline so the test exercises the actual
+// production helpers (no double of `persistSessionTabOrder` / loader).
+function Harness({ sessions: rawSessions }: { sessions: SessionTabData[] }) {
+  const [tabOrder, setTabOrder] = useState<string[]>(() => loadPersistedSessionTabOrder())
+  const ordered = useMemo(() => {
+    const byId = new Map(rawSessions.map(s => [s.sessionId, s]))
+    const out: SessionTabData[] = []
+    const seen = new Set<string>()
+    for (const id of tabOrder) {
+      const s = byId.get(id)
+      if (s && !seen.has(id)) { out.push(s); seen.add(id) }
+    }
+    for (const s of rawSessions) {
+      if (!seen.has(s.sessionId)) out.push(s)
+    }
+    return out
+  }, [rawSessions, tabOrder])
+  return (
+    <SessionBar
+      sessions={ordered}
+      onSwitch={vi.fn()}
+      onClose={vi.fn()}
+      onRename={vi.fn()}
+      onNewSession={vi.fn()}
+      onReorder={next => {
+        setTabOrder(next)
+        persistSessionTabOrder(next)
+      }}
+    />
+  )
+}
+
+function makeDataTransfer() {
+  return {
+    data: {} as Record<string, string>,
+    setData(format: string, val: string) { this.data[format] = val },
+    getData(format: string) { return this.data[format] ?? '' },
+    effectAllowed: 'all',
+    dropEffect: 'none',
+    types: [] as string[],
+  }
+}
+
+describe('#4831 drag-reorder + persistence integration', () => {
+  it('persists the new order to localStorage on drop', () => {
+    const sessions: SessionTabData[] = [
+      { sessionId: 'a', name: 'Alpha', isBusy: false, isActive: true },
+      { sessionId: 'b', name: 'Beta', isBusy: false, isActive: false },
+      { sessionId: 'c', name: 'Charlie', isBusy: false, isActive: false },
+    ]
+    render(<Harness sessions={sessions} />)
+    const dt = makeDataTransfer()
+    fireEvent.dragStart(screen.getByTestId('session-tab-a'), { dataTransfer: dt })
+    fireEvent.dragOver(screen.getByTestId('session-tab-c'), { dataTransfer: dt })
+    fireEvent.drop(screen.getByTestId('session-tab-c'), { dataTransfer: dt })
+    // Persisted order matches the in-memory reorder
+    expect(loadPersistedSessionTabOrder()).toEqual(['b', 'a', 'c'])
+  })
+
+  it('tab order survives a simulated window.location.reload()', () => {
+    const sessions: SessionTabData[] = [
+      { sessionId: 'a', name: 'Alpha', isBusy: false, isActive: true },
+      { sessionId: 'b', name: 'Beta', isBusy: false, isActive: false },
+      { sessionId: 'c', name: 'Charlie', isBusy: false, isActive: false },
+    ]
+    const first = render(<Harness sessions={sessions} />)
+    // Drag "c" onto "a" — expected order: ["c", "a", "b"]
+    const dt = makeDataTransfer()
+    fireEvent.dragStart(screen.getByTestId('session-tab-c'), { dataTransfer: dt })
+    fireEvent.dragOver(screen.getByTestId('session-tab-a'), { dataTransfer: dt })
+    fireEvent.drop(screen.getByTestId('session-tab-a'), { dataTransfer: dt })
+    // Sanity: the in-memory render reflects the new order
+    let tabs = document.querySelectorAll<HTMLElement>('[role="tab"]')
+    expect(Array.from(tabs).map(t => t.dataset.testid)).toEqual([
+      'session-tab-c', 'session-tab-a', 'session-tab-b',
+    ])
+    first.unmount()
+    // "Reload": React tree goes away, localStorage survives. New tree
+    // reads the persisted order on mount and applies it.
+    render(<Harness sessions={sessions} />)
+    tabs = document.querySelectorAll<HTMLElement>('[role="tab"]')
+    expect(Array.from(tabs).map(t => t.dataset.testid)).toEqual([
+      'session-tab-c', 'session-tab-a', 'session-tab-b',
+    ])
+  })
+
+  it('new server-supplied sessions append at the end of the persisted order', () => {
+    // Persist an existing order, then introduce a brand-new session id —
+    // the new one should land at the end, not break the persisted order.
+    persistSessionTabOrder(['c', 'a', 'b'])
+    const sessions: SessionTabData[] = [
+      { sessionId: 'a', name: 'Alpha', isBusy: false, isActive: true },
+      { sessionId: 'b', name: 'Beta', isBusy: false, isActive: false },
+      { sessionId: 'c', name: 'Charlie', isBusy: false, isActive: false },
+      { sessionId: 'd', name: 'Delta', isBusy: false, isActive: false },
+    ]
+    render(<Harness sessions={sessions} />)
+    const tabs = document.querySelectorAll<HTMLElement>('[role="tab"]')
+    expect(Array.from(tabs).map(t => t.dataset.testid)).toEqual([
+      'session-tab-c', 'session-tab-a', 'session-tab-b', 'session-tab-d',
+    ])
+  })
+
+  it('removed sessions are silently dropped from the visible order', () => {
+    persistSessionTabOrder(['a', 'gone', 'b'])
+    const sessions: SessionTabData[] = [
+      { sessionId: 'a', name: 'Alpha', isBusy: false, isActive: true },
+      { sessionId: 'b', name: 'Beta', isBusy: false, isActive: false },
+    ]
+    render(<Harness sessions={sessions} />)
+    const tabs = document.querySelectorAll<HTMLElement>('[role="tab"]')
+    expect(Array.from(tabs).map(t => t.dataset.testid)).toEqual([
+      'session-tab-a', 'session-tab-b',
+    ])
+  })
+})

--- a/packages/dashboard/src/store/persistence-tab-order.test.ts
+++ b/packages/dashboard/src/store/persistence-tab-order.test.ts
@@ -1,0 +1,79 @@
+/**
+ * SessionBar tab-order persistence tests (#4831)
+ *
+ * The persisted order must:
+ *   - Round-trip through localStorage (survive `window.location.reload()`)
+ *   - Be server-scoped so different chroxy servers have independent tab orders
+ *   - Reject malformed payloads gracefully (no throws, return [])
+ *   - Drop the localStorage entry when persisted as the empty array (so a
+ *     "reset" state is genuinely empty, not a literal "[]" string we'd then
+ *     read back as a no-op overlay)
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  persistSessionTabOrder,
+  loadPersistedSessionTabOrder,
+  setServerScope,
+  _resetForTesting,
+} from './persistence'
+
+beforeEach(() => {
+  localStorage.clear()
+  _resetForTesting()
+  setServerScope(null)
+})
+
+describe('SessionBar tab-order persistence (#4831)', () => {
+  it('round-trips a custom order through localStorage', () => {
+    persistSessionTabOrder(['s3', 's1', 's2'])
+    // Simulating a `window.location.reload()` is equivalent to calling
+    // the loader fresh — module state is irrelevant for plain localStorage
+    // helpers (no debounce, no in-memory cache).
+    expect(loadPersistedSessionTabOrder()).toEqual(['s3', 's1', 's2'])
+  })
+
+  it('returns [] when no order has been persisted', () => {
+    expect(loadPersistedSessionTabOrder()).toEqual([])
+  })
+
+  it('isolates tab order by server scope', () => {
+    setServerScope('srv_A')
+    persistSessionTabOrder(['a1', 'a2'])
+
+    setServerScope('srv_B')
+    persistSessionTabOrder(['b1', 'b2', 'b3'])
+
+    setServerScope('srv_A')
+    expect(loadPersistedSessionTabOrder()).toEqual(['a1', 'a2'])
+    setServerScope('srv_B')
+    expect(loadPersistedSessionTabOrder()).toEqual(['b1', 'b2', 'b3'])
+  })
+
+  it('removes the persisted entry when saving an empty order', () => {
+    persistSessionTabOrder(['s1', 's2'])
+    expect(loadPersistedSessionTabOrder()).toEqual(['s1', 's2'])
+    persistSessionTabOrder([])
+    // A "reset" state should not leave behind a literal `"[]"` blob — the
+    // loader treating an empty stored value as null is the contract here,
+    // so removing the key matters.
+    expect(loadPersistedSessionTabOrder()).toEqual([])
+  })
+
+  it('returns [] when the stored value is invalid JSON', () => {
+    localStorage.setItem('chroxy_persist_session_tab_order', '{not json')
+    expect(loadPersistedSessionTabOrder()).toEqual([])
+  })
+
+  it('returns [] when the stored value is JSON but not an array', () => {
+    localStorage.setItem('chroxy_persist_session_tab_order', '{"x":1}')
+    expect(loadPersistedSessionTabOrder()).toEqual([])
+  })
+
+  it('filters non-string entries from a malformed array', () => {
+    localStorage.setItem(
+      'chroxy_persist_session_tab_order',
+      JSON.stringify(['ok1', 42, null, 'ok2']),
+    )
+    expect(loadPersistedSessionTabOrder()).toEqual(['ok1', 'ok2'])
+  })
+})

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -31,6 +31,8 @@ const KEY_SIDEBAR_PANEL_COLLAPSED = `${KEY_PREFIX}sidebar_panel_collapsed`;
 // orders without clobbering each other.
 const KEY_SIDEBAR_REPO_ORDER = `${KEY_PREFIX}sidebar_repo_order`;
 const KEY_SIDEBAR_SESSION_ORDER = `${KEY_PREFIX}sidebar_session_order`;
+// #4831 — user-defined SessionBar tab order (overlay on server-supplied sessions)
+const KEY_SESSION_TAB_ORDER = `${KEY_PREFIX}session_tab_order`;
 
 // ---------------------------------------------------------------------------
 // Server-scoped persistence — keys scoped by server ID to prevent data loss
@@ -446,6 +448,53 @@ export function loadPersistedShowConsoleTab(): boolean {
     return localStorage.getItem(KEY_SHOW_CONSOLE_TAB) === 'true';
   } catch {
     return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// #4831 — SessionBar tab order persistence
+//
+// The server returns `sessions[]` in the order they were created / activated;
+// users want to drag tabs in the top SessionBar strip to reorder them. We
+// keep the server's list as the source of truth for *membership* (created /
+// removed / restored) but layer a user-defined ORDER on top, persisted in
+// localStorage so it survives reload + Tauri restart.
+//
+// Storage shape: `string[]` of sessionIds in user order. Sessions not yet
+// seen by the user (server added one between reloads) get appended to the
+// end on render; sessions removed by the server are filtered out of the
+// order array on the next reorder save (no GC needed — the array is
+// reapplied by id, so stale ids are harmlessly ignored).
+//
+// Server-scoped — different servers have different session sets, so each
+// server gets its own persisted tab order.
+// ---------------------------------------------------------------------------
+
+/** Persist the SessionBar tab order (server-scoped). */
+export function persistSessionTabOrder(order: string[]): void {
+  try {
+    const key = scopedKey(KEY_SESSION_TAB_ORDER);
+    if (order.length === 0) {
+      localStorage.removeItem(key);
+    } else {
+      localStorage.setItem(key, JSON.stringify(order));
+    }
+  } catch {
+    // Storage not available
+  }
+}
+
+/** Load the persisted SessionBar tab order. Returns [] when unset / invalid. */
+export function loadPersistedSessionTabOrder(): string[] {
+  try {
+    const raw = scopedRead(KEY_SESSION_TAB_ORDER);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    // Defensive: only string entries — anything else is corrupt persistence
+    return parsed.filter((x): x is string => typeof x === 'string');
+  } catch {
+    return [];
   }
 }
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1090,6 +1090,32 @@
   outline-offset: -2px;
 }
 
+/* #4831 — drag affordances for the SessionBar tab strip.
+ * `cursor: grab` only when the drag handler is wired (parent passes
+ * `[draggable="true"]`). Lifted state (keyboard reorder) and drag-over
+ * state visually telegraph what's happening without animating layout. */
+.session-tab[draggable="true"] {
+  cursor: grab;
+}
+.session-tab[draggable="true"]:active {
+  cursor: grabbing;
+}
+.session-tab.dragging {
+  opacity: 0.55;
+  /* Slight scale to lift the tab visually — purely cosmetic, GPU-cheap. */
+  transform: scale(0.97);
+}
+.session-tab.drag-over {
+  /* A left-edge accent indicates the drop slot. Insert-before semantics:
+   * a drop on this tab pushes it right and the dragged tab takes its place. */
+  box-shadow: inset 2px 0 0 0 var(--accent-blue);
+}
+.session-tab.lifted {
+  /* Mirror the dragging affordance for the keyboard reorder path. */
+  outline: 2px dashed var(--accent-blue);
+  outline-offset: -2px;
+}
+
 .tab-name {
   pointer-events: none;
 }


### PR DESCRIPTION
Closes #4831.

## Summary
- Top SessionBar tabs are now drag-and-drop reorderable with native HTML5 DnD (no new dependency).
- The chosen order persists across page reload + Tauri restart via a new server-scoped localStorage overlay (`chroxy_persist_session_tab_order`). The server stays authoritative for session membership; this slice only controls visual order.
- Keyboard reorder ladder (Shift+Space lift, Arrow keys step, Space/Enter commit, Escape cancel) keeps the feature usable for non-mouse users.

## Behaviour
- Drag a tab onto another tab: insert-before semantics, immediate reorder + persist.
- The `+` (new session) button stays anchored at the right edge and is not draggable / not a drop target.
- Click-to-activate, double-click-to-rename, and the close button continue to work unchanged.
- Visual affordances: grab cursor on draggable tabs, dimmed opacity on the dragged tab, a blue inset accent on the drop target, a dashed outline on the keyboard-lifted tab.
- New `onReorder` callback on `SessionBar` is OPTIONAL — existing call sites that don't opt in stay non-draggable (back-compat).

## Persistence
- `persistSessionTabOrder` / `loadPersistedSessionTabOrder` round-trip the order as `string[]`.
- Empty array drops the stored key (so a "reset" state genuinely empties, not a literal `"[]"`).
- Malformed JSON, non-array values, and non-string entries are all defended against.
- Sessions added by the server after the last reorder fall through to the natural order at the end of the strip; stale ids are silently ignored on render.

## Test plan
- [x] `vitest run` passes with the new SessionBar drag tests + reorderTabs helper tests
- [x] `vitest run` passes with the new persistence-tab-order round-trip + scope tests
- [x] `vitest run` passes with the integration test that simulates `window.location.reload()` (mount → drag → unmount → remount preserves order)
- [x] Full `npm run test` (134 files, 2626 tests) green
- [x] `npm run typecheck` clean
- [ ] Visual verification in the rebuilt Tauri app (mark as smoke-test follow-up — not blocked on this PR)

## Related
- Sister issue #4832 (sidebar list reorder) is being implemented in parallel; this PR keeps the reorder logic local to SessionBar and reuses no #4832 code so the two changes can land independently.

## Implementation notes
- Chose native HTML5 drag-and-drop over `@dnd-kit/sortable` because (a) chroxy has zero DnD deps today and the scope is bounded (single linear list), (b) the keyboard ladder is simple enough to write inline. If multi-select drag or cross-window drag lands in the future, a lib migration would be the right call — flagged for follow-up.
- The reorder semantics are insert-before (dropping `a` onto `c` in `[a,b,c]` yields `[b,a,c]`), matching how most browsers' tab strips behave; the `reorderTabs` helper is exported + unit-tested for the corner cases.