### PR TITLE
fix(dashboard): stop SessionBar drag-over flicker when crossing inner chips

### DIFF
--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -3,7 +3,7 @@
  * StatusBar tests are in StatusBar.test.tsx
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup, within } from '@testing-library/react'
+import { render, screen, fireEvent, cleanup, within, act } from '@testing-library/react'
 import { SessionBar, reorderTabs, type SessionTabData } from './SessionBar'
 
 afterEach(cleanup)
@@ -643,6 +643,153 @@ describe('SessionBar', () => {
       expect(tabA.getAttribute('aria-grabbed')).toBe('true')
       fireEvent.keyDown(tabA, { key: 'ArrowRight' })
       expect(onReorder).toHaveBeenCalledWith(['b', 'a', 'c'])
+    })
+
+    // #4946 — Native HTML5 dragleave fires when the cursor crosses into a
+    // child element (status dot, cwd/model/provider chips, close button),
+    // even though the user hasn't actually left the tab. Without the
+    // relatedTarget guard this causes the .drag-over affordance to flicker.
+    //
+    // Helper: `fireEvent.dragLeave(..., { relatedTarget })` does not actually
+    // attach relatedTarget to the synthesized event (jsdom limitation — the
+    // EventInit shape doesn't pass DragEventInit.relatedTarget through). We
+    // build a bubbling dragleave Event manually and defineProperty the field
+    // so the React handler sees a real DOM-like dragleave.
+    function dispatchDragLeave(target: Element, relatedTarget: Node | null) {
+      const evt = new Event('dragleave', { bubbles: true, cancelable: true })
+      Object.defineProperty(evt, 'relatedTarget', { value: relatedTarget, configurable: true })
+      // act() flushes the synchronous React state update triggered by the
+      // dispatched event (fireEvent does this automatically; raw
+      // dispatchEvent does not).
+      act(() => { target.dispatchEvent(evt) })
+    }
+
+    it('does not clear drag-over highlight when crossing inner chips (#4946)', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={[
+            { sessionId: 'a', name: 'Alpha', isBusy: false, isActive: true },
+            {
+              sessionId: 'b', name: 'Beta', isBusy: false, isActive: false,
+              cwd: '/home/user/projects/api',
+              model: 'claude-opus-4-6',
+              provider: 'claude',
+            },
+            { sessionId: 'c', name: 'Charlie', isBusy: false, isActive: false },
+          ]}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      const tabB = screen.getByTestId('session-tab-b')
+      const dataTransfer = {
+        data: {} as Record<string, string>,
+        setData(format: string, val: string) { this.data[format] = val },
+        getData(format: string) { return this.data[format] ?? '' },
+        effectAllowed: 'all',
+        dropEffect: 'none',
+        types: [] as string[],
+      }
+      // Start dragging A, hover B → drag-over highlight applied.
+      fireEvent.dragStart(tabA, { dataTransfer })
+      fireEvent.dragOver(tabB, { dataTransfer })
+      expect(tabB.className).toContain('drag-over')
+
+      // Simulate cursor crossing into an inner child (the cwd chip).
+      // Native browsers fire dragleave on tabB with relatedTarget pointing at
+      // the child — without the guard this would clear dragOverId and remove
+      // the highlight, causing visible flicker.
+      const cwdChip = tabB.querySelector('.tab-cwd')!
+      expect(cwdChip).toBeTruthy()
+      dispatchDragLeave(tabB, cwdChip)
+      expect(tabB.className).toContain('drag-over')
+
+      const modelChip = tabB.querySelector('.tab-model')!
+      expect(modelChip).toBeTruthy()
+      dispatchDragLeave(tabB, modelChip)
+      expect(tabB.className).toContain('drag-over')
+
+      const providerChip = tabB.querySelector('.tab-provider')!
+      expect(providerChip).toBeTruthy()
+      dispatchDragLeave(tabB, providerChip)
+      expect(tabB.className).toContain('drag-over')
+    })
+
+    it('clears drag-over highlight when cursor genuinely leaves the tab (#4946)', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={[
+            { sessionId: 'a', name: 'Alpha', isBusy: false, isActive: true },
+            { sessionId: 'b', name: 'Beta', isBusy: false, isActive: false },
+            { sessionId: 'c', name: 'Charlie', isBusy: false, isActive: false },
+          ]}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      const tabB = screen.getByTestId('session-tab-b')
+      const tabC = screen.getByTestId('session-tab-c')
+      const dataTransfer = {
+        data: {} as Record<string, string>,
+        setData(format: string, val: string) { this.data[format] = val },
+        getData(format: string) { return this.data[format] ?? '' },
+        effectAllowed: 'all',
+        dropEffect: 'none',
+        types: [] as string[],
+      }
+      fireEvent.dragStart(tabA, { dataTransfer })
+      fireEvent.dragOver(tabB, { dataTransfer })
+      expect(tabB.className).toContain('drag-over')
+
+      // Leave to a sibling tab — relatedTarget is NOT contained in tabB, so
+      // the highlight should clear.
+      dispatchDragLeave(tabB, tabC)
+      expect(tabB.className).not.toContain('drag-over')
+    })
+
+    it('clears drag-over highlight when relatedTarget is null (cursor leaves window) (#4946)', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={[
+            { sessionId: 'a', name: 'Alpha', isBusy: false, isActive: true },
+            { sessionId: 'b', name: 'Beta', isBusy: false, isActive: false },
+          ]}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      const tabB = screen.getByTestId('session-tab-b')
+      const dataTransfer = {
+        data: {} as Record<string, string>,
+        setData(format: string, val: string) { this.data[format] = val },
+        getData(format: string) { return this.data[format] ?? '' },
+        effectAllowed: 'all',
+        dropEffect: 'none',
+        types: [] as string[],
+      }
+      fireEvent.dragStart(tabA, { dataTransfer })
+      fireEvent.dragOver(tabB, { dataTransfer })
+      expect(tabB.className).toContain('drag-over')
+
+      // relatedTarget is null when the cursor leaves the browser window —
+      // treat as a genuine boundary exit and clear the highlight.
+      dispatchDragLeave(tabB, null)
+      expect(tabB.className).not.toContain('drag-over')
     })
 
     it('click-to-activate still works when reorder is wired', () => {

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -220,7 +220,17 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
               if (dragOverId !== session.sessionId) setDragOverId(session.sessionId)
             }}
