### PR TITLE
fix(desktop): log a warning when speech.rs 3s SIGTERM fallback fires (#4986)

### DIFF
--- a/packages/desktop/src-tauri/src/speech.rs
+++ b/packages/desktop/src-tauri/src/speech.rs
@@ -204,6 +204,19 @@ pub fn stop(state: &SpeechState) {
                     unsafe {
                         let status = libc::waitpid(pid as i32, std::ptr::null_mut(), libc::WNOHANG);
                         if status == 0 {
+                            // #4986 — the helper ignored the clean "stop\n"
+                            // signal AND the EOF on stdin. Log loudly so
+                            // future regressions like #4985 (where the
+                            // helper was silently SIGTERM'd every session
+                            // since 0.8.x and voice never actually
+                            // transcribed) surface instead of hiding behind
+                            // a "graceful" kill. The no-op branch (process
+                            // already exited cleanly) stays silent.
+                            eprintln!(
+                                "[speech] WARN: helper (pid {}) did not exit within 3s of clean shutdown; sending SIGTERM. \
+This usually means the helper crashed or hung — voice transcription may have silently failed for this session.",
+                                pid
+                            );
                             libc::kill(pid as i32, libc::SIGTERM);
                         }
                     }


### PR DESCRIPTION
## Summary

The 3s SIGTERM safety net in `speech.rs::stop()` fired silently. So when #4985 (helper SIGTERM'd every session since 0.8.x, voice never actually transcribed) regressed, the Tauri-side behaviour looked normal and the bug hid behind a "graceful" kill for months.

The no-op branch (process already exited cleanly via the \`stop\\n\` signal) stays silent — only the \`WNOHANG == 0\` branch logs, which is the exact path that masked the prior bug. Future regressions in the helper's clean-shutdown path now surface immediately.

Skipping the optional \`voice_error\` event — log is enough for a developer-facing regression signal; surfacing it as a UI toast on every legitimate hang would be noisy without a clear actionable next step.

Closes #4986

## Test plan

- [x] cargo check passes
- [ ] Manual: kill helper mid-recording, verify warn line appears in tray-app stderr