### PR TITLE
test(platform): pin icacls ACE removals to well-known SIDs

### DIFF
--- a/packages/server/tests/platform-windows.test.js
+++ b/packages/server/tests/platform-windows.test.js
@@ -197,10 +197,19 @@ try {
       const restrictedDir = join(tmpDir, 'restricted')
       mkdirSync(restrictedDir)
 
-      // Parse the current user's SID from `whoami /user`. The SID format
-      // (`S-1-<authority>-<rid>...`) is invariant across locales, so the
-      // regex match holds regardless of the column headers' language.
-      const whoami = spawnSync('whoami', ['/user'], { encoding: 'utf-8' })
+      // Parse the current user's SID from Windows' `whoami /user`. The SID
+      // format (`S-1-<authority>-<rid>...`) is invariant across locales, so
+      // the regex match holds regardless of the column headers' language.
+      //
+      // We invoke `whoami.exe` by absolute path under %SystemRoot%\System32
+      // because the Windows CI job runs under Git Bash (`shell: bash` in
+      // .github/workflows/ci.yml), and Git Bash ships its own Unix-style
+      // `whoami` earlier on PATH which does not accept `/user` — see #5003.
+      // `whoami /user` outputs exactly one SID-shaped token (the current
+      // user's), so first-match semantics are intentional.
+      const systemRoot = process.env.SystemRoot || 'C:\\Windows'
+      const whoamiExe = `${systemRoot}\\System32\\whoami.exe`
+      const whoami = spawnSync(whoamiExe, ['/user'], { encoding: 'utf-8' })
       assert.strictEqual(whoami.status, 0, `whoami /user failed: ${whoami.stderr}`)
       const userSid = (whoami.stdout.match(/\bS-1-[\d-]+/) || [])[0]
       assert.ok(userSid, `failed to extract current user SID from whoami /user output:\n${whoami.stdout}`)
@@ -225,39 +234,71 @@ try {
       assert.strictEqual(grant.status, 0, `icacls /grant failed: ${grant.stderr}`)
 
       // Write the file via the helper and read back its ACL via
-      // `icacls /save`, which emits the ACL in SDDL form. SDDL is a
-      // locale-independent serialisation that references principals by
-      // SID string (e.g. `(A;;FA;;;S-1-5-32-545)` for an Allow ACE on
-      // BUILTIN\Users) — the plain `icacls <file>` output resolves SIDs
-      // back to display names, which would be locale-dependent and undo
-      // the point of using SIDs above. `/save` expects a relative
-      // filename and writes it under the targeted file's directory.
+      // PowerShell's `(Get-Acl <path>).Sddl`, which returns a single line
+      // of canonical SDDL with principals serialised as raw `S-1-...`
+      // strings (no two-letter abbreviations like `WD`/`AU`/`BU`, no
+      // locale-dependent display names). This is the documented
+      // contract for the .NET FileSecurity / DirectorySecurity SDDL
+      // property the cmdlet wraps.
+      //
+      // Why not `icacls /save`: its output file is not specified to be
+      // SDDL (the docs only call it "an ACL file for later use with
+      // /restore"), is UTF-16 LE with BOM (so a utf-8 readFileSync
+      // returns nul-interleaved garbage), and even when it does emit
+      // SDDL fragments, well-known principals get two-letter
+      // abbreviations rather than raw SID strings — all three failure
+      // modes make the absence assertions vacuously true.
+      // Why not `icacls <file>`: it resolves SIDs back to display names,
+      // which would be locale-dependent and undo the entire point of
+      // pinning to SIDs above.
       const filePath = join(restrictedDir, 'secret.json')
       writeFileRestricted(filePath, JSON.stringify({ token: 'sensitive' }))
       assert.ok(existsSync(filePath), 'file must exist after writeFileRestricted')
 
-      const sddlFile = 'secret.json.sddl'
-      const save = spawnSync(
-        'icacls',
-        ['secret.json', '/save', sddlFile, '/Q'],
-        { cwd: restrictedDir, encoding: 'utf-8' }
+      // PowerShell on `windows-latest` is `powershell.exe` (Windows
+      // PowerShell 5.1). `-NoProfile` skips any user profile that could
+      // perturb the output; the `;` after the assignment keeps the
+      // emitted line to just the SDDL string.
+      const getAcl = spawnSync(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `(Get-Acl -LiteralPath '${filePath.replace(/'/g, "''")}').Sddl`,
+        ],
+        { encoding: 'utf-8' }
       )
-      assert.strictEqual(save.status, 0, `icacls /save failed: ${save.stderr}`)
-      const sddl = readFileSync(join(restrictedDir, sddlFile), 'utf-8')
+      assert.strictEqual(getAcl.status, 0, `Get-Acl failed: ${getAcl.stderr}`)
+      const sddl = getAcl.stdout.trim()
+      assert.ok(sddl.length > 0, `Get-Acl returned empty SDDL`)
 
-      // Assert the SDDL does not contain ACEs for the group/world SIDs.
-      // An ACE for a SID embeds it in `(A;...;<sid>)`; if the ACE is
-      // absent the SID simply isn't anywhere in the SDDL text.
+      // Tripwire: confirm the read-back path can actually detect a SID
+      // before we run absence assertions. We assert the current user's
+      // SID IS present (the explicit grant added above must round-trip
+      // into the file's inherited ACL), which means a future regression
+      // that breaks the read-back (encoding, format, parsing) would
+      // fire this assertion before silently green-lighting a real ACL
+      // regression downstream. See #5032.
       assert.ok(
-        !sddl.includes('S-1-5-32-545'),
+        sddl.includes(userSid),
+        `tripwire: SDDL must contain the current user's SID (${userSid}) — read-back path is broken if absent:\n${sddl}`
+      )
+
+      // Assert the SDDL does not contain the group/world SIDs. ACEs in
+      // SDDL are written as `(A;...;<sid>)` — we anchor on the closing
+      // `)` so a prefix collision (e.g. `S-1-5-11` vs `S-1-5-113`,
+      // `S-1-5-114`) cannot cause a false positive. See #5031.
+      assert.ok(
+        !/;S-1-5-32-545\)/.test(sddl),
         `SDDL must not contain BUILTIN\\Users (*S-1-5-32-545):\n${sddl}`
       )
       assert.ok(
-        !sddl.includes('S-1-1-0'),
+        !/;S-1-1-0\)/.test(sddl),
         `SDDL must not contain Everyone (*S-1-1-0):\n${sddl}`
       )
       assert.ok(
-        !sddl.includes('S-1-5-11'),
+        !/;S-1-5-11\)/.test(sddl),
         `SDDL must not contain Authenticated Users (*S-1-5-11):\n${sddl}`
       )
     })

