### PR TITLE
fix(server): surface session-not-found errors after daemon restart (#4935)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -123,10 +123,35 @@ async function handleInput(ws, client, msg, ctx) {
   const targetSessionId = msg.sessionId || client.activeSessionId
   const entry = resolveSession(ctx, msg, client)
   if (!entry) {
-    const message = msg.sessionId
-      ? `Session not found: ${msg.sessionId}`
-      : 'No active session'
-    sendSessionError(ws, ctx, message)
+    // #4935 — visibility fix for the silent post-restart wedge. Before this,
+    // a stale `sessionId` (common when the dashboard's persisted activeSessionId
+    // references a pre-restart session ID that no longer exists after
+    // session-manager regenerates IDs on restoreState) would silently drop
+    // the input on the floor — sendSessionError ran but the operator log only
+    // showed a debug-level `Message from ...` line below, and that line is
+    // never reached on this branch. The dashboard's session_error toast DID
+    // fire, but with a generic "Session not found: <id>" string that gave the
+    // user nothing actionable. Now:
+    //   1. Log at INFO with the attempted ID + client ID so chroxy.log
+    //      shows the mismatch and operators can correlate against the
+    //      session_list / session-state.json after a restart.
+    //   2. Emit a structured `code: 'SESSION_NOT_FOUND'` + `attemptedSessionId`
+    //      on the session_error envelope so the dashboard can surface an
+    //      actionable hint ("session restarted — pick a session below")
+    //      and clear its stale activeSessionId locally. Mirrors the existing
+    //      `code: 'resume_unknown'` affordance (#4947).
+    if (msg.sessionId) {
+      log.info(`input dropped: session not found sessionId=${msg.sessionId} client=${client.id} (likely stale ID after daemon restart — see #4935)`)
+      ctx.send(ws, {
+        type: 'session_error',
+        code: 'SESSION_NOT_FOUND',
+        message: `Session not found: ${msg.sessionId}`,
+        attemptedSessionId: msg.sessionId,
+      })
+    } else {
+      log.info(`input dropped: no active session client=${client.id}`)
+      sendSessionError(ws, ctx, 'No active session')
+    }
     return
   }
 
@@ -448,6 +473,20 @@ function handleInterrupt(ws, client, msg, ctx) {
   if (entry) {
     log.info(`Interrupt from ${client.id} to session ${interruptSessionId}`)
     entry.session.interrupt()
+    return
+  }
+  // #4935 — same visibility fix as handleInput for the silent post-restart
+  // wedge. An interrupt addressed to a stale session ID used to drop on the
+  // floor with no log line and no client-side error. Surface both so the
+  // dashboard can clear stale state and the operator can grep chroxy.log.
+  if (msg.sessionId) {
+    log.info(`interrupt dropped: session not found sessionId=${msg.sessionId} client=${client.id} (likely stale ID after daemon restart — see #4935)`)
+    ctx.send(ws, {
+      type: 'session_error',
+      code: 'SESSION_NOT_FOUND',
+      message: `Session not found: ${msg.sessionId}`,
+      attemptedSessionId: msg.sessionId,
+    })
   }
 }
 

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -6,7 +6,7 @@
  *          notification_prefs_set (#4541)
  */
 import { randomUUID } from 'node:crypto'
-import { validateAttachments, resolveFileRefAttachments, resolveSession, sendError, sendSessionError } from '../handler-utils.js'
+import { validateAttachments, resolveFileRefAttachments, resolveSession, sendError, sendSessionError, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { evaluateDraft as defaultEvaluateDraft, shouldSkipEvaluator } from '../prompt-evaluator.js'
 import { PushManager } from '../push.js'
 import { createLogger, loggerForSession } from '../logger.js'
@@ -140,6 +140,28 @@ async function handleInput(ws, client, msg, ctx) {
     //      actionable hint ("session restarted — pick a session below")
     //      and clear its stale activeSessionId locally. Mirrors the existing
     //      `code: 'resume_unknown'` affordance (#4947).
+    //
+    // IMPORTANT (Copilot review #4979): `resolveSession()` returns null for
+    // two distinct reasons — (a) the session truly does not exist, and
+    // (b) the client has a `boundSessionId` and `msg.sessionId` disagrees with
+    // it (session-token binding enforcement in handler-utils.js). Case (b) is
+    // a SESSION_TOKEN_MISMATCH, not a SESSION_NOT_FOUND, and conflating them
+    // would (i) mislabel the operator log line and (ii) cause a dashboard
+    // consumer keyed on SESSION_NOT_FOUND to clear local state for what is
+    // actually an authorization failure. Check the binding-mismatch case
+    // FIRST and emit the canonical SESSION_TOKEN_MISMATCH envelope (#2912 —
+    // unified shape across all call sites via buildSessionTokenMismatchPayload).
+    if (msg.sessionId && client.boundSessionId && client.boundSessionId !== msg.sessionId) {
+      log.info(`input rejected: session-token mismatch sessionId=${msg.sessionId} boundSessionId=${client.boundSessionId} client=${client.id}`)
+      ctx.send(ws, {
+        type: 'session_error',
+        ...buildSessionTokenMismatchPayload({
+          sessionManager: ctx.sessionManager,
+          boundSessionId: client.boundSessionId,
+        }),
+      })
+      return
+    }
     if (msg.sessionId) {
       log.info(`input dropped: session not found sessionId=${msg.sessionId} client=${client.id} (likely stale ID after daemon restart — see #4935)`)
       ctx.send(ws, {
@@ -479,6 +501,23 @@ function handleInterrupt(ws, client, msg, ctx) {
   // wedge. An interrupt addressed to a stale session ID used to drop on the
   // floor with no log line and no client-side error. Surface both so the
   // dashboard can clear stale state and the operator can grep chroxy.log.
+  //
+  // IMPORTANT (Copilot review #4979): like handleInput, resolveSession() can
+  // return null for binding mismatches as well as truly-missing sessions.
+  // Disambiguate before emitting so a binding mismatch surfaces as the
+  // canonical SESSION_TOKEN_MISMATCH envelope rather than being mislabelled
+  // as a stale-ID drop.
+  if (msg.sessionId && client.boundSessionId && client.boundSessionId !== msg.sessionId) {
+    log.info(`interrupt rejected: session-token mismatch sessionId=${msg.sessionId} boundSessionId=${client.boundSessionId} client=${client.id}`)
+    ctx.send(ws, {
+      type: 'session_error',
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessionManager,
+        boundSessionId: client.boundSessionId,
+      }),
+    })
+    return
+  }
   if (msg.sessionId) {
     log.info(`interrupt dropped: session not found sessionId=${msg.sessionId} client=${client.id} (likely stale ID after daemon restart — see #4935)`)
     ctx.send(ws, {

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -69,6 +69,35 @@ describe('input-handlers', () => {
       assert.match(ctx._sent[0].message, /No active session/)
     })
 
+    // #4935 — visibility for the silent post-restart wedge. A stale `sessionId`
+    // on the wire (the dashboard's persisted activeSessionId points at a
+    // pre-restart session ID that no longer exists post-restore) used to
+    // produce a generic `session_error` envelope with no `code` field — the
+    // dashboard's toast fired with a useless "Session not found: <id>" string
+    // and no machine-readable signal to clear the stale local ID. Now the
+    // envelope carries `code: 'SESSION_NOT_FOUND'` + `attemptedSessionId` so
+    // the dashboard can branch on it and prompt the user to pick another
+    // session (mirrors the existing `code: 'resume_unknown'` affordance from
+    // #4947). The handler also logs at INFO level so chroxy.log shows the
+    // mismatch — pre-#4935, the log line for this path was DEBUG-only.
+    it('sends structured SESSION_NOT_FOUND when sessionId references a non-existent session (#4935)', () => {
+      const ctx = makeCtx()
+      const client = makeClient({ activeSessionId: null })
+      inputHandlers.input(
+        makeWs(),
+        client,
+        { data: 'hello', sessionId: 'deadbeef-stale-session-id' },
+        ctx,
+      )
+      assert.equal(ctx._sent.length, 1, 'exactly one error envelope should be emitted')
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.equal(ctx._sent[0].code, 'SESSION_NOT_FOUND',
+        'envelope must include code:SESSION_NOT_FOUND so dashboard can branch')
+      assert.equal(ctx._sent[0].attemptedSessionId, 'deadbeef-stale-session-id',
+        'envelope must echo the stale sessionId so dashboard can clear its local state')
+      assert.match(ctx._sent[0].message, /Session not found: deadbeef-stale-session-id/)
+    })
+
     it('sends session_error for invalid attachment type', () => {
       const sessions = new Map()
       const session = createMockSession()
@@ -601,6 +630,26 @@ describe('input-handlers', () => {
       // Should not throw
       inputHandlers.interrupt(makeWs(), makeClient(), {}, ctx)
       assert.equal(ctx._sent.length, 0)
+    })
+
+    // #4935 — when the client explicitly addresses a stale sessionId (post-
+    // daemon-restart, the dashboard's persisted activeSessionId points at a
+    // pre-restart session ID), interrupt used to drop silently. Now we mirror
+    // the input-handler structured-error response so the dashboard can clear
+    // its local state and surface an actionable hint. (The no-sessionId case
+    // above stays silent: nothing to clear, no actionable signal.)
+    it('sends structured SESSION_NOT_FOUND when sessionId is stale (#4935)', () => {
+      const ctx = makeCtx()
+      inputHandlers.interrupt(
+        makeWs(),
+        makeClient(),
+        { sessionId: 'deadbeef-stale-session-id' },
+        ctx,
+      )
+      assert.equal(ctx._sent.length, 1)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.equal(ctx._sent[0].code, 'SESSION_NOT_FOUND')
+      assert.equal(ctx._sent[0].attemptedSessionId, 'deadbeef-stale-session-id')
     })
   })
 

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -98,6 +98,36 @@ describe('input-handlers', () => {
       assert.match(ctx._sent[0].message, /Session not found: deadbeef-stale-session-id/)
     })
 
+    // #4935 Copilot review feedback — disambiguate bound-session mismatch from
+    // truly-missing sessions. `resolveSession()` returns null for both cases;
+    // emitting SESSION_NOT_FOUND for an authorization failure would let a
+    // dashboard consumer keyed on SESSION_NOT_FOUND clear its local state
+    // (and ID-binding) when the user is in fact bound to a *different* session
+    // they're allowed to touch. The canonical SESSION_TOKEN_MISMATCH envelope
+    // (#2912) belongs here instead.
+    it('sends SESSION_TOKEN_MISMATCH (not SESSION_NOT_FOUND) when client is bound to a different session (#4935 review)', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('bound-id', { session, name: 'BoundSession', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      // Client is bound to bound-id but addresses a different sessionId.
+      const client = makeClient({ boundSessionId: 'bound-id' })
+      inputHandlers.input(
+        makeWs(),
+        client,
+        { data: 'hello', sessionId: 'some-other-id' },
+        ctx,
+      )
+      assert.equal(ctx._sent.length, 1)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH',
+        'binding mismatch must emit SESSION_TOKEN_MISMATCH, not SESSION_NOT_FOUND')
+      assert.equal(ctx._sent[0].boundSessionId, 'bound-id')
+      assert.equal(ctx._sent[0].boundSessionName, 'BoundSession')
+      assert.equal(ctx._sent[0].attemptedSessionId, undefined,
+        'binding-mismatch envelope must not carry SESSION_NOT_FOUND fields')
+    })
+
     it('sends session_error for invalid attachment type', () => {
       const sessions = new Map()
       const session = createMockSession()
@@ -650,6 +680,29 @@ describe('input-handlers', () => {
       assert.equal(ctx._sent[0].type, 'session_error')
       assert.equal(ctx._sent[0].code, 'SESSION_NOT_FOUND')
       assert.equal(ctx._sent[0].attemptedSessionId, 'deadbeef-stale-session-id')
+    })
+
+    // #4935 Copilot review feedback — same disambiguation as handleInput:
+    // bound-session mismatch on an interrupt is an authorization failure,
+    // not a stale-ID drop.
+    it('sends SESSION_TOKEN_MISMATCH (not SESSION_NOT_FOUND) when client is bound to a different session (#4935 review)', () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      sessions.set('bound-id', { session, name: 'BoundSession', cwd: '/tmp' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ boundSessionId: 'bound-id' })
+      inputHandlers.interrupt(
+        makeWs(),
+        client,
+        { sessionId: 'some-other-id' },
+        ctx,
+      )
+      assert.equal(ctx._sent.length, 1)
+      assert.equal(ctx._sent[0].type, 'session_error')
+      assert.equal(ctx._sent[0].code, 'SESSION_TOKEN_MISMATCH')
+      assert.equal(ctx._sent[0].boundSessionId, 'bound-id')
+      assert.equal(ctx._sent[0].boundSessionName, 'BoundSession')
+      assert.equal(ctx._sent[0].attemptedSessionId, undefined)
     })
   })
 

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -1190,6 +1190,86 @@ describe('SessionManager.restoreState', () => {
 
     mgr.destroyAll()
   })
+
+  // #4935 — pin the daemon-restart contract: restored sessions get FRESH
+  // session IDs (createSession() always calls randomBytes(16) at line 555 of
+  // session-manager.js). The dashboard's persisted activeSessionId pointing
+  // at a pre-restart ID is therefore stale on reconnect, which is the root
+  // cause of the post-restart silent wedge investigated in #4935.
+  //
+  // The test simulates the exact scenario from the issue:
+  //   1. Create sessions, persist state, capture their IDs.
+  //   2. Tear down (`destroyAll` + new SessionManager) — daemon restart.
+  //   3. restoreState() — sessions come back with NEW IDs.
+  //   4. getSession(oldId) returns null — input addressed to the pre-restart
+  //      ID would fail the resolveSession() lookup and trip the structured
+  //      SESSION_NOT_FOUND error path (see input-handlers.test.js for the
+  //      handler-side assertion).
+  //
+  // The fix in input-handlers.js can't restore the old ID (that would
+  // require persisting + restoring the random ID itself, a wider change with
+  // broader implications); what it CAN do is make the silent drop visible.
+  // This test pins the precondition that triggers the visibility fix.
+  it('restored sessions get fresh IDs — old IDs are gone, lookups return null (#4935)', () => {
+    // First boot: create two sessions and let the auto-persist write to disk.
+    // Skip preflight + use a mock provider so we don't fork claude binaries
+    // during the test. Real sessions are constructed via createSession but
+    // the provider is mocked out below so we don't actually spawn anything.
+    const stateFile1 = join(tempDir, 'state-v1.json')
+
+    // Write a state file directly (simpler than driving createSession's
+    // full path — we only need to test the restore-side ID regeneration).
+    writeFileSync(stateFile1, JSON.stringify({
+      version: 1,
+      timestamp: Date.now(),
+      sessions: [
+        {
+          // Pre-restart session ID that the dashboard might still hold.
+          id: 'preRestartId-AAAAAAAAAAAAAAAA',
+          name: 'Rah6',
+          cwd: '/tmp',
+          model: null,
+          permissionMode: 'approve',
+          sdkSessionId: null,
+        },
+        {
+          id: 'preRestartId-BBBBBBBBBBBBBBBB',
+          name: 'No-it-all',
+          cwd: '/tmp',
+          model: null,
+          permissionMode: 'auto',
+          sdkSessionId: null,
+        },
+      ],
+    }))
+
+    // Simulate the daemon restart: fresh SessionManager from the same file.
+    const mgr2 = new SessionManager({ skipPreflight: true, maxSessions: 5, defaultCwd: '/tmp', stateFilePath: stateFile1 })
+    const firstNewId = mgr2.restoreState()
+    assert.ok(firstNewId, 'restoreState should return the first restored session ID')
+
+    // The fresh IDs must differ from the persisted IDs — this is what makes
+    // the dashboard's persisted activeSessionId stale post-restart.
+    assert.notEqual(firstNewId, 'preRestartId-AAAAAAAAAAAAAAAA',
+      'restored session ID must differ from the persisted ID (#4935 precondition)')
+    const sessions = mgr2.listSessions()
+    assert.equal(sessions.length, 2, 'both sessions should restore')
+    for (const s of sessions) {
+      assert.notEqual(s.sessionId, 'preRestartId-AAAAAAAAAAAAAAAA')
+      assert.notEqual(s.sessionId, 'preRestartId-BBBBBBBBBBBBBBBB')
+    }
+
+    // Lookup by the OLD ID returns null — this is the moment the daemon
+    // silently dropped the dashboard's input in the original #4935 wedge.
+    // The visibility fix in input-handlers.js converts that null into a
+    // structured `session_error{code:'SESSION_NOT_FOUND', attemptedSessionId}`
+    // so the dashboard can recover. Pin both invariants here.
+    assert.equal(mgr2.getSession('preRestartId-AAAAAAAAAAAAAAAA'), null,
+      'lookup by stale pre-restart ID must return null — handler then trips the SESSION_NOT_FOUND path')
+    assert.equal(mgr2.getSession('preRestartId-BBBBBBBBBBBBBBBB'), null)
+
+    mgr2.destroyAll()
+  })
 })
 
 describe('SessionManager auto-persist', () => {

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -1191,15 +1191,15 @@ describe('SessionManager.restoreState', () => {
     mgr.destroyAll()
   })
 
-  // #4935 — pin the daemon-restart contract: restored sessions get FRESH
-  // session IDs (createSession() always calls randomBytes(16) at line 555 of
-  // session-manager.js). The dashboard's persisted activeSessionId pointing
-  // at a pre-restart ID is therefore stale on reconnect, which is the root
-  // cause of the post-restart silent wedge investigated in #4935.
+  // #4935 — pin the daemon-restart contract: restoreState() creates fresh
+  // random session IDs for every restored session. The dashboard's persisted
+  // activeSessionId pointing at a pre-restart ID is therefore stale on
+  // reconnect, which is the root cause of the post-restart silent wedge
+  // investigated in #4935.
   //
   // The test simulates the exact scenario from the issue:
-  //   1. Create sessions, persist state, capture their IDs.
-  //   2. Tear down (`destroyAll` + new SessionManager) — daemon restart.
+  //   1. Write a synthetic state file with explicit pre-restart IDs.
+  //   2. Construct a fresh SessionManager from that file — daemon restart.
   //   3. restoreState() — sessions come back with NEW IDs.
   //   4. getSession(oldId) returns null — input addressed to the pre-restart
   //      ID would fail the resolveSession() lookup and trip the structured
@@ -1211,14 +1211,14 @@ describe('SessionManager.restoreState', () => {
   // broader implications); what it CAN do is make the silent drop visible.
   // This test pins the precondition that triggers the visibility fix.
   it('restored sessions get fresh IDs — old IDs are gone, lookups return null (#4935)', () => {
-    // First boot: create two sessions and let the auto-persist write to disk.
-    // Skip preflight + use a mock provider so we don't fork claude binaries
-    // during the test. Real sessions are constructed via createSession but
-    // the provider is mocked out below so we don't actually spawn anything.
+    // We bypass createSession on a first boot and write a synthetic
+    // state file directly — the behavioural contract under test is the
+    // restore-side ID regeneration, not the persistence-write path
+    // (which is covered by the SessionManager auto-persist suite below).
     const stateFile1 = join(tempDir, 'state-v1.json')
 
-    // Write a state file directly (simpler than driving createSession's
-    // full path — we only need to test the restore-side ID regeneration).
+    // Write a state file directly with explicit pre-restart IDs the
+    // dashboard's localStorage might still hold post-restart.
     writeFileSync(stateFile1, JSON.stringify({
       version: 1,
       timestamp: Date.now(),


### PR DESCRIPTION
## Summary

Fixes #4935. After a daemon restart, the dashboard could send messages addressed to stale session IDs that the server silently dropped — no log line, no error response — leaving the UI "connected" but unresponsive.

**Root cause:** `session-manager.restoreState()` always assigns fresh session IDs via `createSession()` (`randomBytes(16)` at line 555), so the dashboard's persisted `activeSessionId` in localStorage points at a pre-restart ID that no longer exists. `handleInput` / `handleInterrupt` would resolve the lookup to `null`, emit a generic `session_error` with no machine-readable `code`, and only log the arrival at debug level — the result was the "ZERO `sendMessage` log lines after the user's sends" diagnostic from #4935.

**Fix scope: visibility-only** (deliberately minimum-viable):

- Logs at INFO when input/interrupt arrives for a stale session ID, with the attempted ID + client ID, so chroxy.log shows the mismatch.
- Emits `session_error` with `code: 'SESSION_NOT_FOUND'` + `attemptedSessionId` so the dashboard can branch on it (mirrors `code: 'resume_unknown'` from #4947) and clear its stale `activeSessionId` locally.
- Pins the daemon-restart contract with a SessionManager integration test that simulates the exact scenario: write `session-state.json` with explicit pre-restart IDs, `restoreState()` with a fresh manager, assert the new IDs differ from the persisted ones AND `getSession(oldId)` returns `null`.

## Test plan

- [x] New `input` handler test: stale `sessionId` produces `session_error{code:'SESSION_NOT_FOUND', attemptedSessionId}`
- [x] New `interrupt` handler test: stale `sessionId` produces the same structured envelope (was previously silent)
- [x] New SessionManager integration test: `restoreState()` regenerates IDs; `getSession(oldId)` returns `null`
- [x] `lint-tests-state-file-path.sh` passes (test uses temp `stateFilePath`)
- [x] `lint-session-opt-forwarding.sh` passes (no BaseSession opts touched)
- [x] All 363 handler tests pass; all 186 session-manager tests pass; 6802/6811 server tests pass total (the 3 pre-existing failures in `service.test.js` + `web-task-manager.test.js` reproduce on `main` and are unrelated to touched files)
- [ ] Manual repro from issue: daemon restart + send → INFO log + structured error envelope (recommend local verify)

## Follow-ups

- **Dashboard side:** consume `code: 'SESSION_NOT_FOUND'` to clear stale `activeSessionId` and prompt the user to pick a live session (parallel to `ResumeUnknownChip.tsx` from #4947). File as separate dashboard issue.
- **Deeper fix candidates not in this PR:**
  - Preserve session IDs across `restoreState()` (would require coordinated wire-protocol change + auto-binding rewrite).
  - Or: have dashboard re-map by session name on reconnect (lossy when names collide).
  - The backpressure WARN-then-disconnect pattern in the issue's diagnostic log (suspected cause 1) was also investigated — the 256KB pause threshold from #4845 helps replay, but heavy live broadcasts can still trip the 1MB hard eviction after 10 consecutive drops. Out of scope here.

Closes #4935