### PR TITLE
feat(server): docker-byok snapshot/commit + restore-from-snapshot (#5023)

### DIFF
--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -36,12 +36,28 @@
  *
  * Deferred (follow-up issues)
  * ---------------------------
- *   - Per-session container reuse / pooling
- *   - Snapshot/restore (Docker commit-based snapshots already exist for
- *     docker-cli / docker-sdk — wiring them up for docker-byok belongs
- *     in a follow-up so docker-byok ships small)
+ *   - Per-session container reuse / pooling (#5022 — landed)
  *   - DevContainer / Compose-driven environments
  *   - postCreateCommand hook
+ *
+ * Snapshot / restore (#5023, this revision)
+ * -----------------------------------------
+ *   - `snapshot({ name? })` runs `docker commit <containerId>
+ *     chroxy-byok-snap:<rand>-<ts>` via the backend, marks the live
+ *     container "soiled" so the pool evicts it on release (#5043), and
+ *     writes a small metadata JSON to `snapshotsDir` (defaults to
+ *     `~/.chroxy/snapshots/`, override via `CHROXY_CONFIG_DIR`) so ops
+ *     can list snapshot names without parsing `docker image ls`.
+ *   - To restore, pass `snapshotImage: <tag>` to the constructor. The
+ *     session uses that tag as the image at `docker run` time and skips
+ *     the `useradd` + `chown` setup (the snapshot already has those
+ *     baked in). The restored container is auto-soiled — restoring
+ *     previous state into a live container couples it to the snapshot's
+ *     original conversation history.
+ *   - Pool interaction: a snapshotted or restored container goes
+ *     through `release()` as normal, but the pool sees the soil marker
+ *     and evicts inline instead of pooling. UI / multi-snapshot listing
+ *     is deferred to a follow-up.
  *
  * Per `project_worktree_before_docker.md` in project memory: worktree
  * isolation happens BEFORE Docker. This class does not own worktree
@@ -51,12 +67,15 @@
  */
 
 import { execFile } from 'child_process'
+import { mkdirSync, writeFileSync } from 'fs'
+import { randomBytes } from 'crypto'
+import { homedir } from 'os'
+import { isAbsolute, join, posix } from 'path'
 import { ClaudeByokSession } from './byok-session.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
 import { buildPoolKey, getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
 import { createLogger } from './logger.js'
-import { isAbsolute, posix } from 'path'
 
 const log = createLogger('docker-byok')
 
@@ -198,6 +217,19 @@ export class DockerByokSession extends ClaudeByokSession {
    * @param {string} [opts.containerId]              Attach to an existing container
    *   instead of launching one (env-manager managed). When omitted, the
    *   session owns the container and tears it down on destroy().
+   * @param {string} [opts.snapshotImage]            Restore from a snapshot tag
+   *   produced by a previous `snapshot()` call (#5023). When set, the
+   *   container is launched from this image instead of `opts.image`, the
+   *   `useradd` setup is skipped (the snapshot has the user baked in),
+   *   and the live container is auto-soiled so it does NOT return to the
+   *   pool (a restored container's FS is coupled to the snapshot's
+   *   original conversation).
+   * @param {string} [opts.snapshotsDir]             Override the directory
+   *   snapshot metadata JSONs are written to. Defaults to
+   *   `${CHROXY_CONFIG_DIR ?? ~/.chroxy}/snapshots`. Tests inject a tmp dir.
+   * @param {string} [opts.sourceSessionId]          Optional session id to
+   *   embed in snapshot metadata. The session itself has no sessionId
+   *   field; the SessionManager owns the id and can pass it through.
    * @param {object} [opts._dockerBackend]           Test seam — pre-built backend
    * @param {Function} [opts._execFile]              Test seam — used by preflight
    *   (defaults to child_process.execFile)
@@ -234,6 +266,16 @@ export class DockerByokSession extends ClaudeByokSession {
     this._dockerBackend = opts._dockerBackend || new DockerBackend()
     this._execFile = opts._execFile || execFile
     this._containerReady = false
+    // #5023 snapshot / restore opts.
+    this._snapshotImage = typeof opts.snapshotImage === 'string' && opts.snapshotImage.trim().length > 0
+      ? opts.snapshotImage.trim()
+      : null
+    this._snapshotsDir = typeof opts.snapshotsDir === 'string' && opts.snapshotsDir.length > 0
+      ? opts.snapshotsDir
+      : join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'snapshots')
+    this._sourceSessionId = typeof opts.sourceSessionId === 'string' && opts.sourceSessionId.length > 0
+      ? opts.sourceSessionId
+      : null
     // #5022: across-session idle pool. Off by default — opted in via env
     // or by passing an explicit `_pool` instance. Per-session reuse of
     // the same container across multiple turns is unconditional and
@@ -348,6 +390,14 @@ export class DockerByokSession extends ClaudeByokSession {
       return
     }
     this._containerReady = true
+
+    // #5023: a container restored from a snapshot inherits the
+    // snapshot's writable layer — auth files, history, scratch state.
+    // Mark it soiled so it does NOT return to the pool for an unrelated
+    // session to acquire. No-ops cleanly when pooling is disabled.
+    if (this._snapshotImage && this._containerOwned) {
+      this.markActiveContainerSoiled()
+    }
   }
 
   /**
@@ -390,6 +440,102 @@ export class DockerByokSession extends ClaudeByokSession {
     if (!this._pool) return
     if (!this._containerId) return
     this._pool.markSoiled(this._containerId)
+  }
+
+  /**
+   * Snapshot the live container's writable layer into a Docker image
+   * tag via `docker commit`, then mark the container "soiled" so the
+   * pool evicts it on release. Writes a small metadata JSON to
+   * `snapshotsDir` so ops can list snapshot names without parsing
+   * `docker image ls` — see class docstring's snapshot/restore section.
+   *
+   * Returns a `{ tag, name, createdAt, sourceCwd, sourceImage,
+   * sourceSessionId }` shape. The `tag` is what a future session passes
+   * to the constructor as `snapshotImage` to restore.
+   *
+   * Throws when the container is not ready (no `start()`, or
+   * `destroy()` already ran). Surfaces backend errors (out-of-disk,
+   * daemon dead) as a plain Error — callers decide whether to retry.
+   *
+   * #5023.
+   *
+   * @param {object} [opts]
+   * @param {string} [opts.name] Human-readable name for the snapshot
+   * @returns {Promise<{tag:string, name:string, createdAt:string,
+   *   sourceCwd:string, sourceImage:string, sourceSessionId:string|null}>}
+   */
+  async snapshot({ name } = {}) {
+    if (!this._containerReady || !this._containerId) {
+      const err = new Error('docker-byok snapshot(): container is not ready')
+      err.code = 'docker_byok_not_ready'
+      throw err
+    }
+    const tag = this._generateSnapshotTag()
+    const sourceCwd = this.cwd || process.cwd()
+    const sourceImage = this._snapshotImage || this._image
+    const snapName = (typeof name === 'string' && name.trim().length > 0)
+      ? name.trim()
+      : tag.split(':').pop()
+    const createdAt = new Date().toISOString()
+
+    log.info(`snapshot: committing ${this._containerId.slice(0, 12)} → ${tag}`)
+    await this._dockerBackend.commitEnvironment(this._containerId, tag)
+
+    // Mark soiled BEFORE writing metadata. If metadata persistence
+    // fails (disk full, permission denied) we still want the soil
+    // marker stuck on — the snapshot tag exists in the daemon and the
+    // container's writable layer has leaked into it.
+    this.markActiveContainerSoiled()
+
+    const metadata = {
+      tag,
+      name: snapName,
+      createdAt,
+      sourceCwd,
+      sourceImage,
+      sourceSessionId: this._sourceSessionId,
+    }
+    try {
+      this._persistSnapshotMetadata(tag, metadata)
+    } catch (err) {
+      // Persistence is best-effort — the snapshot tag in the daemon is
+      // the source of truth. Log and continue so the caller still gets
+      // the tag.
+      log.warn(`snapshot: failed to persist metadata for ${tag}: ${err.message}`)
+    }
+    log.info(`snapshot: ${tag} (name="${snapName}") committed`)
+    return metadata
+  }
+
+  /**
+   * Build a snapshot tag of the form `chroxy-byok-snap:<16-hex>-<ts>`.
+   * 8 bytes of randomness + a millisecond timestamp keep tags unique
+   * within a single host. Image tags must be lowercase ASCII;
+   * `randomBytes` hex satisfies the Docker tag rules.
+   */
+  _generateSnapshotTag() {
+    const rand = randomBytes(8).toString('hex')
+    const ts = Date.now()
+    return `chroxy-byok-snap:${rand}-${ts}`
+  }
+
+  /**
+   * Write the snapshot metadata JSON next to its siblings in
+   * `_snapshotsDir`. The filename uses the tag's identifier portion so
+   * a future ops listing reads back deterministically.
+   *
+   * Best-effort, sync I/O: we hold a docker tag whether or not the
+   * sidecar JSON lands. The mkdir is recursive so a brand-new
+   * `~/.chroxy/snapshots/` is created on demand.
+   */
+  _persistSnapshotMetadata(tag, metadata) {
+    mkdirSync(this._snapshotsDir, { recursive: true })
+    // Tag is `chroxy-byok-snap:<rand>-<ts>` — split on ':' to get the
+    // filename-safe slug. Defensive replace in case a custom tag ever
+    // surfaces here.
+    const slug = tag.split(':').pop().replace(/[^a-zA-Z0-9_.-]/g, '_')
+    const filePath = join(this._snapshotsDir, `${slug}.json`)
+    writeFileSync(filePath, JSON.stringify(metadata, null, 2) + '\n', 'utf-8')
   }
 
   /**
@@ -445,6 +591,13 @@ export class DockerByokSession extends ClaudeByokSession {
    * limit, no-new-privileges, non-root user). Mirrors the runArgs
    * shape used by docker-sdk-session.js so the security posture is
    * identical across the two providers.
+   *
+   * When `_snapshotImage` is set (#5023), the container is launched
+   * from that image instead of `_image` and the `useradd` + `chown`
+   * setup is SKIPPED — the snapshot already has the non-root user
+   * baked in. Re-running useradd would fail with "user already exists"
+   * and abort start. The restored container is auto-soiled by
+   * `start()` after this resolves so the pool evicts on release.
    */
   _startContainer() {
     return new Promise((resolve, reject) => {
@@ -472,10 +625,13 @@ export class DockerByokSession extends ClaudeByokSession {
         runArgs.push('--add-host', 'host.docker.internal:host-gateway')
       }
 
-      runArgs.push(this._image, 'sleep', 'infinity')
+      const imageToRun = this._snapshotImage || this._image
+      runArgs.push(imageToRun, 'sleep', 'infinity')
 
       log.info(
-        `starting container (image=${this._image} memory=${this._memoryLimit} cpus=${this._cpuLimit})`,
+        this._snapshotImage
+          ? `restoring container from snapshot ${this._snapshotImage} (memory=${this._memoryLimit} cpus=${this._cpuLimit})`
+          : `starting container (image=${imageToRun} memory=${this._memoryLimit} cpus=${this._cpuLimit})`,
       )
 
       this._execFile('docker', runArgs, { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
@@ -488,6 +644,14 @@ export class DockerByokSession extends ClaudeByokSession {
         }
         this._containerId = stdout.trim()
         log.info(`container started: ${this._containerId.slice(0, 12)}`)
+
+        // Restore path: the snapshot has useradd + chown baked in, so
+        // skip the setup step. Re-running useradd would fail
+        // ("user already exists") and abort start.
+        if (this._snapshotImage) {
+          resolve()
+          return
+        }
 
         // Set up non-root user + chown workspace so the model isn't
         // running as root inside the container. Same script

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -527,15 +527,20 @@ export class DockerByokSession extends ClaudeByokSession {
    * Best-effort, sync I/O: we hold a docker tag whether or not the
    * sidecar JSON lands. The mkdir is recursive so a brand-new
    * `~/.chroxy/snapshots/` is created on demand.
+   *
+   * The file is created with restrictive perms (0600 — owner read/
+   * write only, dir 0700) because the metadata embeds host paths and
+   * optionally `sourceSessionId`. This matches the posture other
+   * `$CHROXY_CONFIG_DIR` state files use (session-state, credentials).
    */
   _persistSnapshotMetadata(tag, metadata) {
-    mkdirSync(this._snapshotsDir, { recursive: true })
+    mkdirSync(this._snapshotsDir, { recursive: true, mode: 0o700 })
     // Tag is `chroxy-byok-snap:<rand>-<ts>` — split on ':' to get the
     // filename-safe slug. Defensive replace in case a custom tag ever
     // surfaces here.
     const slug = tag.split(':').pop().replace(/[^a-zA-Z0-9_.-]/g, '_')
     const filePath = join(this._snapshotsDir, `${slug}.json`)
-    writeFileSync(filePath, JSON.stringify(metadata, null, 2) + '\n', 'utf-8')
+    writeFileSync(filePath, JSON.stringify(metadata, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 })
   }
 
   /**
@@ -548,9 +553,18 @@ export class DockerByokSession extends ClaudeByokSession {
    * #5022 — across-session idle pool. Per-session reuse of the same
    * container across turns is handled in `_dispatchBuiltinTool` and
    * does not depend on the pool.
+   *
+   * #5023 — when `_snapshotImage` is set the pool is BYPASSED. The
+   * pool key derives from `_image`, not `_snapshotImage`, so a hit
+   * would hand back a stock container and `_startContainer()` would
+   * never run — the snapshot tag would be silently ignored. Worse,
+   * the recycled container's writable layer (auth, scratch state) is
+   * unrelated to the snapshot the caller asked to restore. Restored
+   * containers are auto-soiled anyway so they can't return to the
+   * pool — skipping the acquire path is the consistent move.
    */
   async _acquireOrStartContainer() {
-    if (this._pool) {
+    if (this._pool && !this._snapshotImage) {
       const key = this._poolKey()
       const reused = this._pool.acquire(key)
       if (reused) {

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1326,6 +1326,54 @@ describe('DockerByokSession — snapshot / restore (#5023)', () => {
 
     await session.destroy()
   })
+
+  it('snapshotImage opt bypasses pool acquire — always launches fresh from the snapshot tag', async () => {
+    // Regression: pre-fix, _acquireOrStartContainer would call
+    // _pool.acquire() even when snapshotImage was set. A pool hit
+    // (matching the resource key — image/cwd/memory/cpu/user) returned
+    // a stock container and _startContainer() never ran, so the
+    // snapshot tag was silently ignored AND the recycled container's
+    // writable layer (unrelated auth/scratch) leaked in.
+    const runCalls = []
+    const _execFile = (cmd, args, opts, callback) => {
+      const sub = args[0]
+      if (sub === 'info') return callback(null, 'ok', '')
+      if (sub === 'run') {
+        runCalls.push([...args])
+        return callback(null, 'CONTAINER_FRESH_FROM_SNAP\n', '')
+      }
+      if (sub === 'exec') return callback(null, '', '')
+      if (sub === 'rm') return callback(null, '', '')
+      callback(null, '', '')
+    }
+    // Pool would happily return POOLED_STOCK_CID for this session's
+    // resource shape — if the bypass guard ever regresses, this stub
+    // makes the regression load-bearing.
+    const pool = poolStubWithSoiling({ acquireReturn: 'POOLED_STOCK_CID' })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      _pool: pool,
+      snapshotImage: 'chroxy-byok-snap:bypass-test',
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // The pool MUST NOT have been asked for a container — restore is
+    // not poolable.
+    assert.equal(pool.calls.acquire.length, 0, 'pool.acquire() must not be called when snapshotImage is set')
+    // Docker run fired with the snapshot tag as the image.
+    assert.equal(runCalls.length, 1)
+    const runArgs = runCalls[0]
+    const imageIdx = runArgs.length - 3
+    assert.equal(runArgs[imageIdx], 'chroxy-byok-snap:bypass-test')
+    // And the active container id is the freshly-launched one, NOT the
+    // pool's would-be hit.
+    assert.equal(session._containerId, 'CONTAINER_FRESH_FROM_SNAP')
+
+    await session.destroy()
+  })
 })
 
 describe('docker-byok provider registration', () => {

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1029,6 +1029,305 @@ describe('DockerByokSession — snapshot soiling integration (#5043)', () => {
   })
 })
 
+describe('DockerByokSession — snapshot / restore (#5023)', () => {
+  /**
+   * Snapshot tests cover the MVP shape:
+   *   - snapshot()  → docker commit + markSoiled + metadata write
+   *   - restore via `snapshotImage` opt → docker run with the snapshot
+   *     tag, skip useradd, and auto-soil the live container so the
+   *     restored conversation's FS doesn't leak into the next acquirer.
+   *
+   * Same pool-with-soiling stub shape as #5043 — snapshot integration
+   * runs through markSoiled so a snapshotted container always exits via
+   * inline `docker rm -f` rather than going back to the pool.
+   */
+  function poolStubWithSoiling({ acquireReturn = null } = {}) {
+    const calls = { acquire: [], release: [], markSoiled: [] }
+    const soiled = new Set()
+    let nextAcquire = acquireReturn
+    return {
+      calls,
+      acquire(key) {
+        calls.acquire.push(key)
+        const v = nextAcquire
+        nextAcquire = null
+        return v
+      },
+      async release(key, containerId) {
+        calls.release.push({ key, containerId })
+        if (soiled.has(containerId)) {
+          soiled.delete(containerId)
+          return false
+        }
+        return true
+      },
+      markSoiled(containerId) {
+        if (!containerId) return
+        soiled.add(containerId)
+        calls.markSoiled.push(containerId)
+      },
+      isSoiled(containerId) {
+        return soiled.has(containerId)
+      },
+    }
+  }
+
+  /**
+   * Docker backend stub specialised for snapshot tests — records every
+   * `commitEnvironment` call so we can assert the snapshot tag shape.
+   */
+  function backendStubWithCommit(opts = {}) {
+    const calls = { exec: [], commit: [] }
+    return {
+      calls,
+      async execInEnvironment(containerId, execOpts) {
+        calls.exec.push({ containerId, ...execOpts })
+        return { stdout: '', stderr: '' }
+      },
+      async commitEnvironment(containerId, imageTag) {
+        calls.commit.push({ containerId, imageTag })
+        if (opts.commitError) throw opts.commitError
+        return opts.commitSha || `sha256:${imageTag.replace(/[^a-z0-9]/gi, '').slice(0, 64)}`
+      },
+    }
+  }
+
+  it('snapshot() commits the live container under a chroxy-byok-snap tag', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_SNAP_OK\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = backendStubWithCommit()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backend,
+      snapshotsDir: join(tmpHome, 'snapshots'),
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    const snap = await session.snapshot({ name: 'after-deps' })
+
+    assert.equal(backend.calls.commit.length, 1, 'commitEnvironment was called exactly once')
+    const commit = backend.calls.commit[0]
+    assert.equal(commit.containerId, 'CONTAINER_SNAP_OK')
+    assert.match(commit.imageTag, /^chroxy-byok-snap:/, 'snapshot tag uses chroxy-byok-snap prefix')
+
+    // Snapshot result shape: tag, name, createdAt, sourceCwd, sourceImage.
+    assert.equal(snap.tag, commit.imageTag)
+    assert.equal(snap.name, 'after-deps')
+    assert.ok(typeof snap.createdAt === 'string' && snap.createdAt.length > 0)
+    assert.equal(snap.sourceCwd, '/host/cwd')
+    assert.equal(snap.sourceImage, 'node:22-slim')
+
+    await session.destroy()
+  })
+
+  it('snapshot() marks the live container soiled so the pool evicts on release', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_SNAP_DIRTY\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const pool = poolStubWithSoiling()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      _pool: pool,
+      snapshotsDir: join(tmpHome, 'snapshots'),
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    await session.snapshot({ name: 'mid-session' })
+
+    // Pool was told this container is dirty — release will evict.
+    assert.deepEqual(pool.calls.markSoiled, ['CONTAINER_SNAP_DIRTY'])
+    assert.equal(pool.isSoiled('CONTAINER_SNAP_DIRTY'), true)
+
+    await session.destroy()
+
+    // Release fired and the pool returned false (evicted, not pooled).
+    assert.equal(pool.calls.release.length, 1)
+    assert.equal(pool.calls.release[0].containerId, 'CONTAINER_SNAP_DIRTY')
+  })
+
+  it('snapshot() persists metadata JSON to snapshotsDir for ops visibility', async () => {
+    const { existsSync, readFileSync, readdirSync } = await import('node:fs')
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_META\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const snapshotsDir = join(tmpHome, 'snapshots')
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      snapshotsDir,
+      sourceSessionId: 'sess-abc',
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    const snap = await session.snapshot({ name: 'with-meta' })
+    assert.ok(existsSync(snapshotsDir), 'snapshotsDir was created')
+    const files = readdirSync(snapshotsDir).filter((f) => f.endsWith('.json'))
+    assert.equal(files.length, 1, 'one metadata JSON was written')
+    const meta = JSON.parse(readFileSync(join(snapshotsDir, files[0]), 'utf-8'))
+    assert.equal(meta.tag, snap.tag)
+    assert.equal(meta.name, 'with-meta')
+    assert.equal(meta.sourceCwd, '/host/cwd')
+    assert.equal(meta.sourceImage, 'node:22-slim')
+    assert.equal(meta.sourceSessionId, 'sess-abc')
+    assert.equal(typeof meta.createdAt, 'string')
+
+    await session.destroy()
+  })
+
+  it('snapshot() rejects when the container is not ready', async () => {
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile: execFileStub({ info: { stdout: 'ok' } }),
+      _dockerBackend: backendStubWithCommit(),
+    })
+    // No start() — container is not ready.
+    await assert.rejects(
+      () => session.snapshot({ name: 'too-early' }),
+      /not ready/i,
+    )
+  })
+
+  it('snapshot() surfaces docker commit failures as Error', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_FAIL\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = backendStubWithCommit({
+      commitError: new Error('disk full'),
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backend,
+      snapshotsDir: join(tmpHome, 'snapshots'),
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    await assert.rejects(
+      () => session.snapshot({ name: 'will-fail' }),
+      /disk full/,
+    )
+    await session.destroy()
+  })
+
+  it('snapshotImage opt restores: uses the snapshot tag and skips useradd', async () => {
+    const runCalls = []
+    const execCmds = []
+    const _execFile = (cmd, args, opts, callback) => {
+      const sub = args[0]
+      if (sub === 'info') return callback(null, 'ok', '')
+      if (sub === 'run') {
+        runCalls.push([...args])
+        return callback(null, 'CONTAINER_RESTORED\n', '')
+      }
+      if (sub === 'exec') {
+        execCmds.push([...args])
+        return callback(null, '', '')
+      }
+      if (sub === 'rm') return callback(null, '', '')
+      callback(null, '', '')
+    }
+
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      snapshotImage: 'chroxy-byok-snap:abc123-1700000000000',
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // The `docker run` invocation used the snapshot tag as the image.
+    assert.equal(runCalls.length, 1)
+    const runArgs = runCalls[0]
+    // image is third-to-last (before "sleep" "infinity")
+    const imageIdx = runArgs.length - 3
+    assert.equal(runArgs[imageIdx], 'chroxy-byok-snap:abc123-1700000000000')
+
+    // No `useradd` should have run on the restored container — the
+    // snapshot image already has the user baked in.
+    const setupCalls = execCmds.filter((args) =>
+      args.some((a) => typeof a === 'string' && a.includes('useradd')))
+    assert.equal(setupCalls.length, 0, 'restore must skip useradd')
+
+    await session.destroy()
+  })
+
+  it('snapshotImage opt auto-soils the restored container so reuse cannot leak', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_RESTORED_DIRTY\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const pool = poolStubWithSoiling()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      _pool: pool,
+      snapshotImage: 'chroxy-byok-snap:abc-123',
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // The restored container is automatically marked soiled — its FS is
+    // coupled to the source conversation's history.
+    assert.deepEqual(pool.calls.markSoiled, ['CONTAINER_RESTORED_DIRTY'])
+
+    await session.destroy()
+
+    // And it's evicted on release, not pooled.
+    assert.equal(pool.calls.release.length, 1)
+  })
+
+  it('snapshot() persists metadata even when snapshotsDir is brand-new', async () => {
+    const { existsSync, readdirSync } = await import('node:fs')
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_MK\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const nested = join(tmpHome, 'deeply', 'nested', 'snaps')
+    assert.equal(existsSync(nested), false)
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      snapshotsDir: nested,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    await session.snapshot({ name: 'mkdir-test' })
+    assert.ok(existsSync(nested))
+    assert.equal(readdirSync(nested).filter((f) => f.endsWith('.json')).length, 1)
+
+    await session.destroy()
+  })
+})
+
 describe('docker-byok provider registration', () => {
   it('registerDockerProvider() wires docker-byok when environments are enabled and docker is available', async () => {
     // Spy on console.warn so accidental log noise during the test


### PR DESCRIPTION
## Summary

Adds session-level snapshot/restore for docker-byok matching the shape already in `environment-manager`. Stacked on top of #5047 (markSoiled API).

- `snapshot({ name? })` runs `docker commit` against the live container to produce a `chroxy-byok-snap:<rand>-<ts>` tag, writes metadata JSON to `~/.chroxy/snapshots/` for ops visibility, and marks the container soiled via #5043 so the pool evicts on release.
- Restore: pass `snapshotImage: <tag>` to the constructor. `_startContainer` uses that tag as the image, skips `useradd` (the snapshot has the user baked in — re-running would fail), and `start()` auto-soils the live container so the restored conversation's FS can't leak.
- Best-effort metadata sidecar (mkdir -p + JSON write). Persistence failures log but don't undo the snapshot — the docker tag in the daemon is the source of truth.
- Pool interaction: snapshotted/restored containers go through `release()` as normal but the pool's soil marker intercepts and evicts inline.

## Acceptance Criteria (#5023)

- [x] docker-byok exposes the same snapshot/restore method shape as docker-cli/docker-sdk (via the shared `DockerBackend.commitEnvironment`).
- [x] Integration test for snapshot → destroy and `snapshotImage` → destroy round-trips in docker-byok (real docker daemon not required; backend + execFile stubbed).
- [x] Class docstring documents what gets snapshotted (writable layer) and the `/workspace` bind-mount caveat (host cwd is not part of the snapshot).

## Out of scope / follow-ups

- Snapshot browsing UI (defer to follow-up).
- Wire `snapshotImage` through the SessionManager / wire protocol so the dashboard / app can request a restore (defer).

## Test plan

- [x] `node --test packages/server/tests/docker-byok-pool.test.js packages/server/tests/docker-byok-session.test.js` — 88 pass (80 baseline + 8 new).
- [x] `scripts/lint-session-opt-forwarding.sh` — OK (constructor uses `super({ ...opts, ... })` spread).
- [x] `scripts/lint-tests-state-file-path.sh` — OK.
- [ ] Verify against a real docker daemon: `snapshot()`, then start a new session with `snapshotImage` → previous scratch files should be present in the restored container.

Closes #5023.