### PR TITLE
fix(desktop): sign speech-helper with audio-input entitlement (#4953)

### DIFF
--- a/packages/desktop/scripts/verify-entitlements.sh
+++ b/packages/desktop/scripts/verify-entitlements.sh
@@ -2,28 +2,42 @@
 # verify-entitlements.sh — assert required entitlements are present in a
 # signed macOS .app bundle (or in a raw entitlements.plist for unit tests).
 #
-# Background: see #4801. The macOS Tauri build was shipping without
-# `com.apple.security.device.audio-input`, which silently denied microphone
-# access to the bundled Swift speech-helper. This script runs against the
-# release-built .app so the next missing-entitlement regression fails the
-# build instead of shipping broken voice input.
+# Background: see #4801 and #4953. The macOS Tauri build originally shipped
+# without `com.apple.security.device.audio-input` on the parent app (#4801),
+# then continued to ship voice-broken because TCC binds entitlements per
+# binary and the bundled Swift speech-helper was signed with empty
+# entitlements even after the parent was patched (#4953). This script
+# verifies BOTH the parent .app bundle AND the embedded
+# Contents/Resources/speech-helper Mach-O so a future missing-entitlement
+# regression fails the build instead of shipping broken voice input.
 #
 # Usage:
 #   scripts/verify-entitlements.sh <path-to-app-or-plist>
 #
 # Modes:
-#   - If the target ends with `.plist` or is a regular file, dump its raw text.
-#   - Otherwise, run `codesign -d --entitlements - <target>` against an app
-#     bundle to extract the embedded entitlements blob.
+#   - If the target ends with `.plist` or is a regular file, dump its raw
+#     text and check the parent-app required-keys set.
+#   - If the target is a `.app` bundle, run `codesign -d --entitlements -`
+#     against the bundle (parent required-keys set) AND against
+#     Contents/Resources/speech-helper (helper required-keys set).
 #
 # Exits non-zero if any required entitlement is missing.
 
 set -euo pipefail
 
+# Parent app needs JIT/library entitlements for the Tauri webview + Node runtime
+# AND audio-input so it can spawn the helper inside its TCC context.
 REQUIRED_ENTITLEMENTS=(
     "com.apple.security.cs.allow-jit"
     "com.apple.security.cs.allow-unsigned-executable-memory"
     "com.apple.security.cs.disable-library-validation"
+    "com.apple.security.device.audio-input"
+)
+
+# Helper subprocess only needs audio-input. TCC evaluates microphone access
+# against the binary that opens the audio device — the helper's own
+# entitlements blob, not the parent's. See #4953.
+HELPER_REQUIRED_ENTITLEMENTS=(
     "com.apple.security.device.audio-input"
 )
 
@@ -43,49 +57,100 @@ if [ ! -e "$TARGET" ]; then
     exit 2
 fi
 
-# Capture entitlements blob. For plist files we just cat; for .app bundles we
-# go through codesign so we're asserting on what was actually signed in, not
-# the source plist.
-if [[ "$TARGET" == *.plist ]] || { [ -f "$TARGET" ] && [[ "$TARGET" != *.app ]]; }; then
-    ENTITLEMENTS_BLOB="$(cat "$TARGET")"
-else
+extract_entitlements() {
+    local target="$1"
+    local blob
+    if [[ "$target" == *.plist ]] || { [ -f "$target" ] && [[ "$target" != *.app ]] && [ ! -d "$target" ]; }; then
+        cat "$target"
+        return 0
+    fi
     if ! command -v codesign >/dev/null 2>&1; then
         echo "verify-entitlements: codesign not found (macOS-only)" >&2
-        exit 2
+        return 2
     fi
     # codesign emits the XML plist on stdout; older macOS versions print a
     # leading header line on stderr which we discard.
-    ENTITLEMENTS_BLOB="$(codesign -d --entitlements - --xml "$TARGET" 2>/dev/null || true)"
-    if [ -z "$ENTITLEMENTS_BLOB" ]; then
+    blob="$(codesign -d --entitlements - --xml "$target" 2>/dev/null || true)"
+    if [ -z "$blob" ]; then
         # Retry without --xml for compatibility with older codesign that
         # emits the plist as the primary output and may not support --xml.
-        ENTITLEMENTS_BLOB="$(codesign -d --entitlements - "$TARGET" 2>/dev/null || true)"
+        blob="$(codesign -d --entitlements - "$target" 2>/dev/null || true)"
     fi
-    if [ -z "$ENTITLEMENTS_BLOB" ]; then
-        echo "verify-entitlements: unable to read entitlements from $TARGET" >&2
-        exit 1
+    if [ -z "$blob" ]; then
+        return 1
     fi
-fi
+    printf '%s' "$blob"
+}
 
-MISSING=()
-for key in "${REQUIRED_ENTITLEMENTS[@]}"; do
-    # Match the `<key>NAME</key>` line as a fixed string (grep -F) so dots in
-    # the entitlement name (`com.apple.security.device.audio-input`) are not
-    # treated as regex "any char" — a regex match would false-positive on
-    # malformed `<key>comXappleXsecurityXdeviceXaudio-input</key>`. The
-    # surrounding `<key>...</key>` anchors also guard against substring
-    # collisions (e.g. `audio-input` vs `audio-input-foo`).
-    if ! printf '%s\n' "$ENTITLEMENTS_BLOB" | grep -qF "<key>${key}</key>"; then
-        MISSING+=("$key")
-    fi
-done
+# Check a blob against a list of required keys. Sets MISSING_KEYS to space-
+# separated missing keys, empty if all present.
+check_keys() {
+    local blob="$1"
+    shift
+    MISSING_KEYS=""
+    for key in "$@"; do
+        # Match the `<key>NAME</key>` line as a fixed string (grep -F) so dots in
+        # the entitlement name (`com.apple.security.device.audio-input`) are not
+        # treated as regex "any char" — a regex match would false-positive on
+        # malformed `<key>comXappleXsecurityXdeviceXaudio-input</key>`. The
+        # surrounding `<key>...</key>` anchors also guard against substring
+        # collisions (e.g. `audio-input` vs `audio-input-foo`).
+        if ! printf '%s\n' "$blob" | grep -qF "<key>${key}</key>"; then
+            if [ -z "$MISSING_KEYS" ]; then
+                MISSING_KEYS="$key"
+            else
+                MISSING_KEYS="$MISSING_KEYS $key"
+            fi
+        fi
+    done
+}
 
-if [ ${#MISSING[@]} -gt 0 ]; then
+EXIT_CODE=0
+
+# --- Parent check (always runs) ---
+PARENT_BLOB="$(extract_entitlements "$TARGET")" || {
+    echo "verify-entitlements: unable to read entitlements from $TARGET" >&2
+    exit 1
+}
+
+check_keys "$PARENT_BLOB" "${REQUIRED_ENTITLEMENTS[@]}"
+if [ -n "$MISSING_KEYS" ]; then
     echo "verify-entitlements: FAIL — missing required entitlements in $TARGET:" >&2
-    for key in "${MISSING[@]}"; do
+    for key in $MISSING_KEYS; do
         echo "  - $key" >&2
     done
-    exit 1
+    EXIT_CODE=1
+else
+    echo "verify-entitlements: OK — all required entitlements present in $TARGET"
 fi
 
-echo "verify-entitlements: OK — all required entitlements present in $TARGET"
+# --- Helper check (only for .app bundles) ---
+# #4953: the speech-helper inside Contents/Resources/ has its own signature
+# and TCC entitlement set. Verify it carries audio-input — the parent's
+# audio-input does NOT propagate to the subprocess.
+if [ -d "$TARGET" ] && [[ "$TARGET" == *.app ]]; then
+    HELPER_PATH="${TARGET}/Contents/Resources/speech-helper"
+    if [ -f "$HELPER_PATH" ]; then
+        HELPER_BLOB="$(extract_entitlements "$HELPER_PATH" || true)"
+        if [ -z "$HELPER_BLOB" ]; then
+            echo "verify-entitlements: FAIL — speech-helper has no embedded entitlements at $HELPER_PATH" >&2
+            echo "  (#4953: helper must be signed with --entitlements entitlements-helper.plist)" >&2
+            EXIT_CODE=1
+        else
+            check_keys "$HELPER_BLOB" "${HELPER_REQUIRED_ENTITLEMENTS[@]}"
+            if [ -n "$MISSING_KEYS" ]; then
+                echo "verify-entitlements: FAIL — missing required entitlements in $HELPER_PATH:" >&2
+                for key in $MISSING_KEYS; do
+                    echo "  - $key" >&2
+                done
+                EXIT_CODE=1
+            else
+                echo "verify-entitlements: OK — all required entitlements present in $HELPER_PATH"
+            fi
+        fi
+    else
+        echo "verify-entitlements: WARN — speech-helper not present at $HELPER_PATH (skipping helper check)" >&2
+    fi
+fi
+
+exit $EXIT_CODE

--- a/packages/desktop/scripts/verify-entitlements.sh
+++ b/packages/desktop/scripts/verify-entitlements.sh
@@ -15,11 +15,13 @@
 #   scripts/verify-entitlements.sh <path-to-app-or-plist>
 #
 # Modes:
-#   - If the target ends with `.plist` or is a regular file, dump its raw
-#     text and check the parent-app required-keys set.
-#   - If the target is a `.app` bundle, run `codesign -d --entitlements -`
-#     against the bundle (parent required-keys set) AND against
-#     Contents/Resources/speech-helper (helper required-keys set).
+#   - If the target ends with `.plist`, dump its raw text and check the
+#     parent-app required-keys set.
+#   - Otherwise (any other file or directory — `.app` bundle or
+#     codesigned Mach-O), run `codesign -d --entitlements -` to extract
+#     the embedded entitlements. When the target is a `.app` bundle, the
+#     embedded `Contents/Resources/speech-helper` Mach-O is also checked
+#     against the helper required-keys set.
 #
 # Exits non-zero if any required entitlement is missing.
 
@@ -60,7 +62,13 @@ fi
 extract_entitlements() {
     local target="$1"
     local blob
-    if [[ "$target" == *.plist ]] || { [ -f "$target" ] && [[ "$target" != *.app ]] && [ ! -d "$target" ]; }; then
+    # Only treat `.plist` targets as raw XML — any other file (including a
+    # Mach-O binary like Contents/Resources/speech-helper) must go through
+    # codesign so we read the embedded entitlements blob instead of cat'ing
+    # the binary, which would either falsely pass (if the binary happens to
+    # contain the matching `<key>...</key>` byte sequence) or falsely report
+    # the wrong failure mode. Caught by Copilot in #4954 review.
+    if [[ "$target" == *.plist ]]; then
         cat "$target"
         return 0
     fi

--- a/packages/desktop/scripts/verify-entitlements.test.sh
+++ b/packages/desktop/scripts/verify-entitlements.test.sh
@@ -94,6 +94,23 @@ assert_exit "fails when target missing" 2 "$(run_verifier "$TMP_DIR/does-not-exi
 LIVE_PLIST="$(cd "$SCRIPT_DIR/.." && pwd)/src-tauri/entitlements.plist"
 assert_exit "src-tauri/entitlements.plist contains all required keys" 0 "$(run_verifier "$LIVE_PLIST")"
 
+# Case 6b — live helper entitlements plist must contain audio-input (#4953).
+# Tested via direct file inspection because the verifier's plist-mode runs the
+# full parent required-keys set (which the helper plist intentionally lacks).
+LIVE_HELPER_PLIST="$(cd "$SCRIPT_DIR/.." && pwd)/src-tauri/entitlements-helper.plist"
+if [ -f "$LIVE_HELPER_PLIST" ]; then
+    if grep -qF '<key>com.apple.security.device.audio-input</key>' "$LIVE_HELPER_PLIST"; then
+        echo "ok   - src-tauri/entitlements-helper.plist contains audio-input (#4953)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL - src-tauri/entitlements-helper.plist missing audio-input (#4953)" >&2
+        FAIL=$((FAIL + 1))
+    fi
+else
+    echo "FAIL - src-tauri/entitlements-helper.plist not found at $LIVE_HELPER_PLIST" >&2
+    FAIL=$((FAIL + 1))
+fi
+
 # Substring-collision guard — ensure the matcher doesn't false-positive on a
 # look-alike key (e.g. `com.apple.security.device.audio-input-foo`).
 COLLIDE_PLIST="$TMP_DIR/collide.plist"

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -128,6 +128,18 @@ fn main() {
                 .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
+            // #4953: the helper-entitlements plist participates in the sign
+            // step now, so its mtime must invalidate the cache — otherwise
+            // edits to the plist (e.g. adding new entitlements) silently
+            // ship under the old signature on a warm cache.
+            let helper_ent_path = format!("{}/entitlements-helper.plist", manifest_dir);
+            println!("cargo:rerun-if-changed={}", helper_ent_path);
+            let helper_ent_mtime = std::fs::metadata(&helper_ent_path)
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
             // `swiftc --version` writes the full toolchain banner (Swift release
             // + Xcode build id on Apple toolchains) to stdout. If swiftc is
             // missing or the call fails, fall back to "unknown" so we still
@@ -144,8 +156,9 @@ fn main() {
                 })
                 .unwrap_or_else(|| "unknown".to_string());
             let cache_key = format!(
-                "v3\nsrc_mtime={}\nidentity={}\nkeychain={}\nswiftc={}\n",
+                "v4\nsrc_mtime={}\nidentity={}\nkeychain={}\nswiftc={}\nhelper_ent_mtime={}\n",
                 src_mtime_secs, identity_for_cache, keychain_for_cache, swiftc_version,
+                helper_ent_mtime,
             );
 
             let cached = std::path::Path::new(&swift_out).exists()
@@ -188,10 +201,22 @@ fn main() {
                         // ambiguity in CI if login.keychain remains on the
                         // search path alongside the temp signing keychain.
                         let keychain = std::env::var("APPLE_KEYCHAIN_PATH").ok();
+                        // Helper-scoped entitlements (#4953). TCC binds
+                        // microphone access per-binary, so the parent app's
+                        // com.apple.security.device.audio-input does NOT
+                        // propagate to this subprocess — the helper needs its
+                        // own audio-input entitlement embedded at sign time.
+                        // Without --entitlements, the helper signs with empty
+                        // entitlements and AVAudioEngine init is denied
+                        // silently. #4801 / #4812 only patched the parent.
+                        let helper_entitlements = format!(
+                            "{}/entitlements-helper.plist", manifest_dir,
+                        );
                         let mut args: Vec<&str> = vec![
                             "--force",
                             "--options", "runtime",
                             "--timestamp",
+                            "--entitlements", &helper_entitlements,
                             "--sign", &identity,
                         ];
                         if let Some(ref kc) = keychain {

--- a/packages/desktop/src-tauri/entitlements-helper.plist
+++ b/packages/desktop/src-tauri/entitlements-helper.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- macOS TCC evaluates microphone access against the entitlements of the
+         binary that opens the audio device. The Swift speech-helper is a
+         separately codesigned Mach-O process — the parent app's
+         com.apple.security.device.audio-input does NOT propagate to it.
+         Without this entitlement on the helper itself, AVAudioEngine and
+         SFSpeechRecognizer authorization calls return denied even when the
+         user has granted Microphone permission in System Settings (#4953,
+         missed by #4801 / #4812 which only patched the parent bundle). -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Voice input on the macOS Tauri desktop has been broken on every shipped build since 0.8.x — clicking the mic flips the icon to stop for ~100ms then reverts. Root cause: macOS TCC binds microphone permission per Mach-O binary, not per bundle. The Swift `speech-helper` subprocess is signed with empty entitlements, so AVAudioEngine init returns denied even when the parent app has been granted Microphone in System Settings.

#4801 / #4812 added `com.apple.security.device.audio-input` to the parent app's entitlements but missed the helper. `verify-entitlements.sh` only inspected the parent `.app` bundle so the regression slipped past release-time verification.

## Changes

- **`entitlements-helper.plist`** — new, just `com.apple.security.device.audio-input`
- **`build.rs`** — codesign call adds `--entitlements <helper-plist>`; cache key gains `helper_ent_mtime` so plist edits invalidate the warm cache
- **`verify-entitlements.sh`** — auto-extends to check `Contents/Resources/speech-helper` when given a `.app`; existing `release.yml` call gains helper coverage with no workflow edit
- **`verify-entitlements.test.sh`** — asserts the live helper plist carries audio-input (regression guard)

## Verified

Running the updated verifier against the currently-installed buggy `Chroxy.app` correctly fails:

\`\`\`
$ bash scripts/verify-entitlements.sh /Applications/Chroxy.app
verify-entitlements: OK — all required entitlements present in /Applications/Chroxy.app
verify-entitlements: FAIL — missing required entitlements in
  /Applications/Chroxy.app/Contents/Resources/speech-helper:
  - com.apple.security.device.audio-input
\`\`\`

All 9 verifier unit tests pass.

## Post-install user step

macOS may cache the prior TCC denial against the helper's old codesign hash. After installing the fixed build:

\`\`\`
tccutil reset Microphone com.chroxy.desktop
tccutil reset SpeechRecognition com.chroxy.desktop
\`\`\`

…or delete Chroxy from System Settings → Privacy & Security → Microphone / Speech Recognition so macOS re-prompts against the new hash.

## Test plan

- [x] `bash packages/desktop/scripts/verify-entitlements.test.sh` — 9/9 pass
- [x] Verifier catches the bug on the currently-installed `Chroxy.app`
- [ ] After v0.9.40 release: confirm `codesign -d --entitlements - /Applications/Chroxy.app/Contents/Resources/speech-helper` contains `audio-input`
- [ ] After v0.9.40 release: voice transcription works end-to-end on macOS 14/15

Closes #4953