### PR TITLE
feat(server): support postCreateCommand opt in docker-byok (#5025)

### DIFF
--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -109,6 +109,7 @@ import {
   validateMounts,
   sanitizeContainerEnv,
 } from './devcontainer-config.js'
+import { isOperatorTimeoutInRange } from './duration.js'
 
 const log = createLogger('docker-byok')
 
@@ -239,6 +240,14 @@ function shellQuote(s) {
  * Returns `null` when the opt is missing, an empty string, or an empty
  * array — those all mean "no post-create hook" and let `start()` skip
  * the marker probe entirely (#5025).
+ *
+ * Strictness: any non-string entry inside an array throws (#5063 review
+ * — Copilot). Silently dropping a non-string entry would mask
+ * misconfiguration (e.g. `postCreateCommand: ['npm install', null,
+ * 'npm test']` would have run install + test, skipping the failed
+ * middle slot, instead of failing loudly at construction). The same
+ * goes for empty-string entries — those almost certainly indicate a
+ * typo / templating bug and should be surfaced.
  */
 export function normalizePostCreateCommand(value) {
   if (value == null) return null
@@ -247,10 +256,19 @@ export function normalizePostCreateCommand(value) {
     return trimmed.length > 0 ? trimmed : null
   }
   if (Array.isArray(value)) {
-    const parts = value
-      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
-      .filter((entry) => entry.length > 0)
-    if (parts.length === 0) return null
+    if (value.length === 0) return null
+    const parts = value.map((entry, idx) => {
+      if (typeof entry !== 'string') {
+        throw new Error(
+          `postCreateCommand[${idx}] must be a string (got ${entry === null ? 'null' : typeof entry})`,
+        )
+      }
+      const trimmed = entry.trim()
+      if (trimmed.length === 0) {
+        throw new Error(`postCreateCommand[${idx}] must be a non-empty string`)
+      }
+      return trimmed
+    })
     return parts.join(' && ')
   }
   throw new Error('postCreateCommand must be a string or an array of strings')
@@ -432,8 +450,18 @@ export class DockerByokSession extends ClaudeByokSession {
     // a marker file on /tmp lets a reused pool container skip the run
     // when the same command was already applied. `null` (the default)
     // disables the hook entirely — start() takes no extra round trips.
+    //
+    // Timeout is validated via the shared `isOperatorTimeoutInRange`
+    // helper (#5063 review — Copilot). Same MAX_SANE_DURATION_MS (24h)
+    // ceiling the protocol schemas + ws-history apply — a typoed
+    // `postCreateTimeoutMs: 99999999999` (extra digit) silently falls
+    // back to the 5-minute default and logs a warning instead of
+    // creating a many-hours `docker exec` hang.
     this._postCreateCommand = normalizePostCreateCommand(opts.postCreateCommand)
-    this._postCreateTimeoutMs = Number.isFinite(opts.postCreateTimeoutMs) && opts.postCreateTimeoutMs > 0
+    this._postCreateTimeoutMs = isOperatorTimeoutInRange(opts.postCreateTimeoutMs, {
+      name: 'postCreateTimeoutMs',
+      log,
+    })
       ? opts.postCreateTimeoutMs
       : DEFAULT_POST_CREATE_TIMEOUT_MS
     this._postCreateMarkerPath = this._postCreateCommand

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -36,9 +36,22 @@
  *
  * Deferred (follow-up issues)
  * ---------------------------
+ *   - (none currently tracked — see "Recently added" below)
+ *
+ * Recently added
+ * --------------
  *   - Per-session container reuse / pooling (#5022 — landed)
  *   - DevContainer / Compose-driven environments (#5024 — landed)
- *   - postCreateCommand hook (#5024 — landed alongside devcontainer)
+ *   - Snapshot / restore (#5023 — landed)
+ *   - postCreateCommand hook (#5025) — opt-in DevContainer-style setup
+ *     command (single string or array) that runs once inside the
+ *     container before any tool dispatch. Marker-cached on /tmp so a
+ *     pooled container that already ran the same command skips it.
+ *     This is the explicit ctor opt with marker caching + timeout +
+ *     error handling. The `useDevcontainer` overlay parses a
+ *     devcontainer.json's own `postCreateCommand` field separately and
+ *     runs it non-fatally inside `_startContainer` — that path predates
+ *     #5025 and remains the devcontainer-config integration.
  *
  * DevContainer + Compose (#5024)
  * -----------------------------
@@ -57,8 +70,8 @@
  *     stack tears down. Pooling is disabled in compose mode.
  *   - Default (neither opt) — original v1 bare-image launch path.
  *
- * Snapshot / restore (#5023, this revision)
- * -----------------------------------------
+ * Snapshot / restore (#5023)
+ * --------------------------
  *   - `snapshot({ name? })` runs `docker commit <containerId>
  *     chroxy-byok-snap:<rand>-<ts>` via the backend, marks the live
  *     container "soiled" so the pool evicts it on release (#5043), and
@@ -84,7 +97,7 @@
  */
 
 import { execFile } from 'child_process'
-import { randomBytes } from 'crypto'
+import { createHash, randomBytes } from 'crypto'
 import { isAbsolute, posix } from 'path'
 import { ClaudeByokSession } from './byok-session.js'
 import { DockerBackend } from './environments/backends/docker.js'
@@ -121,6 +134,27 @@ const READ_MAX_BYTES = 256 * 1024
  * stages the content from a file already inside the container.
  */
 const WRITE_MAX_BYTES = 512 * 1024
+
+/**
+ * Default cap on how long a postCreateCommand can run before it's
+ * treated as a hang. Five minutes mirrors what DevContainer-style
+ * setups (npm install, apt-get install) typically need on first run
+ * while still bounding a runaway script. Callers can override via the
+ * `postCreateTimeoutMs` ctor opt (#5025).
+ */
+const DEFAULT_POST_CREATE_TIMEOUT_MS = 5 * 60 * 1000
+
+/**
+ * Where the post-create completion marker lives inside the container.
+ * `/tmp` survives across `docker exec` invocations within the same
+ * container (the layered FS persists for the container's lifetime), so
+ * a future session that reuses the same container via the pool can
+ * probe this file and skip re-running an already-applied setup.
+ *
+ * The marker filename embeds a SHA-256 fingerprint of the command, so
+ * a CHANGED command produces a different marker and is re-applied.
+ */
+const POST_CREATE_MARKER_PREFIX = '/tmp/.chroxy-post-create-'
 
 /**
  * Map a host-absolute file_path under this.cwd into the container's
@@ -194,6 +228,34 @@ function shellQuote(s) {
   return `'${String(s).replace(/'/g, `'\\''`)}'`
 }
 
+/**
+ * Coerce a `postCreateCommand` opt into a single shell-string that the
+ * container can run via `bash -c`. DevContainer's spec allows either a
+ * single command string or an array of strings; we honour both. Arrays
+ * are joined with ` && ` so every step must succeed — if step 1 fails,
+ * step 2 doesn't run, and the overall exit code is non-zero (which the
+ * session treats as a setup failure).
+ *
+ * Returns `null` when the opt is missing, an empty string, or an empty
+ * array — those all mean "no post-create hook" and let `start()` skip
+ * the marker probe entirely (#5025).
+ */
+export function normalizePostCreateCommand(value) {
+  if (value == null) return null
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
+      .filter((entry) => entry.length > 0)
+    if (parts.length === 0) return null
+    return parts.join(' && ')
+  }
+  throw new Error('postCreateCommand must be a string or an array of strings')
+}
+
 export class DockerByokSession extends ClaudeByokSession {
   static get displayLabel() {
     return 'Claude (BYOK — Docker container)'
@@ -263,6 +325,19 @@ export class DockerByokSession extends ClaudeByokSession {
    *   service name from the compose file to attach to (the "primary"
    *   service). When omitted, the first service from `docker compose
    *   ps` is picked.
+   * @param {string|string[]} [opts.postCreateCommand=null]
+   *   #5025: DevContainer-style setup command(s) that run inside the
+   *   container once after launch and before the session is marked
+   *   ready. Strings run verbatim; arrays are joined with ` && ` so
+   *   every step must succeed. A SHA-256 marker file on /tmp prevents
+   *   re-execution when the same container is reused across sessions
+   *   (#5022 pool). Only runs for owned containers — externally-managed
+   *   containers are the caller's responsibility. This ctor opt is
+   *   independent of (and runs in addition to) any `postCreateCommand`
+   *   field parsed from devcontainer.json under `useDevcontainer`.
+   * @param {number} [opts.postCreateTimeoutMs=300_000]
+   *   #5025: Cap on how long postCreateCommand can run before it's
+   *   treated as a hang (default 5 minutes).
    * @param {object} [opts._dockerBackend]           Test seam — pre-built backend
    * @param {Function} [opts._execFile]              Test seam — used by preflight
    *   (defaults to child_process.execFile)
@@ -351,6 +426,19 @@ export class DockerByokSession extends ClaudeByokSession {
     // from the pool — used at destroy() time to decide between pool
     // release and inline `docker rm -f`.
     this._acquiredFromPool = false
+
+    // #5025 — DevContainer-style postCreateCommand hook. Normalised to
+    // a single string (arrays joined with ` && `) and SHA-256-hashed so
+    // a marker file on /tmp lets a reused pool container skip the run
+    // when the same command was already applied. `null` (the default)
+    // disables the hook entirely — start() takes no extra round trips.
+    this._postCreateCommand = normalizePostCreateCommand(opts.postCreateCommand)
+    this._postCreateTimeoutMs = Number.isFinite(opts.postCreateTimeoutMs) && opts.postCreateTimeoutMs > 0
+      ? opts.postCreateTimeoutMs
+      : DEFAULT_POST_CREATE_TIMEOUT_MS
+    this._postCreateMarkerPath = this._postCreateCommand
+      ? `${POST_CREATE_MARKER_PREFIX}${createHash('sha256').update(this._postCreateCommand).digest('hex').slice(0, 16)}`
+      : null
   }
 
   /**
@@ -409,6 +497,26 @@ export class DockerByokSession extends ClaudeByokSession {
         })
         await this.destroy()
         return
+      }
+
+      // #5025: run the DevContainer-style postCreateCommand after the
+      // container is up but before super.start() — that way a setup
+      // failure (missing package.json, broken npm script) fails the
+      // session start instead of silently surfacing on the first tool
+      // call. Only runs for OWNED containers; externally-managed ones
+      // are the caller's responsibility (e.g. an env-manager that
+      // already drove its own post-create).
+      if (this._postCreateCommand) {
+        try {
+          await this._runPostCreateCommandIfNeeded()
+        } catch (err) {
+          this.emit('error', {
+            code: 'post_create_command_failed',
+            message: `docker-byok postCreateCommand failed: ${err.message}`,
+          })
+          await this.destroy()
+          return
+        }
       }
     } else {
       // External container — verify it's reachable before we lie to
@@ -756,6 +864,70 @@ export class DockerByokSession extends ClaudeByokSession {
         })
       })
     })
+  }
+
+  /**
+   * #5025 — DevContainer-style postCreateCommand hook.
+   *
+   * Idempotency contract: a SHA-256-derived marker file lives at
+   * `/tmp/.chroxy-post-create-<hash>` inside the container. If the
+   * probe (`test -f <marker>`) succeeds, the command has already been
+   * applied to THIS container and we skip the run entirely — that's
+   * the whole reason the #5022 pool layer is useful for setup-heavy
+   * workspaces. A different command produces a different hash, so a
+   * change to `postCreateCommand` between sessions reuses the same
+   * container but re-runs setup.
+   *
+   * Failure surface: any non-zero exit (including timeout, backend
+   * reject, or marker-write failure) throws — the caller is `start()`,
+   * which converts the throw into a `post_create_command_failed` error
+   * event and tears the session down. The marker is only written on
+   * full success (command itself succeeds AND the marker write
+   * succeeds), so a half-applied state can never be cached.
+   */
+  async _runPostCreateCommandIfNeeded() {
+    if (!this._postCreateCommand || !this._postCreateMarkerPath) return
+    // Probe for the marker. The backend rejects on non-zero exit, so a
+    // `test -f` that finds the marker resolves clean and a missing
+    // marker throws. Catch the throw and fall through to the run path
+    // — any OTHER failure (daemon down, exec disabled) will also throw
+    // here, and the run path will rediscover the underlying error.
+    let markerPresent = false
+    try {
+      await this._execAsContainerUser({
+        cmd: `test -f ${shellQuote(this._postCreateMarkerPath)}`,
+        timeout: 10_000,
+      })
+      markerPresent = true
+    } catch {
+      markerPresent = false
+    }
+    if (markerPresent) {
+      log.info(`postCreateCommand already applied (marker ${this._postCreateMarkerPath.slice(-12)}) — skipping`)
+      return
+    }
+
+    log.info(`running postCreateCommand (timeout=${this._postCreateTimeoutMs}ms)`)
+    // Run the command. The backend's execInEnvironment forwards both
+    // stdout and stderr and rejects on non-zero exit, so we don't need
+    // to inspect an exit code here — a throw IS the failure path.
+    await this._execAsContainerUser({
+      cmd: this._postCreateCommand,
+      timeout: this._postCreateTimeoutMs,
+    })
+
+    // Stamp the marker so the next session that lands on this container
+    // skips the run. `mkdir -p` on the prefix would be wrong (the prefix
+    // is /tmp, which always exists), so just `touch` the file. Failure
+    // here ALSO fails the post-create — without a marker write, a
+    // future reuse would re-run a command we just successfully applied,
+    // which would be wasteful and (for non-idempotent commands like
+    // `apt-get install`) potentially incorrect.
+    await this._execAsContainerUser({
+      cmd: `touch ${shellQuote(this._postCreateMarkerPath)}`,
+      timeout: 10_000,
+    })
+    log.info(`postCreateCommand applied — marker stamped at ${this._postCreateMarkerPath.slice(-12)}`)
   }
 
   /**

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1038,6 +1038,422 @@ describe('DockerByokSession — snapshot soiling integration (#5043)', () => {
   })
 })
 
+describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
+  /**
+   * Acceptance: a `postCreateCommand: string | string[]` opt that runs
+   * once after the container is started (or first reused) and before
+   * the session is marked ready.
+   *
+   *   - Success → marker file written inside the container; subsequent
+   *     reuses with the same command skip the run.
+   *   - Failure (non-zero exit, timeout, or any throw from the backend)
+   *     → 'error' event with code 'post_create_command_failed', session
+   *     not marked ready, owned container torn down.
+   *   - Configurable timeout (default 5 min).
+   *   - Externally-managed containerId → caller owns lifecycle, so we
+   *     do NOT run the post-create hook.
+   */
+
+  /**
+   * "Fresh container" backend stub: the marker probe (`test -f
+   * /tmp/.chroxy-post-create-<hash>`) throws on first contact because
+   * the marker file does NOT yet exist. After the impl runs the
+   * postCreateCommand and writes the marker via `touch`, subsequent
+   * probes resolve clean — modelling the real container's filesystem.
+   *
+   * Extra `execResponses` (string-include-keyed) override the default
+   * `{ stdout: '', stderr: '' }` for the command itself, mirroring the
+   * non-post-create `backendStub` helper.
+   */
+  function freshContainerBackend({ execResponses = {} } = {}) {
+    let markerPresent = false
+    const calls = []
+    return {
+      calls,
+      async execInEnvironment(containerId, opts) {
+        calls.push({ containerId, ...opts })
+        const cmd = opts.cmd || ''
+        if (cmd.includes('.chroxy-post-create')) {
+          if (cmd.startsWith('test -f ')) {
+            if (markerPresent) return { stdout: '', stderr: '' }
+            const err = new Error('exit 1')
+            err.code = 'exec_failed'
+            err.exitCode = 1
+            throw err
+          }
+          if (cmd.startsWith('touch ')) {
+            markerPresent = true
+            return { stdout: '', stderr: '' }
+          }
+        }
+        const matcher = Object.keys(execResponses).find((needle) => cmd.includes(needle))
+        if (matcher) {
+          const resp = execResponses[matcher]
+          if (resp.throw) throw resp.throw
+          return { stdout: resp.stdout || '', stderr: resp.stderr || '' }
+        }
+        return { stdout: '', stderr: '' }
+      },
+    }
+  }
+
+  it('runs the postCreateCommand inside the container as the non-root user', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = freshContainerBackend({
+      execResponses: {
+        'npm install': { stdout: 'added 42 packages\n', stderr: '' },
+      },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    assert.equal(session._containerReady, true)
+    const installCalls = backend.calls.filter(
+      (c) => c.cmd && c.cmd.includes('npm install') && !c.cmd.includes('.chroxy-post-create'),
+    )
+    assert.equal(installCalls.length, 1, 'expected one npm install invocation')
+    assert.equal(installCalls[0].user, 'chroxy', 'post-create must run as the non-root user')
+
+    await session.destroy()
+  })
+
+  it('joins an array postCreateCommand with && so all steps run', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE_ARR\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = freshContainerBackend()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: ['npm install', 'npm run build'],
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    const combined = backend.calls.find(
+      (c) => c.cmd && c.cmd.includes('npm install') && c.cmd.includes('npm run build'),
+    )
+    assert.ok(combined, 'expected the combined && command to run')
+    assert.match(combined.cmd, /npm install.*&&.*npm run build/)
+
+    await session.destroy()
+  })
+
+  it('fails session start with a clear error event when post-create exits non-zero', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE_FAIL\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const installErr = Object.assign(new Error('exit 1: npm install failed'), {
+      code: 'exec_failed',
+      exitCode: 1,
+      stderr: 'npm ERR! missing package.json',
+    })
+    const backend = freshContainerBackend({
+      execResponses: { 'npm install': { throw: installErr } },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+
+    assert.equal(session._containerReady, false, 'failed post-create must not mark session ready')
+    const postCreateErr = events.find((e) => /postCreateCommand/.test(e.message))
+    assert.ok(postCreateErr, 'expected a postCreateCommand error event')
+    assert.equal(postCreateErr.code, 'post_create_command_failed')
+    const rmCalls = _execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.ok(rmCalls.some((c) => c.args.includes('CONTAINER_POSTCREATE_FAIL')),
+      'failed start must tear down the owned container')
+  })
+
+  it('forwards a configurable postCreateTimeoutMs to the backend exec', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE_TO\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = freshContainerBackend()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      postCreateTimeoutMs: 60_000,
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    const installCall = backend.calls.find(
+      (c) => c.cmd && c.cmd.includes('npm install') && !c.cmd.includes('.chroxy-post-create'),
+    )
+    assert.ok(installCall, 'expected install invocation')
+    assert.equal(installCall.timeout, 60_000)
+
+    await session.destroy()
+  })
+
+  it('defaults the post-create timeout to 5 minutes', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE_DEFTO\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = freshContainerBackend()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    const installCall = backend.calls.find(
+      (c) => c.cmd && c.cmd.includes('npm install') && !c.cmd.includes('.chroxy-post-create'),
+    )
+    assert.ok(installCall, 'expected install invocation')
+    assert.equal(installCall.timeout, 300_000)
+
+    await session.destroy()
+  })
+
+  it('surfaces a post-create timeout as a clear error event', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE_HANG\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const timeoutErr = Object.assign(new Error('exec timed out after 100ms'), { code: 'ETIMEDOUT' })
+    const backend = freshContainerBackend({
+      execResponses: { 'sleep 999': { throw: timeoutErr } },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'sleep 999',
+      postCreateTimeoutMs: 100,
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+
+    assert.equal(session._containerReady, false)
+    const event = events.find((e) => /postCreateCommand/.test(e.message))
+    assert.ok(event, 'expected post-create timeout error event')
+    assert.equal(event.code, 'post_create_command_failed')
+    assert.match(event.message, /timed out|ETIMEDOUT/)
+  })
+
+  it('writes a cache marker after a successful run', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE_MARKER\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = freshContainerBackend()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // After the command runs, the impl touches a marker file under
+    // /tmp/.chroxy-post-create-<hash> so a future reuse can skip the run.
+    const markerWrite = backend.calls.find(
+      (c) => c.cmd
+        && c.cmd.includes('.chroxy-post-create')
+        && (c.cmd.includes('touch ') || c.cmd.includes('> ')),
+    )
+    assert.ok(markerWrite, 'expected a marker-write call after successful post-create')
+
+    await session.destroy()
+  })
+
+  it('skips re-running postCreateCommand on pool reuse when the cache marker is present', async () => {
+    // Pool hit + marker present → command MUST NOT run again.
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    let postCreateInvocations = 0
+    const backend = {
+      calls: [],
+      async execInEnvironment(containerId, opts) {
+        backend.calls.push({ containerId, ...opts })
+        // Marker probe: empty stdout/stderr signals "present" — the impl
+        // uses `test -f <marker>` which resolves clean on a hit.
+        if (opts.cmd && opts.cmd.includes('.chroxy-post-create') && !opts.cmd.includes('touch')) {
+          return { stdout: '', stderr: '' }
+        }
+        if (opts.cmd && opts.cmd.includes('npm install')) {
+          postCreateInvocations++
+          return { stdout: '', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      },
+    }
+    const pool = {
+      acquire() { return 'CONTAINER_WARM' },
+      async release() { return true },
+    }
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+      _pool: pool,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    assert.equal(session._acquiredFromPool, true)
+    assert.equal(session._containerId, 'CONTAINER_WARM')
+    assert.equal(postCreateInvocations, 0,
+      'cache hit: postCreateCommand must not re-execute when marker is present')
+    const probeCalls = backend.calls.filter(
+      (c) => c.cmd && c.cmd.includes('.chroxy-post-create') && !c.cmd.includes('touch'),
+    )
+    assert.ok(probeCalls.length >= 1, 'expected at least one marker probe on pool reuse')
+
+    await session.destroy()
+  })
+
+  it('re-runs postCreateCommand on pool reuse if the marker is missing', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    let postCreateInvocations = 0
+    const backend = {
+      calls: [],
+      async execInEnvironment(containerId, opts) {
+        backend.calls.push({ containerId, ...opts })
+        // Marker probe: throw with exit 1 → "missing".
+        if (opts.cmd && opts.cmd.includes('.chroxy-post-create') && !opts.cmd.includes('touch')) {
+          const err = new Error('exit 1')
+          err.code = 'exec_failed'
+          err.exitCode = 1
+          err.stderr = ''
+          throw err
+        }
+        if (opts.cmd && opts.cmd.includes('npm ci')) {
+          postCreateInvocations++
+          return { stdout: '', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      },
+    }
+    const pool = {
+      acquire() { return 'CONTAINER_WARM_NEW_CMD' },
+      async release() { return true },
+    }
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm ci',
+      _execFile,
+      _dockerBackend: backend,
+      _pool: pool,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    assert.equal(session._acquiredFromPool, true)
+    assert.equal(postCreateInvocations, 1,
+      'cache miss on warm container: postCreateCommand must run')
+
+    await session.destroy()
+  })
+
+  it('does NOT run postCreateCommand when the session attaches to an external container', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      exec: { stdout: '' },
+    })
+    let postCreateInvocations = 0
+    const backend = {
+      calls: [],
+      async execInEnvironment(containerId, opts) {
+        backend.calls.push({ containerId, ...opts })
+        if (opts.cmd && opts.cmd.includes('npm install')) {
+          postCreateInvocations++
+        }
+        return { stdout: '', stderr: '' }
+      },
+    }
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      containerId: 'EXTERNAL_MANAGED',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    assert.equal(postCreateInvocations, 0,
+      'external container: postCreateCommand must NOT run (caller-owned)')
+
+    await session.destroy()
+  })
+
+  it('default: postCreateCommand is null and no extra backend calls happen at start', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_NOPC\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = backendStub({ defaultResponse: { stdout: '', stderr: '' } })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    assert.equal(session._containerReady, true)
+    assert.equal(backend.calls.length, 0,
+      'with no postCreateCommand, the session must not probe / write any markers')
+
+    await session.destroy()
+  })
+})
+
 describe('docker-byok provider registration', () => {
   it('registerDockerProvider() wires docker-byok when environments are enabled and docker is available', async () => {
     // Spy on console.warn so accidental log noise during the test

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1128,7 +1128,7 @@ describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
     await session.destroy()
   })
 
-  it('joins an array postCreateCommand with && so all steps run', async () => {
+  it('joins an array postCreateCommand with && so steps run sequentially and stop on the first failure', async () => {
     const _execFile = execFileStub({
       info: { stdout: 'ok' },
       run: { stdout: 'CONTAINER_POSTCREATE_ARR\n' },
@@ -1152,6 +1152,42 @@ describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
     assert.match(combined.cmd, /npm install.*&&.*npm run build/)
 
     await session.destroy()
+  })
+
+  it('throws on a non-string entry inside a postCreateCommand array (no silent drop)', () => {
+    // #5063 review (Copilot, comment id 3349258851): silently mapping a
+    // non-string entry to '' would mask misconfiguration — e.g. an
+    // array like ['npm install', null, 'npm test'] would have run only
+    // the first and last steps, skipping the middle slot without any
+    // surface. Now we throw at construction so the operator sees the
+    // typo / templating bug immediately.
+    assert.throws(
+      () => new DockerByokSession({
+        cwd: '/host/cwd',
+        postCreateCommand: ['npm install', null, 'npm test'],
+        _execFile: execFileStub({ info: { stdout: 'ok' } }),
+        _dockerBackend: { async execInEnvironment() { return { stdout: '', stderr: '' } } },
+      }),
+      /postCreateCommand\[1\] must be a string \(got null\)/,
+    )
+    assert.throws(
+      () => new DockerByokSession({
+        cwd: '/host/cwd',
+        postCreateCommand: ['npm install', 42, 'npm test'],
+        _execFile: execFileStub({ info: { stdout: 'ok' } }),
+        _dockerBackend: { async execInEnvironment() { return { stdout: '', stderr: '' } } },
+      }),
+      /postCreateCommand\[1\] must be a string \(got number\)/,
+    )
+    assert.throws(
+      () => new DockerByokSession({
+        cwd: '/host/cwd',
+        postCreateCommand: ['npm install', '   ', 'npm test'],
+        _execFile: execFileStub({ info: { stdout: 'ok' } }),
+        _dockerBackend: { async execInEnvironment() { return { stdout: '', stderr: '' } } },
+      }),
+      /postCreateCommand\[1\] must be a non-empty string/,
+    )
   })
 
   it('fails session start with a clear error event when post-create exits non-zero', async () => {
@@ -1238,6 +1274,40 @@ describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
     )
     assert.ok(installCall, 'expected install invocation')
     assert.equal(installCall.timeout, 300_000)
+
+    await session.destroy()
+  })
+
+  it('caps a typoed postCreateTimeoutMs above MAX_SANE_DURATION_MS (24h) back to the 5-min default', async () => {
+    // #5063 review (Copilot, comment id 3349258916): a typoed timeout
+    // like `99999999999` (extra digit) should fall back to the default
+    // rather than producing a many-hours docker exec. The shared
+    // `isOperatorTimeoutInRange` helper applies the same ceiling the
+    // protocol schemas already enforce.
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE_HUGE\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = freshContainerBackend()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      // 25h — just over MAX_SANE_DURATION_MS (24h)
+      postCreateTimeoutMs: 25 * 60 * 60 * 1000,
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    const installCall = backend.calls.find(
+      (c) => c.cmd && c.cmd.includes('npm install') && !c.cmd.includes('.chroxy-post-create'),
+    )
+    assert.ok(installCall, 'expected install invocation')
+    assert.equal(installCall.timeout, 300_000,
+      'over-ceiling timeout must fall back to the 5-min default')
 
     await session.destroy()
   })


### PR DESCRIPTION
## Summary

Adds a DevContainer-style `postCreateCommand` opt to `DockerByokSession` (#5025). When the model lands in a freshly-launched docker-byok container, the `/workspace` mount is already there but no dependencies are installed yet — `npm install`, repo bootstrap scripts, language toolchains, etc. all need to run before the first tool dispatch. This wires that step in.

- New ctor opts (docker-byok-specific, not a BaseSession opt):
  - `postCreateCommand: string | string[]` (default `null`) — single shell command or array of commands (joined with ` && `).
  - `postCreateTimeoutMs` (default `300_000` / 5 minutes).
- Runs once after the container is started (or pool-reused) and before `super.start()` marks the session ready. Failure (non-zero exit, timeout, backend reject) emits a `post_create_command_failed` error event and tears the owned container down — no `_containerReady` leak.
- Idempotency: SHA-256 of the command derives a marker file at `/tmp/.chroxy-post-create-<hash>`. A reused pool container with the same command skips the run; a CHANGED command produces a different hash and re-applies. The marker is only written on full success — a half-applied state never gets cached.
- Externally-managed containers (`containerId` opt) are still left alone — caller owns the lifecycle, including any post-create setup.
- Runs as the non-root container user (`chroxy`), same as every other tool dispatch.

## Test plan

- [x] Server test suite passes (`npm test` — the only failures are pre-existing flakes for tunnel manager, claude CLI feature detection, encryption integration; unrelated to this change).
- [x] docker-byok suite: 82/82 pass (`tests/docker-byok-session.test.js` + `tests/docker-byok-pool.test.js`).
- [x] Lints clean: `lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`, `lint-logger-session-scoping.sh`.
- [x] No new BaseSession opt — postCreateCommand stays docker-byok-specific.

### Test coverage

New `describe('DockerByokSession — postCreateCommand hook (#5025)')` block exercises:
- success path + non-root user
- array join semantics
- non-zero exit failure surface + container tear-down
- configurable timeout forwarding
- default 5-min timeout
- timeout surface (`ETIMEDOUT` shape)
- marker write on success
- cache-hit skip on pool reuse
- cache-miss re-run on pool reuse (different command hash)
- external-container no-op
- default-null no-op

Closes #5025