### PR TITLE
feat(server): add docker-byok container provider (#4053)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -1082,8 +1082,11 @@ export class ClaudeByokSession extends BaseSession {
     //      parent's turn totals.
     //   2. MCP tools (mcp__<server>__<tool>) — route through the fleet
     //      to the right child process via stdio JSON-RPC.
-    //   3. Built-in tools (Read/Write/Bash/etc) — run in-process via
-    //      executeBuiltinTool.
+    //   3. Built-in tools (Read/Write/Bash/etc) — route through
+    //      `_dispatchBuiltinTool` which by default runs in-process.
+    //      Subclasses (e.g. DockerByokSession, #4053) override
+    //      `_dispatchBuiltinTool` to redirect execution into an isolated
+    //      environment without touching this loop.
     const effectiveInput = resolvedDecision.updatedInput || input
     let dispatchResult
     if (toolName === 'Task') {
@@ -1096,14 +1099,10 @@ export class ClaudeByokSession extends BaseSession {
     } else if (toolName.startsWith(MCP_TOOL_PREFIX)) {
       dispatchResult = await this._dispatchMcpTool(toolName, effectiveInput)
     } else {
-      dispatchResult = await executeBuiltinTool({
+      dispatchResult = await this._dispatchBuiltinTool({
         toolName,
         input: effectiveInput,
-        cwd: this.cwd,
-        cwdRealCache: this._cwdRealCache,
-        cwdCacheTtl: CWD_CACHE_TTL_MS,
         signal,
-        todoStore: this._todos,
       })
     }
     const { content, isError } = dispatchResult
@@ -1333,6 +1332,36 @@ export class ClaudeByokSession extends BaseSession {
       }
     }
     return { content: summary, isError: false }
+  }
+
+  /**
+   * Dispatch one built-in tool (Read/Write/Edit/Bash/Glob/Grep/WebFetch/
+   * TodoWrite) to the local executor. Returns `{ content, isError }` —
+   * the shape `_executeToolBlock` threads into the next round's
+   * tool_result content block.
+   *
+   * Subclass seam (#4053): `DockerByokSession` overrides this to
+   * redirect tool execution into an isolated Docker container while the
+   * outer agent loop — model streaming, permission gating, MCP dispatch,
+   * cost accounting — stays unchanged. The base implementation runs the
+   * tool in-process on the host, which is what the host-side
+   * `claude-byok` provider has always done.
+   *
+   * @param {object} args
+   * @param {string} args.toolName  Tool name from the model's tool_use block
+   * @param {object} args.input     Already-parsed JSON input from the model
+   * @param {AbortSignal} [args.signal]  Per-turn abort signal
+   */
+  async _dispatchBuiltinTool({ toolName, input, signal }) {
+    return executeBuiltinTool({
+      toolName,
+      input,
+      cwd: this.cwd,
+      cwdRealCache: this._cwdRealCache,
+      cwdCacheTtl: CWD_CACHE_TTL_MS,
+      signal,
+      todoStore: this._todos,
+    })
   }
 
   /**

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -1,0 +1,662 @@
+/**
+ * docker-byok provider (#4053) — runs the claude-byok agent loop on the
+ * host (chroxy speaks HTTPS to api.anthropic.com directly), but redirects
+ * built-in tool execution (Read / Write / Edit / Bash / Glob / Grep) into
+ * an isolated Docker container.
+ *
+ * Design summary
+ * --------------
+ * BYOK is in-process: the agent loop runs inside chroxy and there is no
+ * subprocess for the model. The isolation boundary here is the TOOLS —
+ * the model can still read and write files, but those file ops act on
+ * the CONTAINER'S filesystem (which mounts the host cwd at /workspace),
+ * and Bash commands the model wants to run execute inside the container
+ * with `--cap-drop ALL`, a pids cap, and a non-root user. Anything else
+ * — model streaming, permission gating, MCP dispatch, cost accounting —
+ * is inherited unchanged from ClaudeByokSession.
+ *
+ * What's in v1 (this file)
+ * ------------------------
+ *   - Container lifecycle: start (with preflight `docker info`), destroy
+ *   - Workspace volume mount at /workspace (cwd → /workspace, same as
+ *     docker-sdk-session.js)
+ *   - Tool dispatch override (`_dispatchBuiltinTool`) for the file/bash
+ *     surface. Read uses `cat`; Write uses `tee` via stdin; Edit reads,
+ *     mutates host-side, writes back; Bash/Glob/Grep run via
+ *     `bash -c` inside the container.
+ *   - ANTHROPIC_API_KEY forwarded into the container at `docker run`
+ *     time (the AC asks for it; the running agent in chroxy is what
+ *     actually authenticates to the Anthropic API — the container has
+ *     the env in case a Bash command needs it, e.g. a `claude -p` smoke
+ *     test inside the container).
+ *   - TodoWrite + WebFetch stay host-side (TodoWrite is an in-memory
+ *     map; WebFetch is HTTP from chroxy and doesn't touch the FS).
+ *   - MCP, Task subagent, permission gating, cost accounting — all
+ *     inherited verbatim from ClaudeByokSession.
+ *
+ * Deferred (follow-up issues)
+ * ---------------------------
+ *   - Per-session container reuse / pooling
+ *   - Snapshot/restore (Docker commit-based snapshots already exist for
+ *     docker-cli / docker-sdk — wiring them up for docker-byok belongs
+ *     in a follow-up so docker-byok ships small)
+ *   - DevContainer / Compose-driven environments
+ *   - postCreateCommand hook
+ *
+ * Per `project_worktree_before_docker.md` in project memory: worktree
+ * isolation happens BEFORE Docker. This class does not own worktree
+ * setup — the SessionManager / environment-manager already worktree the
+ * cwd before constructing the session, and we mount whatever cwd the
+ * SessionManager hands us.
+ */
+
+import { execFile } from 'child_process'
+import { ClaudeByokSession } from './byok-session.js'
+import { DockerBackend } from './environments/backends/docker.js'
+import { classifyDockerError } from './docker-session.js'
+import { createLogger } from './logger.js'
+import { isAbsolute, posix } from 'path'
+
+const log = createLogger('docker-byok')
+
+/** POSIX username pattern — same shape as docker-sdk-session.js. */
+const VALID_USERNAME_RE = /^[a-z_][a-z0-9_-]{0,31}$/
+
+const DEFAULT_IMAGE = 'node:22-slim'
+const DEFAULT_MEMORY_LIMIT = '2g'
+const DEFAULT_CPU_LIMIT = '2'
+const DEFAULT_USER = 'chroxy'
+const CONTAINER_WORKSPACE = '/workspace'
+
+/**
+ * Cap on Read output size to keep tool_result payloads bounded.
+ * Mirrors the host-side `readFileTool` philosophy — large files should
+ * be sliced via `offset`/`limit`.
+ */
+const READ_MAX_BYTES = 256 * 1024
+
+/**
+ * Cap on Write payload size. Larger writes should be done by the model
+ * via a sequence of smaller writes or — better — a Bash command that
+ * stages the content from a file already inside the container.
+ */
+const WRITE_MAX_BYTES = 512 * 1024
+
+/**
+ * Map a host-absolute file_path under this.cwd into the container's
+ * /workspace mount. Defends against path traversal by refusing absolute
+ * paths that aren't under cwd. Relative paths are joined onto
+ * /workspace using POSIX semantics — the container is always Linux.
+ *
+ * Returns a string the model can pass into a `docker exec` command, or
+ * throws an Error whose message is safe to surface as a tool_result.
+ *
+ * @param {string} filePath
+ * @param {string} hostCwd
+ */
+export function remapToContainerPath(filePath, hostCwd) {
+  if (typeof filePath !== 'string' || filePath.length === 0) {
+    const err = new Error('file_path is required')
+    err.code = 'EINVAL'
+    throw err
+  }
+  if (typeof hostCwd !== 'string' || hostCwd.length === 0) {
+    const err = new Error('host cwd is not configured')
+    err.code = 'EINVAL'
+    throw err
+  }
+  // POSIX containers — normalise the host cwd to a POSIX-style mount
+  // root so prefix-matching works on Windows hosts too. Trailing
+  // slashes get stripped so `cwd === '/Users/foo'` and the file
+  // `/Users/foo` itself map to '/workspace' rather than '/workspace/'.
+  const normHostCwd = hostCwd.replace(/\/+$/, '')
+  if (isAbsolute(filePath)) {
+    if (filePath === normHostCwd) return CONTAINER_WORKSPACE
+    if (filePath.startsWith(normHostCwd + '/')) {
+      const suffix = filePath.slice(normHostCwd.length)
+      return posix.join(CONTAINER_WORKSPACE, suffix)
+    }
+    const err = new Error(`path outside workspace: ${filePath} is not under ${normHostCwd}`)
+    err.code = 'EACCES'
+    throw err
+  }
+  // Relative path → join onto /workspace.
+  const joined = posix.join(CONTAINER_WORKSPACE, filePath)
+  if (!joined.startsWith(CONTAINER_WORKSPACE)) {
+    // posix.join() collapses `../` segments — if the result escapes
+    // /workspace, refuse the call.
+    const err = new Error(`path outside workspace: ${filePath} resolves to ${joined}`)
+    err.code = 'EACCES'
+    throw err
+  }
+  return joined
+}
+
+/**
+ * Quote a string for safe interpolation inside single-quoted bash
+ * arguments. Mirrors the shellQuote pattern used elsewhere in chroxy.
+ */
+function shellQuote(s) {
+  return `'${String(s).replace(/'/g, `'\\''`)}'`
+}
+
+export class DockerByokSession extends ClaudeByokSession {
+  static get displayLabel() {
+    return 'Claude (BYOK — Docker container)'
+  }
+
+  static get capabilities() {
+    return { ...ClaudeByokSession.capabilities, containerized: true }
+  }
+
+  /**
+   * Preflight credentials block. Same shape as ClaudeByokSession — the
+   * agent loop still runs on the host so the credential set / hint /
+   * required-ness is identical to host-side BYOK. The container itself
+   * does NOT need to be authenticated to talk to Anthropic; chroxy
+   * does that. ANTHROPIC_API_KEY is forwarded as a convenience for the
+   * model's Bash command (e.g. a one-off `curl api.anthropic.com`).
+   */
+  static get preflight() {
+    return {
+      ...ClaudeByokSession.preflight,
+      label: 'Claude (BYOK — Docker container)',
+    }
+  }
+
+  /**
+   * Reuse ClaudeByokSession's resolveAuth: same env vars, same
+   * credential file path, same readiness rules. The container's
+   * absence of ~/.chroxy state does NOT change anything here — the
+   * agent loop runs on the host.
+   */
+  static resolveAuth(env, helpers) {
+    return ClaudeByokSession.resolveAuth(env, helpers)
+  }
+
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.image='node:22-slim']     Container image
+   * @param {string} [opts.memoryLimit='2g']         `docker run --memory`
+   * @param {string} [opts.cpuLimit='2']             `docker run --cpus`
+   * @param {string} [opts.containerUser='chroxy']   Non-root user inside container
+   * @param {string} [opts.containerId]              Attach to an existing container
+   *   instead of launching one (env-manager managed). When omitted, the
+   *   session owns the container and tears it down on destroy().
+   * @param {object} [opts._dockerBackend]           Test seam — pre-built backend
+   * @param {Function} [opts._execFile]              Test seam — used by preflight
+   *   (defaults to child_process.execFile)
+   */
+  constructor(opts = {}) {
+    // Forward every BaseSession/ClaudeByokSession opt verbatim via
+    // spread (`...opts`) so the lint-session-opt-forwarding linter is
+    // satisfied and we never accidentally drop a BaseSession opt
+    // (`feedback_jsonl_subprocess_middle_layer.md` in project memory).
+    // Override `provider` so the session reports `docker-byok` for
+    // wire-protocol consumers (display label, capabilities matrix).
+    super({ ...opts, provider: opts.provider || 'docker-byok' })
+
+    const user = opts.containerUser || DEFAULT_USER
+    if (!VALID_USERNAME_RE.test(user)) {
+      throw new Error(`Invalid containerUser "${user}" — must match POSIX username rules`)
+    }
+    this._containerUser = user
+    this._image = opts.image || DEFAULT_IMAGE
+    this._memoryLimit = opts.memoryLimit || DEFAULT_MEMORY_LIMIT
+    this._cpuLimit = opts.cpuLimit || DEFAULT_CPU_LIMIT
+    // External container support — when an env-manager hands us an
+    // already-running containerId we attach to it and DON'T tear it
+    // down on destroy.
+    const containerId = typeof opts.containerId === 'string' ? opts.containerId.trim() : null
+    this._containerId = containerId || null
+    this._containerOwned = !containerId
+    this._dockerBackend = opts._dockerBackend || new DockerBackend()
+    this._execFile = opts._execFile || execFile
+    this._containerReady = false
+  }
+
+  /**
+   * Preflight check: confirm the local Docker daemon is reachable
+   * before any state mutation. Resolves true on success, rejects with
+   * a classified error (code:'docker_not_running' etc.) on failure.
+   *
+   * Exposed as a method so callers (tests, dashboards) can probe
+   * docker readiness without instantiating the full session.
+   */
+  _preflightDocker() {
+    return new Promise((resolve, reject) => {
+      this._execFile('docker', ['info'], { encoding: 'utf-8', timeout: 10_000 }, (err, _stdout, stderr) => {
+        if (err) {
+          const classified = classifyDockerError(err, stderr)
+          const error = new Error(classified.message)
+          error.code = classified.code
+          reject(error)
+          return
+        }
+        resolve(true)
+      })
+    })
+  }
+
+  /**
+   * Launch the container if we own it, then call super.start() so the
+   * Anthropic client / MCP fleet / ready event all wire up normally.
+   *
+   * When attaching to an external container (env-manager managed),
+   * skips the launch but still preflights `docker info` so a dead
+   * daemon doesn't silently fail the first tool call.
+   */
+  async start() {
+    try {
+      await this._preflightDocker()
+    } catch (err) {
+      // Surface preflight failures as a session error (same shape as
+      // docker-sdk-session uses for its own start-failure path) and
+      // tear down — the session can't function without Docker.
+      this.emit('error', {
+        code: err.code || 'docker_error',
+        message: `docker-byok preflight: ${err.message}`,
+      })
+      await this.destroy()
+      return
+    }
+
+    if (this._containerOwned) {
+      try {
+        await this._startContainer()
+      } catch (err) {
+        this.emit('error', {
+          code: err.code || 'docker_error',
+          message: `docker-byok failed to start container: ${err.message}`,
+        })
+        await this.destroy()
+        return
+      }
+    } else {
+      // External container — verify it's reachable before we lie to
+      // the model about being ready.
+      try {
+        await this._verifyContainer()
+      } catch (err) {
+        this.emit('error', {
+          code: err.code || 'docker_error',
+          message: `docker-byok external container not reachable: ${err.message}`,
+        })
+        await this.destroy()
+        return
+      }
+    }
+
+    this._containerReady = true
+    await super.start()
+  }
+
+  /**
+   * Launch a long-lived container with the host cwd mounted at
+   * /workspace and the standard chroxy hardening (cap-drop, pids
+   * limit, no-new-privileges, non-root user). Mirrors the runArgs
+   * shape used by docker-sdk-session.js so the security posture is
+   * identical across the two providers.
+   */
+  _startContainer() {
+    return new Promise((resolve, reject) => {
+      const runArgs = [
+        'run', '-d', '--init', '--rm',
+        '--memory', this._memoryLimit,
+        '--cpus', this._cpuLimit,
+        '--pids-limit', '512',
+        '--cap-drop', 'ALL',
+        '--security-opt', 'no-new-privileges',
+        '-v', `${this.cwd || process.cwd()}:${CONTAINER_WORKSPACE}`,
+        '-w', CONTAINER_WORKSPACE,
+      ]
+
+      // Issue AC: forward ANTHROPIC_API_KEY at `docker run` time. The
+      // agent loop on the host is what actually authenticates to the
+      // Anthropic API, but the model may want to invoke `curl` or a
+      // CLI inside the container that expects this env var.
+      const apiKey = process.env.ANTHROPIC_API_KEY
+      if (apiKey) {
+        runArgs.push('--env', `ANTHROPIC_API_KEY=${apiKey}`)
+      }
+
+      if (process.platform === 'linux') {
+        runArgs.push('--add-host', 'host.docker.internal:host-gateway')
+      }
+
+      runArgs.push(this._image, 'sleep', 'infinity')
+
+      log.info(
+        `starting container (image=${this._image} memory=${this._memoryLimit} cpus=${this._cpuLimit})`,
+      )
+
+      this._execFile('docker', runArgs, { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
+        if (err) {
+          const classified = classifyDockerError(err, stderr)
+          const error = new Error(classified.message)
+          error.code = classified.code
+          reject(error)
+          return
+        }
+        this._containerId = stdout.trim()
+        log.info(`container started: ${this._containerId.slice(0, 12)}`)
+
+        // Set up non-root user + chown workspace so the model isn't
+        // running as root inside the container. Same script
+        // docker-sdk-session uses — keep the two in lockstep.
+        const setupCmd = [
+          `useradd -m -s /bin/bash ${this._containerUser}`,
+          `chown ${this._containerUser}:${this._containerUser} ${CONTAINER_WORKSPACE}`,
+        ].join(' && ')
+
+        this._execFile('docker', [
+          'exec', this._containerId, 'bash', '-c', setupCmd,
+        ], { encoding: 'utf-8', timeout: 30_000 }, (setupErr) => {
+          if (setupErr) {
+            reject(new Error(`Failed to create container user: ${setupErr.message}`))
+            return
+          }
+          log.info(`created non-root user "${this._containerUser}" in container`)
+          resolve()
+        })
+      })
+    })
+  }
+
+  /**
+   * Confirm an externally-managed container is reachable via
+   * `docker exec`. Used when `containerId` was supplied at construction.
+   */
+  _verifyContainer() {
+    return new Promise((resolve, reject) => {
+      this._execFile('docker', [
+        'exec', this._containerId, 'true',
+      ], { encoding: 'utf-8', timeout: 10_000 }, (err, _stdout, stderr) => {
+        if (err) {
+          const classified = classifyDockerError(err, stderr)
+          const error = new Error(classified.message)
+          error.code = classified.code
+          reject(error)
+          return
+        }
+        resolve()
+      })
+    })
+  }
+
+  /**
+   * Override ClaudeByokSession's dispatcher: route file ops and Bash
+   * into the container instead of running them in-process on the host.
+   *
+   * TodoWrite stays host-side (it's a pure in-memory map). WebFetch
+   * stays host-side (it's HTTP and never touches the host FS — putting
+   * it in the container would only add latency).
+   */
+  async _dispatchBuiltinTool({ toolName, input, signal }) {
+    if (!this._containerReady || !this._containerId) {
+      return {
+        content: `docker-byok: container not ready (tool ${toolName})`,
+        isError: true,
+      }
+    }
+    try {
+      switch (toolName) {
+        case 'Read':
+          return await this._containerRead(input)
+        case 'Write':
+          return await this._containerWrite(input)
+        case 'Edit':
+          return await this._containerEdit(input)
+        case 'Bash':
+          return await this._containerBash(input, signal)
+        case 'Glob':
+          return await this._containerGlob(input, signal)
+        case 'Grep':
+          return await this._containerGrep(input, signal)
+        case 'TodoWrite':
+        case 'WebFetch':
+        case 'AskUserQuestion':
+          // Host-side execution is correct for these — see class docstring.
+          return await super._dispatchBuiltinTool({ toolName, input, signal })
+        default:
+          return await super._dispatchBuiltinTool({ toolName, input, signal })
+      }
+    } catch (err) {
+      // Mirror byok-tool-executor.js's catch-all: surface as an
+      // is_error tool_result so the model can recover or report up.
+      return {
+        content: `Tool ${toolName} failed in docker-byok: ${err?.message || String(err)}`,
+        isError: true,
+      }
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Tool implementations — container-side
+  // ─────────────────────────────────────────────────────────────────────────
+
+  async _containerRead(input) {
+    const containerPath = remapToContainerPath(input?.file_path, this.cwd)
+    // Use sed for offset/limit slicing inside the container so we
+    // don't transfer megabytes only to throw them away on the host.
+    // Default cap mirrors readFileTool's "2000 lines" — apply both a
+    // line cap (sed -n) AND a byte cap (head -c) so a single 1GB line
+    // can't blow the tool_result payload.
+    const offset = Number(input?.offset)
+    const limit = Number(input?.limit)
+    const startLine = Number.isFinite(offset) && offset > 0 ? offset : 1
+    const lineCap = Number.isFinite(limit) && limit > 0 ? limit : 2000
+    const endLine = startLine + lineCap - 1
+    const cmd = `sed -n '${startLine},${endLine}p' ${shellQuote(containerPath)} | head -c ${READ_MAX_BYTES}`
+    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
+      this._containerId,
+      { cmd, timeout: 30_000 },
+    )
+    if (stderr && stderr.trim()) {
+      return { content: `Read failed: ${stderr.trim()}`, isError: true }
+    }
+    return { content: stdout, isError: false }
+  }
+
+  async _containerWrite(input) {
+    const containerPath = remapToContainerPath(input?.file_path, this.cwd)
+    const content = typeof input?.content === 'string' ? input.content : ''
+    if (Buffer.byteLength(content, 'utf8') > WRITE_MAX_BYTES) {
+      return {
+        content: `Write refused: content exceeds ${WRITE_MAX_BYTES} bytes — split into smaller writes`,
+        isError: true,
+      }
+    }
+    // Stream the content via a heredoc-style pipe. `tee` is friendly
+    // when stdin is provided; `mkdir -p` ensures parent dirs exist.
+    // We base64-encode on the way in to dodge any quoting hazards
+    // with newlines / single quotes / backticks in `content`.
+    const encoded = Buffer.from(content, 'utf8').toString('base64')
+    const parentDir = posix.dirname(containerPath)
+    const cmd = [
+      `mkdir -p ${shellQuote(parentDir)}`,
+      `echo ${shellQuote(encoded)} | base64 -d > ${shellQuote(containerPath)}`,
+      `wc -c < ${shellQuote(containerPath)}`,
+    ].join(' && ')
+    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
+      this._containerId,
+      { cmd, timeout: 30_000 },
+    )
+    if (stderr && stderr.trim()) {
+      return { content: `Write failed: ${stderr.trim()}`, isError: true }
+    }
+    const bytesWritten = Number(stdout.trim()) || 0
+    return {
+      content: `Wrote ${bytesWritten} bytes to ${input.file_path}.`,
+      isError: false,
+    }
+  }
+
+  async _containerEdit(input) {
+    const containerPath = remapToContainerPath(input?.file_path, this.cwd)
+    const oldString = typeof input?.old_string === 'string' ? input.old_string : ''
+    const newString = typeof input?.new_string === 'string' ? input.new_string : ''
+    const replaceAll = input?.replace_all === true
+    if (oldString.length === 0) {
+      return { content: 'Edit refused: old_string is required', isError: true }
+    }
+    // Read the file via the same execInEnvironment path so a missing
+    // file surfaces as a tool_result rather than an exception.
+    const { stdout: existing, stderr: readErr } = await this._dockerBackend.execInEnvironment(
+      this._containerId,
+      { cmd: `cat ${shellQuote(containerPath)}`, timeout: 30_000 },
+    )
+    if (readErr && readErr.trim()) {
+      return { content: `Edit failed: ${readErr.trim()}`, isError: true }
+    }
+    let replacements = 0
+    let updated
+    if (replaceAll) {
+      const parts = existing.split(oldString)
+      replacements = parts.length - 1
+      updated = parts.join(newString)
+    } else {
+      const idx = existing.indexOf(oldString)
+      if (idx === -1) {
+        return {
+          content: `Edit failed: old_string not found in ${input.file_path}`,
+          isError: true,
+        }
+      }
+      const dup = existing.indexOf(oldString, idx + oldString.length)
+      if (dup !== -1) {
+        return {
+          content: `Edit failed: old_string matches multiple sites in ${input.file_path}; add context or pass replace_all`,
+          isError: true,
+        }
+      }
+      replacements = 1
+      updated = existing.slice(0, idx) + newString + existing.slice(idx + oldString.length)
+    }
+    if (replacements === 0) {
+      return {
+        content: `Edit failed: old_string not found in ${input.file_path}`,
+        isError: true,
+      }
+    }
+    const writeResult = await this._containerWrite({ file_path: input.file_path, content: updated })
+    if (writeResult.isError) return writeResult
+    return {
+      content: `Replaced ${replacements} occurrence(s) in ${input.file_path}.`,
+      isError: false,
+    }
+  }
+
+  async _containerBash(input, signal) {
+    const command = input?.command
+    if (typeof command !== 'string' || command.length === 0) {
+      return { content: 'EINVAL: command is required', isError: true }
+    }
+    if (signal?.aborted) {
+      return { content: 'Interrupted before docker exec', isError: true }
+    }
+    const requested = Number(input?.timeout)
+    // 600s ceiling mirrors the host-side Bash tool — long enough for
+    // a slow test suite but bounded so the session never strands on a
+    // runaway loop.
+    const timeoutMs = Number.isFinite(requested) && requested > 0
+      ? Math.min(requested, 600_000)
+      : 30_000
+    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
+      this._containerId,
+      { cmd: command, timeout: timeoutMs },
+    )
+    const parts = []
+    if (stdout) parts.push(`stdout:\n${stdout}`)
+    if (stderr) parts.push(`stderr:\n${stderr}`)
+    parts.push('[exit=0]')
+    return { content: parts.join('\n\n'), isError: false }
+  }
+
+  async _containerGlob(input, signal) {
+    const pattern = input?.pattern
+    if (typeof pattern !== 'string' || pattern.length === 0) {
+      return { content: 'EINVAL: pattern is required', isError: true }
+    }
+    if (/[$`;|&><()\\\n\r]/.test(pattern)) {
+      return {
+        content: 'EINVAL: glob pattern contains shell-dangerous characters',
+        isError: true,
+      }
+    }
+    if (signal?.aborted) {
+      return { content: 'Interrupted before docker exec', isError: true }
+    }
+    const root = input?.path
+      ? remapToContainerPath(input.path, this.cwd)
+      : CONTAINER_WORKSPACE
+    const cmd = `shopt -s globstar nullglob; cd ${shellQuote(root)} && for f in ${pattern}; do printf '%s\\n' "$f"; done`
+    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
+      this._containerId,
+      { cmd, timeout: 30_000 },
+    )
+    if (!stdout && stderr && stderr.trim()) {
+      return { content: `Glob failed: ${stderr.trim()}`, isError: true }
+    }
+    const files = stdout.split('\n').filter(Boolean)
+    if (files.length === 0) return { content: `No matches for ${pattern}`, isError: false }
+    return { content: files.join('\n'), isError: false }
+  }
+
+  async _containerGrep(input, signal) {
+    const pattern = input?.pattern
+    if (typeof pattern !== 'string' || pattern.length === 0) {
+      return { content: 'EINVAL: pattern is required', isError: true }
+    }
+    if (signal?.aborted) {
+      return { content: 'Interrupted before docker exec', isError: true }
+    }
+    const root = input?.path
+      ? remapToContainerPath(input.path, this.cwd)
+      : CONTAINER_WORKSPACE
+    const ci = input?.['-i'] === true ? '-i' : ''
+    const ln = input?.['-n'] !== false ? '-n' : ''
+    const globArg = typeof input?.glob === 'string' && input.glob.length > 0
+      ? ` --glob ${shellQuote(input.glob)}` : ''
+    const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(root)}`
+    const grepCmd = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(root)}`
+    const cmd = `if command -v rg >/dev/null 2>&1; then ${rgCmd}; else ${grepCmd}; fi`
+    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
+      this._containerId,
+      { cmd, timeout: 30_000 },
+    )
+    if (!stdout && stderr && stderr.trim()) {
+      return { content: `Grep failed: ${stderr.trim()}`, isError: true }
+    }
+    if (!stdout) return { content: `No matches for ${pattern}`, isError: false }
+    return { content: stdout, isError: false }
+  }
+
+  /**
+   * Tear down the container we own, then call super.destroy() so the
+   * agent-loop teardown (MCP fleet, permissions, listeners) runs.
+   * When attached to an external container, leave it running.
+   */
+  async destroy() {
+    const containerId = this._containerId
+    const owned = this._containerOwned
+    this._containerId = null
+    this._containerReady = false
+    try {
+      await super.destroy()
+    } finally {
+      if (containerId && owned) {
+        log.info(`removing container ${containerId.slice(0, 12)}`)
+        await new Promise((resolve) => {
+          this._execFile('docker', ['rm', '-f', containerId], { stdio: 'ignore' }, (err) => {
+            if (err) log.warn(`failed to remove container ${containerId.slice(0, 12)}: ${err.message}`)
+            resolve()
+          })
+        })
+      }
+    }
+  }
+}
+
+// Re-exported for tests + dashboard introspection.
+export { CONTAINER_WORKSPACE }

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -114,7 +114,19 @@ export function remapToContainerPath(filePath, hostCwd) {
     if (filePath === normHostCwd) return CONTAINER_WORKSPACE
     if (filePath.startsWith(normHostCwd + '/')) {
       const suffix = filePath.slice(normHostCwd.length)
-      return posix.join(CONTAINER_WORKSPACE, suffix)
+      const joined = posix.join(CONTAINER_WORKSPACE, suffix)
+      // The suffix preserves a leading `/`, so a payload like
+      // `${cwd}/../etc/passwd` makes posix.join() see the second
+      // argument as absolute and DISCARD the /workspace prefix — the
+      // result would be `/etc/passwd`. Re-assert the same containment
+      // guard as the relative branch so a `..` after the cwd prefix
+      // can't escape the workspace mount.
+      if (joined !== CONTAINER_WORKSPACE && !joined.startsWith(CONTAINER_WORKSPACE + '/')) {
+        const err = new Error(`path outside workspace: ${filePath} resolves to ${joined}`)
+        err.code = 'EACCES'
+        throw err
+      }
+      return joined
     }
     const err = new Error(`path outside workspace: ${filePath} is not under ${normHostCwd}`)
     err.code = 'EACCES'
@@ -122,9 +134,11 @@ export function remapToContainerPath(filePath, hostCwd) {
   }
   // Relative path → join onto /workspace.
   const joined = posix.join(CONTAINER_WORKSPACE, filePath)
-  if (!joined.startsWith(CONTAINER_WORKSPACE)) {
+  if (joined !== CONTAINER_WORKSPACE && !joined.startsWith(CONTAINER_WORKSPACE + '/')) {
     // posix.join() collapses `../` segments — if the result escapes
-    // /workspace, refuse the call.
+    // /workspace, refuse the call. The `+ '/'` is important so that
+    // `/workspaceX` (some sibling path that happens to share the
+    // prefix) can't masquerade as the workspace.
     const err = new Error(`path outside workspace: ${filePath} resolves to ${joined}`)
     err.code = 'EACCES'
     throw err
@@ -287,8 +301,30 @@ export class DockerByokSession extends ClaudeByokSession {
       }
     }
 
+    // Fix for PR #5021 review (Copilot, comment id 3348029212): only
+    // mark the container ready AFTER super.start() succeeds, and
+    // self-destroy on its failure. Pre-fix, super.start()'s missing-
+    // creds path emitted 'error' and returned without setting
+    // _processReady — leaving the owned container running with
+    // _containerReady === true and nobody guaranteed to call destroy().
+    try {
+      await super.start()
+    } catch (err) {
+      this.emit('error', {
+        code: 'session_start_failed',
+        message: `docker-byok session start failed: ${err.message}`,
+      })
+      await this.destroy()
+      return
+    }
+    if (!this._processReady) {
+      // super.start() emitted its own 'error' event (e.g. missing
+      // creds) and returned without marking the session ready. Tear
+      // down the owned container so we don't leak it.
+      await this.destroy()
+      return
+    }
     this._containerReady = true
-    await super.start()
   }
 
   /**
@@ -435,6 +471,26 @@ export class DockerByokSession extends ClaudeByokSession {
   // Tool implementations — container-side
   // ─────────────────────────────────────────────────────────────────────────
 
+  /**
+   * Run a bash command inside the container as the non-root container
+   * user. Single source of truth for every tool dispatch so the `useradd`
+   * + `chown /workspace` setup done at container start is actually
+   * respected. Mirrors `streamCliInEnvironment`'s `-u <user>` behaviour.
+   *
+   * Fix for PR #5021 review (Copilot, comment id 3348029166): pre-fix,
+   * every tool ran as root in the container because the backend's
+   * execInEnvironment didn't forward a `-u` flag. The hardening
+   * (`--cap-drop ALL`, `no-new-privileges`) still capped what root could
+   * do, but the explicit non-root design intent was silently violated.
+   */
+  _execAsContainerUser({ cmd, timeout = 30_000 }) {
+    return this._dockerBackend.execInEnvironment(this._containerId, {
+      cmd,
+      timeout,
+      user: this._containerUser,
+    })
+  }
+
   async _containerRead(input) {
     const containerPath = remapToContainerPath(input?.file_path, this.cwd)
     // Use sed for offset/limit slicing inside the container so we
@@ -447,11 +503,14 @@ export class DockerByokSession extends ClaudeByokSession {
     const startLine = Number.isFinite(offset) && offset > 0 ? offset : 1
     const lineCap = Number.isFinite(limit) && limit > 0 ? limit : 2000
     const endLine = startLine + lineCap - 1
-    const cmd = `sed -n '${startLine},${endLine}p' ${shellQuote(containerPath)} | head -c ${READ_MAX_BYTES}`
-    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
-      this._containerId,
-      { cmd, timeout: 30_000 },
-    )
+    // Fix for PR #5021 review (Copilot, comment id 3348029235): match
+    // the host-side BYOK Read output format (5-space-padded line number,
+    // arrow separator) so the model sees the same line-numbered shape
+    // regardless of provider. The `awk` runs INSIDE the container after
+    // the `sed | head` slice, so we still apply the line cap and the
+    // byte cap before formatting (a 1GB line stays bounded).
+    const cmd = `sed -n '${startLine},${endLine}p' ${shellQuote(containerPath)} | head -c ${READ_MAX_BYTES} | awk -v start=${startLine} 'BEGIN{n=start} {printf "%5d→%s\\n", n, $0; n++}'`
+    const { stdout, stderr } = await this._execAsContainerUser({ cmd, timeout: 30_000 })
     if (stderr && stderr.trim()) {
       return { content: `Read failed: ${stderr.trim()}`, isError: true }
     }
@@ -460,7 +519,15 @@ export class DockerByokSession extends ClaudeByokSession {
 
   async _containerWrite(input) {
     const containerPath = remapToContainerPath(input?.file_path, this.cwd)
-    const content = typeof input?.content === 'string' ? input.content : ''
+    // Fix for PR #5021 review (Copilot, comment id 3348029266): host-side
+    // writeFileTool returns EINVAL when content is missing/non-string;
+    // pre-fix this branch silently truncated the file to zero bytes.
+    // Allow an empty string (the model may legitimately want to clear a
+    // file) but refuse undefined / number / boolean / null.
+    if (typeof input?.content !== 'string') {
+      return { content: 'EINVAL: content is required (string)', isError: true }
+    }
+    const content = input.content
     if (Buffer.byteLength(content, 'utf8') > WRITE_MAX_BYTES) {
       return {
         content: `Write refused: content exceeds ${WRITE_MAX_BYTES} bytes — split into smaller writes`,
@@ -478,10 +545,7 @@ export class DockerByokSession extends ClaudeByokSession {
       `echo ${shellQuote(encoded)} | base64 -d > ${shellQuote(containerPath)}`,
       `wc -c < ${shellQuote(containerPath)}`,
     ].join(' && ')
-    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
-      this._containerId,
-      { cmd, timeout: 30_000 },
-    )
+    const { stdout, stderr } = await this._execAsContainerUser({ cmd, timeout: 30_000 })
     if (stderr && stderr.trim()) {
       return { content: `Write failed: ${stderr.trim()}`, isError: true }
     }
@@ -502,10 +566,10 @@ export class DockerByokSession extends ClaudeByokSession {
     }
     // Read the file via the same execInEnvironment path so a missing
     // file surfaces as a tool_result rather than an exception.
-    const { stdout: existing, stderr: readErr } = await this._dockerBackend.execInEnvironment(
-      this._containerId,
-      { cmd: `cat ${shellQuote(containerPath)}`, timeout: 30_000 },
-    )
+    const { stdout: existing, stderr: readErr } = await this._execAsContainerUser({
+      cmd: `cat ${shellQuote(containerPath)}`,
+      timeout: 30_000,
+    })
     if (readErr && readErr.trim()) {
       return { content: `Edit failed: ${readErr.trim()}`, isError: true }
     }
@@ -562,10 +626,10 @@ export class DockerByokSession extends ClaudeByokSession {
     const timeoutMs = Number.isFinite(requested) && requested > 0
       ? Math.min(requested, 600_000)
       : 30_000
-    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
-      this._containerId,
-      { cmd: command, timeout: timeoutMs },
-    )
+    const { stdout, stderr } = await this._execAsContainerUser({
+      cmd: command,
+      timeout: timeoutMs,
+    })
     const parts = []
     if (stdout) parts.push(`stdout:\n${stdout}`)
     if (stderr) parts.push(`stderr:\n${stderr}`)
@@ -591,10 +655,7 @@ export class DockerByokSession extends ClaudeByokSession {
       ? remapToContainerPath(input.path, this.cwd)
       : CONTAINER_WORKSPACE
     const cmd = `shopt -s globstar nullglob; cd ${shellQuote(root)} && for f in ${pattern}; do printf '%s\\n' "$f"; done`
-    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
-      this._containerId,
-      { cmd, timeout: 30_000 },
-    )
+    const { stdout, stderr } = await this._execAsContainerUser({ cmd, timeout: 30_000 })
     if (!stdout && stderr && stderr.trim()) {
       return { content: `Glob failed: ${stderr.trim()}`, isError: true }
     }
@@ -620,11 +681,15 @@ export class DockerByokSession extends ClaudeByokSession {
       ? ` --glob ${shellQuote(input.glob)}` : ''
     const rgCmd = `rg ${ci} ${ln} --no-heading${globArg} ${shellQuote(pattern)} ${shellQuote(root)}`
     const grepCmd = `grep -r ${ci} ${ln} ${shellQuote(pattern)} ${shellQuote(root)}`
-    const cmd = `if command -v rg >/dev/null 2>&1; then ${rgCmd}; else ${grepCmd}; fi`
-    const { stdout, stderr } = await this._dockerBackend.execInEnvironment(
-      this._containerId,
-      { cmd, timeout: 30_000 },
-    )
+    // Fix for PR #5021 review (Copilot, comment id 3348029186): rg and
+    // grep -r both exit 1 on "no matches", and execInEnvironment rejects
+    // on any non-zero exit, so the "No matches for ${pattern}" branch
+    // was unreachable. Mask the exit code so we can distinguish
+    // legitimate "no matches" (empty stdout, empty stderr) from real
+    // failures (non-empty stderr). The host-side equivalent
+    // (byok-tool-executor.js) uses the same `|| true` pattern.
+    const cmd = `if command -v rg >/dev/null 2>&1; then ${rgCmd}; else ${grepCmd}; fi; true`
+    const { stdout, stderr } = await this._execAsContainerUser({ cmd, timeout: 30_000 })
     if (!stdout && stderr && stderr.trim()) {
       return { content: `Grep failed: ${stderr.trim()}`, isError: true }
     }

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -154,10 +154,30 @@ export class DockerBackend {
    * opts.cwd — forwarded as `--workdir <cwd>`.  The path must already be an
    * absolute path *inside* the container; callers are responsible for remapping
    * host paths to container paths if necessary.
+   *
+   * opts.user — forwarded as `-u <user>` so the command runs as a non-root
+   * container user. Validated against the same POSIX username regex as
+   * `streamCliInEnvironment` to refuse shell-injection payloads. Optional
+   * for backward compatibility (docker-sdk's CLI bootstrap path runs as
+   * root for `npm install -g`, then `streamCliInEnvironment` switches to
+   * the non-root user for the long-lived Claude process). docker-byok
+   * (#5021) passes it for every tool dispatch so file ops respect the
+   * `useradd` + `chown /workspace` setup done at container start.
    */
-  execInEnvironment(containerId, { cmd, env, cwd, timeout = 30_000 }) {
+  execInEnvironment(containerId, { cmd, env, cwd, timeout = 30_000, user } = {}) {
     return new Promise((resolve, reject) => {
       const execArgs = ['exec']
+
+      if (user) {
+        // POSIX username pattern — same regex as docker-sdk-session.js
+        // and docker-byok-session.js. Refuse anything weirder so a
+        // caller-supplied string can't smuggle a flag.
+        if (!/^[a-z_][a-z0-9_-]{0,31}$/.test(user)) {
+          reject(new Error(`Invalid user "${user}" — must match POSIX username rules`))
+          return
+        }
+        execArgs.push('-u', user)
+      }
 
       if (cwd) {
         execArgs.push('--workdir', cwd)

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -327,8 +327,17 @@ export async function registerDockerProvider(config) {
   const { DockerSdkSession } = await import('./docker-sdk-session.js')
   registerProvider('docker-sdk', DockerSdkSession)
 
+  // #4053: docker-byok — runs the BYOK agent loop on the host, tool
+  // execution inside the container. Same gating story as the other
+  // docker-* providers: only registered when environments are enabled
+  // AND `docker info` succeeded above. The provider's own start()
+  // does a second `docker info` preflight per session because the
+  // daemon can go down between server boot and session create.
+  const { DockerByokSession } = await import('./docker-byok-session.js')
+  registerProvider('docker-byok', DockerByokSession)
+
   // Backward compatibility: 'docker' maps to 'docker-cli' (hidden from listProviders)
   registerProvider('docker', DockerSession, { alias: true })
 
-  log.info('Docker providers registered (docker-cli, docker-sdk)')
+  log.info('Docker providers registered (docker-cli, docker-sdk, docker-byok)')
 }

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -285,6 +285,32 @@ describe('DockerByokSession start() — preflight + lifecycle', () => {
     assert.equal(rmCall, undefined, 'external container must not be removed by the session')
   })
 
+  it('tears down owned container and stays not-ready when super.start fails (missing creds)', async () => {
+    // PR #5021 review fix (Copilot, comment id 3348029212): pre-fix,
+    // _containerReady was set BEFORE super.start(); a missing-creds
+    // failure would leak the owned container.
+    delete process.env.ANTHROPIC_API_KEY
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_ID_leak_test\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const session = new DockerByokSession({ cwd: tmpHome, _execFile, _dockerBackend: backendStub() })
+    // Do NOT stub _client — let super.start() see no key and bail.
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+    // super.start() emits an error from byok-session.js:369. The
+    // session should NOT mark itself ready, and the owned container
+    // must have been destroyed.
+    assert.equal(session._containerReady, false)
+    assert.equal(session._processReady, false)
+    const rmCall = _execFile.calls.find((c) => c.args[0] === 'rm')
+    assert.ok(rmCall, 'docker rm -f must be called when super.start fails')
+    assert.ok(rmCall.args.includes('CONTAINER_ID_leak_test'))
+  })
+
   it('surfaces a docker_image_not_found error when the run fails', async () => {
     const _execFile = execFileStub({
       info: { stdout: 'ok' },
@@ -327,6 +353,34 @@ describe('remapToContainerPath()', () => {
     )
   })
 
+  it('refuses an absolute path that starts with cwd but escapes via ..', () => {
+    // Regression for PR #5021 review (path traversal):
+    // /host/cwd/../etc/passwd has `slice(cwd.length)` -> '/../etc/passwd',
+    // and posix.join('/workspace', '/../etc/passwd') returns '/etc/passwd'
+    // because the second arg is absolute. Re-asserting startsWith catches it.
+    assert.throws(
+      () => remapToContainerPath('/host/cwd/../etc/passwd', '/host/cwd'),
+      /outside workspace/,
+    )
+    assert.throws(
+      () => remapToContainerPath('/host/cwd/legit/../../etc/passwd', '/host/cwd'),
+      /outside workspace/,
+    )
+    assert.throws(
+      () => remapToContainerPath('/host/cwd/../../root/.ssh/id_rsa', '/host/cwd'),
+      /outside workspace/,
+    )
+  })
+
+  it('refuses a sibling path that shares the cwd prefix (e.g. /host/cwd-evil)', () => {
+    // /host/cwd-evil/secret begins with '/host/cwd' but is not under it.
+    // The `startsWith(normHostCwd + '/')` check covers this — verify it.
+    assert.throws(
+      () => remapToContainerPath('/host/cwd-evil/secret', '/host/cwd'),
+      /outside workspace/,
+    )
+  })
+
   it('refuses an empty file_path', () => {
     assert.throws(
       () => remapToContainerPath('', '/host/cwd'),
@@ -364,9 +418,9 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
     assert.equal(_dockerBackend.calls.length, 0)
   })
 
-  it('Read routes to `sed | head` inside the container', async () => {
+  it('Read routes to `sed | head | awk` inside the container and forwards the container user', async () => {
     const _dockerBackend = backendStub({
-      defaultResponse: { stdout: 'file contents here\n', stderr: '' },
+      defaultResponse: { stdout: '    1→file contents here\n', stderr: '' },
     })
     const { session } = buildSession({ backend: _dockerBackend })
     const result = await session._dispatchBuiltinTool({
@@ -378,6 +432,14 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
     assert.equal(_dockerBackend.calls.length, 1)
     assert.match(_dockerBackend.calls[0].cmd, /sed -n '1,2000p' '\/workspace\/foo\.txt'/)
     assert.match(_dockerBackend.calls[0].cmd, /head -c/)
+    // PR #5021 review fix (Copilot, comment id 3348029235): the awk
+    // pass formats each line as 5-space-padded line number + arrow,
+    // matching readFileTool's output shape.
+    assert.match(_dockerBackend.calls[0].cmd, /awk.*printf.*%5d→%s/)
+    // PR #5021 review fix (Copilot, comment id 3348029166): every
+    // tool dispatch must forward the non-root container user to
+    // docker exec so the useradd + chown setup is respected.
+    assert.equal(_dockerBackend.calls[0].user, 'chroxy')
   })
 
   it('Read with offset and limit slices in the container', async () => {
@@ -419,6 +481,35 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
     assert.match(cmd, /base64 -d > '\/workspace\/src\/new\.js'/)
     // The base64 of 'hello' is aGVsbG8=
     assert.match(cmd, /aGVsbG8=/)
+  })
+
+  it('Write refuses missing/non-string content with EINVAL', async () => {
+    // PR #5021 review fix (Copilot, comment id 3348029266): pre-fix,
+    // a missing `content` field silently truncated the file to zero
+    // bytes. Now it returns EINVAL like host-side writeFileTool.
+    const _dockerBackend = backendStub()
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Write',
+      input: { file_path: 'foo.txt' },
+    })
+    assert.equal(result.isError, true)
+    assert.match(result.content, /EINVAL.*content is required/)
+    assert.equal(_dockerBackend.calls.length, 0, 'must not docker exec when content is missing')
+    // Non-string types should also be refused.
+    const result2 = await session._dispatchBuiltinTool({
+      toolName: 'Write',
+      input: { file_path: 'foo.txt', content: 12345 },
+    })
+    assert.equal(result2.isError, true)
+    assert.match(result2.content, /EINVAL/)
+    assert.equal(_dockerBackend.calls.length, 0)
+    // Empty string is legitimate (clearing a file) — must still succeed.
+    const result3 = await session._dispatchBuiltinTool({
+      toolName: 'Write',
+      input: { file_path: 'foo.txt', content: '' },
+    })
+    assert.equal(result3.isError, false)
   })
 
   it('Write refuses oversize content', async () => {
@@ -502,6 +593,26 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
     // Cmd is the rg-or-grep wrapper so both binaries appear:
     assert.match(_dockerBackend.calls[0].cmd, /rg /)
     assert.match(_dockerBackend.calls[0].cmd, /grep -r/)
+    // PR #5021 review fix (Copilot, comment id 3348029186): the
+    // command is suffixed with `; true` so rg/grep's exit code 1
+    // (no matches) doesn't bubble up to execInEnvironment's reject.
+    assert.match(_dockerBackend.calls[0].cmd, /; true$/)
+  })
+
+  it('Grep returns "No matches" when stdout is empty and stderr is clean', async () => {
+    // PR #5021 review fix (Copilot, comment id 3348029186): the
+    // no-match branch was unreachable pre-fix because rg/grep exit 1.
+    // With `; true` masking the exit code, this branch now fires.
+    const _dockerBackend = backendStub({
+      defaultResponse: { stdout: '', stderr: '' },
+    })
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Grep',
+      input: { pattern: 'nosuchstring' },
+    })
+    assert.equal(result.isError, false)
+    assert.match(result.content, /No matches for nosuchstring/)
   })
 
   it('TodoWrite remains host-side (falls through to super._dispatchBuiltinTool)', async () => {

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1,0 +1,553 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
+
+import { DockerByokSession, remapToContainerPath, CONTAINER_WORKSPACE } from '../src/docker-byok-session.js'
+import { ClaudeByokSession } from '../src/byok-session.js'
+import { registerDockerProvider, getProvider } from '../src/providers.js'
+
+/**
+ * Tests for the docker-byok provider (#4053).
+ *
+ * The session extends ClaudeByokSession — the agent loop and Anthropic
+ * client are exercised in byok-session.test.js, so this suite focuses
+ * on the docker-byok additions:
+ *   - constructor wiring (provider id, defaults, opt validation)
+ *   - container preflight + lifecycle (start, destroy, attach-external)
+ *   - host→container path remapping (incl. traversal refusal)
+ *   - the _dispatchBuiltinTool override routes Read/Write/Edit/Bash/Glob/
+ *     Grep into the container while leaving TodoWrite/WebFetch host-side
+ *   - provider registration via registerDockerProvider()
+ *
+ * No real Docker daemon is required — every shellout to docker(8) is
+ * stubbed via the `_execFile` and `_dockerBackend` constructor seams.
+ */
+
+/**
+ * Build a stub `execFile` that records calls and returns canned results.
+ * Keyed by the first docker subcommand (`info`, `run`, `exec`, `rm`).
+ *
+ *   execFileStub({
+ *     info: { stdout: 'ok', stderr: '', error: null },
+ *     run:  { stdout: 'CONTAINER_ID_0123456789ab\n', stderr: '', error: null },
+ *     exec: { stdout: '', stderr: '', error: null },
+ *     rm:   { stdout: '', stderr: '', error: null },
+ *   })
+ */
+function execFileStub(byCmd = {}) {
+  const calls = []
+  const fn = (cmd, args, opts, callback) => {
+    const sub = args[0]
+    calls.push({ cmd, args: [...args], opts })
+    const cfg = byCmd[sub] || { stdout: '', stderr: '', error: null }
+    if (typeof callback !== 'function') return
+    if (cfg.error) {
+      const err = cfg.error instanceof Error ? cfg.error : new Error(cfg.error)
+      err.stderr = cfg.stderr || ''
+      callback(err, cfg.stdout || '', cfg.stderr || '')
+      return
+    }
+    callback(null, cfg.stdout || '', cfg.stderr || '')
+  }
+  fn.calls = calls
+  return fn
+}
+
+/**
+ * Stub DockerBackend that captures `execInEnvironment` calls and returns
+ * a canned `{ stdout, stderr }`. Lets us assert the exact bash commands
+ * the docker-byok tool dispatcher constructs for each tool.
+ */
+function backendStub({ execResponses = {}, defaultResponse = { stdout: '', stderr: '' } } = {}) {
+  const calls = []
+  return {
+    calls,
+    async execInEnvironment(containerId, opts) {
+      calls.push({ containerId, ...opts })
+      const matcher = Object.keys(execResponses).find((needle) => opts.cmd.includes(needle))
+      const resp = matcher ? execResponses[matcher] : defaultResponse
+      return { stdout: resp.stdout || '', stderr: resp.stderr || '' }
+    },
+  }
+}
+
+let tmpHome
+let originalHome
+let originalApiKey
+let originalMcpTrustPath
+
+beforeEach(() => {
+  tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-docker-byok-test-'))
+  originalHome = process.env.HOME
+  originalApiKey = process.env.ANTHROPIC_API_KEY
+  originalMcpTrustPath = process.env.CHROXY_MCP_TRUST_PATH
+  process.env.HOME = tmpHome
+  process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-fixture'
+  process.env.CHROXY_MCP_TRUST_PATH = join(tmpHome, 'mcp-trust.json')
+})
+
+afterEach(() => {
+  if (originalHome) process.env.HOME = originalHome
+  else delete process.env.HOME
+  if (originalApiKey) process.env.ANTHROPIC_API_KEY = originalApiKey
+  else delete process.env.ANTHROPIC_API_KEY
+  if (originalMcpTrustPath) process.env.CHROXY_MCP_TRUST_PATH = originalMcpTrustPath
+  else delete process.env.CHROXY_MCP_TRUST_PATH
+  rmSync(tmpHome, { recursive: true, force: true })
+})
+
+describe('DockerByokSession static configuration', () => {
+  it('exposes the expected displayLabel', () => {
+    assert.equal(DockerByokSession.displayLabel, 'Claude (BYOK — Docker container)')
+  })
+
+  it('inherits BYOK capabilities and adds containerized: true', () => {
+    const caps = DockerByokSession.capabilities
+    assert.equal(caps.containerized, true)
+    // Sanity-check that the inherited BYOK capabilities still flow:
+    assert.equal(caps.permissions, true)
+    assert.equal(caps.inProcessPermissions, true)
+    assert.equal(caps.streaming, true)
+  })
+
+  it('declares BYOK credentials in preflight (label overridden)', () => {
+    const pf = DockerByokSession.preflight
+    assert.deepEqual(pf.credentials.envVars, ['ANTHROPIC_API_KEY'])
+    assert.equal(pf.credentials.optional, false)
+    assert.match(pf.label, /BYOK.*Docker/)
+  })
+
+  it('resolveAuth() returns the BYOK ready shape when ANTHROPIC_API_KEY is set', () => {
+    const helpers = {
+      cachedResolveCredentialFile: () => ({ key: 'sk-ant-test', source: 'env' }),
+    }
+    const result = DockerByokSession.resolveAuth({ ANTHROPIC_API_KEY: 'sk-ant-test' }, helpers)
+    assert.equal(result.ready, true)
+    assert.equal(result.source, 'env')
+    assert.equal(result.envVar, 'ANTHROPIC_API_KEY')
+  })
+
+  it('resolveAuth() returns not-ready when no key resolved', () => {
+    const helpers = {
+      cachedResolveCredentialFile: () => ({ key: null, source: 'none', reason: 'no credential file' }),
+    }
+    const result = DockerByokSession.resolveAuth({}, helpers)
+    assert.equal(result.ready, false)
+    assert.equal(result.source, 'none')
+  })
+})
+
+describe('DockerByokSession constructor', () => {
+  it('reports provider id "docker-byok"', () => {
+    const session = new DockerByokSession({ cwd: tmpHome, _execFile: execFileStub(), _dockerBackend: backendStub() })
+    assert.equal(session._provider, 'docker-byok')
+  })
+
+  it('extends ClaudeByokSession so the agent loop is inherited', () => {
+    const session = new DockerByokSession({ cwd: tmpHome, _execFile: execFileStub(), _dockerBackend: backendStub() })
+    assert.ok(session instanceof ClaudeByokSession)
+  })
+
+  it('applies sane defaults for image / memory / cpu / user', () => {
+    const session = new DockerByokSession({ cwd: tmpHome, _execFile: execFileStub(), _dockerBackend: backendStub() })
+    assert.equal(session._image, 'node:22-slim')
+    assert.equal(session._memoryLimit, '2g')
+    assert.equal(session._cpuLimit, '2')
+    assert.equal(session._containerUser, 'chroxy')
+    assert.equal(session._containerOwned, true)
+    assert.equal(session._containerId, null)
+  })
+
+  it('honors caller-provided overrides', () => {
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      image: 'node:22-bookworm',
+      memoryLimit: '4g',
+      cpuLimit: '4',
+      containerUser: 'agent',
+      _execFile: execFileStub(),
+      _dockerBackend: backendStub(),
+    })
+    assert.equal(session._image, 'node:22-bookworm')
+    assert.equal(session._memoryLimit, '4g')
+    assert.equal(session._cpuLimit, '4')
+    assert.equal(session._containerUser, 'agent')
+  })
+
+  it('refuses an invalid containerUser', () => {
+    assert.throws(
+      () => new DockerByokSession({ cwd: tmpHome, containerUser: 'BAD;USER', _execFile: execFileStub(), _dockerBackend: backendStub() }),
+      /Invalid containerUser/,
+    )
+  })
+
+  it('marks the session as not-owning when containerId is supplied', () => {
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      containerId: 'external-id-1234',
+      _execFile: execFileStub(),
+      _dockerBackend: backendStub(),
+    })
+    assert.equal(session._containerOwned, false)
+    assert.equal(session._containerId, 'external-id-1234')
+  })
+})
+
+describe('DockerByokSession start() — preflight + lifecycle', () => {
+  it('emits a docker_not_running error when `docker info` fails', async () => {
+    const _execFile = execFileStub({
+      info: { error: new Error('Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?'), stderr: 'Cannot connect to the Docker daemon' },
+    })
+    const session = new DockerByokSession({ cwd: tmpHome, _execFile, _dockerBackend: backendStub() })
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+    assert.equal(events.length, 1)
+    assert.equal(events[0].code, 'docker_not_running')
+    assert.match(events[0].message, /preflight/)
+  })
+
+  it('launches a container with the cwd mounted and ANTHROPIC_API_KEY forwarded', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_ID_0123456789ab\n' },
+      exec: { stdout: '' },
+    })
+    const session = new DockerByokSession({
+      cwd: '/tmp/chroxy-workspace',
+      _execFile,
+      _dockerBackend: backendStub(),
+    })
+    // Stub the Anthropic client so super.start() doesn't need network.
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // First call: `docker info` (preflight).
+    assert.equal(_execFile.calls[0].args[0], 'info')
+    // Second call: `docker run`.
+    const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+    assert.ok(runCall, 'expected a `docker run` call')
+    assert.ok(runCall.args.includes('-v'), 'volume flag missing')
+    const volumeFlag = runCall.args[runCall.args.indexOf('-v') + 1]
+    assert.equal(volumeFlag, '/tmp/chroxy-workspace:/workspace')
+    // API key is forwarded.
+    assert.ok(
+      runCall.args.some((a) => a.startsWith('ANTHROPIC_API_KEY=sk-ant-test-key-fixture')),
+      'ANTHROPIC_API_KEY not forwarded into container',
+    )
+    // Container hardening flags.
+    assert.ok(runCall.args.includes('--cap-drop'))
+    assert.ok(runCall.args.includes('--security-opt'))
+    assert.ok(runCall.args.includes('--pids-limit'))
+
+    assert.equal(session._containerId, 'CONTAINER_ID_0123456789ab')
+    assert.equal(session._containerReady, true)
+
+    await session.destroy()
+  })
+
+  it('destroys the container on session destroy when owned', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_ID_owned_999\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const session = new DockerByokSession({ cwd: tmpHome, _execFile, _dockerBackend: backendStub() })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    await session.destroy()
+
+    const rmCall = _execFile.calls.find((c) => c.args[0] === 'rm')
+    assert.ok(rmCall, 'docker rm -f was not called on destroy')
+    assert.ok(rmCall.args.includes('CONTAINER_ID_owned_999'))
+  })
+
+  it('does NOT destroy the container on session destroy when externally provided', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      exec: { stdout: '' },
+    })
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      containerId: 'external-managed',
+      _execFile,
+      _dockerBackend: backendStub(),
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    await session.destroy()
+
+    const rmCall = _execFile.calls.find((c) => c.args[0] === 'rm')
+    assert.equal(rmCall, undefined, 'external container must not be removed by the session')
+  })
+
+  it('surfaces a docker_image_not_found error when the run fails', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { error: new Error('Unable to find image \'nonexistent:latest\' locally\nno such image: nonexistent'), stderr: 'no such image: nonexistent' },
+    })
+    const session = new DockerByokSession({ cwd: tmpHome, image: 'nonexistent:latest', _execFile, _dockerBackend: backendStub() })
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+    assert.ok(events.length >= 1)
+    assert.equal(events[0].code, 'docker_image_not_found')
+  })
+})
+
+describe('remapToContainerPath()', () => {
+  it('maps an absolute path under cwd to /workspace/<suffix>', () => {
+    const result = remapToContainerPath('/host/cwd/src/foo.js', '/host/cwd')
+    assert.equal(result, '/workspace/src/foo.js')
+  })
+
+  it('maps the cwd itself to /workspace', () => {
+    assert.equal(remapToContainerPath('/host/cwd', '/host/cwd'), '/workspace')
+  })
+
+  it('maps a relative path onto /workspace', () => {
+    assert.equal(remapToContainerPath('src/foo.js', '/host/cwd'), '/workspace/src/foo.js')
+  })
+
+  it('refuses an absolute path outside cwd', () => {
+    assert.throws(
+      () => remapToContainerPath('/etc/passwd', '/host/cwd'),
+      /outside workspace/,
+    )
+  })
+
+  it('refuses a relative path that escapes via ..', () => {
+    assert.throws(
+      () => remapToContainerPath('../../etc/passwd', '/host/cwd'),
+      /outside workspace/,
+    )
+  })
+
+  it('refuses an empty file_path', () => {
+    assert.throws(
+      () => remapToContainerPath('', '/host/cwd'),
+      /required/,
+    )
+  })
+
+  it('normalizes a cwd with a trailing slash', () => {
+    assert.equal(remapToContainerPath('/host/cwd/foo', '/host/cwd/'), '/workspace/foo')
+  })
+
+  it('exports the canonical /workspace mount root', () => {
+    assert.equal(CONTAINER_WORKSPACE, '/workspace')
+  })
+})
+
+describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
+  function buildSession({ backend, execFile } = {}) {
+    const _dockerBackend = backend || backendStub()
+    const _execFile = execFile || execFileStub({ info: { stdout: 'ok' }, run: { stdout: 'CONTAINER_ID_aaa\n' }, exec: { stdout: '' } })
+    const session = new DockerByokSession({ cwd: '/host/cwd', _execFile, _dockerBackend })
+    // Simulate a started container so tool dispatch is allowed.
+    session._containerReady = true
+    session._containerId = 'CONTAINER_ID_aaa'
+    return { session, _dockerBackend, _execFile }
+  }
+
+  it('refuses tools when the container is not ready', async () => {
+    const _dockerBackend = backendStub()
+    const session = new DockerByokSession({ cwd: '/host/cwd', _execFile: execFileStub(), _dockerBackend })
+    // container NOT ready — default constructor state
+    const result = await session._dispatchBuiltinTool({ toolName: 'Bash', input: { command: 'true' } })
+    assert.equal(result.isError, true)
+    assert.match(result.content, /container not ready/)
+    assert.equal(_dockerBackend.calls.length, 0)
+  })
+
+  it('Read routes to `sed | head` inside the container', async () => {
+    const _dockerBackend = backendStub({
+      defaultResponse: { stdout: 'file contents here\n', stderr: '' },
+    })
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Read',
+      input: { file_path: '/host/cwd/foo.txt' },
+    })
+    assert.equal(result.isError, false)
+    assert.match(result.content, /file contents here/)
+    assert.equal(_dockerBackend.calls.length, 1)
+    assert.match(_dockerBackend.calls[0].cmd, /sed -n '1,2000p' '\/workspace\/foo\.txt'/)
+    assert.match(_dockerBackend.calls[0].cmd, /head -c/)
+  })
+
+  it('Read with offset and limit slices in the container', async () => {
+    const _dockerBackend = backendStub({ defaultResponse: { stdout: 'lines 10-15\n' } })
+    const { session } = buildSession({ backend: _dockerBackend })
+    await session._dispatchBuiltinTool({
+      toolName: 'Read',
+      input: { file_path: '/host/cwd/foo.txt', offset: 10, limit: 6 },
+    })
+    assert.match(_dockerBackend.calls[0].cmd, /sed -n '10,15p'/)
+  })
+
+  it('Read refuses a path outside cwd (returns is_error)', async () => {
+    const _dockerBackend = backendStub()
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Read',
+      input: { file_path: '/etc/passwd' },
+    })
+    assert.equal(result.isError, true)
+    assert.match(result.content, /outside workspace/)
+    assert.equal(_dockerBackend.calls.length, 0, 'must not docker exec a path-escape attempt')
+  })
+
+  it('Write base64-encodes content and pipes it into the container', async () => {
+    const _dockerBackend = backendStub({
+      defaultResponse: { stdout: '5\n', stderr: '' },
+    })
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Write',
+      input: { file_path: 'src/new.js', content: 'hello' },
+    })
+    assert.equal(result.isError, false)
+    assert.match(result.content, /Wrote 5 bytes/)
+    assert.equal(_dockerBackend.calls.length, 1)
+    const cmd = _dockerBackend.calls[0].cmd
+    assert.match(cmd, /mkdir -p '\/workspace\/src'/)
+    assert.match(cmd, /base64 -d > '\/workspace\/src\/new\.js'/)
+    // The base64 of 'hello' is aGVsbG8=
+    assert.match(cmd, /aGVsbG8=/)
+  })
+
+  it('Write refuses oversize content', async () => {
+    const _dockerBackend = backendStub()
+    const { session } = buildSession({ backend: _dockerBackend })
+    const bigContent = 'x'.repeat(512 * 1024 + 1)
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Write',
+      input: { file_path: 'big.bin', content: bigContent },
+    })
+    assert.equal(result.isError, true)
+    assert.match(result.content, /exceeds/)
+    assert.equal(_dockerBackend.calls.length, 0)
+  })
+
+  it('Bash routes the raw command through docker exec', async () => {
+    const _dockerBackend = backendStub({
+      defaultResponse: { stdout: 'hello\n', stderr: '' },
+    })
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Bash',
+      input: { command: 'echo hello' },
+    })
+    assert.equal(result.isError, false)
+    assert.match(result.content, /stdout:\nhello/)
+    assert.equal(_dockerBackend.calls.length, 1)
+    assert.equal(_dockerBackend.calls[0].cmd, 'echo hello')
+  })
+
+  it('Bash refuses when command is empty', async () => {
+    const _dockerBackend = backendStub()
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Bash',
+      input: { command: '' },
+    })
+    assert.equal(result.isError, true)
+    assert.match(result.content, /command is required/)
+    assert.equal(_dockerBackend.calls.length, 0)
+  })
+
+  it('Bash honors a pre-aborted signal without docker-exec', async () => {
+    const _dockerBackend = backendStub()
+    const { session } = buildSession({ backend: _dockerBackend })
+    const controller = new AbortController()
+    controller.abort()
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Bash',
+      input: { command: 'rm -rf /' },
+      signal: controller.signal,
+    })
+    assert.equal(result.isError, true)
+    assert.match(result.content, /Interrupted/)
+    assert.equal(_dockerBackend.calls.length, 0)
+  })
+
+  it('Glob refuses shell-dangerous patterns', async () => {
+    const _dockerBackend = backendStub()
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Glob',
+      input: { pattern: '*.js; rm -rf /' },
+    })
+    assert.equal(result.isError, true)
+    assert.match(result.content, /shell-dangerous/)
+    assert.equal(_dockerBackend.calls.length, 0)
+  })
+
+  it('Grep falls back to grep when rg is unavailable (cmd shape)', async () => {
+    const _dockerBackend = backendStub({
+      defaultResponse: { stdout: 'foo.js:1:match\n', stderr: '' },
+    })
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'Grep',
+      input: { pattern: 'match' },
+    })
+    assert.equal(result.isError, false)
+    assert.equal(_dockerBackend.calls.length, 1)
+    // Cmd is the rg-or-grep wrapper so both binaries appear:
+    assert.match(_dockerBackend.calls[0].cmd, /rg /)
+    assert.match(_dockerBackend.calls[0].cmd, /grep -r/)
+  })
+
+  it('TodoWrite remains host-side (falls through to super._dispatchBuiltinTool)', async () => {
+    const _dockerBackend = backendStub()
+    const { session } = buildSession({ backend: _dockerBackend })
+    const result = await session._dispatchBuiltinTool({
+      toolName: 'TodoWrite',
+      input: { todos: [{ id: 't1', content: 'thing', status: 'pending', activeForm: 'doing thing' }] },
+    })
+    // Super's executor will accept this — no docker call.
+    assert.equal(_dockerBackend.calls.length, 0)
+    assert.equal(result.isError, false)
+  })
+})
+
+describe('docker-byok provider registration', () => {
+  it('registerDockerProvider() wires docker-byok when environments are enabled and docker is available', async () => {
+    // Spy on console.warn so accidental log noise during the test
+    // doesn't leak into the suite output.
+    const config = { environments: { enabled: true } }
+    // The lazy import inside registerDockerProvider() shellsout to
+    // `docker info` via execFileSync. We can't stub that without
+    // patching child_process globally — but the registration is
+    // idempotent: if docker is unavailable, the function returns
+    // early. Either way, the result we care about is the registry
+    // shape after the call.
+    await registerDockerProvider(config).catch(() => {})
+    try {
+      const Klass = getProvider('docker-byok')
+      assert.ok(Klass === DockerByokSession, 'docker-byok must point at DockerByokSession')
+    } catch (err) {
+      // docker info failed on the CI runner → docker providers were
+      // skipped. That's an expected no-op path; the provider class is
+      // still importable and the lazy registration is idempotent.
+      assert.match(err.message, /Unknown provider/)
+    }
+  })
+})
+
+// Force a tick so any background EventEmitter cleanup completes
+// before the test runner exits.
+afterEach(async () => {
+  await new Promise((r) => setImmediate(r))
+})
+
+// Suppress an unused-import lint by referencing EventEmitter (kept
+// for forward-compat: future tests may need to assert event shape
+// without going through the full session).
+void EventEmitter


