### PR TITLE
feat(desktop): "Reset macOS speech permissions" affordance (#4956)

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -2290,10 +2290,11 @@ describe('SettingsPanel', () => {
       tauriInvoke.mockResolvedValue(undefined)
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       fireEvent.click(screen.getByTestId('speech-reset-button'))
-      // Allow the async chain (invoke → state update) to flush.
-      await new Promise((r) => setTimeout(r, 0))
+      // findByTestId waits for the success hint to mount, replacing the
+      // earlier `setTimeout(..., 0)` flush which was flaky across runtimes
+      // (#4998 review).
+      await screen.findByTestId('speech-reset-success')
       expect(tauriInvoke).toHaveBeenCalledWith('reset_speech_permissions')
-      expect(screen.getByTestId('speech-reset-success')).toBeInTheDocument()
     })
 
     it('surfaces an error hint when the Tauri command rejects', async () => {
@@ -2301,8 +2302,7 @@ describe('SettingsPanel', () => {
       tauriInvoke.mockRejectedValue(new Error('tccutil reset Microphone exited with status 1'))
       render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
       fireEvent.click(screen.getByTestId('speech-reset-button'))
-      await new Promise((r) => setTimeout(r, 0))
-      const errEl = screen.getByTestId('speech-reset-error')
+      const errEl = await screen.findByTestId('speech-reset-error')
       expect(errEl.textContent).toContain('tccutil reset Microphone exited with status 1')
     })
   })

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -2233,4 +2233,77 @@ describe('SettingsPanel', () => {
       expect(text).toMatch(/Stop after silence \(browser decides\)/)
     })
   })
+
+  // #4956 — Reset macOS speech permissions affordance. Gated on
+  // inTauri && macOS so the button doesn't show as a no-op on Linux/
+  // Windows or in browser (where there's no shell to invoke tccutil).
+  describe('Reset macOS speech permissions (#4956)', () => {
+    const tauriInvoke = vi.fn()
+    const setTauriEnv = (mac: boolean, tauri: boolean) => {
+      Object.defineProperty(window.navigator, 'userAgent', {
+        configurable: true,
+        value: mac
+          ? 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Test'
+          : 'Mozilla/5.0 (X11; Linux x86_64) Test',
+      })
+      if (tauri) {
+        ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {
+          invoke: tauriInvoke,
+        }
+      } else {
+        delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+      }
+    }
+
+    afterEach(() => {
+      tauriInvoke.mockReset()
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+    })
+
+    it('does NOT render the reset row in the browser (non-Tauri)', () => {
+      setTauriEnv(true, false) // macOS UA but not Tauri
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.queryByTestId('speech-reset-row')).toBeNull()
+    })
+
+    it('does NOT render the reset row on Linux even when running in Tauri', () => {
+      setTauriEnv(false, true)
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.queryByTestId('speech-reset-row')).toBeNull()
+    })
+
+    it('renders the reset row with an idle hint on macOS-in-Tauri', () => {
+      setTauriEnv(true, true)
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      expect(screen.getByTestId('speech-reset-row')).toBeInTheDocument()
+      expect(screen.getByTestId('speech-reset-button')).toHaveTextContent('Reset now')
+      // Idle hint mentions both reset targets so an operator triaging knows
+      // what the button is about to do.
+      const row = screen.getByTestId('speech-reset-row')
+      expect(row.textContent).toContain('Microphone')
+      expect(row.textContent).toContain('SpeechRecognition')
+      expect(row.textContent).toContain('com.chroxy.desktop')
+    })
+
+    it('invokes the reset_speech_permissions Tauri command and surfaces a success hint', async () => {
+      setTauriEnv(true, true)
+      tauriInvoke.mockResolvedValue(undefined)
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('speech-reset-button'))
+      // Allow the async chain (invoke → state update) to flush.
+      await new Promise((r) => setTimeout(r, 0))
+      expect(tauriInvoke).toHaveBeenCalledWith('reset_speech_permissions')
+      expect(screen.getByTestId('speech-reset-success')).toBeInTheDocument()
+    })
+
+    it('surfaces an error hint when the Tauri command rejects', async () => {
+      setTauriEnv(true, true)
+      tauriInvoke.mockRejectedValue(new Error('tccutil reset Microphone exited with status 1'))
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('speech-reset-button'))
+      await new Promise((r) => setTimeout(r, 0))
+      const errEl = screen.getByTestId('speech-reset-error')
+      expect(errEl.textContent).toContain('tccutil reset Microphone exited with status 1')
+    })
+  })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -764,6 +764,11 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
     setAutoPermError(null)
     setAutoPermDirty(false)
     setAutoPermSaving(false)
