### PR TITLE
feat(app): mirror ResumeUnknownChip in mobile MessageBubble (#4971)

### DIFF
--- a/packages/app/src/components/ResumeUnknownChip.tsx
+++ b/packages/app/src/components/ResumeUnknownChip.tsx
@@ -1,0 +1,116 @@
+/**
+ * ResumeUnknownChip — #4971 (mobile-app companion to dashboard #4947).
+ *
+ * Replaces the generic red error bubble when the server emits
+ * `error{code: 'resume_unknown'}` (server PR #4944). The server fires this
+ * code when claude CLI rejects a `--resume <id>` because the conversation
+ * id is unknown locally (operator wiped `~/.claude/projects/` between
+ * chroxy boots, restored a state file from a different machine, etc.).
+ *
+ * The CliSession has already auto-fallen-back to a fresh conversation by
+ * the time this chip surfaces — the model loses the prior transcript but
+ * the chroxy ring buffer transcript is preserved in the UI. So we render a
+ * calm operator-friendly explanation rather than the loud red crash toast,
+ * matching the spirit of the mobile StreamStallChip (#4476): "recoverable,
+ * here's what happened, here's what to expect next".
+ *
+ * `attemptedResumeId` (when provided) renders as small mono-spaced subtext
+ * for operator correlation against the persisted state file
+ * (`resumeConversationId` in ~/.chroxy/session-state.json) — answers "which
+ * conversation did we lose?" without forcing the operator to grep logs.
+ * Defensive empty/whitespace guard mirrors the dashboard component so a
+ * stale or trimmed empty value can't produce a broken-looking "Attempted
+ * id: " slot.
+ *
+ * Uses `accentYellow500` from constants/colors to match StreamStallChip
+ * (and the other amber-recoverable surfaces) so the user learns one
+ * affordance — the chip visual language is shared.
+ */
+import { StyleSheet, Text, View } from 'react-native';
+import { COLORS } from '../constants/colors';
+
+export interface ResumeUnknownChipProps {
+  /**
+   * Raw error text from the server (e.g. "Previous Claude conversation
+   * could not be resumed (the id is unknown to the local claude CLI — ...)").
+   * Preserved verbatim in `accessibilityHint` for assistive-tech triage.
+   */
+  errorText: string;
+  /**
+   * The conversation id chroxy passed to `claude --resume <id>` before
+   * the CLI rejected it. Surfaced as mono-spaced subtext when present;
+   * empty / whitespace / undefined hides the subtext slot entirely
+   * (matches the dashboard chip's defensive guard).
+   */
+  attemptedResumeId?: string;
+}
+
+export function ResumeUnknownChip({ errorText, attemptedResumeId }: ResumeUnknownChipProps) {
+  // Empty-string defense — same rationale as the dashboard chip and the
+  // SessionNotFoundChip: a stale or trimmed empty value should not produce
+  // a broken-looking "Attempted id: " slot with no value.
+  const hasId = typeof attemptedResumeId === 'string' && attemptedResumeId.trim().length > 0;
+
+  return (
+    <View
+      testID="resume-unknown-chip"
+      accessibilityRole="alert"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel="Previous conversation could not be resumed — starting fresh"
+      accessibilityHint={errorText}
+      style={styles.container}
+    >
+      <View style={styles.dot} />
+      <Text style={styles.label}>
+        Previous conversation could not be resumed — starting fresh
+      </Text>
+      {hasId && (
+        <Text
+          testID="resume-unknown-chip-id"
+          style={styles.idSubtext}
+          accessibilityElementsHidden
+          importantForAccessibility="no"
+          selectable
+        >
+          Attempted id: {attemptedResumeId}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    marginVertical: 4,
+    gap: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: COLORS.accentYellow500,
+    backgroundColor: 'rgba(217, 165, 12, 0.12)',
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: COLORS.accentYellow500,
+  },
+  label: {
+    fontSize: 13,
+    color: COLORS.textPrimary,
+    fontWeight: '500',
+  },
+  idSubtext: {
+    width: '100%',
+    marginTop: 4,
+    fontSize: 12,
+    fontFamily: 'monospace',
+    color: COLORS.textSecondary,
+    opacity: 0.85,
+  },
+});

--- a/packages/app/src/components/ResumeUnknownChip.tsx
+++ b/packages/app/src/components/ResumeUnknownChip.tsx
@@ -26,7 +26,7 @@
  * (and the other amber-recoverable surfaces) so the user learns one
  * affordance — the chip visual language is shared.
  */
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import { COLORS } from '../constants/colors';
 
 export interface ResumeUnknownChipProps {
@@ -65,11 +65,16 @@ export function ResumeUnknownChip({ errorText, attemptedResumeId }: ResumeUnknow
         Previous conversation could not be resumed — starting fresh
       </Text>
       {hasId && (
+        // #4971 review: drop `accessibilityElementsHidden` /
+        // `importantForAccessibility="no"` so the attempted id is
+        // naturally announced by screen readers (mirrors the dashboard
+        // chip, which renders the id as visible text the AT tree picks
+        // up via the standard sibling traversal). The container's
+        // `accessibilityLabel` stays minimal and `accessibilityHint`
+        // continues to carry the raw error verbatim for triage.
         <Text
           testID="resume-unknown-chip-id"
           style={styles.idSubtext}
-          accessibilityElementsHidden
-          importantForAccessibility="no"
           selectable
         >
           Attempted id: {attemptedResumeId}
@@ -109,7 +114,12 @@ const styles = StyleSheet.create({
     width: '100%',
     marginTop: 4,
     fontSize: 12,
-    fontFamily: 'monospace',
+    // #4971 review: iOS doesn't ship a font literally named "monospace" —
+    // RN falls back to a system font that varies by iOS version. Use the
+    // same Menlo/monospace pair as ToolBubble / DiffViewer /
+    // MarkdownRenderer so the attempted id renders in a consistent
+    // monospace face across platforms.
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
     color: COLORS.textSecondary,
     opacity: 0.85,
   },

--- a/packages/app/src/components/__tests__/MessageBubble.resumeUnknown.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.resumeUnknown.test.tsx
@@ -93,7 +93,10 @@ describe('MessageBubble resume-unknown handling (#4971)', () => {
     const response = {
       id: 'resp-1',
       type: 'response',
-      // @ts-expect-error — deliberately wrong shape for the regression guard
+      // Deliberately wrong shape for the regression guard — a non-error
+      // message carrying `code: 'resume_unknown'` should NOT route into
+      // the chip (the dispatch table gates on `isError`). Cast through
+      // ChatMessage so the test compiles without weakening callers.
       code: 'resume_unknown',
       content: 'Assistant response content',
       timestamp: Date.now(),

--- a/packages/app/src/components/__tests__/MessageBubble.resumeUnknown.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.resumeUnknown.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * MessageBubble resume-unknown integration — #4971
+ *
+ * Asserts that MessageBubble special-cases `error{code:'resume_unknown'}`
+ * and renders the ResumeUnknownChip in place of the generic red error
+ * bubble (analogous to the stream_stall dispatch covered by
+ * MessageBubble.streamStall.test.tsx). Without this, the branch-order
+ * inside MessageBubble (stream_stall vs. resume_unknown vs. generic
+ * error) could regress unnoticed — e.g. a future refactor that swaps the
+ * dispatch table, or a code/type mismatch between server and client.
+ *
+ * Also pins `attemptedResumeId` passthrough so the operator-correlation
+ * subtext survives end-to-end from server payload to chip render.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { MessageBubble } from '../chat/MessageBubble';
+import type { ChatMessage } from '../../store/types';
+
+function makeResumeUnknownMessage(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'err-resume-1',
+    type: 'error',
+    code: 'resume_unknown',
+    content: 'Previous Claude conversation could not be resumed',
+    attemptedResumeId: 'abc-123',
+    timestamp: Date.now(),
+    ...overrides,
+  } as ChatMessage;
+}
+
+function render(message: ChatMessage) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(
+      <MessageBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onLongPress={() => {}}
+        onPress={() => {}}
+        onOpenDetail={() => {}}
+      />,
+    );
+  });
+  return tree;
+}
+
+describe('MessageBubble resume-unknown handling (#4971)', () => {
+  it('renders the ResumeUnknownChip for error{code: "resume_unknown"}', () => {
+    const tree = render(makeResumeUnknownMessage());
+    const chip = tree.root.findByProps({ testID: 'resume-unknown-chip' });
+    expect(chip).toBeDefined();
+  });
+
+  it('forwards attemptedResumeId so the id subtext renders', () => {
+    const tree = render(
+      makeResumeUnknownMessage({ attemptedResumeId: 'corr-id-xyz' }),
+    );
+    const idSubtext = tree.root.findByProps({ testID: 'resume-unknown-chip-id' });
+    expect(idSubtext).toBeDefined();
+  });
+
+  it('omits the id subtext when attemptedResumeId is undefined (pre-#4944 server)', () => {
+    const tree = render(
+      makeResumeUnknownMessage({ attemptedResumeId: undefined }),
+    );
+    const ids = tree.root.findAllByProps({ testID: 'resume-unknown-chip-id' });
+    expect(ids).toHaveLength(0);
+  });
+
+  it('does not render the resume chip for stream_stall (regression: branch order matters)', () => {
+    // Guard against a future refactor that swaps the dispatch order or
+    // type-checks the wrong code value — the stream_stall branch must
+    // continue to win for stream_stall errors.
+    const stall = {
+      id: 'err-stall-1',
+      type: 'error',
+      code: 'stream_stall',
+      content: 'Stream stalled',
+      timestamp: Date.now(),
+    } as ChatMessage;
+    const tree = render(stall);
+    const chips = tree.root.findAllByProps({ testID: 'resume-unknown-chip' });
+    expect(chips).toHaveLength(0);
+  });
+
+  it('does not render the resume chip for non-error message types (chip is error-only)', () => {
+    // Defense-in-depth: even if a non-error message somehow carries
+    // `code: 'resume_unknown'` (e.g. a bug in a future server payload),
+    // the chip must only surface from the error branch — otherwise we'd
+    // mask legitimate assistant text.
+    const response = {
+      id: 'resp-1',
+      type: 'response',
+      // @ts-expect-error — deliberately wrong shape for the regression guard
+      code: 'resume_unknown',
+      content: 'Assistant response content',
+      timestamp: Date.now(),
+    } as ChatMessage;
+    const tree = render(response);
+    const chips = tree.root.findAllByProps({ testID: 'resume-unknown-chip' });
+    expect(chips).toHaveLength(0);
+  });
+});

--- a/packages/app/src/components/__tests__/ResumeUnknownChip.test.tsx
+++ b/packages/app/src/components/__tests__/ResumeUnknownChip.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * ResumeUnknownChip tests — #4971
+ *
+ * Mobile companion to packages/dashboard/src/components/ResumeUnknownChip
+ * (#4947). Pins the conditional id-subtext slot (so a stale empty value
+ * can't produce a broken "Attempted id: " row), the calm headline copy,
+ * and `accessibilityRole="alert"` for assistive-tech parity with
+ * StreamStallChip.
+ *
+ * Mirrors StreamStallChip.test.tsx — react-test-renderer + act, no
+ * `@testing-library/react-native` dependency required.
+ */
+import React from 'react';
+import renderer, { act, ReactTestInstance } from 'react-test-renderer';
+import { Text } from 'react-native';
+import { ResumeUnknownChip } from '../ResumeUnknownChip';
+
+function collectVisibleText(root: ReactTestInstance): string {
+  return root
+    .findAllByType(Text)
+    .map((node) => {
+      const c = node.props.children;
+      if (typeof c === 'string' || typeof c === 'number') return String(c);
+      if (Array.isArray(c)) {
+        return c
+          .map((x) => (typeof x === 'string' || typeof x === 'number' ? String(x) : ''))
+          .join('');
+      }
+      return '';
+    })
+    .join(' ');
+}
+
+describe('ResumeUnknownChip (#4971)', () => {
+  let activeTree: renderer.ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (activeTree) {
+      act(() => {
+        activeTree!.unmount();
+      });
+      activeTree = null;
+    }
+  });
+
+  function render(node: React.ReactElement): renderer.ReactTestRenderer {
+    let tree!: renderer.ReactTestRenderer;
+    act(() => {
+      tree = renderer.create(node);
+    });
+    activeTree = tree;
+    return tree;
+  }
+
+  it('renders the calm "starting fresh" headline', () => {
+    const tree = render(<ResumeUnknownChip errorText="Resume failed: id unknown" />);
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Previous conversation could not be resumed');
+    expect(text).toContain('starting fresh');
+  });
+
+  it('renders attempted id subtext when attemptedResumeId is provided', () => {
+    const tree = render(
+      <ResumeUnknownChip
+        errorText="Resume failed"
+        attemptedResumeId="abc123-def456-7890"
+      />,
+    );
+    const text = collectVisibleText(tree.root);
+    expect(text).toContain('Attempted id: abc123-def456-7890');
+    expect(tree.root.findByProps({ testID: 'resume-unknown-chip-id' })).toBeTruthy();
+  });
+
+  it('omits attempted id subtext when attemptedResumeId is undefined (pre-#4944 server)', () => {
+    const tree = render(<ResumeUnknownChip errorText="Resume failed" />);
+    expect(tree.root.findAllByProps({ testID: 'resume-unknown-chip-id' })).toHaveLength(0);
+    const text = collectVisibleText(tree.root);
+    expect(text).not.toContain('Attempted id:');
+  });
+
+  it('omits attempted id subtext when attemptedResumeId is empty string', () => {
+    const tree = render(
+      <ResumeUnknownChip errorText="Resume failed" attemptedResumeId="" />,
+    );
+    expect(tree.root.findAllByProps({ testID: 'resume-unknown-chip-id' })).toHaveLength(0);
+  });
+
+  it('omits attempted id subtext when attemptedResumeId is whitespace-only (defense in depth)', () => {
+    // Mirrors the dashboard chip's empty-string defense — a stale or
+    // trimmed empty value shouldn't degrade the headline into a broken
+    // "Attempted id: " slot with no value.
+    const tree = render(
+      <ResumeUnknownChip errorText="Resume failed" attemptedResumeId="   " />,
+    );
+    expect(tree.root.findAllByProps({ testID: 'resume-unknown-chip-id' })).toHaveLength(0);
+  });
+
+  it('exposes the raw error text via accessibilityHint for assistive tech', () => {
+    const verbatim = 'Previous Claude conversation could not be resumed (id unknown to local CLI)';
+    const tree = render(<ResumeUnknownChip errorText={verbatim} />);
+    const chip = tree.root.findByProps({ testID: 'resume-unknown-chip' });
+    expect(chip.props.accessibilityHint).toBe(verbatim);
+  });
+
+  it('declares accessibilityRole="alert" for parity with StreamStallChip', () => {
+    const tree = render(<ResumeUnknownChip errorText="Resume failed" />);
+    const chip = tree.root.findByProps({ testID: 'resume-unknown-chip' });
+    expect(chip.props.accessibilityRole).toBe('alert');
+  });
+});

--- a/packages/app/src/components/__tests__/ResumeUnknownChip.test.tsx
+++ b/packages/app/src/components/__tests__/ResumeUnknownChip.test.tsx
@@ -107,4 +107,19 @@ describe('ResumeUnknownChip (#4971)', () => {
     const chip = tree.root.findByProps({ testID: 'resume-unknown-chip' });
     expect(chip.props.accessibilityRole).toBe('alert');
   });
+
+  it('leaves the attempted id subtext natively accessible (regression: do not hide from SR)', () => {
+    // #4971 review: an earlier revision set `accessibilityElementsHidden`
+    // / `importantForAccessibility="no"` on the id subtext, which
+    // silently masked the attempted conversation id from screen readers
+    // even though it was the most operationally relevant detail in the
+    // chip. Pin the natural-accessibility behavior so a future
+    // refactor can't re-hide it.
+    const tree = render(
+      <ResumeUnknownChip errorText="Resume failed" attemptedResumeId="abc-123" />,
+    );
+    const idSubtext = tree.root.findByProps({ testID: 'resume-unknown-chip-id' });
+    expect(idSubtext.props.accessibilityElementsHidden).toBeUndefined();
+    expect(idSubtext.props.importantForAccessibility).toBeUndefined();
+  });
 });

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -183,7 +183,12 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
   if (isError && message.code === 'resume_unknown') {
     return (
       <ResumeUnknownChip
-        errorText={message.content?.trim() || ''}
+        // #4971 review: pass the raw content through (no `.trim()`) so
+        // any meaningful trailing context / newlines the server includes
+        // (e.g. wrapped CLI stderr) survive end-to-end into the chip's
+        // `accessibilityHint`. Matches the dashboard call site, which
+        // forwards `message.content` verbatim.
+        errorText={message.content ?? ''}
         attemptedResumeId={message.attemptedResumeId}
       />
     );

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -23,6 +23,7 @@ import { PermissionDetailOrFallback, PermissionCountdown, PermissionPill, permis
 import { ThinkingIndicator } from './ThinkingIndicator';
 import { ToolBubble } from './ToolBubble';
 import { StreamStallChip } from '../StreamStallChip';
+import { ResumeUnknownChip } from '../ResumeUnknownChip';
 
 /**
  * #4755 — single-question Other / freeform answer payload (mobile parity
@@ -169,6 +170,21 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
       <StreamStallChip
         errorText={message.content?.trim() || ''}
         onRetry={onRetryStreamStall}
+      />
+    );
+  }
+
+  // #4971: dedicated chip for `error{code: 'resume_unknown'}` (server PR
+  // #4944, dashboard companion #4947). CliSession has already auto-fallen-
+  // back to a fresh conversation by the time this lands — the chip
+  // explains that calmly instead of the loud red crash bubble, and
+  // surfaces `attemptedResumeId` as subtext for operator correlation
+  // against `~/.chroxy/session-state.json.resumeConversationId`.
+  if (isError && message.code === 'resume_unknown') {
+    return (
+      <ResumeUnknownChip
+        errorText={message.content?.trim() || ''}
+        attemptedResumeId={message.attemptedResumeId}
       />
     );
   }


### PR DESCRIPTION
## Summary

Mobile companion to dashboard #4967 (ResumeUnknownChip). The shared store-core change in #4967 preserves `attemptedResumeId` end-to-end on `ChatMessage`, so the wire data was already on the mobile-app side — only the renderer was missing. Without this, `error{code:'resume_unknown'}` on mobile still falls through to the generic red crash bubble (the overstated-severity UX #4947 fixed for the dashboard).

- New `packages/app/src/components/ResumeUnknownChip.tsx` mirrors the dashboard chip's copy ("Previous conversation could not be resumed — starting fresh") + amber-recoverable palette (matches `StreamStallChip` so users learn one chip visual language)
- `MessageBubble` branches on `isError && message.code === 'resume_unknown'` parallel to the existing `stream_stall` branch
- `attemptedResumeId` rendered as mono subtext when present; empty / whitespace / undefined hides the slot (same defensive guard as the dashboard chip and the new SessionNotFoundChip)
- `accessibilityRole="alert"` for parity with `StreamStallChip`

Closes #4971

## Test plan

- [x] 7 new ResumeUnknownChip render tests (headline, id present, id undefined, id empty, id whitespace, raw text via accessibilityHint, accessibilityRole)
- [x] 12 existing StreamStallChip + MessageBubble.streamStall tests still pass — wire-up didn't regress the prior chip