### PR TITLE
feat(server): distinguish postCreateCommand vs marker-write failures (#5068)

### DIFF
--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -538,12 +538,30 @@ export class DockerByokSession extends ClaudeByokSession {
         try {
           await this._runPostCreateCommandIfNeeded()
         } catch (err) {
-          this.emit('error', {
-            code: 'post_create_command_failed',
-            message: `docker-byok postCreateCommand failed: ${err.message}`,
-          })
-          await this.destroy()
-          return
+          // #5068: distinguish two failure modes that previously shared
+          // one error code. A `post_create_marker_write_failed` tag on
+          // the throw means the command itself succeeded — only the
+          // SHA-256 marker `touch` failed. The session is functional
+          // (setup was applied inside this container), but a future
+          // pool reuse will re-run setup because the cache marker
+          // wasn't stamped. Surface that as a non-fatal warning and
+          // keep the session alive. Anything else (or a missing tag)
+          // is a real command failure: tear down the owned container.
+          if (err && err.code === 'post_create_marker_write_failed') {
+            log.warn(`docker-byok postCreateCommand marker write failed (non-fatal — command did succeed): ${err.message}`)
+            this.emit('error', {
+              code: 'post_create_marker_write_failed',
+              message: `docker-byok postCreateCommand marker write failed: ${err.message}`,
+              fatal: false,
+            })
+          } else {
+            this.emit('error', {
+              code: 'post_create_command_failed',
+              message: `docker-byok postCreateCommand failed: ${err.message}`,
+            })
+            await this.destroy()
+            return
+          }
         }
       }
     } else {
@@ -906,12 +924,15 @@ export class DockerByokSession extends ClaudeByokSession {
    * change to `postCreateCommand` between sessions reuses the same
    * container but re-runs setup.
    *
-   * Failure surface: any non-zero exit (including timeout, backend
-   * reject, or marker-write failure) throws — the caller is `start()`,
-   * which converts the throw into a `post_create_command_failed` error
-   * event and tears the session down. The marker is only written on
-   * full success (command itself succeeds AND the marker write
-   * succeeds), so a half-applied state can never be cached.
+   * Failure surface: any non-zero exit on the command itself (timeout,
+   * backend reject, etc.) throws bare — the caller in `start()` converts
+   * the throw into a `post_create_command_failed` error event and tears
+   * the session down. A failure on the marker `touch` step throws an
+   * error tagged with `code: 'post_create_marker_write_failed'` so the
+   * caller can distinguish: the command DID succeed, only the cache
+   * stamp didn't land, and the session is still functional (#5068).
+   * The marker is only written on full success of the command, so a
+   * half-applied state can never be cached as "already applied".
    */
   async _runPostCreateCommandIfNeeded() {
     if (!this._postCreateCommand || !this._postCreateMarkerPath) return
@@ -947,14 +968,23 @@ export class DockerByokSession extends ClaudeByokSession {
     // Stamp the marker so the next session that lands on this container
     // skips the run. `mkdir -p` on the prefix would be wrong (the prefix
     // is /tmp, which always exists), so just `touch` the file. Failure
-    // here ALSO fails the post-create — without a marker write, a
-    // future reuse would re-run a command we just successfully applied,
-    // which would be wasteful and (for non-idempotent commands like
-    // `apt-get install`) potentially incorrect.
-    await this._execAsContainerUser({
-      cmd: `touch ${shellQuote(this._postCreateMarkerPath)}`,
-      timeout: 10_000,
-    })
+    // here is rethrown with a distinct `post_create_marker_write_failed`
+    // tag (#5068) so the caller in start() can tell it apart from a
+    // command failure — the command DID succeed for THIS session, but
+    // without a marker write a future pool reuse will re-run setup,
+    // which is wasteful for idempotent commands like `npm install` and
+    // potentially incorrect for non-idempotent ones like `apt-get install`.
+    try {
+      await this._execAsContainerUser({
+        cmd: `touch ${shellQuote(this._postCreateMarkerPath)}`,
+        timeout: 10_000,
+      })
+    } catch (err) {
+      const wrapped = new Error(err && err.message ? err.message : String(err))
+      wrapped.code = 'post_create_marker_write_failed'
+      wrapped.cause = err
+      throw wrapped
+    }
     log.info(`postCreateCommand applied — marker stamped at ${this._postCreateMarkerPath.slice(-12)}`)
   }
 

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -549,6 +549,19 @@ export class DockerByokSession extends ClaudeByokSession {
           // is a real command failure: tear down the owned container.
           if (err && err.code === 'post_create_marker_write_failed') {
             log.warn(`docker-byok postCreateCommand marker write failed (non-fatal — command did succeed): ${err.message}`)
+            // #5089 review (Copilot, comment id 3349977279): soil the
+            // pool container so it isn't recycled. Without this, the
+            // next session that acquires this container sees no marker,
+            // re-runs the full postCreateCommand, and almost certainly
+            // re-fails the marker write for the same underlying reason
+            // (read-only /tmp, no space, AppArmor profile). That re-run
+            // is wasteful for idempotent commands like `npm install`
+            // and potentially incorrect for non-idempotent ones like
+            // `apt-get install`. Soiling makes the pool evict THIS
+            // container on release() and start a fresh one for the
+            // next acquire, while the current session continues to
+            // ready — the command DID succeed inside this container.
+            this.markActiveContainerSoiled()
             this.emit('error', {
               code: 'post_create_marker_write_failed',
               message: `docker-byok postCreateCommand marker write failed: ${err.message}`,

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1286,6 +1286,74 @@ describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
     await session.destroy()
   })
 
+  it('soils the pool container when the marker write fails so it is evicted on release (#5089 review)', async () => {
+    // #5089 review (Copilot, comment id 3349977279): a container whose
+    // marker write failed is broken in a real way for the cache stamp
+    // (likely read-only /tmp, no space, AppArmor profile). If we let
+    // it back into the pool, the next acquire will re-run the full
+    // postCreateCommand, find no marker, and re-fail the touch for the
+    // same underlying reason — wasteful for `npm install`, potentially
+    // incorrect for `apt-get install`. Soiling the container makes the
+    // pool evict it on release(), so the next session gets a fresh
+    // container. THIS session still completes because the command did
+    // succeed inside the container.
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE_MARKERSOIL\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const markerErr = Object.assign(new Error('exec_failed: cannot touch /tmp/.chroxy-post-create-…: Read-only file system'), {
+      code: 'exec_failed',
+      exitCode: 1,
+    })
+    const backend = freshContainerBackend({
+      execResponses: {
+        'npm install': { stdout: 'added 42 packages\n', stderr: '' },
+      },
+      markerWriteError: markerErr,
+    })
+    // Tiny pool spy — only `markSoiled` is exercised by the path under
+    // test. `acquire`/`release` return null/undefined so the start()
+    // flow falls through to the normal owned-container path used by the
+    // sibling marker-fail test.
+    const soilCalls = []
+    const poolSpy = {
+      acquire: () => null,
+      release: async () => {},
+      markSoiled: (id) => { soilCalls.push(id) },
+      forget: async () => {},
+    }
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+      _pool: poolSpy,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+
+    // Distinct marker code still surfaces (regression guard on #5068).
+    const markerEvent = events.find((e) => e.code === 'post_create_marker_write_failed')
+    assert.ok(markerEvent, 'expected post_create_marker_write_failed event')
+
+    // Session continues to ready — the command DID succeed.
+    assert.equal(session._containerReady, true,
+      'marker-write failure must not tear down — session still functional')
+
+    // The container must have been soiled exactly once with this
+    // session's containerId. Without the soil call, the pool would
+    // recycle a container whose marker write keeps failing.
+    assert.equal(soilCalls.length, 1, 'expected exactly one markSoiled call')
+    assert.equal(soilCalls[0], session._containerId,
+      'soil call must target this session\'s container id')
+
+    await session.destroy()
+  })
+
   it('forwards a configurable postCreateTimeoutMs to the backend exec', async () => {
     const _execFile = execFileStub({
       info: { stdout: 'ok' },

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1065,7 +1065,7 @@ describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
    * `{ stdout: '', stderr: '' }` for the command itself, mirroring the
    * non-post-create `backendStub` helper.
    */
-  function freshContainerBackend({ execResponses = {} } = {}) {
+  function freshContainerBackend({ execResponses = {}, markerWriteError = null } = {}) {
     let markerPresent = false
     const calls = []
     return {
@@ -1082,6 +1082,11 @@ describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
             throw err
           }
           if (cmd.startsWith('touch ')) {
+            // #5068: opt-in marker-write failure so the
+            // command-success / marker-write-failure path is testable.
+            // Without this we'd have to write a bespoke backend stub
+            // for every test in that family.
+            if (markerWriteError) throw markerWriteError
             markerPresent = true
             return { stdout: '', stderr: '' }
           }
@@ -1223,6 +1228,62 @@ describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
     const rmCalls = _execFile.calls.filter((c) => c.args[0] === 'rm')
     assert.ok(rmCalls.some((c) => c.args.includes('CONTAINER_POSTCREATE_FAIL')),
       'failed start must tear down the owned container')
+  })
+
+  it('emits post_create_marker_write_failed (not post_create_command_failed) when the command succeeded but the marker touch failed', async () => {
+    // #5068: the marker-write path is internal infrastructure — if the
+    // command itself succeeded, the operator should not see a
+    // `post_create_command_failed` and assume their setup script
+    // exploded. They should see a distinct code that tells them future
+    // pool reuses will re-run setup because the cache stamp didn't land.
+    // The session itself stays alive because setup DID apply inside the
+    // container — it's the cache that broke, not the workload.
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_POSTCREATE_MARKERFAIL\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const markerErr = Object.assign(new Error('exec_failed: cannot touch /tmp/.chroxy-post-create-…: Read-only file system'), {
+      code: 'exec_failed',
+      exitCode: 1,
+    })
+    const backend = freshContainerBackend({
+      execResponses: {
+        'npm install': { stdout: 'added 42 packages\n', stderr: '' },
+      },
+      markerWriteError: markerErr,
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+
+    const markerEvent = events.find((e) => e.code === 'post_create_marker_write_failed')
+    assert.ok(markerEvent, 'expected a post_create_marker_write_failed error event')
+    assert.equal(markerEvent.fatal, false, 'marker-write failure must be flagged non-fatal — the command did succeed')
+    assert.match(markerEvent.message, /marker write failed/)
+
+    const cmdFailEvent = events.find((e) => e.code === 'post_create_command_failed')
+    assert.equal(cmdFailEvent, undefined,
+      'marker-write failure must NOT surface as post_create_command_failed (the command actually succeeded)')
+
+    // Command succeeded → session should still come up ready and the
+    // owned container MUST NOT be torn down. An operator can retry on
+    // the next session; the workload is functional now.
+    assert.equal(session._containerReady, true,
+      'marker-write failure must not tear down — the command succeeded and the session is functional')
+    const rmCalls = _execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 0,
+      'marker-write failure must not trigger container tear-down')
+
+    await session.destroy()
   })
 
   it('forwards a configurable postCreateTimeoutMs to the backend exec', async () => {


### PR DESCRIPTION
## Summary

Closes #5068. PR #5063 collapsed two operationally-distinct postCreateCommand failure modes into a single `post_create_command_failed` error event. Operators couldn't tell them apart without re-reading source:

1. **Command failed** — user's command exited non-zero; setup didn't apply; container is correctly torn down.
2. **Marker write failed** — command succeeded but the SHA-256 cache marker `touch` failed; setup DID apply inside the container, only the cache stamp didn't land. Future pool reuse will needlessly re-run setup (wasteful for `npm install`, potentially incorrect for `apt-get install`).

## Changes

- `_runPostCreateCommandIfNeeded()` wraps the marker `touch` in a try/catch and rethrows with `code: 'post_create_marker_write_failed'` so the caller can distinguish.
- `start()` inspects the thrown code:
  - **Command failure** → existing `post_create_command_failed` error event + `destroy()` (unchanged).
  - **Marker-write failure** → `log.warn` (the workload IS functional), emit a non-fatal `error` event with code `post_create_marker_write_failed` and `fatal: false`, but DO NOT tear down the container. The session continues to ready state because setup actually applied.
- `freshContainerBackend` test helper gains a `markerWriteError` opt so the new failure path is unit-testable without a bespoke stub.

## Acceptance Criteria

- [x] Marker-write failures emit a distinct error code (`post_create_marker_write_failed`).
- [x] Logged at warn level (the command did actually succeed) rather than error.
- [x] Test in `tests/docker-byok-session.test.js` for the marker-write-only failure path.

## Test plan

- [x] `node --test --test-force-exit packages/server/tests/docker-byok-session.test.js` — 84/84 pass, new test logs at WARN as expected
- [x] `lint-tests-state-file-path.sh` — OK
- [x] `lint-session-opt-forwarding.sh` — OK
- [x] `lint-logger-session-scoping.sh` — OK
- [x] `npm run lint` (eslint) — no new warnings/errors

## Behavioral notes

- Existing `post_create_command_failed` test still asserts the same code on real command failure — no regression.
- The new `error` event for marker-write failure carries `fatal: false`. Existing consumers that ignore unknown codes are unaffected; new operator dashboards can highlight the distinct code.