### PR TITLE
feat: docker-byok pool observability panel (stats endpoint + dashboard)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -85,6 +85,7 @@ import { StartupErrorScreen } from './components/StartupErrorScreen'
 import { ConsolePage } from './components/ConsolePage'
 import { EnvironmentPanel } from './components/EnvironmentPanel'
 import { SnapshotsPanel } from './components/SnapshotsPanel'
+import { PoolStatsPanel } from './components/PoolStatsPanel'
 
 /** Server-injected config from <meta name="chroxy-config"> tag */
 interface ChroxyConfig {
@@ -122,7 +123,7 @@ function formatContext(usage: { inputTokens: number; outputTokens: number } | nu
   return `${formatTokensCompact(total)} tokens`
 }
 
-type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots'
+type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool'
 
 /** Scrollable tab bar with arrow buttons when overflowing */
 function ViewSwitcher({
@@ -231,6 +232,7 @@ function ViewSwitcher({
         )}
         <button className={`view-tab${viewMode === 'environments' ? ' active' : ''}`} onClick={() => { setViewMode('environments'); setSplitMode(null); persistSplitMode(null) }} type="button">Envs</button>
         <button className={`view-tab${viewMode === 'snapshots' ? ' active' : ''}`} onClick={() => { setViewMode('snapshots'); setSplitMode(null); persistSplitMode(null) }} type="button">Snapshots</button>
+        <button className={`view-tab${viewMode === 'pool' ? ' active' : ''}`} onClick={() => { setViewMode('pool'); setSplitMode(null); persistSplitMode(null) }} type="button">Pool</button>
         <div className="view-switch-spacer" />
         <button className={`view-tab view-tab-right${checkpointsOpen ? ' active' : ''}`} onClick={() => setCheckpointsOpen(prev => !prev)} type="button" title="Toggle checkpoint timeline">Checkpoints</button>
         <button className={`view-tab${viewMode === 'diff' ? ' active' : ''}`} onClick={() => setViewMode('diff')} type="button">Diff</button>
@@ -2407,6 +2409,9 @@ export function App() {
                 )}
                 {viewMode === 'snapshots' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <SnapshotsPanel />
+                )}
+                {viewMode === 'pool' && connectionPhase !== 'connecting' && !isSwitchingSession && (
+                  <PoolStatsPanel />
                 )}
               </div>
               {checkpointsOpen && (

--- a/packages/dashboard/src/components/PoolStatsPanel.test.tsx
+++ b/packages/dashboard/src/components/PoolStatsPanel.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react'
+import { PoolStatsPanel, type PoolStats } from './PoolStatsPanel'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function makeFetch(handler: (init?: RequestInit) => Response | Promise<Response>) {
+  return vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url === '/api/pool/stats') return handler(init)
+    return new Response('not found', { status: 404 })
+  })
+}
+
+const ENABLED_STATS: PoolStats = {
+  enabled: true,
+  hits: 8,
+  misses: 2,
+  releases: 5,
+  shutdowns: 1,
+  hitRate: 0.8,
+  totalSize: 3,
+  buckets: [
+    { key: 'node:22|/repo|512m|1|root', size: 2, oldestIdleMs: 65000 },
+    { key: 'python:3.12|/app|512m|1|root', size: 1, oldestIdleMs: 5000 },
+  ],
+  evictionsByReason: { idle: 4, over_cap: 1 },
+  recentEvictions: [
+    { key: 'k', containerId: 'aaaaaaaaaaaa11', reason: 'idle', timestamp: 1000 },
+    { key: 'k', containerId: 'bbbbbbbbbbbb22', reason: 'over_cap', timestamp: 2000 },
+  ],
+}
+
+describe('PoolStatsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('sends the bearer token on the stats request', async () => {
+    const fetchImpl = makeFetch(() => jsonResponse({ enabled: false }))
+    render(
+      <PoolStatsPanel
+        fetchImpl={fetchImpl as unknown as typeof fetch}
+        getToken={() => 'tok'}
+        pollMs={0}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('pool-stats-disabled')).toBeTruthy()
+    })
+    expect(fetchImpl).toHaveBeenCalledWith('/api/pool/stats', expect.objectContaining({
+      headers: { Authorization: 'Bearer tok' },
+    }))
+  })
+
+  it('renders the disabled notice when the pool is off', async () => {
+    const fetchImpl = makeFetch(() => jsonResponse({ enabled: false }))
+    render(
+      <PoolStatsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} pollMs={0} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('pool-stats-disabled')).toBeTruthy()
+    })
+    // The enabled body must not render.
+    expect(screen.queryByTestId('pool-stats-body')).toBeNull()
+  })
+
+  it('renders hit rate, hits/misses, and total parked size when enabled', async () => {
+    const fetchImpl = makeFetch(() => jsonResponse(ENABLED_STATS))
+    render(
+      <PoolStatsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} pollMs={0} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('pool-stats-body')).toBeTruthy()
+    })
+    expect(screen.getByTestId('pool-stats-hitrate').textContent).toBe('80.0%')
+    expect(screen.getByTestId('pool-stats-hitmiss').textContent).toBe('8 / 2')
+    expect(screen.getByTestId('pool-stats-total-size').textContent).toBe('3')
+  })
+
+  it('renders per-key buckets with size and oldest idle age', async () => {
+    const fetchImpl = makeFetch(() => jsonResponse(ENABLED_STATS))
+    render(
+      <PoolStatsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} pollMs={0} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('pool-bucket-node:22|/repo|512m|1|root')).toBeTruthy()
+    })
+    expect(screen.getByTestId('pool-bucket-python:3.12|/app|512m|1|root')).toBeTruthy()
+    // 65000ms -> "1m 5s"
+    expect(screen.getByText('1m 5s')).toBeTruthy()
+  })
+
+  it('renders eviction-by-reason counts', async () => {
+    const fetchImpl = makeFetch(() => jsonResponse(ENABLED_STATS))
+    render(
+      <PoolStatsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} pollMs={0} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('pool-stats-evictions-by-reason')).toBeTruthy()
+    })
+    expect(screen.getByTestId('pool-eviction-reason-idle')).toBeTruthy()
+    expect(screen.getByTestId('pool-eviction-reason-over_cap')).toBeTruthy()
+  })
+
+  it('renders the recent evictions tail newest-first', async () => {
+    const fetchImpl = makeFetch(() => jsonResponse(ENABLED_STATS))
+    render(
+      <PoolStatsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} pollMs={0} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('pool-stats-recent-evictions')).toBeTruthy()
+    })
+    const rows = screen.getAllByTestId('pool-recent-eviction')
+    expect(rows.length).toBe(2)
+    // Newest (over_cap, ts 2000) first, then idle.
+    expect(rows[0]?.textContent).toContain('bbbbbbbbbbbb')
+    expect(rows[0]?.textContent).toContain('over_cap')
+    expect(rows[1]?.textContent).toContain('aaaaaaaaaaaa')
+  })
+
+  it('shows empty states for buckets and evictions when none exist', async () => {
+    const fetchImpl = makeFetch(() =>
+      jsonResponse({
+        enabled: true,
+        hits: 0,
+        misses: 0,
+        hitRate: 0,
+        totalSize: 0,
+        buckets: [],
+        evictionsByReason: {},
+        recentEvictions: [],
+      }),
+    )
+    render(
+      <PoolStatsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} pollMs={0} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('pool-stats-buckets-empty')).toBeTruthy()
+    })
+    expect(screen.getByTestId('pool-stats-evictions-empty')).toBeTruthy()
+    // Hit rate with 0/0 must render 0.0%, not NaN.
+    expect(screen.getByTestId('pool-stats-hitrate').textContent).toBe('0.0%')
+  })
+
+  it('surfaces an error when the endpoint fails', async () => {
+    const fetchImpl = makeFetch(() => jsonResponse({ error: 'kaboom' }, 500))
+    render(
+      <PoolStatsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} pollMs={0} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('pool-stats-error').textContent).toBe('kaboom')
+    })
+  })
+
+  it('refresh button re-fetches', async () => {
+    const fetchImpl = makeFetch(() => jsonResponse({ enabled: false }))
+    render(
+      <PoolStatsPanel fetchImpl={fetchImpl as unknown as typeof fetch} getToken={() => 'tok'} pollMs={0} />,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId('pool-stats-disabled')).toBeTruthy()
+    })
+    const initial = fetchImpl.mock.calls.length
+    fireEvent.click(screen.getByTestId('pool-stats-refresh'))
+    await waitFor(() => {
+      expect(fetchImpl.mock.calls.length).toBe(initial + 1)
+    })
+  })
+
+  it('polls on the configured interval and clears the timer on unmount', async () => {
+    vi.useFakeTimers()
+    try {
+      const fetchImpl = makeFetch(() => jsonResponse({ enabled: false }))
+      const { unmount } = render(
+        <PoolStatsPanel
+          fetchImpl={fetchImpl as unknown as typeof fetch}
+          getToken={() => 'tok'}
+          pollMs={1000}
+        />,
+      )
+      // Initial mount fetch.
+      await vi.waitFor(() => expect(fetchImpl.mock.calls.length).toBe(1))
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(fetchImpl.mock.calls.length).toBe(2)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(fetchImpl.mock.calls.length).toBe(3)
+      // After unmount the timer must stop firing.
+      unmount()
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(fetchImpl.mock.calls.length).toBe(3)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/packages/dashboard/src/components/PoolStatsPanel.tsx
+++ b/packages/dashboard/src/components/PoolStatsPanel.tsx
@@ -1,0 +1,313 @@
+/**
+ * PoolStatsPanel (#5053) — docker-byok container pool observability.
+ *
+ * The server pool (#5051) emits structured lifecycle events; a server-side
+ * aggregator (#5053) accumulates them into a rolling snapshot exposed at
+ * GET /api/pool/stats. This panel polls that endpoint and renders:
+ *
+ *   - Pool size: total parked containers + a per-key breakdown
+ *     (size + oldest idle age, from pool.inspect()).
+ *   - Hit rate: hits / (hits + misses) over the aggregator's lifetime.
+ *   - Recent evictions: the tail of the last N evictions, newest-first,
+ *     plus an eviction-by-reason summary (idle / over_cap / shutdown /
+ *     over_age / soiled / …).
+ *
+ * The pool is default-OFF (CHROXY_DOCKER_BYOK_POOL=1). The endpoint returns
+ * `{ enabled: false }` when the pool is disabled; this panel renders a short
+ * "disabled" notice in that case (App.tsx still mounts the tab, but the body
+ * is driven by the snapshot's `enabled` flag).
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getAuthToken } from '../utils/auth'
+
+export interface PoolBucket {
+  key: string
+  size: number
+  oldestIdleMs: number
+}
+
+export interface PoolEviction {
+  key: string
+  containerId: string | null
+  reason: string
+  timestamp: number
+}
+
+export interface PoolStats {
+  enabled: boolean
+  hits?: number
+  misses?: number
+  releases?: number
+  shutdowns?: number
+  hitRate?: number
+  totalSize?: number
+  buckets?: PoolBucket[]
+  evictionsByReason?: Record<string, number>
+  recentEvictions?: PoolEviction[]
+}
+
+interface PoolStatsPanelProps {
+  /**
+   * Override the fetch impl. Tests inject a stub; production omits it and
+   * gets the real `window.fetch`.
+   */
+  fetchImpl?: typeof fetch
+  /**
+   * Override the auth token resolver. Tests pass a fixed string; production
+   * omits it and uses the shared `getAuthToken()`.
+   */
+  getToken?: () => string | null
+  /**
+   * Poll interval in ms. Tests pass 0 to disable the timer (single fetch on
+   * mount). Production omits it and gets the default.
+   */
+  pollMs?: number
+}
+
+const DEFAULT_POLL_MS = 5000
+
+function formatHitRate(rate: number | undefined): string {
+  if (typeof rate !== 'number' || !Number.isFinite(rate)) return '—'
+  return `${(rate * 100).toFixed(1)}%`
+}
+
+function formatIdle(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '0s'
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rem = s % 60
+  if (m < 60) return rem ? `${m}m ${rem}s` : `${m}m`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
+
+function formatTimestamp(ms: number): string {
+  if (!Number.isFinite(ms)) return ''
+  const d = new Date(ms)
+  return d.toLocaleTimeString()
+}
+
+export function PoolStatsPanel({ fetchImpl, getToken, pollMs }: PoolStatsPanelProps = {}) {
+  const [stats, setStats] = useState<PoolStats | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Hoist for testability — production passes neither override.
+  const resolvedFetch: typeof fetch =
+    fetchImpl ?? ((input: RequestInfo | URL, init?: RequestInit) => window.fetch(input, init))
+  const resolvedGetToken = getToken ?? getAuthToken
+  const interval = pollMs ?? DEFAULT_POLL_MS
+
+  // Keep the latest fetch in a ref so the polling effect can call it without
+  // re-subscribing the timer on every render.
+  const refresh = useCallback(async () => {
+    setError(null)
+    const token = resolvedGetToken()
+    try {
+      const res = await resolvedFetch('/api/pool/stats', {
+        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({ error: `HTTP ${res.status}` }))
+        throw new Error((body as { error?: string }).error || `HTTP ${res.status}`)
+      }
+      const body = (await res.json()) as PoolStats
+      setStats(body)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load pool stats')
+    } finally {
+      setLoading(false)
+    }
+  }, [resolvedFetch, resolvedGetToken])
+
+  const refreshRef = useRef(refresh)
+  refreshRef.current = refresh
+
+  useEffect(() => {
+    void refreshRef.current()
+    if (interval <= 0) return
+    const id = setInterval(() => {
+      void refreshRef.current()
+    }, interval)
+    return () => clearInterval(id)
+  }, [interval])
+
+  const enabled = stats?.enabled === true
+  const buckets = stats?.buckets ?? []
+  const recent = stats?.recentEvictions ?? []
+  const byReason = stats?.evictionsByReason ?? {}
+  const reasonEntries = Object.entries(byReason).sort((a, b) => b[1] - a[1])
+
+  return (
+    <div className="environment-panel" data-testid="pool-stats-panel">
+      <div className="env-panel-header">
+        <h2>Container Pool</h2>
+        <button
+          className="btn-env-new"
+          data-testid="pool-stats-refresh"
+          onClick={() => void refresh()}
+          disabled={loading}
+        >
+          {loading ? 'Loading…' : 'Refresh'}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          className="env-empty"
+          data-testid="pool-stats-error"
+          style={{ color: 'var(--status-error, #ef4444)' }}
+        >
+          {error}
+        </div>
+      )}
+
+      {!error && stats && !enabled && (
+        <div className="env-empty" data-testid="pool-stats-disabled">
+          <p>The docker-byok container pool is disabled.</p>
+          <p style={{ color: 'var(--text-secondary)', fontSize: '0.9em' }}>
+            Set <code>CHROXY_DOCKER_BYOK_POOL=1</code> on the server to enable
+            cross-session container reuse, then this panel will show pool size,
+            hit rate, and recent evictions.
+          </p>
+        </div>
+      )}
+
+      {!error && enabled && stats && (
+        <div data-testid="pool-stats-body">
+          {/* Headline counters */}
+          <div className="env-card" data-testid="pool-stats-summary">
+            <div className="env-card-details">
+              <div className="env-card-row">
+                <span className="env-card-label">Hit rate</span>
+                <span className="env-card-value" data-testid="pool-stats-hitrate">
+                  {formatHitRate(stats.hitRate)}
+                </span>
+              </div>
+              <div className="env-card-row">
+                <span className="env-card-label">Hits / Misses</span>
+                <span className="env-card-value" data-testid="pool-stats-hitmiss">
+                  {stats.hits ?? 0} / {stats.misses ?? 0}
+                </span>
+              </div>
+              <div className="env-card-row">
+                <span className="env-card-label">Parked containers</span>
+                <span className="env-card-value" data-testid="pool-stats-total-size">
+                  {stats.totalSize ?? 0}
+                </span>
+              </div>
+              {typeof stats.shutdowns === 'number' && stats.shutdowns > 0 && (
+                <div className="env-card-row">
+                  <span className="env-card-label">Shutdowns</span>
+                  <span className="env-card-value">{stats.shutdowns}</span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Per-key parked buckets */}
+          <h3 style={{ marginTop: '1rem' }}>Parked by key</h3>
+          {buckets.length === 0 ? (
+            <div className="env-empty" data-testid="pool-stats-buckets-empty">
+              No containers parked.
+            </div>
+          ) : (
+            <div className="env-grid">
+              {buckets.map((b) => (
+                <div
+                  className="env-card"
+                  key={b.key}
+                  data-testid={`pool-bucket-${b.key}`}
+                >
+                  <div className="env-card-header">
+                    <span
+                      className="env-card-name"
+                      style={{
+                        fontFamily: 'var(--font-mono, monospace)',
+                        fontSize: '0.8em',
+                        wordBreak: 'break-all',
+                      }}
+                    >
+                      {b.key}
+                    </span>
+                  </div>
+                  <div className="env-card-details">
+                    <div className="env-card-row">
+                      <span className="env-card-label">Size</span>
+                      <span className="env-card-value">{b.size}</span>
+                    </div>
+                    <div className="env-card-row">
+                      <span className="env-card-label">Oldest idle</span>
+                      <span className="env-card-value">{formatIdle(b.oldestIdleMs)}</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Eviction-by-reason summary */}
+          <h3 style={{ marginTop: '1rem' }}>Evictions by reason</h3>
+          {reasonEntries.length === 0 ? (
+            <div className="env-empty" data-testid="pool-stats-evictions-empty">
+              No evictions recorded.
+            </div>
+          ) : (
+            <div className="env-card" data-testid="pool-stats-evictions-by-reason">
+              <div className="env-card-details">
+                {reasonEntries.map(([reason, count]) => (
+                  <div className="env-card-row" key={reason}>
+                    <span
+                      className="env-card-label"
+                      data-testid={`pool-eviction-reason-${reason}`}
+                    >
+                      {reason}
+                    </span>
+                    <span className="env-card-value">{count}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Recent evictions tail (newest-first) */}
+          {recent.length > 0 && (
+            <>
+              <h3 style={{ marginTop: '1rem' }}>Recent evictions</h3>
+              <div className="env-card" data-testid="pool-stats-recent-evictions">
+                <div className="env-card-details">
+                  {recent
+                    .slice()
+                    .reverse()
+                    .map((e, i) => (
+                      <div
+                        className="env-card-row"
+                        key={`${e.containerId ?? 'x'}-${e.timestamp}-${i}`}
+                        data-testid="pool-recent-eviction"
+                      >
+                        <span
+                          className="env-card-label"
+                          style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: '0.8em' }}
+                        >
+                          {e.containerId ? e.containerId.slice(0, 12) : '—'}
+                        </span>
+                        <span className="env-card-value">
+                          {e.reason}
+                          {Number.isFinite(e.timestamp) && (
+                            <span style={{ color: 'var(--text-secondary)', marginLeft: '0.5rem' }}>
+                              {formatTimestamp(e.timestamp)}
+                            </span>
+                          )}
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -90,7 +90,7 @@ const MAX_MESSAGES = 100;
 const MAX_TERMINAL_SIZE = 50_000;
 
 /** Valid view modes — used to validate persisted values */
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments', 'snapshots'] as const;
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments', 'snapshots', 'pool'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -642,7 +642,7 @@ export interface ConnectionState {
   pairingRefreshedCount: number;
 
   // View mode
-  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots';
+  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool';
 
   // Input settings
   inputSettings: InputSettings;
@@ -661,7 +661,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string }) => void;
   appendTerminalData: (data: string) => void;

--- a/packages/server/src/docker-byok-pool-stats.js
+++ b/packages/server/src/docker-byok-pool-stats.js
@@ -1,0 +1,221 @@
+/**
+ * PoolStatsAggregator (#5053) — server-side observability for the
+ * docker-byok container pool.
+ *
+ * The pool (`DockerContainerPool`, #5051) emits `POOL_EVENTS.*` for every
+ * lifecycle transition but keeps no history. This aggregator subscribes to
+ * that stream and maintains bounded rolling state so the dashboard can poll
+ * a single snapshot:
+ *
+ *   - `hits` / `misses`        — monotonic counters (scalars).
+ *   - `evictionsByReason`      — count keyed by eviction reason
+ *                                (idle / over_cap / shutdown / over_age /
+ *                                soiled / …). Open-ended: any new reason the
+ *                                pool emits is counted under its own key.
+ *   - `recentEvictions`        — ring buffer of the last N evictions
+ *                                ({ key, containerId, reason, timestamp }).
+ *   - `shutdowns`              — count of `pool:shutdown` events.
+ *
+ * The per-key parked-bucket view (size / oldestIdleMs) is NOT tracked here —
+ * it's read live from `pool.inspect()` (#5052) at snapshot time so it always
+ * reflects the current parked set rather than a replayed event history.
+ *
+ * Memory is bounded by construction: counters are scalars, the eviction
+ * history is a fixed-capacity ring buffer (default 50). Listener exceptions
+ * cannot wedge the pool — the pool already catches subscriber throws
+ * (#5051) — but the handlers here are allocation-free and total-order safe
+ * regardless.
+ *
+ * Wiring is idempotent (`attach()` guards against double-subscription) so a
+ * second call on the same pool instance does not leak duplicate listeners.
+ */
+import { POOL_EVENTS } from './docker-byok-pool.js'
+
+/** Default cap on the eviction ring buffer. */
+export const DEFAULT_RECENT_EVICTIONS_CAP = 50
+
+export class PoolStatsAggregator {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.recentEvictionsCap] — ring buffer capacity for
+   *   the recent-evictions tail. Must be a positive integer; falls back to
+   *   the default otherwise.
+   */
+  constructor({ recentEvictionsCap } = {}) {
+    const cap = Number(recentEvictionsCap)
+    this._cap = Number.isInteger(cap) && cap > 0 ? cap : DEFAULT_RECENT_EVICTIONS_CAP
+
+    this._hits = 0
+    this._misses = 0
+    this._releases = 0
+    this._shutdowns = 0
+    /** @type {Record<string, number>} */
+    this._evictionsByReason = Object.create(null)
+    /** @type {Array<{ key: string, containerId: string|null, reason: string, timestamp: number }>} */
+    this._recentEvictions = []
+
+    /** @type {import('./docker-byok-pool.js').DockerContainerPool|null} */
+    this._pool = null
+    /** @type {Record<string, Function>|null} bound handlers, kept so detach can remove them */
+    this._handlers = null
+  }
+
+  /**
+   * Subscribe to a pool's event stream. Idempotent: attaching the same pool
+   * twice (or a different pool after a prior attach) is a no-op after the
+   * first wiring unless `detach()` is called in between. Returns `this` for
+   * chaining.
+   *
+   * @param {import('./docker-byok-pool.js').DockerContainerPool|null|undefined} pool
+   * @returns {this}
+   */
+  attach(pool) {
+    if (!pool || typeof pool.on !== 'function') return this
+    // Already wired (to this or any pool) — don't double-subscribe.
+    if (this._handlers) return this
+
+    const onHit = () => { this._hits += 1 }
+    const onMiss = () => { this._misses += 1 }
+    const onReleased = () => { this._releases += 1 }
+    const onEvicted = (payload) => this._recordEviction(payload)
+    const onShutdown = () => { this._shutdowns += 1 }
+
+    pool.on(POOL_EVENTS.HIT, onHit)
+    pool.on(POOL_EVENTS.MISS, onMiss)
+    pool.on(POOL_EVENTS.RELEASED, onReleased)
+    pool.on(POOL_EVENTS.EVICTED, onEvicted)
+    pool.on(POOL_EVENTS.SHUTDOWN, onShutdown)
+
+    this._pool = pool
+    this._handlers = {
+      [POOL_EVENTS.HIT]: onHit,
+      [POOL_EVENTS.MISS]: onMiss,
+      [POOL_EVENTS.RELEASED]: onReleased,
+      [POOL_EVENTS.EVICTED]: onEvicted,
+      [POOL_EVENTS.SHUTDOWN]: onShutdown,
+    }
+    return this
+  }
+
+  /**
+   * Remove all listeners from the attached pool. Safe to call when not
+   * attached. After detach, `attach()` can wire a fresh pool again.
+   */
+  detach() {
+    if (this._pool && this._handlers) {
+      for (const [event, handler] of Object.entries(this._handlers)) {
+        this._pool.off(event, handler)
+      }
+    }
+    this._pool = null
+    this._handlers = null
+  }
+
+  /**
+   * Record one eviction into the by-reason counter and the ring buffer.
+   * Unknown / missing reasons bucket under 'unknown' so the count stays
+   * well-formed for any future open-ended reason.
+   *
+   * @param {{ key?: string, containerId?: string|null, reason?: string, timestamp?: number }} [payload]
+   */
+  _recordEviction(payload = {}) {
+    const reason = typeof payload.reason === 'string' && payload.reason.length > 0
+      ? payload.reason
+      : 'unknown'
+    this._evictionsByReason[reason] = (this._evictionsByReason[reason] || 0) + 1
+
+    this._recentEvictions.push({
+      key: typeof payload.key === 'string' ? payload.key : '',
+      containerId: typeof payload.containerId === 'string' ? payload.containerId : null,
+      reason,
+      timestamp: typeof payload.timestamp === 'number' ? payload.timestamp : Date.now(),
+    })
+    // Bound the buffer: drop the oldest once over capacity.
+    if (this._recentEvictions.length > this._cap) {
+      this._recentEvictions.splice(0, this._recentEvictions.length - this._cap)
+    }
+  }
+
+  /**
+   * Hit rate over the lifetime of the aggregator: hits / (hits + misses).
+   * Returns 0 when there have been no acquire attempts (avoids 0/0 = NaN).
+   *
+   * @returns {number} a value in [0, 1].
+   */
+  hitRate() {
+    const total = this._hits + this._misses
+    if (total === 0) return 0
+    return this._hits / total
+  }
+
+  /**
+   * Build a JSON-serialisable snapshot. The per-key parked view is read
+   * live from the attached pool's `inspect()` so it reflects the CURRENT
+   * parked set, not replayed history. The recent-evictions tail is returned
+   * newest-LAST (insertion order) so the dashboard can `.reverse()` or read
+   * the tail as it sees fit; it's a defensive copy so callers can't mutate
+   * internal state.
+   *
+   * @returns {{
+   *   hits: number,
+   *   misses: number,
+   *   releases: number,
+   *   shutdowns: number,
+   *   hitRate: number,
+   *   totalSize: number,
+   *   buckets: Array<{ key: string, size: number, oldestIdleMs: number }>,
+   *   evictionsByReason: Record<string, number>,
+   *   recentEvictions: Array<{ key: string, containerId: string|null, reason: string, timestamp: number }>,
+   * }}
+   */
+  snapshot() {
+    const buckets = this._pool && typeof this._pool.inspect === 'function'
+      ? this._pool.inspect()
+      : []
+    const totalSize = buckets.reduce((sum, b) => sum + (b.size || 0), 0)
+    return {
+      hits: this._hits,
+      misses: this._misses,
+      releases: this._releases,
+      shutdowns: this._shutdowns,
+      hitRate: this.hitRate(),
+      totalSize,
+      buckets,
+      // Shallow copy of the by-reason map so callers can't mutate internals.
+      evictionsByReason: { ...this._evictionsByReason },
+      // Defensive copy (new array, fresh objects) — bounded by `_cap`.
+      recentEvictions: this._recentEvictions.map((e) => ({ ...e })),
+    }
+  }
+}
+
+/**
+ * Process-wide singleton aggregator (lazy). Mirrors `getSharedPool` so the
+ * HTTP route and any future consumer share one accumulating view. Returns a
+ * single instance; callers `attach()` it to the shared pool once.
+ *
+ * @type {PoolStatsAggregator|null}
+ */
+let _sharedAggregator = null
+
+/**
+ * Lazily construct (and return) the shared aggregator. Does NOT attach it to
+ * any pool — call `attach(getSharedPool())` from the wiring site so the
+ * caller controls when subscription happens and the aggregator stays
+ * pool-agnostic for tests.
+ *
+ * @returns {PoolStatsAggregator}
+ */
+export function getSharedPoolStats() {
+  if (!_sharedAggregator) _sharedAggregator = new PoolStatsAggregator()
+  return _sharedAggregator
+}
+
+/**
+ * Reset the shared singleton. Tests use this to keep state from leaking
+ * across cases. Production code never calls this.
+ */
+export function _resetSharedPoolStats() {
+  if (_sharedAggregator) _sharedAggregator.detach()
+  _sharedAggregator = null
+}

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -8,6 +8,8 @@ import { metrics } from './metrics.js'
 import { buildDiagnosticsSnapshot } from './diagnostics.js'
 import { getRateLimitKey } from './rate-limiter.js'
 import { listSnapshots, deleteSnapshot } from './snapshots-store.js'
+import { isPoolEnabled } from './docker-byok-pool.js'
+import { getSharedPoolStats } from './docker-byok-pool-stats.js'
 
 const log = createLogger('ws')
 
@@ -305,6 +307,44 @@ export function createHttpHandler(server) {
         log.warn(`DELETE /api/snapshots/${slug} failed: ${err.message}`)
         res.writeHead(500, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ error: 'Failed to delete snapshot' }))
+      }
+      return
+    }
+
+    // docker-byok pool stats endpoint (#5053). Returns a rolling
+    // observability snapshot — hit/miss counters, hit rate,
+    // eviction-by-reason, the recent-evictions tail, and the live per-key
+    // parked buckets from pool.inspect(). Bearer-auth gated like every other
+    // /api route (primary token = full host authority; see
+    // docs/security/bearer-token-authority.md — this is read-only operational
+    // telemetry, no narrower scope needed).
+    //
+    // The pool is default-OFF (CHROXY_DOCKER_BYOK_POOL=1 to enable). When
+    // disabled we return a stable `{ enabled: false }` shape (still authed)
+    // so the dashboard can hide the panel without special-casing a 404.
+    //
+    // Test seams: `server._poolStatsEnabled` / `server._poolStats` override
+    // the env probe + aggregator so http-routes tests don't depend on
+    // process.env or a live pool.
+    if (req.method === 'GET' && snapPath === '/api/pool/stats') {
+      if (!server._validateBearerAuth(req, res)) return
+      const enabled = typeof server._poolStatsEnabled === 'boolean'
+        ? server._poolStatsEnabled
+        : isPoolEnabled(process.env)
+      if (!enabled) {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ enabled: false }))
+        return
+      }
+      try {
+        const aggregator = server._poolStats ?? getSharedPoolStats()
+        const stats = aggregator.snapshot()
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ enabled: true, ...stats }))
+      } catch (err) {
+        log.warn(`GET /api/pool/stats failed: ${err.message}`)
+        res.writeHead(500, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'Failed to read pool stats' }))
       }
       return
     }

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -23,6 +23,7 @@ import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
 import { registerDockerProvider, resolveProviderLabel } from './providers.js'
 import { getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
+import { getSharedPoolStats } from './docker-byok-pool-stats.js'
 import { loadModelsCache, getModels } from './models.js'
 // Imported from a dedicated constants module rather than environment-manager.js
 // so we don't eagerly pull in DockerBackend when environments are disabled —
@@ -772,6 +773,16 @@ export async function startCliServer(config) {
   })
   // Bind to localhost-only when auth is disabled
   wsServer.start(NO_AUTH ? '127.0.0.1' : undefined)
+
+  // #5053: wire the pool stats aggregator to the shared pool so the
+  // dashboard's GET /api/pool/stats has rolling counters (hit rate,
+  // eviction-by-reason, recent evictions) to read. Default-OFF — only the
+  // shared pool exists when CHROXY_DOCKER_BYOK_POOL is enabled, so this is a
+  // no-op otherwise. attach() is idempotent (won't double-subscribe).
+  if (isPoolEnabled(process.env)) {
+    const statsPool = getSharedPool(process.env)
+    if (statsPool) getSharedPoolStats().attach(statsPool)
+  }
 
   // Wire session timeout to WsServer viewer checks
   sessionManager.setActiveViewersFn((sid) => wsServer.hasActiveViewersForSession(sid))

--- a/packages/server/tests/docker-byok-pool-stats.test.js
+++ b/packages/server/tests/docker-byok-pool-stats.test.js
@@ -1,0 +1,272 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import {
+  PoolStatsAggregator,
+  getSharedPoolStats,
+  _resetSharedPoolStats,
+  DEFAULT_RECENT_EVICTIONS_CAP,
+} from '../src/docker-byok-pool-stats.js'
+import { POOL_EVENTS } from '../src/docker-byok-pool.js'
+
+/**
+ * Tests for the docker-byok pool stats aggregator (#5053).
+ *
+ * The aggregator subscribes to the pool's `POOL_EVENTS.*` stream and
+ * accumulates bounded rolling state. We drive it with a fake EventEmitter
+ * pool (the real pool's event contract) plus a stub `inspect()` so no Docker
+ * daemon is involved.
+ */
+
+/** Minimal fake pool: an EventEmitter with a stubbable `inspect()`. */
+function makeFakePool(inspectResult = []) {
+  const pool = new EventEmitter()
+  pool.inspect = () => inspectResult
+  return pool
+}
+
+describe('PoolStatsAggregator', () => {
+  describe('counters', () => {
+    it('increments hits on POOL_EVENTS.HIT', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.HIT, { key: 'k', containerId: 'c1' })
+      pool.emit(POOL_EVENTS.HIT, { key: 'k', containerId: 'c2' })
+      assert.equal(agg.snapshot().hits, 2)
+      assert.equal(agg.snapshot().misses, 0)
+    })
+
+    it('increments misses on POOL_EVENTS.MISS', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.MISS, { key: 'k', reason: 'empty' })
+      assert.equal(agg.snapshot().misses, 1)
+    })
+
+    it('increments releases on POOL_EVENTS.RELEASED', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.RELEASED, { key: 'k', containerId: 'c1' })
+      pool.emit(POOL_EVENTS.RELEASED, { key: 'k', containerId: 'c2' })
+      assert.equal(agg.snapshot().releases, 2)
+    })
+
+    it('increments shutdowns on POOL_EVENTS.SHUTDOWN', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.SHUTDOWN, { drained: 3 })
+      assert.equal(agg.snapshot().shutdowns, 1)
+    })
+  })
+
+  describe('hit rate', () => {
+    it('is 0 when there have been no acquire attempts (no divide-by-zero)', () => {
+      const agg = new PoolStatsAggregator().attach(makeFakePool())
+      assert.equal(agg.hitRate(), 0)
+      assert.equal(agg.snapshot().hitRate, 0)
+    })
+
+    it('computes hits / (hits + misses)', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.HIT, {})
+      pool.emit(POOL_EVENTS.HIT, {})
+      pool.emit(POOL_EVENTS.HIT, {})
+      pool.emit(POOL_EVENTS.MISS, {})
+      // 3 / (3 + 1) = 0.75
+      assert.equal(agg.hitRate(), 0.75)
+      assert.equal(agg.snapshot().hitRate, 0.75)
+    })
+
+    it('is 1 when every acquire hit', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.HIT, {})
+      pool.emit(POOL_EVENTS.HIT, {})
+      assert.equal(agg.hitRate(), 1)
+    })
+  })
+
+  describe('eviction by reason', () => {
+    it('counts evictions keyed by reason', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.EVICTED, { key: 'k', containerId: 'a', reason: 'idle' })
+      pool.emit(POOL_EVENTS.EVICTED, { key: 'k', containerId: 'b', reason: 'idle' })
+      pool.emit(POOL_EVENTS.EVICTED, { key: 'k', containerId: 'c', reason: 'over_cap' })
+      pool.emit(POOL_EVENTS.EVICTED, { key: 'k', containerId: 'd', reason: 'shutdown' })
+      const snap = agg.snapshot()
+      assert.deepEqual(snap.evictionsByReason, { idle: 2, over_cap: 1, shutdown: 1 })
+    })
+
+    it('counts an open-ended (future) reason like soiled', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.EVICTED, { key: 'k', containerId: 'a', reason: 'soiled' })
+      assert.equal(agg.snapshot().evictionsByReason.soiled, 1)
+    })
+
+    it('buckets a missing reason under "unknown"', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.EVICTED, { key: 'k', containerId: 'a' })
+      assert.equal(agg.snapshot().evictionsByReason.unknown, 1)
+    })
+  })
+
+  describe('recent evictions ring buffer', () => {
+    it('records evictions with key, containerId, reason, timestamp', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.EVICTED, { key: 'k1', containerId: 'c1', reason: 'idle', timestamp: 111 })
+      const recent = agg.snapshot().recentEvictions
+      assert.equal(recent.length, 1)
+      assert.deepEqual(recent[0], { key: 'k1', containerId: 'c1', reason: 'idle', timestamp: 111 })
+    })
+
+    it('caps the buffer at the configured capacity (drops oldest)', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator({ recentEvictionsCap: 3 }).attach(pool)
+      for (let i = 0; i < 5; i++) {
+        pool.emit(POOL_EVENTS.EVICTED, { key: 'k', containerId: `c${i}`, reason: 'idle', timestamp: i })
+      }
+      const recent = agg.snapshot().recentEvictions
+      assert.equal(recent.length, 3)
+      // Oldest two (c0, c1) dropped; newest three remain in insertion order.
+      assert.deepEqual(recent.map((e) => e.containerId), ['c2', 'c3', 'c4'])
+    })
+
+    it('uses the default cap when none is supplied', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      for (let i = 0; i < DEFAULT_RECENT_EVICTIONS_CAP + 10; i++) {
+        pool.emit(POOL_EVENTS.EVICTED, { key: 'k', containerId: `c${i}`, reason: 'idle' })
+      }
+      assert.equal(agg.snapshot().recentEvictions.length, DEFAULT_RECENT_EVICTIONS_CAP)
+    })
+
+    it('ignores a non-positive / non-integer cap and uses the default', () => {
+      const a = new PoolStatsAggregator({ recentEvictionsCap: 0 })
+      const b = new PoolStatsAggregator({ recentEvictionsCap: -5 })
+      const c = new PoolStatsAggregator({ recentEvictionsCap: 2.5 })
+      // Internal cap is private but observable via overflow behaviour.
+      for (const agg of [a, b, c]) {
+        const pool = makeFakePool()
+        agg.attach(pool)
+        for (let i = 0; i < DEFAULT_RECENT_EVICTIONS_CAP + 5; i++) {
+          pool.emit(POOL_EVENTS.EVICTED, { containerId: `c${i}`, reason: 'idle' })
+        }
+        assert.equal(agg.snapshot().recentEvictions.length, DEFAULT_RECENT_EVICTIONS_CAP)
+      }
+    })
+  })
+
+  describe('snapshot', () => {
+    it('reads per-key buckets live from pool.inspect()', () => {
+      const buckets = [
+        { key: 'a', size: 2, oldestIdleMs: 1000 },
+        { key: 'b', size: 1, oldestIdleMs: 500 },
+      ]
+      const pool = makeFakePool(buckets)
+      const agg = new PoolStatsAggregator().attach(pool)
+      const snap = agg.snapshot()
+      assert.deepEqual(snap.buckets, buckets)
+      assert.equal(snap.totalSize, 3)
+    })
+
+    it('returns empty buckets / 0 size when nothing is parked', () => {
+      const agg = new PoolStatsAggregator().attach(makeFakePool([]))
+      const snap = agg.snapshot()
+      assert.deepEqual(snap.buckets, [])
+      assert.equal(snap.totalSize, 0)
+    })
+
+    it('returns a defensive copy — mutating it does not affect internal state', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      pool.emit(POOL_EVENTS.EVICTED, { key: 'k', containerId: 'c1', reason: 'idle' })
+      const snap = agg.snapshot()
+      snap.recentEvictions.push({ key: 'x', containerId: 'y', reason: 'z', timestamp: 0 })
+      snap.evictionsByReason.idle = 999
+      // Second snapshot is unaffected.
+      const snap2 = agg.snapshot()
+      assert.equal(snap2.recentEvictions.length, 1)
+      assert.equal(snap2.evictionsByReason.idle, 1)
+    })
+
+    it('works with no attached pool (empty buckets, no throw)', () => {
+      const agg = new PoolStatsAggregator()
+      const snap = agg.snapshot()
+      assert.deepEqual(snap.buckets, [])
+      assert.equal(snap.totalSize, 0)
+      assert.equal(snap.hits, 0)
+    })
+  })
+
+  describe('attach / detach (no listener leak)', () => {
+    it('attach is idempotent — does not double-subscribe', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator()
+      agg.attach(pool)
+      agg.attach(pool) // second call must be a no-op
+      assert.equal(pool.listenerCount(POOL_EVENTS.HIT), 1)
+      pool.emit(POOL_EVENTS.HIT, {})
+      assert.equal(agg.snapshot().hits, 1) // not 2
+    })
+
+    it('detach removes every listener', () => {
+      const pool = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(pool)
+      for (const ev of Object.values(POOL_EVENTS)) {
+        assert.equal(pool.listenerCount(ev), 1)
+      }
+      agg.detach()
+      for (const ev of Object.values(POOL_EVENTS)) {
+        assert.equal(pool.listenerCount(ev), 0)
+      }
+    })
+
+    it('detach then attach a fresh pool re-subscribes', () => {
+      const p1 = makeFakePool()
+      const p2 = makeFakePool()
+      const agg = new PoolStatsAggregator().attach(p1)
+      agg.detach()
+      agg.attach(p2)
+      assert.equal(p2.listenerCount(POOL_EVENTS.HIT), 1)
+      p2.emit(POOL_EVENTS.HIT, {})
+      assert.equal(agg.snapshot().hits, 1)
+    })
+
+    it('attach tolerates null / non-emitter pools', () => {
+      const agg = new PoolStatsAggregator()
+      assert.doesNotThrow(() => agg.attach(null))
+      assert.doesNotThrow(() => agg.attach(undefined))
+      assert.doesNotThrow(() => agg.attach({}))
+      assert.equal(agg.snapshot().hits, 0)
+    })
+  })
+
+  describe('getSharedPoolStats singleton', () => {
+    beforeEach(() => _resetSharedPoolStats())
+    afterEach(() => _resetSharedPoolStats())
+
+    it('returns the same instance across calls', () => {
+      const a = getSharedPoolStats()
+      const b = getSharedPoolStats()
+      assert.equal(a, b)
+    })
+
+    it('_resetSharedPoolStats detaches and creates a fresh instance', () => {
+      const pool = makeFakePool()
+      const first = getSharedPoolStats()
+      first.attach(pool)
+      assert.equal(pool.listenerCount(POOL_EVENTS.HIT), 1)
+      _resetSharedPoolStats()
+      // Listener removed on reset.
+      assert.equal(pool.listenerCount(POOL_EVENTS.HIT), 0)
+      const second = getSharedPoolStats()
+      assert.notEqual(first, second)
+    })
+  })
+})

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -460,4 +460,84 @@ describe('http-routes', () => {
       })
     })
   })
