### PR TITLE
docs(server): cite cli-session._handleStreamStall in cost-gate invariant (#5085)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1694,11 +1694,13 @@ export class SessionManager extends EventEmitter {
         //   - byok-session error path: a single `error` (with finite cost
         //     for the partial spend, see #5037).
         //   - Stream-stall path (sdk-session._handleStreamStall and
-        //     cli-session._emitInterruptedTurnResult): emits BOTH a
-        //     synthetic `result` AND `error` for the same turn — but the
-        //     synthetic `result` carries `cost: null`, so the
-        //     Number.isFinite gate filters it. The `error` half is
-        //     plain stream-stall metadata (no cost field), also filtered.
+        //     cli-session._handleStreamStall — the latter calls
+        //     _emitInterruptedTurnResult for the synthetic `result` and
+        //     then emits the `error` itself): emits BOTH a synthetic
+        //     `result` AND `error` for the same turn — but the synthetic
+        //     `result` carries `cost: null`, so the Number.isFinite gate
+        //     filters it. The `error` half is plain stream-stall metadata
+        //     (no cost field), also filtered.
         // No emit topology change is needed to add new failure paths as
         // long as they keep this invariant (priced terminal ⇒ exactly one
         // event with a finite cost per turn).


### PR DESCRIPTION
## Summary

Tighten the cost-gate comment in `session-manager.js:_wireSessionEvents` so the cli-side reference points to the actual emit site for the stream-stall `error` event.

The previous comment (post-#5082) cited `cli-session._emitInterruptedTurnResult` as the cli-side emit site for the synthetic-`result` + `error` pair. That's imprecise: `_emitInterruptedTurnResult` only emits the synthetic `result`. The `error` event is emitted by `_handleStreamStall` (cli-session.js:796-799), which calls `_emitInterruptedTurnResult` and then emits the `error` itself.

This swaps the citation to `cli-session._handleStreamStall` (mentioning that it calls `_emitInterruptedTurnResult` for the `result` half) so a reader grepping for the `error` emit site finds it by symbol. Symmetry with the sdk-session reference (which already correctly cites `_handleStreamStall`) is preserved.

Comment-only; no behavior change. The accounting invariant is unaffected — both the synthetic `result` (`cost: null`) and the `error` (no cost field) are still filtered by `Number.isFinite`.

Closes #5085

## Test plan

- [ ] Comment renders correctly (visual review of diff)
- [ ] No behavior change — existing session-manager tests still pass