### PR TITLE
feat(server): stream docker-byok postCreateCommand output to session log

### DIFF
--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -339,6 +339,22 @@ export class DockerByokSession extends ClaudeByokSession {
   }
 
   /**
+   * #5069 — surface streamed `postCreateCommand` output. `setup_log` is a
+   * transient event carrying one chunk of the container-setup command's
+   * stdout/stderr as it runs, so the dashboard / mobile client can show
+   * progress during a multi-minute `npm install` / `apt-get` instead of a
+   * silent session. session-manager.js:_wireSessionEvents reads
+   * `customEvents` to build the TRANSIENT_EVENTS set it bridges to
+   * `session_event` listeners; an event missing from this list fires on the
+   * local EventEmitter and never reaches ws-forwarding. We extend (rather
+   * than replace) the inherited BYOK set so tool_start / tool_result /
+   * tool_input_delta / agent_* keep flowing.
+   */
+  static get customEvents() {
+    return [...ClaudeByokSession.customEvents, 'setup_log']
+  }
+
+  /**
    * Preflight credentials block. Same shape as ClaudeByokSession — the
    * agent loop still runs on the host so the credential set / hint /
    * required-ness is identical to host-side BYOK. The container itself
@@ -1696,9 +1712,22 @@ export class DockerByokSession extends ClaudeByokSession {
     // Run the command. The backend's execInEnvironment forwards both
     // stdout and stderr and rejects on non-zero exit, so we don't need
     // to inspect an exit code here — a throw IS the failure path.
+    //
+    // #5069 — stream output to the session log surface as bytes arrive so
+    // the operator gets progress during a multi-minute setup instead of a
+    // silent dashboard. Each chunk becomes a transient `setup_log` event
+    // (forwarded via DockerByokSession.customEvents). The backend STILL
+    // accumulates stdout/stderr and attaches the last-N-KiB tail to the
+    // rejected Error on failure (#5067), so the failure-event payload is
+    // unchanged — streaming is purely additive.
     await this._execAsContainerUser({
       cmd: this._postCreateCommand,
       timeout: this._postCreateTimeoutMs,
+      onData: (chunk, stream) => {
+        // Defensive: never let a malformed chunk break the run loop.
+        if (typeof chunk !== 'string' || chunk.length === 0) return
+        this.emit('setup_log', { phase: 'post_create', stream, chunk })
+      },
     })
 
     // Stamp the marker so the next session that lands on this container
@@ -1815,12 +1844,16 @@ export class DockerByokSession extends ClaudeByokSession {
    * sessions don't need this: their `docker run --env ANTHROPIC_API_KEY`
    * already attached the key to the container env at launch time.
    */
