### PR TITLE
fix(server): anchor \bid\b + cover gerund 'resuming' in RESUME_UNKNOWN_STDERR_PATTERNS (#4968, #4969)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -64,9 +64,18 @@ export const RESUME_UNKNOWN_STDERR_PATTERNS = [
   // #4950 — tightened replacements for the dropped `/resume.*failed/i`. Each
   // requires the resume verb to co-occur with session/conversation/id so the
   // matcher stays scoped to the --resume-id failure mode it was designed for.
-  /resume.*(fail|error).*(session|conversation|id)/i,
-  /resume.*(session|conversation|id).*(fail|error)/i,
-  /(fail|could not|unable to|cannot).*resume.*(session|conversation|id)/i,
+  //
+  // #4968 — `id` is anchored with \b so it doesn't bleed into substrings of
+  // unrelated words (invalid, considered, avoided, widget, mid, kid, …). The
+  // long tokens `session` and `conversation` don't need anchoring.
+  //
+  // #4969 — `resum(e|ing)` covers the gerund form claude CLI may emit
+  // ("Error resuming session abc-123"). Original `resume.*` patterns missed
+  // the gerund and silently fell through to the generic "exited unexpectedly"
+  // respawn loop reported in #4929.
+  /resum(e|ing).*(fail|error).*(session|conversation|\bid\b)/i,
+  /resum(e|ing).*(session|conversation|\bid\b).*(fail|error)/i,
+  /(fail|error|could not|unable to|cannot).*resum(e|ing).*(session|conversation|\bid\b)/i,
 ]
 
 /**

--- a/packages/server/tests/cli-session-resume-unknown.test.js
+++ b/packages/server/tests/cli-session-resume-unknown.test.js
@@ -83,6 +83,14 @@ describe('CliSession resume-unknown — stderr matcher (#4929)', () => {
       'Unable to resume conversation: missing id',
       'Cannot resume conversation: deleted',
       'Resume of session abc-123 failed',
+      // #4969 — gerund form ("resuming") must classify the same way as the
+      // imperative ("resume"). claude CLI may emit either; both indicate the
+      // same --resume-id failure mode.
+      'Error resuming session abc-123',
+      'Error resuming conversation abc',
+      'Resuming session failed',
+      'resuming conversation failed: not found',
+      'Could not finish resuming session abc',
     ]
     for (const line of samples) {
       assert.equal(stderrIndicatesUnknownResume([line]), true,
@@ -103,6 +111,25 @@ describe('CliSession resume-unknown — stderr matcher (#4929)', () => {
     for (const line of safeSamples) {
       assert.equal(stderrIndicatesUnknownResume([line]), false,
         `"${line}" must NOT trigger resume-unknown — wiping _sessionId on transient errors would discard the prior conversation`)
+    }
+  })
+
+  it('#4968 — does NOT match "id" substring inside unrelated words (invalid, considered, avoided, widget, mid, kid)', () => {
+    // Bare `id` (no word boundary) would match as a substring inside common
+    // English words, re-introducing the false positives #4966 was designed to
+    // prevent. Each of these would wipe `_sessionId` mid-conversation if the
+    // anchor regressed, breaking the same #4950 invariant.
+    const substringBleeds = [
+      'failed to resume invalid input',
+      'resume considered failed',
+      'Could not resume — avoided',
+      'resume widget failed',
+      'unable to resume mid-write',
+      'Failed to resume kid mode',
+    ]
+    for (const line of substringBleeds) {
+      assert.equal(stderrIndicatesUnknownResume([line]), false,
+        `#4968 — "${line}" must NOT classify as resume-unknown; \`id\` is a substring of an unrelated word here, not the keyword we care about`)
     }
   })
 


### PR DESCRIPTION
## Summary

Two #4966 follow-ups land together because they edit the same three regexes.

**#4968 — Anchor `\bid\b`:** Bare `id` matched as a substring inside `invalid`, `considered`, `avoided`, `widget`, `mid`, `kid` — any of which, if logged during an in-flight `--resume`, would wipe `_sessionId` mid-conversation. This re-introduced the false-positive failure mode #4950 fixed.

**#4969 — Cover gerund `resuming`:** Patterns required the literal token `resume`, missing `Error resuming session abc-123` which claude CLI plausibly emits. Broadened to `resum(e|ing)` so imperative + gerund both classify.

I also extended pattern 3's prefix alternation with `error` so `Error resuming session …` matches the `<verb-prefix>.*resume.*session` branch. Without this addition, the gerund-with-error-prefix form (the most plausible CLI wording) silently falls through to the generic "exited unexpectedly" loop reported in #4929.

## Test plan

- [x] 5 positive gerund-form lines added — all classify as `resume_unknown`
- [x] 6 substring-bleed lines added as negative cases — none classify  
- [x] All existing 7 negative-case lines from #4950/#4966 still negative
- [x] All existing 13 positive-case lines from #4929/#4950 still positive
- [x] 18/18 tests pass in `cli-session-resume-unknown.test.js`

Closes #4968
Closes #4969