### PR TITLE
feat(server): per-session container reuse for docker-byok (#5022)

### DIFF
--- a/packages/server/src/docker-byok-pool.js
+++ b/packages/server/src/docker-byok-pool.js
@@ -1,0 +1,327 @@
+/**
+ * DockerContainerPool — opt-in idle pool for docker-byok containers (#5022).
+ *
+ * Background
+ * ----------
+ * Each `DockerByokSession` already reuses ONE container across every turn
+ * in its session — `_startContainer()` is called once in `start()` and
+ * the same container id services every tool dispatch until `destroy()`.
+ * That's the per-session reuse baseline and is unconditional.
+ *
+ * What this module adds
+ * ---------------------
+ * A small ACROSS-SESSION idle pool. When a session calls `destroy()` and
+ * the pool is enabled, the container (if still healthy) is released back
+ * to the pool instead of being `docker rm -f`'d. The next session whose
+ * acquire-key matches picks it up — skipping the `docker run` + `useradd`
+ * + `chown` cold-start path (~500ms-2s, or ~10-30s on image pull).
+ *
+ * Design decisions (matches issue #5022 AC)
+ * -----------------------------------------
+ *   - Default OFF: opt-in via `CHROXY_DOCKER_BYOK_POOL=1` or pool option
+ *     so today's per-session behaviour is preserved unless asked for.
+ *   - Cache key: `image|cwd|memoryLimit|cpuLimit|containerUser`. Cwd is
+ *     part of the key because the host cwd is bind-mounted at /workspace
+ *     — reusing a container across cwds would silently leak host paths.
+ *     Resource limits are part of the key so a session that asked for
+ *     `--memory 4g` doesn't pick up a 1g container.
+ *   - Eviction: per-entry idle timeout (default 5 minutes) — a setTimeout
+ *     fires `docker rm -f` and drops the entry. Caps on pool size per
+ *     key (default 2) and total pool size (default 8) keep the daemon
+ *     load bounded; over-cap releases trigger immediate eviction.
+ *   - Lifecycle:
+ *       - acquire(key)  → first available entry, or null on miss.
+ *                          Removes from pool (a session OWNS it while held).
+ *       - release(key, containerId)
+ *                       → put back into the pool with a fresh idle timer.
+ *                          Over-cap releases evict instead.
+ *       - shutdown()    → cancel all timers and `docker rm -f` everything.
+ *   - Health: pool returns containers AS-IS. DockerByokSession is
+ *     responsible for `_verifyContainer()` after acquire — if the
+ *     container died while idle (docker daemon restart, OOM kill, host
+ *     reboot), the session falls back to `_startContainer()`.
+ *   - Interaction with snapshot/restore: deferred — pooled containers do
+ *     NOT participate in snapshot/restore yet (a snapshot of a pooled
+ *     container could be acquired by an unrelated session). When a
+ *     snapshot is taken, the session must mark the container "soiled" so
+ *     it goes to eviction on release.
+ *
+ * Why a separate module
+ * ---------------------
+ * Keeps the pool side-effect free from the session's start/destroy path:
+ * if the pool throws or stalls, the session can fall back to direct
+ * container ownership without leaking. Tests can drive the pool with no
+ * session involvement.
+ */
+
+import { execFile as defaultExecFile } from 'child_process'
+import { createLogger } from './logger.js'
+
+const log = createLogger('docker-byok-pool')
+
+/** Default idle TTL before an entry is evicted (`docker rm -f`'d). */
+export const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000
+
+/** Default cap on entries kept per pool key. */
+export const DEFAULT_MAX_PER_KEY = 2
+
+/** Default cap on total pool size across all keys. */
+export const DEFAULT_MAX_TOTAL = 8
+
+/**
+ * Build the canonical cache key for a session's resource shape. Same
+ * shape used by `DockerContainerPool#acquire` / `#release` so the
+ * session and the pool can compute keys independently.
+ *
+ * @param {object} spec
+ * @param {string} spec.image
+ * @param {string} spec.cwd
+ * @param {string} spec.memoryLimit
+ * @param {string} spec.cpuLimit
+ * @param {string} spec.containerUser
+ * @returns {string}
+ */
+export function buildPoolKey(spec) {
+  if (!spec || typeof spec !== 'object') {
+    throw new Error('buildPoolKey: spec is required')
+  }
+  const { image, cwd, memoryLimit, cpuLimit, containerUser } = spec
+  if (!image || !cwd || !memoryLimit || !cpuLimit || !containerUser) {
+    throw new Error('buildPoolKey: image, cwd, memoryLimit, cpuLimit, containerUser are required')
+  }
+  return [image, cwd, memoryLimit, cpuLimit, containerUser].join('|')
+}
+
+/**
+ * In-memory idle pool of docker-byok containers, keyed by resource shape.
+ *
+ * Not thread-safe (Node is single-threaded). All public methods are sync
+ * except `shutdown()` and `_evict()` which `docker rm -f` via execFile.
+ */
+export class DockerContainerPool {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.idleTimeoutMs=300000] — TTL per idle entry
+   * @param {number} [opts.maxPerKey=2]          — cap per resource shape
+   * @param {number} [opts.maxTotal=8]           — cap across all shapes
+   * @param {Function} [opts._execFile]          — test seam (execFile)
+   * @param {Function} [opts._setTimeout]        — test seam (setTimeout)
+   * @param {Function} [opts._clearTimeout]      — test seam (clearTimeout)
+   */
+  constructor(opts = {}) {
+    this._idleTimeoutMs = Number.isFinite(opts.idleTimeoutMs)
+      ? opts.idleTimeoutMs
+      : DEFAULT_IDLE_TIMEOUT_MS
+    this._maxPerKey = Number.isFinite(opts.maxPerKey)
+      ? opts.maxPerKey
+      : DEFAULT_MAX_PER_KEY
+    this._maxTotal = Number.isFinite(opts.maxTotal)
+      ? opts.maxTotal
+      : DEFAULT_MAX_TOTAL
+    this._execFile = opts._execFile || defaultExecFile
+    this._setTimeout = opts._setTimeout || setTimeout
+    this._clearTimeout = opts._clearTimeout || clearTimeout
+    /** @type {Map<string, Array<{ containerId: string, timer: any }>>} */
+    this._entries = new Map()
+    this._shuttingDown = false
+  }
+
+  /**
+   * Try to claim an idle container for `key`. Returns the container id
+   * on hit, `null` on miss. The entry is REMOVED from the pool — the
+   * caller now owns the container until they call `release()` or
+   * `evict()`.
+   *
+   * @param {string} key
+   * @returns {string|null}
+   */
+  acquire(key) {
+    if (this._shuttingDown) return null
+    const bucket = this._entries.get(key)
+    if (!bucket || bucket.length === 0) return null
+    const entry = bucket.shift()
+    if (bucket.length === 0) this._entries.delete(key)
+    this._clearTimeout(entry.timer)
+    log.info(`pool hit: ${entry.containerId.slice(0, 12)} for ${key}`)
+    return entry.containerId
+  }
+
+  /**
+   * Hand a container back to the pool for reuse. If over the per-key or
+   * total cap, or if the pool is shutting down, the container is evicted
+   * (`docker rm -f`) instead of being kept. Returns `true` if the
+   * container was retained, `false` if it was evicted.
+   *
+   * @param {string} key
+   * @param {string} containerId
+   * @returns {Promise<boolean>}
+   */
+  async release(key, containerId) {
+    if (this._shuttingDown) {
+      await this._evict(containerId)
+      return false
+    }
+    if (!containerId) return false
+    const total = this._totalSize()
+    const bucket = this._entries.get(key) || []
+    if (bucket.length >= this._maxPerKey || total >= this._maxTotal) {
+      log.info(`pool over cap (key=${bucket.length}/${this._maxPerKey} total=${total}/${this._maxTotal}); evicting ${containerId.slice(0, 12)}`)
+      await this._evict(containerId)
+      return false
+    }
+    const timer = this._setTimeout(() => {
+      this._removeEntry(key, containerId, /*alreadyTimedOut*/ true)
+      this._evict(containerId).catch((err) => {
+        log.warn(`idle eviction of ${containerId.slice(0, 12)} failed: ${err.message}`)
+      })
+    }, this._idleTimeoutMs)
+    // setTimeout returns a Timer object on Node; unref so a pooled
+    // container doesn't keep the event loop alive on shutdown.
+    if (timer && typeof timer.unref === 'function') timer.unref()
+    bucket.push({ containerId, timer })
+    this._entries.set(key, bucket)
+    log.info(`pool release: ${containerId.slice(0, 12)} → ${key} (idle ${this._idleTimeoutMs}ms)`)
+    return true
+  }
+
+  /**
+   * Snapshot the current entry count. Useful for tests / dashboards.
+   * @returns {number}
+   */
+  size() {
+    return this._totalSize()
+  }
+
+  /**
+   * Snapshot the entry count for a specific key.
+   * @param {string} key
+   * @returns {number}
+   */
+  sizeOf(key) {
+    const bucket = this._entries.get(key)
+    return bucket ? bucket.length : 0
+  }
+
+  /**
+   * Cancel all idle timers and `docker rm -f` every entry. After
+   * shutdown, `acquire()` always returns null and `release()` evicts
+   * inline. Idempotent.
+   */
+  async shutdown() {
+    this._shuttingDown = true
+    const toRemove = []
+    for (const bucket of this._entries.values()) {
+      for (const entry of bucket) {
+        this._clearTimeout(entry.timer)
+        toRemove.push(entry.containerId)
+      }
+    }
+    this._entries.clear()
+    log.info(`shutdown: evicting ${toRemove.length} pooled container(s)`)
+    await Promise.all(toRemove.map((id) => this._evict(id).catch((err) => {
+      log.warn(`shutdown eviction of ${id.slice(0, 12)} failed: ${err.message}`)
+    })))
+  }
+
+  // ─────────────────────────────────────────────────────────────────
+  // internals
+  // ─────────────────────────────────────────────────────────────────
+
+  _totalSize() {
+    let n = 0
+    for (const bucket of this._entries.values()) n += bucket.length
+    return n
+  }
+
+  /**
+   * Remove an entry from the bucket without evicting. Used by the idle
+   * timer callback (which then evicts separately) so the pool's view of
+   * "what's idle" stays in sync.
+   */
+  _removeEntry(key, containerId, alreadyTimedOut = false) {
+    const bucket = this._entries.get(key)
+    if (!bucket) return
+    const idx = bucket.findIndex((e) => e.containerId === containerId)
+    if (idx === -1) return
+    const [entry] = bucket.splice(idx, 1)
+    if (!alreadyTimedOut) this._clearTimeout(entry.timer)
+    if (bucket.length === 0) this._entries.delete(key)
+  }
+
+  /**
+   * `docker rm -f` a container, swallowing the "no such container"
+   * error so we don't crash on a container that died on its own.
+   */
+  _evict(containerId) {
+    return new Promise((resolve) => {
+      this._execFile('docker', ['rm', '-f', containerId], { stdio: 'ignore' }, (err) => {
+        if (err) {
+          log.warn(`docker rm -f ${containerId.slice(0, 12)} failed: ${err.message}`)
+        }
+        resolve()
+      })
+    })
+  }
+}
+
+/**
+ * Process-wide singleton (lazy). Most callers should go through this so
+ * sessions across the server share one pool. Tests inject their own
+ * pool via the `_pool` constructor seam.
+ *
+ * @type {DockerContainerPool|null}
+ */
+let _sharedPool = null
+
+/**
+ * Lazily-construct the shared pool. Returns `null` when pooling is
+ * disabled — callers check the return value before using it.
+ *
+ * Enabled when `CHROXY_DOCKER_BYOK_POOL` is truthy (1, true, yes, on).
+ * Optional knobs:
+ *   - CHROXY_DOCKER_BYOK_POOL_IDLE_MS — override idle TTL (ms)
+ *   - CHROXY_DOCKER_BYOK_POOL_MAX_PER_KEY — override per-key cap
+ *   - CHROXY_DOCKER_BYOK_POOL_MAX_TOTAL — override total cap
+ *
+ * @param {Record<string,string|undefined>} [env=process.env]
+ * @returns {DockerContainerPool|null}
+ */
+export function getSharedPool(env = process.env) {
+  if (!isPoolEnabled(env)) return null
+  if (_sharedPool) return _sharedPool
+  const idleRaw = env.CHROXY_DOCKER_BYOK_POOL_IDLE_MS
+  const perKeyRaw = env.CHROXY_DOCKER_BYOK_POOL_MAX_PER_KEY
+  const totalRaw = env.CHROXY_DOCKER_BYOK_POOL_MAX_TOTAL
+  const idleTimeoutMs = Number(idleRaw)
+  const maxPerKey = Number(perKeyRaw)
+  const maxTotal = Number(totalRaw)
+  _sharedPool = new DockerContainerPool({
+    idleTimeoutMs: Number.isFinite(idleTimeoutMs) && idleTimeoutMs > 0 ? idleTimeoutMs : undefined,
+    maxPerKey: Number.isFinite(maxPerKey) && maxPerKey > 0 ? maxPerKey : undefined,
+    maxTotal: Number.isFinite(maxTotal) && maxTotal > 0 ? maxTotal : undefined,
+  })
+  return _sharedPool
+}
+
+/**
+ * Whether the docker-byok pool is enabled in the given env. Exposed so
+ * the session constructor can short-circuit pool work entirely when
+ * disabled (no map lookups, no allocations).
+ *
+ * @param {Record<string,string|undefined>} [env=process.env]
+ * @returns {boolean}
+ */
+export function isPoolEnabled(env = process.env) {
+  const raw = env.CHROXY_DOCKER_BYOK_POOL
+  if (typeof raw !== 'string') return false
+  const norm = raw.trim().toLowerCase()
+  return norm === '1' || norm === 'true' || norm === 'yes' || norm === 'on'
+}
+
+/**
+ * Reset the shared singleton. Tests use this to keep state from leaking
+ * across cases. Production code never calls this.
+ */
+export function _resetSharedPool() {
+  _sharedPool = null
+}

