### PR TITLE
feat(dashboard): a11y + theme polish for notifications widget (#5009)

### DIFF
--- a/packages/dashboard/src/components/NotificationsWidget.test.tsx
+++ b/packages/dashboard/src/components/NotificationsWidget.test.tsx
@@ -273,6 +273,278 @@ describe('NotificationsWidget — panel content + interactions', () => {
   })
 })
 
+// #5009 — a11y + theme polish follow-up to #5005. Pins the WAI-ARIA
+// Authoring Practices menu pattern (matching HeaderOverflowMenu #4980):
+// role="menu" + role="menuitem" rows, roving tabindex, ArrowDown/Up
+// wrap-around, Home/End jumps, focus-on-open, focus-restore on every
+// dismiss path, and aria-controls wiring.
+describe('NotificationsWidget — WAI-ARIA keyboard navigation (#5009)', () => {
+  it('trigger advertises aria-haspopup="menu" so AT announces the relationship', () => {
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1' })]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    const trigger = screen.getByTestId('notifications-widget-trigger')
+    expect(trigger.getAttribute('aria-haspopup')).toBe('menu')
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('panel is role="menu" with menuitem rows once open', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1' }),
+          makeNotification({ id: 'n-2', requestId: 'req-other' }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    const panel = screen.getByTestId('notifications-widget-panel')
+    expect(panel.getAttribute('role')).toBe('menu')
+    expect(
+      screen.getByTestId('notifications-widget-item-body-n-1').getAttribute('role'),
+    ).toBe('menuitem')
+    expect(
+      screen.getByTestId('notifications-widget-item-body-n-2').getAttribute('role'),
+    ).toBe('menuitem')
+    // aria-expanded flips when the panel opens.
+    expect(
+      screen.getByTestId('notifications-widget-trigger').getAttribute('aria-expanded'),
+    ).toBe('true')
+  })
+
+  it('wires aria-controls between trigger and panel', () => {
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1' })]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    const trigger = screen.getByTestId('notifications-widget-trigger')
+    const ariaControls = trigger.getAttribute('aria-controls')
+    expect(ariaControls).toBeTruthy()
+    fireEvent.click(trigger)
+    const panel = screen.getByTestId('notifications-widget-panel')
+    expect(panel.getAttribute('id')).toBe(ariaControls)
+  })
+
+  it('moves initial focus into the first row when the panel opens', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1', timestamp: 2000 }),
+          makeNotification({ id: 'n-2', requestId: 'req-2', timestamp: 1000 }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    // Sorted newest-first → n-1 (timestamp 2000) is first.
+    expect(document.activeElement).toBe(
+      screen.getByTestId('notifications-widget-item-body-n-1'),
+    )
+  })
+
+  it('uses roving tabindex — only the focused row is tabIndex=0', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1', timestamp: 3000 }),
+          makeNotification({ id: 'n-2', requestId: 'req-2', timestamp: 2000 }),
+          makeNotification({ id: 'n-3', requestId: 'req-3', timestamp: 1000 }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    expect(screen.getByTestId('notifications-widget-item-body-n-1').tabIndex).toBe(0)
+    expect(screen.getByTestId('notifications-widget-item-body-n-2').tabIndex).toBe(-1)
+    expect(screen.getByTestId('notifications-widget-item-body-n-3').tabIndex).toBe(-1)
+  })
+
+  it('ArrowDown moves focus to the next row with wrap-around', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1', timestamp: 3000 }),
+          makeNotification({ id: 'n-2', requestId: 'req-2', timestamp: 2000 }),
+          makeNotification({ id: 'n-3', requestId: 'req-3', timestamp: 1000 }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    const first = screen.getByTestId('notifications-widget-item-body-n-1')
+    const second = screen.getByTestId('notifications-widget-item-body-n-2')
+    const third = screen.getByTestId('notifications-widget-item-body-n-3')
+    fireEvent.keyDown(first, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(second)
+    fireEvent.keyDown(second, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(third)
+    // Wrap from last → first
+    fireEvent.keyDown(third, { key: 'ArrowDown' })
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('ArrowUp moves focus to the previous row with wrap-around', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1', timestamp: 3000 }),
+          makeNotification({ id: 'n-2', requestId: 'req-2', timestamp: 2000 }),
+          makeNotification({ id: 'n-3', requestId: 'req-3', timestamp: 1000 }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    const first = screen.getByTestId('notifications-widget-item-body-n-1')
+    const third = screen.getByTestId('notifications-widget-item-body-n-3')
+    // Wrap from first → last
+    fireEvent.keyDown(first, { key: 'ArrowUp' })
+    expect(document.activeElement).toBe(third)
+  })
+
+  it('Home jumps focus to the first row', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1', timestamp: 3000 }),
+          makeNotification({ id: 'n-2', requestId: 'req-2', timestamp: 2000 }),
+          makeNotification({ id: 'n-3', requestId: 'req-3', timestamp: 1000 }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    const first = screen.getByTestId('notifications-widget-item-body-n-1')
+    const third = screen.getByTestId('notifications-widget-item-body-n-3')
+    fireEvent.keyDown(first, { key: 'End' })
+    expect(document.activeElement).toBe(third)
+    fireEvent.keyDown(third, { key: 'Home' })
+    expect(document.activeElement).toBe(first)
+  })
+
+  it('End jumps focus to the last row', () => {
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1', timestamp: 3000 }),
+          makeNotification({ id: 'n-2', requestId: 'req-2', timestamp: 2000 }),
+          makeNotification({ id: 'n-3', requestId: 'req-3', timestamp: 1000 }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    const first = screen.getByTestId('notifications-widget-item-body-n-1')
+    const third = screen.getByTestId('notifications-widget-item-body-n-3')
+    fireEvent.keyDown(first, { key: 'End' })
+    expect(document.activeElement).toBe(third)
+  })
+
+  it('Escape returns focus to the trigger', () => {
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1' })]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    const trigger = screen.getByTestId('notifications-widget-trigger')
+    fireEvent.click(trigger)
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('returns focus to the trigger after row activation (so Tab continues into the next header control)', () => {
+    const onMarkRead = vi.fn()
+    const onSwitchSession = vi.fn()
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1', sessionId: 'sess-target' })]}
+        onSwitchSession={onSwitchSession}
+        onMarkRead={onMarkRead}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    const trigger = screen.getByTestId('notifications-widget-trigger')
+    fireEvent.click(trigger)
+    fireEvent.click(screen.getByTestId('notifications-widget-item-body-n-1'))
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('returns focus to the trigger after outside-click dismissal', () => {
+    render(
+      <div>
+        <button data-testid="outside-btn">outside</button>
+        <NotificationsWidget
+          notifications={[makeNotification({ id: 'n-1' })]}
+          onSwitchSession={vi.fn()}
+          onMarkRead={vi.fn()}
+          onMarkAllRead={vi.fn()}
+          onDismiss={vi.fn()}
+        />
+      </div>,
+    )
+    const trigger = screen.getByTestId('notifications-widget-trigger')
+    fireEvent.click(trigger)
+    fireEvent.mouseDown(screen.getByTestId('outside-btn'))
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('returns focus to the trigger when the panel is dismissed via window blur', () => {
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1' })]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    const trigger = screen.getByTestId('notifications-widget-trigger')
+    fireEvent.click(trigger)
+    expect(screen.getByTestId('notifications-widget-panel')).toBeInTheDocument()
+    fireEvent.blur(window)
+    expect(screen.queryByTestId('notifications-widget-panel')).not.toBeInTheDocument()
+    expect(document.activeElement).toBe(trigger)
+  })
+})
+
 describe('NotificationsWidget — end-to-end: viewing decrements unread', () => {
   it('clicking an item marks it read so the badge decrements on next render', () => {
     // Simulate the App-side wiring: the widget receives notifications + the

--- a/packages/dashboard/src/components/NotificationsWidget.test.tsx
+++ b/packages/dashboard/src/components/NotificationsWidget.test.tsx
@@ -294,7 +294,7 @@ describe('NotificationsWidget — WAI-ARIA keyboard navigation (#5009)', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false')
   })
 
-  it('panel is role="menu" with menuitem rows once open', () => {
+  it('list is role="menu" with menuitem rows once open', () => {
     render(
       <NotificationsWidget
         notifications={[
@@ -308,8 +308,16 @@ describe('NotificationsWidget — WAI-ARIA keyboard navigation (#5009)', () => {
       />,
     )
     fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    // #5009 — role="menu" sits on the <ul>, not the outer panel <div>,
+    // so the menu's only children are role="menuitem" rows (per the
+    // WAI-ARIA menu pattern). The header / "Mark all read" / per-row
+    // action buttons stay outside the menu sub-tree.
+    const list = screen.getByTestId('notifications-widget-list')
+    expect(list.getAttribute('role')).toBe('menu')
+    expect(list.getAttribute('aria-orientation')).toBe('vertical')
+    // Outer panel keeps its labelling but does NOT carry role="menu".
     const panel = screen.getByTestId('notifications-widget-panel')
-    expect(panel.getAttribute('role')).toBe('menu')
+    expect(panel.getAttribute('role')).toBeNull()
     expect(
       screen.getByTestId('notifications-widget-item-body-n-1').getAttribute('role'),
     ).toBe('menuitem')
@@ -542,6 +550,84 @@ describe('NotificationsWidget — WAI-ARIA keyboard navigation (#5009)', () => {
     fireEvent.blur(window)
     expect(screen.queryByTestId('notifications-widget-panel')).not.toBeInTheDocument()
     expect(document.activeElement).toBe(trigger)
+  })
+
+  it('role="menu" sits on the <ul>, with "Mark all read" outside the menu sub-tree and per-row actions excluded from Tab order', () => {
+    // #5009 — Copilot review feedback (PR #5030). The original
+    // implementation put role="menu" on the outer panel <div> which
+    // also wrapped the header "Mark all read" button — breaking the
+    // WAI-ARIA menu pattern (a menu's only top-level descendants
+    // should be menuitems). After the fix, role="menu" sits on the
+    // <ul>, "Mark all read" lives in the header above the menu, and
+    // the per-row eye / × action buttons (which DO sit inside the <li>
+    // for visual alignment) carry tabIndex={-1} so they can't pollute
+    // the menu's Tab order while it's open.
+    render(
+      <NotificationsWidget
+        notifications={[
+          makeNotification({ id: 'n-1' }),
+          makeNotification({ id: 'n-2', requestId: 'req-other' }),
+        ]}
+        onSwitchSession={vi.fn()}
+        onMarkRead={vi.fn()}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    const menu = screen.getByTestId('notifications-widget-list')
+    expect(menu.getAttribute('role')).toBe('menu')
+    // "Mark all read" sits OUTSIDE the role="menu" sub-tree.
+    expect(menu.contains(screen.getByTestId('notifications-widget-mark-all-read'))).toBe(false)
+    // Per-row action buttons are tabIndex=-1 — they don't pollute the
+    // menu's Tab order even though they live inside the <li> for
+    // visual alignment with the row.
+    expect(screen.getByTestId('notifications-widget-item-mark-read-n-1').tabIndex).toBe(-1)
+    expect(screen.getByTestId('notifications-widget-item-dismiss-n-1').tabIndex).toBe(-1)
+    expect(screen.getByTestId('notifications-widget-item-dismiss-n-2').tabIndex).toBe(-1)
+  })
+
+  it('Enter activates the focused row (mark read + switch session + close)', () => {
+    const onMarkRead = vi.fn()
+    const onSwitchSession = vi.fn()
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1', sessionId: 'sess-target' })]}
+        onSwitchSession={onSwitchSession}
+        onMarkRead={onMarkRead}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    const first = screen.getByTestId('notifications-widget-item-body-n-1')
+    fireEvent.keyDown(first, { key: 'Enter' })
+    expect(onMarkRead).toHaveBeenCalledWith('n-1')
+    expect(onSwitchSession).toHaveBeenCalledWith('sess-target')
+    expect(screen.queryByTestId('notifications-widget-panel')).not.toBeInTheDocument()
+  })
+
+  it('Space activates the focused row (mark read + switch session + close)', () => {
+    // #5009 — Space activation explicitly wired so a focused button
+    // inside an overflow-y container doesn't scroll the panel instead
+    // of activating the row. Matches HeaderOverflowMenu.
+    const onMarkRead = vi.fn()
+    const onSwitchSession = vi.fn()
+    render(
+      <NotificationsWidget
+        notifications={[makeNotification({ id: 'n-1', sessionId: 'sess-target' })]}
+        onSwitchSession={onSwitchSession}
+        onMarkRead={onMarkRead}
+        onMarkAllRead={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('notifications-widget-trigger'))
+    const first = screen.getByTestId('notifications-widget-item-body-n-1')
+    fireEvent.keyDown(first, { key: ' ' })
+    expect(onMarkRead).toHaveBeenCalledWith('n-1')
+    expect(onSwitchSession).toHaveBeenCalledWith('sess-target')
+    expect(screen.queryByTestId('notifications-widget-panel')).not.toBeInTheDocument()
   })
 })
 

--- a/packages/dashboard/src/components/NotificationsWidget.tsx
+++ b/packages/dashboard/src/components/NotificationsWidget.tsx
@@ -26,13 +26,23 @@
  * follow-up issue.
  *
  * Dismiss pattern mirrors HeaderOverflowMenu (#4974/#4980): capturing
- * mousedown for outside click, Escape, window blur. Focus is NOT trapped
- * inside the panel because the list can be long and operators may want
- * to Tab into the surrounding header — assistive tech still gets the
- * `role="dialog"` + `aria-label` wire-up, and the trigger's
- * `aria-expanded` advertises the open state.
+ * mousedown for outside click, Escape, window blur.
+ *
+ * #5009 — a11y + theme polish (follow-up to #5005):
+ *   - Full WAI-ARIA Authoring Practices menu pattern (matches
+ *     HeaderOverflowMenu #4980): role="menu", role="menuitem" rows,
+ *     roving tabindex, ArrowDown/Up wrap-around, Home/End jumps, Enter
+ *     activates focused row.
+ *   - Focus moves into the first item when the panel opens and returns
+ *     to the trigger on every dismiss path (Escape, outside-click,
+ *     window blur, item activation).
+ *   - `aria-controls` wires the trigger to the panel id via `useId()`.
+ *   - Bell + eye glyphs are inline SVG (consistent with other header
+ *     icons that render via CSS / plain unicode, not platform color
+ *     emoji fonts — important inside stripped-down Tauri webviews).
  */
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
 import type { SessionNotification } from '../store/types'
 
 const EVENT_LABELS: Record<SessionNotification['eventType'], string> = {
@@ -70,6 +80,55 @@ function formatRelative(ts: number, now: number): string {
   return `${day}d ago`
 }
 
+/**
+ * Inline bell glyph (#5009). Replaces the U+1F514 emoji code-point so
+ * the trigger renders consistently in webviews without color-emoji
+ * fonts (e.g. stripped-down Tauri WKWebView profiles) — matches the
+ * approach taken by the surrounding header icons (`+`, `⋯`).
+ */
+function BellIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+      <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" />
+    </svg>
+  )
+}
+
+/** Inline eye glyph (#5009). Same rationale as BellIcon. */
+function EyeIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  )
+}
+
 export function NotificationsWidget({
   notifications,
   onSwitchSession,
@@ -78,8 +137,18 @@ export function NotificationsWidget({
   onDismiss,
 }: NotificationsWidgetProps) {
   const [open, setOpen] = useState(false)
+  // #5009 — roving tabindex: tracks which row is currently in the Tab
+  // order. Reset to 0 on open so re-opens always land on the first row.
+  const [focusedIndex, setFocusedIndex] = useState(0)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const panelRef = useRef<HTMLDivElement>(null)
+  // #5009 — item refs for imperative focus on arrow-key nav. A ref array
+  // keeps the API independent of the data-testid contract and avoids
+  // DOM lookups on every focus shift. Mirrors HeaderOverflowMenu.
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([])
+  // #5009 — stable id for `aria-controls` wire-up between trigger and
+  // panel. `useId` is React 18+ SSR-safe; matches HeaderOverflowMenu.
+  const panelId = useId()
 
   // Newest first — sorted by timestamp descending. Memoised so the array
   // reference is stable across re-renders for downstream useEffect deps.
@@ -103,13 +172,15 @@ export function NotificationsWidget({
       const target = e.target as Node
       if (panelRef.current && panelRef.current.contains(target)) return
       if (triggerRef.current && triggerRef.current.contains(target)) return
+      // #5009 — focus restoration is handled centrally by the cleanup
+      // effect below; just flip `open` and let every dismiss path
+      // converge through the same restore branch.
       setOpen(false)
     }
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.stopPropagation()
         setOpen(false)
-        triggerRef.current?.focus()
       }
     }
     const onBlur = () => setOpen(false)
@@ -122,6 +193,56 @@ export function NotificationsWidget({
       window.removeEventListener('blur', onBlur)
     }
   }, [open])
+
+  // #5009 — on open, reset focused index AND imperatively move focus to
+  // the first row. Mirrors HeaderOverflowMenu's open-focus effect. The
+  // tabIndex={0} alone only governs Tab traversal; programmatic focus is
+  // required to land the cursor inside the panel for keyboard users.
+  useEffect(() => {
+    if (!open) return
+    setFocusedIndex(0)
+    const first = itemRefs.current[0]
+    if (first) first.focus()
+  }, [open])
+
+  // #5009 — single focus-restore cleanup runs on every open → close
+  // transition so every dismiss path (Escape, outside-click, window
+  // blur, item activation) reliably returns focus to the trigger.
+  // Matches the pattern landed for HeaderOverflowMenu in #4996.
+  useEffect(() => {
+    if (!open) return
+    const active = document.activeElement as HTMLElement | null
+    const previouslyFocused =
+      active && active !== document.body && !panelRef.current?.contains(active)
+        ? active
+        : triggerRef.current
+    return () => {
+      if (previouslyFocused && previouslyFocused.isConnected) {
+        previouslyFocused.focus()
+      }
+    }
+  }, [open])
+
+  // #5009 — when focusedIndex changes (via arrow keys / Home / End),
+  // imperatively move focus to the matching row.
+  useEffect(() => {
+    if (!open) return
+    const target = itemRefs.current[focusedIndex]
+    if (target && document.activeElement !== target) {
+      target.focus()
+    }
+  }, [focusedIndex, open])
+
+  // #5009 — clamp focusedIndex when the visible row set shrinks while
+  // the panel is open (e.g. an alert is dismissed mid-interaction). If
+  // we don't clamp, no row holds tabIndex={0} and the focus-sync effect
+  // reads a null ref — arrow nav silently stops working.
+  useEffect(() => {
+    if (!open) return
+    if (focusedIndex >= sorted.length && sorted.length > 0) {
+      setFocusedIndex(sorted.length - 1)
+    }
+  }, [sorted.length, focusedIndex, open])
 
   const badgeText =
     unreadCount === 0
@@ -144,13 +265,16 @@ export function NotificationsWidget({
         data-testid="notifications-widget-trigger"
         onClick={() => setOpen((prev) => !prev)}
         aria-label={triggerLabel}
-        aria-haspopup="dialog"
+        aria-haspopup="menu"
         aria-expanded={open}
+        // #5009 — aria-controls links the trigger to the panel's id so
+        // assistive tech announces the relationship. Per WAI-ARIA the
+        // attribute is allowed regardless of open state.
+        aria-controls={panelId}
         title={triggerLabel}
       >
-        {/* Inline bell glyph — avoids pulling an icon font for one symbol. */}
-        <span className="notifications-widget-icon" aria-hidden="true">
-          {'\u{1F514}'}
+        <span className="notifications-widget-icon">
+          <BellIcon />
         </span>
         {badgeText !== null && (
           <span
@@ -165,10 +289,12 @@ export function NotificationsWidget({
       {open && (
         <div
           ref={panelRef}
+          id={panelId}
           className="notifications-widget-panel"
           data-testid="notifications-widget-panel"
-          role="dialog"
+          role="menu"
           aria-label="Intervention notifications"
+          aria-orientation="vertical"
         >
           <div className="notifications-widget-header">
             <span className="notifications-widget-title">Notifications</span>
@@ -195,7 +321,7 @@ export function NotificationsWidget({
               className="notifications-widget-list"
               data-testid="notifications-widget-list"
             >
-              {sorted.map((n) => {
+              {sorted.map((n, index) => {
                 const isUnread = n.readAt === undefined
                 const rowClass = [
                   'notifications-widget-item',
@@ -204,6 +330,41 @@ export function NotificationsWidget({
                     : 'notifications-widget-item--read',
                   `notifications-widget-item--${n.eventType}`,
                 ].join(' ')
+                const isFocused = focusedIndex === index
+                const handleKeyDown = (e: ReactKeyboardEvent<HTMLButtonElement>) => {
+                  switch (e.key) {
+                    case 'ArrowDown': {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      setFocusedIndex((i) => (i + 1) % sorted.length)
+                      break
+                    }
+                    case 'ArrowUp': {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      setFocusedIndex((i) => (i - 1 + sorted.length) % sorted.length)
+                      break
+                    }
+                    case 'Home': {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      setFocusedIndex(0)
+                      break
+                    }
+                    case 'End': {
+                      e.preventDefault()
+                      e.stopPropagation()
+                      setFocusedIndex(sorted.length - 1)
+                      break
+                    }
+                    // Escape is handled at the document level so it
+                    // still fires when focus has drifted away from the
+                    // panel. Enter/Space activate the body button's
+                    // default click handler — no extra wire-up needed.
+                    default:
+                      break
+                  }
+                }
                 return (
                   <li
                     key={n.id}
@@ -212,7 +373,17 @@ export function NotificationsWidget({
                     data-read={isUnread ? 'false' : 'true'}
                   >
                     <button
+                      ref={(node) => {
+                        itemRefs.current[index] = node
+                      }}
                       type="button"
+                      role="menuitem"
+                      // #5009 — roving tabindex: only the focused row
+                      // is in the Tab order. The rest stay
+                      // programmatically focusable (arrow-key handler
+                      // calls .focus()) without polluting the outer
+                      // header's Tab order.
+                      tabIndex={isFocused ? 0 : -1}
                       className="notifications-widget-item-body"
                       data-testid={`notifications-widget-item-body-${n.id}`}
                       onClick={() => {
@@ -220,6 +391,7 @@ export function NotificationsWidget({
                         onSwitchSession(n.sessionId)
                         setOpen(false)
                       }}
+                      onKeyDown={handleKeyDown}
                     >
                       <span className="notifications-widget-item-type">
                         {EVENT_LABELS[n.eventType]}
@@ -247,8 +419,7 @@ export function NotificationsWidget({
                             onMarkRead(n.id)
                           }}
                         >
-                          {/* eye glyph */}
-                          {'\u{1F441}'}
+                          <EyeIcon />
                         </button>
                       )}
                       <button

--- a/packages/dashboard/src/components/NotificationsWidget.tsx
+++ b/packages/dashboard/src/components/NotificationsWidget.tsx
@@ -30,13 +30,18 @@
  *
  * #5009 — a11y + theme polish (follow-up to #5005):
  *   - Full WAI-ARIA Authoring Practices menu pattern (matches
- *     HeaderOverflowMenu #4980): role="menu", role="menuitem" rows,
- *     roving tabindex, ArrowDown/Up wrap-around, Home/End jumps, Enter
- *     activates focused row.
+ *     HeaderOverflowMenu #4980): role="menu" on the <ul> (so its only
+ *     children are role="menuitem" rows — the surrounding header /
+ *     "Mark all read" / per-row action buttons stay outside the menu
+ *     sub-tree), roving tabindex, ArrowDown/Up wrap-around, Home/End
+ *     jumps, Enter/Space activate focused row.
  *   - Focus moves into the first item when the panel opens and returns
  *     to the trigger on every dismiss path (Escape, outside-click,
  *     window blur, item activation).
  *   - `aria-controls` wires the trigger to the panel id via `useId()`.
+ *     The panel is the popover container; the menu (the <ul>) is one
+ *     of its children. AT announces the panel as a labelled region and
+ *     the menu as the keyboard-navigable list inside it.
  *   - Bell + eye glyphs are inline SVG (consistent with other header
  *     icons that render via CSS / plain unicode, not platform color
  *     emoji fonts — important inside stripped-down Tauri webviews).
@@ -292,9 +297,7 @@ export function NotificationsWidget({
           id={panelId}
           className="notifications-widget-panel"
           data-testid="notifications-widget-panel"
-          role="menu"
           aria-label="Intervention notifications"
-          aria-orientation="vertical"
         >
           <div className="notifications-widget-header">
             <span className="notifications-widget-title">Notifications</span>
@@ -317,9 +320,18 @@ export function NotificationsWidget({
               No notifications.
             </div>
           ) : (
+            // #5009 — role="menu" sits on the <ul> so its only
+            // descendants are role="menuitem" rows. The surrounding
+            // header / "Mark all read" / per-row eye / × buttons stay
+            // outside the menu sub-tree (placing them inside would
+            // violate the WAI-ARIA menu pattern and undermine roving
+            // tabindex). Mirrors HeaderOverflowMenu / SessionContextMenu.
             <ul
               className="notifications-widget-list"
               data-testid="notifications-widget-list"
+              role="menu"
+              aria-label="Intervention notifications"
+              aria-orientation="vertical"
             >
               {sorted.map((n, index) => {
                 const isUnread = n.readAt === undefined
@@ -357,10 +369,25 @@ export function NotificationsWidget({
                       setFocusedIndex(sorted.length - 1)
                       break
                     }
+                    case 'Enter':
+                    case ' ': {
+                      // #5009 — Enter activates the row natively on a
+                      // <button>, but Space scrolls the overflow-y
+                      // container in some browsers when focus is on a
+                      // button inside it. preventDefault + explicit
+                      // activation matches HeaderOverflowMenu's handler
+                      // and keeps Space behavior consistent across
+                      // browsers.
+                      e.preventDefault()
+                      e.stopPropagation()
+                      onMarkRead(n.id)
+                      onSwitchSession(n.sessionId)
+                      setOpen(false)
+                      break
+                    }
                     // Escape is handled at the document level so it
                     // still fires when focus has drifted away from the
-                    // panel. Enter/Space activate the body button's
-                    // default click handler — no extra wire-up needed.
+                    // panel.
                     default:
                       break
                   }
@@ -406,10 +433,19 @@ export function NotificationsWidget({
                         {formatRelative(n.timestamp, now)}
                       </span>
                     </button>
+                    {/* #5009 — per-row action buttons sit inside the
+                        <li> for visual alignment, but tabIndex={-1}
+                        keeps them out of the Tab order while the menu
+                        is open. Keyboard activation uses the menuitem
+                        button's Enter/Space (which marks read + switches
+                        session) or the dedicated "Mark all read" button
+                        in the header. Mouse users still get per-row
+                        affordances. */}
                     <div className="notifications-widget-item-actions">
                       {isUnread && (
                         <button
                           type="button"
+                          tabIndex={-1}
                           className="notifications-widget-item-mark-read"
                           data-testid={`notifications-widget-item-mark-read-${n.id}`}
                           aria-label="Mark as read"
@@ -424,6 +460,7 @@ export function NotificationsWidget({
                       )}
                       <button
                         type="button"
+                        tabIndex={-1}
                         className="notifications-widget-item-dismiss"
                         data-testid={`notifications-widget-item-dismiss-${n.id}`}
                         aria-label="Dismiss"

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -2999,6 +2999,9 @@
   justify-content: center;
   font-size: var(--text-base);
   line-height: 1;
+  /* #5009 — bell glyph is inline SVG; inherit currentColor from the
+     header button so light/dark themes both render correctly. */
+  color: currentColor;
 }
 
 .notifications-widget-badge {
@@ -3125,8 +3128,22 @@
   overflow: hidden;
 }
 
-.notifications-widget-item-body:hover {
-  background: var(--bg-quaternary, rgba(255, 255, 255, 0.04));
+.notifications-widget-item-body:hover,
+.notifications-widget-item-body:focus-visible {
+  /* #5009 — `--bg-quaternary` wasn't defined in any theme; the previous
+     `rgba(255,255,255,0.04)` fallback was a dark-theme-only white tint
+     that washed out in light themes. `--bg-tertiary` is an existing
+     theme token so the hover swatch tracks both light and dark.
+     :focus-visible is paired so keyboard-only nav surfaces the same
+     emphasis as mouse hover. */
+  background: var(--bg-tertiary);
+}
+
+.notifications-widget-item-body:focus-visible {
+  /* Explicit focus ring on top of the hover swatch so keyboard users
+     can see exactly which row holds the cursor as they arrow through. */
+  outline: 2px solid var(--accent-blue);
+  outline-offset: -2px;
 }
 
 .notifications-widget-item-type {
@@ -3185,6 +3202,12 @@
   border-radius: 4px;
   font-size: var(--text-sm);
   line-height: 1;
+  /* #5009 — center the inline SVG glyph in the action button so the
+     mark-read and dismiss affordances align on the baseline regardless
+     of glyph height. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .notifications-widget-item-mark-read:hover,


### PR DESCRIPTION
Closes #5009.

Follow-up to #5005 — brings the intervention notifications widget up to the same WAI-ARIA Authoring Practices menu pattern as [`HeaderOverflowMenu`](https://github.com/blamechris/chroxy/blob/main/packages/dashboard/src/components/HeaderOverflowMenu.tsx) (hardened in #4980), and fixes a theme-token regression in the row hover state.

## Summary

Addresses every item from #5009:

1. **`role=\"dialog\"` → `role=\"menu\"` (full pattern).** `role=\"dialog\"` implies focus management, but the widget intentionally doesn't trap focus. Matching the sibling component (HeaderOverflowMenu's menu pattern) is the honest fix:
   - `role=\"menu\"` on the panel, `role=\"menuitem\"` on each row body
   - Roving tabindex — only the focused row sits in the Tab order
   - ArrowDown/ArrowUp wrap-around, Home/End jumps
   - Enter/Space activate via the row body's native click handler
   - Focus moves into the first row on open
   - Focus restores to the trigger on every dismiss path (Escape, outside-click, window blur, item activation) via a single open-transition cleanup effect (mirrors #4996)
   - `focusedIndex` clamps when the visible row set shrinks mid-interaction so arrow nav doesn't silently break

2. **`aria-controls` linking trigger ↔ panel** — wired via `useId()` exactly like HeaderOverflowMenu.

3. **ArrowDown / ArrowUp / Home / End navigation between rows** — landed as part of (1).

4. **`--bg-quaternary` hover fallback theme regression** — the token wasn't defined in any theme; the `rgba(255,255,255,0.04)` fallback was a dark-theme-only white tint that washed out in light themes. Switched to `--bg-tertiary` (existing token, theme-aware). Added a `:focus-visible` outline so keyboard-only nav surfaces the same row emphasis as mouse hover.

5. **Bell + eye emoji glyphs** — replaced U+1F514 / U+1F441 with inline SVGs. The other header icons (`+`, `⋯`) render via CSS / plain unicode rather than platform color-emoji fonts; the emoji glyphs were inconsistent in stripped-down Tauri WKWebView profiles.

## Test plan

- [x] 13 new tests in `NotificationsWidget.test.tsx` pin the WAI-ARIA contract (aria-haspopup=\"menu\", aria-controls wiring, role=menu, role=menuitem, roving tabindex, ArrowDown/ArrowUp wrap, Home/End jumps, focus-on-open, focus-restore via Escape / row activation / outside-click / window blur)
- [x] All 2828 dashboard tests pass (`npx vitest run`)
- [x] `tsc --noEmit` clean
- [x] Production build clean (`npx vite build`)
- [ ] Manual smoke (after merge): open widget with keyboard only, verify arrow nav, verify focus returns to bell on Escape, verify hover/focus background in both light and dark themes