### PR TITLE
test(server): pin SUBAGENT_PROFILES systemPrompt under SESSION_PREAMBLE_MAX_LENGTH (#5073)

### DIFF
--- a/packages/server/src/byok-subagent-profiles.js
+++ b/packages/server/src/byok-subagent-profiles.js
@@ -34,13 +34,15 @@
  * (`general-purpose`, etc.).
  *
  * Each `systemPrompt` MUST stay under `SESSION_PREAMBLE_MAX_LENGTH` (4000
- * chars). The byok Task tool applies the profile to a child via direct
- * `child.sessionPreamble = profile.systemPrompt` assignment, bypassing the
- * `setSessionPreamble` setter's trim + cap — so an over-long prompt would
- * sail past silently and push the combined system prompt
- * (`_buildSystemPrompt` joins preamble + context hint + skills text) past
- * Anthropic's token budget. The bound is pinned by a unit test in
- * `tests/byok-subagent-profiles.test.js` (#5073).
+ * chars). The byok Task tool applies the profile via
+ * `child.setSessionPreamble(profile.systemPrompt)` (see
+ * `byok-session.js:_executeTaskTool`), which silently trims and caps at
+ * `SESSION_PREAMBLE_MAX_LENGTH`. An over-long profile wouldn't crash, but
+ * its tail would be truncated and the child would see only a half-
+ * instruction — the model behaviour silently degrades. The bound is
+ * pinned by a unit test in `tests/byok-subagent-profiles.test.js`
+ * (#5073) so a profile addition that would rely on silent truncation
+ * fails at CI rather than at runtime.
  *
  * @type {Readonly<Record<string, Readonly<{systemPrompt: string, toolSet: 'all' | readonly string[]}>>>}
  */

--- a/packages/server/src/byok-subagent-profiles.js
+++ b/packages/server/src/byok-subagent-profiles.js
@@ -33,6 +33,15 @@
  * Anthropic convention used in the official Claude Code subagent UX
  * (`general-purpose`, etc.).
  *
+ * Each `systemPrompt` MUST stay under `SESSION_PREAMBLE_MAX_LENGTH` (4000
+ * chars). The byok Task tool applies the profile to a child via direct
+ * `child.sessionPreamble = profile.systemPrompt` assignment, bypassing the
+ * `setSessionPreamble` setter's trim + cap — so an over-long prompt would
+ * sail past silently and push the combined system prompt
+ * (`_buildSystemPrompt` joins preamble + context hint + skills text) past
+ * Anthropic's token budget. The bound is pinned by a unit test in
+ * `tests/byok-subagent-profiles.test.js` (#5073).
+ *
  * @type {Readonly<Record<string, Readonly<{systemPrompt: string, toolSet: 'all' | readonly string[]}>>>}
  */
 export const SUBAGENT_PROFILES = Object.freeze({

--- a/packages/server/tests/byok-subagent-profiles.test.js
+++ b/packages/server/tests/byok-subagent-profiles.test.js
@@ -67,24 +67,21 @@ describe('SUBAGENT_PROFILES (#5018)', () => {
 
   it('every profile systemPrompt fits under SESSION_PREAMBLE_MAX_LENGTH (#5073)', () => {
     // #5073: the byok Task tool applies a profile to a child session via
-    // direct field assignment (`child.sessionPreamble = profile.systemPrompt`)
-    // rather than the `setSessionPreamble` setter, intentionally bypassing
-    // the 4000-char user-preamble cap for in-source profiles we control.
-    // That's fine for today's seed (~200-400 chars each), but a future
-    // contributor could add a profile with a multi-kilobyte systemPrompt
-    // and the implicit "fits in the system-prompt slot" invariant would
-    // break silently — `_buildSystemPrompt` joins the preamble with the
-    // chroxy context hint + skills text, and an over-long preamble could
-    // push the combined prompt past Anthropic's token budget.
+    // `child.setSessionPreamble(profile.systemPrompt)` (see
+    // `byok-session.js:_executeTaskTool`), which silently trims and caps
+    // at SESSION_PREAMBLE_MAX_LENGTH. Today's seed (~200-400 chars each)
+    // is well under the cap, but a future contributor could add a profile
+    // with a multi-kilobyte systemPrompt — that wouldn't crash, but the
+    // cap would silently truncate the tail, and the child would see a
+    // half-instruction. The model behaviour silently degrades.
     //
     // Pinning every profile under SESSION_PREAMBLE_MAX_LENGTH here makes
-    // that invariant explicit so a future profile addition fails at CI
-    // rather than at runtime.
+    // the invariant explicit so a future profile addition that would rely
+    // on silent truncation fails at CI rather than at runtime.
     for (const [id, profile] of Object.entries(SUBAGENT_PROFILES)) {
       assert.ok(
         profile.systemPrompt.length <= SESSION_PREAMBLE_MAX_LENGTH,
-        `profile ${id} systemPrompt (${profile.systemPrompt.length} chars) `
-        + `exceeds SESSION_PREAMBLE_MAX_LENGTH (${SESSION_PREAMBLE_MAX_LENGTH})`,
+        `profile ${id} systemPrompt (${profile.systemPrompt.length} chars) exceeds SESSION_PREAMBLE_MAX_LENGTH (${SESSION_PREAMBLE_MAX_LENGTH})`,
       )
     }
   })

--- a/packages/server/tests/byok-subagent-profiles.test.js
+++ b/packages/server/tests/byok-subagent-profiles.test.js
@@ -5,6 +5,7 @@ import {
   SUBAGENT_PROFILE_NAMES,
   getSubagentProfile,
 } from '../src/byok-subagent-profiles.js'
+import { SESSION_PREAMBLE_MAX_LENGTH } from '../src/base-session.js'
 
 /**
  * #5018: subagent profile registry. The byok Task tool looks up profiles
@@ -62,6 +63,30 @@ describe('SUBAGENT_PROFILES (#5018)', () => {
 
   it('SUBAGENT_PROFILE_NAMES is frozen', () => {
     assert.ok(Object.isFrozen(SUBAGENT_PROFILE_NAMES))
+  })
+
+  it('every profile systemPrompt fits under SESSION_PREAMBLE_MAX_LENGTH (#5073)', () => {
+    // #5073: the byok Task tool applies a profile to a child session via
+    // direct field assignment (`child.sessionPreamble = profile.systemPrompt`)
+    // rather than the `setSessionPreamble` setter, intentionally bypassing
+    // the 4000-char user-preamble cap for in-source profiles we control.
+    // That's fine for today's seed (~200-400 chars each), but a future
+    // contributor could add a profile with a multi-kilobyte systemPrompt
+    // and the implicit "fits in the system-prompt slot" invariant would
+    // break silently — `_buildSystemPrompt` joins the preamble with the
+    // chroxy context hint + skills text, and an over-long preamble could
+    // push the combined prompt past Anthropic's token budget.
+    //
+    // Pinning every profile under SESSION_PREAMBLE_MAX_LENGTH here makes
+    // that invariant explicit so a future profile addition fails at CI
+    // rather than at runtime.
+    for (const [id, profile] of Object.entries(SUBAGENT_PROFILES)) {
+      assert.ok(
+        profile.systemPrompt.length <= SESSION_PREAMBLE_MAX_LENGTH,
+        `profile ${id} systemPrompt (${profile.systemPrompt.length} chars) `
+        + `exceeds SESSION_PREAMBLE_MAX_LENGTH (${SESSION_PREAMBLE_MAX_LENGTH})`,
+      )
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

- Add a unit test in `packages/server/tests/byok-subagent-profiles.test.js` that asserts every entry in `SUBAGENT_PROFILES` has a `systemPrompt.length` under `SESSION_PREAMBLE_MAX_LENGTH` (4000 chars).
- Add a JSDoc note on `SUBAGENT_PROFILES` documenting the upper bound and pointing at the pinning test.

## Why

`_executeTaskTool` applies a subagent profile to the child via `child.setSessionPreamble(profile.systemPrompt)` (see `byok-session.js:1374-1378`), which routes through `_coerceSessionPreambleOpt`'s trim + 4000-char cap. That means an over-long profile wouldn't crash — but its tail would be silently truncated and the child would see only a half-instruction, degrading the model behaviour without any signal.

Today's seed is well under the cap (`general-purpose`: 363, `code-reviewer`: 345, `research`: 340 chars), but a future contributor could land a multi-kilobyte profile and the implicit "fits in the system-prompt slot" invariant would break silently.

Pinning every profile under `SESSION_PREAMBLE_MAX_LENGTH` here makes the invariant explicit so a future profile addition that would rely on silent truncation fails at CI rather than at runtime.

Closes #5073.

## Test plan

- [x] `node --test --import ./tests/_setup.mjs tests/byok-subagent-profiles.test.js` — 11/11 pass (was 10, +1 new).
- [x] `node --test --import ./tests/_setup.mjs tests/byok-subagent-profiles.test.js tests/base-session.test.js` — 137/137 pass (no regression on the cap setter).
- [x] `./scripts/lint-tests-state-file-path.sh` — clean.
- [x] `./scripts/lint-session-opt-forwarding.sh` — clean.
- [x] Verified the assertion bites: synthesised a 4500-char profile against the same assertion locally → `profile too-long systemPrompt (4500 chars) exceeds SESSION_PREAMBLE_MAX_LENGTH (4000)`.