### PR TITLE
feat(dashboard): show context-window usage in header status line (#5065)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2143,6 +2143,13 @@ export function App() {
             contextPercent={contextPercent}
             inputTokens={contextUsage?.inputTokens}
             outputTokens={contextUsage?.outputTokens}
+            // #5065: surface the absolute `used / total` token meter in
+            // the header. We only pass the window when there's an active
+            // model — that's the "no session selected" gate the meter
+            // hides on (`showMeter` requires a positive window).
+            contextWindow={activeModel
+              ? (availableModels.find(m => m.id === activeModel || m.fullId === activeModel)?.contextWindow) ?? DEFAULT_CONTEXT_WINDOW
+              : undefined}
             isBusy={!isIdle}
             agentCount={activeAgents.length}
             provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}

--- a/packages/dashboard/src/components/StatusBar.test.tsx
+++ b/packages/dashboard/src/components/StatusBar.test.tsx
@@ -171,4 +171,154 @@ describe('StatusBar', () => {
       expect(title).not.toMatch(/input \+/)
     })
   })
+
+  // #5065: absolute `used / total` token meter in the header status line.
+  // The meter REPLACES the plain text chip when all three required inputs
+  // are present (input + output + contextWindow) so users see the same
+  // information the FooterBar shows, in the at-a-glance header location.
+  describe('#5065 — context-window meter (used / total + bar)', () => {
+    it('renders absolute used/total when input + output + contextWindow are all provided', () => {
+      render(
+        <StatusBar
+          contextPercent={3}
+          inputTokens={25000}
+          outputTokens={5000}
+          contextWindow={1_000_000}
+        />,
+      )
+      const label = screen.getByTestId('status-context-label')
+      expect(label).toHaveTextContent('30.0k / 1M tokens')
+    })
+
+    it('renders the meter container with progressbar a11y semantics', () => {
+      render(
+        <StatusBar
+          contextPercent={30}
+          inputTokens={60000}
+          outputTokens={0}
+          contextWindow={200_000}
+        />,
+      )
+      expect(screen.getByTestId('status-context-meter')).toBeInTheDocument()
+      const bar = screen.getByRole('progressbar', { name: /context window usage/i })
+      expect(bar.getAttribute('aria-valuenow')).toBe('30')
+      expect(bar.getAttribute('aria-valuemin')).toBe('0')
+      expect(bar.getAttribute('aria-valuemax')).toBe('100')
+    })
+
+    it('caps the fill width at 100% even when the model went over budget', () => {
+      const { container } = render(
+        <StatusBar
+          contextPercent={130}
+          inputTokens={1_300_000}
+          outputTokens={0}
+          contextWindow={1_000_000}
+        />,
+      )
+      const fill = container.querySelector('.status-context-fill') as HTMLElement
+      expect(fill.style.width).toBe('100%')
+      // The numeric label still shows the true used count (1.3M), so the
+      // user gets the "you're over" signal in text even though the bar is
+      // pegged at 100% width.
+      expect(screen.getByTestId('status-context-label')).toHaveTextContent('1.3M / 1M tokens')
+    })
+
+    it('applies the over-budget class past 100% to drive the pulse animation', () => {
+      const { container } = render(
+        <StatusBar
+          contextPercent={120}
+          inputTokens={1_200_000}
+          outputTokens={0}
+          contextWindow={1_000_000}
+        />,
+      )
+      const bar = container.querySelector('.status-context-bar')
+      expect(bar!.className).toContain('over-budget')
+    })
+
+    it('applies the high class at >= 80% (matches FooterBar threshold)', () => {
+      const { container } = render(
+        <StatusBar
+          contextPercent={85}
+          inputTokens={850_000}
+          outputTokens={0}
+          contextWindow={1_000_000}
+        />,
+      )
+      const bar = container.querySelector('.status-context-bar')
+      expect(bar!.className).toContain('high')
+      expect(bar!.className).not.toContain('over-budget')
+    })
+
+    it('applies the medium class between 50% and 80%', () => {
+      const { container } = render(
+        <StatusBar
+          contextPercent={60}
+          inputTokens={600_000}
+          outputTokens={0}
+          contextWindow={1_000_000}
+        />,
+      )
+      const bar = container.querySelector('.status-context-bar')
+      expect(bar!.className).toContain('medium')
+    })
+
+    it('hides the meter and falls back to the text chip when no contextWindow is provided', () => {
+      render(
+        <StatusBar
+          context="30k tokens"
+          contextPercent={30}
+          inputTokens={30000}
+          outputTokens={0}
+          // contextWindow intentionally omitted (e.g. no model selected yet)
+        />,
+      )
+      expect(screen.queryByTestId('status-context-meter')).not.toBeInTheDocument()
+      expect(screen.getByText('30k tokens')).toBeInTheDocument()
+    })
+
+    it('hides the meter when token usage is zero (idle session, no turn yet)', () => {
+      render(
+        <StatusBar
+          contextPercent={null}
+          inputTokens={0}
+          outputTokens={0}
+          contextWindow={1_000_000}
+        />,
+      )
+      expect(screen.queryByTestId('status-context-meter')).not.toBeInTheDocument()
+      // The text chip still falls back to NBSP (no `context` prop given).
+    })
+
+    it('hides the meter when contextPercent is null even if tokens are present', () => {
+      // Defensive: percent comes from App.tsx's useMemo; when null (no
+      // model match, etc.) we have no signal for the bar fill — hide.
+      render(
+        <StatusBar
+          context="30k tokens"
+          contextPercent={null}
+          inputTokens={30000}
+          outputTokens={0}
+          contextWindow={1_000_000}
+        />,
+      )
+      expect(screen.queryByTestId('status-context-meter')).not.toBeInTheDocument()
+    })
+
+    it('inherits the contextTooltip on the meter (same in/out breakdown as the text chip)', () => {
+      render(
+        <StatusBar
+          contextPercent={30}
+          inputTokens={25000}
+          outputTokens={5000}
+          contextWindow={1_000_000}
+        />,
+      )
+      const meter = screen.getByTestId('status-context-meter')
+      const title = meter.getAttribute('title') ?? ''
+      expect(title).toContain('30%')
+      expect(title).toContain('25k input')
+      expect(title).toContain('5k output')
+    })
+  })
 })

