### PR TITLE
a11y(dashboard): swap deprecated aria-grabbed for live-region drag announcements

### DIFF
--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -770,6 +770,36 @@ describe('SessionBar', () => {
       expect(region.textContent).toMatch(/2 of 3/)
     })
 
+    // #4963 follow-up — Space is the documented "drop" key alongside
+    // Enter. The original implementation set a bare "Dropped X." here
+    // which clobbered the more informative "Dropped X at position N
+    // of M" narration that `stepKeyboard` had just pushed. Guard the
+    // regression: after a Space-commit the position narration must
+    // still be the visible announcement.
+    it('preserves "position N of M" narration when committing with Space', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      // Lift "a", step right (announces "Dropped Alpha at position 2 of 3."),
+      // then commit with Space — the position narration must survive.
+      fireEvent.keyDown(tabA, { key: ' ' })
+      fireEvent.keyDown(tabA, { key: 'ArrowRight' })
+      fireEvent.keyDown(tabA, { key: ' ' })
+      const region = screen.getByTestId('session-bar-reorder-announcer')
+      expect(region.textContent).toMatch(/dropped/i)
+      expect(region.textContent).toMatch(/alpha/i)
+      expect(region.textContent).toMatch(/2 of 3/)
+    })
+
     it('announces "Cancelled" when Escape ends the lift', () => {
       render(
         <SessionBar

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -615,15 +615,18 @@ describe('SessionBar', () => {
         />
       )
       const tabA = screen.getByTestId('session-tab-a')
-      // Lift "a" into reorder mode (plain Space matches #4831 AC)
+      // Lift "a" into reorder mode (plain Space matches #4831 AC).
+      // #4951 — the lifted state is marked with the `lifted` class instead
+      // of the deprecated aria-grabbed attribute; aria-grabbed was removed
+      // in WAI-ARIA 1.1.
       fireEvent.keyDown(tabA, { key: ' ' })
-      expect(tabA.getAttribute('aria-grabbed')).toBe('true')
+      expect(tabA.classList.contains('lifted')).toBe(true)
       // Move "a" one slot right — should land in position 1 of ['b','a','c']
       fireEvent.keyDown(tabA, { key: 'ArrowRight' })
       expect(onReorder).toHaveBeenCalledWith(['b', 'a', 'c'])
       // Escape clears the lift state (no further reorder)
       fireEvent.keyDown(tabA, { key: 'Escape' })
-      expect(tabA.getAttribute('aria-grabbed')).toBe(null)
+      expect(tabA.classList.contains('lifted')).toBe(false)
     })
 
     it('keyboard reorder: Shift+Space alias also lifts', () => {
@@ -639,8 +642,9 @@ describe('SessionBar', () => {
         />
       )
       const tabA = screen.getByTestId('session-tab-a')
+      // #4951 — lifted state uses the `lifted` class, not aria-grabbed.
       fireEvent.keyDown(tabA, { key: ' ', shiftKey: true })
-      expect(tabA.getAttribute('aria-grabbed')).toBe('true')
+      expect(tabA.classList.contains('lifted')).toBe(true)
       fireEvent.keyDown(tabA, { key: 'ArrowRight' })
       expect(onReorder).toHaveBeenCalledWith(['b', 'a', 'c'])
     })
@@ -659,6 +663,195 @@ describe('SessionBar', () => {
       )
       fireEvent.click(screen.getByTestId('session-tab-b'))
       expect(onSwitch).toHaveBeenCalledWith('b')
+    })
+  })
+
+  // #4951 — a11y follow-up to #4831 / PR #4945. aria-grabbed is deprecated
+  // in WAI-ARIA 1.1; the modern pattern is a polite live region that
+  // announces drag state changes (pickup / over / drop / cancel) plus an
+  // aria-describedby hint that tells SR users the reorder shortcut keys.
+  describe('#4951 live-region drag announcements', () => {
+    function makeThree(): SessionTabData[] {
+      return [
+        { sessionId: 'a', name: 'Alpha', isBusy: false, isActive: true },
+        { sessionId: 'b', name: 'Beta', isBusy: false, isActive: false },
+        { sessionId: 'c', name: 'Charlie', isBusy: false, isActive: false },
+      ]
+    }
+
+    function dataTransferStub() {
+      return {
+        data: {} as Record<string, string>,
+        setData(format: string, val: string) { this.data[format] = val },
+        getData(format: string) { return this.data[format] ?? '' },
+        effectAllowed: 'all',
+        dropEffect: 'none',
+        types: [] as string[],
+      }
+    }
+
+    it('does NOT set the deprecated aria-grabbed attribute on draggable tabs', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      // Even after a keyboard lift, aria-grabbed must not appear — it's
+      // deprecated in ARIA 1.1+ and most screen readers ignore it.
+      fireEvent.keyDown(tabA, { key: ' ' })
+      expect(tabA.hasAttribute('aria-grabbed')).toBe(false)
+    })
+
+    it('renders a polite live region for drag announcements', () => {
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={vi.fn()}
+        />
+      )
+      const region = screen.getByTestId('session-bar-reorder-announcer')
+      expect(region.getAttribute('aria-live')).toBe('polite')
+      expect(region.getAttribute('aria-atomic')).toBe('true')
+      expect(region.getAttribute('role')).toBe('status')
+      // Initially empty so the first paint does not announce anything.
+      expect(region.textContent).toBe('')
+    })
+
+    it('announces "Picked up" on keyboard lift', () => {
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={vi.fn()}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      fireEvent.keyDown(tabA, { key: ' ' })
+      const region = screen.getByTestId('session-bar-reorder-announcer')
+      expect(region.textContent).toMatch(/picked up/i)
+      expect(region.textContent).toMatch(/alpha/i)
+    })
+
+    it('announces "Dropped" with the new position on keyboard commit', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      // Lift, move, commit
+      fireEvent.keyDown(tabA, { key: ' ' })
+      fireEvent.keyDown(tabA, { key: 'ArrowRight' })
+      fireEvent.keyDown(tabA, { key: 'Enter' })
+      const region = screen.getByTestId('session-bar-reorder-announcer')
+      expect(region.textContent).toMatch(/dropped/i)
+      expect(region.textContent).toMatch(/alpha/i)
+      // "2 of 3" — alpha moved from position 1 to position 2.
+      expect(region.textContent).toMatch(/2 of 3/)
+    })
+
+    it('announces "Cancelled" when Escape ends the lift', () => {
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={vi.fn()}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      fireEvent.keyDown(tabA, { key: ' ' })
+      fireEvent.keyDown(tabA, { key: 'Escape' })
+      const region = screen.getByTestId('session-bar-reorder-announcer')
+      expect(region.textContent).toMatch(/cancelled|canceled/i)
+      expect(region.textContent).toMatch(/alpha/i)
+    })
+
+    it('announces "Picked up" / "Over" / "Dropped" on pointer drag', () => {
+      const onReorder = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={onReorder}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      const tabC = screen.getByTestId('session-tab-c')
+      const dataTransfer = dataTransferStub()
+
+      fireEvent.dragStart(tabA, { dataTransfer })
+      const region = screen.getByTestId('session-bar-reorder-announcer')
+      expect(region.textContent).toMatch(/picked up/i)
+
+      fireEvent.dragOver(tabC, { dataTransfer })
+      expect(region.textContent).toMatch(/over/i)
+      expect(region.textContent).toMatch(/charlie/i)
+
+      fireEvent.drop(tabC, { dataTransfer })
+      expect(region.textContent).toMatch(/dropped/i)
+    })
+
+    it('exposes a hidden reorder hint via aria-describedby on each tab', () => {
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={vi.fn()}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      const describedBy = tabA.getAttribute('aria-describedby')
+      expect(describedBy).toBeTruthy()
+      const hint = document.getElementById(describedBy!)
+      expect(hint).toBeTruthy()
+      // Hint should mention the reorder shortcut so SR users discover it.
+      expect(hint!.textContent).toMatch(/space/i)
+      expect(hint!.textContent).toMatch(/arrow/i)
+    })
+
+    it('does NOT set aria-describedby when reorder is not wired', () => {
+      // Back-compat: callers that haven't opted into reorder shouldn't be
+      // told about a shortcut that doesn't apply.
+      render(
+        <SessionBar
+          sessions={makeThree()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+        />
+      )
+      const tabA = screen.getByTestId('session-tab-a')
+      expect(tabA.getAttribute('aria-describedby')).toBe(null)
     })
   })
 })

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -205,13 +205,17 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
     }
   }, [sessions, onReorder])
 