--- a/packages/server/tests/platform-windows.test.js
+++ b/packages/server/tests/platform-windows.test.js
@@ -180,56 +180,86 @@ try {
       // _setup.mjs blocks writes to the real %USERPROFILE%\.chroxy\
       // anyway).
       //
-      // icacls steps:
+      // icacls steps (all principal identification via well-known SIDs so
+      // the test stays locale-portable — display-language changes on a
+      // future windows-latest image must not break ACE matching, #5003):
       //   1. /inheritance:d  — break inheritance so we can replace ACEs.
-      //   2. /remove "Users" /remove "Everyone" /remove "Authenticated Users"
-      //      — strip group/world access (these are the SIDs that a
-      //      profile-rooted directory would also lack).
-      //   3. /grant <user>:(OI)(CI)F — grant the current user full
-      //      control with object + container inherit so child files
-      //      inherit user-only access.
+      //   2. /remove *S-1-5-32-545 (BUILTIN\Users), *S-1-1-0 (Everyone),
+      //      *S-1-5-11 (Authenticated Users) — strip group/world access
+      //      (these are the SIDs that a profile-rooted directory would
+      //      also lack). icacls accepts the `*<SID>` prefix in place of a
+      //      principal name.
+      //   3. /grant *<current-user-SID>:(OI)(CI)F — grant the current user
+      //      full control with object + container inherit so child files
+      //      inherit user-only access. The current user's SID is parsed
+      //      from `whoami /user` so we don't rely on %USERNAME% resolving
+      //      to a locale-stable display name.
       const restrictedDir = join(tmpDir, 'restricted')
       mkdirSync(restrictedDir)
 
-      const user = process.env.USERNAME || process.env.USER || ''
-      assert.ok(user, 'USERNAME env var must be set to assert ACL inheritance')
+      // Parse the current user's SID from `whoami /user`. The SID format
+      // (`S-1-<authority>-<rid>...`) is invariant across locales, so the
+      // regex match holds regardless of the column headers' language.
+      const whoami = spawnSync('whoami', ['/user'], { encoding: 'utf-8' })
+      assert.strictEqual(whoami.status, 0, `whoami /user failed: ${whoami.stderr}`)
+      const userSid = (whoami.stdout.match(/\bS-1-[\d-]+/) || [])[0]
+      assert.ok(userSid, `failed to extract current user SID from whoami /user output:\n${whoami.stdout}`)
 
       const breakInherit = spawnSync('icacls', [restrictedDir, '/inheritance:d'], { encoding: 'utf-8' })
       assert.strictEqual(breakInherit.status, 0, `icacls /inheritance:d failed: ${breakInherit.stderr}`)
 
-      // Remove group/world SIDs. We use unlocalized strings — GitHub-hosted
-      // windows-latest is en-US, and non-en runners are not a current
-      // target. We tolerate "no such ACE" exits (the SIDs may not be
-      // present in the inherited ACL after :d), so we don't assert
-      // success on the remove steps.
-      spawnSync('icacls', [restrictedDir, '/remove', 'Users'], { encoding: 'utf-8' })
-      spawnSync('icacls', [restrictedDir, '/remove', 'Everyone'], { encoding: 'utf-8' })
-      spawnSync('icacls', [restrictedDir, '/remove', 'Authenticated Users'], { encoding: 'utf-8' })
+      // Remove group/world ACEs by well-known SID rather than by their
+      // localised principal names. We tolerate "no such ACE" exits (the
+      // SIDs may not be present in the inherited ACL after :d), so we
+      // don't assert success on the remove steps.
+      //   *S-1-5-32-545  BUILTIN\Users
+      //   *S-1-1-0       Everyone
+      //   *S-1-5-11      NT AUTHORITY\Authenticated Users
+      spawnSync('icacls', [restrictedDir, '/remove', '*S-1-5-32-545'], { encoding: 'utf-8' })
+      spawnSync('icacls', [restrictedDir, '/remove', '*S-1-1-0'], { encoding: 'utf-8' })
+      spawnSync('icacls', [restrictedDir, '/remove', '*S-1-5-11'], { encoding: 'utf-8' })
 
       // Grant the current user full control with OI/CI so files inherit
-      // user-only access.
-      const grant = spawnSync('icacls', [restrictedDir, '/grant', `${user}:(OI)(CI)F`], { encoding: 'utf-8' })
+      // user-only access. `*<SID>` keeps the call locale-independent.
+      const grant = spawnSync('icacls', [restrictedDir, '/grant', `*${userSid}:(OI)(CI)F`], { encoding: 'utf-8' })
       assert.strictEqual(grant.status, 0, `icacls /grant failed: ${grant.stderr}`)
 
-      // Write the file via the helper and read back its ACL. The
-      // security contract: a file written under a user-only profile
-      // directory inherits an ACL that excludes Users, Everyone, and
-      // Authenticated Users.
+      // Write the file via the helper and read back its ACL via
+      // `icacls /save`, which emits the ACL in SDDL form. SDDL is a
+      // locale-independent serialisation that references principals by
+      // SID string (e.g. `(A;;FA;;;S-1-5-32-545)` for an Allow ACE on
+      // BUILTIN\Users) — the plain `icacls <file>` output resolves SIDs
+      // back to display names, which would be locale-dependent and undo
+      // the point of using SIDs above. `/save` expects a relative
+      // filename and writes it under the targeted file's directory.
       const filePath = join(restrictedDir, 'secret.json')
       writeFileRestricted(filePath, JSON.stringify({ token: 'sensitive' }))
       assert.ok(existsSync(filePath), 'file must exist after writeFileRestricted')
 
-      const acl = spawnSync('icacls', [filePath], { encoding: 'utf-8' })
-      assert.strictEqual(acl.status, 0, `icacls read failed: ${acl.stderr}`)
+      const sddlFile = 'secret.json.sddl'
+      const save = spawnSync(
+        'icacls',
+        ['secret.json', '/save', sddlFile, '/Q'],
+        { cwd: restrictedDir, encoding: 'utf-8' }
+      )
+      assert.strictEqual(save.status, 0, `icacls /save failed: ${save.stderr}`)
+      const sddl = readFileSync(join(restrictedDir, sddlFile), 'utf-8')
 
-      // Each ACE line looks like:  "  BUILTIN\\Users:(R)"  or
-      // "  Everyone:(F)" — case-insensitive substring is robust enough
-      // for the assertion. If the ACE is missing entirely, the substring
-      // simply isn't found, which is what we want.
-      const output = acl.stdout.toLowerCase()
-      assert.ok(!output.includes('\\users:'), `icacls output must not grant BUILTIN\\Users access:\n${acl.stdout}`)
-      assert.ok(!output.includes('everyone:'), `icacls output must not grant Everyone access:\n${acl.stdout}`)
-      assert.ok(!output.includes('authenticated users:'), `icacls output must not grant Authenticated Users access:\n${acl.stdout}`)
+      // Assert the SDDL does not contain ACEs for the group/world SIDs.
+      // An ACE for a SID embeds it in `(A;...;<sid>)`; if the ACE is
+      // absent the SID simply isn't anywhere in the SDDL text.
+      assert.ok(
+        !sddl.includes('S-1-5-32-545'),
+        `SDDL must not contain BUILTIN\\Users (*S-1-5-32-545):\n${sddl}`
+      )
+      assert.ok(
+        !sddl.includes('S-1-1-0'),
+        `SDDL must not contain Everyone (*S-1-1-0):\n${sddl}`
+      )
+      assert.ok(
+        !sddl.includes('S-1-5-11'),
+        `SDDL must not contain Authenticated Users (*S-1-5-11):\n${sddl}`
+      )
     })
   })
 


