### PR TITLE
feat(server): expose markSoiled() on docker-byok pool for snapshot integration (#5043)

### DIFF
--- a/packages/server/src/docker-byok-pool.js
+++ b/packages/server/src/docker-byok-pool.js
@@ -40,11 +40,16 @@
  *     responsible for `_verifyContainer()` after acquire — if the
  *     container died while idle (docker daemon restart, OOM kill, host
  *     reboot), the session falls back to `_startContainer()`.
- *   - Interaction with snapshot/restore: deferred — pooled containers do
- *     NOT participate in snapshot/restore yet (a snapshot of a pooled
- *     container could be acquired by an unrelated session). When a
- *     snapshot is taken, the session must mark the container "soiled" so
- *     it goes to eviction on release.
+ *   - Interaction with snapshot/restore (#5043): the pool exposes
+ *     `markSoiled(containerId)` so when docker-byok grows snapshot
+ *     support (#5023), a session that took a snapshot can mark its
+ *     container so the next `release()` call evicts it inline instead of
+ *     pooling. A soiled container's filesystem may have leaked into a
+ *     snapshot image layer (or otherwise become coupled to a specific
+ *     conversation) — handing it to an unrelated session would silently
+ *     surface another conversation's files / auth. Soiling is a property
+ *     of the container id, not the session, so it survives across the
+ *     release call and is cleared once the container is evicted.
  *
  * Why a separate module
  * ---------------------
@@ -123,6 +128,13 @@ export class DockerContainerPool {
     this._clearTimeout = opts._clearTimeout || clearTimeout
     /** @type {Map<string, Array<{ containerId: string, timer: any }>>} */
     this._entries = new Map()
+    /**
+     * Container ids marked soiled by `markSoiled()`. A soiled id at
+     * `release()` time is evicted inline instead of being pooled — see
+     * #5043 and the class docstring's snapshot/restore section.
+     * @type {Set<string>}
+     */
+    this._soiledIds = new Set()
     this._shuttingDown = false
   }
 
@@ -164,6 +176,18 @@ export class DockerContainerPool {
     // with no id was calling `docker rm -f` with an empty argument.
     if (!containerId) return false
     if (this._shuttingDown) {
+      this._soiledIds.delete(containerId)
+      await this._evict(containerId)
+      return false
+    }
+    // #5043: soiled containers (snapshot taken, or otherwise coupled to a
+    // particular conversation) MUST NOT be returned to the pool — the
+    // next session of the same shape would silently inherit the previous
+    // session's filesystem state. Evict inline and clear the marker so
+    // the soiled set doesn't grow unbounded.
+    if (this._soiledIds.has(containerId)) {
+      this._soiledIds.delete(containerId)
+      log.info(`pool release: ${containerId.slice(0, 12)} marked soiled; evicting instead of pooling`)
       await this._evict(containerId)
       return false
     }
@@ -208,6 +232,43 @@ export class DockerContainerPool {
   }
 
   /**
+   * Mark a container "soiled" so the next `release()` call evicts it
+   * inline instead of returning it to the pool. Used by callers that
+   * have done something to the container's filesystem which couples it
+   * to the current session — most importantly, taking a Docker snapshot
+   * (#5023). A snapshot includes the container's writable layer, so any
+   * files the previous session wrote / authenticated would silently leak
+   * into the next acquirer of this container.
+   *
+   * Idempotent — calling twice with the same id is a no-op. Null / empty
+   * / non-string ids are silently ignored so callers don't need to
+   * branch on whether they actually hold a container. No-ops cleanly
+   * when the pool is disabled (the session holds `this._pool = null`
+   * and never gets here).
+   *
+   * @param {string} containerId
+   */
+  markSoiled(containerId) {
+    if (typeof containerId !== 'string' || containerId.length === 0) return
+    if (this._soiledIds.has(containerId)) return
+    this._soiledIds.add(containerId)
+    log.info(`marked container ${containerId.slice(0, 12)} soiled — next release will evict`)
+  }
+
+  /**
+   * Whether a container has been marked soiled. Exposed for tests and
+   * dashboard introspection; production callers use `markSoiled()` and
+   * let `release()` handle the eviction.
+   *
+   * @param {string} containerId
+   * @returns {boolean}
+   */
+  isSoiled(containerId) {
+    if (typeof containerId !== 'string' || containerId.length === 0) return false
+    return this._soiledIds.has(containerId)
+  }
+
+  /**
    * Cancel all idle timers and `docker rm -f` every entry. After
    * shutdown, `acquire()` always returns null and `release()` evicts
    * inline. Idempotent.
@@ -222,6 +283,9 @@ export class DockerContainerPool {
       }
     }
     this._entries.clear()
+    // Clear the soiled-id tracking — a future pool instance (lazy
+    // singleton, test reset) starts from a clean slate.
+    this._soiledIds.clear()
     log.info(`shutdown: evicting ${toRemove.length} pooled container(s)`)
     await Promise.all(toRemove.map((id) => this._evict(id).catch((err) => {
       log.warn(`shutdown eviction of ${id.slice(0, 12)} failed: ${err.message}`)

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -369,6 +369,30 @@ export class DockerByokSession extends ClaudeByokSession {
   }
 
   /**
+   * Mark this session's live container "soiled" — its filesystem has
+   * been coupled to the current conversation (most often by taking a
+   * Docker snapshot) and MUST NOT be handed to a future session via the
+   * pool. The pool intercepts the next `release()` and evicts inline.
+   *
+   * Integration point for #5023 (docker-byok snapshot/restore): when
+   * snapshot support lands, the snapshot helper must call this AFTER
+   * `docker commit` succeeds (the snapshot includes the writable layer,
+   * so the container's auth / files / artifacts are now part of an
+   * image that's tied to this conversation). The restore-from-snapshot
+   * path does the same — restoring previous state into the live
+   * container couples it to a specific session's history.
+   *
+   * No-ops cleanly when pooling is disabled (no `_pool`) or when the
+   * session does not hold a container (no `_containerId` yet). Safe to
+   * call multiple times — `markSoiled` is idempotent.
+   */
+  markActiveContainerSoiled() {
+    if (!this._pool) return
+    if (!this._containerId) return
+    this._pool.markSoiled(this._containerId)
+  }
+
+  /**
    * If pooling is enabled, try to claim a warm container for this
    * session's resource shape. On a hit, verify the container still
    * responds to `docker exec` — if so, skip `_startContainer()`

--- a/packages/server/tests/docker-byok-pool.test.js
+++ b/packages/server/tests/docker-byok-pool.test.js
@@ -299,6 +299,76 @@ describe('DockerContainerPool — shutdown', () => {
   })
 })
 
+describe('DockerContainerPool — markSoiled() (#5043)', () => {
+  /**
+   * A "soiled" container is one whose filesystem may have leaked into a
+   * snapshot image layer (or otherwise become coupled to a specific
+   * conversation). It MUST NOT be returned to the pool for another
+   * session to acquire. The session marks the container soiled when it
+   * takes a snapshot, then calls release() as normal — the pool
+   * intercepts the release and evicts inline instead of pooling.
+   *
+   * This is the design hook for #5023 (docker-byok snapshot/restore).
+   */
+  it('release after markSoiled evicts instead of pooling', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    pool.markSoiled('CONTAINER_SOILED')
+    const kept = await pool.release('k', 'CONTAINER_SOILED')
+    assert.equal(kept, false, 'soiled container must NOT be retained')
+    assert.equal(pool.size(), 0)
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1)
+    assert.ok(rmCalls[0].args.includes('CONTAINER_SOILED'))
+    // After eviction the soiled tracking entry is cleared so the same
+    // container id (if docker recycles ids in a future run) isn't
+    // poisoned forever.
+    assert.equal(pool.isSoiled('CONTAINER_SOILED'), false)
+  })
+
+  it('markSoiled is idempotent — calling twice is a no-op', () => {
+    const pool = new DockerContainerPool({ _execFile: execFileStub() })
+    pool.markSoiled('CONTAINER_DUP')
+    pool.markSoiled('CONTAINER_DUP')
+    assert.equal(pool.isSoiled('CONTAINER_DUP'), true)
+  })
+
+  it('markSoiled ignores null / empty container ids', () => {
+    const pool = new DockerContainerPool({ _execFile: execFileStub() })
+    pool.markSoiled(null)
+    pool.markSoiled('')
+    pool.markSoiled(undefined)
+    assert.equal(pool.isSoiled(null), false)
+    assert.equal(pool.isSoiled(''), false)
+  })
+
+  it('soiled marker only affects the specific container id', async () => {
+    const pool = new DockerContainerPool({
+      _execFile: execFileStub(),
+      _setTimeout: timerStubs().setT,
+      _clearTimeout: timerStubs().clearT,
+    })
+    pool.markSoiled('CONTAINER_A')
+    // Releasing a DIFFERENT id with the same key still works normally.
+    const kept = await pool.release('k', 'CONTAINER_B')
+    assert.equal(kept, true)
+    assert.equal(pool.size(), 1)
+  })
+
+  it('shutdown clears the soiled set', async () => {
+    const pool = new DockerContainerPool({ _execFile: execFileStub() })
+    pool.markSoiled('CONTAINER_X')
+    assert.equal(pool.isSoiled('CONTAINER_X'), true)
+    await pool.shutdown()
+    assert.equal(pool.isSoiled('CONTAINER_X'), false)
+  })
+})
+
 describe('getSharedPool() — singleton + env wiring', () => {
   beforeEach(() => _resetSharedPool())
   afterEach(() => _resetSharedPool())

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -900,6 +900,135 @@ describe('DockerByokSession — across-session pool (#5022)', () => {
   })
 })
 
