### PR TITLE
feat(ci): auto-tag release PRs on merge to prevent missed tags

### DIFF
--- a/.github/workflows/auto-tag-on-release.yml
+++ b/.github/workflows/auto-tag-on-release.yml
@@ -1,17 +1,36 @@
 name: Auto-tag Release PR
 
 # Fires when a `chore(release): cut vX.Y.Z` PR merges to main and pushes the
-# matching `vX.Y.Z` annotated tag. The release workflow (release.yml) is
-# triggered on `tags: ['v*']` and takes it from there.
+# matching `vX.Y.Z` annotated tag. After pushing, the workflow explicitly
+# dispatches release.yml (via workflow_dispatch) instead of relying on the
+# tag-push to trigger it.
 #
 # Background: v0.9.13–v0.9.19 release PRs all merged successfully but the tags
 # were never pushed by hand, so no release artifacts (Docker, Tauri bundles,
 # GitHub Release) ever shipped for those versions. See #4627. This workflow
 # removes the manual tag-push step entirely.
 #
+# Why explicit dispatch (not tag-push trigger): per GitHub Actions docs,
+# events triggered by the default GITHUB_TOKEN (with the exception of
+# workflow_dispatch and repository_dispatch) do NOT create a new workflow run.
+# Tag-pushes from GITHUB_TOKEN are therefore inert from release.yml's
+# perspective. We sidestep that by calling `gh workflow run release.yml` after
+# the tag lands — release.yml already has a workflow_dispatch trigger with a
+# `confirm` input.
+# Ref: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+#
+# Robust commit-message parsing: the `if:` guard and the parser both scan the
+# entire commit message (not just the first line) for any line matching
+# `chore(release): cut vX.Y.Z`. This works for squash merges (subject is the
+# PR title) AND merge commits (subject is "Merge pull request..." with the
+# PR title later in the body). Per CLAUDE.md, releases are squash-merged, but
+# the cheap defence-in-depth means a hand-merged release commit still tags.
+#
 # Idempotency: if the tag already exists on the remote (e.g. a maintainer
 # pushed it by hand before the workflow ran, or this workflow is re-run on
-# the same commit), the job exits 0 without trying to recreate it.
+# the same commit), the tag-push step is skipped and the dispatch step still
+# runs — so a hand-pushed tag that didn't fire release.yml still gets the
+# pipeline kicked off.
 
 on:
   push:
@@ -23,22 +42,21 @@ jobs:
   tag:
     name: Tag release commit
     runs-on: ubuntu-24.04
