### PR TITLE
feat(dashboard): distinct affordance for error{code:'resume_unknown'} (#4947)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -44,6 +44,7 @@ import { PastedTextModal } from './components/PastedTextModal'
 import { EvaluatorRewriteBanner, EvaluatorClarifyPrompt } from './components/EvaluatorPrompts'
 import { StreamStallChip } from './components/StreamStallChip'
 import { AskUserQuestionStallChip } from './components/AskUserQuestionStallChip'
+import { ResumeUnknownChip } from './components/ResumeUnknownChip'
 import { PlanApproval } from './components/PlanApproval'
 import { ReconnectBanner } from './components/ReconnectBanner'
 import { ConnectionAnnouncer } from './components/ConnectionAnnouncer'
@@ -1626,6 +1627,28 @@ export function App() {
         <AskUserQuestionStallChip
           errorText={storeMsg.content}
           onRetry={lastUserInput ? () => sendInput(lastUserInput.content) : undefined}
+        />
+      )
+    }
+
+    // #4947: dedicated chip for `error{code: 'resume_unknown'}` errors
+    // (server PR #4944). The server emits this when the claude CLI rejects
+    // a `--resume <id>` because the conversation id is unknown locally
+    // (operator wiped ~/.claude/projects/ between chroxy boots, restored a
+    // state file from a different machine, etc.). CliSession has ALREADY
+    // auto-fallen-back to a fresh conversation by the time this lands —
+    // the chip explains that and (when present) surfaces
+    // `attemptedResumeId` as subtext for operator correlation against
+    // `~/.chroxy/session-state.json.resumeConversationId`. Distinct from
+    // the stream_stall / ASK_USER_QUESTION_STALL chips because no retry
+    // affordance is needed: the fresh conversation is already running.
+    // Mirrors the chip pattern for consistency with the recoverable-error
+    // visual language.
+    if (storeMsg.type === 'error' && storeMsg.code === 'resume_unknown') {
+      return (
+        <ResumeUnknownChip
+          errorText={storeMsg.content}
+          attemptedResumeId={storeMsg.attemptedResumeId}
         />
       )
     }

