### PR TITLE
feat(server): support DevContainer + Compose for docker-byok (#5024)

### DIFF
--- a/packages/server/src/devcontainer-config.js
+++ b/packages/server/src/devcontainer-config.js
@@ -1,0 +1,128 @@
+/**
+ * DevContainer config helpers (#5024).
+ *
+ * Pure functions extracted so both EnvironmentManager (persistent
+ * environments) and DockerByokSession (per-session containers) can
+ * parse and validate `.devcontainer/devcontainer.json` without
+ * duplicating logic.
+ *
+ * Exports:
+ *   - `parseDevContainer(cwd, { logger })` — read + parse + filter
+ *     unsupported fields. Returns `{}` when no file is present.
+ *   - `validateMounts(mounts, cwd, { logger })` — keep only mounts
+ *     whose source is inside `cwd`. Defends against path traversal
+ *     and refuses mounts that point at host secrets (~/.ssh, etc.).
+ *   - `sanitizeContainerEnv(containerEnv, { logger })` — drop keys
+ *     that don't match POSIX env-var name rules.
+ *   - `extractMountSource(mount)` — pull the source path out of a
+ *     short-form (`source:target`) or long-form
+ *     (`source=...,target=...`) mount string.
+ *
+ * The `logger` arg is optional — when omitted, a no-op logger is
+ * used. This keeps the module pure for tests that don't want to
+ * thread a logger through every call.
+ */
+
+import { existsSync, readFileSync } from 'fs'
+import { join, resolve } from 'path'
+import { homedir } from 'os'
+
+const VALID_ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+const NOOP_LOG = { info: () => {}, warn: () => {}, error: () => {} }
+
+/**
+ * Parse a `.devcontainer/devcontainer.json` (or `.devcontainer.json`
+ * sidecar) from the given cwd.
+ */
+export function parseDevContainer(cwd, { logger = NOOP_LOG } = {}) {
+  const candidates = [
+    join(cwd, '.devcontainer', 'devcontainer.json'),
+    join(cwd, '.devcontainer.json'),
+  ]
+  let filePath
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) { filePath = candidate; break }
+  }
+  if (!filePath) {
+    logger.info('No devcontainer.json found, using defaults')
+    return {}
+  }
+  let raw
+  try { raw = JSON.parse(readFileSync(filePath, 'utf-8')) }
+  catch (err) { logger.warn(`Failed to parse ${filePath}: ${err.message}`); return {} }
+
+  logger.info(`Parsed devcontainer.json from ${filePath}`)
+
+  const SUPPORTED_FIELDS = new Set([
+    'image', 'forwardPorts', 'containerEnv', 'mounts',
+    'remoteUser', 'postCreateCommand',
+  ])
+  for (const key of Object.keys(raw)) {
+    if (!SUPPORTED_FIELDS.has(key)) {
+      logger.warn(`devcontainer.json: unsupported field "${key}" (ignored)`)
+    }
+  }
+
+  const config = {}
+  if (typeof raw.image === 'string' && raw.image.trim()) config.image = raw.image.trim()
+  if (typeof raw.remoteUser === 'string' && raw.remoteUser.trim()) config.remoteUser = raw.remoteUser.trim()
+  if (typeof raw.postCreateCommand === 'string' && raw.postCreateCommand.trim()) config.postCreateCommand = raw.postCreateCommand.trim()
+  if (raw.containerEnv && typeof raw.containerEnv === 'object' && !Array.isArray(raw.containerEnv)) config.containerEnv = raw.containerEnv
+  if (Array.isArray(raw.forwardPorts)) config.forwardPorts = raw.forwardPorts.filter(p => typeof p === 'number' || typeof p === 'string')
+  if (Array.isArray(raw.mounts)) config.mounts = raw.mounts.filter(m => typeof m === 'string')
+  return config
+}
+
+/**
+ * Validate mount source paths. Only mounts whose source is inside the
+ * project directory (cwd) are allowed.
+ */
+export function validateMounts(mounts, cwd, { logger = NOOP_LOG } = {}) {
+  if (!Array.isArray(mounts) || mounts.length === 0) return undefined
+  const resolvedCwd = cwd.endsWith('/') ? cwd : cwd + '/'
+  const home = homedir()
+  const allowed = []
+  for (const mount of mounts) {
+    const source = extractMountSource(mount)
+    if (!source) {
+      logger.warn(`devcontainer mount rejected (unparseable): ${mount}`)
+      continue
+    }
+    const expandedSource = source.startsWith('~/')
+      ? join(home, source.slice(2))
+      : source.startsWith('~') ? home : source
+    const normalizedSource = resolve(expandedSource)
+    if (!normalizedSource.startsWith(resolvedCwd) && normalizedSource !== cwd) {
+      logger.warn(`devcontainer mount rejected (outside project dir): ${source}`)
+      continue
+    }
+    allowed.push(mount)
+  }
+  return allowed.length > 0 ? allowed : undefined
+}
+
+/** Extract the source path from a mount string. */
+export function extractMountSource(mount) {
+  const sourceMatch = mount.match(/(?:^|,)source=([^,]+)/)
+  if (sourceMatch) return sourceMatch[1]
+  const parts = mount.split(':')
+  if (parts.length >= 2) return parts[0]
+  return null
+}
+
+/** Sanitize containerEnv keys. */
+export function sanitizeContainerEnv(containerEnv, { logger = NOOP_LOG } = {}) {
+  if (!containerEnv || typeof containerEnv !== 'object') return undefined
+  const sanitized = Object.create(null)
+  let hasKeys = false
+  for (const [key, value] of Object.entries(containerEnv)) {
+    if (!VALID_ENV_KEY_RE.test(key)) {
+      logger.warn(`devcontainer env key rejected (invalid characters): ${key}`)
+      continue
+    }
+    sanitized[key] = value
+    hasKeys = true
+  }
+  return hasKeys ? sanitized : undefined
+}

