### PR TITLE
test(server): pin CLI-mode usage emission on streamed turns (#5095)

### DIFF
--- a/packages/server/tests/cli-session-events.test.js
+++ b/packages/server/tests/cli-session-events.test.js
@@ -856,5 +856,84 @@ describe('CliSession stream-event handling', () => {
       assert.equal(results[0].cost, 0.001)
       assert.equal(results[0].duration, 250)
     })
+
+    it('forwards the full usage payload on streamed turns, with no fallback message (#5095)', () => {
+      // Companion pin to #5084's fallback gate. The fallback is suppressed
+      // on streamed turns (ctx.hasStreamStarted === true), but we must also
+      // prove the `result` event still carries the canonical `usage` payload
+      // — input_tokens, output_tokens, cache_creation_input_tokens,
+      // cache_read_input_tokens — so the session-manager cost-gate
+      // (session-manager.js:1709 → _trackUsage) has the raw token counts to
+      // accumulate for the dashboard meter. A regression where #5084's
+      // fallback gate swallowed `usage` emission for streamed turns would
+      // silently zero the meter for every subscription user. This is the
+      // verification gap PR #5087 deferred.
+      const session = createSession()
+      const messages = []
+      const results = []
+      session.on('message', (m) => messages.push(m))
+      session.on('result', (r) => results.push(r))
+
+      // Drive a normal streamed turn end-to-end.
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          content_block: { type: 'text' },
+        },
+      })
+      session._handleEvent({
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          delta: { type: 'text_delta', text: 'streamed reply' },
+        },
+      })
+
+      // Subscription-billed result: cost is null (no per-turn $$$), but
+      // usage carries real token counts. The `usage` payload here is the
+      // exact shape `claude -p` emits on a subscription-billing path.
+      const usage = {
+        input_tokens: 137,
+        output_tokens: 42,
+        cache_creation_input_tokens: 1024,
+        cache_read_input_tokens: 8192,
+      }
+      session._handleEvent({
+        type: 'result',
+        session_id: 'sess-1',
+        subtype: 'success',
+        result: 'streamed reply',
+        total_cost_usd: null,
+        duration_ms: 250,
+        usage,
+      })
+
+      // Primary contract: NO synthetic fallback message on streamed turns.
+      // The stream_delta is the canonical surface for the text — a fallback
+      // here would double-emit the reply.
+      assert.equal(messages.length, 0)
+
+      // Canonical contract: the `result` event the session-manager listens
+      // for carries the full usage object verbatim. session-manager's
+      // _trackUsage reads `resultData.usage.{input_tokens, output_tokens,
+      // cache_read_input_tokens, cache_creation_input_tokens}` — pin all
+      // four so a future regression that drops a field (e.g. shallow
+      // restructure that forgets cache_* keys) fails here, not silently in
+      // the meter.
+      assert.equal(results.length, 1)
+      assert.equal(results[0].sessionId, 'sess-1')
+      assert.equal(results[0].cost, null)
+      assert.equal(results[0].duration, 250)
+      assert.ok(results[0].usage, 'usage must be present on streamed-turn result')
+      assert.equal(results[0].usage.input_tokens, 137)
+      assert.equal(results[0].usage.output_tokens, 42)
+      assert.equal(results[0].usage.cache_creation_input_tokens, 1024)
+      assert.equal(results[0].usage.cache_read_input_tokens, 8192)
+      // Identity check: the result event must forward the same usage object
+      // reference (or an equivalent shape) that the wire payload carried —
+      // not a synthesized subset that drops cache fields.
+      assert.deepEqual(results[0].usage, usage)
+    })
   })
 })

--- a/packages/server/tests/cli-session-events.test.js
+++ b/packages/server/tests/cli-session-events.test.js
@@ -891,8 +891,10 @@ describe('CliSession stream-event handling', () => {
       })
 
       // Subscription-billed result: cost is null (no per-turn $$$), but
-      // usage carries real token counts. The `usage` payload here is the
-      // exact shape `claude -p` emits on a subscription-billing path.
+      // usage carries real token counts. The `usage` payload here is a
+      // representative example of the shape `claude -p` emits on a
+      // subscription-billing path (illustrative values, not a captured
+      // wire sample).
       const usage = {
         input_tokens: 137,
         output_tokens: 42,
@@ -930,9 +932,9 @@ describe('CliSession stream-event handling', () => {
       assert.equal(results[0].usage.output_tokens, 42)
       assert.equal(results[0].usage.cache_creation_input_tokens, 1024)
       assert.equal(results[0].usage.cache_read_input_tokens, 8192)
-      // Identity check: the result event must forward the same usage object
-      // reference (or an equivalent shape) that the wire payload carried —
-      // not a synthesized subset that drops cache fields.
+      // Structural-equality check: the result event must forward a usage
+      // object deeply equal to the one the wire payload carried — not a
+      // synthesized subset that drops cache fields.
       assert.deepEqual(results[0].usage, usage)
     })
   })


### PR DESCRIPTION
## Summary

Companion pin to PR #5084's `/compact` fallback gate. Verifies that on a normal streamed turn, `cli-session.js`'s `result` event forwards the full `usage` payload — `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens` — to the subscription path, with **no synthetic fallback message**.

This closes the verification gap PR #5087 deferred: "did the fallback inadvertently swallow usage emission for normal streamed turns?"

## What this pins

- Streamed turn (`stream_event` → `text` block → `text_delta`) → `result` with `total_cost_usd: null` (subscription billing) and a full 4-field `usage` object.
- The `result` event emitted by `cli-session.js` carries `usage` verbatim — all four token fields preserved.
- The `message` channel sees nothing — the streamed turn's `stream_delta` is the canonical text surface; the fallback message added in #5084 stays gated behind `!hasStreamStarted`.

## Why this matters

A regression where #5084's fallback gate inadvertently dropped `usage` emission for streamed turns would silently zero the dashboard meter for every subscription user. The `session-manager.js` cost-gate (`_trackUsage`) consumes `resultData.usage.{input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens}` — pinning all four here means a future shallow restructure that forgets a cache field fails at this test, not silently in the meter.

## Result

Pure pinning — the contract holds on current main. All 37 tests in `cli-session-events.test.js` pass. No production code change.

Closes #5095

## Test plan

- [x] `node --import ./packages/server/tests/_setup.mjs --test packages/server/tests/cli-session-events.test.js` → 37/37 pass