### PR TITLE
feat(server): enforce max container age in docker-byok pool (#5045)

### DIFF
--- a/packages/server/src/docker-byok-pool.js
+++ b/packages/server/src/docker-byok-pool.js
@@ -193,11 +193,12 @@ export class DockerContainerPool {
     const bucket = this._entries.get(key)
     if (!bucket || bucket.length === 0) return null
     // Lazily skip + evict any over-age entries at the head of the bucket
-    // (#5045). The bucket is FIFO so the oldest entry is at the front;
-    // once we hit an in-age entry the rest are guaranteed to be in-age
-    // as well (createdAt is monotonic with insertion order for a fresh
-    // container, but a re-released container can be older than a younger
-    // sibling — we still walk the whole bucket to be safe).
+    // (#5045). The bucket is FIFO so we only sweep the head — we stop at
+    // the first in-age entry and hand it to the caller. If a re-released
+    // container ends up trailing a younger sibling, the older one keeps
+    // its idle timer; when it bubbles to the head on a future acquire
+    // it gets caught here. We deliberately don't filter the whole bucket
+    // every acquire (would be O(n) on the hot path).
     const now = this._now()
     while (bucket.length > 0) {
       const entry = bucket[0]
@@ -293,6 +294,31 @@ export class DockerContainerPool {
     this._entries.set(key, bucket)
     log.info(`pool release: ${containerId.slice(0, 12)} → ${key} (idle ${this._idleTimeoutMs}ms, age ${age}ms/${this._maxAgeMs}ms)`)
     return true
+  }
+
+  /**
+   * Forget a container the pool was tracking and `docker rm -f` it. Use
+   * this from a caller that has ALREADY acquired the container and now
+   * knows the container is unhealthy / soiled / otherwise not poolable
+   * (e.g. `_verifyContainer()` failed after `acquire()` returned a hit).
+   * Without this, `_createdAt` would retain the id forever — `acquire()`
+   * removes the entry from `_entries` on hit, but leaves `_createdAt`
+   * intact so a follow-up `release()` of the same id preserves total
+   * lifetime. If the caller chooses NOT to release (because the
+   * container is already dead), they must call `forget()` so the map
+   * doesn't slowly leak across long-running servers.
+   *
+   * Idempotent: safe to call on an id that's not tracked. Returns a
+   * promise that resolves after `docker rm -f` completes (or fails —
+   * errors are logged, not rethrown).
+   *
+   * @param {string} containerId
+   * @returns {Promise<void>}
+   */
+  async forget(containerId) {
+    if (!containerId) return
+    this._createdAt.delete(containerId)
+    await this._evict(containerId)
   }
 
   /**
@@ -452,12 +478,21 @@ export function getSharedPool(env = process.env) {
   const idleTimeoutMs = Number(idleRaw)
   const maxPerKey = Number(perKeyRaw)
   const maxTotal = Number(totalRaw)
+  // Special-case `Infinity` / `infinity` so the documented opt-out path
+  // (constructor accepts `Infinity`) works through the env knob too. A
+  // bare `Number('Infinity')` evaluates to `Infinity` but `isFinite()`
+  // rejects it; users wanting the pre-#5045 idle-only behaviour need a
+  // way to say so via env, not just by constructing the pool by hand.
+  const maxAgeOptOut = typeof maxAgeRaw === 'string'
+    && maxAgeRaw.trim().toLowerCase() === 'infinity'
   const maxAgeMs = Number(maxAgeRaw)
   _sharedPool = new DockerContainerPool({
     idleTimeoutMs: Number.isFinite(idleTimeoutMs) && idleTimeoutMs > 0 ? idleTimeoutMs : undefined,
     maxPerKey: Number.isFinite(maxPerKey) && maxPerKey > 0 ? maxPerKey : undefined,
     maxTotal: Number.isFinite(maxTotal) && maxTotal > 0 ? maxTotal : undefined,
-    maxAgeMs: Number.isFinite(maxAgeMs) && maxAgeMs > 0 ? maxAgeMs : undefined,
+    maxAgeMs: maxAgeOptOut
+      ? Infinity
+      : (Number.isFinite(maxAgeMs) && maxAgeMs > 0 ? maxAgeMs : undefined),
   })
   return _sharedPool
 }

--- a/packages/server/src/docker-byok-pool.js
+++ b/packages/server/src/docker-byok-pool.js
@@ -74,6 +74,18 @@ export const DEFAULT_MAX_PER_KEY = 2
 export const DEFAULT_MAX_TOTAL = 8
 
 /**
+ * Default hard cap on total container lifetime (#5045). Idle TTL alone
+ * cannot evict a container that's continuously reused — every release
+ * resets the idle timer. Without a max age, a hot container can survive
+ * for days, accumulating state (file growth, package caches, drifting
+ * cgroup accounting) that never gets reset. Max age is checked on both
+ * `acquire()` (so a stale pooled entry isn't handed out) and `release()`
+ * (so a session that held a container across the threshold doesn't put
+ * it back into the pool).
+ */
+export const DEFAULT_MAX_AGE_MS = 30 * 60 * 1000
+
+/**
  * Build the canonical cache key for a session's resource shape. Same
  * shape used by `DockerContainerPool#acquire` / `#release` so the
  * session and the pool can compute keys independently.
@@ -109,9 +121,14 @@ export class DockerContainerPool {
    * @param {number} [opts.idleTimeoutMs=300000] — TTL per idle entry
    * @param {number} [opts.maxPerKey=2]          — cap per resource shape
    * @param {number} [opts.maxTotal=8]           — cap across all shapes
+   * @param {number} [opts.maxAgeMs=1800000]     — hard cap on total
+   *   container lifetime regardless of activity (#5045). Checked on both
+   *   acquire and release. Pass `Infinity` to opt out (matches the
+   *   pre-#5045 behaviour of idle-only eviction).
    * @param {Function} [opts._execFile]          — test seam (execFile)
    * @param {Function} [opts._setTimeout]        — test seam (setTimeout)
    * @param {Function} [opts._clearTimeout]      — test seam (clearTimeout)
+   * @param {Function} [opts._now]               — test seam (Date.now)
    */
   constructor(opts = {}) {
     this._idleTimeoutMs = Number.isFinite(opts.idleTimeoutMs)
@@ -123,10 +140,25 @@ export class DockerContainerPool {
     this._maxTotal = Number.isFinite(opts.maxTotal)
       ? opts.maxTotal
       : DEFAULT_MAX_TOTAL
+    // Accept Infinity (not "finite") as a valid opt-out — Number.isFinite
+    // rejects it, which is exactly what we don't want here.
+    this._maxAgeMs = typeof opts.maxAgeMs === 'number' && opts.maxAgeMs > 0
+      ? opts.maxAgeMs
+      : DEFAULT_MAX_AGE_MS
     this._execFile = opts._execFile || defaultExecFile
     this._setTimeout = opts._setTimeout || setTimeout
     this._clearTimeout = opts._clearTimeout || clearTimeout
-    /** @type {Map<string, Array<{ containerId: string, timer: any }>>} */
+    this._now = opts._now || (() => Date.now())
+    /**
+     * Each entry tracks the wall-clock time the container was FIRST
+     * released to the pool (`createdAt`). That is the closest proxy we
+     * have to "container birth" — we don't know when `docker run` fired,
+     * only when the session was done with it. The createdAt persists
+     * across acquire/release cycles for the same container id so the
+     * max-age cap measures total in-pool lifetime, not idle-time-since-
+     * last-release.
+     * @type {Map<string, Array<{ containerId: string, timer: any, createdAt: number }>>}
+     */
     this._entries = new Map()
     /**
      * Container ids marked soiled by `markSoiled()`. A soiled id at
@@ -135,6 +167,12 @@ export class DockerContainerPool {
      * @type {Set<string>}
      */
     this._soiledIds = new Set()
+    /**
+     * createdAt by container id, kept separate from `_entries` so it
+     * survives across acquire/release cycles. Cleared on eviction.
+     * @type {Map<string, number>}
+     */
+    this._createdAt = new Map()
     this._shuttingDown = false
   }
 
@@ -154,6 +192,30 @@ export class DockerContainerPool {
     if (this._shuttingDown) return null
     const bucket = this._entries.get(key)
     if (!bucket || bucket.length === 0) return null
+    // Lazily skip + evict any over-age entries at the head of the bucket
+    // (#5045). The bucket is FIFO so the oldest entry is at the front;
+    // once we hit an in-age entry the rest are guaranteed to be in-age
+    // as well (createdAt is monotonic with insertion order for a fresh
+    // container, but a re-released container can be older than a younger
+    // sibling — we still walk the whole bucket to be safe).
+    const now = this._now()
+    while (bucket.length > 0) {
+      const entry = bucket[0]
+      const age = now - entry.createdAt
+      if (age <= this._maxAgeMs) break
+      bucket.shift()
+      this._clearTimeout(entry.timer)
+      this._createdAt.delete(entry.containerId)
+      log.info(`pool over-age on acquire (${age}ms > ${this._maxAgeMs}ms): evicting ${entry.containerId.slice(0, 12)}`)
+      // Fire-and-forget — caller's acquire path stays sync.
+      this._evict(entry.containerId).catch((err) => {
+        log.warn(`over-age eviction of ${entry.containerId.slice(0, 12)} failed: ${err.message}`)
+      })
+    }
+    if (bucket.length === 0) {
+      this._entries.delete(key)
+      return null
+    }
     const entry = bucket.shift()
     if (bucket.length === 0) this._entries.delete(key)
     this._clearTimeout(entry.timer)
@@ -177,6 +239,7 @@ export class DockerContainerPool {
     if (!containerId) return false
     if (this._shuttingDown) {
       this._soiledIds.delete(containerId)
+      this._createdAt.delete(containerId)
       await this._evict(containerId)
       return false
     }
@@ -187,7 +250,23 @@ export class DockerContainerPool {
     // the soiled set doesn't grow unbounded.
     if (this._soiledIds.has(containerId)) {
       this._soiledIds.delete(containerId)
+      this._createdAt.delete(containerId)
       log.info(`pool release: ${containerId.slice(0, 12)} marked soiled; evicting instead of pooling`)
+      await this._evict(containerId)
+      return false
+    }
+    // Resolve / record createdAt before any other check so an over-age
+    // container that's never been pooled before still gets its real birth
+    // time (now) — only re-released containers carry an older createdAt.
+    const now = this._now()
+    const createdAt = this._createdAt.get(containerId) ?? now
+    // Hard max-age cap (#5045): even if the bucket has room, refuse to
+    // pool a container that's exceeded total lifetime. Without this, a
+    // hot container can survive forever via repeated acquire/release.
+    const age = now - createdAt
+    if (age > this._maxAgeMs) {
+      log.info(`pool over-age on release (${age}ms > ${this._maxAgeMs}ms): evicting ${containerId.slice(0, 12)}`)
+      this._createdAt.delete(containerId)
       await this._evict(containerId)
       return false
     }
@@ -195,11 +274,14 @@ export class DockerContainerPool {
     const bucket = this._entries.get(key) || []
     if (bucket.length >= this._maxPerKey || total >= this._maxTotal) {
       log.info(`pool over cap (key=${bucket.length}/${this._maxPerKey} total=${total}/${this._maxTotal}); evicting ${containerId.slice(0, 12)}`)
+      this._createdAt.delete(containerId)
       await this._evict(containerId)
       return false
     }
+    this._createdAt.set(containerId, createdAt)
     const timer = this._setTimeout(() => {
       this._removeEntry(key, containerId, /*alreadyTimedOut*/ true)
+      this._createdAt.delete(containerId)
       this._evict(containerId).catch((err) => {
         log.warn(`idle eviction of ${containerId.slice(0, 12)} failed: ${err.message}`)
       })
@@ -207,9 +289,9 @@ export class DockerContainerPool {
     // setTimeout returns a Timer object on Node; unref so a pooled
     // container doesn't keep the event loop alive on shutdown.
     if (timer && typeof timer.unref === 'function') timer.unref()
-    bucket.push({ containerId, timer })
+    bucket.push({ containerId, timer, createdAt })
     this._entries.set(key, bucket)
-    log.info(`pool release: ${containerId.slice(0, 12)} → ${key} (idle ${this._idleTimeoutMs}ms)`)
+    log.info(`pool release: ${containerId.slice(0, 12)} → ${key} (idle ${this._idleTimeoutMs}ms, age ${age}ms/${this._maxAgeMs}ms)`)
     return true
   }
 
@@ -286,6 +368,7 @@ export class DockerContainerPool {
     // Clear the soiled-id tracking — a future pool instance (lazy
     // singleton, test reset) starts from a clean slate.
     this._soiledIds.clear()
+    this._createdAt.clear()
     log.info(`shutdown: evicting ${toRemove.length} pooled container(s)`)
     await Promise.all(toRemove.map((id) => this._evict(id).catch((err) => {
       log.warn(`shutdown eviction of ${id.slice(0, 12)} failed: ${err.message}`)
@@ -354,6 +437,7 @@ let _sharedPool = null
  *   - CHROXY_DOCKER_BYOK_POOL_IDLE_MS — override idle TTL (ms)
  *   - CHROXY_DOCKER_BYOK_POOL_MAX_PER_KEY — override per-key cap
  *   - CHROXY_DOCKER_BYOK_POOL_MAX_TOTAL — override total cap
+ *   - CHROXY_DOCKER_BYOK_POOL_MAX_AGE_MS — override max container age (#5045)
  *
  * @param {Record<string,string|undefined>} [env=process.env]
  * @returns {DockerContainerPool|null}
@@ -364,13 +448,16 @@ export function getSharedPool(env = process.env) {
   const idleRaw = env.CHROXY_DOCKER_BYOK_POOL_IDLE_MS
   const perKeyRaw = env.CHROXY_DOCKER_BYOK_POOL_MAX_PER_KEY
   const totalRaw = env.CHROXY_DOCKER_BYOK_POOL_MAX_TOTAL
+  const maxAgeRaw = env.CHROXY_DOCKER_BYOK_POOL_MAX_AGE_MS
   const idleTimeoutMs = Number(idleRaw)
   const maxPerKey = Number(perKeyRaw)
   const maxTotal = Number(totalRaw)
+  const maxAgeMs = Number(maxAgeRaw)
   _sharedPool = new DockerContainerPool({
     idleTimeoutMs: Number.isFinite(idleTimeoutMs) && idleTimeoutMs > 0 ? idleTimeoutMs : undefined,
     maxPerKey: Number.isFinite(maxPerKey) && maxPerKey > 0 ? maxPerKey : undefined,
     maxTotal: Number.isFinite(maxTotal) && maxTotal > 0 ? maxTotal : undefined,
+    maxAgeMs: Number.isFinite(maxAgeMs) && maxAgeMs > 0 ? maxAgeMs : undefined,
   })
   return _sharedPool
 }

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -424,15 +424,14 @@ export class DockerByokSession extends ClaudeByokSession {
           return
         } catch (err) {
           // The pooled container died while idle (daemon restart, OOM
-          // kill). Forget it and fall through to a fresh launch.
+          // kill). Forget it and fall through to a fresh launch. Use
+          // the pool's `forget()` helper so `_createdAt` gets cleared
+          // alongside the `docker rm -f` — otherwise the map slowly
+          // leaks across long-running servers (#5045 review). Fire-and-
+          // forget; we don't block start on cleanup of a dead id.
           log.warn(`pooled container ${reused.slice(0, 12)} failed verify: ${err.message} — launching fresh`)
           this._containerId = null
-          // Best-effort cleanup of the stale id — fire-and-forget. We
-          // don't await this because the pool has already untracked the
-          // id; the rm is just hygiene. `execFile` ignores `stdio`, so
-          // cap `maxBuffer` instead to keep a misbehaving docker(8)
-          // bounded.
-          this._execFile('docker', ['rm', '-f', reused], { maxBuffer: 64 * 1024 }, () => {})
+          this._pool.forget(reused).catch(() => {})
         }
       }
     }

--- a/packages/server/tests/docker-byok-pool.test.js
+++ b/packages/server/tests/docker-byok-pool.test.js
@@ -508,4 +508,69 @@ describe('getSharedPool() — singleton + env wiring', () => {
     const pool = getSharedPool({ CHROXY_DOCKER_BYOK_POOL: '1' })
     assert.equal(pool._maxAgeMs, DEFAULT_MAX_AGE_MS)
   })
+
+  it('honors CHROXY_DOCKER_BYOK_POOL_MAX_AGE_MS=Infinity as an opt-out', () => {
+    // Documented opt-out path: pass `Infinity` to disable the cap.
+    // Constructor accepts `Infinity` directly; env wiring has to parse
+    // the string `'Infinity'` because `isFinite(Infinity) === false`
+    // and would otherwise silently fall back to the 30-min default.
+    const pool = getSharedPool({
+      CHROXY_DOCKER_BYOK_POOL: '1',
+      CHROXY_DOCKER_BYOK_POOL_MAX_AGE_MS: 'Infinity',
+    })
+    assert.equal(pool._maxAgeMs, Infinity)
+  })
+
+  it('honors lowercase `infinity` env value as an opt-out', () => {
+    const pool = getSharedPool({
+      CHROXY_DOCKER_BYOK_POOL: '1',
+      CHROXY_DOCKER_BYOK_POOL_MAX_AGE_MS: 'infinity',
+    })
+    assert.equal(pool._maxAgeMs, Infinity)
+  })
+})
+
+describe('DockerContainerPool — forget() (#5045 review)', () => {
+  it('clears _createdAt and docker rm -f s the container', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    await pool.release('k', 'C1')
+    // After release, _createdAt has the entry.
+    assert.equal(pool._createdAt.has('C1'), true)
+    assert.equal(pool.acquire('k'), 'C1')
+    // After acquire, _createdAt STILL has the entry (preserved across
+    // hold so a follow-up release keeps lifetime). forget() is the path
+    // the caller uses when they decide NOT to release.
+    assert.equal(pool._createdAt.has('C1'), true)
+    await pool.forget('C1')
+    assert.equal(pool._createdAt.has('C1'), false)
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1)
+    assert.ok(rmCalls[0].args.includes('C1'))
+  })
+
+  it('is idempotent on an unknown container id', async () => {
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({ _execFile: execFile })
+    await pool.forget('NEVER_SEEN')
+    // Still runs docker rm -f — that's the contract; the pool can't
+    // tell whether the id is real or stale, and the caller is asserting
+    // it is. rm -f's "no such container" path is already swallowed in
+    // _evict.
+    assert.equal(execFile.calls.filter((c) => c.args[0] === 'rm').length, 1)
+  })
+
+  it('silently ignores null/empty container id', async () => {
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({ _execFile: execFile })
+    await pool.forget('')
+    await pool.forget(null)
+    await pool.forget(undefined)
+    assert.equal(execFile.calls.length, 0, 'must not call docker rm -f with an empty id')
+  })
 })

--- a/packages/server/tests/docker-byok-pool.test.js
+++ b/packages/server/tests/docker-byok-pool.test.js
@@ -10,6 +10,7 @@ import {
   DEFAULT_IDLE_TIMEOUT_MS,
   DEFAULT_MAX_PER_KEY,
   DEFAULT_MAX_TOTAL,
+  DEFAULT_MAX_AGE_MS,
 } from '../src/docker-byok-pool.js'
 
 /**
@@ -120,6 +121,7 @@ describe('DockerContainerPool — defaults', () => {
     assert.equal(DEFAULT_IDLE_TIMEOUT_MS, 5 * 60 * 1000)
     assert.equal(DEFAULT_MAX_PER_KEY, 2)
     assert.equal(DEFAULT_MAX_TOTAL, 8)
+    assert.equal(DEFAULT_MAX_AGE_MS, 30 * 60 * 1000)
   })
 
   it('starts empty', () => {
@@ -369,6 +371,109 @@ describe('DockerContainerPool — markSoiled() (#5043)', () => {
   })
 })
 
+describe('DockerContainerPool — max age (#5045)', () => {
+  it('acquire evicts and reports miss when the head entry is over max age', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    let now = 1_000_000
+    const pool = new DockerContainerPool({
+      maxAgeMs: 1000,
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+      _now: () => now,
+    })
+    await pool.release('k', 'OLD_CONTAINER')
+    assert.equal(pool.size(), 1)
+    // Advance past the max-age threshold.
+    now += 1500
+    const got = pool.acquire('k')
+    assert.equal(got, null, 'over-age entry must NOT be returned to caller')
+    assert.equal(pool.size(), 0, 'over-age entry must be removed from the pool')
+    // Drain microtasks so the async _evict() runs.
+    await new Promise((r) => setImmediate(r))
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1, 'over-age entry must be docker rm -f')
+    assert.ok(rmCalls[0].args.includes('OLD_CONTAINER'))
+  })
+
+  it('acquire skips over-age entries and returns the next valid one in the bucket', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    let now = 1_000_000
+    const pool = new DockerContainerPool({
+      maxAgeMs: 1000,
+      maxPerKey: 5,
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+      _now: () => now,
+    })
+    await pool.release('k', 'OLD_1')
+    await pool.release('k', 'OLD_2')
+    // Both entries are now over age.
+    now += 2000
+    await pool.release('k', 'FRESH')
+    const got = pool.acquire('k')
+    assert.equal(got, 'FRESH', 'must skip past over-age entries to reach a fresh one')
+    await new Promise((r) => setImmediate(r))
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    const evicted = rmCalls.map((c) => c.args[c.args.length - 1]).sort()
+    assert.deepEqual(evicted, ['OLD_1', 'OLD_2'])
+  })
+
+  it('release rejects an over-age container and evicts inline', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    let now = 1_000_000
+    const pool = new DockerContainerPool({
+      maxAgeMs: 1000,
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+      _now: () => now,
+    })
+    // First release happens at t=0; second-acquire/release simulates a
+    // session that held the container for longer than maxAgeMs.
+    await pool.release('k', 'C1')
+    assert.equal(pool.acquire('k'), 'C1')
+    now += 2000
+    const kept = await pool.release('k', 'C1')
+    assert.equal(kept, false, 'release of over-age container must NOT pool it')
+    assert.equal(pool.size(), 0)
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1)
+    assert.ok(rmCalls[0].args.includes('C1'))
+  })
+
+  it('release tracks createdAt from the FIRST release, not the most recent', async () => {
+    // A container that's been bounced through the pool many times is
+    // still "old" for max-age purposes — we cap total lifetime, not
+    // time-since-last-release.
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    let now = 1_000_000
+    const pool = new DockerContainerPool({
+      maxAgeMs: 1000,
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+      _now: () => now,
+    })
+    await pool.release('k', 'C1') // createdAt recorded here at t=1_000_000
+    assert.equal(pool.acquire('k'), 'C1')
+    now += 500 // still under max age
+    await pool.release('k', 'C1')
+    assert.equal(pool.acquire('k'), 'C1')
+    now += 600 // now total age > 1000ms
+    const kept = await pool.release('k', 'C1')
+    assert.equal(kept, false, 'lifetime exceeds cap even though the latest hold was short')
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1)
+    assert.ok(rmCalls[0].args.includes('C1'))
+  })
+})
+
 describe('getSharedPool() — singleton + env wiring', () => {
   beforeEach(() => _resetSharedPool())
   afterEach(() => _resetSharedPool())
@@ -391,9 +496,16 @@ describe('getSharedPool() — singleton + env wiring', () => {
       CHROXY_DOCKER_BYOK_POOL_IDLE_MS: '15000',
       CHROXY_DOCKER_BYOK_POOL_MAX_PER_KEY: '5',
       CHROXY_DOCKER_BYOK_POOL_MAX_TOTAL: '20',
+      CHROXY_DOCKER_BYOK_POOL_MAX_AGE_MS: '120000',
     })
     assert.equal(pool._idleTimeoutMs, 15000)
     assert.equal(pool._maxPerKey, 5)
     assert.equal(pool._maxTotal, 20)
+    assert.equal(pool._maxAgeMs, 120000)
+  })
+
+  it('defaults max-age when env var is unset', () => {
+    const pool = getSharedPool({ CHROXY_DOCKER_BYOK_POOL: '1' })
+    assert.equal(pool._maxAgeMs, DEFAULT_MAX_AGE_MS)
   })
 })

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -679,7 +679,7 @@ describe('DockerByokSession — across-session pool (#5022)', () => {
    * without spinning up a real DockerContainerPool.
    */
   function poolStub({ acquireReturn = null } = {}) {
-    const calls = { acquire: [], release: [] }
+    const calls = { acquire: [], release: [], forget: [] }
     let nextAcquire = acquireReturn
     return {
       calls,
@@ -692,6 +692,13 @@ describe('DockerByokSession — across-session pool (#5022)', () => {
       async release(key, containerId) {
         calls.release.push({ key, containerId })
         return true
+      },
+      async forget(containerId) {
+        // Mirrors the real pool's contract: drop tracking + best-effort
+        // docker rm -f. The stub just records the call; tests inspect
+        // `pool.calls.forget` instead of asserting on `execFile` rm
+        // invocations, because the real pool owns its own _execFile.
+        calls.forget.push(containerId)
       },
       setNextAcquire(id) {
         nextAcquire = id
@@ -809,9 +816,11 @@ describe('DockerByokSession — across-session pool (#5022)', () => {
     assert.equal(session._acquiredFromPool, false)
     const runCalls = _execFile.calls.filter((c) => c.args[0] === 'run')
     assert.equal(runCalls.length, 1)
-    // The dead pooled id was best-effort docker-rm-f'd.
-    const rmCalls = _execFile.calls.filter((c) => c.args[0] === 'rm')
-    assert.ok(rmCalls.some((c) => c.args.includes('CONTAINER_DEAD')))
+    // The dead pooled id was routed through `pool.forget()` so the
+    // pool's `_createdAt` map gets cleared alongside the `docker rm -f`.
+    // The actual `docker rm -f` runs through the pool's own _execFile
+    // (not the session's), so we assert on `pool.calls.forget` here.
+    assert.deepEqual(pool.calls.forget, ['CONTAINER_DEAD'])
 
     await session.destroy()
   })


### PR DESCRIPTION
Closes #5045.

## Summary

Idle TTL alone cannot evict a container that's continuously reused — every `release()` resets the idle timer, so a hot container could survive indefinitely, accumulating state (file growth, package caches, drifting cgroup accounting). This change adds a hard cap on total container lifetime, independent of idle activity.

- Default cap: **30 minutes** (configurable via `CHROXY_DOCKER_BYOK_POOL_MAX_AGE_MS` env var, or `maxAgeMs` constructor opt; pass `Infinity` to opt out).
- `acquire()` lazily evicts any over-age entries at the head of the bucket (fire-and-forget `docker rm -f`) and reports miss if the whole bucket has aged out. The session's existing fallback path then runs `docker run` for a fresh container.
- `release()` refuses to pool a container whose lifetime exceeds the cap and evicts inline.
- `createdAt` is tracked in a separate `Map` keyed by container id, so it persists across acquire/release cycles. The cap measures **total lifetime**, not time-since-last-release — a container that's been bounced through the pool many short times still ages out.

## Acceptance criteria

- [x] New env var `CHROXY_DOCKER_BYOK_POOL_MAX_AGE_MS` with a sensible default (30 min).
- [x] `release()` evicts inline when the container's age exceeds the cap.
- [x] `acquire()` evicts and reports miss when the bucket head is over-age (lazily cleans the queue).
- [x] Tests cover the new age-bound eviction path.

## Test plan

- [x] `node --import ./tests/_setup.mjs --test tests/docker-byok-pool.test.js` — 27/27 pass (4 new max-age cases + 1 new env-wiring case).
- [x] Lint scripts pass (`lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`).
- [x] Public API unchanged — `acquire(key)` and `release(key, containerId)` signatures preserved, so `docker-byok-session.js` integration needs no changes.