### PR TITLE
feat(server): forward ANTHROPIC_API_KEY into compose primary service (#5079)

### DIFF
--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -98,7 +98,9 @@
 
 import { execFile } from 'child_process'
 import { createHash, randomBytes } from 'crypto'
-import { isAbsolute, posix } from 'path'
+import { writeFileSync, unlinkSync } from 'fs'
+import { tmpdir } from 'os'
+import { isAbsolute, join, posix } from 'path'
 import { ClaudeByokSession } from './byok-session.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
@@ -405,6 +407,19 @@ export class DockerByokSession extends ClaudeByokSession {
     // environment-manager's `chroxy-${envId}` naming. Resolved lazily
     // in start() so construction stays deterministic.
     this._composeProject = null
+    // #5079 — host-side tmpfile path for the compose env-file. Written
+    // at compose-up time when ANTHROPIC_API_KEY is present in the host
+    // env, passed to every `docker exec` via `--env-file` so the key is
+    // forwarded into model-spawned commands WITHOUT exposing it on the
+    // host's process-listing (`docker exec --env KEY=secret` is visible
+    // in `ps`). The file is mode 0600 and lives under os.tmpdir(); it's
+    // unlinked on destroy() (and best-effort on start-failure paths).
+    this._composeEnvFile = null
+    // Test seam: override the writer / unlinker so tests can assert the
+    // file lifecycle without touching the real filesystem.
+    this._writeEnvFile = opts._writeEnvFile || ((p, c) => writeFileSync(p, c, { mode: 0o600 }))
+    this._unlinkEnvFile = opts._unlinkEnvFile || ((p) => { try { unlinkSync(p) } catch { /* ignore */ } })
+    this._envForApiKey = opts._envForApiKey || process.env
 
     const user = opts.containerUser || DEFAULT_USER
     if (!VALID_USERNAME_RE.test(user)) {
@@ -737,12 +752,48 @@ export class DockerByokSession extends ClaudeByokSession {
    * host cwd is mounted at /workspace via the compose file (the user
    * is responsible for that volume mapping), and tool dispatch goes
    * through the same `_execAsContainerUser` path.
+   *
+   * #5079 — ANTHROPIC_API_KEY forwarding. The bare-image path forwards
+   * the key via `docker run --env`; compose mode does the same job via
+   * an `--env-file` tmpfile so the key is symmetric with the bare path
+   * without being exposed in `ps` output. The tmpfile is written at
+   * 0600 under os.tmpdir() and:
+   *   - passed to `docker compose --env-file <path>` so a service that
+   *     references `${ANTHROPIC_API_KEY}` in its compose file resolves
+   *     the value during interpolation; and
+   *   - reused on every `_execAsContainerUser` dispatch so a Bash command
+   *     the model spawns inside the container (e.g. `curl
+   *     api.anthropic.com` or a one-off `claude -p`) sees the key.
+   * destroy() unlinks the file. When `ANTHROPIC_API_KEY` is not set in
+   * the host env, no tmpfile is created — the path stays at `null` and
+   * `_execAsContainerUser` skips the `--env-file` flag.
    */
   async _startComposeStack() {
     if (!this._composeProject) {
       this._composeProject = `chroxy-byok-${randomBytes(6).toString('hex')}`
     }
     const cwd = this.cwd || process.cwd()
+    // #5079: write the ANTHROPIC_API_KEY tmpfile BEFORE compose up so
+    // the file is on disk for both compose interpolation AND for the
+    // exec dispatches that follow. Created at 0600 under os.tmpdir()
+    // with a session-scoped random suffix to avoid collision between
+    // parallel byok sessions on the same host.
+    const apiKey = this._envForApiKey?.ANTHROPIC_API_KEY
+    if (apiKey) {
+      const envFilePath = join(tmpdir(), `chroxy-byok-${this._composeProject}.env`)
+      try {
+        this._writeEnvFile(envFilePath, `ANTHROPIC_API_KEY=${apiKey}\n`)
+        this._composeEnvFile = envFilePath
+      } catch (err) {
+        // Non-fatal: log and proceed without the env file. The model
+        // running inside the container won't see the key (matching the
+        // pre-#5079 behaviour) but the host-side agent loop is what
+        // actually authenticates to Anthropic, so the session still
+        // functions for the common case.
+        log.warn(`docker-byok compose: failed to write env-file ${envFilePath}: ${err.message}`)
+        this._composeEnvFile = null
+      }
+    }
     log.info(`docker-byok compose stack starting (file=${this._composeFile} project=${this._composeProject} service=${this._composeService || '<first>'})`)
     let result
     try {
@@ -753,8 +804,15 @@ export class DockerByokSession extends ClaudeByokSession {
         composeProject: this._composeProject,
         containerUser: this._containerUser,
         primaryService: this._composeService,
+        envFile: this._composeEnvFile,
       })
     } catch (err) {
+      // Compose up failed — unlink the tmpfile before re-throwing so a
+      // start-failure path doesn't leak the key on disk.
+      if (this._composeEnvFile) {
+        this._unlinkEnvFile(this._composeEnvFile)
+        this._composeEnvFile = null
+      }
       const error = new Error(`docker compose start failed: ${err.message}`)
       error.code = err.code || 'compose_start_failed'
       throw error
@@ -1041,12 +1099,20 @@ export class DockerByokSession extends ClaudeByokSession {
    * execInEnvironment didn't forward a `-u` flag. The hardening
    * (`--cap-drop ALL`, `no-new-privileges`) still capped what root could
    * do, but the explicit non-root design intent was silently violated.
+   *
+   * #5079: in compose mode, when a tmpfile holding ANTHROPIC_API_KEY was
+   * written at start time, forward it via `--env-file` so the model's
+   * Bash commands inside the container see the key — without exposing
+   * it on the host's `ps` output (`--env KEY=secret` would). Bare-image
+   * sessions don't need this: their `docker run --env ANTHROPIC_API_KEY`
+   * already attached the key to the container env at launch time.
    */
   _execAsContainerUser({ cmd, timeout = 30_000 }) {
     return this._dockerBackend.execInEnvironment(this._containerId, {
       cmd,
       timeout,
       user: this._containerUser,
+      envFile: this._composeEnvFile || undefined,
     })
   }
 
@@ -1278,10 +1344,17 @@ export class DockerByokSession extends ClaudeByokSession {
     // nulling state so the finally-block has them.
     const composeFile = this._composeFile
     const composeProject = this._composeProject
+    // #5079: unlink the ANTHROPIC_API_KEY tmpfile created at compose-up
+    // time. Snapshot the path BEFORE nulling so the finally-block has
+    // it; unlink AFTER `compose down` runs (the tmpfile is referenced
+    // by the down call indirectly via the project metadata, and we want
+    // a clean teardown order — compose first, then secret material).
+    const composeEnvFile = this._composeEnvFile
     const cwd = this.cwd || process.cwd()
     this._containerId = null
     this._containerReady = false
     this._acquiredFromPool = false
+    this._composeEnvFile = null
     try {
       await super.destroy()
     } finally {
@@ -1297,6 +1370,10 @@ export class DockerByokSession extends ClaudeByokSession {
           })
         } catch (err) {
           log.warn(`compose destroy failed: ${err.message}`)
+        }
+        // Unlink the env-file last — best-effort, silent on missing.
+        if (composeEnvFile) {
+          this._unlinkEnvFile(composeEnvFile)
         }
       } else if (!containerId || !owned) {
         // Nothing for us to clean up — externally-managed container

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -76,9 +76,9 @@ export class DockerBackend {
    * @returns {Promise<{ containerId: string, containerCliPath: string, services: Array }>}
    */
   async createComposeEnvironment(opts) {
-    const { cwd, composeFile, composeProject, containerUser, primaryService } = opts
+    const { cwd, composeFile, composeProject, containerUser, primaryService, envFile } = opts
 
-    await this._composeUp(composeFile, composeProject, cwd)
+    await this._composeUp(composeFile, composeProject, cwd, envFile)
 
     let containerId
     try {
@@ -137,7 +137,7 @@ export class DockerBackend {
 
   /**
    * @param {string} containerId
-   * @param {{ cmd: string, env?: Object.<string,string>, cwd?: string, timeout?: number }} opts
+   * @param {{ cmd: string, env?: Object.<string,string>, envFile?: string, cwd?: string, timeout?: number }} opts
    * @returns {Promise<{ stdout: string, stderr: string }>}
    *
    * opts.env — all key/value pairs are forwarded as `--env KEY=VAL` flags.
@@ -150,6 +150,15 @@ export class DockerBackend {
    * execInEnvironment is a general-purpose helper invoked with an explicit env
    * object constructed by the caller. The caller is responsible for passing only
    * the vars required for the command. process.env is never consulted.
+   *
+   * opts.envFile — forwarded as `--env-file <path>`. Useful for secrets that
+   * must not appear in `ps` output (`docker exec --env KEY=secret` exposes
+   * the value in the process listing). The file format follows Docker's own
+   * env file spec: one `KEY=VALUE` pair per line, no quoting required.
+   * Callers are responsible for creating the file with 0600 permissions and
+   * unlinking it when no longer needed. docker-byok (#5079) uses this to
+   * forward `ANTHROPIC_API_KEY` into compose-managed containers without
+   * exposing the key in argv.
    *
    * opts.cwd — forwarded as `--workdir <cwd>`.  The path must already be an
    * absolute path *inside* the container; callers are responsible for remapping
@@ -164,7 +173,7 @@ export class DockerBackend {
    * (#5021) passes it for every tool dispatch so file ops respect the
    * `useradd` + `chown /workspace` setup done at container start.
    */
-  execInEnvironment(containerId, { cmd, env, cwd, timeout = 30_000, user } = {}) {
+  execInEnvironment(containerId, { cmd, env, envFile, cwd, timeout = 30_000, user } = {}) {
     return new Promise((resolve, reject) => {
       const execArgs = ['exec']
 
@@ -181,6 +190,10 @@ export class DockerBackend {
 
       if (cwd) {
         execArgs.push('--workdir', cwd)
+      }
+
+      if (envFile) {
+        execArgs.push('--env-file', envFile)
       }
 
       if (env) {
@@ -545,11 +558,19 @@ export class DockerBackend {
     })
   }
 
-  _composeUp(composeFile, project, cwd) {
+  _composeUp(composeFile, project, cwd, envFile) {
     return new Promise((resolve, reject) => {
-      this._execFile('docker', [
-        'compose', '-f', composeFile, '-p', project, 'up', '-d',
-      ], { encoding: 'utf-8', timeout: 120_000, cwd }, (err, _stdout, stderr) => {
+      // `docker compose --env-file <path>` (before the subcommand) sets the
+      // env used for compose-file interpolation, so a compose service that
+      // declares `environment: [ANTHROPIC_API_KEY]` or `${ANTHROPIC_API_KEY}`
+      // picks the value up without the operator having to hand-edit their
+      // compose file. The file is short-lived (tmpfile created + unlinked
+      // by the caller) and lives at 0600 so the key never appears in `ps`
+      // output. (#5079)
+      const args = ['compose']
+      if (envFile) args.push('--env-file', envFile)
+      args.push('-f', composeFile, '-p', project, 'up', '-d')
+      this._execFile('docker', args, { encoding: 'utf-8', timeout: 120_000, cwd }, (err, _stdout, stderr) => {
         if (err) {
           reject(new Error(stderr ? stderr.trim() : err.message))
           return

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -2026,6 +2026,139 @@ describe('DockerByokSession — Docker Compose support (#5024)', () => {
     })
     assert.equal(session._pool, null)
   })
+
+  // #5079 — ANTHROPIC_API_KEY forwarding into compose primary service
+  // via a host-side tmpfile + `docker --env-file`. The bare-image path
+  // already forwards via `docker run --env`; these tests pin the
+  // symmetric compose behaviour.
+
+  it('writes an --env-file tmpfile with ANTHROPIC_API_KEY at compose-up and unlinks on destroy (#5079)', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const writes = []
+    const unlinks = []
+    const backend = composeBackendStub({ primaryId: 'COMPOSE_API_KEY' })
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      composeService: 'web',
+      _execFile,
+      _dockerBackend: backend,
+      _writeEnvFile: (path, content) => writes.push({ path, content }),
+      _unlinkEnvFile: (path) => unlinks.push(path),
+      _envForApiKey: { ANTHROPIC_API_KEY: 'sk-ant-tmpfile-secret' },
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    // Exactly one tmpfile written, containing the key — never bare argv.
+    assert.equal(writes.length, 1, 'expected one env-file write at compose-up')
+    assert.match(writes[0].path, /chroxy-byok-.+\.env$/, 'tmpfile path should be session-scoped')
+    assert.equal(writes[0].content, 'ANTHROPIC_API_KEY=sk-ant-tmpfile-secret\n')
+    // The session tracks the path so destroy can clean it up.
+    assert.equal(session._composeEnvFile, writes[0].path)
+    // Backend received the file via the documented opt.
+    assert.equal(backend.createCalls[0].envFile, writes[0].path)
+    // No --env flag in argv — confirm the key never appears in any
+    // execFile call (info, etc.) on the host side.
+    const argvDump = JSON.stringify(_execFile.calls)
+    assert.equal(
+      argvDump.includes('sk-ant-tmpfile-secret'), false,
+      'ANTHROPIC_API_KEY must not appear in host argv',
+    )
+    await session.destroy()
+    // File is unlinked on destroy (best-effort, idempotent).
+    assert.deepEqual(unlinks, [writes[0].path], 'env-file should be unlinked on destroy')
+  })
+
+  it('skips the env-file when ANTHROPIC_API_KEY is absent (#5079)', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const writes = []
+    const unlinks = []
+    const backend = composeBackendStub()
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      _execFile,
+      _dockerBackend: backend,
+      _writeEnvFile: (p, c) => writes.push({ p, c }),
+      _unlinkEnvFile: (p) => unlinks.push(p),
+      _envForApiKey: { /* no ANTHROPIC_API_KEY */ },
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    assert.equal(writes.length, 0, 'no env-file should be written when ANTHROPIC_API_KEY is absent')
+    assert.equal(session._composeEnvFile, null)
+    assert.equal(backend.createCalls[0].envFile, null)
+    await session.destroy()
+    assert.equal(unlinks.length, 0, 'no env-file to unlink')
+  })
+
+  it('forwards --env-file on every _execAsContainerUser dispatch in compose mode (#5079)', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const execCalls = []
+    const backend = {
+      createCalls: [],
+      destroyCalls: [],
+      async createComposeEnvironment(opts) {
+        this.createCalls.push(opts)
+        return { containerId: 'C', containerCliPath: '/x', services: [] }
+      },
+      async destroyComposeEnvironment() {},
+      async execInEnvironment(_containerId, opts) {
+        execCalls.push(opts)
+        return { stdout: '', stderr: '' }
+      },
+    }
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      _execFile,
+      _dockerBackend: backend,
+      _writeEnvFile: () => {},
+      _unlinkEnvFile: () => {},
+      _envForApiKey: { ANTHROPIC_API_KEY: 'sk-ant-exec-secret' },
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    // Trigger a tool dispatch via the public helper.
+    await session._execAsContainerUser({ cmd: 'true' })
+    const dispatch = execCalls.at(-1)
+    assert.ok(dispatch.envFile, 'compose mode must pass envFile on dispatch')
+    assert.match(dispatch.envFile, /chroxy-byok-.+\.env$/)
+    // Key MUST NOT appear in the dispatch's env object (that would
+    // bypass the tmpfile and leak to argv via --env KEY=VAL).
+    assert.equal(dispatch.env, undefined, 'compose dispatch must not pass --env for the API key')
+    await session.destroy()
+  })
+
+  it('unlinks the env-file on compose start failure (#5079)', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const writes = []
+    const unlinks = []
+    const backend = {
+      createCalls: [],
+      destroyCalls: [],
+      async createComposeEnvironment(opts) {
+        this.createCalls.push(opts)
+        throw new Error('compose primary not running')
+      },
+      async destroyComposeEnvironment(opts) { this.destroyCalls.push(opts) },
+      async execInEnvironment() { return { stdout: '', stderr: '' } },
+    }
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      _execFile,
+      _dockerBackend: backend,
+      _writeEnvFile: (p, c) => writes.push({ p, c }),
+      _unlinkEnvFile: (p) => unlinks.push(p),
+      _envForApiKey: { ANTHROPIC_API_KEY: 'sk-ant-fail-secret' },
+    })
+    session.on('error', () => {})
+    await session.start()
+    assert.equal(writes.length, 1, 'tmpfile written before compose up')
+    assert.equal(unlinks.length >= 1, true, 'tmpfile unlinked on start failure')
+    assert.equal(session._composeEnvFile, null, 'env-file path cleared on failure')
+  })
 })
 
 // Force a tick so any background EventEmitter cleanup completes

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -276,6 +276,72 @@ describe('DockerBackend.createComposeEnvironment()', () => {
     assert.ok(result.containerCliPath.includes('cli.js'))
   })
 
+  it('forwards opts.envFile as `docker compose --env-file <path>` before the subcommand (#5079)', async () => {
+    let upArgs = null
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) {
+        upArgs = [...args]
+        cb(null, '', '')
+        return
+      }
+      if (args[0] === 'compose' && args.includes('ps')) {
+        cb(null, '{"ID":"ctr-1","Service":"app","State":"running"}\n', '')
+        return
+      }
+      if (args[0] === 'exec') { cb(null, '/usr/local\n', ''); return }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    await backend.createComposeEnvironment({
+      envId: 'env-envfile',
+      cwd: '/proj',
+      composeFile: '/proj/docker-compose.yml',
+      composeProject: 'chroxy-env-envfile',
+      containerUser: 'chroxy',
+      envFile: '/tmp/chroxy-byok-secret.env',
+    })
+
+    assert.ok(upArgs, 'compose up should have been called')
+    // --env-file MUST come before the `up` subcommand to scope it to
+    // compose itself (Docker's CLI ignores --env-file after the
+    // subcommand for compose-level interpolation).
+    const envFileIdx = upArgs.indexOf('--env-file')
+    const upIdx = upArgs.indexOf('up')
+    assert.ok(envFileIdx >= 0, '--env-file must be present in compose up args')
+    assert.ok(envFileIdx < upIdx, '--env-file must precede the up subcommand')
+    assert.equal(upArgs[envFileIdx + 1], '/tmp/chroxy-byok-secret.env')
+  })
+
+  it('omits --env-file from docker compose up when opts.envFile is absent (#5079)', async () => {
+    let upArgs = null
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) { upArgs = [...args]; cb(null, '', ''); return }
+      if (args[0] === 'compose' && args.includes('ps')) {
+        cb(null, '{"ID":"ctr-1","Service":"app","State":"running"}\n', '')
+        return
+      }
+      if (args[0] === 'exec') { cb(null, '/usr/local\n', ''); return }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    await backend.createComposeEnvironment({
+      envId: 'env-no-envfile',
+      cwd: '/proj',
+      composeFile: '/proj/docker-compose.yml',
+      composeProject: 'chroxy-env-no-envfile',
+      containerUser: 'chroxy',
+    })
+
+    assert.ok(upArgs, 'compose up should have been called')
+    assert.equal(upArgs.indexOf('--env-file'), -1, '--env-file must be absent when not requested')
+  })
+
   it('calls compose down and re-throws when primary container not found', async () => {
     let downCalled = false
     function mockExec(_cmd, args, opts, cb) {
@@ -959,6 +1025,23 @@ describe('DockerBackend.execInEnvironment()', () => {
     const execCall = mockExec.calls.find(c => c.args[0] === 'exec')
     const joined = execCall.args.join(' ')
     assert.ok(!joined.includes('_TEST_EXEC_LEAK'), 'process.env must never be forwarded')
+  })
+
+  it('passes --env-file <path> when opts.envFile is set (#5079)', async () => {
+    const mockExec = createMockExecFile({ results: { exec: '' } })
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.execInEnvironment('ctr-abc', {
+      cmd: 'printenv',
+      envFile: '/tmp/chroxy-byok-secret.env',
+    })
+
+    const execCall = mockExec.calls.find(c => c.args[0] === 'exec')
+    const idx = execCall.args.indexOf('--env-file')
+    assert.ok(idx >= 0, '--env-file flag must be present when opts.envFile is set')
+    assert.equal(execCall.args[idx + 1], '/tmp/chroxy-byok-secret.env')
+    // Container ID must come after the flag — same ordering invariant as --env.
+    assert.ok(execCall.args.indexOf('ctr-abc') > idx + 1)
   })
 })
 


### PR DESCRIPTION
Closes #5079.

## Summary

Compose mode previously delegated to `DockerBackend.createComposeEnvironment` without forwarding `ANTHROPIC_API_KEY` into the primary service container. Bare-image mode already forwards it via `docker run --env ANTHROPIC_API_KEY=...`; this PR brings compose mode to parity so a model-issued Bash command (e.g. `curl api.anthropic.com` or a one-off `claude -p`) authenticates the same way regardless of how the session was launched.

## Approach

Write the key to an `os.tmpdir()` tmpfile at mode 0600 keyed by the session-scoped compose project id, then pass it via two `--env-file` channels:

- **`docker compose --env-file <path>`** (before the `up` subcommand) — compose-level `${ANTHROPIC_API_KEY}` interpolation in the user's compose file resolves the value. A service that declares `environment: [ANTHROPIC_API_KEY]` picks it up without the operator hand-editing their compose.
- **`docker exec --env-file <path>`** on every `_execAsContainerUser` dispatch — Bash / Glob / Grep / postCreateCommand inside the container all see the key.

The key never appears in argv: `--env KEY=secret` would expose it in `ps` output on the host, but `--env-file <path>` only puts the file path there. The tmpfile is created with 0600 permissions and unlinked on `destroy()` (and on the compose start-failure path, so a leak can't survive an aborted launch).

When `ANTHROPIC_API_KEY` is absent from the host env, no tmpfile is written and `--env-file` is omitted from both compose and exec args — pre-#5079 behaviour for unauthenticated environments is preserved.

## Acceptance criteria

- [x] `ANTHROPIC_API_KEY` available to model-spawned commands in compose mode
- [x] Test covers both modes end-to-end (mocked backend) — bare-image path was already covered; this PR adds 4 compose-mode tests + 3 backend-level tests
- [x] Docstring on `_startComposeStack` calls out the chosen behaviour

## Test plan

- [x] 4 new tests in `tests/docker-byok-session.test.js` covering: tmpfile created/unlinked across the session lifecycle, key never appears in host argv, `--env-file` forwarded on every exec dispatch, env-file skipped when the key is absent, env-file unlinked on compose-up failure
- [x] 3 new tests in `tests/environments/backends/docker.test.js` covering: `execInEnvironment` forwards `--env-file`, `createComposeEnvironment` forwards `--env-file` to `docker compose up`, `--env-file` is omitted from `compose up` when not requested
- [x] 258 existing docker-byok / byok-session / pool tests pass
- [x] 143 environment-manager + docker backend tests pass
- [x] `lint-tests-state-file-path.sh` and `lint-session-opt-forwarding.sh` clean