### PR TITLE
fix(server): handle /compact slash command in CLI provider mode (#5064)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -1075,6 +1075,23 @@ export class CliSession extends BaseSession {
         const messageId = this._currentMessageId
         const ctx = this._currentCtx
 
+        // #5064 — Fallback for turns that complete without ever emitting
+        // streamed assistant text. The canonical case is `/compact`: the
+        // CLI returns the compaction summary in `data.result` but emits
+        // either no `assistant` event at all, or one with empty/no-growth
+        // text content, so the dashboard sees nothing. Mirror the SDK
+        // fallback (sdk-session.js:801) and surface `data.result` as a
+        // `message` of type `response` before the `result` event fires.
+        // Guard on !hasStreamStarted so normal streamed turns aren't
+        // double-emitted.
+        if (!ctx?.hasStreamStarted && typeof data.result === 'string' && data.result.length > 0) {
+          this.emit('message', {
+            type: 'response',
+            content: data.result,
+            timestamp: Date.now(),
+          })
+        }
+
         // Close any open stream before emitting result
         if (ctx?.hasStreamStarted) {
           this.emit('stream_end', { messageId })

--- a/packages/server/tests/cli-session-events.test.js
+++ b/packages/server/tests/cli-session-events.test.js
@@ -722,4 +722,139 @@ describe('CliSession stream-event handling', () => {
       session.destroy()
     })
   })
+
+  describe('result fallback for non-streamed text (#5064 — /compact)', () => {
+    // The CLI's `/compact` slash command returns the compaction summary in
+    // `data.result` but emits either no `assistant` event at all, or one
+    // with empty / no-growth text content. Without a fallback the dashboard
+    // sees nothing — no stream_start, no message, no acknowledgement.
+    // SDK mode mirrors this fallback at sdk-session.js:801.
+
+    it('emits a fallback response message when result text exists and no stream started', () => {
+      const session = createSession()
+      const messages = []
+      const streams = []
+      session.on('message', (m) => messages.push(m))
+      session.on('stream_start', () => streams.push('start'))
+      session.on('stream_end', () => streams.push('end'))
+
+      // Simulate /compact: result arrives directly with summary text,
+      // no stream_event, no assistant event with non-empty text.
+      session._handleEvent({
+        type: 'result',
+        session_id: 'sess-1',
+        subtype: 'success',
+        result: 'Conversation compacted to summary.',
+        total_cost_usd: 0,
+        duration_ms: 100,
+        usage: {},
+      })
+
+      assert.equal(messages.length, 1)
+      assert.equal(messages[0].type, 'response')
+      assert.equal(messages[0].content, 'Conversation compacted to summary.')
+      // No stream_start / stream_end — pure fallback path.
+      assert.equal(streams.length, 0)
+    })
+
+    it('does not emit fallback when a stream already fired (normal streamed turn)', () => {
+      const session = createSession()
+      const messages = []
+      session.on('message', (m) => messages.push(m))
+
+      // Simulate normal streamed turn: stream_event drives text delta,
+      // then result arrives with the same text echoed in data.result.
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'text' },
+        },
+      })
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'streamed reply' },
+        },
+      })
+      session._handleEvent({
+        type: 'result',
+        session_id: 'sess-1',
+        subtype: 'success',
+        result: 'streamed reply',
+        total_cost_usd: 0,
+        duration_ms: 100,
+        usage: {},
+      })
+
+      // Streamed turns must NOT double-emit a fallback message —
+      // the stream_delta is the canonical surface for the text.
+      assert.equal(messages.length, 0)
+    })
+
+    it('does not emit fallback when data.result is empty or missing', () => {
+      const session = createSession()
+      const messages = []
+      session.on('message', (m) => messages.push(m))
+
+      // Result with no `result` field at all (e.g. error subtype, tool turn).
+      session._handleEvent({
+        type: 'result',
+        session_id: 'sess-1',
+        subtype: 'success',
+        total_cost_usd: 0,
+        duration_ms: 100,
+        usage: {},
+      })
+
+      assert.equal(messages.length, 0)
+
+      // Result with empty string `result`.
+      session._currentMessageId = 'msg-2'
+      session._currentCtx = {
+        hasStreamStarted: false,
+        didStreamText: false,
+        assistantTextSeen: 0,
+        currentContentBlockType: null,
+        currentToolName: null,
+        currentToolUseId: null,
+        toolInputChunks: '',
+        toolInputBytes: 0,
+        toolInputOverflow: false,
+      }
+      session._handleEvent({
+        type: 'result',
+        session_id: 'sess-1',
+        subtype: 'success',
+        result: '',
+        total_cost_usd: 0,
+        duration_ms: 100,
+        usage: {},
+      })
+
+      assert.equal(messages.length, 0)
+    })
+
+    it('emits a result event regardless of fallback path', () => {
+      const session = createSession()
+      const results = []
+      session.on('result', (r) => results.push(r))
+
+      session._handleEvent({
+        type: 'result',
+        session_id: 'sess-1',
+        subtype: 'success',
+        result: 'Conversation compacted.',
+        total_cost_usd: 0.001,
+        duration_ms: 250,
+        usage: { input_tokens: 10 },
+      })
+
+      assert.equal(results.length, 1)
+      assert.equal(results[0].sessionId, 'sess-1')
+      assert.equal(results[0].cost, 0.001)
+      assert.equal(results[0].duration, 250)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #5064.

The CLI provider (`claude -p` / `cli-session.js`) silently dropped `/compact`: the `assistant` event only emits `stream_start` when `fullText.length > prevLen`, and the `result` event only emits `stream_end` when `hasStreamStarted` was set. `/compact` returns its summary in `data.result` with no streamed assistant content, so the dashboard saw nothing — no bubble, no acknowledgement.

## Fix

Mirror the SDK fallback (`sdk-session.js:801`) inside the `result` handler in `cli-session.js`: when no stream has started and `data.result` carries non-empty text, emit a `message` of type `response` so the dashboard surfaces the compaction summary. Streamed turns are unaffected — the `!hasStreamStarted` guard prevents double-emission.

## Tests

Added 4 unit tests in `packages/server/tests/cli-session-events.test.js`:

- Emits a fallback `response` message when `result` text exists and no stream started (the `/compact` case)
- Does NOT emit fallback when a stream already fired (normal streamed turn)
- Does NOT emit fallback when `data.result` is empty or missing
- The `result` event still fires alongside the fallback

## Test plan

- [x] `cli-session-events.test.js` — 36/36 pass (including 4 new tests)
- [x] `cli-session*.test.js` — 208/208 pass (full CLI suite, no regression)
- [x] `sdk-session.test.js` — 147/147 pass (SDK unaffected)
- [x] `lint-session-opt-forwarding.sh` — pass
- [x] `lint-tests-state-file-path.sh` — pass
- [ ] Manual: send `/compact` in CLI-provider session → response bubble appears with summary
- [ ] Manual: regression check — normal streamed turns still render once (not twice)

---

## Also bundled: dashboard New Session overflow-menu move (#5062)

This branch also carries commit `02f9994` which folds the standalone `.chrome-new-session-btn` into the header overflow (⋯) menu as a regular menu item. The header-right zone no longer crowds the permissions/model dropdowns; `Cmd+N` and the macOS "File > New Session" menu item continue to fire `handleNewSession`.

Tests updated: `App.test.tsx` (4 cases for the overflow-menu integration, asserting the standalone button no longer renders), `HeaderOverflowMenu.test.tsx` (1 case pinning the `new-session` row contract). 104/104 dashboard tests pass.

Closes #5062.