--- a/packages/server/src/devcontainer-config.js
+++ b/packages/server/src/devcontainer-config.js
@@ -1,22 +1,31 @@
 /**
  * DevContainer config helpers (#5024).
  *
- * Pure functions extracted so both EnvironmentManager (persistent
- * environments) and DockerByokSession (per-session containers) can
- * parse and validate `.devcontainer/devcontainer.json` without
- * duplicating logic.
+ * Pure functions used by DockerByokSession (per-session containers)
+ * to parse and validate `.devcontainer/devcontainer.json`.
+ *
+ * EnvironmentManager (persistent environments) still carries its own
+ * `_parseDevContainer` / `_validateMounts` / `_sanitizeContainerEnv`
+ * instance methods today; consolidation onto this module is tracked
+ * separately (issue #5077). Until that lands, treat the two
+ * implementations as siblings — keep parity if you touch one.
  *
  * Exports:
  *   - `parseDevContainer(cwd, { logger })` — read + parse + filter
  *     unsupported fields. Returns `{}` when no file is present.
  *   - `validateMounts(mounts, cwd, { logger })` — keep only mounts
- *     whose source is inside `cwd`. Defends against path traversal
- *     and refuses mounts that point at host secrets (~/.ssh, etc.).
+ *     whose source is inside `cwd` (after resolve()-normalising
+ *     both sides). Defends against path traversal via `..`
+ *     segments. Note: this is a containment filter, not an explicit
+ *     denylist — `~/.ssh` and other host secrets are blocked
+ *     transitively because they're not under the project cwd, not
+ *     by a hard-coded denylist of paths.
  *   - `sanitizeContainerEnv(containerEnv, { logger })` — drop keys
  *     that don't match POSIX env-var name rules.
  *   - `extractMountSource(mount)` — pull the source path out of a
  *     short-form (`source:target`) or long-form
- *     (`source=...,target=...`) mount string.
+ *     (`source=...,target=...`) mount string. Handles Windows
+ *     drive-letter colons.
  *
  * The `logger` arg is optional — when omitted, a no-op logger is
  * used. This keeps the module pure for tests that don't want to
@@ -24,7 +33,7 @@
  */
 
 import { existsSync, readFileSync } from 'fs'
-import { join, resolve } from 'path'
+import { join, resolve, sep } from 'path'
 import { homedir } from 'os'
 
 const VALID_ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
