### PR TITLE
feat(dashboard): drain resolved/expired permission notifications from widget (#5008)

### DIFF
--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1913,10 +1913,21 @@ function handlePermissionResolved(msg: Record<string, unknown>, get: MsgGet, set
     if (!found) {
       set({ messages: updater({ messages: get().messages }).messages });
     }
-    // Auto-dismiss matching notification banner
+    // #5008 — drain the banner stack (which filters by `readAt === undefined`)
+    // without dropping the entry from `sessionNotifications`. Pre-#5008 we
+    // hard-removed the row, which silently drained every resolved alert from
+    // the NotificationsWidget's "durable history" view. Stamping `readAt`
+    // instead keeps the row visible in the widget (read row treatment) while
+    // the banner stack still vanishes.
+    //
+    // Idempotent — only stamp entries that have not already been acked, so a
+    // server-driven resolution arriving after the operator already marked the
+    // row read via the widget can't clobber the original ack timestamp.
     set((s) => ({
-      sessionNotifications: s.sessionNotifications.filter(
-        (n) => n.requestId !== resolvedRequestId
+      sessionNotifications: s.sessionNotifications.map((n) =>
+        n.requestId === resolvedRequestId && n.readAt === undefined
+          ? { ...n, readAt: Date.now() }
+          : n
       ),
     }));
   }
@@ -2900,10 +2911,15 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // append so the UI does not surface this as an error to the user.
         const alreadyResolved = Boolean(get().resolvedPermissions?.[expiredRequestId]);
         if (alreadyResolved) {
-          // Still dismiss any lingering notification banner for this request.
+          // #5008 — drain the banner stack without dropping the row from the
+          // widget's durable history. See handlePermissionResolved for the
+          // full rationale; this branch handles the #2833 race where expiry
+          // arrives after we already resolved locally.
           set((s) => ({
-            sessionNotifications: s.sessionNotifications.filter(
-              (n) => n.requestId !== expiredRequestId
+            sessionNotifications: s.sessionNotifications.map((n) =>
+              n.requestId === expiredRequestId && n.readAt === undefined
+                ? { ...n, readAt: Date.now() }
+                : n
             ),
           }));
           // #2839: surface a user-centric info toast confirming the
@@ -2923,10 +2939,16 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             ),
           }));
         }
