### PR TITLE
fix(server): defense-in-depth check against _soiledIds in pool acquire (#5049)

### DIFF
--- a/packages/server/src/docker-byok-pool.js
+++ b/packages/server/src/docker-byok-pool.js
@@ -274,19 +274,36 @@ export class DockerContainerPool extends EventEmitter {
       log.debug(`pool miss for ${key}`)
       return null
     }
-    // Lazily skip + evict any over-age entries at the head of the bucket (#5045).
+    // Lazily skip + evict any over-age or soiled entries at the head of
+    // the bucket. Over-age is #5045; the soiled check (#5049) is
+    // defense-in-depth — the documented session lifecycle never lets
+    // `markSoiled(id)` race against `release()` (destroy() nulls
+    // _containerId before pool.release()), but the public markSoiled(id)
+    // API takes any id, so a future non-session caller could mark an
+    // already-pooled id. Without this check the next acquire() would
+    // silently hand out a soiled container. The soiled marker is
+    // consumed on the inline eviction so the same id isn't poisoned
+    // forever — matches the release-path semantics.
     const now = this._now()
     while (bucket.length > 0) {
       const head = bucket[0]
       const age = now - (head.createdAt ?? now)
-      if (age <= this._maxAgeMs) break
+      const overAge = age > this._maxAgeMs
+      const soiled = this._soiledIds.has(head.containerId)
+      if (!overAge && !soiled) break
       bucket.shift()
       this._clearTimeout(head.timer)
       this._createdAt.delete(head.containerId)
-      this._emitPoolEvent(POOL_EVENTS.EVICTED, { key, containerId: head.containerId, reason: 'over_age' })
-      log.info(`pool over-age on acquire (${age}ms > ${this._maxAgeMs}ms): evicting ${head.containerId.slice(0, 12)}`)
+      if (soiled) {
+        this._soiledIds.delete(head.containerId)
+        this._emitPoolEvent(POOL_EVENTS.EVICTED, { key, containerId: head.containerId, reason: 'soiled' })
+        log.info(`pool soiled on acquire: evicting ${head.containerId.slice(0, 12)}`)
+      } else {
+        this._emitPoolEvent(POOL_EVENTS.EVICTED, { key, containerId: head.containerId, reason: 'over_age' })
+        log.info(`pool over-age on acquire (${age}ms > ${this._maxAgeMs}ms): evicting ${head.containerId.slice(0, 12)}`)
+      }
       this._evict(head.containerId).catch((err) => {
-        log.warn(`over-age eviction of ${head.containerId.slice(0, 12)} failed: ${err.message}`)
+        log.warn(`acquire-time eviction of ${head.containerId.slice(0, 12)} failed: ${err.message}`)
       })
     }
     if (bucket.length === 0) {

--- a/packages/server/tests/docker-byok-pool.test.js
+++ b/packages/server/tests/docker-byok-pool.test.js
@@ -461,6 +461,71 @@ describe('DockerContainerPool — markSoiled() (#5043)', () => {
     await pool.shutdown()
     assert.equal(pool.isSoiled('CONTAINER_X'), false)
   })
+
+  /**
+   * Defense-in-depth check (#5049): the documented session lifecycle
+   * never lets `markSoiled(id)` race against `release()` — `destroy()`
+   * nulls `_containerId` before calling `pool.release()`, so the marker
+   * can only fire while the container is acquired (not pooled). But the
+   * public `markSoiled(id)` API takes any id, and a future non-session
+   * caller (dashboard endpoint, admin tool, snapshot helper that bypasses
+   * the session) could mark an already-pooled id. Without this check the
+   * next `acquire()` would silently hand it out before the soiled marker
+   * fires on release.
+   *
+   * Fix: in `acquire()`, after popping an entry from the bucket, check
+   * `this._soiledIds.has(entry.containerId)`. If so, evict it inline and
+   * continue draining the bucket until a non-soiled entry surfaces (or
+   * the bucket is empty, returning null).
+   */
+  it('acquire skips a soiled container in the pool and evicts it inline', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    // Seed the bucket the normal way, then mark the pooled id soiled
+    // out-of-band — simulating a future caller that bypasses the session.
+    await pool.release('k', 'POOLED_THEN_SOILED')
+    assert.equal(pool.size(), 1)
+    pool.markSoiled('POOLED_THEN_SOILED')
+    const got = pool.acquire('k')
+    assert.equal(got, null, 'soiled pool entry must NOT be returned to caller')
+    assert.equal(pool.size(), 0, 'soiled pool entry must be removed from the pool')
+    // Drain microtasks so the async _evict() runs.
+    await new Promise((r) => setImmediate(r))
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1, 'soiled pool entry must be docker rm -f')
+    assert.ok(rmCalls[0].args.includes('POOLED_THEN_SOILED'))
+    // The soiled marker is consumed on the inline acquire-time eviction
+    // so the same id doesn't stay poisoned forever (matches the
+    // release-path semantics).
+    assert.equal(pool.isSoiled('POOLED_THEN_SOILED'), false)
+  })
+
+  it('acquire skips a soiled head entry and returns the next clean one in the bucket', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      maxPerKey: 5,
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    await pool.release('k', 'SOILED_HEAD')
+    await pool.release('k', 'CLEAN_NEXT')
+    pool.markSoiled('SOILED_HEAD')
+    const got = pool.acquire('k')
+    assert.equal(got, 'CLEAN_NEXT', 'must skip past soiled entry to reach a clean one')
+    await new Promise((r) => setImmediate(r))
+    const rmCalls = execFile.calls.filter((c) => c.args[0] === 'rm')
+    assert.equal(rmCalls.length, 1)
+    assert.ok(rmCalls[0].args.includes('SOILED_HEAD'))
+    // The clean entry is now held by the caller, pool is empty.
+    assert.equal(pool.size(), 0)
+  })
 })
 
 describe('DockerContainerPool — max age (#5045)', () => {


### PR DESCRIPTION
Closes #5049

## Summary

- `DockerContainerPool#acquire(key)` now skips entries whose container id is in `_soiledIds`, evicting them inline (fire-and-forget) and continuing to the next entry in the bucket.
- The soiled marker is consumed on the inline acquire-time eviction so the same id doesn't stay poisoned forever (matches the release-path semantics).
- Eviction is emitted as `POOL_EVENTS.EVICTED` with `reason: 'soiled'`, matching the release-path event.

## Why

Within the documented session lifecycle this code path is unreachable — `DockerByokSession#destroy()` nulls `_containerId` before calling `pool.release()`, so `markActiveContainerSoiled` cannot race against release. But the public `markSoiled(id)` API takes any id. If a future, non-session caller (a dashboard endpoint, an admin tool, or a snapshot helper that doesn't go through the session) marks an already-pooled id, the next `acquire()` would silently hand it out before the soiled marker fires on release. This is the defense-in-depth check called out during review of PR #5047.

## Implementation

Folded the soiled check into the existing over-age head-scan loop in `acquire()` so both lazy-eviction conditions share one drain path. The break condition is now `!overAge && !soiled` and the eviction emits the right `reason` based on which condition fired.

## Test plan

- [x] New test: pool a container, mark it soiled, `acquire(key)` returns `null` and an `rm -f` is issued; `isSoiled(id)` returns `false` after eviction.
- [x] New test: bucket of `[SOILED_HEAD, CLEAN_NEXT]` — `acquire(key)` evicts `SOILED_HEAD` and returns `CLEAN_NEXT`.
- [x] Full `docker-byok-pool.test.js` suite still green (52/52).