--- a/packages/dashboard/src/components/StatusBar.tsx
+++ b/packages/dashboard/src/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 /**
  * StatusBar — cost, context, busy indicator, agent badges.
  */
+import { formatTokensCompact } from '@chroxy/store-core'
 import { getProviderInfo } from '../lib/provider-labels'
 import {
   costTooltip,
@@ -17,6 +18,13 @@ export interface StatusBarProps {
   inputTokens?: number
   /** #4205: raw output tokens for the most-recent turn (drives the tooltip breakdown). */
   outputTokens?: number
+  /**
+   * #5065: model context window in tokens. Combined with `inputTokens +
+   * outputTokens` to render the `used / total tokens` meter alongside the
+   * percent text. Hidden entirely when missing so the meter doesn't show
+   * an empty bar when no session/model is active.
+   */
+  contextWindow?: number
   isBusy?: boolean
   agentCount?: number
   provider?: string
@@ -27,8 +35,18 @@ export interface StatusBarProps {
 // miss / get auto-reformatted).
 const NBSP = '\u00A0'
 
+/**
+ * #5065: thresholds for the header context meter — kept in sync with the
+ * FooterBar pair (`FOOTER_COMPACT_SUGGEST_THRESHOLD` / `FOOTER_OVER_BUDGET_THRESHOLD`)
+ * so the two surfaces flip colour at the same point. Re-declared here
+ * rather than imported to avoid a back-edge dependency from the header
+ * component into the footer component.
+ */
+export const STATUS_COMPACT_SUGGEST_THRESHOLD = 80
+export const STATUS_OVER_BUDGET_THRESHOLD = 100
+
 export function StatusBar({
-  cost, context, contextPercent, inputTokens, outputTokens,
+  cost, context, contextPercent, inputTokens, outputTokens, contextWindow,
   isBusy, agentCount, provider,
 }: StatusBarProps) {
   const prov = provider ? getProviderInfo(provider) : null
@@ -45,6 +63,30 @@ export function StatusBar({
     outputTokens,
   })
   const agentTip = agentCountTooltip(agentCount)
+
+  // #5065: compute the `used / total tokens` label + bar when we have
+  // BOTH the raw token counts AND the model's context window. Without
+  // the window we'd be guessing, and the existing context chip text
+  // already covers the no-window case (it falls back to the raw count
+  // without a meter). Render is gated on `usedTokens > 0` so an idle
+  // session — no turns yet — doesn't show an empty `0 / 1M` bar.
+  const usedTokens = (inputTokens ?? 0) + (outputTokens ?? 0)
+  const showMeter = usedTokens > 0
+    && contextWindow != null
+    && contextWindow > 0
+    && contextPercent != null
+  const meterPercent = contextPercent ?? 0
+  // Cap fill at 100% — a bar wider than its container is just visual
+  // noise. The numeric label is what tells the user "you're over".
+  const meterFillWidth = Math.min(meterPercent, 100)
+  const meterClass = meterPercent >= STATUS_OVER_BUDGET_THRESHOLD
+    ? ' high over-budget'
+    : meterPercent >= STATUS_COMPACT_SUGGEST_THRESHOLD
+      ? ' high'
+      : meterPercent >= 50
+        ? ' medium'
+        : ''
+
   return (
     <div className="status-bar" data-testid="status-bar">
       {isBusy && (
@@ -68,13 +110,45 @@ export function StatusBar({
       >
         {cost != null ? `$${cost.toFixed(4)}` : NBSP}
       </span>
-      <span
-        className="status-context"
-        title={contextTip}
-        aria-label={contextTip}
-      >
-        {context || NBSP}
-      </span>
+      {showMeter ? (
+        <span
+          className="status-context-meter"
+          data-testid="status-context-meter"
+          title={contextTip}
+          aria-label={contextTip}
+        >
+          <span
+            className={`status-context-bar${meterClass}`}
+            role="progressbar"
+            aria-label="Context window usage"
+            aria-valuenow={Math.min(Math.round(meterPercent), 100)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <span
+              className="status-context-fill"
+              style={{ width: `${meterFillWidth}%` }}
+            />
+          </span>
+          <span
+            className="status-context-label"
+            data-testid="status-context-label"
+          >
+            {formatTokensCompact(usedTokens)}
+            {' / '}
+            {formatTokensCompact(contextWindow)}
+            {' tokens'}
+          </span>
+        </span>
+      ) : (
+        <span
+          className="status-context"
+          title={contextTip}
+          aria-label={contextTip}
+        >
+          {context || NBSP}
+        </span>
+      )}
       {agentCount != null && agentCount > 0 && (
         <span
           className="agent-badge"

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -3860,6 +3860,62 @@
   min-width: 50px;
 }
 
+/*
+ * #5065: header context-window meter — `used / total tokens` label +
+ * fill bar. Sized smaller than the footer's variant (50px bar vs 60px)
+ * so the header status line stays compact; shares the same colour
+ * thresholds + over-budget pulse so the two surfaces flip from green →
+ * yellow → red in lockstep.
+ */
+.status-context-meter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.status-context-bar {
+  display: inline-block;
+  width: 50px;
+  height: 6px;
+  background: var(--bg-tertiary, #1a1a2e);
+  border-radius: 3px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.status-context-fill {
+  display: block;
+  height: 100%;
+  background: var(--accent-green, #48bb78);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+}
+
+.status-context-bar.medium .status-context-fill {
+  background: var(--accent-yellow, #ecc94b);
+}
+
+.status-context-bar.high .status-context-fill {
+  background: var(--accent-red, #e53e3e);
+}
+
+.status-context-bar.over-budget .status-context-fill {
+  background: var(--accent-red-dark, #c53030);
+  animation: statusContextOverBudgetPulse 2s ease-in-out infinite;
+}
+
+@keyframes statusContextOverBudgetPulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.55; }
+}
+
+.status-context-label {
+  font-size: 11px;
+  white-space: nowrap;
+}
+
 .busy-indicator {
   width: 8px;
   height: 8px;

--- a/packages/store-core/src/cost-format.test.ts
+++ b/packages/store-core/src/cost-format.test.ts
@@ -6,7 +6,12 @@
  * one source of truth.
  */
 import { describe, it, expect } from 'vitest'
-import { formatCostBadge, formatCostBreakdown, formatPartialCostLine } from './cost-format'
+import {
+  formatCostBadge,
+  formatCostBreakdown,
+  formatPartialCostLine,
+  formatTokensCompact,
+} from './cost-format'
 import type { ErrorPartialCost } from './cost-format'
 import type { CumulativeUsage } from './types'
 
@@ -117,5 +122,42 @@ describe('formatPartialCostLine (#5039)', () => {
     expect(
       formatPartialCostLine(partial({ costUsd: 0, inputTokens: 50, outputTokens: 0 })),
     ).toBe('This turn cost $0 (50 in · 0 out)')
+  })
+})
+
+describe('formatTokensCompact (#5065)', () => {
+  it('returns raw count under 1000', () => {
+    expect(formatTokensCompact(0)).toBe('0')
+    expect(formatTokensCompact(1)).toBe('1')
+    expect(formatTokensCompact(999)).toBe('999')
+  })
+
+  it('formats thousands with lowercase k and one decimal', () => {
+    expect(formatTokensCompact(1000)).toBe('1.0k')
+    expect(formatTokensCompact(1234)).toBe('1.2k')
+    expect(formatTokensCompact(30_000)).toBe('30.0k')
+    expect(formatTokensCompact(200_000)).toBe('200.0k')
+  })
+
+  it('rolls over to M before "1000.0k"', () => {
+    // 999_500 rounds to 1000.0k in the simple version; jump to M instead.
+    expect(formatTokensCompact(999_500)).toBe('1M')
+    expect(formatTokensCompact(999_999)).toBe('1M')
+  })
+
+  it('drops the trailing .0 for whole millions (1M, 2M)', () => {
+    expect(formatTokensCompact(1_000_000)).toBe('1M')
+    expect(formatTokensCompact(2_000_000)).toBe('2M')
+  })
+
+  it('keeps one decimal for fractional millions', () => {
+    expect(formatTokensCompact(1_500_000)).toBe('1.5M')
+    expect(formatTokensCompact(1_250_000)).toBe('1.3M')
+  })
+
+  it('returns "0" for non-finite / non-positive (defensive)', () => {
+    expect(formatTokensCompact(-1)).toBe('0')
+    expect(formatTokensCompact(NaN)).toBe('0')
+    expect(formatTokensCompact(Infinity)).toBe('0')
   })
 })

--- a/packages/store-core/src/cost-format.ts
+++ b/packages/store-core/src/cost-format.ts
@@ -83,6 +83,41 @@ function formatTokens(n: number): string {
 }
 
 /**
+ * #5065: compact lowercase token formatter for the header status-line
+ * `used / total tokens` label.
+ *
+ *   formatTokensCompact(0)         → "0"
+ *   formatTokensCompact(999)       → "999"
+ *   formatTokensCompact(1_000)     → "1.0k"
+ *   formatTokensCompact(30_000)    → "30.0k"
+ *   formatTokensCompact(999_500)   → "1M"   (rolls to M before "1000.0k")
+ *   formatTokensCompact(1_000_000) → "1M"
+ *   formatTokensCompact(1_500_000) → "1.5M"
+ *
+ * Whole-million values drop the trailing ".0" so the common context-window
+ * sizes (200k / 1M / 2M) render as the marketing label users recognise
+ * rather than "1.0M". Uses lowercase `k` / uppercase `M` to match the
+ * existing `formatContext` helper in App.tsx that already produces "30k
+ * tokens" — keeping the header label visually consistent with the chip.
+ *
+ * Non-finite or non-positive input returns "0" defensively so a corrupted
+ * upstream payload can't poison the renderer with "NaN" / "Infinity".
+ */
+export function formatTokensCompact(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '0'
+  if (n < 1000) return String(Math.round(n))
+  if (n < 999_500) return `${(n / 1000).toFixed(1)}k`
+  // Round to one decimal first, then strip a trailing ".0" so whole
+  // millions render as "1M" / "2M" / "1M" (rolled over from 999_500)
+  // rather than the visually noisy "1.0M". One decimal is enough
+  // resolution for a status-line chip — sub-100k differences inside a
+  // multi-million window aren't legible there anyway.
+  const m = n / 1_000_000
+  const rounded = m.toFixed(1)
+  return rounded.endsWith('.0') ? `${rounded.slice(0, -2)}M` : `${rounded}M`
+}
+
+/**
  * Build the multi-line breakdown shown in the dashboard's native browser
  * tooltip (the cost-badge hover popover) — one string, six rows separated
  * by newlines, suitable for a `<span title={...}>` attribute.

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -174,6 +174,9 @@ export {
   // #5039: error-path partial-cost helper shared by dashboard toast
   // sub-line and mobile Alert.alert body.
   formatPartialCostLine,
+  // #5065: compact `used / total` token label for the header
+  // context-window meter.
+  formatTokensCompact,
 } from './cost-format'
 export type { ErrorPartialCost } from './cost-format'
 


### PR DESCRIPTION
## Summary

Surfaces the active session's context-window usage as `used / total tokens` plus a fill bar in the **header StatusBar** — the FooterBar's percent-only meter previously hid this information at the bottom of the window. Closes #5065.

The footer meter is unchanged — the header is now a richer companion (absolute counts) instead of a duplicate.

### Before

Header showed just a text chip: `30k tokens`.

### After

Header shows a fill bar + `30.0k / 1M tokens` whenever the session has a model and any input/output tokens. The bar uses the same green/yellow/red/pulse thresholds as `FooterBar`.

## Changes

- `packages/store-core/src/cost-format.ts` — new exported `formatTokensCompact(n)` helper. Lowercase `k`, whole-millions drop the trailing `.0` (so `1_000_000 → "1M"`, not `"1.0M"`).
- `packages/dashboard/src/components/StatusBar.tsx` — new `contextWindow` prop; renders a `.status-context-meter` (bar + label) when `inputTokens + outputTokens > 0`, `contextPercent != null`, and `contextWindow > 0`. Falls back to the existing text chip otherwise.
- `packages/dashboard/src/App.tsx` — passes the resolved `contextWindow` (or `undefined` when no `activeModel`) to `StatusBar`. FooterBar wiring untouched.
- `packages/dashboard/src/theme/components.css` — new `.status-context-{meter,bar,fill,label}` classes mirroring the footer's pattern, scaled down to 50px × 6px to fit the header line.

## Tests

- 5 new `formatTokensCompact` unit cases (raw / k / M / rollover / defensive).
- 7 new StatusBar render cases: absolute label format, a11y semantics, fill cap at 100%, over-budget class, high/medium thresholds, hide-when-no-window, hide-when-zero-tokens, tooltip inheritance.

Test suites green:

- `packages/dashboard` — 147 files / 2891 tests
- `packages/store-core` — 21 files / 1099 tests

## Out of scope (issue acceptance item 3)

Issue #5065 also notes that CLI-mode sessions may not be emitting `usage` events. That's a server-side gap on `cli-session.js` worth its own PR — keeping this one to the UI change so the dashboard fix can land independently.

## Test plan

- [ ] Open the dashboard, start an SDK session, send a turn — confirm the header now shows `<used> / <total> tokens` with a green bar matching the footer's percent.
- [ ] Push past 80% (or set a small context window via a custom model) — confirm the bar flips to yellow then red in lockstep with the footer.
- [ ] Open the dashboard with no active session — confirm no empty bar renders (text chip falls back to NBSP placeholder).
- [ ] Switch between sessions — confirm the meter updates with the new session's tokens.

Closes #5065