### PR TITLE
feat(server): add Task subagent tool to claude-byok provider (#4049)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -1188,25 +1188,48 @@ export class ClaudeByokSession extends BaseSession {
     // ran once. mcpConfigPath: null skips MCP discovery in the child
     // (v1: child has no MCP — keeps the scope bounded and avoids the
     // per-spawn child-process startup cost).
-    const ClaudeByokSessionCtor = this.constructor
-    const child = new ClaudeByokSessionCtor({
-      cwd: this.cwd,
-      model: this.model || this._defaultModel,
-      mcpConfigPath: null,
-    })
-    // Skip start()'s credential resolution — share the parent's client
-    // so the child uses the same API key path. Also avoids a duplicate
-    // credentials.json read which could rate-limit on disk for parallel
-    // fan-outs.
-    child._client = this._client
-    child._apiKeySource = this._apiKeySource
-    child._processReady = true
-    // Inherit permission mode so the subagent runs under the same
-    // gating policy as the parent — a user who set `auto` doesn't
-    // want the child to start prompting again, and a user in
-    // `approve` mode expects to gate the child's tools too.
-    child.permissionMode = this.permissionMode
-    this._subagentSessions.set(toolUseId, child)
+    //
+    // #5015 review: wrap construction + init in try/catch. If the
+    // ClaudeByokSession ctor or any of the field assignments throws
+    // (unlikely today but a future refactor could add an init step
+    // that does), the parent has already emitted agent_spawned and
+    // populated _activeAgents — we MUST balance that with a matching
+    // agent_completed + _activeAgents delete + matching error tool_result
+    // so the dashboard badge clears and we don't leak the entry.
+    let child
+    try {
+      const ClaudeByokSessionCtor = this.constructor
+      child = new ClaudeByokSessionCtor({
+        cwd: this.cwd,
+        model: this.model || this._defaultModel,
+        mcpConfigPath: null,
+      })
+      // Skip start()'s credential resolution — share the parent's client
+      // so the child uses the same API key path. Also avoids a duplicate
+      // credentials.json read which could rate-limit on disk for parallel
+      // fan-outs.
+      child._client = this._client
+      child._apiKeySource = this._apiKeySource
+      child._processReady = true
+      // Inherit permission mode so the subagent runs under the same
+      // gating policy as the parent — a user who set `auto` doesn't
+      // want the child to start prompting again, and a user in
+      // `approve` mode expects to gate the child's tools too. Direct
+      // assignment (vs setPermissionMode) is safe here: the child is
+      // fresh, not busy, and has no pending permissions to flush.
+      child.permissionMode = this.permissionMode
+      this._subagentSessions.set(toolUseId, child)
+    } catch (ctorErr) {
+      // Balance the agent_spawned emit + _activeAgents.set above so the
+      // dashboard badge clears and the entry doesn't leak forever.
+      this._activeAgents.delete(toolUseId)
+      this.emit('agent_completed', { toolUseId })
+      log.warn(`subagent construction failed: ${ctorErr?.message || ctorErr}`)
+      return {
+        content: `Subagent construction failed: ${ctorErr?.message || ctorErr}`,
+        isError: true,
+      }
+    }
 
     // Collect the child's stream_delta text into a buffer that becomes
     // the tool_result content. usage / cost are taken from the child's
@@ -1253,6 +1276,24 @@ export class ClaudeByokSession extends BaseSession {
       else signal.addEventListener('abort', onAbort, { once: true })
     }
 
+    // #5015 review: second abort check immediately before sendMessage.
+    // Closes the micro-race where the signal aborts AFTER the top-of-
+    // function `signal?.aborted` check but BEFORE the child flips
+    // _isBusy=true. In that window, the `onAbort` listener fires
+    // child.interrupt() which no-ops (`if (!this._isBusy) return`) —
+    // sendMessage would then proceed and burn tokens after Stop.
+    // Short-circuit with an interrupted result so cancellation is
+    // honored even when the abort lands during this narrow gap.
+    if (signal?.aborted) {
+      if (signal) signal.removeEventListener?.('abort', onAbort)
+      this._subagentSessions.delete(toolUseId)
+      try { await child.destroy() } catch (err) {
+        log.warn(`subagent destroy on pre-send abort failed: ${err?.message || err}`)
+      }
+      this._activeAgents.delete(toolUseId)
+      this.emit('agent_completed', { toolUseId })
+      return { content: 'Interrupted by user before subagent started', isError: true }
+    }
     try {
       await child.sendMessage(prompt)
       await done

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -110,7 +110,13 @@ export class ClaudeByokSession extends BaseSession {
     // build the TRANSIENT_EVENTS set it bridges to `session_event`
     // listeners; without it the emit fires on the local EventEmitter
     // and never reaches ws-forwarding.
-    return ['tool_start', 'tool_result', 'tool_input_delta']
+    //
+    // #4049: agent_spawned / agent_completed are part of the built-in
+    // transient set in session-manager.js (so they already flow without
+    // being listed), but pin them here so the capability matrix /
+    // dashboard introspection reflect that this provider emits them
+    // when the Task tool dispatches a subagent.
+    return ['tool_start', 'tool_result', 'tool_input_delta', 'agent_spawned', 'agent_completed']
   }
 
   /**
@@ -286,6 +292,25 @@ export class ClaudeByokSession extends BaseSession {
     // UI.) The PermissionManager keys its pending map by requestId, not
     // toolUseId, so we maintain a separate Set on the session.
     this._pendingPermissionToolUseIds = new Set()
+
+    // #4049: active subagent sessions spawned by the Task tool, keyed by
+    // toolUseId. interrupt() iterates this map to cascade the abort
+    // signal to every child; destroy() does the same to tear down each
+    // child's resources (PermissionManager, listeners, MCP fleet) so a
+    // long-running parent with many delegated tasks doesn't leak state.
+    // Each subagent is itself a full ClaudeByokSession and owns its own
+    // _subagentSessions map — nested Task → Task is naturally supported.
+    this._subagentSessions = new Map()
+
+    // #4049: per-turn accumulators for subagent (Task tool) usage + cost.
+    // Folded into the parent's result.usage / result.cost just before
+    // the result event fires so cost attribution stays on the user-
+    // facing session (acceptance criteria: "child tokens attributed to
+    // the parent session"). Reset in _finishTurn() on every exit path
+    // — success, error, abort — so a stale parent's totals can never
+    // leak into a future turn.
+    this._subagentUsageThisTurn = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+    this._subagentCostThisTurn = 0
 
     // #4076: MCP config discovery. Parses ~/.claude.json (or an
     // override) for the `mcpServers` block. Parse-only at this stage —
@@ -795,6 +820,17 @@ export class ClaudeByokSession extends BaseSession {
         }
       }
 
+      // #4049: fold any subagent (Task tool) usage + cost into the
+      // user-facing turn totals. Cost accounting must attribute the
+      // child's API spend to the parent session so the user sees a
+      // single number for "what did this turn cost?" rather than
+      // having delegated work disappear from accounting.
+      turnUsage.input_tokens += this._subagentUsageThisTurn.input_tokens
+      turnUsage.output_tokens += this._subagentUsageThisTurn.output_tokens
+      turnUsage.cache_read_input_tokens += this._subagentUsageThisTurn.cache_read_input_tokens
+      turnUsage.cache_creation_input_tokens += this._subagentUsageThisTurn.cache_creation_input_tokens
+      turnCost += this._subagentCostThisTurn
+
       this.emit('stream_end', { messageId })
       this.emit('result', {
         sessionId: null,
@@ -1038,21 +1074,39 @@ export class ClaudeByokSession extends BaseSession {
       }
     }
 
-    // Execute locally. MCP tools (mcp__<server>__<tool>) route through
-    // the fleet to the right child process via stdio JSON-RPC; everything
-    // else runs in-process (Read/Write/Bash/etc).
+    // Execute locally. Three dispatch paths:
+    //   1. Task (#4049) — recursive subagent. Spawns a fresh
+    //      ClaudeByokSession with isolated history but shared client +
+    //      cwd + permission mode, emits agent_spawned / agent_completed
+    //      events, and folds the child's cost/usage back into the
+    //      parent's turn totals.
+    //   2. MCP tools (mcp__<server>__<tool>) — route through the fleet
+    //      to the right child process via stdio JSON-RPC.
+    //   3. Built-in tools (Read/Write/Bash/etc) — run in-process via
+    //      executeBuiltinTool.
     const effectiveInput = resolvedDecision.updatedInput || input
-    const { content, isError } = toolName.startsWith(MCP_TOOL_PREFIX)
-      ? await this._dispatchMcpTool(toolName, effectiveInput)
-      : await executeBuiltinTool({
-          toolName,
-          input: effectiveInput,
-          cwd: this.cwd,
-          cwdRealCache: this._cwdRealCache,
-          cwdCacheTtl: CWD_CACHE_TTL_MS,
-          signal,
-          todoStore: this._todos,
-        })
+    let dispatchResult
+    if (toolName === 'Task') {
+      dispatchResult = await this._executeTaskTool({
+        toolUseId,
+        input: effectiveInput,
+        messageId,
+        signal,
+      })
+    } else if (toolName.startsWith(MCP_TOOL_PREFIX)) {
+      dispatchResult = await this._dispatchMcpTool(toolName, effectiveInput)
+    } else {
+      dispatchResult = await executeBuiltinTool({
+        toolName,
+        input: effectiveInput,
+        cwd: this.cwd,
+        cwdRealCache: this._cwdRealCache,
+        cwdCacheTtl: CWD_CACHE_TTL_MS,
+        signal,
+        todoStore: this._todos,
+      })
+    }
+    const { content, isError } = dispatchResult
 
     this.emit('tool_result', {
       messageId,
@@ -1067,6 +1121,177 @@ export class ClaudeByokSession extends BaseSession {
       content,
       is_error: isError,
     }
+  }
+
+  /**
+   * #4049: dispatch the Task tool by spawning a child ClaudeByokSession.
+   *
+   * Design (v1 minimum protocol surface):
+   *   - Child inherits the parent's cwd, model, permission mode, and
+   *     Anthropic SDK client — same API key authenticates both, no
+   *     second resolveCredentials() pass.
+   *   - Child gets a FRESH _history (the subagent doesn't see the
+   *     parent's conversation — that's the point of delegating to a
+   *     focused scope). The prompt arrives as its first user message.
+   *   - Child's intermediate tool calls are silent on the wire — the
+   *     parent only sees `agent_spawned` (when the child starts) and
+   *     `agent_completed` (when it returns). Surfacing per-child tool
+   *     streams as sub-bubbles is a deliberate v2 follow-up (the issue
+   *     calls it out as "optional"). Keeping v1 silent matches how
+   *     sdk-session.js surfaces Task today.
+   *   - Cost + usage from the child fold into _subagentUsageThisTurn /
+   *     _subagentCostThisTurn, which sendMessage() adds to the user-
+   *     facing result.cost before emitting (acceptance criteria:
+   *     "child tokens attributed to the parent session").
+   *   - Cancellation cascade: the parent's AbortSignal triggers
+   *     child.interrupt() via the interrupt() override that iterates
+   *     _subagentSessions. A signal that aborts mid-flight also fires
+   *     the local onAbort listener so the cascade happens even on a
+   *     micro-race between the abort and the child's sendMessage.
+   *
+   * Deferred (per scope note):
+   *   - Sub-bubble UI / mid-flight tool surfacing for the child
+   *   - Per-launch permission-mode override (currently inherits)
+   *   - subagent_type profile registry — the field is accepted in the
+   *     schema for forward-compat but the runner ignores it in v1
+   *
+   * @returns {Promise<{content: string, isError: boolean}>}
+   */
+  async _executeTaskTool({ toolUseId, input, messageId, signal }) {
+    void messageId
+    const description = typeof input?.description === 'string'
+      ? input.description.slice(0, 200)
+      : 'Background task'
+    const prompt = typeof input?.prompt === 'string' ? input.prompt : ''
+    if (!prompt) {
+      return {
+        content: 'Task tool requires a non-empty `prompt` field describing the work for the subagent.',
+        isError: true,
+      }
+    }
+    if (signal?.aborted) {
+      return { content: 'Interrupted by user before subagent spawned', isError: true }
+    }
+    // Emit agent_spawned BEFORE creating the child so the dashboard's
+    // active-agents badge updates immediately. Same shape as
+    // sdk-session.js's emit on _handleToolUseBlock (`toolUseId`,
+    // `description`, `startedAt`). The toolUseId matches the parent
+    // turn's tool_use block id so the dashboard correlates the spawn
+    // with the open tool_call bubble.
+    const startedAt = Date.now()
+    const agentInfo = { toolUseId, description, startedAt }
+    this._activeAgents.set(toolUseId, agentInfo)
+    this.emit('agent_spawned', agentInfo)
+
+    // Build a child session. Reuse this session's already-resolved
+    // client so the API key resolution + Anthropic constructor only
+    // ran once. mcpConfigPath: null skips MCP discovery in the child
+    // (v1: child has no MCP — keeps the scope bounded and avoids the
+    // per-spawn child-process startup cost).
+    const ClaudeByokSessionCtor = this.constructor
+    const child = new ClaudeByokSessionCtor({
+      cwd: this.cwd,
+      model: this.model || this._defaultModel,
+      mcpConfigPath: null,
+    })
+    // Skip start()'s credential resolution — share the parent's client
+    // so the child uses the same API key path. Also avoids a duplicate
+    // credentials.json read which could rate-limit on disk for parallel
+    // fan-outs.
+    child._client = this._client
+    child._apiKeySource = this._apiKeySource
+    child._processReady = true
+    // Inherit permission mode so the subagent runs under the same
+    // gating policy as the parent — a user who set `auto` doesn't
+    // want the child to start prompting again, and a user in
+    // `approve` mode expects to gate the child's tools too.
+    child.permissionMode = this.permissionMode
+    this._subagentSessions.set(toolUseId, child)
+
+    // Collect the child's stream_delta text into a buffer that becomes
+    // the tool_result content. usage / cost are taken from the child's
+    // single `result` event (the agent loop's per-round usage already
+    // folds into the child's own result.usage).
+    const textChunks = []
+    let childCost = 0
+    const childUsage = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+    let childError = null
+    let resolveDone
+    const done = new Promise((r) => { resolveDone = r })
+
+    child.on('stream_delta', (e) => {
+      if (typeof e?.delta === 'string') textChunks.push(e.delta)
+    })
+    child.on('result', (e) => {
+      const u = e?.usage || {}
+      childUsage.input_tokens = Number(u.input_tokens) || 0
+      childUsage.output_tokens = Number(u.output_tokens) || 0
+      childUsage.cache_read_input_tokens = Number(u.cache_read_input_tokens) || 0
+      childUsage.cache_creation_input_tokens = Number(u.cache_creation_input_tokens) || 0
+      childCost = Number(e?.cost) || 0
+      resolveDone()
+    })
+    child.on('error', (e) => {
+      // First error wins — capture the message but DON'T resolve yet,
+      // wait for the eventual stream_end so usage still folds in.
+      if (!childError) childError = e?.message || 'subagent failed'
+    })
+    child.on('stream_end', () => {
+      // Belt-and-braces: if `result` never fires (provider error,
+      // abort, or stream-init throw), stream_end still resolves the
+      // promise so this method doesn't hang the parent's tool loop.
+      resolveDone()
+    })
+
+    // Register a cascade hook on the parent's signal — interrupt()
+    // already iterates _subagentSessions, but this listener also
+    // catches the micro-race when the signal aborts between the
+    // top-of-function check and child.sendMessage's first await.
+    const onAbort = () => { try { child.interrupt() } catch { /* noop */ } }
+    if (signal) {
+      if (signal.aborted) onAbort()
+      else signal.addEventListener('abort', onAbort, { once: true })
+    }
+
+    try {
+      await child.sendMessage(prompt)
+      await done
+    } finally {
+      if (signal) signal.removeEventListener?.('abort', onAbort)
+      // Drop the child from _subagentSessions before destroy() so a
+      // racing interrupt() during teardown doesn't try to abort an
+      // already-half-destroyed child.
+      this._subagentSessions.delete(toolUseId)
+      try { await child.destroy() } catch (err) {
+        log.warn(`subagent destroy on Task completion failed: ${err?.message || err}`)
+      }
+      this._activeAgents.delete(toolUseId)
+      this.emit('agent_completed', { toolUseId })
+    }
+
+    // Fold child usage + cost into the parent's per-turn accumulators
+    // so the user-facing result.cost includes every API call this
+    // turn caused (acceptance criteria #4049).
+    this._subagentUsageThisTurn.input_tokens += childUsage.input_tokens
+    this._subagentUsageThisTurn.output_tokens += childUsage.output_tokens
+    this._subagentUsageThisTurn.cache_read_input_tokens += childUsage.cache_read_input_tokens
+    this._subagentUsageThisTurn.cache_creation_input_tokens += childUsage.cache_creation_input_tokens
+    this._subagentCostThisTurn += childCost
+
+    if (childError) {
+      // Surface the child's error as the tool_result content so the
+      // parent model can see what went wrong and decide whether to
+      // retry / re-prompt / abandon.
+      return { content: `Subagent failed: ${childError}`, isError: true }
+    }
+    const summary = textChunks.join('').trim()
+    if (!summary) {
+      return {
+        content: 'Subagent finished without producing any output text.',
+        isError: true,
+      }
+    }
+    return { content: summary, isError: false }
   }
 
   /**
@@ -1157,12 +1382,27 @@ export class ClaudeByokSession extends BaseSession {
     this._isBusy = false
     this._currentMessageId = null
     this._abortController = null
+    // #4049: reset the subagent accumulators so the next turn starts
+    // clean — even on error / abort paths where the result event never
+    // fired and the fold-in step above was skipped.
+    this._subagentUsageThisTurn = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
+    this._subagentCostThisTurn = 0
   }
 
   interrupt() {
     if (!this._isBusy) return
     if (this._abortController) {
       this._abortController.abort()
+    }
+    // #4049: cascade the interrupt to any active subagent sessions.
+    // Each child has its own AbortController — interrupt() short-
+    // circuits its in-flight stream so it returns promptly, which lets
+    // _executeTaskTool's awaited promise resolve and the parent's
+    // outer agent loop can finish the user-facing result event.
+    for (const child of this._subagentSessions.values()) {
+      try { child.interrupt() } catch (err) {
+        log.warn(`subagent interrupt failed: ${err?.message || err}`)
+      }
     }
   }
 
@@ -1230,6 +1470,20 @@ export class ClaudeByokSession extends BaseSession {
     // reference (test capture, future export) would keep them alive.
     this._streamingIndexToToolUseId.clear()
     this._pendingPermissionToolUseIds.clear()
+    // #4049: tear down any active subagent sessions. interrupt() (run
+    // at the top of destroy()) already cascaded the abort signal; this
+    // step also drops each child's PermissionManager, MCP fleet, and
+    // EventEmitter listeners so a long-running parent that fanned-out
+    // a series of Task subagents doesn't leak per-child resources.
+    if (this._subagentSessions.size > 0) {
+      const children = [...this._subagentSessions.values()]
+      this._subagentSessions.clear()
+      for (const child of children) {
+        try { await child.destroy() } catch (err) {
+          log.warn(`subagent destroy failed: ${err?.message || err}`)
+        }
+      }
+    }
     this._client = null
     // #4077: tear down MCP children with SIGTERM → SIGKILL grace.
     // Awaits up to FLEET_KILL_GRACE_MS (2s) + 500ms safety margin so a

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -10,7 +10,6 @@
  * the SDK consumes them as Anthropic API tool definitions.
  *
  * Deferred to follow-up issues (see #4047 epic):
- *   - Task (subagent) — #4049
  *   - MCP — #4048
  */
 
@@ -151,6 +150,38 @@ export const BUILTIN_TOOLS = [
         },
       },
       required: ['todos'],
+    },
+  },
+  {
+    name: 'Task',
+    description:
+      'Spawn a focused sub-agent (subagent) to handle a delegated piece of work. The ' +
+      'sub-agent runs as a fresh ClaudeByokSession with its own isolated message history, ' +
+      'inheriting this session\'s permission mode and cwd. Use it to: research a topic without ' +
+      'polluting the parent context, run multi-step work in a focused scope, or delegate a ' +
+      'task that needs its own tool budget. The sub-agent\'s final assistant text is returned ' +
+      'as the tool_result — intermediate tool calls happen inside the child and are NOT ' +
+      'surfaced to the parent (only `agent_spawned` / `agent_completed` events fire). ' +
+      'Token cost is accumulated into the parent turn\'s `result.cost` so accounting stays ' +
+      'attributed to the user-facing session. ' +
+      'Cancellation: interrupting the parent cascades to the child via a shared AbortSignal.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        description: {
+          type: 'string',
+          description: 'Short (3-5 word) description of the task. Surfaced as the sub-agent label in the UI.',
+        },
+        prompt: {
+          type: 'string',
+          description: 'Full task prompt sent to the sub-agent as its initial user message.',
+        },
+        subagent_type: {
+          type: 'string',
+          description: 'Optional subagent profile id (e.g. "general", "researcher"). Currently informational only — ignored by the runner in v1.',
+        },
+      },
+      required: ['description', 'prompt'],
     },
   },
   {

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -54,6 +54,9 @@ function captureEvents(session) {
     // the dashboard tool-call bubble can live-preview the model's
     // evolving tool input (especially valuable for Bash early-abort).
     'tool_input_delta',
+    // #4049: Task tool spawns a subagent and emits agent_spawned /
+    // agent_completed so the dashboard's active-agents badge ticks.
+    'agent_spawned', 'agent_completed',
   ]
   for (const name of known) {
     session.on(name, (payload) => captured.push({ name, payload }))
@@ -3174,6 +3177,291 @@ describe('ClaudeByokSession', () => {
         assert.match(toolResultBlock.content, /outside workspace/i)
         await session.destroy()
       })
+    })
+  })
+
+  describe('Task tool dispatch (#4049)', () => {
+    /**
+     * Build a parent that emits a single Task tool_use on round 1, then
+     * end_turn on round 2. The child session's _client.messages.stream
+     * is stubbed by the caller via `childStreamImpl(messages, round)`
+     * so each test can shape the subagent's behaviour independently.
+     */
+    function setupParentEmittingTaskOnce(session, { taskInput, childStreamImpl }) {
+      let parentRound = 0
+      let childRound = 0
+      session._client = {
+        messages: {
+          stream: ({ messages }) => {
+            parentRound += 1
+            if (parentRound === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'tu_task_1', name: 'Task', input: taskInput }],
+                  usage: { input_tokens: 5, output_tokens: 5 },
+                },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }],
+              { stop_reason: 'end_turn', content: [{ type: 'text', text: 'parent done' }], usage: { input_tokens: 2, output_tokens: 2 } },
+            )
+          },
+        },
+      }
+      // _executeTaskTool creates a fresh child session and shares this
+      // parent's client. To make the child's stream stub deterministic
+      // we install a wrapper around _executeTaskTool that injects the
+      // child's _client BEFORE the child runs.
+      const origExecuteTaskTool = session._executeTaskTool.bind(session)
+      session._executeTaskTool = function (args) {
+        // Wrap the parent's _client.messages.stream so when the child
+        // calls it, we return the per-round child stream. The child
+        // shares the parent's client at the time of construction, but
+        // we can swap individual call-time behavior by monkey-patching
+        // the messages object the child holds. Simpler: replace the
+        // parent's stream impl with a router that dispatches based on
+        // whether the active session is the parent or the child via a
+        // counter.
+        return origExecuteTaskTool.call(this, args)
+      }
+      // Replace parent client.messages.stream with a router that
+      // returns the parent stream on the first 2 calls (round 1 + 2)
+      // and the child stream impl on subsequent calls.
+      const parentStreamFactory = session._client.messages.stream
+      let totalCalls = 0
+      session._client.messages.stream = (...streamArgs) => {
+        totalCalls += 1
+        // Parent emits exactly 1 stream call BEFORE the Task dispatches
+        // (round 1 producing the tool_use), then exactly 1 stream call
+        // AFTER (round 2 with the tool_result). The child fires its
+        // own stream calls in between. We detect the child by checking
+        // the active subagent count — if any child is live, this call
+        // belongs to that child.
+        if (session._subagentSessions.size > 0) {
+          childRound += 1
+          return childStreamImpl(streamArgs[0]?.messages || [], childRound)
+        }
+        return parentStreamFactory(...streamArgs)
+      }
+    }
+
+    it('happy path: spawns child, captures its text, emits agent_spawned + agent_completed', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      const captured = captureEvents(session)
+      setupParentEmittingTaskOnce(session, {
+        taskInput: { description: 'summarize doc', prompt: 'Summarize /tmp/foo.txt' },
+        childStreamImpl: () => fakeStream(
+          [
+            { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'Summary: ' } },
+            { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'looks good.' } },
+            { type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+          ],
+          { stop_reason: 'end_turn', content: [{ type: 'text', text: 'Summary: looks good.' }], usage: { input_tokens: 100, output_tokens: 30 } },
+        ),
+      })
+      await session.start()
+      await session.sendMessage('please research')
+
+      // agent_spawned must fire BEFORE agent_completed and carry the
+      // tool_use id + description (#4049 acceptance).
+      const spawned = captured.find((e) => e.name === 'agent_spawned')
+      const completed = captured.find((e) => e.name === 'agent_completed')
+      assert.ok(spawned, 'agent_spawned must fire')
+      assert.equal(spawned.payload.toolUseId, 'tu_task_1')
+      assert.equal(spawned.payload.description, 'summarize doc')
+      assert.equal(typeof spawned.payload.startedAt, 'number')
+      assert.ok(completed, 'agent_completed must fire')
+      assert.equal(completed.payload.toolUseId, 'tu_task_1')
+
+      // tool_result for Task must carry the child's stitched text and
+      // is_error: false on the happy path.
+      const toolResults = captured.filter((e) => e.name === 'tool_result')
+      const taskResult = toolResults.find((e) => e.payload.toolUseId === 'tu_task_1')
+      assert.ok(taskResult, 'tool_result for the Task block must fire')
+      assert.match(taskResult.payload.result, /Summary: looks good/)
+      assert.equal(taskResult.payload.isError, false)
+
+      await session.destroy()
+    })
+
+    it('attributes child usage + cost into the parent turn result', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
+      session.setPermissionMode('auto')
+      const captured = captureEvents(session)
+      setupParentEmittingTaskOnce(session, {
+        taskInput: { description: 'delegate', prompt: 'do the thing' },
+        childStreamImpl: () => fakeStream(
+          [],
+          { stop_reason: 'end_turn', content: [{ type: 'text', text: 'child output' }], usage: { input_tokens: 1000, output_tokens: 500 } },
+        ),
+      })
+      await session.start()
+      await session.sendMessage('delegate please')
+      const result = captured.find((e) => e.name === 'result')
+      assert.ok(result)
+      // Parent's own rounds: round 1 (5in/5out) + round 2 (2in/2out) = 7in/7out
+      // Child: 1000in/500out
+      // Total: 1007in/507out
+      assert.equal(result.payload.usage.input_tokens, 1007, 'child input tokens fold into parent total')
+      assert.equal(result.payload.usage.output_tokens, 507, 'child output tokens fold into parent total')
+      // Cost (Opus 4.7): (1007 * 15 + 507 * 75) / 1e6
+      const expectedCost = (1007 * 15 + 507 * 75) / 1e6
+      assert.ok(Math.abs(result.payload.cost - expectedCost) < 1e-9,
+        `expected cost ~= ${expectedCost}, got ${result.payload.cost}`)
+      await session.destroy()
+    })
+
+    it('parent interrupt cascades to child subagent', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      let childInterruptCalled = 0
+      let childInstance = null
+      // Patch the child constructor so we can record interrupt() calls.
+      const origExecute = session._executeTaskTool.bind(session)
+      session._executeTaskTool = async function (args) {
+        // Wrap interrupt() on the next child that gets registered. We
+        // can't override before _executeTaskTool constructs the child,
+        // so install a one-shot watcher on _subagentSessions.set.
+        const origSet = this._subagentSessions.set.bind(this._subagentSessions)
+        this._subagentSessions.set = (k, v) => {
+          childInstance = v
+          const origInterrupt = v.interrupt.bind(v)
+          v.interrupt = function () {
+            childInterruptCalled += 1
+            return origInterrupt()
+          }
+          return origSet(k, v)
+        }
+        try {
+          return await origExecute(args)
+        } finally {
+          this._subagentSessions.set = origSet
+        }
+      }
+      // Child stream that hangs until aborted — we trigger interrupt()
+      // on the parent and expect the child to receive an interrupt() call.
+      setupParentEmittingTaskOnce(session, {
+        taskInput: { description: 'long', prompt: 'long work' },
+        childStreamImpl: () => ({
+          async *[Symbol.asyncIterator]() {
+            // Yield once then wait on a long timeout that the abort
+            // signal will tear down.
+            yield { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'starting...' } }
+            await new Promise((resolve, reject) => {
+              const t = setTimeout(resolve, 60_000)
+              // When child.interrupt() fires, the child's abort
+              // controller aborts and the SDK's APIUserAbortError
+              // surfaces via finalMessage. We approximate by clearing
+              // the timeout on the child's abort controller.
+              childInstance?._abortController?.signal.addEventListener('abort', () => {
+                clearTimeout(t)
+                reject(new APIUserAbortError())
+              }, { once: true })
+            })
+          },
+          async finalMessage() {
+            return { stop_reason: 'end_turn', content: [{ type: 'text', text: 'partial' }], usage: {} }
+          },
+        }),
+      })
+      await session.start()
+      const turn = session.sendMessage('do long task')
+      // Wait for the child to spawn, then interrupt the parent.
+      await new Promise((r) => setTimeout(r, 20))
+      session.interrupt()
+      await turn
+      assert.ok(childInterruptCalled > 0, 'parent.interrupt() must cascade to child.interrupt()')
+      await session.destroy()
+    })
+
+    it('rejects Task with empty prompt as is_error tool_result', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      const captured = captureEvents(session)
+      // Parent emits Task with empty prompt — we should short-circuit
+      // BEFORE spawning a child (no agent_spawned).
+      let parentRound = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            parentRound += 1
+            if (parentRound === 1) {
+              return fakeStream(
+                [],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'tu_bad', name: 'Task', input: { description: 'd', prompt: '' } }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            return fakeStream([], { stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }], usage: {} })
+          },
+        },
+      }
+      await session.start()
+      await session.sendMessage('delegate')
+      const spawned = captured.find((e) => e.name === 'agent_spawned')
+      assert.equal(spawned, undefined, 'agent_spawned must NOT fire when prompt is empty')
+      const taskResult = captured.find((e) => e.name === 'tool_result' && e.payload.toolUseId === 'tu_bad')
+      assert.ok(taskResult)
+      assert.equal(taskResult.payload.isError, true)
+      assert.match(taskResult.payload.result, /prompt/i)
+      await session.destroy()
+    })
+
+    it('child error surfaces as is_error tool_result without crashing the parent', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      const captured = captureEvents(session)
+      setupParentEmittingTaskOnce(session, {
+        taskInput: { description: 'flaky', prompt: 'do something flaky' },
+        childStreamImpl: () => {
+          throw Object.assign(new Error('upstream 500'), { status: 500 })
+        },
+      })
+      await session.start()
+      await session.sendMessage('delegate')
+      const taskResult = captured.find((e) => e.name === 'tool_result' && e.payload.toolUseId === 'tu_task_1')
+      assert.ok(taskResult, 'tool_result must fire even when child errored')
+      assert.equal(taskResult.payload.isError, true)
+      assert.match(taskResult.payload.result, /Subagent failed|upstream 500/i)
+      // Parent's own result MUST still fire — the child's error doesn't
+      // kill the parent turn.
+      const result = captured.find((e) => e.name === 'result')
+      assert.ok(result, 'parent result must still fire after child error')
+      // agent_completed fires regardless of success/failure so the
+      // dashboard's active-agents badge clears.
+      const completed = captured.find((e) => e.name === 'agent_completed')
+      assert.ok(completed)
+      await session.destroy()
+    })
+
+    it('Task tool dispatch path is reached via _executeToolBlock (not executeBuiltinTool)', async () => {
+      // The Task tool MUST be routed before executeBuiltinTool — otherwise
+      // it would land in the Unknown-tool fallback which would return an
+      // is_error tool_result with the BUILTIN_TOOL_NAMES enumeration.
+      // This test pins the routing by stubbing _executeTaskTool and
+      // asserting it gets called.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      let taskCalled = false
+      session._executeTaskTool = async ({ toolUseId }) => {
+        taskCalled = true
+        return { content: 'routed ok', isError: false }
+      }
+      const toolResult = await runOneToolRound(session, {
+        id: 'tu_route', name: 'Task', input: { description: 'd', prompt: 'p' },
+      })
+      assert.equal(taskCalled, true, '_executeTaskTool must run for the Task tool')
+      assert.ok(toolResult)
+      assert.equal(toolResult.is_error, false)
+      assert.equal(toolResult.content, 'routed ok')
+      await session.destroy()
     })
   })
 

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3370,8 +3370,15 @@ describe('ClaudeByokSession', () => {
       })
       await session.start()
       const turn = session.sendMessage('do long task')
