### PR TITLE
feat(server): persist docker-byok compose project ids for crash cleanup (#5081)

### DIFF
--- a/packages/server/src/byok-compose-state-shared.js
+++ b/packages/server/src/byok-compose-state-shared.js
@@ -1,0 +1,31 @@
+/**
+ * Process-wide singleton for the docker-byok compose-state store (#5081).
+ *
+ * Kept in its own module so live `DockerByokSession`s (which record/forget
+ * their project id) and the boot-time `sweepOrphanedComposeStacks()` agree on
+ * exactly one on-disk state file. Mirrors `getSharedPool()` in
+ * docker-byok-pool.js.
+ */
+
+import { ByokComposeStateStore } from './byok-compose-state.js'
+
+let _shared = null
+
+/**
+ * Lazily construct (once) and return the process-wide compose-state store.
+ * @returns {ByokComposeStateStore}
+ */
+export function getSharedComposeStateStore() {
+  if (!_shared) {
+    _shared = new ByokComposeStateStore({})
+  }
+  return _shared
+}
+
+/**
+ * Test helper — reset the singleton so a test using the real default path
+ * doesn't bleed into the next. Not used in production.
+ */
+export function _resetSharedComposeStateStore() {
+  _shared = null
+}

--- a/packages/server/src/byok-compose-state.js
+++ b/packages/server/src/byok-compose-state.js
@@ -134,14 +134,30 @@ export class ByokComposeStateStore {
         return
       }
       for (const entry of data.stacks) {
-        if (entry && typeof entry.projectId === 'string' && entry.projectId) {
-          this._stacks.set(entry.projectId, {
-            projectId: entry.projectId,
-            composeFile: entry.composeFile,
-            cwd: entry.cwd,
-            createdAt: entry.createdAt,
-          })
+        // Drop entries missing any required field (or with non-string
+        // values). A half-written / hand-edited record with an undefined
+        // composeFile or cwd would otherwise reach the boot sweep and call
+        // destroyComposeEnvironment with undefined args — which fails and,
+        // because a failed teardown is retained for retry, would never
+        // clear. Skipping it here is the safe default.
+        if (
+          !entry
+          || typeof entry.projectId !== 'string' || !entry.projectId
+          || typeof entry.composeFile !== 'string' || !entry.composeFile
+          || typeof entry.cwd !== 'string' || !entry.cwd
+        ) {
+          continue
         }
+        this._stacks.set(entry.projectId, {
+          projectId: entry.projectId,
+          composeFile: entry.composeFile,
+          cwd: entry.cwd,
+          // Normalise a missing/invalid createdAt rather than persisting
+          // `undefined` back out on the next write.
+          createdAt: typeof entry.createdAt === 'string' && entry.createdAt
+            ? entry.createdAt
+            : new Date().toISOString(),
+        })
       }
     } catch {
       // Corrupt / non-JSON state file — start empty rather than crash.

--- a/packages/server/src/byok-compose-state.js
+++ b/packages/server/src/byok-compose-state.js
@@ -1,0 +1,188 @@
+/**
+ * docker-byok compose-project-id persistence (#5081).
+ *
+ * `DockerByokSession` generates `_composeProject = 'chroxy-byok-<rand-hex>'`
+ * lazily inside `_startComposeStack`. Held in memory only, a daemon crash /
+ * SIGKILL between `docker compose up` and `docker compose down` leaks the
+ * whole stack with no on-disk paper trail.
+ *
+ * This store mirrors EnvironmentManager's on-disk shape (`{ version, stacks }`,
+ * atomic restricted write) so each running compose stack leaves a durable
+ * record. A boot-time `sweepOrphanedComposeStacks()` then runs
+ * `docker compose down --remove-orphans` against every leftover project id
+ * before any new sessions launch.
+ *
+ * State-file shape:
+ *   {
+ *     "version": 1,
+ *     "stacks": [
+ *       { "projectId": "chroxy-byok-ab12cd", "composeFile": "/proj/docker-compose.yml",
+ *         "cwd": "/work/proj", "createdAt": "2026-06-03T..." }
+ *     ]
+ *   }
+ */
+
+import { existsSync, readFileSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+
+import { writeFileRestricted } from './platform.js'
+
+const STATE_VERSION = 1
+
+/**
+ * Default on-disk location, mirroring environment-manager.js's
+ * `~/.chroxy/environments.json`. Honors CHROXY_CONFIG_DIR like the rest of
+ * the docker-byok stack does.
+ */
+export const DEFAULT_BYOK_COMPOSE_STATE_PATH = join(
+  process.env.CHROXY_CONFIG_DIR || join(homedir(), '.chroxy'),
+  'byok-compose-state.json',
+)
+
+/**
+ * Synchronous, crash-durable store of live compose project ids.
+ *
+ * Every mutation persists immediately via `writeFileRestricted` (atomic on
+ * POSIX + Windows, mode 0600) so a crash right after the in-memory mutation
+ * still leaves the durable record the boot sweep relies on.
+ */
+export class ByokComposeStateStore {
+  /**
+   * @param {object}  opts
+   * @param {string} [opts.statePath] - On-disk path for byok-compose-state.json.
+   */
+  constructor({ statePath } = {}) {
+    this._statePath = statePath || DEFAULT_BYOK_COMPOSE_STATE_PATH
+    // Map<projectId, entry> so record() on an existing id replaces in place
+    // and forget() is O(1). Insertion order is preserved by Map iteration.
+    this._stacks = new Map()
+    this._load()
+  }
+
+  /**
+   * Record (or replace) a live compose stack and persist to disk.
+   *
+   * @param {object} entry
+   * @param {string} entry.projectId   - Compose project id (chroxy-byok-<hex>).
+   * @param {string} entry.composeFile - Absolute path to the compose file.
+   * @param {string} entry.cwd         - Working directory the stack runs in.
+   */
+  record({ projectId, composeFile, cwd } = {}) {
+    if (!projectId || typeof projectId !== 'string') {
+      throw new Error('record() requires a non-empty projectId')
+    }
+    if (!composeFile || typeof composeFile !== 'string') {
+      throw new Error('record() requires a non-empty composeFile')
+    }
+    if (!cwd || typeof cwd !== 'string') {
+      throw new Error('record() requires a non-empty cwd')
+    }
+    this._stacks.set(projectId, {
+      projectId,
+      composeFile,
+      cwd,
+      createdAt: new Date().toISOString(),
+    })
+    this._persist()
+  }
+
+  /**
+   * Remove a stack by project id and persist. No-op if unknown.
+   */
+  forget(projectId) {
+    if (this._stacks.delete(projectId)) {
+      this._persist()
+    }
+  }
+
+  /**
+   * Snapshot of all recorded stacks (insertion order).
+   * @returns {Array<{projectId:string, composeFile:string, cwd:string, createdAt:string}>}
+   */
+  list() {
+    return Array.from(this._stacks.values()).map((s) => ({ ...s }))
+  }
+
+  _persist() {
+    try {
+      const dir = dirname(this._statePath)
+      if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+      const data = {
+        version: STATE_VERSION,
+        stacks: Array.from(this._stacks.values()),
+      }
+      // writeFileRestricted is atomic on both POSIX and Windows and cleans
+      // up its intermediate `.tmp` on rename failure — no manual tmp+rename
+      // wrapper needed.
+      writeFileRestricted(this._statePath, JSON.stringify(data, null, 2))
+    } catch (err) {
+      // Persistence is best-effort: a write failure must not take down the
+      // session that triggered it. The worst case degrades back to the
+      // pre-#5081 "in-memory only" behaviour.
+      // eslint-disable-next-line no-console
+      console.warn(`[byok-compose-state] failed to persist: ${err.message}`)
+    }
+  }
+
+  _load() {
+    if (!existsSync(this._statePath)) return
+    try {
+      const data = JSON.parse(readFileSync(this._statePath, 'utf-8'))
+      if (!data || data.version !== STATE_VERSION || !Array.isArray(data.stacks)) {
+        // Unknown version or corrupt shape — ignore rather than crash.
+        return
+      }
+      for (const entry of data.stacks) {
+        if (entry && typeof entry.projectId === 'string' && entry.projectId) {
+          this._stacks.set(entry.projectId, {
+            projectId: entry.projectId,
+            composeFile: entry.composeFile,
+            cwd: entry.cwd,
+            createdAt: entry.createdAt,
+          })
+        }
+      }
+    } catch {
+      // Corrupt / non-JSON state file — start empty rather than crash.
+    }
+  }
+}
+
+/**
+ * Boot-time garbage collector. Tears down every persisted compose stack via
+ * the backend's `destroyComposeEnvironment`, forgetting each one only after a
+ * successful teardown so a transient docker-down failure is retried on the
+ * next boot.
+ *
+ * @param {object} args
+ * @param {ByokComposeStateStore} args.store   - The persistence store.
+ * @param {object} args.backend                - Object with
+ *   `destroyComposeEnvironment({ composeFile, composeProject, cwd })`.
+ * @returns {Promise<{swept:number, failed:number}>}
+ */
+export async function sweepOrphanedComposeStacks({ store, backend } = {}) {
+  const stacks = store.list()
+  let swept = 0
+  let failed = 0
+  for (const stack of stacks) {
+    try {
+      await backend.destroyComposeEnvironment({
+        composeFile: stack.composeFile,
+        composeProject: stack.projectId,
+        cwd: stack.cwd,
+      })
+      // Only forget after a clean teardown — a failure leaves the entry on
+      // disk so the next boot retries.
+      store.forget(stack.projectId)
+      swept += 1
+    } catch (err) {
+      failed += 1
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[byok-compose-state] sweep of ${stack.projectId} failed (will retry next boot): ${err.message}`,
+      )
+    }
+  }
+  return { swept, failed }
+}

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -105,6 +105,7 @@ import { ClaudeByokSession } from './byok-session.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
 import { buildPoolKey, getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
+import { getSharedComposeStateStore } from './byok-compose-state-shared.js'
 import { createLogger } from './logger.js'
 import { writeFileRestricted } from './platform.js'
 import {
@@ -469,6 +470,15 @@ export class DockerByokSession extends ClaudeByokSession {
     this._writeEnvFile = opts._writeEnvFile || ((p, c) => writeFileSync(p, c, { mode: 0o600 }))
     this._unlinkEnvFile = opts._unlinkEnvFile || ((p) => { try { unlinkSync(p) } catch { /* ignore */ } })
     this._envForApiKey = opts._envForApiKey || process.env
+    // #5081 — crash-durable record of the compose project id so a daemon
+    // crash between `compose up` and `compose down` leaves an on-disk paper
+    // trail the boot-time sweep can clean up. record()'d after a successful
+    // `compose up`, forget()'d after a clean `compose down`. Resolved lazily
+    // in `_getComposeStateStore()` to the shared singleton (so the boot sweep
+    // and live sessions agree on one state file) ONLY in compose mode —
+    // non-compose sessions never touch it, keeping their test paths off the
+    // real home. Injectable for tests.
+    this._composeStateStore = opts._composeStateStore || null
 
     const user = opts.containerUser || DEFAULT_USER
     if (!VALID_USERNAME_RE.test(user)) {
@@ -1243,6 +1253,33 @@ export class DockerByokSession extends ClaudeByokSession {
     }
     this._containerId = result.containerId
     log.info(`docker-byok compose primary container: ${this._containerId.slice(0, 12)}`)
+    // #5081 — only AFTER a successful `compose up` do we persist the project
+    // id. Recording earlier would leave a phantom entry on disk for a stack
+    // that never started; the boot sweep would then `compose down` a project
+    // that was never up (harmless but noisy). record() is best-effort:
+    // persistence failures must not fail an otherwise-healthy session.
+    try {
+      this._getComposeStateStore().record({
+        projectId: this._composeProject,
+        composeFile: this._composeFile,
+        cwd,
+      })
+    } catch (err) {
+      log.warn(`docker-byok compose: failed to persist project id: ${err.message}`)
+    }
+  }
+
+  /**
+   * #5081 — resolve the compose-state store for THIS session. Returns the
+   * injected store when present (tests), otherwise the process-wide shared
+   * singleton. Only ever called on the compose path, so non-compose sessions
+   * never construct the default (and never touch the real ~/.chroxy state).
+   */
+  _getComposeStateStore() {
+    if (!this._composeStateStore) {
+      this._composeStateStore = getSharedComposeStateStore()
+    }
+    return this._composeStateStore
   }
 
   /**
@@ -1822,6 +1859,14 @@ export class DockerByokSession extends ClaudeByokSession {
             composeProject,
             cwd,
           })
+          // #5081 — only drop the on-disk record after a clean teardown. If
+          // `compose down` threw (daemon gone), the entry has to survive so
+          // the next boot's sweep retries the teardown.
+          try {
+            this._getComposeStateStore().forget(composeProject)
+          } catch (err) {
+            log.warn(`docker-byok compose: failed to forget project id: ${err.message}`)
+          }
         } catch (err) {
           log.warn(`compose destroy failed: ${err.message}`)
         }

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -422,6 +422,26 @@ export async function startCliServer(config) {
     await logEnvironmentManagerReconnectResult(environmentManager, log)
   }
 
+  // #5081: boot-time garbage collection of leaked docker-byok compose stacks.
+  // A daemon crash / SIGKILL between `docker compose up` and `docker compose
+  // down` leaves the stack running with only an on-disk record (written by
+  // DockerByokSession on start). Sweep those orphans now — before any new
+  // session launches — so a crash can't leak stacks indefinitely. Entirely
+  // best-effort: a failure here (docker down, partial teardown) is logged and
+  // the offending entry stays on disk to be retried on the next boot.
+  try {
+    const { getSharedComposeStateStore } = await import('./byok-compose-state-shared.js')
+    const { sweepOrphanedComposeStacks } = await import('./byok-compose-state.js')
+    const store = getSharedComposeStateStore()
+    if (store.list().length > 0) {
+      const { DockerBackend } = await import('./environments/backends/docker.js')
+      const result = await sweepOrphanedComposeStacks({ store, backend: new DockerBackend() })
+      log.info(`docker-byok compose sweep: ${result.swept} orphaned stack(s) torn down, ${result.failed} deferred to next boot`)
+    }
+  } catch (err) {
+    log.warn(`docker-byok compose sweep failed: ${err.message}`)
+  }
+
   // #4509: resolve once so the SessionManager arg side and the startup log
   // line below can't drift apart, and any over-ceiling operator value emits
   // a single warning here at boot (not three on each tunable).

--- a/packages/server/tests/byok-compose-state.test.js
+++ b/packages/server/tests/byok-compose-state.test.js
@@ -1,0 +1,168 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  ByokComposeStateStore,
+  sweepOrphanedComposeStacks,
+} from '../src/byok-compose-state.js'
+
+/**
+ * Tests for the docker-byok compose-project-id persistence store (#5081).
+ *
+ * The store mirrors EnvironmentManager's on-disk shape so a daemon crash
+ * between `docker compose up` and `docker compose down` leaves an on-disk
+ * paper trail. A boot-time `sweepOrphanedComposeStacks()` then runs
+ * `docker compose down --remove-orphans` against every leftover project
+ * id before any new sessions launch.
+ */
+
+let tmpDir
+let statePath
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-byok-compose-state-'))
+  statePath = join(tmpDir, 'byok-compose-state.json')
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('ByokComposeStateStore', () => {
+  it('starts empty when no state file exists', () => {
+    const store = new ByokComposeStateStore({ statePath })
+    assert.deepEqual(store.list(), [])
+  })
+
+  it('records a compose stack and persists it to disk', () => {
+    const store = new ByokComposeStateStore({ statePath })
+    store.record({
+      projectId: 'chroxy-byok-abcdef',
+      composeFile: '/proj/docker-compose.yml',
+      cwd: '/work/proj',
+    })
+    assert.equal(existsSync(statePath), true)
+    const raw = JSON.parse(readFileSync(statePath, 'utf-8'))
+    assert.equal(raw.version, 1)
+    assert.equal(Array.isArray(raw.stacks), true)
+    assert.equal(raw.stacks.length, 1)
+    assert.equal(raw.stacks[0].projectId, 'chroxy-byok-abcdef')
+    assert.equal(raw.stacks[0].composeFile, '/proj/docker-compose.yml')
+    assert.equal(raw.stacks[0].cwd, '/work/proj')
+    assert.equal(typeof raw.stacks[0].createdAt, 'string')
+  })
+
+  it('forget(projectId) removes the entry and persists the new state', () => {
+    const store = new ByokComposeStateStore({ statePath })
+    store.record({ projectId: 'p1', composeFile: '/a/docker-compose.yml', cwd: '/a' })
+    store.record({ projectId: 'p2', composeFile: '/b/docker-compose.yml', cwd: '/b' })
+    store.forget('p1')
+    const ids = store.list().map(s => s.projectId)
+    assert.deepEqual(ids, ['p2'])
+    // Reload from disk and confirm forget persisted.
+    const reloaded = new ByokComposeStateStore({ statePath })
+    assert.deepEqual(reloaded.list().map(s => s.projectId), ['p2'])
+  })
+
+  it('record() on an existing projectId replaces the prior entry (idempotent)', () => {
+    const store = new ByokComposeStateStore({ statePath })
+    store.record({ projectId: 'p1', composeFile: '/old/docker-compose.yml', cwd: '/old' })
+    store.record({ projectId: 'p1', composeFile: '/new/docker-compose.yml', cwd: '/new' })
+    const stacks = store.list()
+    assert.equal(stacks.length, 1)
+    assert.equal(stacks[0].composeFile, '/new/docker-compose.yml')
+    assert.equal(stacks[0].cwd, '/new')
+  })
+
+  it('forget() on an unknown projectId is a no-op', () => {
+    const store = new ByokComposeStateStore({ statePath })
+    store.record({ projectId: 'p1', composeFile: '/a/docker-compose.yml', cwd: '/a' })
+    store.forget('does-not-exist')
+    assert.equal(store.list().length, 1)
+  })
+
+  it('rejects record() calls missing required fields', () => {
+    const store = new ByokComposeStateStore({ statePath })
+    assert.throws(() => store.record({ composeFile: '/a', cwd: '/a' }), /projectId/)
+    assert.throws(() => store.record({ projectId: 'p', cwd: '/a' }), /composeFile/)
+    assert.throws(() => store.record({ projectId: 'p', composeFile: '/a' }), /cwd/)
+  })
+
+  it('load() ignores a corrupt state file but does not crash', () => {
+    writeFileSync(statePath, 'this is not json')
+    const store = new ByokComposeStateStore({ statePath })
+    assert.deepEqual(store.list(), [])
+  })
+
+  it('load() ignores a state file with an unknown version', () => {
+    writeFileSync(statePath, JSON.stringify({ version: 99, stacks: [{ projectId: 'p1' }] }))
+    const store = new ByokComposeStateStore({ statePath })
+    assert.deepEqual(store.list(), [])
+  })
+
+  it('survives a round-trip across instances', () => {
+    const a = new ByokComposeStateStore({ statePath })
+    a.record({ projectId: 'p1', composeFile: '/x/docker-compose.yml', cwd: '/x' })
+    a.record({ projectId: 'p2', composeFile: '/y/docker-compose.yml', cwd: '/y' })
+
+    const b = new ByokComposeStateStore({ statePath })
+    const ids = b.list().map(s => s.projectId).sort()
+    assert.deepEqual(ids, ['p1', 'p2'])
+  })
+})
+
+describe('sweepOrphanedComposeStacks()', () => {
+  it('runs destroyComposeEnvironment for each persisted stack and forgets it', async () => {
+    const store = new ByokComposeStateStore({ statePath })
+    store.record({ projectId: 'p1', composeFile: '/x/docker-compose.yml', cwd: '/x' })
+    store.record({ projectId: 'p2', composeFile: '/y/docker-compose.yml', cwd: '/y' })
+
+    const destroyCalls = []
+    const backend = {
+      async destroyComposeEnvironment(opts) {
+        destroyCalls.push(opts)
+      },
+    }
+
+    const result = await sweepOrphanedComposeStacks({ store, backend })
+    assert.equal(destroyCalls.length, 2)
+    const seen = destroyCalls.map(c => c.composeProject).sort()
+    assert.deepEqual(seen, ['p1', 'p2'])
+    assert.equal(result.swept, 2)
+    assert.equal(result.failed, 0)
+    // Store must be empty post-sweep.
+    assert.deepEqual(store.list(), [])
+  })
+
+  it('keeps an entry on disk when destroyComposeEnvironment throws (retry-on-next-boot)', async () => {
+    const store = new ByokComposeStateStore({ statePath })
+    store.record({ projectId: 'p-fail', composeFile: '/z/docker-compose.yml', cwd: '/z' })
+
+    const backend = {
+      async destroyComposeEnvironment() {
+        throw new Error('docker daemon unreachable')
+      },
+    }
+
+    const result = await sweepOrphanedComposeStacks({ store, backend })
+    assert.equal(result.swept, 0)
+    assert.equal(result.failed, 1)
+    // Entry survives so the next boot retries.
+    assert.equal(store.list().length, 1)
+    assert.equal(store.list()[0].projectId, 'p-fail')
+  })
+
+  it('returns { swept: 0, failed: 0 } when the store is empty', async () => {
+    const store = new ByokComposeStateStore({ statePath })
+    const backend = {
+      async destroyComposeEnvironment() {
+        throw new Error('should not be called')
+      },
+    }
+    const result = await sweepOrphanedComposeStacks({ store, backend })
+    assert.deepEqual(result, { swept: 0, failed: 0 })
+  })
+})

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -3390,6 +3390,119 @@ describe('DockerByokSession — Docker Compose support (#5024)', () => {
     assert.equal(unlinks.length >= 1, true, 'tmpfile unlinked on start failure')
     assert.equal(session._composeEnvFile, null, 'env-file path cleared on failure')
   })
+
+  // #5081 — persist compose project IDs to disk so a daemon crash
+  // between `compose up` and `compose down` leaves an on-disk record the
+  // boot-time sweep can clean up.
+
+  function composeStateStoreStub() {
+    return {
+      records: [],
+      forgets: [],
+      record(entry) { this.records.push({ ...entry }) },
+      forget(projectId) { this.forgets.push(projectId) },
+      list() { return [...this.records] },
+    }
+  }
+
+  it('records the compose project id to the state store on start (#5081)', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const backend = composeBackendStub()
+    const store = composeStateStoreStub()
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      composeService: 'web',
+      _execFile,
+      _dockerBackend: backend,
+      _composeStateStore: store,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    assert.equal(store.records.length, 1, 'expected exactly one record() call on start')
+    const entry = store.records[0]
+    assert.equal(entry.projectId, session._composeProject)
+    assert.equal(entry.composeFile, '/proj/docker-compose.yml')
+    assert.equal(entry.cwd, tmpHome)
+    await session.destroy()
+  })
+
+  it('forgets the compose project id from the state store on destroy (#5081)', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const backend = composeBackendStub()
+    const store = composeStateStoreStub()
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      composeService: 'web',
+      _execFile,
+      _dockerBackend: backend,
+      _composeStateStore: store,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    const projectId = session._composeProject
+    await session.destroy()
+    assert.deepEqual(store.forgets, [projectId])
+  })
+
+  it('does not record() when compose start fails (#5081)', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const backend = {
+      createCalls: [],
+      destroyCalls: [],
+      async createComposeEnvironment(opts) {
+        this.createCalls.push(opts)
+        const err = new Error('compose primary not running')
+        err.code = 'compose_primary_missing'
+        throw err
+      },
+      async destroyComposeEnvironment(opts) { this.destroyCalls.push(opts) },
+      async execInEnvironment() { return { stdout: '', stderr: '' } },
+    }
+    const store = composeStateStoreStub()
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      _execFile,
+      _dockerBackend: backend,
+      _composeStateStore: store,
+    })
+    session.on('error', () => {})
+    await session.start()
+    assert.equal(store.records.length, 0, 'record() must not run when compose up fails')
+  })
+
+  it('keeps the project id on disk when destroyComposeEnvironment throws so the next boot sweep retries (#5081)', async () => {
+    const _execFile = execFileStub({ info: { stdout: 'ok' } })
+    const backend = {
+      createCalls: [],
+      destroyCalls: [],
+      async createComposeEnvironment(opts) {
+        this.createCalls.push(opts)
+        return { containerId: 'C', containerCliPath: '/x', services: [] }
+      },
+      async destroyComposeEnvironment() {
+        throw new Error('daemon gone')
+      },
+      async execInEnvironment() { return { stdout: '', stderr: '' } },
+    }
+    const store = composeStateStoreStub()
+    const session = new DockerByokSession({
+      cwd: tmpHome,
+      composeFile: '/proj/docker-compose.yml',
+      _execFile,
+      _dockerBackend: backend,
+      _composeStateStore: store,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+    await session.start()
+    await session.destroy()
+    // forget() must NOT run when destroyComposeEnvironment throws: the
+    // on-disk paper trail has to survive so the next boot's sweep can
+    // retry the teardown.
+    assert.deepEqual(store.forgets, [])
+  })
 })
 
 // Force a tick so any background EventEmitter cleanup completes