--- a/packages/server/src/docker-byok-pool.js
+++ b/packages/server/src/docker-byok-pool.js
@@ -157,11 +157,13 @@ export class DockerContainerPool {
    * @returns {Promise<boolean>}
    */
   async release(key, containerId) {
+    // Guard a null/empty id before any eviction work — a shutdown release
+    // with no id was calling `docker rm -f` with an empty argument.
+    if (!containerId) return false
     if (this._shuttingDown) {
       await this._evict(containerId)
       return false
     }
-    if (!containerId) return false
     const total = this._totalSize()
     const bucket = this._entries.get(key) || []
     if (bucket.length >= this._maxPerKey || total >= this._maxTotal) {
@@ -254,7 +256,10 @@ export class DockerContainerPool {
    */
   _evict(containerId) {
     return new Promise((resolve) => {
-      this._execFile('docker', ['rm', '-f', containerId], { stdio: 'ignore' }, (err) => {
+      // `execFile` ignores `stdio`; cap the buffer so a misbehaving
+      // docker(8) can't OOM us on stderr. 64 KiB is plenty for an error
+      // path that should produce a one-line "no such container" at most.
+      this._execFile('docker', ['rm', '-f', containerId], { maxBuffer: 64 * 1024 }, (err) => {
         if (err) {
           log.warn(`docker rm -f ${containerId.slice(0, 12)} failed: ${err.message}`)
         }

--- a/packages/server/src/docker-byok-pool.js
+++ b/packages/server/src/docker-byok-pool.js
@@ -129,8 +129,11 @@ export class DockerContainerPool {
   /**
    * Try to claim an idle container for `key`. Returns the container id
    * on hit, `null` on miss. The entry is REMOVED from the pool — the
-   * caller now owns the container until they call `release()` or
-   * `evict()`.
+   * caller now owns the container until they call `release()` (to hand
+   * it back) or `docker rm -f` it themselves. There is no public
+   * `evict()` — eviction is internal (`_evict`); a caller that wants to
+   * forcibly destroy an acquired container just runs `docker rm -f` and
+   * never calls `release()`.
    *
    * @param {string} key
    * @returns {string|null}

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -54,6 +54,7 @@ import { execFile } from 'child_process'
 import { ClaudeByokSession } from './byok-session.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
+import { buildPoolKey, getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
 import { createLogger } from './logger.js'
 import { isAbsolute, posix } from 'path'
 
@@ -200,6 +201,12 @@ export class DockerByokSession extends ClaudeByokSession {
    * @param {object} [opts._dockerBackend]           Test seam — pre-built backend
    * @param {Function} [opts._execFile]              Test seam — used by preflight
    *   (defaults to child_process.execFile)
+   * @param {object} [opts._pool]                    Test seam — explicit pool
+   *   instance. When omitted and pooling is enabled (via env), the shared
+   *   process-wide pool is used. When omitted and pooling is disabled,
+   *   pooling is skipped entirely (per-session lifecycle only).
+   * @param {Record<string,string>} [opts._poolEnv]  Test seam — alternate env
+   *   for pool enablement, defaults to `process.env`.
    */
   constructor(opts = {}) {
     // Forward every BaseSession/ClaudeByokSession opt verbatim via
@@ -227,6 +234,22 @@ export class DockerByokSession extends ClaudeByokSession {
     this._dockerBackend = opts._dockerBackend || new DockerBackend()
     this._execFile = opts._execFile || execFile
     this._containerReady = false
+    // #5022: across-session idle pool. Off by default — opted in via env
+    // or by passing an explicit `_pool` instance. Per-session reuse of
+    // the same container across multiple turns is unconditional and
+    // independent of pooling.
+    const poolEnv = opts._poolEnv || process.env
+    if (opts._pool) {
+      this._pool = opts._pool
+    } else if (!opts.containerId && isPoolEnabled(poolEnv)) {
+      this._pool = getSharedPool(poolEnv)
+    } else {
+      this._pool = null
+    }
+    // Set to `true` if the container picked up THIS session originated
+    // from the pool — used at destroy() time to decide between pool
+    // release and inline `docker rm -f`.
+    this._acquiredFromPool = false
   }
 
   /**
@@ -277,7 +300,7 @@ export class DockerByokSession extends ClaudeByokSession {
 
     if (this._containerOwned) {
       try {
-        await this._startContainer()
+        await this._acquireOrStartContainer()
       } catch (err) {
         this.emit('error', {
           code: err.code || 'docker_error',
@@ -325,6 +348,62 @@ export class DockerByokSession extends ClaudeByokSession {
       return
     }
     this._containerReady = true
+  }
+
+  /**
+   * Compute the pool key for this session's resource shape. Same shape
+   * used by `DockerContainerPool` so acquire / release lookups match.
+   *
+   * The host cwd is part of the key because /workspace is bind-mounted
+   * from cwd — reusing a container across cwds would silently surface
+   * files from another workspace.
+   */
+  _poolKey() {
+    return buildPoolKey({
+      image: this._image,
+      cwd: this.cwd || process.cwd(),
+      memoryLimit: this._memoryLimit,
+      cpuLimit: this._cpuLimit,
+      containerUser: this._containerUser,
+    })
+  }
+
+  /**
+   * If pooling is enabled, try to claim a warm container for this
+   * session's resource shape. On a hit, verify the container still
+   * responds to `docker exec` — if so, skip `_startContainer()`
+   * entirely. On a miss (or on a verify failure), fall back to a fresh
+   * launch.
+   *
+   * #5022 — across-session idle pool. Per-session reuse of the same
+   * container across turns is handled in `_dispatchBuiltinTool` and
+   * does not depend on the pool.
+   */
+  async _acquireOrStartContainer() {
+    if (this._pool) {
+      const key = this._poolKey()
+      const reused = this._pool.acquire(key)
+      if (reused) {
+        this._containerId = reused
+        try {
+          await this._verifyContainer()
+          // Pool hit: skip `useradd` + `chown` — already done by the
+          // session that originally provisioned this container, and
+          // the user persists across container restarts (image layer).
+          this._acquiredFromPool = true
+          log.info(`reused pooled container ${reused.slice(0, 12)}`)
+          return
+        } catch (err) {
+          // The pooled container died while idle (daemon restart, OOM
+          // kill). Forget it and fall through to a fresh launch.
+          log.warn(`pooled container ${reused.slice(0, 12)} failed verify: ${err.message} — launching fresh`)
+          this._containerId = null
+          // Best-effort cleanup of the stale id — fire-and-forget.
+          this._execFile('docker', ['rm', '-f', reused], { stdio: 'ignore' }, () => {})
+        }
+      }
+    }
+    await this._startContainer()
   }
 
   /**
@@ -701,25 +780,67 @@ export class DockerByokSession extends ClaudeByokSession {
    * Tear down the container we own, then call super.destroy() so the
    * agent-loop teardown (MCP fleet, permissions, listeners) runs.
    * When attached to an external container, leave it running.
+   *
+   * #5022: when pooling is enabled and the session went start-clean
+   * (`_containerReady` was set), the container is released back to the
+   * pool for the next session of the same resource shape to claim. On
+   * any error path — or if pooling is disabled — fall back to inline
+   * `docker rm -f`.
    */
   async destroy() {
     const containerId = this._containerId
     const owned = this._containerOwned
+    const wasReady = this._containerReady
+    const pool = this._pool
+    const acquiredFromPool = this._acquiredFromPool
     this._containerId = null
     this._containerReady = false
+    this._acquiredFromPool = false
     try {
       await super.destroy()
     } finally {
-      if (containerId && owned) {
-        log.info(`removing container ${containerId.slice(0, 12)}`)
-        await new Promise((resolve) => {
-          this._execFile('docker', ['rm', '-f', containerId], { stdio: 'ignore' }, (err) => {
-            if (err) log.warn(`failed to remove container ${containerId.slice(0, 12)}: ${err.message}`)
-            resolve()
-          })
-        })
+      if (!containerId || !owned) {
+        // Nothing for us to clean up — externally-managed container
+        // stays running for whoever owns it.
+      } else if (pool && wasReady) {
+        // Healthy session end → hand back to the pool. The pool may
+        // still evict (over cap, shutting down) but that's its call.
+        log.info(`releasing container ${containerId.slice(0, 12)} to pool`)
+        try {
+          await pool.release(this._poolKeyFor(containerId), containerId)
+        } catch (err) {
+          log.warn(`pool release of ${containerId.slice(0, 12)} failed: ${err.message} — falling back to docker rm -f`)
+          await this._rmContainer(containerId)
+        }
+      } else {
+        log.info(`removing container ${containerId.slice(0, 12)}${acquiredFromPool ? ' (was pooled)' : ''}`)
+        await this._rmContainer(containerId)
       }
     }
+  }
+
+  /**
+   * Inline `docker rm -f` fallback. Swallows errors — the alternative
+   * is leaking a container, which is worse than a warn log.
+   */
+  _rmContainer(containerId) {
+    return new Promise((resolve) => {
+      this._execFile('docker', ['rm', '-f', containerId], { stdio: 'ignore' }, (err) => {
+        if (err) log.warn(`failed to remove container ${containerId.slice(0, 12)}: ${err.message}`)
+        resolve()
+      })
+    })
+  }
+
+  /**
+   * Pool key for a specific container id. Currently this just computes
+   * from the session's resource shape — the containerId arg is here
+   * because the destroy() path may be called after `this._containerId`
+   * has been nulled out. Kept as a method so a future variant (per-
+   * container key derived from labels) can override.
+   */
+  _poolKeyFor(_containerId) {
+    return this._poolKey()
   }
 }
 

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -387,9 +387,14 @@ export class DockerByokSession extends ClaudeByokSession {
         this._containerId = reused
         try {
           await this._verifyContainer()
-          // Pool hit: skip `useradd` + `chown` — already done by the
-          // session that originally provisioned this container, and
-          // the user persists across container restarts (image layer).
+          // Pool hit: skip `useradd` + `chown` — the previous session
+          // ran them inside THIS container, and we're reusing the same
+          // running container (it never stopped, so `/etc/passwd` and
+          // `/workspace` ownership stay put). If pooling ever switches
+          // to stop/start (or commit/restart), this assumption needs to
+          // be revisited — a stopped-then-restarted container preserves
+          // its layered FS but the previous-session assumption about
+          // "the user already exists" still holds at the FS level.
           this._acquiredFromPool = true
           log.info(`reused pooled container ${reused.slice(0, 12)}`)
           return

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -398,8 +398,12 @@ export class DockerByokSession extends ClaudeByokSession {
           // kill). Forget it and fall through to a fresh launch.
           log.warn(`pooled container ${reused.slice(0, 12)} failed verify: ${err.message} — launching fresh`)
           this._containerId = null
-          // Best-effort cleanup of the stale id — fire-and-forget.
-          this._execFile('docker', ['rm', '-f', reused], { stdio: 'ignore' }, () => {})
+          // Best-effort cleanup of the stale id — fire-and-forget. We
+          // don't await this because the pool has already untracked the
+          // id; the rm is just hygiene. `execFile` ignores `stdio`, so
+          // cap `maxBuffer` instead to keep a misbehaving docker(8)
+          // bounded.
+          this._execFile('docker', ['rm', '-f', reused], { maxBuffer: 64 * 1024 }, () => {})
         }
       }
     }
@@ -825,7 +829,9 @@ export class DockerByokSession extends ClaudeByokSession {
    */
   _rmContainer(containerId) {
     return new Promise((resolve) => {
-      this._execFile('docker', ['rm', '-f', containerId], { stdio: 'ignore' }, (err) => {
+      // `execFile` ignores `stdio`; cap `maxBuffer` so a misbehaving
+      // docker(8) can't OOM us on stderr.
+      this._execFile('docker', ['rm', '-f', containerId], { maxBuffer: 64 * 1024 }, (err) => {
         if (err) log.warn(`failed to remove container ${containerId.slice(0, 12)}: ${err.message}`)
         resolve()
       })

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -22,6 +22,7 @@ import { getLanIp } from './lan-ip.js'
 import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
 import { registerDockerProvider, resolveProviderLabel } from './providers.js'
+import { getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
 import { loadModelsCache, getModels } from './models.js'
 // Imported from a dedicated constants module rather than environment-manager.js
 // so we don't eagerly pull in DockerBackend when environments are disabled —
@@ -1014,6 +1015,20 @@ export async function startCliServer(config) {
       log.error(`Failed to serialize session state: ${err?.message || err}`)
     }
     sessionManager.destroyAll()
+    // #5042: drain the docker-byok across-session pool so the `sleep
+    // infinity` containers it holds don't outlive the server. Default-OFF
+    // (`isPoolEnabled` returns false unless `CHROXY_DOCKER_BYOK_POOL=1`),
+    // so this is a no-op for the common path. When the flag is on, the
+    // pool's `docker rm -f` calls run in parallel and we let them settle
+    // before `process.exit(0)` strands them.
+    if (isPoolEnabled(process.env)) {
+      try {
+        const pool = getSharedPool(process.env)
+        if (pool) await pool.shutdown()
+      } catch (err) {
+        log.error(`Failed to drain docker-byok pool: ${err?.message || err}`)
+      }
+    }
     wsServer.close()
     if (tunnel) await tunnel.stop()
     removeConnectionInfo()

--- a/packages/server/tests/docker-byok-pool.test.js
+++ b/packages/server/tests/docker-byok-pool.test.js
@@ -1,0 +1,329 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  DockerContainerPool,
+  buildPoolKey,
+  isPoolEnabled,
+  getSharedPool,
+  _resetSharedPool,
+  DEFAULT_IDLE_TIMEOUT_MS,
+  DEFAULT_MAX_PER_KEY,
+  DEFAULT_MAX_TOTAL,
+} from '../src/docker-byok-pool.js'
+
+/**
+ * Tests for the docker-byok idle container pool (#5022).
+ *
+ * The pool itself does only two things: bucket idle containers by key,
+ * and `docker rm -f` evicted ones. All shellouts are stubbed via
+ * `_execFile` so no real Docker daemon is required.
+ */
+
+/**
+ * Build a stub `execFile` that records `docker rm -f` calls and returns
+ * canned results. Same shape as the session-test stub but trimmed to
+ * the `rm` subcommand.
+ */
+function execFileStub({ rmError = null } = {}) {
+  const calls = []
+  const fn = (cmd, args, _opts, callback) => {
+    calls.push({ cmd, args: [...args] })
+    if (typeof callback !== 'function') return
+    if (rmError) {
+      const err = rmError instanceof Error ? rmError : new Error(rmError)
+      callback(err)
+      return
+    }
+    callback(null, '', '')
+  }
+  fn.calls = calls
+  return fn
+}
+
+/**
+ * Inline timer stubs so a 5-minute idle timeout doesn't actually block
+ * the test runner. The fake `setTimeout` returns a token; the test fires
+ * the callback manually via `runTimer(token)`.
+ */
+function timerStubs() {
+  const timers = new Map()
+  let nextId = 1
+  const setT = (cb, _ms) => {
+    const id = nextId++
+    timers.set(id, { cb, cleared: false })
+    return id
+  }
+  const clearT = (id) => {
+    const t = timers.get(id)
+    if (t) t.cleared = true
+  }
+  return {
+    setT,
+    clearT,
+    runTimer(id) {
+      const t = timers.get(id)
+      if (!t || t.cleared) throw new Error(`timer ${id} cleared or unknown`)
+      timers.delete(id)
+      t.cb()
+    },
+    pending() {
+      return [...timers.entries()].filter(([, t]) => !t.cleared).map(([id]) => id)
+    },
+  }
+}
+
+describe('buildPoolKey()', () => {
+  it('joins the five shape fields with |', () => {
+    const key = buildPoolKey({
+      image: 'node:22-slim',
+      cwd: '/host/cwd',
+      memoryLimit: '2g',
+      cpuLimit: '2',
+      containerUser: 'chroxy',
+    })
+    assert.equal(key, 'node:22-slim|/host/cwd|2g|2|chroxy')
+  })
+
+  it('throws when any required field is missing', () => {
+    assert.throws(() => buildPoolKey({ image: 'x', cwd: '/y' }), /required/)
+  })
+
+  it('throws when spec is not an object', () => {
+    assert.throws(() => buildPoolKey(null), /required/)
+  })
+})
+
+describe('isPoolEnabled()', () => {
+  it('returns false for undefined / empty', () => {
+    assert.equal(isPoolEnabled({}), false)
+    assert.equal(isPoolEnabled({ CHROXY_DOCKER_BYOK_POOL: '' }), false)
+  })
+
+  it('returns true for truthy string values', () => {
+    assert.equal(isPoolEnabled({ CHROXY_DOCKER_BYOK_POOL: '1' }), true)
+    assert.equal(isPoolEnabled({ CHROXY_DOCKER_BYOK_POOL: 'true' }), true)
+    assert.equal(isPoolEnabled({ CHROXY_DOCKER_BYOK_POOL: 'yes' }), true)
+    assert.equal(isPoolEnabled({ CHROXY_DOCKER_BYOK_POOL: 'on' }), true)
+    assert.equal(isPoolEnabled({ CHROXY_DOCKER_BYOK_POOL: 'TRUE' }), true)
+  })
+
+  it('returns false for falsy strings', () => {
+    assert.equal(isPoolEnabled({ CHROXY_DOCKER_BYOK_POOL: '0' }), false)
+    assert.equal(isPoolEnabled({ CHROXY_DOCKER_BYOK_POOL: 'false' }), false)
+    assert.equal(isPoolEnabled({ CHROXY_DOCKER_BYOK_POOL: 'off' }), false)
+  })
+})
+
+describe('DockerContainerPool — defaults', () => {
+  it('exports stable default constants', () => {
+    assert.equal(DEFAULT_IDLE_TIMEOUT_MS, 5 * 60 * 1000)
+    assert.equal(DEFAULT_MAX_PER_KEY, 2)
+    assert.equal(DEFAULT_MAX_TOTAL, 8)
+  })
+
+  it('starts empty', () => {
+    const pool = new DockerContainerPool({ _execFile: execFileStub() })
+    assert.equal(pool.size(), 0)
+    assert.equal(pool.sizeOf('any-key'), 0)
+    assert.equal(pool.acquire('any-key'), null)
+  })
+})
+
+describe('DockerContainerPool acquire / release', () => {
+  let timers
+  let execFile
+  let pool
+
+  beforeEach(() => {
+    timers = timerStubs()
+    execFile = execFileStub()
+    pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+  })
+
+  it('release puts a container into the pool, acquire pulls it back out', async () => {
+    const key = 'shape-a'
+    const kept = await pool.release(key, 'CONTAINER_A')
+    assert.equal(kept, true)
+    assert.equal(pool.size(), 1)
+    assert.equal(pool.sizeOf(key), 1)
+
+    const acquired = pool.acquire(key)
+    assert.equal(acquired, 'CONTAINER_A')
+    assert.equal(pool.size(), 0, 'acquire removes the entry from the pool')
+    // The idle timer for the acquired entry must be cleared so it
+    // doesn't fire after the session has the container.
+    assert.equal(timers.pending().length, 0)
+  })
+
+  it('acquire returns null on a miss', () => {
+    assert.equal(pool.acquire('nothing-here'), null)
+  })
+
+  it('different keys do not collide', async () => {
+    await pool.release('shape-a', 'CONTAINER_A')
+    await pool.release('shape-b', 'CONTAINER_B')
+    assert.equal(pool.size(), 2)
+    assert.equal(pool.acquire('shape-a'), 'CONTAINER_A')
+    assert.equal(pool.acquire('shape-b'), 'CONTAINER_B')
+    assert.equal(pool.size(), 0)
+  })
+
+  it('release over per-key cap evicts immediately', async () => {
+    const small = new DockerContainerPool({
+      maxPerKey: 1,
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    assert.equal(await small.release('k', 'C1'), true)
+    assert.equal(await small.release('k', 'C2'), false, 'second release over cap must evict')
+    assert.equal(small.size(), 1)
+    // The evicted container was docker-rm-f'd.
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1)
+    assert.ok(rmCalls[0].args.includes('C2'))
+  })
+
+  it('release over total cap evicts immediately', async () => {
+    const small = new DockerContainerPool({
+      maxTotal: 1,
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    assert.equal(await small.release('k1', 'C1'), true)
+    assert.equal(await small.release('k2', 'C2'), false)
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1)
+    assert.ok(rmCalls[0].args.includes('C2'))
+  })
+
+  it('FIFO order: first released is first acquired', async () => {
+    await pool.release('shape', 'C1')
+    await pool.release('shape', 'C2')
+    assert.equal(pool.acquire('shape'), 'C1')
+    assert.equal(pool.acquire('shape'), 'C2')
+  })
+})
+
+describe('DockerContainerPool — idle eviction', () => {
+  it('fires docker rm -f when the idle timer fires', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    await pool.release('k', 'CONTAINER_IDLE')
+    assert.equal(pool.size(), 1)
+
+    const pending = timers.pending()
+    assert.equal(pending.length, 1, 'release schedules exactly one idle timer')
+
+    // Fire the timer.
+    timers.runTimer(pending[0])
+
+    // Drain microtasks so the async _evict() resolves.
+    await new Promise((r) => setImmediate(r))
+
+    assert.equal(pool.size(), 0, 'expired entry removed from pool')
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1)
+    assert.ok(rmCalls[0].args.includes('CONTAINER_IDLE'))
+  })
+
+  it('eviction in the middle of a session does not affect held containers', async () => {
+    // Cache-eviction-mid-session: a session has already ACQUIRED the
+    // container, so there is no entry in the pool — the idle timer
+    // doesn't apply. New release with the same id starts a fresh timer.
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    await pool.release('k', 'CONTAINER_X')
+    assert.equal(pool.acquire('k'), 'CONTAINER_X')
+    // While the session holds the container, no idle timer is active.
+    assert.equal(timers.pending().length, 0)
+    // Releasing again starts a fresh timer.
+    await pool.release('k', 'CONTAINER_X')
+    assert.equal(timers.pending().length, 1)
+  })
+})
+
+describe('DockerContainerPool — shutdown', () => {
+  it('drains all entries via docker rm -f', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    await pool.release('k1', 'C1')
+    await pool.release('k2', 'C2')
+    assert.equal(pool.size(), 2)
+
+    await pool.shutdown()
+    assert.equal(pool.size(), 0)
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 2)
+    const ids = rmCalls.map((c) => c.args[c.args.length - 1]).sort()
+    assert.deepEqual(ids, ['C1', 'C2'])
+  })
+
+  it('acquire returns null after shutdown', async () => {
+    const pool = new DockerContainerPool({ _execFile: execFileStub() })
+    await pool.release('k', 'C1')
+    await pool.shutdown()
+    assert.equal(pool.acquire('k'), null)
+  })
+
+  it('release after shutdown evicts inline', async () => {
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({ _execFile: execFile })
+    await pool.shutdown()
+    const kept = await pool.release('k', 'C_LATE')
+    assert.equal(kept, false)
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1)
+    assert.ok(rmCalls[0].args.includes('C_LATE'))
+  })
+})
+
+describe('getSharedPool() — singleton + env wiring', () => {
+  beforeEach(() => _resetSharedPool())
+  afterEach(() => _resetSharedPool())
+
+  it('returns null when pooling is disabled', () => {
+    assert.equal(getSharedPool({}), null)
+    assert.equal(getSharedPool({ CHROXY_DOCKER_BYOK_POOL: '0' }), null)
+  })
+
+  it('returns a singleton when enabled', () => {
+    const a = getSharedPool({ CHROXY_DOCKER_BYOK_POOL: '1' })
+    const b = getSharedPool({ CHROXY_DOCKER_BYOK_POOL: '1' })
+    assert.ok(a instanceof DockerContainerPool)
+    assert.equal(a, b)
+  })
+
+  it('honors override env vars', () => {
+    const pool = getSharedPool({
+      CHROXY_DOCKER_BYOK_POOL: '1',
+      CHROXY_DOCKER_BYOK_POOL_IDLE_MS: '15000',
+      CHROXY_DOCKER_BYOK_POOL_MAX_PER_KEY: '5',
+      CHROXY_DOCKER_BYOK_POOL_MAX_TOTAL: '20',
+    })
+    assert.equal(pool._idleTimeoutMs, 15000)
+    assert.equal(pool._maxPerKey, 5)
+    assert.equal(pool._maxTotal, 20)
+  })
+})

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -628,6 +628,278 @@ describe('DockerByokSession _dispatchBuiltinTool — tool routing', () => {
   })
 })
 
+describe('DockerByokSession — per-session container reuse', () => {
+  /**
+   * #5022 invariant: one `docker run` per session, regardless of how
+   * many tool dispatches the session performs. This is the baseline
+   * the pool layer builds on top of — without it, even one warm-pool
+   * acquire would only save the first turn's cold-start.
+   */
+  it('keeps the same container id across multiple tool dispatches (no fresh docker run)', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_REUSE_42\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const _dockerBackend = backendStub({
+      defaultResponse: { stdout: 'hello\n', stderr: '' },
+    })
+    const session = new DockerByokSession({ cwd: '/host/cwd', _execFile, _dockerBackend })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    const idAfterStart = session._containerId
+    assert.equal(idAfterStart, 'CONTAINER_REUSE_42')
+
+    // Three back-to-back tool dispatches.
+    await session._dispatchBuiltinTool({ toolName: 'Bash', input: { command: 'echo a' } })
+    await session._dispatchBuiltinTool({ toolName: 'Bash', input: { command: 'echo b' } })
+    await session._dispatchBuiltinTool({ toolName: 'Bash', input: { command: 'echo c' } })
+
+    // Same container id throughout the session.
+    assert.equal(session._containerId, idAfterStart)
+    // Only ONE `docker run` for the entire session (the initial launch).
+    const runCalls = _execFile.calls.filter((c) => c.args[0] === 'run')
+    assert.equal(runCalls.length, 1, 'expected exactly one docker run per session')
+    // All three dispatches went through the backend (not via docker run).
+    assert.equal(_dockerBackend.calls.length, 3)
+    for (const call of _dockerBackend.calls) {
+      assert.equal(call.containerId, idAfterStart)
+    }
+
+    await session.destroy()
+  })
+})
+
+describe('DockerByokSession — across-session pool (#5022)', () => {
+  /**
+   * Minimal pool stub: records `acquire` / `release` calls so we can
+   * assert the session's start/destroy paths flow through the pool
+   * without spinning up a real DockerContainerPool.
+   */
+  function poolStub({ acquireReturn = null } = {}) {
+    const calls = { acquire: [], release: [] }
+    let nextAcquire = acquireReturn
+    return {
+      calls,
+      acquire(key) {
+        calls.acquire.push(key)
+        const v = nextAcquire
+        nextAcquire = null
+        return v
+      },
+      async release(key, containerId) {
+        calls.release.push({ key, containerId })
+        return true
+      },
+      setNextAcquire(id) {
+        nextAcquire = id
+      },
+    }
+  }
+
+  it('cache miss: launches a fresh container and releases it to the pool on destroy', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_FRESH\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const _dockerBackend = backendStub()
+    const pool = poolStub({ acquireReturn: null })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend,
+      _pool: pool,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // Pool was asked, but missed → docker run was called.
+    assert.equal(pool.calls.acquire.length, 1)
+    const runCalls = _execFile.calls.filter((c) => c.args[0] === 'run')
+    assert.equal(runCalls.length, 1)
+    assert.equal(session._containerId, 'CONTAINER_FRESH')
+    assert.equal(session._acquiredFromPool, false)
+
+    await session.destroy()
+
+    // On destroy, the container is released to the pool (not docker-rm-f'd).
+    assert.equal(pool.calls.release.length, 1)
+    assert.equal(pool.calls.release[0].containerId, 'CONTAINER_FRESH')
+    const rmCalls = _execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 0, 'destroy must NOT inline-rm when releasing to pool')
+  })
+
+  it('cache hit: reuses the pooled container, skips docker run + useradd', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      // `exec` matches the verify call (`docker exec <id> true`).
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const _dockerBackend = backendStub()
+    const pool = poolStub({ acquireReturn: 'CONTAINER_POOLED' })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend,
+      _pool: pool,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    assert.equal(session._containerId, 'CONTAINER_POOLED')
+    assert.equal(session._acquiredFromPool, true)
+    // Crucially: no `docker run` happened.
+    const runCalls = _execFile.calls.filter((c) => c.args[0] === 'run')
+    assert.equal(runCalls.length, 0, 'pool hit must skip docker run')
+    // And no `useradd` on the reused container (already provisioned).
+    const setupCalls = _execFile.calls.filter((c) =>
+      c.args[0] === 'exec' && c.args.some((a) => typeof a === 'string' && a.includes('useradd')))
+    assert.equal(setupCalls.length, 0, 'pool hit must skip useradd')
+
+    await session.destroy()
+    // Container released back to the pool.
+    assert.equal(pool.calls.release.length, 1)
+    assert.equal(pool.calls.release[0].containerId, 'CONTAINER_POOLED')
+  })
+
+  it('cache hit but pooled container dead: evicts the dead id and launches fresh', async () => {
+    // The verify call (`docker exec <id> true`) fails — pooled
+    // container died while idle. The session should drop it and
+    // launch a fresh container.
+    let execCount = 0
+    const _execFile = (cmd, args, opts, callback) => {
+      _execFile.calls.push({ cmd, args: [...args], opts })
+      const sub = args[0]
+      if (sub === 'info') return callback(null, 'ok', '')
+      if (sub === 'exec') {
+        execCount++
+        // First exec is the verify of the pooled container — fail it.
+        // Subsequent execs (useradd + chown for the fresh container) succeed.
+        if (execCount === 1) {
+          const err = new Error('No such container: CONTAINER_DEAD')
+          err.stderr = 'No such container: CONTAINER_DEAD'
+          return callback(err, '', 'No such container: CONTAINER_DEAD')
+        }
+        return callback(null, '', '')
+      }
+      if (sub === 'run') return callback(null, 'CONTAINER_FALLBACK\n', '')
+      if (sub === 'rm') return callback(null, '', '')
+      callback(null, '', '')
+    }
+    _execFile.calls = []
+
+    const _dockerBackend = backendStub()
+    const pool = poolStub({ acquireReturn: 'CONTAINER_DEAD' })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend,
+      _pool: pool,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // Fell back to docker run with a new id.
+    assert.equal(session._containerId, 'CONTAINER_FALLBACK')
+    assert.equal(session._acquiredFromPool, false)
+    const runCalls = _execFile.calls.filter((c) => c.args[0] === 'run')
+    assert.equal(runCalls.length, 1)
+    // The dead pooled id was best-effort docker-rm-f'd.
+    const rmCalls = _execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.ok(rmCalls.some((c) => c.args.includes('CONTAINER_DEAD')))
+
+    await session.destroy()
+  })
+
+  it('does NOT engage the pool when externally-managed containerId is supplied', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      exec: { stdout: '' },
+    })
+    const pool = poolStub()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      containerId: 'EXTERNAL_MANAGED',
+      _execFile,
+      _dockerBackend: backendStub(),
+      _pool: pool,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // External container path — pool was never consulted.
+    assert.equal(pool.calls.acquire.length, 0)
+    assert.equal(session._containerId, 'EXTERNAL_MANAGED')
+
+    await session.destroy()
+
+    // External container is NOT released to the pool, and NOT removed.
+    assert.equal(pool.calls.release.length, 0)
+    const rmCalls = _execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 0)
+  })
+
+  it('does NOT engage the pool when pool flag is disabled (default behaviour)', async () => {
+    // No _pool injected, no CHROXY_DOCKER_BYOK_POOL env var → session
+    // should fall through to the existing inline `docker rm -f` path.
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_DEFAULT\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStub(),
+      _poolEnv: {}, // explicitly empty env → disabled
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    assert.equal(session._pool, null)
+
+    await session.destroy()
+    const rmCalls = _execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1, 'with pool disabled, destroy() falls back to docker rm -f')
+    assert.ok(rmCalls[0].args.includes('CONTAINER_DEFAULT'))
+  })
+
+  it('skips pool release when session start failed (no leak via dirty pool)', async () => {
+    // Missing creds → super.start() bails before _containerReady is set.
+    // The pool MUST NOT receive a container that never went healthy.
+    delete process.env.ANTHROPIC_API_KEY
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_HALF\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const pool = poolStub()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStub(),
+      _pool: pool,
+    })
+    // Do NOT stub _client — super.start() will see no key and bail.
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+
+    assert.equal(session._containerReady, false)
+    // Pool was never released — the dirty container was docker-rm-f'd.
+    assert.equal(pool.calls.release.length, 0)
+    const rmCalls = _execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.ok(rmCalls.some((c) => c.args.includes('CONTAINER_HALF')),
+      'half-started container must be rm-f\'d, not pooled')
+  })
+})
+
 describe('docker-byok provider registration', () => {
   it('registerDockerProvider() wires docker-byok when environments are enabled and docker is available', async () => {
     // Spy on console.warn so accidental log noise during the test


### PR DESCRIPTION
Closes #5022.

## Summary

- Add `DockerContainerPool` — opt-in across-session idle pool for `docker-byok` containers. Default OFF (`CHROXY_DOCKER_BYOK_POOL=1` to enable), so today's per-session behaviour is preserved unless asked for.
- Pin the per-session container-reuse invariant with a regression test: one `docker run` per session, regardless of tool-dispatch count.
- Wire the pool into `DockerByokSession#start()` (acquire + verify → fall through on dead container) and `#destroy()` (release healthy containers, inline `docker rm -f` on half-started / pool-disabled / external paths).

## Design

Detailed design notes live in the docstring of `packages/server/src/docker-byok-pool.js`. Highlights:

- **Cache key:** `image|cwd|memoryLimit|cpuLimit|containerUser`. Cwd is included because `/workspace` is bind-mounted from the host cwd — reusing across cwds would silently leak host paths. Resource limits are part of the key so a `--memory 4g` request can't pick up a 1g container.
- **Eviction:** per-entry `setTimeout` (default 5 min) fires `docker rm -f`. Caps per-key (2) and total (8) keep daemon load bounded; over-cap releases evict inline.
- **Health on acquire:** the session runs the existing `_verifyContainer()` (`docker exec <id> true`) after acquire. If the pooled container died while idle (daemon restart, OOM kill), the session evicts the stale id and falls back to `_startContainer()`.
- **Snapshot/restore:** deferred — pooled containers do NOT participate in snapshot/restore yet. Noted inline; needs a follow-up if/when docker-byok wants snapshots.

## Acceptance Criteria

- [x] Design doc covering cache key (image+cwd+resourceLimits), eviction policy, lifecycle on session destroy — inline in `docker-byok-pool.js` docstring
- [x] Implementation behind a config flag so default behaviour stays per-session — `CHROXY_DOCKER_BYOK_POOL` env var, default off
- [x] Tests cover cache hit / cache miss / eviction-mid-session paths — see test plan below
- [x] Documented interaction with snapshot/restore — deferred note in pool module docstring

## Test plan

- [x] `tests/docker-byok-pool.test.js` (22 tests): acquire/release, FIFO, per-key + total cap eviction, mid-session timer behaviour, shutdown drain, shared singleton env wiring.
- [x] `tests/docker-byok-session.test.js` (+7 tests):
  - per-session reuse invariant — one `docker run` across N tool dispatches
  - cache miss → fresh launch → release to pool
  - cache hit → skips `docker run` + useradd
  - dead pooled container → evicts and launches fresh
  - external `containerId` → pool bypassed entirely
  - pool flag disabled → falls back to inline `docker rm -f` (default)
  - half-started session (super.start fails) → no dirty pool release
- [x] `./scripts/lint-session-opt-forwarding.sh` — OK
- [x] `./scripts/lint-tests-state-file-path.sh` — OK
- [x] `eslint` on changed files — 0 errors
- [x] All 49 docker-byok-session tests pass; all 22 pool tests pass

## Scope notes / deferred

- Snapshot/restore interaction noted but not implemented — pooled containers should mark themselves "soiled" when a snapshot is taken so they go to eviction on release. Belongs in a follow-up issue.
- Pool metrics / dashboard surface — not added in this PR; `pool.size()` / `pool.sizeOf(key)` exposed for future wiring.