### PR TITLE
feat(dashboard): surface sidebar reorder shortcut in cheat sheet and aria (#4941)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -311,6 +311,24 @@ describe('App', () => {
     expect(screen.queryByText('Cmd+Enter')).not.toBeInTheDocument()
   })
 
+  // #4941 — the sidebar drag-to-reorder shortcut was previously invisible
+  // anywhere outside the source code. After landing the discoverability
+  // follow-up, opening the `?` cheat sheet shows the two reorder entries
+  // alongside their descriptions and a dedicated "Sidebar" section
+  // heading, so users can find them.
+  it('lists the sidebar reorder shortcuts in the cheat sheet under a Sidebar section (#4941)', () => {
+    render(<App />)
+    fireEvent.keyDown(window, { key: '?' })
+
+    expect(screen.getByText('Alt+ArrowUp')).toBeInTheDocument()
+    expect(screen.getByText('Alt+ArrowDown')).toBeInTheDocument()
+    expect(screen.getByText('Move sidebar row up (when focused)')).toBeInTheDocument()
+    expect(screen.getByText('Move sidebar row down (when focused)')).toBeInTheDocument()
+    // Confirm the entries render under the new "Sidebar" group (h3),
+    // not folded into another section.
+    expect(screen.getByRole('heading', { level: 3, name: 'Sidebar' })).toBeInTheDocument()
+  })
+
   // #4432 — the cheat sheet's tab-switch row used to be derived from
   // session.switch.1's binding alone, then string-replaced "1$" with
   // "1-9". When the other eight bindings still pointed at their

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1649,6 +1649,7 @@ export function App() {
       navigation: 'Global',
       view: 'Global',
       session: 'Session',
+      sidebar: 'Sidebar',
       composer: 'Input',
       other: 'Global',
     }

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -631,6 +631,14 @@ export function Sidebar({
                   data-testid={`sidebar-repo-${repo.path}`}
                   data-drop-position={repoDragOver ?? undefined}
                   tabIndex={visibleIds.indexOf(`repo:${repo.path}`) === focusedIndex ? 0 : -1}
+                  // #4941: surface the Alt+ArrowUp/Down keyboard reorder
+                  // shortcut for screen readers and assistive tech. Only
+                  // set when reorder is actually wired (callback present
+                  // AND no filter active) so the announced shortcut
+                  // doesn't lie when the row isn't actually reorderable.
+                  // The space-separated multi-combo format follows the
+                  // WAI-ARIA spec (`Alt+ArrowUp Alt+ArrowDown`).
+                  aria-keyshortcuts={!!onReorderRepos && !filter ? 'Alt+ArrowUp Alt+ArrowDown' : undefined}
                   // #4372: bind onContextMenu on the outer treeitem (not the
                   // inner .sidebar-repo-header) so that App's handler can
                   // call `event.currentTarget.focus()` on a focusable element.
@@ -712,6 +720,11 @@ export function Sidebar({
                             // confusing partial ordering.
                             draggable={!!onReorderSessions && !filter}
                             data-drop-position={sessionDragOver ?? undefined}
+                            // #4941: see the matching repo-row attribute
+                            // above — same rationale (discoverability for
+                            // assistive tech, only set when the shortcut
+                            // is functionally wired on this row).
+                            aria-keyshortcuts={!!onReorderSessions && !filter ? 'Alt+ArrowUp Alt+ArrowDown' : undefined}
                             onClick={() => onSessionClick(session.sessionId)}
                             onContextMenu={e => {
                               // #4372: stopPropagation so the right-click

--- a/packages/dashboard/src/components/SidebarReorder.test.tsx
+++ b/packages/dashboard/src/components/SidebarReorder.test.tsx
@@ -406,6 +406,50 @@ describe('Sidebar keyboard reorder (#4832)', () => {
   })
 })
 
+// #4941 — discoverability follow-up: the Alt+ArrowUp/Down reorder
+// shortcut is invisible without `aria-keyshortcuts`, so assistive tech
+// can't announce it and sighted users have no surfacing either. The
+// attribute must be set when (and ONLY when) reorder is functionally
+// wired on a row, so the announced shortcut doesn't mislead users on
+// rows where the keypress is a no-op.
+describe('Sidebar aria-keyshortcuts (#4941)', () => {
+  it('exposes Alt+ArrowUp Alt+ArrowDown on session rows when reorder is wired', () => {
+    renderSidebar({ onReorderSessions: vi.fn() })
+    const s1 = screen.getByTestId('session-item-s1')
+    expect(s1.getAttribute('aria-keyshortcuts')).toBe('Alt+ArrowUp Alt+ArrowDown')
+  })
+
+  it('exposes Alt+ArrowUp Alt+ArrowDown on repo rows when reorder is wired', () => {
+    renderSidebar({ onReorderRepos: vi.fn() })
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    expect(apiRepo.getAttribute('aria-keyshortcuts')).toBe('Alt+ArrowUp Alt+ArrowDown')
+  })
+
+  it('omits aria-keyshortcuts on session rows when no reorder callback is wired', () => {
+    renderSidebar({})
+    const s1 = screen.getByTestId('session-item-s1')
+    expect(s1.hasAttribute('aria-keyshortcuts')).toBe(false)
+  })
+
+  it('omits aria-keyshortcuts on repo rows when no reorder callback is wired', () => {
+    renderSidebar({})
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    expect(apiRepo.hasAttribute('aria-keyshortcuts')).toBe(false)
+  })
+
+  it('omits aria-keyshortcuts while a filter is active (matches functional gate)', () => {
+    // Reorder is disabled while filtering (see handleSessionReorderKey /
+    // handleRepoReorderKey guards). The aria attribute must agree so
+    // screen readers don't announce a shortcut that the row will
+    // refuse to act on.
+    renderSidebar({ filter: 'api', onReorderSessions: vi.fn(), onReorderRepos: vi.fn() })
+    const apiRepo = screen.getByTestId('sidebar-repo-/home/user/projects/api')
+    const s1 = screen.getByTestId('session-item-s1')
+    expect(apiRepo.hasAttribute('aria-keyshortcuts')).toBe(false)
+    expect(s1.hasAttribute('aria-keyshortcuts')).toBe(false)
+  })
+})
+
 describe('Sidebar reorder persistence (#4832)', () => {
   it('round-trips the repo order through localStorage', () => {
     const order = [

--- a/packages/dashboard/src/shortcuts/ShortcutsSection.test.tsx
+++ b/packages/dashboard/src/shortcuts/ShortcutsSection.test.tsx
@@ -136,4 +136,29 @@ describe('<ShortcutsSection>', () => {
     render(<ShortcutsSection />)
     expect(screen.getByTestId('shortcut-binding-palette.toggle')).toHaveTextContent('Ctrl+K')
   })
+
+  // #4941 — the sidebar drag-to-reorder shortcut from #4832 used to be
+  // hardcoded in Sidebar.tsx with no registry entry, so it never showed
+  // up in the Settings rebind panel OR the `?` cheat sheet. Users had
+  // to read the PR / source to discover Alt+ArrowUp/Down even existed.
+  // The reorder handler is still hardcoded for now (a follow-up will
+  // migrate it to registry.matchEvent), but these entries surface the
+  // shortcut in both discoverability UIs.
+  describe('sidebar reorder shortcut discoverability (#4941)', () => {
+    it('lists the up/down reorder entries under the Sidebar group', () => {
+      installFreshRegistry()
+      render(<ShortcutsSection />)
+      expect(screen.getByTestId('shortcut-row-sidebar.reorder.up')).toBeInTheDocument()
+      expect(screen.getByTestId('shortcut-row-sidebar.reorder.down')).toBeInTheDocument()
+      // Default bindings should render with the Mac/Option prefix.
+      expect(screen.getByTestId('shortcut-binding-sidebar.reorder.up')).toHaveTextContent('Option+ArrowUp')
+      expect(screen.getByTestId('shortcut-binding-sidebar.reorder.down')).toHaveTextContent('Option+ArrowDown')
+    })
+
+    it('renders the "Sidebar" group heading so the entries are discoverable visually', () => {
+      installFreshRegistry()
+      render(<ShortcutsSection />)
+      expect(screen.getByText('Sidebar')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/shortcuts/ShortcutsSection.tsx
+++ b/packages/dashboard/src/shortcuts/ShortcutsSection.tsx
@@ -24,10 +24,11 @@ const CATEGORY_LABELS: Record<ShortcutCategory, string> = {
   composer: 'Composer',
   session: 'Session',
   view: 'View',
+  sidebar: 'Sidebar',
   other: 'Other',
 }
 
-const CATEGORY_ORDER: ShortcutCategory[] = ['navigation', 'view', 'session', 'composer', 'other']
+const CATEGORY_ORDER: ShortcutCategory[] = ['navigation', 'view', 'session', 'sidebar', 'composer', 'other']
 
 export function ShortcutsSection() {
   const registry = useShortcutRegistry()

--- a/packages/dashboard/src/shortcuts/defaults.ts
+++ b/packages/dashboard/src/shortcuts/defaults.ts
@@ -157,4 +157,30 @@ export const DEFAULT_SHORTCUTS: ShortcutDef[] = [
   },
   // Cmd+1 .. Cmd+9 tab-switch entries — one per digit.
   ...tabSwitchShortcuts,
+  // -- #4941: sidebar reorder discoverability ----------------------
+  // These two entries describe the existing Alt+ArrowUp / Alt+ArrowDown
+  // keyboard reorder shortcut on draggable sidebar rows (#4832). They
+  // are intentionally informational-only: the actual keydown handler
+  // lives in Sidebar.tsx and matches `event.altKey && event.key ===
+  // 'ArrowUp'|'ArrowDown'` directly rather than via the registry, so a
+  // user rebind here does NOT change runtime behaviour today. The
+  // entries exist so the `?` cheat sheet and Settings rebind list both
+  // surface the shortcut — the previous gap left users with no path
+  // to discover keyboard reorder short of reading the PR or the source.
+  // When the row-level handler is migrated to `registry.matchEvent`,
+  // these entries become functional without further migration.
+  {
+    id: 'sidebar.reorder.up',
+    defaultBinding: 'alt+arrowup',
+    description: 'Move sidebar row up (when focused)',
+    category: 'sidebar',
+    scope: 'global',
+  },
+  {
+    id: 'sidebar.reorder.down',
+    defaultBinding: 'alt+arrowdown',
+    description: 'Move sidebar row down (when focused)',
+    category: 'sidebar',
+    scope: 'global',
+  },
 ]

--- a/packages/dashboard/src/shortcuts/registry.test.ts
+++ b/packages/dashboard/src/shortcuts/registry.test.ts
@@ -73,6 +73,20 @@ describe('formatBindingForDisplay', () => {
     expect(formatBindingForDisplay('cmd+,', true)).toBe('Cmd+,')
     expect(formatBindingForDisplay('cmd+\\', true)).toBe('Cmd+\\')
   })
+
+  // #4964 review (Copilot) — PRETTY_KEY_NAMES lookup must do an
+  // own-property check so a binding whose key happens to be an
+  // Object.prototype name ("constructor", "toString", "__proto__")
+  // does not pick up the inherited function/object and render a
+  // function reference (or "[object Object]") in the cheat-sheet UI.
+  // These inputs are not produced by real KeyboardEvent.key today but
+  // can arrive via tampered localStorage overrides or a future binding
+  // source, so we guard at the lookup site.
+  it('falls back to title-case for key names that collide with Object.prototype', () => {
+    expect(formatBindingForDisplay('cmd+constructor', true)).toBe('Cmd+Constructor')
+    expect(formatBindingForDisplay('cmd+tostring', true)).toBe('Cmd+Tostring')
+    expect(formatBindingForDisplay('alt+hasownproperty', true)).toBe('Option+Hasownproperty')
+  })
 })
 
 describe('createShortcutRegistry', () => {

--- a/packages/dashboard/src/shortcuts/registry.ts
+++ b/packages/dashboard/src/shortcuts/registry.ts
@@ -24,7 +24,7 @@
  *   machine sync, server-side shortcuts.
  */
 
-export type ShortcutCategory = 'navigation' | 'composer' | 'session' | 'view' | 'other'
+export type ShortcutCategory = 'navigation' | 'composer' | 'session' | 'view' | 'sidebar' | 'other'
 export type ShortcutScope = 'global' | 'composer'
 
 export interface ShortcutDef {
@@ -120,12 +120,39 @@ export function parseBinding(input: string): ParsedBinding {
 }
 
 /**
+ * Pretty-name lookup for KeyboardEvent.key values whose default
+ * title-case rendering ("Arrowup", "Pageup") looks broken. Keys not in
+ * this table fall back to the generic capitalisation rule below.
+ *
+ * #4941: introduced when the sidebar reorder shortcut (alt+arrowup /
+ * alt+arrowdown) started appearing in the cheat sheet — the bare
+ * title-case form rendered as "Option+Arrowup" which is visually wrong.
+ */
+const PRETTY_KEY_NAMES: Record<string, string> = {
+  arrowup: 'ArrowUp',
+  arrowdown: 'ArrowDown',
+  arrowleft: 'ArrowLeft',
+  arrowright: 'ArrowRight',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+  enter: 'Enter',
+  tab: 'Tab',
+  escape: 'Escape',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  home: 'Home',
+  end: 'End',
+  space: 'Space',
+  insert: 'Insert',
+}
+
+/**
  * Render a canonical binding ("cmd+shift+p") in a human-friendly form
  * for the UI. On macOS the modifier reads "Cmd", elsewhere "Ctrl".
  *
  * Single-character keys are uppercased; punctuation and longer key
- * names ("Enter", "Tab", "Escape") are normalised to title case so the
- * cheat sheet stays readable.
+ * names ("Enter", "Tab", "Escape") are normalised via PRETTY_KEY_NAMES
+ * so the cheat sheet stays readable.
  */
 export function formatBindingForDisplay(canonical: string, isMac: boolean): string {
   if (!canonical) return ''
@@ -137,9 +164,12 @@ export function formatBindingForDisplay(canonical: string, isMac: boolean): stri
     else if (part === 'shift') out.push('Shift')
     else if (part === 'alt') out.push(isMac ? 'Option' : 'Alt')
     else if (i === parts.length - 1) {
-      // Final token is the key. Uppercase single ASCII letters; leave
-      // punctuation as-is; title-case multi-char names like "enter".
+      // Final token is the key. Uppercase single ASCII letters; consult
+      // PRETTY_KEY_NAMES for the W3C `KeyboardEvent.key` names whose
+      // generic title-case rendering looks broken; otherwise leave
+      // punctuation as-is and title-case the rest.
       if (/^[a-z]$/.test(part)) out.push(part.toUpperCase())
+      else if (PRETTY_KEY_NAMES[part]) out.push(PRETTY_KEY_NAMES[part])
       else if (/^[a-z]/.test(part)) out.push(part.charAt(0).toUpperCase() + part.slice(1))
       else out.push(part)
     } else {

--- a/packages/dashboard/src/shortcuts/registry.ts
+++ b/packages/dashboard/src/shortcuts/registry.ts
@@ -168,8 +168,14 @@ export function formatBindingForDisplay(canonical: string, isMac: boolean): stri
       // PRETTY_KEY_NAMES for the W3C `KeyboardEvent.key` names whose
       // generic title-case rendering looks broken; otherwise leave
       // punctuation as-is and title-case the rest.
+      //
+      // Use an own-property check on PRETTY_KEY_NAMES so a binding with
+      // a key like "constructor" / "toString" / "__proto__" (possible
+      // via localStorage override tampering or a future binding source)
+      // does not pick up `Object.prototype.<name>` and render a
+      // function reference in the UI.
       if (/^[a-z]$/.test(part)) out.push(part.toUpperCase())
-      else if (PRETTY_KEY_NAMES[part]) out.push(PRETTY_KEY_NAMES[part])
+      else if (Object.prototype.hasOwnProperty.call(PRETTY_KEY_NAMES, part)) out.push(PRETTY_KEY_NAMES[part]!)
       else if (/^[a-z]/.test(part)) out.push(part.charAt(0).toUpperCase() + part.slice(1))
       else out.push(part)
     } else {


### PR DESCRIPTION
## Summary

PR #4832 wired `Alt+ArrowUp` / `Alt+ArrowDown` as the keyboard reorder shortcut on draggable sidebar rows. The shortcut was functional but undiscoverable — no entry in the `?` cheat sheet, no entry in the Settings rebind panel, no `aria-keyshortcuts` for assistive tech.

This PR closes that discoverability gap:

- Adds a `sidebar` category to `ShortcutCategory` and two informational entries (`sidebar.reorder.up`, `sidebar.reorder.down`) in the central registry. The `?` cheat sheet (registry-driven since #4412) and the Settings rebind panel both pick them up automatically. The entries are intentionally informational only for now — the row-level handler in `Sidebar.tsx` still matches `Alt+ArrowUp/Down` directly via `event.altKey && event.key === 'ArrowUp'|'ArrowDown'`, so user rebinds in Settings do **not** change runtime behaviour. A follow-up can migrate the handler to `registry.matchEvent('global')` without touching the registry rows.
- Adds `aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown"` to draggable repo and session rows, gated on the same predicate as the functional handler (callback wired AND no filter active). Screen readers will not announce a shortcut that the row would refuse to act on.
- Extends `formatBindingForDisplay` with a pretty-name table for `arrowup`/`arrowdown`/`enter`/etc. so the cheat sheet renders `ArrowUp` instead of the default title-case `Arrowup`. No other display strings change (single-character keys still use the existing branch).

Closes #4941. The sister issue #4949 (SessionBar reorder discoverability) remains open and will be tackled separately; coordinating both onto a shared utility was considered but the two shortcut surfaces are distinct enough (different combos, different categories) that a shared util would over-abstract for two rows.

## Files changed

- `packages/dashboard/src/shortcuts/registry.ts` — new `sidebar` category, pretty-name table
- `packages/dashboard/src/shortcuts/defaults.ts` — two new shortcut entries
- `packages/dashboard/src/shortcuts/ShortcutsSection.tsx` — register the new category in label/order maps
- `packages/dashboard/src/App.tsx` — register the new category in cheat-sheet section map
- `packages/dashboard/src/components/Sidebar.tsx` — `aria-keyshortcuts` on draggable rows

## Test plan

- [x] `npm test --prefix packages/dashboard` (137 files, 2677 tests pass)
- [x] `npm run typecheck --prefix packages/dashboard`
- [x] `npm run build --prefix packages/dashboard`
- New tests:
  - `SidebarReorder.test.tsx`: aria attribute present when reorder wired, absent without callback, absent during filter
  - `ShortcutsSection.test.tsx`: new entries appear with prettified key labels under the Sidebar group
  - `App.test.tsx`: cheat-sheet shows the entries and a "Sidebar" `<h3>` heading