### PR TITLE
feat(consumers): wire resume_unknown_exhausted to chip + protocol docs

### DIFF
--- a/packages/app/src/components/ResumeUnknownChip.tsx
+++ b/packages/app/src/components/ResumeUnknownChip.tsx
@@ -1,23 +1,32 @@
 /**
- * ResumeUnknownChip — #4971 (mobile-app companion to dashboard #4947).
+ * ResumeUnknownChip — #4971 / #5006 (mobile-app companion to dashboard
+ * #4947 / #5006).
  *
- * Replaces the generic red error bubble when the server emits
- * `error{code: 'resume_unknown'}` (server PR #4944). The server fires this
- * code when claude CLI rejects a `--resume <id>` because the conversation
- * id is unknown locally (operator wiped `~/.claude/projects/` between
- * chroxy boots, restored a state file from a different machine, etc.).
+ * Replaces the generic red error bubble when the server emits one of the
+ * two resume-failure codes from CliSession's `_handleChildClose` path:
  *
- * The CliSession has already auto-fallen-back to a fresh conversation by
- * the time this chip surfaces — the model loses the prior transcript but
- * the chroxy ring buffer transcript is preserved in the UI. So we render a
- * calm operator-friendly explanation rather than the loud red crash toast,
- * matching the spirit of the mobile StreamStallChip (#4476): "recoverable,
- * here's what happened, here's what to expect next".
+ *   - `error{code: 'resume_unknown'}` (server PR #4944) — RECOVERABLE.
+ *     CliSession has already auto-fallen-back to a fresh conversation by
+ *     the time the chip surfaces. The model loses the prior transcript
+ *     but the chroxy ring buffer transcript is preserved in the UI. We
+ *     render a calm operator-friendly explanation rather than the loud
+ *     red crash toast.
+ *
+ *   - `error{code: 'resume_unknown_exhausted'}` (server PR #5004) —
+ *     TERMINAL. The post-fallback retry ALSO matched the unknown-resume
+ *     pattern; the server has stopped auto-respawning and the user must
+ *     start a fresh session manually. The chip switches headline /
+ *     accessibilityLabel copy so AT users get the "auto-recovery
+ *     exhausted, action needed" signal — `accessibilityRole="alert"` is
+ *     already used on the recoverable variant (mobile RN convention is
+ *     louder by default than the dashboard's status/alert split), so the
+ *     variant difference rides on the label + visible text.
  *
  * `attemptedResumeId` (when provided) renders as small mono-spaced subtext
  * for operator correlation against the persisted state file
  * (`resumeConversationId` in ~/.chroxy/session-state.json) — answers "which
  * conversation did we lose?" without forcing the operator to grep logs.
+ * Surfaces on both variants because the correlation use case is identical.
  * Defensive empty/whitespace guard mirrors the dashboard component so a
  * stale or trimmed empty value can't produce a broken-looking "Attempted
  * id: " slot.
@@ -43,27 +52,49 @@ export interface ResumeUnknownChipProps {
    * (matches the dashboard chip's defensive guard).
    */
   attemptedResumeId?: string;
+  /**
+   * #5006 — variant switch matched against the server error code:
+   *   - `'recoverable'` (default) — `code: 'resume_unknown'`; chip renders
+   *     the "starting fresh" headline.
+   *   - `'exhausted'` — `code: 'resume_unknown_exhausted'`; chip renders
+   *     the "auto-recovery exhausted" headline + "start a new session
+   *     manually" call-to-action.
+   * Optional + defaulted so existing call sites that pre-date #5006
+   * continue to render the recoverable copy unchanged.
+   */
+  variant?: 'recoverable' | 'exhausted';
 }
 
