### PR TITLE
feat(server): add pool.inspect() per-key bucket snapshots (#5052)

### DIFF
--- a/packages/server/src/docker-byok-pool.js
+++ b/packages/server/src/docker-byok-pool.js
@@ -391,7 +391,11 @@ export class DockerContainerPool extends EventEmitter {
     // container doesn't keep the event loop alive on shutdown.
     if (timer && typeof timer.unref === 'function') timer.unref()
     this._createdAt.set(containerId, createdAt)
-    bucket.push({ containerId, timer, createdAt })
+    // Stamp releasedAt on every pooled entry so `inspect()` (#5052) can
+    // report `oldestIdleMs` without iterating timers. We already have
+    // `now` from the over-age check above; reuse it so the stamp matches
+    // the bookkeeping time exactly.
+    bucket.push({ containerId, timer, createdAt, releasedAt: now })
     this._entries.set(key, bucket)
     this._emitPoolEvent(POOL_EVENTS.RELEASED, { key, containerId })
     log.info(`pool release: ${containerId.slice(0, 12)} → ${key} (idle ${this._idleTimeoutMs}ms, age ${age}ms/${this._maxAgeMs}ms)`)
@@ -414,6 +418,52 @@ export class DockerContainerPool extends EventEmitter {
   sizeOf(key) {
     const bucket = this._entries.get(key)
     return bucket ? bucket.length : 0
+  }
+
+  /**
+   * Read-only per-key bucket snapshot (#5052). Returns one
+   * `{ key, size, oldestIdleMs }` for every non-empty bucket, sorted by
+   * key ascending so output is stable for tests and dashboard diffs.
+   *
+   *   - `size`          — number of containers currently parked under
+   *                       this key.
+   *   - `oldestIdleMs`  — `now - max(entry.releasedAt)` across the
+   *                       bucket; the idle age of the OLDEST parked
+   *                       container. Useful for leak detection and
+   *                       idle-lifetime distribution.
+   *
+   * Companion to the structured event stream (#5044):
+   *   - Events answer "what did the pool DO recently?"
+   *   - `inspect()` answers "what's parked right now?"
+   *
+   * SHALLOW snapshot: caller mutations on the returned array (or its
+   * entry objects) MUST NOT affect pool state. We build fresh plain
+   * objects and never expose the internal `_entries` Map.
+   *
+   * @returns {Array<{ key: string, size: number, oldestIdleMs: number }>}
+   */
+  inspect() {
+    const now = this._now()
+    const snapshot = []
+    for (const [key, bucket] of this._entries.entries()) {
+      if (!bucket || bucket.length === 0) continue
+      // `oldestIdleMs` = max(now - releasedAt) across the bucket. The
+      // oldest entry is the one with the SMALLEST releasedAt — fall
+      // back to `now` (idle 0) if an entry somehow lacks the stamp so
+      // the snapshot stays well-formed in pathological cases.
+      let oldestReleasedAt = now
+      for (const entry of bucket) {
+        const ra = typeof entry.releasedAt === 'number' ? entry.releasedAt : now
+        if (ra < oldestReleasedAt) oldestReleasedAt = ra
+      }
+      snapshot.push({
+        key,
+        size: bucket.length,
+        oldestIdleMs: now - oldestReleasedAt,
+      })
+    }
+    snapshot.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
+    return snapshot
   }
 
   /**

--- a/packages/server/src/docker-byok-pool.js
+++ b/packages/server/src/docker-byok-pool.js
@@ -427,10 +427,11 @@ export class DockerContainerPool extends EventEmitter {
    *
    *   - `size`          — number of containers currently parked under
    *                       this key.
-   *   - `oldestIdleMs`  — `now - max(entry.releasedAt)` across the
-   *                       bucket; the idle age of the OLDEST parked
-   *                       container. Useful for leak detection and
-   *                       idle-lifetime distribution.
+   *   - `oldestIdleMs`  — `now - min(entry.releasedAt)` across the
+   *                       bucket; i.e. `max(now - releasedAt)`, the idle
+   *                       age of the OLDEST parked container (the one
+   *                       released longest ago). Useful for leak
+   *                       detection and idle-lifetime distribution.
    *
    * Companion to the structured event stream (#5044):
    *   - Events answer "what did the pool DO recently?"

--- a/packages/server/tests/docker-byok-pool.test.js
+++ b/packages/server/tests/docker-byok-pool.test.js
@@ -892,7 +892,8 @@ describe('DockerContainerPool — inspect() (#5052)', () => {
    *     non-empty bucket.
    *   - Sorted by `key` ascending so the output is stable for tests and
    *     dashboard diffs.
-   *   - `oldestIdleMs` = `now - max(releasedAt for entry in bucket)`.
+   *   - `oldestIdleMs` = `now - min(releasedAt for entry in bucket)`, i.e.
+   *     `max(now - releasedAt)` — the idle age of the OLDEST parked entry.
    *   - SHALLOW snapshot: caller mutations to the returned array MUST NOT
    *     leak back into pool state (no live Map / array references).
    *   - `release()` stamps `releasedAt` on every entry so `oldestIdleMs`

--- a/packages/server/tests/docker-byok-pool.test.js
+++ b/packages/server/tests/docker-byok-pool.test.js
@@ -879,3 +879,192 @@ describe('DockerContainerPool — forget() (#5045 review)', () => {
     assert.equal(execFile.calls.length, 0, 'must not call docker rm -f with an empty id')
   })
 })
+
+describe('DockerContainerPool — inspect() (#5052)', () => {
+  /**
+   * `inspect()` is a read-only snapshot of what's currently parked in the
+   * pool. The event stream (#5044) answers "what did the pool do in the
+   * last 60s?"; `inspect()` answers "what's parked right now, and for how
+   * long?" — feeding the dashboard pool-health panel (#5053).
+   *
+   * Contract per #5052:
+   *   - Returns an Array of `{ key, size, oldestIdleMs }` — one entry per
+   *     non-empty bucket.
+   *   - Sorted by `key` ascending so the output is stable for tests and
+   *     dashboard diffs.
+   *   - `oldestIdleMs` = `now - max(releasedAt for entry in bucket)`.
+   *   - SHALLOW snapshot: caller mutations to the returned array MUST NOT
+   *     leak back into pool state (no live Map / array references).
+   *   - `release()` stamps `releasedAt` on every entry so `oldestIdleMs`
+   *     can be computed without iterating timers.
+   */
+
+  it('returns an empty array on an empty pool', () => {
+    const pool = new DockerContainerPool({ _execFile: execFileStub() })
+    const snap = pool.inspect()
+    assert.ok(Array.isArray(snap))
+    assert.equal(snap.length, 0)
+  })
+
+  it('returns one entry per non-empty bucket with key, size, oldestIdleMs', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    let now = 1_000_000
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+      _now: () => now,
+    })
+    await pool.release('shape-a', 'C1')
+    now += 250
+    const snap = pool.inspect()
+    assert.equal(snap.length, 1)
+    assert.equal(snap[0].key, 'shape-a')
+    assert.equal(snap[0].size, 1)
+    assert.equal(snap[0].oldestIdleMs, 250)
+  })
+
+  it('computes oldestIdleMs from the OLDEST entry in the bucket (highest age)', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    let now = 1_000_000
+    const pool = new DockerContainerPool({
+      maxPerKey: 5,
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+      _now: () => now,
+    })
+    await pool.release('shape', 'OLD') // releasedAt = 1_000_000
+    now += 1000
+    await pool.release('shape', 'NEW') // releasedAt = 1_001_000
+    now += 500 // inspect at 1_001_500
+    const snap = pool.inspect()
+    assert.equal(snap.length, 1)
+    assert.equal(snap[0].key, 'shape')
+    assert.equal(snap[0].size, 2)
+    // OLD's idle age: 1_001_500 - 1_000_000 = 1500
+    // NEW's idle age: 1_001_500 - 1_001_000 = 500
+    // oldestIdleMs picks the larger one — the oldest entry.
+    assert.equal(snap[0].oldestIdleMs, 1500)
+  })
+
+  it('returns buckets sorted by key ascending (stable output)', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    // Release in non-alphabetical order; inspect() must still sort asc.
+    await pool.release('shape-c', 'C_C')
+    await pool.release('shape-a', 'C_A')
+    await pool.release('shape-b', 'C_B')
+    const snap = pool.inspect()
+    assert.deepEqual(snap.map((b) => b.key), ['shape-a', 'shape-b', 'shape-c'])
+  })
+
+  it('omits empty buckets — only non-empty buckets appear in the snapshot', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    await pool.release('shape-keep', 'C_KEEP')
+    await pool.release('shape-drain', 'C_DRAIN')
+    // Drain shape-drain so its bucket is empty.
+    assert.equal(pool.acquire('shape-drain'), 'C_DRAIN')
+    const snap = pool.inspect()
+    assert.equal(snap.length, 1)
+    assert.equal(snap[0].key, 'shape-keep')
+  })
+
+  it('reflects state after eviction (over-cap release does not appear in snapshot)', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      maxPerKey: 1,
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    await pool.release('k', 'C1')
+    await pool.release('k', 'C2') // evicted over cap
+    const snap = pool.inspect()
+    assert.equal(snap.length, 1)
+    assert.equal(snap[0].size, 1)
+  })
+
+  it('reflects state after markSoiled+release (soiled-evicted entry does not appear)', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    pool.markSoiled('C_SOILED')
+    await pool.release('k', 'C_SOILED')
+    const snap = pool.inspect()
+    assert.equal(snap.length, 0)
+  })
+
+  it('returns a SHALLOW snapshot — mutating the returned array must not affect pool state', async () => {
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+    })
+    await pool.release('shape-a', 'C1')
+    await pool.release('shape-b', 'C2')
+    const snap = pool.inspect()
+    // Mutate the array and the entry objects.
+    snap.length = 0
+    const snap2 = pool.inspect()
+    assert.equal(snap2.length, 2, 'pool must still report both buckets')
+    snap2[0].size = 999
+    snap2[0].key = 'tampered'
+    const snap3 = pool.inspect()
+    assert.notEqual(snap3[0].size, 999, 'pool state must not have been mutated')
+    assert.notEqual(snap3[0].key, 'tampered')
+  })
+
+  it('release stamps releasedAt on every pooled entry', async () => {
+    // The pool needs releasedAt to compute oldestIdleMs without
+    // iterating timers. Verify the stamp lands on the internal entry.
+    const timers = timerStubs()
+    const execFile = execFileStub()
+    let now = 1_000_000
+    const pool = new DockerContainerPool({
+      _execFile: execFile,
+      _setTimeout: timers.setT,
+      _clearTimeout: timers.clearT,
+      _now: () => now,
+    })
+    await pool.release('k', 'C1')
+    const bucket = pool._entries.get('k')
+    assert.ok(bucket && bucket.length === 1)
+    assert.equal(bucket[0].releasedAt, 1_000_000)
+    // A second release of the same id resets releasedAt to "now".
+    assert.equal(pool.acquire('k'), 'C1')
+    now += 5000
+    await pool.release('k', 'C1')
+    const bucket2 = pool._entries.get('k')
+    assert.equal(bucket2[0].releasedAt, 1_005_000)
+  })
+
+  it('inspect after shutdown returns an empty array', async () => {
+    const execFile = execFileStub()
+    const pool = new DockerContainerPool({ _execFile: execFile })
+    await pool.release('k', 'C1')
+    await pool.shutdown()
+    const snap = pool.inspect()
+    assert.equal(snap.length, 0)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a read-only `pool.inspect()` to `DockerContainerPool` returning a per-key bucket snapshot for debugging and dashboard pool-health views. Complements the structured event stream (#5044): events report what the pool *did*; `inspect()` reports what is *currently parked* and for how long.

`release()` now stamps `releasedAt: now` on each pooled entry so idle age can be computed without iterating timers.

## Acceptance criteria (#5052)

- [x] `release()` stamps `releasedAt: this._now()` on each entry (uses the pool's existing `_now` time seam)
- [x] `pool.inspect()` returns `[{ key, size, oldestIdleMs }]` for every non-empty bucket
- [x] `oldestIdleMs = now - min(releasedAt in bucket)` = `max(now - releasedAt)` (idle age of the OLDEST parked container — the issue's literal `max(releasedAt)` is a typo; intent is the oldest container)
- [x] Snapshot sorted by key ascending for stable output
- [x] Tests cover empty pool, single bucket, multi-bucket

## Notes

- Shallow snapshot: builds fresh plain objects, never exposes the internal `_entries` Map — caller mutation cannot leak back into pool state.
- Empty buckets are omitted from the snapshot.
- Plays nicely with the #5106 soiled-skip / over-cap / over-age eviction paths: `inspect()` reads live bucket state so evicted entries never appear.

## Test plan

- `node --test packages/server/tests/docker-byok-pool.test.js` — 62 tests pass (10 new `inspect()` cases).
- `./scripts/lint-tests-state-file-path.sh` — pass.
- `./scripts/lint-session-opt-forwarding.sh` — pass.

Closes #5052