### PR TITLE
fix(server): surface Task subagent cost on parent error-path turns (#5020)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -862,8 +862,23 @@ export class ClaudeByokSession extends BaseSession {
       if (this._history.length > historyLengthBeforeSend) {
         this._history.length = historyLengthBeforeSend
       }
+      // #5020: fold any subagent (Task tool) usage + cost into the
+      // partial turn totals BEFORE the error fires so the user sees
+      // what the failed turn cost. Without this fold the child's
+      // tokens are silently dropped at _finishTurn reset even though
+      // the user is still billed for them. Mirrors the success-path
+      // fold above; the partial totals reflect every completed parent
+      // round + every completed child API call before the failure.
+      turnUsage.input_tokens += this._subagentUsageThisTurn.input_tokens
+      turnUsage.output_tokens += this._subagentUsageThisTurn.output_tokens
+      turnUsage.cache_read_input_tokens += this._subagentUsageThisTurn.cache_read_input_tokens
+      turnUsage.cache_creation_input_tokens += this._subagentUsageThisTurn.cache_creation_input_tokens
+      turnCost += this._subagentCostThisTurn
       this.emit('stream_end', { messageId })
-      this._emitTurnError(messageId, err, 'STREAM_ERROR')
+      this._emitTurnError(messageId, err, 'STREAM_ERROR', {
+        usage: turnUsage,
+        cost: turnCost,
+      })
     } finally {
       // #4080: per-turn isolation guarantee. The per-round clear after
       // finalMessage() above runs on the success path; an iteration or
@@ -1421,7 +1436,7 @@ export class ClaudeByokSession extends BaseSession {
     }
   }
 