-  // #4831 — keyboard step. `dir` is +1 (right) / -1 (left). Mutates via
-  // `emitReorder` (insert-before semantics: stepping right swaps with the
-  // next neighbor by inserting after it).
+  // #4831 — keyboard step. `dir` is +1 (right) / -1 (left). Calls
+  // `onReorder` directly with the result of `reorderTabs` (insert-before
+  // semantics: stepping right swaps with the next neighbor by inserting
+  // after it). We don't go through `emitReorder` here because the
+  // sessionId → sessionId lookup of that helper is built for the pointer
+  // drop path; the keyboard step already knows the moved tab's index.
   //
-  // #4951 — the live-region "Dropped …" announcement is emitted by
-  // `emitReorder` itself, so each keyboard step also produces a polite
-  // narration of the new position.
+  // #4951 — also pushes a "Dropped … at position N of M" announcement
+  // into the live region inline (each keyboard step is a settled state
+  // worth narrating, so SR users hear the new position after every
+  // ArrowLeft / ArrowRight).
   const stepKeyboard = useCallback((sessionId: string, dir: 1 | -1) => {
     if (!onReorder) return
     const ids = sessions.map(s => s.sessionId)
@@ -324,10 +328,15 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
                 // #4951 — announce the lift / commit transitions in the
                 // live region. Plain Space toggles the lift state, so the
                 // narration depends on whether we're entering or leaving
-                // reorder mode for THIS tab.
+                // reorder mode for THIS tab. On commit (toggling lift off)
+                // we deliberately do NOT overwrite the live region — each
+                // prior ArrowLeft / ArrowRight already pushed a precise
+                // "Dropped X at position N of M" via `stepKeyboard`, and
+                // that's the settled narration we want SR users to hear
+                // (#4963 follow-up: a bare "Dropped X." here would clobber
+                // the position information).
                 setKeyboardLiftId(prev => {
                   if (prev === session.sessionId) {
-                    setReorderAnnouncement(`Dropped ${session.name}.`)
                     return null
                   }
                   setReorderAnnouncement(
@@ -349,14 +358,15 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
                   e.preventDefault()
                   setKeyboardLiftId(null)
                   // #4951 — Enter is the "commit" alias. Each prior
-                  // ArrowLeft / ArrowRight already announced the
-                  // new position via `stepKeyboard` → `emitReorder`,
-                  // so we don't re-narrate the resting state here
-                  // (that would risk reading a stale position if
-                  // the parent has not yet propagated the new order
-                  // back through the `sessions` prop). Leaving the
-                  // last "Dropped X at position N of M" announcement
-                  // in the live region is the settled narration.
+                  // ArrowLeft / ArrowRight already announced the new
+                  // position via `stepKeyboard`'s inline
+                  // `setReorderAnnouncement`, so we don't re-narrate
+                  // the resting state here (that would risk reading a
+                  // stale position if the parent has not yet
+                  // propagated the new order back through the
+                  // `sessions` prop). Leaving the last
+                  // "Dropped X at position N of M" announcement in
+                  // the live region is the settled narration.
                   return
                 }
                 if (e.key === 'ArrowRight') {

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -10,8 +10,16 @@
  * and matches the #4831 acceptance criteria; Shift+Space is retained as an
  * alias. The `+` (new session) button is anchored at the right edge and is
  * NOT draggable / not a drop target.
+ *
+ * #4951 — accessibility follow-up to #4831 / PR #4945. `aria-grabbed` is
+ * deprecated in WAI-ARIA 1.1+ (and never had reliable screen-reader
+ * support); the modern pattern is a visually-hidden polite live region
+ * that announces drag-state transitions ("Picked up X", "Over Y",
+ * "Dropped X at position 2 of 3", "Cancelled"). Each draggable tab also
+ * carries `aria-describedby` pointing at a hidden hint that explains the
+ * reorder shortcut, so SR users discover it on focus.
  */
-import { useState, useCallback, useRef, useEffect } from 'react'
+import { useState, useCallback, useRef, useEffect, useId } from 'react'
 import type { SessionVisualStatus } from '@chroxy/store-core'
 import { getProviderInfo } from '../lib/provider-labels'
 
@@ -68,6 +76,24 @@ function shortenProvider(provider: string): string {
 }
 
 /**
+ * #4951 — visually-hidden style for the drag-state live region and the
+ * reorder-shortcut hint. Mirrors the "1px clipped box" recipe used by
+ * `ConnectionAnnouncer` so screen readers still announce the content
+ * (unlike `display: none` / `visibility: hidden`).
+ */
+const SR_ONLY_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+}
+
+/**
  * #4831 — pure reorder helper, exported for tests. Moves the entry at
  * `fromIndex` to `toIndex` (insert-before semantics; matches typical drop
  * UX where the dragged tab takes the dropped-on tab's slot and pushes it
@@ -113,6 +139,17 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
   // a pointer; Space / Enter commits, Escape cancels.
   const [keyboardLiftId, setKeyboardLiftId] = useState<string | null>(null)
 
+  // #4951 — live-region announcement string. Replaces deprecated
+  // `aria-grabbed`. We coalesce all drag-state transitions into a single
+  // polite live region so SR users get a narrative ("Picked up Alpha. …
+  // Dropped Alpha at position 2 of 3.") rather than silent state changes.
+  // Starts empty so the initial mount doesn't announce anything.
+  const [reorderAnnouncement, setReorderAnnouncement] = useState('')
+  // Stable id for the hidden reorder-shortcut hint that draggable tabs
+  // reference via `aria-describedby`. `useId` keeps it unique per render
+  // tree (important if multiple SessionBars are mounted in tests).
+  const reorderHintId = useId()
+
   useEffect(() => {
     if (renamingId && inputRef.current) {
       inputRef.current.focus()
@@ -145,6 +182,9 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
   // so we look up indices from the live `sessions` array (which already
   // reflects the user's current order, since App.tsx feeds it back in via
   // `onReorder`). No-ops when `onReorder` isn't wired.
+  //
+  // #4951 — also pushes a "Dropped …" announcement into the live region
+  // describing the final position so SR users hear where the tab landed.
   const emitReorder = useCallback((from: string, to: string) => {
     if (!onReorder) return
     if (from === to) return
@@ -154,11 +194,24 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
     if (fromIdx === -1 || toIdx === -1) return
     const next = reorderTabs(ids, fromIdx, toIdx)
     onReorder(next)
+    const movedSession = sessions.find(s => s.sessionId === from)
+    if (movedSession) {
+      // 1-indexed position so the announcement reads naturally
+      // ("position 2 of 3", not "position 1 of 3" for the second slot).
+      const landed = next.indexOf(from) + 1
+      setReorderAnnouncement(
+        `Dropped ${movedSession.name} at position ${landed} of ${next.length}.`
+      )
+    }
   }, [sessions, onReorder])
 
   // #4831 — keyboard step. `dir` is +1 (right) / -1 (left). Mutates via
   // `emitReorder` (insert-before semantics: stepping right swaps with the
   // next neighbor by inserting after it).
+  //
+  // #4951 — the live-region "Dropped …" announcement is emitted by
+  // `emitReorder` itself, so each keyboard step also produces a polite
+  // narration of the new position.
   const stepKeyboard = useCallback((sessionId: string, dir: 1 | -1) => {
     if (!onReorder) return
     const ids = sessions.map(s => s.sessionId)
@@ -171,6 +224,13 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
     const insertAt = dir > 0 ? idx + 2 : idx - 1
     const next = reorderTabs(ids, idx, insertAt)
     onReorder(next)
+    const movedSession = sessions.find(s => s.sessionId === sessionId)
+    if (movedSession) {
+      const landed = next.indexOf(sessionId) + 1
+      setReorderAnnouncement(
+        `Dropped ${movedSession.name} at position ${landed} of ${next.length}.`
+      )
+    }
   }, [sessions, onReorder])
 
   return (
@@ -193,7 +253,12 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
             data-testid={`session-tab-${session.sessionId}`}
             role="tab"
             aria-selected={session.isActive}
-            aria-grabbed={isLifted || isDragging ? true : undefined}
+            // #4951 — aria-grabbed (and aria-dropeffect) were removed in
+            // WAI-ARIA 1.1; the lift state is conveyed via the `lifted`
+            // CSS class (visual) + the live-region announcement (SR).
+            // aria-describedby points SR users at the hidden reorder hint
+            // so they discover the Space / Arrow shortcut on focus.
+            aria-describedby={reorderDisabled ? undefined : reorderHintId}
             tabIndex={0}
             // #4831 — native HTML5 DnD attributes. `draggable` is only enabled
             // when a reorder callback is wired (so consumers that don't opt
@@ -207,6 +272,10 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               // the payload isn't read on drop (we resolve from state).
               try { e.dataTransfer.setData('text/plain', session.sessionId) } catch { /* jsdom */ }
               if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move'
+              // #4951 — narrate the pickup so SR users know the drag started.
+              setReorderAnnouncement(
+                `Picked up ${session.name}. Use Arrow Left or Arrow Right to move, Space or Enter to drop, Escape to cancel.`
+              )
             }}
             onDragEnd={() => {
               setDraggingId(null)
@@ -218,7 +287,14 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               // drop target — without it the drop event never fires.
               e.preventDefault()
               if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
-              if (dragOverId !== session.sessionId) setDragOverId(session.sessionId)
+              if (dragOverId !== session.sessionId) {
+                setDragOverId(session.sessionId)
+                // #4951 — announce hover-over so SR users hear which tab
+                // they're about to displace. We only announce on the FIRST
+                // entry into a given target (not every dragover tick) by
+                // guarding with the `dragOverId !== sessionId` check above.
+                setReorderAnnouncement(`Over ${session.name}.`)
+              }
             }}
             onDragLeave={() => {
               if (dragOverId === session.sessionId) setDragOverId(null)
@@ -245,18 +321,42 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               // role="tab" semantics are preserved; Enter always activates.
               if (e.key === ' ' && !reorderDisabled) {
                 e.preventDefault()
-                setKeyboardLiftId(prev => prev === session.sessionId ? null : session.sessionId)
+                // #4951 — announce the lift / commit transitions in the
+                // live region. Plain Space toggles the lift state, so the
+                // narration depends on whether we're entering or leaving
+                // reorder mode for THIS tab.
+                setKeyboardLiftId(prev => {
+                  if (prev === session.sessionId) {
+                    setReorderAnnouncement(`Dropped ${session.name}.`)
+                    return null
+                  }
+                  setReorderAnnouncement(
+                    `Picked up ${session.name}. Use Arrow Left or Arrow Right to move, Space or Enter to drop, Escape to cancel.`
+                  )
+                  return session.sessionId
+                })
                 return
               }
               if (keyboardLiftId === session.sessionId) {
                 if (e.key === 'Escape') {
                   e.preventDefault()
                   setKeyboardLiftId(null)
+                  // #4951 — narrate cancel so SR users know nothing moved.
+                  setReorderAnnouncement(`Cancelled reorder of ${session.name}.`)
                   return
                 }
                 if (e.key === 'Enter') {
                   e.preventDefault()
                   setKeyboardLiftId(null)
+                  // #4951 — Enter is the "commit" alias. Each prior
+                  // ArrowLeft / ArrowRight already announced the
+                  // new position via `stepKeyboard` → `emitReorder`,
+                  // so we don't re-narrate the resting state here
+                  // (that would risk reading a stale position if
+                  // the parent has not yet propagated the new order
+                  // back through the `sessions` prop). Leaving the
+                  // last "Dropped X at position N of M" announcement
+                  // in the live region is the settled narration.
                   return
                 }
                 if (e.key === 'ArrowRight') {
@@ -414,6 +514,29 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
       >
         +
       </button>
+
+      {/* #4951 — visually-hidden hint referenced via `aria-describedby`
+          on each draggable tab. Renders unconditionally so the id stays
+          stable; tabs only point at it when `onReorder` is wired. */}
+      <span id={reorderHintId} style={SR_ONLY_STYLE}>
+        Press Space to pick up this tab for reorder, then use Arrow Left or
+        Arrow Right to move it. Press Space or Enter to drop, Escape to
+        cancel.
+      </span>
+
+      {/* #4951 — polite live region that narrates drag-state transitions
+          (pickup, hover-over, drop, cancel). Replaces the deprecated
+          `aria-grabbed` attribute. `aria-atomic="true"` so the entire
+          message is re-read on each change, not just the diff. */}
+      <div
+        data-testid="session-bar-reorder-announcer"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        style={SR_ONLY_STYLE}
+      >
+        {reorderAnnouncement}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #4951.

A11y follow-up to PR #4945 (issue #4831 — drag-to-reorder session tabs).

## Why

`aria-grabbed` was deprecated in WAI-ARIA 1.1+ and has never had reliable screen-reader support. The WAI-ARIA Authoring Practices now recommend a polite live region for drag-and-drop instead. PR #4945 still set `aria-grabbed` on lifted / dragging tabs; this PR replaces that pattern with the modern one.

## What changes

- **Remove `aria-grabbed`** from session tabs.
- **Add a polite live region** (`role="status"` + `aria-live="polite"` + `aria-atomic="true"`) — `data-testid="session-bar-reorder-announcer"` — that narrates:
  - `Picked up {tab}. Use Arrow Left or Arrow Right to move, Space or Enter to drop, Escape to cancel.` — on pointer dragstart + keyboard Space lift.
  - `Over {tab}.` — on first entry into a new drop target (guarded so it doesn't fire every dragover tick).
  - `Dropped {tab} at position N of M.` — on each keyboard step + pointer drop.
  - `Cancelled reorder of {tab}.` — when Escape ends a keyboard lift.
- **Add `aria-describedby`** on each draggable tab pointing at a hidden hint span that tells SR users the reorder shortcut (Space / Arrow / Enter / Escape). The hint is only wired up when `onReorder` is passed — back-compat for callers that haven't opted into reorder.
- Reuse the "1px clipped box" SR-only style from `ConnectionAnnouncer` for both the hint and the live region (avoids `display:none` / `visibility:hidden`, which silence SR announcements).
- The `lifted` CSS class now carries the visual lift state on its own (previously paired with `aria-grabbed`).

## Test plan

- [x] Updated existing keyboard-reorder tests to assert the `lifted` class instead of `aria-grabbed`.
- [x] New `#4951 live-region drag announcements` suite (7 tests) covering:
  - `aria-grabbed` is absent even after a keyboard lift.
  - Live region is present with the right ARIA attributes and starts empty.
  - "Picked up" announcement on keyboard Space lift.
  - "Dropped … at position N of M" announcement on keyboard commit.
  - "Cancelled" announcement on Escape.
  - "Picked up" / "Over" / "Dropped" pointer drag flow.
  - `aria-describedby` points at a hint that mentions Space + Arrow keys, and is omitted entirely when `onReorder` is not wired.
- [x] Full `vitest run` green — 137 files, 2677 tests pass.
- [x] `npm run typecheck` clean.

## References

- WAI-ARIA Authoring Practices, Drag and Drop pattern
- MDN: `aria-grabbed` (deprecated)
- PR #4945 (introduced the original drag-to-reorder)