### PR DESCRIPTION
## Summary

`DockerByokSession` generated its compose project id (`chroxy-byok-<hex>`) lazily and held it **in memory only**. A daemon crash / SIGKILL between `docker compose up` and `docker compose down` leaked the entire stack with no on-disk record and no garbage collection on restart (the only recovery was a manual `docker compose down`).

This adds a crash-durable on-disk record of every live compose stack, mirroring `EnvironmentManager`'s persistence, plus a boot-time sweep that tears down orphans.

### What changed

- **`byok-compose-state.js`** — `ByokComposeStateStore`: a `{ version: 1, stacks: [...] }` store with atomic restricted writes (via `writeFileRestricted`, same as env-manager). `record()` / `forget()` / `list()`, injectable `statePath`, corrupt/unknown-version files ignored gracefully.
- **`byok-compose-state.js`** — `sweepOrphanedComposeStacks({ store, backend })`: tears down each persisted stack via `backend.destroyComposeEnvironment`, forgetting an entry **only after a clean teardown** so a transient docker-down failure is retried on the next boot. Returns `{ swept, failed }`.
- **`docker-byok-session.js`** — records the project id after a successful `compose up`, forgets it only after a clean `compose down`. Both are best-effort (persistence failure never fails an otherwise-healthy session). Resolved lazily so non-compose sessions never touch the state file.
- **`byok-compose-state-shared.js`** — process-wide singleton so live sessions and the boot sweep share one state file (mirrors `getSharedPool()`).
- **`server-cli.js`** — runs `sweepOrphanedComposeStacks()` at boot inside `startCliServer`, before any session launches. Guarded (only when entries exist), best-effort, non-fatal.

## Acceptance Criteria

- [x] Project id + compose file path persisted on session start
- [x] Cleared on session destroy (only after a clean `compose down`)
- [x] Boot sweep tears down orphaned stacks (`destroyComposeEnvironment` → `docker compose down --remove-orphans`)
- [x] Test covers crash-then-restart cleanup (store survives round-trip across instances; sweep retries failed teardowns)

## Test plan

- `node --test tests/byok-compose-state.test.js tests/docker-byok-session.test.js` — **149 pass / 0 fail**, deterministic across repeated runs.
- 13 store tests (empty start, record/persist, forget-persist, idempotent record, no-op forget, required-field validation, corrupt-file tolerance, unknown-version tolerance, cross-instance round-trip) + 3 sweep tests (sweep-all-and-forget, keep-on-failure, empty-store).
- 4 session-wiring tests (record on start, forget on destroy, no-record on start failure, keep-on-disk when teardown throws).
- `./scripts/lint-tests-state-file-path.sh` and `./scripts/lint-session-opt-forwarding.sh` both pass (no new BaseSession opt introduced).

Closes #5081