-  _execAsContainerUser({ cmd, timeout = 30_000 }) {
+  _execAsContainerUser({ cmd, timeout = 30_000, onData } = {}) {
     return this._dockerBackend.execInEnvironment(this._containerId, {
       cmd,
       timeout,
       user: this._containerUser,
       envFile: this._composeEnvFile || undefined,
+      // #5069: forward an optional streaming callback. When absent the
+      // backend keeps the buffered `execFile` path, so every existing tool
+      // dispatch (Read/Write/Bash/...) is unchanged.
+      onData,
     })
   }
 

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -137,8 +137,19 @@ export class DockerBackend {
 
   /**
    * @param {string} containerId
-   * @param {{ cmd: string, env?: Object.<string,string>, envFile?: string, cwd?: string, timeout?: number }} opts
+   * @param {{ cmd: string, env?: Object.<string,string>, envFile?: string, cwd?: string, timeout?: number, user?: string, onData?: (chunk: string, stream: 'stdout'|'stderr') => void }} opts
    * @returns {Promise<{ stdout: string, stderr: string }>}
+   *
+   * opts.onData — OPTIONAL streaming callback (#5069). When provided, the
+   * command runs via a streaming `spawn` instead of the buffered `execFile`,
+   * and `onData(chunk, 'stdout'|'stderr')` is invoked with each decoded chunk
+   * as bytes arrive. This lets a caller surface progress for multi-minute
+   * setups (npm install, apt-get) instead of staring at a silent dashboard.
+   * The buffered last-N-KiB tail is STILL accumulated and attached to the
+   * rejected Error on failure (#5067 contract preserved), so streaming and
+   * the failure-tail capture coexist. When `onData` is absent the original
+   * buffered `execFile` path is used unchanged — every existing caller keeps
+   * its exact behaviour.
    *
    * opts.env — all key/value pairs are forwarded as `--env KEY=VAL` flags.
    * Entries whose value is null or undefined are skipped with a `log.warn`
@@ -173,7 +184,7 @@ export class DockerBackend {
    * (#5021) passes it for every tool dispatch so file ops respect the
    * `useradd` + `chown /workspace` setup done at container start.
    */
-  execInEnvironment(containerId, { cmd, env, envFile, cwd, timeout = 30_000, user } = {}) {
+  execInEnvironment(containerId, { cmd, env, envFile, cwd, timeout = 30_000, user, onData } = {}) {
     return new Promise((resolve, reject) => {
       const execArgs = ['exec']
 
@@ -209,6 +220,94 @@ export class DockerBackend {
       }
 
       execArgs.push(containerId, 'bash', '-c', cmd)
+
+      // #5069 — Streaming path. When the caller supplies `onData`, run the
+      // command via `spawn` so stdout/stderr surface incrementally as bytes
+      // arrive (long-running setup like `npm install` / `apt-get`). We still
+      // accumulate the full stdout/stderr so the resolved value and the
+      // failure-tail attached to the rejected Error (#5067) are identical to
+      // the buffered path. When `onData` is absent we keep the original
+      // `execFile` call untouched for every existing caller.
+      if (typeof onData === 'function') {
+        const child = this._spawn('docker', execArgs, { stdio: ['ignore', 'pipe', 'pipe'] })
+
+        let stdout = ''
+        let stderr = ''
+        let settled = false
+        let timedOut = false
+        let timer = null
+
+        const settle = (fn, arg) => {
+          if (settled) return
+          settled = true
+          if (timer) clearTimeout(timer)
+          fn(arg)
+        }
+
+        if (timeout && timeout > 0) {
+          timer = setTimeout(() => {
+            timedOut = true
+            // SIGTERM the docker exec wrapper so we don't leak the process
+            // on a stuck setup. Matches execFile's `timeout` semantics.
+            if (child && !child.killed) {
+              try { child.kill('SIGTERM') } catch { /* already gone */ }
+            }
+          }, timeout)
+          // Don't let the timeout keep the event loop alive on its own.
+          if (timer && typeof timer.unref === 'function') timer.unref()
+        }
+
+        if (child.stdout) {
+          child.stdout.setEncoding('utf-8')
+          child.stdout.on('data', (chunk) => {
+            stdout += chunk
+            // Never let an onData throw escape and orphan the child.
+            try { onData(chunk, 'stdout') } catch { /* listener error — ignore */ }
+          })
+        }
+        if (child.stderr) {
+          child.stderr.setEncoding('utf-8')
+          child.stderr.on('data', (chunk) => {
+            stderr += chunk
+            try { onData(chunk, 'stderr') } catch { /* listener error — ignore */ }
+          })
+        }
+
+        child.on('error', (err) => {
+          // spawn failure (docker binary missing, etc.) — surface with the
+          // same enriched-Error shape the buffered path uses.
+          const wrapped = new Error(stderr ? stderr.trim() : err.message)
+          wrapped.stdout = stdout
+          wrapped.stderr = stderr
+          if (err.code) wrapped.code = err.code
+          settle(reject, wrapped)
+        })
+
+        child.on('close', (code, signal) => {
+          if (timedOut) {
+            const err = new Error(`Command timed out after ${timeout}ms`)
+            err.killed = true
+            err.signal = signal || 'SIGTERM'
+            err.stdout = stdout
+            err.stderr = stderr
+            settle(reject, err)
+            return
+          }
+          if (code === 0) {
+            settle(resolve, { stdout, stderr })
+            return
+          }
+          // Non-zero exit — mirror the buffered-path enriched Error so the
+          // #5067 stdout/stderr capture is preserved for the failure event.
+          const wrapped = new Error(stderr ? stderr.trim() : `Command exited with code ${code}`)
+          wrapped.stdout = stdout
+          wrapped.stderr = stderr
+          if (code != null) wrapped.code = code
+          if (signal) wrapped.signal = signal
+          settle(reject, wrapped)
+        })
+        return
+      }
 
       this._execFile('docker', execArgs, { encoding: 'utf-8', timeout }, (err, stdout, stderr) => {
         if (err) {

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -2359,6 +2359,205 @@ describe('DockerByokSession — postCreateCommand hook (#5025)', () => {
 
     await session.destroy()
   })
+
+  // ─────────────────────────────────────────────────────────────────────
+  // #5069 — stream postCreateCommand output to the session log surface as
+  // bytes arrive (long-running setup feedback)
+  // ─────────────────────────────────────────────────────────────────────
+
+  /**
+   * Streaming-aware "fresh container" backend. Like freshContainerBackend
+   * but, for the postCreateCommand run (any cmd matching a key in
+   * `streamChunks`), it invokes `opts.onData(chunk, stream)` with each
+   * canned chunk in order BEFORE resolving — modelling the docker backend's
+   * spawn path firing 'data' events as bytes arrive. The marker probe /
+   * touch behaviour is identical so idempotency stays testable.
+   *
+   * `failAfterStream` (an Error) makes the matched command reject AFTER
+   * streaming the chunks, so we can assert that the buffered tail is still
+   * attached to the failure event even when output was streamed.
+   */
+  function streamingContainerBackend({ streamChunks = {}, failAfterStream = null } = {}) {
+    let markerPresent = false
+    const calls = []
+    return {
+      calls,
+      async execInEnvironment(containerId, opts) {
+        calls.push({ containerId, ...opts })
+        const cmd = opts.cmd || ''
+        if (cmd.includes('.chroxy-post-create')) {
+          if (cmd.startsWith('test -f ')) {
+            if (markerPresent) return { stdout: '', stderr: '' }
+            const err = new Error('exit 1')
+            err.code = 'exec_failed'
+            throw err
+          }
+          if (cmd.startsWith('touch ')) {
+            markerPresent = true
+            return { stdout: '', stderr: '' }
+          }
+        }
+        const matcher = Object.keys(streamChunks).find((needle) => cmd.includes(needle))
+        if (matcher) {
+          let stdout = ''
+          let stderr = ''
+          for (const [stream, chunk] of streamChunks[matcher]) {
+            if (stream === 'stdout') stdout += chunk
+            else stderr += chunk
+            if (typeof opts.onData === 'function') opts.onData(chunk, stream)
+          }
+          if (failAfterStream) {
+            const err = failAfterStream instanceof Error ? failAfterStream : new Error(failAfterStream)
+            err.stdout = stdout
+            err.stderr = stderr
+            throw err
+          }
+          return { stdout, stderr }
+        }
+        return { stdout: '', stderr: '' }
+      },
+    }
+  }
+
+  it('#5069: streams postCreateCommand output as setup_log events in arrival order', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_STREAM\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const backend = streamingContainerBackend({
+      streamChunks: {
+        'npm install': [
+          ['stdout', 'npm WARN deprecated foo@1\n'],
+          ['stderr', 'fetching metadata...\n'],
+          ['stdout', 'added 42 packages in 3s\n'],
+        ],
+      },
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+
+    const logs = []
+    session.on('setup_log', (e) => logs.push(e))
+    await session.start()
+
+    assert.equal(session._containerReady, true)
+    assert.equal(logs.length, 3, 'expected one setup_log per streamed chunk')
+    assert.deepEqual(
+      logs.map((l) => [l.stream, l.chunk]),
+      [
+        ['stdout', 'npm WARN deprecated foo@1\n'],
+        ['stderr', 'fetching metadata...\n'],
+        ['stdout', 'added 42 packages in 3s\n'],
+      ],
+      'setup_log events must preserve arrival order and stream tagging',
+    )
+    assert.ok(logs.every((l) => l.phase === 'post_create'), 'every chunk tagged with phase post_create')
+
+    await session.destroy()
+  })
+
+  it('#5069: setup_log is declared in customEvents so it reaches ws-forwarding', () => {
+    // session-manager.js:_wireSessionEvents only bridges events listed in
+    // the constructor's customEvents to session_event listeners. Without
+    // this, setup_log would fire on the local EventEmitter and never reach
+    // the dashboard.
+    assert.ok(
+      DockerByokSession.customEvents.includes('setup_log'),
+      'setup_log must be in customEvents',
+    )
+    // Inherited BYOK events must still be present (extend, not replace).
+    assert.ok(DockerByokSession.customEvents.includes('tool_start'))
+    assert.ok(DockerByokSession.customEvents.includes('tool_result'))
+  })
+
+  it('#5069: a failed streamed postCreateCommand still attaches the buffered tail to the error event', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_STREAM_FAIL\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    const failErr = Object.assign(new Error('exit 1'), { code: 1 })
+    const backend = streamingContainerBackend({
+      streamChunks: {
+        'npm install': [
+          ['stdout', 'OUT: building native module\n'],
+          ['stderr', 'ERR: node-gyp rebuild failed\n'],
+        ],
+      },
+      failAfterStream: failErr,
+    })
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+
+    const logs = []
+    const errors = []
+    session.on('setup_log', (e) => logs.push(e))
+    session.on('error', (e) => errors.push(e))
+    await session.start()
+
+    // Streaming still happened before the failure.
+    assert.equal(logs.length, 2, 'chunks streamed before the failure')
+    // Failure event carries the buffered tail (#5067 preserved).
+    const pcErr = errors.find((e) => e.code === 'post_create_command_failed')
+    assert.ok(pcErr, 'expected a post_create_command_failed error event')
+    assert.match(pcErr.stdout, /OUT: building native module/, 'buffered stdout tail attached')
+    assert.match(pcErr.stderr, /ERR: node-gyp rebuild failed/, 'buffered stderr tail attached')
+    assert.equal(session._containerReady, false, 'failed post-create must not mark ready')
+  })
+
+  it('#5069: cached marker skips the run — no setup_log when command already applied', async () => {
+    const _execFile = execFileStub({
+      info: { stdout: 'ok' },
+      run: { stdout: 'CONTAINER_STREAM_CACHED\n' },
+      exec: { stdout: '' },
+      rm: { stdout: '' },
+    })
+    // Marker probe resolves clean (marker present) → run path is skipped.
+    const calls = []
+    const backend = {
+      calls,
+      async execInEnvironment(containerId, opts) {
+        calls.push({ containerId, ...opts })
+        const cmd = opts.cmd || ''
+        if (cmd.startsWith('test -f ') && cmd.includes('.chroxy-post-create')) {
+          return { stdout: '', stderr: '' } // marker present
+        }
+        if (typeof opts.onData === 'function') opts.onData('should-not-stream', 'stdout')
+        return { stdout: '', stderr: '' }
+      },
+    }
+    const session = new DockerByokSession({
+      cwd: '/host/cwd',
+      postCreateCommand: 'npm install',
+      _execFile,
+      _dockerBackend: backend,
+    })
+    session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+
+    const logs = []
+    session.on('setup_log', (e) => logs.push(e))
+    await session.start()
+
+    assert.equal(session._containerReady, true)
+    assert.equal(logs.length, 0, 'cached marker must skip the run — no streamed output')
+    const installRun = calls.find((c) => c.cmd === 'npm install')
+    assert.ok(!installRun, 'the postCreateCommand itself must not run when marker is present')
+
+    await session.destroy()
+  })
 })
 
 describe('docker-byok provider registration', () => {

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -1096,6 +1096,153 @@ describe('DockerBackend.execInEnvironment()', () => {
     // Container ID must come after the flag — same ordering invariant as --env.
     assert.ok(execCall.args.indexOf('ctr-abc') > idx + 1)
   })
+
+  // ───────────────────────────────────────────────────────────────────────
+  // #5069 — streaming path: when opts.onData is supplied, run via spawn and
+  // surface stdout/stderr incrementally while still buffering for the result
+  // and the failure tail (#5067).
+  // ───────────────────────────────────────────────────────────────────────
+
+  // Build a fake child + spawn spy. Tests drive child.stdout/stderr/exit
+  // by hand to simulate the docker exec process producing output over time.
+  function makeStreamingBackend() {
+    let lastSpawn = null
+    const fakeChild = new EventEmitter()
+    fakeChild.stdout = new PassThrough()
+    fakeChild.stderr = new PassThrough()
+    fakeChild.killed = false
+    fakeChild.kill = (sig) => { fakeChild.killed = true; fakeChild.lastSignal = sig }
+    function fakeSpawn(cmd, args, opts) {
+      lastSpawn = { cmd, args, opts }
+      return fakeChild
+    }
+    const backend = new DockerBackend({ _spawn: fakeSpawn })
+    return { backend, fakeChild, getLastSpawn: () => lastSpawn }
+  }
+
+  it('#5069: invokes onData with each chunk in arrival order and resolves with the full buffer', async () => {
+    const { backend, fakeChild } = makeStreamingBackend()
+    const seen = []
+
+    const p = backend.execInEnvironment('ctr-abc', {
+      cmd: 'npm install',
+      onData: (chunk, stream) => seen.push([stream, chunk]),
+    })
+
+    // Simulate output arriving over time, then a clean exit.
+    fakeChild.stdout.write('npm WARN foo\n')
+    fakeChild.stderr.write('fetching...\n')
+    fakeChild.stdout.write('added 42 packages\n')
+    // Let the stream 'data' events flush before closing.
+    await new Promise((r) => setImmediate(r))
+    fakeChild.emit('close', 0, null)
+
+    const result = await p
+    assert.deepEqual(seen, [
+      ['stdout', 'npm WARN foo\n'],
+      ['stderr', 'fetching...\n'],
+      ['stdout', 'added 42 packages\n'],
+    ], 'onData must fire per chunk in arrival order with the right stream tag')
+    assert.equal(result.stdout, 'npm WARN foo\nadded 42 packages\n', 'full stdout buffered')
+    assert.equal(result.stderr, 'fetching...\n', 'full stderr buffered')
+  })
+
+  it('#5069: uses spawn (not execFile) when onData is supplied', async () => {
+    const { backend, fakeChild, getLastSpawn } = makeStreamingBackend()
+    const p = backend.execInEnvironment('ctr-abc', {
+      cmd: 'echo hi',
+      user: 'chroxy',
+      onData: () => {},
+    })
+    await new Promise((r) => setImmediate(r))
+    fakeChild.emit('close', 0, null)
+    await p
+
+    const spawnCall = getLastSpawn()
+    assert.ok(spawnCall, 'spawn must be used for the streaming path')
+    // Same argv shape as the buffered path: exec -u <user> ... bash -c <cmd>.
+    assert.deepEqual(spawnCall.args, ['exec', '-u', 'chroxy', 'ctr-abc', 'bash', '-c', 'echo hi'])
+  })
+
+  it('#5069: keeps the buffered execFile path when onData is absent (backward compat)', async () => {
+    const mockExec = createMockExecFile({ results: { exec: 'buffered\n' } })
+    const backend = new DockerBackend({
+      _execFile: mockExec,
+      _spawn: () => { throw new Error('spawn must NOT be called when onData is absent') },
+    })
+    const result = await backend.execInEnvironment('ctr-abc', { cmd: 'echo hi' })
+    assert.equal(result.stdout, 'buffered\n')
+    assert.ok(mockExec.calls.some(c => c.args[0] === 'exec'), 'execFile path must be used')
+  })
+
+  it('#5069: streamed failure still attaches the buffered stdout/stderr tail to the rejected Error', async () => {
+    const { backend, fakeChild } = makeStreamingBackend()
+    const seen = []
+    const p = backend.execInEnvironment('ctr-abc', {
+      cmd: 'broken-setup.sh',
+      onData: (chunk, stream) => seen.push([stream, chunk]),
+    })
+
+    fakeChild.stdout.write('OUT: building native module\n')
+    fakeChild.stderr.write('ERR: node-gyp rebuild failed\n')
+    await new Promise((r) => setImmediate(r))
+    fakeChild.emit('close', 1, null)
+
+    let caught
+    try {
+      await p
+      assert.fail('expected rejection on non-zero exit')
+    } catch (err) {
+      caught = err
+    }
+    // Streaming happened.
+    assert.equal(seen.length, 2)
+    // #5067 contract: both streams attached to the error.
+    assert.match(caught.stdout, /OUT: building native module/, 'stdout tail attached on failure')
+    assert.match(caught.stderr, /ERR: node-gyp rebuild failed/, 'stderr tail attached on failure')
+    // Message is stderr-first, mirroring the buffered path.
+    assert.match(caught.message, /ERR: node-gyp rebuild failed/)
+    assert.equal(caught.code, 1)
+  })
+
+  it('#5069: SIGTERMs the child and rejects on timeout (no leaked process)', async () => {
+    const { backend, fakeChild } = makeStreamingBackend()
+    const p = backend.execInEnvironment('ctr-abc', {
+      cmd: 'hangs-forever',
+      timeout: 20,
+      onData: () => {},
+    })
+
+    let caught
+    try {
+      // The timer fires (20ms), SIGTERMs the child; the real docker exec
+      // would then close. Simulate that close after the kill.
+      await new Promise((r) => setTimeout(r, 40))
+      assert.ok(fakeChild.killed, 'child must be SIGTERM-killed on timeout')
+      assert.equal(fakeChild.lastSignal, 'SIGTERM')
+      fakeChild.emit('close', null, 'SIGTERM')
+      await p
+      assert.fail('expected rejection on timeout')
+    } catch (err) {
+      caught = err
+    }
+    assert.match(caught.message, /timed out after 20ms/)
+    assert.equal(caught.killed, true)
+  })
+
+  it('#5069: a throwing onData listener does not orphan the child or reject the run', async () => {
+    const { backend, fakeChild } = makeStreamingBackend()
+    const p = backend.execInEnvironment('ctr-abc', {
+      cmd: 'echo hi',
+      onData: () => { throw new Error('listener boom') },
+    })
+    fakeChild.stdout.write('hello\n')
+    await new Promise((r) => setImmediate(r))
+    fakeChild.emit('close', 0, null)
+    // Listener throw is swallowed; the run still resolves with the buffer.
+    const result = await p
+    assert.equal(result.stdout, 'hello\n')
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`postCreateCommand` ran via `dockerBackend.execInEnvironment`, which buffered stdout/stderr (`execFile`) until the command exited. For multi-minute setups (`npm install` on a fresh tree, `apt-get install -y build-essential`) the operator stared at a silent dashboard/session for minutes with no signal anything was happening (#5069).

This streams the command's stdout/stderr to the session log surface as bytes arrive, while preserving the buffered last-N-KiB tail on the failure error (#5067) and leaving marker idempotency / teardown untouched.

## Surface chosen for streamed bytes

A new transient **`setup_log`** session event (`{ phase: 'post_create', stream: 'stdout'|'stderr', chunk }`), one per decoded chunk. It is added to `DockerByokSession.customEvents`, which `session-manager.js:_wireSessionEvents` reads to build the `TRANSIENT_EVENTS` set it bridges to `session_event` listeners → ws-forwarding → dashboard/mobile. Transient (not replayed on reconnect), mirroring how `tool_start`/`stream_delta` flow. This reuses the existing structured-event pipeline rather than introducing a parallel raw-`terminal_data` channel.

## How it works

- `DockerBackend.execInEnvironment` gains an **optional** `onData(chunk, stream)` param. When supplied, the command runs via a streaming `spawn` (`_spawn` seam) and `onData` fires per chunk as bytes arrive. The full stdout/stderr are STILL accumulated so the resolved value and the failure-tail attached to the rejected Error are identical to the buffered path.
- When `onData` is **absent**, the original buffered `execFile` path is used unchanged.
- `DockerByokSession._runPostCreateCommandIfNeeded` passes an `onData` that emits `setup_log`. `_execAsContainerUser` forwards `onData` through.

## Backward-compat for other execInEnvironment callers

`execInEnvironment` callers were audited. Only the postCreateCommand path passes `onData`; every other caller (tool dispatch: Read/Write/Edit/Bash/Glob/Grep, marker probe/touch, verify, devcontainer overlay) calls it without `onData` and keeps the exact buffered `execFile` behaviour. `K8sBackend.execInEnvironment` is a separate impl and ignores the extra opt; docker-byok only ever uses `DockerBackend`.

## Acceptance criteria

- [x] postCreateCommand stdout/stderr stream to the session log surface as bytes arrive (`setup_log` transient event).
- [x] Buffered tail of the last N KiB still attached to the failure error event (#5067 preserved — streaming path attaches `stdout`/`stderr` to the rejected Error exactly like the buffered path; `tailCapture` in the session is unchanged).
- [x] Marker idempotency unchanged (cached marker still skips the run — no streamed output) and teardown ordering untouched.

## Test plan

`node --test tests/environments/backends/docker.test.js tests/docker-byok-session.test.js` — all pass (208 tests; 60 in docker.test.js incl. 7 new streaming tests, 148 in docker-byok-session.test.js incl. 4 new streaming tests).

New coverage:
- backend: onData fires per chunk in arrival order with stream tag; resolves with full buffer; uses spawn only when onData present; buffered execFile path kept when onData absent (spawn asserted NOT called); streamed failure still attaches stdout/stderr tail; SIGTERM + reject on timeout (no leaked process); throwing onData listener does not orphan the child.
- session: streams setup_log in arrival order; setup_log declared in customEvents; failed streamed run still attaches buffered tail to error event; cached marker skips the run (no setup_log).

`./scripts/lint-tests-state-file-path.sh` and `./scripts/lint-session-opt-forwarding.sh` both pass.

Note: an unrelated pre-existing env-dependent test (`tests/web-task-manager.test.js` — asserts the locally-installed `claude` CLI lacks `--remote`) fails on this machine because the local CLI now supports `--remote`. It touches nothing in this PR.

Closes #5069