### PR TITLE
feat(server): validate snapshot tag name (lowercase, length, charset) (#5076)

### DIFF
--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -796,9 +796,7 @@ export class DockerByokSession extends ClaudeByokSession {
     const tag = this._generateSnapshotTag()
     const sourceCwd = this.cwd || process.cwd()
     const sourceImage = this._snapshotImage || this._image
-    const snapName = (typeof name === 'string' && name.trim().length > 0)
-      ? name.trim()
-      : tag.split(':').pop()
+    const snapName = this._resolveSnapshotName(name, tag)
     const createdAt = new Date().toISOString()
 
     log.info(`snapshot: committing ${this._containerId.slice(0, 12)} → ${tag}`)
@@ -832,6 +830,81 @@ export class DockerByokSession extends ClaudeByokSession {
     }
     log.info(`snapshot: ${tag} (name="${snapName}") committed`)
     return metadata
+  }
+
+  /**
+   * Validate `opts.name` against Docker tag rules so the field stays
+   * safe to surface into the image tag later (#5076).
+   *
+   *   - undefined / null         → fall back to the tag slug (the
+   *     "name is optional" contract: omitted = auto-generated slug)
+   *   - non-string               → EINVAL
+   *   - empty / whitespace-only  → EINVAL (per #5076 AC: a string that
+   *     trims to nothing is not "omitted" — the caller passed
+   *     something and it carries no usable identifier, so reject at
+   *     the API boundary rather than silently substituting the slug)
+   *   - > 64 chars (post-trim)   → EINVAL (Docker caps at 128; we cap
+   *     at 64 to leave headroom for a `<name>-<ts>` composite tag)
+   *   - uppercase or chars       → EINVAL
+   *     outside `[a-z0-9._-]`,
+   *     or leading `.` / `-`     → EINVAL (Docker tag grammar requires
+   *     the leading char to be `[a-zA-Z0-9_]`; we mirror that minus
+   *     the uppercase half)
+   *
+   * Returns the trimmed, validated name (or the tag-slug fallback for
+   * the omitted case).
+   *
+   * @param {unknown} name
+   * @param {string} tag The auto-generated tag, used for the fallback
+   * @returns {string}
+   */
+  _resolveSnapshotName(name, tag) {
+    if (name === undefined || name === null) {
+      return tag.split(':').pop()
+    }
+    if (typeof name !== 'string') {
+      const err = new Error(
+        `docker-byok snapshot(): name must be a string, got ${typeof name}`,
+      )
+      err.code = 'EINVAL'
+      throw err
+    }
+    const trimmed = name.trim()
+    if (trimmed.length === 0) {
+      // Whitespace-only — the caller passed *something*, but it
+      // carries no usable identifier. Per #5076 AC, this is EINVAL at
+      // the API boundary rather than a silent fallback (which would
+      // mask the caller's bug and produce repeated warn-line noise).
+      const err = new Error(
+        'docker-byok snapshot(): name must not be empty or whitespace-only',
+      )
+      err.code = 'EINVAL'
+      throw err
+    }
+    // 64 chars leaves room for a `<name>-<13-digit-ts>` composite tag
+    // under Docker's 128-char ceiling. Bias toward strictness now so
+    // tightening later is not a breaking change.
+    if (trimmed.length > 64) {
+      const err = new Error(
+        `docker-byok snapshot(): name is ${trimmed.length} chars; max is 64`,
+      )
+      err.code = 'EINVAL'
+      throw err
+    }
+    // Docker tag charset: lowercase ASCII letters, digits, `.`, `_`,
+    // `-`. The leading character must be `[a-z0-9_]` — Docker's own
+    // grammar permits a leading underscore (`[a-zA-Z0-9_][a-zA-Z0-9._-]
+    // {0,127}`), so we mirror that minus the uppercase half. `.` and
+    // `-` are still forbidden as the leading char per the reference
+    // grammar.
+    if (!/^[a-z0-9_][a-z0-9._-]*$/.test(trimmed)) {
+      const err = new Error(
+        'docker-byok snapshot(): name must be lowercase and contain only [a-z0-9._-], starting with [a-z0-9_]',
+      )
+      err.code = 'EINVAL'
+      throw err
+    }
+    return trimmed
   }
 
   /**

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1393,6 +1393,195 @@ describe('DockerByokSession — snapshot / restore (#5023)', () => {
   })
 })
 
+describe('DockerByokSession — snapshot name validation (#5076)', () => {
+  /**
+   * The `name` arg is currently only persisted into the metadata
+   * sidecar (the tag is auto-generated), but it is validated up front
+   * against Docker tag rules so a future revision can surface it into
+   * the tag without breaking callers.
+   *
+   * Rules enforced by `_resolveSnapshotName`:
+   *   - undefined / null   → fall back to tag slug (the omitted case)
+   *   - whitespace-only    → EINVAL (per #5076 AC)
+   *   - non-string         → EINVAL
+   *   - > 64 chars         → EINVAL
+   *   - uppercase or       → EINVAL
+   *     chars outside
+   *     [a-z0-9._-], or
+   *     leading . / -
+   *
+   * The validation runs BEFORE docker commit so a bad name does not
+   * leave a stranded tag in the daemon.
+   */
+  function backendStubCounting() {
+    const calls = { commit: [] }
+    return {
+      calls,
+      async execInEnvironment() {
+        return { stdout: '', stderr: '' }
+      },
+      async commitEnvironment(containerId, imageTag) {
+        calls.commit.push({ containerId, imageTag })
+        return `sha256:${imageTag.replace(/[^a-z0-9]/gi, '').slice(0, 64)}`
+      },
+    }
+  }
+
+  async function startedSession({ backend, snapshotsDir } = {}) {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_NV\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backend || backendStubCounting(),
+      snapshotsDir: snapshotsDir || join(tmpHome, 'snapshots'),
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    return session
+  }
+
+  it('accepts a valid lowercase name and propagates it through to metadata', async () => {
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    const snap = await session.snapshot({ name: 'after-deps.v1_2' })
+    assert.equal(snap.name, 'after-deps.v1_2')
+    // Commit still ran (validation passed; docker side fired).
+    assert.equal(backend.calls.commit.length, 1)
+    await session.destroy()
+  })
+
+  it('omitted name falls back to the tag slug (auto-generated)', async () => {
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    const snap = await session.snapshot()
+    // Tag slug shape: `<16-hex>-<13+ digit ts>`
+    assert.match(snap.name, /^[a-f0-9]{16}-\d{13,}$/)
+    assert.equal(snap.tag.split(':').pop(), snap.name)
+    await session.destroy()
+  })
+
+  it('null and undefined name both fall back to the tag slug', async () => {
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    const snap1 = await session.snapshot({ name: undefined })
+    assert.equal(snap1.tag.split(':').pop(), snap1.name)
+    const snap2 = await session.snapshot({ name: null })
+    assert.equal(snap2.tag.split(':').pop(), snap2.name)
+    await session.destroy()
+  })
+
+  it('rejects whitespace-only name with EINVAL BEFORE docker commit fires', async () => {
+    // #5076 AC: a string that trims to nothing is not "omitted" — the
+    // caller passed something and it carries no usable identifier, so
+    // reject at the API boundary rather than silently substituting the
+    // slug. `undefined`/`null` remain the "name is optional" sentinel.
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    for (const bad of ['', '   ', '\t', '\n', ' \t \n ']) {
+      await assert.rejects(
+        () => session.snapshot({ name: bad }),
+        (err) => err.code === 'EINVAL' && /empty|whitespace/i.test(err.message),
+        `expected EINVAL for ${JSON.stringify(bad)}`,
+      )
+    }
+    assert.equal(backend.calls.commit.length, 0, 'commit must not run on whitespace-only name')
+    await session.destroy()
+  })
+
+  it('rejects non-string name with EINVAL BEFORE docker commit fires', async () => {
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    for (const bad of [123, true, {}, [], Symbol('x')]) {
+      await assert.rejects(
+        () => session.snapshot({ name: bad }),
+        (err) => err.code === 'EINVAL' && /must be a string/i.test(err.message),
+      )
+    }
+    assert.equal(backend.calls.commit.length, 0, 'commit must not run on invalid name')
+    await session.destroy()
+  })
+
+  it('rejects name with uppercase characters', async () => {
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    await assert.rejects(
+      () => session.snapshot({ name: 'After-Deps' }),
+      (err) => err.code === 'EINVAL' && /lowercase/i.test(err.message),
+    )
+    assert.equal(backend.calls.commit.length, 0)
+    await session.destroy()
+  })
+
+  it('rejects name with invalid characters (space, slash, colon, etc.)', async () => {
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    for (const bad of ['has space', 'has/slash', 'has:colon', 'has@at', 'has!bang', 'has,comma']) {
+      await assert.rejects(
+        () => session.snapshot({ name: bad }),
+        (err) => err.code === 'EINVAL' && /lowercase|\[a-z0-9/i.test(err.message),
+        `expected EINVAL for ${JSON.stringify(bad)}`,
+      )
+    }
+    assert.equal(backend.calls.commit.length, 0)
+    await session.destroy()
+  })
+
+  it('rejects name with a leading dot or dash (not a valid Docker tag start)', async () => {
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    await assert.rejects(
+      () => session.snapshot({ name: '.hidden' }),
+      (err) => err.code === 'EINVAL',
+    )
+    await assert.rejects(
+      () => session.snapshot({ name: '-leading-dash' }),
+      (err) => err.code === 'EINVAL',
+    )
+    assert.equal(backend.calls.commit.length, 0)
+    await session.destroy()
+  })
+
+  it('accepts a name with a leading underscore (Docker tag grammar permits it)', async () => {
+    // Docker's tag grammar is `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}` — a
+    // leading `_` is explicitly valid. We mirror that minus the
+    // uppercase half. Pins the difference vs. leading `.` / `-`, which
+    // ARE rejected.
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    const snap = await session.snapshot({ name: '_internal' })
+    assert.equal(snap.name, '_internal')
+    assert.equal(backend.calls.commit.length, 1)
+    await session.destroy()
+  })
+
+  it('rejects name longer than 64 characters', async () => {
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    const tooLong = 'a'.repeat(65)
+    await assert.rejects(
+      () => session.snapshot({ name: tooLong }),
+      (err) => err.code === 'EINVAL' && /65 chars.*max is 64/i.test(err.message),
+    )
+    assert.equal(backend.calls.commit.length, 0)
+    await session.destroy()
+  })
+
+  it('accepts a name of exactly 64 characters (boundary)', async () => {
+    const backend = backendStubCounting()
+    const session = await startedSession({ backend })
+    const max = 'a'.repeat(64)
+    const snap = await session.snapshot({ name: max })
+    assert.equal(snap.name, max)
+    assert.equal(backend.calls.commit.length, 1)
+    await session.destroy()
+  })
+})
+
 describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
   /**
    * Acceptance: a `postCreateCommand: string | string[]` opt that runs


### PR DESCRIPTION
## Summary

Lock down the shape of `DockerByokSession.snapshot({ name })` so the field can safely surface into a future composite image tag (`<name>-<ts>`) without re-litigating callers. Today `name` is metadata-only, but it's the obvious input to a tag-grammar bug if we ever evolve the API — bias toward strictness now so tightening later is not a breaking change.

Rules (all enforced **before** `docker commit` fires, so a bad name never strands an image in the daemon):

- non-string → `EINVAL`
- > 64 chars (post-trim) → `EINVAL` (leaves headroom under Docker's 128-char tag limit)
- uppercase or chars outside `[a-z0-9._-]` → `EINVAL`
- leading `.` or `-` → `EINVAL` (not a valid Docker tag start)
- whitespace-only → falls back to tag slug + `log.warn` (preserves the documented "name is optional" contract — no breaking change for callers that pass `''`)
- omitted / null / undefined → falls back to tag slug (unchanged)

## Test plan

- [x] `node --test --test-force-exit tests/docker-byok-session.test.js` — 72 / 72 pass (10 new in the `#5076` describe block)
- [x] Cross-suite check: `tests/docker-byok-session.test.js` + `tests/docker-byok-pool.test.js` + `tests/byok-session.test.js` — 210 / 210 pass
- [x] `npm run lint` — 0 errors (6 pre-existing warnings in unrelated files)
- [x] `./scripts/lint-session-opt-forwarding.sh` — 6 subclasses forward all 19 opts
- [x] `./scripts/lint-tests-state-file-path.sh` — every `new SessionManager` in tests uses a tmp path

Coverage:

- valid lowercase name with `.`, `_`, `-`, digits → propagated through to metadata
- omitted / `null` / `undefined` → tag-slug fallback
- whitespace-only → tag-slug fallback (no throw)
- non-string types (`number`, `boolean`, `object`, `array`, `symbol`) → `EINVAL`, **commit never fires**
- uppercase rejected
- invalid chars (space, slash, colon, `@`, `!`, `,`) rejected
- leading `.` or `-` rejected
- 65 chars rejected; 64-char boundary accepted

Closes #5076.