### PR TITLE
feat(server): land docker-byok snapshot/restore on main (originally #5023/#5071)

### DIFF
--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -106,6 +106,7 @@ import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
 import { buildPoolKey, getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
 import { createLogger } from './logger.js'
+import { writeFileRestricted } from './platform.js'
 import {
   parseDevContainer,
   validateMounts,
@@ -479,15 +480,19 @@ export class DockerByokSession extends ClaudeByokSession {
     this._dockerBackend = opts._dockerBackend || new DockerBackend()
     this._execFile = opts._execFile || execFile
     this._containerReady = false
-    // #5023 snapshot / restore opts.
+    // #5023 snapshot / restore opts. All string opts are trimmed before
+    // the length check so callers passing whitespace-only values (e.g.
+    // `'   '`) get the same default as no-opt-at-all — matches how
+    // composeFile / composeService / containerId / snapshotImage handle
+    // their inputs (#5100 review).
     this._snapshotImage = typeof opts.snapshotImage === 'string' && opts.snapshotImage.trim().length > 0
       ? opts.snapshotImage.trim()
       : null
-    this._snapshotsDir = typeof opts.snapshotsDir === 'string' && opts.snapshotsDir.length > 0
-      ? opts.snapshotsDir
+    this._snapshotsDir = typeof opts.snapshotsDir === 'string' && opts.snapshotsDir.trim().length > 0
+      ? opts.snapshotsDir.trim()
       : join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'snapshots')
-    this._sourceSessionId = typeof opts.sourceSessionId === 'string' && opts.sourceSessionId.length > 0
-      ? opts.sourceSessionId
+    this._sourceSessionId = typeof opts.sourceSessionId === 'string' && opts.sourceSessionId.trim().length > 0
+      ? opts.sourceSessionId.trim()
       : null
     // #5022: across-session idle pool. Off by default — opted in via env
     // or by passing an explicit `_pool` instance. Per-session reuse of
@@ -802,8 +807,12 @@ export class DockerByokSession extends ClaudeByokSession {
     } catch (err) {
       // Persistence is best-effort — the snapshot tag in the daemon is
       // the source of truth. Log and continue so the caller still gets
-      // the tag.
-      log.warn(`snapshot: failed to persist metadata for ${tag}: ${err.message}`)
+      // the tag. Defensive message extraction (#5100 review) so a
+      // non-Error throw (string / plain object) doesn't crash the
+      // log call itself — the whole point of this branch is to keep
+      // snapshot() reliable when metadata persistence fails.
+      const msg = err && typeof err.message === 'string' ? err.message : String(err)
+      log.warn(`snapshot: failed to persist metadata for ${tag}: ${msg}`)
     }
     log.info(`snapshot: ${tag} (name="${snapName}") committed`)
     return metadata
@@ -830,10 +839,12 @@ export class DockerByokSession extends ClaudeByokSession {
    * sidecar JSON lands. The mkdir is recursive so a brand-new
    * `~/.chroxy/snapshots/` is created on demand.
    *
-   * The file is created with restrictive perms (0600 — owner read/
-   * write only, dir 0700) because the metadata embeds host paths and
-   * optionally `sourceSessionId`. This matches the posture other
-   * `$CHROXY_CONFIG_DIR` state files use (session-state, credentials).
+   * Uses the shared `writeFileRestricted` helper (#5100 review) so the
+   * write is atomic (temp+rename) and the file lands at 0600 on POSIX
+   * with the same cross-platform contract every other
+   * `$CHROXY_CONFIG_DIR` state file uses (session-state, credentials,
+   * device-preferences, models cache). Dir is 0o700 on POSIX; the dir
+   * mode is ignored on Windows where ACLs are the right mechanism.
    */
   _persistSnapshotMetadata(tag, metadata) {
     mkdirSync(this._snapshotsDir, { recursive: true, mode: 0o700 })
@@ -842,7 +853,7 @@ export class DockerByokSession extends ClaudeByokSession {
     // surfaces here.
     const slug = tag.split(':').pop().replace(/[^a-zA-Z0-9_.-]/g, '_')
     const filePath = join(this._snapshotsDir, `${slug}.json`)
-    writeFileSync(filePath, JSON.stringify(metadata, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 })
+    writeFileRestricted(filePath, JSON.stringify(metadata, null, 2) + '\n')
   }
 
   /**

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -97,8 +97,10 @@
  */
 
 import { execFile } from 'child_process'
+import { mkdirSync, writeFileSync } from 'fs'
 import { createHash, randomBytes } from 'crypto'
-import { isAbsolute, posix } from 'path'
+import { homedir } from 'os'
+import { isAbsolute, join, posix } from 'path'
 import { ClaudeByokSession } from './byok-session.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
@@ -384,6 +386,19 @@ export class DockerByokSession extends ClaudeByokSession {
    * @param {number} [opts.postCreateTimeoutMs=300_000]
    *   #5025: Cap on how long postCreateCommand can run before it's
    *   treated as a hang (default 5 minutes).
+   * @param {string} [opts.snapshotImage]            Restore from a snapshot tag
+   *   produced by a previous `snapshot()` call (#5023). When set, the
+   *   container is launched from this image instead of `opts.image`, the
+   *   `useradd` setup is skipped (the snapshot has the user baked in),
+   *   and the live container is auto-soiled so it does NOT return to the
+   *   pool (a restored container's FS is coupled to the snapshot's
+   *   original conversation).
+   * @param {string} [opts.snapshotsDir]             Override the directory
+   *   snapshot metadata JSONs are written to. Defaults to
+   *   `${CHROXY_CONFIG_DIR ?? ~/.chroxy}/snapshots`. Tests inject a tmp dir.
+   * @param {string} [opts.sourceSessionId]          Optional session id to
+   *   embed in snapshot metadata. The session itself has no sessionId
+   *   field; the SessionManager owns the id and can pass it through.
    * @param {object} [opts._dockerBackend]           Test seam — pre-built backend
    * @param {Function} [opts._execFile]              Test seam — used by preflight
    *   (defaults to child_process.execFile)
@@ -451,6 +466,16 @@ export class DockerByokSession extends ClaudeByokSession {
     this._dockerBackend = opts._dockerBackend || new DockerBackend()
     this._execFile = opts._execFile || execFile
     this._containerReady = false
+    // #5023 snapshot / restore opts.
+    this._snapshotImage = typeof opts.snapshotImage === 'string' && opts.snapshotImage.trim().length > 0
+      ? opts.snapshotImage.trim()
+      : null
+    this._snapshotsDir = typeof opts.snapshotsDir === 'string' && opts.snapshotsDir.length > 0
+      ? opts.snapshotsDir
+      : join(process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'), 'snapshots')
+    this._sourceSessionId = typeof opts.sourceSessionId === 'string' && opts.sourceSessionId.length > 0
+      ? opts.sourceSessionId
+      : null
     // #5022: across-session idle pool. Off by default — opted in via env
     // or by passing an explicit `_pool` instance. Per-session reuse of
     // the same container across multiple turns is unconditional and
@@ -654,6 +679,14 @@ export class DockerByokSession extends ClaudeByokSession {
       return
     }
     this._containerReady = true
+
+    // #5023: a container restored from a snapshot inherits the
+    // snapshot's writable layer — auth files, history, scratch state.
+    // Mark it soiled so it does NOT return to the pool for an unrelated
+    // session to acquire. No-ops cleanly when pooling is disabled.
+    if (this._snapshotImage && this._containerOwned) {
+      this.markActiveContainerSoiled()
+    }
   }
 
   /**
@@ -699,6 +732,107 @@ export class DockerByokSession extends ClaudeByokSession {
   }
 
   /**
+   * Snapshot the live container's writable layer into a Docker image
+   * tag via `docker commit`, then mark the container "soiled" so the
+   * pool evicts it on release. Writes a small metadata JSON to
+   * `snapshotsDir` so ops can list snapshot names without parsing
+   * `docker image ls` — see class docstring's snapshot/restore section.
+   *
+   * Returns a `{ tag, name, createdAt, sourceCwd, sourceImage,
+   * sourceSessionId }` shape. The `tag` is what a future session passes
+   * to the constructor as `snapshotImage` to restore.
+   *
+   * Throws when the container is not ready (no `start()`, or
+   * `destroy()` already ran). Surfaces backend errors (out-of-disk,
+   * daemon dead) as a plain Error — callers decide whether to retry.
+   *
+   * #5023.
+   *
+   * @param {object} [opts]
+   * @param {string} [opts.name] Human-readable name for the snapshot
+   * @returns {Promise<{tag:string, name:string, createdAt:string,
+   *   sourceCwd:string, sourceImage:string, sourceSessionId:string|null}>}
+   */
+  async snapshot({ name } = {}) {
+    if (!this._containerReady || !this._containerId) {
+      const err = new Error('docker-byok snapshot(): container is not ready')
+      err.code = 'docker_byok_not_ready'
+      throw err
+    }
+    const tag = this._generateSnapshotTag()
+    const sourceCwd = this.cwd || process.cwd()
+    const sourceImage = this._snapshotImage || this._image
+    const snapName = (typeof name === 'string' && name.trim().length > 0)
+      ? name.trim()
+      : tag.split(':').pop()
+    const createdAt = new Date().toISOString()
+
+    log.info(`snapshot: committing ${this._containerId.slice(0, 12)} → ${tag}`)
+    await this._dockerBackend.commitEnvironment(this._containerId, tag)
+
+    // Mark soiled BEFORE writing metadata. If metadata persistence
+    // fails (disk full, permission denied) we still want the soil
+    // marker stuck on — the snapshot tag exists in the daemon and the
+    // container's writable layer has leaked into it.
+    this.markActiveContainerSoiled()
+
+    const metadata = {
+      tag,
+      name: snapName,
+      createdAt,
+      sourceCwd,
+      sourceImage,
+      sourceSessionId: this._sourceSessionId,
+    }
+    try {
+      this._persistSnapshotMetadata(tag, metadata)
+    } catch (err) {
+      // Persistence is best-effort — the snapshot tag in the daemon is
+      // the source of truth. Log and continue so the caller still gets
+      // the tag.
+      log.warn(`snapshot: failed to persist metadata for ${tag}: ${err.message}`)
+    }
+    log.info(`snapshot: ${tag} (name="${snapName}") committed`)
+    return metadata
+  }
+
+  /**
+   * Build a snapshot tag of the form `chroxy-byok-snap:<16-hex>-<ts>`.
+   * 8 bytes of randomness + a millisecond timestamp keep tags unique
+   * within a single host. Image tags must be lowercase ASCII;
+   * `randomBytes` hex satisfies the Docker tag rules.
+   */
+  _generateSnapshotTag() {
+    const rand = randomBytes(8).toString('hex')
+    const ts = Date.now()
+    return `chroxy-byok-snap:${rand}-${ts}`
+  }
+
+  /**
+   * Write the snapshot metadata JSON next to its siblings in
+   * `_snapshotsDir`. The filename uses the tag's identifier portion so
+   * a future ops listing reads back deterministically.
+   *
+   * Best-effort, sync I/O: we hold a docker tag whether or not the
+   * sidecar JSON lands. The mkdir is recursive so a brand-new
+   * `~/.chroxy/snapshots/` is created on demand.
+   *
+   * The file is created with restrictive perms (0600 — owner read/
+   * write only, dir 0700) because the metadata embeds host paths and
+   * optionally `sourceSessionId`. This matches the posture other
+   * `$CHROXY_CONFIG_DIR` state files use (session-state, credentials).
+   */
+  _persistSnapshotMetadata(tag, metadata) {
+    mkdirSync(this._snapshotsDir, { recursive: true, mode: 0o700 })
+    // Tag is `chroxy-byok-snap:<rand>-<ts>` — split on ':' to get the
+    // filename-safe slug. Defensive replace in case a custom tag ever
+    // surfaces here.
+    const slug = tag.split(':').pop().replace(/[^a-zA-Z0-9_.-]/g, '_')
+    const filePath = join(this._snapshotsDir, `${slug}.json`)
+    writeFileSync(filePath, JSON.stringify(metadata, null, 2) + '\n', { encoding: 'utf-8', mode: 0o600 })
+  }
+
+  /**
    * If pooling is enabled, try to claim a warm container for this
    * session's resource shape. On a hit, verify the container still
    * responds to `docker exec` — if so, skip `_startContainer()`
@@ -708,6 +842,15 @@ export class DockerByokSession extends ClaudeByokSession {
    * #5022 — across-session idle pool. Per-session reuse of the same
    * container across turns is handled in `_dispatchBuiltinTool` and
    * does not depend on the pool.
+   *
+   * #5023 — when `_snapshotImage` is set the pool is BYPASSED. The
+   * pool key derives from `_image`, not `_snapshotImage`, so a hit
+   * would hand back a stock container and `_startContainer()` would
+   * never run — the snapshot tag would be silently ignored. Worse,
+   * the recycled container's writable layer (auth, scratch state) is
+   * unrelated to the snapshot the caller asked to restore. Restored
+   * containers are auto-soiled anyway so they can't return to the
+   * pool — skipping the acquire path is the consistent move.
    */
   async _acquireOrStartContainer() {
     // #5024: compose mode short-circuits the entire pool + bare-image
@@ -722,7 +865,7 @@ export class DockerByokSession extends ClaudeByokSession {
     if (this._useDevcontainer) {
       this._resolveDevContainer()
     }
-    if (this._pool) {
+    if (this._pool && !this._snapshotImage) {
       const key = this._poolKey()
       const reused = this._pool.acquire(key)
       if (reused) {
@@ -838,6 +981,13 @@ export class DockerByokSession extends ClaudeByokSession {
    * limit, no-new-privileges, non-root user). Mirrors the runArgs
    * shape used by docker-sdk-session.js so the security posture is
    * identical across the two providers.
+   *
+   * When `_snapshotImage` is set (#5023), the container is launched
+   * from that image instead of `_image` and the `useradd` + `chown`
+   * setup is SKIPPED — the snapshot already has the non-root user
+   * baked in. Re-running useradd would fail with "user already exists"
+   * and abort start. The restored container is auto-soiled by
+   * `start()` after this resolves so the pool evicts on release.
    */
   _startContainer() {
     return new Promise((resolve, reject) => {
@@ -903,10 +1053,13 @@ export class DockerByokSession extends ClaudeByokSession {
         runArgs.push('--add-host', 'host.docker.internal:host-gateway')
       }
 
-      runArgs.push(this._image, 'sleep', 'infinity')
+      const imageToRun = this._snapshotImage || this._image
+      runArgs.push(imageToRun, 'sleep', 'infinity')
 
       log.info(
-        `starting container (image=${this._image} memory=${this._memoryLimit} cpus=${this._cpuLimit})`,
+        this._snapshotImage
+          ? `restoring container from snapshot ${this._snapshotImage} (memory=${this._memoryLimit} cpus=${this._cpuLimit})`
+          : `starting container (image=${imageToRun} memory=${this._memoryLimit} cpus=${this._cpuLimit})`,
       )
 
       this._execFile('docker', runArgs, { encoding: 'utf-8', timeout: 120_000 }, (err, stdout, stderr) => {
@@ -919,6 +1072,14 @@ export class DockerByokSession extends ClaudeByokSession {
         }
         this._containerId = stdout.trim()
         log.info(`container started: ${this._containerId.slice(0, 12)}`)
+
+        // Restore path: the snapshot has useradd + chown baked in, so
+        // skip the setup step. Re-running useradd would fail
+        // ("user already exists") and abort start.
+        if (this._snapshotImage) {
+          resolve()
+          return
+        }
 
         // Set up non-root user + chown workspace so the model isn't
         // running as root inside the container. Same script

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1269,9 +1269,13 @@ describe('DockerByokSession — snapshot / restore (#5023)', () => {
     // The `docker run` invocation used the snapshot tag as the image.
     assert.equal(runCalls.length, 1)
     const runArgs = runCalls[0]
-    // image is third-to-last (before "sleep" "infinity")
-    const imageIdx = runArgs.length - 3
-    assert.equal(runArgs[imageIdx], 'chroxy-byok-snap:abc123-1700000000000')
+    // Anchor on the known `sleep infinity` command tail rather than the
+    // arg-list length so adding/removing unrelated `docker run` flags
+    // doesn't shift the assertion off the image position (#5100 review).
+    const sleepIdx = runArgs.indexOf('sleep')
+    assert.ok(sleepIdx > 0 && runArgs[sleepIdx + 1] === 'infinity',
+      'docker run tail must end "<image> sleep infinity"')
+    assert.equal(runArgs[sleepIdx - 1], 'chroxy-byok-snap:abc123-1700000000000')
 
     // No `useradd` should have run on the restored container — the
     // snapshot image already has the user baked in.
@@ -1372,11 +1376,15 @@ describe('DockerByokSession — snapshot / restore (#5023)', () => {
     // The pool MUST NOT have been asked for a container — restore is
     // not poolable.
     assert.equal(pool.calls.acquire.length, 0, 'pool.acquire() must not be called when snapshotImage is set')
-    // Docker run fired with the snapshot tag as the image.
+    // Docker run fired with the snapshot tag as the image. Anchor on
+    // the known `sleep infinity` command tail so unrelated `docker run`
+    // flag changes don't shift the assertion (#5100 review).
     assert.equal(runCalls.length, 1)
     const runArgs = runCalls[0]
-    const imageIdx = runArgs.length - 3
-    assert.equal(runArgs[imageIdx], 'chroxy-byok-snap:bypass-test')
+    const sleepIdx = runArgs.indexOf('sleep')
+    assert.ok(sleepIdx > 0 && runArgs[sleepIdx + 1] === 'infinity',
+      'docker run tail must end "<image> sleep infinity"')
+    assert.equal(runArgs[sleepIdx - 1], 'chroxy-byok-snap:bypass-test')
     // And the active container id is the freshly-launched one, NOT the
     // pool's would-be hit.
     assert.equal(session._containerId, 'CONTAINER_FRESH_FROM_SNAP')

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -1038,6 +1038,353 @@ describe('DockerByokSession — snapshot soiling integration (#5043)', () => {
   })
 })
 
+describe('DockerByokSession — snapshot / restore (#5023)', () => {
+  /**
+   * Snapshot tests cover the MVP shape:
+   *   - snapshot()  → docker commit + markSoiled + metadata write
+   *   - restore via `snapshotImage` opt → docker run with the snapshot
+   *     tag, skip useradd, and auto-soil the live container so the
+   *     restored conversation's FS doesn't leak into the next acquirer.
+   *
+   * Same pool-with-soiling stub shape as #5043 — snapshot integration
+   * runs through markSoiled so a snapshotted container always exits via
+   * inline `docker rm -f` rather than going back to the pool.
+   */
+  function poolStubWithSoiling({ acquireReturn = null } = {}) {
+    const calls = { acquire: [], release: [], markSoiled: [] }
+    const soiled = new Set()
+    let nextAcquire = acquireReturn
+    return {
+      calls,
+      acquire(key) {
+        calls.acquire.push(key)
+        const v = nextAcquire
+        nextAcquire = null
+        return v
+      },
+      async release(key, containerId) {
+        calls.release.push({ key, containerId })
+        if (soiled.has(containerId)) {
+          soiled.delete(containerId)
+          return false
+        }
+        return true
+      },
+      markSoiled(containerId) {
+        if (!containerId) return
+        soiled.add(containerId)
+        calls.markSoiled.push(containerId)
+      },
+      isSoiled(containerId) {
+        return soiled.has(containerId)
+      },
+    }
+  }
+
+  /**
+   * Docker backend stub specialised for snapshot tests — records every
+   * `commitEnvironment` call so we can assert the snapshot tag shape.
+   */
+  function backendStubWithCommit(opts = {}) {
+    const calls = { exec: [], commit: [] }
+    return {
+      calls,
+      async execInEnvironment(containerId, execOpts) {
+        calls.exec.push({ containerId, ...execOpts })
+        return { stdout: '', stderr: '' }
+      },
+      async commitEnvironment(containerId, imageTag) {
+        calls.commit.push({ containerId, imageTag })
+        if (opts.commitError) throw opts.commitError
+        return opts.commitSha || `sha256:${imageTag.replace(/[^a-z0-9]/gi, '').slice(0, 64)}`
+      },
+    }
+  }
+
+  it('snapshot() commits the live container under a chroxy-byok-snap tag', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_SNAP_OK\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = backendStubWithCommit()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backend,
+      snapshotsDir: join(tmpHome, 'snapshots'),
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    const snap = await session.snapshot({ name: 'after-deps' })
+
+    assert.equal(backend.calls.commit.length, 1, 'commitEnvironment was called exactly once')
+    const commit = backend.calls.commit[0]
+    assert.equal(commit.containerId, 'CONTAINER_SNAP_OK')
+    assert.match(commit.imageTag, /^chroxy-byok-snap:/, 'snapshot tag uses chroxy-byok-snap prefix')
+
+    // Snapshot result shape: tag, name, createdAt, sourceCwd, sourceImage.
+    assert.equal(snap.tag, commit.imageTag)
+    assert.equal(snap.name, 'after-deps')
+    assert.ok(typeof snap.createdAt === 'string' && snap.createdAt.length > 0)
+    assert.equal(snap.sourceCwd, '/host/cwd')
+    assert.equal(snap.sourceImage, 'node:22-slim')
+
+    await session.destroy()
+  })
+
+  it('snapshot() marks the live container soiled so the pool evicts on release', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_SNAP_DIRTY\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const pool = poolStubWithSoiling()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      _pool: pool,
+      snapshotsDir: join(tmpHome, 'snapshots'),
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    await session.snapshot({ name: 'mid-session' })
+
+    // Pool was told this container is dirty — release will evict.
+    assert.deepEqual(pool.calls.markSoiled, ['CONTAINER_SNAP_DIRTY'])
+    assert.equal(pool.isSoiled('CONTAINER_SNAP_DIRTY'), true)
+
+    await session.destroy()
+
+    // Release fired and the pool returned false (evicted, not pooled).
+    assert.equal(pool.calls.release.length, 1)
+    assert.equal(pool.calls.release[0].containerId, 'CONTAINER_SNAP_DIRTY')
+  })
+
+  it('snapshot() persists metadata JSON to snapshotsDir for ops visibility', async () => {
+    const { existsSync, readFileSync, readdirSync } = await import('node:fs')
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_META\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const snapshotsDir = join(tmpHome, 'snapshots')
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      snapshotsDir,
+      sourceSessionId: 'sess-abc',
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    const snap = await session.snapshot({ name: 'with-meta' })
+    assert.ok(existsSync(snapshotsDir), 'snapshotsDir was created')
+    const files = readdirSync(snapshotsDir).filter((f) => f.endsWith('.json'))
+    assert.equal(files.length, 1, 'one metadata JSON was written')
+    const meta = JSON.parse(readFileSync(join(snapshotsDir, files[0]), 'utf-8'))
+    assert.equal(meta.tag, snap.tag)
+    assert.equal(meta.name, 'with-meta')
+    assert.equal(meta.sourceCwd, '/host/cwd')
+    assert.equal(meta.sourceImage, 'node:22-slim')
+    assert.equal(meta.sourceSessionId, 'sess-abc')
+    assert.equal(typeof meta.createdAt, 'string')
+
+    await session.destroy()
+  })
+
+  it('snapshot() rejects when the container is not ready', async () => {
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile: execFileStub({ info: { stdout: 'ok' } }),
+      _dockerBackend: backendStubWithCommit(),
+    })
+    // No start() — container is not ready.
+    await assert.rejects(
+      () => session.snapshot({ name: 'too-early' }),
+      /not ready/i,
+    )
+  })
+
+  it('snapshot() surfaces docker commit failures as Error', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_FAIL\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = backendStubWithCommit({
+      commitError: new Error('disk full'),
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backend,
+      snapshotsDir: join(tmpHome, 'snapshots'),
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    await assert.rejects(
+      () => session.snapshot({ name: 'will-fail' }),
+      /disk full/,
+    )
+    await session.destroy()
+  })
+
+  it('snapshotImage opt restores: uses the snapshot tag and skips useradd', async () => {
+    const runCalls = []
+    const execCmds = []
+    const _execFile = (cmd, args, opts, callback) => {
+      const sub = args[0]
+      if (sub === 'info') return callback(null, 'ok', '')
+      if (sub === 'run') {
+        runCalls.push([...args])
+        return callback(null, 'CONTAINER_RESTORED\n', '')
+      }
+      if (sub === 'exec') {
+        execCmds.push([...args])
+        return callback(null, '', '')
+      }
+      if (sub === 'rm') return callback(null, '', '')
+      callback(null, '', '')
+    }
+
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      snapshotImage: 'chroxy-byok-snap:abc123-1700000000000',
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // The `docker run` invocation used the snapshot tag as the image.
+    assert.equal(runCalls.length, 1)
+    const runArgs = runCalls[0]
+    // image is third-to-last (before "sleep" "infinity")
+    const imageIdx = runArgs.length - 3
+    assert.equal(runArgs[imageIdx], 'chroxy-byok-snap:abc123-1700000000000')
+
+    // No `useradd` should have run on the restored container — the
+    // snapshot image already has the user baked in.
+    const setupCalls = execCmds.filter((args) =>
+      args.some((a) => typeof a === 'string' && a.includes('useradd')))
+    assert.equal(setupCalls.length, 0, 'restore must skip useradd')
+
+    await session.destroy()
+  })
+
+  it('snapshotImage opt auto-soils the restored container so reuse cannot leak', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_RESTORED_DIRTY\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const pool = poolStubWithSoiling()
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      _pool: pool,
+      snapshotImage: 'chroxy-byok-snap:abc-123',
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // The restored container is automatically marked soiled — its FS is
+    // coupled to the source conversation's history.
+    assert.deepEqual(pool.calls.markSoiled, ['CONTAINER_RESTORED_DIRTY'])
+
+    await session.destroy()
+
+    // And it's evicted on release, not pooled.
+    assert.equal(pool.calls.release.length, 1)
+  })
+
+  it('snapshot() persists metadata even when snapshotsDir is brand-new', async () => {
+    const { existsSync, readdirSync } = await import('node:fs')
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_MK\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const nested = join(tmpHome, 'deeply', 'nested', 'snaps')
+    assert.equal(existsSync(nested), false)
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      snapshotsDir: nested,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    await session.snapshot({ name: 'mkdir-test' })
+    assert.ok(existsSync(nested))
+    assert.equal(readdirSync(nested).filter((f) => f.endsWith('.json')).length, 1)
+
+    await session.destroy()
+  })
+
+  it('snapshotImage opt bypasses pool acquire — always launches fresh from the snapshot tag', async () => {
+    // Regression: pre-fix, _acquireOrStartContainer would call
+    // _pool.acquire() even when snapshotImage was set. A pool hit
+    // (matching the resource key — image/cwd/memory/cpu/user) returned
+    // a stock container and _startContainer() never ran, so the
+    // snapshot tag was silently ignored AND the recycled container's
+    // writable layer (unrelated auth/scratch) leaked in.
+    const runCalls = []
+    const _execFile = (cmd, args, opts, callback) => {
+      const sub = args[0]
+      if (sub === 'info') return callback(null, 'ok', '')
+      if (sub === 'run') {
+        runCalls.push([...args])
+        return callback(null, 'CONTAINER_FRESH_FROM_SNAP\n', '')
+      }
+      if (sub === 'exec') return callback(null, '', '')
+      if (sub === 'rm') return callback(null, '', '')
+      callback(null, '', '')
+    }
+    // Pool would happily return POOLED_STOCK_CID for this session's
+    // resource shape — if the bypass guard ever regresses, this stub
+    // makes the regression load-bearing.
+    const pool = poolStubWithSoiling({ acquireReturn: 'POOLED_STOCK_CID' })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      _execFile,
+      _dockerBackend: backendStubWithCommit(),
+      _pool: pool,
+      snapshotImage: 'chroxy-byok-snap:bypass-test',
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+
+    // The pool MUST NOT have been asked for a container — restore is
+    // not poolable.
+    assert.equal(pool.calls.acquire.length, 0, 'pool.acquire() must not be called when snapshotImage is set')
+    // Docker run fired with the snapshot tag as the image.
+    assert.equal(runCalls.length, 1)
+    const runArgs = runCalls[0]
+    const imageIdx = runArgs.length - 3
+    assert.equal(runArgs[imageIdx], 'chroxy-byok-snap:bypass-test')
+    // And the active container id is the freshly-launched one, NOT the
+    // pool's would-be hit.
+    assert.equal(session._containerId, 'CONTAINER_FRESH_FROM_SNAP')
+
+    await session.destroy()
+  })
+})
+
 describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
   /**
    * Acceptance: a `postCreateCommand: string | string[]` opt that runs


### PR DESCRIPTION
Originally landed on the defunct `feat/docker-byok-pool-soiling` staging branch in PR #5071 but never reached main. This PR brings the snapshot/restore APIs to main, rebased onto current main with #5050/#5063/#5070 features preserved.

## Summary
- snapshot({ name? }) — runs docker commit, marks container soiled, writes metadata sidecar
- snapshotImage opt + restore start path
- bypass-pool-when-snapshotImage (from #5071's review fix 9e8a7d359)

## Test plan
- [x] All existing docker-byok-session + docker-byok-pool tests pass
- [x] Snapshot/restore tests carried over from #5071 pass
- [x] Lints clean