### PR TITLE
feat(dashboard): warn when snapshot image survives a failed docker rmi (#5102)

### DIFF
--- a/packages/dashboard/src/components/SnapshotsPanel.test.tsx
+++ b/packages/dashboard/src/components/SnapshotsPanel.test.tsx
@@ -241,4 +241,142 @@ describe('SnapshotsPanel', () => {
     })
     expect(screen.getByTestId('snapshot-card-snap-fail')).toBeTruthy()
   })
+
+  // #5102 — `DELETE /api/snapshots/:slug` reports `imageRemoved: false` when
+  // the sidecar dropped but `docker rmi` failed (image still in use by
+  // another container, daemon down, etc.). The row legitimately disappears
+  // because the metadata is gone, but the operator needs to know an image
+  // is still on disk and which tag to clean up manually.
+  it('surfaces a warning with the tag when imageRemoved is false on a successful delete', async () => {
+    let listCalled = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (init?.method === 'DELETE') {
+        return new Response(
+          JSON.stringify({ ok: true, tag: 'chroxy-byok-snap:ghost-1', imageRemoved: false }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      if (url === '/api/snapshots') {
+        listCalled += 1
+        const snaps =
+          listCalled === 1
+            ? [makeSnap({ slug: 'snap-ghost', tag: 'chroxy-byok-snap:ghost-1' })]
+            : []
+        return new Response(JSON.stringify({ snapshots: snaps }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response('not found', { status: 404 })
+    })
+
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-card-snap-ghost')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByTestId('snapshot-delete-snap-ghost'))
+    fireEvent.click(screen.getByTestId('snapshot-confirm-yes-snap-ghost'))
+
+    // Sidecar dropped, row removed — same as the happy path so far.
+    await waitFor(() => {
+      expect(screen.queryByTestId('snapshot-card-snap-ghost')).toBeNull()
+    })
+
+    // But a warning notice must surface the leaked image tag so the
+    // operator knows to clean it up manually.
+    const warn = await screen.findByTestId('snapshots-warning')
+    expect(warn.textContent).toContain('chroxy-byok-snap:ghost-1')
+    expect(warn.textContent).toContain('docker rmi')
+
+    // The error banner stays unused — this is a partial-success warning,
+    // not an error.
+    expect(screen.queryByTestId('snapshots-error')).toBeNull()
+  })
+
+  it('dismisses the imageRemoved warning when its dismiss button is clicked', async () => {
+    let listCalled = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (init?.method === 'DELETE') {
+        return new Response(
+          JSON.stringify({ ok: true, tag: 'chroxy-byok-snap:leaked', imageRemoved: false }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      if (url === '/api/snapshots') {
+        listCalled += 1
+        const snaps =
+          listCalled === 1
+            ? [makeSnap({ slug: 'snap-leak', tag: 'chroxy-byok-snap:leaked' })]
+            : []
+        return new Response(JSON.stringify({ snapshots: snaps }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response('not found', { status: 404 })
+    })
+
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-card-snap-leak')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByTestId('snapshot-delete-snap-leak'))
+    fireEvent.click(screen.getByTestId('snapshot-confirm-yes-snap-leak'))
+
+    const warn = await screen.findByTestId('snapshots-warning')
+    expect(warn).toBeTruthy()
+
+    fireEvent.click(screen.getByTestId('snapshots-warning-dismiss'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('snapshots-warning')).toBeNull()
+    })
+  })
+
+  it('does not surface a warning when imageRemoved is true (happy path)', async () => {
+    let listCalled = 0
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (init?.method === 'DELETE') {
+        return new Response(
+          JSON.stringify({ ok: true, tag: 'chroxy-byok-snap:clean', imageRemoved: true }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      if (url === '/api/snapshots') {
+        listCalled += 1
+        const snaps =
+          listCalled === 1
+            ? [makeSnap({ slug: 'snap-clean', tag: 'chroxy-byok-snap:clean' })]
+            : []
+        return new Response(JSON.stringify({ snapshots: snaps }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      return new Response('not found', { status: 404 })
+    })
+
+    render(<SnapshotsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('snapshot-card-snap-clean')).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByTestId('snapshot-delete-snap-clean'))
+    fireEvent.click(screen.getByTestId('snapshot-confirm-yes-snap-clean'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('snapshot-card-snap-clean')).toBeNull()
+    })
+
+    // No warning should appear on the happy path.
+    expect(screen.queryByTestId('snapshots-warning')).toBeNull()
+  })
 })

--- a/packages/dashboard/src/components/SnapshotsPanel.tsx
+++ b/packages/dashboard/src/components/SnapshotsPanel.tsx
@@ -162,6 +162,10 @@ export function SnapshotsPanel({ fetchImpl, getToken }: SnapshotsPanelProps = {}
   const [snapshots, setSnapshots] = useState<Snapshot[]>([])
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<string | null>(null)
+  // #5102 — partial-success notice: the sidecar dropped but `docker rmi`
+  // failed (image still in use, daemon down). The row legitimately
+  // disappears, so without this the leaked image would be invisible.
+  const [warning, setWarning] = useState<string | null>(null)
   const [deletingSlug, setDeletingSlug] = useState<string | null>(null)
 
   // Hoist for testability — production passes neither override and falls
@@ -205,9 +209,23 @@ export function SnapshotsPanel({ fetchImpl, getToken }: SnapshotsPanelProps = {}
           const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
           throw new Error((body as { error?: string }).error || `HTTP ${res.status}`)
         }
+        const body = (await res
+          .json()
+          .catch(() => ({}))) as { tag?: string; imageRemoved?: boolean }
         // Drop locally so the row disappears even if a follow-up
         // /api/snapshots round-trip is slow. refresh() will reconcile.
         setSnapshots((prev) => prev.filter((s) => s.slug !== slug))
+        // #5102 — the metadata is gone (row removed) but `docker rmi`
+        // failed, so the image is still on disk. Surface the tag + the
+        // manual cleanup command since the operator can no longer see it.
+        if (body.imageRemoved === false) {
+          const tag = body.tag || slug
+          setWarning(
+            `Snapshot deleted, but its Docker image (${tag}) could not be removed — ` +
+              `it may still be in use or the daemon is unavailable. ` +
+              `Run \`docker rmi ${tag}\` to clean it up manually.`,
+          )
+        }
         // Best-effort refresh to catch any other state drift.
         void refresh()
       } catch (err) {
@@ -244,6 +262,30 @@ export function SnapshotsPanel({ fetchImpl, getToken }: SnapshotsPanelProps = {}
           style={{ color: 'var(--status-error, #ef4444)' }}
         >
           {error}
+        </div>
+      )}
+
+      {warning && (
+        <div
+          className="env-empty"
+          data-testid="snapshots-warning"
+          style={{
+            color: 'var(--status-warning, #f59e0b)',
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: '0.75rem',
+            justifyContent: 'space-between',
+          }}
+        >
+          <span>{warning}</span>
+          <button
+            className="btn-env-new"
+            data-testid="snapshots-warning-dismiss"
+            onClick={() => setWarning(null)}
+            title="Dismiss"
+          >
+            Dismiss
+          </button>
         </div>
       )}
 

--- a/packages/dashboard/src/components/SnapshotsPanel.tsx
+++ b/packages/dashboard/src/components/SnapshotsPanel.tsx
@@ -199,6 +199,9 @@ export function SnapshotsPanel({ fetchImpl, getToken }: SnapshotsPanelProps = {}
     async (slug: string) => {
       setDeletingSlug(slug)
       setError(null)
+      // Reset any warning from a prior delete so each operation starts
+      // clean — otherwise a stale tag can linger across a later success.
+      setWarning(null)
       const token = resolvedGetToken()
       try {
         const res = await resolvedFetch(`/api/snapshots/${encodeURIComponent(slug)}`, {
@@ -269,6 +272,8 @@ export function SnapshotsPanel({ fetchImpl, getToken }: SnapshotsPanelProps = {}
         <div
           className="env-empty"
           data-testid="snapshots-warning"
+          role="status"
+          aria-live="polite"
           style={{
             color: 'var(--status-warning, #f59e0b)',
             display: 'flex',
@@ -282,6 +287,7 @@ export function SnapshotsPanel({ fetchImpl, getToken }: SnapshotsPanelProps = {}
             className="btn-env-new"
             data-testid="snapshots-warning-dismiss"
             onClick={() => setWarning(null)}
+            aria-label="Dismiss warning"
             title="Dismiss"
           >
             Dismiss


### PR DESCRIPTION
## Summary

Closes #5102.

`DELETE /api/snapshots/:slug` returns `imageRemoved: false` when the metadata sidecar dropped but `docker rmi` failed (image still in use by another container, daemon down, etc.). The row legitimately disappears because the metadata is gone — so the leaked image was previously invisible to the operator.

This surfaces a dismissable warning in `SnapshotsPanel` showing the image tag and the manual `docker rmi <tag>` cleanup command. The error banner stays unused since this is a partial success, not a failure.

- New `warning` state, set from the DELETE response body when `imageRemoved === false`.
- New `snapshots-warning` notice + `snapshots-warning-dismiss` button.
- Happy path (`imageRemoved: true` or field absent) shows nothing.

## Test plan
- [x] `npx vitest run src/components/SnapshotsPanel.test.tsx` — 11/11 pass, including 3 new `imageRemoved` cases.