-export function ResumeUnknownChip({ errorText, attemptedResumeId }: ResumeUnknownChipProps) {
+const RECOVERABLE_HEADLINE = 'Previous conversation could not be resumed — starting fresh';
+const EXHAUSTED_HEADLINE = 'Auto-recovery exhausted — start a new session manually to continue';
+
+export function ResumeUnknownChip({
+  errorText,
+  attemptedResumeId,
+  variant = 'recoverable',
+}: ResumeUnknownChipProps) {
   // Empty-string defense — same rationale as the dashboard chip and the
   // SessionNotFoundChip: a stale or trimmed empty value should not produce
   // a broken-looking "Attempted id: " slot with no value.
   const hasId = typeof attemptedResumeId === 'string' && attemptedResumeId.trim().length > 0;
+
+  // #5006: switch headline copy on the variant. accessibilityRole stays
+  // `'alert'` for both variants — the mobile RN convention is to use the
+  // assertive role on recoverable amber chips too (parity with
+  // StreamStallChip). The label difference carries the urgency signal.
+  const headline = variant === 'exhausted' ? EXHAUSTED_HEADLINE : RECOVERABLE_HEADLINE;
 
   return (
     <View
       testID="resume-unknown-chip"
       accessibilityRole="alert"
       accessibilityLiveRegion="polite"
-      accessibilityLabel="Previous conversation could not be resumed — starting fresh"
+      accessibilityLabel={headline}
       accessibilityHint={errorText}
       style={styles.container}
     >
       <View style={styles.dot} />
-      <Text style={styles.label}>
-        Previous conversation could not be resumed — starting fresh
-      </Text>
+      <Text style={styles.label}>{headline}</Text>
       {hasId && (
         // #4971 review: drop `accessibilityElementsHidden` /
         // `importantForAccessibility="no"` so the attempted id is

--- a/packages/app/src/components/__tests__/MessageBubble.resumeUnknown.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.resumeUnknown.test.tsx
@@ -105,4 +105,41 @@ describe('MessageBubble resume-unknown handling (#4971)', () => {
     const chips = tree.root.findAllByProps({ testID: 'resume-unknown-chip' });
     expect(chips).toHaveLength(0);
   });
+
+  // #5006: terminal-escalation code from server PR #5004. MessageBubble
+  // must route both resume-failure codes through the chip — otherwise
+  // `resume_unknown_exhausted` falls through to the generic red error
+  // bubble and the user never sees the "auto-recovery exhausted, start
+  // a new session manually" affordance.
+  it('renders the ResumeUnknownChip for error{code: "resume_unknown_exhausted"} (#5006)', () => {
+    const tree = render({
+      id: 'err-exhausted-1',
+      type: 'error',
+      code: 'resume_unknown_exhausted',
+      content: 'Auto-recovery exhausted: …',
+      attemptedResumeId: 'abc-123',
+      timestamp: Date.now(),
+    } as ChatMessage);
+    const chip = tree.root.findByProps({ testID: 'resume-unknown-chip' });
+    expect(chip).toBeDefined();
+    // accessibilityLabel must reflect the exhausted variant so AT users
+    // get the right urgency signal — not the recoverable "starting fresh"
+    // copy.
+    expect(chip.props.accessibilityLabel).toMatch(
+      /exhausted|start a (new|fresh) session/i,
+    );
+  });
+
+  it('forwards attemptedResumeId on the exhausted variant too (#5006)', () => {
+    const tree = render({
+      id: 'err-exhausted-2',
+      type: 'error',
+      code: 'resume_unknown_exhausted',
+      content: 'Auto-recovery exhausted: …',
+      attemptedResumeId: 'corr-xyz',
+      timestamp: Date.now(),
+    } as ChatMessage);
+    const idSubtext = tree.root.findByProps({ testID: 'resume-unknown-chip-id' });
+    expect(idSubtext).toBeDefined();
+  });
 });

--- a/packages/app/src/components/__tests__/ResumeUnknownChip.test.tsx
+++ b/packages/app/src/components/__tests__/ResumeUnknownChip.test.tsx
@@ -122,4 +122,60 @@ describe('ResumeUnknownChip (#4971)', () => {
     expect(idSubtext.props.accessibilityElementsHidden).toBeUndefined();
     expect(idSubtext.props.importantForAccessibility).toBeUndefined();
   });
+
+  // #5006: terminal-escalation variant for `resume_unknown_exhausted`
+  // (server PR #5004). When the post-fallback retry ALSO matches the
+  // unknown-resume pattern, the server has stopped auto-respawning — the
+  // user MUST start a fresh session manually. The chip switches to a
+  // distinct headline so the user doesn't mistake this for the recoverable
+  // variant on its second occurrence and wait for an auto-fallback that
+  // isn't coming.
+  describe('variant="exhausted" (#5006 — terminal escalation)', () => {
+    it('renders the "auto-recovery exhausted" headline instead of "starting fresh"', () => {
+      const tree = render(
+        <ResumeUnknownChip
+          variant="exhausted"
+          errorText="Auto-recovery exhausted: …"
+        />,
+      );
+      const text = collectVisibleText(tree.root);
+      // Headline must convey the terminal nature (operator action required
+      // is "start a new session manually") — distinct from the recoverable
+      // variant's "starting fresh" auto-fallback phrasing.
+      expect(text).toMatch(/auto-recovery|exhausted/i);
+      expect(text).toMatch(/start a (new|fresh) session/i);
+      expect(text).not.toContain('starting fresh');
+    });
+
+    it('still surfaces attemptedResumeId subtext on the exhausted variant', () => {
+      const tree = render(
+        <ResumeUnknownChip
+          variant="exhausted"
+          errorText="x"
+          attemptedResumeId="abc123-def456-7890"
+        />,
+      );
+      const text = collectVisibleText(tree.root);
+      expect(text).toContain('Attempted id: abc123-def456-7890');
+    });
+
+    it('reflects the variant on the accessibilityLabel for AT announcement parity', () => {
+      // The mobile chip already uses accessibilityRole="alert" for both
+      // variants (RN convention is louder by default than the dashboard's
+      // status/alert split). The variant difference rides on the
+      // accessibilityLabel so AT users hear the right copy.
+      const tree = render(<ResumeUnknownChip variant="exhausted" errorText="x" />);
+      const chip = tree.root.findByProps({ testID: 'resume-unknown-chip' });
+      expect(chip.props.accessibilityLabel).toMatch(/exhausted|start a (new|fresh) session/i);
+      expect(chip.props.accessibilityLabel).not.toContain('starting fresh');
+    });
+
+    it('defaults to the recoverable headline when variant is omitted (back-compat)', () => {
+      // Existing call sites pass no variant — they must continue to render
+      // the recoverable copy unchanged.
+      const tree = render(<ResumeUnknownChip errorText="x" />);
+      const text = collectVisibleText(tree.root);
+      expect(text).toContain('starting fresh');
+    });
+  });
 });

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -174,15 +174,24 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
     );
   }
 
