### PR TITLE
feat(dashboard): intervention notifications read/unread widget (#4890)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -173,6 +173,11 @@ vi.mock('./store/connection', () => {
     // `addServerErrorMock` so tests can assert on the call args directly.
     addServerError: addServerErrorMock,
     dismissSessionNotification: vi.fn(),
+    // #4890 — Slack-style intervention notifications widget read/unread
+    // actions wired through the store. The widget consumes these
+    // selectors at render time so the mock state needs them present.
+    markSessionNotificationRead: vi.fn(),
+    markAllSessionNotificationsRead: vi.fn(),
     markPromptAnsweredByRequestId: vi.fn(),
     sessionNotifications: [],
     setTerminalWriteCallback: vi.fn(),

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -34,6 +34,7 @@ import { StatusBar } from './components/StatusBar'
 import { ChatSettingsDropdown } from './components/ChatSettingsDropdown'
 import { SkillsPanel } from './components/SkillsPanel'
 import { HeaderOverflowMenu, type HeaderOverflowItem } from './components/HeaderOverflowMenu'
+import { NotificationsWidget } from './components/NotificationsWidget'
 import { PermissionPrompt } from './components/PermissionPrompt'
 import { formatTranscript } from './lib/transcript'
 import { QuestionPrompt } from './components/QuestionPrompt'
@@ -529,6 +530,11 @@ export function App() {
   const dismissServerError = useConnectionStore(s => s.dismissServerError)
   const dismissInfoNotification = useConnectionStore(s => s.dismissInfoNotification)
   const dismissSessionNotification = useConnectionStore(s => s.dismissSessionNotification)
+  // #4890 — Slack-style notifications widget read/unread actions. Pulled
+  // as discrete selectors so a notifications-only state change doesn't
+  // re-render unrelated chrome.
+  const markSessionNotificationRead = useConnectionStore(s => s.markSessionNotificationRead)
+  const markAllSessionNotificationsRead = useConnectionStore(s => s.markAllSessionNotificationsRead)
   const markPromptAnsweredByRequestId = useConnectionStore(s => s.markPromptAnsweredByRequestId)
   const conversationHistory = useConnectionStore(s => s.conversationHistory)
   const fetchConversationHistory = useConnectionStore(s => s.fetchConversationHistory)
@@ -1985,6 +1991,20 @@ export function App() {
             <span className="chrome-new-session-icon" aria-hidden="true">+</span>
             <span className="chrome-new-session-label">New Session</span>
           </button>
+          {/* #4890 — Slack-style intervention notifications widget. Bell
+              with unread badge → dropdown listing every intervention alert
+              (read + unread) so the operator gets a durable "do I have
+              outstanding interventions to deal with?" signal. The earlier
+              transient banners (NotificationBanners — still rendered above
+              the main content for unread alerts) keep their role as
+              foreground popups; the widget owns the durable history. */}
+          <NotificationsWidget
+            notifications={sessionNotifications}
+            onSwitchSession={handleSwitchSession}
+            onMarkRead={markSessionNotificationRead}
+            onMarkAllRead={markAllSessionNotificationsRead}
+            onDismiss={dismissSessionNotification}
+          />
           {/* #4974: Skills / Copy / Settings collapsed behind a single
               "⋯" overflow trigger. Previously these three icon buttons
               lived inline in header-right alongside `+ New Session` and

--- a/packages/dashboard/src/components/NotificationBanners.test.tsx
+++ b/packages/dashboard/src/components/NotificationBanners.test.tsx
@@ -191,6 +191,74 @@ describe('NotificationBanners', () => {
   })
 })
 
+describe('NotificationBanners — read/unread filtering (#4890)', () => {
+  // Regression coverage for the #4890 widget behaviour change: NotificationBanners
+  // now filters out notifications with `readAt !== undefined` so the transient
+  // banner stack matches "outstanding interventions" while the widget retains
+  // the full history. Without this filter the banners would keep pulsing for
+  // alerts the operator has already acknowledged via the widget.
+  it('renders nothing when every notification has been marked read', () => {
+    const { container } = render(
+      <NotificationBanners
+        notifications={[
+          makeNotification({ id: 'n-1', readAt: 1 }),
+          makeNotification({ id: 'n-2', requestId: 'req-other', readAt: 2 }),
+        ]}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+        onDismiss={vi.fn()}
+        onSwitchSession={vi.fn()}
+      />
+    )
+    expect(container.querySelector('.notification-banners')).not.toBeInTheDocument()
+  })
+
+  it('renders only the unread subset alongside read entries', () => {
+    render(
+      <NotificationBanners
+        notifications={[
+          makeNotification({ id: 'n-read', sessionName: 'Read Session', readAt: 1 }),
+          makeNotification({ id: 'n-unread', sessionName: 'Unread Session', requestId: 'req-unread' }),
+        ]}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+        onDismiss={vi.fn()}
+        onSwitchSession={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Unread Session')).toBeInTheDocument()
+    expect(screen.queryByText('Read Session')).not.toBeInTheDocument()
+  })
+
+  it('computes overflow count from the unread subset, not the total list', () => {
+    // Total of 5 notifications but only 4 are unread → expect 3 visible
+    // banners + "+1 more" overflow (NOT "+2 more", which would be the
+    // pre-#4890 overflow had read entries also been counted).
+    const notifications: SessionNotification[] = [
+      makeNotification({ id: 'n-1', sessionName: 'Session 1', requestId: 'req-1' }),
+      makeNotification({ id: 'n-2', sessionName: 'Session 2', requestId: 'req-2' }),
+      makeNotification({ id: 'n-3', sessionName: 'Session 3', requestId: 'req-3' }),
+      makeNotification({ id: 'n-4', sessionName: 'Session 4', requestId: 'req-4' }),
+      makeNotification({ id: 'n-already-read', sessionName: 'Already Read', requestId: 'req-r', readAt: 1 }),
+    ]
+    render(
+      <NotificationBanners
+        notifications={notifications}
+        onApprove={vi.fn()}
+        onDeny={vi.fn()}
+        onDismiss={vi.fn()}
+        onSwitchSession={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Session 1')).toBeInTheDocument()
+    expect(screen.getByText('Session 2')).toBeInTheDocument()
+    expect(screen.getByText('Session 3')).toBeInTheDocument()
+    expect(screen.queryByText('Session 4')).not.toBeInTheDocument()
+    expect(screen.queryByText('Already Read')).not.toBeInTheDocument()
+    expect(screen.getByText(/\+1 more/)).toBeInTheDocument()
+  })
+})
+
 describe('NotificationBanners source analysis', () => {
   const typesSource = fs.readFileSync(
     path.resolve(__dirname, '../store/types.ts'),

--- a/packages/dashboard/src/components/NotificationBanners.tsx
+++ b/packages/dashboard/src/components/NotificationBanners.tsx
@@ -4,6 +4,15 @@
  * Renders stacked banners above the content area for background session events.
  * Permission notifications get inline Approve/Deny buttons for quick action
  * without switching sessions. Max 3 visible + overflow count.
+ *
+ * #4890 — Banners now only render notifications with `readAt === undefined`.
+ * The NotificationsWidget owns the full read+unread history list; once the
+ * operator acknowledges an alert (via the widget, via switchSession, or via
+ * "Mark all read"), the banner stack drops it but the widget retains the
+ * entry as part of the durable history. Pre-#4890 the banners filtered the
+ * target session out on switch; the new model achieves the same visual
+ * outcome — banners vanish for the active session — while keeping the
+ * widget's history populated.
  */
 import type { SessionNotification } from '../store/types'
 
@@ -31,10 +40,12 @@ export function NotificationBanners({
   onDismiss,
   onSwitchSession,
 }: NotificationBannersProps) {
-  if (notifications.length === 0) return null
+  // #4890 — render unread only; read history lives in the widget.
+  const unread = notifications.filter((n) => n.readAt === undefined)
+  if (unread.length === 0) return null
 
-  const visible = notifications.slice(0, MAX_VISIBLE)
-  const overflow = notifications.length - MAX_VISIBLE
+  const visible = unread.slice(0, MAX_VISIBLE)
+  const overflow = unread.length - MAX_VISIBLE
 
   return (
     <div className="notification-banners" role="log" aria-label="Background session notifications">

--- a/packages/dashboard/src/components/NotificationsWidget.test.tsx
+++ b/packages/dashboard/src/components/NotificationsWidget.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * NotificationsWidget (#4890) — Slack-style intervention notifications inbox
+ *
+ * Verifies the widget surface:
+ *   - bell trigger shows an unread badge sourced from `readAt === undefined`
+ *   - opening the panel renders every notification (read + unread)
+ *   - clicking a row marks it read AND switches sessions
+ *   - the per-row eye affordance marks-read without switching sessions
+ *   - the per-row close affordance dismisses outright (delegates to onDismiss)
+ *   - "Mark all read" delegates to onMarkAllRead
+ *   - badge caps at "99+" once unread > 99 (preserves header chrome layout)
+ *   - empty state renders when there are no notifications
+ *   - outside-click and Escape dismiss the panel
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { NotificationsWidget } from './NotificationsWidget'
+import type { SessionNotification } from '../store/types'
+
+afterEach(cleanup)
+
+function makeNotification(overrides: Partial<SessionNotification> = {}): SessionNotification {
+  return {
+    id: 'n-1',
+    sessionId: 'sess-1',
+    sessionName: 'My Session',
+    eventType: 'permission',
+    message: 'Write to /tmp/test.txt',
+    timestamp: Date.now(),
+    requestId: 'req-abc',
+    ...overrides,
+  }
+}
+
+describe('NotificationsWidget — trigger + unread badge', () => {
+  it('shows no badge when there are no unread notifications', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1', readAt: 1 }),
+          makeNotification({ id: 'n-2', readAt: 2 }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('notifications-widget-badge')).not.toBeInTheDocument()
+  })
+
+  it('shows the unread count when at least one notification is unread', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1' }),
+          makeNotification({ id: 'n-2', readAt: 1 }),
+          makeNotification({ id: 'n-3' }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('notifications-widget-badge')).toHaveTextContent('2')
+  })
+
+  it('caps the unread badge at "99+" once unread count exceeds 99', () => {
+    const notifications = Array.from({ length: 120 }, (_, i) =>
+      makeNotification({ id: `n-${i}`, requestId: `req-${i}` }),
+    )
+    render(
+      <NotificationsWidget
+        notifications={notifications}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('notifications-widget-badge')).toHaveTextContent('99+')
+  })
+
+  it('reflects the unread count in the trigger aria-label for assistive tech', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1' }),
+          makeNotification({ id: 'n-2', requestId: 'req-def' }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('notifications-widget-trigger')).toHaveAccessibleName(
+      'Notifications, 2 unread',
+    )
+  })
+})
+
+describe('NotificationsWidget — panel content + interactions', () => {
+  it('opens the panel on trigger click and lists every notification (read + unread)', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-unread', message: 'Write /etc/hosts' }),
+          makeNotification({
+            id: 'n-read',
+            requestId: 'req-other',
+            message: 'Read package.json',
+            readAt: 1234,
+          }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    expect(screen.getByTestId('notifications-widget-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('notifications-widget-item-n-unread')).toBeInTheDocument()
+    expect(screen.getByTestId('notifications-widget-item-n-read')).toBeInTheDocument()
+  })
+
+  it('distinguishes read vs unread via data-read attribute', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-unread' }),
+          makeNotification({ id: 'n-read', requestId: 'req-other', readAt: 1 }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    expect(
+      screen.getByTestId('notifications-widget-item-n-unread'),
+    ).toHaveAttribute('data-read', 'false')
+    expect(
+      screen.getByTestId('notifications-widget-item-n-read'),
+    ).toHaveAttribute('data-read', 'true')
+  })
+
+  it('clicking the row marks it read AND switches sessions', () => {
+    const onMarkRead = vi.fn()
+    const onSwitchSession = vi.fn()
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1', sessionId: 'sess-target' })]}
+        onSwitchSession={onSwitchSession}
+        onMarkRead={onMarkRead}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    fireEvent.click(screen.getByTestId('notifications-widget-item-body-n-1'))
+    expect(onMarkRead).toHaveBeenCalledWith('n-1')
+    expect(onSwitchSession).toHaveBeenCalledWith('sess-target')
+  })
+
+  it('per-row eye affordance marks read WITHOUT switching sessions (unread rows only)', () => {
+    const onMarkRead = vi.fn()
+    const onSwitchSession = vi.fn()
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1', sessionId: 'sess-target' }),
+          makeNotification({ id: 'n-2', requestId: 'req-other', readAt: 1 }),
+        ]}
+        onSwitchSession={onSwitchSession}
+        onMarkRead={onMarkRead}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    fireEvent.click(screen.getByTestId('notifications-widget-item-mark-read-n-1'))
+    expect(onMarkRead).toHaveBeenCalledWith('n-1')
+    expect(onSwitchSession).not.toHaveBeenCalled()
+    // Already-read row has no mark-read button (it would be a no-op + redundant)
+    expect(
+      screen.queryByTestId('notifications-widget-item-mark-read-n-2'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('per-row dismiss button delegates to onDismiss without switching sessions', () => {
+    const onDismiss = vi.fn()
+    const onSwitchSession = vi.fn()
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1' })]}
+        onSwitchSession={onSwitchSession}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={onDismiss}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    fireEvent.click(screen.getByTestId('notifications-widget-item-dismiss-n-1'))
+    expect(onDismiss).toHaveBeenCalledWith('n-1')
+    expect(onSwitchSession).not.toHaveBeenCalled()
+  })
+
+  it('"Mark all read" delegates to onMarkAllRead', () => {
+    const onMarkAllRead = vi.fn()
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1' })]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={onMarkAllRead}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    fireEvent.click(screen.getByTestId('notifications-widget-mark-all-read'))
+    expect(onMarkAllRead).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides "Mark all read" when there are no unread notifications', () => {
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1', readAt: 1 })]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    expect(
+      screen.queryByTestId('notifications-widget-mark-all-read'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('renders empty state when notifications array is empty', () => {
+    render(
+      <NotificationsWidget
+        notifications={[]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    expect(screen.getByTestId('notifications-widget-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('notifications-widget-list')).not.toBeInTheDocument()
+  })
+
+  it('Escape closes the panel', () => {
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1' })]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    expect(screen.getByTestId('notifications-widget-panel')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('notifications-widget-panel')).not.toBeInTheDocument()
+  })
+})
+
+describe('NotificationsWidget — end-to-end: viewing decrements unread', () => {
+  it('clicking an item marks it read so the badge decrements on next render', () => {
+    // Simulate the App-side wiring: the widget receives notifications + the
+    // store-action callbacks. We re-render after onMarkRead fires to assert
+    // the badge updates — this mirrors what useConnectionStore selectors do.
+    const onMarkRead = vi.fn()
+    const onSwitchSession = vi.fn()
+    const initial = [
+      makeNotification({ id: 'n-1', sessionId: 'sess-target' }),
+      makeNotification({ id: 'n-2', requestId: 'req-other' }),
+    ]
+    const { rerender } = render(
+      <NotificationsWidget
+        notifications={initial}
+        onSwitchSession={onSwitchSession}
+        onMarkRead={onMarkRead}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('notifications-widget-badge')).toHaveTextContent('2')
+
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    fireEvent.click(screen.getByTestId('notifications-widget-item-body-n-1'))
+    expect(onMarkRead).toHaveBeenCalledWith('n-1')
+    expect(onSwitchSession).toHaveBeenCalledWith('sess-target')
+
+    // Re-render with n-1 now marked read — the store-side update propagates
+    // back as a new `notifications` reference.
+    rerender(
+      <NotificationsWidget
+        notifications={[
+          { ...initial[0]!, readAt: Date.now() },
+          initial[1]!,
+        ]}
+        onSwitchSession={onSwitchSession}
+        onMarkRead={onMarkRead}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('notifications-widget-badge')).toHaveTextContent('1')
+  })
+})

--- a/packages/dashboard/src/components/NotificationsWidget.tsx
+++ b/packages/dashboard/src/components/NotificationsWidget.tsx
@@ -1,0 +1,276 @@
+/**
+ * NotificationsWidget (#4890) — Slack-style intervention notifications
+ * inbox. Bell-icon trigger in the header with an unread count badge;
+ * clicking opens a dropdown listing every session notification (read +
+ * unread) so the operator gets a durable "do I have outstanding
+ * interventions to deal with?" signal instead of toasts that vanish.
+ *
+ * Read/unread model — handled by the connection store actions
+ * `markSessionNotificationRead(id)` and `markAllSessionNotificationsRead()`
+ * (see store/connection.ts). The widget is a pure consumer:
+ *
+ *   - Items render with a bolder weight / `notifications-widget-item--unread`
+ *     class while `readAt === undefined`; once stamped they fade to a
+ *     muted "read" treatment but stay in the list.
+ *   - Clicking a row marks the alert as read AND switches to its session
+ *     (the most common operator intent — both intents are also achievable
+ *     individually via the row's two affordances: the session label
+ *     anchor switches sessions, the eyeball icon marks-read-only).
+ *   - "Mark all read" stamps every currently-unread alert in one batch.
+ *
+ * Scope — in-memory only. `sessionNotifications` is transient and resets
+ * on reload/reconnect, so read state can't outlive a session anyway. The
+ * "should read state persist across reload?" decision in the AC is
+ * documented as "no, for v1" — server-side persistence is deferred to a
+ * follow-up issue.
+ *
+ * Dismiss pattern mirrors HeaderOverflowMenu (#4974/#4980): capturing
+ * mousedown for outside click, Escape, window blur. Focus is NOT trapped
+ * inside the panel because the list can be long and operators may want
+ * to Tab into the surrounding header — assistive tech still gets the
+ * `role="dialog"` + `aria-label` wire-up, and the trigger's
+ * `aria-expanded` advertises the open state.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { SessionNotification } from '../store/types'
+
+const EVENT_LABELS: Record<SessionNotification['eventType'], string> = {
+  permission: 'Permission',
+  question: 'Question',
+  completed: 'Completed',
+  error: 'Error',
+}
+
+/**
+ * Soft cap on the widget's unread badge — once we cross 99 the badge
+ * shows "99+" so a runaway broadcasting session can't blow up the
+ * fixed-width header chrome. The full list (rendered in the dropdown)
+ * is not truncated; the operator still gets to triage every entry.
+ */
+const UNREAD_BADGE_CAP = 99
+
+export interface NotificationsWidgetProps {
+  notifications: SessionNotification[]
+  onSwitchSession: (sessionId: string) => void
+  onMarkRead: (notificationId: string) => void
+  onMarkAllRead: () => void
+  onDismiss: (notificationId: string) => void
+}
+
+function formatRelative(ts: number, now: number): string {
+  const delta = Math.max(0, now - ts)
+  const sec = Math.floor(delta / 1000)
+  if (sec < 60) return 'just now'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const day = Math.floor(hr / 24)
+  return `${day}d ago`
+}
+
+export function NotificationsWidget({
+  notifications,
+  onSwitchSession,
+  onMarkRead,
+  onMarkAllRead,
+  onDismiss,
+}: NotificationsWidgetProps) {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Newest first — sorted by timestamp descending. Memoised so the array
+  // reference is stable across re-renders for downstream useEffect deps.
+  const sorted = useMemo(() => {
+    return [...notifications].sort((a, b) => b.timestamp - a.timestamp)
+  }, [notifications])
+
+  const unreadCount = useMemo(
+    () => notifications.reduce((acc, n) => (n.readAt === undefined ? acc + 1 : acc), 0),
+    [notifications],
+  )
+
+  // Stamp `now` once per render so each row's relative timestamp doesn't
+  // race against a re-render mid-frame. A fresh `now` on every render is
+  // fine — the helper is pure.
+  const now = Date.now()
+
+  useEffect(() => {
+    if (!open) return
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (panelRef.current && panelRef.current.contains(target)) return
+      if (triggerRef.current && triggerRef.current.contains(target)) return
+      setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+    const onBlur = () => setOpen(false)
+    document.addEventListener('mousedown', onMouseDown, true)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown, true)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('blur', onBlur)
+    }
+  }, [open])
+
+  const badgeText =
+    unreadCount === 0
+      ? null
+      : unreadCount > UNREAD_BADGE_CAP
+        ? `${UNREAD_BADGE_CAP}+`
+        : String(unreadCount)
+
+  const triggerLabel =
+    unreadCount === 0
+      ? 'Notifications'
+      : `Notifications, ${unreadCount} unread`
+
+  return (
+    <div className="notifications-widget">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="header-icon-btn notifications-widget-trigger"
+        data-testid="notifications-widget-trigger"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label={triggerLabel}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        title={triggerLabel}
+      >
+        {/* Inline bell glyph — avoids pulling an icon font for one symbol. */}
+        <span className="notifications-widget-icon" aria-hidden="true">
+          {'\u{1F514}'}
+        </span>
+        {badgeText !== null && (
+          <span
+            className="notifications-widget-badge"
+            data-testid="notifications-widget-badge"
+            aria-hidden="true"
+          >
+            {badgeText}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div
+          ref={panelRef}
+          className="notifications-widget-panel"
+          data-testid="notifications-widget-panel"
+          role="dialog"
+          aria-label="Intervention notifications"
+        >
+          <div className="notifications-widget-header">
+            <span className="notifications-widget-title">Notifications</span>
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                className="notifications-widget-mark-all"
+                data-testid="notifications-widget-mark-all-read"
+                onClick={onMarkAllRead}
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+          {sorted.length === 0 ? (
+            <div
+              className="notifications-widget-empty"
+              data-testid="notifications-widget-empty"
+            >
+              No notifications.
+            </div>
+          ) : (
+            <ul
+              className="notifications-widget-list"
+              data-testid="notifications-widget-list"
+            >
+              {sorted.map((n) => {
+                const isUnread = n.readAt === undefined
+                const rowClass = [
+                  'notifications-widget-item',
+                  isUnread
+                    ? 'notifications-widget-item--unread'
+                    : 'notifications-widget-item--read',
+                  `notifications-widget-item--${n.eventType}`,
+                ].join(' ')
+                return (
+                  <li
+                    key={n.id}
+                    className={rowClass}
+                    data-testid={`notifications-widget-item-${n.id}`}
+                    data-read={isUnread ? 'false' : 'true'}
+                  >
+                    <button
+                      type="button"
+                      className="notifications-widget-item-body"
+                      data-testid={`notifications-widget-item-body-${n.id}`}
+                      onClick={() => {
+                        onMarkRead(n.id)
+                        onSwitchSession(n.sessionId)
+                        setOpen(false)
+                      }}
+                    >
+                      <span className="notifications-widget-item-type">
+                        {EVENT_LABELS[n.eventType]}
+                      </span>
+                      <span className="notifications-widget-item-session">
+                        {n.sessionName}
+                      </span>
+                      <span className="notifications-widget-item-message">
+                        {n.message}
+                      </span>
+                      <span className="notifications-widget-item-time">
+                        {formatRelative(n.timestamp, now)}
+                      </span>
+                    </button>
+                    <div className="notifications-widget-item-actions">
+                      {isUnread && (
+                        <button
+                          type="button"
+                          className="notifications-widget-item-mark-read"
+                          data-testid={`notifications-widget-item-mark-read-${n.id}`}
+                          aria-label="Mark as read"
+                          title="Mark as read"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onMarkRead(n.id)
+                          }}
+                        >
+                          {/* eye glyph */}
+                          {'\u{1F441}'}
+                        </button>
+                      )}
+                      <button
+                        type="button"
+                        className="notifications-widget-item-dismiss"
+                        data-testid={`notifications-widget-item-dismiss-${n.id}`}
+                        aria-label="Dismiss"
+                        title="Dismiss"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          onDismiss(n.id)
+                        }}
+                      >
+                        &times;
+                      </button>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/NotificationsWidget.tsx
+++ b/packages/dashboard/src/components/NotificationsWidget.tsx
@@ -12,10 +12,11 @@
  *   - Items render with a bolder weight / `notifications-widget-item--unread`
  *     class while `readAt === undefined`; once stamped they fade to a
  *     muted "read" treatment but stay in the list.
- *   - Clicking a row marks the alert as read AND switches to its session
- *     (the most common operator intent — both intents are also achievable
- *     individually via the row's two affordances: the session label
- *     anchor switches sessions, the eyeball icon marks-read-only).
+ *   - Clicking a row body marks the alert as read AND switches to its
+ *     session (the most common operator intent). Two per-row affordances
+ *     decompose the intent: the eyeball button marks-read without
+ *     switching (only rendered on unread rows), and the "×" button
+ *     dismisses (removes) the alert outright.
  *   - "Mark all read" stamps every currently-unread alert in one batch.
  *
  * Scope — in-memory only. `sessionNotifications` is transient and resets

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2439,11 +2439,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
 
   // #4890 — Slack-style intervention notifications widget. `read` (a
   // timestamp) is distinct from `dismiss` (removal). Reading means the
-  // operator acknowledged the alert (opened the widget, clicked through to
-  // the session, or hit "Mark all read") and it should stop counting toward
-  // the unread badge while remaining in the widget's history list.
-  // Idempotent: a second mark-read keeps the first timestamp so re-opens
-  // don't masquerade as fresh acknowledges.
+  // operator explicitly acknowledged the alert — clicking a widget row,
+  // hitting the per-row "mark as read" button, "Mark all read", or
+  // switching to the alert's session via any session-switch path. Opening
+  // the widget panel by itself does NOT mark notifications read; only the
+  // explicit per-row / bulk / session-switch actions do. Once stamped, the
+  // alert stops counting toward the unread badge but remains in the
+  // widget's history list. Idempotent: a second mark-read keeps the first
+  // timestamp so re-opens don't masquerade as fresh acknowledges.
   markSessionNotificationRead: (id: string) => {
     set((state) => ({
       sessionNotifications: state.sessionNotifications.map((n) =>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2157,10 +2157,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     // a stale banner doesn't outlive the resolution.
     if (get().sessionNotFoundError) set({ sessionNotFoundError: null });
 
-    // Optimistically switch to cached state + dismiss notifications for target session
+    // Optimistically switch to cached state + mark notifications for target
+    // session as read. #4890 — pre-widget we filtered the target session's
+    // alerts out entirely, but the new Slack-style widget needs the entries
+    // to persist as acknowledged history; the banners stack filters by
+    // `readAt === undefined` at render time so the visual behaviour
+    // (banners vanish on switch) is unchanged.
     const cached = sessionStates[sessionId];
-    const filteredNotifications = get().sessionNotifications.filter(
-      (n) => n.sessionId !== sessionId,
+    const switchReadStamp = Date.now();
+    const filteredNotifications = get().sessionNotifications.map((n) =>
+      n.sessionId === sessionId && n.readAt === undefined
+        ? { ...n, readAt: switchReadStamp }
+        : n,
     );
     if (cached) {
       set({
@@ -2426,6 +2434,32 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   dismissSessionNotification: (id: string) => {
     set((state) => ({
       sessionNotifications: state.sessionNotifications.filter((n) => n.id !== id),
+    }));
+  },
+
+  // #4890 — Slack-style intervention notifications widget. `read` (a
+  // timestamp) is distinct from `dismiss` (removal). Reading means the
+  // operator acknowledged the alert (opened the widget, clicked through to
+  // the session, or hit "Mark all read") and it should stop counting toward
+  // the unread badge while remaining in the widget's history list.
+  // Idempotent: a second mark-read keeps the first timestamp so re-opens
+  // don't masquerade as fresh acknowledges.
+  markSessionNotificationRead: (id: string) => {
+    set((state) => ({
+      sessionNotifications: state.sessionNotifications.map((n) =>
+        n.id === id && n.readAt === undefined
+          ? { ...n, readAt: Date.now() }
+          : n,
+      ),
+    }));
+  },
+
+  markAllSessionNotificationsRead: () => {
+    const now = Date.now();
+    set((state) => ({
+      sessionNotifications: state.sessionNotifications.map((n) =>
+        n.readAt === undefined ? { ...n, readAt: now } : n,
+      ),
     }));
   },
 

--- a/packages/dashboard/src/store/intervention-notifications-read.test.ts
+++ b/packages/dashboard/src/store/intervention-notifications-read.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Intervention notifications read/unread tracking (#4890)
+ *
+ * Slack-style notifications widget — verifies the store-side mechanics:
+ *   - new alerts arrive unread (`readAt` absent)
+ *   - `markSessionNotificationRead(id)` stamps `readAt`
+ *   - `markAllSessionNotificationsRead()` stamps every currently-unread alert
+ *   - re-reading is idempotent (does NOT overwrite the first read timestamp)
+ *   - `switchSession(sessionId)` marks corresponding alerts as read (replaces
+ *     the pre-#4890 "filter them out" behaviour so the widget can keep a
+ *     persistent history of acknowledged interventions)
+ *   - `dismissSessionNotification(id)` still removes outright (explicit
+ *     dismissal is distinct from "viewed")
+ *
+ * Scope is in-memory only — `sessionNotifications` is transient and resets
+ * on reload/reconnect (see types.ts:SessionNotification.readAt JSDoc).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { SessionNotification } from './types'
+
+function makeNotification(overrides: Partial<SessionNotification> = {}): SessionNotification {
+  return {
+    id: 'n-1',
+    sessionId: 'sess-1',
+    sessionName: 'My Session',
+    eventType: 'permission',
+    message: 'Write to /tmp/test.txt',
+    timestamp: Date.now(),
+    requestId: 'req-abc',
+    ...overrides,
+  }
+}
+
+describe('SessionNotification read/unread tracking (#4890)', () => {
+  beforeEach(async () => {
+    const { useConnectionStore } = await import('./connection')
+    useConnectionStore.setState({
+      sessionNotifications: [],
+      activeSessionId: null,
+      sessions: [],
+      sessionStates: {},
+    })
+  })
+
+  it('markSessionNotificationRead stamps readAt on the matching notification', async () => {
+    const { useConnectionStore } = await import('./connection')
+    useConnectionStore.setState({
+      sessionNotifications: [
+        makeNotification({ id: 'n-1' }),
+        makeNotification({ id: 'n-2', requestId: 'req-def' }),
+      ],
+    })
+
+    const before = Date.now()
+    useConnectionStore.getState().markSessionNotificationRead('n-1')
+    const after = Date.now()
+
+    const list = useConnectionStore.getState().sessionNotifications
+    const n1 = list.find(n => n.id === 'n-1')!
+    const n2 = list.find(n => n.id === 'n-2')!
+    expect(n1.readAt).toBeTypeOf('number')
+    expect(n1.readAt!).toBeGreaterThanOrEqual(before)
+    expect(n1.readAt!).toBeLessThanOrEqual(after)
+    // sibling notification untouched
+    expect(n2.readAt).toBeUndefined()
+  })
+
+  it('markSessionNotificationRead is idempotent — second call preserves the first readAt', async () => {
+    const { useConnectionStore } = await import('./connection')
+    useConnectionStore.setState({
+      sessionNotifications: [makeNotification({ id: 'n-1' })],
+    })
+
+    useConnectionStore.getState().markSessionNotificationRead('n-1')
+    const firstReadAt = useConnectionStore.getState().sessionNotifications[0]!.readAt
+    expect(firstReadAt).toBeTypeOf('number')
+
+    // Wait a tick to ensure a distinct timestamp would otherwise be recorded
+    await new Promise(r => setTimeout(r, 5))
+
+    useConnectionStore.getState().markSessionNotificationRead('n-1')
+    const secondReadAt = useConnectionStore.getState().sessionNotifications[0]!.readAt
+    expect(secondReadAt).toBe(firstReadAt)
+  })
+
+  it('markSessionNotificationRead is a no-op for unknown id', async () => {
+    const { useConnectionStore } = await import('./connection')
+    useConnectionStore.setState({
+      sessionNotifications: [makeNotification({ id: 'n-1' })],
+    })
+
+    useConnectionStore.getState().markSessionNotificationRead('does-not-exist')
+    const list = useConnectionStore.getState().sessionNotifications
+    expect(list).toHaveLength(1)
+    expect(list[0]!.readAt).toBeUndefined()
+  })
+
+  it('markAllSessionNotificationsRead stamps every currently-unread notification', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const alreadyRead = 1000
+    useConnectionStore.setState({
+      sessionNotifications: [
+        makeNotification({ id: 'n-1' }),
+        makeNotification({ id: 'n-2', requestId: 'req-def' }),
+        makeNotification({ id: 'n-3', readAt: alreadyRead }),
+      ],
+    })
+
+    useConnectionStore.getState().markAllSessionNotificationsRead()
+    const list = useConnectionStore.getState().sessionNotifications
+
+    expect(list.find(n => n.id === 'n-1')!.readAt).toBeTypeOf('number')
+    expect(list.find(n => n.id === 'n-2')!.readAt).toBeTypeOf('number')
+    // Already-read entry must not have its readAt clobbered (preserves the
+    // original acknowledge timestamp so a "Mark all read" doesn't masquerade
+    // as a fresh acknowledge for items already seen).
+    expect(list.find(n => n.id === 'n-3')!.readAt).toBe(alreadyRead)
+  })
+
+  it('dismissSessionNotification still removes outright (distinct from "viewed")', async () => {
+    const { useConnectionStore } = await import('./connection')
+    useConnectionStore.setState({
+      sessionNotifications: [
+        makeNotification({ id: 'n-1' }),
+        makeNotification({ id: 'n-2', requestId: 'req-def' }),
+      ],
+    })
+
+    useConnectionStore.getState().dismissSessionNotification('n-1')
+    const list = useConnectionStore.getState().sessionNotifications
+    expect(list).toHaveLength(1)
+    expect(list[0]!.id).toBe('n-2')
+  })
+})
+
+describe('switchSession marks notifications as read instead of removing (#4890)', () => {
+  it('marks notifications for the target session as read without dropping them', async () => {
+    const { useConnectionStore } = await import('./connection')
+    const makeSession = (id: string) => ({
+      sessionId: id, name: id, cwd: '/tmp', type: 'cli' as const,
+      hasTerminal: false, model: null, permissionMode: null, isBusy: false,
+      createdAt: 0, conversationId: null,
+    })
+    useConnectionStore.setState({
+      sessions: [makeSession('sess-a'), makeSession('sess-b')],
+      activeSessionId: 'sess-a',
+      sessionStates: {},
+      sessionNotifications: [
+        makeNotification({ id: 'n-b-1', sessionId: 'sess-b' }),
+        makeNotification({ id: 'n-b-2', sessionId: 'sess-b', requestId: 'req-def' }),
+        makeNotification({ id: 'n-c-1', sessionId: 'sess-c' }),
+      ],
+    })
+
+    useConnectionStore.getState().switchSession('sess-b')
+
+    const list = useConnectionStore.getState().sessionNotifications
+    // All three entries are preserved — switching no longer wipes history.
+    expect(list).toHaveLength(3)
+    // The two entries for sess-b are now flagged as read.
+    expect(list.find(n => n.id === 'n-b-1')!.readAt).toBeTypeOf('number')
+    expect(list.find(n => n.id === 'n-b-2')!.readAt).toBeTypeOf('number')
+    // The unrelated sess-c entry remains unread.
+    expect(list.find(n => n.id === 'n-c-1')!.readAt).toBeUndefined()
+  })
+})

--- a/packages/dashboard/src/store/intervention-notifications-read.test.ts
+++ b/packages/dashboard/src/store/intervention-notifications-read.test.ts
@@ -15,7 +15,7 @@
  * Scope is in-memory only — `sessionNotifications` is transient and resets
  * on reload/reconnect (see types.ts:SessionNotification.readAt JSDoc).
  */
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import type { SessionNotification } from './types'
 
 function makeNotification(overrides: Partial<SessionNotification> = {}): SessionNotification {
@@ -71,16 +71,21 @@ describe('SessionNotification read/unread tracking (#4890)', () => {
       sessionNotifications: [makeNotification({ id: 'n-1' })],
     })
 
+    // Deterministic Date.now() so we can prove the second call would have
+    // observed a distinct value if the action weren't idempotent — without
+    // depending on real-time setTimeout (which could land in the same ms
+    // on fast machines and miss a regression).
+    const nowSpy = vi.spyOn(Date, 'now')
+    nowSpy.mockReturnValueOnce(1_700_000_000_000) // first mark-read
     useConnectionStore.getState().markSessionNotificationRead('n-1')
     const firstReadAt = useConnectionStore.getState().sessionNotifications[0]!.readAt
-    expect(firstReadAt).toBeTypeOf('number')
+    expect(firstReadAt).toBe(1_700_000_000_000)
 
-    // Wait a tick to ensure a distinct timestamp would otherwise be recorded
-    await new Promise(r => setTimeout(r, 5))
-
+    nowSpy.mockReturnValueOnce(1_700_000_000_999) // second mark-read — would clobber if non-idempotent
     useConnectionStore.getState().markSessionNotificationRead('n-1')
     const secondReadAt = useConnectionStore.getState().sessionNotifications[0]!.readAt
     expect(secondReadAt).toBe(firstReadAt)
+    nowSpy.mockRestore()
   })
 
   it('markSessionNotificationRead is a no-op for unknown id', async () => {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -268,10 +268,13 @@ export interface SessionNotification {
   requestId?: string;
   /**
    * #4890 — Slack-style read/unread tracking. Set to `Date.now()` when the
-   * operator has acknowledged the alert (opened the notifications widget,
-   * clicked through to the session, or hit "Mark all read"). Absent means
-   * unread; presence means the alert no longer counts toward the
-   * widget's unread badge count.
+   * operator has acknowledged the alert via an explicit action: clicking a
+   * row in the notifications widget (which both marks read and switches
+   * sessions), the per-row "mark as read" affordance, "Mark all read", or
+   * by switching to the alert's session via any session-switch path.
+   * Absent means unread; presence means the alert no longer counts toward
+   * the widget's unread badge count. Note: simply opening the widget panel
+   * does NOT mark notifications as read on its own.
    *
    * Tracked in memory only — `sessionNotifications` itself is transient and
    * resets on reload/reconnect, so persisting `readAt` would outlive the

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -266,6 +266,19 @@ export interface SessionNotification {
   message: string;
   timestamp: number;
   requestId?: string;
+  /**
+   * #4890 — Slack-style read/unread tracking. Set to `Date.now()` when the
+   * operator has acknowledged the alert (opened the notifications widget,
+   * clicked through to the session, or hit "Mark all read"). Absent means
+   * unread; presence means the alert no longer counts toward the
+   * widget's unread badge count.
+   *
+   * Tracked in memory only — `sessionNotifications` itself is transient and
+   * resets on reload/reconnect, so persisting `readAt` would outlive the
+   * matching alert. Cross-device read sync is out of scope for v1 and would
+   * need a server-side persistence model (see PR #4890 follow-ups).
+   */
+  readAt?: number;
 }
 
 /**
@@ -800,6 +813,19 @@ export interface ConnectionState {
 
   // Session notification actions
   dismissSessionNotification: (id: string) => void;
+  /**
+   * #4890 — Slack-style notifications widget read/unread tracking.
+   *
+   * `markSessionNotificationRead(id)` stamps `readAt = Date.now()` on a single
+   * alert so it no longer counts toward the unread badge. Idempotent: calling
+   * twice keeps the first read timestamp (we don't want re-opens to look
+   * like a brand-new acknowledge).
+   *
+   * `markAllSessionNotificationsRead()` is the "Mark all read" affordance —
+   * stamps every currently-unread alert in one batch.
+   */
+  markSessionNotificationRead: (id: string) => void;
+  markAllSessionNotificationsRead: () => void;
 
   // #4982 — session-not-found chip state
   setSessionNotFoundError: (err: SessionNotFoundErrorState | null) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2979,6 +2979,220 @@
   padding: 2px 0;
 }
 
+/* ---- Intervention notifications widget (#4890) ---------------------------
+   Slack-style inbox in the header-right zone. Bell trigger with unread badge,
+   click-to-open dropdown listing every notification (read + unread). The
+   transient banners (above) still surface unread alerts inline above main
+   content; the widget owns durable history + per-row acknowledge. */
+.notifications-widget {
+  position: relative;
+  display: inline-flex;
+}
+
+.notifications-widget-trigger {
+  position: relative;
+}
+
+.notifications-widget-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--text-base);
+  line-height: 1;
+}
+
+.notifications-widget-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--accent-red, #c44);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-align: center;
+  pointer-events: none;
+  box-sizing: border-box;
+}
+
+.notifications-widget-panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  width: 360px;
+  max-height: 480px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 100;
+}
+
+.notifications-widget-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.notifications-widget-title {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.notifications-widget-mark-all {
+  background: none;
+  border: none;
+  color: var(--accent-blue);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 2px 4px;
+}
+
+.notifications-widget-mark-all:hover {
+  text-decoration: underline;
+}
+
+.notifications-widget-empty {
+  padding: 24px 12px;
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.notifications-widget-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.notifications-widget-item {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  padding: 0;
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.notifications-widget-item:last-child {
+  border-bottom: none;
+}
+
+.notifications-widget-item--unread {
+  background: var(--bg-tertiary);
+}
+
+.notifications-widget-item--unread .notifications-widget-item-type,
+.notifications-widget-item--unread .notifications-widget-item-session,
+.notifications-widget-item--unread .notifications-widget-item-message {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.notifications-widget-item--read .notifications-widget-item-type,
+.notifications-widget-item--read .notifications-widget-item-session,
+.notifications-widget-item--read .notifications-widget-item-message {
+  color: var(--text-secondary);
+  opacity: 0.75;
+}
+
+.notifications-widget-item-body {
+  flex: 1;
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 8px 12px;
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  align-items: baseline;
+  gap: 6px;
+  cursor: pointer;
+  font-size: var(--text-sm);
+  color: inherit;
+  overflow: hidden;
+}
+
+.notifications-widget-item-body:hover {
+  background: var(--bg-quaternary, rgba(255, 255, 255, 0.04));
+}
+
+.notifications-widget-item-type {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.notifications-widget-item--unread.notifications-widget-item--permission
+  .notifications-widget-item-type {
+  color: var(--accent-orange);
+  opacity: 1;
+}
+
+.notifications-widget-item--unread.notifications-widget-item--error
+  .notifications-widget-item-type {
+  color: var(--accent-red, #e55);
+  opacity: 1;
+}
+
+.notifications-widget-item-session {
+  color: var(--accent-blue);
+  font-size: var(--text-sm);
+}
+
+.notifications-widget-item-message {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-sm);
+}
+
+.notifications-widget-item-time {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.notifications-widget-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  flex-shrink: 0;
+}
+
+.notifications-widget-item-mark-read,
+.notifications-widget-item-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: var(--text-sm);
+  line-height: 1;
+}
+
+.notifications-widget-item-mark-read:hover,
+.notifications-widget-item-dismiss:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
 /* ---- Slash Command Picker (#1281) ---- */
 .slash-picker {
   position: absolute;


### PR DESCRIPTION
Closes #4890.

## Summary

Adds a Slack-style intervention notifications widget in the dashboard header — a bell trigger with an unread badge plus a dropdown listing every intervention alert (read + unread). Replaces the "toasts vanish and leave no trace" UX so the operator gets a durable at-a-glance signal for outstanding interventions.

- New optional `readAt?: number` on `SessionNotification` (in-memory only; see scope note below).
- New store actions: `markSessionNotificationRead(id)` (idempotent), `markAllSessionNotificationsRead()`.
- `switchSession()` now **marks** the target session's notifications as read instead of removing them outright — the widget keeps the history while the transient banner stack still vanishes for the active session.
- Banners (`NotificationBanners`) filter by `readAt === undefined` at render time so the visual UX is unchanged: they still surface only unread alerts, max 3 visible + overflow.
- `dismissSessionNotification()` continues to remove outright (explicit dismissal is distinct from "viewed").
- Already-resolved interventions (permission_expired, permission_resolved) already filter the notification out via the existing message-handler paths — no new wiring needed; the widget never shows a stale "pending" entry for an alert the server retired.

## Widget UX
- Bell trigger with unread badge (caps at "99+").
- Dropdown rows: event type chip, session name, message, relative timestamp.
- Click the row body → marks read + switches sessions.
- Per-row eyeball → marks read without switching (unread rows only).
- Per-row × → outright dismiss.
- "Mark all read" → bulk acknowledge.
- Outside-click / Escape / window-blur all dismiss the panel.
- Read rows fade to muted; unread render bolder with accent-coloured type chip.

## Acceptance criteria

- [x] `SessionNotification` carries a read/unread state (`readAt?: number`).
- [x] The bottom-right widget shows an unread/pending count that excludes already-viewed alerts.
- [x] Viewing an alert (clicking through to the session, opening the widget row, or "Mark all read") marks it read so it no longer counts as pending.
- [x] Already-resolved interventions (permission_expired / permission_resolved) do not remain pending — existing message-handler paths already filter them out of `sessionNotifications`.
- [x] Read state persistence decision recorded: **in-memory only for v1**.

## Scope — deferred to follow-up

- **Cross-device read sync** would require a server-side notifications model and a wire protocol bump. Not in scope here.
- **Persisting read state across reload** is moot because `sessionNotifications` itself doesn't persist — the list resets on reload/reconnect, so the read flag couldn't outlive its target anyway. If notifications themselves are ever persisted, read state can ride alongside.

## Test plan

- [x] `npx vitest run` — 2792 tests passing (144 files), including 20 new tests:
  - `intervention-notifications-read.test.ts` — store actions, idempotency, `switchSession` mark-vs-remove behaviour.
  - `NotificationsWidget.test.tsx` — trigger + badge, panel content, click-row-marks-read-and-switches, per-row eye / dismiss / mark-all-read, empty state, Escape dismiss, end-to-end "unread decrements on view".
- [x] `tsc --noEmit` clean.
- [ ] Manual smoke (after merge): trigger a permission prompt from a background session, confirm the bell badges, open the widget, click through, confirm the badge decrements and the row fades to read.