### PR DESCRIPTION
## Summary

Adds a `docker-byok` provider that runs the **claude-byok agent loop on the host** but redirects **tool execution** (Read / Write / Edit / Bash / Glob / Grep) into an **isolated Docker container**. Everything else — model streaming, permission gating, MCP dispatch, cost accounting — is inherited unchanged from `ClaudeByokSession`.

This is the natural docker-* sibling to the existing `docker-cli` and `docker-sdk` providers, but for the BYOK provider that's now landing.

## Scope decisions (v1)

**In:**
- `DockerByokSession` extends `ClaudeByokSession` via a new `_dispatchBuiltinTool` seam in `byok-session.js`. The base impl runs tools in-process (host-side, unchanged behavior); the subclass overrides it to route through `docker exec`.
- Container lifecycle: `docker info` preflight, long-lived `sleep infinity` container with the standard chroxy hardening (`--cap-drop ALL`, `--pids-limit`, `--security-opt no-new-privileges`, non-root user, `--memory` / `--cpus`). Same shape as `docker-sdk-session.js`.
- Workspace mount: host `cwd` → `/workspace`. Tool inputs map through `remapToContainerPath()` which refuses path traversal (absolute paths outside cwd, relative paths that escape via `..`).
- `ANTHROPIC_API_KEY` forwarded at `docker run` time per the AC. (The host-side agent loop is what actually authenticates to Anthropic; the in-container env var is for Bash commands the model might want to run that need it.)
- External-container support: when a `containerId` is supplied at construction, the session attaches instead of launching, and does NOT teardown on destroy (env-manager owns the lifecycle).
- `TodoWrite` / `WebFetch` stay host-side — they don't touch the container FS, so containerization adds latency for no benefit.
- Registered via `registerDockerProvider()` in `providers.js`. Skips silently if `docker info` fails at server boot — same gating as `docker-cli` / `docker-sdk`.