--- a/packages/dashboard/src/components/ResumeUnknownChip.test.tsx
+++ b/packages/dashboard/src/components/ResumeUnknownChip.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * ResumeUnknownChip tests — #4947
+ *
+ * Asserts the dedicated chip (not the generic red error bubble) renders for
+ * `error{code: 'resume_unknown'}` (server PR #4944). The server emits this
+ * code when claude CLI rejects a `--resume <id>` because the conversation id
+ * is unknown locally (operator wiped ~/.claude/projects/ between chroxy boots,
+ * restored a state file from a different machine, etc.). The CLI session
+ * auto-falls-back to a fresh conversation — the chip surfaces that as a
+ * calm, operator-friendly explanation instead of the loud red crash toast.
+ *
+ * Mirrors the StreamStallChip / AskUserQuestionStallChip patterns (#4476,
+ * #4615): operator-friendly headline, raw server text preserved via the
+ * title attribute for diagnostics, distinct testID so E2E and integration
+ * tests can disambiguate this affordance from the other stall chips and
+ * the generic error bubble.
+ *
+ * Adds: `attemptedResumeId` subtext for operator correlation against the
+ * persisted session-state.json (`resumeConversationId` field). The
+ * attempted id is the one the chroxy server passed to `claude --resume`,
+ * which is exactly what's missing from `~/.claude/projects/` — surfacing
+ * it lets the operator confirm WHICH conversation was lost rather than
+ * having to grep server logs.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ResumeUnknownChip } from './ResumeUnknownChip'
+
+afterEach(cleanup)
+
+describe('ResumeUnknownChip (#4947)', () => {
+  it('renders an operator-friendly headline explaining the auto-fallback', () => {
+    render(
+      <ResumeUnknownChip errorText="Previous Claude conversation could not be resumed (the id is unknown to the local claude CLI)." />,
+    )
+    const chip = screen.getByTestId('resume-unknown-chip')
+    expect(chip).toBeInTheDocument()
+    // Headline must explain the situation, not the jargon-y server text.
+    // Match on the user-facing concept: the prior conversation is gone and
+    // a fresh one is starting. Operator must understand they aren't losing
+    // anything else (chroxy ring buffer transcript is preserved in the UI).
+    expect(chip.textContent).toMatch(/previous conversation/i)
+    expect(chip.textContent).toMatch(/starting fresh/i)
+  })
+
+  it('preserves the raw server error text via the title attribute', () => {
+    // Operators investigating a recurring resume-failure pattern need the
+    // underlying server message — the chip's prose is friendly, but the
+    // diagnostic detail must remain accessible via tooltip without losing it.
+    const raw =
+      'Previous Claude conversation could not be resumed (the id is unknown to the local claude CLI — ' +
+      'it may have been wiped from ~/.claude/projects/). Starting a fresh conversation; the model will ' +
+      'not see the earlier transcript.'
+    render(<ResumeUnknownChip errorText={raw} />)
+    const chip = screen.getByTestId('resume-unknown-chip')
+    expect(chip.getAttribute('title')).toBe(raw)
+  })
+
+  it('surfaces attemptedResumeId in a subtext slot when provided', () => {
+    // Acceptance criterion: `attemptedResumeId` surfaced somewhere for
+    // operator correlation against the persisted state file. We render it
+    // as a small mono-spaced subtext under the headline so the operator
+    // can copy/grep without leaving the chat.
+    render(
+      <ResumeUnknownChip
+        errorText="x"
+        attemptedResumeId="abc123-def456-7890"
+      />,
+    )
+    const subtext = screen.getByTestId('resume-unknown-chip-id')
+    expect(subtext).toBeInTheDocument()
+    expect(subtext.textContent).toContain('abc123-def456-7890')
+  })
+
+  it('omits the attemptedResumeId subtext when the id is missing', () => {
+    // Older servers (pre-#4944) and the rare edge where the resume-failure
+    // path fires without an attempt tracked (defensive, shouldn't happen in
+    // practice) must not render an empty "id:" slot. The headline alone is
+    // still useful — the chip degrades cleanly to "no extra correlation hint".
+    render(<ResumeUnknownChip errorText="x" />)
+    expect(screen.queryByTestId('resume-unknown-chip-id')).toBeNull()
+  })
+
+  it('omits the attemptedResumeId subtext when the id is an empty string', () => {
+    // Empty string is treated as missing — rendering "Attempted id:" with
+    // no value would look broken.
+    render(<ResumeUnknownChip errorText="x" attemptedResumeId="" />)
+    expect(screen.queryByTestId('resume-unknown-chip-id')).toBeNull()
+  })
+
+  it('uses role="status" so assistive tech announces the fallback non-disruptively', () => {
+    // Same accessibility rationale as StreamStallChip / AskUserQuestionStallChip:
+    // this is recoverable (the server has already auto-fallen-back to a fresh
+    // conversation, no operator action needed), so announce with `polite`
+    // live-region semantics rather than the assertive `alert` role used for
+    // destructive errors.
+    render(<ResumeUnknownChip errorText="x" />)
+    const chip = screen.getByTestId('resume-unknown-chip')
+    expect(chip.getAttribute('role')).toBe('status')
+  })
+
+  it('does not collide with the StreamStallChip or AskUserQuestionStallChip testIDs', () => {
+    // All three chips share the amber-warning palette; the testID
+    // disambiguates so integration tests can target the correct affordance.
+    render(<ResumeUnknownChip errorText="x" attemptedResumeId="x" />)
+    expect(screen.queryByTestId('stream-stall-chip')).toBeNull()
+    expect(screen.queryByTestId('ask-user-question-stall-chip')).toBeNull()
+  })
+})

--- a/packages/dashboard/src/components/ResumeUnknownChip.tsx
+++ b/packages/dashboard/src/components/ResumeUnknownChip.tsx
@@ -1,0 +1,90 @@
+/**
+ * ResumeUnknownChip — #4947
+ *
+ * Replaces the generic red error bubble when the server emits
+ * `error{code: 'resume_unknown'}` (server PR #4944). The server fires this
+ * code when claude CLI rejects a `--resume <id>` because the conversation
+ * id is unknown locally (operator wiped `~/.claude/projects/` between
+ * chroxy boots, restored a state file from a different machine, etc.).
+ *
+ * The CliSession has already auto-fallen-back to a fresh conversation by
+ * the time this chip surfaces — the model loses the prior transcript but
+ * the chroxy ring buffer transcript is preserved in the UI. So we render a
+ * calm operator-friendly explanation rather than the loud red crash toast,
+ * matching the spirit of StreamStallChip (#4476) and AskUserQuestionStallChip
+ * (#4615): "this is recoverable, here's what happened, here's what to
+ * expect next".
+ *
+ * `attemptedResumeId` (when provided) renders as small mono-spaced subtext
+ * for operator correlation against the persisted state file
+ * (`resumeConversationId` in ~/.chroxy/session-state.json) — answers "which
+ * conversation did we lose?" without forcing the operator to grep logs.
+ *
+ * Reuses the `stream-stall-chip` CSS classes — the amber-warning palette
+ * already conveys "recoverable" and the three stall chips share a single
+ * visual language so the user learns the affordance once. Distinct
+ * `data-testid` makes the chip targetable from integration / E2E tests.
+ */
+import type { CSSProperties } from 'react'
+
+export interface ResumeUnknownChipProps {
+  /**
+   * The raw error text from the server (e.g. "Previous Claude conversation
+   * could not be resumed (the id is unknown to the local claude CLI — ...)").
+   * Preserved verbatim in the title attribute for operator triage.
+   */
+  errorText: string
+  /**
+   * #4947 — the conversation id chroxy passed to `claude --resume <id>`
+   * before the CLI rejected it. Surfaced as small mono-spaced subtext so
+   * operators investigating a recurring resume failure can correlate against
+   * the persisted state file (`resumeConversationId` in
+   * `~/.chroxy/session-state.json`) without grepping server logs.
+   *
+   * Empty string and undefined are treated identically — the subtext slot
+   * is omitted entirely rather than rendered with no value, which would
+   * look like a UI bug.
+   */
+  attemptedResumeId?: string
+}
+
+// #4947 — small mono-spaced subtext for the attempted id slot. Inline to
+// avoid touching the theme CSS (the chip reuses `stream-stall-chip` for
+// its primary palette and we don't want to bloat components.css with a
+// near-duplicate selector). The font-family fallback matches the rest of
+// the app's mono usage (see InputBar / ToolBubble code blocks).
+const ID_SUBTEXT_STYLE: CSSProperties = {
+  display: 'block',
+  marginTop: 4,
+  fontSize: '0.8em',
+  fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace",
+  opacity: 0.75,
+}
+
+export function ResumeUnknownChip({ errorText, attemptedResumeId }: ResumeUnknownChipProps) {
+  // Treat empty / whitespace-only strings as missing so a stale or
+  // defensive empty value can't degrade the headline into a broken-looking
+  // "Attempted id: " slot.
+  const hasId = typeof attemptedResumeId === 'string' && attemptedResumeId.trim().length > 0
+
+  return (
+    <div
+      className="stream-stall-chip"
+      data-testid="resume-unknown-chip"
+      role="status"
+      title={errorText}
+    >
+      <span className="stream-stall-chip-text">
+        Previous conversation could not be resumed — starting fresh
+      </span>
+      {hasId && (
+        <span
+          data-testid="resume-unknown-chip-id"
+          style={ID_SUBTEXT_STYLE}
+        >
+          Attempted id: {attemptedResumeId}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -92,6 +92,7 @@ export declare const ServerMessageSchema: z.ZodObject<{
     options: z.ZodOptional<z.ZodAny>;
     timestamp: z.ZodNumber;
     code: z.ZodOptional<z.ZodString>;
+    attemptedResumeId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const ServerToolStartSchema: z.ZodObject<{
     type: z.ZodLiteral<"tool_start">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -124,6 +124,15 @@ export const ServerMessageSchema = z.object({
     options: z.any().optional(),
     timestamp: z.number(),
     code: z.string().max(64).optional(),
+    // #4947: only set on `messageType: 'error'` envelopes whose `code` is
+    // `'resume_unknown'` (CliSession `_handleChildClose` resume-failure path,
+    // server PR #4944). Carries the conversation id chroxy passed to
+    // `claude --resume <id>` before the CLI rejected it; dashboards surface
+    // it under the auto-fallback affordance for operator correlation against
+    // the persisted state file (`resumeConversationId` in
+    // `~/.chroxy/session-state.json`). Optional + length-capped so a
+    // malformed producer can't pollute the wire with megabyte payloads.
+    attemptedResumeId: z.string().max(256).optional(),
 });
 export const ServerToolStartSchema = z.object({
     type: z.literal('tool_start'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -134,6 +134,15 @@ export const ServerMessageSchema = z.object({
   options: z.any().optional(),
   timestamp: z.number(),
   code: z.string().max(64).optional(),
+  // #4947: only set on `messageType: 'error'` envelopes whose `code` is
+  // `'resume_unknown'` (CliSession `_handleChildClose` resume-failure path,
+  // server PR #4944). Carries the conversation id chroxy passed to
+  // `claude --resume <id>` before the CLI rejected it; dashboards surface
+  // it under the auto-fallback affordance for operator correlation against
+  // the persisted state file (`resumeConversationId` in
+  // `~/.chroxy/session-state.json`). Optional + length-capped so a
+  // malformed producer can't pollute the wire with megabyte payloads.
+  attemptedResumeId: z.string().max(256).optional(),
 })
 
 export const ServerToolStartSchema = z.object({

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -401,6 +401,20 @@ Object.assign(EVENT_MAP, {
       timestamp: Date.now(),
     }
     if (data.code) msg.code = data.code
+    // #4947: forward `attemptedResumeId` when CliSession's resume-failure
+    // path tagged the error envelope (see cli-session.js
+    // `_handleChildClose` — emits `error{code:'resume_unknown',
+    // attemptedResumeId, message}` from server PR #4944). The dashboard
+    // ResumeUnknownChip surfaces this id as subtext so operators can
+    // correlate against `~/.chroxy/session-state.json.resumeConversationId`
+    // without grepping logs. Only a non-empty string is forwarded — a
+    // missing or empty field would render as an "Attempted id:" slot with
+    // no value, which looks broken. Length cap on the wire schema
+    // (`ServerMessageSchema.attemptedResumeId`, 256 chars) keeps a
+    // malformed producer from polluting the wire.
+    if (typeof data.attemptedResumeId === 'string' && data.attemptedResumeId.length > 0) {
+      msg.attemptedResumeId = data.attemptedResumeId
+    }
     return { messages: [{ msg }] }
   },
 

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -407,13 +407,31 @@ Object.assign(EVENT_MAP, {
     // attemptedResumeId, message}` from server PR #4944). The dashboard
     // ResumeUnknownChip surfaces this id as subtext so operators can
     // correlate against `~/.chroxy/session-state.json.resumeConversationId`
-    // without grepping logs. Only a non-empty string is forwarded — a
-    // missing or empty field would render as an "Attempted id:" slot with
-    // no value, which looks broken. Length cap on the wire schema
-    // (`ServerMessageSchema.attemptedResumeId`, 256 chars) keeps a
-    // malformed producer from polluting the wire.
-    if (typeof data.attemptedResumeId === 'string' && data.attemptedResumeId.length > 0) {
-      msg.attemptedResumeId = data.attemptedResumeId
+    // without grepping logs.
+    //
+    // Hardening (from PR #4967 Copilot review):
+    //   1. Gate strictly on `code === 'resume_unknown'` so a buggy producer
+    //      can't sneak the field onto unrelated error envelopes.
+    //   2. Trim whitespace and treat whitespace-only as missing — same UX
+    //      guard the chip's render-time check already applies, but enforced
+    //      at the wire boundary so downstream consumers (mobile app, future
+    //      log/console viewers) see a consistent "present or absent, never
+    //      present-but-empty" shape.
+    //   3. Enforce the same 256-char cap the wire schema declares
+    //      (`ServerMessageSchema.attemptedResumeId`). The server doesn't
+    //      validate outgoing messages against ServerMessageSchema before
+    //      send, so without this guard a misbehaving producer could ship a
+    //      megabyte payload that the dashboard accepts (lax client parse)
+    //      but trips Zod-validating consumers. Silently truncate rather
+    //      than drop — the truncated id still helps operator triage.
+    if (
+      data.code === 'resume_unknown' &&
+      typeof data.attemptedResumeId === 'string'
+    ) {
+      const trimmed = data.attemptedResumeId.trim()
+      if (trimmed.length > 0) {
+        msg.attemptedResumeId = trimmed.length > 256 ? trimmed.slice(0, 256) : trimmed
+      }
     }
     return { messages: [{ msg }] }
   },

--- a/packages/server/tests/event-normalizer-resume-unknown.test.js
+++ b/packages/server/tests/event-normalizer-resume-unknown.test.js
@@ -81,4 +81,64 @@ describe('EventNormalizer error mapping — #4947', () => {
     const msg = result.messages[0].msg
     assert.equal(msg.attemptedResumeId, undefined)
   })
+
+  // PR #4967 Copilot review hardening: gate-on-code + trim + 256-char cap.
+  it('omits attemptedResumeId when code is not resume_unknown (out-of-contract gating)', () => {
+    // The field is documented as set only on resume_unknown errors. A
+    // buggy producer attaching it to other error codes should NOT reach
+    // the wire — keeps the contract clean and prevents downstream
+    // consumers from special-casing junk.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'stream_stall',
+      message: 'x',
+      attemptedResumeId: 'abc123',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.attemptedResumeId, undefined,
+      'attemptedResumeId must not flow through on non-resume_unknown errors')
+  })
+
+  it('trims whitespace from attemptedResumeId before emitting', () => {
+    // Defensive normalisation at the wire boundary — same UX guard the
+    // dashboard chip applies at render time, but enforced upstream so
+    // every downstream consumer sees the same shape.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'resume_unknown',
+      message: 'x',
+      attemptedResumeId: '  abc123  ',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.attemptedResumeId, 'abc123')
+  })
+
+  it('omits attemptedResumeId on the wire when only whitespace', () => {
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'resume_unknown',
+      message: 'x',
+      attemptedResumeId: '   \t  ',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.attemptedResumeId, undefined)
+  })
+
+  it('truncates attemptedResumeId to 256 chars (matches wire schema cap)', () => {
+    // The wire schema rejects > 256 chars, but the server doesn't
+    // self-validate outgoing messages against ServerMessageSchema. Enforce
+    // the cap here so a misbehaving producer can't ship a megabyte id
+    // that the dashboard accepts (lax client parse) but trips Zod-
+    // validating consumers. Silently truncate rather than drop — the
+    // truncated id still helps operator triage.
+    const oversized = 'a'.repeat(500)
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'resume_unknown',
+      message: 'x',
+      attemptedResumeId: oversized,
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.attemptedResumeId, 'a'.repeat(256))
+  })
 })

--- a/packages/server/tests/event-normalizer-resume-unknown.test.js
+++ b/packages/server/tests/event-normalizer-resume-unknown.test.js
@@ -1,0 +1,84 @@
+/**
+ * EventNormalizer error mapping — `resume_unknown` payload forwarding (#4947)
+ *
+ * Pins the contract for the `error` event coming out of CliSession's
+ * resume-failure path (server PR #4944): the normalizer must forward both
+ * `code` AND `attemptedResumeId` onto the wire so the dashboard
+ * ResumeUnknownChip (#4947) can surface the attempted id as subtext for
+ * operator correlation against the persisted state file
+ * (`resumeConversationId` in `~/.chroxy/session-state.json`).
+ *
+ * Pre-fix this normalizer dropped every field except `data.message` and
+ * `data.code` — the (Optional) acceptance-criterion subtext on the chip
+ * would never have a value to render. The original PR #4944 review comment
+ * called this out explicitly: "no dashboard/WS consumer reads it today".
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventNormalizer } from '../src/event-normalizer.js'
+
+describe('EventNormalizer error mapping — #4947', () => {
+  const ctx = { sessionId: 'sess-1', mode: 'multi', getSessionEntry: () => null }
+
+  it('forwards attemptedResumeId onto the wire message for resume_unknown errors', () => {
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'resume_unknown',
+      message: 'Previous Claude conversation could not be resumed',
+      attemptedResumeId: 'abc123-def456-7890',
+    }, ctx)
+    assert.ok(result && Array.isArray(result.messages) && result.messages.length === 1)
+    const msg = result.messages[0].msg
+    assert.equal(msg.type, 'message')
+    assert.equal(msg.messageType, 'error')
+    assert.equal(msg.code, 'resume_unknown')
+    assert.equal(msg.attemptedResumeId, 'abc123-def456-7890',
+      'attemptedResumeId must round-trip the wire so ResumeUnknownChip can correlate')
+  })
+
+  it('omits attemptedResumeId on the wire when the field is missing', () => {
+    // Generic errors (no resume attempt) must continue to flow through
+    // the normalizer unchanged — wire stays at the legacy 3-field shape
+    // (type, messageType, content, timestamp, [code]).
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      message: 'something exploded',
+    }, ctx)
+    assert.ok(result && Array.isArray(result.messages) && result.messages.length === 1)
+    const msg = result.messages[0].msg
+    assert.equal(msg.attemptedResumeId, undefined,
+      'normalizer must NOT add an empty attemptedResumeId field — that would render "Attempted id: " with no value')
+  })
+
+  it('omits attemptedResumeId on the wire when the field is empty string', () => {
+    // Defensive: a producer that defaults to '' rather than undefined must
+    // not pollute the wire with an empty slot. The chip's render guard
+    // already treats whitespace-only as absent, but normalising at the
+    // wire boundary means the dashboard message-handler sees a consistent
+    // shape and downstream consumers (mobile app) get the same treatment
+    // without re-implementing the guard.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'resume_unknown',
+      message: 'x',
+      attemptedResumeId: '',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.attemptedResumeId, undefined)
+  })
+
+  it('omits attemptedResumeId on the wire when the field is not a string', () => {
+    // Defense in depth — the wire schema (ServerMessageSchema) constrains
+    // attemptedResumeId to a string, but the event-normalizer is upstream
+    // of any wire-level validation. Drop non-string payloads here so a
+    // malformed producer can't reach the dashboard with junk on the field.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'resume_unknown',
+      message: 'x',
+      attemptedResumeId: 42,
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.attemptedResumeId, undefined)
+  })
+})

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -5640,6 +5640,103 @@ describe('handleMessage', () => {
     }
   })
 
+  // #4947: server PR #4944 emits `error{code:'resume_unknown',
+  // attemptedResumeId, message}` when the claude CLI rejects a `--resume
+  // <id>` because the conversation id is unknown locally. The dashboard
+  // ResumeUnknownChip surfaces `attemptedResumeId` as subtext so operators
+  // can correlate against the persisted state file. Without preserving the
+  // field on the ChatMessage here, the chip would degrade to "headline
+  // only" and the (Optional) acceptance-criterion subtext would never
+  // render in practice.
+  describe('attemptedResumeId preservation (#4947)', () => {
+    it('preserves a string attemptedResumeId on the ChatMessage', () => {
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content: 'Previous Claude conversation could not be resumed',
+          code: 'resume_unknown',
+          attemptedResumeId: 'abc123-def456-7890',
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.code).toBe('resume_unknown')
+        expect(out.chatMessage.attemptedResumeId).toBe('abc123-def456-7890')
+      }
+    })
+
+    it('leaves attemptedResumeId undefined when the wire field is missing', () => {
+      // Pre-#4944 servers and every non-resume_unknown error envelope omit
+      // the field entirely. ChatMessage simply stays undefined and the
+      // chip's hasId guard hides the subtext slot.
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content: 'something else',
+          code: 'stream_stall',
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.attemptedResumeId).toBeUndefined()
+      }
+    })
+
+    it('coerces a non-string attemptedResumeId to undefined (defense in depth)', () => {
+      // Same hardening as `code: 42` above. A malformed producer must not
+      // populate the chat-message field with garbage that the chip will
+      // then render verbatim.
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content: 'x',
+          code: 'resume_unknown',
+          attemptedResumeId: 42,
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.attemptedResumeId).toBeUndefined()
+      }
+    })
+
+    it('coerces an empty-string attemptedResumeId to undefined', () => {
+      // Empty string is treated as missing — the chip's render guard
+      // already treats whitespace-only as absent, but normalising at the
+      // store boundary means downstream consumers (mobile app, future
+      // log/console viewers) see the same shape: present or absent, never
+      // present-but-empty.
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content: 'x',
+          code: 'resume_unknown',
+          attemptedResumeId: '',
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.attemptedResumeId).toBeUndefined()
+      }
+    })
+  })
+
   it('skips user_input outside replay (live echo handled elsewhere)', () => {
     const out = handleMessage(
       { messageType: 'user_input', content: 'hi', timestamp: 1 },

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -5735,6 +5735,109 @@ describe('handleMessage', () => {
         expect(out.chatMessage.attemptedResumeId).toBeUndefined()
       }
     })
+
+    // PR #4967 Copilot review hardening: gating + trim + 256-char cap.
+    it('drops attemptedResumeId when messageType is not error (out-of-contract gating)', () => {
+      // Documented as set only on `type === 'error'`; a buggy producer
+      // attaching it to e.g. a `response` envelope must not pollute the
+      // store with out-of-contract data.
+      const out = handleMessage(
+        {
+          messageType: 'response',
+          content: 'hello',
+          code: 'resume_unknown',
+          attemptedResumeId: 'abc123',
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.attemptedResumeId).toBeUndefined()
+      }
+    })
+
+    it('drops attemptedResumeId when code is not resume_unknown (out-of-contract gating)', () => {
+      // Only the resume-unknown error path documents this field; other
+      // error codes attaching it (drift or producer bug) shouldn't make
+      // it into the store.
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content: 'x',
+          code: 'stream_stall',
+          attemptedResumeId: 'abc123',
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.attemptedResumeId).toBeUndefined()
+      }
+    })
+
+    it('trims whitespace from attemptedResumeId before storing', () => {
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content: 'x',
+          code: 'resume_unknown',
+          attemptedResumeId: '  abc123  ',
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.attemptedResumeId).toBe('abc123')
+      }
+    })
+
+    it('drops attemptedResumeId when only whitespace', () => {
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content: 'x',
+          code: 'resume_unknown',
+          attemptedResumeId: '   \t  ',
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.attemptedResumeId).toBeUndefined()
+      }
+    })
+
+    it('truncates attemptedResumeId to 256 chars (matches wire schema cap)', () => {
+      const oversized = 'a'.repeat(500)
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content: 'x',
+          code: 'resume_unknown',
+          attemptedResumeId: oversized,
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.attemptedResumeId).toBe('a'.repeat(256))
+      }
+    })
   })
 
   it('skips user_input outside replay (live echo handled elsewhere)', () => {

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3919,13 +3919,31 @@ export function handleMessage(
     // #4947: preserve `attemptedResumeId` for `error{code:'resume_unknown'}`
     // bubbles (server PR #4944). The dashboard ResumeUnknownChip surfaces
     // it as subtext for operator correlation against the persisted state
-    // file. Same defensive type-check pattern as `code`: a non-string or
-    // empty-string payload is dropped rather than stored, so a malformed
-    // producer can't render "Attempted id: " with no value (which looks
-    // like a UI bug). Pre-#4944 servers omit the field entirely and the
-    // ChatMessage simply stays `attemptedResumeId: undefined`.
-    ...(typeof msg.attemptedResumeId === 'string' && msg.attemptedResumeId.length > 0
-      ? { attemptedResumeId: msg.attemptedResumeId }
+    // file. Pre-#4944 servers omit the field entirely and the ChatMessage
+    // simply stays `attemptedResumeId: undefined`.
+    //
+    // Hardening (from PR #4967 Copilot review):
+    //   1. Gate strictly on `msgType === 'error' && msg.code === 'resume_unknown'`
+    //      — the field is documented as only valid on that envelope, so a
+    //      buggy producer attaching it to other types shouldn't pollute the
+    //      store with out-of-contract data.
+    //   2. Trim whitespace and treat whitespace-only as missing — matches
+    //      the chip's render-time guard so the store and the renderer
+    //      agree.
+    //   3. Enforce the same 256-char cap the wire schema declares
+    //      (`ServerMessageSchema.attemptedResumeId`). Defense in depth
+    //      against a malformed wire-bypassing path (e.g. localStorage
+    //      replay of a corrupted message) — silently truncate rather than
+    //      drop so the truncated id still helps operator triage.
+    ...(msgType === 'error' &&
+    typeof msg.code === 'string' &&
+    msg.code === 'resume_unknown' &&
+    typeof msg.attemptedResumeId === 'string'
+      ? (() => {
+          const trimmed = msg.attemptedResumeId.trim()
+          if (trimmed.length === 0) return {}
+          return { attemptedResumeId: trimmed.length > 256 ? trimmed.slice(0, 256) : trimmed }
+        })()
       : {}),
   }
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3916,6 +3916,17 @@ export function handleMessage(
     // (defensive against malformed payloads) is dropped to keep junk off
     // the store.
     ...(typeof msg.code === 'string' ? { code: msg.code } : {}),
+    // #4947: preserve `attemptedResumeId` for `error{code:'resume_unknown'}`
+    // bubbles (server PR #4944). The dashboard ResumeUnknownChip surfaces
+    // it as subtext for operator correlation against the persisted state
+    // file. Same defensive type-check pattern as `code`: a non-string or
+    // empty-string payload is dropped rather than stored, so a malformed
+    // producer can't render "Attempted id: " with no value (which looks
+    // like a UI bug). Pre-#4944 servers omit the field entirely and the
+    // ChatMessage simply stays `attemptedResumeId: undefined`.
+    ...(typeof msg.attemptedResumeId === 'string' && msg.attemptedResumeId.length > 0
+      ? { attemptedResumeId: msg.attemptedResumeId }
+      : {}),
   }
 
   // Surface rate-limit / usage-limit / quota / overloaded errors prominently (#616).

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -86,6 +86,19 @@ export interface ChatMessage {
    * Undefined for legacy errors that carry no code.
    */
   code?: string;
+  /**
+   * #4947: only set on `type: 'error'` bubbles whose `code` is
+   * `'resume_unknown'` (server PR #4944 — CliSession's
+   * `_handleChildClose` resume-failure path). Carries the conversation id
+   * chroxy passed to `claude --resume <id>` before the CLI rejected it.
+   * The dashboard `ResumeUnknownChip` surfaces this as small mono-spaced
+   * subtext under the headline so operators investigating a recurring
+   * resume failure can correlate against the persisted state file
+   * (`resumeConversationId` in `~/.chroxy/session-state.json`) without
+   * grepping logs. Undefined for every other error code and for
+   * pre-#4944 servers that don't emit the field.
+   */
+  attemptedResumeId?: string;
   /** Base64 images from tool results (e.g. computer use screenshots) */
   toolResultImages?: ToolResultImage[];
   /**


### PR DESCRIPTION
Closes #4947. Follow-up to PR #4944 which added a distinct `error{code:'resume_unknown', attemptedResumeId, message}` event from `CliSession._handleChildClose` when the claude CLI rejects `--resume <id>` and the server auto-falls-back to a fresh conversation. Before this PR the dashboard treated that case identically to a generic crash — a red "Claude process exited unexpectedly" bubble that overstated the severity.

## Summary

- **`ResumeUnknownChip`** — new amber-warning chip rendering "Previous conversation could not be resumed — starting fresh" with the raw server text preserved via the `title` attribute for triage. Mirrors the visual language of `StreamStallChip` (#4476) and `AskUserQuestionStallChip` (#4615) so the operator learns the recoverable-error affordance once.
- **`attemptedResumeId` plumbing end-to-end** — extends `ServerMessageSchema` (protocol), `event-normalizer.js` (server), shared `handleMessage` (store-core), and `ChatMessage.attemptedResumeId` (store-core types) so the chip can surface the attempted conversation id as small mono-spaced subtext for operator correlation against `~/.chroxy/session-state.json.resumeConversationId` without grepping logs. Pre-#4944 review explicitly called out that this field had no consumer; the field now flows wire-to-render.
- **App.tsx wiring** — adds a third `code === 'resume_unknown'` branch in the `renderMessage` chain alongside the existing two stall-chip branches. No retry affordance because the server has already auto-fallen-back to a fresh conversation by the time the chip surfaces.
- **Mobile mirroring** — the shared store-core change means mobile-app `ChatMessage` also carries `attemptedResumeId` cleanly. A native chip mirror is out of scope here (no RN component change in this PR).

## Acceptance criteria from #4947

- [x] Dashboard branches on `error.code === 'resume_unknown'` and renders a distinct toast/banner (not the generic crash toast).
- [x] Toast copy explains the auto-fallback in operator-friendly language.
- [x] `attemptedResumeId` surfaced (chip subtext) for correlation against the persisted state file.
- [x] Mobile app handling mirrored "where applicable" — shared store-core plumbing preserves the field on `ChatMessage` for any future RN renderer; no destructive divergence introduced.
- [x] Tests pin the branch.

## Test plan

- [x] `packages/dashboard`: 138 test files / **2676 tests pass** (baseline was 137 / 2669; +1 file / +7 tests = new `ResumeUnknownChip.test.tsx`).
- [x] `packages/store-core`: 21 test files / **1064 tests pass** (added 4 new tests for `attemptedResumeId` preservation in `handlers.test.ts`).
- [x] `packages/server` (`event-normalizer-resume-unknown` + `event-normalizer` + `cli-session-resume-unknown` + `permission-expired-broadcast`): **120 tests pass** across the affected suites (added 4 new tests in `event-normalizer-resume-unknown.test.js`).
- [x] Typecheck clean across `packages/dashboard`, `packages/store-core`, `packages/protocol`.
- [x] Server lint clean (pre-existing warnings only — no new ones).

## Files changed

- `packages/dashboard/src/components/ResumeUnknownChip.tsx` (new) — chip component.
- `packages/dashboard/src/components/ResumeUnknownChip.test.tsx` (new) — 7 tests.
- `packages/dashboard/src/App.tsx` — import + `renderMessage` branch.
- `packages/protocol/src/schemas/server.ts` — `attemptedResumeId` field on `ServerMessageSchema`.
- `packages/server/src/event-normalizer.js` — forward `attemptedResumeId` from session event to wire.
- `packages/server/tests/event-normalizer-resume-unknown.test.js` (new) — 4 tests.
- `packages/store-core/src/handlers/index.ts` — preserve `attemptedResumeId` on the built `ChatMessage` from the shared `handleMessage`.
- `packages/store-core/src/handlers/handlers.test.ts` — 4 new tests under "attemptedResumeId preservation".
- `packages/store-core/src/types.ts` — `attemptedResumeId?: string` on `ChatMessage` with rationale doc.