### PR TITLE
feat(task): render child agent progress as nested sub-bubbles (#5016)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -1659,6 +1659,7 @@ export function App() {
           serverName={storeMsg.serverName}
           isTail={msg.id === chatTailMessageId}
           resultImages={storeMsg.toolResultImages}
+          childAgentEvents={storeMsg.childAgentEvents}
         />
       )
     }

--- a/packages/dashboard/src/components/ChildAgentEventList.test.tsx
+++ b/packages/dashboard/src/components/ChildAgentEventList.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * ChildAgentEventList tests — #5016
+ *
+ * Covers both the pure reducer (`__reduceEventsForTest`) and the
+ * rendered output. The reducer carries the load-bearing logic
+ * (per-tool row construction, stream_delta concatenation, defensive
+ * synthesis on out-of-order tool_result) so most assertions live there.
+ * Render tests focus on what users see: collapsed by default, expands
+ * on click, surfaces input summary + result text.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { ChildAgentEventList, __reduceEventsForTest } from './ChildAgentEventList'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('reduceEvents (#5016)', () => {
+  it('builds one row per child tool_start, in arrival order', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read', input: { file_path: '/a' } } },
+      { type: 'tool_start', payload: { toolUseId: 'c2', tool: 'Bash', input: { command: 'ls' } } },
+    ])
+    expect(out.tools).toHaveLength(2)
+    expect(out.tools[0]?.toolUseId).toBe('c1')
+    expect(out.tools[0]?.toolName).toBe('Read')
+    expect(out.tools[1]?.toolUseId).toBe('c2')
+    expect(out.tools[1]?.toolName).toBe('Bash')
+  })
+
+  it('accumulates tool_input_delta partialJson onto the matching row', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+      { type: 'tool_input_delta', payload: { toolUseId: 'c1', partialJson: '{"file_path":' } },
+      { type: 'tool_input_delta', payload: { toolUseId: 'c1', partialJson: '"/a"}' } },
+    ])
+    expect(out.tools[0]?.inputPartial).toBe('{"file_path":"/a"}')
+  })
+
+  it('marks a row resolved when tool_result arrives, captures result text', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+      { type: 'tool_result', payload: { toolUseId: 'c1', result: 'hello\nworld' } },
+    ])
+    expect(out.tools[0]?.hasResult).toBe(true)
+    expect(out.tools[0]?.result).toBe('hello\nworld')
+  })
+
+  it('concatenates stream_delta chunks into assistantText', () => {
+    const out = __reduceEventsForTest([
+      { type: 'stream_delta', payload: { delta: 'Hello ' } },
+      { type: 'stream_delta', payload: { delta: 'world.' } },
+    ])
+    expect(out.assistantText).toBe('Hello world.')
+    expect(out.tools).toHaveLength(0)
+  })
+
+  it('synthesises a row when tool_result arrives without a preceding tool_start', () => {
+    // Defensive against a child race where the events arrive out of order.
+    const out = __reduceEventsForTest([
+      { type: 'tool_result', payload: { toolUseId: 'cX', result: 'oops' } },
+    ])
+    expect(out.tools).toHaveLength(1)
+    expect(out.tools[0]?.toolUseId).toBe('cX')
+    expect(out.tools[0]?.hasResult).toBe(true)
+  })
+
+  it('ignores tool_input_delta for an unknown toolUseId (pre-tool_start race)', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_input_delta', payload: { toolUseId: 'unknown', partialJson: 'x' } },
+    ])
+    expect(out.tools).toHaveLength(0)
+  })
+
+  it('ignores stream_delta chunks without a string delta', () => {
+    const out = __reduceEventsForTest([
+      { type: 'stream_delta', payload: { delta: null } },
+      { type: 'stream_delta', payload: {} },
+      { type: 'stream_delta', payload: { delta: 'good' } },
+    ])
+    expect(out.assistantText).toBe('good')
+  })
+
+  it('ignores unknown event types (forward-compat against future server emits)', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+      { type: 'permission_request', payload: { tool: 'Bash' } },
+      { type: 'something_new', payload: { foo: 'bar' } },
+    ])
+    expect(out.tools).toHaveLength(1)
+    expect(out.assistantText).toBe('')
+  })
+
+  it('replays of tool_start preserve resolved state on the row', () => {
+    // A defensive replay (e.g. broadcast retry) must not reset hasResult.
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+      { type: 'tool_result', payload: { toolUseId: 'c1', result: 'done' } },
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+    ])
+    expect(out.tools).toHaveLength(1)
+    expect(out.tools[0]?.hasResult).toBe(true)
+    expect(out.tools[0]?.result).toBe('done')
+  })
+})
+
+describe('ChildAgentEventList render (#5016)', () => {
+  it('renders nothing when the events array is empty', () => {
+    const { container } = render(
+      <ChildAgentEventList events={[]} parentToolUseId="tu-parent-1" />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows the Subagent progress header and per-tool rows', () => {
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read', input: { file_path: '/a' } } },
+          { type: 'tool_result', payload: { toolUseId: 'c1', result: 'hello' } },
+        ]}
+        parentToolUseId="tu-parent-2"
+      />,
+    )
+    expect(screen.getByTestId('child-agent-events-header')).toHaveTextContent('Subagent progress')
+    expect(screen.getByTestId('child-agent-tool-c1')).toBeInTheDocument()
+    expect(screen.getByTestId('child-agent-tool-input-c1')).toHaveTextContent('/a')
+  })
+
+  it('rows start collapsed; clicking a row expands the result', () => {
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+          { type: 'tool_result', payload: { toolUseId: 'c1', result: 'hello' } },
+        ]}
+        parentToolUseId="tu-parent-3"
+      />,
+    )
+    expect(screen.queryByTestId('child-agent-tool-result-c1')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('child-agent-tool-c1'))
+    expect(screen.getByTestId('child-agent-tool-result-c1')).toHaveTextContent('hello')
+  })
+
+  it('surfaces a pulse marker on rows that have not resolved yet', () => {
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+        ]}
+        parentToolUseId="tu-parent-4"
+      />,
+    )
+    expect(screen.getByTestId('child-agent-tool-pulse-c1')).toBeInTheDocument()
+  })
+
+  it('renders the child stream text block when stream_delta arrived', () => {
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'stream_delta', payload: { delta: 'Hello ' } },
+          { type: 'stream_delta', payload: { delta: 'world.' } },
+        ]}
+        parentToolUseId="tu-parent-5"
+      />,
+    )
+    expect(screen.getByTestId('child-agent-stream-text-tu-parent-5'))
+      .toHaveTextContent('Hello world.')
+  })
+
+  it('clicking a row does not propagate (parent ToolBubble must not collapse)', () => {
+    const onContainerClick = () => {
+      throw new Error('outer onClick should not fire')
+    }
+    render(
+      <div onClick={onContainerClick} role="presentation">
+        <ChildAgentEventList
+          events={[
+            { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+            { type: 'tool_result', payload: { toolUseId: 'c1', result: 'hello' } },
+          ]}
+          parentToolUseId="tu-parent-6"
+        />
+      </div>,
+    )
+    fireEvent.click(screen.getByTestId('child-agent-tool-c1'))
+    // No throw — stopPropagation is working.
+  })
+})

--- a/packages/dashboard/src/components/ChildAgentEventList.test.tsx
+++ b/packages/dashboard/src/components/ChildAgentEventList.test.tsx
@@ -56,6 +56,23 @@ describe('reduceEvents (#5016)', () => {
     expect(out.tools).toHaveLength(0)
   })
 
