### PR TITLE
feat(server): support per-launch permission_mode override in Task tool (#5017)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -31,7 +31,7 @@ import {
 } from './models.js'
 import { resolveAnthropicApiKey, maskApiKey } from './byok-credentials.js'
 import { translateSdkEvent } from './byok-event-translator.js'
-import { BUILTIN_TOOLS } from './byok-tools.js'
+import { BUILTIN_TOOLS, TASK_PERMISSION_MODE_LIST, TASK_PERMISSION_MODE_RANK } from './byok-tools.js'
 import { executeBuiltinTool } from './byok-tool-executor.js'
 import { loadClaudeMcpConfig, toMcpServerMetadata } from './byok-mcp-config.js'
 import { MCPFleet, MCP_TOOL_PREFIX } from './byok-mcp-fleet.js'
@@ -1148,9 +1148,16 @@ export class ClaudeByokSession extends BaseSession {
    *     the local onAbort listener so the cascade happens even on a
    *     micro-race between the abort and the child's sendMessage.
    *
+   * Per-launch permission-mode override (#5017):
+   *   The model may pass an optional `permission_mode` field on the Task
+   *   input. When set, it overrides the inherited mode for this one
+   *   launch — but only if it is at-most-as-permissive as the parent
+   *   (plan < approve < acceptEdits < auto). Requesting a stricter mode
+   *   is allowed; requesting a more permissive mode is rejected with
+   *   an is_error tool_result.
+   *
    * Deferred (per scope note):
    *   - Sub-bubble UI / mid-flight tool surfacing for the child
-   *   - Per-launch permission-mode override (currently inherits)
    *   - subagent_type profile registry — the field is accepted in the
    *     schema for forward-compat but the runner ignores it in v1
    *
@@ -1167,6 +1174,33 @@ export class ClaudeByokSession extends BaseSession {
         content: 'Task tool requires a non-empty `prompt` field describing the work for the subagent.',
         isError: true,
       }
+    }
+    // #5017: per-launch permission_mode override. When omitted, the child
+    // inherits the parent's mode (existing v1 behaviour). When set, the
+    // value must be a known mode AND at-most-as-permissive as the parent
+    // (plan < approve < acceptEdits < auto) — a subagent must not be able
+    // to escalate beyond the policy the user picked for the parent.
+    let childPermissionMode = this.permissionMode
+    if (input?.permission_mode !== undefined) {
+      const requested = input.permission_mode
+      if (typeof requested !== 'string' || !TASK_PERMISSION_MODE_LIST.includes(requested)) {
+        return {
+          content: `Task tool: invalid \`permission_mode\` "${requested}". Allowed values: ${TASK_PERMISSION_MODE_LIST.join(', ')}.`,
+          isError: true,
+        }
+      }
+      const parentRank = TASK_PERMISSION_MODE_RANK[this.permissionMode]
+      const requestedRank = TASK_PERMISSION_MODE_RANK[requested]
+      // parentRank can be undefined if the parent's mode is somehow
+      // off-list (shouldn't happen — base-session validates — but defend
+      // anyway). Treat that as "no override allowed".
+      if (parentRank === undefined || requestedRank > parentRank) {
+        return {
+          content: `Task tool: \`permission_mode\` "${requested}" is more permissive than the parent's mode "${this.permissionMode}". Subagents must be at-most-as-permissive as the parent.`,
+          isError: true,
+        }
+      }
+      childPermissionMode = requested
     }
     if (signal?.aborted) {
       return { content: 'Interrupted by user before subagent spawned', isError: true }
@@ -1213,10 +1247,13 @@ export class ClaudeByokSession extends BaseSession {
       // Inherit permission mode so the subagent runs under the same
       // gating policy as the parent — a user who set `auto` doesn't
       // want the child to start prompting again, and a user in
-      // `approve` mode expects to gate the child's tools too. Direct
-      // assignment (vs setPermissionMode) is safe here: the child is
-      // fresh, not busy, and has no pending permissions to flush.
-      child.permissionMode = this.permissionMode
+      // `approve` mode expects to gate the child's tools too. When the
+      // model passes a `permission_mode` override on the Task input
+      // (#5017), we use that instead — already validated above to be
+      // at-most-as-permissive as the parent. Direct assignment (vs
+      // setPermissionMode) is safe here: the child is fresh, not busy,
+      // and has no pending permissions to flush.
+      child.permissionMode = childPermissionMode
       this._subagentSessions.set(toolUseId, child)
     } catch (ctorErr) {
       // Balance the agent_spawned emit + _activeAgents.set above so the

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -21,6 +21,32 @@
 export const TODO_STATUS_LIST = Object.freeze(['pending', 'in_progress', 'completed'])
 export const TODO_STATUSES = new Set(TODO_STATUS_LIST)
 
+/**
+ * Permissiveness ranking for the Task tool's per-launch `permission_mode`
+ * override (#5017). Lower number = more restrictive; higher = more permissive.
+ *
+ *   plan        (0) — model is asked to plan before acting; tool calls still
+ *                     gate on approval (and `plan` mode itself short-circuits
+ *                     write tools server-side).
+ *   approve     (1) — default; every tool call gates on user approval.
+ *   acceptEdits (2) — Read/Write/Edit/NotebookEdit/Glob/Grep auto-approved.
+ *   auto        (3) — every tool call auto-approved (skip-permissions).
+ *
+ * The Task tool refuses to launch a subagent under a mode strictly more
+ * permissive than the parent's. Equal-or-stricter is allowed.
+ *
+ * Kept here (next to the schema enum) so the JSON-schema property, the
+ * runtime validator in byok-session, and the test matrix all read from
+ * one source of truth.
+ */
+export const TASK_PERMISSION_MODE_LIST = Object.freeze(['plan', 'approve', 'acceptEdits', 'auto'])
+export const TASK_PERMISSION_MODE_RANK = Object.freeze({
+  plan: 0,
+  approve: 1,
+  acceptEdits: 2,
+  auto: 3,
+})
+
 export const BUILTIN_TOOLS = [
   {
     name: 'Read',
@@ -157,14 +183,18 @@ export const BUILTIN_TOOLS = [
     description:
       'Spawn a focused sub-agent (subagent) to handle a delegated piece of work. The ' +
       'sub-agent runs as a fresh ClaudeByokSession with its own isolated message history, ' +
-      'inheriting this session\'s permission mode and cwd. Use it to: research a topic without ' +
-      'polluting the parent context, run multi-step work in a focused scope, or delegate a ' +
-      'task that needs its own tool budget. The sub-agent\'s final assistant text is returned ' +
+      'inheriting this session\'s permission mode and cwd by default. Use it to: research a topic ' +
+      'without polluting the parent context, run multi-step work in a focused scope, or delegate ' +
+      'a task that needs its own tool budget. The sub-agent\'s final assistant text is returned ' +
       'as the tool_result — intermediate tool calls happen inside the child and are NOT ' +
       'surfaced to the parent (only `agent_spawned` / `agent_completed` events fire). ' +
       'Token cost is accumulated into the parent turn\'s `result.cost` so accounting stays ' +
       'attributed to the user-facing session. ' +
-      'Cancellation: interrupting the parent cascades to the child via a shared AbortSignal.',
+      'Cancellation: interrupting the parent cascades to the child via a shared AbortSignal. ' +
+      'Optional `permission_mode` overrides the inherited mode for this single launch, but ' +
+      'is constrained to be at-most-as-permissive as the parent (ranking: plan < approve < ' +
+      'acceptEdits < auto). Requesting a stricter mode is allowed; requesting a more ' +
+      'permissive mode is rejected with an is_error tool_result.',
     input_schema: {
       type: 'object',
       properties: {
@@ -179,6 +209,11 @@ export const BUILTIN_TOOLS = [
         subagent_type: {
           type: 'string',
           description: 'Optional subagent profile id (e.g. "general", "researcher"). Currently informational only — ignored by the runner in v1.',
+        },
+        permission_mode: {
+          type: 'string',
+          enum: [...TASK_PERMISSION_MODE_LIST],
+          description: 'Optional per-launch permission mode for the subagent. Must be at-most-as-permissive as the parent (plan < approve < acceptEdits < auto). When omitted, the subagent inherits the parent\'s mode.',
         },
       },
       required: ['description', 'prompt'],

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -25,9 +25,14 @@ export const TODO_STATUSES = new Set(TODO_STATUS_LIST)
  * Permissiveness ranking for the Task tool's per-launch `permission_mode`
  * override (#5017). Lower number = more restrictive; higher = more permissive.
  *
- *   plan        (0) — model is asked to plan before acting; tool calls still
- *                     gate on approval (and `plan` mode itself short-circuits
- *                     write tools server-side).
+ *   plan        (0) — system prompt asks the model to plan before acting;
+ *                     every tool call still gates on user approval through
+ *                     PermissionManager (the byok provider has
+ *                     `planMode: false` and PermissionManager does not
+ *                     special-case 'plan', so the gating is identical to
+ *                     'approve' from the executor's point of view — the
+ *                     restrictiveness comes from the prompt + approval gate,
+ *                     not a server-side write-tool block).
  *   approve     (1) — default; every tool call gates on user approval.
  *   acceptEdits (2) — Read/Write/Edit/NotebookEdit/Glob/Grep auto-approved.
  *   auto        (3) — every tool call auto-approved (skip-permissions).

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3470,6 +3470,166 @@ describe('ClaudeByokSession', () => {
       assert.equal(toolResult.content, 'routed ok')
       await session.destroy()
     })
+
+    /**
+     * Helper for the #5017 override tests: wires the parent to emit a
+     * single Task tool_use carrying `taskInput`, intercepts the child
+     * registration to capture its permissionMode, and returns
+     * { childMode, taskResult } after the parent turn completes.
+     *
+     * The parent's permission gate is stubbed to always allow regardless
+     * of parentMode — these tests focus on the per-launch override
+     * semantics inside _executeTaskTool, not on whether the parent gates
+     * Task in approve/acceptEdits/plan modes. Without this stub, parent
+     * modes other than 'auto' block on the permission_request emit
+     * waiting for a UI response that never arrives in unit tests.
+     */
+    async function runTaskWithPermissionOverride({ parentMode, permissionMode }) {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode(parentMode)
+      session._gateToolBlock = async () => ({ behavior: 'allow' })
+      const captured = captureEvents(session)
+      const taskInput = { description: 'd', prompt: 'p' }
+      if (permissionMode !== undefined) taskInput.permission_mode = permissionMode
+      let childMode = null
+      const origSet = session._subagentSessions.set.bind(session._subagentSessions)
+      session._subagentSessions.set = (k, v) => {
+        // Snapshot the child's permission mode at the moment it gets
+        // registered — this is AFTER _executeTaskTool assigns
+        // child.permissionMode and BEFORE any further setup.
+        childMode = v.permissionMode
+        // Force-allow the child's permission gate too — defensive,
+        // since the child stream in this helper never emits tool_use,
+        // but if a future change adds child tool_use deltas they
+        // shouldn't block.
+        v._gateToolBlock = async () => ({ behavior: 'allow' })
+        return origSet(k, v)
+      }
+      setupParentEmittingTaskOnce(session, {
+        taskInput,
+        childStreamImpl: () => fakeStream(
+          [
+            { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'child ok' } },
+            { type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+          ],
+          { stop_reason: 'end_turn', content: [{ type: 'text', text: 'child ok' }], usage: { input_tokens: 1, output_tokens: 1 } },
+        ),
+      })
+      await session.start()
+      await session.sendMessage('delegate')
+      const taskResult = captured.find((e) => e.name === 'tool_result' && e.payload.toolUseId === 'tu_task_1')
+      await session.destroy()
+      return { childMode, taskResult, captured }
+    }
+
+    it('Task `permission_mode` omitted: child inherits parent mode (#5017)', async () => {
+      const { childMode, taskResult } = await runTaskWithPermissionOverride({
+        parentMode: 'auto',
+        // omitted
+      })
+      assert.equal(childMode, 'auto', 'child must inherit parent permissionMode when override omitted')
+      assert.ok(taskResult)
+      assert.equal(taskResult.payload.isError, false,
+        `expected tool_result not to be is_error, got: ${taskResult.payload.result}`)
+    })
+
+    it('Task `permission_mode` downgrade allowed (parent auto → child approve) (#5017)', async () => {
+      const { childMode, taskResult } = await runTaskWithPermissionOverride({
+        parentMode: 'auto',
+        permissionMode: 'approve',
+      })
+      assert.equal(childMode, 'approve', 'child must take the override when downgrading')
+      assert.ok(taskResult)
+      assert.equal(taskResult.payload.isError, false)
+    })
+
+    it('Task `permission_mode` downgrade to plan allowed (parent acceptEdits → child plan) (#5017)', async () => {
+      const { childMode, taskResult } = await runTaskWithPermissionOverride({
+        parentMode: 'acceptEdits',
+        permissionMode: 'plan',
+      })
+      assert.equal(childMode, 'plan')
+      assert.equal(taskResult.payload.isError, false)
+    })
+
+    it('Task `permission_mode` equal-to-parent allowed (parent approve → child approve) (#5017)', async () => {
+      const { childMode, taskResult } = await runTaskWithPermissionOverride({
+        parentMode: 'approve',
+        permissionMode: 'approve',
+      })
+      assert.equal(childMode, 'approve')
+      assert.equal(taskResult.payload.isError, false)
+    })
+
+    it('Task `permission_mode` upgrade rejected (parent approve → child auto) (#5017)', async () => {
+      const { childMode, taskResult } = await runTaskWithPermissionOverride({
+        parentMode: 'approve',
+        permissionMode: 'auto',
+      })
+      assert.equal(childMode, null, 'no child must be spawned when override is rejected')
+      assert.ok(taskResult)
+      assert.equal(taskResult.payload.isError, true)
+      assert.match(taskResult.payload.result, /permissive/i,
+        'rejection message must explain the at-most-as-permissive rule')
+    })
+
+    it('Task `permission_mode` upgrade rejected (parent plan → child approve) (#5017)', async () => {
+      const { childMode, taskResult } = await runTaskWithPermissionOverride({
+        parentMode: 'plan',
+        permissionMode: 'approve',
+      })
+      assert.equal(childMode, null)
+      assert.equal(taskResult.payload.isError, true)
+      assert.match(taskResult.payload.result, /permissive/i)
+    })
+
+    it('Task `permission_mode` invalid value rejected (#5017)', async () => {
+      const { childMode, taskResult } = await runTaskWithPermissionOverride({
+        parentMode: 'auto',
+        permissionMode: 'sudo',
+      })
+      assert.equal(childMode, null, 'no child spawned for invalid mode')
+      assert.ok(taskResult)
+      assert.equal(taskResult.payload.isError, true)
+      assert.match(taskResult.payload.result, /invalid.*permission_mode|allowed values/i)
+    })
+
+    it('Task `permission_mode` non-string value rejected (#5017)', async () => {
+      const { childMode, taskResult } = await runTaskWithPermissionOverride({
+        parentMode: 'auto',
+        permissionMode: 7,
+      })
+      assert.equal(childMode, null)
+      assert.equal(taskResult.payload.isError, true)
+      assert.match(taskResult.payload.result, /invalid.*permission_mode|allowed values/i)
+    })
+
+    it('Task `permission_mode` downgrade-allowed / upgrade-rejected matrix is exhaustive (#5017)', async () => {
+      // Verify every (parent, child) pair against the ranking
+      // plan < approve < acceptEdits < auto.
+      const modes = ['plan', 'approve', 'acceptEdits', 'auto']
+      const rank = { plan: 0, approve: 1, acceptEdits: 2, auto: 3 }
+      for (const parent of modes) {
+        for (const requested of modes) {
+          const expectedAllowed = rank[requested] <= rank[parent]
+          const { childMode, taskResult } = await runTaskWithPermissionOverride({
+            parentMode: parent,
+            permissionMode: requested,
+          })
+          if (expectedAllowed) {
+            assert.equal(childMode, requested,
+              `parent=${parent} requested=${requested}: child should be ${requested} but was ${childMode}`)
+            assert.equal(taskResult.payload.isError, false,
+              `parent=${parent} requested=${requested}: should be allowed`)
+          } else {
+            assert.equal(childMode, null,
+              `parent=${parent} requested=${requested}: must reject (no child spawned)`)
+            assert.equal(taskResult.payload.isError, true,
+              `parent=${parent} requested=${requested}: must be is_error`)
+          }
+        }
+      }
+    })
   })
 
   describe('lifecycle', () => {

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { BUILTIN_TOOLS, BUILTIN_TOOL_NAMES, TODO_STATUS_LIST, TODO_STATUSES } from '../src/byok-tools.js'
+import { BUILTIN_TOOLS, BUILTIN_TOOL_NAMES, TODO_STATUS_LIST, TODO_STATUSES, TASK_PERMISSION_MODE_LIST, TASK_PERMISSION_MODE_RANK } from '../src/byok-tools.js'
 
 /**
  * BUILTIN_TOOLS is the array passed verbatim into the SDK's
@@ -121,5 +121,38 @@ describe('BUILTIN_TOOLS', () => {
   it('BUILTIN_TOOL_NAMES contains Task (#4049)', () => {
     assert.ok(BUILTIN_TOOL_NAMES.has('Task'),
       'Task must be in BUILTIN_TOOL_NAMES so the executor catches misrouted dispatches')
+  })
+
+  it('Task input_schema exposes optional `permission_mode` enum (#5017)', () => {
+    const task = BUILTIN_TOOLS.find((t) => t.name === 'Task')
+    const prop = task.input_schema.properties.permission_mode
+    assert.ok(prop, 'permission_mode property must exist on Task input_schema')
+    assert.equal(prop.type, 'string')
+    assert.deepEqual([...prop.enum].sort(), [...TASK_PERMISSION_MODE_LIST].sort())
+    // Must remain optional — required list is only description + prompt.
+    assert.ok(!task.input_schema.required.includes('permission_mode'),
+      'permission_mode must NOT be in required')
+  })
+
+  it('Task description discloses the per-launch permission_mode override + at-most-as-permissive rule (#5017)', () => {
+    const task = BUILTIN_TOOLS.find((t) => t.name === 'Task')
+    assert.match(task.description, /permission_mode/, 'description must name the override field')
+    assert.match(task.description, /permissive|stricter|at-most/i,
+      'description must disclose the at-most-as-permissive rule')
+  })
+
+  it('TASK_PERMISSION_MODE_RANK orders modes by permissiveness (#5017)', () => {
+    // Lower number = more restrictive. The strict ordering pins the
+    // contract that drives _executeTaskTool's validation:
+    // plan < approve < acceptEdits < auto.
+    assert.equal(TASK_PERMISSION_MODE_LIST.length, 4)
+    assert.ok(TASK_PERMISSION_MODE_RANK.plan < TASK_PERMISSION_MODE_RANK.approve)
+    assert.ok(TASK_PERMISSION_MODE_RANK.approve < TASK_PERMISSION_MODE_RANK.acceptEdits)
+    assert.ok(TASK_PERMISSION_MODE_RANK.acceptEdits < TASK_PERMISSION_MODE_RANK.auto)
+    // Every list entry must have a rank.
+    for (const mode of TASK_PERMISSION_MODE_LIST) {
+      assert.equal(typeof TASK_PERMISSION_MODE_RANK[mode], 'number',
+        `${mode} must have a rank`)
+    }
   })
 })


### PR DESCRIPTION
## Summary

Closes #5017.

The byok Task subagent tool now accepts an optional `permission_mode` field on its input, so the model can launch an individual subagent under a different permission mode than the parent for that one delegation. Override is constrained to be at-most-as-permissive as the parent (ranking: `plan < approve < acceptEdits < auto`) — subagents can never escalate beyond the policy the user picked for the session.

Default behaviour is unchanged: when `permission_mode` is omitted from the Task input, the child still inherits the parent's mode.

## Changes

- `packages/server/src/byok-tools.js`
  - Add `TASK_PERMISSION_MODE_LIST` and `TASK_PERMISSION_MODE_RANK` exports — single source of truth for the permissiveness ordering used by the JSON-schema enum, the runtime validator, and the test matrix.
  - Extend the Task `input_schema.properties` with an optional `permission_mode` enum field.
  - Update the Task description to disclose the override field and the at-most-as-permissive rule.
- `packages/server/src/byok-session.js`
  - In `_executeTaskTool`, validate `input.permission_mode` before spawning the child:
    - Unknown / non-string values are rejected with an `is_error` tool_result (same pattern as the existing empty-prompt check).
    - A value strictly more permissive than the parent's mode is rejected with an `is_error` tool_result that explains the rule.
    - A valid, equal-or-stricter value is applied to `child.permissionMode` instead of the inherited mode.
  - Update the doc comment to move the override out of the deferred-features list.
- `packages/server/tests/byok-tools.test.js`
  - Pin the schema shape (enum values, optional flag), the description disclosure, and the rank ordering.
- `packages/server/tests/byok-session.test.js`
  - New tests for: omitted-inherits, downgrade-allowed, equal-allowed, upgrade-rejected (two parent/child pairs), invalid-value-rejected, non-string-rejected, and an exhaustive 4x4 (parent, requested) matrix.

## Test plan

- [x] `node --test tests/byok-tools.test.js` — 17/17 pass
- [x] `node --test tests/byok-session.test.js` — 110/110 pass (existing 6 Task tool dispatch tests + 9 new #5017 tests, plus the rest of the suite)
- [x] Related byok suites (`byok-tool-executor`, `byok-event-translator`, `byok-mcp-fleet`) — 141/141 pass total
- [x] `scripts/lint-session-opt-forwarding.sh` — clean (no new BaseSession opt introduced)
- [x] `scripts/lint-tests-state-file-path.sh` — clean
- [x] `scripts/lint-logger-session-scoping.sh` — clean
- [x] `eslint src/byok-session.js src/byok-tools.js` — clean

## Notes

- No new BaseSession opt was introduced — the override is per-tool-call, not per-session, so the middle-layer-trap (#4797) lint doesn't need to change.
- The trust-boundary question raised in the issue ("should subagents always be at-most-as-permissive as the parent?") is answered "yes" here. Equal-to-parent is allowed; strictly-more-permissive is rejected.
- `subagent_type` remains forward-compat / ignored in v1, same as before.