### PR DESCRIPTION
## Summary

Identified during review of #5001. The Windows-only platform test suite removed group/world ACEs by their localised principal names (`Users`, `Everyone`, `Authenticated Users`) and asserted on lowercase substrings of the resolved `icacls <file>` output. Both sides of that contract are locale-dependent — a future `windows-latest` image shipped in any locale other than en-US would silently no-op the `/remove` calls and produce false results on the read-back.

This PR pins every ACE reference to its well-known SID, using icacls's `*<SID>` prefix syntax:

| SID | Principal |
|---|---|
| `*S-1-5-32-545` | `BUILTIN\Users` |
| `*S-1-1-0` | `Everyone` |
| `*S-1-5-11` | `NT AUTHORITY\Authenticated Users` |

For `/grant`, parse the current user's SID from `whoami /user` (the `S-1-<authority>-<rid>...` format is invariant across locales) and pass it via the same `*<SID>` syntax rather than relying on `%USERNAME%`.

For the read-back, switch from `icacls <file>` (resolves SIDs back to display names — locale-dependent) to `icacls <file> /save`, which emits the ACL in SDDL form. SDDL references principals by SID string directly, so absence assertions match against the raw SID regardless of runner locale.

## Scope

- Single test file: `packages/server/tests/platform-windows.test.js`.
- Suite is still gated on `process.platform === 'win32'`, so POSIX runners remain unaffected (still skip cleanly).
- No production code or other tests touch `icacls`, so the change is contained.

## Test plan

- [x] `node --check` on the test file passes.
- [x] `node --import ./tests/_setup.mjs --test tests/platform-windows.test.js` on macOS still reports the suite as skipped (1 suite, 0 tests).
- [x] `lint-tests-state-file-path.sh` and `lint-session-opt-forwarding.sh` pass.
- [ ] CI on this PR re-runs `Server Platform Tests (Windows)` against the new SID-based assertions on the en-US `windows-latest` image.

## Acceptance criteria mapping (#5003)

- [x] `/remove` and read-back substring checks use SID strings instead of localised principal names — `/remove` uses `*S-1-5-32-545`, `*S-1-1-0`, `*S-1-5-11`; read-back parses SDDL output (`icacls /save`) for the raw SID strings.
- [x] `/grant` for the current user uses the SID returned by `whoami /user` rather than `%USERNAME%` — regex-extracted `S-1-...` from `whoami /user` is passed as `*<SID>:(OI)(CI)F`.
- [ ] Test still passes on en-US `windows-latest` (verified via CI run on this PR).

Closes #5003.