### PR TITLE
feat(consumers): render Task error-path partial cost in chips (#5039)

### DIFF
--- a/packages/app/src/__tests__/store/message-handler.test.ts
+++ b/packages/app/src/__tests__/store/message-handler.test.ts
@@ -4043,6 +4043,95 @@ describe('error handler', () => {
 
     expect(Alert.alert).toHaveBeenCalledWith('Server Error', 'An unexpected server error occurred');
   });
+
+  // #5039 — PR #5037 added optional `usage` + `cost` to the server's error
+  // envelope when the failed turn folded any parent + Task subagent rounds
+  // before erroring out. The mobile Alert must append the pre-formatted
+  // partial-cost sub-line to the body so the user sees what the failed turn
+  // cost; the dashboard surfaces the same line under its error toast.
+  describe('partial-cost sub-line (#5039)', () => {
+    it('appends the partial-cost line to the Alert body when cost+usage present', () => {
+      const alertSpy = Alert.alert as jest.Mock;
+      alertSpy.mockClear();
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: createEmptySessionState() },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({
+        type: 'error',
+        requestId: null,
+        code: 'STREAM_ERROR',
+        message: 'stream failed',
+        cost: 0.0875,
+        usage: {
+          input_tokens: 1234,
+          output_tokens: 3400,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      });
+
+      // Sub-line is appended on a blank line so the cost stands out from
+      // the headline error message. Pre-formatted via the shared
+      // `formatPartialCostLine` helper, so the mobile alert and the
+      // dashboard toast sub-line stay byte-identical.
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Server Error',
+        'stream failed\n\nThis turn cost $0.087 (1.2K in · 3.4K out)',
+      );
+    });
+
+    it('renders the cost-only line when usage is missing (subscription provider)', () => {
+      const alertSpy = Alert.alert as jest.Mock;
+      alertSpy.mockClear();
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: createEmptySessionState() },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({
+        type: 'error',
+        requestId: null,
+        code: 'ABORT',
+        message: 'cancelled',
+        cost: 0.05,
+      });
+      expect(alertSpy).toHaveBeenCalledWith(
+        'Server Error',
+        'cancelled\n\nThis turn cost $0.050',
+      );
+    });
+
+    it('does NOT append a sub-line when the wire shape has no partials (pre-#5037)', () => {
+      // Pre-PR #5037 servers don't carry partials; the Alert body must
+      // remain the bare error message — no trailing newlines, no
+      // empty cost line.
+      const alertSpy = Alert.alert as jest.Mock;
+      alertSpy.mockClear();
+      const store = createMockStore({
+        activeSessionId: 's1',
+        sessions: [{ sessionId: 's1', name: 'S1' } as any],
+        sessionStates: { s1: createEmptySessionState() },
+      });
+      setStore(store as any);
+      _testMessageHandler.setContext(createMockContext() as any);
+
+      _testMessageHandler.handle({
+        type: 'error',
+        requestId: null,
+        code: 'STREAM_ERROR',
+        message: 'no partials here',
+      });
+      expect(alertSpy).toHaveBeenCalledWith('Server Error', 'no partials here');
+    });
+  });
 });
 
 // Issue #2944: web_task_error with SESSION_TOKEN_MISMATCH + boundSessionName should

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -116,6 +116,10 @@ import {
   handleUserQuestion as sharedUserQuestion,
   applyOrphanDeltas,
   isActivityEvent,
+  // #5039: shared partial-cost line helper — the same one the dashboard
+  // toast uses, so the mobile Alert and the dashboard sub-line can't
+  // drift apart on copy/format.
+  formatPartialCostLine,
 } from '@chroxy/store-core';
 import { PROTOCOL_VERSION } from '@chroxy/protocol';
 import { ServerNotificationPrefsSchema } from '@chroxy/protocol/schemas';
