### PR TITLE
fix(store-core): coalesce assistant text across interleaved tool_use blocks (#4999)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2301,8 +2301,15 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
   // another -- visually fragmented mid-word. The handler peels the
   // trailing partial word off the prior slot and seeds the continuation
   // buffer with it so the word reassembles in the post-tool bubble.
+  //
+  // #4999 follow-up -- the mid-sentence gate added on the post-#4889
+  // split now coalesces these cases into a single bubble before the peel
+  // runs, so the trailing-word and whitespace-led tests below now assert
+  // the coalesced shape. The peel stays as defense-in-depth for the
+  // sentence-boundary path (prior ends in `.` but the next word continues
+  // mid-word, like `PR #3.Del` -> tool -> `egating`).
   describe('mid-word peel across tool boundary (#4975)', () => {
-    it('peels trailing partial word from prior slot and prepends to continuation when text-tool-text splits mid-word', () => {
+    it('coalesces mid-word splits into a single bubble (post-#4999 -- peel no longer needed for mid-word inside a sentence)', () => {
       const store = createMockStore({
         activeSessionId: 's1',
         sessions: [{ sessionId: 's1', name: 'S1' } as any],
@@ -2311,6 +2318,10 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       setStore(store as any);
       _testMessageHandler.setContext(createMockContext() as any);
 
+      // text "Starting Phase 1 — agent-review on PR #3.Del" -> tool ->
+      // "egating...". The pre-tool content ends with `l` (mid-sentence),
+      // so the mid-sentence gate from #4999 routes the post-tool delta
+      // to the existing slot -- one bubble, no mid-word artifact possible.
       _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
       _testMessageHandler.handle({
         type: 'stream_delta',
@@ -2337,15 +2348,14 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
 
       const ss = store.getState().sessionStates.s1;
       const responses = ss.messages.filter((m) => m.type === 'response');
-      expect(responses).toHaveLength(2);
-      // Prior slot must end with the period -- "Del" was peeled off.
-      expect(responses[0].content).toBe('Starting Phase 1 — agent-review on PR #3.');
-      // Continuation bubble: "Del" + incoming delta reassembles into
-      // "Delegating the deep review...".
-      expect(responses[1].content).toBe('Delegating the deep review to an independent reviewer agent.');
+      // One coalesced bubble -- the word "Delegating" reads cleanly.
+      expect(responses).toHaveLength(1);
+      expect(responses[0].content).toBe(
+        'Starting Phase 1 — agent-review on PR #3.Delegating the deep review to an independent reviewer agent.',
+      );
     });
 
-    it('peels even when prior content is still buffered (delta not yet flushed)', () => {
+    it('coalesces mid-word splits even when prior content is still buffered (delta not yet flushed)', () => {
       const store = createMockStore({
         activeSessionId: 's1',
         sessions: [{ sessionId: 's1', name: 'S1' } as any],
@@ -2380,9 +2390,10 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
 
       const ss = store.getState().sessionStates.s1;
       const responses = ss.messages.filter((m) => m.type === 'response');
-      expect(responses).toHaveLength(2);
-      expect(responses[0].content).toBe('PR #3.');
-      expect(responses[1].content).toBe('Delegating now.');
+      // Mid-sentence gate sees the buffered "PR #3.Del" ending in `l`
+      // and routes the post-tool delta to the same bubble.
+      expect(responses).toHaveLength(1);
+      expect(responses[0].content).toBe('PR #3.Delegating now.');
     });
 
     it('does NOT peel when prior content ends at a sentence boundary (clean break)', () => {
@@ -2425,15 +2436,13 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       expect(responses[1].content).toBe('Filing now.');
     });
 
-    it('does NOT peel when prior ends in word char BUT incoming delta starts with whitespace (normal word boundary)', () => {
-      // #4975 follow-up -- Copilot found that the original heuristic only
-      // inspected the prior tail and would peel a complete trailing word
-      // ("Running") even when the post-tool delta starts with whitespace
-      // (a normal word boundary, no mid-word split to repair). The peel
-      // must require BOTH the prior slot to end in a word char AND the
-      // incoming delta to begin with one. Without this gate the prior
-      // bubble loses its trailing word and the continuation bubble
-      // inherits it, visibly moving text across the tool boundary.
+    it('coalesces when prior ends mid-sentence and incoming delta starts with whitespace (post-#4999)', () => {
+      // Pre-#4999: this case (prior ends in word char `Running`, incoming
+      // starts with whitespace) split into two bubbles to avoid moving a
+      // complete word across the tool boundary. Post-#4999: the
+      // mid-sentence gate sees `Running` is not a sentence terminator and
+      // coalesces into one bubble -- the LLM emitted a single sentence
+      // interrupted by a tool.
       const store = createMockStore({
         activeSessionId: 's1',
         sessions: [{ sessionId: 's1', name: 'S1' } as any],
@@ -2459,9 +2468,8 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         toolUseId: 'toolu_a',
         input: { description: 'agent-review' },
       });
-      // Incoming delta starts with a space -- a normal word boundary.
-      // The heuristic must NOT peel `"Running"` even though the prior
-      // ends in a word char.
+      // Incoming delta starts with a space -- a normal word boundary but
+      // mid-sentence (no terminator before the tool).
       _testMessageHandler.handle({
         type: 'stream_delta',
         messageId: 'resp-1',
@@ -2472,17 +2480,18 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
 
       const ss = store.getState().sessionStates.s1;
       const responses = ss.messages.filter((m) => m.type === 'response');
-      expect(responses).toHaveLength(2);
-      // `Running` stays on the pre-tool bubble -- no peel.
-      expect(responses[0].content).toBe('Starting Phase 1 — agent-review on PR #3 is up. Running');
-      // Post-tool bubble starts with the leading space exactly as the
-      // server sent it; no `Running` prefix.
-      expect(responses[1].content).toBe(' /full-review then /batch-merge.');
+      // One bubble -- the sentence "Running /full-review..." reads cleanly.
+      expect(responses).toHaveLength(1);
+      expect(responses[0].content).toBe(
+        'Starting Phase 1 — agent-review on PR #3 is up. Running /full-review then /batch-merge.',
+      );
     });
 
-    it('does NOT peel when prior ends in word char BUT incoming delta starts with punctuation', () => {
-      // Mirror of the whitespace case -- `.`, `\n`, `(`, `:` etc. are all
-      // word boundaries the LLM emits. The peel must stay dormant.
+    it('coalesces when prior ends mid-sentence and incoming delta starts with non-terminator punctuation (post-#4999)', () => {
+      // Mirror of the whitespace case -- `,`, `(`, `:` etc. are NOT
+      // sentence terminators on the prior side, so the mid-sentence gate
+      // coalesces. Note: a sentence terminator (`.`) on the INCOMING side
+      // does not affect the gate; only the prior bubble's tail matters.
       const store = createMockStore({
         activeSessionId: 's1',
         sessions: [{ sessionId: 's1', name: 'S1' } as any],
@@ -2507,7 +2516,8 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
         toolUseId: 'toolu_a',
         input: {},
       });
-      // Newline + punctuation start -- `.` is not a word char, so no peel.
+      // Incoming starts with `.` then a new sentence -- but the prior
+      // bubble itself ends mid-sentence (`R` is a word char), so coalesce.
       _testMessageHandler.handle({
         type: 'stream_delta',
         messageId: 'resp-1',
@@ -2518,9 +2528,99 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
 
       const ss = store.getState().sessionStates.s1;
       const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(1);
+      expect(responses[0].content).toBe('Fetched PR. Next step: review.');
+    });
+  });
+
+  // #4999 -- mirror of dashboard tests. The mid-sentence gate prevents the
+  // post-#4889 continuation split when the prior bubble's content doesn't
+  // end at a sentence boundary, so a single sentence interrupted by a tool
+  // call renders as ONE bubble (followed by the tool) rather than two
+  // timestamped bubbles around the tool.
+  describe('no split when prior bubble ends mid-sentence (#4999)', () => {
+    it('coalesces text into a single bubble when prior content ends in a word char with whitespace-led continuation', () => {
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      // Repro from #4999.
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'Now the keyboard handler + render need updates (overlay + className + CSS',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Read',
+        toolUseId: 'toolu_a',
+        input: { file_path: '/x' },
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: ' vars).',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      const tools = ss.messages.filter((m) => m.type === 'tool_use');
+      expect(responses).toHaveLength(1);
+      expect(tools).toHaveLength(1);
+      expect(responses[0].content).toBe(
+        'Now the keyboard handler + render need updates (overlay + className + CSS vars).',
+      );
+    });
+
+    it('STILL splits when prior content ends at a sentence boundary (paragraph break preserved, #4889)', () => {
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'Let me check chroxy before filing.',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Bash',
+        toolUseId: 'toolu_a',
+        input: { command: 'gh issue list' },
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'Filing now.',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
       expect(responses).toHaveLength(2);
-      expect(responses[0].content).toBe('Fetched PR');
-      expect(responses[1].content).toBe('. Next step: review.');
+      expect(responses[0].content).toBe('Let me check chroxy before filing.');
+      expect(responses[1].content).toBe('Filing now.');
     });
   });
 });

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2622,6 +2622,172 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       expect(responses[0].content).toBe('Let me check chroxy before filing.');
       expect(responses[1].content).toBe('Filing now.');
     });
+
+    it('coalesces when prior ends in an open paren and incoming starts mid-sentence', () => {
+      // Defensive: punctuation that isn't a sentence terminator (open paren,
+      // colon, comma) also indicates the sentence continues.
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'See the helper (',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Read',
+        toolUseId: 'toolu_a',
+        input: { file_path: '/x' },
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'utils.ts).',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(1);
+      expect(responses[0].content).toBe('See the helper (utils.ts).');
+    });
+
+    it('STILL splits when prior ends in a question mark', () => {
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'What is the state of the PR?',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Bash',
+        toolUseId: 'toolu_a',
+        input: {},
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'It looks open.',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(2);
+      expect(responses[0].content).toBe('What is the state of the PR?');
+      expect(responses[1].content).toBe('It looks open.');
+    });
+
+    it('STILL splits when prior ends in a sentence terminator wrapped in closing punctuation/quotes', () => {
+      // Copilot review of #5011 -- a completed sentence followed by closing
+      // punctuation (`.")`, `."`, `!'`, `?)`) was being treated as
+      // mid-sentence because the gate only inspected the very last char.
+      // Strip trailing closers before evaluating the terminator so the
+      // #4889 paragraph split still fires.
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'He said "the build is done."',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Bash',
+        toolUseId: 'toolu_a',
+        input: {},
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'Filing the report now.',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(2);
+      expect(responses[0].content).toBe('He said "the build is done."');
+      expect(responses[1].content).toBe('Filing the report now.');
+    });
+
+    it('STILL splits when prior ends in a terminator wrapped in a closing paren', () => {
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: '(see the docs for more.)',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Read',
+        toolUseId: 'toolu_a',
+        input: { file_path: '/x' },
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'Continuing with the next section.',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(2);
+      expect(responses[0].content).toBe('(see the docs for more.)');
+      expect(responses[1].content).toBe('Continuing with the next section.');
+    });
   });
 });
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1679,7 +1679,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             if (toolAfter) {
               const priorFullForGate = slot.type === 'response' ? slot.content + bufferedContent : '';
               const lastNonWs = priorFullForGate.replace(/\s+$/, '');
-              const lastChar = lastNonWs.charAt(lastNonWs.length - 1);
+              // Strip trailing closing punctuation/quotes that commonly follow
+              // a sentence terminator (`.")`, `."`, `!'`, `?)`, etc.) so the
+              // gate looks at the terminator itself, not the wrapper. Without
+              // this, `"He said \"done.\""` reads as ending in `"` and the
+              // #4889 split would wrongly disable -- paragraph breaks across
+              // a tool boundary would be lost.
+              const stripped = lastNonWs.replace(/[)\]}"'’”»›]+$/, '');
+              const lastChar = stripped.charAt(stripped.length - 1);
               const endsSentence = lastChar === '.' || lastChar === '!' || lastChar === '?';
               const endsHardBreak = /\n\s*$/.test(priorFullForGate);
               if (!endsSentence && !endsHardBreak) {

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1665,6 +1665,27 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
                 }
               }
             }
+            // #4999 -- mid-sentence fragmentation gate. The post-#4889 split
+            // only makes sense when the prior bubble's text reached a sentence
+            // boundary (the LLM finished a thought before invoking the tool);
+            // otherwise the tool interrupted mid-sentence and the post-tool
+            // delta is the same sentence continuing. Treat the prior slot as
+            // "sentence-complete" only when its trailing non-whitespace char
+            // is a sentence terminator (`.`, `!`, `?`) or a hard line break
+            // (`\n`). A bubble ending in a word char, open paren, comma,
+            // colon, dash, etc. is mid-sentence -- route the delta back to
+            // the existing slot so the sentence renders as one contiguous
+            // bubble (followed by the tool).
+            if (toolAfter) {
+              const priorFullForGate = slot.type === 'response' ? slot.content + bufferedContent : '';
+              const lastNonWs = priorFullForGate.replace(/\s+$/, '');
+              const lastChar = lastNonWs.charAt(lastNonWs.length - 1);
+              const endsSentence = lastChar === '.' || lastChar === '!' || lastChar === '?';
+              const endsHardBreak = /\n\s*$/.test(priorFullForGate);
+              if (!endsSentence && !endsHardBreak) {
+                toolAfter = false;
+              }
+            }
             if (toolAfter) {
               // #4975 -- mid-word peel. The LLM sometimes interrupts a
               // text content block to call a tool, splitting a word across

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1833,6 +1833,117 @@ describe('dashboard message-handler dispatch', () => {
         expect(responses[0].content).toBe('What is the state of the PR?')
         expect(responses[1].content).toBe('It looks open.')
       })
+
+      it('STILL splits when prior ends in a sentence terminator wrapped in closing punctuation/quotes', () => {
+        // Copilot review of #5011 — a completed sentence followed by closing
+        // punctuation (`.")`, `."`, `!'`, `?)`) was being treated as
+        // mid-sentence because the gate only inspected the very last char.
+        // Strip trailing closers before evaluating the terminator so the
+        // #4889 paragraph split still fires.
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'He said "the build is done."',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: {},
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'Filing the report now.',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(2)
+        expect(responses[0].content).toBe('He said "the build is done."')
+        expect(responses[1].content).toBe('Filing the report now.')
+      })
+
+      it('STILL splits when prior ends in a terminator wrapped in a closing paren', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: '(see the docs for more.)',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Read',
+            toolUseId: 'toolu_a',
+            input: { file_path: '/x' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'Continuing with the next section.',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(2)
+        expect(responses[0].content).toBe('(see the docs for more.)')
+        expect(responses[1].content).toBe('Continuing with the next section.')
+      })
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1295,8 +1295,15 @@ describe('dashboard message-handler dispatch', () => {
     // visually fragmented mid-word. The handler peels the trailing partial
     // word off the prior slot and seeds the continuation buffer with it so
     // the word reassembles in the post-tool bubble.
+    //
+    // #4999 follow-up — the mid-sentence gate added on the post-#4889 split
+    // now coalesces these cases into a single bubble before the peel runs,
+    // so the trailing-word and whitespace-led tests below now assert the
+    // coalesced shape. The peel itself stays as defense-in-depth for the
+    // sentence-boundary path (prior ends in `.` but the next word continues
+    // mid-word, like `PR #3.Del` -> tool -> `egating`).
     describe('mid-word peel across tool boundary (#4975)', () => {
-      it('peels trailing partial word from prior slot and prepends to continuation when text-tool-text splits mid-word', () => {
+      it('coalesces mid-word splits into a single bubble (post-#4999 — peel no longer needed for mid-word inside a sentence)', () => {
         store = createMockStore(
           baseState({
             activeSessionId: 's1',
@@ -1307,6 +1314,9 @@ describe('dashboard message-handler dispatch', () => {
         setStore(store)
 
         // text "Starting Phase 1 — agent-review on PR #3.Del" -> tool -> "egating..."
+        // The pre-tool content ends with `l` (mid-sentence), so the
+        // mid-sentence gate from #4999 routes the post-tool delta to the
+        // existing slot — one bubble, no mid-word artifact possible.
         handleMessage(
           { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
           ctx() as any,
@@ -1345,19 +1355,15 @@ describe('dashboard message-handler dispatch', () => {
 
         const ss = (store.getState() as any).sessionStates.s1
         const responses = ss.messages.filter((m: any) => m.type === 'response')
-        expect(responses).toHaveLength(2)
-        // Prior slot must end with the period — the trailing "Del" was peeled.
-        expect(responses[0].content).toBe('Starting Phase 1 — agent-review on PR #3.')
-        // Continuation bubble starts with the peeled "Del" + the incoming
-        // delta — the word "Delegating" reassembles in this bubble.
-        expect(responses[1].content).toBe('Delegating the deep review to an independent reviewer agent.')
-        // No mid-word artifact anywhere — the joined transcript reads cleanly.
-        const joined = responses.map((r: any) => r.content).join('\n\n')
-        expect(joined).toContain('Delegating')
-        expect(joined).not.toContain('Del\n\nDel')
+        // One coalesced bubble — the word "Delegating" reads cleanly.
+        expect(responses).toHaveLength(1)
+        expect(responses[0].content).toBe(
+          'Starting Phase 1 — agent-review on PR #3.Delegating the deep review to an independent reviewer agent.',
+        )
+        expect(responses[0].content).toContain('Delegating')
       })
 
-      it('peels even when prior content is still buffered (delta not yet flushed)', () => {
+      it('coalesces mid-word splits even when prior content is still buffered (delta not yet flushed)', () => {
         store = createMockStore(
           baseState({
             activeSessionId: 's1',
@@ -1405,9 +1411,10 @@ describe('dashboard message-handler dispatch', () => {
 
         const ss = (store.getState() as any).sessionStates.s1
         const responses = ss.messages.filter((m: any) => m.type === 'response')
-        expect(responses).toHaveLength(2)
-        expect(responses[0].content).toBe('PR #3.')
-        expect(responses[1].content).toBe('Delegating now.')
+        // Mid-sentence gate sees the buffered "PR #3.Del" ending in `l`
+        // and routes the post-tool delta to the same bubble.
+        expect(responses).toHaveLength(1)
+        expect(responses[0].content).toBe('PR #3.Delegating now.')
       })
 
       it('does NOT peel when prior content ends at a sentence boundary (clean break)', () => {
@@ -1467,15 +1474,13 @@ describe('dashboard message-handler dispatch', () => {
         expect(responses[1].content).toBe('Filing now.')
       })
 
-      it('does NOT peel when prior ends in word char BUT incoming delta starts with whitespace (normal word boundary)', () => {
-        // #4975 follow-up — Copilot found that the original heuristic only
-        // inspected the prior tail and would peel a complete trailing word
-        // ("Running") even when the post-tool delta starts with whitespace
-        // (a normal word boundary, no mid-word split to repair). The peel
-        // must require BOTH the prior slot to end in a word char AND the
-        // incoming delta to begin with one. Without this gate the prior
-        // bubble loses its trailing word and the continuation bubble
-        // inherits it, visibly moving text across the tool boundary.
+      it('coalesces when prior ends mid-sentence and incoming delta starts with whitespace (post-#4999)', () => {
+        // Pre-#4999: this case (prior ends in word char `Running`, incoming
+        // starts with whitespace) split into two bubbles to avoid moving
+        // a complete word across the tool boundary. Post-#4999: the
+        // mid-sentence gate sees `Running` is not a sentence terminator
+        // and coalesces into one bubble — the LLM emitted a single
+        // sentence interrupted by a tool.
         store = createMockStore(
           baseState({
             activeSessionId: 's1',
@@ -1511,9 +1516,8 @@ describe('dashboard message-handler dispatch', () => {
           },
           ctx() as any,
         )
-        // Incoming delta starts with a space — a normal word boundary.
-        // The heuristic must NOT peel `"Running"` even though the prior
-        // ends in a word char.
+        // Incoming delta starts with a space — a normal word boundary
+        // but mid-sentence (no terminator before the tool).
         handleMessage(
           {
             type: 'stream_delta',
@@ -1527,17 +1531,19 @@ describe('dashboard message-handler dispatch', () => {
 
         const ss = (store.getState() as any).sessionStates.s1
         const responses = ss.messages.filter((m: any) => m.type === 'response')
-        expect(responses).toHaveLength(2)
-        // `Running` stays on the pre-tool bubble — no peel.
-        expect(responses[0].content).toBe('Starting Phase 1 — agent-review on PR #3 is up. Running')
-        // Post-tool bubble starts with the leading space exactly as the
-        // server sent it; no `Running` prefix.
-        expect(responses[1].content).toBe(' /full-review then /batch-merge.')
+        // One bubble — the sentence "Running /full-review..." reads cleanly.
+        expect(responses).toHaveLength(1)
+        expect(responses[0].content).toBe(
+          'Starting Phase 1 — agent-review on PR #3 is up. Running /full-review then /batch-merge.',
+        )
       })
 
-      it('does NOT peel when prior ends in word char BUT incoming delta starts with punctuation', () => {
-        // Mirror of the whitespace case — `.`, `\n`, `(`, `:` etc. are all
-        // word boundaries the LLM emits. The peel must stay dormant.
+      it('coalesces when prior ends mid-sentence and incoming delta starts with non-terminator punctuation (post-#4999)', () => {
+        // Mirror of the whitespace case — `,`, `(`, `:` etc. are NOT
+        // sentence terminators on the prior side, so the mid-sentence gate
+        // coalesces. Note: a sentence terminator (`.`) on the INCOMING
+        // side does not affect the gate; only the prior bubble's tail
+        // matters.
         store = createMockStore(
           baseState({
             activeSessionId: 's1',
@@ -1572,7 +1578,9 @@ describe('dashboard message-handler dispatch', () => {
           },
           ctx() as any,
         )
-        // Newline + punctuation start — `.` is not a word char, so no peel.
+        // Incoming starts with `.` then a new sentence — but the prior
+        // bubble itself ends mid-sentence (`R` is a word char), so
+        // coalesce.
         handleMessage(
           {
             type: 'stream_delta',
@@ -1586,9 +1594,244 @@ describe('dashboard message-handler dispatch', () => {
 
         const ss = (store.getState() as any).sessionStates.s1
         const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(1)
+        expect(responses[0].content).toBe('Fetched PR. Next step: review.')
+      })
+    })
+
+    // #4999 — Mid-sentence fragmentation. When the LLM emits a single sentence
+    // interrupted mid-stream by a tool call (e.g. "...CSS" → tool → " vars).")
+    // the post-#4889 continuation split produced two visible bubbles around
+    // the tool, breaking the sentence in two. The #4975 mid-word peel only
+    // covered the narrow case where both sides of the boundary were in a word;
+    // a normal word boundary mid-sentence (prior ends in `S`, incoming starts
+    // with whitespace) still fragmented. The split should only fire when the
+    // prior bubble's content ends at a sentence boundary (`.`, `!`, `?`, `\n`)
+    // — otherwise the delta routes back to the existing slot so the text
+    // renders as one contiguous bubble followed by the tool.
+    describe('no split when prior bubble ends mid-sentence (#4999)', () => {
+      it('coalesces text into a single bubble when prior content ends in a word char with whitespace-led continuation', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        // Repro from #4999 — the visible bubbles were:
+        //   A: "Now the keyboard handler + render need updates (overlay + className + CSS"
+        //   tool (Read)
+        //   B: " vars)."
+        // The sentence is broken mid-stream; the user expects ONE bubble.
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'Now the keyboard handler + render need updates (overlay + className + CSS',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Read',
+            toolUseId: 'toolu_a',
+            input: { file_path: '/x' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: ' vars).',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        const tools = ss.messages.filter((m: any) => m.type === 'tool_use')
+        // ONE response bubble carrying the full sentence — no mid-sentence split.
+        expect(responses).toHaveLength(1)
+        expect(tools).toHaveLength(1)
+        expect(responses[0].content).toBe(
+          'Now the keyboard handler + render need updates (overlay + className + CSS vars).',
+        )
+      })
+
+      it('coalesces when prior ends in an open paren and incoming starts mid-sentence', () => {
+        // Defensive: punctuation that isn't a sentence terminator (open paren,
+        // colon, comma) also indicates the sentence continues.
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'See the helper (',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Read',
+            toolUseId: 'toolu_a',
+            input: { file_path: '/x' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'utils.ts).',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(1)
+        expect(responses[0].content).toBe('See the helper (utils.ts).')
+      })
+
+      it('STILL splits when prior content ends at a sentence boundary (paragraph break preserved, #4889)', () => {
+        // The #4889 case must keep working: "...filing." → tool → "Filing now."
+        // is two separate sentences, so each gets its own bubble.
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'Let me check chroxy before filing.',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: { command: 'gh issue list' },
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'Filing now.',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
         expect(responses).toHaveLength(2)
-        expect(responses[0].content).toBe('Fetched PR')
-        expect(responses[1].content).toBe('. Next step: review.')
+        expect(responses[0].content).toBe('Let me check chroxy before filing.')
+        expect(responses[1].content).toBe('Filing now.')
+      })
+
+      it('STILL splits when prior ends in a question mark', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'What is the state of the PR?',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: {},
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'It looks open.',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(2)
+        expect(responses[0].content).toBe('What is the state of the PR?')
+        expect(responses[1].content).toBe('It looks open.')
       })
     })
   })

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1516,7 +1516,14 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
           // Trim trailing whitespace before inspecting the last char so e.g.
           // `"...sentence.   "` still reads as sentence-complete.
           const lastNonWs = priorFullForGate.replace(/\s+$/, '');
-          const lastChar = lastNonWs.charAt(lastNonWs.length - 1);
+          // Strip trailing closing punctuation/quotes that commonly follow a
+          // sentence terminator (`.")`, `."`, `!'`, `?)`, etc.) so the gate
+          // looks at the terminator itself, not the wrapper. Without this,
+          // `"He said \"done.\""` reads as ending in `"` and the #4889 split
+          // would wrongly disable — paragraph breaks across a tool boundary
+          // would be lost.
+          const stripped = lastNonWs.replace(/[)\]}"'’”»›]+$/, '');
+          const lastChar = stripped.charAt(stripped.length - 1);
           const endsSentence = lastChar === '.' || lastChar === '!' || lastChar === '?';
           const endsHardBreak = /\n\s*$/.test(priorFullForGate);
           if (!endsSentence && !endsHardBreak) {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1501,6 +1501,28 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
             }
           }
         }
+        // #4999 — mid-sentence fragmentation gate. The post-#4889 split only
+        // makes sense when the prior bubble's text reached a sentence boundary
+        // (the LLM finished a thought before invoking the tool); otherwise the
+        // tool interrupted mid-sentence and the post-tool delta is the same
+        // sentence continuing. Treat the prior slot as "sentence-complete"
+        // only when its trailing non-whitespace character is a sentence
+        // terminator (`.`, `!`, `?`) or a hard line break (`\n`). A bubble
+        // that ends with a word char, open paren, comma, colon, dash, etc.
+        // is mid-sentence — route the delta back to the existing slot so the
+        // sentence renders as one contiguous bubble (followed by the tool).
+        if (toolAfter) {
+          const priorFullForGate = slot.type === 'response' ? slot.content + bufferedContent : '';
+          // Trim trailing whitespace before inspecting the last char so e.g.
+          // `"...sentence.   "` still reads as sentence-complete.
+          const lastNonWs = priorFullForGate.replace(/\s+$/, '');
+          const lastChar = lastNonWs.charAt(lastNonWs.length - 1);
+          const endsSentence = lastChar === '.' || lastChar === '!' || lastChar === '?';
+          const endsHardBreak = /\n\s*$/.test(priorFullForGate);
+          if (!endsSentence && !endsHardBreak) {
+            toolAfter = false;
+          }
+        }
         if (toolAfter) {
           // #4975 — mid-word peel. The LLM sometimes interrupts a text
           // content block to call a tool, splitting a word across the


### PR DESCRIPTION
## Summary

- Adds a mid-sentence gate on the post-#4889 continuation split: text-tool-text only splits into separate bubbles when the prior bubble's content ends at a sentence boundary (`.`, `!`, `?`, `\n`). Mid-sentence interruptions coalesce into a single response bubble followed by the tool, matching #4999's expected behavior.
- Mirrors the gate in both dashboard and mobile app handlers.
- Updates the existing #4975 mid-word peel tests to assert coalesced bubbles for the cases the new gate now intercepts.

## Why

Per #4999, a single sentence interrupted by a tool call (e.g. `...CSS` -> Read bubble -> ` vars).`) rendered as two timestamped bubbles around the tool. The #4889 split was designed for paragraph-break preservation across a tool, and #4975 covered the narrow mid-word case, but a normal word boundary mid-sentence (`Running` + space -> tool -> ` /full-review then ...`) still fragmented because the split fired unconditionally on `toolAfter`.

The gate checks the prior bubble's trailing non-whitespace char: only a sentence terminator or hard newline keeps the split, otherwise the post-tool delta routes back to the existing slot. #4889's `...filing.` -> tool -> `Filing now.` case stays as two bubbles (paragraph break preserved); #4975's `PR #3.Del` -> tool -> `egating` case stays as defense-in-depth for the rare sentence-terminated mid-word continuation.

## Test plan

- [x] New `#4999` test suite in `packages/dashboard/src/store/message-handler.test.ts` covering:
  - Repro from the issue: `...CSS` -> Read -> ` vars).` -> one coalesced bubble
  - Open paren mid-sentence -> coalesce
  - Sentence terminator -> still splits (#4889 preserved)
  - Question mark -> still splits
- [x] Mirror tests added in `packages/app/src/__tests__/store/message-handler.test.ts`
- [x] Existing #4975 / #4889 mid-word peel tests updated to reflect coalesced shape where the new gate intercepts
- [x] `packages/dashboard/src/store/message-handler.test.ts` -- 186/186 pass
- [x] `packages/store-core` -- 1070/1070 pass

Closes #4999