-    # Only fire on `chore(release): cut vX.Y.Z` commits. Checking head_commit
-    # here scopes the workflow off the wire (no checkout for non-release
-    # commits). The job step does a defence-in-depth re-parse before tagging.
-    if: "startsWith(github.event.head_commit.message, 'chore(release): cut v')"
+    # Job-level filter: scan the full commit message for the release line.
+    # `contains` matches across the whole multi-line message, so we cover both
+    # squash-merge subjects and merge-commit bodies without spinning up a
+    # runner for unrelated pushes. The step-level parser re-validates with
+    # anchored semver before any tag is created.
+    if: "contains(github.event.head_commit.message, 'chore(release): cut v')"
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          fetch-depth: 0
-          # Use the default GITHUB_TOKEN for the push. Tags pushed by this
-          # token DO trigger other workflows (unlike the documented
-          # restriction for branches/PRs) when the workflow uses
-          # `permissions: contents: write` — confirmed by GitHub Actions docs
-          # for tag refs. release.yml's `on: push: tags: ['v*']` will fire.
+          # Shallow clone is enough — we only tag `github.sha`, no history walk.
+          fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Parse version from commit message
@@ -46,17 +64,20 @@ jobs:
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          # Match `chore(release): cut vX.Y.Z` on the first line, ignoring any
-          # trailing PR number, parenthetical, or suffix. Refuse to tag if the
-          # version doesn't match strict semver — guards against typos like
-          # `cut v0.9` or `cut v0.9.x-rc1` accidentally producing a release.
-          first_line=$(printf '%s\n' "$COMMIT_MESSAGE" | head -n 1)
-          echo "First line: $first_line"
+          # Scan every line of the commit message for `chore(release): cut vX.Y.Z`.
+          # Anchored to the start of the line and required to terminate at
+          # whitespace or end-of-line so `cut v1.0.0-rc1` does NOT slip through
+          # as `1.0.0` and `cut v0.9.13.0` does NOT slip through as `0.9.13`.
+          # The package-version cross-check below is the second line of defence.
+          version=$(printf '%s' "$COMMIT_MESSAGE" \
+            | grep -oE '^chore\(release\): cut v[0-9]+\.[0-9]+\.[0-9]+([[:space:]]|$)' \
+            | head -n 1 \
+            | sed -nE 's/^chore\(release\): cut v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
 
-          version=$(printf '%s' "$first_line" | sed -nE 's/^chore\(release\): cut v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
           if [ -z "$version" ]; then
-            echo "::error::Commit message did not match 'chore(release): cut vX.Y.Z' — refusing to tag."
-            echo "First line was: $first_line"
+            echo "::error::Commit message did not contain a valid 'chore(release): cut vX.Y.Z' line — refusing to tag."
+            echo "Commit message was:"
+            printf '%s\n' "$COMMIT_MESSAGE"
             exit 1
           fi
 
@@ -75,7 +96,9 @@ jobs:
           # files (e.g. an aborted bump, hand-edit, or mis-typed subject). If
           # they disagree, refuse to tag — pushing a wrong tag would trigger
           # a release for a version that doesn't match what's in package.json.
-          pkg_version=$(node -e "console.log(require('./packages/server/package.json').version)")
+          # `jq` is dependency-free vs. `node -e` and is preinstalled on the
+          # ubuntu-24.04 runner image.
+          pkg_version=$(jq -r .version packages/server/package.json)
           echo "Package version: $pkg_version"
           echo "Subject version: $PARSED_VERSION"
           if [ "$pkg_version" != "$PARSED_VERSION" ]; then
@@ -89,11 +112,14 @@ jobs:
           TAG: ${{ steps.parse.outputs.tag }}
         run: |
           # Idempotency: if someone pushed the tag by hand before this workflow
-          # ran (or this workflow is re-run on the same commit), skip cleanly.
+          # ran (or this workflow is re-run on the same commit), skip the
+          # create/push step but STILL dispatch release.yml below — a
+          # hand-pushed tag that didn't fire release.yml still needs the
+          # pipeline kicked off.
           # `git ls-remote --tags` queries the remote directly so we don't get
           # tricked by a stale local refs/tags/.
           if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "::notice::Tag $TAG already exists on origin — nothing to do."
+            echo "::notice::Tag $TAG already exists on origin — skipping create, will still dispatch release.yml."
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "Tag $TAG does not exist yet — will create it."
@@ -104,7 +130,6 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         env:
           TAG: ${{ steps.parse.outputs.tag }}
-          VERSION: ${{ steps.parse.outputs.version }}
           SHA: ${{ github.sha }}
         run: |
           # Annotated tag (-a) so `git describe` and release tooling can find
@@ -116,4 +141,22 @@ jobs:
 
           git tag -a "$TAG" "$SHA" -m "Release $TAG"
           git push origin "refs/tags/$TAG"
-          echo "::notice::Pushed tag $TAG at $SHA — release.yml will pick it up."
+          echo "::notice::Pushed tag $TAG at $SHA."
+
+      - name: Dispatch release workflow
+        env:
+          TAG: ${{ steps.parse.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # GITHUB_TOKEN-pushed tags do NOT trigger release.yml's `on: push:
+          # tags` handler. workflow_dispatch IS one of the two exceptions
+          # (alongside repository_dispatch) that GITHUB_TOKEN is allowed to
+          # fire, so we explicitly kick release.yml here with --ref pointing
+          # at the tag we just pushed (or that already existed).
+          #
+          # release.yml gates workflow_dispatch behind a `confirm` input —
+          # we pass `confirm=release` to satisfy that gate.
+          gh workflow run release.yml \
+            --ref "$TAG" \
+            -f confirm=release
+          echo "::notice::Dispatched release.yml at ref $TAG."

--- a/.github/workflows/auto-tag-on-release.yml
+++ b/.github/workflows/auto-tag-on-release.yml
@@ -1,0 +1,119 @@
+name: Auto-tag Release PR
+
+# Fires when a `chore(release): cut vX.Y.Z` PR merges to main and pushes the
+# matching `vX.Y.Z` annotated tag. The release workflow (release.yml) is
+# triggered on `tags: ['v*']` and takes it from there.
+#
+# Background: v0.9.13–v0.9.19 release PRs all merged successfully but the tags
+# were never pushed by hand, so no release artifacts (Docker, Tauri bundles,
+# GitHub Release) ever shipped for those versions. See #4627. This workflow
+# removes the manual tag-push step entirely.
+#
+# Idempotency: if the tag already exists on the remote (e.g. a maintainer
+# pushed it by hand before the workflow ran, or this workflow is re-run on
+# the same commit), the job exits 0 without trying to recreate it.
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  tag:
+    name: Tag release commit
+    runs-on: ubuntu-24.04
+    # Only fire on `chore(release): cut vX.Y.Z` commits. Checking head_commit
+    # here scopes the workflow off the wire (no checkout for non-release
+    # commits). The job step does a defence-in-depth re-parse before tagging.
+    if: "startsWith(github.event.head_commit.message, 'chore(release): cut v')"
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          # Use the default GITHUB_TOKEN for the push. Tags pushed by this
+          # token DO trigger other workflows (unlike the documented
+          # restriction for branches/PRs) when the workflow uses
+          # `permissions: contents: write` — confirmed by GitHub Actions docs
+          # for tag refs. release.yml's `on: push: tags: ['v*']` will fire.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Parse version from commit message
+        id: parse
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          # Match `chore(release): cut vX.Y.Z` on the first line, ignoring any
+          # trailing PR number, parenthetical, or suffix. Refuse to tag if the
+          # version doesn't match strict semver — guards against typos like
+          # `cut v0.9` or `cut v0.9.x-rc1` accidentally producing a release.
+          first_line=$(printf '%s\n' "$COMMIT_MESSAGE" | head -n 1)
+          echo "First line: $first_line"
+
+          version=$(printf '%s' "$first_line" | sed -nE 's/^chore\(release\): cut v([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')
+          if [ -z "$version" ]; then
+            echo "::error::Commit message did not match 'chore(release): cut vX.Y.Z' — refusing to tag."
+            echo "First line was: $first_line"
+            exit 1
+          fi
+
+          tag="v$version"
+          echo "Parsed version: $version"
+          echo "Tag: $tag"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Verify package version matches commit subject
+        env:
+          PARSED_VERSION: ${{ steps.parse.outputs.version }}
+        run: |
+          # Defence-in-depth: the commit subject claims version $PARSED_VERSION,
+          # but the actual bump might have a different number in the package
+          # files (e.g. an aborted bump, hand-edit, or mis-typed subject). If
+          # they disagree, refuse to tag — pushing a wrong tag would trigger
+          # a release for a version that doesn't match what's in package.json.
+          pkg_version=$(node -e "console.log(require('./packages/server/package.json').version)")
+          echo "Package version: $pkg_version"
+          echo "Subject version: $PARSED_VERSION"
+          if [ "$pkg_version" != "$PARSED_VERSION" ]; then
+            echo "::error::packages/server/package.json version ($pkg_version) does not match commit subject version ($PARSED_VERSION) — refusing to tag."
+            exit 1
+          fi
+
+      - name: Check if tag already exists
+        id: check
+        env:
+          TAG: ${{ steps.parse.outputs.tag }}
+        run: |
+          # Idempotency: if someone pushed the tag by hand before this workflow
+          # ran (or this workflow is re-run on the same commit), skip cleanly.
+          # `git ls-remote --tags` queries the remote directly so we don't get
+          # tricked by a stale local refs/tags/.
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::notice::Tag $TAG already exists on origin — nothing to do."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag $TAG does not exist yet — will create it."
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.check.outputs.exists == 'false'
+        env:
+          TAG: ${{ steps.parse.outputs.tag }}
+          VERSION: ${{ steps.parse.outputs.version }}
+          SHA: ${{ github.sha }}
+        run: |
+          # Annotated tag (-a) so `git describe` and release tooling can find
+          # the message. Use github-actions[bot] identity — this is the same
+          # identity GitHub uses for auto-merge commits, so it's the
+          # conventional choice for workflow-authored tags.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -a "$TAG" "$SHA" -m "Release $TAG"
+          git push origin "refs/tags/$TAG"
+          echo "::notice::Pushed tag $TAG at $SHA — release.yml will pick it up."


### PR DESCRIPTION
## Summary

Adds `.github/workflows/auto-tag-on-release.yml` — a workflow that fires when a `chore(release): cut vX.Y.Z` commit lands on `main` and pushes the matching annotated `vX.Y.Z` tag. The existing `release.yml` triggers on `tags: ['v*']`, so a successful release-PR merge now produces a release artifact (Docker image, Tauri bundles, GitHub Release) without any manual tag-push step.

Part 2 of #4627.

## Background

v0.9.13 through v0.9.19 release PRs all merged successfully and bumped every package file, but the matching tags were never pushed by hand. As a result:
- `gh release list` had stopped at v0.9.12 when the issue was filed
- `release.yml` never fired for any of those versions
- No Docker, Tauri, or GitHub Release artifacts shipped for v0.9.13–v0.9.19

This workflow removes the manual tag-push step entirely so the gap can't reopen.

## Guards in the new workflow

- **Job-level `if`** checks the commit subject starts with `chore(release): cut v` — non-release pushes to `main` don't spin up a runner.
- **Strict semver regex** on the version (`[0-9]+\.[0-9]+\.[0-9]+`) — refuses tags for malformed subjects like `cut v0.9` or `cut v0.9.x-rc1`.
- **Defence-in-depth subject↔package check**: parses `packages/server/package.json` and refuses to tag if it doesn't match the subject — guards against typo'd subjects, aborted bumps, and hand-edited mismatches.
- **Idempotent**: `git ls-remote --exit-code --tags origin refs/tags/$TAG` before tagging, so a manual tag-push (or a workflow re-run on the same commit) exits cleanly instead of failing.
- **Minimal permissions**: top-level `permissions: {}`, scoped to `contents: write` only on the tag job — matches the pattern in `release.yml`.

## Out of scope — Backfill of v0.9.13–v0.9.19

**This PR does NOT push the missing tags.** Doing so retroactively would trigger 5–6 concurrent runs of `release.yml`, each one publishing a Docker image, Tauri bundles, and a GitHub Release for a version that was never shipped at the time. That's a human decision (ship those artifacts now, or write off the gap), not something the CI workflow should make.

To backfill manually after this PR merges:

```bash
# For each missing version, tag the matching cut commit and push:
for v in 0.9.13 0.9.14 0.9.15 0.9.16 0.9.17 0.9.19; do
  COMMIT=$(git log --oneline --grep="cut v$v" --format=%H | head -1)
  if [ -n "$COMMIT" ]; then
    git tag -a "v$v" "$COMMIT" -m "Release v$v"
  fi
done
# Push selectively (NOT --tags — that's a footgun) and watch release.yml run:
git push origin v0.9.13   # (and so on, one at a time, or in a small batch)
```

v0.9.18 was never cut to main (local dogfood build only per the issue), so it's not in the backfill list.

## Trigger choice

I went with `on: push: branches: [main]` rather than `on: pull_request: types: [closed]` because:
- A `pull_request` trigger needs `if: github.event.pull_request.merged == true`, plus title/branch matching — more brittle than reading the commit message that already landed.
- A `push` trigger fires once per merge commit regardless of merge strategy (squash, rebase, merge commit) — release PRs are normally squash-merged so this is the simplest path.
- The original issue specifically suggests "Triggers on push to main when the commit message matches `chore(release): cut vX.Y.Z`".

## Test plan

- [ ] Confirm workflow YAML parses (already validated locally via js-yaml)
- [ ] Merge this PR, then watch the *next* release-cut PR merge to verify the tag fires automatically and `release.yml` picks it up
- [ ] If we want a smoke test before then: temporarily change the `if:` to also match a sentinel like `cut vX.Y.Z` and merge a no-op PR, then revert (probably overkill — the workflow is short enough to review by inspection)

Closes #4627