+
+  // #5053 — docker-byok pool stats endpoint. Test seams: `_poolStatsEnabled`
+  // overrides the env probe, `_poolStats` injects a stub aggregator so the
+  // route doesn't depend on process.env or a live pool.
+  describe('pool stats endpoint', () => {
+    function fakeAggregator(snapshot) {
+      return { snapshot: () => snapshot }
+    }
+
+    it('GET /api/pool/stats returns the snapshot when the pool is enabled', async () => {
+      const snap = {
+        hits: 7,
+        misses: 3,
+        releases: 4,
+        shutdowns: 0,
+        hitRate: 0.7,
+        totalSize: 2,
+        buckets: [{ key: 'k', size: 2, oldestIdleMs: 1234 }],
+        evictionsByReason: { idle: 5, over_cap: 1 },
+        recentEvictions: [{ key: 'k', containerId: 'c1', reason: 'idle', timestamp: 111 }],
+      }
+      const mock = createMockServer({
+        _poolStatsEnabled: true,
+        _poolStats: fakeAggregator(snap),
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/pool/stats`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.equal(body.enabled, true)
+      assert.equal(body.hits, 7)
+      assert.equal(body.misses, 3)
+      assert.equal(body.hitRate, 0.7)
+      assert.equal(body.totalSize, 2)
+      assert.deepEqual(body.buckets, snap.buckets)
+      assert.deepEqual(body.evictionsByReason, snap.evictionsByReason)
+      assert.deepEqual(body.recentEvictions, snap.recentEvictions)
+    })
+
+    it('GET /api/pool/stats returns { enabled: false } when the pool is disabled', async () => {
+      const mock = createMockServer({
+        _poolStatsEnabled: false,
+        // _poolStats must NOT be consulted when disabled.
+        _poolStats: { snapshot: () => { throw new Error('should not be called') } },
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/pool/stats`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 200)
+      const body = await res.json()
+      assert.deepEqual(body, { enabled: false })
+    })
+
+    it('GET /api/pool/stats rejects without bearer auth', async () => {
+      const mock = createMockServer({
+        _poolStatsEnabled: true,
+        _poolStats: fakeAggregator({ hits: 1 }),
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/pool/stats`)
+      assert.equal(res.status, 403)
+    })
+
+    it('GET /api/pool/stats returns 500 when the aggregator throws', async () => {
+      const mock = createMockServer({
+        _poolStatsEnabled: true,
+        _poolStats: { snapshot: () => { throw new Error('boom') } },
+      })
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/api/pool/stats`, {
+        headers: { 'Authorization': 'Bearer test-token' },
+      })
+      assert.equal(res.status, 500)
+      const body = await res.json()
+      assert.ok(body.error)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Implements AC #2 of #5044 — the docker-byok pool observability panel — building on the structured events (#5051) and `pool.inspect()` (#5052) that already landed.

Three pieces:

1. **Server aggregator** (`docker-byok-pool-stats.js`, `PoolStatsAggregator`) — subscribes to the shared pool's `POOL_EVENTS.*` stream and maintains bounded rolling state: hit/miss/release/shutdown counters, eviction-by-reason map, and a fixed-capacity ring buffer (default 50) of recent evictions. Per-key parked buckets are read live from `pool.inspect()` at snapshot time, so they reflect the current parked set rather than replayed history. `attach()` is idempotent (no duplicate listeners on the shared pool); `detach()` removes them all. Wired to the shared pool in `server-cli.js` after `wsServer.start()`, gated on `isPoolEnabled`.
2. **HTTP endpoint** — `GET /api/pool/stats`, bearer-auth gated via `_validateBearerAuth` like every other `/api` route. Returns `{ enabled: false }` when the pool is disabled.
3. **Dashboard panel** (`PoolStatsPanel.tsx`) — polls the endpoint (5s default, `clearInterval` on unmount), renders total + per-key pool size with oldest-idle age, hit rate, eviction-by-reason, and the recent-evictions tail (newest-first). Mounted as a new **Pool** tab in `App.tsx`; the snapshot's `enabled` flag drives the body (disabled notice otherwise).

## Endpoint shape

`GET /api/pool/stats` (Authorization: Bearer <token>)

Enabled:
```json
{
  "enabled": true,
  "hits": 8, "misses": 2, "releases": 5, "shutdowns": 1,
  "hitRate": 0.8,
  "totalSize": 3,
  "buckets": [{ "key": "node:22|/repo|512m|1|root", "size": 2, "oldestIdleMs": 65000 }],
  "evictionsByReason": { "idle": 4, "over_cap": 1 },
  "recentEvictions": [{ "key": "k", "containerId": "abc...", "reason": "idle", "timestamp": 111 }]
}
```

Disabled: `{ "enabled": false }`

## Acceptance criteria

- [x] Server-side aggregator subscribes to `POOL_EVENTS.*` and maintains rolling counters (hit, miss, eviction-by-reason, last-N evictions)
- [x] Snapshot exposed via HTTP (`GET /api/pool/stats`)
- [x] Dashboard panel renders pool size, hit rate, recent evictions
- [x] Panel only shown when pool is enabled (driven by snapshot `enabled` flag)

All four ACs land in this PR (`Closes #5053`).

## Security

The new route is gated by `server._validateBearerAuth(req, res)` before any work, identical to `/api/snapshots`, `/metrics`, `/version`. The primary API token already carries full host authority (see `docs/security/bearer-token-authority.md`); this is read-only operational telemetry, so no narrower scope is needed. Unauthed requests get 403 (covered by a test). No container IDs or secrets beyond short IDs already in the event stream are exposed.

## Test plan

- Server: `node --import ./tests/_setup.mjs --test tests/docker-byok-pool-stats.test.js tests/http-routes.test.js tests/docker-byok-pool.test.js` — 114/114 pass (24 new aggregator, 4 new endpoint).
- `./scripts/lint-tests-state-file-path.sh` and `./scripts/lint-session-opt-forwarding.sh` — OK.
- Dashboard: `npx vitest run src/components/PoolStatsPanel.test.tsx src/App.test.tsx` — 95/95 pass (10 new panel). `npx tsc --noEmit` — clean.