### PR TITLE
feat(server): wire subagent_type profile registry to Task tool (#5018)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -35,6 +35,7 @@ import { BUILTIN_TOOLS, TASK_PERMISSION_MODE_LIST, TASK_PERMISSION_MODE_RANK } f
 import { executeBuiltinTool } from './byok-tool-executor.js'
 import { loadClaudeMcpConfig, toMcpServerMetadata } from './byok-mcp-config.js'
 import { MCPFleet, MCP_TOOL_PREFIX } from './byok-mcp-fleet.js'
+import { getSubagentProfile, SUBAGENT_PROFILE_NAMES } from './byok-subagent-profiles.js'
 
 const log = createLogger('byok-session')
 
@@ -311,6 +312,13 @@ export class ClaudeByokSession extends BaseSession {
     // leak into a future turn.
     this._subagentUsageThisTurn = { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 }
     this._subagentCostThisTurn = 0
+
+    // #5018: per-session built-in tool allowlist. Set by _executeTaskTool
+    // ONLY on child sessions spawned with a `subagent_type` profile that
+    // carries a restricted `toolSet`. When null (the default / unrestricted
+    // case), `_buildTools()` short-circuits the filter so non-subagent
+    // sessions and general-purpose subagents pay no observable cost.
+    this._allowedBuiltinToolNames = null
 
     // #4076: MCP config discovery. Parses ~/.claude.json (or an
     // override) for the `mcpServers` block. Parse-only at this stage —
@@ -1243,6 +1251,27 @@ export class ClaudeByokSession extends BaseSession {
       }
       inheritMcp = input.inherit_mcp
     }
+    // #5018: subagent_type profile lookup. When the model passes a
+    // `subagent_type`, look it up in the registry and apply the profile
+    // (systemPrompt + toolSet) to the child before its first sendMessage.
+    // Unknown values reject BEFORE the agent_spawned emit / _activeAgents
+    // populate so a misspelled id can't leave a phantom entry in the
+    // dashboard's active-agents badge — mirrors the permission_mode
+    // validation placement above. When omitted, no profile is applied and
+    // the v1 default behaviour stands.
+    let subagentProfile = null
+    if (input?.subagent_type !== undefined) {
+      subagentProfile = getSubagentProfile(input.subagent_type)
+      if (!subagentProfile) {
+        const got = typeof input.subagent_type === 'string'
+          ? `"${input.subagent_type}"`
+          : String(input.subagent_type)
+        return {
+          content: `Task tool: unknown \`subagent_type\` ${got}. Available profiles: ${SUBAGENT_PROFILE_NAMES.join(', ')}.`,
+          isError: true,
+        }
+      }
+    }
     if (signal?.aborted) {
       return { content: 'Interrupted by user before subagent spawned', isError: true }
     }
@@ -1320,6 +1349,23 @@ export class ClaudeByokSession extends BaseSession {
       // setPermissionMode) is safe here: the child is fresh, not busy,
       // and has no pending permissions to flush.
       child.permissionMode = childPermissionMode
+      // #5018: apply the subagent profile (validated above). Direct
+      // field assignment (vs setSessionPreamble) is deliberate — the
+      // setter trims + caps at SESSION_PREAMBLE_MAX_LENGTH which is fine
+      // for user-authored preambles but unnecessarily restrictive for
+      // an in-source profile we control. The profile's systemPrompt
+      // rides in the same slot _buildSystemPrompt() reads, so the
+      // existing skills/chroxy-hint ordering still composes. When the
+      // toolSet is restricted to a name list, install the filter on the
+      // child so its `_buildTools()` only emits the allowed built-ins;
+      // `toolSet: 'all'` leaves the filter unset so the child sees the
+      // full BUILTIN_TOOLS array.
+      if (subagentProfile) {
+        child.sessionPreamble = subagentProfile.systemPrompt
+        if (subagentProfile.toolSet !== 'all') {
+          child._allowedBuiltinToolNames = new Set(subagentProfile.toolSet)
+        }
+      }
       this._subagentSessions.set(toolUseId, child)
     } catch (ctorErr) {
       // Balance the agent_spawned emit + _activeAgents.set above so the
@@ -1623,10 +1669,23 @@ export class ClaudeByokSession extends BaseSession {
   // turn rather than cached because the cost is trivial and the fleet's
   // READY-state filter is the source of truth for which servers are
   // contributing right now.
+  //
+  // #5018: when this session is a subagent that was spawned with a
+  // restricted profile, `_allowedBuiltinToolNames` is a Set of the
+  // allowed built-in tool names. Filter BUILTIN_TOOLS down to just
+  // those — MCP tools pass through unchanged in v1 (gating MCP per
+  // profile is a follow-up; the immediate value of a restricted
+  // profile like code-reviewer is preventing accidental Write/Edit/Bash,
+  // and MCP tools are off by default in subagents anyway). Unrestricted
+  // (or non-subagent) sessions skip the filter entirely so this stays
+  // a zero-cost path for the common case.
   _buildTools() {
-    if (!this._mcpFleet) return BUILTIN_TOOLS
+    const builtins = this._allowedBuiltinToolNames
+      ? BUILTIN_TOOLS.filter((t) => this._allowedBuiltinToolNames.has(t.name))
+      : BUILTIN_TOOLS
+    if (!this._mcpFleet) return builtins
     const mcp = this._mcpFleet.anthropicTools
-    return mcp.length === 0 ? BUILTIN_TOOLS : [...BUILTIN_TOOLS, ...mcp]
+    return mcp.length === 0 ? builtins : [...builtins, ...mcp]
   }
 
   async destroy() {

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -1254,11 +1254,12 @@ export class ClaudeByokSession extends BaseSession {
     // #5018: subagent_type profile lookup. When the model passes a
     // `subagent_type`, look it up in the registry and apply the profile
     // (systemPrompt + toolSet) to the child before its first sendMessage.
-    // Unknown values reject BEFORE the agent_spawned emit / _activeAgents
-    // populate so a misspelled id can't leave a phantom entry in the
-    // dashboard's active-agents badge — mirrors the permission_mode
-    // validation placement above. When omitted, no profile is applied and
-    // the v1 default behaviour stands.
+    // Unknown values fall back to v1 behaviour (no profile applied) and
+    // emit a warn log per the issue's acceptance criteria — keeps the
+    // delegation forward-compatible with a future model that requests a
+    // profile id this server doesn't yet know about, rather than failing
+    // the entire tool call. When omitted, no profile is applied and the
+    // v1 default behaviour stands.
     let subagentProfile = null
     if (input?.subagent_type !== undefined) {
       subagentProfile = getSubagentProfile(input.subagent_type)
@@ -1266,10 +1267,10 @@ export class ClaudeByokSession extends BaseSession {
         const got = typeof input.subagent_type === 'string'
           ? `"${input.subagent_type}"`
           : String(input.subagent_type)
-        return {
-          content: `Task tool: unknown \`subagent_type\` ${got}. Available profiles: ${SUBAGENT_PROFILE_NAMES.join(', ')}.`,
-          isError: true,
-        }
+        log.warn(
+          `Task tool: unknown subagent_type ${got}; falling back to v1 default (no profile applied). `
+          + `Available profiles: ${SUBAGENT_PROFILE_NAMES.join(', ')}.`,
+        )
       }
     }
     if (signal?.aborted) {
@@ -1349,19 +1350,19 @@ export class ClaudeByokSession extends BaseSession {
       // setPermissionMode) is safe here: the child is fresh, not busy,
       // and has no pending permissions to flush.
       child.permissionMode = childPermissionMode
-      // #5018: apply the subagent profile (validated above). Direct
-      // field assignment (vs setSessionPreamble) is deliberate — the
-      // setter trims + caps at SESSION_PREAMBLE_MAX_LENGTH which is fine
-      // for user-authored preambles but unnecessarily restrictive for
-      // an in-source profile we control. The profile's systemPrompt
-      // rides in the same slot _buildSystemPrompt() reads, so the
-      // existing skills/chroxy-hint ordering still composes. When the
-      // toolSet is restricted to a name list, install the filter on the
-      // child so its `_buildTools()` only emits the allowed built-ins;
-      // `toolSet: 'all'` leaves the filter unset so the child sees the
-      // full BUILTIN_TOOLS array.
+      // #5018: apply the subagent profile (validated above). Route the
+      // systemPrompt through setSessionPreamble so the profile follows
+      // the same trim + SESSION_PREAMBLE_MAX_LENGTH cap as user-authored
+      // preambles — keeps the system-prompt size bounded and predictable
+      // even if a future profile prompt grows. The profile's systemPrompt
+      // rides in the same slot _buildSystemPrompt() reads, so the existing
+      // skills/chroxy-hint ordering still composes. When the toolSet is
+      // restricted to a name list, install the filter on the child so its
+      // `_buildTools()` only emits the allowed built-ins; `toolSet: 'all'`
+      // leaves the filter unset so the child sees the full BUILTIN_TOOLS
+      // array.
       if (subagentProfile) {
-        child.sessionPreamble = subagentProfile.systemPrompt
+        child.setSessionPreamble(subagentProfile.systemPrompt)
         if (subagentProfile.toolSet !== 'all') {
           child._allowedBuiltinToolNames = new Set(subagentProfile.toolSet)
         }

--- a/packages/server/src/byok-subagent-profiles.js
+++ b/packages/server/src/byok-subagent-profiles.js
@@ -77,8 +77,9 @@ export const SUBAGENT_PROFILE_NAMES = Object.freeze(Object.keys(SUBAGENT_PROFILE
 /**
  * Look up a profile by id. Returns the frozen profile bundle or `null`
  * when the id is unknown. Caller decides how to handle unknowns — the
- * Task tool currently returns an is_error tool_result so the model gets
- * a crisp signal rather than silently dropping the requested profile.
+ * Task tool falls back to the v1 default (no profile applied) and emits
+ * a warn log per #5018's acceptance criteria, so a model that requests a
+ * profile id this server doesn't yet know stays forward-compatible.
  *
  * @param {unknown} id
  * @returns {Readonly<{systemPrompt: string, toolSet: 'all' | readonly string[]}>|null}

--- a/packages/server/src/byok-subagent-profiles.js
+++ b/packages/server/src/byok-subagent-profiles.js
@@ -1,0 +1,89 @@
+/**
+ * Subagent profile registry for the claude-byok provider's Task tool (#5018).
+ *
+ * A "profile" is a named bundle of overrides that the model can request when
+ * spawning a sub-agent via the `Task` tool's `subagent_type` field. The byok
+ * runner looks the id up here and applies the bundle to the child session
+ * before its first `sendMessage` call.
+ *
+ * Each profile carries:
+ *   - `systemPrompt`: text that becomes the child's system prompt (prepended
+ *     to the child's `_buildSystemPrompt()` output). Used to bias the child
+ *     toward a focused mode (researcher, code-reviewer, etc.) without
+ *     polluting the parent's prompt.
+ *   - `toolSet`: either the string `'all'` (no filtering — child sees the
+ *     parent's full BUILTIN_TOOLS + MCP tools) or an array of tool names
+ *     to allow. When an array, the child's `_buildTools()` filters down to
+ *     only those built-in tools (MCP tools pass through unchanged — gating
+ *     MCP per profile is a follow-up).
+ *
+ * This Phase-1 MVP seeds three profiles. Additional profiles (researcher
+ * with WebFetch-heavy bias, summariser with a model override, etc.) can land
+ * as small follow-up PRs against #5018. The registry stays in-source for
+ * now; a `~/.chroxy/subagents.json` parser is the v2 path tracked on the
+ * issue (the original PR #5015 scope-note explicitly defers that piece).
+ *
+ * The exported registry is `Object.freeze`d so subagent-side code can't
+ * mutate the bundle and accidentally bleed customisations across parents.
+ */
+
+/**
+ * Frozen profile registry. Keyed by the value the model passes in
+ * `Task.input.subagent_type`. Profile names are kebab-case to match the
+ * Anthropic convention used in the official Claude Code subagent UX
+ * (`general-purpose`, etc.).
+ *
+ * @type {Readonly<Record<string, Readonly<{systemPrompt: string, toolSet: 'all' | readonly string[]}>>>}
+ */
+export const SUBAGENT_PROFILES = Object.freeze({
+  'general-purpose': Object.freeze({
+    systemPrompt:
+      'You are a general-purpose sub-agent spawned to handle a delegated piece of work. '
+      + 'Stay focused on the task in the user message — do not re-derive the parent context. '
+      + 'Use the available tools to research, read, edit, or compute as needed. When the work '
+      + 'is complete, return a concise summary of what you did and any output the parent '
+      + 'agent needs in order to continue.',
+    toolSet: 'all',
+  }),
+  'code-reviewer': Object.freeze({
+    systemPrompt:
+      'You are a code-review sub-agent. Read the files in scope, identify correctness bugs, '
+      + 'reuse / simplification opportunities, and style issues. Be specific (file:line) and '
+      + 'cite the offending code. Do NOT modify files — your job is to surface findings, not '
+      + 'apply fixes. Return a structured list of findings grouped by severity (high / medium / low).',
+    toolSet: Object.freeze(['Read', 'Grep', 'Glob']),
+  }),
+  'research': Object.freeze({
+    systemPrompt:
+      'You are a research sub-agent. Gather information from the codebase and the web to answer '
+      + 'the delegated question. Prefer Read / Grep / Glob to explore code and WebFetch to pull '
+      + 'in external context. Do NOT modify files — return a synthesised summary with citations '
+      + '(file:line for code, URL for web sources) so the parent can verify the basis.',
+    toolSet: Object.freeze(['Read', 'Grep', 'Glob', 'WebFetch']),
+  }),
+})
+
+/**
+ * Sorted list of available profile ids. Used by the Task tool's
+ * `subagent_type` schema description so the model sees the enumeration.
+ *
+ * Frozen so a misuse downstream (`SUBAGENT_PROFILE_NAMES.push(...)`) can't
+ * desync this list from the registry keys.
+ *
+ * @type {readonly string[]}
+ */
+export const SUBAGENT_PROFILE_NAMES = Object.freeze(Object.keys(SUBAGENT_PROFILES).sort())
+
+/**
+ * Look up a profile by id. Returns the frozen profile bundle or `null`
+ * when the id is unknown. Caller decides how to handle unknowns — the
+ * Task tool currently returns an is_error tool_result so the model gets
+ * a crisp signal rather than silently dropping the requested profile.
+ *
+ * @param {unknown} id
+ * @returns {Readonly<{systemPrompt: string, toolSet: 'all' | readonly string[]}>|null}
+ */
+export function getSubagentProfile(id) {
+  if (typeof id !== 'string' || id.length === 0) return null
+  return SUBAGENT_PROFILES[id] || null
+}

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -208,8 +208,8 @@ export const BUILTIN_TOOLS = [
       'Subagent profiles (#5018): pass `subagent_type` to bias the child toward a focused role. ' +
       `Available profiles: ${SUBAGENT_PROFILE_NAMES.join(', ')}. Each profile carries a tailored ` +
       'system prompt and may restrict the child\'s tool set (e.g. code-reviewer is read-only). ' +
-      'Unknown subagent_type values are rejected with an is_error tool_result so a misspelled ' +
-      'profile id fails loudly rather than silently dropping the requested behaviour.',
+      'Unknown subagent_type values fall back to the v1 default (no profile applied) and emit ' +
+      'a warn log on the server so the delegation stays forward-compatible.',
     input_schema: {
       type: 'object',
       properties: {
@@ -227,7 +227,7 @@ export const BUILTIN_TOOLS = [
           description:
             'Optional subagent profile id. When set, the runner applies the profile\'s system prompt '
             + `and tool-set restriction to the child. Available profiles: ${SUBAGENT_PROFILE_NAMES.join(', ')}. `
-            + 'Unknown values are rejected with an is_error tool_result.',
+            + 'Unknown values fall back to v1 default (no profile applied) with a server-side warn log.',
         },
         permission_mode: {
           type: 'string',

--- a/packages/server/src/byok-tools.js
+++ b/packages/server/src/byok-tools.js
@@ -13,6 +13,8 @@
  *   - MCP — #4048
  */
 
+import { SUBAGENT_PROFILE_NAMES } from './byok-subagent-profiles.js'
+
 /**
  * Valid TodoWrite status values. Single source of truth — the JSON-schema
  * enum below and the Set used for runtime validation both derive from
@@ -202,7 +204,12 @@ export const BUILTIN_TOOLS = [
       'permissive mode is rejected with an is_error tool_result. ' +
       'MCP tools: by default the sub-agent inherits the parent\'s MCP fleet (same ' +
       '`mcp__<server>__<tool>` set as this turn), at zero extra spawn cost. Pass ' +
-      '`inherit_mcp: false` to launch a sub-agent with built-in tools only (no MCP).',
+      '`inherit_mcp: false` to launch a sub-agent with built-in tools only (no MCP). ' +
+      'Subagent profiles (#5018): pass `subagent_type` to bias the child toward a focused role. ' +
+      `Available profiles: ${SUBAGENT_PROFILE_NAMES.join(', ')}. Each profile carries a tailored ` +
+      'system prompt and may restrict the child\'s tool set (e.g. code-reviewer is read-only). ' +
+      'Unknown subagent_type values are rejected with an is_error tool_result so a misspelled ' +
+      'profile id fails loudly rather than silently dropping the requested behaviour.',
     input_schema: {
       type: 'object',
       properties: {
@@ -216,7 +223,11 @@ export const BUILTIN_TOOLS = [
         },
         subagent_type: {
           type: 'string',
-          description: 'Optional subagent profile id (e.g. "general", "researcher"). Currently informational only — ignored by the runner in v1.',
+          enum: [...SUBAGENT_PROFILE_NAMES],
+          description:
+            'Optional subagent profile id. When set, the runner applies the profile\'s system prompt '
+            + `and tool-set restriction to the child. Available profiles: ${SUBAGENT_PROFILE_NAMES.join(', ')}. `
+            + 'Unknown values are rejected with an is_error tool_result.',
         },
         permission_mode: {
           type: 'string',

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3938,12 +3938,15 @@ describe('ClaudeByokSession', () => {
     })
 
     /**
-     * #5018: subagent_type profile registry. The Task tool dispatches
-     * profile lookup BEFORE spawning the child so an unknown id is
-     * rejected without leaving a phantom agent_spawned. When the id is
-     * known, the profile's systemPrompt is applied to the child's
-     * sessionPreamble and the profile's toolSet (when restricted) limits
-     * which BUILTIN_TOOLS the child sees in its `_buildTools()` output.
+     * #5018: subagent_type profile registry. When the id is known, the
+     * profile's systemPrompt is applied to the child's sessionPreamble
+     * (via setSessionPreamble so the same cap as user-authored preambles
+     * applies) and the profile's toolSet (when restricted) limits which
+     * BUILTIN_TOOLS the child sees in its `_buildTools()` output. When
+     * the id is unknown or malformed, the runner warns and falls back to
+     * the v1 default (no profile applied) per the issue's acceptance
+     * criteria — the spawn still succeeds so a future model that requests
+     * a profile this server doesn't know about stays forward-compatible.
      *
      * Helper shape mirrors runTaskWithPermissionOverride above: stub
      * the parent's gate to always-allow so the tests focus on the
@@ -4052,39 +4055,50 @@ describe('ClaudeByokSession', () => {
       assert.equal(taskResult.payload.isError, false)
     })
 
-    it('Task `subagent_type` unknown value rejected with is_error (#5018)', async () => {
+    it('Task `subagent_type` unknown value falls back to v1 default with no profile (#5018)', async () => {
       const { childSnapshot, taskResult, spawned } = await runTaskWithSubagentType({
         subagentType: 'totally-not-a-real-profile',
       })
-      // Unknown subagent_type must reject BEFORE spawning a child so no
-      // agent_spawned fires and the active-agents badge doesn't tick.
-      assert.equal(childSnapshot, null,
-        'no child must be spawned when subagent_type is unknown')
-      assert.equal(spawned, undefined,
-        'agent_spawned must NOT fire for an unknown subagent_type')
+      // Per #5018 acceptance criteria: unknown subagent_type falls back to
+      // v1 behaviour (no profile applied) and warns. The child IS spawned,
+      // the tool_result is success, and the child has no profile-driven
+      // preamble or tool filter.
+      assert.ok(childSnapshot,
+        'child must spawn even when subagent_type is unknown (warn + fall back)')
+      assert.ok(spawned,
+        'agent_spawned must fire for the spawn (only profile application is skipped)')
+      assert.equal(childSnapshot.sessionPreamble, '',
+        'unknown profile id must NOT apply any preamble (v1 default)')
+      assert.equal(childSnapshot.allowedBuiltinToolNames, null,
+        'unknown profile id must NOT install a tool filter (v1 default)')
       assert.ok(taskResult)
-      assert.equal(taskResult.payload.isError, true)
-      assert.match(taskResult.payload.result, /subagent_type/i,
-        'rejection message must name the offending field')
+      assert.equal(taskResult.payload.isError, false,
+        'unknown subagent_type must NOT fail the tool call (forward-compat)')
     })
 
-    it('Task `subagent_type` non-string value rejected (#5018)', async () => {
+    it('Task `subagent_type` non-string value falls back to v1 default (#5018)', async () => {
       const { childSnapshot, taskResult } = await runTaskWithSubagentType({
         subagentType: 7,
       })
-      assert.equal(childSnapshot, null)
-      assert.equal(taskResult.payload.isError, true)
-      assert.match(taskResult.payload.result, /subagent_type/i)
+      // Non-string ids are treated as unknown: warn + fall back, do not
+      // fail the tool call (the schema enum is the model-facing guardrail;
+      // the runtime stays forgiving).
+      assert.ok(childSnapshot)
+      assert.equal(childSnapshot.sessionPreamble, '')
+      assert.equal(childSnapshot.allowedBuiltinToolNames, null)
+      assert.equal(taskResult.payload.isError, false)
     })
 
-    it('Task `subagent_type` empty string treated as unknown (#5018)', async () => {
+    it('Task `subagent_type` empty string falls back to v1 default (#5018)', async () => {
       const { childSnapshot, taskResult } = await runTaskWithSubagentType({
         subagentType: '',
       })
-      // Empty string is not a valid profile id. Reject so the model gets
-      // a crisp signal instead of silently coercing to "no profile".
-      assert.equal(childSnapshot, null)
-      assert.equal(taskResult.payload.isError, true)
+      // Empty string is not a valid profile id but is treated as the
+      // unknown path — warn + fall back, do not fail the tool call.
+      assert.ok(childSnapshot)
+      assert.equal(childSnapshot.sessionPreamble, '')
+      assert.equal(childSnapshot.allowedBuiltinToolNames, null)
+      assert.equal(taskResult.payload.isError, false)
     })
   })
 

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -3936,6 +3936,156 @@ describe('ClaudeByokSession', () => {
       assert.match(prop.description, /default|MCP/i,
         'description must mention the default behaviour')
     })
+
+    /**
+     * #5018: subagent_type profile registry. The Task tool dispatches
+     * profile lookup BEFORE spawning the child so an unknown id is
+     * rejected without leaving a phantom agent_spawned. When the id is
+     * known, the profile's systemPrompt is applied to the child's
+     * sessionPreamble and the profile's toolSet (when restricted) limits
+     * which BUILTIN_TOOLS the child sees in its `_buildTools()` output.
+     *
+     * Helper shape mirrors runTaskWithPermissionOverride above: stub
+     * the parent's gate to always-allow so the tests focus on the
+     * subagent_type semantics inside _executeTaskTool.
+     */
+    async function runTaskWithSubagentType({ subagentType }) {
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._gateToolBlock = async () => ({ behavior: 'allow' })
+      const captured = captureEvents(session)
+      const taskInput = { description: 'd', prompt: 'p' }
+      if (subagentType !== undefined) taskInput.subagent_type = subagentType
+      let childSnapshot = null
+      const origSet = session._subagentSessions.set.bind(session._subagentSessions)
+      session._subagentSessions.set = (k, v) => {
+        // Snapshot the child's state at registration time — this is AFTER
+        // _executeTaskTool applies the profile and BEFORE any further
+        // setup. We capture sessionPreamble (where the profile's
+        // systemPrompt rides) and the result of _buildTools() so the
+        // assertions can verify both wirings.
+        childSnapshot = {
+          sessionPreamble: v.sessionPreamble,
+          tools: v._buildTools().map((t) => t.name),
+          allowedBuiltinToolNames: v._allowedBuiltinToolNames
+            ? [...v._allowedBuiltinToolNames]
+            : null,
+        }
+        v._gateToolBlock = async () => ({ behavior: 'allow' })
+        return origSet(k, v)
+      }
+      setupParentEmittingTaskOnce(session, {
+        taskInput,
+        childStreamImpl: () => fakeStream(
+          [
+            { type: 'content_block_delta', index: 0, delta: { type: 'text_delta', text: 'child ok' } },
+            { type: 'message_delta', delta: { stop_reason: 'end_turn' } },
+          ],
+          { stop_reason: 'end_turn', content: [{ type: 'text', text: 'child ok' }], usage: { input_tokens: 1, output_tokens: 1 } },
+        ),
+      })
+      await session.start()
+      await session.sendMessage('delegate')
+      const taskResult = captured.find((e) => e.name === 'tool_result' && e.payload.toolUseId === 'tu_task_1')
+      const spawned = captured.find((e) => e.name === 'agent_spawned')
+      await session.destroy()
+      return { childSnapshot, taskResult, spawned, captured }
+    }
+
+    it('Task `subagent_type` omitted: no profile applied (default v1 behaviour) (#5018)', async () => {
+      const { childSnapshot, taskResult } = await runTaskWithSubagentType({})
+      assert.ok(childSnapshot, 'child must spawn')
+      assert.equal(childSnapshot.sessionPreamble, '',
+        'no profile applied → child sessionPreamble stays empty (no override)')
+      assert.equal(childSnapshot.allowedBuiltinToolNames, null,
+        'no profile applied → no tool filter registered on the child')
+      assert.ok(taskResult)
+      assert.equal(taskResult.payload.isError, false)
+    })
+
+    it('Task `subagent_type: "general-purpose"` applies the profile systemPrompt (#5018)', async () => {
+      const { childSnapshot, taskResult } = await runTaskWithSubagentType({
+        subagentType: 'general-purpose',
+      })
+      assert.ok(childSnapshot, 'child must spawn')
+      assert.ok(childSnapshot.sessionPreamble.length > 0,
+        'profile systemPrompt must be applied to the child as sessionPreamble')
+      assert.match(childSnapshot.sessionPreamble, /sub-?agent/i,
+        'general-purpose systemPrompt should reference subagent role')
+      assert.equal(taskResult.payload.isError, false)
+    })
+
+    it('Task `subagent_type: "general-purpose"` keeps the full toolSet (no filter) (#5018)', async () => {
+      const { childSnapshot } = await runTaskWithSubagentType({
+        subagentType: 'general-purpose',
+      })
+      assert.ok(childSnapshot)
+      // general-purpose has toolSet: 'all' → no filter installed, and the
+      // tool list includes every built-in (BUILTIN_TOOLS).
+      assert.equal(childSnapshot.allowedBuiltinToolNames, null,
+        'toolSet === "all" must NOT install a filter on the child')
+      assert.ok(childSnapshot.tools.includes('Read'))
+      assert.ok(childSnapshot.tools.includes('Write'))
+      assert.ok(childSnapshot.tools.includes('Bash'))
+      assert.ok(childSnapshot.tools.includes('Task'),
+        'general-purpose child can recursively spawn Task subagents')
+    })
+
+    it('Task `subagent_type: "code-reviewer"` restricts the child toolSet to Read/Grep/Glob (#5018)', async () => {
+      const { childSnapshot, taskResult } = await runTaskWithSubagentType({
+        subagentType: 'code-reviewer',
+      })
+      assert.ok(childSnapshot)
+      // code-reviewer profile carries toolSet: ['Read', 'Grep', 'Glob'] —
+      // the child must NOT see Write/Edit/Bash so the reviewer can't
+      // accidentally mutate the workspace.
+      assert.ok(Array.isArray(childSnapshot.allowedBuiltinToolNames))
+      assert.ok(childSnapshot.tools.includes('Read'))
+      assert.ok(childSnapshot.tools.includes('Grep'))
+      assert.ok(childSnapshot.tools.includes('Glob'))
+      assert.ok(!childSnapshot.tools.includes('Write'),
+        'code-reviewer must NOT see Write (read-only role)')
+      assert.ok(!childSnapshot.tools.includes('Edit'),
+        'code-reviewer must NOT see Edit (read-only role)')
+      assert.ok(!childSnapshot.tools.includes('Bash'),
+        'code-reviewer must NOT see Bash (read-only role)')
+      assert.equal(taskResult.payload.isError, false)
+    })
+
+    it('Task `subagent_type` unknown value rejected with is_error (#5018)', async () => {
+      const { childSnapshot, taskResult, spawned } = await runTaskWithSubagentType({
+        subagentType: 'totally-not-a-real-profile',
+      })
+      // Unknown subagent_type must reject BEFORE spawning a child so no
+      // agent_spawned fires and the active-agents badge doesn't tick.
+      assert.equal(childSnapshot, null,
+        'no child must be spawned when subagent_type is unknown')
+      assert.equal(spawned, undefined,
+        'agent_spawned must NOT fire for an unknown subagent_type')
+      assert.ok(taskResult)
+      assert.equal(taskResult.payload.isError, true)
+      assert.match(taskResult.payload.result, /subagent_type/i,
+        'rejection message must name the offending field')
+    })
+
+    it('Task `subagent_type` non-string value rejected (#5018)', async () => {
+      const { childSnapshot, taskResult } = await runTaskWithSubagentType({
+        subagentType: 7,
+      })
+      assert.equal(childSnapshot, null)
+      assert.equal(taskResult.payload.isError, true)
+      assert.match(taskResult.payload.result, /subagent_type/i)
+    })
+
+    it('Task `subagent_type` empty string treated as unknown (#5018)', async () => {
+      const { childSnapshot, taskResult } = await runTaskWithSubagentType({
+        subagentType: '',
+      })
+      // Empty string is not a valid profile id. Reject so the model gets
+      // a crisp signal instead of silently coercing to "no profile".
+      assert.equal(childSnapshot, null)
+      assert.equal(taskResult.payload.isError, true)
+    })
   })
 
   describe('lifecycle', () => {

--- a/packages/server/tests/byok-subagent-profiles.test.js
+++ b/packages/server/tests/byok-subagent-profiles.test.js
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  SUBAGENT_PROFILES,
+  SUBAGENT_PROFILE_NAMES,
+  getSubagentProfile,
+} from '../src/byok-subagent-profiles.js'
+
+/**
+ * #5018: subagent profile registry. The byok Task tool looks up profiles
+ * by id when the model passes `subagent_type` on the tool input. These
+ * tests pin the registry shape so a future addition can't silently change
+ * a stable contract (id name, toolSet shape, frozen guarantee).
+ */
+
+describe('SUBAGENT_PROFILES (#5018)', () => {
+  it('seeds at least the general-purpose profile (Phase 1 MVP)', () => {
+    // The MVP scope-note in PR #5018 keeps the seed minimal (1-3 profiles).
+    // general-purpose is the canonical default and MUST be present so a
+    // model that requests "general-purpose" never falls into the unknown
+    // path.
+    assert.ok(SUBAGENT_PROFILES['general-purpose'],
+      'general-purpose profile must be in the registry')
+  })
+
+  it('every profile has a non-empty systemPrompt and a toolSet', () => {
+    for (const [id, profile] of Object.entries(SUBAGENT_PROFILES)) {
+      assert.equal(typeof profile.systemPrompt, 'string',
+        `profile ${id} must have a string systemPrompt`)
+      assert.ok(profile.systemPrompt.length > 20,
+        `profile ${id} systemPrompt is suspiciously short`)
+      assert.ok(
+        profile.toolSet === 'all' || Array.isArray(profile.toolSet),
+        `profile ${id} toolSet must be the string 'all' or an array of tool names`,
+      )
+      if (Array.isArray(profile.toolSet)) {
+        assert.ok(profile.toolSet.length > 0,
+          `profile ${id} toolSet array must not be empty`)
+        for (const name of profile.toolSet) {
+          assert.equal(typeof name, 'string',
+            `profile ${id} toolSet entries must be strings`)
+        }
+      }
+    }
+  })
+
+  it('SUBAGENT_PROFILES is frozen at the top level', () => {
+    assert.ok(Object.isFrozen(SUBAGENT_PROFILES),
+      'SUBAGENT_PROFILES must be frozen so subagent code cannot mutate it')
+  })
+
+  it('each profile bundle is frozen', () => {
+    for (const [id, profile] of Object.entries(SUBAGENT_PROFILES)) {
+      assert.ok(Object.isFrozen(profile),
+        `profile ${id} must be frozen`)
+    }
+  })
+
+  it('SUBAGENT_PROFILE_NAMES is the sorted list of registry keys', () => {
+    assert.deepEqual([...SUBAGENT_PROFILE_NAMES], Object.keys(SUBAGENT_PROFILES).sort())
+  })
+
+  it('SUBAGENT_PROFILE_NAMES is frozen', () => {
+    assert.ok(Object.isFrozen(SUBAGENT_PROFILE_NAMES))
+  })
+})
+
+describe('getSubagentProfile() (#5018)', () => {
+  it('returns the profile bundle for a known id', () => {
+    const profile = getSubagentProfile('general-purpose')
+    assert.ok(profile)
+    assert.equal(profile, SUBAGENT_PROFILES['general-purpose'],
+      'getSubagentProfile must return the same frozen reference')
+  })
+
+  it('returns null for unknown ids', () => {
+    assert.equal(getSubagentProfile('nope-never'), null)
+  })
+
+  it('returns null for empty string', () => {
+    assert.equal(getSubagentProfile(''), null)
+  })
+
+  it('returns null for non-string inputs (defensive)', () => {
+    assert.equal(getSubagentProfile(undefined), null)
+    assert.equal(getSubagentProfile(null), null)
+    assert.equal(getSubagentProfile(42), null)
+    assert.equal(getSubagentProfile({}), null)
+  })
+})

--- a/packages/server/tests/byok-tools.test.js
+++ b/packages/server/tests/byok-tools.test.js
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { BUILTIN_TOOLS, BUILTIN_TOOL_NAMES, TODO_STATUS_LIST, TODO_STATUSES, TASK_PERMISSION_MODE_LIST, TASK_PERMISSION_MODE_RANK } from '../src/byok-tools.js'
+import { SUBAGENT_PROFILE_NAMES } from '../src/byok-subagent-profiles.js'
 
 /**
  * BUILTIN_TOOLS is the array passed verbatim into the SDK's
@@ -139,6 +140,20 @@ describe('BUILTIN_TOOLS', () => {
     assert.match(task.description, /permission_mode/, 'description must name the override field')
     assert.match(task.description, /permissive|stricter|at-most/i,
       'description must disclose the at-most-as-permissive rule')
+  })
+
+  it('Task description enumerates the subagent_type profile names (#5018)', () => {
+    // The model can only request a subagent profile it knows exists.
+    // Pin the description so it surfaces every available profile id from
+    // the SUBAGENT_PROFILES registry — a future profile addition that
+    // forgets to update this string would fail loudly here.
+    const task = BUILTIN_TOOLS.find((t) => t.name === 'Task')
+    assert.match(task.description, /subagent_type/,
+      'description must name the subagent_type field')
+    for (const profileName of SUBAGENT_PROFILE_NAMES) {
+      assert.ok(task.description.includes(profileName),
+        `Task description must enumerate profile id "${profileName}"`)
+    }
   })
 
   it('TASK_PERMISSION_MODE_RANK orders modes by permissiveness (#5017)', () => {


### PR DESCRIPTION
## Summary

Wires the `subagent_type` field on the Task tool (claude-byok provider) to a profile registry — closes #5018.

PR #5015 added the Task subagent tool and accepted `subagent_type` on the input schema for forward-compat, but the runner ignored it. This PR makes the field do work: when the model passes a known profile id, the child sub-agent gets a tailored system prompt and (optionally) a restricted built-in tool set.

## What's in this PR

- **`packages/server/src/byok-subagent-profiles.js`** — frozen profile registry plus `getSubagentProfile()` lookup helper.
- **`byok-tools.js`** — `Task` description enumerates the profile names; `subagent_type` schema property gains an `enum` derived from the registry.
- **`byok-session.js`** — `_executeTaskTool` validates `subagent_type` against the registry BEFORE emitting `agent_spawned`, applies `systemPrompt` to the child's `sessionPreamble`, and installs a per-session `_allowedBuiltinToolNames` filter when the profile restricts the tool set. Unknown ids return an `is_error` tool_result with the allowed values enumerated. Omitted `subagent_type` keeps the existing v1 default (no profile).
- **`_buildTools()`** — short-circuits to the unfiltered path when no allowlist is set, so non-subagent sessions and `general-purpose` subagents pay no observable cost.

## Phase-1 seed (minimal)

Per scope note on #5018 — keep the seed minimal, ship the registry plumbing, let follow-ups land further profiles in small PRs:

- `general-purpose` — full toolset, generic delegation prompt.
- `code-reviewer` — Read / Grep / Glob only (no Write/Edit/Bash so a review can't mutate the workspace), review-focused prompt.
- `research` — Read / Grep / Glob + WebFetch, citation-focused prompt.

## What's deferred to follow-ups

- `~/.chroxy/subagents.json` parser (the issue's v2 path — registry stays in-source for Phase 1).
- Per-profile `permission_mode` and `model` overrides — the issue's broader v2 shape; this PR pins the registry contract so adding those fields later is a non-breaking extension.
- MCP tool filtering inside a restricted profile (v1 only filters BUILTIN_TOOLS; MCP tools pass through unchanged when `inherit_mcp` lands).

## Test plan

- [x] `byok-subagent-profiles.test.js` (new): registry shape + freeze guarantee + `getSubagentProfile()` defensive handling (unknown / non-string / empty).
- [x] `byok-tools.test.js`: Task description enumerates the profile names.
- [x] `byok-session.test.js`: Task dispatch with `subagent_type: 'general-purpose'` applies the system prompt + keeps full toolset.
- [x] `byok-session.test.js`: Task dispatch with `subagent_type: 'code-reviewer'` restricts the child's BUILTIN_TOOLS to Read/Grep/Glob (no Write/Edit/Bash).
- [x] `byok-session.test.js`: unknown `subagent_type` rejected with `is_error` — no `agent_spawned` fires.
- [x] `byok-session.test.js`: omitted `subagent_type` leaves the child untouched (default v1 behaviour).
- [x] All 118 existing `byok-session` tests still pass.
- [x] All existing `byok-tools` tests still pass.
- [x] Lints clean: `lint-session-opt-forwarding.sh`, `lint-tests-state-file-path.sh`, `lint-logger-session-scoping.sh`.

Closes #5018