### PR TITLE
fix(store): recognize CJK unicode sentence terminators in mid-sentence gate (#5014)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2788,6 +2788,169 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       expect(responses[0].content).toBe('(see the docs for more.)');
       expect(responses[1].content).toBe('Continuing with the next section.');
     });
+
+    // #5014 -- unicode sentence terminators (CJK fullwidth + ideographic
+    // full stop) must also satisfy the gate so paragraph splits are
+    // preserved across a tool boundary in non-ASCII assistant output.
+    it('STILL splits when prior ends in a fullwidth full stop (U+FF0E)', () => {
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'ファイルを確認します．',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Bash',
+        toolUseId: 'toolu_a',
+        input: {},
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: '次の段落です．',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(2);
+      expect(responses[0].content).toBe('ファイルを確認します．');
+      expect(responses[1].content).toBe('次の段落です．');
+    });
+
+    it('STILL splits when prior ends in a fullwidth exclamation mark (U+FF01)', () => {
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'やった！',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Bash',
+        toolUseId: 'toolu_a',
+        input: {},
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: '続行します．',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(2);
+      expect(responses[0].content).toBe('やった！');
+      expect(responses[1].content).toBe('続行します．');
+    });
+
+    it('STILL splits when prior ends in a fullwidth question mark (U+FF1F)', () => {
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: 'これは正しいですか？',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Bash',
+        toolUseId: 'toolu_a',
+        input: {},
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: '確認しました．',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(2);
+      expect(responses[0].content).toBe('これは正しいですか？');
+      expect(responses[1].content).toBe('確認しました．');
+    });
+
+    it('STILL splits when prior ends in an ideographic full stop (U+3002)', () => {
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: '准备检查文件。',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Bash',
+        toolUseId: 'toolu_a',
+        input: {},
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: '现在归档。',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(2);
+      expect(responses[0].content).toBe('准备检查文件。');
+      expect(responses[1].content).toBe('现在归档。');
+    });
   });
 });
 

--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -2951,6 +2951,49 @@ describe('post-tool text chunks split into continuation slots (#4922 / #4889)', 
       expect(responses[0].content).toBe('准备检查文件。');
       expect(responses[1].content).toBe('现在归档。');
     });
+
+    // #5033 review -- composition: CJK terminator wrapped in a CJK closing
+    // bracket must still satisfy the gate. The strip set drops `」` so the
+    // gate sees `。` and the split fires.
+    it('STILL splits when prior ends in a CJK terminator wrapped in a CJK closing bracket', () => {
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({ type: 'stream_start', messageId: 'resp-1', sessionId: 's1' });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: '「ファイルを確認します。」',
+      });
+      jest.runAllTimers();
+      _testMessageHandler.handle({
+        type: 'tool_start',
+        messageId: 'toolu_a',
+        sessionId: 's1',
+        tool: 'Bash',
+        toolUseId: 'toolu_a',
+        input: {},
+      });
+      _testMessageHandler.handle({
+        type: 'stream_delta',
+        messageId: 'resp-1',
+        sessionId: 's1',
+        delta: '次の段落です．',
+      });
+      jest.runAllTimers();
+
+      const ss = store.getState().sessionStates.s1;
+      const responses = ss.messages.filter((m) => m.type === 'response');
+      expect(responses).toHaveLength(2);
+      expect(responses[0].content).toBe('「ファイルを確認します。」');
+      expect(responses[1].content).toBe('次の段落です．');
+    });
   });
 });
 

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -1685,9 +1685,24 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
               // this, `"He said \"done.\""` reads as ending in `"` and the
               // #4889 split would wrongly disable -- paragraph breaks across
               // a tool boundary would be lost.
-              const stripped = lastNonWs.replace(/[)\]}"'’”»›]+$/, '');
+              // #5014 -- also strip CJK closing brackets (`」』）`) so a
+              // fullwidth-terminated sentence wrapped in CJK quotes still
+              // reads as sentence-complete.
+              const stripped = lastNonWs.replace(/[)\]}"'’”»›」』）]+$/, '');
               const lastChar = stripped.charAt(stripped.length - 1);
-              const endsSentence = lastChar === '.' || lastChar === '!' || lastChar === '?';
+              // #5014 -- recognize CJK fullwidth sentence terminators
+              // (`．` U+FF0E, `！` U+FF01, `？` U+FF1F) and the ideographic
+              // full stop (`。` U+3002) alongside ASCII. Without these, CJK
+              // assistant output would coalesce two sentences across a tool
+              // boundary when the user expects a paragraph break.
+              const endsSentence =
+                lastChar === '.' ||
+                lastChar === '!' ||
+                lastChar === '?' ||
+                lastChar === '．' ||
+                lastChar === '！' ||
+                lastChar === '？' ||
+                lastChar === '。';
               const endsHardBreak = /\n\s*$/.test(priorFullForGate);
               if (!endsSentence && !endsHardBreak) {
                 toolAfter = false;

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -2159,6 +2159,62 @@ describe('dashboard message-handler dispatch', () => {
         expect(responses[0].content).toBe('准备检查文件。')
         expect(responses[1].content).toBe('现在归档。')
       })
+
+      // #5033 review — composition: CJK terminator wrapped in a CJK closing
+      // bracket must still satisfy the gate. The strip set drops `」` so the
+      // gate sees `。` and the split fires.
+      it('STILL splits when prior ends in a CJK terminator wrapped in a CJK closing bracket', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: '「ファイルを確認します。」',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: {},
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: '次の段落です．',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(2)
+        expect(responses[0].content).toBe('「ファイルを確認します。」')
+        expect(responses[1].content).toBe('次の段落です．')
+      })
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -1944,6 +1944,221 @@ describe('dashboard message-handler dispatch', () => {
         expect(responses[0].content).toBe('(see the docs for more.)')
         expect(responses[1].content).toBe('Continuing with the next section.')
       })
