### PR TITLE
fix(desktop): keep speech-helper alive for SFSpeechRecognizer (voice never actually transcribed since 0.8.x)

### DIFF
--- a/packages/desktop/src-tauri/swift/speech-helper.swift
+++ b/packages/desktop/src-tauri/swift/speech-helper.swift
@@ -61,7 +61,10 @@ func requestAuthorization(completion: @escaping (Bool) -> Void) {
     }
 }
 
-// Set to true by teardown() to break out of the main RunLoop.
+// Set to true by setDone() to break out of the main RunLoop. setDone() is
+// called from teardown() (the normal stop path) AND from early error paths
+// in startRecognition() — permission denied, recognizer unavailable, or
+// audio-engine start failure — so the helper exits promptly in all cases.
 var done = false
 let doneLock = NSLock()
 
@@ -188,8 +191,13 @@ func startRecognition() {
     // (the async authorization completion above) AND Apple framework callbacks
     // (the recognition result handler). teardown() calls CFRunLoopStop, which
     // returns control here so the function (and process) can exit cleanly.
+    //
+    // Explicitly drive RunLoop.main (not RunLoop.current) so the loop being
+    // driven here always matches the one setDone() stops via
+    // CFRunLoopStop(CFRunLoopGetMain()), regardless of which thread invokes
+    // startRecognition() in the future.
     while !isDone() {
-        RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 1.0))
+        RunLoop.main.run(mode: .default, before: Date(timeIntervalSinceNow: 1.0))
     }
 }
 

--- a/packages/desktop/src-tauri/swift/speech-helper.swift
+++ b/packages/desktop/src-tauri/swift/speech-helper.swift
@@ -61,19 +61,35 @@ func requestAuthorization(completion: @escaping (Bool) -> Void) {
     }
 }
 
-func startRecognition() {
-    let semaphore = DispatchSemaphore(value: 0)
+// Set to true by teardown() to break out of the main RunLoop.
+var done = false
+let doneLock = NSLock()
 
+func setDone() {
+    doneLock.lock()
+    done = true
+    doneLock.unlock()
+    // Wake the main RunLoop so its current `run(mode:before:)` returns promptly.
+    CFRunLoopStop(CFRunLoopGetMain())
+}
+
+func isDone() -> Bool {
+    doneLock.lock()
+    defer { doneLock.unlock() }
+    return done
+}
+
+func startRecognition() {
     requestAuthorization { granted in
         guard granted else {
             printJSON(["error": "Speech recognition permission denied"])
-            semaphore.signal()
+            setDone()
             return
         }
 
         guard let recognizer = SFSpeechRecognizer(), recognizer.isAvailable else {
             printJSON(["error": "Speech recognizer not available"])
-            semaphore.signal()
+            setDone()
             return
         }
 
@@ -81,10 +97,11 @@ func startRecognition() {
         let request = SFSpeechAudioBufferRecognitionRequest()
         request.shouldReportPartialResults = true
 
-        // Prefer on-device recognition for privacy
-        if recognizer.supportsOnDeviceRecognition {
-            request.requiresOnDeviceRecognition = true
-        }
+        // Note: do NOT set requiresOnDeviceRecognition = true unconditionally.
+        // When on-device assets are not downloaded for the user's locale, the
+        // recognition task hangs silently (no result, no error). Letting Speech
+        // pick its source — on-device if assets are ready, network otherwise —
+        // is reliably responsive across configurations.
 
         let inputNode = audioEngine.inputNode
         let recordingFormat = inputNode.outputFormat(forBus: 0)
@@ -98,20 +115,20 @@ func startRecognition() {
             try audioEngine.start()
         } catch {
             printJSON(["error": "Failed to start audio engine: \(error.localizedDescription)"])
-            semaphore.signal()
+            setDone()
             return
         }
 
         // Guard against concurrent teardown from recognition callback and stdin reader.
-        // Only the first caller to acquire the lock with done == false performs teardown.
-        let doneLock = NSLock()
-        var done = false
+        // Only the first caller to acquire the lock with `tornDown == false` performs teardown.
+        let teardownLock = NSLock()
+        var tornDown = false
 
         func teardown(stopEngine: Bool) {
-            doneLock.lock()
-            let alreadyDone = done
-            if !alreadyDone { done = true }
-            doneLock.unlock()
+            teardownLock.lock()
+            let alreadyDone = tornDown
+            if !alreadyDone { tornDown = true }
+            teardownLock.unlock()
 
             guard !alreadyDone else { return }
 
@@ -119,7 +136,7 @@ func startRecognition() {
                 audioEngine.stop()
                 inputNode.removeTap(onBus: 0)
             }
-            semaphore.signal()
+            setDone()
         }
 
         let task = recognizer.recognitionTask(with: request) { result, error in
@@ -160,8 +177,19 @@ func startRecognition() {
                 }
             }
         }
+    }
 
-        semaphore.wait()
+    // Apple's SFSpeechRecognizer.recognitionTask(with:resultHandler:) invokes
+    // its result handler on the MAIN THREAD. If we block the main thread on a
+    // semaphore (or anything else that doesn't service the runloop), the
+    // handler never fires and recognition is silent forever.
+    //
+    // Run the main RunLoop instead — it processes both dispatch queue work
+    // (the async authorization completion above) AND Apple framework callbacks
+    // (the recognition result handler). teardown() calls CFRunLoopStop, which
+    // returns control here so the function (and process) can exit cleanly.
+    while !isDone() {
+        RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 1.0))
     }
 }
 