@@ -3064,7 +3068,21 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     case 'error': {
       // Structured error response from a handler catch block.
       // Log it and surface a modal alert so the user knows something failed.
-      const { code: errCode, message: errMsg, requestId: errRequestId } = sharedError(msg);
+      // #5039: `partialCost` carries the optional PR #5037 fold of parent
+      // + Task subagent rounds completed before the error fired. When
+      // present, append the pre-formatted sub-line to the Alert body so
+      // the user sees what the failed turn cost — same wording as the
+      // dashboard toast sub-line.
+      const {
+        code: errCode,
+        message: errMsg,
+        requestId: errRequestId,
+        partialCost,
+      } = sharedError(msg);
+      const partialCostLine = partialCost ? formatPartialCostLine(partialCost) : null;
+      // Build the Alert body once so the permission-mode branch below and
+      // the generic fallback both surface the partial-cost line.
+      const alertBody = partialCostLine ? `${errMsg}\n\n${partialCostLine}` : errMsg;
       console.error(`[ws] Server handler error [${errCode}]: ${errMsg}`);
 
       // Match against an in-flight set_permission_mode request — if the
@@ -3092,9 +3110,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           set({ pendingPermissionConfirm: null });
 
           if (errCode === 'CAPABILITY_NOT_SUPPORTED') {
+            // The targeted "Permission Mode Unavailable" alert uses its
+            // own fallback copy when errMsg is empty; the partial-cost
+            // line stays appended either way.
+            const permissionBody = errMsg || 'This provider does not support permission mode switching.';
             Alert.alert(
               'Permission Mode Unavailable',
-              errMsg || 'This provider does not support permission mode switching.',
+              partialCostLine ? `${permissionBody}\n\n${partialCostLine}` : permissionBody,
             );
             break;
           }
@@ -3104,7 +3126,7 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         }
       }
 
-      Alert.alert('Server Error', errMsg);
+      Alert.alert('Server Error', alertBody);
       break;
     }
 

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1163,6 +1163,12 @@ export function App() {
                 actionDisabledLabel: 'Reconnecting…',
               }
             : {}),
+          // #5039: optional partial-cost sub-line surfaced under the
+          // main toast message when PR #5037 folded any parent + Task
+          // subagent rounds onto the error envelope before the error
+          // fired. Undefined for every error path that didn't carry
+          // partials, so the existing message-only toast is unchanged.
+          ...(e.partialCostLine ? { subMessage: e.partialCostLine } : {}),
         })),
       ...infoNotifications
         .map(e => ({ id: e.id, message: e.message, level: 'info' as const })),

--- a/packages/dashboard/src/components/Toast.test.tsx
+++ b/packages/dashboard/src/components/Toast.test.tsx
@@ -629,4 +629,61 @@ describe('Toast', () => {
       expect(onDismiss).toHaveBeenCalledWith('fh1')
     })
   })
