### PR TITLE
feat(dashboard): move New Session into header overflow menu (#5062)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -85,10 +85,10 @@ vi.mock('./components/PermissionPrompt', () => ({
   ),
 }))
 
-// #4695 — CreateSessionModal pulls multiple store-callback selectors
+// #4695 / #5062 — CreateSessionModal pulls multiple store-callback selectors
 // (setDirectoryListingCallback / requestDirectoryListing / …) that the
 // App-test store mock doesn't enumerate. Stubbing the modal lets the
-// chrome-new-session click assertion verify the `open` prop transition
+// New Session overflow-menu click assertion verify the `open` prop transition
 // without dragging in directory-browser store wiring. Production
 // behaviour is exercised by the CreateSessionModal*.test.tsx suites.
 vi.mock('./components/CreateSessionModal', () => ({
@@ -2147,37 +2147,49 @@ describe('App', () => {
   // scanning the dashboard chrome. The chrome button lives in
   // `header-right` and reuses the existing handleNewSession path
   // (setShowCreateSession → CreateSessionModal), so the test pins:
-  //   1. The button renders inside #header (always-visible chrome).
-  //   2. It has accessible title + aria-label (matches the #4630
-  //      header-button convention checked above).
+  //   1. The entry renders inside #header (always-visible chrome),
+  //      reached by opening the overflow (⋯) menu.
+  //   2. It has a visible "New Session" label and a title with the
+  //      Cmd+N shortcut hint.
   //   3. Clicking it opens the Create Session modal (the modal renders
   //      its overlay only when open=true, mirrored on Modal.tsx's
   //      `if (!open) return null` guard).
-  describe('chrome-new-session button (#4695)', () => {
+  //   4. The standalone `chrome-new-session` button no longer renders —
+  //      the affordance lives only inside the overflow menu now.
+  describe('New Session in header overflow menu (#5062)', () => {
     const baseHeaderState = {
       connectionPhase: 'connected' as const,
       sessions: [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }],
       activeSessionId: 's1',
     }
 
-    it('renders inside the dashboard #header chrome', () => {
+    it('no longer renders the standalone chrome-new-session button (#5062)', () => {
+      stateOverrides = baseHeaderState
+      render(<App />)
+      expect(screen.queryByTestId('chrome-new-session')).not.toBeInTheDocument()
+    })
+
+    it('renders the New Session entry inside the header overflow menu', () => {
       stateOverrides = baseHeaderState
       const { container } = render(<App />)
       const header = container.querySelector('#header')
       expect(header, '#header must render').toBeTruthy()
-      const btn = within(header as HTMLElement).getByTestId('chrome-new-session')
-      expect(btn).toBeInTheDocument()
+      const trigger = within(header as HTMLElement).getByTestId('header-overflow-trigger')
+      fireEvent.click(trigger)
+      const item = screen.getByTestId('header-overflow-item-new-session')
+      expect(item).toBeInTheDocument()
+      expect(item.textContent).toMatch(/New Session/)
     })
 
-    it('exposes accessible title + aria-label + visible "New Session" label', () => {
+    it('exposes a title attribute containing the Cmd+N shortcut hint', () => {
       stateOverrides = baseHeaderState
       render(<App />)
-      const btn = screen.getByTestId('chrome-new-session')
-      expect(btn.getAttribute('aria-label'), 'chrome-new-session needs aria-label').toBe('New session')
-      expect(btn.getAttribute('title'), 'chrome-new-session needs title with shortcut hint').toMatch(/New session/)
-      // The visible label is part of the muscle-memory affordance —
-      // without it the button reads as just another icon glyph.
-      expect(btn.textContent).toMatch(/New Session/)
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const item = screen.getByTestId('header-overflow-item-new-session')
+      // The HeaderOverflowMenu copies `item.title` straight onto the
+      // <li>'s `title` attribute — assert the shortcut hint survives.
+      expect(item.getAttribute('title')).toMatch(/New session/)
+      expect(item.getAttribute('title')).toMatch(/N/)
     })
 
     it('opens the Create Session modal on click', () => {
@@ -2185,7 +2197,8 @@ describe('App', () => {
       render(<App />)
       // Modal mock renders the testID node only when `open=true`.
       expect(screen.queryByTestId('create-session-modal-mock')).not.toBeInTheDocument()
-      fireEvent.click(screen.getByTestId('chrome-new-session'))
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      fireEvent.click(screen.getByTestId('header-overflow-item-new-session'))
       expect(screen.getByTestId('create-session-modal-mock')).toBeInTheDocument()
     })
   })

--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -2139,14 +2139,17 @@ describe('App', () => {
     })
   })
 
-  // #4695 — prominent chrome-level "New Session" entry point.
+  // #4695 / #5062 — discoverable chrome-level "New Session" entry point.
   //
   // The per-project sidebar button (`sidebar-new-session-<path>`) and the
   // command palette (`new-session` id) were the only two entry points
-  // before this change — neither discoverable to a first-time user
-  // scanning the dashboard chrome. The chrome button lives in
-  // `header-right` and reuses the existing handleNewSession path
-  // (setShowCreateSession → CreateSessionModal), so the test pins:
+  // before #4695 — neither discoverable to a first-time user scanning
+  // the dashboard chrome. #4695 added a standalone button in the
+  // `header-right` zone; #5062 then folded that button INTO the header
+  // overflow (⋯) menu so the right zone stops crowding the model
+  // selector. The discoverable entry now lives as the first row of the
+  // overflow menu, reusing the existing `handleNewSession` path
+  // (setShowCreateSession → CreateSessionModal). The tests pin:
   //   1. The entry renders inside #header (always-visible chrome),
   //      reached by opening the overflow (⋯) menu.
   //   2. It has a visible "New Session" label and a title with the
@@ -2188,8 +2191,12 @@ describe('App', () => {
       const item = screen.getByTestId('header-overflow-item-new-session')
       // The HeaderOverflowMenu copies `item.title` straight onto the
       // <li>'s `title` attribute — assert the shortcut hint survives.
+      // formatShortcutKeys() emits `Cmd+N` on macOS and `Ctrl+N`
+      // elsewhere, so match either modifier joined to `N` by a `+`. The
+      // earlier `/N/` was too loose — it would still pass if the
+      // modifier disappeared and the title read just "New session (N)".
       expect(item.getAttribute('title')).toMatch(/New session/)
-      expect(item.getAttribute('title')).toMatch(/N/)
+      expect(item.getAttribute('title')).toMatch(/(Cmd|Ctrl)\+N/)
     })
 
     it('opens the Create Session modal on click', () => {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2051,30 +2051,6 @@ export function App() {
           />
         </div>
         <div className="header-right">
-          {/* #4695 — prominent always-visible New Session entry point.
-              Previously the affordance lived only on the per-project
-              sidebar row (`sidebar-new-session-<path>`) and inside the
-              command palette, neither of which a first-time user finds
-              by scanning the chrome. This button and the macOS menu-bar
-              "File > New Session" item both invoke `handleNewSession`,
-              which clears `pendingCwd` and opens the create-session
-              dialog without a preselected project. The sidebar's "+"
-              row and the palette's `new-session` command each have
-              their own inline handlers (the sidebar passes a cwd; the
-              palette opens the dialog directly), so they share the end
-              state (`setShowCreateSession(true)`) but not this
-              callback. */}
-          <button
-            type="button"
-            className="chrome-new-session-btn"
-            data-testid="chrome-new-session"
-            onClick={handleNewSession}
-            aria-label="New session"
-            title={`New session (${formatShortcutKeys('Cmd+N')})`}
-          >
-            <span className="chrome-new-session-icon" aria-hidden="true">+</span>
-            <span className="chrome-new-session-label">New Session</span>
-          </button>
           {/* #4890 — Slack-style intervention notifications widget. Bell
               with unread badge → dropdown listing every intervention alert
               (read + unread) so the operator gets a durable "do I have
@@ -2105,6 +2081,21 @@ export function App() {
               dead rows. */}
           {(() => {
             const overflowItems: HeaderOverflowItem[] = [
+              // #5062 — New Session moved INTO the overflow menu (was a
+              // standalone `chrome-new-session-btn` in the header-right
+              // zone). The Cmd+N shortcut still fires `handleNewSession`
+              // via the global keymap and the macOS menu-bar "File >
+              // New Session" item — this row is just the discoverable
+              // chrome entry point now. Listed first so a user scanning
+              // the menu top-to-bottom finds the most-used action
+              // immediately.
+              {
+                id: 'new-session',
+                label: 'New Session',
+                icon: '+',
+                title: `New session (${formatShortcutKeys('Cmd+N')})`,
+                onClick: handleNewSession,
+              },
               {
                 id: 'skills',
                 label: 'Skills',

--- a/packages/dashboard/src/components/HeaderOverflowMenu.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflowMenu.test.tsx
@@ -295,4 +295,38 @@ describe('HeaderOverflowMenu (#4974)', () => {
       expect(menu.getAttribute('id')).toBe(ariaControls)
     })
   })
+
+  // #5062 — New Session is now a regular overflow-menu item (was a
+  // standalone `chrome-new-session-btn` in the header-right zone). The
+  // component itself is generic — these tests pin the contract that the
+  // App.tsx integration relies on: an item with id `new-session` fires
+  // its handler when clicked and closes the menu, just like every other
+  // row.
+  describe('New Session menu item (#5062)', () => {
+    it('renders a new-session row when supplied and fires its handler on click', () => {
+      const onNewSession = vi.fn()
+      const items: HeaderOverflowItem[] = [
+        {
+          id: 'new-session',
+          label: 'New Session',
+          icon: '+',
+          title: 'New session (Cmd+N)',
+          onClick: onNewSession,
+        },
+        { id: 'settings', label: 'Settings', onClick: vi.fn() },
+      ]
+      render(<HeaderOverflowMenu items={items} />)
+      fireEvent.click(screen.getByTestId('header-overflow-trigger'))
+      const row = screen.getByTestId('header-overflow-item-new-session')
+      expect(row).toBeInTheDocument()
+      // Title attribute survives onto the <li> so the shortcut hint is
+      // discoverable on hover.
+      expect(row.getAttribute('title')).toMatch(/New session/)
+      expect(row.textContent).toMatch(/New Session/)
+      fireEvent.click(row)
+      expect(onNewSession).toHaveBeenCalledTimes(1)
+      // Activation dismisses the menu (same contract as every other row).
+      expect(screen.queryByTestId('header-overflow-menu')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -5379,53 +5379,22 @@
   outline-offset: 2px;
 }
 
-/* #4695 — prominent "New Session" chrome button. Lives in header-right
-   ahead of the icon-only buttons (Skills / Copy / Settings) so it is
-   the first affordance a new user spots. Uses the accent color filled
-   in (rather than outlined) to read as the primary chrome action. */
-.chrome-new-session-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  background: var(--accent-blue);
-  color: #fff;
-  border: 1px solid var(--accent-blue);
-  border-radius: 6px;
-  padding: 4px 10px;
-  font-size: 13px;
-  font-weight: 500;
-  cursor: pointer;
-  flex-shrink: 0;
-  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
-}
+/* #4695 / #5062 — the prominent "New Session" chrome button used to
+   live here as `.chrome-new-session-btn`. It has been folded into the
+   header overflow (⋯) menu as a regular menu item so the header-right
+   zone no longer crowds the permissions/model dropdowns. Cmd+N and
+   the macOS "File > New Session" menu item continue to fire
+   `handleNewSession`; the discoverable chrome entry is now inside the
+   overflow menu. */
 
-.chrome-new-session-btn:hover {
-  opacity: 0.88;
-}
-
-.chrome-new-session-btn:focus-visible {
-  outline: 2px solid var(--accent-blue);
-  outline-offset: 2px;
-}
-
-.chrome-new-session-icon {
-  font-size: 16px;
-  line-height: 1;
-  font-weight: 600;
-}
-
-.chrome-new-session-label {
-  white-space: nowrap;
-}
-
-/* --- Header overflow menu (#4974) ---
-   Skills / Copy / Settings collapsed behind a single "⋯" trigger so
-   the right zone has room for the prominent + New Session button and
-   the cost/token StatusBar without overlapping the model selector in
-   the center column. The trigger reuses `.header-icon-btn` for chrome
-   parity (hover bg, focus ring, no shrink), and the popover mirrors
-   the existing `.session-context-menu` look — same surface, border,
-   shadow — so the dashboard reads as one component family. */
+/* --- Header overflow menu (#4974, #5062) ---
+   Skills / Copy / Settings + New Session collapsed behind a single
+   "⋯" trigger so the right zone stays clean and doesn't overlap the
+   model selector in the center column. The trigger reuses
+   `.header-icon-btn` for chrome parity (hover bg, focus ring, no
+   shrink), and the popover mirrors the existing `.session-context-menu`
+   look — same surface, border, shadow — so the dashboard reads as one
+   component family. */
 .header-overflow {
   position: relative;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary

Move the "New Session" entry from the header-right zone into the existing `⋯` overflow menu (alongside Skills / Copy transcript / Settings). The standalone `.chrome-new-session-btn` was visually crowding the permissions/model dropdowns; collapsing it into the existing overflow menu cleans up the header.

Closes #5062.

## Changes

- `packages/dashboard/src/App.tsx`
  - Remove the standalone `chrome-new-session` button from `header-right`
  - Prepend a `new-session` item to `HeaderOverflowMenu`'s `items[]` so it's the first row in the dropdown (most-used action surfaces first)
  - Wire its `onClick` to the existing `handleNewSession`
  - Carry the `Cmd+N` shortcut hint through the row's `title`
- `packages/dashboard/src/App.test.tsx`
  - Rewrite the `chrome-new-session` suite as a `New Session in header overflow menu (#5062)` suite. New assertions: no standalone button, row renders inside the overflow menu with the `New Session` label, title attribute carries the Cmd+N hint, clicking the row opens `CreateSessionModal`.
- `packages/dashboard/src/components/HeaderOverflowMenu.test.tsx`
  - Add a unit-level test pinning the generic contract for the new `new-session` row id (label + title + click handler + menu dismissal).
- `packages/dashboard/src/theme/components.css`
  - Drop the now-dead `.chrome-new-session-*` rules; leave a pointer comment so a future reader sees where the affordance went.

## Non-changes (intentional)

- `Cmd+N` still fires via the global keymap (unchanged) — only the discoverable chrome entry-point moved.
- The macOS `File > New Session` menu-bar item still invokes `handleNewSession` (unchanged).
- `SessionBar`'s separate `+` button (`sidebar-new-session-…`) is out of scope per the issue.

## Test plan

- [x] `cd packages/dashboard && npx vitest run HeaderOverflowMenu` — 21/21 pass
- [x] `cd packages/dashboard && npx vitest run src/App.test.tsx` — 85/85 pass
- [x] Full dashboard suite — `npx vitest run` — 2881/2881 pass
- [x] `npx tsc --noEmit` clean (TS strict)
- [ ] Visual: open the dashboard, click `⋯`, confirm `New Session` is the first row; click it, confirm the Create Session modal opens; Cmd+N still works
- [ ] Confirm there is no standalone "New Session" pill in `header-right` at any width