+describe('DockerByokSession — snapshot soiling integration (#5043)', () => {
+  /**
+   * Same shape as the across-session pool stub above, but with the
+   * `markSoiled` hook the session calls when its container has taken
+   * (or restored from) a snapshot. Records every markSoiled call.
+   */
+  function poolStubWithSoiling({ acquireReturn = null } = {}) {
+    const calls = { acquire: [], release: [], markSoiled: [] }
+    const soiled = new Set()
+    let nextAcquire = acquireReturn
+    return {
+      calls,
+      acquire(key) {
+        calls.acquire.push(key)
+        const v = nextAcquire
+        nextAcquire = null
+        return v
+      },
+      async release(key, containerId) {
+        calls.release.push({ key, containerId })
+        if (soiled.has(containerId)) {
+          soiled.delete(containerId)
+          return false
+        }
+        return true
+      },
+      markSoiled(containerId) {
+        if (!containerId) return
+        soiled.add(containerId)
+        calls.markSoiled.push(containerId)
+      },
+      isSoiled(containerId) {
+        return soiled.has(containerId)
+      },
+    }
+  }
+
+  it('markActiveContainerSoiled forwards the live container id to the pool', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_SNAP\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const pool = poolStubWithSoiling()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStub(),
+      _pool: pool,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    assert.equal(session._containerId, 'CONTAINER_SNAP')
+    session.markActiveContainerSoiled()
+    assert.deepEqual(pool.calls.markSoiled, ['CONTAINER_SNAP'])
+    assert.equal(pool.isSoiled('CONTAINER_SNAP'), true)
+
+    await session.destroy()
+  })
+
+  it('markActiveContainerSoiled is a no-op when pooling is disabled', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_NOPOOL\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStub(),
+      _poolEnv: {}, // pool disabled
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    assert.equal(session._pool, null)
+    // Must not throw, must not crash — just silently no-op.
+    session.markActiveContainerSoiled()
+    await session.destroy()
+  })
+
+  it('markActiveContainerSoiled is a no-op when there is no live container', () => {
+    const pool = poolStubWithSoiling()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile: execFileStub({ info: { stdout: 'ok' } }),
+      _dockerBackend: backendStub(),
+      _pool: pool,
+    })
+    // No start() — no container assigned. Should not crash and should
+    // not call into the pool with a null id.
+    session.markActiveContainerSoiled()
+    assert.deepEqual(pool.calls.markSoiled, [])
+  })
+
+  it('soiled containers are docker-rm-f\'d on destroy, not pooled', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_DIRTY\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const pool = poolStubWithSoiling()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStub(),
+      _pool: pool,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // Snapshot taken mid-session — mark the container soiled.
+    session.markActiveContainerSoiled()
+
+    await session.destroy()
+
+    // The session called release(), and the pool returned false
+    // (evicted) because of the soiled marker. From the session's POV
+    // it released to the pool — the pool is responsible for the actual
+    // `docker rm -f`. We assert release WAS called (so the session
+    // didn't bypass the pool, which would defeat the design hook).
+    assert.equal(pool.calls.release.length, 1)
+    assert.equal(pool.calls.release[0].containerId, 'CONTAINER_DIRTY')
+  })
+})
+
 describe('docker-byok provider registration', () => {
   it('registerDockerProvider() wires docker-byok when environments are enabled and docker is available', async () => {
     // Spy on console.warn so accidental log noise during the test


### PR DESCRIPTION
Closes #5043.

## Summary

Adds the design hook so when docker-byok grows snapshot/restore support (#5023), the pool integration is already gated against handing snapshot-coupled containers to an unrelated session.

A snapshot includes the container's writable layer (auth, files, scratch state from the previous turn), so handing a snapshotted container to another session via the pool would silently surface another conversation's filesystem. Soiling guards that.

## Changes

**`packages/server/src/docker-byok-pool.js`**
- `markSoiled(containerId)` — idempotent; ignores empty / non-string ids
- `isSoiled(containerId)` — introspection seam for tests + dashboards
- `release()` short-circuits when a container is soiled, evicting inline via `docker rm -f` instead of pooling. The soiled marker is consumed so the same id (recycled by docker in a later run) isn't poisoned forever.
- `shutdown()` clears the soiled set so a lazy-singleton restart starts clean
- Class docstring updated to document the snapshot/restore interaction (was previously deferred)

**`packages/server/src/docker-byok-session.js`**
- `markActiveContainerSoiled()` — forwards the live container id to the pool. No-ops cleanly when pooling is disabled (`this._pool === null`) or when the session hasn't started yet (no `_containerId`). Method docstring spells out the #5023 integration point so the snapshot/restore consumer knows exactly where to call this.

## Snapshot/restore consumer

Snapshot/restore for docker-byok itself is **not** included here — that's #5023. When that PR lands, the snapshot helper must call `session.markActiveContainerSoiled()` immediately after `docker commit` succeeds (and on the restore path too — restoring previous state into the live container couples it to a specific session's history).

## Tests

- 5 new pool tests (`docker-byok-pool.test.js`):
  - release after `markSoiled` evicts instead of pooling
  - `markSoiled` is idempotent
  - `markSoiled` ignores null / empty / undefined ids
  - soiled marker only affects the specific container id
  - `shutdown()` clears the soiled set
- 4 new session tests (`docker-byok-session.test.js`):
  - `markActiveContainerSoiled` forwards live container id to pool
  - no-op when pooling is disabled (no crash, no call into pool)
  - no-op when there is no live container (pre-`start()` call)
  - soiled containers go through `pool.release()` not bypassing the pool

All 80 existing + new pool + session tests pass:

```
PATH="/opt/homebrew/opt/node@22/bin:$PATH" node --import ./tests/_setup.mjs --test tests/docker-byok-pool.test.js tests/docker-byok-session.test.js
# tests 80
# pass 80
# fail 0
```

CI lints (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`, `lint-logger-session-scoping.sh`) all pass; `npm run lint --workspace=packages/server` reports 0 errors.

## Test plan

- [x] `markSoiled` evicts on next release
- [x] `markSoiled` is idempotent
- [x] No-op when pool is disabled
- [x] No-op when session has no live container
- [x] `shutdown` clears soiled set
- [x] Existing pool + session tests still pass (76 → 80, no regressions)
- [x] Server lint clean