### PR TITLE
test(server): pin stream_delta content on streamed turns (#5090)

### DIFF
--- a/packages/server/tests/cli-session-events.test.js
+++ b/packages/server/tests/cli-session-events.test.js
@@ -793,6 +793,64 @@ describe('CliSession stream-event handling', () => {
       assert.equal(messages.length, 0)
     })
 
+    it('exposes the streamed reply via stream_delta on a normal streamed turn (#5090)', () => {
+      // Companion to the no-fallback case above. The `messages.length === 0`
+      // assertion only proves the fallback was suppressed — it does NOT prove
+      // the consumer sees the streamed text. Without this companion, a future
+      // regression where `stream_delta` is silently dropped AND the fallback
+      // is also suppressed would still pass the no-fallback test (both bugs
+      // would cancel out and the consumer would see nothing).
+      //
+      // Pin that the concatenated `stream_delta` chunks compose the final
+      // response text the consumer would render.
+      const session = createSession()
+      const messages = []
+      const streamDeltas = []
+      session.on('message', (m) => messages.push(m))
+      session.on('stream_delta', (d) => streamDeltas.push(d.delta))
+
+      // Same wire sequence as the no-fallback case, but split the text across
+      // two deltas so we also pin that concatenation order is preserved.
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'text' },
+        },
+      })
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'streamed ' },
+        },
+      })
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'reply' },
+        },
+      })
+      session._handleEvent({
+        type: 'result',
+        session_id: 'sess-1',
+        subtype: 'success',
+        result: 'streamed reply',
+        total_cost_usd: 0,
+        duration_ms: 100,
+        usage: {},
+      })
+
+      // Primary contract (mirrors the no-fallback case): no synthesized
+      // response message on streamed turns.
+      assert.equal(messages.length, 0)
+      // New contract: the streamed text reached the consumer via stream_delta,
+      // and the concatenated chunks equal the canonical reply text.
+      assert.equal(streamDeltas.length, 2)
+      assert.equal(streamDeltas.join(''), 'streamed reply')
+    })
+
     it('does not emit fallback when data.result is empty or missing', () => {
       const session = createSession()
       const messages = []


### PR DESCRIPTION
## Summary

Closes #5090.

PR #5084 added a result-event fallback in `cli-session.js` for the `/compact` case (no stream + `data.result` → synthesize response). One of its tests pinned that the fallback does NOT fire on normal streamed turns by asserting `messages.length === 0`. That's load-bearing, but it doesn't separately prove the streamed text actually reached the consumer — a future regression where `stream_delta` is silently dropped AND the fallback is suppressed would still pass (both bugs would cancel out).

This adds a companion test in `packages/server/tests/cli-session-events.test.js` that:

- Runs the same wire sequence (`stream_event` → `content_block_start` text + two `text_delta` chunks → `result`).
- Captures `stream_delta` events into an array.
- Keeps the `messages.length === 0` assertion (no fallback emit).
- Asserts the concatenated delta text equals `'streamed reply'` — i.e. the chunks compose the canonical reply text in order.

Test-only addition — no production code change. Passes on current main.

## Test plan

- [x] `node --test packages/server/tests/cli-session-events.test.js` — 37/37 pass, including the new `exposes the streamed reply via stream_delta on a normal streamed turn (#5090)` case.