### PR TITLE
feat(server): reconcile orphaned docker-byok snapshots (#5075)

### DIFF
--- a/packages/server/src/snapshots-store.js
+++ b/packages/server/src/snapshots-store.js
@@ -24,6 +24,25 @@
  * still drop the sidecar so the dashboard stops listing a ghost entry.
  * The caller learns about the rmi failure via the returned `imageRemoved`
  * flag.
+ *
+ * Reconciliation (#5075) closes the drift gap left by the snapshot/restore
+ * landings (#5100 / #5092 / #5098): a snapshot is the pair (image tag,
+ * sidecar JSON), and either side can outlive the other —
+ *
+ *   - User runs `docker rmi chroxy-byok-snap:foo` directly: the image is
+ *     gone but the sidecar lingers, so the dashboard lists a ghost entry
+ *     whose DELETE just re-fails. Also covers the existing best-effort
+ *     `imageRemoved: false` case in `deleteSnapshot` above — by the next
+ *     reconcile pass the image truly is gone, so we drop the sidecar.
+ *   - Sidecar corrupted or manually deleted: the image still sits on the
+ *     host eating disk. We log a warning so the operator can decide to
+ *     `docker rmi` it themselves, but we DO NOT auto-rm — a user may have
+ *     intentionally retagged something into the `chroxy-byok-snap` prefix.
+ *
+ * `reconcileOrphans()` is the surface for both. It is a pure function over
+ * an injected `listImages(): Promise<string[]>` callback (filtered to the
+ * `chroxy-byok-snap:` prefix at the docker shell level so we never touch
+ * an image outside our scope) and the on-disk sidecar directory.
  */
 
 import { readdirSync, readFileSync, existsSync, unlinkSync } from 'fs'
@@ -208,4 +227,108 @@ export async function deleteSnapshot(slug, { removeImage, dir } = {}) {
   }
 
   return { ok: true, tag: tag || '', imageRemoved }
+}
+
+/**
+ * Image-tag prefix every docker-byok snapshot is published under. The
+ * reconciler only ever reasons about images in this namespace so it can
+ * never touch (or even consider an orphan) an unrelated image on the host.
+ */
+const SNAPSHOT_TAG_PREFIX = 'chroxy-byok-snap:'
+
+/**
+ * @typedef {Object} ReconcileResult
+ * @property {number} sidecarsScanned          Count of valid (taggable) sidecars considered.
+ * @property {number} imagesScanned            Count of `chroxy-byok-snap:` images on the host.
+ * @property {string[]} orphanedSidecarsRemoved Slugs of sidecars unlinked (tag gone from daemon).
+ * @property {string[]} orphanedImagesLogged    Snapshot image tags with no sidecar (logged, NOT removed).
+ */
+
+/**
+ * Reconcile the two halves of a docker-byok snapshot — the image tag in
+ * the local daemon and the JSON sidecar on disk — and repair drift.
+ *
+ * Strategy (documented in the module header, #5075):
+ *
+ *   - sidecar WITHOUT a matching image tag  → the image was deleted out
+ *     from under us (`docker rmi` by hand, or a best-effort
+ *     `deleteSnapshot` that left `imageRemoved: false`). The sidecar is a
+ *     ghost the dashboard would re-list forever, so we UNLINK it.
+ *   - image tag WITHOUT a matching sidecar  → an image sits on the host
+ *     eating disk but nothing tracks it. We LOG it for the operator and
+ *     deliberately do NOT `docker rmi` — a user may have intentionally
+ *     retagged something into the `chroxy-byok-snap:` namespace, and a
+ *     reconciler must never destroy data it didn't create.
+ *
+ * `listImages` is treated as the source of truth for what exists in the
+ * daemon. If it rejects (daemon down, docker missing) we propagate the
+ * error and take NO destructive action — reconciling against a partial or
+ * empty image list would wrongly delete every live sidecar. This keeps the
+ * pass idempotent and safe to run on a schedule.
+ *
+ * Pairing is by exact image tag: a sidecar's `tag` field is matched against
+ * the set of `chroxy-byok-snap:`-prefixed tags returned by `listImages`.
+ * Non-snapshot images returned by `listImages` are filtered out up front so
+ * they neither count toward `imagesScanned` nor surface as orphans.
+ *
+ * @param {object} opts
+ * @param {() => Promise<string[]>} opts.listImages  Returns docker image tags (any namespace; filtered here).
+ * @param {string} [opts.dir]  Override the snapshots dir (tests).
+ * @returns {Promise<ReconcileResult>}
+ */
+export async function reconcileOrphans({ listImages, dir } = {}) {
+  if (typeof listImages !== 'function') {
+    throw new Error('reconcileOrphans: listImages callback required')
+  }
+
+  // Source of truth first. A rejection here is fatal BY DESIGN — we must
+  // never act on a partial/empty image list (it would nuke live sidecars).
+  const rawImages = await listImages()
+  const snapshotImages = (Array.isArray(rawImages) ? rawImages : []).filter(
+    (tag) => typeof tag === 'string' && tag.startsWith(SNAPSHOT_TAG_PREFIX),
+  )
+  const imageSet = new Set(snapshotImages)
+
+  // listSnapshots already skips unreadable/malformed/tag-less sidecars and
+  // hands back a slug per entry, so reconcile only ever reasons about
+  // sidecars it can pair by tag.
+  const snapshotsDir = dir || getSnapshotsDir()
+  const sidecars = listSnapshots({ dir: snapshotsDir })
+
+  const orphanedSidecarsRemoved = []
+  const trackedTags = new Set()
+
+  for (const entry of sidecars) {
+    trackedTags.add(entry.tag)
+    if (imageSet.has(entry.tag)) continue
+    // Sidecar's image is gone from the daemon — drop the ghost.
+    const filePath = join(snapshotsDir, `${entry.slug}.json`)
+    try {
+      unlinkSync(filePath)
+      orphanedSidecarsRemoved.push(entry.slug)
+      log.info(
+        `reconcileOrphans: removed orphaned sidecar ${entry.slug}.json (image ${entry.tag} no longer present)`,
+      )
+    } catch (err) {
+      log.warn(`reconcileOrphans: failed to unlink orphaned sidecar ${filePath}: ${err.message}`)
+    }
+  }
+
+  const orphanedImagesLogged = []
+  for (const tag of snapshotImages) {
+    if (trackedTags.has(tag)) continue
+    // Image with no sidecar — log only, never auto-rm.
+    orphanedImagesLogged.push(tag)
+    log.warn(
+      `reconcileOrphans: snapshot image ${tag} has no metadata sidecar; ` +
+        `leaving in place (run "docker rmi ${tag}" to reclaim disk if unwanted)`,
+    )
+  }
+
+  return {
+    sidecarsScanned: sidecars.length,
+    imagesScanned: snapshotImages.length,
+    orphanedSidecarsRemoved,
+    orphanedImagesLogged,
+  }
 }

--- a/packages/server/src/snapshots-store.js
+++ b/packages/server/src/snapshots-store.js
@@ -283,8 +283,13 @@ export async function reconcileOrphans({ listImages, dir } = {}) {
 
   // Source of truth first. A rejection here is fatal BY DESIGN — we must
   // never act on a partial/empty image list (it would nuke live sidecars).
+  // A non-array return is treated the same way: fail loud rather than
+  // coerce to [] and silently delete every sidecar (fail-destructive).
   const rawImages = await listImages()
-  const snapshotImages = (Array.isArray(rawImages) ? rawImages : []).filter(
+  if (!Array.isArray(rawImages)) {
+    throw new Error('reconcileOrphans: listImages must resolve to an array')
+  }
+  const snapshotImages = rawImages.filter(
     (tag) => typeof tag === 'string' && tag.startsWith(SNAPSHOT_TAG_PREFIX),
   )
   const imageSet = new Set(snapshotImages)

--- a/packages/server/src/snapshots-store.js
+++ b/packages/server/src/snapshots-store.js
@@ -304,6 +304,12 @@ export async function reconcileOrphans({ listImages, dir } = {}) {
   const trackedTags = new Set()
 
   for (const entry of sidecars) {
+    // Only reconcile sidecars that reference an image in OUR namespace. A
+    // sidecar whose tag was corrupted (or written by a future format) into
+    // a non-snapshot namespace is outside our authority — `listImages` only
+    // returns `chroxy-byok-snap:` tags, so such an entry would never match
+    // and we'd wrongly unlink it. Leave it untouched.
+    if (!entry.tag.startsWith(SNAPSHOT_TAG_PREFIX)) continue
     trackedTags.add(entry.tag)
     if (imageSet.has(entry.tag)) continue
     // Sidecar's image is gone from the daemon — drop the ghost.

--- a/packages/server/tests/snapshots-store.test.js
+++ b/packages/server/tests/snapshots-store.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, writeFileSync, mkdirSync, existsSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { listSnapshots, deleteSnapshot, getSnapshotsDir } from '../src/snapshots-store.js'
+import { listSnapshots, deleteSnapshot, getSnapshotsDir, reconcileOrphans } from '../src/snapshots-store.js'
 
 describe('snapshots-store', () => {
   let workDir
@@ -163,6 +163,138 @@ describe('snapshots-store', () => {
         () => deleteSnapshot('snap-3', { dir: snapDir }),
         /removeImage callback required/,
       )
+    })
+  })
+
+  describe('reconcileOrphans', () => {
+    it('returns empty counts when directory does not exist and no images present', async () => {
+      const result = await reconcileOrphans({
+        listImages: async () => [],
+        dir: join(workDir, 'nope'),
+      })
+      assert.deepEqual(result, {
+        sidecarsScanned: 0,
+        imagesScanned: 0,
+        orphanedSidecarsRemoved: [],
+        orphanedImagesLogged: [],
+      })
+    })
+
+    it('throws when listImages callback is missing', async () => {
+      await assert.rejects(
+        () => reconcileOrphans({ dir: snapDir }),
+        /listImages callback required/,
+      )
+    })
+
+    it('removes a sidecar whose image tag is gone from the daemon', async () => {
+      writeSidecar('snap-gone', {
+        tag: 'chroxy-byok-snap:gone-1',
+        createdAt: '2024-01-01T00:00:00Z',
+      })
+      writeSidecar('snap-live', {
+        tag: 'chroxy-byok-snap:live-1',
+        createdAt: '2024-02-01T00:00:00Z',
+      })
+      const result = await reconcileOrphans({
+        listImages: async () => ['chroxy-byok-snap:live-1'],
+        dir: snapDir,
+      })
+      assert.equal(result.sidecarsScanned, 2)
+      assert.equal(result.imagesScanned, 1)
+      assert.deepEqual(result.orphanedSidecarsRemoved, ['snap-gone'])
+      assert.deepEqual(result.orphanedImagesLogged, [])
+      // gone sidecar unlinked, live sidecar preserved
+      assert.equal(existsSync(join(snapDir, 'snap-gone.json')), false)
+      assert.equal(existsSync(join(snapDir, 'snap-live.json')), true)
+    })
+
+    it('logs an image tag without a matching sidecar but does NOT remove it', async () => {
+      writeSidecar('snap-tracked', {
+        tag: 'chroxy-byok-snap:tracked-1',
+        createdAt: '2024-01-01T00:00:00Z',
+      })
+      const removedImages = []
+      const result = await reconcileOrphans({
+        listImages: async () => [
+          'chroxy-byok-snap:tracked-1',
+          'chroxy-byok-snap:rogue-9',
+        ],
+        // removeImage is optional for image-orphans; passing one would be a bug.
+        removeImage: async (tag) => { removedImages.push(tag) },
+        dir: snapDir,
+      })
+      assert.equal(result.sidecarsScanned, 1)
+      assert.equal(result.imagesScanned, 2)
+      assert.deepEqual(result.orphanedSidecarsRemoved, [])
+      assert.deepEqual(result.orphanedImagesLogged, ['chroxy-byok-snap:rogue-9'])
+      // Critical: we MUST NOT shell out docker rmi for an unknown tag.
+      assert.deepEqual(removedImages, [])
+      // Tracked sidecar still on disk.
+      assert.equal(existsSync(join(snapDir, 'snap-tracked.json')), true)
+    })
+
+    it('reconciles both directions in a single pass', async () => {
+      writeSidecar('snap-orphan-a', { tag: 'chroxy-byok-snap:orphan-a' })
+      writeSidecar('snap-orphan-b', { tag: 'chroxy-byok-snap:orphan-b' })
+      writeSidecar('snap-paired', { tag: 'chroxy-byok-snap:paired' })
+      const result = await reconcileOrphans({
+        listImages: async () => [
+          'chroxy-byok-snap:paired',
+          'chroxy-byok-snap:floating',
+        ],
+        dir: snapDir,
+      })
+      assert.equal(result.sidecarsScanned, 3)
+      assert.equal(result.imagesScanned, 2)
+      assert.deepEqual(result.orphanedSidecarsRemoved.sort(), ['snap-orphan-a', 'snap-orphan-b'])
+      assert.deepEqual(result.orphanedImagesLogged, ['chroxy-byok-snap:floating'])
+      assert.equal(existsSync(join(snapDir, 'snap-paired.json')), true)
+      assert.equal(existsSync(join(snapDir, 'snap-orphan-a.json')), false)
+      assert.equal(existsSync(join(snapDir, 'snap-orphan-b.json')), false)
+    })
+
+    it('skips sidecars with missing or malformed tag fields (they are ignored, not removed)', async () => {
+      // No tag — listSnapshots already skips it, reconcile should too.
+      writeSidecar('snap-broken', { name: 'no-tag-here', createdAt: '2024-01-01T00:00:00Z' })
+      writeSidecar('snap-good', { tag: 'chroxy-byok-snap:good' })
+      const result = await reconcileOrphans({
+        listImages: async () => ['chroxy-byok-snap:good'],
+        dir: snapDir,
+      })
+      // Broken file does not get removed by reconcile (listSnapshots's job
+      // is to skip it; reconcile only acts on entries it can reason about).
+      assert.deepEqual(result.orphanedSidecarsRemoved, [])
+      assert.equal(existsSync(join(snapDir, 'snap-broken.json')), true)
+      assert.equal(existsSync(join(snapDir, 'snap-good.json')), true)
+    })
+
+    it('treats listImages rejection as fatal — no destructive action on partial state', async () => {
+      writeSidecar('snap-x', { tag: 'chroxy-byok-snap:x' })
+      await assert.rejects(
+        () => reconcileOrphans({
+          listImages: async () => { throw new Error('docker daemon down') },
+          dir: snapDir,
+        }),
+        /docker daemon down/,
+      )
+      // Sidecar NOT removed — we never reached the decision phase.
+      assert.equal(existsSync(join(snapDir, 'snap-x.json')), true)
+    })
+
+    it('ignores non-snapshot images returned by listImages (defensive filter)', async () => {
+      writeSidecar('snap-a', { tag: 'chroxy-byok-snap:a' })
+      const result = await reconcileOrphans({
+        listImages: async () => [
+          'chroxy-byok-snap:a',
+          'node:22-slim',
+          'some-other:latest',
+        ],
+        dir: snapDir,
+      })
+      assert.equal(result.imagesScanned, 1)
+      assert.deepEqual(result.orphanedSidecarsRemoved, [])
+      assert.deepEqual(result.orphanedImagesLogged, [])
     })
   })
 })

--- a/packages/server/tests/snapshots-store.test.js
+++ b/packages/server/tests/snapshots-store.test.js
@@ -296,5 +296,21 @@ describe('snapshots-store', () => {
       assert.deepEqual(result.orphanedSidecarsRemoved, [])
       assert.deepEqual(result.orphanedImagesLogged, [])
     })
+
+    it('never unlinks a sidecar whose tag is outside the snapshot namespace', async () => {
+      // A corrupted/foreign-namespace tag is outside our authority: listImages
+      // only ever returns chroxy-byok-snap: tags, so such an entry could never
+      // match and would be wrongly classified as orphaned. It must be left alone.
+      writeSidecar('snap-foreign', { tag: 'node:22-slim' })
+      writeSidecar('snap-real', { tag: 'chroxy-byok-snap:real' })
+      const result = await reconcileOrphans({
+        listImages: async () => ['chroxy-byok-snap:real'],
+        dir: snapDir,
+      })
+      assert.deepEqual(result.orphanedSidecarsRemoved, [])
+      assert.deepEqual(result.orphanedImagesLogged, [])
+      assert.equal(existsSync(join(snapDir, 'snap-foreign.json')), true)
+      assert.equal(existsSync(join(snapDir, 'snap-real.json')), true)
+    })
   })
 })


