### PR TITLE
feat(server): support devcontainer build/dockerFile/dockerComposeFile

### DIFF
--- a/packages/server/src/devcontainer-config.js
+++ b/packages/server/src/devcontainer-config.js
@@ -29,7 +29,7 @@
  */
 
 import { existsSync, readFileSync } from 'fs'
-import { join, resolve, sep } from 'path'
+import { dirname, join, resolve, sep } from 'path'
 import { homedir } from 'os'
 
 const VALID_ENV_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
@@ -62,6 +62,8 @@ export function parseDevContainer(cwd, { logger = NOOP_LOG } = {}) {
   const SUPPORTED_FIELDS = new Set([
     'image', 'forwardPorts', 'containerEnv', 'mounts',
     'remoteUser', 'postCreateCommand',
+    // #5078 — build-from-Dockerfile and compose-from-devcontainer.
+    'build', 'dockerFile', 'dockerComposeFile', 'service',
   ])
   for (const key of Object.keys(raw)) {
     if (!SUPPORTED_FIELDS.has(key)) {
@@ -70,13 +72,120 @@ export function parseDevContainer(cwd, { logger = NOOP_LOG } = {}) {
   }
 
   const config = {}
+  // `dir` is the directory the devcontainer.json lives in — `build.context`
+  // and `dockerComposeFile` are resolved relative to THIS directory (the
+  // devcontainer spec), not the session cwd. Surfaced so the consuming
+  // session can compute the docker-build context / compose-file path
+  // without re-deriving the file location.
+  config.dir = dirname(filePath)
   if (typeof raw.image === 'string' && raw.image.trim()) config.image = raw.image.trim()
   if (typeof raw.remoteUser === 'string' && raw.remoteUser.trim()) config.remoteUser = raw.remoteUser.trim()
   if (typeof raw.postCreateCommand === 'string' && raw.postCreateCommand.trim()) config.postCreateCommand = raw.postCreateCommand.trim()
   if (raw.containerEnv && typeof raw.containerEnv === 'object' && !Array.isArray(raw.containerEnv)) config.containerEnv = raw.containerEnv
   if (Array.isArray(raw.forwardPorts)) config.forwardPorts = raw.forwardPorts.filter(p => typeof p === 'number' || typeof p === 'string')
   if (Array.isArray(raw.mounts)) config.mounts = raw.mounts.filter(m => typeof m === 'string')
+  // #5078 — `service` is the official devcontainer spec name for the
+  // primary compose service (used with `dockerComposeFile`). Kept as a
+  // trimmed string so the session can pick the right service container.
+  if (typeof raw.service === 'string' && raw.service.trim()) config.service = raw.service.trim()
+  // #5078 — `dockerComposeFile` is a string or array of compose-file
+  // paths relative to the devcontainer.json dir. Normalise to an array of
+  // non-empty strings; drop the field entirely if nothing usable remains.
+  const composeFiles = parseDockerComposeFile(raw.dockerComposeFile, { logger })
+  if (composeFiles) config.dockerComposeFile = composeFiles
+  // #5078 — `build` (object) and `dockerFile` (legacy string) both
+  // declare a Dockerfile-driven image. Normalise to a single `build`
+  // shape: { dockerfile, context, args, target }. The legacy `dockerFile`
+  // string is sugar for `{ build: { dockerfile: <string> } }`. An explicit
+  // `build` object wins when both are present.
+  const build = parseBuild(raw.build, raw.dockerFile, { logger })
+  if (build) config.build = build
   return config
+}
+
+/**
+ * #5078 — Normalise `dockerComposeFile` (string | array) into an array of
+ * non-empty path strings. Returns undefined when nothing usable remains so
+ * the caller can `if (composeFiles)` cleanly.
+ */
+function parseDockerComposeFile(value, { logger = NOOP_LOG } = {}) {
+  if (value == null) return undefined
+  const list = Array.isArray(value) ? value : [value]
+  const files = list.filter((f) => typeof f === 'string' && f.trim()).map((f) => f.trim())
+  if (files.length === 0) {
+    if (value !== undefined) logger.warn('devcontainer.json: dockerComposeFile has no usable string paths (ignored)')
+    return undefined
+  }
+  return files
+}
+
+/**
+ * #5078 — Normalise `build` (object) + legacy `dockerFile` (string) into a
+ * single `{ dockerfile, context, args, target }` shape. All fields are
+ * optional except that SOME Dockerfile reference must exist. Returns
+ * undefined when neither input declares a build.
+ *
+ * Strictness: `build.args` values must be primitive (string/number/bool) —
+ * an object/array value is dropped with a warning, because these are
+ * threaded into `docker build --build-arg KEY=VALUE` and a non-scalar
+ * value has no safe textual form. `dockerfile` / `context` / `target`
+ * must be strings; non-string values are dropped with a warning rather
+ * than silently coerced.
+ */
+function parseBuild(rawBuild, rawDockerFile, { logger = NOOP_LOG } = {}) {
+  let dockerfile
+  let context
+  let target
+  let args
+
+  if (rawBuild && typeof rawBuild === 'object' && !Array.isArray(rawBuild)) {
+    if (typeof rawBuild.dockerfile === 'string' && rawBuild.dockerfile.trim()) {
+      dockerfile = rawBuild.dockerfile.trim()
+    }
+    if (typeof rawBuild.context === 'string' && rawBuild.context.trim()) {
+      context = rawBuild.context.trim()
+    }
+    if (typeof rawBuild.target === 'string' && rawBuild.target.trim()) {
+      target = rawBuild.target.trim()
+    }
+    if (rawBuild.args && typeof rawBuild.args === 'object' && !Array.isArray(rawBuild.args)) {
+      const out = {}
+      let has = false
+      for (const [key, value] of Object.entries(rawBuild.args)) {
+        if (!VALID_ENV_KEY_RE.test(key)) {
+          logger.warn(`devcontainer.json: build.args key rejected (invalid characters): ${key}`)
+          continue
+        }
+        if (value == null || typeof value === 'object') {
+          logger.warn(`devcontainer.json: build.args["${key}"] rejected (must be a scalar)`)
+          continue
+        }
+        out[key] = String(value)
+        has = true
+      }
+      if (has) args = out
+    }
+  }
+
+  // Legacy `dockerFile` string is sugar for build.dockerfile. The explicit
+  // build object wins when both name a Dockerfile.
+  if (!dockerfile && typeof rawDockerFile === 'string' && rawDockerFile.trim()) {
+    dockerfile = rawDockerFile.trim()
+  }
+
+  // A build with no Dockerfile and no context is meaningless — but the
+  // devcontainer spec defaults the Dockerfile to `Dockerfile` relative to
+  // the context. Only emit a build when at least one signal is present.
+  if (!dockerfile && !context && !target && !args) return undefined
+
+  const build = {}
+  // Default the dockerfile to `Dockerfile` (the docker / devcontainer
+  // default) when a build object was declared without naming one.
+  build.dockerfile = dockerfile || 'Dockerfile'
+  if (context) build.context = context
+  if (target) build.target = target
+  if (args) build.args = args
+  return build
 }
 
 /**

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -70,6 +70,29 @@
  *     stack tears down. Pooling is disabled in compose mode.
  *   - Default (neither opt) — original v1 bare-image launch path.
  *
+ * DevContainer build / dockerFile / dockerComposeFile (#5078)
+ * ----------------------------------------------------------
+ *   - `build` (object: dockerfile / context / args / target) or the
+ *     legacy `dockerFile` string in devcontainer.json — start() shells
+ *     `docker build` against the project dir and uses the resulting tag
+ *     as the image. The tag is a deterministic SHA-256 of the build
+ *     inputs, so a repeat session with identical inputs reuses the
+ *     already-built image (docker's own layer cache makes the rebuild a
+ *     fast no-op). `build.target` threads to `docker build --target`.
+ *     `build.context` (and `..`) resolves relative to the
+ *     devcontainer.json DIRECTORY, then is contained to the project cwd —
+ *     a context that escapes the workspace is refused. An explicit `image`
+ *     constructor opt always wins over a devcontainer build.
+ *   - `dockerComposeFile` (string | array) in devcontainer.json — when
+ *     `useDevcontainer` is set and no explicit `composeFile` opt was
+ *     passed, the file (resolved relative to the devcontainer.json dir)
+ *     is treated as if the operator passed `composeFile`, and the primary
+ *     service is taken from devcontainer.json's `service` field. The same
+ *     compose lifecycle (up / attach / down) and pooling-disabled posture
+ *     as the explicit `composeFile` opt applies. Arrays use the FIRST
+ *     file (compose overlay merge is not yet supported — the extras are
+ *     logged, not silently dropped).
+ *
  * Snapshot / restore (#5023)
  * --------------------------
  *   - `snapshot({ name? })` runs `docker commit <containerId>
@@ -100,7 +123,7 @@ import { execFile } from 'child_process'
 import { mkdirSync, writeFileSync, unlinkSync } from 'fs'
 import { createHash, randomBytes } from 'crypto'
 import { homedir, tmpdir } from 'os'
-import { isAbsolute, join, posix } from 'path'
+import { isAbsolute, join, posix, resolve, sep } from 'path'
 import { ClaudeByokSession } from './byok-session.js'
 import { DockerBackend } from './environments/backends/docker.js'
 import { classifyDockerError } from './docker-session.js'
@@ -432,6 +455,10 @@ export class DockerByokSession extends ClaudeByokSession {
     this._explicitImage = opts.image
     this._explicitContainerUser = opts.containerUser
     this._dcConfig = null
+    // #5078: normalised devcontainer.json `build` / `dockerFile` spec,
+    // resolved in `_resolveDevContainer()`. Stays null until then (or
+    // when no build is declared / an explicit image opt wins).
+    this._dcBuild = null
     // #5080: short SHA-1 of the resolved devcontainer overlay, used to
     // namespace the pool key so a changed devcontainer.json invalidates
     // any pooled container provisioned against the old config. Stays
@@ -992,21 +1019,34 @@ export class DockerByokSession extends ClaudeByokSession {
    * fingerprint and their pool key shape is unchanged.
    */
   async _acquireOrStartContainer() {
-    // #5024: compose mode short-circuits the entire pool + bare-image
-    // path. The compose stack owns its own container; destroy()
-    // unwinds it with `docker compose down`.
+    // #5024: devcontainer parsing must happen BEFORE the compose +
+    // pool branches because the resolved devcontainer overlay can ITSELF
+    // declare a compose stack (#5078 `dockerComposeFile`) or a
+    // build-from-Dockerfile image, and the resolved image/user are part
+    // of the pool key. #5080: the same call also computes
+    // `_devcontainerFingerprint`, folded into the pool key so a changed
+    // devcontainer.json overlay invalidates any pooled container
+    // provisioned against the old config.
+    if (this._useDevcontainer) {
+      this._resolveDevContainer()
+    }
+    // #5024 / #5078: compose mode short-circuits the entire pool +
+    // bare-image path. The compose stack owns its own container;
+    // destroy() unwinds it with `docker compose down`. `_composeFile`
+    // may have been set by an explicit constructor opt OR by the
+    // devcontainer.json `dockerComposeFile` field resolved just above.
     if (this._composeFile) {
       await this._startComposeStack()
       return
     }
-    // #5024: devcontainer parsing must happen BEFORE the pool lookup
-    // because the resolved image/user are part of the pool key. #5080:
-    // the same call also computes `_devcontainerFingerprint`, which
-    // is folded into the pool key so a changed devcontainer.json
-    // overlay invalidates any pooled container provisioned against the
-    // old config.
-    if (this._useDevcontainer) {
-      this._resolveDevContainer()
+    // #5078: build-from-Dockerfile. When the resolved devcontainer
+    // overlay declares a `build` / `dockerFile`, shell `docker build`
+    // against the project dir and use the resulting tag as the image.
+    // Cached by tag so a repeat session with the same build inputs
+    // reuses the already-built image. Runs BEFORE the pool lookup so the
+    // built tag is the image segment of the pool key.
+    if (this._dcBuild && !this._explicitImage) {
+      await this._buildDevcontainerImage()
     }
     if (this._pool && !this._snapshotImage) {
       const key = this._poolKey()
@@ -1079,6 +1119,13 @@ export class DockerByokSession extends ClaudeByokSession {
       mounts: validateMounts(config.mounts, cwd, { logger: log }),
       containerEnv: sanitizeContainerEnv(config.containerEnv, { logger: log }),
     }
+    // #5078 — devcontainer.json may declare a build (Dockerfile) or a
+    // compose stack. Resolve those onto session state here so
+    // `_acquireOrStartContainer` can branch on them. Explicit constructor
+    // opts (image / composeFile) always win — devcontainer.json is the
+    // fallback, mirroring the image/remoteUser precedence above.
+    this._resolveDevContainerBuild(config, cwd)
+    this._resolveDevContainerCompose(config, cwd)
     // #5080: Compute the pool-key fingerprint from the FULLY-RESOLVED
     // overlay (after mount validation + env sanitisation), not the raw
     // parsed file. That way two devcontainer.json files that differ
@@ -1091,6 +1138,169 @@ export class DockerByokSession extends ClaudeByokSession {
     // misses when an explicit constructor opt has overridden them but
     // the devcontainer.json file value changed.
     this._devcontainerFingerprint = this._computeDevcontainerFingerprint(this._dcConfig)
+  }
+
+  /**
+   * #5078 — Resolve a devcontainer.json `build` / `dockerFile` declaration
+   * onto session state. Stores a normalised build spec in `this._dcBuild`
+   * with absolute, contained paths:
+   *   - `context`   absolute project-relative build context (defaults to
+   *                 the devcontainer.json directory; honours `..`)
+   *   - `dockerfile` path passed to `docker build -f`
+   *   - `target`    multi-stage build target (→ `--target`)
+   *   - `args`      validated `--build-arg KEY=VALUE` pairs
+   *
+   * The build context is resolved relative to the devcontainer.json
+   * DIRECTORY (the spec), not the session cwd, then contained to the
+   * project cwd — a `context: '../..'` that escapes the project tree is
+   * rejected so a malicious devcontainer.json can't hand `docker build` a
+   * context outside the workspace.
+   *
+   * No-op when the overlay declares no build, OR when an explicit
+   * constructor `image` was passed (the operator's image wins — same
+   * precedence the image overlay uses).
+   */
+  _resolveDevContainerBuild(config, cwd) {
+    this._dcBuild = null
+    if (!config || !config.build) return
+    if (this._explicitImage) {
+      log.info('devcontainer.json build ignored — explicit image opt wins')
+      return
+    }
+    const dcDir = config.dir || cwd
+    const absCwd = resolve(cwd)
+    const cwdPrefix = absCwd.endsWith(sep) ? absCwd : absCwd + sep
+
+    // Context defaults to the devcontainer.json dir per spec. Resolve it
+    // relative to that dir so `..` walks up from there, then contain to
+    // the project cwd.
+    const contextResolved = resolve(dcDir, config.build.context || '.')
+    if (contextResolved !== absCwd && !contextResolved.startsWith(cwdPrefix)) {
+      log.warn(
+        `devcontainer.json build.context "${config.build.context}" resolves outside the project dir (${contextResolved}) — ignoring build`,
+      )
+      return
+    }
+
+    // Dockerfile is resolved relative to the build context (docker's own
+    // default) and must also stay inside the project tree.
+    const dockerfileResolved = resolve(contextResolved, config.build.dockerfile)
+    if (dockerfileResolved !== absCwd && !dockerfileResolved.startsWith(cwdPrefix)) {
+      log.warn(
+        `devcontainer.json build.dockerfile "${config.build.dockerfile}" resolves outside the project dir (${dockerfileResolved}) — ignoring build`,
+      )
+      return
+    }
+
+    this._dcBuild = {
+      context: contextResolved,
+      dockerfile: dockerfileResolved,
+      target: typeof config.build.target === 'string' ? config.build.target : null,
+      args: config.build.args && typeof config.build.args === 'object' ? config.build.args : null,
+    }
+  }
+
+  /**
+   * #5078 — Resolve a devcontainer.json `dockerComposeFile` declaration
+   * into the session's compose opts. When present (and no explicit
+   * `composeFile` constructor opt was passed), sets `_composeFile` to the
+   * primary compose file resolved relative to the devcontainer.json dir,
+   * picks the primary service from devcontainer.json's `service` field,
+   * and disables pooling (compose stacks own their container lifecycle).
+   *
+   * The devcontainer spec allows an ARRAY of compose files (base +
+   * overrides). The current backend `_composeUp` shells a single `-f`;
+   * we attach to the FIRST file and warn that overlays are not yet
+   * merged, rather than silently dropping the extras.
+   *
+   * No-op when the overlay declares no compose file or an explicit
+   * `composeFile` constructor opt already won.
+   */
+  _resolveDevContainerCompose(config, cwd) {
+    if (!config || !Array.isArray(config.dockerComposeFile) || config.dockerComposeFile.length === 0) return
+    if (this._composeFile) {
+      log.info('devcontainer.json dockerComposeFile ignored — explicit composeFile opt wins')
+      return
+    }
+    const dcDir = config.dir || cwd
+    const files = config.dockerComposeFile
+    if (files.length > 1) {
+      log.warn(
+        `devcontainer.json dockerComposeFile lists ${files.length} files; only the first ("${files[0]}") is used (compose overlay merge is not yet supported)`,
+      )
+    }
+    this._composeFile = resolve(dcDir, files[0])
+    // Primary service: devcontainer.json `service` field wins; otherwise
+    // fall back to the first service the backend reports.
+    if (!this._composeService && config.service) {
+      this._composeService = config.service
+    }
+    // Compose stacks own their container — pooling is disabled (mirrors
+    // the constructor's compose-mode pool guard).
+    this._pool = null
+  }
+
+  /**
+   * #5078 — Build a Docker image from a devcontainer.json `build` /
+   * `dockerFile` declaration via `docker build`, then use the resulting
+   * tag as `this._image`. Cached by tag: the tag is a deterministic
+   * SHA-256 fingerprint of the build inputs (context, dockerfile, target,
+   * args), so a repeat session with identical inputs produces the same
+   * tag and `docker build`'s own layer cache makes the rebuild a fast
+   * no-op (the image already exists locally).
+   *
+   * Security: every value is passed to `_execFile` as a discrete argv
+   * entry — never string-interpolated into a shell. `--build-arg
+   * KEY=VALUE` pairs use keys already constrained to POSIX env-var shape
+   * by `parseBuild`; values are passed verbatim as a single argv token so
+   * shell metacharacters in a value are inert.
+   */
+  _buildDevcontainerImage() {
+    return new Promise((resolve, reject) => {
+      const build = this._dcBuild
+      const tag = this._computeBuildTag(build)
+      const buildArgs = ['build', '-t', tag, '-f', build.dockerfile]
+      if (build.target) buildArgs.push('--target', build.target)
+      if (build.args) {
+        for (const [key, value] of Object.entries(build.args)) {
+          buildArgs.push('--build-arg', `${key}=${value}`)
+        }
+      }
+      // Context is the final positional argument.
+      buildArgs.push(build.context)
+
+      log.info(`docker-byok building image ${tag} (context=${build.context} dockerfile=${build.dockerfile}${build.target ? ` target=${build.target}` : ''})`)
+      this._execFile('docker', buildArgs, { encoding: 'utf-8', timeout: 600_000 }, (err, _stdout, stderr) => {
+        if (err) {
+          const classified = classifyDockerError(err, stderr)
+          const error = new Error(`docker build failed: ${classified.message}`)
+          error.code = classified.code || 'docker_build_failed'
+          reject(error)
+          return
+        }
+        this._image = tag
+        log.info(`docker-byok built image ${tag}`)
+        resolve()
+      })
+    })
+  }
+
+  /**
+   * #5078 — Deterministic, lowercase, Docker-tag-safe image tag derived
+   * from the build inputs. Same inputs → same tag → `docker build` hits
+   * its local layer cache and the image is reused across sessions.
+   */
+  _computeBuildTag(build) {
+    const fingerprint = createHash('sha256')
+      .update(this._canonicalStringify({
+        context: build.context,
+        dockerfile: build.dockerfile,
+        target: build.target,
+        args: build.args,
+      }))
+      .digest('hex')
+      .slice(0, 16)
+    return `chroxy-byok-build:${fingerprint}`
   }
 
   /**

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -1167,6 +1167,13 @@ export class DockerByokSession extends ClaudeByokSession {
       log.info('devcontainer.json build ignored — explicit image opt wins')
       return
     }
+    // The devcontainer spec treats `image` and `build` as mutually
+    // exclusive. If both are present we honour `build` (it overwrites the
+    // image overlay applied just above) — surface a warning so the
+    // operator knows the declared `image` field was superseded.
+    if (config.image) {
+      log.warn(`devcontainer.json declares both "image" (${config.image}) and "build" — building from the Dockerfile; "image" is ignored`)
+    }
     const dcDir = config.dir || cwd
     const absCwd = resolve(cwd)
     const cwdPrefix = absCwd.endsWith(sep) ? absCwd : absCwd + sep

--- a/packages/server/tests/devcontainer-config.test.js
+++ b/packages/server/tests/devcontainer-config.test.js
@@ -105,6 +105,107 @@ describe('parseDevContainer()', () => {
     const config = parseDevContainer(tmpDir)
     assert.deepEqual(config, {})
   })
+
+  // #5078 — build / dockerFile / dockerComposeFile
+  it('does not warn on build / dockerFile / dockerComposeFile / service', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      build: { dockerfile: 'Dockerfile' },
+      dockerComposeFile: 'docker-compose.yml',
+      service: 'app',
+    }))
+    parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.equal(warnings.filter(m => m.includes('unsupported field')).length, 0)
+  })
+
+  it('surfaces the devcontainer.json directory as config.dir', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({ image: 'node:22' }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.equal(config.dir, join(tmpDir, '.devcontainer'))
+  })
+
+  it('parses build object with dockerfile / context / target / args', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      build: { dockerfile: 'Dockerfile.dev', context: '..', target: 'builder', args: { NODE_VERSION: '22', FLAG: true } },
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.deepEqual(config.build, {
+      dockerfile: 'Dockerfile.dev',
+      context: '..',
+      target: 'builder',
+      args: { NODE_VERSION: '22', FLAG: 'true' },
+    })
+  })
+
+  it('parses legacy dockerFile string as build.dockerfile', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      dockerFile: 'Dockerfile',
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.deepEqual(config.build, { dockerfile: 'Dockerfile' })
+  })
+
+  it('explicit build object wins over legacy dockerFile', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      dockerFile: 'Legacy.Dockerfile',
+      build: { dockerfile: 'New.Dockerfile' },
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.equal(config.build.dockerfile, 'New.Dockerfile')
+  })
+
+  it('build object without a dockerfile defaults to "Dockerfile"', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      build: { context: '..' },
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.equal(config.build.dockerfile, 'Dockerfile')
+    assert.equal(config.build.context, '..')
+  })
+
+  it('drops non-scalar / invalid-key build.args with a warning', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      build: { dockerfile: 'Dockerfile', args: { GOOD: 'x', NESTED: { a: 1 }, 'BAD;KEY': 'y' } },
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.deepEqual(config.build.args, { GOOD: 'x' })
+    assert.ok(warnings.some(m => m.includes('build.args')))
+  })
+
+  it('normalises dockerComposeFile string to a one-element array', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      dockerComposeFile: 'docker-compose.yml',
+      service: 'web',
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.deepEqual(config.dockerComposeFile, ['docker-compose.yml'])
+    assert.equal(config.service, 'web')
+  })
+
+  it('keeps dockerComposeFile array order and drops non-strings', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      dockerComposeFile: ['base.yml', '', 'override.yml', 42],
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.deepEqual(config.dockerComposeFile, ['base.yml', 'override.yml'])
+  })
+
+  it('drops dockerComposeFile when no usable string paths remain', () => {
+    mkdirSync(join(tmpDir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(tmpDir, '.devcontainer', 'devcontainer.json'), JSON.stringify({
+      dockerComposeFile: ['', '   '],
+    }))
+    const config = parseDevContainer(tmpDir, { logger: captureLogger })
+    assert.equal(config.dockerComposeFile, undefined)
+  })
 })
 
 describe('validateMounts()', () => {

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -3505,6 +3505,309 @@ describe('DockerByokSession — Docker Compose support (#5024)', () => {
   })
 })
 
+// ─────────────────────────────────────────────────────────────────────
+// #5078 — devcontainer build / dockerFile / dockerComposeFile
+// ─────────────────────────────────────────────────────────────────────
+
+describe('DockerByokSession — devcontainer build / compose (#5078)', () => {
+  function makeDevcontainerCwd(content, { files = {} } = {}) {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-dc-5078-'))
+    mkdirSync(join(dir, '.devcontainer'), { recursive: true })
+    writeFileSync(join(dir, '.devcontainer', 'devcontainer.json'), JSON.stringify(content))
+    for (const [rel, body] of Object.entries(files)) {
+      writeFileSync(join(dir, rel), body)
+    }
+    return dir
+  }
+
+  function composeBackendStub({ primaryId = 'COMPOSE_5078', destroyCalls = [] } = {}) {
+    return {
+      createCalls: [],
+      destroyCalls,
+      async createComposeEnvironment(opts) {
+        this.createCalls.push(opts)
+        return {
+          containerId: primaryId,
+          containerCliPath: '/usr/local/bin/claude',
+          services: [{ name: opts.primaryService || 'app', status: 'running', primary: true }],
+        }
+      },
+      async destroyComposeEnvironment(opts) { destroyCalls.push(opts) },
+      async execInEnvironment() { return { stdout: '', stderr: '' } },
+    }
+  }
+
+  it('build object → docker build, resulting tag becomes the image', async () => {
+    const cwd = makeDevcontainerCwd({ build: { dockerfile: 'Dockerfile' } }, {
+      '.devcontainer/Dockerfile': 'FROM node:22-slim\n',
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        build: { stdout: '' },
+        run: { stdout: 'CONTAINER_build\n' },
+        exec: { stdout: '' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        _execFile,
+        _dockerBackend: backendStub(),
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const buildCall = _execFile.calls.find(c => c.args[0] === 'build')
+      assert.ok(buildCall, 'docker build was not called')
+      const tagIdx = buildCall.args.indexOf('-t')
+      const tag = buildCall.args[tagIdx + 1]
+      assert.match(tag, /^chroxy-byok-build:[0-9a-f]{16}$/)
+      // The built tag must be the image docker run launches.
+      const runCall = _execFile.calls.find(c => c.args[0] === 'run')
+      const sleepIdx = runCall.args.indexOf('sleep')
+      assert.equal(runCall.args[sleepIdx - 1], tag)
+      assert.equal(session._image, tag)
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('legacy dockerFile string also drives docker build', async () => {
+    const cwd = makeDevcontainerCwd({ dockerFile: 'Dockerfile' }, {
+      '.devcontainer/Dockerfile': 'FROM node:22-slim\n',
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' }, build: { stdout: '' }, run: { stdout: 'C\n' }, exec: { stdout: '' }, rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backendStub() })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      assert.ok(_execFile.calls.some(c => c.args[0] === 'build'), 'docker build not called for dockerFile')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('build.target is threaded to docker build --target', async () => {
+    const cwd = makeDevcontainerCwd({ build: { dockerfile: 'Dockerfile', target: 'builder' } }, {
+      '.devcontainer/Dockerfile': 'FROM node:22-slim AS builder\n',
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' }, build: { stdout: '' }, run: { stdout: 'C\n' }, exec: { stdout: '' }, rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backendStub() })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const buildCall = _execFile.calls.find(c => c.args[0] === 'build')
+      const tIdx = buildCall.args.indexOf('--target')
+      assert.ok(tIdx > 0, '--target not present')
+      assert.equal(buildCall.args[tIdx + 1], 'builder')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('build.args become discrete --build-arg KEY=VALUE argv tokens', async () => {
+    const cwd = makeDevcontainerCwd({ build: { dockerfile: 'Dockerfile', args: { NODE_VERSION: '22' } } }, {
+      '.devcontainer/Dockerfile': 'FROM node:22-slim\n',
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' }, build: { stdout: '' }, run: { stdout: 'C\n' }, exec: { stdout: '' }, rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backendStub() })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const buildCall = _execFile.calls.find(c => c.args[0] === 'build')
+      const baIdx = buildCall.args.indexOf('--build-arg')
+      assert.ok(baIdx > 0, '--build-arg not present')
+      assert.equal(buildCall.args[baIdx + 1], 'NODE_VERSION=22')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('build.context "." resolves to the devcontainer.json dir, not cwd', async () => {
+    const cwd = makeDevcontainerCwd({ build: { dockerfile: 'Dockerfile', context: '.' } }, {
+      '.devcontainer/Dockerfile': 'FROM node:22-slim\n',
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' }, build: { stdout: '' }, run: { stdout: 'C\n' }, exec: { stdout: '' }, rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backendStub() })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const buildCall = _execFile.calls.find(c => c.args[0] === 'build')
+      // Context is the last positional arg.
+      const context = buildCall.args[buildCall.args.length - 1]
+      assert.equal(context, join(cwd, '.devcontainer'))
+      // -f path is under the context (devcontainer dir), not cwd root.
+      const fIdx = buildCall.args.indexOf('-f')
+      assert.equal(buildCall.args[fIdx + 1], join(cwd, '.devcontainer', 'Dockerfile'))
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('build.context ".." resolves up from the devcontainer dir to project root', async () => {
+    const cwd = makeDevcontainerCwd({ build: { dockerfile: 'Dockerfile', context: '..' } }, {
+      'Dockerfile': 'FROM node:22-slim\n',
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' }, build: { stdout: '' }, run: { stdout: 'C\n' }, exec: { stdout: '' }, rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backendStub() })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const buildCall = _execFile.calls.find(c => c.args[0] === 'build')
+      const context = buildCall.args[buildCall.args.length - 1]
+      // `..` from `<cwd>/.devcontainer` lands back at cwd.
+      assert.equal(context, cwd)
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('build.context escaping the project dir is rejected (no build)', async () => {
+    const cwd = makeDevcontainerCwd({ build: { dockerfile: 'Dockerfile', context: '../../..' } })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' }, run: { stdout: 'C\n' }, exec: { stdout: '' }, rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backendStub() })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      assert.ok(!_execFile.calls.some(c => c.args[0] === 'build'), 'build should be refused for escaping context')
+      // Falls back to the default image (no build happened).
+      assert.equal(session._image, 'node:22-slim')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('explicit image constructor opt wins over devcontainer build', async () => {
+    const cwd = makeDevcontainerCwd({ build: { dockerfile: 'Dockerfile' } }, {
+      '.devcontainer/Dockerfile': 'FROM node:22-slim\n',
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' }, run: { stdout: 'C\n' }, exec: { stdout: '' }, rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, image: 'alpine:3.20', _execFile, _dockerBackend: backendStub() })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      assert.ok(!_execFile.calls.some(c => c.args[0] === 'build'), 'build must be skipped when explicit image is set')
+      assert.equal(session._image, 'alpine:3.20')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('docker build failure tears down and emits session error', async () => {
+    const cwd = makeDevcontainerCwd({ build: { dockerfile: 'Dockerfile' } }, {
+      '.devcontainer/Dockerfile': 'FROM node:22-slim\n',
+    })
+    try {
+      const _execFile = execFileStub({
+        info: { stdout: 'ok' },
+        build: { error: new Error('build boom'), stderr: 'no such stage' },
+        rm: { stdout: '' },
+      })
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backendStub() })
+      const events = []
+      session.on('error', e => events.push(e))
+      await session.start()
+      assert.ok(events.some(e => /failed to start container|docker build failed/.test(e.message)),
+        `expected build failure error, got: ${JSON.stringify(events)}`)
+      assert.equal(session._containerReady, false)
+      assert.ok(!_execFile.calls.some(c => c.args[0] === 'run'), 'run must not happen after build failure')
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('dockerComposeFile (string) drives compose with service from devcontainer.json', async () => {
+    const cwd = makeDevcontainerCwd({
+      dockerComposeFile: 'docker-compose.yml',
+      service: 'web',
+    }, { '.devcontainer/docker-compose.yml': 'services:\n  web: { image: node:22 }\n' })
+    try {
+      const _execFile = execFileStub({ info: { stdout: 'ok' } })
+      const backend = composeBackendStub({ primaryId: 'COMPOSE_dc' })
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backend })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      assert.equal(backend.createCalls.length, 1, 'compose stack not brought up')
+      const call = backend.createCalls[0]
+      // Compose file path resolves relative to the devcontainer.json dir.
+      assert.equal(call.composeFile, join(cwd, '.devcontainer', 'docker-compose.yml'))
+      assert.equal(call.primaryService, 'web')
+      assert.equal(session._containerId, 'COMPOSE_dc')
+      assert.equal(session._containerReady, true)
+      assert.equal(session._pool, null, 'pooling must be disabled in compose mode')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('dockerComposeFile (array) uses the first file and resolves relative to devcontainer dir', async () => {
+    const cwd = makeDevcontainerCwd({
+      dockerComposeFile: ['../base.yml', 'override.yml'],
+      service: 'app',
+    })
+    try {
+      const _execFile = execFileStub({ info: { stdout: 'ok' } })
+      const backend = composeBackendStub()
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backend })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const call = backend.createCalls[0]
+      // ../base.yml from <cwd>/.devcontainer resolves to <cwd>/base.yml
+      assert.equal(call.composeFile, join(cwd, 'base.yml'))
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('explicit composeFile constructor opt wins over devcontainer dockerComposeFile', async () => {
+    const cwd = makeDevcontainerCwd({ dockerComposeFile: 'dc-compose.yml', service: 'web' })
+    try {
+      const _execFile = execFileStub({ info: { stdout: 'ok' } })
+      const backend = composeBackendStub()
+      const session = new DockerByokSession({
+        cwd,
+        useDevcontainer: true,
+        composeFile: '/explicit/compose.yml',
+        composeService: 'explicit-svc',
+        _execFile,
+        _dockerBackend: backend,
+      })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const call = backend.createCalls[0]
+      assert.equal(call.composeFile, '/explicit/compose.yml')
+      assert.equal(call.primaryService, 'explicit-svc')
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})
+
 // Force a tick so any background EventEmitter cleanup completes
 // before the test runner exits.
 afterEach(async () => {


### PR DESCRIPTION
## Summary

`devcontainer-config.js#parseDevContainer` previously warned-and-dropped three commonly-used devcontainer.json fields. This wires up functional support in the docker-byok provider so a VSCode/Codespaces devcontainer.json lifted into chroxy works without translation.

Closes #5078

## Per-AC status

- [x] **`parseDevContainer` no longer warns on `dockerFile` / `build` / `dockerComposeFile`** — added (plus `service`) to the supported set; normalised into the parsed config shape (`build → { dockerfile, context, args, target }`, legacy `dockerFile` is sugar for `build.dockerfile`, `dockerComposeFile → string[]`). The parsed config now also surfaces `dir` (the devcontainer.json directory) so paths resolve relative to it per spec.
- [x] **`DockerByokSession.start()` honours each** —
  - **build / dockerFile** → shells `docker build` against the project dir, then uses the resulting tag as the image. Cached by a deterministic SHA-256 tag of the build inputs, so a repeat session with identical inputs reuses the already-built image (docker layer cache makes the rebuild a no-op). Build failure tears down and emits a session error before any `docker run`.
  - **dockerComposeFile** → when `useDevcontainer` is set and no explicit `composeFile` opt was passed, treated as if the operator passed `composeFile`; primary service picked from devcontainer.json's `service` field; pooling disabled (compose owns its container lifecycle); array form uses the first file (overlay merge not yet supported — extras are logged).
- [x] **Tests cover the build-image path (mock `docker build` via `_execFile`) and the compose-from-devcontainer path** — added.
- [x] **Multi-stage `build.target` is parsed and threaded to `--target`** — parsed in `parseDevContainer`, threaded in `_buildDevcontainerImage`, covered by a test.

## Path resolution (AC #3)

`build.context` (and `..`) resolves relative to the **devcontainer.json directory**, not cwd, then is contained to the project cwd. A context that escapes the project tree is refused (no build, falls back to default image). The Dockerfile path is resolved relative to the build context and likewise contained.

## Security — docker build argument handling

- Every value is passed to `_execFile` as a **discrete argv token** — never string-interpolated into a shell. No `bash -c`.
- `build.args` keys are constrained to POSIX env-var shape (`[A-Za-z_][A-Za-z0-9_]*`); non-scalar (object/array/null) values are dropped with a warning. `--build-arg KEY=VALUE` is a single argv entry so shell metacharacters in a value are inert.
- `build.context` / Dockerfile path containment defends against a malicious devcontainer.json handing `docker build` a context outside the workspace.

## Test plan

```
cd packages/server && node --test \
  tests/devcontainer-config.test.js \
  tests/docker-byok-session.test.js \
  tests/docker-byok-pool.test.js \
  tests/environment-manager.test.js
# 335 pass / 0 fail

./scripts/lint-tests-state-file-path.sh   # OK
./scripts/lint-session-opt-forwarding.sh  # OK
```