+
+  // #5039 — secondary sub-line under the main toast message, surfaced
+  // for the PR #5037 error-path partial-cost ("This turn cost $X").
+  // Rendered as a small `<span data-testid="toast-partial-cost-{id}">`
+  // inside the existing `.toast-msg` flex column so the action + close
+  // buttons stay aligned; absent for every error path that didn't carry
+  // partials so the single-line layout is preserved.
+  describe('subMessage sub-line (#5039)', () => {
+    it('renders the sub-line with a testID when subMessage is set', () => {
+      const items: ToastItem[] = [
+        { id: 'pc1', message: 'Stream error', subMessage: 'This turn cost $0.087 (1.2K in · 3.4K out)' },
+      ]
+      render(<Toast items={items} onDismiss={vi.fn()} />)
+      const sub = screen.getByTestId('toast-partial-cost-pc1')
+      expect(sub).toBeInTheDocument()
+      expect(sub.textContent).toBe('This turn cost $0.087 (1.2K in · 3.4K out)')
+    })
+
+    it('does NOT render the sub-line element when subMessage is absent', () => {
+      // Preserve the pre-#5039 single-line layout for every error path
+      // that doesn't carry partials — no empty `<span class="toast-submsg">`
+      // wrapper should leak into the DOM.
+      const items: ToastItem[] = [{ id: 'pc2', message: 'Plain error' }]
+      const { container } = render(<Toast items={items} onDismiss={vi.fn()} />)
+      expect(screen.queryByTestId('toast-partial-cost-pc2')).toBeNull()
+      expect(container.querySelector('.toast-submsg')).toBeNull()
+    })
+
+    it('keeps the main message text rendered alongside the sub-line', () => {
+      // Belt-and-braces: the sub-line must NOT replace the main
+      // message — both must surface so the user sees the error context
+      // AND the failed-turn cost.
+      const items: ToastItem[] = [
+        { id: 'pc3', message: 'Stream error', subMessage: 'This turn cost $0.050' },
+      ]
+      render(<Toast items={items} onDismiss={vi.fn()} />)
+      expect(screen.getByText('Stream error')).toBeInTheDocument()
+      expect(screen.getByTestId('toast-partial-cost-pc3')).toBeInTheDocument()
+    })
+
+    it('does not interfere with action button rendering when both are present', () => {
+      // The sub-line lives inside `.toast-msg`, the action button is a
+      // sibling of `.toast-msg` — both must surface without one
+      // hiding the other.
+      const items: ToastItem[] = [
+        {
+          id: 'pc4',
+          message: 'Stream error',
+          subMessage: 'This turn cost $0.050',
+          action: { label: 'Retry', onClick: vi.fn() },
+        },
+      ]
+      render(<Toast items={items} onDismiss={vi.fn()} />)
+      expect(screen.getByTestId('toast-partial-cost-pc4')).toBeInTheDocument()
+      expect(screen.getByTestId('toast-action-pc4')).toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/components/Toast.tsx
+++ b/packages/dashboard/src/components/Toast.tsx
@@ -29,6 +29,14 @@ export type ToastAction = ServerErrorAction
 export interface ToastItem {
   id: string
   message: string
+  /**
+   * #5039: optional secondary line rendered under `message` as a small
+   * sub-text. Used to surface the PR #5037 error-path partial-cost line
+   * ("This turn cost $0.087 (1.2K in · 3.4K out)") without restyling
+   * the main toast layout — when unset (the common path) the toast
+   * keeps its single-line look from before.
+   */
+  subMessage?: string
   // #4148: 'warning' is a non-destructive yellow toast — used for
   // MAX_TOOL_ROUNDS_REACHED and other fatal: false server signals so
   // the user doesn't see a red error for a recoverable condition.
@@ -242,7 +250,20 @@ export function Toast({ items, onDismiss }: ToastProps) {
             resumeTimer(item.id, 'focus')
           }}
         >
-          <span className="toast-msg">{item.message}</span>
+          <span className="toast-msg">
+            {item.message}
+            {item.subMessage ? (
+              // #5039: error-path partial-cost sub-line. Rendered as a
+              // small block under the main message; testID lets Maestro
+              // assert presence on mobile-mirror parity tests too.
+              <span
+                className="toast-submsg"
+                data-testid={`toast-partial-cost-${item.id}`}
+              >
+                {item.subMessage}
+              </span>
+            ) : null}
+          </span>
           {item.action ? (
             <button
               className="toast-action"

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2378,7 +2378,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     set({ logEntries: [] });
   },
 
-  addServerError: (message, action, severity) => {
+  addServerError: (message, action, severity, partialCostLine) => {
     const now = Date.now();
     const err = {
       id: nextMessageId('info'),
@@ -2395,6 +2395,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // MAX_TOOL_ROUNDS_REACHED) from destructive STREAM_ERROR / ABORT.
       // Defaults to 'error' when unset — existing call sites unchanged.
       ...(severity ? { severity } : {}),
+      // #5039: optional partial-cost sub-line surfaced under the main
+      // message when PR #5037 folded parent + Task subagent rounds onto
+      // the error envelope. Only attached when the caller has a
+      // non-empty pre-formatted line — undefined for every error path
+      // that doesn't carry partials so the toast renders message-only.
+      ...(partialCostLine ? { partialCostLine } : {}),
     };
     set((state) => ({
       serverErrors: [...state.serverErrors, err].slice(-10),

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -3215,6 +3215,94 @@ describe('dashboard message-handler dispatch', () => {
     })
   })
 
+  // #5039 — PR #5037 added optional `usage` + `cost` to the error envelope so
+  // a Task subagent error path can surface "this turn cost $X" in the
+  // dashboard toast. The dispatch must pass the pre-formatted sub-line into
+  // addServerError as the 4th positional arg; without it, the partial-cost
+  // information reaches the wire but never makes it onto the toast.
+  describe('error dispatch — partial-cost sub-line (#5039)', () => {
+    it('threads the partial-cost line into addServerError when cost+usage present', () => {
+      const calls: Array<{ message: unknown; partialCostLine: unknown }> = []
+      store = createMockStore(baseState())
+      setStore(store)
+      ;(store.getState() as any).addServerError = (
+        message: unknown,
+        _action: unknown,
+        _severity: unknown,
+        partialCostLine?: string,
+      ) => {
+        calls.push({ message, partialCostLine })
+      }
+      handleMessage(
+        {
+          type: 'error',
+          code: 'STREAM_ERROR',
+          message: 'stream failed',
+          cost: 0.0875,
+          usage: {
+            input_tokens: 1234,
+            output_tokens: 3400,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        } as any,
+        ctx() as any,
+      )
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.message).toBe('stream failed')
+      // Pre-formatted via the shared `formatPartialCostLine` helper so
+      // the dashboard + mobile alerts can't drift on copy/format.
+      expect(calls[0]?.partialCostLine).toBe('This turn cost $0.087 (1.2K in · 3.4K out)')
+    })
+
+    it('passes undefined when the wire shape has no partials (pre-#5037 servers)', () => {
+      // Default error envelope without cost — the dispatch must NOT
+      // synthesize an empty/zero sub-line. Asserting `undefined` (not
+      // empty string) pins the addServerError 4th-arg contract: the
+      // store's spread-on-truthy guard skips the field entirely.
+      const calls: Array<{ partialCostLine: unknown }> = []
+      store = createMockStore(baseState())
+      setStore(store)
+      ;(store.getState() as any).addServerError = (
+        _message: unknown,
+        _action: unknown,
+        _severity: unknown,
+        partialCostLine?: string,
+      ) => {
+        calls.push({ partialCostLine })
+      }
+      handleMessage(
+        { type: 'error', code: 'STREAM_ERROR', message: 'no partials here' } as any,
+        ctx() as any,
+      )
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.partialCostLine).toBeUndefined()
+    })
+
+    it('renders cost-only line when usage is missing (subscription provider)', () => {
+      // Subscription-billed providers can produce a cost without a
+      // token breakdown — the sub-line must still surface so the user
+      // sees the failed-turn spend.
+      const calls: Array<{ partialCostLine: unknown }> = []
+      store = createMockStore(baseState())
+      setStore(store)
+      ;(store.getState() as any).addServerError = (
+        _message: unknown,
+        _action: unknown,
+        _severity: unknown,
+        partialCostLine?: string,
+      ) => {
+        calls.push({ partialCostLine })
+      }
+      handleMessage(
+        { type: 'error', code: 'ABORT', message: 'cancelled', cost: 0.05 } as any,
+        ctx() as any,
+      )
+      expect(calls).toHaveLength(1)
+      expect(calls[0]?.partialCostLine).toBe('This turn cost $0.050')
+    })
+  })
+
   describe('pairing_refreshed dispatch (#2916)', () => {
     it('increments pairingRefreshedCount when pairing_refreshed arrives', () => {
       store = createMockStore(baseState({ pairingRefreshedCount: 0 } as any))

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -98,6 +98,9 @@ import {
   handleUserQuestion as sharedUserQuestion,
   applyOrphanDeltas,
   isActivityEvent,
+  // #5039: pre-formatted partial-cost sub-line used by the `case 'error'`
+  // branch so the toast and the mobile Alert share copy.
+  formatPartialCostLine,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
@@ -3486,7 +3489,12 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // + app share a single normalised shape (no `msg.fatal` reach-in,
       // no per-client type guard, and a typo'd value can't silently
       // degrade severity).
-      const { code: errCode, message: errMsg, fatal: errFatal } = sharedError(msg);
+      // #5039: `partialCost` carries the optional PR #5037 fold of
+      // parent + Task subagent rounds completed before the error fired.
+      // Pre-formatted with the shared helper so the dashboard toast and
+      // mobile alert show identical wording.
+      const { code: errCode, message: errMsg, fatal: errFatal, partialCost } = sharedError(msg);
+      const partialCostLine = partialCost ? formatPartialCostLine(partialCost) : undefined;
       console.error(`[ws] Server handler error [${errCode}]: ${errMsg}`);
       // #3588: clear any in-flight skill_trust_grant whose requestId
       // matches this error envelope so the SkillsPanel "Pending review"
@@ -3562,7 +3570,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // the loud red toast instead of silently degrading.
       const isNonFatal = errFatal === false || NON_FATAL_ERROR_CODES.has(errCode);
       const severity: 'error' | 'warning' = isNonFatal ? 'warning' : 'error';
-      get().addServerError(surfaced, action, severity);
+      // #5039: thread the optional partial-cost sub-line through to the
+      // store. addServerError keeps it undefined for every pre-#5037
+      // error path so the existing toast layout is unchanged.
+      get().addServerError(surfaced, action, severity, partialCostLine);
       break;
     }
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -812,7 +812,15 @@ export interface ConnectionState {
   // recovery button to the toast. Existing call sites that pass only
   // `message` keep working — `action` is undefined and the toast renders
   // message-only as before.
-  addServerError: (message: string, action?: ServerErrorAction, severity?: ServerError['severity']) => void;
+  // #5039: optional `partialCostLine` surfaces the PR #5037 partial-cost
+  // sub-line under the main toast message when the failed turn folded
+  // any parent + Task subagent rounds before erroring out.
+  addServerError: (
+    message: string,
+    action?: ServerErrorAction,
+    severity?: ServerError['severity'],
+    partialCostLine?: string,
+  ) => void;
   dismissServerError: (id: string) => void;
 
   // Info notification actions

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -4186,7 +4186,18 @@
   animation: slideUp 0.2s ease-out;
 }
 
-.toast-msg { flex: 1; }
+.toast-msg { flex: 1; display: flex; flex-direction: column; gap: 4px; }
+
+/* #5039: small secondary line under the main toast message, surfaced
+ * for the PR #5037 error-path partial-cost ("This turn cost $X").
+ * Slightly dimmer + smaller than the main message so it reads as a
+ * sub-line, not a peer. Kept inside `.toast-msg` so the flex layout
+ * (action button + close button alignment) stays untouched. */
+.toast-submsg {
+  font-size: 12px;
+  opacity: 0.85;
+  line-height: 1.3;
+}
 
 .toast-close {
   background: none;

--- a/packages/store-core/src/cost-format.test.ts
+++ b/packages/store-core/src/cost-format.test.ts
@@ -6,7 +6,8 @@
  * one source of truth.
  */
 import { describe, it, expect } from 'vitest'
-import { formatCostBadge, formatCostBreakdown } from './cost-format'
+import { formatCostBadge, formatCostBreakdown, formatPartialCostLine } from './cost-format'
+import type { ErrorPartialCost } from './cost-format'
 import type { CumulativeUsage } from './types'
 
 describe('formatCostBadge (#4123)', () => {
@@ -67,5 +68,54 @@ describe('formatCostBreakdown (#4123)', () => {
       turnsBilled: 0,
     }
     expect(formatCostBreakdown(usage)).toContain(`Input tokens: ${localeNum(1234567)}`)
+  })
+})
+
+describe('formatPartialCostLine (#5039)', () => {
+  const partial = (over: Partial<ErrorPartialCost> = {}): ErrorPartialCost => ({
+    costUsd: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    ...over,
+  })
+
+  it('includes cost + abbreviated input/output tokens when both present', () => {
+    // Cost formatting delegates to `formatCostBadge`: $0.01-$1 → 3 decimals.
+    expect(
+      formatPartialCostLine(partial({ costUsd: 0.0875, inputTokens: 1234, outputTokens: 3400 })),
+    ).toBe('This turn cost $0.087 (1.2K in · 3.4K out)')
+  })
+
+  it('falls back to cost-only when both input and output tokens are zero', () => {
+    // Subscription-billed providers can emit a cost without a usage
+    // breakdown — surface the cost alone rather than a misleading
+    // "(0 in · 0 out)" suffix. Cost formatting matches formatCostBadge:
+    // $0.05 lands in the 3-decimal band → "$0.050".
+    expect(formatPartialCostLine(partial({ costUsd: 0.05 }))).toBe('This turn cost $0.050')
+  })
+
+  it('still renders sub-line when only one of the token counters is non-zero', () => {
+    expect(
+      formatPartialCostLine(partial({ costUsd: 0.001, inputTokens: 500, outputTokens: 0 })),
+    ).toBe('This turn cost $0.0010 (500 in · 0 out)')
+    expect(
+      formatPartialCostLine(partial({ costUsd: 0.001, inputTokens: 0, outputTokens: 750 })),
+    ).toBe('This turn cost $0.0010 (0 in · 750 out)')
+  })
+
+  it('uses K/M abbreviation matching SidebarTokenView.formatTokenCount', () => {
+    expect(
+      formatPartialCostLine(
+        partial({ costUsd: 1.5, inputTokens: 1_234_567, outputTokens: 999_499 }),
+      ),
+    ).toBe('This turn cost $1.50 (1.23M in · 999.5K out)')
+  })
+
+  it('renders $0 when costUsd is exactly 0 (free / fully-cached turn)', () => {
+    expect(
+      formatPartialCostLine(partial({ costUsd: 0, inputTokens: 50, outputTokens: 0 })),
+    ).toBe('This turn cost $0 (50 in · 0 out)')
   })
 })

--- a/packages/store-core/src/cost-format.ts
+++ b/packages/store-core/src/cost-format.ts
@@ -35,6 +35,54 @@ export function formatCostBadge(costUsd: number): string {
 }
 
 /**
+ * #5039: error-path partial-cost snapshot folded onto a server `error`
+ * event when the failed turn ran any parent rounds + Task subagent
+ * calls before the error fired. Shape returned by `handleError` and
+ * consumed by `formatPartialCostLine` below — see PR #5037 wire side
+ * and #5038 cumulative-tracker fold.
+ */
+export interface ErrorPartialCost {
+  costUsd: number
+  inputTokens: number
+  outputTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+}
+
+/**
+ * #5039: human-readable one-liner for the error-path partial cost.
+ *
+ *   `"This turn cost $0.087 (1.2K in · 3.4K out)"`
+ *
+ * Used as a sub-line under the main error message on the dashboard
+ * toast (`<span data-testid="toast-partial-cost-*">`) and appended to
+ * the mobile `Alert.alert` body. Single source of truth so the two
+ * surfaces can't drift apart in copy/format.
+ *
+ * Falls back to a cost-only string when the usage object was empty (a
+ * subscription-billed provider that only produced a cost). Token counts
+ * use the same K/M abbreviation as `SidebarTokenView.formatTokenCount`
+ * — kept inline here to keep cost-format dependency-free.
+ */
+export function formatPartialCostLine(partial: ErrorPartialCost): string {
+  const cost = formatCostBadge(partial.costUsd)
+  const inTokens = partial.inputTokens
+  const outTokens = partial.outputTokens
+  if (inTokens <= 0 && outTokens <= 0) {
+    return `This turn cost ${cost}`
+  }
+  return `This turn cost ${cost} (${formatTokens(inTokens)} in · ${formatTokens(outTokens)} out)`
+}
+
+/** Token-count abbreviation mirroring `SidebarTokenView.formatTokenCount`. */
+function formatTokens(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '0'
+  if (n < 1000) return String(n)
+  if (n < 999_500) return `${(n / 1000).toFixed(1)}K`
+  return `${(n / 1_000_000).toFixed(2)}M`
+}
+
+/**
  * Build the multi-line breakdown shown in the dashboard's native browser
  * tooltip (the cost-badge hover popover) — one string, six rows separated
  * by newlines, suitable for a `<span title={...}>` attribute.

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -869,6 +869,127 @@ describe('handleError', () => {
     expect(handleError({ fatal: 0 as unknown as boolean }).fatal).toBeUndefined()
     expect(handleError({ fatal: null as unknown as boolean }).fatal).toBeUndefined()
   })
+
+  // #5039 — partial-cost passthrough. PR #5037 added optional usage + cost
+  // fields to the server's error envelope when the failed turn folded any
+  // parent + Task subagent rounds before the error fired. The dashboard
+  // toast and mobile alert use the parsed snapshot to render a "this turn
+  // cost $X" sub-line; the parser is the single source of truth for the
+  // strict-finite gate that decides whether the snapshot is usable.
+  describe('partialCost (#5039 — PR #5037 wire passthrough)', () => {
+    it('parses cost + usage into the partialCost slot when both present', () => {
+      const result = handleError({
+        code: 'STREAM_ERROR',
+        message: 'stream failed',
+        cost: 0.0875,
+        usage: {
+          input_tokens: 1200,
+          output_tokens: 3400,
+          cache_read_input_tokens: 500,
+          cache_creation_input_tokens: 100,
+        },
+      })
+      expect(result.partialCost).toEqual({
+        costUsd: 0.0875,
+        inputTokens: 1200,
+        outputTokens: 3400,
+        cacheReadTokens: 500,
+        cacheCreationTokens: 100,
+      })
+    })
+
+    it('keeps partialCost when usage is missing (subscription-billed provider)', () => {
+      // Subscription-billed providers can produce a cost without a usage
+      // breakdown — keep the cost surfaced so the user still sees the
+      // failed-turn spend even when the token counters are unavailable.
+      const result = handleError({
+        code: 'STREAM_ERROR',
+        message: 'stream failed',
+        cost: 0.05,
+      })
+      expect(result.partialCost).toEqual({
+        costUsd: 0.05,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      })
+    })
+
+    it('falls back to null when cost is missing (pre-#5037 wire shape)', () => {
+      // Pre-PR #5037 servers don't carry partials; the parser must
+      // surface null so consumers can branch on presence without
+      // re-implementing the gate.
+      expect(handleError({ code: 'STREAM_ERROR', message: 'x' }).partialCost).toBeNull()
+    })
+
+    it('rejects NaN / Infinity / negative / non-number cost (matches _trackUsage gate)', () => {
+      // Server-side _trackUsage (#5038) only accumulates Number.isFinite
+      // costs — mirror that gate here so a provider bug can't poison
+      // the partial-cost display either.
+      expect(handleError({ cost: NaN }).partialCost).toBeNull()
+      expect(handleError({ cost: Infinity }).partialCost).toBeNull()
+      expect(handleError({ cost: -0.01 }).partialCost).toBeNull()
+      expect(handleError({ cost: '0.05' as unknown as number }).partialCost).toBeNull()
+      expect(handleError({ cost: null as unknown as number }).partialCost).toBeNull()
+    })
+
+    it('zeroes individual non-finite token fields without losing other counters', () => {
+      // Best-effort token parse: a single bad counter (NaN, negative,
+      // non-number) drops just that field — the rest of the breakdown
+      // still surfaces. Without this, a provider that emits one bogus
+      // counter would null the whole partial snapshot.
+      const result = handleError({
+        cost: 0.02,
+        usage: {
+          input_tokens: 1000,
+          output_tokens: NaN,
+          cache_read_input_tokens: -5,
+          cache_creation_input_tokens: 'x',
+        },
+      })
+      expect(result.partialCost).toEqual({
+        costUsd: 0.02,
+        inputTokens: 1000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      })
+    })
+
+    it('treats non-object usage as empty (zero tokens, cost still surfaced)', () => {
+      // A wire-side typo (`usage: 'oops'`) must not poison the cost
+      // surface — fall back to zero counters and still render the cost.
+      const result = handleError({
+        cost: 0.03,
+        usage: 'oops' as unknown as Record<string, number>,
+      })
+      expect(result.partialCost).toEqual({
+        costUsd: 0.03,
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      })
+    })
+
+    it('accepts cost: 0 (free / cache-only turn) and surfaces the snapshot', () => {
+      // A 100%-cached turn can still fold a non-zero usage breakdown
+      // without billing — the user benefits from seeing those tokens
+      // even if the cost is $0.
+      const result = handleError({
+        cost: 0,
+        usage: { input_tokens: 50, output_tokens: 0, cache_read_input_tokens: 1000 },
+      })
+      expect(result.partialCost).toEqual({
+        costUsd: 0,
+        inputTokens: 50,
+        outputTokens: 0,
+        cacheReadTokens: 1000,
+        cacheCreationTokens: 0,
+      })
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -37,6 +37,10 @@ import { MAX_SESSION_INTERVENTIONS, nextMessageId, stripAnsi } from '../utils'
 import { parseUserInputMessage } from '../user-input-handler'
 import { isReplayDuplicate } from '../replay-dedup'
 import { resolveStreamId } from '../stream-id'
+// #5039: ErrorPartialCost surfaced on the optional `partialCost` slot of
+// `handleError`'s return shape so dashboard + app can render the
+// PR #5037 partial-cost sub-line under the error toast.
+import type { ErrorPartialCost } from '../cost-format'
 // Centralised client-side error-category detection (#3151).
 import { isRateLimitMessage } from '@chroxy/protocol'
 // Established Zod-handler pattern (#3138).
@@ -1044,6 +1048,19 @@ export function handleError(msg: Record<string, unknown>): {
    * surface loudly instead of silently degrading).
    */
   fatal: boolean | undefined
+  /**
+   * #5039: optional partial-cost snapshot from PR #5037. When the
+   * error fired AFTER any parent rounds + subagent Task calls had
+   * already billed, byok-session folds those totals onto the error
+   * envelope (`usage` / `cost`) so the user can see what the failed
+   * turn cost. Only populated when `cost` is a finite non-negative
+   * number — undefined / NaN / Infinity / negative / non-number all
+   * resolve to null, matching the strict-finite gate that
+   * `_trackUsage` applies on the success path (#5038). Tokens default
+   * to 0 when missing/non-finite so a subscription-billed provider
+   * (cost present, usage absent) still surfaces a cost-only line.
+   */
+  partialCost: ErrorPartialCost | null
 } {
   const code = typeof msg.code === 'string' ? msg.code : 'UNKNOWN'
   const rawMessage =
@@ -1053,6 +1070,24 @@ export function handleError(msg: Record<string, unknown>): {
   // Strict boolean check — a typo (e.g. fatal: 'false' string) must NOT
   // degrade to a warning toast. Treat anything non-boolean as undefined.
   const fatal = typeof msg.fatal === 'boolean' ? msg.fatal : undefined
+  // #5039: parse optional partial usage + cost (PR #5037 wire shape).
+  // `cost` is the gate — null/undefined/NaN/Infinity/non-number/negative
+  // all mean "no usable partial info", matching the strict-finite check
+  // on the success-path `_trackUsage` fold (#5038). Tokens are
+  // best-effort: any field that isn't a finite non-negative number
+  // falls to 0 so a single bogus counter can't poison the rest of the
+  // display.
+  const rawCost = msg.cost
+  const partialCost: ErrorPartialCost | null =
+    typeof rawCost === 'number' && Number.isFinite(rawCost) && rawCost >= 0
+      ? {
+          costUsd: rawCost,
+          inputTokens: pickFiniteTokenCount(msg.usage, 'input_tokens'),
+          outputTokens: pickFiniteTokenCount(msg.usage, 'output_tokens'),
+          cacheReadTokens: pickFiniteTokenCount(msg.usage, 'cache_read_input_tokens'),
+          cacheCreationTokens: pickFiniteTokenCount(msg.usage, 'cache_creation_input_tokens'),
+        }
+      : null
   // `systemMessage` was dropped from the return shape (#3112) — neither
   // call site (`dashboard:store/message-handler.ts:case 'error'`,
   // `app:store/message-handler.ts:case 'error'`) consumed it.
@@ -1061,7 +1096,20 @@ export function handleError(msg: Record<string, unknown>): {
     message,
     requestId,
     fatal,
+    partialCost,
   }
+}
+
+/**
+ * #5039: best-effort extract of a single token-count field from the
+ * untyped server `error.usage` payload. Non-object/null usage and any
+ * non-finite / negative numeric falls to 0 — see `handleError` JSDoc
+ * for the contract.
+ */
+function pickFiniteTokenCount(rawUsage: unknown, key: string): number {
+  if (rawUsage == null || typeof rawUsage !== 'object') return 0
+  const v = (rawUsage as Record<string, unknown>)[key]
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : 0
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -168,7 +168,11 @@ export {
 export {
   formatCostBadge,
   formatCostBreakdown,
+  // #5039: error-path partial-cost helper shared by dashboard toast
+  // sub-line and mobile Alert.alert body.
+  formatPartialCostLine,
 } from './cost-format'
+export type { ErrorPartialCost } from './cost-format'
 
 export type {
   SessionVisualStatus,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -473,6 +473,16 @@ export interface ServerError {
    * existing callers continue to render as red error toasts.
    */
   severity?: 'error' | 'warning';
+  /**
+   * #5039: optional partial-cost sub-line surfaced when PR #5037 folded
+   * any parent + Task subagent rounds onto an error envelope before the
+   * error fired. Rendered as a small secondary text under the main
+   * toast message; absent for every error path that didn't carry a
+   * usable partial snapshot. Pre-formatted (via
+   * `formatPartialCostLine`) so the dashboard and mobile surfaces can
+   * share copy without re-implementing the cost/token formatting.
+   */
+  partialCostLine?: string;
 }
 
 export interface DevPreview {


### PR DESCRIPTION
## Summary

PR #5037 (merged) added optional `usage` + `cost` passthrough on the server's `error` envelope when the failed turn folded any parent + Task subagent rounds before erroring out. PR #5038/#5046 then folded those partials into the session cumulative tracker. But the dashboard error toast and mobile Alert still dropped them at parse time — the operator never saw what the failed turn cost.

This PR wires the partial-cost line into both consumer surfaces.

- **store-core**: `handleError` surfaces `partialCost` in its typed return; strict-finite cost gate mirrors the server-side `_trackUsage` fold (#5038); a single non-finite token counter falls to 0 so it can't poison the whole snapshot.
- **store-core/cost-format**: new `formatPartialCostLine` helper renders `"This turn cost $0.087 (1.2K in · 3.4K out)"` — single source of truth so dashboard sub-line and mobile Alert body can't drift.
- **dashboard**: `addServerError` gains an optional `partialCostLine` arg; `Toast` renders it as a small `<span class="toast-submsg">` under the main message with `data-testid="toast-partial-cost-{id}"`. Absent for every pre-#5037 error path so the existing single-line layout stays unchanged.
- **mobile**: `case 'error'` dispatch appends the partial-cost line to the `Alert.alert` body on a blank line; CAPABILITY_NOT_SUPPORTED branch threads it through too.

## Test plan

- [x] `handleError` parser: 7 cases pin partial-cost extraction, strict-finite gate, token-best-effort fallback, non-object `usage` handling, `cost: 0` cache-only surfacing.
- [x] `formatPartialCostLine`: 5 cases pin rendered string, cost-only fallback, K/M abbreviation parity with `SidebarTokenView.formatTokenCount`.
- [x] Dashboard `case 'error'` dispatch: 3 cases pin 4th-arg threading, `undefined` for pre-#5037 wire, subscription-provider cost-only line.
- [x] `Toast` component: 4 cases pin sub-line rendering with testID, absence when unset, coexistence with main message + action button.
- [x] Mobile `case 'error'` dispatch: 3 cases mirror dashboard pins on the `Alert.alert` body shape.
- [x] Full `store-core` suite (1085 tests), full dashboard suite (2856 tests), full app suite (1586 tests) all pass.
- [x] `tsc --noEmit` clean on all three packages.

Closes #5039.