-  _emitTurnError(messageId, err, fallbackCode) {
+  _emitTurnError(messageId, err, fallbackCode, partials) {
     // #4057: SDK v0.81+ throws `APIUserAbortError` (not the generic
     // `AbortError`) when an in-flight messages.stream sees its signal
     // aborted. Primary check is `instanceof` — the SDK class itself
@@ -1431,6 +1446,15 @@ export class ClaudeByokSession extends BaseSession {
     // (the SDK's own internal abort helper uses this convention). The
     // signal.aborted fallback catches paths where the SDK swallowed
     // the original error and re-threw something we don't recognise.
+    //
+    // #5020: `partials` carries the parent's completed-round usage +
+    // cost (already folded with any subagent Task tool spend). Surface
+    // it on every error path — ABORT and STREAM_ERROR alike — so the
+    // user can see what the failed turn cost. The error envelope schema
+    // is `.passthrough()` (ServerErrorEnvelopeSchema, protocol/server.ts)
+    // so additional fields propagate without a wire-side schema change.
+    // Optional / undefined-safe: pre-#5020 call sites pass nothing and
+    // the fields are simply absent on the event payload.
     const aborted =
       err instanceof APIUserAbortError ||
       err?.name === 'AbortError' ||
@@ -1440,12 +1464,18 @@ export class ClaudeByokSession extends BaseSession {
         messageId,
         message: 'Interrupted by user',
         code: 'ABORT',
+        ...(partials ? { usage: partials.usage, cost: partials.cost } : {}),
       })
       return
     }
     const code = err?.status ? `HTTP_${err.status}` : (err?.code || fallbackCode)
     const message = err?.message || String(err)
-    this.emit('error', { messageId, message, code })
+    this.emit('error', {
+      messageId,
+      message,
+      code,
+      ...(partials ? { usage: partials.usage, cost: partials.cost } : {}),
+    })
   }
 
   _finishTurn() {

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3315,6 +3315,93 @@ describe('ClaudeByokSession', () => {
       await session.destroy()
     })
 
+    it('surfaces subagent cost on parent error-path turns (#5020)', async () => {
+      // Pin the #5020 contract: when the parent's overall turn errors AFTER
+      // a subagent already ran, the user is still billed for the child's
+      // API calls — those must surface in the parent's STREAM_ERROR event
+      // payload so the user can see what the failed turn cost.
+      //
+      // Pre-#5020: error event carried only { code, message } — child cost
+      // was silently dropped at _finishTurn reset.
+      const session = new ClaudeByokSession({ cwd: '/tmp', model: 'claude-opus-4-7' })
+      session.setPermissionMode('auto')
+      const captured = captureEvents(session)
+      let parentRound = 0
+      let childInFlight = false
+      session._client = {
+        messages: {
+          stream: () => {
+            // If a child session is live, return the child's stream.
+            if (childInFlight) {
+              return fakeStream(
+                [],
+                {
+                  stop_reason: 'end_turn',
+                  content: [{ type: 'text', text: 'child finished' }],
+                  usage: { input_tokens: 2000, output_tokens: 800 },
+                },
+              )
+            }
+            parentRound += 1
+            if (parentRound === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'tu_task_err', name: 'Task', input: { description: 'd', prompt: 'do work' } }],
+                  usage: { input_tokens: 10, output_tokens: 10 },
+                },
+              )
+            }
+            // Parent's round 2 (after child has run) — throw to drive the
+            // STREAM_ERROR path. This is the bug surface: the child's
+            // usage is already in _subagentUsageThisTurn but the catch
+            // block never folds it in before _finishTurn resets.
+            throw new Error('upstream blew up on round 2')
+          },
+        },
+      }
+      // Wrap _executeTaskTool to flip the childInFlight flag while the
+      // child's stream runs (the child shares the parent's client).
+      const origExecute = session._executeTaskTool.bind(session)
+      session._executeTaskTool = async function (args) {
+        childInFlight = true
+        try { return await origExecute(args) }
+        finally { childInFlight = false }
+      }
+      await session.start()
+      await session.sendMessage('delegate then fail')
+
+      const errs = captured.filter((e) => e.name === 'error')
+      const streamErr = errs.find((e) => e.payload?.code === 'STREAM_ERROR')
+      assert.ok(streamErr, 'STREAM_ERROR must fire on parent round-2 failure')
+      // The parent's round-1 usage (10in/10out) + child's usage
+      // (2000in/800out) MUST be surfaced on the error event so the user
+      // sees what the failed turn cost. Round 2 never completed so its
+      // usage is 0 (no finalMessage to read from).
+      assert.ok(streamErr.payload.usage, 'STREAM_ERROR must carry partial usage')
+      assert.equal(streamErr.payload.usage.input_tokens, 2010,
+        'parent round-1 input + child input fold into error event')
+      assert.equal(streamErr.payload.usage.output_tokens, 810,
+        'parent round-1 output + child output fold into error event')
+      // Cost (Opus 4.7): (2010 * 15 + 810 * 75) / 1e6
+      const expectedCost = (2010 * 15 + 810 * 75) / 1e6
+      assert.ok(typeof streamErr.payload.cost === 'number',
+        'STREAM_ERROR must carry partial cost')
+      assert.ok(Math.abs(streamErr.payload.cost - expectedCost) < 1e-9,
+        `expected partial cost ~= ${expectedCost}, got ${streamErr.payload.cost}`)
+      // No result event fires on the error path — usage/cost surface
+      // exclusively via the error event.
+      assert.equal(captured.filter((e) => e.name === 'result').length, 0,
+        'no result event on error path')
+      // Accumulators must reset for the next turn (existing #4049 contract).
+      assert.equal(session._subagentCostThisTurn, 0,
+        'subagent cost accumulator resets after the failed turn')
+      assert.equal(session._subagentUsageThisTurn.input_tokens, 0,
+        'subagent usage accumulator resets after the failed turn')
+      await session.destroy()
+    })
+
     it('parent interrupt cascades to child subagent', async () => {
       const session = new ClaudeByokSession({ cwd: '/tmp' })
       session.setPermissionMode('auto')


### PR DESCRIPTION
## Summary

Closes #5020.

When the parent's overall turn errors AFTER a Task subagent has already run, the user was still billed for the child's API calls — but the parent's `error` event had no way to surface that cost. The child's accumulated usage in `_subagentUsageThisTurn` / `_subagentCostThisTurn` was silently dropped at `_finishTurn` reset.

This PR folds those accumulators into the partial turn totals on the catch path and surfaces them via a new optional `partials` arg on `_emitTurnError`. The error event payload now carries `usage` + `cost` fields on both `ABORT` and `STREAM_ERROR` paths.

## Changes

- `packages/server/src/byok-session.js`: catch-block folds `_subagentUsageThisTurn` / `_subagentCostThisTurn` into `turnUsage` / `turnCost` (mirroring the success-path fold), then passes them through to `_emitTurnError` which surfaces them on the emitted `error` event payload.
- `packages/server/tests/byok-session.test.js`: new test pins the contract — a parent that emits a Task on round 1 and throws on round 2 must surface the child's usage + cost on the `STREAM_ERROR` event.

## Wire-side compatibility

`ServerErrorEnvelopeSchema` is `.passthrough()`, so the extra `usage` / `cost` fields propagate without a schema bump. Existing `handleError` consumers in `store-core` ignore unknown fields — UI surfacing is a separate follow-up.

## Test plan

- [x] New test passes (`--test-name-pattern="surfaces subagent cost"`)
- [x] All 102 byok-session tests pass with `--test-force-exit`
- [x] `lint-session-opt-forwarding.sh` and `lint-tests-state-file-path.sh` green
- [ ] CI checks pass