+  it('inserts a blank-line boundary when stream_delta messageId changes', () => {
+    // Multi-round Tasks fire stream_delta on multiple child messageIds.
+    // Without a boundary, the two paragraphs would fuse mid-sentence.
+    const out = __reduceEventsForTest([
+      { type: 'stream_delta', payload: { messageId: 'r1', delta: 'First.' } },
+      { type: 'stream_delta', payload: { messageId: 'r2', delta: 'Second.' } },
+    ])
+    expect(out.assistantText).toBe('First.\n\nSecond.')
+  })
+
+  it('does not insert a boundary on the very first stream_delta', () => {
+    const out = __reduceEventsForTest([
+      { type: 'stream_delta', payload: { messageId: 'r1', delta: 'Hi.' } },
+    ])
+    expect(out.assistantText).toBe('Hi.')
+  })
+
   it('synthesises a row when tool_result arrives without a preceding tool_start', () => {
     // Defensive against a child race where the events arrive out of order.
     const out = __reduceEventsForTest([

--- a/packages/dashboard/src/components/ChildAgentEventList.tsx
+++ b/packages/dashboard/src/components/ChildAgentEventList.tsx
@@ -1,0 +1,244 @@
+/**
+ * ChildAgentEventList — #5016
+ *
+ * Renders the nested per-event timeline inside a Task tool_call bubble
+ * when the dispatched subagent has emitted intermediate progress
+ * (`tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`)
+ * via the server's `agent_event` re-emit path.
+ *
+ * Design:
+ *   - One row per `tool_start` / `tool_result` pair, keyed by the
+ *     child's `toolUseId`. `tool_input_delta` chunks accumulate onto
+ *     the row's `inputPartial`; `tool_result` resolves the row.
+ *   - `stream_delta` chunks are concatenated into a single text block
+ *     keyed by `messageId` so the child's assistant text reads as one
+ *     paragraph rather than N fragments.
+ *   - The collapsing rules mirror the top-level `ToolBubble`'s: a row
+ *     opens collapsed and expands on click. The default starting state
+ *     is "all collapsed" so a Task with many child tools doesn't
+ *     explode the layout the first time it's expanded.
+ *   - Unknown event types are rendered as a small grey muted line so
+ *     a future event kind (e.g. `result` from the child's per-round
+ *     summary) doesn't disappear silently.
+ *
+ * Why a flat list and not a recursive `ToolBubble`:
+ *   The child's tool_use events are not first-class `ChatMessage`s on
+ *   the parent's `messages` array — they live on
+ *   `ChatMessage.childAgentEvents[]`. A recursive `ToolBubble` would
+ *   need a `ChatMessage[]`-shaped projection; the cost is a duplicate
+ *   render path with subtle drift risk. The flat list keeps the
+ *   reducer trivial (append) and lets us style nested rows distinctly
+ *   ("this is sub-tool progress, not top-level work").
+ *
+ * What this does NOT render in v2:
+ *   - `permission_request` from the child (the server gates these on
+ *     the parent's permission manager today; deferred until the child
+ *     gets its own per-launch permission_mode override surface).
+ *   - Errors from the child are surfaced via the parent's Task
+ *     tool_result `is_error: true` content (the byok-session.js
+ *     fold), so a child error renders in the parent bubble's normal
+ *     result section — no special chip here.
+ */
+
+import { useMemo, useState } from 'react'
+import type { ChildAgentEvent } from '@chroxy/store-core'
+import { formatToolName, getInputSummary, getPartialSummary } from '@chroxy/store-core'
+
+interface ChildAgentEventListProps {
+  events: ChildAgentEvent[]
+  /** Parent Task tool_use id — used to scope testIDs so nested rows from sibling Tasks don't collide. */
+  parentToolUseId: string
+}
+
+/**
+ * One row in the nested list — a tool_use from the child agent, with
+ * its accumulated input + final result text (when present).
+ */
+interface ChildToolRow {
+  /** Child's toolUseId — used as the React key + collapse-state key. */
+  toolUseId: string
+  /** Child's tool name (`Read`, `Bash`, `Grep`, etc.). */
+  toolName: string
+  /** Final input from `tool_start`, when present. */
+  input?: Record<string, unknown> | string
+  /** Accumulated `tool_input_delta` partialJson chunks (best-effort JSON). */
+  inputPartial?: string
+  /** Resolved result text from `tool_result`. */
+  result?: string
+  /** MCP server name if the child invoked an MCP tool. */
+  serverName?: string
+  /** Whether this row has a resolved tool_result. */
+  hasResult: boolean
+}
+
+/**
+ * Reduce the flat `agent_event` log into a structured per-tool list +
+ * one concatenated assistant-text block (or null when the child
+ * produced no streaming text). Pure — recomputed via `useMemo` when
+ * `events` changes.
+ *
+ * The reducer is forgiving:
+ *   - `tool_input_delta` for an unknown `toolUseId` is ignored (no
+ *     matching row to attach to — pre-tool_start, shouldn't happen
+ *     given server ordering but defended).
+ *   - `tool_result` for an unknown `toolUseId` synthesises a row
+ *     (defensive: a race in the child where `tool_result` arrives
+ *     before `tool_start` would otherwise drop the result silently).
+ *   - `stream_delta` chunks without a string `delta` are skipped.
+ */
+function reduceEvents(events: ChildAgentEvent[]): {
+  tools: ChildToolRow[]
+  assistantText: string
+} {
+  const tools: ChildToolRow[] = []
+  const byId = new Map<string, ChildToolRow>()
+  let assistantText = ''
+  for (const ev of events) {
+    const p = ev.payload || {}
+    if (ev.type === 'tool_start') {
+      const toolUseId = typeof p.toolUseId === 'string' ? p.toolUseId : null
+      if (!toolUseId) continue
+      const toolName = typeof p.tool === 'string' ? p.tool : 'tool'
+      const serverName = typeof p.serverName === 'string' ? p.serverName : undefined
+      const input = (p.input && typeof p.input === 'object') || typeof p.input === 'string'
+        ? (p.input as Record<string, unknown> | string)
+        : undefined
+      const existing = byId.get(toolUseId)
+      if (existing) {
+        // Idempotent — a replayed `tool_start` overwrites name/input
+        // but preserves the resolved state.
+        existing.toolName = toolName
+        existing.input = input ?? existing.input
+        existing.serverName = serverName ?? existing.serverName
+        continue
+      }
+      const row: ChildToolRow = {
+        toolUseId,
+        toolName,
+        input,
+        serverName,
+        hasResult: false,
+      }
+      byId.set(toolUseId, row)
+      tools.push(row)
+    } else if (ev.type === 'tool_input_delta') {
+      const toolUseId = typeof p.toolUseId === 'string' ? p.toolUseId : null
+      const partialJson = typeof p.partialJson === 'string' ? p.partialJson : null
+      if (!toolUseId || partialJson === null) continue
+      const row = byId.get(toolUseId)
+      if (!row) continue
+      row.inputPartial = (row.inputPartial || '') + partialJson
+    } else if (ev.type === 'tool_result') {
+      const toolUseId = typeof p.toolUseId === 'string' ? p.toolUseId : null
+      const result = typeof p.result === 'string' ? p.result : ''
+      if (!toolUseId) continue
+      let row = byId.get(toolUseId)
+      if (!row) {
+        // Defensive: tool_result arrived without a preceding
+        // tool_start. Synthesise a row so the result is visible.
+        row = { toolUseId, toolName: 'tool', hasResult: false }
+        byId.set(toolUseId, row)
+        tools.push(row)
+      }
+      row.result = result
+      row.hasResult = true
+    } else if (ev.type === 'stream_delta') {
+      const delta = typeof p.delta === 'string' ? p.delta : null
+      if (delta) assistantText += delta
+    }
+    // Unknown types fall through silently — kept off the rendered
+    // list since they could be permission_request / result / etc.
+    // that aren't part of the nested-bubble surface in v2.
+  }
+  return { tools, assistantText }
+}
+
+export function ChildAgentEventList({ events, parentToolUseId }: ChildAgentEventListProps) {
+  const reduced = useMemo(() => reduceEvents(events), [events])
+  // Collapse-state map keyed by toolUseId. Default = collapsed (false).
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const toggle = (id: string) => setExpanded((s) => ({ ...s, [id]: !s[id] }))
+
+  if (reduced.tools.length === 0 && !reduced.assistantText) {
+    // Render nothing — the parent ToolBubble only mounts us when
+    // there is at least one event, so this branch is the
+    // safety-net for an all-`stream_delta`-empty payload.
+    return null
+  }
+  return (
+    <div
+      className="child-agent-event-list"
+      data-testid={`child-agent-events-${parentToolUseId}`}
+    >
+      <div className="child-agent-event-list-header" data-testid="child-agent-events-header">
+        Subagent progress
+      </div>
+      {reduced.tools.map((row) => {
+        const isExpanded = !!expanded[row.toolUseId]
+        const summary = getInputSummary(row.input)
+          || (row.inputPartial ? getPartialSummary(row.inputPartial) : '')
+          || (row.inputPartial ? row.inputPartial.slice(0, 100) : '')
+        return (
+          <div
+            key={row.toolUseId}
+            className={`child-agent-tool${isExpanded ? ' expanded' : ''}`}
+            data-testid={`child-agent-tool-${row.toolUseId}`}
+            role="button"
+            tabIndex={0}
+            aria-expanded={isExpanded}
+            onClick={(e) => {
+              e.stopPropagation()
+              toggle(row.toolUseId)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                e.stopPropagation()
+                toggle(row.toolUseId)
+              }
+            }}
+          >
+            {!row.hasResult && (
+              <span
+                className="child-agent-tool-pulse"
+                data-testid={`child-agent-tool-pulse-${row.toolUseId}`}
+                aria-hidden="true"
+              />
+            )}
+            <span className="child-agent-tool-name">{formatToolName(row.toolName, row.serverName)}</span>
+            {summary && (
+              <span
+                className="child-agent-tool-input"
+                data-testid={`child-agent-tool-input-${row.toolUseId}`}
+                style={{ color: '#666' }}
+              >
+                {summary}
+              </span>
+            )}
+            {isExpanded && row.result !== undefined && (
+              <div
+                className="child-agent-tool-result"
+                data-testid={`child-agent-tool-result-${row.toolUseId}`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <pre>{row.result}</pre>
+              </div>
+            )}
+          </div>
+        )
+      })}
+      {reduced.assistantText && (
+        <div
+          className="child-agent-stream-text"
+          data-testid={`child-agent-stream-text-${parentToolUseId}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {reduced.assistantText}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Exported for unit-test reach into the reducer without rendering React.
+export { reduceEvents as __reduceEventsForTest }

--- a/packages/dashboard/src/components/ChildAgentEventList.tsx
+++ b/packages/dashboard/src/components/ChildAgentEventList.tsx
@@ -10,16 +10,21 @@
  *   - One row per `tool_start` / `tool_result` pair, keyed by the
  *     child's `toolUseId`. `tool_input_delta` chunks accumulate onto
  *     the row's `inputPartial`; `tool_result` resolves the row.
- *   - `stream_delta` chunks are concatenated into a single text block
- *     keyed by `messageId` so the child's assistant text reads as one
- *     paragraph rather than N fragments.
+ *   - `stream_delta` chunks are concatenated into a single text block;
+ *     contiguous deltas inside the same `messageId` merge directly,
+ *     while a `messageId` transition inserts a blank line so multi-
+ *     round child output doesn't fuse unrelated paragraphs.
  *   - The collapsing rules mirror the top-level `ToolBubble`'s: a row
  *     opens collapsed and expands on click. The default starting state
  *     is "all collapsed" so a Task with many child tools doesn't
  *     explode the layout the first time it's expanded.
- *   - Unknown event types are rendered as a small grey muted line so
- *     a future event kind (e.g. `result` from the child's per-round
- *     summary) doesn't disappear silently.
+ *   - Unknown event types are silently ignored by the reducer (they
+ *     don't appear in the rendered list). This is intentional: today
+ *     the only possible non-recognised types are forward-compat
+ *     payloads (e.g. a future `permission_request` re-emit). A
+ *     surfaced "unknown event" row would confuse users in v2; if a
+ *     new event kind ships, add an explicit branch to the reducer
+ *     and a styled row at the same time.
  *
  * Why a flat list and not a recursive `ToolBubble`:
  *   The child's tool_use events are not first-class `ChatMessage`s on
@@ -93,6 +98,11 @@ function reduceEvents(events: ChildAgentEvent[]): {
   const tools: ChildToolRow[] = []
   const byId = new Map<string, ChildToolRow>()
   let assistantText = ''
+  // Track the messageId of the last stream_delta we appended so we can
+  // insert a blank-line boundary on transition. Without this, multi-
+  // round Tasks (multiple child messageIds within one parent dispatch)
+  // would fuse two unrelated paragraphs of assistant text together.
+  let lastStreamMessageId: string | null = null
   for (const ev of events) {
     const p = ev.payload || {}
     if (ev.type === 'tool_start') {
@@ -144,11 +154,27 @@ function reduceEvents(events: ChildAgentEvent[]): {
       row.hasResult = true
     } else if (ev.type === 'stream_delta') {
       const delta = typeof p.delta === 'string' ? p.delta : null
-      if (delta) assistantText += delta
+      if (delta) {
+        const messageId = typeof p.messageId === 'string' ? p.messageId : null
+        // On a messageId transition (and only if we have any prior
+        // text), insert a blank-line boundary so the previous round's
+        // paragraph is visually separated from the new round.
+        if (
+          messageId
+          && lastStreamMessageId
+          && messageId !== lastStreamMessageId
+          && assistantText.length > 0
+        ) {
+          assistantText += '\n\n'
+        }
+        assistantText += delta
+        if (messageId) lastStreamMessageId = messageId
+      }
     }
-    // Unknown types fall through silently — kept off the rendered
-    // list since they could be permission_request / result / etc.
-    // that aren't part of the nested-bubble surface in v2.
+    // Unknown types fall through silently and are NOT rendered.
+    // Adding a new surface (e.g. nested permission_request rows) means
+    // adding an explicit branch above AND a styled row in the JSX —
+    // a generic "unknown event" line would just be noise to users.
   }
   return { tools, assistantText }
 }

--- a/packages/dashboard/src/components/ToolBubble.tsx
+++ b/packages/dashboard/src/components/ToolBubble.tsx
@@ -29,8 +29,9 @@ import {
   getPartialSummary,
   tryParseCompleteJson,
 } from '@chroxy/store-core'
-import type { ToolResultImage } from '@chroxy/store-core'
+import type { ChildAgentEvent, ToolResultImage } from '@chroxy/store-core'
 import { TodoList, parseTodoList } from './TodoList'
+import { ChildAgentEventList } from './ChildAgentEventList'
 
 export interface ToolBubbleProps {
   toolName: string
@@ -65,6 +66,15 @@ export interface ToolBubbleProps {
    * (#3794) and ActivityIndicator (#4311) so all three surfaces agree.
    */
   resultImages?: ToolResultImage[]
+  /**
+   * #5016 — Task subagent nested progress events. When this Task tool
+   * dispatches a subagent the parent forwards the child's `tool_start`
+   * / `tool_result` / `tool_input_delta` / `stream_delta` events under
+   * the parent's `toolUseId`; the message handler attaches each to
+   * this bubble. Rendered as a nested list inside the expanded
+   * Task tool_call. Only meaningful when `toolName === 'Task'`.
+   */
+  childAgentEvents?: ChildAgentEvent[]
 }
 
 // #4243: `getInputSummary` and `getPartialSummary` now live in
@@ -99,7 +109,7 @@ export interface ToolBubbleProps {
 // what #4655's generic key:value fallback in `tool-summary.ts` is for.
 const SUPPRESS_RAW_INPUT_TOOLS = new Set(['AskUserQuestion'])
 
-export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName, isTail = false, resultImages }: ToolBubbleProps) {
+export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, serverName, isTail = false, resultImages, childAgentEvents }: ToolBubbleProps) {
   // #4313 — tail bubbles mount expanded so the singleton trailing-tool
   // case matches the #4309 tail-group behavior. Initial-state only via
   // the lazy `useState` initializer.
@@ -236,6 +246,23 @@ export function ToolBubble({ toolName, toolUseId, input, inputPartial, result, s
           ) : (
             <pre>{result}</pre>
           )}
+        </div>
+      )}
+      {/* #5016 — Task subagent nested progress. When this bubble is the
+          parent of a Task dispatch, the child's per-tool wire events
+          arrive as `agent_event` and accumulate in `childAgentEvents`.
+          Rendered as a nested list inside the expanded Task tool_call
+          so users can see the subagent's reasoning steps in progress
+          without leaving the parent bubble. Click guard mirrors the
+          tool-result block above — interacting with a nested item must
+          not collapse the outer bubble. */}
+      {expanded && childAgentEvents && childAgentEvents.length > 0 && (
+        <div
+          className="tool-bubble-child-events"
+          data-testid={`tool-bubble-child-events-${toolUseId}`}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <ChildAgentEventList events={childAgentEvents} parentToolUseId={toolUseId} />
         </div>
       )}
       {/* #4081: streaming preview — shown only while expanded AND no

--- a/packages/dashboard/src/components/ToolGroup.tsx
+++ b/packages/dashboard/src/components/ToolGroup.tsx
@@ -17,6 +17,7 @@ import {
   tryParseCompleteJson,
   getInputSummary,
 } from '@chroxy/store-core'
+import { ChildAgentEventList } from './ChildAgentEventList'
 
 export interface ToolGroupProps {
   messages: ChatMessage[]
@@ -192,6 +193,19 @@ function ToolGroupEntry({
               {resultDetail || resultPlaceholder}
             </pre>
           </div>
+          {/* #5016 — Task subagent nested progress in grouped-entry view.
+              When this entry is a Task tool_use whose subagent emitted
+              intermediate events, surface them here so the user sees the
+              same nested rendering as the singleton-bubble path. */}
+          {message.childAgentEvents && message.childAgentEvents.length > 0 && message.toolUseId && (
+            <div className="tool-group-entry-detail-section">
+              <div className="tool-group-entry-detail-label">Subagent</div>
+              <ChildAgentEventList
+                events={message.childAgentEvents}
+                parentToolUseId={message.toolUseId}
+              />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -79,6 +79,10 @@ import {
   handleGitStatusResult as sharedGitStatusResult,
   handleAgentSpawned as sharedAgentSpawned,
   handleAgentCompleted as sharedAgentCompleted,
+  // #5016 — Task subagent nested progress (one wire event per child
+  // `tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`,
+  // attached to the parent Task tool_use bubble's `childAgentEvents[]`).
+  handleAgentEvent as sharedAgentEvent,
   handleBackgroundWorkChanged as sharedBackgroundWorkChanged,
   handleEnvironmentList as sharedEnvironmentList,
   handleEnvironmentError as sharedEnvironmentError,
@@ -2793,6 +2797,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         updateSession(builder.sessionId, (ss) => {
           const next = builder.applyTo(ss.activeAgents);
           return next === ss.activeAgents ? {} : { activeAgents: next };
+        });
+      }
+      break;
+    }
+
+    case 'agent_event': {
+      // #5016 — Task subagent intermediate progress. Builder appends one
+      // entry to the parent Task tool_use bubble's `childAgentEvents[]`.
+      // Same-reference no-op when the parent bubble isn't found (event
+      // arrived before tool_start, which should not happen given the
+      // server's ordering guarantee but is defended).
+      const builder = sharedAgentEvent(msg, get().activeSessionId);
+      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
+        updateSession(builder.sessionId, (ss) => {
+          const next = builder.applyTo(ss.messages);
+          return next === ss.messages ? {} : { messages: next };
         });
       }
       break;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -207,6 +207,35 @@ export declare const ServerAgentCompletedSchema: z.ZodObject<{
     toolUseId: z.ZodString;
 }, z.core.$strip>;
 /**
+ * #5016 — Task subagent intermediate progress event.
+ *
+ * Carries a re-emit of a Task subagent's intermediate wire event
+ * (`tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`)
+ * tagged with the parent Task tool_use id so the dashboard can render
+ * the child's progress as nested sub-bubbles inside the parent's Task
+ * tool_call bubble.
+ *
+ * `parentToolUseId` — the id of the parent's `Task` tool_use block
+ *   (same id used for `agent_spawned` / `agent_completed`). Consumers
+ *   key the nested sub-bubble container off this id.
+ * `eventType` — the child's original event name (e.g. `'tool_start'`).
+ *   Consumers switch on this to render the wire event in the same
+ *   shape they would for a top-level event.
+ * `payload` — the verbatim child event payload. Fields are best-effort;
+ *   renderers MUST treat absence as a no-op.
+ *
+ * Nested Task: when a Task subagent itself dispatches a Task, the
+ * grand-child's events are forwarded up the chain re-tagged with the
+ * IMMEDIATE parent's `toolUseId`. The dashboard sees a flat stream
+ * — nested-nested rendering is intentionally not in v2.
+ */
+export declare const ServerAgentEventSchema: z.ZodObject<{
+    type: z.ZodLiteral<"agent_event">;
+    parentToolUseId: z.ZodString;
+    eventType: z.ZodString;
+    payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
+}, z.core.$strip>;
+/**
  * #4307 — one entry per backgrounded `Bash` shell the session is still
  * waiting on. Pushed when the agent dispatches a `Bash` tool call with
  * `run_in_background: true` (the matching tool_result carries the

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -287,6 +287,35 @@ export const ServerAgentCompletedSchema = z.object({
     toolUseId: z.string(),
 });
 /**
+ * #5016 — Task subagent intermediate progress event.
+ *
+ * Carries a re-emit of a Task subagent's intermediate wire event
+ * (`tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`)
+ * tagged with the parent Task tool_use id so the dashboard can render
+ * the child's progress as nested sub-bubbles inside the parent's Task
+ * tool_call bubble.
+ *
+ * `parentToolUseId` — the id of the parent's `Task` tool_use block
+ *   (same id used for `agent_spawned` / `agent_completed`). Consumers
+ *   key the nested sub-bubble container off this id.
+ * `eventType` — the child's original event name (e.g. `'tool_start'`).
+ *   Consumers switch on this to render the wire event in the same
+ *   shape they would for a top-level event.
+ * `payload` — the verbatim child event payload. Fields are best-effort;
+ *   renderers MUST treat absence as a no-op.
+ *
+ * Nested Task: when a Task subagent itself dispatches a Task, the
+ * grand-child's events are forwarded up the chain re-tagged with the
+ * IMMEDIATE parent's `toolUseId`. The dashboard sees a flat stream
+ * — nested-nested rendering is intentionally not in v2.
+ */
+export const ServerAgentEventSchema = z.object({
+    type: z.literal('agent_event'),
+    parentToolUseId: z.string(),
+    eventType: z.string(),
+    payload: z.record(z.string(), z.unknown()),
+});
+/**
  * #4307 — one entry per backgrounded `Bash` shell the session is still
  * waiting on. Pushed when the agent dispatches a `Bash` tool call with
  * `run_in_background: true` (the matching tool_result carries the

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -316,6 +316,36 @@ export const ServerAgentCompletedSchema = z.object({
 })
 
 /**
+ * #5016 — Task subagent intermediate progress event.
+ *
+ * Carries a re-emit of a Task subagent's intermediate wire event
+ * (`tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`)
+ * tagged with the parent Task tool_use id so the dashboard can render
+ * the child's progress as nested sub-bubbles inside the parent's Task
+ * tool_call bubble.
+ *
+ * `parentToolUseId` — the id of the parent's `Task` tool_use block
+ *   (same id used for `agent_spawned` / `agent_completed`). Consumers
+ *   key the nested sub-bubble container off this id.
+ * `eventType` — the child's original event name (e.g. `'tool_start'`).
+ *   Consumers switch on this to render the wire event in the same
+ *   shape they would for a top-level event.
+ * `payload` — the verbatim child event payload. Fields are best-effort;
+ *   renderers MUST treat absence as a no-op.
+ *
+ * Nested Task: when a Task subagent itself dispatches a Task, the
+ * grand-child's events are forwarded up the chain re-tagged with the
+ * IMMEDIATE parent's `toolUseId`. The dashboard sees a flat stream
+ * — nested-nested rendering is intentionally not in v2.
+ */
+export const ServerAgentEventSchema = z.object({
+  type: z.literal('agent_event'),
+  parentToolUseId: z.string(),
+  eventType: z.string(),
+  payload: z.record(z.string(), z.unknown()),
+})
+
+/**
  * #4307 — one entry per backgrounded `Bash` shell the session is still
  * waiting on. Pushed when the agent dispatches a `Bash` tool call with
  * `run_in_background: true` (the matching tool_result carries the

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -103,6 +103,7 @@ const PLATFORM_SPECIFIC = {
   // Coverage test passes because each handler has a
   // `case 'multi_question_intervention':` clause.
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
+  'agent_event': 'dashboard', // #5016 — Task subagent intermediate progress wire-event re-emit; dashboard renders nested sub-bubbles inside the parent Task tool_call. Mobile app rendering is the v2-deferred follow-up tracked in #5060.
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -116,7 +116,13 @@ export class ClaudeByokSession extends BaseSession {
     // being listed), but pin them here so the capability matrix /
     // dashboard introspection reflect that this provider emits them
     // when the Task tool dispatches a subagent.
-    return ['tool_start', 'tool_result', 'tool_input_delta', 'agent_spawned', 'agent_completed']
+    //
+    // #5016: `agent_event` carries the child Task subagent's intermediate
+    // wire events (tool_start / tool_result / tool_input_delta /
+    // stream_delta / result) tagged with the parent `toolUseId` so the
+    // dashboard can render the child's progress as nested sub-bubbles
+    // under the parent's Task tool_call.
+    return ['tool_start', 'tool_result', 'tool_input_delta', 'agent_spawned', 'agent_completed', 'agent_event']
   }
 
   /**
@@ -1295,6 +1301,9 @@ export class ClaudeByokSession extends BaseSession {
 
     child.on('stream_delta', (e) => {
       if (typeof e?.delta === 'string') textChunks.push(e.delta)
+      // #5016: forward the child's stream_delta to the parent so the
+      // dashboard can render its assistant text as a nested sub-bubble.
+      this._emitAgentEvent(toolUseId, 'stream_delta', e)
     })
     child.on('result', (e) => {
       const u = e?.usage || {}
@@ -1315,6 +1324,30 @@ export class ClaudeByokSession extends BaseSession {
       // abort, or stream-init throw), stream_end still resolves the
       // promise so this method doesn't hang the parent's tool loop.
       resolveDone()
+    })
+    // #5016: forward the child's per-tool wire events to the parent as
+    // `agent_event` carrying the parent toolUseId so the dashboard
+    // groups them under the Task tool_call bubble. Cost / usage are
+    // intentionally NOT replayed here (they fold once via the parent's
+    // own per-turn accumulators above — no double-counting).
+    child.on('tool_start', (e) => {
+      this._emitAgentEvent(toolUseId, 'tool_start', e)
+    })
+    child.on('tool_input_delta', (e) => {
+      this._emitAgentEvent(toolUseId, 'tool_input_delta', e)
+    })
+    child.on('tool_result', (e) => {
+      this._emitAgentEvent(toolUseId, 'tool_result', e)
+    })
+    // #5016: when the child itself dispatches a Task (grand-child),
+    // its own `agent_event` fires on the child. Forward those too,
+    // re-tagged with THIS parent's toolUseId so the dashboard groups
+    // all descendants under the outermost Task bubble. The original
+    // (grand-child) `parentToolUseId` is preserved on the payload's
+    // `parentToolUseId` for downstream renderers that may want to
+    // distinguish depth.
+    child.on('agent_event', (e) => {
+      this._emitAgentEvent(toolUseId, e?.type || 'agent_event', e?.payload ?? {})
     })
 
     // Register a cascade hook on the parent's signal — interrupt()
@@ -1384,6 +1417,43 @@ export class ClaudeByokSession extends BaseSession {
       }
     }
     return { content: summary, isError: false }
+  }
+
+  /**
+   * #5016: re-emit a Task subagent's intermediate wire event under the
+   * parent's `agent_event` channel so the dashboard can render nested
+   * sub-bubbles inside the parent's Task tool_call.
+   *
+   * `parentToolUseId` is the toolUseId of the parent's Task tool_use
+   * block (the same id used for `agent_spawned` / `agent_completed`) —
+   * the consumer keys the nested sub-bubble container off this id.
+   *
+   * `type` is the child's original event name (`tool_start`,
+   * `tool_input_delta`, `tool_result`, `stream_delta`). The dashboard
+   * switches on this to render the child's wire event in the same
+   * shape it would for a top-level event.
+   *
+   * `payload` is the original child event payload, passed through
+   * verbatim. Renderers MUST treat fields as best-effort (some payloads
+   * carry messageId / toolUseId, others carry delta text only).
+   *
+   * Nested-Task support: when a Task subagent itself dispatches a Task,
+   * the grand-child's events arrive as `agent_event` on the child
+   * (because each session's `_emitAgentEvent` re-emits to itself), and
+   * we surface them on the parent under the parent's toolUseId. This
+   * means the dashboard sees a flat stream tagged with the IMMEDIATE
+   * parent's id — nested-nested rendering is intentionally not in v2.
+   *
+   * @param {string} parentToolUseId
+   * @param {string} type
+   * @param {object} payload
+   */
+  _emitAgentEvent(parentToolUseId, type, payload) {
+    this.emit('agent_event', {
+      parentToolUseId,
+      type,
+      payload: payload ?? {},
+    })
   }
 
   /**

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -118,10 +118,14 @@ export class ClaudeByokSession extends BaseSession {
     // when the Task tool dispatches a subagent.
     //
     // #5016: `agent_event` carries the child Task subagent's intermediate
-    // wire events (tool_start / tool_result / tool_input_delta /
-    // stream_delta / result) tagged with the parent `toolUseId` so the
-    // dashboard can render the child's progress as nested sub-bubbles
-    // under the parent's Task tool_call.
+    // wire events (tool_start / tool_input_delta / tool_result /
+    // stream_delta) tagged with the parent `toolUseId` so the dashboard
+    // can render the child's progress as nested sub-bubbles under the
+    // parent's Task tool_call. The child's `result` is intentionally NOT
+    // forwarded — usage/cost folds into the parent's per-turn
+    // accumulator and the final summary text becomes the parent's
+    // Task tool_result content; replaying it as a nested event would
+    // double-render the same content.
     return ['tool_start', 'tool_result', 'tool_input_delta', 'agent_spawned', 'agent_completed', 'agent_event']
   }
 
@@ -1345,9 +1349,23 @@ export class ClaudeByokSession extends BaseSession {
     // all descendants under the outermost Task bubble. The original
     // (grand-child) `parentToolUseId` is preserved on the payload's
     // `parentToolUseId` for downstream renderers that may want to
-    // distinguish depth.
+    // distinguish depth — we merge it INTO the forwarded payload so
+    // consumers can read `payload.parentToolUseId` to recover the
+    // immediate-parent (grand-child Task) id. Without this merge the
+    // grand-child's id is lost on the way up; the comment claimed
+    // preservation but the original implementation dropped it.
+    // A non-string `e?.type` would re-emit as `'agent_event'` which
+    // the consumer reducer doesn't recognise — skip those so noise
+    // doesn't reach the wire.
     child.on('agent_event', (e) => {
-      this._emitAgentEvent(toolUseId, e?.type || 'agent_event', e?.payload ?? {})
+      if (typeof e?.type !== 'string') return
+      const basePayload = (e?.payload && typeof e.payload === 'object' && !Array.isArray(e.payload))
+        ? e.payload
+        : {}
+      const mergedPayload = e?.parentToolUseId
+        ? { ...basePayload, parentToolUseId: e.parentToolUseId }
+        : basePayload
+      this._emitAgentEvent(toolUseId, e.type, mergedPayload)
     })
 
     // Register a cascade hook on the parent's signal — interrupt()

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -145,6 +145,24 @@ Object.assign(EVENT_MAP, {
     }],
   }),
 
+  // #5016: nested-sub-bubble support — a Task subagent's intermediate
+  // wire event (tool_start / tool_result / tool_input_delta /
+  // stream_delta) re-emitted by the parent under `agent_event` so the
+  // dashboard renders it inside the parent's Task tool_call bubble.
+  // `parentToolUseId` is the parent's tool_use id (same key used by
+  // agent_spawned / agent_completed). `eventType` is the child's
+  // original event name. `payload` is the verbatim child event payload.
+  agent_event: (data) => ({
+    messages: [{
+      msg: {
+        type: 'agent_event',
+        parentToolUseId: data.parentToolUseId,
+        eventType: data.type,
+        payload: data.payload ?? {},
+      },
+    }],
+  }),
+
   // #4307: pending-background-shells snapshot changed for a session.
   // BaseSession emits this on both push (run_in_background tool_result
   // observed) and clear (BashOutput tool_use observed). Full snapshot

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1712,7 +1712,11 @@ export class SessionManager extends EventEmitter {
     // Transient so it isn't replayed on reconnect — by the time a client
     // reconnects, either the session was destroyed or the user already saw
     // the confirmation.
-    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted', 'inactivity_warning', 'background_work_changed', 'stopped']
+    // #5016: `agent_event` carries a Task subagent's intermediate wire
+    // events (tool_start / tool_result / tool_input_delta / stream_delta)
+    // tagged with the parent's toolUseId. Transient (not replayed on
+    // reconnect — the canonical Task tool_result fold lands in history).
+    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'agent_event', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted', 'inactivity_warning', 'background_work_changed', 'stopped']
     const customEvents = Array.isArray(session.constructor.customEvents) ? session.constructor.customEvents : []
     const TRANSIENT_EVENTS = [...new Set([...builtinTransient, ...customEvents])]
     for (const event of TRANSIENT_EVENTS) {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -387,6 +387,7 @@ function _isSecureRequest(req) {
  *   { type: 'rate_limited', message }                   — client rate-limited
  *   { type: 'agent_spawned', sessionId, agentId, parentToolId, model } — background agent spawned
  *   { type: 'agent_completed', sessionId, agentId, parentToolId }       — background agent completed
+ *   { type: 'agent_event', sessionId, parentToolUseId, eventType, payload } — Task subagent intermediate wire event re-emit (#5016, transient; eventType is one of `tool_start` / `tool_input_delta` / `tool_result` / `stream_delta`)
  *   { type: 'background_work_changed', sessionId, pending } — pending background shells snapshot changed (#4307, transient; `pending: [{ shellId, command, startedAt }, …]`)
  *   { type: 'provider_list', providers }                — available providers
  *   { type: 'byok_credentials_status', requestId?, status, source, masked?, reason? } — BYOK credentials state for the dashboard (#4052)

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3846,6 +3846,11 @@ describe('ClaudeByokSession', () => {
       assert.ok(forwarded, 'grand-child tool_start must be forwarded')
       assert.equal(forwarded.parentToolUseId, 'tu_task_5016',
         'grand-child events must re-tag with the OUTERMOST parent toolUseId')
+      // The original grand-child parentToolUseId (immediate parent = the
+      // child Task) is preserved on payload.parentToolUseId so
+      // depth-aware consumers can reconstruct the chain.
+      assert.equal(forwarded.payload.parentToolUseId, 'tu_grandchild_task',
+        'grand-child events must preserve the immediate parent toolUseId on payload')
     })
 
     it('agent_event listed in customEvents so SessionManager forwards it as a transient event', () => {

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3719,6 +3719,141 @@ describe('ClaudeByokSession', () => {
     })
   })
 
+  describe('Task subagent nested progress events (#5016)', () => {
+    /**
+     * Build a parent that emits a single Task tool_use. Once the child
+     * is registered we manually drive its EventEmitter via the captured
+     * reference so we can simulate the child emitting tool_start /
+     * tool_input_delta / tool_result / stream_delta without having to
+     * stand up a second full agent loop. The parent's `_executeTaskTool`
+     * subscribes to those child events and re-emits `agent_event` —
+     * which is what these tests exercise.
+     */
+    async function runTaskAndDriveChild(driveChild) {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      // Force-allow any parent permission check (mirrors the override
+      // tests). These cases focus on event forwarding inside
+      // _executeTaskTool; permission gating is exercised elsewhere.
+      session._gateToolBlock = async () => ({ behavior: 'allow' })
+      const captured = []
+      session.on('agent_event', (e) => captured.push(e))
+      session.on('agent_spawned', (e) => captured.push({ ...e, _name: 'agent_spawned' }))
+      session.on('agent_completed', (e) => captured.push({ ...e, _name: 'agent_completed' }))
+      // Replace the child-construction step so we can grab the child
+      // reference + control its `sendMessage` to deterministically emit
+      // a sequence of intermediate events, then resolve.
+      let childRef = null
+      const origSet = session._subagentSessions.set.bind(session._subagentSessions)
+      session._subagentSessions.set = (k, v) => {
+        childRef = v
+        // Stub child.sendMessage to drive the simulated child events,
+        // then emit `result` (which causes _executeTaskTool's done
+        // promise to resolve and finalise the parent's tool_result).
+        v.sendMessage = async () => {
+          await driveChild(v)
+          v.emit('result', {
+            messageId: 'cm_1',
+            usage: { input_tokens: 10, output_tokens: 20 },
+            cost: 0,
+          })
+          v.emit('stream_end', { messageId: 'cm_1' })
+          v._isBusy = false
+        }
+        return origSet(k, v)
+      }
+      // Stub parent's client to emit Task once then end-turn.
+      let parentRound = 0
+      session._client = {
+        messages: {
+          stream: () => {
+            parentRound += 1
+            if (parentRound === 1) {
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'tu_task_5016', name: 'Task', input: { description: 'd', prompt: 'p' } }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }],
+              { stop_reason: 'end_turn', content: [{ type: 'text', text: 'done' }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      await session.start()
+      await session.sendMessage('go')
+      await session.destroy()
+      return { captured, childRef }
+    }
+
+    it('re-emits child tool_start/tool_input_delta/tool_result as agent_event tagged with parentToolUseId', async () => {
+      const { captured } = await runTaskAndDriveChild((child) => {
+        child.emit('tool_start', { messageId: 'cm_1', toolUseId: 'tu_child_read', tool: 'Read', input: { file_path: '/tmp/x.txt' } })
+        child.emit('tool_input_delta', { messageId: 'cm_1', toolUseId: 'tu_child_read', partialJson: '{"file_path":' })
+        child.emit('tool_input_delta', { messageId: 'cm_1', toolUseId: 'tu_child_read', partialJson: '"/tmp/x.txt"}' })
+        child.emit('tool_result', { messageId: 'cm_1', toolUseId: 'tu_child_read', result: 'hello\nfrom child', isError: false })
+      })
+      const events = captured.filter((e) => e.parentToolUseId)
+      assert.ok(events.length >= 4, `expected >=4 agent_events, got ${events.length}`)
+      // Each event carries the parent's toolUseId, the child's wire
+      // event name, and the verbatim child payload.
+      assert.ok(events.every((e) => e.parentToolUseId === 'tu_task_5016'),
+        'every agent_event must carry the parent toolUseId')
+      const toolStart = events.find((e) => e.type === 'tool_start')
+      assert.ok(toolStart)
+      assert.equal(toolStart.payload.toolUseId, 'tu_child_read')
+      assert.equal(toolStart.payload.tool, 'Read')
+      const toolResult = events.find((e) => e.type === 'tool_result')
+      assert.ok(toolResult)
+      assert.equal(toolResult.payload.toolUseId, 'tu_child_read')
+      assert.equal(toolResult.payload.result, 'hello\nfrom child')
+      const deltas = events.filter((e) => e.type === 'tool_input_delta')
+      assert.equal(deltas.length, 2)
+      assert.equal(deltas[0].payload.partialJson, '{"file_path":')
+      assert.equal(deltas[1].payload.partialJson, '"/tmp/x.txt"}')
+    })
+
+    it('re-emits child stream_delta as agent_event so dashboard sees child assistant text', async () => {
+      const { captured } = await runTaskAndDriveChild((child) => {
+        child.emit('stream_delta', { messageId: 'cm_1', delta: 'Hello ' })
+        child.emit('stream_delta', { messageId: 'cm_1', delta: 'world.' })
+      })
+      const deltas = captured.filter((e) => e.type === 'stream_delta')
+      assert.equal(deltas.length, 2, 'both stream_delta chunks must be re-emitted')
+      assert.equal(deltas[0].parentToolUseId, 'tu_task_5016')
+      assert.equal(deltas[0].payload.delta, 'Hello ')
+      assert.equal(deltas[1].payload.delta, 'world.')
+    })
+
+    it('nested Task: grand-child agent_event is re-tagged with the outermost parent toolUseId', async () => {
+      // The child's `agent_event` listener forwards grand-child progress
+      // up the chain re-tagged with THIS parent's toolUseId. Simulate
+      // by emitting a synthetic `agent_event` on the child as if the
+      // child itself had dispatched a Task.
+      const { captured } = await runTaskAndDriveChild((child) => {
+        child.emit('agent_event', {
+          parentToolUseId: 'tu_grandchild_task',
+          type: 'tool_start',
+          payload: { messageId: 'gc_1', toolUseId: 'tu_gc_read', tool: 'Read', input: {} },
+        })
+      })
+      const forwarded = captured.find((e) => e.type === 'tool_start' && e.payload.toolUseId === 'tu_gc_read')
+      assert.ok(forwarded, 'grand-child tool_start must be forwarded')
+      assert.equal(forwarded.parentToolUseId, 'tu_task_5016',
+        'grand-child events must re-tag with the OUTERMOST parent toolUseId')
+    })
+
+    it('agent_event listed in customEvents so SessionManager forwards it as a transient event', () => {
+      assert.ok(ClaudeByokSession.customEvents.includes('agent_event'),
+        'agent_event must be in customEvents for ws-forwarding to pick it up')
+    })
+  })
+
   describe('lifecycle', () => {
     it('destroy() is idempotent and clears history', async () => {
       const session = new ClaudeByokSession({ cwd: '/tmp' })

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -73,6 +73,7 @@ import {
   handleGitCommitResult,
   handleAgentSpawned,
   handleAgentCompleted,
+  handleAgentEvent,
   handleBackgroundWorkChanged,
   handleEnvironmentList,
   handleEnvironmentError,
@@ -3857,6 +3858,140 @@ describe('handleAgentCompleted', () => {
       'tu-1',
       'tu-3',
     ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #5016 — handleAgentEvent (Task subagent nested progress)
+// ---------------------------------------------------------------------------
+describe('handleAgentEvent (#5016)', () => {
+  const mkTaskBubble = (toolUseId: string): ChatMessage => ({
+    id: 'm-' + toolUseId,
+    type: 'tool_use',
+    content: '',
+    tool: 'Task',
+    toolUseId,
+    timestamp: 1000,
+  })
+
+  it('appends a child event to the parent Task tool_use bubble', () => {
+    const existing: ChatMessage[] = [mkTaskBubble('tu-task-1')]
+    const builder = handleAgentEvent(
+      {
+        sessionId: 'sess-1',
+        parentToolUseId: 'tu-task-1',
+        eventType: 'tool_start',
+        payload: { toolUseId: 'tu-child-1', tool: 'Read', input: { file_path: '/a' } },
+      },
+      'active-1',
+    )
+    expect(builder.sessionId).toBe('sess-1')
+    const next = builder.applyTo(existing)
+    expect(next).not.toBe(existing)
+    expect(next[0]?.childAgentEvents).toEqual([
+      { type: 'tool_start', payload: { toolUseId: 'tu-child-1', tool: 'Read', input: { file_path: '/a' } } },
+    ])
+  })
+
+  it('accumulates multiple child events in order on the same bubble', () => {
+    let messages: ChatMessage[] = [mkTaskBubble('tu-task-2')]
+    const events: { eventType: string; payload: Record<string, unknown> }[] = [
+      { eventType: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+      { eventType: 'tool_input_delta', payload: { toolUseId: 'c1', partialJson: '{"x":' } },
+      { eventType: 'tool_result', payload: { toolUseId: 'c1', result: 'hello' } },
+    ]
+    for (const ev of events) {
+      const builder = handleAgentEvent(
+        { parentToolUseId: 'tu-task-2', ...ev },
+        'active-1',
+      )
+      messages = builder.applyTo(messages)
+    }
+    expect(messages[0]?.childAgentEvents).toHaveLength(3)
+    expect(messages[0]?.childAgentEvents?.map((e) => e.type)).toEqual([
+      'tool_start',
+      'tool_input_delta',
+      'tool_result',
+    ])
+  })
+
+  it('returns the same array reference when parentToolUseId is missing', () => {
+    const existing: ChatMessage[] = [mkTaskBubble('tu-task-3')]
+    const builder = handleAgentEvent(
+      { eventType: 'tool_start', payload: {} },
+      'active-1',
+    )
+    expect(builder.applyTo(existing)).toBe(existing)
+  })
+
+  it('returns the same array reference when eventType is missing/empty', () => {
+    const existing: ChatMessage[] = [mkTaskBubble('tu-task-4')]
+    const builder = handleAgentEvent(
+      { parentToolUseId: 'tu-task-4', payload: {} },
+      'active-1',
+    )
+    expect(builder.applyTo(existing)).toBe(existing)
+  })
+
+  it('returns the same array reference when no matching parent bubble exists', () => {
+    const existing: ChatMessage[] = [mkTaskBubble('tu-task-5')]
+    const builder = handleAgentEvent(
+      {
+        parentToolUseId: 'tu-task-NOT-PRESENT',
+        eventType: 'tool_start',
+        payload: { toolUseId: 'c1' },
+      },
+      'active-1',
+    )
+    expect(builder.applyTo(existing)).toBe(existing)
+  })
+
+  it('ignores bubbles whose type is not tool_use even when toolUseId matches', () => {
+    const existing: ChatMessage[] = [
+      // A `response` bubble that happens to carry the same id —
+      // shouldn't be mutated.
+      {
+        id: 'm-decoy',
+        type: 'response',
+        content: 'parent text',
+        toolUseId: 'tu-task-6',
+        timestamp: 100,
+      },
+      mkTaskBubble('tu-task-6'),
+    ]
+    const builder = handleAgentEvent(
+      {
+        parentToolUseId: 'tu-task-6',
+        eventType: 'stream_delta',
+        payload: { delta: 'hi' },
+      },
+      'active-1',
+    )
+    const next = builder.applyTo(existing)
+    // Only the tool_use bubble is patched.
+    expect(next[0]).toBe(existing[0])
+    expect(next[1]?.childAgentEvents).toHaveLength(1)
+  })
+
+  it('normalises non-object payload to {}', () => {
+    const existing: ChatMessage[] = [mkTaskBubble('tu-task-7')]
+    const builder = handleAgentEvent(
+      {
+        parentToolUseId: 'tu-task-7',
+        eventType: 'stream_delta',
+        payload: null,
+      },
+      'active-1',
+    )
+    expect(builder.applyTo(existing)[0]?.childAgentEvents?.[0]?.payload).toEqual({})
+  })
+
+  it('falls back to active session when message has no sessionId', () => {
+    const builder = handleAgentEvent(
+      { parentToolUseId: 'x', eventType: 'tool_start', payload: {} },
+      'active-1',
+    )
+    expect(builder.sessionId).toBe('active-1')
   })
 })
 

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -2875,6 +2875,93 @@ export function handleAgentCompleted(
 }
 
 // ---------------------------------------------------------------------------
+// #5016 — agent_event (Task subagent nested progress)
+//
+// Server forwards each child wire event (tool_start / tool_result /
+// tool_input_delta / stream_delta) as `agent_event{parentToolUseId,
+// eventType, payload}`. This handler resolves the target session and
+// returns a builder that appends the event to the parent Task `tool_use`
+// bubble's `childAgentEvents[]`. Renderers iterate the list to surface
+// nested sub-bubbles inside the Task tool_call.
+//
+// Coalescing: `stream_delta` events are appended verbatim — the
+// renderer concatenates contiguous deltas per messageId. We don't
+// coalesce in the handler because the child's stream may carry
+// multiple distinct `messageId`s across rounds within one Task, and
+// the renderer is the source of truth for grouping by id.
+// ---------------------------------------------------------------------------
+
+/** Builder result for `agent_event` — patch depends on the existing message list. */
+export interface AgentEventBuilder {
+  sessionId: string | null
+  /**
+   * Apply the builder to the session's current chat-message list.
+   * Returns the same reference when no matching parent bubble is
+   * present (event arrives before the Task tool_use is registered —
+   * extremely rare given the server's ordering guarantee that
+   * tool_start fires before any nested agent_event, but defended
+   * for robustness against test stubs and replay paths).
+   */
+  applyTo: (current: ChatMessage[]) => ChatMessage[]
+}
+
+/**
+ * Resolve target session and produce a builder that appends one nested
+ * child wire event to the parent Task tool_use bubble's
+ * `childAgentEvents[]`.
+ *
+ * Missing / non-string `parentToolUseId` is a no-op (returns same
+ * reference). Missing / non-string `eventType` is also a no-op — the
+ * downstream renderer keys on `type`, and a bubble with `type: ''`
+ * would render nothing useful while still bloating state.
+ *
+ * `payload` is normalised to `{}` when missing / non-object so the
+ * `ChildAgentEvent.payload` field stays a stable plain object shape.
+ * Arrays and primitives are rejected (treated as `{}`) — payloads
+ * from the server are always objects.
+ *
+ * No-op when the parent bubble is absent: the event is dropped on the
+ * floor. We deliberately do NOT buffer pending events for a parent
+ * that hasn't arrived yet — the server's ordering guarantees that the
+ * parent's `tool_start` (which creates the bubble) fires before any
+ * nested `agent_event` carrying its `toolUseId`. If that invariant
+ * breaks in future, the symptom is a missing sub-bubble (visible to
+ * users), not data corruption.
+ */
+export function handleAgentEvent(
+  msg: Record<string, unknown>,
+  activeSessionId: string | null,
+): AgentEventBuilder {
+  const parentToolUseId = typeof msg.parentToolUseId === 'string'
+    ? msg.parentToolUseId
+    : null
+  const eventType = typeof msg.eventType === 'string' && msg.eventType
+    ? msg.eventType
+    : null
+  const rawPayload = msg.payload
+  const payload: Record<string, unknown> =
+    rawPayload !== null
+    && typeof rawPayload === 'object'
+    && !Array.isArray(rawPayload)
+      ? (rawPayload as Record<string, unknown>)
+      : {}
+  return {
+    sessionId: resolveSessionId(msg, activeSessionId),
+    applyTo: (current) => {
+      if (!parentToolUseId || !eventType) return current
+      let mutated = false
+      const next = current.map((m) => {
+        if (m.type !== 'tool_use' || m.toolUseId !== parentToolUseId) return m
+        mutated = true
+        const nextEvents = [...(m.childAgentEvents || []), { type: eventType, payload }]
+        return { ...m, childAgentEvents: nextEvents }
+      })
+      return mutated ? next : current
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
 // #4307 — background_work_changed
 //
 // Snapshot-replacement: each event carries the full pending list for the

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -28,6 +28,9 @@ export type {
   MessageAttachment,
   ToolResultImage,
   ChatMessage,
+  // #5016 — one nested wire event from a Task subagent, attached to
+  // the parent Task tool_use bubble via `ChatMessage.childAgentEvents[]`.
+  ChildAgentEvent,
   // #4604 Chunk B — one entry per question in a multi-question AskUserQuestion form
   ChatMessageQuestion,
   // #3188: auto-evaluator rewrite metadata attached to system ChatMessages
@@ -407,6 +410,9 @@ export {
   handleGitCommitResult,
   handleAgentSpawned,
   handleAgentCompleted,
+  // #5016 — Task subagent nested progress (one wire event per child
+  // `tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`).
+  handleAgentEvent,
   handleBackgroundWorkChanged,
   handleEnvironmentList,
   handleEnvironmentError,

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -157,6 +157,34 @@ export interface ChatMessage {
    * the banner from the cached metadata.
    */
   evaluator?: EvaluatorRewriteMeta;
+  /**
+   * #5016 — Task subagent child progress, attached to the parent's
+   * `tool_use` (Task) bubble. Each entry is one wire event the child
+   * emitted (re-emitted by the parent as `agent_event` and routed back
+   * to the parent bubble by `handleAgentEvent`). Renderers iterate this
+   * list to surface nested sub-bubbles inside the Task tool_call.
+   *
+   * Only set on `type: 'tool_use'` bubbles whose `toolUseId` matches a
+   * Task tool_use whose subagent emitted at least one progress event.
+   * Undefined for all other bubbles and for Task tool_use bubbles whose
+   * child finished without intermediate output (rare — child went
+   * straight from spawn to final text in one shot).
+   */
+  childAgentEvents?: ChildAgentEvent[];
+}
+
+/**
+ * #5016 — One nested wire event emitted by a Task subagent. Kept
+ * shape-loose because the underlying payload mirrors the server's
+ * `tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`
+ * event shapes, and a strict union here would duplicate that surface.
+ * Renderers switch on `type` and access the fields they recognise.
+ */
+export interface ChildAgentEvent {
+  /** Wire event name (`'tool_start'`, `'tool_result'`, `'tool_input_delta'`, `'stream_delta'`). */
+  type: string;
+  /** Verbatim payload from the child's event (shape depends on `type`). */
+  payload: Record<string, unknown>;
 }
 
 export interface SavedConnection {


### PR DESCRIPTION
## Summary

PR #5015 wired the byok `Task` subagent tool with `agent_spawned` / `agent_completed` lifecycle events. The child's intermediate `tool_start` / `tool_result` / `tool_input_delta` / `stream_delta` events fired silently on the child's `EventEmitter` — the dashboard saw the parent's tool_call bubble open and close with no progress in between.

This wires the v2 nested-sub-bubble surface across server, protocol, store-core, and dashboard.

## What changes

- **Server (`byok-session.js`)** — `_executeTaskTool` subscribes to the child's wire events and re-emits them on the parent under a new `agent_event` channel tagged with `parentToolUseId`. Nested Task is handled by forwarding the child's own `agent_event` re-tagged with the outermost parent's `toolUseId`. New `_emitAgentEvent` helper centralises the emit. `customEvents` advertises `agent_event`.
- **Protocol** — adds `ServerAgentEventSchema { type, parentToolUseId, eventType, payload }`. `session-manager.js` adds `agent_event` to the built-in transient events list so it forwards to clients. `event-normalizer.js` translates the session event into the wire message.
- **store-core** — `handleAgentEvent` resolves the target session and produces a builder that appends the event to the parent Task `tool_use` bubble's new `childAgentEvents[]` array. `ChildAgentEvent` type and `ChatMessage.childAgentEvents` field added.
- **Dashboard** — `ToolBubble` and `ToolGroup` render the nested events via a new `ChildAgentEventList` component. The list reduces the flat event log into per-tool rows (`tool_start` / `tool_input_delta` / `tool_result`) plus concatenated assistant text from `stream_delta`. Rows start collapsed and expand on click. `stopPropagation` is wired so clicking a nested row does not collapse the outer Task bubble.

Cost / usage accounting is unchanged — the existing per-turn fold in `_subagentUsageThisTurn` / `_subagentCostThisTurn` remains the source of truth; `agent_event` is cosmetic for the dashboard. Mobile rendering is intentionally deferred to a follow-up (issue scope is `(v2)` on the dashboard).

## Scope note

Total diff is ~1000 LOC including ~460 LOC of tests and a ~240 LOC new component. The implementation itself is ~250 LOC of source code; the rest is comments matching repo style and a dedicated component file. Slightly over the soft scope budget but the surface is one coherent feature — splitting it into 3 PRs (server forwarding / protocol+consumer / UI) would have produced larger total cost in coordination and review overhead.

## Test plan

- [x] **Server byok-session** — re-emit of child `tool_start` / `tool_input_delta` / `tool_result` / `stream_delta` carries `parentToolUseId`; nested Task grand-child events are re-tagged with the outer parent's id; `customEvents` includes `agent_event`. (4 new tests, all 117 byok-session tests pass.)
- [x] **store-core handler** — `handleAgentEvent` appends to the right bubble, no-ops on missing parent / missing eventType / unknown parent bubble / non-`tool_use` match; normalises non-object payloads; falls back to `activeSessionId`. (8 new tests, all 1081 store-core tests pass.)
- [x] **Dashboard component** — `ChildAgentEventList` reducer (per-tool row construction, `stream_delta` concatenation, out-of-order `tool_result` synthesis, unknown-type forward-compat, replay-preserves-resolved) + render (collapse / expand / `stopPropagation` / pulse marker on unresolved). (15 new tests, all 2864 dashboard tests pass.)
- [x] **Server lints** — `lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`, `lint-logger-session-scoping.sh` all green.
- [x] **TS** — protocol, store-core, dashboard, app typechecks all clean.
- [ ] Manual smoke (deferred to the merge checklist) — dispatch a Task in the dashboard, expand the bubble, confirm child progress lights up nested as the subagent fires its first `Read`/`Bash`.

Closes #5016