### PR DESCRIPTION
## Summary

A docker-byok snapshot is the pair **(image tag, sidecar JSON)**, and either side can outlive the other:

- A hand-run `docker rmi chroxy-byok-snap:foo` leaves a **ghost sidecar** the dashboard re-lists forever (and whose DELETE just re-fails).
- A corrupted or manually deleted sidecar leaves an **untracked image** eating host disk.

Neither was ever garbage-collected. This PR adds `reconcileOrphans()` to `snapshots-store.js` — a programmatic GC primitive over an injected `listImages()` callback and the on-disk sidecar directory.

## Documented strategy

| Drift | Action | Why |
|-------|--------|-----|
| sidecar **without** matching image tag | **unlink** the ghost sidecar | the image is gone; the sidecar is a ghost the dashboard would re-list forever |
| image tag **without** matching sidecar | **log only**, never `docker rmi` | a user may have intentionally retagged something into the `chroxy-byok-snap:` namespace — a reconciler must never destroy data it didn't create |

`listImages()` is the **source of truth**. A rejection (daemon down / docker missing) is **fatal by design** — reconciling against a partial/empty image list would wrongly delete every live sidecar. The pass is idempotent and safe to run on a schedule. Pairing is by exact image tag; non-snapshot images are filtered out up front so they never count toward `imagesScanned` nor surface as orphans.

Returns `{ sidecarsScanned, imagesScanned, orphanedSidecarsRemoved[], orphanedImagesLogged[] }`.

## Acceptance criteria

- [x] Reconciler / GC primitive lands (programmatic `reconcileOrphans()`)
- [x] Strategy documented (module header + function docstring + table above)
- [x] Tests cover sidecar-only-orphan **and** tag-only-orphan paths

## Test plan

`node --test packages/server/tests/snapshots-store.test.js` — 22 pass / 0 fail. New `reconcileOrphans` suite (8 cases) covers:

- sidecar-only orphan removed; live sidecar preserved
- tag-only orphan logged, **never** rmi'd (asserts `removeImage` is not called)
- both directions in a single pass
- malformed / tag-less sidecars ignored (not removed)
- `listImages` rejection is fatal — no destructive action on partial state
- non-snapshot images filtered out (defensive)
- missing `listImages` callback throws

Both state-file-path and session-opt-forwarding lints pass.

Closes #5075
