### PR TITLE
feat(server): inherit parent MCP fleet in Task subagents (#5019)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -332,6 +332,13 @@ export class ClaudeByokSession extends BaseSession {
     // #4077: MCPFleet is lazy — created in start() only if servers exist.
     // Held here so destroy() can tear down even if start() never ran.
     this._mcpFleet = null
+    // #5019: when a Task subagent borrows the parent's MCP fleet (the
+    // default behaviour for nested tool use — avoids per-spawn MCP
+    // child-process startup cost), it points _mcpFleet at the parent's
+    // already-running fleet and flips this flag to false. destroy() then
+    // skips fleet.destroy() so the parent's MCP children aren't killed
+    // when the subagent finishes. The parent always owns its own fleet.
+    this._ownsMcpFleet = true
     // #4482: per-call MCP tools/call timeout (ms). null = use byok-mcp-client's
     // DEFAULT_TOOL_CALL_TIMEOUT_MS (30s) via the destructured default in
     // MCPFleet.callTool. Forwarded from session-manager via providerOpts →
@@ -1233,9 +1240,26 @@ export class ClaudeByokSession extends BaseSession {
 
     // Build a child session. Reuse this session's already-resolved
     // client so the API key resolution + Anthropic constructor only
-    // ran once. mcpConfigPath: null skips MCP discovery in the child
-    // (v1: child has no MCP — keeps the scope bounded and avoids the
-    // per-spawn child-process startup cost).
+    // ran once. mcpConfigPath: null skips MCP-config DISCOVERY in the
+    // child — the child does not parse a second copy of ~/.claude.json
+    // and does not spawn its own fleet. Whether the child gets MCP tools
+    // is controlled by the fleet-sharing block below (#5019), not by
+    // the constructor.
+    //
+    // #5019: by default the child borrows the parent's already-running
+    // MCP fleet — this gives nested Task subagents access to the same
+    // mcp__<server>__<tool> set the parent sees, at zero extra spawn
+    // cost (the parent's MCP children are reused). The child does NOT
+    // own the fleet, so destroy() won't kill the parent's MCP children
+    // when the subagent finishes. Per-call permission gating still
+    // runs through the child's own PermissionManager — only the fleet
+    // (process pool + tool catalogue) is shared.
+    //
+    // The model can opt out per-launch by passing `inherit_mcp: false`
+    // on the Task input — useful when the subagent's prompt should be
+    // strictly scoped to built-in tools or when an MCP server is known
+    // to be misbehaving and the user wants to isolate it from the
+    // delegated work. `inherit_mcp` defaults to true when omitted.
     //
     // #5015 review: wrap construction + init in try/catch. If the
     // ClaudeByokSession ctor or any of the field assignments throws
@@ -1244,6 +1268,21 @@ export class ClaudeByokSession extends BaseSession {
     // populated _activeAgents — we MUST balance that with a matching
     // agent_completed + _activeAgents delete + matching error tool_result
     // so the dashboard badge clears and we don't leak the entry.
+    //
+    // Validate inherit_mcp type before reading: a non-boolean value
+    // (string "true", number 1, null) is rejected with an is_error
+    // tool_result so the model gets a clear signal rather than us
+    // silently coercing to one of the two paths.
+    let inheritMcp = true
+    if (input?.inherit_mcp !== undefined) {
+      if (typeof input.inherit_mcp !== 'boolean') {
+        return {
+          content: `Task tool: invalid \`inherit_mcp\` value (got ${typeof input.inherit_mcp}). Must be a boolean.`,
+          isError: true,
+        }
+      }
+      inheritMcp = input.inherit_mcp
+    }
     let child
     try {
       const ClaudeByokSessionCtor = this.constructor
@@ -1259,6 +1298,14 @@ export class ClaudeByokSession extends BaseSession {
       child._client = this._client
       child._apiKeySource = this._apiKeySource
       child._processReady = true
+      // #5019: share the parent's MCP fleet (default) unless the model
+      // explicitly opted out via `inherit_mcp: false`. Borrowed fleets
+      // MUST set _ownsMcpFleet = false so the child's destroy() doesn't
+      // tear down the parent's MCP children.
+      if (inheritMcp && this._mcpFleet) {
+        child._mcpFleet = this._mcpFleet
+        child._ownsMcpFleet = false
+      }
       // Inherit permission mode so the subagent runs under the same
       // gating policy as the parent — a user who set `auto` doesn't
       // want the child to start prompting again, and a user in
@@ -1625,11 +1672,19 @@ export class ClaudeByokSession extends BaseSession {
     // #4077: tear down MCP children with SIGTERM → SIGKILL grace.
     // Awaits up to FLEET_KILL_GRACE_MS (2s) + 500ms safety margin so a
     // hung child cannot stall destroy() indefinitely.
+    //
+    // #5019: only the owning session tears the fleet down. A Task subagent
+    // that borrowed the parent's fleet (_ownsMcpFleet === false) just
+    // drops its reference — destroying the parent's MCP children mid-flight
+    // would kill MCP tool access for the parent and any sibling subagents.
     if (this._mcpFleet) {
       const fleet = this._mcpFleet
+      const owns = this._ownsMcpFleet
       this._mcpFleet = null
-      try { await fleet.destroy() } catch (err) {
-        log.warn(`MCP fleet teardown failed: ${err?.message || err}`)
+      if (owns) {
+        try { await fleet.destroy() } catch (err) {
+          log.warn(`MCP fleet teardown failed: ${err?.message || err}`)
+        }
       }
     }
     this.removeAllListeners()

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -1224,6 +1224,25 @@ export class ClaudeByokSession extends BaseSession {
       }
       childPermissionMode = requested
     }
+    // #5019: validate inherit_mcp type BEFORE the agent_spawned emit /
+    // _activeAgents.set so a non-boolean value (string "true", number 1,
+    // null — anything `typeof !== 'boolean'`) returns an is_error result
+    // without leaving a phantom entry in _activeAgents or emitting an
+    // unbalanced agent_spawned. The dashboard's active-agents badge would
+    // otherwise show a spawn that never clears. Mirrors the placement of
+    // the permission_mode validation above. The model gets a crisp signal
+    // naming the offending field rather than us silently coercing to one
+    // of the two paths.
+    let inheritMcp = true
+    if (input?.inherit_mcp !== undefined) {
+      if (typeof input.inherit_mcp !== 'boolean') {
+        return {
+          content: `Task tool: invalid \`inherit_mcp\` value (got ${typeof input.inherit_mcp}). Must be a boolean.`,
+          isError: true,
+        }
+      }
+      inheritMcp = input.inherit_mcp
+    }
     if (signal?.aborted) {
       return { content: 'Interrupted by user before subagent spawned', isError: true }
     }
@@ -1268,21 +1287,6 @@ export class ClaudeByokSession extends BaseSession {
     // populated _activeAgents — we MUST balance that with a matching
     // agent_completed + _activeAgents delete + matching error tool_result
     // so the dashboard badge clears and we don't leak the entry.
-    //
-    // Validate inherit_mcp type before reading: a non-boolean value
-    // (string "true", number 1, null) is rejected with an is_error
-    // tool_result so the model gets a clear signal rather than us
-    // silently coercing to one of the two paths.
-    let inheritMcp = true
-    if (input?.inherit_mcp !== undefined) {
-      if (typeof input.inherit_mcp !== 'boolean') {
-        return {
-          content: `Task tool: invalid \`inherit_mcp\` value (got ${typeof input.inherit_mcp}). Must be a boolean.`,
-          isError: true,
-        }
-      }
-      inheritMcp = input.inherit_mcp
-    }
     let child
     try {
       const ClaudeByokSessionCtor = this.constructor

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -199,7 +199,10 @@ export const BUILTIN_TOOLS = [
       'Optional `permission_mode` overrides the inherited mode for this single launch, but ' +
       'is constrained to be at-most-as-permissive as the parent (ranking: plan < approve < ' +
       'acceptEdits < auto). Requesting a stricter mode is allowed; requesting a more ' +
-      'permissive mode is rejected with an is_error tool_result.',
+      'permissive mode is rejected with an is_error tool_result. ' +
+      'MCP tools: by default the sub-agent inherits the parent\'s MCP fleet (same ' +
+      '`mcp__<server>__<tool>` set as this turn), at zero extra spawn cost. Pass ' +
+      '`inherit_mcp: false` to launch a sub-agent with built-in tools only (no MCP).',
     input_schema: {
       type: 'object',
       properties: {
@@ -219,6 +222,10 @@ export const BUILTIN_TOOLS = [
           type: 'string',
           enum: [...TASK_PERMISSION_MODE_LIST],
           description: 'Optional per-launch permission mode for the subagent. Must be at-most-as-permissive as the parent (plan < approve < acceptEdits < auto). When omitted, the subagent inherits the parent\'s mode.',
+        },
+        inherit_mcp: {
+          type: 'boolean',
+          description: 'When true (the default), the sub-agent inherits the parent\'s MCP fleet so nested tool use can call the same mcp__<server>__<tool> tools the parent sees — at zero extra spawn cost. Pass false to run the sub-agent with built-in tools only (no MCP).',
         },
       },
       required: ['description', 'prompt'],

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3911,6 +3911,16 @@ describe('ClaudeByokSession', () => {
         'rejection message must name the offending field')
       assert.equal(childSpawned, false,
         'no subagent must be spawned when inherit_mcp is invalid')
+      // #5019 review: the rejection must run BEFORE agent_spawned is
+      // emitted and BEFORE _activeAgents is populated — otherwise the
+      // dashboard's active-agents badge would show a phantom entry that
+      // never clears. Mirrors the placement of the permission_mode
+      // typecheck (#5017). Pins the early-return cleanliness.
+      const spawnEvents = captured.filter((e) => e.name === 'agent_spawned')
+      assert.equal(spawnEvents.length, 0,
+        'agent_spawned must NOT be emitted when inherit_mcp rejection fires')
+      assert.equal(session._activeAgents.size, 0,
+        '_activeAgents must stay empty on inherit_mcp rejection — no phantom badge entry')
       await session.destroy()
     })
 

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -6,6 +6,7 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { APIUserAbortError } from '@anthropic-ai/sdk'
 import { ClaudeByokSession } from '../src/byok-session.js'
+import { BUILTIN_TOOLS } from '../src/byok-tools.js'
 import { MCP_STATES } from '../src/byok-mcp-client.js'
 import { recordTrust } from '../src/byok-mcp-trust.js'
 
@@ -3716,6 +3717,214 @@ describe('ClaudeByokSession', () => {
           }
         }
       }
+    })
+
+    /**
+     * #5019: subagent MCP inheritance helpers.
+     *
+     * The Task subagent should — by default — borrow the parent's
+     * already-running MCP fleet so nested tool use can call the same
+     * `mcp__<server>__<tool>` set the parent sees, at zero extra
+     * spawn cost. The child must NOT own the fleet (destroy() on the
+     * child must leave the parent's MCP children alive). An explicit
+     * `inherit_mcp: false` on the Task input reverts to the pre-#5019
+     * behaviour of running the subagent with built-in tools only.
+     */
+    function captureChildFromTaskCall(session, taskInput, opts = {}) {
+      // Snapshot the child the moment _executeTaskTool registers it.
+      // Tests inspect _mcpFleet / _ownsMcpFleet on this reference, and
+      // we ALSO snapshot the field values at registration time because
+      // the Task tool's finally block calls child.destroy() before
+      // sendMessage resolves — destroy() nulls _mcpFleet, so reading
+      // these fields off the captured child after-the-fact always sees
+      // the post-destroy state. The snapshot lets tests assert what the
+      // child looked like while it was actually running, AND we expose
+      // a tools snapshot so _buildTools() can be exercised pre-destroy.
+      let capturedChild = null
+      let snapshot = null
+      const origSet = session._subagentSessions.set.bind(session._subagentSessions)
+      session._subagentSessions.set = (k, v) => {
+        capturedChild = v
+        snapshot = {
+          mcpFleet: v._mcpFleet,
+          ownsMcpFleet: v._ownsMcpFleet,
+          tools: v._buildTools(),
+        }
+        // Force-allow the child's permission gate — Task subagents
+        // run their own permission flow on tool_use blocks, but the
+        // dummy child stream below never emits one. This matches the
+        // pattern used by runTaskWithPermissionOverride.
+        v._gateToolBlock = async () => ({ behavior: 'allow' })
+        // #5019 leak test: optional hook so a test can intercept the
+        // child's destroy() and observe whether fleet.destroy() ran.
+        if (opts.onChildRegistered) opts.onChildRegistered(v)
+        return origSet(k, v)
+      }
+      setupParentEmittingTaskOnce(session, {
+        taskInput,
+        childStreamImpl: () => fakeStream(
+          [
+            { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'ok' } },
+            { type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+          ],
+          { stop_reason: 'end_turn', content: [{ type: 'text', text: 'ok' }], usage: { input_tokens: 1, output_tokens: 1 } },
+        ),
+      })
+      return () => ({ child: capturedChild, snapshot })
+    }
+
+    it('Task subagent inherits parent MCP fleet by default (#5019)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      // Simulate a running parent MCP fleet. The exact shape doesn't
+      // matter for inheritance — the child should just point at the
+      // same object reference.
+      const parentFleet = {
+        anthropicTools: [{ name: 'mcp__stub__echo' }],
+        async destroy() { /* noop */ },
+      }
+      session._mcpFleet = parentFleet
+      const getChild = captureChildFromTaskCall(session, { description: 'd', prompt: 'p' })
+      await session.start()
+      await session.sendMessage('go')
+      const { child, snapshot } = getChild()
+      assert.ok(child, 'subagent must be registered')
+      // Snapshot taken at registration time — child.destroy() in the
+      // Task tool's finally block nulls _mcpFleet by the time
+      // sendMessage resolves, but the registration-time snapshot
+      // captures what the child looked like while it was running.
+      assert.strictEqual(snapshot.mcpFleet, parentFleet,
+        'child must share the parent fleet reference (no per-spawn child-process cost)')
+      assert.equal(snapshot.ownsMcpFleet, false,
+        'child must NOT own the borrowed fleet — destroy() will leave it alive')
+      // _buildTools() output captured pre-destroy proves the child
+      // surfaces the parent's MCP tools to the model on its next turn.
+      const mcpToolNames = snapshot.tools.filter((t) => t.name.startsWith('mcp__')).map((t) => t.name)
+      assert.deepEqual(mcpToolNames, ['mcp__stub__echo'],
+        'child must expose the parent fleet\'s mcp__ tools to its model')
+      await session.destroy()
+    })
+
+    it('Task subagent destroy() does NOT tear down the parent MCP fleet (#5019)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      let fleetDestroyed = false
+      const parentFleet = {
+        anthropicTools: [],
+        async destroy() { fleetDestroyed = true },
+      }
+      session._mcpFleet = parentFleet
+      // The Task tool's finally block calls child.destroy() after the
+      // child's result event fires. If we incorrectly let the child
+      // own the fleet, this destroy would invoke parentFleet.destroy()
+      // mid-parent-turn — killing every MCP child for any sibling Task
+      // still in flight.
+      const getChild = captureChildFromTaskCall(session, { description: 'd', prompt: 'p' })
+      await session.start()
+      await session.sendMessage('go')
+      const { child } = getChild()
+      assert.ok(child)
+      // child.destroy() has already run inside _executeTaskTool's
+      // finally block by the time sendMessage resolves. Assert the
+      // fleet survived.
+      assert.equal(fleetDestroyed, false,
+        'child.destroy() MUST NOT call parentFleet.destroy() — parent owns the fleet')
+      // Now destroy the parent explicitly — fleet must run exactly
+      // once, from the owning session's teardown.
+      await session.destroy()
+      assert.equal(fleetDestroyed, true,
+        'parent destroy must tear down its own fleet')
+    })
+
+    it('Task `inherit_mcp: false` runs the subagent without MCP (#5019)', async () => {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      const parentFleet = {
+        anthropicTools: [{ name: 'mcp__stub__echo' }],
+        async destroy() { /* noop */ },
+      }
+      session._mcpFleet = parentFleet
+      const getChild = captureChildFromTaskCall(session, {
+        description: 'd',
+        prompt: 'p',
+        inherit_mcp: false,
+      })
+      await session.start()
+      await session.sendMessage('go')
+      const { child, snapshot } = getChild()
+      assert.ok(child, 'subagent must still be registered when inherit_mcp:false')
+      assert.equal(snapshot.mcpFleet, null,
+        'inherit_mcp:false must skip fleet inheritance — child runs without MCP')
+      assert.equal(snapshot.ownsMcpFleet, true,
+        'an MCP-less child keeps the default ownership flag (no borrowing happened)')
+      const mcpToolNames = snapshot.tools.filter((t) => t.name.startsWith('mcp__'))
+      assert.equal(mcpToolNames.length, 0,
+        'inherit_mcp:false child must not expose any mcp__ tools')
+      await session.destroy()
+    })
+
+    it('Task subagent skips inheritance when the parent has no fleet (#5019)', async () => {
+      // No MCP config → no parent fleet → child gets nothing to
+      // borrow. Should not throw, should not flip _ownsMcpFleet, and
+      // _buildTools() should fall through to BUILTIN_TOOLS only.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      assert.equal(session._mcpFleet, null, 'precondition: parent has no fleet')
+      const getChild = captureChildFromTaskCall(session, { description: 'd', prompt: 'p' })
+      await session.start()
+      await session.sendMessage('go')
+      const { child, snapshot } = getChild()
+      assert.ok(child)
+      assert.equal(snapshot.mcpFleet, null, 'no fleet to inherit')
+      assert.equal(snapshot.ownsMcpFleet, true, 'ownership flag stays at default when no borrow happens')
+      await session.destroy()
+    })
+
+    it('Task `inherit_mcp` non-boolean value rejected (#5019)', async () => {
+      // Strings, numbers, null — anything non-boolean must be rejected
+      // with an is_error tool_result rather than silently coerced.
+      // The model needs a crisp signal so it can fix its tool_use.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._gateToolBlock = async () => ({ behavior: 'allow' })
+      const captured = captureEvents(session)
+      let childSpawned = false
+      const origSet = session._subagentSessions.set.bind(session._subagentSessions)
+      session._subagentSessions.set = (k, v) => {
+        childSpawned = true
+        return origSet(k, v)
+      }
+      setupParentEmittingTaskOnce(session, {
+        taskInput: { description: 'd', prompt: 'p', inherit_mcp: 'yes' },
+        childStreamImpl: () => fakeStream(
+          [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }],
+          { stop_reason: 'end_turn', content: [{ type: 'text', text: '' }], usage: { input_tokens: 1, output_tokens: 1 } },
+        ),
+      })
+      await session.start()
+      await session.sendMessage('go')
+      const taskResult = captured.find((e) => e.name === 'tool_result' && e.payload.toolUseId === 'tu_task_1')
+      assert.ok(taskResult, 'a tool_result must be emitted even on rejection')
+      assert.equal(taskResult.payload.isError, true,
+        'non-boolean inherit_mcp must produce is_error tool_result')
+      assert.match(taskResult.payload.result, /inherit_mcp/i,
+        'rejection message must name the offending field')
+      assert.equal(childSpawned, false,
+        'no subagent must be spawned when inherit_mcp is invalid')
+      await session.destroy()
+    })
+
+    it('Task input_schema declares inherit_mcp as a boolean (#5019)', () => {
+      // Protocol-surface assertion: the Task tool advertises its
+      // inherit_mcp affordance so the model can discover it. This
+      // guards against accidental schema regressions.
+      const taskTool = BUILTIN_TOOLS.find((t) => t.name === 'Task')
+      assert.ok(taskTool, 'BUILTIN_TOOLS must include the Task tool')
+      const prop = taskTool.input_schema.properties.inherit_mcp
+      assert.ok(prop, 'Task input_schema must expose inherit_mcp')
+      assert.equal(prop.type, 'boolean', 'inherit_mcp must be typed as boolean')
+      assert.match(prop.description, /default|MCP/i,
+        'description must mention the default behaviour')
     })
   })
 


### PR DESCRIPTION
## Summary

The v1 Task subagent (#5015) was constructed with `mcpConfigPath: null`, so the child session had no MCP tools at all. Nested tool use inside a delegated subagent couldn't call `mcp__<server>__<tool>` even when the user had MCP servers running for the parent session.

This PR makes the parent's already-running MCP fleet the **default** inheritance: the child session points `_mcpFleet` at the parent's existing fleet object, and the model on the child's next turn sees the exact same `mcp__*` tools the parent sees. Zero extra child-process spawn cost — the parent's MCP children are reused by reference.

## Design notes

- **Shared fleet, not copy.** `child._mcpFleet = this._mcpFleet`. Same `MCPFleet` instance, same processes, same tool catalogue.
- **Borrowed-fleet ownership flag.** `_ownsMcpFleet` defaults to `true` on every session. When a Task subagent borrows the parent's fleet it's flipped to `false`. `destroy()` only calls `fleet.destroy()` when the session owns the fleet. The child drops its reference; the parent's MCP children stay alive for sibling subagents and the parent's subsequent turns.
- **Per-call permission gating is unchanged.** Only the fleet (process pool + tool catalogue) is shared. The child still runs MCP tool calls through its own `PermissionManager` against the inherited permission mode.

## Protocol surface

New optional `inherit_mcp: boolean` on the `Task` tool input.

- **Default** (omitted): the sub-agent inherits the parent's MCP fleet.
- **`inherit_mcp: false`**: the sub-agent runs without MCP — built-in tools only. Useful for strictly scoped delegations or for isolating a suspect MCP server from delegated work.
- **Non-boolean** (string, number, null): rejected with an `is_error` tool_result naming the offending field. No subagent is spawned. The model gets a crisp signal rather than a silent coercion to one of the two paths.

The `Task` tool description was updated to document this affordance, and `input_schema.properties.inherit_mcp` advertises the boolean so model discovery picks it up.

## Test coverage

- Default inheritance wires the fleet reference (`child._mcpFleet === parentFleet` and `_ownsMcpFleet === false`), and `_buildTools()` surfaces the parent's `mcp__*` tools on the child's next turn.
- `child.destroy()` (in the Task tool's finally block) does **not** invoke `parentFleet.destroy()`. The parent's own `destroy()` is the only path that runs the fleet teardown.
- `inherit_mcp: false` skips inheritance — child's `_mcpFleet` stays `null`, ownership flag stays `true` (no borrow happened), `_buildTools()` returns built-ins only.
- Missing parent fleet (no MCP config) is a no-op: child gets `null`, ownership stays `true`.
- Non-boolean `inherit_mcp` produces an `is_error` tool_result; no child is registered.
- Protocol-surface guard: `BUILTIN_TOOLS` Task entry exposes `inherit_mcp` as a `boolean` property.

All 22 Task-tool tests pass (117/117 across `byok-session.test.js`), as do the 17 `byok-tools.test.js` tests and both server lints (`lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`).

Closes #5019

## Test plan
- [x] `node --test --test-force-exit tests/byok-session.test.js` — 117 pass
- [x] `node --test --test-force-exit tests/byok-tools.test.js` — 17 pass
- [x] `./scripts/lint-session-opt-forwarding.sh` — OK
- [x] `./scripts/lint-tests-state-file-path.sh` — OK
- [ ] Manual: configure a real MCP server, launch a Task with default `inherit_mcp`, have the subagent call an `mcp__*` tool, and confirm the result flows back via tool_result without spawning a second MCP child process
- [ ] Manual: launch a Task with `inherit_mcp: false` and confirm the subagent's tool list is built-ins only