### PR TITLE
test(app): Maestro flow for AskUserQuestion Other → freeform send-path

### DIFF
--- a/packages/app/.maestro/ask-question-other-freeform.yaml
+++ b/packages/app/.maestro/ask-question-other-freeform.yaml
@@ -1,0 +1,204 @@
+appId: com.blamechris.chroxy
+name: ChatView AskUserQuestion Other → freeform send-path (#4877 / #4755)
+---
+
+# #4877 — Maestro coverage for the third (deferred) acceptance criterion of
+# #4755: the mobile Other → freeform send-path. PR #4864 landed mobile parity
+# for the dashboard's `{answer:<otherLabel>, freeformText, toolUseId}` wire
+# shape (#4651 / PR #4753 server side); this flow exercises that path
+# end-to-end on a real RN runtime so a regression in any layer
+# (MessageBubble's Other-mode toggle, the freetext input testIDs, the
+# `OtherFreeformAnswer` shape produced by handleSelectOption, the wire
+# serializer in connection.ts, or the answered-text post-submit render)
+# surfaces as a hard test failure rather than a silent footgun.
+#
+# Trigger: 'show-ask-other' user input → mock-server.mjs emits a
+# `user_question` envelope with two real options ('production' / 'staging').
+# The store-core `handleUserQuestion` normalizer auto-appends the synthetic
+# OTHER_OPTION_VALUE (`__chroxy_other__`) sentinel to every single-select
+# question with at least one real option (see packages/store-core/src/
+# handlers/index.ts ~L3680). The MessageBubble therefore renders three
+# option buttons; tapping the Other one swaps the option row for the
+# freetext input that PR #4864 anchored with `approval-freetext-input`
+# + `approval-freetext-send` testIDs.
+#
+# Selectors:
+#   id: approval-question-0                       — prompt header (Q[0])
+#   id: approval-button-production                — model option (value === label)
+#   id: approval-button-staging                   — model option
+#   id: approval-button-__chroxy_other__          — synthesized Other sentinel
+#                                                   (value === OTHER_OPTION_VALUE)
+#   id: approval-freetext-input                   — freetext TextInput (#4864)
+#   id: approval-freetext-send                    — Send button (#4864)
+#
+# Regression coverage:
+#   - Wire→render path: server emits `user_question` with real options →
+#     store-core appends Other sentinel → MessageBubble renders three buttons.
+#   - Other-tap path: `approval-button-__chroxy_other__` press flips local
+#     `otherActive` true → option row unmounts, freetext input + Send mount.
+#   - Send path: typed text + Send tap fires `handleSelectOption` with the
+#     `{otherLabel, freeformText}` object shape → `sendUserQuestionResponse`
+#     serializes `{type:'user_question_response', answer:<label>,
+#     freeformText:<typed>, toolUseId}` on the wire.
+#   - Answered render: `markPromptAnswered` stores the typed text (NOT the
+#     literal 'Other' label) — `answeredIsFreeText` becomes true and
+#     `styles.promptFreetextAnswered` renders the user's actual answer
+#     (matches dashboard `formatQuestionAnswerSummary` UX behaviour).
+#
+# Self-contained (no `runFlow: setup/...`) for the same reason the sibling
+# ask-user-question{,-deny,-multi}.yaml flows are: setup/ targets Expo Go
+# (host.exp.Exponent) while this needs the chroxy dev client
+# (com.blamechris.chroxy).
+#
+# Tested devices: portrait iPhone 15 Pro (iOS 17+).
+# Requires: dev client installed + mock server on port 9876
+#   cd packages/app && npx expo run:ios
+#   bash packages/app/.maestro/scripts/start-mock-server.sh
+
+- launchApp:
+    clearState: true
+- openLink: "exp+chroxy://expo-development-client/?url=http://localhost:8081"
+
+# Dismiss the dev menu sheet (intro 'Continue' OR main menu close).
+- tapOn:
+    text: "Continue"
+    optional: true
+- tapOn:
+    point: "50%,10%"
+    optional: true
+
+# Skip onboarding carousel post-clearState.
+- tapOn:
+    text: "Skip"
+    optional: true
+
+# Wait until either ConnectScreen OR Chat lands.
+- extendedWaitUntil:
+    visible:
+      text: "Connect to Chroxy|Chat"
+    timeout: 30000
+
+# If we landed on ConnectScreen, fill the manual-entry form.
+- runFlow:
+    when:
+      visible: "Connect to Chroxy"
+    commands:
+      - tapOn:
+          id: "connect-manual-toggle"
+
+      - tapOn:
+          id: "connect-server-url"
+      - eraseText: 50
+      - inputText: "ws://localhost:9876"
+
+      - tapOn:
+          id: "connect-api-token"
+      - eraseText: 50
+      - inputText: "test-token-maestro"
+
+      - hideKeyboard
+
+      - tapOn:
+          id: "connect-submit"
+
+      - extendedWaitUntil:
+          visible: "Chat"
+          timeout: 10000
+
+# Ensure Chat tab.
+- tapOn: "Chat"
+- waitForAnimationToEnd
+
+# Type the trigger phrase that makes the mock server emit a
+# `user_question` envelope. Real options here are 'production' /
+# 'staging' so the synthesized Other sentinel is visually distinct
+# from any model-supplied label and the post-answer freeform text
+# can't be confused with an option label by the assertion.
+- tapOn:
+    id: "chat-message-input"
+- inputText: "show-ask-other"
+
+- tapOn:
+    id: "chat-send-button"
+
+# Drop the keyboard so the prompt bubble + option buttons aren't
+# covered by the input area.
+- hideKeyboard
+
+# Wait for the prompt bubble header to render.
+- extendedWaitUntil:
+    visible:
+      id: "approval-question-0"
+    timeout: 10000
+
+# Pin all three buttons are visible — the two model-supplied options +
+# the auto-appended Other sentinel. The presence of the Other button
+# proves the store-core normalizer's auto-append still fires for
+# single-select questions with at least one option (regression for
+# #3746 / #3752).
+- assertVisible:
+    id: "approval-button-production"
+- assertVisible:
+    id: "approval-button-staging"
+- assertVisible:
+    id: "approval-button-__chroxy_other__"
+
+- takeScreenshot: ask-question-other-prompt-rendered
+
+# Tap the synthesized Other button. MessageBubble flips local
+# `otherActive` true, which swaps the option row for the freetext
+# input + Send/Cancel buttons. Per the PR #4864 testIDs landing.
+- tapOn:
+    id: "approval-button-__chroxy_other__"
+- waitForAnimationToEnd
+
+# Assert the freetext input + Send button materialized. These are
+# the canonical PR #4864 anchors — a regression that drops the
+# testIDs (e.g. an Other → freetext refactor that loses the prop)
+# fails the flow here.
+- extendedWaitUntil:
+    visible:
+      id: "approval-freetext-input"
+    timeout: 5000
+- assertVisible:
+    id: "approval-freetext-send"
+
+- takeScreenshot: ask-question-other-freetext-mounted
+
+# Type a freeform answer into the input. Choose a phrase distinct
+# from any option label so the post-answer assertion can't pass
+# accidentally by matching 'production' / 'staging' / 'Other'.
+- tapOn:
+    id: "approval-freetext-input"
+- inputText: "ephemeral-preview-env-42"
+- hideKeyboard
+
+# Tap Send. SessionScreen.handleSelectOption receives the
+# `{otherLabel:'Other', freeformText:'ephemeral-preview-env-42'}`
+# shape, forwards it to `sendUserQuestionResponse`, which serializes
+# `{type:'user_question_response', answer:'Other',
+# freeformText:'ephemeral-preview-env-42', toolUseId}` on the wire.
+# The mock-server `case 'user_question_response'` logs the payload
+# (visible in the `[mock]` audit trail). Locally, `markPromptAnswered`
+# stores the typed text (NOT the 'Other' label) — matches the
+# dashboard parity shape pinned by PR #4864 / #4651.
+- tapOn:
+    id: "approval-freetext-send"
+- waitForAnimationToEnd
+
+- takeScreenshot: ask-question-other-freeform-sent
+
+# Post-answer assertions:
+#   1. The freetext input + Send button unmounted — `showFreetextInput`
+#      gates on `!message.answered`, so once the answer arrives the
+#      whole row disappears (regression for the answered-state UX).
+#   2. The typed text renders in `styles.promptFreetextAnswered`
+#      (italic, textSecondary) — `answeredIsFreeText` is true because
+#      `message.answered === 'ephemeral-preview-env-42'` doesn't
+#      match any option's value. This is the parity behaviour with
+#      `formatQuestionAnswerSummary` on the dashboard.
+- assertNotVisible:
+    id: "approval-freetext-input"
+- assertNotVisible:
+    id: "approval-freetext-send"
+- assertVisible: "ephemeral-preview-env-42"

--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -502,6 +502,52 @@ wss.on('connection', (ws) => {
           break
         }
 
+        // #4877: trigger phrase 'show-ask-other' emits a single-question
+        // AskUserQuestion so the Maestro ask-question-other-freeform flow
+        // can exercise the Other → freeform send-path on a real RN
+        // runtime. Mirrors the production wire shape `show-ask-user-question`
+        // uses, but with model-supplied option labels that are distinct
+        // from 'approve'/'deny' so the synthesized Other sentinel is the
+        // obvious target — and so the post-answer freeform text bubble
+        // can't be confused with a regular option label.
+        //
+        // The store-core `handleUserQuestion` normalizer appends the
+        // synthetic OTHER_OPTION_VALUE option to every single-select
+        // question that has at least one real option (see
+        // packages/store-core/src/handlers/index.ts ~L3680). The Maestro
+        // flow therefore taps `approval-button-__chroxy_other__` to drop
+        // the MessageBubble into freetext mode, types a freeform answer,
+        // and submits via `approval-freetext-send` — the testIDs that
+        // landed with PR #4864.
+        //
+        // The freeform shape `{otherLabel, freeformText}` is forwarded
+        // by SessionScreen.handleSelectOption to `sendUserQuestionResponse`,
+        // which serializes `{type:'user_question_response', answer:<label>,
+        // freeformText:<typed>, toolUseId}` on the wire. Mock handler
+        // `case 'user_question_response'` logs the payload so a maintainer
+        // can eyeball the wire shape in `[mock]` output; the Maestro
+        // assertion targets the answered-state render (the typed text
+        // renders in `styles.promptFreetextAnswered` after submit).
+        if (text.trim() === 'show-ask-other') {
+          showAskUserQuestionCounter += 1
+          const toolUseId = `tu-askuserquestion-other-mock-${showAskUserQuestionCounter}`
+          send(ws, {
+            type: 'user_question',
+            sessionId: 'mock-sess-1',
+            toolUseId,
+            questions: [
+              {
+                question: 'Which environment should I deploy to?',
+                options: [
+                  { label: 'production' },
+                  { label: 'staging' },
+                ],
+              },
+            ],
+          })
+          break
+        }
+
         // #4697 Chunk B: 4-question multi-question form mirrors the
         // shape #4604 Chunk B pinned at the server level. The mobile
         // MessageBubble currently renders only `questions[0]` (the
@@ -592,7 +638,13 @@ wss.on('connection', (ws) => {
       // path (ws-server.js processes `user_question_response` /
       // `permission_response` symmetrically).
       case 'user_question_response':
-        console.log(`[mock] user_question_response: answer="${msg.answer}" toolUseId="${msg.toolUseId || ''}"`)
+        // #4877: log `freeformText` alongside `answer` so the Other →
+        // freeform send-path's wire shape is visible in the mock audit
+        // trail. When the user picks the synthesized Other option,
+        // `sendUserQuestionResponse` serializes the wire payload
+        // `{answer:<otherLabel>, freeformText:<typed>, toolUseId}` —
+        // the dashboard parity shape pinned by PR #4864.
+        console.log(`[mock] user_question_response: answer="${msg.answer}" freeformText="${msg.freeformText || ''}" toolUseId="${msg.toolUseId || ''}"`)
         break
 
       case 'permission_response':

--- a/packages/app/.maestro/run-all.yaml
+++ b/packages/app/.maestro/run-all.yaml
@@ -92,3 +92,12 @@ name: All E2E flows
 # multi-question payload without bailing. Extends once mobile
 # renderer iterates all N questions.
 - runFlow: ask-user-question-multi.yaml
+
+# Flow 19: AskUserQuestion Other → freeform send-path (#4877 / #4755)
+# — exercises the third (deferred) acceptance criterion of #4755:
+# tapping the synthesized Other sentinel, typing a freeform answer,
+# and pressing Send. Pins the PR #4864 mobile parity with the
+# dashboard's `{answer:<otherLabel>, freeformText, toolUseId}` wire
+# shape end-to-end on a real RN runtime (testIDs `approval-freetext-input`
+# / `approval-freetext-send`).
+- runFlow: ask-question-other-freeform.yaml


### PR DESCRIPTION
Closes #4877

Follow-up to PR #4864 (mobile parity for the single-question Other / freeform answer shape) and the original feature work in #4755. This PR adds the third acceptance criterion from #4755 that was deferred at the time:

> Maestro flow covers the Other → freeform send-path

## Summary

- **`packages/app/.maestro/mock-server.mjs`** — adds a new `show-ask-other` trigger that emits a single-question `user_question` envelope with two model-supplied options (`production` / `staging`). The store-core `handleUserQuestion` normalizer auto-appends the `OTHER_OPTION_VALUE` (`__chroxy_other__`) sentinel for every single-select question with ≥1 real option, so the rendered prompt has three buttons end-to-end via the production wire path. Also extends the existing `case 'user_question_response'` audit log to include `msg.freeformText`, so the wire payload is visible in the `[mock]` trail when the Other branch fires.
- **`packages/app/.maestro/ask-question-other-freeform.yaml`** (new) — Maestro flow that types `show-ask-other`, asserts all three option buttons render (including `approval-button-__chroxy_other__`), taps the Other button, asserts the freetext input + Send materialize (testIDs `approval-freetext-input` / `approval-freetext-send` from PR #4864), types a distinctive answer (`ephemeral-preview-env-42`), presses Send, and asserts the input row unmounts while the typed text renders in the post-answer state (`answeredIsFreeText` / `styles.promptFreetextAnswered`).
- **`packages/app/.maestro/run-all.yaml`** — registers the new flow as #19 in the suite.

The flow is self-contained (no `runFlow: setup/…`) for the same reason the sibling `ask-user-question{,-deny,-multi}.yaml` flows are — the existing setup/ targets Expo Go (`host.exp.Exponent`) while this needs the chroxy dev client (`com.blamechris.chroxy`).

## Regression coverage

The flow pins the full Other → freeform send-path against future regressions in any layer:

1. **Wire→render:** server emits `user_question` → store-core appends Other sentinel → MessageBubble renders three buttons.
2. **Other-tap:** `approval-button-__chroxy_other__` press flips `otherActive` → option row unmounts, freetext input + Send mount.
3. **Send path:** typed text + Send tap fires `handleSelectOption` with the `{otherLabel, freeformText}` object shape → `sendUserQuestionResponse` serializes the dashboard-parity `{answer:<label>, freeformText:<typed>, toolUseId}` wire payload.
4. **Answered render:** `markPromptAnswered` stores the typed text (not the literal `Other` label) — `answeredIsFreeText` becomes true and the typed text renders in the italic freetext-answered style. Matches dashboard `formatQuestionAnswerSummary` UX.

## Test plan

- [x] `mock-server.mjs` parses cleanly (`node --check`).
- [x] New flow YAML parses cleanly (js-yaml loadAll).
- [x] Flow registered in `run-all.yaml` (slot #19, after the existing `ask-user-question*` siblings).
- [ ] Flow passes locally on iPhone 15 Pro simulator. **Not validated in this worktree** — no booted simulator and Metro server in the autonomous environment, and the chroxy dev client requires an EAS build (per CLAUDE.md). The flow mirrors the proven structure of `ask-user-question.yaml` / `ask-user-question-deny.yaml`, uses only testIDs that landed in PR #4864 (`approval-freetext-input` / `approval-freetext-send`) and PR #4697 (`approval-question-0` / `approval-button-<value>`), and the Other sentinel value (`__chroxy_other__`) comes straight from the store-core constant. Recommended local validation before merge:

  ```bash
  # Boot a simulator + start Metro + start mock server
  xcrun simctl boot <device-id>
  cd packages/app && npx expo run:ios
  bash packages/app/.maestro/scripts/start-mock-server.sh

  # Run the single flow
  export PATH="$PATH:$HOME/.maestro/bin"
  maestro test --device <device-id> packages/app/.maestro/ask-question-other-freeform.yaml
  ```

## Related

- #4755 — original Mobile Other/freeform feature issue (3rd AC deferred).
- PR #4864 — mobile parity (`approval-freetext-*` testIDs landed here).
- #4651 / PR #4753 — dashboard + server chain for the `{answer, freeformText}` two-stage TUI write.