### PR TITLE
feat(dashboard): polish docker-byok provider selector (#5026)

### DIFF
--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -686,13 +686,18 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
             </div>
           )
         })()}
-        {/* #5026: when a containerized provider is selected and no
-            environment is picked, hint at the Environments panel as the
-            path for customising image / memory / cpu / containerUser.
-            The provider will fall back to its built-in defaults
-            (node:22-slim, 2g, 2 cpus, chroxy user) when launched without
-            an environmentId. */}
-        {availableProviders.length > 0 && selectedProviderInfo?.capabilities?.containerized && !selectedProviderUnready && (
+        {/* #5026: when a containerized provider is selected and the
+            user hasn't yet picked an environment, hint at the Environments
+            panel as the path for customising image / memory / cpu /
+            containerUser. The provider will fall back to its built-in
+            defaults (node:22-slim, 2g, 2 cpus, chroxy user) when launched
+            without an environmentId. Once an environment is selected we
+            hide the hint — the Environment dropdown's own form-hint
+            ("Connect to a persistent environment container") takes over
+            and tells the user what they'll get. (#5036 Copilot review:
+            without the !environmentId gate, the hint and the dropdown
+            both ended up describing the same thing.) */}
+        {availableProviders.length > 0 && selectedProviderInfo?.capabilities?.containerized && !selectedProviderUnready && !environmentId && (
           <div
             className="provider-container-hint"
             data-testid="provider-container-hint"
@@ -701,8 +706,8 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
             <span className="provider-container-hint-label">Container settings:</span>{' '}
             <span className="provider-container-hint-body">
               {environments.length > 0
-                ? 'Pick an environment below to use its image / memory / CPU. Otherwise the provider defaults apply (node:22-slim, 2g RAM, 2 CPUs).'
-                : 'Uses the provider defaults (node:22-slim, 2g RAM, 2 CPUs). Create an Environment to customise image / memory / CPU / container user.'}
+                ? 'Pick an Environment in Advanced to use its image / memory / CPU. Otherwise the provider defaults apply (node:22-slim, 2g RAM, 2 CPUs).'
+                : 'Uses the provider defaults (node:22-slim, 2g RAM, 2 CPUs). Open the Environments panel to create one with a custom image / memory / CPU / container user.'}
             </span>
           </div>
         )}

--- a/packages/dashboard/src/components/CreateSessionModal.tsx
+++ b/packages/dashboard/src/components/CreateSessionModal.tsx
@@ -79,12 +79,21 @@ const PROVIDER_BILLING: Record<string, string> = {
   'claude-byok': 'Direct Anthropic API — per-token billing with your own ANTHROPIC_API_KEY. No claude binary required.',
   'docker-cli': 'Docker-isolated — uses your Claude subscription',
   'docker-sdk': 'Docker-isolated — uses Anthropic API credits',
+  // #5026: docker-byok runs the BYOK agent loop on the host (so chroxy talks
+  // to api.anthropic.com directly) while file/Bash tool execution happens
+  // inside an isolated Docker container. Trade-off vs. claude-byok: same
+  // billing (your ANTHROPIC_API_KEY), but tool side-effects are sandboxed.
+  'docker-byok': 'Direct Anthropic API (your ANTHROPIC_API_KEY) — tool execution sandboxed in a Docker container. Same billing as claude-byok, isolated filesystem.',
   'codex': 'Uses OpenAI API credits',
   'gemini': 'Uses Google API credits',
 }
 
 /** Short labels for capability badges. */
 const CAPABILITY_BADGES: [keyof import('../store/types').ProviderCapabilities, string][] = [
+  // #5026: containerized first so the most-distinctive capability of
+  // docker-* providers reads at a glance. Stays hidden for host-only
+  // providers (capabilities.containerized is falsy on those).
+  ['containerized', 'Containerized'],
   ['resume', 'Resume'],
   ['planMode', 'Plan'],
   ['permissions', 'Permissions'],
@@ -663,12 +672,40 @@ export function CreateSessionModal({ open, onClose, onCreate, initialCwd, knownC
           if (badges.length === 0) return null
           return (
             <div className="provider-capabilities" data-testid="provider-capabilities">
-              {badges.map(([, label]) => (
-                <span key={label} className="capability-badge">{label}</span>
+              {badges.map(([key, label]) => (
+                // #5026: data-capability lets CSS pick out the
+                // containerized badge for a distinct chrome so the eye
+                // reads "this provider is sandboxed" at a glance,
+                // without changing how the other badges render.
+                <span
+                  key={label}
+                  className="capability-badge"
+                  data-capability={key}
+                >{label}</span>
               ))}
             </div>
           )
         })()}
+        {/* #5026: when a containerized provider is selected and no
+            environment is picked, hint at the Environments panel as the
+            path for customising image / memory / cpu / containerUser.
+            The provider will fall back to its built-in defaults
+            (node:22-slim, 2g, 2 cpus, chroxy user) when launched without
+            an environmentId. */}
+        {availableProviders.length > 0 && selectedProviderInfo?.capabilities?.containerized && !selectedProviderUnready && (
+          <div
+            className="provider-container-hint"
+            data-testid="provider-container-hint"
+            role="note"
+          >
+            <span className="provider-container-hint-label">Container settings:</span>{' '}
+            <span className="provider-container-hint-body">
+              {environments.length > 0
+                ? 'Pick an environment below to use its image / memory / CPU. Otherwise the provider defaults apply (node:22-slim, 2g RAM, 2 CPUs).'
+                : 'Uses the provider defaults (node:22-slim, 2g RAM, 2 CPUs). Create an Environment to customise image / memory / CPU / container user.'}
+            </span>
+          </div>
+        )}
       </div>
       <div className="advanced-toggle">
         <button

--- a/packages/dashboard/src/components/CreateSessionModalDockerByok.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalDockerByok.test.tsx
@@ -13,7 +13,7 @@
  *     to docker-* providers)
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, cleanup } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent } from '@testing-library/react'
 import type { ProviderInfo } from '../store/types'
 
 vi.mock('../hooks/usePathAutocomplete', () => ({
@@ -184,8 +184,60 @@ describe('docker-byok provider-selector runtime polish (#5026)', () => {
     )
     const hint = screen.getByTestId('provider-container-hint')
     // When environments exist the hint should steer the user to the
-    // dropdown rather than telling them to create one.
-    expect(hint.textContent).toMatch(/Pick an environment/i)
+    // dropdown rather than telling them to create one. The dropdown lives
+    // in the Advanced section, so the copy must point there (#5036
+    // Copilot review) — not the previous misleading "below" wording.
+    expect(hint.textContent).toMatch(/Pick an Environment/i)
+    expect(hint.textContent).toMatch(/Advanced/)
+  })
+
+  // #5036 Copilot review: the previous gate left the hint visible even
+  // after the user had explicitly selected an Environment, at which point
+  // the dropdown's own form-hint already explains what container will
+  // launch and the redundant "Container settings:" block was noise.
+  it('hides the container hint once an Environment is selected', () => {
+    ;(globalThis as unknown as { __TEST_STATE__: Record<string, unknown> }).__TEST_STATE__ = {
+      ...buildState('docker-byok', [DOCKER_BYOK_PROVIDER]),
+      environments: [
+        {
+          id: 'env-1',
+          name: 'main',
+          cwd: '/tmp',
+          image: 'node:22-slim',
+          containerId: 'abc',
+          containerUser: 'chroxy',
+          containerCliPath: '/usr/local/bin/claude',
+          status: 'running',
+          sessions: [],
+          createdAt: new Date().toISOString(),
+          memoryLimit: '2g',
+          cpuLimit: '2',
+        },
+      ],
+    }
+    render(
+      <CreateSessionModal
+        open={true}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        initialCwd=""
+        knownCwds={[]}
+        existingNames={[]}
+      />,
+    )
+    // Hint visible before an Environment is picked.
+    expect(screen.getByTestId('provider-container-hint')).toBeTruthy()
+    // Open Advanced so the Environment dropdown is reachable.
+    // Multiple nodes contain "Advanced" (the toggle button + the new
+    // copy inside the hint), so target the toggle button explicitly.
+    const advancedToggle = document.querySelector('.advanced-toggle-btn') as HTMLButtonElement
+    expect(advancedToggle).toBeTruthy()
+    fireEvent.click(advancedToggle)
+    const envSelect = screen.getByLabelText(/^Environment$/) as HTMLSelectElement
+    fireEvent.change(envSelect, { target: { value: 'env-1' } })
+    // Hint must disappear — the dropdown's own form-hint now describes
+    // what will launch.
+    expect(screen.queryByTestId('provider-container-hint')).toBeNull()
   })
 
   it('surfaces the docker-byok vs. claude-byok trade-off in the billing hint', () => {

--- a/packages/dashboard/src/components/CreateSessionModalDockerByok.test.tsx
+++ b/packages/dashboard/src/components/CreateSessionModalDockerByok.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Runtime polish tests for the docker-byok provider selector (#5026).
+ *
+ * Asserts the rendered behaviour:
+ *   - the option label resolves through PROVIDER_LABELS (not the raw
+ *     provider id)
+ *   - the "Containerized" capability badge renders with the
+ *     data-capability="containerized" hook so CSS can style it distinctly
+ *   - selecting docker-byok shows the container-settings hint (gated on
+ *     `capabilities.containerized`)
+ *   - selecting claude-byok does NOT show the container hint or the
+ *     Containerized badge (regression guard so the polish stays scoped
+ *     to docker-* providers)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import type { ProviderInfo } from '../store/types'
+
+vi.mock('../hooks/usePathAutocomplete', () => ({
+  usePathAutocomplete: () => ({ suggestions: [] }),
+}))
+
+const baseCaps = {
+  permissions: true,
+  inProcessPermissions: false,
+  modelSwitch: true,
+  permissionModeSwitch: true,
+  planMode: true,
+  resume: true,
+  terminal: false,
+}
+
+const DOCKER_BYOK_PROVIDER: ProviderInfo = {
+  name: 'docker-byok',
+  capabilities: {
+    ...baseCaps,
+    containerized: true,
+    sessionRules: true,
+  },
+  auth: {
+    ready: true,
+    source: 'env',
+    envVar: 'ANTHROPIC_API_KEY',
+    envVars: ['ANTHROPIC_API_KEY'],
+    hint: '',
+    detail: 'Direct Anthropic API (your ANTHROPIC_API_KEY set)',
+  },
+}
+
+const CLAUDE_BYOK_PROVIDER: ProviderInfo = {
+  name: 'claude-byok',
+  capabilities: {
+    ...baseCaps,
+    sessionRules: true,
+  },
+  auth: {
+    ready: true,
+    source: 'env',
+    envVar: 'ANTHROPIC_API_KEY',
+    envVars: ['ANTHROPIC_API_KEY'],
+    hint: '',
+    detail: 'Direct Anthropic API (your ANTHROPIC_API_KEY set)',
+  },
+}
+
+function buildState(defaultProvider: string, providers: ProviderInfo[]) {
+  return {
+    defaultProvider,
+    defaultModel: '',
+    availableModels: [],
+    availableModelsProvider: null,
+    availableProviders: providers,
+    availablePermissionModes: [],
+    environments: [],
+    requestDirectoryListing: () => {},
+    setDirectoryListingCallback: () => {},
+    defaultCwd: null,
+  }
+}
+
+vi.mock('../store/connection', () => ({
+  useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector((globalThis as unknown as { __TEST_STATE__: Record<string, unknown> }).__TEST_STATE__),
+}))
+
+import { CreateSessionModal } from './CreateSessionModal'
+
+afterEach(() => {
+  cleanup()
+  delete (globalThis as unknown as { __TEST_STATE__?: Record<string, unknown> }).__TEST_STATE__
+})
+
+function renderWithState(defaultProvider: string, providers: ProviderInfo[]) {
+  ;(globalThis as unknown as { __TEST_STATE__: Record<string, unknown> }).__TEST_STATE__ =
+    buildState(defaultProvider, providers)
+  return render(
+    <CreateSessionModal
+      open={true}
+      onClose={vi.fn()}
+      onCreate={vi.fn()}
+      initialCwd=""
+      knownCwds={[]}
+      existingNames={[]}
+    />,
+  )
+}
+
+describe('docker-byok provider-selector runtime polish (#5026)', () => {
+  it('renders the human-readable label for docker-byok (not the raw id)', () => {
+    renderWithState('docker-byok', [DOCKER_BYOK_PROVIDER])
+    const select = screen.getByLabelText('Select provider') as HTMLSelectElement
+    const option = Array.from(select.options).find(o => o.value === 'docker-byok')
+    expect(option).toBeTruthy()
+    expect(option!.textContent).toMatch(/Claude \(BYOK — Docker container\)/)
+    // The raw id alone is a regression — the label must render the
+    // human-readable copy from PROVIDER_LABELS.
+    expect(option!.textContent).not.toBe('docker-byok')
+  })
+
+  it('renders the "Containerized" capability badge with data-capability="containerized"', () => {
+    renderWithState('docker-byok', [DOCKER_BYOK_PROVIDER])
+    const badges = screen.getByTestId('provider-capabilities')
+    const containerizedBadge = badges.querySelector('[data-capability="containerized"]')
+    expect(containerizedBadge).toBeTruthy()
+    expect(containerizedBadge!.textContent).toBe('Containerized')
+  })
+
+  it('shows the container-settings hint when docker-byok is selected', () => {
+    renderWithState('docker-byok', [DOCKER_BYOK_PROVIDER])
+    const hint = screen.getByTestId('provider-container-hint')
+    expect(hint).toBeTruthy()
+    // Default branch (no environments) must explain the built-in defaults
+    // so the user knows what they'll get without picking an Environment.
+    expect(hint.textContent).toMatch(/node:22-slim/)
+    expect(hint.textContent).toMatch(/2g/i)
+    expect(hint.textContent).toMatch(/Environment/i)
+  })
+
+  it('does NOT show the container hint for claude-byok (regression guard)', () => {
+    renderWithState('claude-byok', [CLAUDE_BYOK_PROVIDER])
+    expect(screen.queryByTestId('provider-container-hint')).toBeNull()
+  })
+
+  it('does NOT render a Containerized badge for claude-byok (regression guard)', () => {
+    renderWithState('claude-byok', [CLAUDE_BYOK_PROVIDER])
+    const badges = screen.queryByTestId('provider-capabilities')
+    // claude-byok may not have any badges at all if none of resume / plan /
+    // permissions / terminal apply — either way the containerized hook
+    // must not appear.
+    if (badges) {
+      expect(badges.querySelector('[data-capability="containerized"]')).toBeNull()
+    }
+  })
+
+  it('switches the hint copy when an environment exists', () => {
+    ;(globalThis as unknown as { __TEST_STATE__: Record<string, unknown> }).__TEST_STATE__ = {
+      ...buildState('docker-byok', [DOCKER_BYOK_PROVIDER]),
+      environments: [
+        {
+          id: 'env-1',
+          name: 'main',
+          cwd: '/tmp',
+          image: 'node:22-slim',
+          containerId: 'abc',
+          containerUser: 'chroxy',
+          containerCliPath: '/usr/local/bin/claude',
+          status: 'running',
+          sessions: [],
+          createdAt: new Date().toISOString(),
+          memoryLimit: '2g',
+          cpuLimit: '2',
+        },
+      ],
+    }
+    render(
+      <CreateSessionModal
+        open={true}
+        onClose={vi.fn()}
+        onCreate={vi.fn()}
+        initialCwd=""
+        knownCwds={[]}
+        existingNames={[]}
+      />,
+    )
+    const hint = screen.getByTestId('provider-container-hint')
+    // When environments exist the hint should steer the user to the
+    // dropdown rather than telling them to create one.
+    expect(hint.textContent).toMatch(/Pick an environment/i)
+  })
+
+  it('surfaces the docker-byok vs. claude-byok trade-off in the billing hint', () => {
+    renderWithState('docker-byok', [DOCKER_BYOK_PROVIDER])
+    // The live auth.detail wins over PROVIDER_BILLING here (auth.ready
+    // is true with a populated detail), but the static PROVIDER_BILLING
+    // entry MUST still be present so a server without the detail field
+    // (or one running older code) gets the trade-off copy. The source
+    // file assertion in ProviderPicker.test.tsx checks the static map.
+    // This runtime test asserts the live detail surfaces the API-key
+    // billing identity.
+    const billing = screen.getByTestId('provider-billing-hint')
+    expect(billing.textContent).toMatch(/ANTHROPIC_API_KEY/)
+  })
+})

--- a/packages/dashboard/src/components/ProviderPicker.test.tsx
+++ b/packages/dashboard/src/components/ProviderPicker.test.tsx
@@ -123,3 +123,76 @@ describe('Provider picker in session creation (#1366)', () => {
     expect(sidebarSrc).toMatch(/sidebar-provider|provider-badge/)
   })
 })
+
+// #5026: docker-byok provider-selector polish.
+//
+// PR #5021 added docker-byok server-side. The follow-up scope is purely the
+// dashboard's provider selector — surface a human-readable label, explain
+// the docker-byok vs. claude-byok trade-off, and visually distinguish
+// containerized providers in the capability-badge row.
+describe('docker-byok provider-selector polish (#5026)', () => {
+  test('PROVIDER_BILLING has a docker-byok entry distinct from claude-byok', () => {
+    // The two must NOT share the same billing copy — the whole point of
+    // surfacing the polish is to explain the trade-off (sandboxed tools
+    // vs. host-side tools, same ANTHROPIC_API_KEY).
+    const billingMatch = modalSrc.match(/PROVIDER_BILLING[^}]*}/s)
+    expect(billingMatch).toBeTruthy()
+    const block = billingMatch![0]
+    expect(block).toMatch(/['"]docker-byok['"]/)
+    // Must mention BOTH "container" (the sandbox) and "ANTHROPIC_API_KEY"
+    // (the billing identity) so the user can reason about the trade-off
+    // without leaving the modal.
+    const dockerByokLine = block.match(/['"]docker-byok['"]\s*:\s*['"][^'"]*['"]/)
+    expect(dockerByokLine).toBeTruthy()
+    expect(dockerByokLine![0]).toMatch(/container/i)
+    expect(dockerByokLine![0]).toMatch(/ANTHROPIC_API_KEY/)
+  })
+
+  test('CAPABILITY_BADGES includes a Containerized entry', () => {
+    // The badge row must surface `containerized` so docker-* providers
+    // read as sandboxed at a glance. Without this, the badge row would
+    // be identical to claude-byok's and the visual distinction collapses.
+    // Match from `const CAPABILITY_BADGES` through the closing `]` of the
+    // outer array — the inner `[]` for the tuple type makes a single
+    // `[^\]]*` greedy stop too early.
+    const badgesMatch = modalSrc.match(/const CAPABILITY_BADGES[\s\S]*?\n\]/)
+    expect(badgesMatch).toBeTruthy()
+    expect(badgesMatch![0]).toMatch(/['"]containerized['"]/)
+    expect(badgesMatch![0]).toMatch(/['"]Containerized['"]/)
+  })
+
+  test('ProviderCapabilities type exposes the containerized field', () => {
+    // The server-side ProviderClass.capabilities already returns
+    // containerized for docker-*; the dashboard MUST expose it on the
+    // shared interface so the badge filter and selector lookups are
+    // type-safe (TS strict catches the typo if it isn't there).
+    expect(typesSrc).toMatch(/interface ProviderCapabilities[\s\S]*?containerized\??\s*:\s*boolean/)
+  })
+
+  test('container settings hint surfaces when a containerized provider is selected', () => {
+    // The polish issue's AC asks for "container image / memory / cpu /
+    // containerUser knobs" to be surfaced. We route the user to the
+    // Environments panel (the canonical settings surface) and explain
+    // the defaults — both branches of the hint must reference the same
+    // mental model.
+    expect(modalSrc).toMatch(/provider-container-hint/)
+    expect(modalSrc).toMatch(/containerized/)
+    // Must mention the default image / memory / cpu so a user reading
+    // the modal cold knows what they'll get without configuring.
+    expect(modalSrc).toMatch(/node:22-slim/)
+    expect(modalSrc).toMatch(/2g/i)
+  })
+
+  test('docker-byok appears in PROVIDER_LABELS', () => {
+    // The selector renders `PROVIDER_LABELS[p.name] || p.name`; without
+    // an entry the option would say "docker-byok" verbatim.
+    const labelsSrc = fs.readFileSync(
+      path.resolve(__dirname, '../../../..', 'packages/store-core/src/provider-labels.ts'),
+      'utf-8',
+    )
+    expect(labelsSrc).toMatch(/['"]docker-byok['"]/)
+    // Must NOT regress to the generic external-provider fallback —
+    // explicitly require the canonical metadata fields.
+    expect(labelsSrc).toMatch(/['"]docker-byok['"][\s\S]*?label:\s*['"]Claude \(BYOK — Docker container\)['"]/)
+  })
+})

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -123,6 +123,11 @@ export interface ProviderCapabilities {
   // method existence — only providers whose session class implements
   // setPermissionRules report this as true (#3072).
   sessionRules?: boolean;
+  // #5026: true when the provider runs sessions inside an isolated Docker
+  // container (docker-cli, docker-sdk, docker-byok). The dashboard surfaces
+  // this with a visual badge + container settings knobs (image / memory /
+  // cpu / containerUser) in the New Session modal's advanced section.
+  containerized?: boolean;
 }
 
 // #3404 audit (F1+F5): per-provider auth state for grey-out + billing panel.

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4378,6 +4378,40 @@
   letter-spacing: 0.02em;
 }
 
+/* #5026: distinct chrome for the "Containerized" badge so docker-* providers
+   read as sandboxed at a glance. Borrows the accent-blue palette already
+   used for primary affordances elsewhere in the modal. */
+.capability-badge[data-capability="containerized"] {
+  background: var(--accent-blue-subtle, rgba(96, 165, 250, 0.15));
+  border-color: var(--accent-blue, #60a5fa);
+  color: var(--accent-blue, #60a5fa);
+  font-weight: 600;
+}
+
+/* #5026: hint shown under the capability badges when a containerized
+   provider is selected. Lower-emphasis than the warning-toned fix-hint
+   but matches its block geometry so the modal still rhythms cleanly. */
+.provider-container-hint {
+  display: block;
+  margin-top: 6px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: var(--bg-session-bar, var(--bg-tertiary));
+  border-left: 3px solid var(--accent-blue, #60a5fa);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+}
+
+.provider-container-hint-label {
+  font-weight: 600;
+  color: var(--accent-blue, #60a5fa);
+}
+
+.provider-container-hint-body {
+  color: var(--text-secondary);
+}
+
 .provider-billing-hint {
   width: 100%;
   font-size: 11px;

--- a/packages/store-core/src/provider-labels.test.ts
+++ b/packages/store-core/src/provider-labels.test.ts
@@ -8,7 +8,7 @@ import {
 describe('PROVIDER_LABELS', () => {
   it('contains entries for all known providers', () => {
     const expectedKeys = [
-      'claude-sdk', 'claude-cli', 'claude-tui', 'docker-cli', 'docker-sdk', 'docker', 'gemini', 'codex',
+      'claude-sdk', 'claude-cli', 'claude-tui', 'claude-byok', 'docker-cli', 'docker-sdk', 'docker-byok', 'docker', 'gemini', 'codex',
     ]
     for (const key of expectedKeys) {
       expect(PROVIDER_LABELS).toHaveProperty(key)
@@ -100,6 +100,18 @@ describe('getProviderInfo', () => {
     const info = getProviderInfo('claude-experimental')
     expect(info.short).toBe('EXPERIMENTAL')
     expect(info.type).toBe('other')
+  })
+
+  // #5026: docker-byok must not regress to the generic fallback. The
+  // selector reads `getProviderLabel('docker-byok')` for the option label;
+  // without this entry it would show the bare provider id.
+  it('docker-byok returns canonical metadata', () => {
+    const info = getProviderInfo('docker-byok')
+    expect(info.short).toBe('Docker BYOK')
+    expect(info.label).toBe('Claude (BYOK — Docker container)')
+    expect(info.type).toBe('sdk')
+    expect(info.tooltip).toContain('container')
+    expect(info.tooltip).toContain('ANTHROPIC_API_KEY')
   })
 
   it('every known provider has a label field matching PROVIDER_LABELS', () => {

--- a/packages/store-core/src/provider-labels.ts
+++ b/packages/store-core/src/provider-labels.ts
@@ -39,6 +39,12 @@ const KNOWN_PROVIDERS: Record<string, ProviderDisplayInfo> = {
     tooltip: 'Direct Anthropic API via @anthropic-ai/sdk — per-token billing with your own ANTHROPIC_API_KEY. No claude binary required.',
     type: 'sdk',
   },
+  'docker-byok': {
+    short: 'Docker BYOK',
+    label: 'Claude (BYOK — Docker container)',
+    tooltip: 'BYOK agent loop on the host, tool execution (Read/Write/Edit/Bash/Glob/Grep) inside an isolated Docker container. Per-token billing with your own ANTHROPIC_API_KEY.',
+    type: 'sdk',
+  },
   'docker-cli': {
     short: 'Docker CLI',
     label: 'Claude Code (Docker CLI)',


### PR DESCRIPTION
## Summary

Closes #5026. PR #5021 landed `docker-byok` server-side but the dashboard's New Session modal surfaced it as a bare provider id with no visual distinction from `claude-byok`. This polish:

- Adds the human-readable label and tooltip via `store-core/provider-labels` so the selector renders `Claude (BYOK - Docker container)` instead of `docker-byok`.
- Adds a `Containerized` capability badge (accent-blue chrome) so docker-* providers read as sandboxed at a glance. Gated on `capabilities.containerized` from the server, so claude-byok / claude-sdk / claude-cli are unchanged.
- Adds a `PROVIDER_BILLING` entry that explains the docker-byok vs. claude-byok trade-off: same `ANTHROPIC_API_KEY` billing, sandboxed filesystem for tool execution.
- Adds a container-settings hint under the badges that points users to the Environments panel for custom image / memory / cpu / containerUser, and surfaces the provider defaults (`node:22-slim`, 2g RAM, 2 CPUs) when no environment is picked.

No protocol or server changes - the polish only consumes the existing `capabilities.containerized` field and the existing `environmentId` wire field. No new tauri commands. Speech-helper untouched.

## Files changed

- `packages/store-core/src/provider-labels.ts` + test - register docker-byok metadata
- `packages/dashboard/src/store/types.ts` - add optional `containerized` field on `ProviderCapabilities`
- `packages/dashboard/src/components/CreateSessionModal.tsx` - PROVIDER_BILLING entry, Containerized badge, container hint
- `packages/dashboard/src/theme/components.css` - distinct chrome for the badge + hint
- `packages/dashboard/src/components/ProviderPicker.test.tsx` - source-level assertions on the polish
- `packages/dashboard/src/components/CreateSessionModalDockerByok.test.tsx` (new) - runtime tests covering the label, badge, hint copy switch, and claude-byok regression guard

## Test plan

- [x] `cd packages/dashboard && npx vitest run` - 2827 tests pass (145 files)
- [x] `cd packages/store-core && npx vitest run` - 1073 tests pass (21 files)
- [x] `cd packages/dashboard && npx tsc --noEmit` - clean
- [x] `cd packages/store-core && npx tsc --noEmit` - clean
- [ ] Manual smoke: open the dashboard, open New Session, select docker-byok, confirm label + Containerized badge + container hint render