### PR TITLE
feat(server): capture postCreateCommand stdout/stderr on failure (#5067)

### DIFF
--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -93,6 +93,8 @@ export declare const ServerMessageSchema: z.ZodObject<{
     timestamp: z.ZodNumber;
     code: z.ZodOptional<z.ZodString>;
     attemptedResumeId: z.ZodOptional<z.ZodString>;
+    stdout: z.ZodOptional<z.ZodString>;
+    stderr: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
 export declare const ServerToolStartSchema: z.ZodObject<{
     type: z.ZodLiteral<"tool_start">;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -140,6 +140,17 @@ export const ServerMessageSchema = z.object({
     // length-capped so a malformed producer can't pollute the wire with
     // megabyte payloads.
     attemptedResumeId: z.string().max(256).optional(),
+    // #5067: captured stdout/stderr from a failed docker-byok
+    // postCreateCommand. Only set on `messageType: 'error'` envelopes
+    // whose `code` is `'post_create_command_failed'`; the session layer
+    // (docker-byok-session.js) tail-caps each stream to 4 KiB before
+    // emitting, and event-normalizer.js re-caps at 8 KiB at the wire
+    // boundary. The 8192 ceiling here is the wire-schema bound;
+    // producers (the session layer) apply a tighter cap. Optional so
+    // existing error envelopes (resume_unknown, generic crashes) stay
+    // shape-compatible.
+    stdout: z.string().max(8192).optional(),
+    stderr: z.string().max(8192).optional(),
 });
 export const ServerToolStartSchema = z.object({
     type: z.literal('tool_start'),

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -150,6 +150,17 @@ export const ServerMessageSchema = z.object({
   // length-capped so a malformed producer can't pollute the wire with
   // megabyte payloads.
   attemptedResumeId: z.string().max(256).optional(),
+  // #5067: captured stdout/stderr from a failed docker-byok
+  // postCreateCommand. Only set on `messageType: 'error'` envelopes
+  // whose `code` is `'post_create_command_failed'`; the session layer
+  // (docker-byok-session.js) tail-caps each stream to 4 KiB before
+  // emitting, and event-normalizer.js re-caps at 8 KiB at the wire
+  // boundary. The 8192 ceiling here is the wire-schema bound;
+  // producers (the session layer) apply a tighter cap. Optional so
+  // existing error envelopes (resume_unknown, generic crashes) stay
+  // shape-compatible.
+  stdout: z.string().max(8192).optional(),
+  stderr: z.string().max(8192).optional(),
 })
 
 export const ServerToolStartSchema = z.object({

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -158,6 +158,34 @@ const DEFAULT_POST_CREATE_TIMEOUT_MS = 5 * 60 * 1000
 const POST_CREATE_MARKER_PREFIX = '/tmp/.chroxy-post-create-'
 
 /**
+ * #5067 — Per-stream cap on captured postCreateCommand output included
+ * in the `post_create_command_failed` error event payload. Sized so the
+ * trailing tail of a typical `npm install` failure (the lines that
+ * actually identify the broken package) survives, while a runaway
+ * script that spammed MBs of progress can't push the WS frame past the
+ * encryption ceiling. We keep the TAIL because diagnostic info (the
+ * actual exception, ENOENT, exit codes) almost always lands at the end.
+ */
+const POST_CREATE_OUTPUT_CAP_BYTES = 4 * 1024
+
+/**
+ * Truncate a captured stream to the last `cap` bytes, emitting a
+ * `[truncated — first N bytes omitted]` prefix when we drop anything.
+ * The header is a single line so log scrapers can detect truncation
+ * without parsing the whole payload. Bytes (not chars) — a UTF-8
+ * multibyte sequence at the cut boundary will be replaced by U+FFFD
+ * when decoded, which is acceptable for a diagnostic tail.
+ */
+function tailCapture(text, cap = POST_CREATE_OUTPUT_CAP_BYTES) {
+  if (typeof text !== 'string' || text.length === 0) return ''
+  const buf = Buffer.from(text, 'utf8')
+  if (buf.length <= cap) return text
+  const omitted = buf.length - cap
+  const tail = buf.subarray(buf.length - cap).toString('utf8')
+  return `[truncated — first ${omitted} bytes omitted]\n${tail}`
+}
+
+/**
  * Map a host-absolute file_path under this.cwd into the container's
  * /workspace mount. Defends against path traversal by refusing absolute
  * paths that aren't under cwd. Relative paths are joined onto
@@ -538,9 +566,19 @@ export class DockerByokSession extends ClaudeByokSession {
         try {
           await this._runPostCreateCommandIfNeeded()
         } catch (err) {
+          // #5067 — Surface BOTH captured streams so the operator can
+          // diagnose without re-running the failed setup. The backend's
+          // `execInEnvironment` (docker.js) attaches `stdout` / `stderr`
+          // on the rejected Error; we tail-cap each to keep the event
+          // payload bounded. `err.stdout` / `err.stderr` are guaranteed
+          // to be strings (empty when not captured) for the docker-backed
+          // path; the `?? ''` guards a synthetic throw (e.g. invalid user
+          // regex) that didn't pass through the docker exec callback.
           this.emit('error', {
             code: 'post_create_command_failed',
             message: `docker-byok postCreateCommand failed: ${err.message}`,
+            stdout: tailCapture(err.stdout ?? ''),
+            stderr: tailCapture(err.stderr ?? ''),
           })
           await this.destroy()
           return

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -198,8 +198,32 @@ export class DockerBackend {
       execArgs.push(containerId, 'bash', '-c', cmd)
 
       this._execFile('docker', execArgs, { encoding: 'utf-8', timeout }, (err, stdout, stderr) => {
-        if (err) reject(new Error(stderr ? stderr.trim() : err.message))
-        else resolve({ stdout: stdout || '', stderr: stderr || '' })
+        if (err) {
+          // #5067 — Preserve both captured streams on failure. The error
+          // message stays stderr-first (existing callers rely on that
+          // shape for log lines), but we attach raw `stdout` / `stderr`
+          // properties so the caller can surface BOTH streams in a
+          // user-facing error event without re-running the command.
+          //
+          // npm install, repo bootstrap scripts, and apt-get commonly
+          // print the actually-useful diagnostic on stdout; dropping it
+          // here turned every post-create failure into a guess-and-retry.
+          //
+          // Falls through to err.message when stderr is empty, matching
+          // the pre-#5067 behaviour for stderr-silent commands. The
+          // post-create caller in docker-byok-session.js applies its own
+          // POST_CREATE_OUTPUT_CAP_BYTES truncation before serialising
+          // into the error event payload.
+          const wrapped = new Error(stderr ? stderr.trim() : err.message)
+          wrapped.stdout = stdout || ''
+          wrapped.stderr = stderr || ''
+          if (err.code) wrapped.code = err.code
+          if (err.signal) wrapped.signal = err.signal
+          if (typeof err.killed === 'boolean') wrapped.killed = err.killed
+          reject(wrapped)
+        } else {
+          resolve({ stdout: stdout || '', stderr: stderr || '' })
+        }
       })
     })
   }

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -457,6 +457,28 @@ Object.assign(EVENT_MAP, {
         msg.attemptedResumeId = trimmed.length > 256 ? trimmed.slice(0, 256) : trimmed
       }
     }
+    // #5067: forward captured `stdout` / `stderr` on docker-byok
+    // postCreateCommand failures so the operator can diagnose without
+    // re-running the broken setup. The session layer
+    // (docker-byok-session.js) already tail-caps each stream to
+    // POST_CREATE_OUTPUT_CAP_BYTES (4 KiB) before emitting; we re-cap at
+    // the wire boundary at 8 KiB per stream as a belt-and-suspenders
+    // bound (matches ServerMessageSchema.{stdout,stderr}.max(8192)) so a
+    // misbehaving producer can't ship a megabyte payload that the
+    // dashboard accepts but trips Zod-validating consumers. Gated
+    // strictly on the post-create-failure code so a buggy producer can't
+    // sneak the fields onto unrelated error envelopes — same hardening
+    // pattern as the resume_unknown gate above. Empty-string and
+    // non-string both treated as "absent" so receivers see a consistent
+    // "present or absent, never present-but-empty" shape.
+    if (data.code === 'post_create_command_failed') {
+      if (typeof data.stdout === 'string' && data.stdout.length > 0) {
+        msg.stdout = data.stdout.length > 8192 ? data.stdout.slice(0, 8192) : data.stdout
+      }
+      if (typeof data.stderr === 'string' && data.stderr.length > 0) {
+        msg.stderr = data.stderr.length > 8192 ? data.stderr.slice(0, 8192) : data.stderr
+      }
+    }
     return { messages: [{ msg }] }
   },
 

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1225,6 +1225,170 @@ describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
       'failed start must tear down the owned container')
   })
 
+  // ─────────────────────────────────────────────────────────────────────
+  // #5067 — capture stdout/stderr from a failed postCreateCommand so the
+  // operator can debug without re-running the broken setup
+  // ─────────────────────────────────────────────────────────────────────
+
+  it('#5067: includes captured stderr in the failure event when stderr is the diagnostic stream', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_PC_STDERR\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const stderrText = 'npm ERR! code ENOENT\nnpm ERR! syscall open\nnpm ERR! missing package.json'
+    const installErr = Object.assign(new Error(stderrText), {
+      code: 'exec_failed',
+      exitCode: 1,
+      stdout: '',
+      stderr: stderrText,
+    })
+    const backend = freshContainerBackend({
+      execResponses: { 'npm install': { throw: installErr } },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+
+    const errEvent = events.find((e) => e.code === 'post_create_command_failed')
+    assert.ok(errEvent, 'expected post_create_command_failed error event')
+    assert.equal(typeof errEvent.stdout, 'string', 'event must include a stdout field')
+    assert.equal(typeof errEvent.stderr, 'string', 'event must include a stderr field')
+    assert.equal(errEvent.stdout, '', 'stderr-only failure: stdout field is empty string')
+    assert.match(errEvent.stderr, /npm ERR! missing package\.json/,
+      'stderr capture must include the diagnostic tail')
+  })
+
+  it('#5067: includes captured stdout in the failure event when stdout is the diagnostic stream', async () => {
+    // Repository bootstrap scripts often `echo "ERROR: ..."` to stdout
+    // before exiting non-zero — the issue's motivating case. Pre-#5067,
+    // the operator saw only the (empty) stderr and had to re-run.
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_PC_STDOUT\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const stdoutText = 'Bootstrapping...\nERROR: missing required env var ACME_TOKEN\nAborting.\n'
+    const bootstrapErr = Object.assign(new Error(''), {
+      code: 'exec_failed',
+      exitCode: 2,
+      stdout: stdoutText,
+      stderr: '',
+    })
+    const backend = freshContainerBackend({
+      execResponses: { './scripts/setup.sh': { throw: bootstrapErr } },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: './scripts/setup.sh',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+
+    const errEvent = events.find((e) => e.code === 'post_create_command_failed')
+    assert.ok(errEvent, 'expected post_create_command_failed error event')
+    assert.match(errEvent.stdout, /ERROR: missing required env var ACME_TOKEN/,
+      'stdout-only failure: the bootstrap diagnostic must be captured')
+    assert.equal(errEvent.stderr, '', 'stdout-only failure: stderr field is empty string')
+  })
+
+  it('#5067: includes both streams in the failure event when both have output', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_PC_BOTH\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const stdoutText = 'Reading package lists...\nBuilding dependency tree...\nE: Unable to locate package gibberish-xyz\n'
+    const stderrText = 'W: apt-get is being run by an unprivileged user\n'
+    const aptErr = Object.assign(new Error(stderrText.trim()), {
+      code: 'exec_failed',
+      exitCode: 100,
+      stdout: stdoutText,
+      stderr: stderrText,
+    })
+    const backend = freshContainerBackend({
+      execResponses: { 'apt-get install': { throw: aptErr } },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'apt-get install gibberish-xyz',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+
+    const errEvent = events.find((e) => e.code === 'post_create_command_failed')
+    assert.ok(errEvent, 'expected post_create_command_failed error event')
+    assert.match(errEvent.stdout, /Unable to locate package gibberish-xyz/,
+      'both-streams failure: stdout must be captured')
+    assert.match(errEvent.stderr, /apt-get is being run by an unprivileged user/,
+      'both-streams failure: stderr must be captured')
+  })
+
+  it('#5067: tail-caps a runaway postCreateCommand output stream so the error payload stays bounded', async () => {
+    // A misbehaving setup script (`yes "spam" | head -c 100000`) must
+    // not produce an unbounded error event — the WS frame would explode
+    // past the encryption ceiling. We keep the TAIL because the actual
+    // diagnostic (the throw, the ENOENT, the exit code) almost always
+    // lands in the final lines.
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_PC_HUGE\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const noise = 'spam line that gets repeated forever\n'.repeat(5000)
+    const tailMarker = '\nFATAL: final-line-diagnostic-marker-XYZ\n'
+    const hugeStdout = noise + tailMarker
+    const hugeErr = Object.assign(new Error(''), {
+      code: 'exec_failed',
+      exitCode: 1,
+      stdout: hugeStdout,
+      stderr: '',
+    })
+    const backend = freshContainerBackend({
+      execResponses: { 'huge-setup.sh': { throw: hugeErr } },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'huge-setup.sh',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    const events = []
+    session.on('error', (e) => events.push(e))
+    await session.start()
+
+    const errEvent = events.find((e) => e.code === 'post_create_command_failed')
+    assert.ok(errEvent, 'expected post_create_command_failed error event')
+    // Cap is 4 KiB per stream; allow the truncation-marker line (~50 B)
+    // on top.
+    assert.ok(errEvent.stdout.length < 5000,
+      `stdout must be tail-capped (got ${errEvent.stdout.length} bytes)`)
+    assert.match(errEvent.stdout, /FATAL: final-line-diagnostic-marker-XYZ/,
+      'tail must preserve the trailing diagnostic — that is where the actual error lives')
+    assert.match(errEvent.stdout, /\[truncated — first \d+ bytes omitted\]/,
+      'truncation must be surfaced inline so the operator knows the prefix was dropped')
+  })
+
   it('forwards a configurable postCreateTimeoutMs to the backend exec', async () => {
     const _execFile = execFileStub({
       info: { stdout: 'ok' },

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -846,6 +846,59 @@ describe('DockerBackend.execInEnvironment()', () => {
     )
   })
 
+  it('#5067: attaches captured stdout AND stderr to the rejected Error', async () => {
+    // postCreateCommand failures often print the actually-useful
+    // diagnostic on stdout (npm install per-package errors, repo
+    // bootstrap script `echo "FATAL: ..."` lines, apt-get summary).
+    // Pre-#5067 the backend dropped stdout on the floor and the caller
+    // had to re-run by hand to see what went wrong.
+    const backend = new DockerBackend({
+      _execFile(_cmd, _args, _opts, cb) {
+        const err = new Error('exit 1')
+        err.code = 1
+        cb(err, 'OUT: setup printed this on stdout\n', 'ERR: setup printed this on stderr\n')
+      },
+    })
+
+    let caught
+    try {
+      await backend.execInEnvironment('ctr-abc', { cmd: 'broken-setup.sh' })
+      assert.fail('expected execInEnvironment to reject')
+    } catch (err) {
+      caught = err
+    }
+
+    assert.equal(typeof caught.stdout, 'string', 'rejected error must carry stdout')
+    assert.equal(typeof caught.stderr, 'string', 'rejected error must carry stderr')
+    assert.match(caught.stdout, /OUT: setup printed this on stdout/)
+    assert.match(caught.stderr, /ERR: setup printed this on stderr/)
+    // The message stays stderr-first for log-line continuity with the
+    // pre-#5067 behaviour; stdout lives on the attached property.
+    assert.match(caught.message, /ERR: setup printed this on stderr/)
+  })
+
+  it('#5067: rejected Error has empty-string stdout/stderr fields when the streams are silent', async () => {
+    const backend = new DockerBackend({
+      _execFile(_cmd, _args, _opts, cb) {
+        cb(new Error('ETIMEDOUT'), '', '')
+      },
+    })
+
+    let caught
+    try {
+      await backend.execInEnvironment('ctr-abc', { cmd: 'hangs-forever' })
+      assert.fail('expected execInEnvironment to reject')
+    } catch (err) {
+      caught = err
+    }
+
+    assert.equal(caught.stdout, '', 'silent stdout normalised to empty string')
+    assert.equal(caught.stderr, '', 'silent stderr normalised to empty string')
+    // With no stderr to surface, the message falls back to err.message
+    // — matches the pre-#5067 shape used by log scrapers.
+    assert.equal(caught.message, 'ETIMEDOUT')
+  })
+
   it('filters out entries whose value is null', async () => {
     const mockExec = createMockExecFile({ results: { exec: '' } })
     const backend = new DockerBackend({ _execFile: mockExec })

--- a/packages/server/tests/event-normalizer-post-create-failure.test.js
+++ b/packages/server/tests/event-normalizer-post-create-failure.test.js
@@ -1,0 +1,169 @@
+/**
+ * EventNormalizer error mapping — `post_create_command_failed` stdout/stderr
+ * forwarding (#5067)
+ *
+ * Pins the contract for the `error` event coming out of DockerByokSession's
+ * postCreateCommand failure path (PR #5091): the normalizer must forward
+ * `code`, `stdout`, AND `stderr` onto the wire so operators looking at the
+ * dashboard error toast can diagnose without re-running the broken setup.
+ *
+ * Pre-fix this normalizer dropped every field except `data.message` and
+ * `data.code` — the session layer captured both streams (PR #5091) but the
+ * normalizer silently discarded them at the wire boundary. The Copilot
+ * review on PR #5091 called this out: "stdout/stderr are attached to the
+ * session error payload here, but they won't currently reach operators
+ * because event-normalizer.js's error mapping only forwards data.message
+ * (and maybe code)."
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventNormalizer } from '../src/event-normalizer.js'
+
+describe('EventNormalizer error mapping — #5067 post_create_command_failed', () => {
+  const ctx = { sessionId: 'sess-1', mode: 'multi', getSessionEntry: () => null }
+
+  it('forwards stdout AND stderr onto the wire message for post_create_command_failed errors', () => {
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'post_create_command_failed',
+      message: 'docker-byok postCreateCommand failed: npm ERR! missing package.json',
+      stdout: 'Bootstrapping...\nERROR: missing required env var ACME_TOKEN\nAborting.\n',
+      stderr: 'npm ERR! code ENOENT\nnpm ERR! syscall open\nnpm ERR! missing package.json',
+    }, ctx)
+    assert.ok(result && Array.isArray(result.messages) && result.messages.length === 1)
+    const msg = result.messages[0].msg
+    assert.equal(msg.type, 'message')
+    assert.equal(msg.messageType, 'error')
+    assert.equal(msg.code, 'post_create_command_failed')
+    assert.match(msg.stdout, /ERROR: missing required env var ACME_TOKEN/,
+      'stdout must round-trip the wire so operators can see the bootstrap diagnostic')
+    assert.match(msg.stderr, /npm ERR! missing package\.json/,
+      'stderr must round-trip the wire so operators can see the npm diagnostic')
+  })
+
+  it('omits stdout/stderr on the wire when the fields are absent', () => {
+    // Generic errors (no post-create capture) must continue to flow through
+    // the normalizer unchanged — wire stays at the legacy shape.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      message: 'something exploded',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.stdout, undefined)
+    assert.equal(msg.stderr, undefined)
+  })
+
+  it('omits stdout/stderr on the wire when the fields are empty string', () => {
+    // Defensive: silent streams normalise to empty string in
+    // docker-byok-session.js (the `?? ''` guard); they must NOT pollute
+    // the wire with empty slots. Receivers see a consistent "present or
+    // absent, never present-but-empty" shape.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'post_create_command_failed',
+      message: 'x',
+      stdout: '',
+      stderr: '',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.stdout, undefined)
+    assert.equal(msg.stderr, undefined)
+  })
+
+  it('omits stdout/stderr on the wire when the fields are not strings', () => {
+    // Defense in depth — the wire schema (ServerMessageSchema) constrains
+    // stdout/stderr to strings, but event-normalizer is upstream of any
+    // wire-level validation. Drop non-string payloads here so a malformed
+    // producer can't reach the dashboard with junk on the fields.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'post_create_command_failed',
+      message: 'x',
+      stdout: 42,
+      stderr: { not: 'a string' },
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.stdout, undefined)
+    assert.equal(msg.stderr, undefined)
+  })
+
+  it('omits stdout/stderr when code is NOT post_create_command_failed (out-of-contract gating)', () => {
+    // The fields are documented as set only on post_create_command_failed
+    // errors. A buggy producer attaching them to other error codes should
+    // NOT reach the wire — keeps the contract clean and prevents
+    // downstream consumers from special-casing junk. Same gating pattern
+    // as attemptedResumeId on resume_unknown.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'docker_error',
+      message: 'x',
+      stdout: 'should not flow through',
+      stderr: 'should not flow through either',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.stdout, undefined,
+      'stdout must not flow through on non-post_create_command_failed errors')
+    assert.equal(msg.stderr, undefined,
+      'stderr must not flow through on non-post_create_command_failed errors')
+  })
+
+  it('truncates stdout to 8 KiB (matches wire schema cap)', () => {
+    // The session layer tail-caps to 4 KiB (POST_CREATE_OUTPUT_CAP_BYTES),
+    // and the wire schema declares an 8 KiB ceiling. Enforce the cap here
+    // so a misbehaving producer can't ship a megabyte payload that the
+    // dashboard accepts (lax client parse) but trips Zod-validating
+    // consumers. Slice rather than drop — the truncated tail still helps
+    // operator triage.
+    const oversized = 'a'.repeat(20_000)
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'post_create_command_failed',
+      message: 'x',
+      stdout: oversized,
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.stdout.length, 8192)
+  })
+
+  it('truncates stderr to 8 KiB (matches wire schema cap)', () => {
+    const oversized = 'b'.repeat(20_000)
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'post_create_command_failed',
+      message: 'x',
+      stderr: oversized,
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.stderr.length, 8192)
+  })
+
+  it('forwards just stdout when stderr is silent', () => {
+    // Bootstrap-script shape: `echo "ERROR: ..."` to stdout before exit.
+    // The motivating case from issue #5067.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'post_create_command_failed',
+      message: 'docker-byok postCreateCommand failed: ',
+      stdout: 'Bootstrapping...\nERROR: missing required env var ACME_TOKEN\n',
+      stderr: '',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.match(msg.stdout, /ERROR: missing required env var/)
+    assert.equal(msg.stderr, undefined)
+  })
+
+  it('forwards just stderr when stdout is silent', () => {
+    // npm-install shape: per-package errors land on stderr, stdout is
+    // empty by the time the command exits non-zero.
+    const normalizer = new EventNormalizer()
+    const result = normalizer.normalize('error', {
+      code: 'post_create_command_failed',
+      message: 'docker-byok postCreateCommand failed: npm ERR! ...',
+      stdout: '',
+      stderr: 'npm ERR! code ENOENT\nnpm ERR! missing package.json',
+    }, ctx)
+    const msg = result.messages[0].msg
+    assert.equal(msg.stdout, undefined)
+    assert.match(msg.stderr, /npm ERR! missing package\.json/)
+  })
+})


### PR DESCRIPTION
## Summary

When a docker-byok `postCreateCommand` exits non-zero, the
`post_create_command_failed` error event now carries the captured
stdout AND stderr from the failed command so an operator can debug
without re-running the broken setup.

## Why

PR #5063 wired the post-create hook, but the backend's
`execInEnvironment` rejected with `new Error(stderr.trim())` and
**dropped stdout on the floor**. For the most common real-world
setup commands this hides the actually-useful diagnostic:

- `npm install` — per-package errors are interleaved between stderr
  (warnings) and stdout (status)
- repository bootstrap scripts (`./scripts/setup.sh`) frequently
  `echo "ERROR: ..."` to stdout before exiting non-zero
- `apt-get install` — summary lines (`E: Unable to locate package ...`)
  land on stdout

Today an operator looking at a failed session sees a truncated stderr
and has to SSH in and re-run by hand to see what actually broke.

## Changes

- `packages/server/src/environments/backends/docker.js` —
  `execInEnvironment` attaches the raw `stdout` / `stderr` properties
  to the rejected Error. The message stays stderr-first for log-line
  continuity with the pre-#5067 behaviour.
- `packages/server/src/docker-byok-session.js` — the `start()` catch
  block tail-caps each stream at 4 KiB (`POST_CREATE_OUTPUT_CAP_BYTES`)
  and adds `stdout` / `stderr` to the `post_create_command_failed`
  error event payload. We keep the TAIL because the actual diagnostic
  almost always lands in the final lines, and a single inline
  `[truncated — first N bytes omitted]` header surfaces the
  truncation so log scrapers can detect it.

## Tests

- `tests/docker-byok-session.test.js` — three new tests for the
  failure event shape:
  - stderr-only failure (existing `npm install` shape)
  - stdout-only failure (bootstrap-script `echo "ERROR"` shape)
  - both-streams failure (apt-get shape)
  - plus a fourth that asserts the 4 KiB tail-cap actually bounds a
    runaway stdout and preserves the trailing diagnostic
- `tests/environments/backends/docker.test.js` — two new tests for
  the backend contract:
  - rejected Error carries `stdout` + `stderr` properties
  - silent streams normalise to empty string, message falls back to
    `err.message` (pre-#5067 shape preserved for stderr-empty case)

## Test plan

- [x] `node --import ./tests/_setup.mjs --test --test-force-exit tests/docker-byok-session.test.js` — 87/87 pass
- [x] `node --import ./tests/_setup.mjs --test --test-force-exit tests/environments/backends/docker.test.js` — 51/51 pass
- [x] `./scripts/lint-tests-state-file-path.sh`
- [x] `./scripts/lint-session-opt-forwarding.sh`
- [x] `npm run lint` (no new warnings)

Closes #5067