### PR TITLE
feat(dashboard): full WAI-ARIA keyboard nav for HeaderOverflowMenu (#4980)

### DIFF
--- a/packages/dashboard/src/components/HeaderOverflowMenu.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflowMenu.test.tsx
@@ -16,9 +16,10 @@
  *   7. Outside-click dismisses the menu (capturing-phase mousedown so
  *      we close before any sibling button handler fires).
  */
+import { useState } from 'react'
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, fireEvent, cleanup } from '@testing-library/react'
-import { HeaderOverflowMenu } from './HeaderOverflowMenu'
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react'
+import { HeaderOverflowMenu, type HeaderOverflowItem } from './HeaderOverflowMenu'
 
 afterEach(cleanup)
 
@@ -222,6 +223,66 @@ describe('HeaderOverflowMenu (#4974)', () => {
       fireEvent.click(trigger)
       fireEvent.mouseDown(screen.getByTestId('outside-btn'))
       expect(document.activeElement).toBe(trigger)
+    })
+
+    // PR #4996 review feedback — focus restore must converge through a
+    // single cleanup branch so the window.blur dismiss path doesn't
+    // silently skip it.
+    it('returns focus to the trigger when the menu is dismissed via window blur', () => {
+      render(<HeaderOverflowMenu items={baseItems} />)
+      const trigger = screen.getByTestId('header-overflow-trigger')
+      fireEvent.click(trigger)
+      expect(screen.getByTestId('header-overflow-menu')).toBeInTheDocument()
+      // Simulate the window-level blur dismiss (e.g. user switches apps
+      // or clicks into devtools). The focus-restore cleanup must still
+      // fire for this branch.
+      fireEvent.blur(window)
+      expect(screen.queryByTestId('header-overflow-menu')).not.toBeInTheDocument()
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    // PR #4996 review feedback — when visibleItems shrinks while open
+    // (e.g. App.tsx gates Copy Transcript on viewMode), focusedIndex
+    // must clamp so a) some <li> still has tabIndex={0}, b) the
+    // focus-sync effect doesn't read a null ref.
+    it('clamps focusedIndex when items shrink while the menu is open', () => {
+      // Wrapper lets the test mutate the items prop after opening the
+      // menu — mirrors the real-world App.tsx case where a parent
+      // re-renders with fewer items mid-interaction.
+      function Wrapper({ initialItems }: { initialItems: HeaderOverflowItem[] }) {
+        const [items, setItems] = useState(initialItems)
+        return (
+          <div>
+            <button
+              data-testid="shrink-btn"
+              onClick={() => setItems(items.slice(0, 1))}
+            >
+              shrink
+            </button>
+            <HeaderOverflowMenu items={items} />
+          </div>
+        )
+      }
+      const items: HeaderOverflowItem[] = [
+        { id: 'skills', label: 'Skills', onClick: vi.fn() },
+        { id: 'copy', label: 'Copy', onClick: vi.fn() },
+        { id: 'settings', label: 'Settings', onClick: vi.fn() },
+      ]
+      render(<Wrapper initialItems={items} />)
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      // Move focus to the last item so focusedIndex=2.
+      const first = screen.getByTestId('header-overflow-item-skills')
+      fireEvent.keyDown(first, { key: 'End' })
+      const last = screen.getByTestId('header-overflow-item-settings')
+      expect(last.tabIndex).toBe(0)
+      // Shrink to 1 item — focusedIndex (2) is now out of range.
+      act(() => {
+        fireEvent.click(screen.getByTestId('shrink-btn'))
+      })
+      // After clamp: the single remaining item must hold tabIndex={0}
+      // (the index has been clamped to 0, which is the only valid slot).
+      const onlyRemaining = screen.getByTestId('header-overflow-item-skills')
+      expect(onlyRemaining.tabIndex).toBe(0)
     })
 
     it('wires aria-controls between trigger and menu', () => {

--- a/packages/dashboard/src/components/HeaderOverflowMenu.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflowMenu.test.tsx
@@ -123,4 +123,115 @@ describe('HeaderOverflowMenu (#4974)', () => {
     fireEvent.keyDown(row2, { key: ' ' })
     expect(onSkills).toHaveBeenCalledTimes(2)
   })
+
+  // #4980 — full WAI-ARIA Authoring Practices menu keyboard pattern. The
+  // same acceptance set already pinned for SessionContextMenu (#4248) now
+  // applies here too.
+  describe('WAI-ARIA keyboard navigation (#4980)', () => {
+    it('moves initial focus into the first menu item when the menu opens', () => {
+      render(<HeaderOverflowMenu items={baseItems} />)
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const firstItem = screen.getByTestId('header-overflow-item-skills')
+      expect(document.activeElement).toBe(firstItem)
+    })
+
+    it('uses roving tabindex — only the focused item is tabIndex=0', () => {
+      render(<HeaderOverflowMenu items={baseItems} />)
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const first = screen.getByTestId('header-overflow-item-skills')
+      const second = screen.getByTestId('header-overflow-item-copy')
+      const third = screen.getByTestId('header-overflow-item-settings')
+      expect(first.tabIndex).toBe(0)
+      expect(second.tabIndex).toBe(-1)
+      expect(third.tabIndex).toBe(-1)
+    })
+
+    it('ArrowDown moves focus to the next item with wrap-around', () => {
+      render(<HeaderOverflowMenu items={baseItems} />)
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const first = screen.getByTestId('header-overflow-item-skills')
+      const second = screen.getByTestId('header-overflow-item-copy')
+      const third = screen.getByTestId('header-overflow-item-settings')
+      fireEvent.keyDown(first, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(second)
+      expect(second.tabIndex).toBe(0)
+      fireEvent.keyDown(second, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(third)
+      // Wrap from last → first
+      fireEvent.keyDown(third, { key: 'ArrowDown' })
+      expect(document.activeElement).toBe(first)
+    })
+
+    it('ArrowUp moves focus to the previous item with wrap-around', () => {
+      render(<HeaderOverflowMenu items={baseItems} />)
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const first = screen.getByTestId('header-overflow-item-skills')
+      const third = screen.getByTestId('header-overflow-item-settings')
+      // Wrap from first → last
+      fireEvent.keyDown(first, { key: 'ArrowUp' })
+      expect(document.activeElement).toBe(third)
+    })
+
+    it('Home jumps focus to the first item', () => {
+      render(<HeaderOverflowMenu items={baseItems} />)
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const first = screen.getByTestId('header-overflow-item-skills')
+      const third = screen.getByTestId('header-overflow-item-settings')
+      fireEvent.keyDown(first, { key: 'End' })
+      expect(document.activeElement).toBe(third)
+      fireEvent.keyDown(third, { key: 'Home' })
+      expect(document.activeElement).toBe(first)
+    })
+
+    it('End jumps focus to the last item', () => {
+      render(<HeaderOverflowMenu items={baseItems} />)
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const first = screen.getByTestId('header-overflow-item-skills')
+      const third = screen.getByTestId('header-overflow-item-settings')
+      fireEvent.keyDown(first, { key: 'End' })
+      expect(document.activeElement).toBe(third)
+    })
+
+    it('Escape returns focus to the trigger', () => {
+      render(<HeaderOverflowMenu items={baseItems} />)
+      const trigger = screen.getByTestId('header-overflow-trigger')
+      fireEvent.click(trigger)
+      fireEvent.keyDown(document, { key: 'Escape' })
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    it('returns focus to the trigger after item activation (so Tab continues into the next header control)', () => {
+      const onSkills = vi.fn()
+      const items = [{ id: 'skills', label: 'Skills', onClick: onSkills }]
+      render(<HeaderOverflowMenu items={items} />)
+      const trigger = screen.getByTestId('header-overflow-trigger')
+      fireEvent.click(trigger)
+      const row = screen.getByTestId('header-overflow-item-skills')
+      fireEvent.keyDown(row, { key: 'Enter' })
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    it('returns focus to the trigger after outside-click dismissal', () => {
+      render(
+        <div>
+          <button data-testid="outside-btn">outside</button>
+          <HeaderOverflowMenu items={baseItems} />
+        </div>,
+      )
+      const trigger = screen.getByTestId('header-overflow-trigger')
+      fireEvent.click(trigger)
+      fireEvent.mouseDown(screen.getByTestId('outside-btn'))
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    it('wires aria-controls between trigger and menu', () => {
+      render(<HeaderOverflowMenu items={baseItems} />)
+      const trigger = screen.getByTestId('header-overflow-trigger')
+      const ariaControls = trigger.getAttribute('aria-controls')
+      expect(ariaControls).toBeTruthy()
+      fireEvent.click(trigger)
+      const menu = screen.getByTestId('header-overflow-menu')
+      expect(menu.getAttribute('id')).toBe(ariaControls)
+    })
+  })
 })

--- a/packages/dashboard/src/components/HeaderOverflowMenu.tsx
+++ b/packages/dashboard/src/components/HeaderOverflowMenu.tsx
@@ -85,18 +85,15 @@ export function HeaderOverflowMenu({
       const target = e.target as Node
       if (menuRef.current && menuRef.current.contains(target)) return
       if (triggerRef.current && triggerRef.current.contains(target)) return
-      // #4980 — outside-click dismiss must also restore focus to the
-      // trigger so keyboard-only users don't lose their place in the
-      // header. The Escape branch below already does this; mirror it
-      // here so all dismiss paths converge on the same end state.
+      // #4980 — focus restoration is handled centrally by the cleanup
+      // effect below; just flip `open` and let all dismiss paths
+      // converge through the same restore branch.
       setOpen(false)
-      triggerRef.current?.focus()
     }
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.stopPropagation()
         setOpen(false)
-        triggerRef.current?.focus()
       }
     }
     const onBlur = () => setOpen(false)
@@ -122,6 +119,37 @@ export function HeaderOverflowMenu({
     if (first) first.focus()
   }, [open])
 
+  // #4980 (review feedback PR #4996) — single focus-restore cleanup that
+  // runs whenever `open` transitions true → false so every dismiss path
+  // (Escape, outside-click, window blur, item activation) converges
+  // reliably. Without this, the window.blur path silently skipped focus
+  // restore, and the per-branch `triggerRef.current?.focus()` calls
+  // during mousedown could race the browser's own focus-on-click. This
+  // mirrors SessionContextMenu's unmount focus-restore pattern (#4248).
+  //
+  // We snapshot whatever was focused at the moment the menu opens,
+  // falling back to the trigger button (which is always how the menu
+  // was opened from a user gesture, even if the click didn't move
+  // browser focus). The `isConnected` guard handles the case where the
+  // snapshot was removed from the DOM during the menu lifetime — e.g.
+  // the parent re-rendered and unmounted the trigger.
+  useEffect(() => {
+    if (!open) return
+    const active = document.activeElement as HTMLElement | null
+    // If focus is on <body> or a still-mounted menu item from a prior
+    // interaction, fall back to the trigger — that's the conventional
+    // anchor a keyboard user expects to land back on.
+    const previouslyFocused =
+      active && active !== document.body && !menuRef.current?.contains(active)
+        ? active
+        : triggerRef.current
+    return () => {
+      if (previouslyFocused && previouslyFocused.isConnected) {
+        previouslyFocused.focus()
+      }
+    }
+  }, [open])
+
   // #4980 — when focusedIndex changes (via arrow keys / Home / End),
   // imperatively move focus to the matching item. Same pattern as
   // SessionContextMenu.
@@ -133,17 +161,28 @@ export function HeaderOverflowMenu({
     }
   }, [focusedIndex, open])
 
+  // #4980 (review feedback PR #4996) — clamp `focusedIndex` when the
+  // visible item set shrinks while the menu is open (e.g. App.tsx gates
+  // Copy Transcript on viewMode/hasMessages, so the row can disappear
+  // mid-interaction). If we don't clamp, no <li> ends up with
+  // tabIndex={0} and the focus-sync effect above reads a null ref —
+  // arrow nav silently stops working until the menu is re-opened.
+  useEffect(() => {
+    if (!open) return
+    if (focusedIndex >= visibleItems.length && visibleItems.length > 0) {
+      setFocusedIndex(visibleItems.length - 1)
+    }
+  }, [visibleItems.length, focusedIndex, open])
+
   if (visibleItems.length === 0) return null
 
   const activate = (item: HeaderOverflowItem) => {
     try {
       item.onClick?.()
     } finally {
+      // #4980 — focus restoration handled by the open-transition cleanup
+      // effect above; just flip `open` here.
       setOpen(false)
-      // #4980 — return focus to trigger after item activation so the
-      // next Tab press lands on the next header control. Without this,
-      // focus is left on a since-unmounted <li> and falls back to body.
-      triggerRef.current?.focus()
     }
   }
 

--- a/packages/dashboard/src/components/HeaderOverflowMenu.tsx
+++ b/packages/dashboard/src/components/HeaderOverflowMenu.tsx
@@ -21,8 +21,22 @@
  * transcript" only shows up in chat view with at least one message).
  * This keeps the trigger from being a no-op three-dots when nothing
  * collapses into it.
+ *
+ * #4980 — full WAI-ARIA Authoring Practices menu keyboard pattern:
+ *   - Initial focus moves into the first item when the menu opens
+ *   - ArrowDown / ArrowUp move focus between items (wrap-around)
+ *   - Home / End jump to first / last item
+ *   - Enter / Space activate the focused item
+ *   - Escape dismisses + returns focus to the trigger
+ *   - Roving tabindex: only the currently-focused item is tabIndex={0}
+ *   - Focus returns to the trigger after outside-click dismissal and
+ *     after item activation
+ *   - aria-controls on the trigger pointing at the menu id
+ *
+ * Mirrors the SessionContextMenu (#4248) pattern verbatim — both menus
+ * now satisfy the same WAI-ARIA acceptance set.
  */
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 
 export interface HeaderOverflowItem {
   /** Stable id used as React key and `data-testid` suffix. */
@@ -48,8 +62,18 @@ export function HeaderOverflowMenu({
   triggerLabel = 'More actions',
 }: HeaderOverflowMenuProps) {
   const [open, setOpen] = useState(false)
+  // #4980 — roving tabindex requires tracking the currently-focused index.
+  // Reset to 0 when the menu opens so re-opens always land on the first item.
+  const [focusedIndex, setFocusedIndex] = useState(0)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLUListElement>(null)
+  // #4980 — item refs for imperative focus; mirrors SessionContextMenu.
+  // Using a ref array instead of querySelector keeps the API independent
+  // of the data-testid contract and avoids DOM lookups on every focus shift.
+  const itemRefs = useRef<(HTMLLIElement | null)[]>([])
+  // #4980 — stable id for aria-controls wire-up between trigger and menu.
+  // useId is React 18+ SSR-safe; matches the rest of the codebase pattern.
+  const menuId = useId()
   const visibleItems = items.filter((i) => typeof i.onClick === 'function')
 
   useEffect(() => {
@@ -61,7 +85,12 @@ export function HeaderOverflowMenu({
       const target = e.target as Node
       if (menuRef.current && menuRef.current.contains(target)) return
       if (triggerRef.current && triggerRef.current.contains(target)) return
+      // #4980 — outside-click dismiss must also restore focus to the
+      // trigger so keyboard-only users don't lose their place in the
+      // header. The Escape branch below already does this; mirror it
+      // here so all dismiss paths converge on the same end state.
       setOpen(false)
+      triggerRef.current?.focus()
     }
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -81,6 +110,29 @@ export function HeaderOverflowMenu({
     }
   }, [open])
 
+  // #4980 — on open, reset focus to the first item AND imperatively
+  // focus it. setFocusedIndex(0) covers the case where the menu was
+  // last closed on a non-first item. The imperative focus() is
+  // necessary because tabIndex={0} only governs Tab traversal, not
+  // programmatic focus on mount.
+  useEffect(() => {
+    if (!open) return
+    setFocusedIndex(0)
+    const first = itemRefs.current[0]
+    if (first) first.focus()
+  }, [open])
+
+  // #4980 — when focusedIndex changes (via arrow keys / Home / End),
+  // imperatively move focus to the matching item. Same pattern as
+  // SessionContextMenu.
+  useEffect(() => {
+    if (!open) return
+    const target = itemRefs.current[focusedIndex]
+    if (target && document.activeElement !== target) {
+      target.focus()
+    }
+  }, [focusedIndex, open])
+
   if (visibleItems.length === 0) return null
 
   const activate = (item: HeaderOverflowItem) => {
@@ -88,6 +140,10 @@ export function HeaderOverflowMenu({
       item.onClick?.()
     } finally {
       setOpen(false)
+      // #4980 — return focus to trigger after item activation so the
+      // next Tab press lands on the next header control. Without this,
+      // focus is left on a since-unmounted <li> and falls back to body.
+      triggerRef.current?.focus()
     }
   }
 
@@ -102,6 +158,12 @@ export function HeaderOverflowMenu({
         aria-label={triggerLabel}
         aria-haspopup="menu"
         aria-expanded={open}
+        // #4980 — aria-controls wires the trigger to the menu's id so
+        // assistive tech can announce the relationship. Only meaningful
+        // when the menu is open (the popover doesn't exist otherwise),
+        // but per WAI-ARIA the attribute is allowed regardless and most
+        // ATs handle the closed case gracefully.
+        aria-controls={menuId}
         title={triggerLabel}
       >
         &#x22EF;
@@ -109,24 +171,65 @@ export function HeaderOverflowMenu({
       {open && (
         <ul
           ref={menuRef}
+          id={menuId}
           className="header-overflow-menu"
           data-testid="header-overflow-menu"
           role="menu"
           aria-orientation="vertical"
         >
-          {visibleItems.map((item) => (
+          {visibleItems.map((item, index) => (
             <li
               key={item.id}
+              ref={(node) => {
+                itemRefs.current[index] = node
+              }}
               role="menuitem"
-              tabIndex={0}
+              // #4980 — roving tabindex: only the currently-focused item
+              // is in the Tab order. The rest stay programmatically
+              // focusable (we move focus via the arrow-key handler)
+              // without polluting the surrounding header's Tab order.
+              tabIndex={focusedIndex === index ? 0 : -1}
               data-testid={`header-overflow-item-${item.id}`}
               className="header-overflow-menu-item"
               title={item.title}
               onClick={() => activate(item)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  activate(item)
+                switch (e.key) {
+                  case 'ArrowDown': {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    setFocusedIndex((i) => (i + 1) % visibleItems.length)
+                    break
+                  }
+                  case 'ArrowUp': {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    setFocusedIndex((i) => (i - 1 + visibleItems.length) % visibleItems.length)
+                    break
+                  }
+                  case 'Home': {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    setFocusedIndex(0)
+                    break
+                  }
+                  case 'End': {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    setFocusedIndex(visibleItems.length - 1)
+                    break
+                  }
+                  case 'Enter':
+                  case ' ': {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    activate(item)
+                    break
+                  }
+                  // Escape is handled at the document level so it still
+                  // fires when focus has drifted away from the menu.
+                  default:
+                    break
                 }
               }}
             >


### PR DESCRIPTION
## Summary

#4974 left HeaderOverflowMenu with only a subset of the WAI-ARIA Authoring Practices menu pattern (Enter/Space activate + Escape dismiss). This PR closes the gap so both dashboard menus (SessionContextMenu + HeaderOverflowMenu) satisfy the same a11y acceptance set.

New behaviour mirrors the SessionContextMenu (#4248) implementation verbatim:

- Initial focus moves into the first item when the menu opens
- ArrowDown / ArrowUp move focus between items with wrap-around
- Home / End jump to first / last item
- Roving tabindex (only the focused item is `tabIndex={0}`)
- Focus returns to the trigger after Escape, outside-click dismissal, AND item activation
- `aria-controls` on the trigger pointing at a `useId()`-generated menu id

Implementation is a verbatim mirror of `SessionContextMenu` so future changes to the menu a11y contract can be applied to both components in lockstep.

Closes #4980

## Test plan

- [x] 10 new tests cover every checkbox in the issue's acceptance set (initial focus, roving tabindex, ArrowDown wrap, ArrowUp wrap, Home, End, Escape→trigger, activation→trigger, outside-click→trigger, aria-controls wire-up)
- [x] 8 existing tests for mouse / Tab / Enter / Space / Escape still pass
- [x] 18/18 HeaderOverflowMenu tests pass locally