### PR TITLE
feat(server): relay Task subagent permission_request to dashboard (#5056)

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -313,6 +313,20 @@ export class ClaudeByokSession extends BaseSession {
     // _subagentSessions map — nested Task → Task is naturally supported.
     this._subagentSessions = new Map()
 
+    // #5056: routing table for subagent permission responses. When a Task
+    // subagent fires a permission_request (e.g. an MCP tool under approve
+    // mode), the pending entry lives in the CHILD's PermissionManager —
+    // not the parent's. The dashboard, however, only knows the parent
+    // session id (ws-permissions resolves against the parent), so a tap
+    // Approve/Deny lands on `parent.respondToPermission(requestId, ...)`.
+    // This map records `childRequestId -> childSession` while the prompt
+    // is outstanding so the parent can forward the response to the child
+    // whose PermissionManager actually holds it. Entries are added when
+    // the child's permission_request is relayed upward and removed on
+    // permission_resolved (or when the child is torn down), so a stale
+    // requestId can never resolve past its lifetime.
+    this._subagentPermissionRouting = new Map()
+
     // #4049: per-turn accumulators for subagent (Task tool) usage + cost.
     // Folded into the parent's result.usage / result.cost just before
     // the result event fires so cost attribution stays on the user-
@@ -1441,6 +1455,39 @@ export class ClaudeByokSession extends BaseSession {
     child.on('tool_result', (e) => {
       this._emitAgentEvent(toolUseId, 'tool_result', e)
     })
+    // #5056: relay the child's permission_request up to the parent's
+    // wire path so the dashboard can render the nested prompt and the
+    // user can approve/deny it. Without this, an MCP tool the subagent
+    // fires under `approve` mode surfaces a permission_request that
+    // nothing forwards — the dashboard never shows it and the request
+    // silently times out → denied.
+    //
+    // The pending entry lives in the CHILD's PermissionManager, so we
+    // record `requestId -> child` in the parent's routing table. When
+    // the user responds, ws-permissions calls the PARENT's
+    // respondToPermission (the only session id it knows); the parent
+    // consults this table and forwards to the child that actually holds
+    // the pending entry. See respondToPermission below.
+    //
+    // Authority note (bearer-token-authority.md): this relay does NOT
+    // widen the trust boundary. The response still flows through the
+    // existing ws-permissions gate on the PARENT session id (primary or
+    // pairing-bound-to-parent token required). The routing table only
+    // redirects an already-authorized decision to the correct in-process
+    // PermissionManager — it grants no new authority and is unreachable
+    // by the child or the model (in-process Map, no wire surface).
+    child.on('permission_request', (e) => {
+      if (e && e.requestId) {
+        this._subagentPermissionRouting.set(e.requestId, child)
+      }
+      this._emitAgentEvent(toolUseId, 'permission_request', e)
+    })
+    child.on('permission_resolved', (e) => {
+      if (e && e.requestId) {
+        this._subagentPermissionRouting.delete(e.requestId)
+      }
+      this._emitAgentEvent(toolUseId, 'permission_resolved', e)
+    })
     // #5016: when the child itself dispatches a Task (grand-child),
     // its own `agent_event` fires on the child. Forward those too,
     // re-tagged with THIS parent's toolUseId so the dashboard groups
@@ -1463,6 +1510,17 @@ export class ClaudeByokSession extends BaseSession {
       const mergedPayload = e?.parentToolUseId
         ? { ...basePayload, parentToolUseId: e.parentToolUseId }
         : basePayload
+      // #5056: a grand-child permission_request reaches us as an
+      // `agent_event` re-emitted by the child. Route the response one
+      // hop down — to the IMMEDIATE child — which already holds the
+      // grand-child mapping in its own routing table and forwards the
+      // decision the rest of the way. This keeps the chain recursive:
+      // each level only needs to know its direct child.
+      if (e.type === 'permission_request' && basePayload.requestId) {
+        this._subagentPermissionRouting.set(basePayload.requestId, child)
+      } else if (e.type === 'permission_resolved' && basePayload.requestId) {
+        this._subagentPermissionRouting.delete(basePayload.requestId)
+      }
       this._emitAgentEvent(toolUseId, e.type, mergedPayload)
     })
 
@@ -1487,6 +1545,7 @@ export class ClaudeByokSession extends BaseSession {
     if (signal?.aborted) {
       if (signal) signal.removeEventListener?.('abort', onAbort)
       this._subagentSessions.delete(toolUseId)
+      this._purgeSubagentPermissionRouting(child)
       try { await child.destroy() } catch (err) {
         log.warn(`subagent destroy on pre-send abort failed: ${err?.message || err}`)
       }
@@ -1503,6 +1562,11 @@ export class ClaudeByokSession extends BaseSession {
       // racing interrupt() during teardown doesn't try to abort an
       // already-half-destroyed child.
       this._subagentSessions.delete(toolUseId)
+      // #5056: drop any still-outstanding permission routing entries for
+      // this child so a late dashboard response can't dereference a
+      // destroyed child (the child's own teardown rejects its pending
+      // permissions; this just clears the parent's pointer).
+      this._purgeSubagentPermissionRouting(child)
       try { await child.destroy() } catch (err) {
         log.warn(`subagent destroy on Task completion failed: ${err?.message || err}`)
       }
@@ -1573,6 +1637,20 @@ export class ClaudeByokSession extends BaseSession {
   }
 
   /**
+   * #5056: remove every permission-routing entry that points at the given
+   * child session. Called when a Task subagent is torn down so a late
+   * dashboard response can never dereference a destroyed child. Cheap
+   * (the map is empty in the common case where no permission was pending).
+   *
+   * @param {object} child  The subagent session being torn down
+   */
+  _purgeSubagentPermissionRouting(child) {
+    for (const [requestId, routed] of this._subagentPermissionRouting) {
+      if (routed === child) this._subagentPermissionRouting.delete(requestId)
+    }
+  }
+
+  /**
    * Dispatch one built-in tool (Read/Write/Edit/Bash/Glob/Grep/WebFetch/
    * TodoWrite) to the local executor. Returns `{ content, isError }` —
    * the shape `_executeToolBlock` threads into the next round's
@@ -1638,6 +1716,23 @@ export class ClaudeByokSession extends BaseSession {
    * handlePermission() above.
    */
   respondToPermission(requestId, decision) {
+    // #5056: if this requestId belongs to a Task subagent (its pending
+    // entry lives in the CHILD's PermissionManager, not ours), forward
+    // the decision to that child. ws-permissions only ever calls the
+    // PARENT (the session id it knows), so this redirect is what lets a
+    // dashboard Approve/Deny reach a nested MCP permission prompt. The
+    // child's own respondToPermission recurses if the prompt actually
+    // belongs to a grand-child. Authority is unchanged: the caller was
+    // already authorized against the parent session by ws-permissions.
+    const child = this._subagentPermissionRouting.get(requestId)
+    if (child) {
+      // Drop the routing entry first so a duplicate/late response can't
+      // re-resolve a stale id. The child also emits permission_resolved
+      // which our relay listener uses to clear the same entry — deleting
+      // here too is idempotent and closes the lifetime tightly.
+      this._subagentPermissionRouting.delete(requestId)
+      return child.respondToPermission(requestId, decision)
+    }
     return this._permissions.respondToPermission(requestId, decision)
   }
 
@@ -1806,6 +1901,9 @@ export class ClaudeByokSession extends BaseSession {
     // reference (test capture, future export) would keep them alive.
     this._streamingIndexToToolUseId.clear()
     this._pendingPermissionToolUseIds.clear()
+    // #5056: drop any outstanding subagent permission-routing pointers so
+    // the destroyed parent doesn't retain references to its children.
+    this._subagentPermissionRouting.clear()
     // #4049: tear down any active subagent sessions. interrupt() (run
     // at the top of destroy()) already cascaded the abort signal; this
     // step also drops each child's PermissionManager, MCP fleet, and

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -152,16 +152,41 @@ Object.assign(EVENT_MAP, {
   // `parentToolUseId` is the parent's tool_use id (same key used by
   // agent_spawned / agent_completed). `eventType` is the child's
   // original event name. `payload` is the verbatim child event payload.
-  agent_event: (data) => ({
-    messages: [{
-      msg: {
-        type: 'agent_event',
-        parentToolUseId: data.parentToolUseId,
-        eventType: data.type,
-        payload: data.payload ?? {},
-      },
-    }],
-  }),
+  agent_event: (data, ctx) => {
+    const out = {
+      messages: [{
+        msg: {
+          type: 'agent_event',
+          parentToolUseId: data.parentToolUseId,
+          eventType: data.type,
+          payload: data.payload ?? {},
+        },
+      }],
+    }
+    // #5056: a relayed Task-subagent permission_request must register its
+    // requestId in permissionSessionMap (keyed to the PARENT session id,
+    // ctx.sessionId) — exactly like a top-level permission_request does
+    // (see the permission_request normalizer above). Two reasons:
+    //   1. A pairing-BOUND dashboard client's Approve/Deny is rejected
+    //      unless permissionSessionMap[requestId] === boundSessionId
+    //      (handlePermissionResponse, settings-handlers.js ~line 309).
+    //      The dashboard responds on the PARENT session (the only one it
+    //      knows), so the map must point requestId → parent session.
+    //   2. registerPermissionRoute auto-subscribes eligible clients to
+    //      the session so the broadcast actually reaches them (#4798).
+    // The in-process redirect to the child PermissionManager then happens
+    // in ClaudeByokSession.respondToPermission via its routing table — so
+    // the wire-level routing (parent session) and the in-process routing
+    // (child manager) compose correctly. permission_resolved emits the
+    // matching delete so the map is pruned on every resolution path.
+    const payload = (data.payload && typeof data.payload === 'object') ? data.payload : {}
+    if (data.type === 'permission_request' && payload.requestId) {
+      out.registrations = [{ map: 'permission', key: payload.requestId, value: ctx?.sessionId }]
+    } else if (data.type === 'permission_resolved' && payload.requestId) {
+      out.registrations = [{ map: 'permission', key: payload.requestId, action: 'delete' }]
+    }
+    return out
+  },
 
   // #4307: pending-background-shells snapshot changed for a session.
   // BaseSession emits this on both push (run_in_background tool_result

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -4240,6 +4240,154 @@ describe('ClaudeByokSession', () => {
       assert.ok(ClaudeByokSession.customEvents.includes('agent_event'),
         'agent_event must be in customEvents for ws-forwarding to pick it up')
     })
+
+    // #5056 / #5061 — child permission_request relay. The child has its own
+    // PermissionManager (separate identity from the parent's); when the
+    // subagent fires a permission_request (e.g. an MCP tool under approve
+    // mode), nothing previously bridged it up to the parent's wire path.
+    // The dashboard never saw the prompt and the request silently timed out.
+    // These tests pin the relay envelope + the response routing back down.
+    it('#5056: re-emits child permission_request as agent_event with parentToolUseId so dashboard can render it nested', async () => {
+      const { captured } = await runTaskAndDriveChild((child) => {
+        child.emit('permission_request', {
+          requestId: 'perm-child-1',
+          tool: 'mcp__foo__bar',
+          description: 'mcp__foo__bar({"x":1})',
+          input: { x: 1 },
+          remainingMs: 60000,
+          createdAt: Date.now(),
+        })
+      })
+      const permEvents = captured.filter(
+        (e) => e.parentToolUseId && e.type === 'permission_request',
+      )
+      assert.equal(permEvents.length, 1,
+        'child permission_request must surface exactly once on the parent')
+      assert.equal(permEvents[0].parentToolUseId, 'tu_task_5016')
+      assert.equal(permEvents[0].payload.requestId, 'perm-child-1')
+      assert.equal(permEvents[0].payload.tool, 'mcp__foo__bar')
+      assert.equal(permEvents[0].payload.input.x, 1)
+    })
+
+    it('#5056: re-emits child permission_resolved so the dashboard can clear the nested prompt', async () => {
+      const { captured } = await runTaskAndDriveChild((child) => {
+        child.emit('permission_request', {
+          requestId: 'perm-child-2',
+          tool: 'mcp__foo__bar',
+          description: '...',
+          input: {},
+          remainingMs: 60000,
+          createdAt: Date.now(),
+        })
+        child.emit('permission_resolved', {
+          requestId: 'perm-child-2',
+          decision: 'allow',
+          reason: 'user',
+        })
+      })
+      const resolved = captured.find(
+        (e) => e.parentToolUseId && e.type === 'permission_resolved',
+      )
+      assert.ok(resolved, 'permission_resolved must be relayed on the parent')
+      assert.equal(resolved.parentToolUseId, 'tu_task_5016')
+      assert.equal(resolved.payload.requestId, 'perm-child-2')
+      assert.equal(resolved.payload.decision, 'allow')
+    })
+
+    it('#5056: parent.respondToPermission routes a child requestId to the child PermissionManager', async () => {
+      // The user taps Approve/Deny in the dashboard; the wire message lands
+      // on the parent session id (the only one ws-permissions knows about).
+      // The parent must forward the response to the child whose
+      // PermissionManager actually holds the pending entry.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      session.setPermissionMode('auto')
+      session._gateToolBlock = async () => ({ behavior: 'allow' })
+      // Replace the child-set so we can grab the child without running a
+      // full agent loop.
+      let childRef = null
+      const origSet = session._subagentSessions.set.bind(session._subagentSessions)
+      session._subagentSessions.set = (k, v) => {
+        childRef = v
+        v.sendMessage = async () => {
+          // Trigger the child to emit a permission_request — the parent's
+          // listener should record the routing so respondToPermission can
+          // find it.
+          v.emit('permission_request', {
+            requestId: 'perm-child-routed',
+            tool: 'mcp__foo__bar',
+            input: {},
+            remainingMs: 60000,
+          })
+          // Populate the child's own pending map so the response actually
+          // resolves something (the PermissionManager keys by requestId
+          // and rejects unknown requestIds).
+          let resolvedResult = null
+          v._permissions._pendingPermissions.set('perm-child-routed', {
+            resolve: (r) => { resolvedResult = r },
+            input: { x: 1 },
+          })
+          // Sanity: the parent doesn't yet hold the request.
+          assert.equal(session._permissions._pendingPermissions.has('perm-child-routed'), false)
+          // Route a response addressed to the child's requestId via the
+          // parent's respondToPermission (the only API exposed on the WS
+          // surface).
+          const ok = session.respondToPermission('perm-child-routed', 'allow')
+          assert.equal(ok, true, 'parent.respondToPermission must succeed for a child requestId')
+          assert.ok(resolvedResult, 'the child PermissionManager must receive the decision')
+          assert.equal(resolvedResult.behavior, 'allow')
+          v.emit('result', { messageId: 'cm_1', usage: { input_tokens: 0, output_tokens: 0 }, cost: 0 })
+          v.emit('stream_end', { messageId: 'cm_1' })
+          v._isBusy = false
+        }
+        return origSet(k, v)
+      }
+      session._client = {
+        messages: {
+          stream: () => {
+            // First call: emit a Task tool_use. Second call: end_turn.
+            if (!session._client._round) {
+              session._client._round = 1
+              return fakeStream(
+                [{ type: 'message_delta', delta: { stop_reason: 'tool_use' } }],
+                {
+                  stop_reason: 'tool_use',
+                  content: [{ type: 'tool_use', id: 'tu_task_routing', name: 'Task', input: { description: 'd', prompt: 'p' } }],
+                  usage: { input_tokens: 1, output_tokens: 1 },
+                },
+              )
+            }
+            return fakeStream(
+              [{ type: 'message_delta', delta: { stop_reason: 'end_turn' } }],
+              { stop_reason: 'end_turn', content: [{ type: 'text', text: 'done' }], usage: { input_tokens: 1, output_tokens: 1 } },
+            )
+          },
+        },
+      }
+      await session.start()
+      await session.sendMessage('go')
+      // After the child finishes, the routing entry should be cleared so
+      // a stale lookup of the same id doesn't leak past the request's
+      // lifetime.
+      assert.ok(childRef, 'child was created')
+      await session.destroy()
+    })
+
+    it('#5056: parent.respondToPermission falls back to the parent PermissionManager for unknown child ids', async () => {
+      // Sanity: routing must not break the existing top-level path. A
+      // requestId that the parent's PermissionManager holds (the normal
+      // case) still resolves there even when subagents are active.
+      const session = new ClaudeByokSession({ cwd: '/tmp' })
+      let resolvedOnParent = null
+      session._permissions._pendingPermissions.set('perm-parent-1', {
+        resolve: (r) => { resolvedOnParent = r },
+        input: {},
+      })
+      const ok = session.respondToPermission('perm-parent-1', 'deny')
+      assert.equal(ok, true)
+      assert.ok(resolvedOnParent)
+      assert.equal(resolvedOnParent.behavior, 'deny')
+      await session.destroy()
+    })
   })
 
   describe('lifecycle', () => {

--- a/packages/server/tests/byok-session.test.js
+++ b/packages/server/tests/byok-session.test.js
@@ -4369,6 +4369,16 @@ describe('ClaudeByokSession', () => {
       // a stale lookup of the same id doesn't leak past the request's
       // lifetime.
       assert.ok(childRef, 'child was created')
+      assert.equal(
+        session._subagentPermissionRouting.has('perm-child-routed'),
+        false,
+        'routing entry must be cleared after the child resolves + finishes',
+      )
+      assert.equal(
+        session._subagentPermissionRouting.size,
+        0,
+        'no routing entries should leak past the request lifetime',
+      )
       await session.destroy()
     })
 

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -311,6 +311,59 @@ describe('EventNormalizer', () => {
     })
   })
 
+  describe('agent_event event (#5016 / #5056)', () => {
+    it('maps a relayed child wire event to the agent_event message', () => {
+      const data = {
+        parentToolUseId: 'tu_task',
+        type: 'tool_start',
+        payload: { toolUseId: 'tu_child', tool: 'Read' },
+      }
+      const result = normalizer.normalize('agent_event', data, makeCtx())
+      assert.equal(result.messages[0].msg.type, 'agent_event')
+      assert.equal(result.messages[0].msg.parentToolUseId, 'tu_task')
+      assert.equal(result.messages[0].msg.eventType, 'tool_start')
+      assert.deepEqual(result.messages[0].msg.payload, { toolUseId: 'tu_child', tool: 'Read' })
+      // Non-permission events must NOT register a permissionSessionMap entry.
+      assert.equal(result.registrations, undefined)
+    })
+
+    it('#5056: a relayed permission_request registers the requestId to the PARENT session id', () => {
+      const data = {
+        parentToolUseId: 'tu_task',
+        type: 'permission_request',
+        payload: { requestId: 'perm-child-1', tool: 'mcp__foo__bar', input: { x: 1 } },
+      }
+      const result = normalizer.normalize('agent_event', data, makeCtx())
+      // Bound dashboard clients respond on the parent session, so the map
+      // entry MUST point requestId -> parent session id (ctx.sessionId).
+      assert.deepEqual(result.registrations, [
+        { map: 'permission', key: 'perm-child-1', value: 'sess-1' },
+      ])
+    })
+
+    it('#5056: a relayed permission_resolved emits the matching delete registration', () => {
+      const data = {
+        parentToolUseId: 'tu_task',
+        type: 'permission_resolved',
+        payload: { requestId: 'perm-child-1', decision: 'allow' },
+      }
+      const result = normalizer.normalize('agent_event', data, makeCtx())
+      assert.deepEqual(result.registrations, [
+        { map: 'permission', key: 'perm-child-1', action: 'delete' },
+      ])
+    })
+
+    it('#5056: a relayed permission_request without a requestId registers nothing', () => {
+      const data = {
+        parentToolUseId: 'tu_task',
+        type: 'permission_request',
+        payload: {},
+      }
+      const result = normalizer.normalize('agent_event', data, makeCtx())
+      assert.equal(result.registrations, undefined)
+    })
+  })
+
   // ---- EVENT_MAP: plan_started / plan_ready ----
 
   describe('plan_started event', () => {


### PR DESCRIPTION
## Summary

A Task subagent (`ClaudeByokSession._executeTaskTool`) is a full child session with its **own** `PermissionManager`. When the child fires a `permission_request` — e.g. an MCP tool under `approve` mode, now reachable since MCP is inherited by children (#5019) — nothing bridged that request up to the parent's wire path. The dashboard never rendered the prompt, so it sat unanswered until the child's permission timer expired and the tool was denied.

This PR relays the child's permission lifecycle upward and routes the user's response back down to the correct PermissionManager.

## Relay model (and why)

Re-emit, not rewire (option (a) from the issue). The child's `permission_request` / `permission_resolved` are re-emitted on the parent via the **existing `agent_event` channel** — the same upward-relay pattern already used for `tool_start` / `tool_input_delta` / `tool_result` / `stream_delta` (#5016). The envelope is `{ parentToolUseId, type, payload }` where `type` is the child's original event name and `payload` is the verbatim child event. `parentToolUseId` is the parent's Task `tool_use` id, so the dashboard can group the nested prompt under the Task bubble (the same key used by `agent_spawned` / `agent_completed`).

This was chosen over wiring the child's PermissionManager directly into the parent (would conflate two distinct permission identities and risk cross-resolution) and over refusing `approve` for subagents (breaks the legitimate inherited-MCP flow).

### Response routing

`ws-permissions` only knows the **parent** session id, so a dashboard Approve/Deny lands on `parent.respondToPermission(requestId, decision)`. The pending entry, however, lives in the **child's** PermissionManager. A per-session routing table (`_subagentPermissionRouting`: `childRequestId -> child session`) redirects the decision to the child that holds it. The child's own `respondToPermission` recurses for grand-children, so each level only needs to know its immediate child. The parent's own top-level permissions are unaffected — an unknown id falls back to the parent PermissionManager.

Routing entries are added when the child's `permission_request` is relayed and removed on `permission_resolved`, on child teardown (both Task completion and pre-send-abort paths), and on `destroy()` — so a stale id can never resolve past its lifetime.

### Authority (security path — `bearer-token-authority.md`)

The relay adds **no new authority**. The response still flows through the existing `ws-permissions` gate on the **parent** session id (primary token, or a pairing token bound to the parent). The routing table only redirects an already-authorized decision to the correct in-process PermissionManager — it is an in-process `Map` with no wire surface, unreachable by the child or the model, and it cannot widen the trust boundary or let a child self-approve.

## Files

- `packages/server/src/byok-session.js`
  - `_subagentPermissionRouting` map (constructor) + `destroy()` clear
  - `_executeTaskTool`: child `permission_request` / `permission_resolved` listeners (relay + route registration); nested grand-child handling in the `agent_event` forwarder; routing purge on both teardown paths
  - `respondToPermission`: route-to-child with parent fallback
  - `_purgeSubagentPermissionRouting(child)` helper

## Acceptance criteria

- [x] Child `permission_request` surfaces on the parent exactly once, tagged with `parentToolUseId`, verbatim payload (requestId/tool/input)
- [x] Child `permission_resolved` relayed so the dashboard can clear the nested prompt
- [x] `parent.respondToPermission(childRequestId, ...)` resolves the **child's** PermissionManager
- [x] Unknown ids still fall back to the parent PermissionManager (top-level path unbroken)
- [x] No authority widened; gate still on parent session
- [x] Routing entries cleaned up on resolve / teardown / destroy

## Deferred to #5061

The dashboard-side nested sub-bubble **rendering** of the relayed permission prompt depends on per-launch permission_mode override (#5017) and is out of scope here. This PR delivers the server relay end-to-end on the wire (`event-normalizer` already passes `eventType` + verbatim `payload` through for `agent_event`); #5061 stays open for the dashboard work.

## Test plan

- `node --test packages/server/tests/byok-session.test.js` — 132/132 pass (incl. the 4 new #5056 contract tests)
- `docker-byok-session` (subclass) + `permission-manager` + `ws-permissions` suites — 267/267 pass
- `lint-tests-state-file-path.sh` + `lint-session-opt-forwarding.sh` — both OK (no constructor opts touched)