### PR TITLE
feat(server): escalate resume_unknown when post-fallback retry also fails

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -1479,20 +1479,50 @@ export class CliSession extends BaseSession {
     if (attemptedResumeId && stderrIndicatesUnknownResume(stderrLines)) {
       // One-shot fallback latch (#4929 — see constructor). If we already
       // fell back from an unknown resume earlier this lifecycle and the
-      // fresh spawn ALSO died with the same pattern, escalate to the
-      // generic crash path so we don't spin clearing `_sessionId` forever.
+      // fresh spawn ALSO died with the same pattern, escalate to a terminal
+      // "auto-recovery exhausted" path: surface a distinct error code and
+      // STOP the auto-respawn so the session sits down until the user takes
+      // a deliberate next step.
+      //
+      // #4948: previously this branch still called `_scheduleRespawn()` —
+      // but the next spawn would re-confirm via `system.init` (clearing the
+      // latch AND re-setting `_sessionId` from the init payload) which made
+      // the "give up" toast immediately precede what looked like a normal
+      // recovery. Two problems with that:
+      //   1. The user sees a confusing "auto-recovery gave up" message and
+      //      then the session appears to be working again, with no signal
+      //      whether the underlying issue is actually resolved.
+      //   2. If the fresh-start spawn ALSO fails the same way, we'd just
+      //      respawn again, ad infinitum until `_respawnCount` hits the cap
+      //      buried inside `_scheduleRespawn`.
+      // Stopping here gives a clean terminal state: `_sessionId` is null,
+      // the latch resets so a future explicit start can re-arm the one-shot
+      // fallback, and the operator/UI gets an unambiguous "the auto-recovery
+      // gave up, you need to act" signal.
       if (this._didFallbackFromUnknownResume) {
         ;(this._log || log).error(
-          `Resume fallback also failed (code ${code}, attemptedResumeId=${attemptedResumeId}) — giving up auto-recovery`,
+          `Resume fallback also failed (code ${code}, attemptedResumeId=${attemptedResumeId}) — ` +
+          'auto-recovery exhausted; will NOT respawn. User must start a fresh session manually.',
         )
+        // Reset the latch so a future explicit user-driven start can re-arm
+        // the one-shot fallback. Without this reset the latch would persist
+        // past the terminal error and prevent recovery on the very next
+        // manual start (which would silently skip the auto-fallback and
+        // fall straight through to the generic-crash respawn loop).
+        this._didFallbackFromUnknownResume = false
+        // Keep `_sessionId = null` (was already cleared by the first
+        // fallback branch below) so a manual restart omits `--resume` and
+        // mints a brand-new conversation rather than re-attempting the
+        // broken id a third time.
+        this._sessionId = null
         this.emit('error', {
-          code: 'resume_unknown',
+          code: 'resume_unknown_exhausted',
           message:
-            'Claude CLI rejected the resumed conversation id and a fresh-start retry also failed. ' +
+            'Auto-recovery exhausted: Claude CLI rejected the resumed conversation id and a fresh-start ' +
+            'retry also failed. Start a new session manually to continue. ' +
             'Check the chroxy logs for the stderr from the claude subprocess.',
           attemptedResumeId,
         })
-        this._scheduleRespawn()
         return
       }
 

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -409,8 +409,14 @@ Object.assign(EVENT_MAP, {
     // correlate against `~/.chroxy/session-state.json.resumeConversationId`
     // without grepping logs.
     //
+    // #4948: also forward on `resume_unknown_exhausted` — the terminal
+    // escalation code emitted when the post-fallback retry ALSO matches the
+    // unknown-resume pattern. Same operator-correlation rationale; the
+    // dashboard renders a distinct "auto-recovery exhausted" affordance but
+    // still wants to surface the attempted id as subtext.
+    //
     // Hardening (from PR #4967 Copilot review):
-    //   1. Gate strictly on `code === 'resume_unknown'` so a buggy producer
+    //   1. Gate strictly on the two resume-failure codes so a buggy producer
     //      can't sneak the field onto unrelated error envelopes.
     //   2. Trim whitespace and treat whitespace-only as missing — same UX
     //      guard the chip's render-time check already applies, but enforced
@@ -425,7 +431,7 @@ Object.assign(EVENT_MAP, {
     //      but trips Zod-validating consumers. Silently truncate rather
     //      than drop — the truncated id still helps operator triage.
     if (
-      data.code === 'resume_unknown' &&
+      (data.code === 'resume_unknown' || data.code === 'resume_unknown_exhausted') &&
       typeof data.attemptedResumeId === 'string'
     ) {
       const trimmed = data.attemptedResumeId.trim()

--- a/packages/server/tests/cli-session-resume-unknown.test.js
+++ b/packages/server/tests/cli-session-resume-unknown.test.js
@@ -216,7 +216,17 @@ describe('CliSession resume-unknown — _handleChildClose detection (#4929)', ()
     session.destroy()
   })
 
-  it('escalates to a final error when the post-fallback retry ALSO matches the unknown-resume pattern', () => {
+  it('#4948 — escalates with resume_unknown_exhausted and STOPS auto-respawn when post-fallback retry also fails', () => {
+    // #4948 finalises the escalation UX. The first failure path falls back to
+    // a fresh conversation; if THAT spawn ALSO matches the unknown-resume
+    // pattern, the auto-recovery has clearly failed and continuing to respawn
+    // would just produce the confusing "give up" toast followed by what looks
+    // like normal recovery on the next init (issue #4948 question 2).
+    //
+    // Decision recorded inline in cli-session.js: on escalation we stop the
+    // auto-respawn entirely and surface a distinct `resume_unknown_exhausted`
+    // code so the dashboard / mobile app can render a "start a fresh session
+    // manually" affordance instead of the recoverable amber chip.
     const session = createSession({ resumeSessionId: 'cli-stale-123' })
     session._attemptedResumeId = 'cli-stale-123'
     session._recentStderrLines = ['No conversation found']
@@ -230,14 +240,25 @@ describe('CliSession resume-unknown — _handleChildClose detection (#4929)', ()
     session._handleChildClose(1)
 
     assert.equal(errors.length, 1)
-    assert.equal(errors[0].code, 'resume_unknown',
-      'still surfaces with the distinct code so the dashboard can show a "give up" message')
-    assert.match(errors[0].message, /fresh-start|give up|also failed/i,
-      'escalation message should make it clear we already tried the fallback once')
-    // Even on escalation we still respawn so the user can retry manually —
-    // but we do NOT wipe _sessionId a second time (would lose data needlessly
-    // if some unrelated thing matches the same pattern later).
-    assert.equal(session._scheduleRespawn.mock.calls.length, 1)
+    assert.equal(errors[0].code, 'resume_unknown_exhausted',
+      '#4948 — distinct code so the dashboard surfaces a terminal "auto-recovery exhausted" affordance, not the recoverable resume_unknown chip')
+    assert.equal(errors[0].attemptedResumeId, 'cli-stale-123',
+      'attemptedResumeId still rides the envelope so operators can correlate the failed id against the persisted state file')
+    assert.match(errors[0].message, /auto-recovery|exhausted|fresh session/i,
+      '#4948 — escalation message must make it clear auto-recovery gave up and tell the user what to do next (start a fresh session)')
+    // #4948 ACCEPTANCE: do NOT call _scheduleRespawn on escalation. Continuing
+    // to respawn after surfacing "give up auto-recovery" produces the
+    // confusing UX described in the issue (toast says give up, next init
+    // looks like normal recovery). The session stays down and waits for an
+    // explicit user action.
+    assert.equal(session._scheduleRespawn.mock.calls.length, 0,
+      '#4948 — must NOT schedule a respawn on escalation; the session stays down so the user takes the next step deliberately')
+    // Reset the latch so a future explicit user-driven start can re-arm the
+    // one-shot fallback (otherwise the latch would leak and prevent recovery
+    // on the very next session start). _sessionId stays null so a manual
+    // restart omits --resume and mints a brand-new conversation.
+    assert.equal(session._didFallbackFromUnknownResume, false,
+      '#4948 — latch resets on escalation so a future manual start can re-arm the one-shot fallback')
 
     session.destroy()
   })

--- a/packages/server/tests/event-normalizer-resume-unknown.test.js
+++ b/packages/server/tests/event-normalizer-resume-unknown.test.js
@@ -124,6 +124,25 @@ describe('EventNormalizer error mapping — #4947', () => {
     assert.equal(msg.attemptedResumeId, undefined)
   })
 
+  it('#4948 — forwards attemptedResumeId for resume_unknown_exhausted code (terminal escalation)', () => {
+    // The escalation path emitted when the post-fallback retry also matches
+    // the unknown-resume pattern (server cli-session.js _handleChildClose,
+    // PR #4948 follow-up to #4944). The normalizer must forward the attempted
+    // id on this code too so the dashboard's "auto-recovery exhausted" chip
+    // can render the same operator-correlation subtext as the recoverable
+    // resume_unknown chip.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'resume_unknown_exhausted',
+      message: 'Auto-recovery exhausted: …',
+      attemptedResumeId: 'abc123-def456-7890',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.code, 'resume_unknown_exhausted')
+    assert.equal(msg.attemptedResumeId, 'abc123-def456-7890',
+      '#4948 — attemptedResumeId must ride the terminal escalation envelope too so operators can correlate the failed id against the persisted state file')
+  })
+
   it('truncates attemptedResumeId to 256 chars (matches wire schema cap)', () => {
     // The wire schema rejects > 256 chars, but the server doesn't
     // self-validate outgoing messages against ServerMessageSchema. Enforce


### PR DESCRIPTION
## Summary

Closes #4948 (follow-up to #4944).

Finalises the escalation UX added in #4944. Previously, when the first
`resume_unknown` fallback ALSO failed the same way, the escalation branch
emitted a generic "fresh-start retry also failed" toast under the
recoverable `code: 'resume_unknown'` AND still called `_scheduleRespawn()`,
producing the two confusing UX problems described in the issue.

This PR:

- Emits a distinct `error{code: 'resume_unknown_exhausted'}` with a clear
  message: "Auto-recovery exhausted ... Start a new session manually to
  continue."
- Stops the auto-respawn on escalation (the session sits down so the
  operator takes the next step deliberately).
- Resets the one-shot fallback latch (`_didFallbackFromUnknownResume`) so
  a future explicit user-driven start can re-arm it, and keeps
  `_sessionId = null` so a manual restart mints a brand-new conversation.
- Updates `event-normalizer.error` to also forward `attemptedResumeId` for
  the new code so the dashboard / mobile app can surface the attempted id
  as subtext on the terminal-escalation affordance.

## Acceptance criteria (from #4948)

- [x] Decision documented in code comment (cli-session.js inline block)
- [x] Stop auto-respawn entirely on escalation (chose option 2 from the
  issue's two questions — explicit user intervention is the cleanest exit)
- [x] Regression test pinning the chosen behavior (`#4948 — escalates
  with resume_unknown_exhausted and STOPS auto-respawn ...`)

## Test plan

- [x] `node --test tests/cli-session-resume-unknown.test.js
  tests/event-normalizer-resume-unknown.test.js` — 27/27 pass
- [x] `node --test tests/cli-session*.test.js tests/event-normalizer*.test.js
  tests/handlers/input-handlers.test.js` — 366/366 pass
- [x] `./scripts/lint-session-opt-forwarding.sh` — green
- [x] `./scripts/lint-tests-state-file-path.sh` — green