### PR TITLE
docs(server): clarify session-manager cost-gate result/error invariant

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1687,14 +1687,25 @@ export class SessionManager extends EventEmitter {
         // would silently drop out of cumulativeUsage / sessionCost /
         // budget gates (#5038).
         //
-        // Turn-terminal: both events fire exactly once per turn (success
-        // OR error, never both — see byok-session._emitTurnError + the
-        // success-path result emit), so accounting an `error` here can't
-        // double-count with a later `result` for the same turn.
+        // Single-counting guarantee: the `Number.isFinite(data?.cost)`
+        // predicate below — NOT result/error mutual exclusion — is what
+        // ensures we account each priced turn exactly once.
+        //   - Happy path: a single `result` (with finite cost) per turn.
+        //   - byok-session error path: a single `error` (with finite cost
+        //     for the partial spend, see #5037).
+        //   - Stream-stall path (sdk-session._handleStreamStall and
+        //     cli-session._emitInterruptedTurnResult): emits BOTH a
+        //     synthetic `result` AND `error` for the same turn — but the
+        //     synthetic `result` carries `cost: null`, so the
+        //     Number.isFinite gate filters it. The `error` half is
+        //     plain stream-stall metadata (no cost field), also filtered.
+        // No emit topology change is needed to add new failure paths as
+        // long as they keep this invariant (priced terminal ⇒ exactly one
+        // event with a finite cost per turn).
         //
-        // Use Number.isFinite so NaN / Infinity (provider bugs) don't
-        // poison cumulative totals or trigger spurious budget events
-        // (#4088 review).
+        // Number.isFinite also guards against NaN / Infinity (provider
+        // bugs) poisoning cumulative totals or triggering spurious budget
+        // events (#4088 review).
         if ((event === 'result' || event === 'error') && Number.isFinite(data?.cost)) {
           const sessionEntry = this._sessions.get(sessionId)
           const model = session.currentModel || sessionEntry?.model || null


### PR DESCRIPTION
## Summary

Polish the comment block above the widened cost-tracking gate in `session-manager.js:_wireSessionEvents` so it reflects what actually guarantees single-counting.

The previous comment (added in #5046) claimed `result` and `error` are mutually exclusive per turn. That's almost-but-not-quite true: stream-stall paths in `sdk-session._handleStreamStall` (line 1496-1500) and `cli-session._emitInterruptedTurnResult` (line 1422) BOTH emit a synthetic `result` immediately followed by an `error` for the same turn.

Accounting stays correct because the synthetic `result` emits with `cost: null`, so the `Number.isFinite(data?.cost)` predicate filters it. So the predicate — not emit topology — is what guarantees single-counting per turn.

This PR re-words the comment to:
- Lead with the predicate as the single-counting guarantor.
- Enumerate the three emit shapes (happy path, byok error, stream-stall).
- Note the invariant new failure paths must preserve.

No behavior change — comment polish only.

Closes #5048

## Test plan

- [x] `./scripts/lint-tests-state-file-path.sh` passes
- [x] `./scripts/lint-session-opt-forwarding.sh` passes
- [x] `node --import ./tests/_setup.mjs --test --test-force-exit tests/session-manager.test.js` — 171/171 pass