### PR TITLE
fix(dashboard): collapse topbar tertiary icons into overflow menu (#4974)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -1697,10 +1697,17 @@ describe('App', () => {
       const item = openOverflowAndGetCopyItem()
       fireEvent.click(item)
 
+      // Wait for the clipboard write to resolve (state-only assertion —
+      // keeps the waitFor callback side-effect-free per RTL guidance;
+      // re-opening the menu inside the retry loop would toggle it open
+      // and closed on each tick and make the test non-deterministic).
       await waitFor(() => {
-        const after = openOverflowAndGetCopyItem()
-        expect(after.textContent).toContain('✓')
+        expect(clipboardWriteTextMock).toHaveBeenCalledTimes(1)
       })
+      // `transcriptCopied` flipped to true — re-open the menu and read
+      // the row's current glyph.
+      const after = openOverflowAndGetCopyItem()
+      expect(after.textContent).toContain('✓')
       expect(addServerErrorMock).not.toHaveBeenCalled()
     })
   })

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -1600,23 +1600,35 @@ describe('App', () => {
       }),
     }
 
+    // #4974 — Copy transcript moved into the header overflow menu. The
+    // helper opens the menu and returns the "Copy transcript" item so
+    // each test reads as: open → click → assert. We re-query the item
+    // after the click because the App rerenders the menu when
+    // `transcriptCopied` flips, which can rebind the DOM node.
+    const openOverflowAndGetCopyItem = () => {
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      return screen.getByTestId('header-overflow-item-copy-transcript')
+    }
+
     it('does NOT flash the check mark when the clipboard helper returns false', async () => {
       clipboardWriteTextMock.mockResolvedValue(false)
       stateOverrides = connectedWithMessages
       render(<App />)
 
-      const btn = screen.getByTestId('btn-copy-transcript')
+      const item = openOverflowAndGetCopyItem()
       // Title before click reflects the not-copied state (no "Copied!").
-      expect(btn.getAttribute('title')).not.toContain('Copied!')
+      expect(item.getAttribute('title')).not.toContain('Copied!')
 
-      fireEvent.click(btn)
+      fireEvent.click(item)
       await waitFor(() => {
         expect(clipboardWriteTextMock).toHaveBeenCalledTimes(1)
       })
 
       // Indicator must NOT flip — the OS clipboard was never written.
-      expect(btn.textContent).not.toContain('✓')
-      expect(btn.getAttribute('title')).not.toContain('Copied!')
+      // The menu closes after a click; re-open and re-read the item.
+      const after = openOverflowAndGetCopyItem()
+      expect(after.textContent).not.toContain('✓')
+      expect(after.getAttribute('title')).not.toContain('Copied!')
     })
 
     it('DOES flash the check mark when the clipboard helper returns true', async () => {
@@ -1624,14 +1636,19 @@ describe('App', () => {
       stateOverrides = connectedWithMessages
       render(<App />)
 
-      const btn = screen.getByTestId('btn-copy-transcript')
-      fireEvent.click(btn)
+      const item = openOverflowAndGetCopyItem()
+      fireEvent.click(item)
 
       await waitFor(() => {
-        expect(btn.textContent).toContain('✓')
+        expect(clipboardWriteTextMock).toHaveBeenCalledTimes(1)
       })
-      expect(clipboardWriteTextMock).toHaveBeenCalledTimes(1)
-      expect(btn.getAttribute('title')).toContain('Copied!')
+      // Re-open the menu — `transcriptCopied` flipped to true so the
+      // item now renders the check glyph + "Copied!" title.
+      const after = openOverflowAndGetCopyItem()
+      await waitFor(() => {
+        expect(after.textContent).toContain('✓')
+      })
+      expect(after.getAttribute('title')).toContain('Copied!')
     })
 
     // #4629 — the original bug was that a failed clipboard write would
@@ -1647,8 +1664,8 @@ describe('App', () => {
       stateOverrides = connectedWithMessages
       render(<App />)
 
-      const btn = screen.getByTestId('btn-copy-transcript')
-      fireEvent.click(btn)
+      const item = openOverflowAndGetCopyItem()
+      fireEvent.click(item)
 
       await waitFor(() => {
         expect(addServerErrorMock).toHaveBeenCalledTimes(1)
@@ -1667,8 +1684,9 @@ describe('App', () => {
       expect(severity).toBe('warning')
       // Must NOT also flash the success indicator (that was the #4673 bug;
       // this test pins the negative too so a future regression on either
-      // axis is caught).
-      expect(btn.textContent).not.toContain('✓')
+      // axis is caught). Re-open the menu to read the current row state.
+      const after = openOverflowAndGetCopyItem()
+      expect(after.textContent).not.toContain('✓')
     })
 
     it('does NOT surface a server-error toast on a successful copy (#4629)', async () => {
@@ -1676,11 +1694,12 @@ describe('App', () => {
       stateOverrides = connectedWithMessages
       render(<App />)
 
-      const btn = screen.getByTestId('btn-copy-transcript')
-      fireEvent.click(btn)
+      const item = openOverflowAndGetCopyItem()
+      fireEvent.click(item)
 
       await waitFor(() => {
-        expect(btn.textContent).toContain('✓')
+        const after = openOverflowAndGetCopyItem()
+        expect(after.textContent).toContain('✓')
       })
       expect(addServerErrorMock).not.toHaveBeenCalled()
     })
@@ -2030,20 +2049,34 @@ describe('App', () => {
       activeSessionId: 's1',
     }
 
-    it('Skills toggle exposes both title and aria-label', () => {
+    // #4974 — Skills + Settings moved into the header overflow menu.
+    // The trigger itself stays in the chrome with title + aria-label;
+    // the underlying actions sit one click away inside the popover.
+    it('Skills row inside the overflow menu carries a title', () => {
       stateOverrides = connectedWithSession
       render(<App />)
-      const btn = screen.getByTestId('btn-toggle-skills-panel')
-      expect(btn.getAttribute('title')).toBeTruthy()
-      expect(btn.getAttribute('aria-label')).toBeTruthy()
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const item = screen.getByTestId('header-overflow-item-skills')
+      expect(item.getAttribute('title')).toBe('Skills')
+      expect(item.textContent).toMatch(/Skills/)
     })
 
-    it('Settings gear button exposes both title and aria-label', () => {
+    it('Settings row inside the overflow menu carries a Settings title', () => {
       stateOverrides = connectedWithSession
       render(<App />)
-      const btn = screen.getByLabelText('Settings')
-      expect(btn.getAttribute('title')).toMatch(/Settings/)
-      expect(btn.getAttribute('aria-label')).toBe('Settings')
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const item = screen.getByTestId('header-overflow-item-settings')
+      expect(item.getAttribute('title')).toMatch(/Settings/)
+      expect(item.textContent).toMatch(/Settings/)
+    })
+
+    it('header overflow trigger itself exposes title + aria-label (chrome affordance)', () => {
+      stateOverrides = connectedWithSession
+      render(<App />)
+      const trigger = screen.getByTestId('header-overflow-trigger')
+      expect(trigger.getAttribute('title')).toBeTruthy()
+      expect(trigger.getAttribute('aria-label')).toBeTruthy()
+      expect(trigger.getAttribute('aria-haspopup')).toBe('menu')
     })
 
     it('header status dot exposes both title and aria-label so it is discoverable', () => {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -33,6 +33,7 @@ import { SessionBar, type SessionTabData, type SessionStatus } from './component
 import { StatusBar } from './components/StatusBar'
 import { ChatSettingsDropdown } from './components/ChatSettingsDropdown'
 import { SkillsPanel } from './components/SkillsPanel'
+import { HeaderOverflowMenu, type HeaderOverflowItem } from './components/HeaderOverflowMenu'
 import { PermissionPrompt } from './components/PermissionPrompt'
 import { formatTranscript } from './lib/transcript'
 import { QuestionPrompt } from './components/QuestionPrompt'
@@ -1977,46 +1978,54 @@ export function App() {
             <span className="chrome-new-session-icon" aria-hidden="true">+</span>
             <span className="chrome-new-session-label">New Session</span>
           </button>
-          {/* #3209: Skills toggle, moved to header-right as an icon
-              button. Was previously a text button in header-center
-              where it competed for space with the model dropdown. */}
-          <button
-            type="button"
-            className="header-icon-btn"
-            data-testid="btn-toggle-skills-panel"
-            onClick={() => {
-              setSkillsPanelOpen(prev => {
-                const next = !prev
-                if (next) requestListSkills()
-                return next
-              })
-            }}
-            aria-label="Skills"
-            title="Skills"
-          >
-            &#129513;
-          </button>
-          {viewMode === 'chat' && storeMessages.length > 0 && (
-            <button
-              className="header-icon-btn"
-              onClick={handleCopyTranscript}
-              aria-label="Copy chat transcript"
-              data-testid="btn-copy-transcript"
-              title={transcriptCopied ? 'Copied!' : `Copy transcript (${formatShortcutKeys('Cmd+Shift+T')})`}
-              type="button"
-            >
-              {transcriptCopied ? '✓' : '⎘'}
-            </button>
-          )}
-          <button
-            className="header-icon-btn"
-            onClick={() => setSettingsOpen(true)}
-            aria-label="Settings"
-            title={`Settings (${formatShortcutKeys('Cmd+,')})`}
-            type="button"
-          >
-            &#9881;
-          </button>
+          {/* #4974: Skills / Copy / Settings collapsed behind a single
+              "⋯" overflow trigger. Previously these three icon buttons
+              lived inline in header-right alongside `+ New Session` and
+              the StatusBar, which at ≤1400px widths overlapped the
+              model selector chevron in header-center. Each item keeps
+              its existing handler, aria-label, and data-testid via the
+              HeaderOverflowMenu's `items[]` (testids still discoverable
+              from inside the open menu so the existing test coverage
+              for the underlying actions continues to apply).
+              The filter pattern (truthy `onClick`) mirrors the
+              SessionContextMenu capability gate — Copy is only present
+              when the chat view is active and has at least one
+              message, so the dropdown grows/shrinks naturally without
+              dead rows. */}
+          {(() => {
+            const overflowItems: HeaderOverflowItem[] = [
+              {
+                id: 'skills',
+                label: 'Skills',
+                icon: '\u{1F9E9}',
+                title: 'Skills',
+                onClick: () => {
+                  setSkillsPanelOpen(prev => {
+                    const next = !prev
+                    if (next) requestListSkills()
+                    return next
+                  })
+                },
+              },
+              viewMode === 'chat' && storeMessages.length > 0
+                ? {
+                    id: 'copy-transcript',
+                    label: transcriptCopied ? 'Transcript copied' : 'Copy transcript',
+                    icon: transcriptCopied ? '✓' : '⎘',
+                    title: transcriptCopied ? 'Copied!' : `Copy transcript (${formatShortcutKeys('Cmd+Shift+T')})`,
+                    onClick: handleCopyTranscript,
+                  }
+                : { id: 'copy-transcript', label: 'Copy transcript' },
+              {
+                id: 'settings',
+                label: 'Settings',
+                icon: '⚙',
+                title: `Settings (${formatShortcutKeys('Cmd+,')})`,
+                onClick: () => setSettingsOpen(true),
+              },
+            ]
+            return <HeaderOverflowMenu items={overflowItems} />
+          })()}
           <StatusBar
             cost={sessionCost ?? undefined}
             context={formatContext(contextUsage)}

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -117,6 +117,28 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(block![0]).toMatch(/white-space:\s*nowrap/)
   })
 
+  // #4974 — Skills / Copy / Settings collapsed behind a single "⋯"
+  // overflow trigger so the right zone no longer overlaps the model
+  // selector at narrow widths. The trigger reuses `.header-icon-btn`
+  // (so the flex-shrink: 0 protection above still applies) but the
+  // popover gets its own surface so positioning + dismiss don't
+  // collide with the existing CSS for native selects.
+  it('.header-overflow wrapper does not shrink (#4974)', () => {
+    const block = css.match(/\.header-overflow\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/position:\s*relative/)
+    expect(block![0]).toMatch(/flex-shrink:\s*0/)
+  })
+
+  it('.header-overflow-menu is an absolutely-positioned popover anchored to the trigger (#4974)', () => {
+    const block = css.match(/\.header-overflow-menu\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/position:\s*absolute/)
+    // Right-aligned so the menu hangs off the trigger toward the
+    // center of the header (instead of clipping past the right edge).
+    expect(block![0]).toMatch(/right:\s*0/)
+  })
+
   it('responsive breakpoint relaxes the dropdown min-width per-kind (#3705 + #3720)', () => {
     // Narrow viewports get smaller floors for each kind. Anchored to
     // the per-kind selectors introduced in #3720 — the previous shared

--- a/packages/dashboard/src/components/HeaderOverflowMenu.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflowMenu.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * HeaderOverflowMenu unit tests (#4974).
+ *
+ * The component collapses Skills / Copy transcript / Settings behind a
+ * single "⋯" trigger so the right zone of #header no longer overlaps
+ * the model-selector chevron in header-center at narrow desktop widths.
+ *
+ * These tests pin the wiring contract:
+ *   1. The trigger renders with an accessible label + aria-haspopup.
+ *   2. The popover is closed by default.
+ *   3. Clicking the trigger reveals the rows; the row count + order
+ *      matches the input `items[]`.
+ *   4. Items with a falsy `onClick` are filtered out (capability gate).
+ *   5. Clicking a row fires its handler and dismisses the menu.
+ *   6. Escape dismisses the menu and returns focus to the trigger.
+ *   7. Outside-click dismisses the menu (capturing-phase mousedown so
+ *      we close before any sibling button handler fires).
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { HeaderOverflowMenu } from './HeaderOverflowMenu'
+
+afterEach(cleanup)
+
+describe('HeaderOverflowMenu (#4974)', () => {
+  const baseItems = [
+    { id: 'skills', label: 'Skills', icon: 'S', onClick: vi.fn() },
+    { id: 'copy', label: 'Copy', icon: 'C', onClick: vi.fn() },
+    { id: 'settings', label: 'Settings', icon: 'G', onClick: vi.fn() },
+  ]
+
+  it('renders an accessible trigger with aria-haspopup="menu" and starts closed', () => {
+    render(<HeaderOverflowMenu items={baseItems} />)
+    const trigger = screen.getByTestId('header-overflow-trigger')
+    expect(trigger).toBeInTheDocument()
+    expect(trigger.getAttribute('aria-haspopup')).toBe('menu')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(trigger.getAttribute('aria-label')).toBeTruthy()
+    // Popover is not in the DOM until the trigger is clicked.
+    expect(screen.queryByTestId('header-overflow-menu')).not.toBeInTheDocument()
+  })
+
+  it('opens the popover on trigger click and renders all 3 collapsed items', () => {
+    render(<HeaderOverflowMenu items={baseItems} />)
+    fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+    const menu = screen.getByTestId('header-overflow-menu')
+    expect(menu).toBeInTheDocument()
+    expect(menu.getAttribute('role')).toBe('menu')
+    // All 3 tertiary actions are visible inside the dropdown.
+    expect(screen.getByTestId('header-overflow-item-skills')).toBeInTheDocument()
+    expect(screen.getByTestId('header-overflow-item-copy')).toBeInTheDocument()
+    expect(screen.getByTestId('header-overflow-item-settings')).toBeInTheDocument()
+    // aria-expanded flips to true once open.
+    expect(
+      screen.getByTestId('header-overflow-trigger').getAttribute('aria-expanded'),
+    ).toBe('true')
+  })
+
+  it('filters out items whose onClick is falsy (capability gate)', () => {
+    const itemsWithGate = [
+      { id: 'skills', label: 'Skills', onClick: vi.fn() },
+      { id: 'copy', label: 'Copy' }, // no onClick — should not render
+      { id: 'settings', label: 'Settings', onClick: vi.fn() },
+    ]
+    render(<HeaderOverflowMenu items={itemsWithGate} />)
+    fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+    expect(screen.getByTestId('header-overflow-item-skills')).toBeInTheDocument()
+    expect(screen.queryByTestId('header-overflow-item-copy')).not.toBeInTheDocument()
+    expect(screen.getByTestId('header-overflow-item-settings')).toBeInTheDocument()
+  })
+
+  it('does not render the trigger at all when every item is gated out', () => {
+    const allGated = [
+      { id: 'skills', label: 'Skills' },
+      { id: 'copy', label: 'Copy' },
+    ]
+    render(<HeaderOverflowMenu items={allGated} />)
+    expect(screen.queryByTestId('header-overflow-trigger')).not.toBeInTheDocument()
+  })
+
+  it('fires the item handler and dismisses the menu on click', () => {
+    const onSkills = vi.fn()
+    const items = [{ id: 'skills', label: 'Skills', onClick: onSkills }]
+    render(<HeaderOverflowMenu items={items} />)
+    fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+    fireEvent.click(screen.getByTestId('header-overflow-item-skills'))
+    expect(onSkills).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('header-overflow-menu')).not.toBeInTheDocument()
+  })
+
+  it('dismisses on Escape', () => {
+    render(<HeaderOverflowMenu items={baseItems} />)
+    fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+    expect(screen.getByTestId('header-overflow-menu')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('header-overflow-menu')).not.toBeInTheDocument()
+  })
+
+  it('dismisses on outside click (capturing-phase mousedown)', () => {
+    render(
+      <div>
+        <button data-testid="outside-btn">outside</button>
+        <HeaderOverflowMenu items={baseItems} />
+      </div>,
+    )
+    fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+    expect(screen.getByTestId('header-overflow-menu')).toBeInTheDocument()
+    fireEvent.mouseDown(screen.getByTestId('outside-btn'))
+    expect(screen.queryByTestId('header-overflow-menu')).not.toBeInTheDocument()
+  })
+
+  it('Enter and Space on a menu item activate its handler', () => {
+    const onSkills = vi.fn()
+    const items = [{ id: 'skills', label: 'Skills', onClick: onSkills }]
+    render(<HeaderOverflowMenu items={items} />)
+    fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+    const row = screen.getByTestId('header-overflow-item-skills')
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(onSkills).toHaveBeenCalledTimes(1)
+    // Re-open and try Space — should also activate.
+    fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+    const row2 = screen.getByTestId('header-overflow-item-skills')
+    fireEvent.keyDown(row2, { key: ' ' })
+    expect(onSkills).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/dashboard/src/components/HeaderOverflowMenu.tsx
+++ b/packages/dashboard/src/components/HeaderOverflowMenu.tsx
@@ -1,0 +1,145 @@
+/**
+ * HeaderOverflowMenu (#4974) — collapses the tertiary header icons
+ * (Skills, Copy Transcript, Settings) behind a single "..." trigger so
+ * the prominent `+ New Session` button (#4943) and the model selector
+ * dropdown no longer collide at narrow desktop widths.
+ *
+ * Before #4974 the right zone laid out as:
+ *   [+ New Session] [Skills] [Copy?] [Settings] [StatusBar]
+ * which under ~1400px overlapped the model-selector chevron in the
+ * center zone. After this PR:
+ *   [+ New Session] [⋯] [StatusBar]
+ *
+ * The popover reuses the same dismiss pattern as SessionContextMenu —
+ * outside click (capturing mousedown so we close before any underlying
+ * row handler fires), Escape, window blur — and is positioned with CSS
+ * relative to the trigger button rather than a runtime measurement so
+ * SSR / first-paint stays simple.
+ *
+ * Caller provides the visible items via the `items[]` prop. Items with
+ * a falsy `onClick` are filtered out (capability gate — e.g. "Copy
+ * transcript" only shows up in chat view with at least one message).
+ * This keeps the trigger from being a no-op three-dots when nothing
+ * collapses into it.
+ */
+import { useEffect, useRef, useState } from 'react'
+
+export interface HeaderOverflowItem {
+  /** Stable id used as React key and `data-testid` suffix. */
+  id: string
+  /** Visible label inside the dropdown row. */
+  label: string
+  /** Optional glyph rendered alongside the label (decorative). */
+  icon?: string
+  /** Action — when falsy, the item is skipped entirely. */
+  onClick?: () => void
+  /** Optional title attribute (tooltip) for the row. */
+  title?: string
+}
+
+export interface HeaderOverflowMenuProps {
+  items: HeaderOverflowItem[]
+  /** Optional override for the trigger's aria-label / title. */
+  triggerLabel?: string
+}
+
+export function HeaderOverflowMenu({
+  items,
+  triggerLabel = 'More actions',
+}: HeaderOverflowMenuProps) {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLUListElement>(null)
+  const visibleItems = items.filter((i) => typeof i.onClick === 'function')
+
+  useEffect(() => {
+    if (!open) return
+    // Capturing-phase mousedown so an outside click dismisses the menu
+    // BEFORE any underlying button handler fires. Matches the dismiss
+    // pattern used by SessionContextMenu.
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (menuRef.current && menuRef.current.contains(target)) return
+      if (triggerRef.current && triggerRef.current.contains(target)) return
+      setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+    const onBlur = () => setOpen(false)
+    document.addEventListener('mousedown', onMouseDown, true)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown, true)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('blur', onBlur)
+    }
+  }, [open])
+
+  if (visibleItems.length === 0) return null
+
+  const activate = (item: HeaderOverflowItem) => {
+    try {
+      item.onClick?.()
+    } finally {
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div className="header-overflow">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="header-icon-btn header-overflow-trigger"
+        data-testid="header-overflow-trigger"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label={triggerLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={triggerLabel}
+      >
+        &#x22EF;
+      </button>
+      {open && (
+        <ul
+          ref={menuRef}
+          className="header-overflow-menu"
+          data-testid="header-overflow-menu"
+          role="menu"
+          aria-orientation="vertical"
+        >
+          {visibleItems.map((item) => (
+            <li
+              key={item.id}
+              role="menuitem"
+              tabIndex={0}
+              data-testid={`header-overflow-item-${item.id}`}
+              className="header-overflow-menu-item"
+              title={item.title}
+              onClick={() => activate(item)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  activate(item)
+                }
+              }}
+            >
+              {item.icon ? (
+                <span className="header-overflow-menu-icon" aria-hidden="true">
+                  {item.icon}
+                </span>
+              ) : null}
+              <span className="header-overflow-menu-label">{item.label}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5136,6 +5136,64 @@
   white-space: nowrap;
 }
 
+/* --- Header overflow menu (#4974) ---
+   Skills / Copy / Settings collapsed behind a single "⋯" trigger so
+   the right zone has room for the prominent + New Session button and
+   the cost/token StatusBar without overlapping the model selector in
+   the center column. The trigger reuses `.header-icon-btn` for chrome
+   parity (hover bg, focus ring, no shrink), and the popover mirrors
+   the existing `.session-context-menu` look — same surface, border,
+   shadow — so the dashboard reads as one component family. */
+.header-overflow {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.header-overflow-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 1000;
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  background: var(--bg-secondary, var(--bg-card));
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  min-width: 200px;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.header-overflow-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.header-overflow-menu-item:hover,
+.header-overflow-menu-item:focus-visible {
+  background: var(--bg-tertiary);
+  outline: none;
+}
+
+.header-overflow-menu-icon {
+  display: inline-block;
+  width: 18px;
+  text-align: center;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.header-overflow-menu-label {
+  flex: 1;
+}
+
 /* --- Settings panel --- */
 
 .settings-backdrop {


### PR DESCRIPTION
## Summary

Fixes #4974. The prominent `+ New Session` button added in v0.9.39 (#4943) overlapped the model selector at ≤1400px widths.

This PR keeps `+ New Session` and the model selector visible at all widths and collapses the tertiary icons (skills, copy, settings) into a single overflow `...` menu button.

## Test plan
- [ ] Open desktop dashboard at 1024px, 1280px, 1400px widths — verify no overlap
- [ ] Model selector dropdown fully clickable
- [ ] Overflow menu opens, shows skills/copy/settings
- [ ] Token-cost meter remains visible