### PR TITLE
chore(desktop): commit autogenerated reset_speech_permissions capability

### DIFF
--- a/packages/desktop/src-tauri/permissions/autogenerated/reset_speech_permissions.toml
+++ b/packages/desktop/src-tauri/permissions/autogenerated/reset_speech_permissions.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-reset-speech-permissions"
+description = "Enables the reset_speech_permissions command without any pre-configured scope."
+commands.allow = ["reset_speech_permissions"]
+
+[[permission]]
+identifier = "deny-reset-speech-permissions"
+description = "Denies the reset_speech_permissions command without any pre-configured scope."
+commands.deny = ["reset_speech_permissions"]


### PR DESCRIPTION
## Summary

The `reset_speech_permissions` command (#4998) — backing the desktop "Reset macOS speech permissions" affordance — ships in `lib.rs` and is referenced as `allow-reset-speech-permissions` in `capabilities/default.json`. But its Tauri-autogenerated permission TOML was never committed, unlike every sibling in `permissions/autogenerated/`.

Result: every desktop build regenerates the file and leaves the working tree dirty (it was sitting untracked locally). This commits it so the tree stays clean.

No code change — generated artifact only.

## Test plan
- [x] Confirmed `reset_speech_permissions` is defined and registered in `src-tauri/src/lib.rs` and `allow-reset-speech-permissions` is listed in `capabilities/default.json`.
- [x] File content matches the Tauri autogenerated format of its siblings (`# Automatically generated - DO NOT EDIT!`).