### PR TITLE
docs(desktop): document v<N> prefix bump rule above cache_key format (#4957)

### DIFF
--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -155,6 +155,10 @@ fn main() {
                     None
                 })
                 .unwrap_or_else(|| "unknown".to_string());
+            // BUMP THE v<N> PREFIX whenever the key schema (fields/format) changes
+            // — otherwise warm on-disk caches with the old schema match the new
+            // key by coincidence and ship a stale binary. Add a field → bump.
+            // Reorder fields → bump. Change the separator → bump.
             let cache_key = format!(
                 "v4\nsrc_mtime={}\nidentity={}\nkeychain={}\nswiftc={}\nhelper_ent_mtime={}\n",
                 src_mtime_secs, identity_for_cache, keychain_for_cache, swiftc_version,


### PR DESCRIPTION
## Summary

Inline a 4-line comment directly above the `let cache_key = format!("v4\n...")` line in `build.rs` documenting when to bump the `v<N>` prefix:

- Add a field → bump
- Reorder fields → bump
- Change the separator → bump

The existing rationale comment is 50 lines above the format!() call (after `swift_cache`, the rerun-if-changed directive, and 5 input-collection blocks). The next person editing the format string easily misses it.

This is approach (1) from the issue (cheap fix); the principled fix (snapshot test) was not chosen — a comment at the bump site is enough to keep the convention in front of the editor.

Closes #4957

## Test plan

- [x] `git diff` shows comment-only change above `let cache_key = format!(...)`
- [ ] Visual review confirms the comment is at the bump site