+    // #4998 review — match the panel-scoped reset pattern used for
+    // tunnelError / autoPermError so a stale success/error hint from a
+    // previous open doesn't linger across reopens.
+    setSpeechResetStatus('idle')
+    setSpeechResetError(null)
     // Read saved setting (what user selected)
     getTunnelMode().then(mode => {
       if (mode) setTunnelModeState(mode)
@@ -1132,9 +1137,10 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 no-op on Linux/Windows or in browser. */}
             {showSpeechResetButton && (
               <div className="settings-field" data-testid="speech-reset-row">
-                <label>Reset macOS speech permissions</label>
+                <label htmlFor="speech-reset-button">Reset macOS speech permissions</label>
                 <button
                   type="button"
+                  id="speech-reset-button"
                   className="settings-secondary-button"
                   onClick={handleResetSpeechPermissions}
                   disabled={speechResetStatus === 'running'}
@@ -1165,7 +1171,7 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 {speechResetStatus === 'idle' && (
                   <p className="settings-hint">
                     Use this if voice input still says &ldquo;permission
-                    denied&rdquo; after upgrading. Chroxy v0.9.41+ ships with a
+                    denied&rdquo; after upgrading. Chroxy v0.9.40+ ships with a
                     new helper signature; macOS may cache a denial for the old
                     signature. Resets <code>Microphone</code> and{' '}
                     <code>SpeechRecognition</code> for <code>com.chroxy.desktop</code>.

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -21,6 +21,8 @@ import {
   isVoiceInputMode,
 } from '@chroxy/store-core'
 import { isTauri } from '../utils/tauri'
+import { isMacPlatform } from '../utils/platform'
+import { getTauriInvoke } from '../utils/tauri-bridge'
 import {
   getTunnelMode,
   setTunnelMode,
@@ -695,6 +697,31 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const [allowAutoPerm, setAllowAutoPerm] = useState<boolean>(false)
   const [autoPermError, setAutoPermError] = useState<string | null>(null)
   const [autoPermDirty, setAutoPermDirty] = useState<boolean>(false)
+  // #4956 — Tooling reset hint state. The Tauri command runs `tccutil reset
+  // Microphone/SpeechRecognition com.chroxy.desktop`; we only surface the
+  // button on macOS-in-Tauri (other platforms have no TCC, and the browser
+  // can't shell out). Status feedback is intentionally inline (not a toast)
+  // so the user sees the outcome next to the button they pressed.
+  const [speechResetStatus, setSpeechResetStatus] = useState<
+    'idle' | 'running' | 'success' | 'error'
+  >('idle')
+  const [speechResetError, setSpeechResetError] = useState<string | null>(null)
+  const showSpeechResetButton = inTauri && isMacPlatform()
+  const handleResetSpeechPermissions = useCallback(async () => {
+    setSpeechResetStatus('running')
+    setSpeechResetError(null)
+    try {
+      const invoke = getTauriInvoke()
+      if (!invoke) {
+        throw new Error('Tauri invoke unavailable')
+      }
+      await invoke('reset_speech_permissions')
+      setSpeechResetStatus('success')
+    } catch (err) {
+      setSpeechResetStatus('error')
+      setSpeechResetError(err instanceof Error ? err.message : String(err))
+    }
+  }, [])
   const [autoPermSaving, setAutoPermSaving] = useState<boolean>(false)
 
   // #4660 / #4662 / #4739: per-session preamble text area. Local draft
@@ -1094,6 +1121,58 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 end-of-utterance timing.
               </p>
             </div>
+            {/* #4956 — macOS-only reset for cached TCC denials. Surfaced
+                after #4954 shipped the helper-entitlement fix because end
+                users upgrading from a broken build (v0.9.40 and earlier)
+                still hit the old TCC denial against the prior codesign
+                hash. The Rust side runs `tccutil reset Microphone +
+                SpeechRecognition com.chroxy.desktop`; on next mic use macOS
+                re-prompts and the new entitled signature gets allowed.
+                Gated on inTauri + macOS so the button doesn't show as a
+                no-op on Linux/Windows or in browser. */}
+            {showSpeechResetButton && (
+              <div className="settings-field" data-testid="speech-reset-row">
+                <label>Reset macOS speech permissions</label>
+                <button
+                  type="button"
+                  className="settings-secondary-button"
+                  onClick={handleResetSpeechPermissions}
+                  disabled={speechResetStatus === 'running'}
+                  data-testid="speech-reset-button"
+                >
+                  {speechResetStatus === 'running' ? 'Resetting…' : 'Reset now'}
+                </button>
+                {speechResetStatus === 'success' && (
+                  <p
+                    className="settings-hint"
+                    data-testid="speech-reset-success"
+                    role="status"
+                  >
+                    Speech permissions reset. Click the mic again — macOS will
+                    prompt for permission, and the new entitled helper
+                    signature will be allowed.
+                  </p>
+                )}
+                {speechResetStatus === 'error' && speechResetError && (
+                  <p
+                    className="settings-hint settings-error"
+                    data-testid="speech-reset-error"
+                    role="alert"
+                  >
+                    Reset failed: {speechResetError}
+                  </p>
+                )}
+                {speechResetStatus === 'idle' && (
+                  <p className="settings-hint">
+                    Use this if voice input still says &ldquo;permission
+                    denied&rdquo; after upgrading. Chroxy v0.9.41+ ships with a
+                    new helper signature; macOS may cache a denial for the old
+                    signature. Resets <code>Microphone</code> and{' '}
+                    <code>SpeechRecognition</code> for <code>com.chroxy.desktop</code>.
+                  </p>
+                )}
+              </div>
+            )}
           </section>
 
           {/* #3852: customizable keyboard-shortcut bindings. Lives next

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -28,6 +28,7 @@ const APP_COMMANDS: &[&str] = &[
     "voice_available",
     "start_voice_input",
     "stop_voice_input",
+    "reset_speech_permissions",
     "tile_window",
     "read_clipboard_image",
     "reveal_in_finder",

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -36,6 +36,7 @@
     "allow-voice-available",
     "allow-start-voice-input",
     "allow-stop-voice-input",
+    "allow-reset-speech-permissions",
     "allow-tile-window",
     "allow-read-clipboard-image",
     "allow-reveal-in-finder"

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -552,6 +552,44 @@ fn stop_voice_input(
     Ok(())
 }
 
+/// #4956 — reset macOS TCC permissions for Microphone + Speech Recognition
+/// so a user upgrading past a codesign-hash change (e.g. v0.9.40 shipped
+/// the helper-entitlement fix from #4954, but the macOS TCC database
+/// remembered the entitlement-less hash) doesn't have to know `tccutil`
+/// exists. Surfaced in Settings → Voice Input as a button.
+///
+/// Runs both `tccutil reset Microphone com.chroxy.desktop` and
+/// `tccutil reset SpeechRecognition com.chroxy.desktop`. Either failing
+/// individually still returns Err so the UI surfaces the real problem
+/// (most likely: macOS prompted for admin elevation and the user
+/// cancelled). On success the dashboard surfaces a one-shot confirmation
+/// reminding the user to re-grant on the next mic click.
+#[cfg(target_os = "macos")]
+#[tauri::command]
+fn reset_speech_permissions(window: tauri::Window) -> Result<(), String> {
+    require_main_window(&window)?;
+    // The bundle id is fixed at compile-time in tauri.conf.json; keeping it
+    // hard-coded here matches verify-entitlements.sh and the troubleshooting
+    // docs so the three references stay aligned by sight.
+    const BUNDLE_ID: &str = "com.chroxy.desktop";
+
+    for service in ["Microphone", "SpeechRecognition"] {
+        let output = std::process::Command::new("tccutil")
+            .args(["reset", service, BUNDLE_ID])
+            .output()
+            .map_err(|e| format!("Failed to invoke tccutil for {service}: {e}"))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!(
+                "tccutil reset {service} {BUNDLE_ID} exited with status {}: {}",
+                output.status.code().unwrap_or(-1),
+                stderr.trim()
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Read the current clipboard image and return it as a base64-encoded PNG.
 ///
 /// Returns `Ok(None)` when the clipboard does not currently hold an image —
@@ -659,6 +697,8 @@ pub fn run() {
             start_voice_input,
             #[cfg(target_os = "macos")]
             stop_voice_input,
+            #[cfg(target_os = "macos")]
+            reset_speech_permissions,
             tile_window,
             read_clipboard_image,
             reveal_in_finder,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -579,11 +579,16 @@ fn reset_speech_permissions(window: tauri::Window) -> Result<(), String> {
             .output()
             .map_err(|e| format!("Failed to invoke tccutil for {service}: {e}"))?;
         if !output.status.success() {
+            // Some tccutil failures only write diagnostics to stdout (or
+            // stderr is empty); include both so the UI never shows a blank
+            // error string when the exit status is non-zero (#4998 review).
             let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
             return Err(format!(
-                "tccutil reset {service} {BUNDLE_ID} exited with status {}: {}",
+                "tccutil reset {service} {BUNDLE_ID} exited with status {}: stderr={} stdout={}",
                 output.status.code().unwrap_or(-1),
-                stderr.trim()
+                stderr.trim(),
+                stdout.trim()
             ));
         }
     }


### PR DESCRIPTION
## Summary

#4954 shipped the helper-entitlement fix but macOS may have a cached TCC denial against the previous (entitlement-less) `speech-helper` codesign hash. End-users installing v0.9.40+ click mic, still see broken voice input, and don't know that running `tccutil reset` would clear the cached denial. Without UI for this, "voice STILL broken" support reports keep arriving.

New Tauri command `reset_speech_permissions` runs both:
- `tccutil reset Microphone com.chroxy.desktop`
- `tccutil reset SpeechRecognition com.chroxy.desktop`

Surfaced in Settings → Voice Input as a "Reset now" button, gated on `inTauri && isMacPlatform` so Linux/Windows + browser users don't see a no-op button. Inline status feedback (idle/running/success/error) keeps the outcome next to the action instead of a transient toast.

Wire changes:
- `lib.rs`: new `#[tauri::command] reset_speech_permissions` (macOS only)
- `build.rs`: `APP_COMMANDS` entry so Tauri 2.11+ ACL accepts the call
- `capabilities/default.json`: `allow-reset-speech-permissions`
- `SettingsPanel.tsx`: handler + inline status UI

Closes #4956

## Test plan

- [x] 5 new SettingsPanel cases: browser-only gate, Linux-Tauri gate, macOS-Tauri row renders + idle hint copy, success path, error path
- [x] cargo check clean
- [x] 138 SettingsPanel tests pass
- [ ] Manual: install on macOS with stale TCC entry, click "Reset now", verify mic prompts on next use