### PR TITLE
refactor(dashboard): unify token formatters into store-core (#5058, #5094)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import {
   DEFAULT_CONTEXT_WINDOW,
   deriveSessionVisualStatus,
   formatPasteMarker,
+  formatTokensCompact,
   expandPasteMarkers,
   type SessionInfo,
 } from '@chroxy/store-core'
@@ -106,22 +107,19 @@ export function getChroxyConfig(): ChroxyConfig | undefined {
 
 
 /**
- * Format context usage as a compact string.
+ * Format context usage as a compact `<n> tokens` chip label.
  *
- * Trims trailing `.0` on round kilo totals (90000 → `90k tokens`, not
- * `90.0k tokens`) so the chip text stays in lockstep with the
- * `formatTokens` helper in `lib/status-tooltips.ts` — both the chip
- * label and the breakdown inside its tooltip use the same rule. Without
- * this, the same tooltip would read `... (90.0k tokens) ... Breakdown:
- * ... = 90k tokens.` (#4230 Copilot review).
+ * Delegates the number formatting to the canonical `formatTokensCompact`
+ * helper in `@chroxy/store-core` (#5094) so the chip label, the header
+ * meter, and the status-tooltip breakdown all share one casing/decimal
+ * rule and one (correct) 1M rollover. Keeps only the ` tokens` suffix and
+ * the "hide when empty" behaviour here.
  */
 function formatContext(usage: { inputTokens: number; outputTokens: number } | null): string | undefined {
   if (!usage) return undefined
   const total = usage.inputTokens + usage.outputTokens
   if (total === 0) return undefined
-  if (total < 1000) return `${total} tokens`
-  const k = total / 1000
-  return Number.isInteger(k) ? `${k}k tokens` : `${k.toFixed(1)}k tokens`
+  return `${formatTokensCompact(total)} tokens`
 }
 
 type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots'

--- a/packages/dashboard/src/components/FooterBar.test.tsx
+++ b/packages/dashboard/src/components/FooterBar.test.tsx
@@ -183,9 +183,9 @@ describe('FooterBar', () => {
       const ctx = container.querySelector('.footer-context')
       const title = ctx!.getAttribute('title') ?? ''
       expect(title).toContain('45%')
-      expect(title).toContain('80k input')
-      expect(title).toContain('10k output')
-      expect(title).toContain('90k tokens')
+      expect(title).toContain('80.0k input')
+      expect(title).toContain('10.0k output')
+      expect(title).toContain('90.0k tokens')
     })
 
     it('falls back to the plain percent-only tooltip when token counts are absent', () => {

--- a/packages/dashboard/src/components/SidebarTokenView.test.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.test.tsx
@@ -7,7 +7,6 @@ import type { SessionInfo, CumulativeUsage } from '@chroxy/store-core'
 import {
   SidebarTokenView,
   aggregateUsage,
-  formatTokenCount,
   tokenViewCollapsedMetric,
 } from './SidebarTokenView'
 
@@ -141,29 +140,10 @@ describe('SidebarTokenView (#4303 v0)', () => {
     })
   })
 
-  describe('formatTokenCount', () => {
-    it('renders below 1000 verbatim', () => {
-      expect(formatTokenCount(0)).toBe('0')
-      expect(formatTokenCount(999)).toBe('999')
-    })
-
-    it('abbreviates thousands with K', () => {
-      expect(formatTokenCount(1000)).toBe('1.0K')
-      expect(formatTokenCount(1234)).toBe('1.2K')
-      expect(formatTokenCount(999_499)).toBe('999.5K')
-    })
-
-    // #4304 review: avoid the "1000.0K" visual nonsense.
-    it('rolls over to M before the K-rounded value crosses 1000', () => {
-      expect(formatTokenCount(999_500)).toBe('1.00M')
-      expect(formatTokenCount(999_999)).toBe('1.00M')
-    })
-
-    it('abbreviates millions with M', () => {
-      expect(formatTokenCount(1_000_000)).toBe('1.00M')
-      expect(formatTokenCount(1_500_000)).toBe('1.50M')
-    })
-  })
+  // formatTokenCount was unified into the canonical `formatTokens` in
+  // @chroxy/store-core (#5058 / #5094); its unit tests now live in
+  // store-core/src/cost-format.test.ts. The render-level assertions below
+  // (today-total, by-provider) still exercise the formatter end-to-end.
 
   describe('tokenViewCollapsedMetric', () => {
     it('returns the same total as the expanded view', () => {

--- a/packages/dashboard/src/components/SidebarTokenView.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.tsx
@@ -22,7 +22,7 @@
  */
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import type { CumulativeUsage, SessionInfo } from '@chroxy/store-core'
-import { formatCostBadge, getProviderLabel } from '@chroxy/store-core'
+import { formatCostBadge, formatTokens, getProviderLabel } from '@chroxy/store-core'
 
 // Subscription/PTY providers that never emit token usage today (decision #1).
 // claude-tui is the only one in this set right now; if upstream adds usage
@@ -127,24 +127,6 @@ export function aggregateUsage(sessions: SessionInfo[]): AggregateTotals {
     totalSessions,
     hasUntracked,
   }
-}
-
-/**
- * Format integer tokens with K/M abbreviation.
- *
- *   formatTokenCount(0)         → "0"
- *   formatTokenCount(999)       → "999"
- *   formatTokenCount(1234)      → "1.2K"
- *   formatTokenCount(999_999)   → "1.0M"   ← #4304 review: cross to M when K would round to 1000
- *   formatTokenCount(1_500_000) → "1.50M"
- */
-export function formatTokenCount(n: number): string {
-  if (n < 1000) return String(n)
-  // Roll over to "M" when the K-rounded value would be ≥ 1000 (i.e. when
-  // n ≥ 999500 rounds to 1000.0K). Avoid the "1000.0K" visual nonsense
-  // that the simple < 1_000_000 cutoff produced.
-  if (n < 999_500) return `${(n / 1000).toFixed(1)}K`
-  return `${(n / 1_000_000).toFixed(2)}M`
 }
 
 /**
@@ -332,13 +314,13 @@ export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
             className="sidebar-token-view-value"
             data-testid="sidebar-token-view-today-total"
           >
-            {formatTokenCount(totalTokens)} tokens
+            {formatTokens(totalTokens)} tokens
           </span>
         </div>
         <div className="sidebar-token-view-aggregate-row">
           <span className="sidebar-token-view-label">Input · Output</span>
           <span className="sidebar-token-view-value-secondary">
-            {formatTokenCount(agg.totals.inputTokens)} · {formatTokenCount(agg.totals.outputTokens)}
+            {formatTokens(agg.totals.inputTokens)} · {formatTokens(agg.totals.outputTokens)}
           </span>
         </div>
         {agg.totals.costUsd > 0 && (
@@ -390,7 +372,7 @@ export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
                     </InfoDisclosure>
                   ) : (
                     <span className="sidebar-token-view-provider-tokens">
-                      {formatTokenCount(tokens)}
+                      {formatTokens(tokens)}
                       {row.totals.costUsd > 0 && (
                         <span className="sidebar-token-view-provider-cost">
                           {' '}({formatCostBadge(row.totals.costUsd)})
@@ -416,5 +398,5 @@ export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
 export function tokenViewCollapsedMetric(sessions: SessionInfo[]): string {
   const agg = aggregateUsage(sessions)
   const totalTokens = agg.totals.inputTokens + agg.totals.outputTokens
-  return `${formatTokenCount(totalTokens)} tokens`
+  return `${formatTokens(totalTokens)} tokens`
 }

--- a/packages/dashboard/src/components/StatusBar.test.tsx
+++ b/packages/dashboard/src/components/StatusBar.test.tsx
@@ -158,9 +158,9 @@ describe('StatusBar', () => {
       const ctx = container.querySelector('.status-context')
       const title = ctx!.getAttribute('title') ?? ''
       expect(title).toContain('45%')
-      expect(title).toContain('80k input')
-      expect(title).toContain('10k output')
-      expect(title).toContain('90k tokens')
+      expect(title).toContain('80.0k input')
+      expect(title).toContain('10.0k output')
+      expect(title).toContain('90.0k tokens')
     })
 
     it('falls back to the plain percent-only tooltip when token counts are absent', () => {
@@ -317,8 +317,8 @@ describe('StatusBar', () => {
       const meter = screen.getByTestId('status-context-meter')
       const title = meter.getAttribute('title') ?? ''
       expect(title).toContain('30%')
-      expect(title).toContain('25k input')
-      expect(title).toContain('5k output')
+      expect(title).toContain('25.0k input')
+      expect(title).toContain('5.0k output')
     })
   })
 })

--- a/packages/dashboard/src/lib/status-tooltips.test.ts
+++ b/packages/dashboard/src/lib/status-tooltips.test.ts
@@ -160,19 +160,20 @@ describe('contextTooltip rounding (#4204 Copilot review)', () => {
 })
 
 describe('tokenChipTooltip (#4205)', () => {
+  // #5094: now delegates to the canonical `formatTokensCompact`, which keeps
+  // one decimal on all kilo values for consistency with the header meter.
   it('formats in/out/total breakdown in kilo-tokens', () => {
     const t = tokenChipTooltip({ inputTokens: 1200, outputTokens: 8000 })
     expect(t).toContain('1.2k input')
-    expect(t).toContain('8k output')
+    expect(t).toContain('8.0k output')
     expect(t).toContain('9.2k tokens')
   })
 
-  it('trims trailing .0 for round multiples of 1000', () => {
+  it('keeps one decimal for round multiples of 1000 (canonical compact)', () => {
     const t = tokenChipTooltip({ inputTokens: 2000, outputTokens: 1000 })
-    expect(t).toContain('2k input')
-    expect(t).toContain('1k output')
-    expect(t).toContain('3k tokens')
-    expect(t).not.toContain('2.0k')
+    expect(t).toContain('2.0k input')
+    expect(t).toContain('1.0k output')
+    expect(t).toContain('3.0k tokens')
   })
 
   it('renders raw counts under 1000 without the "k" suffix', () => {
@@ -202,9 +203,9 @@ describe('contextTooltip + token breakdown (#4205)', () => {
     expect(t).toContain('45%')
     // …and the breakdown follows so the chip explains where the
     // percent came from (the original #3858 acceptance criterion).
-    expect(t).toContain('80k input')
-    expect(t).toContain('10k output')
-    expect(t).toContain('90k tokens')
+    expect(t).toContain('80.0k input')
+    expect(t).toContain('10.0k output')
+    expect(t).toContain('90.0k tokens')
   })
 
   it('omits the breakdown when only inputTokens is known (defensive)', () => {

--- a/packages/dashboard/src/lib/status-tooltips.ts
+++ b/packages/dashboard/src/lib/status-tooltips.ts
@@ -23,6 +23,10 @@
 // Adding a provider in one site without the other was the bug-in-waiting that
 // motivated the extraction — see that module's header for the full why.
 import { CLIENT_ESTIMATED_COST_PROVIDERS } from './client-estimated-cost-providers'
+// #5094: canonical COMPACT token formatter (lowercase `k`, 1-decimal `M`,
+// correct rollover at 1M). Replaces the old file-private `formatTokens`
+// here that overflowed to "1000.0k" at exactly one million tokens.
+import { formatTokensCompact } from '@chroxy/store-core'
 
 export interface CostTooltipArgs {
   cost: number | undefined
@@ -102,20 +106,13 @@ export interface TokenChipTooltipArgs {
  * "out of scope" section pins this to enriching the existing chip.
  *
  * Token counts under 1000 render in raw form ("450 tokens"); 1000+
- * round to one decimal as kilo ("1.5k"). Matches `formatContext` in
- * App.tsx so the chip text + tooltip stay visually consistent.
+ * abbreviate as kilo ("1.5k") via the canonical `formatTokensCompact`,
+ * matching the header meter + `formatContext` chip in App.tsx so the chip
+ * text + tooltip stay visually consistent (#5094).
  */
 export function tokenChipTooltip({ inputTokens, outputTokens }: TokenChipTooltipArgs): string {
   const total = inputTokens + outputTokens
-  return `Breakdown: ${formatTokens(inputTokens)} input + ${formatTokens(outputTokens)} output = ${formatTokens(total)} tokens.`
-}
-
-function formatTokens(n: number): string {
-  if (n < 1000) return String(n)
-  const k = n / 1000
-  // Trim trailing .0 the same way roundPercent does — "1k" is cleaner
-  // than "1.0k" for round multiples of 1000.
-  return Number.isInteger(k) ? `${k}k` : `${k.toFixed(1)}k`
+  return `Breakdown: ${formatTokensCompact(inputTokens)} input + ${formatTokensCompact(outputTokens)} output = ${formatTokensCompact(total)} tokens.`
 }
 
 function roundPercent(n: number): string {

--- a/packages/store-core/src/cost-format.test.ts
+++ b/packages/store-core/src/cost-format.test.ts
@@ -160,6 +160,15 @@ describe('formatTokens (#5058 / #5094)', () => {
     expect(formatTokens(NaN)).toBe('0')
     expect(formatTokens(Infinity)).toBe('0')
   })
+
+  // Copilot #5122: non-integer wire data must be rounded BEFORE the
+  // threshold checks so 999.6 doesn't slip through the "< 1000" branch and
+  // render "1000" with no K suffix.
+  it('rounds non-integer input before applying thresholds', () => {
+    expect(formatTokens(999.6)).toBe('1.0K')
+    expect(formatTokens(999.4)).toBe('999')
+    expect(formatTokens(1234.5)).toBe('1.2K')
+  })
 })
 
 describe('formatTokensCompact (#5065)', () => {
@@ -196,5 +205,11 @@ describe('formatTokensCompact (#5065)', () => {
     expect(formatTokensCompact(-1)).toBe('0')
     expect(formatTokensCompact(NaN)).toBe('0')
     expect(formatTokensCompact(Infinity)).toBe('0')
+  })
+
+  // Copilot #5122: round non-integer input before the threshold checks.
+  it('rounds non-integer input before applying thresholds', () => {
+    expect(formatTokensCompact(999.6)).toBe('1.0k')
+    expect(formatTokensCompact(999.4)).toBe('999')
   })
 })

--- a/packages/store-core/src/cost-format.test.ts
+++ b/packages/store-core/src/cost-format.test.ts
@@ -10,6 +10,7 @@ import {
   formatCostBadge,
   formatCostBreakdown,
   formatPartialCostLine,
+  formatTokens,
   formatTokensCompact,
 } from './cost-format'
 import type { ErrorPartialCost } from './cost-format'
@@ -110,7 +111,7 @@ describe('formatPartialCostLine (#5039)', () => {
     ).toBe('This turn cost $0.0010 (0 in · 750 out)')
   })
 
-  it('uses K/M abbreviation matching SidebarTokenView.formatTokenCount', () => {
+  it('uses the canonical formatTokens K/M abbreviation', () => {
     expect(
       formatPartialCostLine(
         partial({ costUsd: 1.5, inputTokens: 1_234_567, outputTokens: 999_499 }),
@@ -122,6 +123,42 @@ describe('formatPartialCostLine (#5039)', () => {
     expect(
       formatPartialCostLine(partial({ costUsd: 0, inputTokens: 50, outputTokens: 0 })),
     ).toBe('This turn cost $0 (50 in · 0 out)')
+  })
+})
+
+// STANDARD formatter (#5058 / #5094) — migrated here from
+// SidebarTokenView.test.tsx so each canonical formatter has ONE test home.
+describe('formatTokens (#5058 / #5094)', () => {
+  it('renders below 1000 verbatim', () => {
+    expect(formatTokens(0)).toBe('0')
+    expect(formatTokens(999)).toBe('999')
+  })
+
+  it('abbreviates thousands with uppercase K (one decimal)', () => {
+    expect(formatTokens(1000)).toBe('1.0K')
+    expect(formatTokens(1234)).toBe('1.2K')
+    expect(formatTokens(30_000)).toBe('30.0K')
+    expect(formatTokens(999_499)).toBe('999.5K')
+  })
+
+  // Avoid the "1000.0K" visual nonsense — roll to M before the K-rounded
+  // value crosses 1000.
+  it('rolls over to M before the K-rounded value crosses 1000', () => {
+    expect(formatTokens(999_500)).toBe('1.00M')
+    expect(formatTokens(999_999)).toBe('1.00M')
+  })
+
+  it('abbreviates millions with uppercase M (two decimals)', () => {
+    expect(formatTokens(1_000_000)).toBe('1.00M')
+    expect(formatTokens(1_500_000)).toBe('1.50M')
+    expect(formatTokens(1_234_567)).toBe('1.23M')
+  })
+
+  // #5058 guard decision: the defensive guard lives on the shared helper.
+  it('returns "0" for non-finite / non-positive (defensive)', () => {
+    expect(formatTokens(-1)).toBe('0')
+    expect(formatTokens(NaN)).toBe('0')
+    expect(formatTokens(Infinity)).toBe('0')
   })
 })
 

--- a/packages/store-core/src/cost-format.ts
+++ b/packages/store-core/src/cost-format.ts
@@ -120,10 +120,17 @@ export function formatPartialCostLine(partial: ErrorPartialCost): string {
  * Rolls over to `M` when the K-rounded value would reach 1000 (n ≥ 999_500
  * rounds to 1000.0K) to avoid the "1000.0K" visual nonsense. Returns "0"
  * defensively for zero / negative / non-finite input.
+ *
+ * Non-integer input (possible via untyped wire data through
+ * `pickFiniteTokenCount`) is rounded to an integer FIRST, so the
+ * threshold checks below run on the same value that gets rendered —
+ * otherwise 999.6 would pass the `< 1000` branch yet render as "1000"
+ * with no `K` suffix.
  */
 export function formatTokens(n: number): string {
   if (!Number.isFinite(n) || n <= 0) return '0'
-  if (n < 1000) return String(Math.round(n))
+  n = Math.round(n)
+  if (n < 1000) return String(n)
   if (n < 999_500) return `${(n / 1000).toFixed(1)}K`
   return `${(n / 1_000_000).toFixed(2)}M`
 }
@@ -151,7 +158,11 @@ export function formatTokens(n: number): string {
  */
 export function formatTokensCompact(n: number): string {
   if (!Number.isFinite(n) || n <= 0) return '0'
-  if (n < 1000) return String(Math.round(n))
+  // Round non-integer wire data to an integer first so the threshold
+  // checks below run on the same value that gets rendered (mirrors
+  // `formatTokens`): otherwise 999.6 would pass `< 1000` yet render "1000".
+  n = Math.round(n)
+  if (n < 1000) return String(n)
   if (n < 999_500) return `${(n / 1000).toFixed(1)}k`
   // Round to one decimal first, then strip a trailing ".0" so whole
   // millions render as "1M" / "2M" / "1M" (rolled over from 999_500)

--- a/packages/store-core/src/cost-format.ts
+++ b/packages/store-core/src/cost-format.ts
@@ -61,8 +61,7 @@ export interface ErrorPartialCost {
  *
  * Falls back to a cost-only string when the usage object was empty (a
  * subscription-billed provider that only produced a cost). Token counts
- * use the same K/M abbreviation as `SidebarTokenView.formatTokenCount`
- * — kept inline here to keep cost-format dependency-free.
+ * use the canonical `formatTokens` K/M abbreviation.
  */
 export function formatPartialCostLine(partial: ErrorPartialCost): string {
   const cost = formatCostBadge(partial.costUsd)
@@ -74,16 +73,63 @@ export function formatPartialCostLine(partial: ErrorPartialCost): string {
   return `This turn cost ${cost} (${formatTokens(inTokens)} in · ${formatTokens(outTokens)} out)`
 }
 
-/** Token-count abbreviation mirroring `SidebarTokenView.formatTokenCount`. */
-function formatTokens(n: number): string {
+/**
+ * Canonical token-count formatters (#5058 / #5094).
+ *
+ * The dashboard accumulated five subtly-different K/M token formatters
+ * (uppercase `K` vs lowercase `k`, 1- vs 2-decimal `M`, two of them with
+ * an overflow bug that rendered `1000k` / `1000.0k` at exactly 1M instead
+ * of rolling over). The same fill amount could render as `30k`, `30.0k`,
+ * `30.0K`, or `30K` depending on which surface displayed it.
+ *
+ * We collapse them to TWO canonical helpers, both living here in
+ * `@chroxy/store-core` so every surface (dashboard sidebar, status/footer
+ * tooltips, header meter, error-path cost line) draws from one source:
+ *
+ *   - `formatTokens`        — STANDARD: uppercase `K` (1 decimal), `M`
+ *                             (2 decimals). Used by the sidebar token view,
+ *                             the cost-badge tooltip breakdown, and the
+ *                             error-path partial-cost line. Higher
+ *                             precision for the detailed/breakdown surfaces.
+ *   - `formatTokensCompact` — COMPACT: lowercase `k` (1 decimal), `M`
+ *                             (1 decimal, trailing `.0` stripped so common
+ *                             window sizes show `1M` / `2M`). Used by the
+ *                             header status-line meter, the context chip
+ *                             label, and the context-chip breakdown
+ *                             tooltip. Tighter for single-line chips.
+ *
+ * #5058 guard decision: the defensive `!Number.isFinite(n) || n <= 0 → '0'`
+ * guard lives ON the shared helpers (not as a per-caller wrapper). It is
+ * cheap, and the wire-data consumers (`formatPartialCostLine` via
+ * `pickFiniteTokenCount`, the context tooltip fed from raw turn usage)
+ * need it — putting it on the helper makes every caller safe by default
+ * and a corrupted upstream payload can't poison any renderer with `NaN`.
+ */
+
+/**
+ * STANDARD token-count abbreviation — uppercase `K`, 2-decimal `M`.
+ *
+ *   formatTokens(0)         → "0"
+ *   formatTokens(999)       → "999"
+ *   formatTokens(1234)      → "1.2K"
+ *   formatTokens(999_499)   → "999.5K"
+ *   formatTokens(999_500)   → "1.00M"   ← rolls to M before "1000.0K"
+ *   formatTokens(1_000_000) → "1.00M"
+ *   formatTokens(1_500_000) → "1.50M"
+ *
+ * Rolls over to `M` when the K-rounded value would reach 1000 (n ≥ 999_500
+ * rounds to 1000.0K) to avoid the "1000.0K" visual nonsense. Returns "0"
+ * defensively for zero / negative / non-finite input.
+ */
+export function formatTokens(n: number): string {
   if (!Number.isFinite(n) || n <= 0) return '0'
-  if (n < 1000) return String(n)
+  if (n < 1000) return String(Math.round(n))
   if (n < 999_500) return `${(n / 1000).toFixed(1)}K`
   return `${(n / 1_000_000).toFixed(2)}M`
 }
 
 /**
- * #5065: compact lowercase token formatter for the header status-line
+ * #5065: COMPACT lowercase token formatter for the header status-line
  * `used / total tokens` label.
  *
  *   formatTokensCompact(0)         → "0"

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -174,8 +174,11 @@ export {
   // #5039: error-path partial-cost helper shared by dashboard toast
   // sub-line and mobile Alert.alert body.
   formatPartialCostLine,
-  // #5065: compact `used / total` token label for the header
-  // context-window meter.
+  // #5058 / #5094: canonical token-count formatters. `formatTokens` is the
+  // STANDARD (uppercase K, 2-decimal M) used by the sidebar + breakdown
+  // surfaces; `formatTokensCompact` is the COMPACT (lowercase k, 1-decimal
+  // M) used by the single-line header meter + context chip.
+  formatTokens,
   formatTokensCompact,
 } from './cost-format'
 export type { ErrorPartialCost } from './cost-format'


### PR DESCRIPTION
## Summary

The dashboard had accumulated **five** subtly-different K/M token formatters with inconsistent casing/decimal rules — and two of them carried a real **overflow bug** that rendered `1000.0k` / `1000k tokens` at exactly 1M instead of rolling over. This unifies them into **two** canonical helpers in `@chroxy/store-core`.

## Canonical set chosen

Two helpers, both in `packages/store-core/src/cost-format.ts`, both exported from `@chroxy/store-core`:

| Helper | Casing / decimals | Used by |
|--------|-------------------|---------|
| `formatTokens` (STANDARD) | uppercase `K` (1 dp), `M` (2 dp) | SidebarTokenView, cost-badge breakdown, error-path partial-cost line |
| `formatTokensCompact` (COMPACT) | lowercase `k` (1 dp), `M` (1 dp, trailing `.0` stripped) | header status meter, context chip label, context-chip breakdown tooltip |

Two tiers (not one) is deliberate: the breakdown/detail surfaces want higher precision (`1.23M`), the single-line chips want the tight marketing-style label (`1M`/`2M`).

**#5058 guard decision:** the defensive `!Number.isFinite(n) || n <= 0 → '0'` guard lives **on the shared helpers**, not as a per-caller wrapper. It's cheap and the wire-data consumers (partial-cost line via `pickFiniteTokenCount`, context tooltip fed from raw turn usage) need it — so every caller is safe by default.

## Before / after (rendered output per surface)

| Surface | Helper (before) | `30_000` before → after | `1_000_000` before → after |
|---------|-----------------|--------------------------|-----------------------------|
| Sidebar token view | `formatTokenCount` | `30.0K` → `30.0K` (unchanged) | `1.00M` → `1.00M` (unchanged) |
| Cost-badge breakdown / partial-cost | cost-format private `formatTokens` | `30.0K` → `30.0K` (unchanged) | `1.00M` → `1.00M` (unchanged) |
| Header status meter | `formatTokensCompact` | `30.0k` → `30.0k` (unchanged) | `1M` → `1M` (unchanged) |
| Context chip label (`formatContext`) | private | `30k tokens` → `30.0k tokens` | **`1000k tokens` (BUG) → `1M tokens`** |
| Status/footer tooltip breakdown | status-tooltips private `formatTokens` | `30k` → `30.0k` | **`1000.0k` (BUG) → `1M`** |

Round-thousand chip values now show one decimal (`30.0k`) for consistency with the header meter; the two overflow bugs are fixed.

## AC — #5058

- [x] Move `formatTokenCount` into store-core (consolidated into canonical `formatTokens` in `cost-format.ts`)
- [x] Export from `@chroxy/store-core` and update the SidebarTokenView import
- [x] Guard decision made: lives on the shared helper (documented in code + above)
- [x] `formatPartialCostLine` consumes the shared helper
- [x] `SidebarTokenView.test.tsx` imports updated (formatTokenCount unit tests moved to store-core)
- [x] dashboard + store-core `tsc --noEmit` clean

## AC — #5094

- [x] Canonical set decided in `@chroxy/store-core` (compact + standard)
- [x] `formatContext` / status-tooltips `formatTokens` / `formatTokenCount` migrated to the canonical helpers
- [x] Duplicate private helpers removed
- [x] Tests consolidated — each formatter has one home (store-core)
- [x] dashboard + store-core suites pass

## Test plan

- `packages/store-core`: `npx vitest run` → 1104 passed; `npx tsc --noEmit` clean
- `packages/dashboard`: `npx vitest run` → 2900 passed; `npx tsc --noEmit` clean
- Affected dashboard assertions updated to the new canonical output (round-thousand → `.0k`; overflow → `1M`). No buggy overflow outputs preserved.

## Out of scope / follow-up

`packages/app/src/components/SettingsBar.tsx` has its own RN-only `formatTokenCount`. Both issues scope to dashboard + store-core surfaces only; the mobile helper is a candidate for a follow-up migration but is intentionally left untouched here to keep the PR scoped.