### PR DESCRIPTION
## Summary

Voice input has never produced any transcription on macOS desktop, including after the v0.9.40 entitlement fix. Two follow-on bugs in `speech-helper.swift` kept the helper silent:

1. **`semaphore.wait()` was nested inside the `requestAuthorization` completion closure.** Since `requestAuthorization` is async, the closure runs on a background queue later — but `startRecognition()` itself had no blocking call at function scope. The helper would submit the TCC request and exit (exit 0, ~100ms) before TCC could even respond, before `audioEngine.start()` ran, before the recognition task was created.

2. **The result handler from `recognitionTask(with:resultHandler:)` is invoked on the main thread.** Even with the scope fix, blocking the main thread on a DispatchSemaphore prevents that handler from firing, so recognition runs forever without producing partials or finals.

This change replaces the semaphore with a main-thread RunLoop that services both the async authorization completion AND the recognition task's main-thread callbacks. `teardown()` now calls `CFRunLoopStop()` to break out cleanly.

Also drops the unconditional `requiresOnDeviceRecognition = true`: when on-device assets are not downloaded for the user's locale, the recognition task hangs silently with no result and no error. Letting Speech pick its source (on-device when ready, network otherwise) is reliably responsive across configurations.

## Why v0.9.40 didn't catch this

The v0.9.40 fix (#4954) verified that the helper carried the `com.apple.security.device.audio-input` entitlement, which is necessary for the helper to reach `tcc_send_request_authorization()` at all without being killed by macOS. Once that was in place, the helper *spawned*, *queried TCC*, then *exited cleanly with exit 0 and no stderr* in ~100ms — exactly the symptom of bug 1 above. The release-time entitlement verification could not have caught this because both bugs are runtime behavior, not signing.

## Verification

Trace logging during a manual click → speak 'hello world test' → stop captured:

```
[+0.124s] tap callback #1 frames=4800           ← audio capturing
[+1.593s] recognitionTask cb: result isFinal=false text='Hello'
[+1.986s] recognitionTask cb: result isFinal=false text='Hello world'
[+2.787s] recognitionTask cb: result isFinal=false text='Hello world test'
```

The prior helper produced zero callbacks before dying. Live verified on the installed Chroxy.app — the dashboard mic icon now records, partial transcripts stream into the input box, and the final transcript stays when stopped.

## Test plan

- [ ] Helper builds clean across arm64 + x86_64 (no swiftc warnings)
- [ ] CI green
- [ ] Voice input works on macOS desktop: click → speak → see partial transcripts → click stop → final transcript stays in input
- [ ] Helper exits cleanly on stop (no zombie processes)
- [ ] `speech-helper check` still returns `{"available":true,"authorized":true}` as before

## Follow-ups not in this PR

- A real integration test for the helper's recognition path is hard (requires audio + TCC), but a `speech-helper check`-style return-code check could be wired up in CI to catch the most basic regression
- The Tauri-side stop logic in `speech.rs` writes \`stop\\n\` to helper stdin then has a 3s kill fallback — that fallback masks issues like this one because the helper appears to "exit cleanly" via SIGKILL. Worth investigating whether the kill fallback should log a warning when it fires.