### PR TITLE
ci: gate server-tests-windows on platform-only path filter (#5002)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,18 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     if: github.event_name == 'pull_request'
+    # `dorny/paths-filter` calls the GitHub REST API (`listFiles`) to read the
+    # PR's changed-file list on `pull_request` events. The workflow-level
+    # `permissions: contents: read` block at the top of this file zeros out
+    # every other scope, so we have to re-grant `pull-requests: read` at the
+    # job level — without it, the API call fails with "Resource not accessible
+    # by integration" on fork PRs and (potentially) any future GitHub change
+    # that tightens the implicit same-repo grant. Same-repo PRs happen to work
+    # today via the implicit token grant, but the explicit permission is what
+    # the action documents and what survives a fork PR.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       platform: ${{ steps.filter.outputs.platform }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,41 @@ jobs:
           path: packages/server/coverage/
           retention-days: 14
 
+  changes:
+    name: Detect Changed Paths
+    # Lightweight ubuntu job that classifies which paths a PR touches so
+    # downstream jobs can self-gate. Today this only feeds the Windows
+    # platform-tests job (#5002) — `windows-latest` is billed at a 5x
+    # multiplier vs `ubuntu-24.04`, so we only fire it on PRs that touch
+    # the files it actually covers. Pushes to `main` skip this job and
+    # always run the Windows suite (see `server-tests-windows.if`).
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    if: github.event_name == 'pull_request'
+    outputs:
+      platform: ${{ steps.filter.outputs.platform }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - id: filter
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        with:
+          filters: |
+            platform:
+              # Source — the production Windows code path lives in
+              # platform.js today, but glob with `platform*` so a future
+              # `platform-windows.js` / `platform-posix.js` split still
+              # triggers the Windows job without an edit here.
+              - 'packages/server/src/platform*.js'
+              # Tests — both the cross-platform suite (exercises the
+              # Windows branch via `_isWindowsOverride`) and the
+              # Windows-only suite. Glob covers any future
+              # platform-*.test.js additions.
+              - 'packages/server/tests/platform*.test.js'
+              # Workflow itself — so edits to this gating logic always
+              # exercise the gated job on the same PR.
+              - '.github/workflows/ci.yml'
+
   server-tests-windows:
     name: Server Platform Tests (Windows)
     # Real Windows runner coverage for `writeFileRestricted`'s Windows
@@ -61,6 +96,26 @@ jobs:
     # depends on node-pty / POSIX signals / shell scripts that don't have
     # a Windows analogue. The full POSIX suite continues to run on
     # `ubuntu-24.04` in the `server-tests` job above.
+    #
+    # Trigger gate (#5002): `windows-latest` is 5x the per-minute cost
+    # of `ubuntu-24.04`. To avoid paying that on every PR push:
+    #   * On `push` to `main` we ALWAYS run — catches transitive breakage
+    #     from PRs that merged without touching platform.js but broke
+    #     something the Windows suite covers.
+    #   * On `pull_request` we only run when the `changes` job flagged
+    #     a platform-related edit. Filter scope (see `changes` above) is
+    #     deliberately a touch broader than just `platform.js` to cover
+    #     the foreseeable refactor that splits the file in two.
+    needs: changes
+    # `always()` is required because the `changes` job is gated to
+    # `pull_request` and gets skipped on `push` events. Without it,
+    # the default `needs:` semantics ("skip downstream when any
+    # dependency is skipped") would also skip this job on pushes to
+    # `main`, which is the exact opposite of what we want.
+    if: |
+      always() &&
+      (github.event_name == 'push' ||
+       (github.event_name == 'pull_request' && needs.changes.result == 'success' && needs.changes.outputs.platform == 'true'))
     runs-on: windows-latest
     timeout-minutes: 10
     defaults:


### PR DESCRIPTION
Closes #5002.

## Summary

The `server-tests-windows` job added in #5001 runs on `windows-latest`, which GitHub bills at a **5x per-minute multiplier vs `ubuntu-24.04`**. Today it fires on every PR push regardless of whether the change touches the Windows-only code path it actually covers (`writeFileRestricted` in `platform.js` and the `platform-windows.test.js` suite).

This adds a path filter so we only pay the Windows-runner premium when a PR touches files the job can plausibly affect.

## Approach

1. Add a lightweight `changes` job (ubuntu, 2 min cap) that runs `dorny/paths-filter@v3` pinned by commit SHA. It outputs a single boolean `platform` that flips on for changes under:
   - `packages/server/src/platform*.js`
   - `packages/server/tests/platform*.test.js`
   - `.github/workflows/ci.yml`
2. Gate `server-tests-windows` on the combination:
   - `push` to `main` -> **always** run (catches transitive breakage from a merged PR that didn't touch `platform.js` but broke something the Windows suite covers).
   - `pull_request` -> run **only** when `changes.platform == 'true'`.

## Design notes

- **Glob over exact filenames.** The filter uses `platform*` rather than `platform.js` / `platform-windows.test.js` so a foreseeable refactor that splits the file into `platform-windows.js` + `platform-posix.js` (or adds more `platform-*.test.js` files) still picks up Windows coverage without an extra edit here. The issue body called this risk out explicitly.
- **Self-gating workflow edits.** Adding `.github/workflows/ci.yml` to the filter means any future edit to the gating logic itself triggers the gated job on the same PR — you can never break the gate silently.
- **`always() &&` on the gated job's `if:`.** The `changes` job is itself gated to `pull_request` and gets *skipped* on `push` events. Without `always()` the default `needs:` semantics ("skip downstream when any dependency is skipped") would also skip the Windows job on pushes to `main`, which would silently revoke the safety net the issue explicitly called for.
- **Trigger logic documented in the workflow.** Both jobs carry a comment block tying the gate back to issue #5002 and explaining the push-vs-PR split, so the next person to touch the file isn't reverse-engineering it from `if:` syntax.

## Acceptance criteria mapping

- [x] `server-tests-windows` only triggers on PRs that touch `packages/server/src/platform*.js` or `packages/server/tests/platform*.test.js`.
- [x] Pushes to `main` still always run the job.
- [x] Decision documented in the workflow YAML comment so the next person understands the trigger logic.

## Validation

- `ruby -ryaml -e "YAML.load_file('.github/workflows/ci.yml')"` -> OK
- `actionlint .github/workflows/ci.yml` -> clean
- Other CI jobs (`server-tests`, `server-lint`, `dashboard-tests`, ...) are untouched and continue to run on every PR push as before.

## Test plan

- [ ] Open this PR (no platform changes) -> `changes` runs, reports `platform: false`, `server-tests-windows` is skipped.
- [ ] Cherry-pick a no-op edit to `packages/server/src/platform.js` onto a scratch branch -> `changes` reports `platform: true`, `server-tests-windows` runs and passes.
- [ ] After squash-merge to `main` -> the push event runs `server-tests-windows` unconditionally (the `push` branch of the `if:`).