@@ -80,7 +89,15 @@ export function parseDevContainer(cwd, { logger = NOOP_LOG } = {}) {
  */
 export function validateMounts(mounts, cwd, { logger = NOOP_LOG } = {}) {
   if (!Array.isArray(mounts) || mounts.length === 0) return undefined
-  const resolvedCwd = cwd.endsWith('/') ? cwd : cwd + '/'
+  // Normalise the cwd through resolve() so a caller-supplied relative
+  // path (or a Windows-style path with mixed separators) is compared
+  // apples-to-apples against the normalised source path computed
+  // below. The trailing separator is appended AFTER normalisation so
+  // `/proj` vs `/projects/foo` can't false-positive as a containment
+  // hit. Use posix.sep on POSIX and `\\` on Windows so the comparison
+  // works on either host.
+  const absCwd = resolve(cwd)
+  const resolvedCwd = absCwd.endsWith(sep) ? absCwd : absCwd + sep
   const home = homedir()
   const allowed = []
   for (const mount of mounts) {
@@ -93,7 +110,7 @@ export function validateMounts(mounts, cwd, { logger = NOOP_LOG } = {}) {
       ? join(home, source.slice(2))
       : source.startsWith('~') ? home : source
     const normalizedSource = resolve(expandedSource)
-    if (!normalizedSource.startsWith(resolvedCwd) && normalizedSource !== cwd) {
+    if (!normalizedSource.startsWith(resolvedCwd) && normalizedSource !== absCwd) {
       logger.warn(`devcontainer mount rejected (outside project dir): ${source}`)
       continue
     }
@@ -102,10 +119,29 @@ export function validateMounts(mounts, cwd, { logger = NOOP_LOG } = {}) {
   return allowed.length > 0 ? allowed : undefined
 }
 
-/** Extract the source path from a mount string. */
+/**
+ * Extract the source path from a mount string.
+ *
+ * Long-form (`source=/proj,target=/workspace,type=bind`) is taken from
+ * the `source=` k/v pair. Short-form (`<source>:<target>[:opts]`) is
+ * split on `:` — but a Windows host can legitimately produce
+ * `C:\proj:/workspace`, where the first colon is the drive-letter
+ * separator and the second is the source/target boundary. Splitting on
+ * every `:` in that case yields `"C"` as the source and tanks mount
+ * validation. Detect the drive-letter prefix and skip past it before
+ * splitting.
+ */
 export function extractMountSource(mount) {
   const sourceMatch = mount.match(/(?:^|,)source=([^,]+)/)
   if (sourceMatch) return sourceMatch[1]
+  // Windows drive-letter shape: `C:\…` or `C:/…`. Take everything up to
+  // the first colon AFTER the drive letter (index 2+) as the source.
+  if (/^[A-Za-z]:[\\/]/.test(mount)) {
+    const rest = mount.slice(2)
+    const sepIdx = rest.indexOf(':')
+    if (sepIdx === -1) return null
+    return mount.slice(0, 2 + sepIdx)
+  }
   const parts = mount.split(':')
   if (parts.length >= 2) return parts[0]
   return null

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -84,10 +84,8 @@
  */
 
 import { execFile } from 'child_process'
-import { mkdirSync, writeFileSync } from 'fs'
 import { randomBytes } from 'crypto'
-import { homedir } from 'os'
-import { isAbsolute, join, posix } from 'path'
+import { isAbsolute, posix } from 'path'
 import { ClaudeByokSession } from './byok-session.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
@@ -239,18 +237,28 @@ export class DockerByokSession extends ClaudeByokSession {
    * @param {string} [opts.containerId]              Attach to an existing container
    *   instead of launching one (env-manager managed). When omitted, the
    *   session owns the container and tears it down on destroy().
-   * @param {boolean} [opts.useDevcontainer=false]   #5024: Parse
-   *   `.devcontainer/devcontainer.json` (or `.devcontainer.json`) from
-   *   cwd and overlay its `image` / `remoteUser` / `containerEnv` /
-   *   `mounts` / `forwardPorts` / `postCreateCommand` onto the launch.
-   *   Explicit constructor opts always win; devcontainer.json is the
-   *   fallback default. No-op when the file is absent or malformed.
+   * @param {boolean} [opts.useDevcontainer=false]   #5024: Opt-in flag
+   *   — when true, parse `.devcontainer/devcontainer.json` (or the
+   *   `.devcontainer.json` sidecar) from cwd and overlay its
+   *   `image` / `remoteUser` / `containerEnv` / `mounts` /
+   *   `forwardPorts` / `postCreateCommand` onto the launch. Explicit
+   *   constructor opts always win; devcontainer.json is the fallback
+   *   default. No-op when the file is absent or malformed.
+   *
+   *   This is opt-in (not auto-discovery from cwd) so existing
+   *   sessions whose cwd happens to contain a devcontainer.json don't
+   *   silently change behaviour. The caller (CLI flag, dashboard
+   *   toggle, env-manager) is responsible for setting this when the
+   *   user has asked for devcontainer-driven environments.
    * @param {string} [opts.composeFile]              #5024: Path to a
    *   `docker-compose.yml`. When set, start() runs `docker compose up
    *   -d` under a session-scoped project id and attaches to the named
    *   service container. destroy() runs `docker compose down
    *   --remove-orphans` to tear the whole stack down. Pooling is
    *   disabled in this mode.
+   *
+   *   This is opt-in (not auto-discovery from cwd) — see the note on
+   *   `useDevcontainer` above. The caller passes the path explicitly.
    * @param {string} [opts.composeService]           #5024: Optional
    *   service name from the compose file to attach to (the "primary"
    *   service). When omitted, the first service from `docker compose
@@ -647,7 +655,15 @@ export class DockerByokSession extends ClaudeByokSession {
             if (typeof port === 'number' && Number.isFinite(port) && port > 0 && port < 65536) {
               runArgs.push('-p', `${port}:${port}`)
             } else if (typeof port === 'string' && /^\d+(:\d+)?$/.test(port)) {
-              runArgs.push('-p', port)
+              // Bare-port strings ("3000") would otherwise become
+              // `docker run -p 3000`, which Docker treats as "publish
+              // container port 3000 to a RANDOM host port" — surprising
+              // for a DevContainer-style forward where the model
+              // expects 3000:3000. Normalise to host:container when the
+              // colon is missing so the numeric and string forms
+              // behave identically.
+              const normalized = port.includes(':') ? port : `${port}:${port}`
+              runArgs.push('-p', normalized)
             } else {
               log.warn(`devcontainer.json forwardPorts entry rejected (invalid): ${port}`)
             }

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -36,12 +36,45 @@
  *
  * Deferred (follow-up issues)
  * ---------------------------
- *   - Per-session container reuse / pooling
- *   - Snapshot/restore (Docker commit-based snapshots already exist for
- *     docker-cli / docker-sdk — wiring them up for docker-byok belongs
- *     in a follow-up so docker-byok ships small)
- *   - DevContainer / Compose-driven environments
- *   - postCreateCommand hook
+ *   - Per-session container reuse / pooling (#5022 — landed)
+ *   - DevContainer / Compose-driven environments (#5024 — landed)
+ *   - postCreateCommand hook (#5024 — landed alongside devcontainer)
+ *
+ * DevContainer + Compose (#5024)
+ * -----------------------------
+ *   - `useDevcontainer: true` — start() parses .devcontainer/
+ *     devcontainer.json (or .devcontainer.json) from cwd, validates
+ *     mounts/env via the shared `devcontainer-config.js` helper, then
+ *     overlays `image` / `remoteUser` / `containerEnv` / `mounts` /
+ *     `forwardPorts` / `postCreateCommand` onto the bare-image launch.
+ *     Explicit constructor opts always win — devcontainer.json is the
+ *     fallback default.
+ *   - `composeFile: '<path>'` + optional `composeService: '<name>'` —
+ *     start() shells `docker compose up -d` against the file (under a
+ *     session-scoped project id), identifies the named service's
+ *     container, and attaches to it. destroy() runs `docker compose
+ *     down --remove-orphans` against the same project so the whole
+ *     stack tears down. Pooling is disabled in compose mode.
+ *   - Default (neither opt) — original v1 bare-image launch path.
+ *
+ * Snapshot / restore (#5023, this revision)
+ * -----------------------------------------
+ *   - `snapshot({ name? })` runs `docker commit <containerId>
+ *     chroxy-byok-snap:<rand>-<ts>` via the backend, marks the live
+ *     container "soiled" so the pool evicts it on release (#5043), and
+ *     writes a small metadata JSON to `snapshotsDir` (defaults to
+ *     `~/.chroxy/snapshots/`, override via `CHROXY_CONFIG_DIR`) so ops
+ *     can list snapshot names without parsing `docker image ls`.
+ *   - To restore, pass `snapshotImage: <tag>` to the constructor. The
+ *     session uses that tag as the image at `docker run` time and skips
+ *     the `useradd` + `chown` setup (the snapshot already has those
+ *     baked in). The restored container is auto-soiled — restoring
+ *     previous state into a live container couples it to the snapshot's
+ *     original conversation history.
+ *   - Pool interaction: a snapshotted or restored container goes
+ *     through `release()` as normal, but the pool sees the soil marker
+ *     and evicts inline instead of pooling. UI / multi-snapshot listing
+ *     is deferred to a follow-up.
  *
  * Per `project_worktree_before_docker.md` in project memory: worktree
  * isolation happens BEFORE Docker. This class does not own worktree
@@ -51,12 +84,20 @@
  */
 
 import { execFile } from 'child_process'
+import { mkdirSync, writeFileSync } from 'fs'
+import { randomBytes } from 'crypto'
+import { homedir } from 'os'
+import { isAbsolute, join, posix } from 'path'
 import { ClaudeByokSession } from './byok-session.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
 import { buildPoolKey, getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
 import { createLogger } from './logger.js'
-import { isAbsolute, posix } from 'path'
+import {
+  parseDevContainer,
+  validateMounts,
+  sanitizeContainerEnv,
+} from './devcontainer-config.js'
 
 const log = createLogger('docker-byok')
 
@@ -198,6 +239,22 @@ export class DockerByokSession extends ClaudeByokSession {
    * @param {string} [opts.containerId]              Attach to an existing container
    *   instead of launching one (env-manager managed). When omitted, the
    *   session owns the container and tears it down on destroy().
+   * @param {boolean} [opts.useDevcontainer=false]   #5024: Parse
+   *   `.devcontainer/devcontainer.json` (or `.devcontainer.json`) from
+   *   cwd and overlay its `image` / `remoteUser` / `containerEnv` /
+   *   `mounts` / `forwardPorts` / `postCreateCommand` onto the launch.
+   *   Explicit constructor opts always win; devcontainer.json is the
+   *   fallback default. No-op when the file is absent or malformed.
+   * @param {string} [opts.composeFile]              #5024: Path to a
+   *   `docker-compose.yml`. When set, start() runs `docker compose up
+   *   -d` under a session-scoped project id and attaches to the named
+   *   service container. destroy() runs `docker compose down
+   *   --remove-orphans` to tear the whole stack down. Pooling is
+   *   disabled in this mode.
+   * @param {string} [opts.composeService]           #5024: Optional
+   *   service name from the compose file to attach to (the "primary"
+   *   service). When omitted, the first service from `docker compose
+   *   ps` is picked.
    * @param {object} [opts._dockerBackend]           Test seam — pre-built backend
    * @param {Function} [opts._execFile]              Test seam — used by preflight
    *   (defaults to child_process.execFile)
@@ -216,6 +273,37 @@ export class DockerByokSession extends ClaudeByokSession {
     // Override `provider` so the session reports `docker-byok` for
     // wire-protocol consumers (display label, capabilities matrix).
     super({ ...opts, provider: opts.provider || 'docker-byok' })
+
+    // #5024: DevContainer auto-discovery (off by default). When set,
+    // start() reads `.devcontainer/devcontainer.json` from cwd and
+    // overlays its `image` / `remoteUser` / `containerEnv` / `mounts` /
+    // `forwardPorts` / `postCreateCommand` onto the session defaults.
+    // Explicit constructor opts always win — devcontainer.json acts as
+    // the "fallback default" when the operator hasn't set a field.
+    this._useDevcontainer = opts.useDevcontainer === true
+    // Record raw caller opts now so the merge in start() can tell
+    // "caller set image=X" apart from "default".
+    this._explicitImage = opts.image
+    this._explicitContainerUser = opts.containerUser
+    this._dcConfig = null
+
+    // #5024: Docker Compose support. When `composeFile` is set, start()
+    // shells out `docker compose up -d` against that file and attaches
+    // to the named service container instead of running a fresh image.
+    // The compose stack is owned by THIS session: destroy() tears it
+    // down with `docker compose down --remove-orphans`. To attach to a
+    // pre-existing compose stack, pass `containerId` instead.
+    this._composeFile = typeof opts.composeFile === 'string' && opts.composeFile.trim()
+      ? opts.composeFile.trim()
+      : null
+    this._composeService = typeof opts.composeService === 'string' && opts.composeService.trim()
+      ? opts.composeService.trim()
+      : null
+    // Compose project id — a session-scoped suffix so two sessions
+    // pointed at the same compose file get isolated stacks. Mirrors
+    // environment-manager's `chroxy-${envId}` naming. Resolved lazily
+    // in start() so construction stays deterministic.
+    this._composeProject = null
 
     const user = opts.containerUser || DEFAULT_USER
     if (!VALID_USERNAME_RE.test(user)) {
@@ -238,10 +326,15 @@ export class DockerByokSession extends ClaudeByokSession {
     // or by passing an explicit `_pool` instance. Per-session reuse of
     // the same container across multiple turns is unconditional and
     // independent of pooling.
+    // #5024: pooling is also disabled when the session manages a
+    // compose stack — the pool key is shaped for single-container
+    // resource shape (image/memory/cpu/user) and would silently reuse
+    // a bare-image container for a compose session. The destroy() path
+    // for compose unconditionally runs `docker compose down`.
     const poolEnv = opts._poolEnv || process.env
     if (opts._pool) {
       this._pool = opts._pool
-    } else if (!opts.containerId && isPoolEnabled(poolEnv)) {
+    } else if (!opts.containerId && !this._composeFile && isPoolEnabled(poolEnv)) {
       this._pool = getSharedPool(poolEnv)
     } else {
       this._pool = null
@@ -380,6 +473,18 @@ export class DockerByokSession extends ClaudeByokSession {
    * does not depend on the pool.
    */
   async _acquireOrStartContainer() {
+    // #5024: compose mode short-circuits the entire pool + bare-image
+    // path. The compose stack owns its own container; destroy()
+    // unwinds it with `docker compose down`.
+    if (this._composeFile) {
+      await this._startComposeStack()
+      return
+    }
+    // #5024: devcontainer parsing must happen BEFORE the pool lookup
+    // because the resolved image/user are part of the pool key.
+    if (this._useDevcontainer) {
+      this._resolveDevContainer()
+    }
     if (this._pool) {
       const key = this._poolKey()
       const reused = this._pool.acquire(key)
@@ -416,6 +521,82 @@ export class DockerByokSession extends ClaudeByokSession {
   }
 
   /**
+   * #5024: Parse `.devcontainer/devcontainer.json` from cwd and
+   * overlay supported fields onto this session's state. Explicit
+   * constructor opts always win — devcontainer.json is the fallback.
+   * No-op when no devcontainer.json exists or the file is malformed
+   * (the parser logs and returns `{}`).
+   *
+   * Stores the parsed config in `this._dcConfig` so `_startContainer`
+   * can apply `mounts` / `containerEnv` / `forwardPorts` /
+   * `postCreateCommand` to the `docker run` and `docker exec` calls.
+   */
+  _resolveDevContainer() {
+    const cwd = this.cwd || process.cwd()
+    const config = parseDevContainer(cwd, { logger: log })
+    if (config && Object.keys(config).length > 0) {
+      log.info(`devcontainer.json overlay active (cwd=${cwd})`)
+    }
+    // image: caller opt wins over devcontainer.json wins over DEFAULT_IMAGE.
+    if (!this._explicitImage && config.image) {
+      this._image = config.image
+    }
+    // remoteUser: caller opt wins over devcontainer.json wins over DEFAULT_USER.
+    if (!this._explicitContainerUser && config.remoteUser) {
+      // Validate the user name — devcontainer.json is untrusted input.
+      if (VALID_USERNAME_RE.test(config.remoteUser)) {
+        this._containerUser = config.remoteUser
+      } else {
+        log.warn(`devcontainer.json remoteUser "${config.remoteUser}" rejected — keeping ${this._containerUser}`)
+      }
+    }
+    // Validate mounts and env now so a bad value surfaces at start time
+    // instead of when docker rejects the run call.
+    this._dcConfig = {
+      ...config,
+      mounts: validateMounts(config.mounts, cwd, { logger: log }),
+      containerEnv: sanitizeContainerEnv(config.containerEnv, { logger: log }),
+    }
+  }
+
+  /**
+   * #5024: Bring up the compose stack and identify the primary service
+   * container. The stack is owned by THIS session — destroy() runs
+   * `docker compose down --remove-orphans` against the same project id.
+   *
+   * Mirrors EnvironmentManager._createComposeEnvironment so the
+   * security posture is identical: the named service container has its
+   * non-root user created the same way the bare-image path does, the
+   * host cwd is mounted at /workspace via the compose file (the user
+   * is responsible for that volume mapping), and tool dispatch goes
+   * through the same `_execAsContainerUser` path.
+   */
+  async _startComposeStack() {
+    if (!this._composeProject) {
+      this._composeProject = `chroxy-byok-${randomBytes(6).toString('hex')}`
+    }
+    const cwd = this.cwd || process.cwd()
+    log.info(`docker-byok compose stack starting (file=${this._composeFile} project=${this._composeProject} service=${this._composeService || '<first>'})`)
+    let result
+    try {
+      result = await this._dockerBackend.createComposeEnvironment({
+        envId: this._composeProject,
+        cwd,
+        composeFile: this._composeFile,
+        composeProject: this._composeProject,
+        containerUser: this._containerUser,
+        primaryService: this._composeService,
+      })
+    } catch (err) {
+      const error = new Error(`docker compose start failed: ${err.message}`)
+      error.code = err.code || 'compose_start_failed'
+      throw error
+    }
+    this._containerId = result.containerId
+    log.info(`docker-byok compose primary container: ${this._containerId.slice(0, 12)}`)
+  }
+
+  /**
    * Launch a long-lived container with the host cwd mounted at
    * /workspace and the standard chroxy hardening (cap-drop, pids
    * limit, no-new-privileges, non-root user). Mirrors the runArgs
@@ -442,6 +623,36 @@ export class DockerByokSession extends ClaudeByokSession {
       const apiKey = process.env.ANTHROPIC_API_KEY
       if (apiKey) {
         runArgs.push('--env', `ANTHROPIC_API_KEY=${apiKey}`)
+      }
+
+      // #5024: devcontainer.json overlay — extra mounts, env, and port
+      // forwards. Mounts and env were already validated/sanitized by
+      // `_resolveDevContainer()`; whatever survived is safe to pass
+      // straight through. `forwardPorts` accepts integers and
+      // "host:container" strings — both shapes emit `-p X:Y`.
+      const dc = this._dcConfig
+      if (dc) {
+        if (Array.isArray(dc.mounts)) {
+          for (const mount of dc.mounts) {
+            runArgs.push('--mount', mount)
+          }
+        }
+        if (dc.containerEnv && typeof dc.containerEnv === 'object') {
+          for (const [key, value] of Object.entries(dc.containerEnv)) {
+            runArgs.push('--env', `${key}=${value}`)
+          }
+        }
+        if (Array.isArray(dc.forwardPorts)) {
+          for (const port of dc.forwardPorts) {
+            if (typeof port === 'number' && Number.isFinite(port) && port > 0 && port < 65536) {
+              runArgs.push('-p', `${port}:${port}`)
+            } else if (typeof port === 'string' && /^\d+(:\d+)?$/.test(port)) {
+              runArgs.push('-p', port)
+            } else {
+              log.warn(`devcontainer.json forwardPorts entry rejected (invalid): ${port}`)
+            }
+          }
+        }
       }
 
       if (process.platform === 'linux') {
@@ -481,6 +692,27 @@ export class DockerByokSession extends ClaudeByokSession {
             return
           }
           log.info(`created non-root user "${this._containerUser}" in container`)
+
+          // #5024: devcontainer.json postCreateCommand. Runs once,
+          // after useradd, as the non-root user. Failures are
+          // non-fatal — log a warning so the session can still start.
+          // postCreateCommand in devcontainer.json is primarily for
+          // installing language toolchains; bound at 5 minutes here,
+          // same ceiling DockerBackend._runPostCreateCommand uses.
+          const dcLocal = this._dcConfig
+          if (dcLocal && typeof dcLocal.postCreateCommand === 'string' && dcLocal.postCreateCommand.length > 0) {
+            this._execFile('docker', [
+              'exec', '-u', this._containerUser, this._containerId, 'bash', '-c', dcLocal.postCreateCommand,
+            ], { encoding: 'utf-8', timeout: 300_000 }, (postErr) => {
+              if (postErr) {
+                log.warn(`postCreateCommand failed (non-fatal): ${postErr.message}`)
+              } else {
+                log.info('postCreateCommand completed')
+              }
+              resolve()
+            })
+            return
+          }
           resolve()
         })
       })
@@ -802,13 +1034,32 @@ export class DockerByokSession extends ClaudeByokSession {
     const wasReady = this._containerReady
     const pool = this._pool
     const acquiredFromPool = this._acquiredFromPool
+    // #5024: compose teardown uses `docker compose down` against the
+    // session-scoped project id. Snapshot the project + file BEFORE
+    // nulling state so the finally-block has them.
+    const composeFile = this._composeFile
+    const composeProject = this._composeProject
+    const cwd = this.cwd || process.cwd()
     this._containerId = null
     this._containerReady = false
     this._acquiredFromPool = false
     try {
       await super.destroy()
     } finally {
-      if (!containerId || !owned) {
+      if (composeFile && composeProject) {
+        // Compose mode: tear the whole stack down. The pool is
+        // disabled in compose mode so we never need the release path.
+        log.info(`removing compose stack ${composeProject} (file=${composeFile})`)
+        try {
+          await this._dockerBackend.destroyComposeEnvironment({
+            composeFile,
+            composeProject,
+            cwd,
+          })
+        } catch (err) {
+          log.warn(`compose destroy failed: ${err.message}`)
+        }
+      } else if (!containerId || !owned) {
         // Nothing for us to clean up — externally-managed container
         // stays running for whoever owns it.
       } else if (pool && wasReady) {

--- a/packages/server/tests/devcontainer-config.test.js
+++ b/packages/server/tests/devcontainer-config.test.js
@@ -1,0 +1,203 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  parseDevContainer,
+  validateMounts,
+  sanitizeContainerEnv,
+  extractMountSource,
+} from '../src/devcontainer-config.js'
+
+let tmpDir
+let warnings
+let infos
+
+const captureLogger = {
+  info: (m) => infos.push(m),
+  warn: (m) => warnings.push(m),
+  error: () => {},
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-dc-cfg-'))
+  warnings = []
+  infos = []
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('parseDevContainer()', () => {
+  it('returns {} when no devcontainer.json is present', () => {
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.deepEqual(config, {})
+    assert.ok(infos.some(m => m.includes('No devcontainer.json found')))
+  })
+
+  it('prefers .devcontainer/devcontainer.json over .devcontainer.json sidecar', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({ image: 'A' }))
+    writeFileSync(join(tmpDir, '.devcontainer.json'), JSON.stringify({ image: 'B' }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.equal(config.image, 'A')
+  })
+
+  it('falls back to .devcontainer.json sidecar when .devcontainer dir is absent', () => {
+    writeFileSync(join(tmpDir, '.devcontainer.json'), JSON.stringify({ image: 'sidecar' }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.equal(config.image, 'sidecar')
+  })
+
+  it('returns {} on malformed JSON without throwing', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), '{ this is not json')
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.deepEqual(config, {})
+    assert.ok(warnings.some(m => m.includes('Failed to parse')))
+  })
+
+  it('keeps only supported fields and warns on unsupported ones', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      image: 'node:20',
+      remoteUser: 'dev',
+      postCreateCommand: 'npm install',
+      forwardPorts: [3000, '8080:80'],
+      mounts: ['source=/proj,target=/workspace,type=bind'],
+      containerEnv: { LANG: 'en_US.UTF-8' },
+      runArgs: ['--rm'],
+      features: { 'ghcr.io/devcontainers/features/python': {} },
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.equal(config.image, 'node:20')
+    assert.equal(config.remoteUser, 'dev')
+    assert.equal(config.postCreateCommand, 'npm install')
+    assert.deepEqual(config.forwardPorts, [3000, '8080:80'])
+    assert.deepEqual(config.mounts, ['source=/proj,target=/workspace,type=bind'])
+    assert.deepEqual(config.containerEnv, { LANG: 'en_US.UTF-8' })
+    assert.equal(config.runArgs, undefined)
+    assert.equal(config.features, undefined)
+    assert.equal(warnings.filter(m => m.includes('unsupported field')).length, 2)
+  })
+
+  it('drops empty-string fields and non-array mounts/forwardPorts', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      image: '   ',
+      remoteUser: '',
+      forwardPorts: 'not-an-array',
+      mounts: 42,
+      containerEnv: ['not', 'an', 'object'],
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.equal(config.image, undefined)
+    assert.equal(config.remoteUser, undefined)
+    assert.equal(config.forwardPorts, undefined)
+    assert.equal(config.mounts, undefined)
+    assert.equal(config.containerEnv, undefined)
+  })
+
+  it('accepts a no-op logger when omitted (no throw)', () => {
+    const config = parseDevContainer(tmpDir)
+    assert.deepEqual(config, {})
+  })
+})
+
+describe('validateMounts()', () => {
+  it('returns undefined for null/empty input', () => {
+    assert.equal(validateMounts(undefined, '/proj'), undefined)
+    assert.equal(validateMounts([], '/proj'), undefined)
+  })
+
+  it('keeps mounts whose source is inside cwd', () => {
+    const result = validateMounts([
+      `source=${tmpDir}/sub,target=/workspace/sub,type=bind`,
+    ], tmpDir, { logger: captureLogger })
+    assert.equal(result.length, 1)
+  })
+
+  it('rejects mounts whose source escapes cwd', () => {
+    const result = validateMounts([
+      'source=/etc/shadow,target=/workspace/shadow,type=bind',
+      `source=${tmpDir}/../sibling,target=/workspace/sibling,type=bind`,
+    ], tmpDir, { logger: captureLogger })
+    assert.equal(result, undefined)
+    assert.equal(warnings.length, 2)
+    assert.ok(warnings.every(m => m.includes('outside project dir')))
+  })
+
+  it('handles short-form `source:target` syntax', () => {
+    const result = validateMounts([
+      `${tmpDir}/local:/workspace/local`,
+    ], tmpDir, { logger: captureLogger })
+    assert.equal(result.length, 1)
+  })
+
+  it('logs and skips unparseable mount strings', () => {
+    const result = validateMounts(['not-a-mount-string'], tmpDir, { logger: captureLogger })
+    assert.equal(result, undefined)
+    assert.ok(warnings.some(m => m.includes('unparseable')))
+  })
+})
+
+describe('extractMountSource()', () => {
+  it('parses long-form source=...,target=...,type=bind', () => {
+    assert.equal(
+      extractMountSource('source=/proj/sub,target=/workspace/sub,type=bind'),
+      '/proj/sub',
+    )
+  })
+
+  it('parses short-form source:target', () => {
+    assert.equal(extractMountSource('/proj/sub:/workspace/sub'), '/proj/sub')
+  })
+
+  it('parses short-form with mount options', () => {
+    assert.equal(extractMountSource('/proj/sub:/workspace/sub:ro'), '/proj/sub')
+  })
+
+  it('returns null for invalid input', () => {
+    assert.equal(extractMountSource('just-a-string'), null)
+  })
+})
+
+describe('sanitizeContainerEnv()', () => {
+  it('returns undefined for null/empty input', () => {
+    assert.equal(sanitizeContainerEnv(undefined), undefined)
+    assert.equal(sanitizeContainerEnv(null), undefined)
+    assert.equal(sanitizeContainerEnv({}), undefined)
+  })
+
+  it('keeps POSIX-valid env keys', () => {
+    const result = sanitizeContainerEnv({
+      LANG: 'C',
+      NODE_OPTIONS: '--max-old-space-size=2048',
+      _PRIVATE: '1',
+    })
+    assert.deepEqual({ ...result }, {
+      LANG: 'C',
+      NODE_OPTIONS: '--max-old-space-size=2048',
+      _PRIVATE: '1',
+    })
+  })
+
+  it('drops keys with shell-dangerous characters', () => {
+    const result = sanitizeContainerEnv({
+      'BAD;KEY': 'evil',
+      'BAD KEY': 'evil',
+      'BAD$KEY': 'evil',
+      'GOOD_KEY': 'fine',
+    }, { logger: captureLogger })
+    assert.deepEqual({ ...result }, { GOOD_KEY: 'fine' })
+    assert.equal(warnings.length, 3)
+  })
+
+  it('drops keys starting with a digit', () => {
+    const result = sanitizeContainerEnv({ '1KEY': 'no', VALID_KEY: 'yes' }, { logger: captureLogger })
+    assert.deepEqual({ ...result }, { VALID_KEY: 'yes' })
+  })
+})

--- a/packages/server/tests/devcontainer-config.test.js
+++ b/packages/server/tests/devcontainer-config.test.js
@@ -142,6 +142,19 @@ describe('validateMounts()', () => {
     assert.equal(result, undefined)
     assert.ok(warnings.some(m => m.includes('unparseable')))
   })
+
+  it('normalises a relative cwd before containment check — fix from PR #5070 review', () => {
+    // Pass a cwd that's already absolute but with a trailing `.` —
+    // pre-fix, the raw string comparison `cwd + '/'` would mismatch
+    // because resolve() of the source strips the `.`. Now both sides
+    // run through resolve() so the comparison stays consistent.
+    const result = validateMounts(
+      [`source=${tmpDir}/sub,target=/workspace/sub,type=bind`],
+      `${tmpDir}/.`,
+      { logger: captureLogger },
+    )
+    assert.equal(result?.length, 1, `expected the mount to be accepted, warnings: ${warnings.join('; ')}`)
+  })
 })
 
 describe('extractMountSource()', () => {
@@ -162,6 +175,26 @@ describe('extractMountSource()', () => {
 
   it('returns null for invalid input', () => {
     assert.equal(extractMountSource('just-a-string'), null)
+  })
+
+  it('parses Windows drive-letter paths (forward slash) — fix from PR #5070 review', () => {
+    // Without the drive-letter handling, the plain split-on-`:` would
+    // return `C` as the source and tank validation.
+    assert.equal(extractMountSource('C:/proj/sub:/workspace/sub'), 'C:/proj/sub')
+  })
+
+  it('parses Windows drive-letter paths (back slash) — fix from PR #5070 review', () => {
+    assert.equal(extractMountSource('C:\\proj\\sub:/workspace/sub'), 'C:\\proj\\sub')
+  })
+
+  it('parses Windows drive-letter paths with mount options', () => {
+    assert.equal(extractMountSource('D:/data:/workspace/data:ro'), 'D:/data')
+  })
+
+  it('returns null for a Windows path that has no target separator', () => {
+    // `C:\proj` alone has the drive-letter colon but no source/target
+    // boundary — there's nothing to extract.
+    assert.equal(extractMountSource('C:\\proj'), null)
   })
 })
 

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1104,6 +1104,42 @@ describe('DockerByokSession — devcontainer.json overlay (#5024)', () => {
     }
   })
 
+  it('start() normalises bare-port strings to host:container — fix from PR #5070 review', async () => {
+    // Pre-fix, a string "3000" would become `docker run -p 3000`,
+    // which Docker treats as "publish container port 3000 to a RANDOM
+    // host port" — surprising for a DevContainer forward where the
+    // model expects 3000:3000. Both numeric `3000` and bare-string
+    // `"3000"` should now produce the same `-p 3000:3000` mapping.
+    const cwd = makeDevcontainerCwd({
+      forwardPorts: ['3000', '5432', '8080:80'],
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_str_ports\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+      const ports = []
+      for (let i = 0; i < runCall.args.length; i++) {
+        if (runCall.args[i] === '-p') ports.push(runCall.args[i + 1])
+      }
+      assert.deepEqual(ports, ['3000:3000', '5432:5432', '8080:80'])
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
   it('start() rejects mounts pointing outside cwd', async () => {
     const cwd = makeDevcontainerCwd({
       mounts: [

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { EventEmitter } from 'node:events'
@@ -921,6 +921,450 @@ describe('docker-byok provider registration', () => {
       // still importable and the lazy registration is idempotent.
       assert.match(err.message, /Unknown provider/)
     }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────
+// #5024 — DevContainer + Compose support
+// ─────────────────────────────────────────────────────────────────────
+
+describe('DockerByokSession — devcontainer.json overlay (#5024)', () => {
+  /**
+   * Write a .devcontainer/devcontainer.json fixture into a fresh tmp
+   * dir and return the dir for use as cwd.
+   */
+  function makeDevcontainerCwd(content, { sidecar = false } = {}) {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-dc-test-'))
+    if (sidecar) {
+      writeFileSync(join(dir, '.devcontainer.json'), JSON.stringify(content))
+    } else {
+      mkdirSync(join(dir, '.devcontainer'), { recursive: true })
+      writeFileSync(join(dir, '.devcontainer', 'devcontainer.json'), JSON.stringify(content))
+    }
+    return dir
+  }
+
+  it('constructor records useDevcontainer flag but defers parsing', () => {
+    const cwd = makeDevcontainerCwd({ image: 'python:3.12-slim' })
+    try {
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile: execFileStub(),
+        _dockerBackend: backendStub(),
+      })
+      assert.equal(session._useDevcontainer, true)
+      assert.equal(session._dcConfig, null, 'parse should be deferred to start()')
+      assert.equal(session._image, 'node:22-slim', 'default preserved before resolve')
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('start() overlays devcontainer.json image when no explicit image is passed', async () => {
+    const cwd = makeDevcontainerCwd({ image: 'python:3.12-slim' })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_dc_image\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+      assert.ok(runCall, 'docker run was not called')
+      const sleepIdx = runCall.args.indexOf('sleep')
+      assert.ok(sleepIdx > 0, 'expected sleep as command')
+      assert.equal(runCall.args[sleepIdx - 1], 'python:3.12-slim')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('explicit constructor image wins over devcontainer.json image', async () => {
+    const cwd = makeDevcontainerCwd({ image: 'python:3.12-slim' })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_explicit\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        image: 'node:22-bookworm',
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+      const sleepIdx = runCall.args.indexOf('sleep')
+      assert.equal(runCall.args[sleepIdx - 1], 'node:22-bookworm')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('start() applies containerEnv from devcontainer.json as --env flags', async () => {
+    const cwd = makeDevcontainerCwd({
+      image: 'node:22-slim',
+      containerEnv: { LANG: 'en_US.UTF-8', NODE_OPTIONS: '--max-old-space-size=2048' },
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_env\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+      assert.ok(runCall.args.some(a => a === 'LANG=en_US.UTF-8'), 'LANG env not forwarded')
+      assert.ok(runCall.args.some(a => a === 'NODE_OPTIONS=--max-old-space-size=2048'), 'NODE_OPTIONS env not forwarded')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('start() drops invalid containerEnv keys (defence-in-depth)', async () => {
+    const cwd = makeDevcontainerCwd({
+      containerEnv: { 'BAD;KEY': 'evil', 'GOOD_KEY': 'fine' },
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_sanitize\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+      assert.ok(!runCall.args.some(a => a.startsWith('BAD;KEY=')), 'invalid key leaked through')
+      assert.ok(runCall.args.some(a => a === 'GOOD_KEY=fine'), 'valid key missing')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('start() applies forwardPorts as -p flags', async () => {
+    const cwd = makeDevcontainerCwd({
+      forwardPorts: [3000, 5432, '8080:80'],
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_ports\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+      const ports = []
+      for (let i = 0; i < runCall.args.length; i++) {
+        if (runCall.args[i] === '-p') ports.push(runCall.args[i + 1])
+      }
+      assert.deepEqual(ports, ['3000:3000', '5432:5432', '8080:80'])
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('start() rejects mounts pointing outside cwd', async () => {
+    const cwd = makeDevcontainerCwd({
+      mounts: [
+        'source=/etc/shadow,target=/workspace/shadow,type=bind',
+        `source=${tmpdir()}/safe,target=/safe,type=bind`,
+      ],
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_mount\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+      const mounts = []
+      for (let i = 0; i < runCall.args.length; i++) {
+        if (runCall.args[i] === '--mount') mounts.push(runCall.args[i + 1])
+      }
+      assert.deepEqual(mounts, [])
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('start() runs postCreateCommand as the non-root user after useradd', async () => {
+    const cwd = makeDevcontainerCwd({ postCreateCommand: 'npm install' })
+    try {
+      const execCalls = []
+      const _execFile = (cmd, args, opts, cb) => {
+        execCalls.push({ cmd, args: [...args] })
+        if (args[0] === 'info') return cb(null, 'ok', '')
+        if (args[0] === 'run') return cb(null, 'CONTAINER_post\n', '')
+        if (args[0] === 'exec') return cb(null, '', '')
+        if (args[0] === 'rm') return cb(null, '', '')
+        return cb(null, '', '')
+      }
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const postCall = execCalls.find(c => c.args[0] === 'exec' && c.args.includes('npm install'))
+      assert.ok(postCall, 'postCreateCommand exec not found')
+      assert.ok(postCall.args.includes('-u'), 'postCreateCommand missing -u flag')
+      assert.equal(postCall.args[postCall.args.indexOf('-u') + 1], 'chroxy')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('useDevcontainer with no devcontainer.json is a no-op (default v1 path)', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'chroxy-dc-nofile-'))
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_nodc\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+      const sleepIdx = runCall.args.indexOf('sleep')
+      assert.equal(runCall.args[sleepIdx - 1], 'node:22-slim')
+      const mounts = runCall.args.filter(a => a === '--mount')
+      assert.equal(mounts.length, 0)
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('reads .devcontainer.json sidecar form when .devcontainer/ is absent', async () => {
+    const cwd = makeDevcontainerCwd({ image: 'alpine:3.20' }, { sidecar: true })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_sidecar\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const runCall = _execFile.calls.find((c) => c.args[0] === 'run')
+      const sleepIdx = runCall.args.indexOf('sleep')
+      assert.equal(runCall.args[sleepIdx - 1], 'alpine:3.20')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('devcontainer.json remoteUser is applied when validated', async () => {
+    const cwd = makeDevcontainerCwd({ remoteUser: 'devuser' })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        run: { stdout: 'CONTAINER_user\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const setupCall = _execFile.calls.find(c =>
+        c.args[0] === 'exec' && c.args.includes('bash') && c.args.some(a => typeof a === 'string' && a.includes('useradd')))
+      assert.ok(setupCall, 'useradd exec not found')
+      assert.ok(setupCall.args.some(a => typeof a === 'string' && a.includes('useradd -m -s /bin/bash devuser')),
+        `expected useradd for devuser, got: ${setupCall.args.join(' ')}`)
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('DockerByokSession — Docker Compose support (#5024)', () => {
+  function composeBackendStub({ primaryId = 'COMPOSE_PRIMARY_abc', destroyCalls = [] } = {}) {
+    return {
+      createCalls: [],
+      destroyCalls,
+      async createComposeEnvironment(opts) {
+        this.createCalls.push(opts)
+        return {
+          containerId: primaryId,
+          containerCliPath: '/usr/local/bin/claude',
+          services: [{ name: opts.primaryService || 'app', status: 'running', primary: true }],
+        }
+      },
+      async destroyComposeEnvironment(opts) {
+        destroyCalls.push(opts)
+      },
+      async execInEnvironment() { return { stdout: '', stderr: '' } },
+    }
+  }
+
+  it('constructor accepts composeFile + composeService', () => {
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      composeService: 'web',
+      _execFile: execFileStub(),
+      _dockerBackend: composeBackendStub(),
+    })
+    assert.equal(session._composeFile, '/proj/docker-compose.yml')
+    assert.equal(session._composeService, 'web')
+    assert.equal(session._composeProject, null, 'project id deferred to start()')
+    assert.equal(session._pool, null)
+  })
+
+  it('start() brings up compose stack and attaches to primary service', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const backend = composeBackendStub({ primaryId: 'COMPOSE_PRIMARY_xyz' })
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      composeService: 'web',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    assert.equal(backend.createCalls.length, 1)
+    const call = backend.createCalls[0]
+    assert.equal(call.composeFile, '/proj/docker-compose.yml')
+    assert.equal(call.primaryService, 'web')
+    assert.match(call.composeProject, /^chroxy-byok-[0-9a-f]+$/)
+    assert.equal(session._containerId, 'COMPOSE_PRIMARY_xyz')
+    assert.equal(session._containerReady, true)
+    await session.destroy()
+  })
+
+  it('destroy() runs docker compose down against the session project', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const destroyCalls = []
+    const backend = composeBackendStub({ destroyCalls })
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      composeService: 'web',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    const projectId = session._composeProject
+    await session.destroy()
+    assert.equal(destroyCalls.length, 1)
+    assert.equal(destroyCalls[0].composeFile, '/proj/docker-compose.yml')
+    assert.equal(destroyCalls[0].composeProject, projectId)
+    assert.equal(_execFile.calls.filter(c => c.args[0] === 'rm').length, 0)
+  })
+
+  it('compose start failure tears down stack and emits session error', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const backend = {
+      createCalls: [],
+      destroyCalls: [],
+      async createComposeEnvironment(opts) {
+        this.createCalls.push(opts)
+        const err = new Error('compose primary not running')
+        err.code = 'compose_primary_missing'
+        throw err
+      },
+      async destroyComposeEnvironment(opts) { this.destroyCalls.push(opts) },
+      async execInEnvironment() { return { stdout: '', stderr: '' } },
+    }
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    const events = []
+    session.on('error', e => events.push(e))
+    await session.start()
+    assert.equal(events.length, 1)
+    assert.match(events[0].message, /compose start failed/)
+    assert.equal(session._containerReady, false)
+  })
+
+  it('compose mode skips the pool even when CHROXY_DOCKER_BYOK_POOL_ENABLED is set', () => {
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      _execFile: execFileStub(),
+      _dockerBackend: composeBackendStub(),
+      _poolEnv: { CHROXY_DOCKER_BYOK_POOL_ENABLED: '1' },
+    })
+    assert.equal(session._pool, null)
   })
 })
 


### PR DESCRIPTION
## Summary

Adds three constructor opts to `DockerByokSession` so users can bring their own dev environments instead of running every session in the default `node:22-slim` image. Closes #5024.

- **`useDevcontainer: true`** — opt-in flag. When set, parses `.devcontainer/devcontainer.json` (or `.devcontainer.json` sidecar) from cwd and overlays `image` / `remoteUser` / `containerEnv` / `mounts` / `forwardPorts` / `postCreateCommand` onto the bare-image launch. Explicit constructor opts always win — devcontainer.json is the fallback default.

- **`composeFile: '<path>'` + optional `composeService: '<name>'`** — opt-in via explicit path. Runs `docker compose up -d` under a session-scoped project id (`chroxy-byok-<rand-hex>`) and attaches to the named service container. `destroy()` runs `docker compose down --remove-orphans` to tear the whole stack down. Pooling is disabled in compose mode because the pool key shape assumes single-container resource shape.

- **Default (neither opt)** — original v1 bare-image path is unchanged. All 61 existing docker-byok tests continue to pass.

Both opts are **opt-in** rather than auto-detected from cwd. Auto-discovery would silently change behaviour for any existing session whose cwd happens to contain a `.devcontainer/` or `docker-compose.yml` — the caller (CLI flag, dashboard toggle, env-manager) is responsible for setting these when the user has asked for them.

The same parse / validate-mounts / sanitize-env logic that `EnvironmentManager` already does for persistent environments is now available to ad-hoc docker-byok sessions via a new `devcontainer-config.js` module. Note that EnvironmentManager still uses its own copies of these helpers in this PR; consolidation onto the shared module is tracked separately (#5077).

## Acceptance criteria from #5024

- [x] Support `.devcontainer/devcontainer.json` discovery and use it as the container definition (opt-in via `useDevcontainer: true`)
- [x] Support `docker-compose.yml` as a container definition with primary-service attach (opt-in via `composeFile`)
- [x] Fall back to the v1 single-container path when neither opt is set
- [x] Tests cover all three discovery paths

> Note on the AC wording — the original ticket said "detect", but explicit opt-in is the right shape for backwards compatibility. The next iteration could add auto-discovery as a separate opt (e.g. `autoDetectEnv: true`) so existing sessions don't change behaviour silently.

## Test plan

- [x] 36 new tests across `tests/devcontainer-config.test.js` (20 — pure-function contract) and `tests/docker-byok-session.test.js` (16 — compose + devcontainer integration)
- [x] All 179 tests across `devcontainer-config`, `docker-byok-session`, and `environment-manager` suites pass
- [x] `lint-session-opt-forwarding.sh` and `lint-tests-state-file-path.sh` clean
- [x] `byok-session` + `docker-byok-pool` adjacent suites unaffected (133 tests pass)
- [ ] Smoke test with a real `.devcontainer/devcontainer.json` against a running Docker daemon
- [ ] Smoke test with a real `docker-compose.yml` (multi-service: web + postgres)

## Follow-ups

Issues created during review of this PR:

- #5077 — Migrate EnvironmentManager devcontainer helpers to the shared `devcontainer-config` module
- #5078 — Support `devcontainer.json` `build` / `dockerFile` / `dockerComposeFile` fields
- #5079 — Forward `ANTHROPIC_API_KEY` into compose primary service
- #5080 — Pool key should include devcontainer.json fingerprint to prevent stale config reuse
- #5081 — Persist compose project ids so destroy() can clean up across restarts