-            onDragLeave={() => {
+            onDragLeave={e => {
+              // #4946 — native dragleave fires when the cursor crosses into a
+              // child element (status dot, cwd / model / provider chips, close
+              // button), even though the user hasn't actually left the tab.
+              // Without this guard the drop-target affordance flickers as the
+              // cursor moves over inner chips. Skip the clear when relatedTarget
+              // is still contained within this tab; only clear on a genuine
+              // boundary exit (relatedTarget is null, the document, or another
+              // tab / sibling element).
+              const next = e.relatedTarget as Node | null
+              if (next && e.currentTarget.contains(next)) return
               if (dragOverId === session.sessionId) setDragOverId(null)
             }}
             onDrop={e => {


### PR DESCRIPTION
## Summary

- Native HTML5 `dragleave` fires when the cursor crosses into a child element (status dot, cwd / model / provider chips, close button), even though the user hasn't actually left the tab. The drop-target affordance (`box-shadow: inset 2px 0 0 0 var(--accent-blue)`) flickered as the cursor moved over inner chips during a reorder drag.
- Guard `onDragLeave` with a `relatedTarget` containment check: only clear `dragOverId` when the cursor genuinely leaves the tab. When `relatedTarget` is still contained within the same tab, treat it as an intra-tab traversal and keep the affordance.
- Drop affordance still clears immediately on a genuine boundary exit (sibling tab, or `relatedTarget === null` when the cursor leaves the window).

## Acceptance criteria

- [x] Dragging across a tab does not cause its drop-target outline to flicker
- [x] Drop affordance still clears immediately when the cursor genuinely leaves the tab
- [x] No regression to the existing drop behavior

## Test plan

- [x] Added 3 vitest cases under `SessionBar.test.tsx` -> `#4831 drag-to-reorder`:
  - `does not clear drag-over highlight when crossing inner chips (#4946)` — dragOver tab B, then dragLeave with `relatedTarget` set to each of the cwd / model / provider chips; asserts `.drag-over` class stays.
  - `clears drag-over highlight when cursor genuinely leaves the tab (#4946)` — `relatedTarget = tabC`; asserts the highlight clears.
  - `clears drag-over highlight when relatedTarget is null (cursor leaves window) (#4946)` — `relatedTarget = null`; asserts the highlight clears.
- [x] Confirmed the first new test FAILS without the fix and passes with it.
- [x] Full dashboard test suite (`npm test -- --run`): 137 files, 2672 tests passing.

## Notes

- `fireEvent.dragLeave(..., { relatedTarget })` does not propagate `relatedTarget` through to the React handler in jsdom (the EventInit shape doesn't include `DragEventInit.relatedTarget`). The tests use a small `dispatchDragLeave` helper that builds a bubbling `Event`, defines `relatedTarget` via `Object.defineProperty`, and wraps the `dispatchEvent` in `act()` so React flushes the resulting state update.

Closes #4946