### PR TITLE
chore(release): cut v0.9.42 (voice transcription actually works)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.42] - 2026-06-03
+
+Single-fix release. Voice input on macOS desktop finally produces transcripts — v0.9.40's entitlement fix was necessary but two follow-on bugs in the Swift helper kept it silent until now. No other changes.
+
+### Fixed
+
+- **🚨 Voice input actually transcribes on macOS desktop now (#4985):** v0.9.40's `audio-input` entitlement fix (#4954) let `speech-helper` reach `tcc_send_request_authorization()` without being killed, but two runtime bugs kept the helper from ever producing transcripts:
+  - `semaphore.wait()` was nested INSIDE the `requestAuthorization` completion closure. Since `requestAuthorization` is async, the closure runs on a background queue later — but `startRecognition()` itself had no blocking call at function scope. The helper submitted the TCC request and exited cleanly in ~100ms (exit 0, zero stderr) BEFORE TCC responded, before `audioEngine.start()` ran, before the recognition task was even created. This is why the v0.9.40 entitlement verification didn't catch the regression — the helper signed correctly and the prior `exit 0 in 100ms` *looked* like clean execution.
+  - Apple's `SFSpeechRecognizer.recognitionTask(with:resultHandler:)` invokes its result handler on the **main thread**. Even with the scope bug fixed, blocking main on a DispatchSemaphore prevented the handler from firing, so recognition would run forever without producing partials or finals. Switched to driving `RunLoop.main` instead — services both the async authorization completion AND Apple-framework main-thread callbacks; `teardown()` calls `CFRunLoopStop()` to break out cleanly. Copilot caught that `RunLoop.current` should be `RunLoop.main` explicitly so the loop being driven always matches the one `setDone()` stops, regardless of which thread invokes `startRecognition()` in the future (`ea6e3ba3`).
+  - Dropped the unconditional `requiresOnDeviceRecognition = true`. When on-device assets aren't downloaded for the user's locale, the recognition task hangs silently with no result and no error. Letting Speech pick its source (on-device when ready, network otherwise) is reliably responsive across configurations. Note: voice audio MAY transit Apple's recognition servers for users whose on-device assets aren't installed — same behavior as Apple's first-party Dictation feature.
+  - Live verification: trace logging captured `Hello` at +1.6s → `Hello world` at +2.0s → `Hello world test` at +2.8s on a manual click → speak → stop cycle, where the prior helper produced zero callbacks before dying. Live confirmed working on the installed Chroxy.app — mic icon flips, partial transcripts stream into the input box, final transcript stays when stopped.
+
+### Follow-up issues filed during this sweep
+
+- #4986 — `speech.rs` 3-second SIGTERM kill-fallback in `stop()` previously masked this bug (helper "exited cleanly" via SIGKILL after Tauri timed out). The fallback should log a warning when it fires, so future bugs of this shape don't slip past local testing.
+
+
+
 ## [0.9.41] - 2026-06-02
 
 Sixth daytime sweep: three user-visible bug fixes landed in parallel. One desktop UI fix (topbar overlap from the v0.9.39 New Session button), one chat rendering fix (mid-word fragmentation around tool/skill bubbles), and one server reliability fix (silent send failures after daemon restart now surface a structured error envelope). No version bumps to dependencies, no schema migrations, no breaking changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.41",
+      "version": "0.9.42",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.41",
+      "version": "0.9.42",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.41",
+      "version": "0.9.42",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.41"
+      "version": "0.9.42"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.41",
+      "version": "0.9.42",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.41",
+      "version": "0.9.42",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17111,7 +17111,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.41",
+      "version": "0.9.42",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.41",
+    "version": "0.9.42",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.41</string>
+    <string>0.9.42</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.41"
+version = "0.9.42"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.41",
+      "version": "0.9.42",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
## Summary

Single-fix release. Voice input on macOS desktop finally produces transcripts — v0.9.40's entitlement fix was necessary but two follow-on bugs in the Swift helper kept the helper silent until #4985 landed.

Sequence of voice fixes:
- **v0.9.40** (#4954) — gave the helper a signed `audio-input` entitlement so it could reach TCC without being killed
- **v0.9.42** (#4985) — fixes the two runtime bugs (semaphore-scope + main-thread blocking) that kept the helper silent even after TCC

## Test plan

- [ ] CI green
- [ ] Tag v0.9.42 created on merge
- [ ] Release workflow builds macOS desktop bundle
- [ ] Voice input on installed bundle: click mic → speak → partial transcripts stream into input box → click stop → final transcript stays
- [ ] No zombie speech-helper processes