-  // #4971: dedicated chip for `error{code: 'resume_unknown'}` (server PR
-  // #4944, dashboard companion #4947). CliSession has already auto-fallen-
-  // back to a fresh conversation by the time this lands — the chip
-  // explains that calmly instead of the loud red crash bubble, and
-  // surfaces `attemptedResumeId` as subtext for operator correlation
-  // against `~/.chroxy/session-state.json.resumeConversationId`.
-  if (isError && message.code === 'resume_unknown') {
+  // #4971 / #5006: dedicated chip for the two resume-failure error codes:
+  //   - `error{code: 'resume_unknown'}` (server PR #4944, dashboard #4947,
+  //     mobile #4971) — RECOVERABLE. CliSession has already auto-fallen-
+  //     back to a fresh conversation by the time this lands; chip renders
+  //     the polite "starting fresh" headline.
+  //   - `error{code: 'resume_unknown_exhausted'}` (server PR #5004) —
+  //     TERMINAL. The post-fallback retry ALSO failed; chip renders the
+  //     "auto-recovery exhausted, start a new session manually" headline
+  //     so the user knows auto-recovery has given up.
+  // Both variants surface `attemptedResumeId` as subtext for operator
+  // correlation against `~/.chroxy/session-state.json.resumeConversationId`.
+  if (
+    isError &&
+    (message.code === 'resume_unknown' || message.code === 'resume_unknown_exhausted')
+  ) {
     return (
       <ResumeUnknownChip
+        variant={message.code === 'resume_unknown_exhausted' ? 'exhausted' : 'recoverable'}
         // #4971 review: pass the raw content through (no `.trim()`) so
         // any meaningful trailing context / newlines the server includes
         // (e.g. wrapped CLI stderr) survive end-to-end into the chip's

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1650,22 +1650,28 @@ export function App() {
       )
     }
 
-    // #4947: dedicated chip for `error{code: 'resume_unknown'}` errors
-    // (server PR #4944). The server emits this when the claude CLI rejects
-    // a `--resume <id>` because the conversation id is unknown locally
-    // (operator wiped ~/.claude/projects/ between chroxy boots, restored a
-    // state file from a different machine, etc.). CliSession has ALREADY
-    // auto-fallen-back to a fresh conversation by the time this lands —
-    // the chip explains that and (when present) surfaces
-    // `attemptedResumeId` as subtext for operator correlation against
-    // `~/.chroxy/session-state.json.resumeConversationId`. Distinct from
-    // the stream_stall / ASK_USER_QUESTION_STALL chips because no retry
-    // affordance is needed: the fresh conversation is already running.
-    // Mirrors the chip pattern for consistency with the recoverable-error
-    // visual language.
-    if (storeMsg.type === 'error' && storeMsg.code === 'resume_unknown') {
+    // #4947 / #5006: dedicated chip for the two resume-failure error codes:
+    //   - `error{code: 'resume_unknown'}` (server PR #4944) — RECOVERABLE.
+    //     CliSession has ALREADY auto-fallen-back to a fresh conversation
+    //     by the time this lands; chip renders the polite "starting fresh"
+    //     copy.
+    //   - `error{code: 'resume_unknown_exhausted'}` (server PR #5004) —
+    //     TERMINAL. The post-fallback retry ALSO failed; the server has
+    //     stopped auto-respawning and the chip renders the "auto-recovery
+    //     exhausted, start a fresh session manually" copy + assertive
+    //     `role="alert"` so AT users get the urgency signal.
+    // Both variants surface `attemptedResumeId` as subtext for operator
+    // correlation against `~/.chroxy/session-state.json.resumeConversationId`.
+    // Distinct from the stream_stall / ASK_USER_QUESTION_STALL chips
+    // because no retry affordance is needed (recoverable: fresh conversation
+    // already running; exhausted: user must start a new session manually).
+    if (
+      storeMsg.type === 'error' &&
+      (storeMsg.code === 'resume_unknown' || storeMsg.code === 'resume_unknown_exhausted')
+    ) {
       return (
         <ResumeUnknownChip
+          variant={storeMsg.code === 'resume_unknown_exhausted' ? 'exhausted' : 'recoverable'}
           errorText={storeMsg.content}
           attemptedResumeId={storeMsg.attemptedResumeId}
         />

--- a/packages/dashboard/src/components/ResumeUnknownChip.test.tsx
+++ b/packages/dashboard/src/components/ResumeUnknownChip.test.tsx
@@ -106,4 +106,66 @@ describe('ResumeUnknownChip (#4947)', () => {
     expect(screen.queryByTestId('stream-stall-chip')).toBeNull()
     expect(screen.queryByTestId('ask-user-question-stall-chip')).toBeNull()
   })
+
+  // #5006: terminal-escalation variant for `resume_unknown_exhausted`
+  // (server PR #5004). When the post-fallback retry ALSO matches the
+  // unknown-resume pattern, the server has stopped auto-respawning — the
+  // user MUST start a fresh session manually. The chip switches to a
+  // distinct headline that conveys "auto-recovery exhausted" so the
+  // operator doesn't think this is the recoverable amber chip on its
+  // second occurrence and wait for an auto-fallback that isn't coming.
+  describe('variant="exhausted" (#5006 — terminal escalation)', () => {
+    it('renders a distinct "auto-recovery exhausted" headline', () => {
+      render(
+        <ResumeUnknownChip
+          variant="exhausted"
+          errorText="Auto-recovery exhausted: …"
+        />,
+      )
+      const chip = screen.getByTestId('resume-unknown-chip')
+      expect(chip).toBeInTheDocument()
+      // Headline must convey the terminal nature (the operator action
+      // required is "start a fresh session manually" — distinct from the
+      // recoverable variant's "starting fresh" auto-fallback phrasing).
+      expect(chip.textContent).toMatch(/auto-recovery|exhausted/i)
+      expect(chip.textContent).toMatch(/start a (new|fresh) session/i)
+      // Must NOT match the recoverable variant's headline — different
+      // affordance, different copy.
+      expect(chip.textContent).not.toMatch(/starting fresh/i)
+    })
+
+    it('still surfaces attemptedResumeId subtext on the exhausted variant', () => {
+      // Operator-correlation requirement is the SAME for both variants —
+      // the failed conversation id helps identify the persisted state-file
+      // entry that needs investigating.
+      render(
+        <ResumeUnknownChip
+          variant="exhausted"
+          errorText="x"
+          attemptedResumeId="abc123-def456-7890"
+        />,
+      )
+      const subtext = screen.getByTestId('resume-unknown-chip-id')
+      expect(subtext.textContent).toContain('abc123-def456-7890')
+    })
+
+    it('uses role="alert" so assistive tech announces the terminal state with urgency', () => {
+      // Unlike the recoverable variant (which uses role="status" + polite
+      // live-region — chroxy has already recovered), the exhausted variant
+      // is terminal and demands user action. role="alert" matches the
+      // accessibility convention for an escalated, assertive announcement.
+      render(<ResumeUnknownChip variant="exhausted" errorText="x" />)
+      const chip = screen.getByTestId('resume-unknown-chip')
+      expect(chip.getAttribute('role')).toBe('alert')
+    })
+
+    it('defaults to the recoverable variant when no variant prop is passed (back-compat)', () => {
+      // Existing call sites pass no variant — they must continue to render
+      // the recoverable copy unchanged (variant: 'recoverable' is implicit).
+      render(<ResumeUnknownChip errorText="x" />)
+      const chip = screen.getByTestId('resume-unknown-chip')
+      expect(chip.textContent).toMatch(/starting fresh/i)
+      expect(chip.getAttribute('role')).toBe('status')
+    })
+  })
 })

--- a/packages/dashboard/src/components/ResumeUnknownChip.tsx
+++ b/packages/dashboard/src/components/ResumeUnknownChip.tsx
@@ -1,24 +1,31 @@
 /**
- * ResumeUnknownChip — #4947
+ * ResumeUnknownChip — #4947 / #5006
  *
- * Replaces the generic red error bubble when the server emits
- * `error{code: 'resume_unknown'}` (server PR #4944). The server fires this
- * code when claude CLI rejects a `--resume <id>` because the conversation
- * id is unknown locally (operator wiped `~/.claude/projects/` between
- * chroxy boots, restored a state file from a different machine, etc.).
+ * Replaces the generic red error bubble when the server emits one of the
+ * two resume-failure codes from CliSession's `_handleChildClose` path:
  *
- * The CliSession has already auto-fallen-back to a fresh conversation by
- * the time this chip surfaces — the model loses the prior transcript but
- * the chroxy ring buffer transcript is preserved in the UI. So we render a
- * calm operator-friendly explanation rather than the loud red crash toast,
- * matching the spirit of StreamStallChip (#4476) and AskUserQuestionStallChip
- * (#4615): "this is recoverable, here's what happened, here's what to
- * expect next".
+ *   - `error{code: 'resume_unknown'}` (server PR #4944) — RECOVERABLE.
+ *     CliSession has already auto-fallen-back to a fresh conversation by
+ *     the time the chip surfaces. The model loses the prior transcript
+ *     but the chroxy ring buffer transcript is preserved in the UI. We
+ *     render a calm operator-friendly explanation rather than the loud
+ *     red crash toast, matching the spirit of StreamStallChip (#4476)
+ *     and AskUserQuestionStallChip (#4615): "this is recoverable, here's
+ *     what happened, here's what to expect next".
+ *
+ *   - `error{code: 'resume_unknown_exhausted'}` (server PR #5004) —
+ *     TERMINAL. The post-fallback retry ALSO matched the unknown-resume
+ *     pattern; the server has stopped auto-respawning and the user must
+ *     start a fresh session manually. The chip switches headline copy
+ *     and uses an assertive live-region (`role="alert"`) so AT users get
+ *     an unambiguous "auto-recovery gave up, action needed" signal —
+ *     distinct from the recoverable variant's polite status announce.
  *
  * `attemptedResumeId` (when provided) renders as small mono-spaced subtext
  * for operator correlation against the persisted state file
  * (`resumeConversationId` in ~/.chroxy/session-state.json) — answers "which
  * conversation did we lose?" without forcing the operator to grep logs.
+ * Surfaces on both variants because the correlation use case is identical.
  *
  * Reuses the `stream-stall-chip` CSS classes — the amber-warning palette
  * already conveys "recoverable" and the three stall chips share a single
@@ -46,6 +53,19 @@ export interface ResumeUnknownChipProps {
    * look like a UI bug.
    */
   attemptedResumeId?: string
+  /**
+   * #5006 — variant switch matched against the server error code:
+   *   - `'recoverable'` (default) — `code: 'resume_unknown'`, chroxy has
+   *     already auto-fallen-back; chip renders polite status with the
+   *     "starting fresh" headline.
+   *   - `'exhausted'` — `code: 'resume_unknown_exhausted'`, auto-recovery
+   *     has given up; chip renders an assertive alert with the
+   *     "auto-recovery exhausted" headline and a "start a fresh session
+   *     manually" call-to-action.
+   * Optional + defaulted so existing call sites that pre-date #5006
+   * continue to render the recoverable copy unchanged.
+   */
+  variant?: 'recoverable' | 'exhausted'
 }
 
 // #4947 — small mono-spaced subtext for the attempted id slot. Inline to
@@ -61,22 +81,37 @@ const ID_SUBTEXT_STYLE: CSSProperties = {
   opacity: 0.75,
 }
 
-export function ResumeUnknownChip({ errorText, attemptedResumeId }: ResumeUnknownChipProps) {
+export function ResumeUnknownChip({
+  errorText,
+  attemptedResumeId,
+  variant = 'recoverable',
+}: ResumeUnknownChipProps) {
   // Treat empty / whitespace-only strings as missing so a stale or
   // defensive empty value can't degrade the headline into a broken-looking
   // "Attempted id: " slot.
   const hasId = typeof attemptedResumeId === 'string' && attemptedResumeId.trim().length > 0
 
+  // #5006: switch headline + a11y role on the variant. The recoverable
+  // variant uses `role="status"` (polite live region — chroxy already
+  // recovered) whereas the exhausted variant uses `role="alert"` (assertive
+  // — the user must take action). Keep the same `stream-stall-chip` palette
+  // so the visual language stays shared; the AT role + copy carry the
+  // urgency difference.
+  const isExhausted = variant === 'exhausted'
+  const headline = isExhausted
+    ? 'Auto-recovery exhausted — start a new session manually to continue'
+    : 'Previous conversation could not be resumed — starting fresh'
+  const role = isExhausted ? 'alert' : 'status'
+
   return (
     <div
       className="stream-stall-chip"
       data-testid="resume-unknown-chip"
-      role="status"
+      data-variant={variant}
+      role={role}
       title={errorText}
     >
-      <span className="stream-stall-chip-text">
-        Previous conversation could not be resumed — starting fresh
-      </span>
+      <span className="stream-stall-chip-text">{headline}</span>
       {hasId && (
         <span
           data-testid="resume-unknown-chip-id"

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -124,14 +124,21 @@ export const ServerMessageSchema = z.object({
     options: z.any().optional(),
     timestamp: z.number(),
     code: z.string().max(64).optional(),
-    // #4947: only set on `messageType: 'error'` envelopes whose `code` is
-    // `'resume_unknown'` (CliSession `_handleChildClose` resume-failure path,
-    // server PR #4944). Carries the conversation id chroxy passed to
-    // `claude --resume <id>` before the CLI rejected it; dashboards surface
-    // it under the auto-fallback affordance for operator correlation against
-    // the persisted state file (`resumeConversationId` in
-    // `~/.chroxy/session-state.json`). Optional + length-capped so a
-    // malformed producer can't pollute the wire with megabyte payloads.
+    // #4947 / #5006: only set on `messageType: 'error'` envelopes whose
+    // `code` is one of the two resume-failure codes emitted by CliSession's
+    // `_handleChildClose` resume-failure path:
+    //   - `'resume_unknown'` (server PR #4944) — recoverable; CliSession has
+    //     already auto-fallen-back to a fresh conversation.
+    //   - `'resume_unknown_exhausted'` (server PR #5004) — terminal; the
+    //     post-fallback retry ALSO matched the unknown-resume pattern, the
+    //     server has stopped auto-respawning, and the user must start a
+    //     fresh session manually.
+    // Carries the conversation id chroxy passed to `claude --resume <id>`
+    // before the CLI rejected it; dashboards surface it under the affordance
+    // for operator correlation against the persisted state file
+    // (`resumeConversationId` in `~/.chroxy/session-state.json`). Optional +
+    // length-capped so a malformed producer can't pollute the wire with
+    // megabyte payloads.
     attemptedResumeId: z.string().max(256).optional(),
 });
 export const ServerToolStartSchema = z.object({

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -134,14 +134,21 @@ export const ServerMessageSchema = z.object({
   options: z.any().optional(),
   timestamp: z.number(),
   code: z.string().max(64).optional(),
-  // #4947: only set on `messageType: 'error'` envelopes whose `code` is
-  // `'resume_unknown'` (CliSession `_handleChildClose` resume-failure path,
-  // server PR #4944). Carries the conversation id chroxy passed to
-  // `claude --resume <id>` before the CLI rejected it; dashboards surface
-  // it under the auto-fallback affordance for operator correlation against
-  // the persisted state file (`resumeConversationId` in
-  // `~/.chroxy/session-state.json`). Optional + length-capped so a
-  // malformed producer can't pollute the wire with megabyte payloads.
+  // #4947 / #5006: only set on `messageType: 'error'` envelopes whose
+  // `code` is one of the two resume-failure codes emitted by CliSession's
+  // `_handleChildClose` resume-failure path:
+  //   - `'resume_unknown'` (server PR #4944) — recoverable; CliSession has
+  //     already auto-fallen-back to a fresh conversation.
+  //   - `'resume_unknown_exhausted'` (server PR #5004) — terminal; the
+  //     post-fallback retry ALSO matched the unknown-resume pattern, the
+  //     server has stopped auto-respawning, and the user must start a
+  //     fresh session manually.
+  // Carries the conversation id chroxy passed to `claude --resume <id>`
+  // before the CLI rejected it; dashboards surface it under the affordance
+  // for operator correlation against the persisted state file
+  // (`resumeConversationId` in `~/.chroxy/session-state.json`). Optional +
+  // length-capped so a malformed producer can't pollute the wire with
+  // megabyte payloads.
   attemptedResumeId: z.string().max(256).optional(),
 })
 

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -5838,6 +5838,53 @@ describe('handleMessage', () => {
         expect(out.chatMessage.attemptedResumeId).toBe('a'.repeat(256))
       }
     })
+
+    // #5006: server PR #5004 introduced the terminal-escalation code
+    // `resume_unknown_exhausted` emitted when the post-fallback retry ALSO
+    // matches the unknown-resume pattern. event-normalizer.js already
+    // forwards `attemptedResumeId` for the new code; the store-core gate
+    // must mirror that or the field is silently stripped before reaching
+    // the dashboard / mobile chip. These tests pin the widened gate.
+    it('#5006 — preserves attemptedResumeId on resume_unknown_exhausted (terminal escalation)', () => {
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content:
+            'Auto-recovery exhausted: Claude CLI rejected the resumed conversation id and a fresh-start retry also failed.',
+          code: 'resume_unknown_exhausted',
+          attemptedResumeId: 'abc123-def456-7890',
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.code).toBe('resume_unknown_exhausted')
+        expect(out.chatMessage.attemptedResumeId).toBe('abc123-def456-7890')
+      }
+    })
+
+    it('#5006 — trims and truncates attemptedResumeId on resume_unknown_exhausted (same hardening as resume_unknown)', () => {
+      const oversized = '   ' + 'a'.repeat(500) + '   '
+      const out = handleMessage(
+        {
+          messageType: 'error',
+          content: 'x',
+          code: 'resume_unknown_exhausted',
+          attemptedResumeId: oversized,
+          timestamp: 100,
+        },
+        'sess-active',
+        false,
+        [],
+      )
+      expect(out.shouldDispatch).toBe(true)
+      if (out.shouldDispatch) {
+        expect(out.chatMessage.attemptedResumeId).toBe('a'.repeat(256))
+      }
+    })
   })
 
   it('skips user_input outside replay (live echo handled elsewhere)', () => {

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -3940,11 +3940,22 @@ export function handleMessage(
     // file. Pre-#4944 servers omit the field entirely and the ChatMessage
     // simply stays `attemptedResumeId: undefined`.
     //
+    // #5006: also accept the terminal-escalation code
+    // `resume_unknown_exhausted` (server PR #5004). When the post-fallback
+    // retry ALSO matches the unknown-resume pattern, the server stops
+    // auto-respawning and emits this distinct code so the chip can switch
+    // to an "auto-recovery exhausted, start a fresh session manually"
+    // affordance. event-normalizer.js already forwards `attemptedResumeId`
+    // for the new code; without widening this gate the field would be
+    // silently stripped at the store boundary and the chip would degrade
+    // to "headline only" — defeating the operator-correlation feature.
+    //
     // Hardening (from PR #4967 Copilot review):
-    //   1. Gate strictly on `msgType === 'error' && msg.code === 'resume_unknown'`
-    //      — the field is documented as only valid on that envelope, so a
-    //      buggy producer attaching it to other types shouldn't pollute the
-    //      store with out-of-contract data.
+    //   1. Gate strictly on `msgType === 'error'` AND one of the two
+    //      resume-failure codes — the field is documented as only valid on
+    //      those envelopes, so a buggy producer attaching it to other types
+    //      (or other error codes) shouldn't pollute the store with
+    //      out-of-contract data.
     //   2. Trim whitespace and treat whitespace-only as missing — matches
     //      the chip's render-time guard so the store and the renderer
     //      agree.
@@ -3955,7 +3966,7 @@ export function handleMessage(
     //      drop so the truncated id still helps operator triage.
     ...(msgType === 'error' &&
     typeof msg.code === 'string' &&
-    msg.code === 'resume_unknown' &&
+    (msg.code === 'resume_unknown' || msg.code === 'resume_unknown_exhausted') &&
     typeof msg.attemptedResumeId === 'string'
       ? (() => {
           const trimmed = msg.attemptedResumeId.trim()

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -87,13 +87,22 @@ export interface ChatMessage {
    */
   code?: string;
   /**
-   * #4947: only set on `type: 'error'` bubbles whose `code` is
-   * `'resume_unknown'` (server PR #4944 — CliSession's
-   * `_handleChildClose` resume-failure path). Carries the conversation id
-   * chroxy passed to `claude --resume <id>` before the CLI rejected it.
-   * The dashboard `ResumeUnknownChip` surfaces this as small mono-spaced
-   * subtext under the headline so operators investigating a recurring
-   * resume failure can correlate against the persisted state file
+   * #4947 / #5006: only set on `type: 'error'` bubbles whose `code` is one
+   * of the two resume-failure codes emitted by CliSession's
+   * `_handleChildClose` resume-failure path:
+   *   - `'resume_unknown'` (server PR #4944) — recoverable: the CLI
+   *     rejected `--resume <id>` and chroxy has already auto-fallen-back
+   *     to a fresh conversation.
+   *   - `'resume_unknown_exhausted'` (server PR #5004) — terminal: the
+   *     post-fallback retry ALSO matched the unknown-resume pattern; the
+   *     server has stopped auto-respawning and the user must start a
+   *     fresh session manually.
+   *
+   * Carries the conversation id chroxy passed to `claude --resume <id>`
+   * before the CLI rejected it. The dashboard / mobile
+   * `ResumeUnknownChip` surfaces this as small mono-spaced subtext under
+   * the headline so operators investigating a recurring resume failure
+   * can correlate against the persisted state file
    * (`resumeConversationId` in `~/.chroxy/session-state.json`) without
    * grepping logs. Undefined for every other error code and for
    * pre-#4944 servers that don't emit the field.


### PR DESCRIPTION
Closes #5006.

Pairs with #5004 — should land in the same release window so the new wire code doesn't ship without consumer support.

## Summary

Server PR #5004 introduced a new terminal-escalation error code `resume_unknown_exhausted` emitted when the post-fallback resume retry also fails. Without consumer plumbing, the new code falls through to the generic red error bubble and `attemptedResumeId` is silently dropped at the store-core boundary, defeating the operator-correlation feature.

This change wires the new code end-to-end through every consumer:

- **store-core/handlers**: widens the `attemptedResumeId` preservation gate to accept both `resume_unknown` and `resume_unknown_exhausted` (same trim + 256-char cap hardening from #4967).
- **dashboard ResumeUnknownChip**: adds a `variant: 'recoverable' | 'exhausted'` prop. The exhausted variant renders distinct "auto-recovery exhausted — start a new session manually" copy and uses `role="alert"` (assertive) vs. the recoverable variant's `role="status"` (polite). Default is `'recoverable'` so existing call sites keep their behavior.
- **dashboard App.tsx**: widens the gate to render the chip for both codes, passing the matched variant.
- **mobile ResumeUnknownChip**: same variant prop, same headline switch. Mobile keeps `accessibilityRole="alert"` on both variants (RN convention is louder by default), so the variant difference rides on `accessibilityLabel` + visible text.
- **mobile MessageBubble**: widens the gate, passes the variant through.
- **protocol + store-core JSDoc**: enumerates both codes on `attemptedResumeId`.

## Why a chip variant instead of a separate component?

The two error codes share 90% of the chip's surface area: visual style, structure, attemptedResumeId subtext, testID, dot/border, font. Only the headline copy and (on dashboard) the ARIA role differ. A `variant` prop keeps the implementations DRY without losing the distinction at the call site.

## Test plan (TDD: RED → GREEN)

- [x] **store-core/handlers**: `cd packages/store-core && npx vitest run` — 1072/1072 (2 new tests pin widened gate)
- [x] **dashboard**: `cd packages/dashboard && npx vitest run` — 2776/2776 (4 new variant tests)
- [x] **dashboard TS strict**: `npx tsc --noEmit` — clean
- [x] **mobile chip + bubble**: `npx jest --testPathPattern="(ResumeUnknownChip|MessageBubble\.resumeUnknown)"` — 19/19 (4 + 2 new tests)
- [x] **mobile TS strict**: `npx tsc --noEmit` — clean
- [x] **protocol**: `npm test` — 156/156
- [x] **server lints (regression check)**: `./scripts/lint-tests-state-file-path.sh && ./scripts/lint-session-opt-forwarding.sh` — both green

## Touch points

Per the #5004 review:

- `packages/store-core/src/handlers/index.ts` — `attemptedResumeId` gate widened.
- `packages/store-core/src/types.ts` — JSDoc enumerates both codes.
- `packages/protocol/src/schemas/server.ts` — same JSDoc update.
- `packages/dashboard/src/components/ResumeUnknownChip.tsx` — variant prop + exhausted headline + role switch.
- `packages/dashboard/src/App.tsx` — widened gate, passes variant.
- `packages/app/src/components/ResumeUnknownChip.tsx` — variant prop + exhausted headline.
- `packages/app/src/components/chat/MessageBubble.tsx` — widened gate, passes variant.

No server-side changes (#5004 already covers those).