### PR TITLE
fix(server): canonicalize devcontainer fingerprint input (sort keys) (#5103)

### DIFF
--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -1140,18 +1140,29 @@ export class DockerByokSession extends ClaudeByokSession {
    * boolean, null, undefined). It deliberately omits exotic JSON.stringify
    * features (toJSON, replacer, BigInt) — the call site never sees them.
    *
+   * Matches JSON.stringify's `undefined` semantics so an "empty overlay"
+   * (where mounts/containerEnv/forwardPorts/postCreateCommand are all
+   * absent) serialises to a clean `{}` rather than emitting non-JSON
+   * `...:undefined` slots: object properties whose value is `undefined`
+   * are dropped, and a top-level `undefined` yields the empty string —
+   * exactly as `JSON.stringify` does.
+   *
    * @param {unknown} value
    * @returns {string}
    */
   _canonicalStringify(value) {
     if (Array.isArray(value)) {
-      return '[' + value.map(v => this._canonicalStringify(v)).join(',') + ']'
+      // JSON.stringify renders an undefined array element as `null`.
+      return '[' + value.map(v => (v === undefined ? 'null' : this._canonicalStringify(v))).join(',') + ']'
     }
     if (value && typeof value === 'object') {
-      const keys = Object.keys(value).sort()
+      const keys = Object.keys(value)
+        .filter(k => value[k] !== undefined) // JSON.stringify omits undefined props
+        .sort()
       return '{' + keys.map(k => JSON.stringify(k) + ':' + this._canonicalStringify(value[k])).join(',') + '}'
     }
-    return JSON.stringify(value)
+    // JSON.stringify(undefined) === undefined (not a string); normalise to ''.
+    return JSON.stringify(value) ?? ''
   }
 
   /**

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -1098,12 +1098,12 @@ export class DockerByokSession extends ClaudeByokSession {
    * value, in which case a change to the file's `image` field doesn't
    * actually change the resolved launch shape).
    *
-   * Note on stability: `JSON.stringify` follows insertion order for
-   * plain objects, which is fine for `_dcConfig` because both the
-   * parser and the sanitiser build it in a deterministic order. If a
-   * future refactor reshuffles the fields, two equivalent configs
-   * could fingerprint differently — at worst that's a one-time pool
-   * miss after the change, never a stale-config hit.
+   * Note on stability: #5103 — the input is canonicalised via
+   * `_canonicalStringify` (object keys sorted recursively) before
+   * hashing, so semantically identical overlays produce the same
+   * fingerprint regardless of source-side key order. Arrays are
+   * preserved in declared order because devcontainer.json arrays
+   * (mounts, forwardPorts) are order-sensitive.
    *
    * @param {object|null} resolved
    * @returns {string|null}
@@ -1112,16 +1112,46 @@ export class DockerByokSession extends ClaudeByokSession {
     if (!resolved || typeof resolved !== 'object') return null
     // Project the resolved overlay down to only the fields that
     // affect container provisioning but are NOT already in the base
-    // pool key. Built in a fixed key order so the fingerprint is
-    // stable regardless of how the source `resolved` object was
-    // assembled.
+    // pool key. Key order here is irrelevant — _canonicalStringify
+    // sorts before hashing.
     const fingerprintInput = {
       mounts: resolved.mounts,
       containerEnv: resolved.containerEnv,
       forwardPorts: resolved.forwardPorts,
       postCreateCommand: resolved.postCreateCommand,
     }
-    return createHash('sha1').update(JSON.stringify(fingerprintInput)).digest('hex').slice(0, 16)
+    return createHash('sha1').update(this._canonicalStringify(fingerprintInput)).digest('hex').slice(0, 16)
+  }
+
+  /**
+   * #5103: Canonical (stable) JSON-shaped stringifier that sorts object
+   * keys recursively. Arrays preserve their declared order because
+   * devcontainer.json arrays (mounts, forwardPorts, runArgs) are
+   * order-sensitive — the consuming tool may treat the first mount
+   * differently from the last, and forwarded ports surface in the UI
+   * in declared order.
+   *
+   * Used by `_computeDevcontainerFingerprint` so an editor that
+   * alphabetises object keys (or a hand-edit that reorders them)
+   * cannot bust the pool key for a semantically unchanged overlay.
+   *
+   * NOT a full JSON serialiser — this only handles values reachable
+   * from a parsed devcontainer.json (object, array, string, number,
+   * boolean, null, undefined). It deliberately omits exotic JSON.stringify
+   * features (toJSON, replacer, BigInt) — the call site never sees them.
+   *
+   * @param {unknown} value
+   * @returns {string}
+   */
+  _canonicalStringify(value) {
+    if (Array.isArray(value)) {
+      return '[' + value.map(v => this._canonicalStringify(v)).join(',') + ']'
+    }
+    if (value && typeof value === 'object') {
+      const keys = Object.keys(value).sort()
+      return '{' + keys.map(k => JSON.stringify(k) + ':' + this._canonicalStringify(value[k])).join(',') + '}'
+    }
+    return JSON.stringify(value)
   }
 
   /**

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -3019,6 +3019,91 @@ describe('DockerByokSession — devcontainer fingerprint in pool key (#5080)', (
       rmSync(cwdB, { recursive: true, force: true })
     }
   })
+
+  it('#5103: containerEnv key order in devcontainer.json does NOT change fingerprint', () => {
+    // The pre-#5103 fingerprint used JSON.stringify, which serialises
+    // object keys in insertion order. An editor that alphabetises keys
+    // (or a hand-edit that reorders them) would produce a different
+    // fingerprint for semantically identical overlays, busting the pool
+    // unnecessarily. The fix: canonical-stringify (sort object keys
+    // recursively) before hashing. JSON parsing preserves source order,
+    // so writing the file with two different key orders is a faithful
+    // proxy for the editor-reformat scenario.
+    const cwdA = makeDevcontainerCwd({ containerEnv: { LANG: 'en_US.UTF-8', TZ: 'UTC' } })
+    const cwdB = mkdtempSync(join(tmpdir(), 'chroxy-dc-fp-test-'))
+    mkdirSync(join(cwdB, '.devcontainer'), { recursive: true })
+    // Hand-craft the JSON so the key order is preserved on parse —
+    // JSON.stringify({LANG, TZ}) and JSON.stringify({TZ, LANG}) produce
+    // different strings, and so do their parsed-then-restringified forms
+    // without canonicalisation.
+    writeFileSync(
+      join(cwdB, '.devcontainer', 'devcontainer.json'),
+      '{"containerEnv":{"TZ":"UTC","LANG":"en_US.UTF-8"}}'
+    )
+    try {
+      const sessionA = makeSession(cwdA)
+      const sessionB = makeSession(cwdB)
+      sessionA._resolveDevContainer()
+      sessionB._resolveDevContainer()
+      assert.equal(sessionA._devcontainerFingerprint, sessionB._devcontainerFingerprint,
+        'containerEnv key order must not affect the fingerprint')
+    } finally {
+      rmSync(cwdA, { recursive: true, force: true })
+      rmSync(cwdB, { recursive: true, force: true })
+    }
+  })
+
+  it('#5103: nested object key order does NOT change fingerprint', () => {
+    // Recursion check — a nested object inside the overlay must also be
+    // canonicalised. We exercise this via containerEnv (the most likely
+    // map field) but the contract is: every plain object at every depth
+    // is key-sorted before hashing.
+    const cwdA = mkdtempSync(join(tmpdir(), 'chroxy-dc-fp-test-'))
+    const cwdB = mkdtempSync(join(tmpdir(), 'chroxy-dc-fp-test-'))
+    mkdirSync(join(cwdA, '.devcontainer'), { recursive: true })
+    mkdirSync(join(cwdB, '.devcontainer'), { recursive: true })
+    writeFileSync(
+      join(cwdA, '.devcontainer', 'devcontainer.json'),
+      '{"containerEnv":{"A":"1","B":"2","C":"3"},"postCreateCommand":"echo hi"}'
+    )
+    writeFileSync(
+      join(cwdB, '.devcontainer', 'devcontainer.json'),
+      '{"postCreateCommand":"echo hi","containerEnv":{"C":"3","B":"2","A":"1"}}'
+    )
+    try {
+      const sessionA = makeSession(cwdA)
+      const sessionB = makeSession(cwdB)
+      sessionA._resolveDevContainer()
+      sessionB._resolveDevContainer()
+      assert.equal(sessionA._devcontainerFingerprint, sessionB._devcontainerFingerprint,
+        'top-level and nested key reordering must not affect the fingerprint')
+    } finally {
+      rmSync(cwdA, { recursive: true, force: true })
+      rmSync(cwdB, { recursive: true, force: true })
+    }
+  })
+
+  it('#5103: forwardPorts array order DOES change fingerprint (arrays are order-sensitive)', () => {
+    // Arrays in devcontainer.json are NOT semantically order-insensitive —
+    // forwardPorts: [3000, 8080] is not the same as [8080, 3000] in
+    // every consuming tool, and mounts order can matter for overlay
+    // shadowing. The canonical serializer must NOT sort array values,
+    // only object keys. Two overlays differing only in array order
+    // must therefore still fingerprint differently.
+    const cwdA = makeDevcontainerCwd({ forwardPorts: [3000, 8080] })
+    const cwdB = makeDevcontainerCwd({ forwardPorts: [8080, 3000] })
+    try {
+      const sessionA = makeSession(cwdA)
+      const sessionB = makeSession(cwdB)
+      sessionA._resolveDevContainer()
+      sessionB._resolveDevContainer()
+      assert.notEqual(sessionA._devcontainerFingerprint, sessionB._devcontainerFingerprint,
+        'array order must still bust the fingerprint — arrays are order-sensitive')
+    } finally {
+      rmSync(cwdA, { recursive: true, force: true })
+      rmSync(cwdB, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('DockerByokSession — Docker Compose support (#5024)', () => {

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -3104,6 +3104,42 @@ describe('DockerByokSession — devcontainer fingerprint in pool key (#5080)', (
       rmSync(cwdB, { recursive: true, force: true })
     }
   })
+
+  it('#5103: _canonicalStringify matches JSON.stringify for undefined props (empty overlay → {})', () => {
+    // Copilot review: the canonical serializer must drop object properties
+    // whose value is `undefined` (as JSON.stringify does) rather than
+    // emitting non-JSON `...:undefined` slots. The most important case is
+    // the "empty overlay" where all four fingerprintInput fields are
+    // undefined — it must canonicalise to `{}`, identical to the pre-#5103
+    // JSON.stringify output, so an overlay-free devcontainer.json keeps a
+    // stable, clean fingerprint.
+    const cwd = mkdtempSync(join(tmpdir(), 'chroxy-dc-fp-test-'))
+    mkdirSync(join(cwd, '.devcontainer'), { recursive: true })
+    writeFileSync(join(cwd, '.devcontainer', 'devcontainer.json'), '{}')
+    try {
+      const session = makeSession(cwd)
+      const emptyOverlay = {
+        mounts: undefined,
+        containerEnv: undefined,
+        forwardPorts: undefined,
+        postCreateCommand: undefined,
+      }
+      assert.equal(session._canonicalStringify(emptyOverlay), '{}',
+        'all-undefined overlay must canonicalise to {} like JSON.stringify')
+      // Partial overlay: undefined props dropped, defined props kept + sorted.
+      assert.equal(
+        session._canonicalStringify({ postCreateCommand: 'echo hi', mounts: undefined, containerEnv: { B: '2', A: '1' } }),
+        JSON.stringify({ containerEnv: { A: '1', B: '2' }, postCreateCommand: 'echo hi' }),
+        'undefined props dropped; defined object keys sorted recursively, matching JSON',
+      )
+      // Top-level undefined → empty string, exactly like JSON.stringify(undefined).
+      assert.equal(session._canonicalStringify(undefined), '')
+      // Array undefined element → null, exactly like JSON.stringify([undefined]).
+      assert.equal(session._canonicalStringify([1, undefined, 2]), '[1,null,2]')
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('DockerByokSession — Docker Compose support (#5024)', () => {


### PR DESCRIPTION
## Summary

`_computeDevcontainerFingerprint` hashed `JSON.stringify(fingerprintInput)`, which serialises object keys in **insertion order**. An editor that alphabetises `.devcontainer/devcontainer.json` keys (or a hand-edit that reorders them) produced a *different* fingerprint for a semantically identical overlay, busting the container pool key unnecessarily.

This PR replaces `JSON.stringify` with a recursive `_canonicalStringify` helper that sorts object keys at every depth before encoding. **Arrays preserve their declared order** because devcontainer.json arrays (`mounts`, `forwardPorts`, `runArgs`) are order-sensitive. Primitives serialise identically to `JSON.stringify`.

Follow-up to #5080 / review of #5099.

## Acceptance Criteria

- [x] Reformatted (key-sorted) devcontainer.json with identical semantic content produces the same fingerprint
- [x] Existing fingerprint stability tests still pass
- [x] New test: containerEnv with `{LANG, TZ}` ordering fingerprints identically to `{TZ, LANG}`
- [x] No regression in the "changed field bust" tests (array-order test confirms arrays still bust)

## Test plan

- `node --test packages/server/tests/docker-byok-session.test.js` → **127/127 pass**, including 3 new #5103 cases:
  - containerEnv key order does NOT change fingerprint
  - nested object key order does NOT change fingerprint
  - forwardPorts array order DOES change fingerprint (arrays remain order-sensitive)
- `./scripts/lint-tests-state-file-path.sh` → OK
- `./scripts/lint-session-opt-forwarding.sh` → OK

Closes #5103