-        // Auto-dismiss matching notification banner (#1580)
+        // #5008 — drain banner without dropping widget history. Mark the
+        // matching row read; the banner filter (`readAt === undefined`)
+        // drops it and the widget keeps the entry as part of its durable
+        // intervention history. Updates the original #1580 auto-dismiss
+        // contract from "remove" to "mark-read-and-keep".
         set((s) => ({
-          sessionNotifications: s.sessionNotifications.filter(
-            (n) => n.requestId !== expiredRequestId
+          sessionNotifications: s.sessionNotifications.map((n) =>
+            n.requestId === expiredRequestId && n.readAt === undefined
+              ? { ...n, readAt: Date.now() }
+              : n
           ),
         }));
       }

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1923,10 +1923,16 @@ function handlePermissionResolved(msg: Record<string, unknown>, get: MsgGet, set
     // Idempotent — only stamp entries that have not already been acked, so a
     // server-driven resolution arriving after the operator already marked the
     // row read via the widget can't clobber the original ack timestamp.
+    //
+    // Hoist `Date.now()` out of the `.map(...)` so every matching row in this
+    // mutation shares a single timestamp. Matches the existing pattern at
+    // connection.ts:2167 (`switchReadStamp`) and connection.ts:2461
+    // (`markAllSessionNotificationsRead`).
+    const readStamp = Date.now();
     set((s) => ({
       sessionNotifications: s.sessionNotifications.map((n) =>
         n.requestId === resolvedRequestId && n.readAt === undefined
-          ? { ...n, readAt: Date.now() }
+          ? { ...n, readAt: readStamp }
           : n
       ),
     }));
@@ -2914,11 +2920,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           // #5008 — drain the banner stack without dropping the row from the
           // widget's durable history. See handlePermissionResolved for the
           // full rationale; this branch handles the #2833 race where expiry
-          // arrives after we already resolved locally.
+          // arrives after we already resolved locally. Single timestamp per
+          // mutation — see handlePermissionResolved for the pattern source.
+          const readStamp = Date.now();
           set((s) => ({
             sessionNotifications: s.sessionNotifications.map((n) =>
               n.requestId === expiredRequestId && n.readAt === undefined
-                ? { ...n, readAt: Date.now() }
+                ? { ...n, readAt: readStamp }
                 : n
             ),
           }));
@@ -2943,11 +2951,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         // matching row read; the banner filter (`readAt === undefined`)
         // drops it and the widget keeps the entry as part of its durable
         // intervention history. Updates the original #1580 auto-dismiss
-        // contract from "remove" to "mark-read-and-keep".
+        // contract from "remove" to "mark-read-and-keep". Single timestamp
+        // per mutation — see handlePermissionResolved for the pattern source.
+        const readStamp = Date.now();
         set((s) => ({
           sessionNotifications: s.sessionNotifications.map((n) =>
             n.requestId === expiredRequestId && n.readAt === undefined
-              ? { ...n, readAt: Date.now() }
+              ? { ...n, readAt: readStamp }
               : n
           ),
         }));

--- a/packages/dashboard/src/store/permission-expired-dismiss.test.ts
+++ b/packages/dashboard/src/store/permission-expired-dismiss.test.ts
@@ -1,5 +1,15 @@
 /**
- * Tests that permission_expired messages auto-dismiss matching notification banners (#1580)
+ * Tests that permission_expired messages drain the matching banner stack
+ * while preserving the notifications widget's durable history (#1580 + #5008).
+ *
+ * #5008 — pre-#5008 the handler called `.filter(...)` to remove the entry
+ * outright, which silently drained every resolved/expired alert from the
+ * notifications widget. The widget's framing ("see read+unread history of
+ * every intervention") demands we keep the row and just stamp `readAt`
+ * instead so banners (which filter unread) drop the entry while the widget
+ * (which renders all) retains it. The tests below are pinned to that
+ * "mark-read-and-keep" contract — any future refactor that drops history is
+ * a regression.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setStore, handleMessage, setConnectionContext } from './message-handler'
@@ -41,7 +51,7 @@ function makeNotification(overrides: Partial<SessionNotification> = {}): Session
   }
 }
 
-describe('permission_expired auto-dismisses notification banner (#1580)', () => {
+describe('permission_expired drains banners while preserving widget history (#1580 + #5008)', () => {
   let store: ReturnType<typeof createMockStore>
 
   beforeEach(() => {
@@ -63,19 +73,25 @@ describe('permission_expired auto-dismisses notification banner (#1580)', () => 
     setConnectionContext(mockCtx)
   })
 
-  it('removes the matching notification when permission_expired is received', () => {
+  it('stamps readAt on the matching notification but keeps it in the list (#5008)', () => {
+    const before = Date.now()
     handleMessage({
       type: 'permission_expired',
       requestId: 'req-abc',
       message: 'Permission timed out',
     }, mockCtx)
+    const after = Date.now()
 
     const remaining = store.getState().sessionNotifications
-    expect(remaining).toHaveLength(1)
-    expect(remaining[0]!.requestId).toBe('req-def')
+    // #5008 — both entries preserved; the matching one is just stamped read.
+    expect(remaining).toHaveLength(2)
+    const matched = remaining.find(n => n.requestId === 'req-abc')!
+    expect(matched.readAt).toBeTypeOf('number')
+    expect(matched.readAt!).toBeGreaterThanOrEqual(before)
+    expect(matched.readAt!).toBeLessThanOrEqual(after)
   })
 
-  it('leaves other notifications untouched', () => {
+  it('leaves other notifications untouched (still unread)', () => {
     handleMessage({
       type: 'permission_expired',
       requestId: 'req-abc',
@@ -83,8 +99,10 @@ describe('permission_expired auto-dismisses notification banner (#1580)', () => 
     }, mockCtx)
 
     const remaining = store.getState().sessionNotifications
-    expect(remaining[0]!.id).toBe('n-2')
-    expect(remaining[0]!.message).toBe('Read /etc/hosts')
+    const other = remaining.find(n => n.requestId === 'req-def')!
+    expect(other.id).toBe('n-2')
+    expect(other.message).toBe('Read /etc/hosts')
+    expect(other.readAt).toBeUndefined()
   })
 
   it('does nothing when requestId does not match any notification', () => {
@@ -96,6 +114,35 @@ describe('permission_expired auto-dismisses notification banner (#1580)', () => 
 
     const remaining = store.getState().sessionNotifications
     expect(remaining).toHaveLength(2)
+    // Nothing stamped — both still unread.
+    expect(remaining.every(n => n.readAt === undefined)).toBe(true)
+  })
+
+  it('does not overwrite a previously-set readAt (idempotent mark-read) (#5008)', () => {
+    // Operator already acked the alert via the widget — expiry must not
+    // clobber the original ack timestamp, otherwise the history loses the
+    // "when did I first see this?" signal.
+    const ackedAt = 1_700_000_000_000
+    store = createMockStore({
+      activeSessionId: 'sess-1',
+      sessionNotifications: [
+        makeNotification({ id: 'n-1', requestId: 'req-abc', readAt: ackedAt }),
+      ],
+      sessionStates: {
+        'sess-1': { messages: [] },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+
+    handleMessage({
+      type: 'permission_expired',
+      requestId: 'req-abc',
+      message: 'Permission timed out',
+    }, mockCtx)
+
+    const list = store.getState().sessionNotifications
+    expect(list).toHaveLength(1)
+    expect(list[0]!.readAt).toBe(ackedAt)
   })
 })
 
@@ -156,7 +203,7 @@ describe('permission_expired info toast for resolved requests (#2839)', () => {
     expect(addInfoNotification).not.toHaveBeenCalled()
   })
 
-  it('still dismisses the matching session notification banner for resolved ids', () => {
+  it('marks the matching session notification as read (banner drains, widget retains) for resolved ids (#5008)', () => {
     const addInfoNotification = vi.fn()
     const store = createMockStore({
       activeSessionId: 'sess-1',
@@ -178,7 +225,11 @@ describe('permission_expired info toast for resolved requests (#2839)', () => {
       message: 'Permission timed out',
     }, mockCtx)
 
-    expect(store.getState().sessionNotifications).toHaveLength(0)
+    const list = store.getState().sessionNotifications
+    // #5008 — entry preserved as durable history; just stamped read so the
+    // banner stack (which filters by `readAt === undefined`) drops it.
+    expect(list).toHaveLength(1)
+    expect(list[0]!.readAt).toBeTypeOf('number')
     expect(addInfoNotification).toHaveBeenCalled()
   })
 })

--- a/packages/dashboard/src/store/permission-resolved-drain.test.ts
+++ b/packages/dashboard/src/store/permission-resolved-drain.test.ts
@@ -1,0 +1,198 @@
+/**
+ * permission_resolved drains the banner stack while preserving the
+ * notifications widget's durable history (#5008).
+ *
+ * Pre-#5008 the handler removed the matching notification outright via
+ * `.filter(...)`, which silently drained every approved/denied alert from
+ * the widget. The widget's framing ("see read+unread history of every
+ * intervention") demands we keep the row and just stamp `readAt = Date.now()`
+ * — banners filter by `readAt === undefined` so they still vanish on
+ * resolution, while the widget retains the entry as part of its durable
+ * history.
+ *
+ * Mirrors permission-expired-dismiss.test.ts for the resolved code path.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setStore, handleMessage, setConnectionContext } from './message-handler'
+import type { ConnectionState, SessionNotification } from './types'
+
+function createMockStore(initialState: Partial<ConnectionState>) {
+  let state = initialState as ConnectionState
+  return {
+    getState: () => state,
+    setState: (
+      updater:
+        | Partial<ConnectionState>
+        | ((s: ConnectionState) => Partial<ConnectionState>),
+    ) => {
+      if (typeof updater === 'function') {
+        state = { ...state, ...updater(state) }
+      } else {
+        state = { ...state, ...updater }
+      }
+    },
+  }
+}
+
+const mockCtx = {
+  url: 'wss://test',
+  token: 'test-token',
+  isReconnect: false,
+  silent: false,
+  socket: {} as WebSocket,
+}
+
+function makeNotification(
+  overrides: Partial<SessionNotification> = {},
+): SessionNotification {
+  return {
+    id: 'n-1',
+    sessionId: 'sess-1',
+    sessionName: 'Test Session',
+    eventType: 'permission',
+    message: 'Write to /tmp/test.txt',
+    timestamp: Date.now(),
+    requestId: 'req-abc',
+    ...overrides,
+  }
+}
+
+describe('permission_resolved drains banners while preserving widget history (#5008)', () => {
+  let store: ReturnType<typeof createMockStore>
+
+  beforeEach(() => {
+    store = createMockStore({
+      activeSessionId: 'sess-1',
+      // `messages` is the flat-fallback path inside handlePermissionResolved
+      // when no sessionStates entry owns the requestId — keep it as an empty
+      // array so the fallback `.map()` doesn't NPE.
+      messages: [],
+      sessionNotifications: [
+        makeNotification({ id: 'n-1', requestId: 'req-abc' }),
+        makeNotification({
+          id: 'n-2',
+          requestId: 'req-def',
+          message: 'Read /etc/hosts',
+        }),
+      ],
+      sessionStates: {
+        'sess-1': {
+          messages: [
+            {
+              type: 'prompt',
+              content: 'Allow write?',
+              requestId: 'req-abc',
+              options: ['allow', 'deny'],
+            },
+          ],
+        },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+    setConnectionContext(mockCtx)
+  })
+
+  it('stamps readAt on the matching notification but keeps it in the list (#5008)', () => {
+    const before = Date.now()
+    handleMessage(
+      {
+        type: 'permission_resolved',
+        requestId: 'req-abc',
+        decision: 'allow',
+      },
+      mockCtx,
+    )
+    const after = Date.now()
+
+    const list = store.getState().sessionNotifications
+    // #5008 — entry preserved as durable history.
+    expect(list).toHaveLength(2)
+    const matched = list.find(n => n.requestId === 'req-abc')!
+    expect(matched.readAt).toBeTypeOf('number')
+    expect(matched.readAt!).toBeGreaterThanOrEqual(before)
+    expect(matched.readAt!).toBeLessThanOrEqual(after)
+  })
+
+  it('leaves other notifications untouched (still unread)', () => {
+    handleMessage(
+      {
+        type: 'permission_resolved',
+        requestId: 'req-abc',
+        decision: 'deny',
+      },
+      mockCtx,
+    )
+
+    const list = store.getState().sessionNotifications
+    const other = list.find(n => n.requestId === 'req-def')!
+    expect(other.id).toBe('n-2')
+    expect(other.message).toBe('Read /etc/hosts')
+    expect(other.readAt).toBeUndefined()
+  })
+
+  it('does nothing when requestId does not match any notification', () => {
+    handleMessage(
+      {
+        type: 'permission_resolved',
+        requestId: 'req-unknown',
+        decision: 'allow',
+      },
+      mockCtx,
+    )
+
+    const list = store.getState().sessionNotifications
+    expect(list).toHaveLength(2)
+    expect(list.every(n => n.readAt === undefined)).toBe(true)
+  })
+
+  it('does not overwrite a previously-set readAt (idempotent mark-read) (#5008)', () => {
+    // The operator already acked the notification via the widget; a
+    // subsequent permission_resolved (e.g. another client's decision arrives
+    // over the socket) must not clobber the original ack timestamp.
+    const ackedAt = 1_700_000_000_000
+    store = createMockStore({
+      activeSessionId: 'sess-1',
+      messages: [],
+      sessionNotifications: [
+        makeNotification({ id: 'n-1', requestId: 'req-abc', readAt: ackedAt }),
+      ],
+      sessionStates: {
+        'sess-1': { messages: [] },
+      } as unknown as ConnectionState['sessionStates'],
+    })
+    setStore(store)
+
+    handleMessage(
+      {
+        type: 'permission_resolved',
+        requestId: 'req-abc',
+        decision: 'allow',
+      },
+      mockCtx,
+    )
+
+    const list = store.getState().sessionNotifications
+    expect(list).toHaveLength(1)
+    expect(list[0]!.readAt).toBe(ackedAt)
+  })
+
+  it('drops the entry from the unread banner stack (banner filter contract) (#5008)', () => {
+    // The banner stack filters by `readAt === undefined`. After resolution,
+    // the matching entry must no longer appear in that filtered slice even
+    // though it remains in the underlying list.
+    handleMessage(
+      {
+        type: 'permission_resolved',
+        requestId: 'req-abc',
+        decision: 'allow',
+      },
+      mockCtx,
+    )
+
+    const unreadOnly = store
+      .getState()
+      .sessionNotifications.filter(n => n.readAt === undefined)
+    expect(unreadOnly).toHaveLength(1)
+    expect(unreadOnly[0]!.requestId).toBe('req-def')
+  })
+})

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -1243,8 +1243,13 @@ describe('resolvedPermissions + Allow for Session (#2833, #2834)', () => {
     // user already answered, so the late expiry is a no-op (#2833).
     const promptMsg = state.sessionStates.s1!.messages[0]!;
     expect(promptMsg.content).toBe(originalContent);
-    // Banner is still cleaned up so nothing dangles in the UI.
-    expect(state.sessionNotifications.find((n) => n.requestId === 'req-resolved')).toBeUndefined();
+    // #5008 — the notification row is preserved as durable widget history,
+    // but stamped read so the banner stack drops it. Pre-#5008 we
+    // hard-removed the row, which silently drained every resolved/expired
+    // alert from the NotificationsWidget.
+    const banner = state.sessionNotifications.find((n) => n.requestId === 'req-resolved');
+    expect(banner).toBeDefined();
+    expect(banner!.readAt).toBeTypeOf('number');
 
     _testMessageHandler.clearContext();
   });


### PR DESCRIPTION
## Summary

Closes #5008.

- Pre-#5008, the `permission_resolved` and `permission_expired` handlers in `packages/dashboard/src/store/message-handler.ts` hard-removed matching session notifications via `sessionNotifications.filter(...)`. That silently drained every approved/denied/expired permission alert from the `NotificationsWidget` (Slack-style bell dropdown), contradicting the widget's "see read+unread history of every intervention" framing the operator gets.
- Swap the three `.filter(...)` call sites (one in `handlePermissionResolved`, two in the `permission_expired` case) to `.map(...)` that stamps `readAt = Date.now()` only when the entry has not already been acked. The banner stack (which filters by `readAt === undefined` — see `NotificationBanners.tsx`) still drops the entry on resolution; the widget retains it as durable history with the muted "read" row treatment.
- Idempotent: a server-driven resolution arriving after the operator already acked the row via the widget preserves the original ack timestamp.

## Implementation choice

The issue (#5008) offered two resolution paths:
1. **Convert removal to mark-read-and-keep** — picked here, lines up with the widget's documented "durable history" UX.
2. Keep current behaviour and document it.

Picking Option 1 lets the bell dropdown actually deliver the post-intervention summary scan the widget's framing implies, without changing the banner-stack contract (still unread-only) or the `SessionNotification` protocol shape.

## Tests

- New `permission-resolved-drain.test.ts` (5 tests) — pins the mark-read-and-keep contract for the resolved path: stamps `readAt`, leaves siblings untouched, no-op for unknown `requestId`, idempotent on already-read rows, drops the entry from the unread banner-filter slice.
- Updated `permission-expired-dismiss.test.ts` (6 tests) — swapped the "remove" assertions for the new "mark-read-and-keep" contract, added an idempotency case.
- Updated one `store.test.ts` assertion (`permission_expired for an already-resolved requestId ...`) to match the new behaviour.
- Existing `NotificationsWidget.test.tsx` (30 tests) unchanged, all green — read-row treatment + per-row dismiss + Mark all read flows still work end to end.

## Test plan

- [x] `npx vitest run` in `packages/dashboard` — 2855/2855 pass (was 2854/2855 with my changes + one fix-up assertion in `store.test.ts`; net +6 new tests).
- [x] `npx tsc --noEmit` in `packages/dashboard` — clean (TS strict).
- [ ] Smoke: approve three background-session permissions from banners → open the bell → confirm all three rows are listed with the read treatment instead of an empty dropdown.