### PR TITLE
fix(server): tighten /resume.*failed/i pattern in RESUME_UNKNOWN_STDERR_PATTERNS (#4950)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -45,6 +45,14 @@ const DEFAULT_MAX_TOOL_INPUT_LENGTH = 262144
  * If claude CLI ever changes its wording, the test will fail loudly here
  * rather than silently regressing back into the "exited unexpectedly" respawn
  * loop reported in #4929.
+ *
+ * #4950 — the original seventh pattern `/resume.*failed/i` was too loose:
+ * unrelated stderr like "tool resume failed" or "user wanted to resume after
+ * the failed sync" would falsely classify as resume_unknown and wipe
+ * `_sessionId` mid-conversation. The three replacement patterns require both
+ * the resume verb AND a session/conversation/id keyword nearby, so a tool-side
+ * failure that happens to log "resume failed" in isolation no longer triggers
+ * a phantom `_sessionId` wipe.
  */
 export const RESUME_UNKNOWN_STDERR_PATTERNS = [
   /no conversation found/i,
@@ -53,7 +61,12 @@ export const RESUME_UNKNOWN_STDERR_PATTERNS = [
   /no such conversation/i,
   /unknown session/i,
   /could not find session/i,
-  /resume.*failed/i,
+  // #4950 — tightened replacements for the dropped `/resume.*failed/i`. Each
+  // requires the resume verb to co-occur with session/conversation/id so the
+  // matcher stays scoped to the --resume-id failure mode it was designed for.
+  /resume.*(fail|error).*(session|conversation|id)/i,
+  /resume.*(session|conversation|id).*(fail|error)/i,
+  /(fail|could not|unable to|cannot).*resume.*(session|conversation|id)/i,
 ]
 
 /**

--- a/packages/server/tests/cli-session-resume-unknown.test.js
+++ b/packages/server/tests/cli-session-resume-unknown.test.js
@@ -74,7 +74,15 @@ describe('CliSession resume-unknown — stderr matcher (#4929)', () => {
       'no such conversation: abc',
       'unknown session abc-123',
       'Could not find session abc-123',
+      // #4950 — these all carry both the resume verb AND a session/conversation/id
+      // keyword nearby; the tightened patterns must still classify them.
       'resume failed: conversation gone',
+      'Resume failed for session abc-123',
+      'Failed to resume conversation abc',
+      'Could not resume session abc-123',
+      'Unable to resume conversation: missing id',
+      'Cannot resume conversation: deleted',
+      'Resume of session abc-123 failed',
     ]
     for (const line of samples) {
       assert.equal(stderrIndicatesUnknownResume([line]), true,
@@ -98,6 +106,27 @@ describe('CliSession resume-unknown — stderr matcher (#4929)', () => {
     }
   })
 
+  it('#4950 — does NOT match loose "resume…failed" stderr without session/conversation/id context', () => {
+    // The dropped `/resume.*failed/i` pattern matched all of these. Each one is
+    // a realistic stderr/log line that has nothing to do with the --resume-id
+    // failure mode but contains both "resume" and "failed". Wiping `_sessionId`
+    // on any of them would silently discard the live conversation mid-flight.
+    const looseSamples = [
+      'tool resume failed',
+      'resume hook failed',
+      'user wanted to resume after the failed sync',
+      'failed to write log file during resume',
+      'failed during resume hook',
+      'tool execution failed during the resume window',
+      'background resume task failed: out of memory',
+      'resume timer failed to start',
+    ]
+    for (const line of looseSamples) {
+      assert.equal(stderrIndicatesUnknownResume([line]), false,
+        `#4950 — "${line}" matched the old /resume.*failed/i regex; the tightened patterns must require session/conversation/id nearby so a tool-side failure during a resume window does not trigger a phantom _sessionId wipe`)
+    }
+  })
+
   it('returns false for empty / non-array input', () => {
     assert.equal(stderrIndicatesUnknownResume([]), false)
     assert.equal(stderrIndicatesUnknownResume(null), false)
@@ -112,6 +141,16 @@ describe('CliSession resume-unknown — stderr matcher (#4929)', () => {
     for (const p of RESUME_UNKNOWN_STDERR_PATTERNS) {
       assert.ok(p instanceof RegExp, 'patterns must be RegExp')
     }
+  })
+
+  it('#4950 — does NOT export the dropped loose `/resume.*failed/i` pattern', () => {
+    // The loose pattern was overbroad and matched unrelated "resume…failed"
+    // stderr. If a refactor reintroduces it, the negative-case test above will
+    // start failing — this assertion catches a reintroduction immediately at
+    // the source-of-truth level so the diagnostic is unambiguous.
+    const sources = RESUME_UNKNOWN_STDERR_PATTERNS.map((p) => p.source)
+    assert.ok(!sources.includes('resume.*failed'),
+      '#4950 — the loose `/resume.*failed/i` pattern must stay dropped; reintroducing it re-enables the phantom _sessionId wipe that #4950 fixed')
   })
 })
 


### PR DESCRIPTION
## Summary

The original seventh pattern `/resume.*failed/i` from #4944 was too loose — unrelated stderr lines like "tool resume failed" or "user wanted to resume after the failed sync" would falsely classify as `resume_unknown` and wipe `_sessionId` mid-conversation.

This PR replaces the loose pattern with three tightened patterns that all require the resume verb AND a session/conversation/id keyword nearby:

- `/resume.*(fail|error).*(session|conversation|id)/i`
- `/resume.*(session|conversation|id).*(fail|error)/i`
- `/(fail|could not|unable to|cannot).*resume.*(session|conversation|id)/i`

## Tests

- Negative-case test pins 8 realistic "resume...failed" lines the old regex matched and the new patterns must NOT match
- Positive-case test grows by 6 lines covering the formats the tightened patterns are designed to catch
- Regression-guard test asserts the loose `/resume.*failed/i` stays dropped at the `RESUME_UNKNOWN_STDERR_PATTERNS` array level
- All 17 resume-unknown tests pass

## Test plan

- [x] `node --test --import ./tests/_setup.mjs tests/cli-session-resume-unknown.test.js` — 17/17 pass
- [x] Verified all 8 negative-case lines now classify as NOT resume_unknown
- [x] Verified all positive-case lines still classify correctly

Related to PR #4944.

Closes #4950