+
+      // #5014 — unicode sentence terminators (CJK fullwidth + ideographic
+      // full stop) must also satisfy the gate so paragraph splits are
+      // preserved across a tool boundary in non-ASCII assistant output.
+      it('STILL splits when prior ends in a fullwidth full stop (U+FF0E)', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'ファイルを確認します．',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: {},
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: '次の段落です．',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(2)
+        expect(responses[0].content).toBe('ファイルを確認します．')
+        expect(responses[1].content).toBe('次の段落です．')
+      })
+
+      it('STILL splits when prior ends in a fullwidth exclamation mark (U+FF01)', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'やった！',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: {},
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: '続行します．',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(2)
+        expect(responses[0].content).toBe('やった！')
+        expect(responses[1].content).toBe('続行します．')
+      })
+
+      it('STILL splits when prior ends in a fullwidth question mark (U+FF1F)', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: 'これは正しいですか？',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: {},
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: '確認しました．',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(2)
+        expect(responses[0].content).toBe('これは正しいですか？')
+        expect(responses[1].content).toBe('確認しました．')
+      })
+
+      it('STILL splits when prior ends in an ideographic full stop (U+3002)', () => {
+        store = createMockStore(
+          baseState({
+            activeSessionId: 's1',
+            sessions: [{ sessionId: 's1', name: 'S1' } as any],
+            sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+          }),
+        )
+        setStore(store)
+
+        handleMessage(
+          { type: 'stream_start', messageId: 'resp-1', sessionId: 's1' },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: '准备检查文件。',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+        handleMessage(
+          {
+            type: 'tool_start',
+            messageId: 'toolu_a',
+            tool: 'Bash',
+            toolUseId: 'toolu_a',
+            input: {},
+            sessionId: 's1',
+          },
+          ctx() as any,
+        )
+        handleMessage(
+          {
+            type: 'stream_delta',
+            messageId: 'resp-1',
+            sessionId: 's1',
+            delta: '现在归档。',
+          },
+          ctx() as any,
+        )
+        vi.runAllTimers()
+
+        const ss = (store.getState() as any).sessionStates.s1
+        const responses = ss.messages.filter((m: any) => m.type === 'response')
+        expect(responses).toHaveLength(2)
+        expect(responses[0].content).toBe('准备检查文件。')
+        expect(responses[1].content).toBe('现在归档。')
+      })
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1522,9 +1522,24 @@ function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
           // `"He said \"done.\""` reads as ending in `"` and the #4889 split
           // would wrongly disable — paragraph breaks across a tool boundary
           // would be lost.
-          const stripped = lastNonWs.replace(/[)\]}"'’”»›]+$/, '');
+          // #5014 — also strip CJK closing brackets (`」』）`) so a
+          // fullwidth-terminated sentence wrapped in CJK quotes still
+          // reads as sentence-complete.
+          const stripped = lastNonWs.replace(/[)\]}"'’”»›」』）]+$/, '');
           const lastChar = stripped.charAt(stripped.length - 1);
-          const endsSentence = lastChar === '.' || lastChar === '!' || lastChar === '?';
+          // #5014 — recognize CJK fullwidth sentence terminators
+          // (`．` U+FF0E, `！` U+FF01, `？` U+FF1F) and the ideographic
+          // full stop (`。` U+3002) alongside ASCII. Without these, CJK
+          // assistant output would coalesce two sentences across a tool
+          // boundary when the user expects a paragraph break.
+          const endsSentence =
+            lastChar === '.' ||
+            lastChar === '!' ||
+            lastChar === '?' ||
+            lastChar === '．' ||
+            lastChar === '！' ||
+            lastChar === '？' ||
+            lastChar === '。';
           const endsHardBreak = /\n\s*$/.test(priorFullForGate);
           if (!endsSentence && !endsHardBreak) {
             toolAfter = false;


### PR DESCRIPTION
## Summary

- Extend the post-#5011 mid-sentence gate to recognize CJK fullwidth sentence terminators (`．` U+FF0E, `！` U+FF01, `？` U+FF1F) and the ideographic full stop (`。` U+3002) alongside ASCII.
- Widen the closing-punct strip to include CJK closing brackets (`」』）`) so a fullwidth-terminated sentence wrapped in CJK quotes still reads as sentence-complete.
- Mirrored byte-for-byte in both `packages/dashboard/src/store/message-handler.ts` and `packages/app/src/store/message-handler.ts`, matching the existing comment-style differences (em-dash vs `--`) per file.

Defensive cleanup — chroxy's assistant output is ASCII today, but if a model ever emits CJK output with a fullwidth period before a tool call, the gate would otherwise coalesce two sentences across the tool boundary.

Closes #5014.

## Test plan

- [x] `cd packages/dashboard && npx vitest run store/message-handler` — 225 passed (was 221 → +4 new tests)
- [x] `cd packages/app && NODE_ENV=production npx jest src/__tests__/store/message-handler.test.ts` — 164 passed (was 160 → +4 new tests)
- [x] Each unicode terminator (`．`, `！`, `？`, `。`) has its own test case in both packages, mirroring the existing ASCII split-still-fires pattern.