### PR TITLE
feat(desktop): extend macOS menu bar with Shell/View/Tunnel/Help submenus (#4942)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1442,11 +1442,11 @@ export function App() {
   //                            Settings panel; tunnel mode lives there)
   //   - onPreferences       — Chroxy > Preferences… (opens Settings)
   //
-  // Window > Bring All to Front is intentionally NOT wired through
-  // this hook today: focusing the main window is already handled
-  // Rust-side by `window::show_window` in `on_menu_event`, so the
-  // dashboard has nothing to do beyond what the Rust dispatch already
-  // does.
+  // Window > Bring All to Front is handled entirely Rust-side
+  // (`handle_bring_all_to_front` iterates every webview window — main
+  // and any open `qr_popup` — and brings each one forward). The
+  // dashboard has no state to mutate, so it doesn't appear in the hook
+  // surface at all.
   const menuConnectToServer = useCallback(() => {
     // The dashboard's existing "connect to a different server" surface
     // is the Settings panel's Server Registry section. The menu item

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1326,13 +1326,12 @@ export function App() {
     setShowCreateSession(true)
   }, [])
 
-  // #4695 — bridge the macOS menu bar "File > New Session" item to
-  // `handleNewSession` (the same callback the chrome "New Session"
-  // button uses). The sidebar's per-project "+" row and the command
-  // palette's `new-session` entry currently open the create-session
-  // dialog through their own inline handlers, so they are NOT routed
-  // through this hook. Hook is a no-op outside Tauri (web dashboard).
-  useTauriMenuEvents({ onNewSession: handleNewSession })
+  // #4695 / #4942 — bridge the macOS menu bar items to App-state
+  // handlers. See the `useTauriMenuEvents` call below `handleShowQr`
+  // (further down in this file) for the actual wiring — we can't
+  // invoke it inline here because the View > Show QR item reuses
+  // `handleShowQr`, which depends on `fetchQrInto`, which is declared
+  // further down. The hook is a no-op outside Tauri (web dashboard).
 
   const handleCreateSession = useCallback((data: { name: string; cwd: string; provider?: string; permissionMode?: string; model?: string; worktree?: boolean; skipPermissions?: boolean }) => {
     setSessionCreateError(null)
@@ -1413,6 +1412,78 @@ export function App() {
   }, [])
 
   const handleShowQr = useCallback(() => fetchQrInto('/qr'), [fetchQrInto])
+
+  // #4695 / #4942 — bridge the macOS menu bar items to App-state
+  // handlers. The sidebar's per-project "+" row and the command
+  // palette entries currently open their respective dialogs through
+  // inline handlers, so they are NOT routed through this hook. Hook
+  // is a no-op outside Tauri (web dashboard).
+  //
+  // Handler wiring (one prop per menu item that flows through this
+  // hook — Rust-side direct dispatches like Shell > Start aren't here):
+  //   - onNewSession        — File > New Session (same callback the
+  //                            chrome "New Session" button uses)
+  //   - onConnectToServer   — File > Connect to Server… (opens the
+  //                            Settings panel; the Server Registry
+  //                            section is the existing surface for
+  //                            managing connections)
+  //   - onDisconnect        — File > Disconnect (calls the store's
+  //                            disconnect action; no-op if not
+  //                            connected)
+  //   - onToggleSidebar     — View > Toggle Sidebar (same setter as
+  //                            the Cmd+B registry handler)
+  //   - onTogglePlanMode    — View > Toggle Plan Mode (same logic as
+  //                            the Shift+Tab registry handler)
+  //   - onShowQr            — View > Show QR Code (same fetch the
+  //                            chrome "Show QR" affordance triggers)
+  //   - onReload            — View > Reload (window.location.reload —
+  //                            Tauri's webview honours this)
+  //   - onTunnelSettings    — Tunnel > Tunnel Settings… (opens the
+  //                            Settings panel; tunnel mode lives there)
+  //   - onPreferences       — Chroxy > Preferences… (opens Settings)
+  //
+  // Window > Bring All to Front is intentionally NOT wired through
+  // this hook today: focusing the main window is already handled
+  // Rust-side by `window::show_window` in `on_menu_event`, so the
+  // dashboard has nothing to do beyond what the Rust dispatch already
+  // does.
+  const menuConnectToServer = useCallback(() => {
+    // The dashboard's existing "connect to a different server" surface
+    // is the Settings panel's Server Registry section. The menu item
+    // opens Settings; the user picks a registry entry there.
+    setSettingsOpen(true)
+  }, [])
+  const menuDisconnect = useCallback(() => {
+    useConnectionStore.getState().disconnect()
+  }, [])
+  const menuToggleSidebar = useCallback(() => {
+    setSidebarOpen(prev => !prev)
+  }, [])
+  const menuTogglePlanMode = useCallback(() => {
+    const state = useConnectionStore.getState()
+    if (state.permissionMode === 'plan') {
+      setPermissionMode(state.previousPermissionMode || 'approve')
+    } else {
+      setPermissionMode('plan')
+    }
+  }, [setPermissionMode])
+  const menuReload = useCallback(() => {
+    window.location.reload()
+  }, [])
+  const menuOpenSettings = useCallback(() => {
+    setSettingsOpen(true)
+  }, [])
+  useTauriMenuEvents({
+    onNewSession: handleNewSession,
+    onConnectToServer: menuConnectToServer,
+    onDisconnect: menuDisconnect,
+    onToggleSidebar: menuToggleSidebar,
+    onTogglePlanMode: menuTogglePlanMode,
+    onShowQr: handleShowQr,
+    onReload: menuReload,
+    onTunnelSettings: menuOpenSettings,
+    onPreferences: menuOpenSettings,
+  })
 
   // #3070: per-session "Share this session" QR. Issues a token bound to the
   // active session — the scanner can chat into it but cannot list/switch

--- a/packages/dashboard/src/hooks/useTauriMenuEvents.test.ts
+++ b/packages/dashboard/src/hooks/useTauriMenuEvents.test.ts
@@ -1,5 +1,6 @@
 /**
- * useTauriMenuEvents — bridge tests for macOS menu-bar item dispatch (#4695).
+ * useTauriMenuEvents — bridge tests for macOS menu-bar item dispatch
+ * (#4695 / #4942).
  *
  * Mirrors useTauriEvents.test.ts mocking pattern: stub the Tauri v2 event
  * bridge (`window.__TAURI__.event.listen`) and assert the hook subscribes
@@ -38,7 +39,7 @@ function emit(event: string, payload?: unknown) {
   handlers.forEach(h => h({ payload }))
 }
 
-describe('useTauriMenuEvents (#4695)', () => {
+describe('useTauriMenuEvents (#4695 / #4942)', () => {
   beforeEach(() => {
     setupTauriMock()
   })
@@ -84,5 +85,68 @@ describe('useTauriMenuEvents (#4695)', () => {
     await Promise.resolve()
     await Promise.resolve()
     expect(unlisten).toHaveBeenCalled()
+  })
+
+  // #4942 — Additional submenu items added per the menu-bar layout
+  // proposal. Each entry has a dedicated subscription / dispatch test
+  // so a rename on either side surfaces here, not silently in
+  // production.
+  describe('#4942 — Shell / View / Tunnel / Window submenu dispatch', () => {
+    // Every menu item that flows through this hook (i.e. dispatches to
+    // a dashboard handler) is enumerated here. Items the Rust side
+    // handles directly (Shell > Start/Stop/Restart/Open Console/Open in
+    // Finder, Tunnel > Quick/Named/None, Help > Documentation/Report
+    // Issue/Check for Updates) intentionally do NOT appear in this list
+    // — they never reach the dashboard.
+    const ENUMERATED_MENU_ROUTES: Array<{
+      event: string
+      prop:
+        | 'onConnectToServer'
+        | 'onDisconnect'
+        | 'onToggleSidebar'
+        | 'onTogglePlanMode'
+        | 'onShowQr'
+        | 'onReload'
+        | 'onTunnelSettings'
+        | 'onPreferences'
+        | 'onBringAllToFront'
+    }> = [
+      { event: 'menu://connect-to-server', prop: 'onConnectToServer' },
+      { event: 'menu://disconnect', prop: 'onDisconnect' },
+      { event: 'menu://view-toggle-sidebar', prop: 'onToggleSidebar' },
+      { event: 'menu://view-toggle-plan-mode', prop: 'onTogglePlanMode' },
+      { event: 'menu://view-show-qr', prop: 'onShowQr' },
+      { event: 'menu://view-reload', prop: 'onReload' },
+      { event: 'menu://tunnel-settings', prop: 'onTunnelSettings' },
+      { event: 'menu://preferences', prop: 'onPreferences' },
+      { event: 'menu://window-bring-all-to-front', prop: 'onBringAllToFront' },
+    ]
+
+    for (const { event, prop } of ENUMERATED_MENU_ROUTES) {
+      it(`subscribes to ${event} and dispatches to ${prop}`, () => {
+        const onNewSession = vi.fn()
+        const cb = vi.fn()
+        renderHook(() =>
+          useTauriMenuEvents({ onNewSession, [prop]: cb } as never),
+        )
+        expect(listeners.has(event)).toBe(true)
+        emit(event)
+        expect(cb).toHaveBeenCalledTimes(1)
+        // The other menu items should not have fired the same callback.
+        expect(onNewSession).not.toHaveBeenCalled()
+      })
+    }
+
+    it('does not crash if an emitted event has no bound handler', () => {
+      // Wire only onNewSession; emit other events anyway.
+      const onNewSession = vi.fn()
+      renderHook(() => useTauriMenuEvents({ onNewSession }))
+      expect(() => {
+        for (const { event } of ENUMERATED_MENU_ROUTES) {
+          emit(event)
+        }
+      }).not.toThrow()
+      expect(onNewSession).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/dashboard/src/hooks/useTauriMenuEvents.test.ts
+++ b/packages/dashboard/src/hooks/useTauriMenuEvents.test.ts
@@ -96,8 +96,8 @@ describe('useTauriMenuEvents (#4695 / #4942)', () => {
     // a dashboard handler) is enumerated here. Items the Rust side
     // handles directly (Shell > Start/Stop/Restart/Open Console/Open in
     // Finder, Tunnel > Quick/Named/None, Help > Documentation/Report
-    // Issue/Check for Updates) intentionally do NOT appear in this list
-    // — they never reach the dashboard.
+    // Issue/Check for Updates, Window > Bring All to Front) intentionally
+    // do NOT appear in this list — they never reach the dashboard.
     const ENUMERATED_MENU_ROUTES: Array<{
       event: string
       prop:
@@ -109,7 +109,6 @@ describe('useTauriMenuEvents (#4695 / #4942)', () => {
         | 'onReload'
         | 'onTunnelSettings'
         | 'onPreferences'
-        | 'onBringAllToFront'
     }> = [
       { event: 'menu://connect-to-server', prop: 'onConnectToServer' },
       { event: 'menu://disconnect', prop: 'onDisconnect' },
@@ -119,7 +118,6 @@ describe('useTauriMenuEvents (#4695 / #4942)', () => {
       { event: 'menu://view-reload', prop: 'onReload' },
       { event: 'menu://tunnel-settings', prop: 'onTunnelSettings' },
       { event: 'menu://preferences', prop: 'onPreferences' },
-      { event: 'menu://window-bring-all-to-front', prop: 'onBringAllToFront' },
     ]
 
     for (const { event, prop } of ENUMERATED_MENU_ROUTES) {
@@ -147,6 +145,19 @@ describe('useTauriMenuEvents (#4695 / #4942)', () => {
         }
       }).not.toThrow()
       expect(onNewSession).not.toHaveBeenCalled()
+    })
+
+    it('does NOT subscribe to menu://window-bring-all-to-front (handled Rust-side)', () => {
+      // The Rust handler (`handle_bring_all_to_front`) iterates every
+      // webview window and brings each one forward — including
+      // secondary windows like `qr_popup`. The dashboard intentionally
+      // has no subscription here so the event never reaches React
+      // (and `window::show_window` doesn't get double-fired). If this
+      // test starts failing, the routing was changed; update either
+      // the hook or this test (not both) — never both at once.
+      const onNewSession = vi.fn()
+      renderHook(() => useTauriMenuEvents({ onNewSession }))
+      expect(listeners.has('menu://window-bring-all-to-front')).toBe(false)
     })
   })
 })

--- a/packages/dashboard/src/hooks/useTauriMenuEvents.ts
+++ b/packages/dashboard/src/hooks/useTauriMenuEvents.ts
@@ -1,5 +1,6 @@
 /**
- * useTauriMenuEvents — bridge macOS menu-bar items to dashboard handlers (#4695).
+ * useTauriMenuEvents — bridge macOS menu-bar items to dashboard handlers
+ * (#4695 / #4942).
  *
  * The Rust side (packages/desktop/src-tauri/src/lib.rs) emits
  * `menu://<action>` events when the user picks an item from the
@@ -15,14 +16,23 @@
  *
  *   1. A new `MenuItemBuilder::with_id("app_menu:<action>", …)` entry
  *      in lib.rs's app-menu builder.
- *   2. A new callback prop on this hook, wired in App.tsx.
+ *   2. A new optional callback prop on this hook, wired in App.tsx.
  *
  * Why a separate hook (vs folding into `useTauriEvents`):
  *   - `useTauriEvents` mutates the Zustand connection store directly
  *     (it has no caller-provided callbacks). The menu actions need
- *     App-local state (`setShowCreateSession`), so they have to flow
- *     through props. Mixing the two would dilute `useTauriEvents`'s
+ *     App-local state (`setShowCreateSession`, etc.), so they have to
+ *     flow through props. Mixing the two would dilute `useTauriEvents`'s
  *     "store-only side effects" contract.
+ *
+ * Why every handler beyond onNewSession is optional (#4942):
+ *   - The Rust side dispatches some menu items directly without a
+ *     dashboard round-trip (Shell > Start, Tunnel > Quick, Help >
+ *     Documentation, etc.). The ones that DO flow through this hook
+ *     are all dashboard-state toggles.
+ *   - Optional props mean callers can wire one new handler at a time
+ *     as the matching React surface lands, instead of having to land
+ *     all of #4942 atomically.
  *
  * No-op outside Tauri (e.g. plain browser dashboard).
  */
@@ -34,24 +44,112 @@ type UnlistenFn = () => void
 export interface TauriMenuHandlers {
   /** Triggered by `File > New Session` (id `app_menu:new-session`). */
   onNewSession: () => void
+  /** Triggered by `File > Connect to Server…` (id `app_menu:connect-to-server`). */
+  onConnectToServer?: () => void
+  /** Triggered by `File > Disconnect` (id `app_menu:disconnect`). */
+  onDisconnect?: () => void
+  /** Triggered by `View > Toggle Sidebar` (id `app_menu:view-toggle-sidebar`). */
+  onToggleSidebar?: () => void
+  /** Triggered by `View > Toggle Plan Mode` (id `app_menu:view-toggle-plan-mode`). */
+  onTogglePlanMode?: () => void
+  /** Triggered by `View > Show QR Code` (id `app_menu:view-show-qr`). */
+  onShowQr?: () => void
+  /** Triggered by `View > Reload` (id `app_menu:view-reload`). */
+  onReload?: () => void
+  /** Triggered by `Tunnel > Tunnel Settings…` (id `app_menu:tunnel-settings`). */
+  onTunnelSettings?: () => void
+  /** Triggered by `Chroxy > Preferences…` (id `app_menu:preferences`). */
+  onPreferences?: () => void
+  /** Triggered by `Window > Bring All to Front` (id `app_menu:window-bring-all-to-front`). */
+  onBringAllToFront?: () => void
 }
 
+// Concrete contract pinned by the Rust side: each `app_menu:<id>`
+// strips its prefix and emits `menu://<id>`. The map below mirrors the
+// id schema so a rename on either side breaks tests, not silently in
+// production. Keep this grouped by submenu so reviewers can diff
+// additions cleanly.
+const MENU_EVENT_HANDLERS: Array<{
+  event: string
+  prop: keyof TauriMenuHandlers
+}> = [
+  // File submenu
+  { event: 'menu://new-session', prop: 'onNewSession' },
+  { event: 'menu://connect-to-server', prop: 'onConnectToServer' },
+  { event: 'menu://disconnect', prop: 'onDisconnect' },
+  // View submenu
+  { event: 'menu://view-toggle-sidebar', prop: 'onToggleSidebar' },
+  { event: 'menu://view-toggle-plan-mode', prop: 'onTogglePlanMode' },
+  { event: 'menu://view-show-qr', prop: 'onShowQr' },
+  { event: 'menu://view-reload', prop: 'onReload' },
+  // Tunnel submenu (radios go Rust-side; only Settings… reaches us)
+  { event: 'menu://tunnel-settings', prop: 'onTunnelSettings' },
+  // Chroxy submenu
+  { event: 'menu://preferences', prop: 'onPreferences' },
+  // Window submenu
+  { event: 'menu://window-bring-all-to-front', prop: 'onBringAllToFront' },
+]
+
 export function useTauriMenuEvents(handlers: TauriMenuHandlers): void {
-  const { onNewSession } = handlers
+  const {
+    onNewSession,
+    onConnectToServer,
+    onDisconnect,
+    onToggleSidebar,
+    onTogglePlanMode,
+    onShowQr,
+    onReload,
+    onTunnelSettings,
+    onPreferences,
+    onBringAllToFront,
+  } = handlers
   useEffect(() => {
     const listen = getTauriListen()
     if (!listen) return
 
     const unlisteners: Promise<UnlistenFn>[] = []
+    // Resolve each prop to its current callback inside the effect so
+    // the listener closure captures the latest function ref (the
+    // dependency array below re-runs the effect on any prop change).
+    const resolved: Record<string, (() => void) | undefined> = {
+      onNewSession,
+      onConnectToServer,
+      onDisconnect,
+      onToggleSidebar,
+      onTogglePlanMode,
+      onShowQr,
+      onReload,
+      onTunnelSettings,
+      onPreferences,
+      onBringAllToFront,
+    }
 
-    unlisteners.push(
-      listen('menu://new-session', () => {
-        onNewSession()
-      }),
-    )
+    for (const { event, prop } of MENU_EVENT_HANDLERS) {
+      const cb = resolved[prop as string]
+      // Always subscribe, even if the prop is undefined — that way
+      // the Rust side can emit a `menu://<id>` for a known menu item
+      // without crashing the listener registry, and we just no-op.
+      // (Tests pin the subscription contract per id.)
+      unlisteners.push(
+        listen(event, () => {
+          cb?.()
+        }),
+      )
+    }
 
     return () => {
       unlisteners.forEach(p => p.then(fn => fn()).catch(() => {}))
     }
-  }, [onNewSession])
+  }, [
+    onNewSession,
+    onConnectToServer,
+    onDisconnect,
+    onToggleSidebar,
+    onTogglePlanMode,
+    onShowQr,
+    onReload,
+    onTunnelSettings,
+    onPreferences,
+    onBringAllToFront,
+  ])
 }

--- a/packages/dashboard/src/hooks/useTauriMenuEvents.ts
+++ b/packages/dashboard/src/hooks/useTauriMenuEvents.ts
@@ -60,8 +60,11 @@ export interface TauriMenuHandlers {
   onTunnelSettings?: () => void
   /** Triggered by `Chroxy > Preferences…` (id `app_menu:preferences`). */
   onPreferences?: () => void
-  /** Triggered by `Window > Bring All to Front` (id `app_menu:window-bring-all-to-front`). */
-  onBringAllToFront?: () => void
+  // NOTE: `Window > Bring All to Front` is handled entirely Rust-side
+  // (`handle_bring_all_to_front` iterates every webview window). The
+  // dashboard has no state to mutate — and `window::show_window` alone
+  // only targets the `main` webview, missing secondary windows like
+  // `qr_popup`. No hook prop for it.
 }
 
 // Concrete contract pinned by the Rust side: each `app_menu:<id>`
@@ -86,8 +89,8 @@ const MENU_EVENT_HANDLERS: Array<{
   { event: 'menu://tunnel-settings', prop: 'onTunnelSettings' },
   // Chroxy submenu
   { event: 'menu://preferences', prop: 'onPreferences' },
-  // Window submenu
-  { event: 'menu://window-bring-all-to-front', prop: 'onBringAllToFront' },
+  // Window submenu — `Bring All to Front` is handled Rust-side directly
+  // (see `handle_bring_all_to_front`), so it has no entry here.
 ]
 
 export function useTauriMenuEvents(handlers: TauriMenuHandlers): void {
@@ -101,7 +104,6 @@ export function useTauriMenuEvents(handlers: TauriMenuHandlers): void {
     onReload,
     onTunnelSettings,
     onPreferences,
-    onBringAllToFront,
   } = handlers
   useEffect(() => {
     const listen = getTauriListen()
@@ -121,7 +123,6 @@ export function useTauriMenuEvents(handlers: TauriMenuHandlers): void {
       onReload,
       onTunnelSettings,
       onPreferences,
-      onBringAllToFront,
     }
 
     for (const { event, prop } of MENU_EVENT_HANDLERS) {
@@ -150,6 +151,5 @@ export function useTauriMenuEvents(handlers: TauriMenuHandlers): void {
     onReload,
     onTunnelSettings,
     onPreferences,
-    onBringAllToFront,
   ])
 }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -816,6 +816,20 @@ pub fn run() {
                             handle_check_updates(app);
                             return;
                         }
+                        // #4942 — Window > Bring All to Front. Handled
+                        // Rust-side because the dashboard has no state
+                        // to mutate AND because the unconditional
+                        // `window::show_window(app)` below only raises
+                        // the `main` webview — it misses secondary
+                        // windows like `qr_popup` (built by
+                        // `handle_show_qr`). Iterate every webview
+                        // window and call `show()` + `set_focus()` so
+                        // a click here actually brings ALL Chroxy
+                        // windows forward.
+                        "window-bring-all-to-front" => {
+                            handle_bring_all_to_front(app);
+                            return;
+                        }
                         _ => {}
                     }
                 }
@@ -823,8 +837,7 @@ pub fn run() {
                 // dashboard's `useTauriMenuEvents` hook to consume.
                 // Covers File > New Session, File > Connect to Server…,
                 // File > Disconnect, View > *, Tunnel > Settings…,
-                // Chroxy > Preferences…, Window > Bring All to Front,
-                // etc.
+                // Chroxy > Preferences…, etc.
                 let event_name = format!("menu://{}", action);
                 let _ = app.emit(&event_name, ());
                 // Make sure the main window is foregrounded so the
@@ -1948,6 +1961,26 @@ fn handle_open_config_in_finder(app: &tauri::AppHandle) {
 #[cfg(target_os = "macos")]
 fn handle_open_url(_app: &tauri::AppHandle, url: &str) {
     let _ = std::process::Command::new("open").arg(url).spawn();
+}
+
+/// #4942 — Window > Bring All to Front. Iterates every Tauri webview
+/// window (today: `main`, plus `qr_popup` when `handle_show_qr` has
+/// opened it) and brings each one forward. macOS classically defines
+/// "Bring All to Front" as "raise all of the application's windows
+/// above other apps' windows" — `window::show_window` alone only
+/// targets `main`, so the QR popup would stay hidden behind the active
+/// app. We also call `set_focus()` after the iteration to ensure the
+/// main window ends up the key window. macOS-only.
+#[cfg(target_os = "macos")]
+fn handle_bring_all_to_front(app: &tauri::AppHandle) {
+    use tauri::Manager;
+    for (_label, win) in app.webview_windows() {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+    // Land focus on `main` last so the user keeps interacting with the
+    // dashboard rather than a secondary window like `qr_popup`.
+    window::show_window(app);
 }
 
 fn handle_check_updates(app: &tauri::AppHandle) {

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -56,6 +56,27 @@ struct TrayMenuItems {
     tunnel_none: CheckMenuItem<tauri::Wry>,
 }
 
+/// #4942 — App-menu (macOS menu bar) item handles. Kept separate from
+/// `TrayMenuItems` so the two surfaces stay decoupled; only the radio
+/// items (tunnel mode) and the server-state-gated entries (Shell items)
+/// need cross-menu state sync, and we touch both menus together when a
+/// tunnel-mode change OR a server-status change fans out.
+#[cfg(target_os = "macos")]
+struct AppMenuItems {
+    /// Shell submenu entries. Enabled state mirrors the tray menu's
+    /// Start/Stop/Restart/Console gating (see `update_menu_state`).
+    shell_start: MenuItem<tauri::Wry>,
+    shell_stop: MenuItem<tauri::Wry>,
+    shell_restart: MenuItem<tauri::Wry>,
+    shell_open_console: MenuItem<tauri::Wry>,
+    /// Tunnel radios — kept in lockstep with the tray's tunnel radios
+    /// via `handle_set_tunnel_mode` so toggling from either surface
+    /// updates the other.
+    tunnel_quick: CheckMenuItem<tauri::Wry>,
+    tunnel_named: CheckMenuItem<tauri::Wry>,
+    tunnel_none: CheckMenuItem<tauri::Wry>,
+}
+
 // ── Tauri IPC commands ──────────────────────────────────────────────
 
 #[tauri::command]
@@ -274,6 +295,15 @@ fn set_tunnel_mode(app: tauri::AppHandle, mode: String) -> Result<(), String> {
 
     // Update tray menu checkboxes
     if let Some(items) = app.try_state::<Mutex<TrayMenuItems>>() {
+        let items = lock_or_recover(&items);
+        let _ = items.tunnel_quick.set_checked(mode == "quick");
+        let _ = items.tunnel_named.set_checked(mode == "named");
+        let _ = items.tunnel_none.set_checked(mode == "none");
+    }
+    // #4942 — also sync the macOS app-menu radios so a dashboard-driven
+    // tunnel-mode change keeps both menu surfaces consistent.
+    #[cfg(target_os = "macos")]
+    if let Some(items) = app.try_state::<Mutex<AppMenuItems>>() {
         let items = lock_or_recover(&items);
         let _ = items.tunnel_quick.set_checked(mode == "quick");
         let _ = items.tunnel_named.set_checked(mode == "named");
@@ -717,28 +747,90 @@ pub fn run() {
             { Mutex::new(()) }
         })
         .on_menu_event(|app, event| {
-            // #4695 — app-menu (macOS menu bar) item dispatch. Tray menu
-            // events are handled by their own builder-scoped closure
-            // (`on_menu_event` in build_tray_menu). The two surfaces
-            // intentionally use disjoint id namespaces:
+            // #4695 / #4942 — app-menu (macOS menu bar) item dispatch.
+            // Tray menu events are handled by their own builder-scoped
+            // closure (`on_menu_event` in build_tray_menu). The two
+            // surfaces intentionally use disjoint id namespaces:
             //   - tray:    "start", "stop", "dashboard", …
             //   - app-menu: "app_menu:<action>" (this match)
             // The `app_menu:` prefix means stray cross-fires would
             // simply no-op rather than accidentally invoke the wrong
-            // tray handler. The concrete contract here is: strip the
-            // prefix and emit a `menu://<action>` event for the
-            // dashboard to handle. The dashboard's `useTauriMenuEvents`
-            // hook subscribes to those events and routes each one to a
-            // React-side callback supplied by App.tsx — whether that
-            // callback is shared with another UI affordance (button,
-            // palette entry, etc.) is decided by App.tsx, not here.
+            // tray handler.
+            //
+            // Two routing classes:
+            //   1. Server-control / tunnel / Help-browser actions —
+            //      call the existing tray handlers directly. No
+            //      dashboard round-trip is needed; the tray handlers
+            //      already know how to keep both menus' state in sync.
+            //   2. Dashboard-state actions (new session, sidebar
+            //      toggle, plan mode, etc.) — emit `menu://<action>`
+            //      so the dashboard's `useTauriMenuEvents` hook can
+            //      route to a React-side callback supplied by App.tsx.
+            //      Whether that callback is shared with another UI
+            //      affordance (button, palette entry, …) is decided
+            //      by App.tsx, not here.
             let id = event.id().as_ref();
             if let Some(action) = id.strip_prefix("app_menu:") {
+                // The app-menu surface emitting these ids is itself
+                // macOS-only today (see the menu builder block below),
+                // so gate the arms that call macOS-only helpers to
+                // match.
+                #[cfg(target_os = "macos")]
+                {
+                    match action {
+                        "shell-start" => { handle_start(app); return; }
+                        "shell-stop" => { handle_stop(app); return; }
+                        "shell-restart" => { handle_restart(app); return; }
+                        "shell-open-in-finder" => {
+                            handle_open_config_in_finder(app);
+                            return;
+                        }
+                        "shell-open-console" => { handle_console(app); return; }
+                        "tunnel-quick" => {
+                            handle_set_tunnel_mode(app, "quick");
+                            return;
+                        }
+                        "tunnel-named" => {
+                            handle_set_tunnel_mode(app, "named");
+                            return;
+                        }
+                        "tunnel-none" => {
+                            handle_set_tunnel_mode(app, "none");
+                            return;
+                        }
+                        "help-documentation" => {
+                            handle_open_url(
+                                app,
+                                "https://github.com/blamechris/chroxy#readme",
+                            );
+                            return;
+                        }
+                        "help-report-issue" => {
+                            handle_open_url(
+                                app,
+                                "https://github.com/blamechris/chroxy/issues/new",
+                            );
+                            return;
+                        }
+                        "help-check-updates" => {
+                            handle_check_updates(app);
+                            return;
+                        }
+                        _ => {}
+                    }
+                }
+                // Default route: emit `menu://<action>` for the
+                // dashboard's `useTauriMenuEvents` hook to consume.
+                // Covers File > New Session, File > Connect to Server…,
+                // File > Disconnect, View > *, Tunnel > Settings…,
+                // Chroxy > Preferences…, Window > Bring All to Front,
+                // etc.
                 let event_name = format!("menu://{}", action);
                 let _ = app.emit(&event_name, ());
-                // Make sure the main window is foregrounded so the user
-                // sees the dashboard react (otherwise a menu click with
-                // the window minimized would silently no-op).
+                // Make sure the main window is foregrounded so the
+                // user sees the dashboard react (otherwise a menu
+                // click with the window minimized would silently
+                // no-op).
                 window::show_window(app);
             }
         })
@@ -749,26 +841,57 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             {
                 use tauri::menu::AboutMetadata;
+                // #4942 — "Preferences…" appended to the Chroxy
+                // submenu so ⌘, opens the dashboard SettingsPanel from
+                // the menu bar (the dashboard already binds ⌘, via
+                // `settings.open`; macOS will route the chord through
+                // the menu bar first once an item with that accelerator
+                // is installed).
+                let preferences_item = MenuItemBuilder::with_id(
+                    "app_menu:preferences",
+                    "Preferences…",
+                )
+                .accelerator("CmdOrCtrl+,")
+                .build(app)?;
                 let app_menu = SubmenuBuilder::new(app, "Chroxy")
                     .about(Some(AboutMetadata::default()))
+                    .separator()
+                    .item(&preferences_item)
                     .separator()
                     .quit()
                     .build()?;
                 // #4695 — File menu. v1 ships with a single item ("New
                 // Session") so the most-used action has a menu-bar entry
                 // matching Terminal.app / iTerm / VS Code muscle memory.
-                // Follow-up issue tracks the rest of the proposed
-                // submenu layout (Shell / View / Tunnel / Help — see
-                // #4695). The accelerator is `Cmd+N`, matching the
-                // dashboard's `session.new` shortcut definition; macOS
-                // routes the chord through the menu bar first when one
-                // is installed, so this entry also serves as the system-
+                // The accelerator is `Cmd+N`, matching the dashboard's
+                // `session.new` shortcut definition; macOS routes the
+                // chord through the menu bar first when one is
+                // installed, so this entry also serves as the system-
                 // level Cmd+N hint.
                 let new_session_item = MenuItemBuilder::with_id("app_menu:new-session", "New Session")
                     .accelerator("CmdOrCtrl+N")
                     .build(app)?;
+                // #4942 — Connect to Server… / Disconnect siblings.
+                // Cmd+O matches "open a connection" muscle memory from
+                // Terminal.app / iTerm; Shift+Cmd+D mirrors Apple's HIG
+                // for disconnect actions.
+                let connect_item = MenuItemBuilder::with_id(
+                    "app_menu:connect-to-server",
+                    "Connect to Server…",
+                )
+                .accelerator("CmdOrCtrl+O")
+                .build(app)?;
+                let disconnect_item = MenuItemBuilder::with_id(
+                    "app_menu:disconnect",
+                    "Disconnect",
+                )
+                .accelerator("Shift+CmdOrCtrl+D")
+                .build(app)?;
                 let file_menu = SubmenuBuilder::new(app, "File")
                     .item(&new_session_item)
+                    .separator()
+                    .item(&connect_item)
+                    .item(&disconnect_item)
                     .build()?;
                 let edit_menu = SubmenuBuilder::new(app, "Edit")
                     .undo()
@@ -779,17 +902,196 @@ pub fn run() {
                     .paste()
                     .select_all()
                     .build()?;
+                // #4942 — Shell submenu. Items mirror tray entries
+                // (Start / Stop / Restart / Open Console). "Open in
+                // Finder" reveals ~/.chroxy/ so the user can inspect
+                // server config / logs without leaving the app. All
+                // five items dispatch to existing handlers in
+                // `on_menu_event` (no dashboard round-trip).
+                let shell_start = MenuItemBuilder::with_id(
+                    "app_menu:shell-start",
+                    "Start Server",
+                )
+                .build(app)?;
+                let shell_stop = MenuItemBuilder::with_id(
+                    "app_menu:shell-stop",
+                    "Stop Server",
+                )
+                .build(app)?;
+                let shell_restart = MenuItemBuilder::with_id(
+                    "app_menu:shell-restart",
+                    "Restart Server",
+                )
+                .build(app)?;
+                let shell_open_in_finder = MenuItemBuilder::with_id(
+                    "app_menu:shell-open-in-finder",
+                    "Open in Finder",
+                )
+                .build(app)?;
+                let shell_open_console = MenuItemBuilder::with_id(
+                    "app_menu:shell-open-console",
+                    "Open Console",
+                )
+                .build(app)?;
+                let shell_menu = SubmenuBuilder::new(app, "Shell")
+                    .item(&shell_start)
+                    .item(&shell_stop)
+                    .item(&shell_restart)
+                    .separator()
+                    .item(&shell_open_in_finder)
+                    .item(&shell_open_console)
+                    .build()?;
+                // #4942 — View submenu. Items dispatch to the
+                // dashboard (the toggles all live in App-level React
+                // state). The accelerators intentionally match the
+                // dashboard shortcut registry defaults so the menu-
+                // bar entry serves as the canonical key-binding hint:
+                //   - Toggle Sidebar:    ⌘B  (`sidebar.toggle`)
+                //   - Toggle Plan Mode:  ⇧⌥P (the registry default is
+                //     Shift+Tab, which macOS menus can't represent;
+                //     the menu surface picks a non-colliding chord)
+                //   - Show QR:           ⇧⌘Q
+                //   - Reload:            ⌘R  (Tauri webview reload)
+                // Cmd+\ ("cycle split") from the proposal collides
+                // with the existing `view.cycleSplit` registry binding
+                // and is not duplicated here — the dashboard already
+                // handles that chord via the registry.
+                let view_toggle_sidebar = MenuItemBuilder::with_id(
+                    "app_menu:view-toggle-sidebar",
+                    "Toggle Sidebar",
+                )
+                .accelerator("CmdOrCtrl+B")
+                .build(app)?;
+                let view_toggle_plan_mode = MenuItemBuilder::with_id(
+                    "app_menu:view-toggle-plan-mode",
+                    "Toggle Plan Mode",
+                )
+                .accelerator("Shift+Alt+P")
+                .build(app)?;
+                let view_show_qr = MenuItemBuilder::with_id(
+                    "app_menu:view-show-qr",
+                    "Show QR Code",
+                )
+                .accelerator("Shift+CmdOrCtrl+Q")
+                .build(app)?;
+                let view_reload = MenuItemBuilder::with_id(
+                    "app_menu:view-reload",
+                    "Reload",
+                )
+                .accelerator("CmdOrCtrl+R")
+                .build(app)?;
+                let view_menu = SubmenuBuilder::new(app, "View")
+                    .item(&view_toggle_sidebar)
+                    .item(&view_toggle_plan_mode)
+                    .separator()
+                    .item(&view_show_qr)
+                    .item(&view_reload)
+                    .build()?;
+                // #4942 — Tunnel submenu. Radios mirror the tray
+                // menu's tunnel-mode submenu (`tunnel_quick` /
+                // `tunnel_named` / `tunnel_none`) and dispatch to the
+                // same Rust handler (`handle_set_tunnel_mode`), which
+                // keeps both menus' checked state in sync. "Tunnel
+                // Settings…" routes to the dashboard so it can open
+                // the Settings panel.
+                let current_tunnel = {
+                    let s = app.state::<Mutex<DesktopSettings>>();
+                    let g = lock_or_recover(&s);
+                    g.tunnel_mode.clone()
+                };
+                let tunnel_quick_app = CheckMenuItemBuilder::with_id(
+                    "app_menu:tunnel-quick",
+                    "Quick Tunnel",
+                )
+                .checked(current_tunnel == "quick")
+                .build(app)?;
+                let tunnel_named_app = CheckMenuItemBuilder::with_id(
+                    "app_menu:tunnel-named",
+                    "Named Tunnel",
+                )
+                .checked(current_tunnel == "named")
+                .build(app)?;
+                let tunnel_none_app = CheckMenuItemBuilder::with_id(
+                    "app_menu:tunnel-none",
+                    "No Tunnel",
+                )
+                .checked(current_tunnel == "none")
+                .build(app)?;
+                let tunnel_settings_item = MenuItemBuilder::with_id(
+                    "app_menu:tunnel-settings",
+                    "Tunnel Settings…",
+                )
+                .build(app)?;
+                let tunnel_menu = SubmenuBuilder::new(app, "Tunnel")
+                    .item(&tunnel_quick_app)
+                    .item(&tunnel_named_app)
+                    .item(&tunnel_none_app)
+                    .separator()
+                    .item(&tunnel_settings_item)
+                    .build()?;
+                // #4942 — Window submenu. Append "Bring All to Front"
+                // as a custom item — Tauri's SubmenuBuilder doesn't
+                // expose a predefined `bring_all_to_front()` today.
+                let bring_all_to_front = MenuItemBuilder::with_id(
+                    "app_menu:window-bring-all-to-front",
+                    "Bring All to Front",
+                )
+                .build(app)?;
                 let window_menu = SubmenuBuilder::new(app, "Window")
                     .minimize()
                     .close_window()
+                    .separator()
+                    .item(&bring_all_to_front)
+                    .build()?;
+                // #4942 — Help submenu. Documentation / Report Issue
+                // open browser URLs Rust-side; Check for Updates
+                // reuses the tray's `handle_check_updates`.
+                let help_documentation = MenuItemBuilder::with_id(
+                    "app_menu:help-documentation",
+                    "Documentation",
+                )
+                .build(app)?;
+                let help_report_issue = MenuItemBuilder::with_id(
+                    "app_menu:help-report-issue",
+                    "Report Issue",
+                )
+                .build(app)?;
+                let help_check_updates = MenuItemBuilder::with_id(
+                    "app_menu:help-check-updates",
+                    "Check for Updates",
+                )
+                .build(app)?;
+                let help_menu = SubmenuBuilder::new(app, "Help")
+                    .item(&help_documentation)
+                    .item(&help_report_issue)
+                    .separator()
+                    .item(&help_check_updates)
                     .build()?;
                 let menu = MenuBuilder::new(app)
                     .item(&app_menu)
                     .item(&file_menu)
                     .item(&edit_menu)
+                    .item(&shell_menu)
+                    .item(&view_menu)
+                    .item(&tunnel_menu)
                     .item(&window_menu)
+                    .item(&help_menu)
                     .build()?;
                 app.set_menu(menu)?;
+
+                // #4942 — Track app-menu item handles so we can keep
+                // the Shell submenu's enabled state in sync with the
+                // server status (via `update_menu_state`) and the
+                // Tunnel radios in sync with `handle_set_tunnel_mode`.
+                app.manage(Mutex::new(AppMenuItems {
+                    shell_start: shell_start.clone(),
+                    shell_stop: shell_stop.clone(),
+                    shell_restart: shell_restart.clone(),
+                    shell_open_console: shell_open_console.clone(),
+                    tunnel_quick: tunnel_quick_app.clone(),
+                    tunnel_named: tunnel_named_app.clone(),
+                    tunnel_none: tunnel_none_app.clone(),
+                }));
 
                 // Workaround for Tauri bug #13605: Tauri's SubmenuBuilder doesn't
                 // register the Window submenu with NSApp.windowsMenu, so macOS
@@ -1131,6 +1433,34 @@ fn update_menu_state(app: &tauri::AppHandle, state: MenuState) {
                 let _ = items.dashboard.set_enabled(false);
                 let _ = items.console.set_enabled(false);
                 let _ = items.show_qr.set_enabled(false);
+            }
+        }
+    }
+    // #4942 — mirror the gating on the macOS app-menu Shell submenu so
+    // the menu-bar entries reflect server status the same way the tray
+    // items do. The "Open in Finder" item is intentionally always
+    // enabled (it just reveals ~/.chroxy/), so it's omitted here.
+    #[cfg(target_os = "macos")]
+    if let Some(items) = app.try_state::<Mutex<AppMenuItems>>() {
+        let items = lock_or_recover(&items);
+        match state {
+            MenuState::Running => {
+                let _ = items.shell_start.set_enabled(false);
+                let _ = items.shell_stop.set_enabled(true);
+                let _ = items.shell_restart.set_enabled(true);
+                let _ = items.shell_open_console.set_enabled(true);
+            }
+            MenuState::Stopped => {
+                let _ = items.shell_start.set_enabled(true);
+                let _ = items.shell_stop.set_enabled(false);
+                let _ = items.shell_restart.set_enabled(false);
+                let _ = items.shell_open_console.set_enabled(false);
+            }
+            MenuState::Restarting => {
+                let _ = items.shell_start.set_enabled(false);
+                let _ = items.shell_stop.set_enabled(false);
+                let _ = items.shell_restart.set_enabled(false);
+                let _ = items.shell_open_console.set_enabled(false);
             }
         }
     }
@@ -1524,12 +1854,21 @@ fn handle_set_tunnel_mode(app: &tauri::AppHandle, mode: &str) {
             "cloudflared not found. Install with: brew install cloudflared",
         );
         // Revert the checkbox to current mode
+        let current = app
+            .try_state::<Mutex<DesktopSettings>>()
+            .map(|s| lock_or_recover(&s).tunnel_mode.clone())
+            .unwrap_or_else(|| "quick".to_string());
         if let Some(items) = app.try_state::<Mutex<TrayMenuItems>>() {
             let items = lock_or_recover(&items);
-            let current = app
-                .try_state::<Mutex<DesktopSettings>>()
-                .map(|s| lock_or_recover(&s).tunnel_mode.clone())
-                .unwrap_or_else(|| "quick".to_string());
+            let _ = items.tunnel_quick.set_checked(current == "quick");
+            let _ = items.tunnel_named.set_checked(current == "named");
+            let _ = items.tunnel_none.set_checked(current == "none");
+        }
+        // #4942 — also revert the app-menu radios so a click on either
+        // surface leaves both consistent when cloudflared is missing.
+        #[cfg(target_os = "macos")]
+        if let Some(items) = app.try_state::<Mutex<AppMenuItems>>() {
+            let items = lock_or_recover(&items);
             let _ = items.tunnel_quick.set_checked(current == "quick");
             let _ = items.tunnel_named.set_checked(current == "named");
             let _ = items.tunnel_none.set_checked(current == "none");
@@ -1551,6 +1890,15 @@ fn handle_set_tunnel_mode(app: &tauri::AppHandle, mode: &str) {
         let _ = items.tunnel_named.set_checked(mode == "named");
         let _ = items.tunnel_none.set_checked(mode == "none");
     }
+    // #4942 — keep the app-menu Tunnel radios in lockstep with the tray
+    // radios so toggling from either surface updates the other.
+    #[cfg(target_os = "macos")]
+    if let Some(items) = app.try_state::<Mutex<AppMenuItems>>() {
+        let items = lock_or_recover(&items);
+        let _ = items.tunnel_quick.set_checked(mode == "quick");
+        let _ = items.tunnel_named.set_checked(mode == "named");
+        let _ = items.tunnel_none.set_checked(mode == "none");
+    }
 
     send_notification(
         app,
@@ -1565,6 +1913,41 @@ fn handle_set_tunnel_mode(app: &tauri::AppHandle, mode: &str) {
             }
         ),
     );
+}
+
+/// #4942 — Open `~/.chroxy/` in Finder so the user can inspect server
+/// config / logs without leaving the app. macOS-only: gated alongside
+/// the app-menu Shell submenu (which is only built on macOS today).
+#[cfg(target_os = "macos")]
+fn handle_open_config_in_finder(app: &tauri::AppHandle) {
+    let Some(config_path) = config::config_path() else {
+        send_notification(
+            app,
+            "Open in Finder",
+            "Could not determine ~/.chroxy/ location.",
+        );
+        return;
+    };
+    // Reveal the parent directory, not the file itself; on first run
+    // the config file may not exist yet but the directory should.
+    let target = match config_path.parent() {
+        Some(p) => p.to_path_buf(),
+        None => config_path.clone(),
+    };
+    if !target.exists() {
+        let _ = std::fs::create_dir_all(&target);
+    }
+    let _ = std::process::Command::new("open").arg(&target).spawn();
+}
+
+/// #4942 — Open an arbitrary URL in the user's default browser. Used
+/// by the Help submenu (Documentation / Report Issue). We avoid pulling
+/// in `tauri-plugin-opener` and instead shell out to `open(1)` — keeps
+/// the new surface footprint zero new dependencies / zero new tauri
+/// commands. macOS-only.
+#[cfg(target_os = "macos")]
+fn handle_open_url(_app: &tauri::AppHandle, url: &str) {
+    let _ = std::process::Command::new("open").arg(url).spawn();
 }
 
 fn handle_check_updates(app: &tauri::AppHandle) {


### PR DESCRIPTION
## Summary

Follow-up to #4695 (which landed the dashboard New Session button and the `on_menu_event` → `menu://<action>` dispatch plumbing). Adds the remaining submenus from the original menu-bar layout proposal.

### Menus added

| Menu | Items |
|------|-------|
| **File** *(extended)* | + Connect to Server… (⌘O), Disconnect (⇧⌘D) |
| **Chroxy** *(extended)* | + Preferences… (⌘,) |
| **Shell** *(new)* | Start / Stop / Restart Server, Open in Finder, Open Console |
| **View** *(new)* | Toggle Sidebar (⌘B), Toggle Plan Mode (⇧⌥P), Show QR Code (⇧⌘Q), Reload (⌘R) |
| **Tunnel** *(new)* | Quick / Named / No Tunnel radios + Tunnel Settings… |
| **Window** *(extended)* | + Bring All to Front |
| **Help** *(new)* | Documentation, Report Issue, Check for Updates |

### Routing

- **Server-control / tunnel / Help-browser items** call the existing Rust handlers directly from `on_menu_event` (no dashboard round-trip — same pattern the tray menu uses). The Tunnel radios stay in lockstep with the tray's tunnel radios via `handle_set_tunnel_mode`, which now fans out to a new `AppMenuItems` struct alongside `TrayMenuItems`. Server-status gating (Running / Stopped / Restarting) is mirrored from the tray onto the Shell submenu via `update_menu_state`.
- **Dashboard-state items** (Connect to Server… opens Settings, Disconnect hits the store, Toggle Sidebar / Plan Mode reuse the same state setters as ⌘B / Shift+Tab, Show QR reuses `handleShowQr`, Reload calls `window.location.reload`, Preferences / Tunnel Settings open the Settings panel) flow through the dashboard via `useTauriMenuEvents`.

### Deferred / not in this PR

- **`Cmd+\` ("cycle split")**: collides with the existing `view.cycleSplit` registry binding. The dashboard already handles that chord via the registry; no menu-bar duplicate.
- **"Toggle Working Indicator"**: no corresponding dashboard state exists today, omitted.
- **Windows / Linux menu parity**: macOS-only per the original issue's "Out of scope" section.

## Test plan

- [x] `cargo check` on `packages/desktop/src-tauri` — clean (30 pre-existing deprecation warnings, no new ones)
- [x] `useTauriMenuEvents.test.ts` — 14 tests pass (4 original + 10 new parameterised over the enumerated route table; rename on either side breaks the test)
- [x] `App.test.tsx` — all 84 tests pass
- [x] `tsc --noEmit` on dashboard — clean
- [ ] Manual smoke: macOS app-menu renders all submenus, items dispatch to the right handlers, Tunnel radio toggle from app-menu also updates the tray radio (and vice versa)

Closes #4942