### PR TITLE
feat(dashboard): list and manage docker-byok snapshots (#5074)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -83,6 +83,7 @@ import { SessionLoadingSkeleton } from './components/SessionLoadingSkeleton'
 import { StartupErrorScreen } from './components/StartupErrorScreen'
 import { ConsolePage } from './components/ConsolePage'
 import { EnvironmentPanel } from './components/EnvironmentPanel'
+import { SnapshotsPanel } from './components/SnapshotsPanel'
 
 /** Server-injected config from <meta name="chroxy-config"> tag */
 interface ChroxyConfig {
@@ -123,7 +124,7 @@ function formatContext(usage: { inputTokens: number; outputTokens: number } | nu
   return Number.isInteger(k) ? `${k}k tokens` : `${k.toFixed(1)}k tokens`
 }
 
-type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments'
+type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots'
 
 /** Scrollable tab bar with arrow buttons when overflowing */
 function ViewSwitcher({
@@ -231,6 +232,7 @@ function ViewSwitcher({
           <button className={`view-tab${viewMode === 'console' ? ' active' : ''}`} onClick={() => { setViewMode('console'); setSplitMode(null); persistSplitMode(null) }} type="button">Console</button>
         )}
         <button className={`view-tab${viewMode === 'environments' ? ' active' : ''}`} onClick={() => { setViewMode('environments'); setSplitMode(null); persistSplitMode(null) }} type="button">Envs</button>
+        <button className={`view-tab${viewMode === 'snapshots' ? ' active' : ''}`} onClick={() => { setViewMode('snapshots'); setSplitMode(null); persistSplitMode(null) }} type="button">Snapshots</button>
         <div className="view-switch-spacer" />
         <button className={`view-tab view-tab-right${checkpointsOpen ? ' active' : ''}`} onClick={() => setCheckpointsOpen(prev => !prev)} type="button" title="Toggle checkpoint timeline">Checkpoints</button>
         <button className={`view-tab${viewMode === 'diff' ? ' active' : ''}`} onClick={() => setViewMode('diff')} type="button">Diff</button>
@@ -2404,6 +2406,9 @@ export function App() {
                 )}
                 {viewMode === 'environments' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <EnvironmentPanel />
+                )}
+                {viewMode === 'snapshots' && connectionPhase !== 'connecting' && !isSwitchingSession && (
+                  <SnapshotsPanel />
                 )}
               </div>
               {checkpointsOpen && (

--- a/packages/dashboard/src/components/SnapshotsPanel.test.tsx
+++ b/packages/dashboard/src/components/SnapshotsPanel.test.tsx
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { SnapshotsPanel, type Snapshot } from './SnapshotsPanel'
+
+function makeSnap(overrides: Partial<Snapshot> & { slug: string }): Snapshot {
+  return {
+    tag: `chroxy-byok-snap:${overrides.slug}`,
+    name: '',
+    createdAt: '2024-06-01T12:00:00Z',
+    sourceCwd: '/repo',
+    sourceImage: 'node:22-slim',
+    sourceSessionId: null,
+    ...overrides,
+  }
+}
+
+function makeFetch(handlers: {
+  list?: (init?: RequestInit) => Response | Promise<Response>
+  del?: (slug: string, init?: RequestInit) => Response | Promise<Response>
+}) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (init?.method === 'DELETE' && url.startsWith('/api/snapshots/')) {
+      const slug = decodeURIComponent(url.slice('/api/snapshots/'.length))
+      if (handlers.del) return handlers.del(slug, init)
+      return new Response(JSON.stringify({ ok: true, tag: '', imageRemoved: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url === '/api/snapshots') {
+      if (handlers.list) return handlers.list(init)
+      return new Response(JSON.stringify({ snapshots: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response('not found', { status: 404 })
+  })
+}
+
+describe('SnapshotsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('shows empty state when the server returns no snapshots', async () => {
+    const fetchImpl = makeFetch({})
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshots-empty')).toBeTruthy()
+    })
+    expect(fetchImpl).toHaveBeenCalledWith('/api/snapshots', expect.objectContaining({
+      headers: { Authorization: 'Bearer tok' },
+    }))
+  })
+
+  it('renders one card per snapshot with name, tag, cwd, base image, session', async () => {
+    const fetchImpl = makeFetch({
+      list: () =>
+        new Response(
+          JSON.stringify({
+            snapshots: [
+              makeSnap({
+                slug: 'snap-1',
+                name: 'feature-a',
+                tag: 'chroxy-byok-snap:abc-1',
+                sourceCwd: '/Users/dev/projA',
+                sourceImage: 'node:22-slim',
+                sourceSessionId: 'sess-123',
+              }),
+              makeSnap({
+                slug: 'snap-2',
+                name: 'bugfix-b',
+                tag: 'chroxy-byok-snap:abc-2',
+                sourceCwd: '/Users/dev/projB',
+                sourceImage: 'python:3.12',
+              }),
+            ],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    })
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-card-snap-1')).toBeTruthy()
+      expect(screen.getByTestId('snapshot-card-snap-2')).toBeTruthy()
+    })
+
+    expect(screen.getByTestId('snapshot-name-snap-1').textContent).toBe('feature-a')
+    expect(screen.getByTestId('snapshot-tag-snap-1').textContent).toBe('chroxy-byok-snap:abc-1')
+    expect(screen.getByText('/Users/dev/projA')).toBeTruthy()
+    expect(screen.getByText('sess-123')).toBeTruthy()
+
+    expect(screen.getByTestId('snapshot-name-snap-2').textContent).toBe('bugfix-b')
+    expect(screen.getByText('python:3.12')).toBeTruthy()
+  })
+
+  it('falls back to slug when name is empty', async () => {
+    const fetchImpl = makeFetch({
+      list: () =>
+        new Response(
+          JSON.stringify({
+            snapshots: [makeSnap({ slug: 'snap-only', name: '' })],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    })
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-name-snap-only').textContent).toBe('snap-only')
+    })
+  })
+
+  it('shows the error when /api/snapshots fails', async () => {
+    const fetchImpl = makeFetch({
+      list: () =>
+        new Response(JSON.stringify({ error: 'boom' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    })
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshots-error').textContent).toBe('boom')
+    })
+  })
+
+  it('refresh button re-fetches the list', async () => {
+    const fetchImpl = makeFetch({
+      list: () =>
+        new Response(JSON.stringify({ snapshots: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    })
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshots-empty')).toBeTruthy()
+    })
+    const initialCalls = fetchImpl.mock.calls.length
+    fireEvent.click(screen.getByTestId('snapshots-refresh'))
+    await waitFor(() => {
+      expect(fetchImpl.mock.calls.length).toBe(initialCalls + 1)
+    })
+  })
+
+  it('delete flow: confirm → DELETE call → row removed', async () => {
+    const seen: Array<{ url: string; method: string }> = []
+    let listCalled = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      seen.push({ url, method: init?.method ?? 'GET' })
+      if (init?.method === 'DELETE') {
+        return new Response(JSON.stringify({ ok: true, tag: 'chroxy-byok-snap:x', imageRemoved: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      listCalled += 1
+      // First list returns one row, every subsequent list returns nothing
+      // so we exercise both the optimistic removal path AND the refresh
+      // reconciliation that follows a successful delete.
+      const snaps = listCalled === 1 ? [makeSnap({ slug: 'snap-X', tag: 'chroxy-byok-snap:x' })] : []
+      return new Response(JSON.stringify({ snapshots: snaps }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    })
+
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-card-snap-X')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByTestId('snapshot-delete-snap-X'))
+    fireEvent.click(screen.getByTestId('snapshot-confirm-yes-snap-X'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('snapshot-card-snap-X')).toBeNull()
+    })
+
+    // Last DELETE must have hit the right URL.
+    const deleteCall = seen.find((c) => c.method === 'DELETE')
+    expect(deleteCall?.url).toBe('/api/snapshots/snap-X')
+  })
+
+  it('delete cancel keeps the row', async () => {
+    const fetchImpl = makeFetch({
+      list: () =>
+        new Response(
+          JSON.stringify({ snapshots: [makeSnap({ slug: 'snap-keep' })] }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+    })
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-card-snap-keep')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByTestId('snapshot-delete-snap-keep'))
+    fireEvent.click(screen.getByTestId('snapshot-confirm-no-snap-keep'))
+
+    // Still rendered, delete button is back.
+    expect(screen.getByTestId('snapshot-delete-snap-keep')).toBeTruthy()
+    // And we never issued a DELETE.
+    const deleteCalls = fetchImpl.mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'DELETE',
+    )
+    expect(deleteCalls.length).toBe(0)
+  })
+
+  it('surfaces a delete failure error without removing the row', async () => {
+    const fetchImpl = makeFetch({
+      list: () =>
+        new Response(
+          JSON.stringify({ snapshots: [makeSnap({ slug: 'snap-fail' })] }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      del: () =>
+        new Response(JSON.stringify({ error: 'rmi blocked' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    })
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-card-snap-fail')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByTestId('snapshot-delete-snap-fail'))
+    fireEvent.click(screen.getByTestId('snapshot-confirm-yes-snap-fail'))
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshots-error').textContent).toBe('rmi blocked')
+    })
+    expect(screen.getByTestId('snapshot-card-snap-fail')).toBeTruthy()
+  })
+})

--- a/packages/dashboard/src/components/SnapshotsPanel.tsx
+++ b/packages/dashboard/src/components/SnapshotsPanel.tsx
@@ -1,0 +1,273 @@
+/**
+ * SnapshotsPanel (#5074) — list and manage docker-byok snapshots.
+ *
+ * docker-byok sessions can `snapshot({ name })` their writable layer
+ * into a tagged image (chroxy-byok-snap:<rand>-<ts>) and write a
+ * metadata sidecar to `${CHROXY_CONFIG_DIR ?? ~/.chroxy}/snapshots/`.
+ * Until now the dashboard had no surface for those sidecars — operators
+ * had to `ls ~/.chroxy/snapshots` and `docker image rm` by hand.
+ *
+ * This panel fetches GET /api/snapshots on mount + on a manual refresh,
+ * renders one card per snapshot with name / createdAt / sourceCwd /
+ * sourceSessionId / source image, and exposes a confirm-gated Delete
+ * button that hits DELETE /api/snapshots/:slug.
+ *
+ * "Start session from snapshot" is explicitly deferred to a follow-up
+ * (issue #5074 lists it as a separate bullet point — wiring
+ * `snapshotImage` through SessionManager / the WS protocol is a larger
+ * surface than this panel can own on its own).
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { getAuthToken } from '../utils/auth'
+
+export interface Snapshot {
+  tag: string
+  name: string
+  createdAt: string
+  sourceCwd: string
+  sourceImage: string
+  sourceSessionId: string | null
+  slug: string
+}
+
+interface SnapshotsPanelProps {
+  /**
+   * Override the fetch impl. Tests inject a stub; production omits it
+   * and gets the real `window.fetch`.
+   */
+  fetchImpl?: typeof fetch
+  /**
+   * Override the auth token resolver. Tests skip the URL/cookie lookup
+   * by passing a no-op or fixed string; production omits it and uses
+   * the shared `getAuthToken()`.
+   */
+  getToken?: () => string | null
+}
+
+function formatTimestamp(iso: string): string {
+  if (!iso) return ''
+  const ms = Date.parse(iso)
+  if (!Number.isFinite(ms)) return iso
+  const d = new Date(ms)
+  const now = new Date()
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  return sameDay ? d.toLocaleTimeString() : d.toLocaleString()
+}
+
+function SnapshotCard({
+  snapshot,
+  onDelete,
+  isDeleting,
+}: {
+  snapshot: Snapshot
+  onDelete: (slug: string) => void
+  isDeleting: boolean
+}) {
+  const [confirming, setConfirming] = useState(false)
+  const created = formatTimestamp(snapshot.createdAt)
+
+  return (
+    <div className="env-card" data-testid={`snapshot-card-${snapshot.slug}`}>
+      <div className="env-card-header">
+        <span className="env-card-name" data-testid={`snapshot-name-${snapshot.slug}`}>
+          {snapshot.name || snapshot.slug}
+        </span>
+        {created && (
+          <span
+            className="env-status-badge"
+            data-testid={`snapshot-created-${snapshot.slug}`}
+            style={{ color: 'var(--text-secondary)' }}
+          >
+            {created}
+          </span>
+        )}
+      </div>
+      <div className="env-card-details">
+        <div className="env-card-row">
+          <span className="env-card-label">Tag</span>
+          <span
+            className="env-card-value"
+            style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: '0.85em' }}
+            data-testid={`snapshot-tag-${snapshot.slug}`}
+          >
+            {snapshot.tag}
+          </span>
+        </div>
+        {snapshot.sourceCwd && (
+          <div className="env-card-row">
+            <span className="env-card-label">CWD</span>
+            <span className="env-card-value">{snapshot.sourceCwd}</span>
+          </div>
+        )}
+        {snapshot.sourceImage && (
+          <div className="env-card-row">
+            <span className="env-card-label">Base</span>
+            <span className="env-card-value">{snapshot.sourceImage}</span>
+          </div>
+        )}
+        {snapshot.sourceSessionId && (
+          <div className="env-card-row">
+            <span className="env-card-label">Session</span>
+            <span
+              className="env-card-value"
+              style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: '0.85em' }}
+            >
+              {snapshot.sourceSessionId}
+            </span>
+          </div>
+        )}
+      </div>
+      <div className="env-card-actions">
+        {!confirming ? (
+          <button
+            className="btn-env-destroy"
+            data-testid={`snapshot-delete-${snapshot.slug}`}
+            onClick={() => setConfirming(true)}
+            disabled={isDeleting}
+            title="Delete snapshot (removes Docker image + metadata)"
+          >
+            {isDeleting ? 'Deleting…' : 'Delete'}
+          </button>
+        ) : (
+          <div className="env-confirm-row">
+            <span>Delete this snapshot?</span>
+            <button
+              className="btn-env-confirm-yes"
+              data-testid={`snapshot-confirm-yes-${snapshot.slug}`}
+              onClick={() => {
+                setConfirming(false)
+                onDelete(snapshot.slug)
+              }}
+            >
+              Yes
+            </button>
+            <button
+              className="btn-env-confirm-no"
+              data-testid={`snapshot-confirm-no-${snapshot.slug}`}
+              onClick={() => setConfirming(false)}
+            >
+              No
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function SnapshotsPanel({ fetchImpl, getToken }: SnapshotsPanelProps = {}) {
+  const [snapshots, setSnapshots] = useState<Snapshot[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+  const [deletingSlug, setDeletingSlug] = useState<string | null>(null)
+
+  // Hoist for testability — production passes neither override and falls
+  // back to the shared globals.
+  const resolvedFetch: typeof fetch =
+    fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init))
+  const resolvedGetToken = getToken ?? getAuthToken
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    const token = resolvedGetToken()
+    try {
+      const res = await resolvedFetch('/api/snapshots', {
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+        throw new Error((body as { error?: string }).error || `HTTP ${res.status}`)
+      }
+      const body = (await res.json()) as { snapshots: Snapshot[] }
+      setSnapshots(Array.isArray(body.snapshots) ? body.snapshots : [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load snapshots')
+    } finally {
+      setLoading(false)
+    }
+  }, [resolvedFetch, resolvedGetToken])
+
+  const handleDelete = useCallback(
+    async (slug: string) => {
+      setDeletingSlug(slug)
+      setError(null)
+      const token = resolvedGetToken()
+      try {
+        const res = await resolvedFetch(`/api/snapshots/${encodeURIComponent(slug)}`, {
+          method: 'DELETE',
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        })
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+          throw new Error((body as { error?: string }).error || `HTTP ${res.status}`)
+        }
+        // Drop locally so the row disappears even if a follow-up
+        // /api/snapshots round-trip is slow. refresh() will reconcile.
+        setSnapshots((prev) => prev.filter((s) => s.slug !== slug))
+        // Best-effort refresh to catch any other state drift.
+        void refresh()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to delete snapshot')
+      } finally {
+        setDeletingSlug(null)
+      }
+    },
+    [refresh, resolvedFetch, resolvedGetToken],
+  )
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return (
+    <div className="environment-panel" data-testid="snapshots-panel">
+      <div className="env-panel-header">
+        <h2>Snapshots</h2>
+        <button
+          className="btn-env-new"
+          data-testid="snapshots-refresh"
+          onClick={() => void refresh()}
+          disabled={loading}
+        >
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          className="env-empty"
+          data-testid="snapshots-error"
+          style={{ color: 'var(--status-error, #ef4444)' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {!error && !loading && snapshots.length === 0 && (
+        <div className="env-empty" data-testid="snapshots-empty">
+          <p>No snapshots saved yet.</p>
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.9em' }}>
+            Snapshots are committed Docker images from a docker-byok session's
+            writable layer. Take one from a live session to preserve installed
+            packages, auth state, or scratch files for later reuse.
+          </p>
+        </div>
+      )}
+
+      <div className="env-grid">
+        {snapshots.map((snap) => (
+          <SnapshotCard
+            key={snap.slug}
+            snapshot={snap}
+            onDelete={handleDelete}
+            isDeleting={deletingSlug === snap.slug}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/dashboard/src/hooks/useShortcutDispatch.ts
+++ b/packages/dashboard/src/hooks/useShortcutDispatch.ts
@@ -34,7 +34,7 @@ import { processBase64Image } from '../utils/image-utils'
 import { useConnectionStore } from '../store/connection'
 import { persistSplitMode } from '../store/persistence'
 
-type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments'
+type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots'
 
 export interface ShortcutDispatchProps {
   shortcutRegistry: ShortcutRegistry

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -90,7 +90,7 @@ const MAX_MESSAGES = 100;
 const MAX_TERMINAL_SIZE = 50_000;
 
 /** Valid view modes — used to validate persisted values */
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments'] as const;
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments', 'snapshots'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -642,7 +642,7 @@ export interface ConnectionState {
   pairingRefreshedCount: number;
 
   // View mode
-  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments';
+  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots';
 
   // Input settings
   inputSettings: InputSettings;
@@ -661,7 +661,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string }) => void;
   appendTerminalData: (data: string) => void;

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -7,6 +7,7 @@ import { createLogger } from './logger.js'
 import { metrics } from './metrics.js'
 import { buildDiagnosticsSnapshot } from './diagnostics.js'
 import { getRateLimitKey } from './rate-limiter.js'
+import { listSnapshots, deleteSnapshot } from './snapshots-store.js'
 
 const log = createLogger('ws')
 
@@ -98,6 +99,32 @@ function parseLogTailBytes(url) {
   const int = Math.trunc(n)
   if (int <= 0) return null
   return Math.min(int, LOG_TAIL_BYTES_MAX)
+}
+
+/**
+ * Resolve the `removeImage(tag)` callback for the snapshot DELETE route (#5074).
+ *
+ * Preference order:
+ *   1. `server._snapshotRemoveImage` — test injection seam.
+ *   2. `server.environmentManager._backend.removeImage` — already
+ *      constructed for env-management. Reuses the same `_execFile`
+ *      injection path the env tests rely on.
+ *   3. A lazily-loaded fresh `DockerBackend()` — env management is
+ *      disabled but a snapshot DELETE still needs to call `docker rmi`.
+ *      Imported dynamically so tunnel-only installs that never trigger
+ *      this code path don't pay the module load.
+ */
+async function resolveRemoveImage(server) {
+  if (typeof server._snapshotRemoveImage === 'function') {
+    return server._snapshotRemoveImage
+  }
+  const fromEnvMgr = server.environmentManager?._backend?.removeImage
+  if (typeof fromEnvMgr === 'function') {
+    return (tag) => server.environmentManager._backend.removeImage(tag)
+  }
+  const { DockerBackend } = await import('./environments/backends/docker.js')
+  const backend = new DockerBackend()
+  return (tag) => backend.removeImage(tag)
 }
 
 /**
@@ -206,6 +233,63 @@ export function createHttpHandler(server) {
       }
       res.writeHead(200, { 'Content-Type': 'application/json' })
       res.end(JSON.stringify(payload))
+      return
+    }
+
+    // Snapshot listing endpoint (#5074). Reads docker-byok snapshot
+    // metadata sidecars from `${CHROXY_CONFIG_DIR ?? ~/.chroxy}/snapshots/`
+    // and returns them as a newest-first array. The dashboard polls this
+    // on its SnapshotsPanel.
+    const snapPath = (req.url ?? '').split('?')[0]
+    if (req.method === 'GET' && snapPath === '/api/snapshots') {
+      if (!server._validateBearerAuth(req, res)) return
+      try {
+        const snapshots = listSnapshots()
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ snapshots }))
+      } catch (err) {
+        log.warn(`GET /api/snapshots failed: ${err.message}`)
+        res.writeHead(500, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Failed to list snapshots' }))
+      }
+      return
+    }
+
+    // Snapshot delete endpoint (#5074). Two-step: docker rmi → unlink sidecar.
+    // The slug is the sidecar filename without `.json`, exactly what
+    // /api/snapshots returns, so the server never has to re-derive it
+    // from the tag. Defence-in-depth: snapshots-store re-validates the
+    // slug against the filename-safe charset before joining it to a path.
+    if (req.method === 'DELETE' && snapPath.startsWith('/api/snapshots/')) {
+      if (!server._validateBearerAuth(req, res)) return
+      const rawSlug = snapPath.slice('/api/snapshots/'.length)
+      let slug
+      try {
+        slug = decodeURIComponent(rawSlug)
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'invalid slug encoding' }))
+        return
+      }
+      try {
+        const removeImage = await resolveRemoveImage(server)
+        const result = await deleteSnapshot(slug, { removeImage })
+        if (!result.ok) {
+          res.writeHead(result.status, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: result.error }))
+          return
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({
+          ok: true,
+          tag: result.tag,
+          imageRemoved: result.imageRemoved,
+        }))
+      } catch (err) {
+        log.warn(`DELETE /api/snapshots/${slug} failed: ${err.message}`)
+        res.writeHead(500, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Failed to delete snapshot' }))
+      }
       return
     }
 

--- a/packages/server/src/snapshots-store.js
+++ b/packages/server/src/snapshots-store.js
@@ -1,0 +1,211 @@
+/**
+ * snapshots-store — list and delete docker-byok snapshot metadata sidecars.
+ *
+ * Snapshots produced by `DockerByokSession.snapshot()` (#5023 / #5071) write a
+ * JSON sidecar to `${CHROXY_CONFIG_DIR ?? ~/.chroxy}/snapshots/<slug>.json`
+ * shaped like:
+ *
+ *   { tag, name, createdAt, sourceCwd, sourceImage, sourceSessionId }
+ *
+ * This module gives the HTTP layer a thin read/delete API over that
+ * directory so the dashboard can render a list and trigger removal
+ * without re-implementing the directory contract. See #5074.
+ *
+ * Listing tolerates partial corruption: unreadable, malformed, or
+ * non-object files are skipped with a warn line rather than failing the
+ * entire request, so a single bad sidecar can't take the panel offline.
+ *
+ * Delete is two-step:
+ *   1. `docker rmi <tag>` via the injected `removeImage` callback (the
+ *      DockerBackend's helper in production, a stub in tests).
+ *   2. `unlink` the sidecar.
+ *
+ * Step 1 best-effort: if rmi fails (image already gone, daemon down) we
+ * still drop the sidecar so the dashboard stops listing a ghost entry.
+ * The caller learns about the rmi failure via the returned `imageRemoved`
+ * flag.
+ */
+
+import { readdirSync, readFileSync, existsSync, unlinkSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+import { createLogger } from './logger.js'
+
+const log = createLogger('snapshots')
+
+/**
+ * Resolve the snapshots metadata directory.
+ *
+ * Lazy (no caching): tests that mutate `CHROXY_CONFIG_DIR` between
+ * cases see the new value, matching the pattern used by models.js /
+ * device-preferences.js / connection-info.js.
+ *
+ * @returns {string}
+ */
+export function getSnapshotsDir() {
+  const configDir = process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy')
+  return join(configDir, 'snapshots')
+}
+
+/**
+ * Filename-safe characters per the sidecar slug convention in
+ * docker-byok-session.js `_persistSnapshotMetadata`. Defence-in-depth
+ * against path traversal in the DELETE handler: the URL slug must
+ * match this charset before it's joined to the directory.
+ */
+const SLUG_RE = /^[A-Za-z0-9_.-]+$/
+
+/**
+ * @typedef {Object} SnapshotMetadata
+ * @property {string} tag                Image tag (`chroxy-byok-snap:<rand>-<ts>`)
+ * @property {string} name               Human-readable name (falls back to tag slug)
+ * @property {string} createdAt          ISO-8601 timestamp
+ * @property {string} sourceCwd          Host cwd the session ran in
+ * @property {string} sourceImage        Base image the snapshot derives from
+ * @property {string|null} sourceSessionId
+ * @property {string} slug               Sidecar filename without `.json`
+ */
+
+/**
+ * List all snapshots currently present in the metadata directory.
+ *
+ * Returns an empty array when the directory does not exist (no snapshots
+ * have ever been taken) — that's the documented happy-path for a fresh
+ * install, not an error.
+ *
+ * Each entry carries a `slug` field — the sidecar filename without its
+ * `.json` extension — so the dashboard can pass it back to the DELETE
+ * endpoint without re-deriving it from the tag.
+ *
+ * Files that fail to parse are skipped with a warn line. Sort order is
+ * newest-first by `createdAt` so the dashboard can render the most
+ * recent snapshot at the top; entries without a parseable createdAt
+ * sink to the end.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.dir]  Override the snapshots dir (tests).
+ * @returns {SnapshotMetadata[]}
+ */
+export function listSnapshots({ dir } = {}) {
+  const snapshotsDir = dir || getSnapshotsDir()
+  if (!existsSync(snapshotsDir)) return []
+
+  let entries
+  try {
+    entries = readdirSync(snapshotsDir, { withFileTypes: true })
+  } catch (err) {
+    log.warn(`Could not read snapshots dir ${snapshotsDir}: ${err.message}`)
+    return []
+  }
+
+  const out = []
+  for (const ent of entries) {
+    if (!ent.isFile()) continue
+    if (!ent.name.endsWith('.json')) continue
+    const filePath = join(snapshotsDir, ent.name)
+    let raw
+    try {
+      raw = readFileSync(filePath, 'utf-8')
+    } catch (err) {
+      log.warn(`Skipping unreadable snapshot sidecar ${ent.name}: ${err.message}`)
+      continue
+    }
+    let parsed
+    try {
+      parsed = JSON.parse(raw)
+    } catch (err) {
+      log.warn(`Skipping malformed snapshot sidecar ${ent.name}: ${err.message}`)
+      continue
+    }
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.tag !== 'string') {
+      log.warn(`Skipping snapshot sidecar ${ent.name}: missing required "tag" field`)
+      continue
+    }
+    out.push({
+      tag: parsed.tag,
+      name: typeof parsed.name === 'string' ? parsed.name : '',
+      createdAt: typeof parsed.createdAt === 'string' ? parsed.createdAt : '',
+      sourceCwd: typeof parsed.sourceCwd === 'string' ? parsed.sourceCwd : '',
+      sourceImage: typeof parsed.sourceImage === 'string' ? parsed.sourceImage : '',
+      sourceSessionId: parsed.sourceSessionId == null ? null : String(parsed.sourceSessionId),
+      slug: ent.name.slice(0, -'.json'.length),
+    })
+  }
+
+  out.sort((a, b) => {
+    const ta = Date.parse(a.createdAt)
+    const tb = Date.parse(b.createdAt)
+    const va = Number.isFinite(ta) ? ta : -Infinity
+    const vb = Number.isFinite(tb) ? tb : -Infinity
+    return vb - va
+  })
+  return out
+}
+
+/**
+ * Delete a snapshot by slug — removes the docker image then drops the
+ * sidecar JSON.
+ *
+ * The `removeImage` callback is injected (the DockerBackend helper in
+ * production, a stub in tests) so this module doesn't take a hard
+ * dependency on the docker backend. If `removeImage` rejects, the
+ * sidecar is STILL deleted (image-rm is best-effort — a ghost sidecar
+ * is worse UX than a leaked image, since the dashboard re-lists ghosts
+ * forever) and the failure surfaces via the returned `imageRemoved`
+ * flag.
+ *
+ * Returns:
+ *   - { ok: false, status: 400, error: 'invalid slug' }  — slug fails charset check
+ *   - { ok: false, status: 404, error: 'not found' }     — sidecar missing
+ *   - { ok: true, tag, imageRemoved }                    — sidecar dropped (and image-rm attempted)
+ *
+ * @param {string} slug
+ * @param {object} opts
+ * @param {(tag: string) => Promise<void>} opts.removeImage
+ * @param {string} [opts.dir]  Override the snapshots dir (tests).
+ * @returns {Promise<{ok:true, tag:string, imageRemoved:boolean} | {ok:false, status:number, error:string}>}
+ */
+export async function deleteSnapshot(slug, { removeImage, dir } = {}) {
+  if (typeof slug !== 'string' || slug.length === 0 || !SLUG_RE.test(slug)) {
+    return { ok: false, status: 400, error: 'invalid slug' }
+  }
+  if (typeof removeImage !== 'function') {
+    throw new Error('deleteSnapshot: removeImage callback required')
+  }
+  const snapshotsDir = dir || getSnapshotsDir()
+  const filePath = join(snapshotsDir, `${slug}.json`)
+  if (!existsSync(filePath)) {
+    return { ok: false, status: 404, error: 'not found' }
+  }
+  let metadata
+  try {
+    metadata = JSON.parse(readFileSync(filePath, 'utf-8'))
+  } catch (err) {
+    log.warn(`deleteSnapshot: malformed sidecar ${slug}.json: ${err.message}`)
+    metadata = null
+  }
+  const tag = metadata && typeof metadata.tag === 'string' ? metadata.tag : null
+
+  let imageRemoved = true
+  if (tag) {
+    try {
+      await removeImage(tag)
+    } catch (err) {
+      log.warn(`deleteSnapshot: docker rmi ${tag} failed: ${err.message}`)
+      imageRemoved = false
+    }
+  } else {
+    // No tag to remove — the sidecar was already corrupt. Treat the
+    // image as "removed" in the response since there's nothing to do.
+    imageRemoved = true
+  }
+
+  try {
+    unlinkSync(filePath)
+  } catch (err) {
+    log.warn(`deleteSnapshot: failed to unlink ${filePath}: ${err.message}`)
+    return { ok: false, status: 500, error: 'sidecar unlink failed' }
+  }
+
+  return { ok: true, tag: tag || '', imageRemoved }
+}

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -1,10 +1,10 @@
-import { describe, it, afterEach, before, after } from 'node:test'
+import { describe, it, afterEach, before, after, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { createServer } from 'node:http'
 import { once } from 'node:events'
-import { existsSync, renameSync } from 'node:fs'
+import { existsSync, renameSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
+import { homedir, tmpdir } from 'node:os'
 import { createHttpHandler } from '../src/http-routes.js'
 
 // The QR endpoint falls back to reading ~/.chroxy/connection.json from disk.
@@ -262,6 +262,144 @@ describe('http-routes', () => {
       await startWith(mock)
       const res = await globalThis.fetch(`http://127.0.0.1:${port}/nonexistent`)
       assert.equal(res.status, 404)
+    })
+  })
+
+  // #5074 — snapshot listing + delete routes back the dashboard
+  // SnapshotsPanel. Uses CHROXY_CONFIG_DIR scoped to a tmp dir so the
+  // tests never touch the real ~/.chroxy/snapshots tree.
+  describe('snapshot endpoints', () => {
+    let workDir
+    let prevConfigDir
+
+    beforeEach(() => {
+      workDir = mkdtempSync(join(tmpdir(), 'chroxy-snap-http-'))
+      prevConfigDir = process.env.CHROXY_CONFIG_DIR
+      process.env.CHROXY_CONFIG_DIR = workDir
+    })
+
+    afterEach(() => {
+      if (prevConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+      else process.env.CHROXY_CONFIG_DIR = prevConfigDir
+      if (workDir && existsSync(workDir)) rmSync(workDir, { recursive: true, force: true })
+    })
+
+    function writeSidecar(slug, payload) {
+      const dir = join(workDir, 'snapshots')
+      mkdirSync(dir, { recursive: true })
+      writeFileSync(join(dir, `${slug}.json`), JSON.stringify(payload), 'utf-8')
+    }
+
+    it('GET /api/snapshots returns [] when no snapshots have been taken', async () => {
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/snapshots`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.deepEqual(body, { snapshots: [] })
+    })
+
+    it('GET /api/snapshots returns parsed sidecars sorted newest-first', async () => {
+      writeSidecar('snap-older', {
+        tag: 'chroxy-byok-snap:older',
+        name: 'first-pass',
+        createdAt: '2024-01-01T00:00:00Z',
+        sourceCwd: '/repo/one',
+        sourceImage: 'node:22-slim',
+        sourceSessionId: 'sess-1',
+      })
+      writeSidecar('snap-newer', {
+        tag: 'chroxy-byok-snap:newer',
+        name: 'second-pass',
+        createdAt: '2024-06-01T00:00:00Z',
+        sourceCwd: '/repo/two',
+        sourceImage: 'node:22-slim',
+        sourceSessionId: 'sess-2',
+      })
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/snapshots`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.equal(body.snapshots.length, 2)
+      assert.equal(body.snapshots[0].slug, 'snap-newer')
+      assert.equal(body.snapshots[0].name, 'second-pass')
+      assert.equal(body.snapshots[1].slug, 'snap-older')
+    })
+
+    it('GET /api/snapshots rejects without bearer auth', async () => {
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/snapshots`)
+      assert.equal(res.status, 403)
+    })
+
+    it('DELETE /api/snapshots/:slug removes the image and unlinks the sidecar', async () => {
+      writeSidecar('snap-target', {
+        tag: 'chroxy-byok-snap:target',
+        createdAt: '2024-01-01T00:00:00Z',
+      })
+      const removed = []
+      const mock = createMockServer({
+        _snapshotRemoveImage: async (tag) => { removed.push(tag) },
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/snapshots/snap-target`, {
+        method: 'DELETE',
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.equal(body.ok, true)
+      assert.equal(body.tag, 'chroxy-byok-snap:target')
+      assert.equal(body.imageRemoved, true)
+      assert.deepEqual(removed, ['chroxy-byok-snap:target'])
+      assert.equal(existsSync(join(workDir, 'snapshots', 'snap-target.json')), false)
+    })
+
+    it('DELETE /api/snapshots/:slug returns 404 for missing slug', async () => {
+      const mock = createMockServer({
+        _snapshotRemoveImage: async () => {},
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/snapshots/nope`, {
+        method: 'DELETE',
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 404)
+    })
+
+    it('DELETE /api/snapshots/:slug rejects path-traversal slugs', async () => {
+      const mock = createMockServer({
+        _snapshotRemoveImage: async () => {},
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(
+        `http://127.0.0.1:${port}/api/snapshots/${encodeURIComponent('../etc/passwd')}`,
+        {
+          method: 'DELETE',
+          headers: { 'Authorization': 'Bearer test-token' },
+        },
+      )
+      assert.equal(res.status, 400)
+    })
+
+    it('DELETE /api/snapshots/:slug rejects without bearer auth', async () => {
+      writeSidecar('snap-protected', { tag: 'chroxy-byok-snap:protected' })
+      const mock = createMockServer({
+        _snapshotRemoveImage: async () => {},
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/snapshots/snap-protected`, {
+        method: 'DELETE',
+      })
+      assert.equal(res.status, 403)
+      // Unauthenticated delete must not touch disk.
+      assert.equal(existsSync(join(workDir, 'snapshots', 'snap-protected.json')), true)
     })
   })
 })

--- a/packages/server/tests/snapshots-store.test.js
+++ b/packages/server/tests/snapshots-store.test.js
@@ -1,0 +1,168 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { listSnapshots, deleteSnapshot, getSnapshotsDir } from '../src/snapshots-store.js'
+
+describe('snapshots-store', () => {
+  let workDir
+  let snapDir
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'chroxy-snap-'))
+    snapDir = join(workDir, 'snapshots')
+  })
+
+  afterEach(() => {
+    if (workDir && existsSync(workDir)) rmSync(workDir, { recursive: true, force: true })
+  })
+
+  function writeSidecar(slug, payload) {
+    mkdirSync(snapDir, { recursive: true })
+    writeFileSync(join(snapDir, `${slug}.json`), JSON.stringify(payload), 'utf-8')
+  }
+
+  describe('getSnapshotsDir', () => {
+    it('honors CHROXY_CONFIG_DIR override', () => {
+      const prev = process.env.CHROXY_CONFIG_DIR
+      try {
+        process.env.CHROXY_CONFIG_DIR = '/tmp/chroxy-test-config-x'
+        assert.equal(getSnapshotsDir(), '/tmp/chroxy-test-config-x/snapshots')
+      } finally {
+        if (prev === undefined) delete process.env.CHROXY_CONFIG_DIR
+        else process.env.CHROXY_CONFIG_DIR = prev
+      }
+    })
+  })
+
+  describe('listSnapshots', () => {
+    it('returns [] when directory does not exist', () => {
+      assert.deepEqual(listSnapshots({ dir: join(workDir, 'nope') }), [])
+    })
+
+    it('parses sidecars and returns expected shape', () => {
+      writeSidecar('snap-abc123-1700000000000', {
+        tag: 'chroxy-byok-snap:abc123-1700000000000',
+        name: 'feature-a',
+        createdAt: '2023-11-14T00:53:20.000Z',
+        sourceCwd: '/Users/dev/proj',
+        sourceImage: 'node:22-slim',
+        sourceSessionId: 'sess-1',
+      })
+      const list = listSnapshots({ dir: snapDir })
+      assert.equal(list.length, 1)
+      const s = list[0]
+      assert.equal(s.tag, 'chroxy-byok-snap:abc123-1700000000000')
+      assert.equal(s.name, 'feature-a')
+      assert.equal(s.createdAt, '2023-11-14T00:53:20.000Z')
+      assert.equal(s.sourceCwd, '/Users/dev/proj')
+      assert.equal(s.sourceImage, 'node:22-slim')
+      assert.equal(s.sourceSessionId, 'sess-1')
+      assert.equal(s.slug, 'snap-abc123-1700000000000')
+    })
+
+    it('sorts newest first by createdAt', () => {
+      writeSidecar('a', { tag: 'chroxy-byok-snap:a', createdAt: '2023-01-01T00:00:00Z' })
+      writeSidecar('b', { tag: 'chroxy-byok-snap:b', createdAt: '2024-06-01T00:00:00Z' })
+      writeSidecar('c', { tag: 'chroxy-byok-snap:c', createdAt: '2023-06-01T00:00:00Z' })
+      const list = listSnapshots({ dir: snapDir })
+      assert.deepEqual(list.map(s => s.slug), ['b', 'c', 'a'])
+    })
+
+    it('skips malformed JSON sidecars without failing', () => {
+      mkdirSync(snapDir, { recursive: true })
+      writeFileSync(join(snapDir, 'broken.json'), '{ not valid json', 'utf-8')
+      writeSidecar('good', { tag: 'chroxy-byok-snap:good', createdAt: '2024-01-01T00:00:00Z' })
+      const list = listSnapshots({ dir: snapDir })
+      assert.equal(list.length, 1)
+      assert.equal(list[0].slug, 'good')
+    })
+
+    it('skips sidecars missing the required tag field', () => {
+      writeSidecar('notag', { name: 'orphan', createdAt: '2024-01-01T00:00:00Z' })
+      writeSidecar('good', { tag: 'chroxy-byok-snap:good' })
+      const list = listSnapshots({ dir: snapDir })
+      assert.equal(list.length, 1)
+      assert.equal(list[0].slug, 'good')
+    })
+
+    it('ignores non-.json files and subdirectories', () => {
+      mkdirSync(join(snapDir, 'sub'), { recursive: true })
+      writeFileSync(join(snapDir, 'note.txt'), 'hi', 'utf-8')
+      writeSidecar('good', { tag: 'chroxy-byok-snap:good' })
+      const list = listSnapshots({ dir: snapDir })
+      assert.equal(list.length, 1)
+      assert.equal(list[0].slug, 'good')
+    })
+
+    it('defaults missing string fields to empty string', () => {
+      writeSidecar('minimal', { tag: 'chroxy-byok-snap:minimal' })
+      const list = listSnapshots({ dir: snapDir })
+      assert.equal(list.length, 1)
+      assert.equal(list[0].name, '')
+      assert.equal(list[0].createdAt, '')
+      assert.equal(list[0].sourceCwd, '')
+      assert.equal(list[0].sourceImage, '')
+      assert.equal(list[0].sourceSessionId, null)
+    })
+  })
+
+  describe('deleteSnapshot', () => {
+    it('rejects slugs with path traversal characters', async () => {
+      const removed = []
+      const result = await deleteSnapshot('../etc/passwd', {
+        removeImage: async (tag) => { removed.push(tag) },
+        dir: snapDir,
+      })
+      assert.equal(result.ok, false)
+      assert.equal(result.status, 400)
+      assert.deepEqual(removed, [])
+    })
+
+    it('rejects empty slug', async () => {
+      const result = await deleteSnapshot('', { removeImage: async () => {}, dir: snapDir })
+      assert.equal(result.ok, false)
+      assert.equal(result.status, 400)
+    })
+
+    it('returns 404 when the sidecar does not exist', async () => {
+      const result = await deleteSnapshot('missing', { removeImage: async () => {}, dir: snapDir })
+      assert.equal(result.ok, false)
+      assert.equal(result.status, 404)
+    })
+
+    it('removes the docker image and unlinks the sidecar', async () => {
+      writeSidecar('snap-1', { tag: 'chroxy-byok-snap:abc-1', createdAt: '2024-01-01T00:00:00Z' })
+      const removed = []
+      const result = await deleteSnapshot('snap-1', {
+        removeImage: async (tag) => { removed.push(tag) },
+        dir: snapDir,
+      })
+      assert.equal(result.ok, true)
+      assert.equal(result.tag, 'chroxy-byok-snap:abc-1')
+      assert.equal(result.imageRemoved, true)
+      assert.deepEqual(removed, ['chroxy-byok-snap:abc-1'])
+      assert.equal(existsSync(join(snapDir, 'snap-1.json')), false)
+    })
+
+    it('still drops the sidecar when docker rmi rejects (best-effort)', async () => {
+      writeSidecar('snap-2', { tag: 'chroxy-byok-snap:abc-2' })
+      const result = await deleteSnapshot('snap-2', {
+        removeImage: async () => { throw new Error('image already gone') },
+        dir: snapDir,
+      })
+      assert.equal(result.ok, true)
+      assert.equal(result.imageRemoved, false)
+      assert.equal(existsSync(join(snapDir, 'snap-2.json')), false)
+    })
+
+    it('throws when removeImage callback is missing', async () => {
+      writeSidecar('snap-3', { tag: 'chroxy-byok-snap:abc-3' })
+      await assert.rejects(
+        () => deleteSnapshot('snap-3', { dir: snapDir }),
+        /removeImage callback required/,
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #5074. Adds a Snapshots tab in the dashboard that lists docker-byok snapshot metadata sidecars from `${CHROXY_CONFIG_DIR ?? ~/.chroxy}/snapshots/` and exposes a confirm-gated Delete button.

**Server**
- `GET /api/snapshots` — newest-first array of `{tag, name, createdAt, sourceCwd, sourceImage, sourceSessionId, slug}`. Tolerant of partial corruption (single malformed sidecar never takes the listing offline).
- `DELETE /api/snapshots/:slug` — `docker rmi <tag>` then unlinks the sidecar. Image removal is best-effort: a ghost sidecar is worse UX than a leaked image, so the sidecar drops even if rmi fails (response reports `imageRemoved: false`).
- Both bearer-auth gated. Slug charset `[A-Za-z0-9_.-]+` blocks path traversal.
- `removeImage` resolves through `server.environmentManager._backend` when env-management is enabled, else lazily instantiates a fresh `DockerBackend`. Test seam: `server._snapshotRemoveImage`.

**Dashboard**
- `SnapshotsPanel` — one card per snapshot (name, tag, cwd, base image, source session), Delete with two-step confirm.
- New `ViewMode 'snapshots'` and tab strip entry, threaded through `types.ts`, `persistence.ts`, `useShortcutDispatch.ts`.
- Optimistic local removal on successful DELETE + a follow-up `refresh()` to reconcile drift.

## Out of scope / follow-ups

The issue lists these as separate bullet points; this PR ships listing + delete only:
- "Start session from snapshot" — needs `snapshotImage` threaded through `SessionManager` / the WS protocol (the issue text already flags this as a follow-up).
- "Take snapshot" action on a live docker-byok session.
- Mobile app surface for the snapshot list.

## Test plan

- [x] `node --test --test-force-exit packages/server/tests/snapshots-store.test.js` — 14 cases pass.
- [x] `node --test --test-force-exit packages/server/tests/http-routes.test.js` — 21 cases pass (7 new for snapshot endpoints).
- [x] `npx vitest run packages/dashboard/src/components/SnapshotsPanel.test.tsx` — 8 cases pass.
- [x] `npx vitest run` (full dashboard suite) — 2897 tests pass.
- [x] `npx tsc --noEmit` (dashboard) — clean.
- [x] `scripts/lint-tests-state-file-path.sh` — OK.
- [x] `scripts/lint-session-opt-forwarding.sh` — OK.
- [ ] Manual: take a snapshot via a live docker-byok session, open the dashboard Snapshots tab, confirm the row renders and Delete removes both the image and the sidecar.