**Deferred to follow-up issues:**
- Container pooling / per-session reuse
- Snapshot / commit-based restore
- DevContainer / Compose-driven environments
- `postCreateCommand` hook
- Desktop dashboard provider-selector polish (the provider is already selectable today through the same `listProviders()` surface every other provider uses)

## Notes from project memory

- `feedback_jsonl_subprocess_middle_layer.md`: the constructor uses `super({ ...opts, provider: opts.provider || 'docker-byok' })` so every `BaseSession` opt is forwarded by reference — the opt-forwarding linter is naturally satisfied.
- `project_worktree_before_docker.md`: this class does NOT own worktree setup. The SessionManager / environment-manager already worktrees `cwd` before constructing the session, and we mount whatever cwd we're handed.
- `feedback_test_state_contamination.md`: the test suite does not construct a `SessionManager`, so the temp-`stateFilePath` rule does not apply here — but the `_setup.mjs` sandbox guard is in place for safety.

## Acceptance criteria

- [x] BYOK session running in a Docker container can read files inside the container, execute bash inside the container.
- [x] No host FS access without explicit volume mount (path-remap refuses traversal; `cwd` is the only host mount).
- [x] Container is cleaned up on session destroy (when owned).
- [x] Tests with a stub Docker socket (the `_dockerBackend` + `_execFile` constructor seams). No real Docker required to run the suite.

## Test plan

- [x] `node --test tests/docker-byok-session.test.js` — 37 tests, all pass
- [x] `node --test tests/byok-session.test.js` — 95 tests, all pass (refactor seam is a no-op for host-side)
- [x] `node --test tests/providers.test.js` — 76 tests, all pass
- [x] `node --test tests/docker-sdk-session.test.js tests/docker-session.test.js` — 130 tests, all pass
- [x] `node --test tests/byok-{tools,tool-executor,event-translator,credentials,mcp-config}.test.js` — 150 tests, all pass
- [x] `scripts/lint-session-opt-forwarding.sh` — OK: 6 subclasses forward all 19 BaseSession opts
- [x] `scripts/lint-tests-state-file-path.sh` — OK
- [ ] Manual smoke: spin up a chroxy session with `provider: docker-byok`, send a Bash + Read + Write tool sequence, confirm tool_results carry container output (deferred — Docker desktop UX wiring is a separate follow-up)

Closes #4053