### PR TITLE
test(app): add Maestro mixed multi-question AskUserQuestion E2E flow

### DIFF
--- a/packages/app/.maestro/chat-multi-question.yaml
+++ b/packages/app/.maestro/chat-multi-question.yaml
@@ -1,0 +1,181 @@
+appId: com.blamechris.chroxy
+name: ChatView mixed multi-question AskUserQuestion form (#4762)
+---
+
+# #4762 — Mobile Maestro coverage for the mixed multi-question
+# AskUserQuestion wire payload. Sibling to ask-user-question-multi.yaml
+# (which pins the all-single-select 4-question shape #4604 Chunk B).
+# This flow exercises the *mixed* wire shape #4735 / #4760 wired into
+# the dashboard's MultiQuestionForm:
+#
+#   - Q[0]: single-select with model-supplied 'Other' label
+#   - Q[1]: multi-select (`multiSelect: true`)
+#   - Q[2]: single-select with synthetic 'Other' sentinel
+#
+# Trigger: 'show-multi-question' user input → mock-server.mjs emits a
+# `user_question` envelope with the 3-question mixed shape. Fixture
+# seeding pattern is documented in CLAUDE.md → "Fixture Seeding for
+# Structured Renderers".
+#
+# Coverage today (MessageBubble only renders Q[0]):
+#
+#   - Pins the wire→render path for the mixed payload: a regression in
+#     handleUserQuestion's normalizeQuestion that mishandled
+#     multi-select or the model-supplied Other label on a sibling
+#     question would either (a) drop the whole `user_question`
+#     envelope at the `firstNormalized == null` guard or (b) corrupt
+#     Q[0]'s options. The `approval-question-0` wait + the
+#     `approval-button-approve` / `approval-button-deny` /
+#     `approval-button-Other` assertions catch both.
+#   - Pins the model-supplied 'Other' branch on Q[0] — Q[0]'s third
+#     option uses the model-supplied 'Other' label (not the synthetic
+#     OTHER_OPTION_VALUE sentinel), so the testID resolves to
+#     `approval-button-Other` (value === label). A regression in
+#     normalizeQuestion that double-appended the sentinel would
+#     surface as `approval-button-__chroxy_other__` instead.
+#   - Pins the answered round-trip — taps Approve on Q[0] and asserts
+#     the bubble flips to answered state (options remain in tree,
+#     `approval-card-<id>` still resolves).
+#
+# Out of scope until the mobile multi-question renderer lands:
+#
+#   - The dashboard-equivalent `question-prompt-multi` /
+#     `question-multi-submit` testIDs (per the #4762 acceptance
+#     criteria) come from `packages/dashboard/src/components/
+#     QuestionPrompt.tsx`'s `MultiQuestionForm` — the mobile
+#     `MessageBubble` doesn't yet have a sibling React Native
+#     component. When that component lands the flow extends to:
+#       - Wait for `id: question-prompt-multi`
+#       - Tap `id: question-multi-option-0-approve` for Q[0]
+#       - Tap `id: question-multi-option-1-app` / `-server` for Q[1]
+#         (multi-select — multiple taps add to the array)
+#       - Tap `id: question-multi-option-2-auto-rollback` for Q[2]
+#       - Tap `id: question-multi-submit`
+#       - Assert post-answer summary chip shows the comma-joined
+#         multi-select labels (`Q2 — which areas to verify?: app, server`)
+#         per #4716 / #4735 readability.
+#   - For now the post-answer state pin is via the single-option
+#     `approval-button-<value>` route on Q[0] only.
+#
+# Tested devices: portrait iPhone (iOS 17+). Mirrors
+# ask-user-question.yaml / ask-user-question-multi.yaml. Requires the
+# dev client + mock server on port 9876:
+#
+#   cd packages/app && npx expo run:ios
+#   bash packages/app/.maestro/scripts/start-mock-server.sh
+#
+# Self-contained (no `runFlow: setup/...`) because the existing setup/
+# flows target Expo Go (appId host.exp.Exponent), whereas this needs
+# the chroxy dev client (com.blamechris.chroxy).
+
+- launchApp:
+    clearState: true
+- openLink: "exp+chroxy://expo-development-client/?url=http://localhost:8081"
+
+# Dismiss the dev menu sheet (intro 'Continue' OR main menu close).
+- tapOn:
+    text: "Continue"
+    optional: true
+- tapOn:
+    point: "50%,10%"
+    optional: true
+
+# Skip onboarding carousel post-clearState.
+- tapOn:
+    text: "Skip"
+    optional: true
+
+# Wait until either ConnectScreen OR Chat lands.
+- extendedWaitUntil:
+    visible:
+      text: "Connect to Chroxy|Chat"
+    timeout: 30000
+
+# If we landed on ConnectScreen, fill the manual-entry form.
+- runFlow:
+    when:
+      visible: "Connect to Chroxy"
+    commands:
+      - tapOn:
+          id: "connect-manual-toggle"
+
+      - tapOn:
+          id: "connect-server-url"
+      - eraseText: 50
+      - inputText: "ws://localhost:9876"
+
+      - tapOn:
+          id: "connect-api-token"
+      - eraseText: 50
+      - inputText: "test-token-maestro"
+
+      - hideKeyboard
+
+      - tapOn:
+          id: "connect-submit"
+
+      - extendedWaitUntil:
+          visible: "Chat"
+          timeout: 10000
+
+# Ensure Chat tab.
+- tapOn: "Chat"
+- waitForAnimationToEnd
+
+# Type the trigger phrase that makes the mock server emit the mixed
+# 3-question multi-question payload (single-select + multi-select +
+# with-Other).
+- tapOn:
+    id: "chat-message-input"
+- inputText: "show-multi-question"
+
+- tapOn:
+    id: "chat-send-button"
+
+- hideKeyboard
+
+# Wait for Q[0]'s prompt to render — same selector as the single-
+# question flow because the mobile MessageBubble currently renders
+# Q[0] of every multi-question payload.
+- extendedWaitUntil:
+    visible:
+      id: "approval-question-0"
+    timeout: 10000
+
+- takeScreenshot: chat-multi-question-prompt-rendered
+
+# Assert Q[0]'s options + Q[0]'s question text rendered.
+#   - 'approve' / 'deny' are the canonical lowercase labels (value ===
+#     label, see normalizeQuestion).
+#   - 'Other' is the model-supplied Other on Q[0] — testID resolves to
+#     `approval-button-Other` because the model-supplied label takes
+#     precedence over the synthetic OTHER_OPTION_VALUE sentinel.
+#   - 'Q1 — deploy to production?' pins the wire→render path for the
+#     question text field on the mixed payload.
+- assertVisible:
+    id: "approval-button-approve"
+- assertVisible:
+    id: "approval-button-deny"
+- assertVisible:
+    id: "approval-button-Other"
+- assertVisible: "Q1 — deploy to production?"
+
+# Tap Approve to round-trip the answered state on Q[0]. The mobile
+# `sendUserQuestionResponse` (widened in #4761 / PR #4859) accepts
+# both the legacy single-question string and the multi-question
+# `Record<string, string | string[]>` shape; Q[0]-only tap exercises
+# the string branch.
+- tapOn:
+    id: "approval-button-approve"
+- waitForAnimationToEnd
+
+- takeScreenshot: chat-multi-question-answered
+
+# Buttons remain in the tree post-answer (only their interactivity
+# changes). The answered state on Q[0] is the only pin we can make
+# today — extending to per-question post-answer summary chip lands
+# with the mobile MultiQuestionForm renderer (see header).
+- assertVisible:
+    id: "approval-button-approve"
+- assertVisible:
+    id: "approval-button-deny"

--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -502,6 +502,84 @@ wss.on('connection', (ws) => {
           break
         }
 
+        // #4762: trigger phrase 'show-multi-question' emits the four
+        // wedge shapes #4735 / #4604 Chunk B require coverage for —
+        // mixed (single-select + multi-select + with-Other in one
+        // payload). The dashboard's MultiQuestionForm exercises every
+        // branch in a single payload because the dashboard renders
+        // all N questions inline (#4760 lifted the suppression for
+        // SDK-mode sessions). The mobile MessageBubble currently
+        // renders only `questions[0]` so this flow pins the wire→Q[0]
+        // path for the mixed payload — when the mobile multi-question
+        // renderer lands the flow extends to iterate every question
+        // (`approval-question-1` / `approval-question-2`).
+        //
+        // The mixed shape exercises three independent wire branches
+        // in a single payload:
+        //   - Q[0]: single-select with model-supplied 'Other' label —
+        //     normalizeQuestion's `modelSuppliedOther` path (see
+        //     packages/store-core/src/handlers/index.ts:3670) maps it
+        //     to OTHER_OPTION_VALUE without synthesizing a sentinel.
+        //   - Q[1]: multi-select (`multiSelect: true`) — Other
+        //     sentinel is intentionally NOT appended (see
+        //     normalizeQuestion's `isMultiSelect` branch); a regression
+        //     that flipped the gate would surface as an extra option
+        //     when downstream renderers iterate Q[1].
+        //   - Q[2]: single-select with synthetic 'Other' (no model-
+        //     supplied entry) — handleUserQuestion appends the
+        //     OTHER_OPTION_VALUE sentinel automatically.
+        //
+        // toolUseId reuses the multi-question counter so repeated
+        // triggers don't collide (same rationale as
+        // show-ask-user-question-multi above).
+        if (text.trim() === 'show-multi-question') {
+          showAskUserQuestionCounter += 1
+          const toolUseId = `tu-multi-question-mock-${showAskUserQuestionCounter}`
+          send(ws, {
+            type: 'user_question',
+            sessionId: 'mock-sess-1',
+            toolUseId,
+            questions: [
+              // Q[0] — single-select with model-supplied 'Other'.
+              // Lowercase 'approve' / 'deny' so the
+              // `approval-button-<value>` testID matches the canonical
+              // selectors used by the existing ask-user-question flows.
+              {
+                question: 'Q1 — deploy to production?',
+                options: [
+                  { label: 'approve' },
+                  { label: 'deny' },
+                  { label: 'Other' },
+                ],
+              },
+              // Q[1] — multi-select. The Other sentinel is deliberately
+              // NOT appended by normalizeQuestion for multi-select
+              // questions (multi-select forms produced by claude SDK
+              // never include a free-text fallback).
+              {
+                question: 'Q2 — which areas to verify?',
+                multiSelect: true,
+                options: [
+                  { label: 'app' },
+                  { label: 'server' },
+                  { label: 'dashboard' },
+                ],
+              },
+              // Q[2] — single-select with synthetic Other (no model-
+              // supplied entry; handleUserQuestion appends the
+              // OTHER_OPTION_VALUE sentinel automatically).
+              {
+                question: 'Q3 — rollback strategy?',
+                options: [
+                  { label: 'auto-rollback' },
+                  { label: 'manual-rollback' },
+                ],
+              },
+            ],
+          })
+          break
+        }
+
         // #4697 Chunk B: 4-question multi-question form mirrors the
         // shape #4604 Chunk B pinned at the server level. The mobile
         // MessageBubble currently renders only `questions[0]` (the

--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -518,8 +518,11 @@ wss.on('connection', (ws) => {
         // in a single payload:
         //   - Q[0]: single-select with model-supplied 'Other' label —
         //     normalizeQuestion's `modelSuppliedOther` path (see
-        //     packages/store-core/src/handlers/index.ts:3670) maps it
-        //     to OTHER_OPTION_VALUE without synthesizing a sentinel.
+        //     packages/store-core/src/handlers/index.ts:3670) preserves
+        //     it with `value === label` ("Other") rather than appending
+        //     the synthetic OTHER_OPTION_VALUE sentinel — so the testID
+        //     resolves to `approval-button-Other`, not
+        //     `approval-button-__chroxy_other__`.
         //   - Q[1]: multi-select (`multiSelect: true`) — Other
         //     sentinel is intentionally NOT appended (see
         //     normalizeQuestion's `isMultiSelect` branch); a regression

--- a/packages/app/.maestro/run-all.yaml
+++ b/packages/app/.maestro/run-all.yaml
@@ -92,3 +92,16 @@ name: All E2E flows
 # multi-question payload without bailing. Extends once mobile
 # renderer iterates all N questions.
 - runFlow: ask-user-question-multi.yaml
+
+# Flow 19: ChatView mixed multi-question form (#4762) — sibling to
+# ask-user-question-multi.yaml that exercises the *mixed* wire shape
+# (single-select + multi-select + with-Other) the dashboard's
+# MultiQuestionForm (#4735 / #4760) handles. Today MessageBubble
+# renders Q[0] only; flow asserts Q[0]'s render (including the
+# model-supplied 'Other' label on Q[0]) + the answered round-trip,
+# and pins handleUserQuestion accepts the mixed payload (Q[1]
+# multi-select branch + Q[2] synthetic-Other branch) without
+# bailing on `firstNormalized == null`. Extends with
+# `question-prompt-multi` / `question-multi-submit` + summary-chip
+# assertions once the mobile multi-question renderer lands.
+- runFlow: chat-multi-question.yaml


### PR DESCRIPTION
Related to #4762 (full acceptance criteria tracked in #4973)

## Summary

Adds the missing Maestro E2E coverage for the mixed multi-question `AskUserQuestion` wire shape (single-select + multi-select + with-Other) that the dashboard's `MultiQuestionForm` (#4735 / #4760) handles. Sibling to `ask-user-question-multi.yaml` (which already pins the 4-question all-single-select shape from #4604 Chunk B).

## Changes

- **`packages/app/.maestro/mock-server.mjs`** — new `show-multi-question` trigger emits a 3-question mixed payload:
  - Q[0]: single-select with model-supplied `Other` label — exercises `normalizeQuestion`'s `modelSuppliedOther` branch, which maps the label to `value === 'Other'` (not the synthetic `OTHER_OPTION_VALUE` sentinel).
  - Q[1]: `multiSelect: true` — exercises the branch that deliberately omits the Other sentinel for multi-select questions (`packages/store-core/src/handlers/index.ts:3677-3684`).
  - Q[2]: single-select with synthetic Other — `handleUserQuestion` auto-appends the `OTHER_OPTION_VALUE` sentinel because no model-supplied entry is present.
- **`packages/app/.maestro/chat-multi-question.yaml`** — new flow types `show-multi-question`, asserts Q[0] renders with `approval-button-approve` / `approval-button-deny` / `approval-button-Other` testIDs, taps Approve, and asserts the answered round-trip. Headers document the wire-payload coverage of each branch.
- **`packages/app/.maestro/run-all.yaml`** — added as Flow 19.

## Coverage today vs. future work

The mobile `MessageBubble` currently renders only `questions[0]` of a multi-question payload — no React Native equivalent of `MultiQuestionForm` exists yet. This flow pins what the mobile app actually exposes today:

1. The wire payload arrives intact (a regression in `normalizeQuestion` that mishandled Q[1]/Q[2] would either drop the whole envelope at `firstNormalized == null` or corrupt Q[0]'s options).
2. The model-supplied Other branch resolves to `approval-button-Other` (not the synthetic sentinel).
3. The Q[0] tap-Approve round-trip flips the bubble to answered state.

The #4762 acceptance criteria additionally call for `question-prompt-multi` / `question-multi-submit` testIDs and a post-answer summary chip — these come from `packages/dashboard/src/components/QuestionPrompt.tsx`'s `MultiQuestionForm` and have no mobile equivalent today. The flow header captures the future-work selector list so the flow extends cleanly once the mobile multi-question renderer lands. This pin is the largest implementable surface against the current mobile renderer.

## Test plan

- [x] `node --check packages/app/.maestro/mock-server.mjs` — syntax clean.
- [x] YAML parses cleanly for both `chat-multi-question.yaml` and `run-all.yaml`.
- [x] Booted the mock server and verified the `show-multi-question` trigger emits the 3-question mixed payload with the expected `multiSelect` flag on Q[1] and the model-supplied `Other` label on Q[0].
- [ ] `maestro test --device <iPhone 15 Pro> packages/app/.maestro/chat-multi-question.yaml` — requires the chroxy dev client + booted simulator; deferred to local verification (no CI runner for Maestro flows; same pattern as the existing `ask-user-question-multi.yaml` and `ask-user-question.yaml` flows).

## Open concerns / follow-ups

- **Mobile multi-question renderer is missing.** This flow ships the wire-level mixed payload coverage; the dashboard-equivalent `question-prompt-multi` / `question-multi-submit` testIDs and the post-answer summary chip (`#4716` / `#4735`) require a React Native `MultiQuestionForm` component on mobile. Filing as a follow-up issue would let this PR close #4762's testable surface today while tracking the remaining UI work.