-      // Wait for the child to spawn, then interrupt the parent.
-      await new Promise((r) => setTimeout(r, 20))
+      // #5015 review: wait deterministically for the child to spawn
+      // (agent_spawned fires AFTER _subagentSessions.set + before the
+      // child's sendMessage). A fixed sleep races on loaded CI runners
+      // — if interrupt fires before the spawn, the cascade has nothing
+      // to iterate and the child runs the full 60s timeout.
+      await new Promise((resolve) => {
+        if (session._subagentSessions.size > 0) return resolve()
+        session.once('agent_spawned', resolve)
+      })
       session.interrupt()
       await turn
       assert.ok(childInterruptCalled > 0, 'parent.interrupt() must cascade to child.interrupt()')

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -9,9 +9,9 @@ import { BUILTIN_TOOLS, BUILTIN_TOOL_NAMES, TODO_STATUS_LIST, TODO_STATUSES } fr
  */
 
 describe('BUILTIN_TOOLS', () => {
-  it('exposes the documented toolset (PR 2 v1 + WebFetch #4050 + TodoWrite #4051)', () => {
+  it('exposes the documented toolset (PR 2 v1 + WebFetch #4050 + TodoWrite #4051 + Task #4049)', () => {
     const names = BUILTIN_TOOLS.map((t) => t.name).sort()
-    assert.deepEqual(names, ['Bash', 'Edit', 'Glob', 'Grep', 'Read', 'TodoWrite', 'WebFetch', 'Write'])
+    assert.deepEqual(names, ['Bash', 'Edit', 'Glob', 'Grep', 'Read', 'Task', 'TodoWrite', 'WebFetch', 'Write'])
   })
 
   it('every tool has a name, description, and input_schema', () => {
@@ -97,5 +97,29 @@ describe('BUILTIN_TOOLS', () => {
       assert.ok(TODO_STATUSES.has(status), `TODO_STATUSES Set must include ${status}`)
     }
     assert.equal(TODO_STATUSES.size, TODO_STATUS_LIST.length)
+  })
+
+  it('Task requires description and prompt (#4049)', () => {
+    const task = BUILTIN_TOOLS.find((t) => t.name === 'Task')
+    assert.ok(task, 'Task must be registered')
+    assert.deepEqual(task.input_schema.required.sort(), ['description', 'prompt'])
+    // subagent_type is forward-compat but optional in v1.
+    assert.equal(task.input_schema.properties.subagent_type?.type, 'string')
+  })
+
+  it('Task description discloses subagent semantics + cancellation cascade (#4049)', () => {
+    // Pin the contract so a future rewording can't strip the
+    // user-facing guarantees (focused scope, isolated history,
+    // cancellation cascade, cost attribution).
+    const task = BUILTIN_TOOLS.find((t) => t.name === 'Task')
+    assert.match(task.description, /sub-?agent|subagent/i)
+    assert.match(task.description, /isolated|focused|fresh/i)
+    assert.match(task.description, /cancel|interrupt|abort/i)
+    assert.match(task.description, /cost|token/i)
+  })
+
+  it('BUILTIN_TOOL_NAMES contains Task (#4049)', () => {
+    assert.ok(BUILTIN_TOOL_NAMES.has('Task'),
+      'Task must be in BUILTIN_TOOL_NAMES so the executor catches misrouted dispatches')
   })
 })


### PR DESCRIPTION
## Summary

Adds the `Task` (subagent) tool to the `claude-byok` provider. Closes #4049.

Sub-agents are spawned recursively as fresh `ClaudeByokSession` instances with isolated message history, sharing the parent's Anthropic SDK client / cwd / model / permission mode. The model can now delegate focused work to a child agent the same way it does in the official `claude-sdk` / `claude-cli` providers.

## What's in this PR (v1 — minimum protocol surface)

- `Task` tool registered in `byok-tools.js` with `description` + `prompt` (required) and `subagent_type` (forward-compat, ignored).
- `_executeToolBlock` routes `Task` to a new `_executeTaskTool` method.
- Child runs as a fresh `ClaudeByokSession` with isolated `_history`. Shares the parent's SDK client so no second credential resolution.
- Emits `agent_spawned` (with `toolUseId`, `description`, `startedAt`) and `agent_completed` events. Tracked in `_activeAgents`. Added to `customEvents`.
- **Cost accounting**: child usage + cost fold into the parent's `result.usage` / `result.cost` so the user-facing turn shows the *total* spend (acceptance criteria: "child tokens attributed to the parent session").
- **Cancellation cascade**: `interrupt()` iterates `_subagentSessions` and calls `child.interrupt()`. An abort listener also catches the micro-race between top-of-method check and the child's first `await`.
- `destroy()` awaits `child.destroy()` for every tracked subagent so a fanned-out parent doesn't leak PermissionManager / listeners / MCP fleet state.
- Empty-prompt and child-error paths return `is_error` tool_result without killing the parent turn.

## What's deferred to follow-ups

Per CLAUDE.md scope note ("ship the minimum protocol surface, defer the heavy machinery"):

- **Sub-bubble UI for child progress** — the parent only emits `agent_spawned` / `agent_completed` in v1. Per-child `tool_start` / `stream_delta` surfacing as nested bubbles is the next iteration; the issue calls this out as "optional".
- **Per-launch permission-mode override** — currently inherits the parent's mode. Future: optional `permission_mode` field in the Task input.
- **`subagent_type` profile registry** — field accepted in the schema for forward-compat but the runner ignores it in v1.
- **MCP availability inside the child** — child runs with `mcpConfigPath: null` so it has no MCP tools. Adds bounded scope and avoids per-spawn child-process startup cost.

## Test plan

- [x] `BUILTIN_TOOLS` list includes `Task` (lock test in `byok-tools.test.js`).
- [x] Task tool schema requires `description` + `prompt`, description discloses subagent semantics / cancellation / cost (`byok-tools.test.js`).
- [x] Happy path: parent emits Task → child spawns → agent_spawned + agent_completed fire → tool_result carries child's text.
- [x] Cost attribution: child usage (input/output tokens) folds into parent's `result.usage`; child cost folds into `result.cost` (Opus 4.7 pricing math pinned in the test).
- [x] Parent `interrupt()` cascades to child `interrupt()` (hanging child's abort signal honored).
- [x] Empty-prompt Task rejected as `is_error` without spawning a child.
- [x] Child error surfaces as `is_error` tool_result; parent's `result` event still fires.
- [x] Dispatch path: `_executeTaskTool` is routed before `executeBuiltinTool` (not the unknown-tool fallback).
- [x] All 99 existing byok tool tests still pass.
- [x] All 101 existing byok-session tests still pass.
- [x] Lints clean: `lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`, `lint-logger-session-scoping.sh`.

Closes #4049