### PR TITLE
refactor(store-core): extract sharedStreamDelta to dedupe app/dashboard handlers

### DIFF
--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -50,6 +50,7 @@ import {
   handleToolResult as sharedToolResult,
   handleToolInputDelta as sharedToolInputDelta,
   handleStreamStart as sharedStreamStart,
+  sharedStreamDelta,
   handleStreamEnd as sharedStreamEnd,
   handleAuthOk as sharedAuthOk,
   parseConnectedClients as sharedParseConnectedClients,
@@ -1560,246 +1561,75 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
     }
 
     case 'stream_delta': {
-      // Capture the ORIGINAL incoming messageId before any remap resolution.
-      // The post-tool continuation split (#4922 / #4889) writes its remap entry
-      // against this id (not against the resolved `deltaId`) so successive
-      // splits overwrite a single map entry instead of forming a chain --
-      // keeps `_ctx.deltaIdRemaps` bounded and eliminates the need for
-      // chained lookup.
-      const originalMessageId = msg.messageId as string;
-      let deltaId = originalMessageId;
-      const capturedSessionId = (msg.sessionId as string) || get().activeSessionId;
+      // #4981 — thin wrapper over `sharedStreamDelta`. The platform-neutral
+      // hot path (post-permission split, single-hop defensive remap, post-tool
+      // continuation split with the #4999/#5014 sentence gate and #4975
+      // mid-word peel, buffered append + 100ms flush) lives in store-core.
+      // The app has no terminal-data write, no #4297 reorder, and no flat-
+      // `messages` fallback (it only operates on `sessionStates`), so those
+      // context hooks are no-ops / session-only here.
+      sharedStreamDelta(msg, {
+        activeSessionId: get().activeSessionId,
+        pendingDeltas: _ctx.pendingDeltas,
+        deltaIdRemaps: _ctx.deltaIdRemaps,
+        postPermissionSplits: _ctx.postPermissionSplits,
+        replayingSessions: _ctx.replayingSessions,
 
-      // Permission boundary split: first delta after a split creates a new message
-      if (_ctx.postPermissionSplits.has(deltaId)) {
-        _ctx.postPermissionSplits.delete(deltaId);
-        const newId = `${deltaId}-post-${Date.now()}`;
-        _ctx.deltaIdRemaps.set(deltaId, newId);
-        const newMsg: ChatMessage = {
-          id: newId,
-          type: 'response',
-          content: '',
-          timestamp: Date.now(),
-        };
-        const targetId = capturedSessionId;
-        const effectiveSplitId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
-        if (effectiveSplitId && get().sessionStates[effectiveSplitId]) {
-          updateSession(effectiveSplitId, (ss) => ({
-            streamingMessageId: newId,
-            messages: [...ss.messages, newMsg],
+        getSessionMessages: (sessionId) =>
+          sessionId && get().sessionStates[sessionId]
+            ? get().sessionStates[sessionId].messages
+            : null,
+        // The app has no flat-messages fallback in this handler; an empty
+        // array keeps the shared fn's flat branches inert.
+        getFlatMessages: () => [],
+
+        // No terminal view on the app side.
+        appendTerminalDelta: () => {},
+        // The app never reordered the empty response slot (#4297 is dashboard-
+        // only) — no-op.
+        reorderEmptyResponseSlot: () => {},
+
+        // Append a fresh response slot + set streamingMessageId. Resolve the
+        // effective session the way the app originally did: prefer the passed
+        // target when it has state, else fall back to the active session
+        // (matches the permission-split `effectiveSplitId` / defensive-suffix
+        // `effectiveDeltaId` resolution). Only writes when a session-backed
+        // target exists — the app has no flat fallback.
+        appendResponseSlot: (targetSessionId, slot, opts) => {
+          const eff = (targetSessionId && get().sessionStates[targetSessionId])
+            ? targetSessionId
+            : get().activeSessionId;
+          if (!eff || !get().sessionStates[eff]) return;
+          if (opts?.onlyIfAbsent
+              && get().sessionStates[eff].messages.some((m) => m.id === slot.id)) {
+            return;
+          }
+          updateSession(eff, (ss) => ({
+            streamingMessageId: slot.id,
+            messages: [...ss.messages, slot],
           }));
-        }
-        deltaId = newId;
-      } else if (_ctx.deltaIdRemaps.has(deltaId)) {
-        deltaId = _ctx.deltaIdRemaps.get(deltaId)!;
-      } else {
-        // Defensive: server reuses messageId for tool_start and the post-tool
-        // stream_start. If stream_start was dropped or hasn't registered the
-        // remap yet (e.g., session not in store at the time), the delta would
-        // otherwise concatenate onto the tool_use bubble. Detect that here and
-        // route to a suffixed response id, lazy-creating the bubble.
-        const targetId = capturedSessionId;
-        const effectiveDeltaId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
-        if (effectiveDeltaId && get().sessionStates[effectiveDeltaId]) {
-          const ss = get().sessionStates[effectiveDeltaId];
-          const existing = ss.messages.find((m) => m.id === deltaId);
-          if (existing && existing.type !== 'response') {
-            const suffixed = `${deltaId}-response`;
-            _ctx.deltaIdRemaps.set(deltaId, suffixed);
-            if (!ss.messages.some((m) => m.id === suffixed)) {
-              updateSession(effectiveDeltaId, (s) => ({
-                streamingMessageId: suffixed,
-                messages: [
-                  ...s.messages,
-                  { id: suffixed, type: 'response' as const, content: '', timestamp: Date.now() },
-                ],
-              }));
-            }
-            deltaId = suffixed;
-          }
-        }
-      }
+        },
 
-      // #4922 / #4889 -- post-tool continuation split. The server reuses ONE
-      // messageId for an entire assistant turn even when text -> tool -> text
-      // -> tool -> text. The defensive remap above only fires when the slot
-      // at deltaId is non-response; subsequent text chunks otherwise
-      // concatenate into the same response.content with no separator --
-      // producing `...before filing.Filing now.Filed:` and losing paragraph
-      // breaks.
-      //
-      // Detect the boundary by checking whether a tool_use was appended AFTER
-      // the currently-resolved response slot. If so, materialize a fresh
-      // continuation slot at the end (`<deltaId>-cont-<ts>`) and remap the
-      // ORIGINAL incoming messageId directly to the new slot (single-hop,
-      // never chained -- successive splits overwrite the existing entry so
-      // `_ctx.deltaIdRemaps` stays bounded and `stream_end`'s
-      // `_ctx.deltaIdRemaps.delete(out.messageId)` cleans up completely).
-      // The split mirrors the `-post-` permission-boundary pattern already
-      // in this file. Skipped while the session is replaying -- replayed
-      // history is reassembled server-side and must not be re-split on the
-      // client.
-      {
-        const splitTargetId = capturedSessionId;
-        const splitEffectiveId = (splitTargetId && get().sessionStates[splitTargetId])
-          ? splitTargetId
-          : get().activeSessionId;
-        const isReplaying = splitEffectiveId ? _ctx.replayingSessions.has(splitEffectiveId) : false;
-        if (!isReplaying && splitEffectiveId && get().sessionStates[splitEffectiveId]) {
-          const splitMessages = get().sessionStates[splitEffectiveId].messages;
-          const slotIdx = splitMessages.findIndex((m) => m.id === deltaId);
-          if (slotIdx >= 0) {
-            const slot = splitMessages[slotIdx];
-            // Buffered (not-yet-flushed) text counts as content for the
-            // split decision -- otherwise a chunk that hasn't hit the 100ms
-            // flush yet would look empty and we'd append onto it.
-            const bufferedContent = _ctx.pendingDeltas.get(deltaId)?.delta || '';
-            const hasContent = slot.type === 'response'
-              && (slot.content.length > 0 || bufferedContent.length > 0);
-            // Index-based scan instead of slice().some() -- avoids allocating
-            // a tail array on every delta. stream_delta is called many times
-            // per turn and sessions can carry long histories, so this stays
-            // on the hot path lean.
-            let toolAfter = false;
-            if (hasContent) {
-              for (let i = slotIdx + 1; i < splitMessages.length; i++) {
-                if (splitMessages[i].type === 'tool_use') {
-                  toolAfter = true;
-                  break;
-                }
-              }
-            }
-            // #4999 -- mid-sentence fragmentation gate. The post-#4889 split
-            // only makes sense when the prior bubble's text reached a sentence
-            // boundary (the LLM finished a thought before invoking the tool);
-            // otherwise the tool interrupted mid-sentence and the post-tool
-            // delta is the same sentence continuing. Treat the prior slot as
-            // "sentence-complete" only when its trailing non-whitespace char
-            // is a sentence terminator (`.`, `!`, `?`) or a hard line break
-            // (`\n`). A bubble ending in a word char, open paren, comma,
-            // colon, dash, etc. is mid-sentence -- route the delta back to
-            // the existing slot so the sentence renders as one contiguous
-            // bubble (followed by the tool).
-            if (toolAfter) {
-              const priorFullForGate = slot.type === 'response' ? slot.content + bufferedContent : '';
-              const lastNonWs = priorFullForGate.replace(/\s+$/, '');
-              // Strip trailing closing punctuation/quotes that commonly follow
-              // a sentence terminator (`.")`, `."`, `!'`, `?)`, etc.) so the
-              // gate looks at the terminator itself, not the wrapper. Without
-              // this, `"He said \"done.\""` reads as ending in `"` and the
-              // #4889 split would wrongly disable -- paragraph breaks across
-              // a tool boundary would be lost.
-              // #5014 -- also strip CJK closing brackets (`」』）`) so a
-              // fullwidth-terminated sentence wrapped in CJK quotes still
-              // reads as sentence-complete.
-              const stripped = lastNonWs.replace(/[)\]}"'’”»›」』）]+$/, '');
-              const lastChar = stripped.charAt(stripped.length - 1);
-              // #5014 -- recognize CJK fullwidth sentence terminators
-              // (`．` U+FF0E, `！` U+FF01, `？` U+FF1F) and the ideographic
-              // full stop (`。` U+3002) alongside ASCII. Without these, CJK
-              // assistant output would coalesce two sentences across a tool
-              // boundary when the user expects a paragraph break.
-              const endsSentence =
-                lastChar === '.' ||
-                lastChar === '!' ||
-                lastChar === '?' ||
-                lastChar === '．' ||
-                lastChar === '！' ||
-                lastChar === '？' ||
-                lastChar === '。';
-              const endsHardBreak = /\n\s*$/.test(priorFullForGate);
-              if (!endsSentence && !endsHardBreak) {
-                toolAfter = false;
-              }
-            }
-            if (toolAfter) {
-              // #4975 -- mid-word peel. The LLM sometimes interrupts a
-              // text content block to call a tool, splitting a word across
-              // the boundary (e.g. `"...PR #3.Del"` -> tool -> `"egating..."`).
-              // The post-#4889 split would otherwise show "Del" in one
-              // bubble and "egating..." in another with the tool between.
-              // Detect the mid-word case (last char of the prior slot's
-              // full content is a word char AND the FIRST char of the
-              // incoming post-tool delta is also a word char -- both sides
-              // of the boundary must be in a word, else the LLM emitted
-              // a normal word boundary and the peel would wrongly move a
-              // complete trailing word across the tool bubble) and peel
-              // the trailing partial word off the prior slot, seeding the
-              // continuation buffer with it. Result: the word reassembles
-              // in the continuation bubble.
-              const priorFull = slot.type === 'response' ? slot.content + bufferedContent : '';
-              const incomingDelta = msg.delta as string;
-              const incomingStartsMidWord = /^[A-Za-z0-9_]/.test(incomingDelta);
-              const midWordMatch = incomingStartsMidWord ? priorFull.match(/[A-Za-z0-9_]+$/) : null;
-              let priorTail = '';
-              if (midWordMatch && midWordMatch[0].length > 0) {
-                priorTail = midWordMatch[0];
-                let remaining = priorTail.length;
-                if (bufferedContent.length > 0) {
-                  const peelFromBuf = Math.min(remaining, bufferedContent.length);
-                  const newBuf = bufferedContent.slice(0, bufferedContent.length - peelFromBuf);
-                  if (newBuf.length > 0) {
-                    _ctx.pendingDeltas.set(deltaId, {
-                      sessionId: capturedSessionId,
-                      delta: newBuf,
-                    });
-                  } else {
-                    _ctx.pendingDeltas.delete(deltaId);
-                  }
-                  remaining -= peelFromBuf;
-                }
-                if (remaining > 0 && slot.type === 'response' && slot.content.length > 0) {
-                  updateSession(splitEffectiveId, (ss) => ({
-                    messages: ss.messages.map((m) =>
-                      m.id === deltaId && m.type === 'response'
-                        ? { ...m, content: m.content.slice(0, m.content.length - remaining) }
-                        : m
-                    ),
-                  }));
-                }
-              }
-              const contId = `${deltaId}-cont-${Date.now()}`;
-              // Single-hop remap: write against the ORIGINAL incoming
-              // messageId so successive continuation splits overwrite this
-              // entry rather than building a chain. Keeps
-              // `_ctx.deltaIdRemaps` size bounded by the count of distinct
-              // in-flight turn ids, and lets `stream_end`'s
-              // `_ctx.deltaIdRemaps.delete(out.messageId)` clean up
-              // completely.
-              _ctx.deltaIdRemaps.set(originalMessageId, contId);
-              const contMsg: ChatMessage = {
-                id: contId,
-                type: 'response',
-                content: '',
-                timestamp: Date.now(),
-              };
-              updateSession(splitEffectiveId, (ss) => ({
-                streamingMessageId: contId,
-                messages: [...ss.messages, contMsg],
-              }));
-              deltaId = contId;
-              // Seed the new continuation buffer with the peeled word so
-              // the first delta on `contId` carries the partial word as
-              // its prefix.
-              if (priorTail.length > 0) {
-                _ctx.pendingDeltas.set(contId, {
-                  sessionId: capturedSessionId,
-                  delta: priorTail,
-                });
-              }
-            }
-          }
-        }
-      }
+        // Peel `count` trailing chars off the flushed content of the response
+        // slot at `deltaId`. Session-only (the cont-split only fires for the
+        // app when session state backs the resolved messages).
+        peelSlotContent: (targetSessionId, deltaId, count) => {
+          if (!targetSessionId || !get().sessionStates[targetSessionId]) return;
+          updateSession(targetSessionId, (ss) => ({
+            messages: ss.messages.map((m) =>
+              m.id === deltaId && m.type === 'response'
+                ? { ...m, content: m.content.slice(0, m.content.length - count) }
+                : m
+            ),
+          }));
+        },
 
-      const existingDelta = _ctx.pendingDeltas.get(deltaId);
-      _ctx.pendingDeltas.set(deltaId, {
-        sessionId: capturedSessionId,
-        delta: (existingDelta?.delta || '') + (msg.delta as string),
+        scheduleFlush: () => {
+          if (!_ctx.deltaFlushTimer) {
+            _ctx.deltaFlushTimer = setTimeout(flushPendingDeltas, 100);
+          }
+        },
       });
-      if (!_ctx.deltaFlushTimer) {
-        _ctx.deltaFlushTimer = setTimeout(flushPendingDeltas, 100);
-      }
       break;
     }
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -41,6 +41,7 @@ import {
   handleToolResult as sharedToolResult,
   handleToolInputDelta as sharedToolInputDelta,
   handleStreamStart as sharedStreamStart,
+  sharedStreamDelta,
   handleStreamEnd as sharedStreamEnd,
   handleAuthOk as sharedAuthOk,
   parseConnectedClients as sharedParseConnectedClients,
@@ -1320,341 +1321,127 @@ function handleStreamStart(msg: Record<string, unknown>, get: MsgGet, set: MsgSe
 }
 
 function handleStreamDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
-  // Capture the ORIGINAL incoming messageId before any remap resolution.
-  // The post-tool continuation split (#4889) writes its remap entry against
-  // this id (not against the resolved `deltaId`) so successive splits
-  // overwrite a single map entry instead of forming a chain — keeps
-  // `_deltaIdRemaps` bounded and eliminates the need for chained lookup.
-  const originalMessageId = msg.messageId as string;
-  let deltaId = originalMessageId;
-  const capturedSessionId = (msg.sessionId as string) || get().activeSessionId;
+  // #4981 — thin wrapper over `sharedStreamDelta`. The platform-neutral hot
+  // path (post-permission split, single-hop defensive remap, post-tool
+  // continuation split with the #4999/#5014 sentence gate and #4975 mid-word
+  // peel, buffered append + 100ms flush) lives in store-core. The dashboard-
+  // specific side effects stay here: the terminal-data write, the #4297
+  // empty-response-slot reorder, and the flat-`messages` fallbacks (the app
+  // has neither — see the StreamDeltaContext doc comment).
+  sharedStreamDelta(msg, {
+    activeSessionId: get().activeSessionId,
+    pendingDeltas,
+    deltaIdRemaps: _deltaIdRemaps,
+    postPermissionSplits: _postPermissionSplits,
+    replayingSessions: _replayingSessions,
 
-  // Forward delta text to terminal view (synthesize raw output in CLI mode)
-  if (typeof msg.delta === 'string' && msg.delta.length > 0) {
-    get().appendTerminalData(msg.delta);
-  }
+    getSessionMessages: (sessionId) =>
+      sessionId && get().sessionStates[sessionId]
+        ? get().sessionStates[sessionId]!.messages
+        : null,
+    getFlatMessages: () => get().messages,
 
-  // #4297 — TUI fires stream_start at turn-start (#4010), creating an empty
-  // response slot. Tool events that follow append AFTER the slot. If the
-  // turn ends with a summary stream_delta, the text would otherwise materialize
-  // at the early slot position — making claude's wrap-up appear ABOVE the tool
-  // groups it summarized. On the first delta for an empty response slot, move
-  // it to the current end of the messages array. We gate on content === '' so
-  // a reconnect-replayed response (already populated) is never shifted, and
-  // run BEFORE the post-permission / collision branches below so their
-  // suffixed-response paths (which already append at the end) skip the
-  // reorder by virtue of the deltaId remap.
-  if (typeof deltaId === 'string'
-      && !_postPermissionSplits.has(deltaId)
-      && !_deltaIdRemaps.has(deltaId)
-      && !pendingDeltas.has(deltaId)) {
-    const targetForReorder = (capturedSessionId && get().sessionStates[capturedSessionId])
-      ? capturedSessionId
-      : null;
-    if (targetForReorder) {
-      const ss = get().sessionStates[targetForReorder]!;
-      const idx = ss.messages.findIndex((m) => m.id === deltaId);
-      if (idx >= 0 && idx < ss.messages.length - 1) {
-        const slot = ss.messages[idx]!;
-        if (slot.type === 'response' && slot.content === '') {
-          updateSession(targetForReorder, (s) => ({
-            messages: [
-              ...s.messages.slice(0, idx),
-              ...s.messages.slice(idx + 1),
-              slot,
-            ],
-          }));
-        }
-      }
-    } else {
-      // Flat-messages fallback (pre-session bootstrap)
-      const flat = get().messages;
-      const idx = flat.findIndex((m) => m.id === deltaId);
-      if (idx >= 0 && idx < flat.length - 1) {
-        const slot = flat[idx]!;
-        if (slot.type === 'response' && slot.content === '') {
-          set((state) => ({
-            messages: [
-              ...state.messages.slice(0, idx),
-              ...state.messages.slice(idx + 1),
-              slot,
-            ],
-          }));
-        }
-      }
-    }
-  }
+    // Forward delta text to terminal view (synthesize raw output in CLI mode).
+    // The shared fn already gates on `typeof msg.delta === 'string' && length`.
+    appendTerminalDelta: (delta) => {
+      get().appendTerminalData(delta);
+    },
 
-  // Permission boundary split: first delta after a split creates a new message
-  if (_postPermissionSplits.has(deltaId)) {
-    _postPermissionSplits.delete(deltaId);
-    const newId = `${deltaId}-post-${Date.now()}`;
-    _deltaIdRemaps.set(deltaId, newId);
-    const newMsg: ChatMessage = {
-      id: newId,
-      type: 'response',
-      content: '',
-      timestamp: Date.now(),
-    };
-    const targetId = capturedSessionId;
-    if (targetId && get().sessionStates[targetId]) {
-      updateSession(targetId, (ss) => ({
-        streamingMessageId: newId,
-        messages: [...ss.messages, newMsg],
-      }));
-    } else {
-      set((state: ConnectionState) => ({
-        streamingMessageId: newId,
-        messages: [...state.messages, newMsg],
-      }));
-    }
-    deltaId = newId;
-  } else if (_deltaIdRemaps.has(deltaId)) {
-    deltaId = _deltaIdRemaps.get(deltaId)!;
-  } else {
-    // Defensive: server reuses messageId for tool_start and the post-tool
-    // stream_start. If stream_start was dropped or hasn't registered the
-    // remap yet (e.g., session not in store at the time), the delta would
-    // otherwise concatenate onto the tool_use bubble. Detect that here and
-    // route to a suffixed response id, lazy-creating the bubble.
-    const targetId = capturedSessionId;
-    const effectiveSessionId = (targetId && get().sessionStates[targetId]) ? targetId : get().activeSessionId;
-    if (effectiveSessionId && get().sessionStates[effectiveSessionId]) {
-      const ss = get().sessionStates[effectiveSessionId]!;
-      const existing = ss.messages.find((m) => m.id === deltaId);
-      if (existing && existing.type !== 'response') {
-        const suffixed = `${deltaId}-response`;
-        _deltaIdRemaps.set(deltaId, suffixed);
-        if (!ss.messages.some((m) => m.id === suffixed)) {
-          updateSession(effectiveSessionId, (s) => ({
-            streamingMessageId: suffixed,
-            messages: [
-              ...s.messages,
-              { id: suffixed, type: 'response' as const, content: '', timestamp: Date.now() },
-            ],
-          }));
-        }
-        deltaId = suffixed;
-      }
-    } else {
-      // Flat-messages fallback: when no session state is active (e.g., pre-session
-      // bootstrap, or the session hasn't been registered in sessionStates yet),
-      // the same collision can occur on the flat messages array. Mirror the
-      // sessionStates branch here so deltas don't leak into a tool_use bubble.
-      const flat = get().messages;
-      const existing = flat.find((m) => m.id === deltaId);
-      if (existing && existing.type !== 'response') {
-        const suffixed = `${deltaId}-response`;
-        _deltaIdRemaps.set(deltaId, suffixed);
-        if (!flat.some((m) => m.id === suffixed)) {
-          set((s) => ({
-            streamingMessageId: suffixed,
-            messages: [
-              ...s.messages,
-              { id: suffixed, type: 'response' as const, content: '', timestamp: Date.now() },
-            ],
-          }));
-        }
-        deltaId = suffixed;
-      }
-    }
-  }
-
-  // #4889 — post-tool continuation split. The server reuses ONE messageId for
-  // an entire assistant turn even when text → tool → text → tool → text. The
-  // #4297 reorder only fires on the FIRST delta (gated on content === '');
-  // subsequent text chunks concatenate into the same response.content with no
-  // separator — producing `…before filing.Filing now.Filed:` and losing
-  // paragraph breaks.
-  //
-  // Detect the boundary by checking whether a tool_use was appended AFTER the
-  // currently-resolved response slot. If so, materialize a fresh continuation
-  // slot at the end (`<deltaId>-cont-<ts>`) and remap the ORIGINAL incoming
-  // messageId directly to the new slot (single-hop, never chained — successive
-  // splits overwrite the existing entry so `_deltaIdRemaps` stays bounded and
-  // `handleStreamEnd`'s `_deltaIdRemaps.delete(out.messageId)` cleans up
-  // completely). The split mirrors the `-post-` permission-boundary pattern
-  // already in this file. Skipped while the session is replaying — replayed
-  // history is reassembled server-side and must not be re-split on the client.
-  {
-    const splitTargetId = capturedSessionId;
-    const splitEffectiveId = (splitTargetId && get().sessionStates[splitTargetId])
-      ? splitTargetId
-      : get().activeSessionId;
-    const isReplaying = splitEffectiveId ? _replayingSessions.has(splitEffectiveId) : false;
-    if (!isReplaying) {
-      const splitMessages = (splitEffectiveId && get().sessionStates[splitEffectiveId])
-        ? get().sessionStates[splitEffectiveId]!.messages
-        : get().messages;
-      const slotIdx = splitMessages.findIndex((m) => m.id === deltaId);
-      if (slotIdx >= 0) {
-        const slot = splitMessages[slotIdx]!;
-        // Buffered (not-yet-flushed) text counts as content for the split
-        // decision — otherwise a chunk that hasn't hit the 100ms flush yet
-        // would look empty and we'd append onto it.
-        const bufferedContent = pendingDeltas.get(deltaId)?.delta || '';
-        const hasContent = slot.type === 'response'
-          && (slot.content.length > 0 || bufferedContent.length > 0);
-        // Index-based scan instead of slice().some() — avoids allocating a
-        // tail array on every delta. handleStreamDelta is called many times
-        // per turn and sessions can carry long histories, so this stays on
-        // the hot path lean.
-        let toolAfter = false;
-        if (hasContent) {
-          for (let i = slotIdx + 1; i < splitMessages.length; i++) {
-            if (splitMessages[i]!.type === 'tool_use') {
-              toolAfter = true;
-              break;
-            }
-          }
-        }
-        // #4999 — mid-sentence fragmentation gate. The post-#4889 split only
-        // makes sense when the prior bubble's text reached a sentence boundary
-        // (the LLM finished a thought before invoking the tool); otherwise the
-        // tool interrupted mid-sentence and the post-tool delta is the same
-        // sentence continuing. Treat the prior slot as "sentence-complete"
-        // only when its trailing non-whitespace character is a sentence
-        // terminator (`.`, `!`, `?`) or a hard line break (`\n`). A bubble
-        // that ends with a word char, open paren, comma, colon, dash, etc.
-        // is mid-sentence — route the delta back to the existing slot so the
-        // sentence renders as one contiguous bubble (followed by the tool).
-        if (toolAfter) {
-          const priorFullForGate = slot.type === 'response' ? slot.content + bufferedContent : '';
-          // Trim trailing whitespace before inspecting the last char so e.g.
-          // `"...sentence.   "` still reads as sentence-complete.
-          const lastNonWs = priorFullForGate.replace(/\s+$/, '');
-          // Strip trailing closing punctuation/quotes that commonly follow a
-          // sentence terminator (`.")`, `."`, `!'`, `?)`, etc.) so the gate
-          // looks at the terminator itself, not the wrapper. Without this,
-          // `"He said \"done.\""` reads as ending in `"` and the #4889 split
-          // would wrongly disable — paragraph breaks across a tool boundary
-          // would be lost.
-          // #5014 — also strip CJK closing brackets (`」』）`) so a
-          // fullwidth-terminated sentence wrapped in CJK quotes still
-          // reads as sentence-complete.
-          const stripped = lastNonWs.replace(/[)\]}"'’”»›」』）]+$/, '');
-          const lastChar = stripped.charAt(stripped.length - 1);
-          // #5014 — recognize CJK fullwidth sentence terminators
-          // (`．` U+FF0E, `！` U+FF01, `？` U+FF1F) and the ideographic
-          // full stop (`。` U+3002) alongside ASCII. Without these, CJK
-          // assistant output would coalesce two sentences across a tool
-          // boundary when the user expects a paragraph break.
-          const endsSentence =
-            lastChar === '.' ||
-            lastChar === '!' ||
-            lastChar === '?' ||
-            lastChar === '．' ||
-            lastChar === '！' ||
-            lastChar === '？' ||
-            lastChar === '。';
-          const endsHardBreak = /\n\s*$/.test(priorFullForGate);
-          if (!endsSentence && !endsHardBreak) {
-            toolAfter = false;
-          }
-        }
-        if (toolAfter) {
-          // #4975 — mid-word peel. The LLM sometimes interrupts a text
-          // content block to call a tool, splitting a word across the
-          // boundary (e.g. `"...PR #3.Del"` → tool → `"egating..."`).
-          // The post-#4889 split would otherwise show "Del" in one bubble
-          // and "egating..." in another with the tool between. Detect the
-          // mid-word case (last char of the prior slot's full content is
-          // a word char AND the FIRST char of the incoming post-tool delta
-          // is also a word char — both sides of the boundary must be in
-          // a word, else the LLM emitted a normal word boundary and the
-          // peel would wrongly move a complete trailing word across the
-          // tool bubble) and peel the trailing partial word off the prior
-          // slot, seeding the continuation buffer with it. Result: the
-          // word reassembles in the continuation bubble.
-          const priorFull = slot.type === 'response' ? slot.content + bufferedContent : '';
-          const incomingDelta = msg.delta as string;
-          const incomingStartsMidWord = /^[A-Za-z0-9_]/.test(incomingDelta);
-          const midWordMatch = incomingStartsMidWord ? priorFull.match(/[A-Za-z0-9_]+$/) : null;
-          let priorTail = '';
-          if (midWordMatch && midWordMatch[0].length > 0) {
-            priorTail = midWordMatch[0];
-            // Peel the partial word off the prior slot. It may live in
-            // already-flushed `slot.content` and/or in the still-buffered
-            // `pendingDeltas[deltaId].delta` — strip from buffered first
-            // (it lives at the tail), then from flushed content if needed.
-            let remaining = priorTail.length;
-            if (bufferedContent.length > 0) {
-              const peelFromBuf = Math.min(remaining, bufferedContent.length);
-              const newBuf = bufferedContent.slice(0, bufferedContent.length - peelFromBuf);
-              if (newBuf.length > 0) {
-                pendingDeltas.set(deltaId, {
-                  sessionId: capturedSessionId,
-                  delta: newBuf,
-                });
-              } else {
-                pendingDeltas.delete(deltaId);
-              }
-              remaining -= peelFromBuf;
-            }
-            if (remaining > 0 && slot.type === 'response' && slot.content.length > 0) {
-              const updater = (ss: { messages: ChatMessage[] }) => ({
-                messages: ss.messages.map((m) =>
-                  m.id === deltaId && m.type === 'response'
-                    ? { ...m, content: m.content.slice(0, m.content.length - remaining) }
-                    : m
-                ),
-              });
-              if (splitEffectiveId && get().sessionStates[splitEffectiveId]) {
-                updateSession(splitEffectiveId, updater);
-              } else {
-                set((s) => ({ messages: updater({ messages: s.messages }).messages }));
-              }
-            }
-          }
-          const contId = `${deltaId}-cont-${Date.now()}`;
-          // Single-hop remap: write against the ORIGINAL incoming messageId
-          // so successive continuation splits overwrite this entry rather
-          // than building a chain. Keeps `_deltaIdRemaps` size bounded by
-          // the count of distinct in-flight turn ids, and lets
-          // `handleStreamEnd`'s `_deltaIdRemaps.delete(out.messageId)` clean
-          // up completely.
-          _deltaIdRemaps.set(originalMessageId, contId);
-          const contMsg: ChatMessage = {
-            id: contId,
-            type: 'response',
-            content: '',
-            timestamp: Date.now(),
-          };
-          if (splitEffectiveId && get().sessionStates[splitEffectiveId]) {
-            updateSession(splitEffectiveId, (ss) => ({
-              streamingMessageId: contId,
-              messages: [...ss.messages, contMsg],
-            }));
-          } else {
-            set((state: ConnectionState) => ({
-              streamingMessageId: contId,
-              messages: [...state.messages, contMsg],
+    // #4297 — TUI fires stream_start at turn-start (#4010), creating an empty
+    // response slot. Tool events that follow append AFTER the slot. If the
+    // turn ends with a summary stream_delta, the text would otherwise
+    // materialize at the early slot position — making claude's wrap-up appear
+    // ABOVE the tool groups it summarized. On the first delta for an empty
+    // response slot, move it to the current end of the messages array. We gate
+    // on content === '' so a reconnect-replayed response (already populated)
+    // is never shifted. The shared fn applies the not-split / not-remapped /
+    // not-pending guard before calling this.
+    reorderEmptyResponseSlot: (deltaId, capturedSessionId) => {
+      const targetForReorder = (capturedSessionId && get().sessionStates[capturedSessionId])
+        ? capturedSessionId
+        : null;
+      if (targetForReorder) {
+        const ss = get().sessionStates[targetForReorder]!;
+        const idx = ss.messages.findIndex((m) => m.id === deltaId);
+        if (idx >= 0 && idx < ss.messages.length - 1) {
+          const slot = ss.messages[idx]!;
+          if (slot.type === 'response' && slot.content === '') {
+            updateSession(targetForReorder, (s) => ({
+              messages: [
+                ...s.messages.slice(0, idx),
+                ...s.messages.slice(idx + 1),
+                slot,
+              ],
             }));
           }
-          deltaId = contId;
-          // Seed the new continuation buffer with the peeled word so the
-          // first delta on `contId` carries the partial word as its prefix.
-          // The normal append below (`pendingDeltas.set(deltaId, ...)`)
-          // sees the existing buffer and concatenates correctly.
-          if (priorTail.length > 0) {
-            pendingDeltas.set(contId, {
-              sessionId: capturedSessionId,
-              delta: priorTail,
-            });
+        }
+      } else {
+        // Flat-messages fallback (pre-session bootstrap)
+        const flat = get().messages;
+        const idx = flat.findIndex((m) => m.id === deltaId);
+        if (idx >= 0 && idx < flat.length - 1) {
+          const slot = flat[idx]!;
+          if (slot.type === 'response' && slot.content === '') {
+            set((state) => ({
+              messages: [
+                ...state.messages.slice(0, idx),
+                ...state.messages.slice(idx + 1),
+                slot,
+              ],
+            }));
           }
         }
       }
-    }
-  }
+    },
 
-  const existingDelta = pendingDeltas.get(deltaId);
-  pendingDeltas.set(deltaId, {
-    sessionId: capturedSessionId,
-    delta: (existingDelta?.delta || '') + (msg.delta as string),
+    // Append a fresh response slot + set streamingMessageId. A null target (or
+    // a target without session state) routes to the flat-messages array —
+    // mirroring the dashboard's original session-state-or-flat branches for
+    // the permission split, defensive `-response` suffix, and `-cont-` split.
+    appendResponseSlot: (targetSessionId, slot, opts) => {
+      if (targetSessionId && get().sessionStates[targetSessionId]) {
+        if (opts?.onlyIfAbsent
+            && get().sessionStates[targetSessionId]!.messages.some((m) => m.id === slot.id)) {
+          return;
+        }
+        updateSession(targetSessionId, (ss) => ({
+          streamingMessageId: slot.id,
+          messages: [...ss.messages, slot],
+        }));
+      } else {
+        if (opts?.onlyIfAbsent && get().messages.some((m) => m.id === slot.id)) {
+          return;
+        }
+        set((state: ConnectionState) => ({
+          streamingMessageId: slot.id,
+          messages: [...state.messages, slot],
+        }));
+      }
+    },
+
+    // Peel `count` trailing chars off the flushed content of the response slot
+    // at `deltaId`. Null target routes to flat messages.
+    peelSlotContent: (targetSessionId, deltaId, count) => {
+      const updater = (ss: { messages: ChatMessage[] }) => ({
+        messages: ss.messages.map((m) =>
+          m.id === deltaId && m.type === 'response'
+            ? { ...m, content: m.content.slice(0, m.content.length - count) }
+            : m
+        ),
+      });
+      if (targetSessionId && get().sessionStates[targetSessionId]) {
+        updateSession(targetSessionId, updater);
+      } else {
+        set((s) => ({ messages: updater({ messages: s.messages }).messages }));
+      }
+    },
+
+    scheduleFlush: () => {
+      if (!deltaFlushTimer) {
+        deltaFlushTimer = setTimeout(flushPendingDeltas, 100);
+      }
+    },
   });
-  if (!deltaFlushTimer) {
-    deltaFlushTimer = setTimeout(flushPendingDeltas, 100);
-  }
 }
 
 function handleStreamEnd(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {

--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -98,8 +98,10 @@ import {
   handleToolInputDelta,
   MAX_TOOL_INPUT_PARTIAL_LEN,
   handleStreamStart,
+  sharedStreamDelta,
   handleStreamEnd,
 } from './index'
+import type { StreamDeltaContext, PendingDelta } from './index'
 import { nextMessageId } from '../utils'
 import type {
   ActiveTool,
@@ -7934,5 +7936,223 @@ describe('applyInterventionBuilder', () => {
     const { interventions, isFirst } = applyInterventionBuilder(builder, existing)
     expect(interventions).toBe(existing)
     expect(isFirst).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sharedStreamDelta (#4981) — platform-neutral hot-path logic
+//
+// These exercise the logic that previously lived (duplicated) inside the
+// dashboard `handleStreamDelta` and the app `case 'stream_delta'`: the
+// single-hop defensive remap, the post-tool continuation split (#4889) with
+// the #4999/#5014 mid-sentence gate, and the #4975 mid-word peel. A minimal
+// in-memory harness models a single-session store; the platform-divergent
+// hooks (terminal write, #4297 reorder, flat fallback) are no-ops here and
+// covered by the dashboard/app wrapper integration suites.
+// ---------------------------------------------------------------------------
+
+describe('sharedStreamDelta (#4981)', () => {
+  function makeHarness(sessionId: string) {
+    // Single session-state messages array + streamingMessageId.
+    let messages: ChatMessage[] = []
+    let streamingMessageId: string | null = null
+    const pendingDeltas = new Map<string, PendingDelta>()
+    const deltaIdRemaps = new Map<string, string>()
+    const postPermissionSplits = new Set<string>()
+    const replayingSessions = new Set<string>()
+
+    const ctx: StreamDeltaContext = {
+      activeSessionId: sessionId,
+      pendingDeltas,
+      deltaIdRemaps,
+      postPermissionSplits,
+      replayingSessions,
+      getSessionMessages: (id) => (id === sessionId ? messages : null),
+      getFlatMessages: () => [],
+      appendTerminalDelta: () => {},
+      reorderEmptyResponseSlot: () => {},
+      appendResponseSlot: (targetId, slot, opts) => {
+        if (targetId !== sessionId) return
+        if (opts?.onlyIfAbsent && messages.some((m) => m.id === slot.id)) return
+        streamingMessageId = slot.id
+        messages = [...messages, slot]
+      },
+      peelSlotContent: (targetId, id, count) => {
+        if (targetId !== sessionId) return
+        messages = messages.map((m) =>
+          m.id === id && m.type === 'response'
+            ? { ...m, content: m.content.slice(0, m.content.length - count) }
+            : m,
+        )
+      },
+      scheduleFlush: () => {},
+    }
+
+    // Emulate the 100ms flush: append each buffered delta onto its matching
+    // response slot's flushed content (the matched-id path of the real
+    // flushPendingDeltas).
+    function flush() {
+      for (const [id, { delta }] of pendingDeltas) {
+        messages = messages.map((m) =>
+          m.id === id && m.type === 'response'
+            ? { ...m, content: m.content + delta }
+            : m,
+        )
+      }
+      pendingDeltas.clear()
+    }
+
+    function send(msg: Record<string, unknown>) {
+      sharedStreamDelta({ sessionId, ...msg }, ctx)
+    }
+
+    function seedResponse(id: string, content = '') {
+      streamingMessageId = id
+      messages = [...messages, { id, type: 'response', content, timestamp: 1 }]
+    }
+    function seedTool(id: string) {
+      messages = [...messages, { id, type: 'tool_use', content: 'x', timestamp: 1 }]
+    }
+
+    return {
+      send,
+      flush,
+      seedResponse,
+      seedTool,
+      get messages() { return messages },
+      get streamingMessageId() { return streamingMessageId },
+      pendingDeltas,
+      deltaIdRemaps,
+      postPermissionSplits,
+      replayingSessions,
+    }
+  }
+
+  it('buffers the delta onto the same slot when no tool follows', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'Hello ')
+    h.send({ messageId: 'resp-1', delta: 'world' })
+    h.flush()
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses).toHaveLength(1)
+    expect(responses[0]!.content).toBe('Hello world')
+  })
+
+  it('post-tool continuation split (#4889): sentence-terminated prior slot → fresh -cont- bubble', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'Let me check chroxy before filing.')
+    h.seedTool('toolu_a')
+    h.send({ messageId: 'resp-1', delta: 'Filing now.' })
+    h.flush()
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses).toHaveLength(2)
+    expect(responses[0]!.content).toBe('Let me check chroxy before filing.')
+    expect(responses[1]!.content).toBe('Filing now.')
+    expect(responses[1]!.id).toMatch(/^resp-1-cont-/)
+    // Single-hop remap recorded against the ORIGINAL incoming id.
+    expect(h.deltaIdRemaps.get('resp-1')).toBe(responses[1]!.id)
+  })
+
+  it('single-hop remap: a second post-tool delta reuses the existing remap (no chain)', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'First sentence.')
+    h.seedTool('toolu_a')
+    h.send({ messageId: 'resp-1', delta: 'Second sentence.' })
+    h.flush()
+    const firstCont = h.deltaIdRemaps.get('resp-1')!
+    h.seedTool('toolu_b')
+    h.send({ messageId: 'resp-1', delta: 'Third sentence.' })
+    h.flush()
+    const secondCont = h.deltaIdRemaps.get('resp-1')!
+    // The map still keys on the original id (single entry, overwritten).
+    expect(h.deltaIdRemaps.size).toBe(1)
+    expect(secondCont).not.toBe(firstCont)
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses.map((r) => r.content)).toEqual([
+      'First sentence.',
+      'Second sentence.',
+      'Third sentence.',
+    ])
+  })
+
+  it('mid-sentence gate (#4999): non-terminated prior slot → delta coalesces into same bubble', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'Let me check the')
+    h.seedTool('toolu_a')
+    h.send({ messageId: 'resp-1', delta: ' issue list' })
+    h.flush()
+    const responses = h.messages.filter((m) => m.type === 'response')
+    // No split — one bubble.
+    expect(responses).toHaveLength(1)
+    expect(responses[0]!.content).toBe('Let me check the issue list')
+    expect(h.deltaIdRemaps.has('resp-1')).toBe(false)
+  })
+
+  it('mid-sentence gate (#5014): CJK fullwidth terminator counts as sentence-complete → split', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', '调查问题。')
+    h.seedTool('toolu_a')
+    h.send({ messageId: 'resp-1', delta: '现在提交。' })
+    h.flush()
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses).toHaveLength(2)
+    expect(responses[1]!.id).toMatch(/^resp-1-cont-/)
+  })
+
+  it('mid-word inside a sentence (#4975/#4999): prior ends mid-word → gate coalesces into ONE bubble', () => {
+    const h = makeHarness('s1')
+    // Prior content ends with a word char (`...PR #3.Del` → last char `l`),
+    // so the #4999 mid-sentence gate routes the post-tool delta back to the
+    // existing slot. The word "Delegating" reassembles in a single bubble and
+    // the #4975 peel never needs to fire.
+    h.seedResponse('resp-1', 'Starting on PR #3.Del')
+    h.seedTool('toolu_a')
+    h.send({ messageId: 'resp-1', delta: 'egating the review.' })
+    h.flush()
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses).toHaveLength(1)
+    expect(responses[0]!.content).toBe('Starting on PR #3.Delegating the review.')
+    expect(responses[0]!.content).toContain('Delegating')
+  })
+
+  it('mid-word inside a sentence with still-buffered prior (delta not yet flushed) also coalesces', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'Starting on PR #3.')
+    // Buffer "Del" without flushing — counts as content for the split decision.
+    h.send({ messageId: 'resp-1', delta: 'Del' })
+    h.seedTool('toolu_a')
+    h.send({ messageId: 'resp-1', delta: 'egating the review.' })
+    h.flush()
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses).toHaveLength(1)
+    expect(responses[0]!.content).toBe('Starting on PR #3.Delegating the review.')
+  })
+
+  it('replay guard: no continuation split while the session is replaying', () => {
+    const h = makeHarness('s1')
+    h.replayingSessions.add('s1')
+    h.seedResponse('resp-1', 'First sentence.')
+    h.seedTool('toolu_a')
+    h.send({ messageId: 'resp-1', delta: 'Second sentence.' })
+    h.flush()
+    const responses = h.messages.filter((m) => m.type === 'response')
+    // Replayed history is reassembled server-side — the delta coalesces onto
+    // the existing slot instead of splitting into a fresh -cont- bubble.
+    expect(responses).toHaveLength(1)
+    expect(responses[0]!.content).toBe('First sentence.Second sentence.')
+    expect(h.deltaIdRemaps.has('resp-1')).toBe(false)
+  })
+
+  it('defensive remap: delta whose slot is a tool_use routes to a -response slot', () => {
+    const h = makeHarness('s1')
+    // A tool_use occupies the incoming id (server reused messageId).
+    h.seedTool('resp-collide')
+    h.send({ messageId: 'resp-collide', delta: 'hi' })
+    h.flush()
+    const suffixed = h.messages.find((m) => m.id === 'resp-collide-response')
+    expect(suffixed).toBeDefined()
+    expect(suffixed!.type).toBe('response')
+    expect(suffixed!.content).toBe('hi')
+    expect(h.deltaIdRemaps.get('resp-collide')).toBe('resp-collide-response')
   })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -4799,11 +4799,13 @@ export function sharedStreamDelta(
       content: '',
       timestamp: Date.now(),
     }
-    // Both originals resolve the permission-split target as "captured session
-    // when it has state, else active session"; the dashboard additionally
-    // falls back to flat messages. `appendResponseSlot` receives the captured
-    // id and applies that platform's resolution (the dashboard re-derives the
-    // effective id / flat fallback inside its callback).
+    // The two originals resolved the permission-split target DIFFERENTLY, so
+    // `appendResponseSlot` receives the raw captured id and each platform's
+    // callback applies its own resolution:
+    //   - dashboard: captured session when it has state, ELSE the flat
+    //     `messages` array (NO active-session fallback).
+    //   - app: captured session when it has state, ELSE the active session;
+    //     session-only (no flat fallback).
     ctx.appendResponseSlot(capturedSessionId, newMsg)
     deltaId = newId
   } else if (ctx.deltaIdRemaps.has(deltaId)) {

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -4641,6 +4641,375 @@ export function handleStreamStart(
 }
 
 // ---------------------------------------------------------------------------
+// stream_delta — #4981
+//
+// The post-tool continuation-split (#4889), #4297 defensive reorder, single-
+// hop `_deltaIdRemaps` remap, mid-sentence gate (#4999/#5014), and mid-word
+// peel (#4975) logic was previously duplicated verbatim between the dashboard
+// (`handleStreamDelta`) and the app (`case 'stream_delta'`). Both maintain the
+// same module-local state (`pendingDeltas`, `deltaIdRemaps`,
+// `postPermissionSplits`, `replayingSessions`, the 100ms flush timer).
+//
+// `sharedStreamDelta` owns the platform-NEUTRAL algorithm. Platform-specific
+// side-effects stay at the call site, surfaced through `StreamDeltaContext`
+// callbacks:
+//   - dashboard's terminal-data write (`appendTerminalDelta`)
+//   - dashboard's #4297 empty-response-slot reorder + flat-messages fallbacks
+//     (the app has neither — it only ever operates on `sessionStates`)
+//
+// The two originals were NOT byte-identical: the dashboard additionally ran
+// the #4297 reorder pre-step and carried flat-`messages` fallbacks in the
+// defensive-remap and continuation-split branches. To preserve BOTH behaviours
+// exactly (pure refactor, no behaviour change), those divergent pieces are
+// supplied by the call site:
+//   - `appendTerminalDelta` — dashboard writes, app no-op
+//   - `reorderEmptyResponseSlot` — dashboard performs the #4297 shift, app no-op
+//   - `getSessionMessages` / `getFlatMessages` / `appendResponseSlot` /
+//     `peelSlotContent` — each resolves the effective target (session-state vs
+//     flat) the way that platform does, so the dashboard keeps its flat
+//     fallback and the app stays session-only.
+// ---------------------------------------------------------------------------
+
+/**
+ * A buffered (not-yet-flushed) delta entry. Mirrors the `pendingDeltas` value
+ * shape used by both call sites.
+ */
+export interface PendingDelta {
+  sessionId: string | null
+  delta: string
+}
+
+/**
+ * Platform surface for {@link sharedStreamDelta}. The shared function reads and
+ * mutates the four module-local collections directly (they are identical on
+ * both platforms) and delegates every store-touching or platform-divergent
+ * operation to a callback.
+ */
+export interface StreamDeltaContext {
+  /** The store's current active session id (`get().activeSessionId`). */
+  activeSessionId: string | null
+  /**
+   * Resolve the messages array for a target session. Returns the session's
+   * `sessionStates[id].messages` when present, else `null` so the shared
+   * function knows to fall through to the flat-messages path. Pass `null`/an
+   * unknown id to force the flat fallback.
+   */
+  getSessionMessages: (sessionId: string | null) => readonly ChatMessage[] | null
+  /**
+   * The flat (legacy / pre-session-bootstrap) `messages` array. The dashboard
+   * supplies the real array; the app — which has no flat fallback in this
+   * handler — returns an empty array so the flat branches are inert.
+   */
+  getFlatMessages: () => readonly ChatMessage[]
+  /** `pendingDeltas` buffer (shared, identical on both platforms). */
+  pendingDeltas: Map<string, PendingDelta>
+  /** Single-hop `_deltaIdRemaps` map (shared). */
+  deltaIdRemaps: Map<string, string>
+  /** `_postPermissionSplits` set (shared). */
+  postPermissionSplits: Set<string>
+  /** Per-session replay guard set (shared). */
+  replayingSessions: Set<string>
+  /**
+   * Forward the raw delta text to the terminal view. Dashboard-only side
+   * effect; the app passes a no-op. Called once at the top of the handler,
+   * before any remap resolution, exactly as the dashboard did inline.
+   */
+  appendTerminalDelta: (delta: string) => void
+  /**
+   * #4297 — move an empty (`content === ''`) response slot at `deltaId` to the
+   * end of the messages array on its first delta, so a turn-final summary
+   * renders below the tool groups it summarised. Dashboard implements the
+   * session-state + flat shift; the app passes a no-op (it never reordered).
+   */
+  reorderEmptyResponseSlot: (deltaId: string, capturedSessionId: string | null) => void
+  /**
+   * Append a fresh response slot (used by the `-post-` permission split, the
+   * defensive `-response` suffix, and the `-cont-` continuation split) and set
+   * `streamingMessageId` to its id. `onlyIfAbsent` mirrors the defensive
+   * branch's "lazy-create only when not already present" guard. A `null`
+   * `targetSessionId` selects the flat-messages path (dashboard only).
+   */
+  appendResponseSlot: (
+    targetSessionId: string | null,
+    slot: ChatMessage,
+    opts?: { onlyIfAbsent?: boolean },
+  ) => void
+  /**
+   * Peel `count` trailing characters off the flushed `content` of the response
+   * slot at `deltaId` in the resolved target. Used by the #4975 mid-word peel
+   * when the partial word lives in already-flushed content. A `null`
+   * `targetSessionId` selects the flat-messages path (dashboard only).
+   */
+  peelSlotContent: (
+    targetSessionId: string | null,
+    deltaId: string,
+    count: number,
+  ) => void
+  /**
+   * Schedule the 100ms `flushPendingDeltas` timer if one isn't already armed.
+   * The timer handle lives at the call site (module-local), so scheduling is
+   * delegated.
+   */
+  scheduleFlush: () => void
+}
+
+/**
+ * Shared `stream_delta` handler (#4981). Owns the platform-neutral hot path:
+ * the #4297 reorder dispatch, post-permission split, single-hop defensive
+ * remap, post-tool continuation split (#4889) with the mid-sentence gate
+ * (#4999/#5014) and mid-word peel (#4975), and the buffered append + 100ms
+ * flush scheduling. All store writes and platform-divergent fallbacks go
+ * through {@link StreamDeltaContext}.
+ */
+export function sharedStreamDelta(
+  msg: Record<string, unknown>,
+  ctx: StreamDeltaContext,
+): void {
+  // Capture the ORIGINAL incoming messageId before any remap resolution.
+  // The post-tool continuation split (#4889) writes its remap entry against
+  // this id (not against the resolved `deltaId`) so successive splits
+  // overwrite a single map entry instead of forming a chain — keeps
+  // `deltaIdRemaps` bounded and eliminates the need for chained lookup.
+  const originalMessageId = msg.messageId as string
+  let deltaId = originalMessageId
+  const capturedSessionId = (msg.sessionId as string) || ctx.activeSessionId
+
+  // Forward delta text to terminal view (dashboard-only; app no-op).
+  if (typeof msg.delta === 'string' && msg.delta.length > 0) {
+    ctx.appendTerminalDelta(msg.delta)
+  }
+
+  // #4297 — empty-response-slot reorder pre-step. Dashboard performs the shift;
+  // the app passes a no-op. Gated identically to the dashboard's inline guard.
+  if (typeof deltaId === 'string'
+      && !ctx.postPermissionSplits.has(deltaId)
+      && !ctx.deltaIdRemaps.has(deltaId)
+      && !ctx.pendingDeltas.has(deltaId)) {
+    ctx.reorderEmptyResponseSlot(deltaId, capturedSessionId)
+  }
+
+  // Permission boundary split: first delta after a split creates a new message.
+  if (ctx.postPermissionSplits.has(deltaId)) {
+    ctx.postPermissionSplits.delete(deltaId)
+    const newId = `${deltaId}-post-${Date.now()}`
+    ctx.deltaIdRemaps.set(deltaId, newId)
+    const newMsg: ChatMessage = {
+      id: newId,
+      type: 'response',
+      content: '',
+      timestamp: Date.now(),
+    }
+    // Both originals resolve the permission-split target as "captured session
+    // when it has state, else active session"; the dashboard additionally
+    // falls back to flat messages. `appendResponseSlot` receives the captured
+    // id and applies that platform's resolution (the dashboard re-derives the
+    // effective id / flat fallback inside its callback).
+    ctx.appendResponseSlot(capturedSessionId, newMsg)
+    deltaId = newId
+  } else if (ctx.deltaIdRemaps.has(deltaId)) {
+    deltaId = ctx.deltaIdRemaps.get(deltaId)!
+  } else {
+    // Defensive: server reuses messageId for tool_start and the post-tool
+    // stream_start. If stream_start was dropped or hasn't registered the
+    // remap yet (e.g., session not in store at the time), the delta would
+    // otherwise concatenate onto the tool_use bubble. Detect that here and
+    // route to a suffixed response id, lazy-creating the bubble.
+    //
+    // Resolve the effective target the same way both call sites did: prefer
+    // the captured session when it has state, else the active session; fall
+    // through to the flat messages when neither has session state (dashboard
+    // only — the app's `getSessionMessages`/`getFlatMessages` keep it inert).
+    const capturedMessages = capturedSessionId ? ctx.getSessionMessages(capturedSessionId) : null
+    const sessionMessages =
+      capturedMessages ||
+      (ctx.activeSessionId ? ctx.getSessionMessages(ctx.activeSessionId) : null) ||
+      null
+    const effectiveSessionId = capturedMessages ? capturedSessionId : ctx.activeSessionId
+    const resolvedMessages = sessionMessages ?? ctx.getFlatMessages()
+    const targetForSuffix = sessionMessages ? effectiveSessionId : null
+    const existing = resolvedMessages.find((m) => m.id === deltaId)
+    if (existing && existing.type !== 'response') {
+      const suffixed = `${deltaId}-response`
+      ctx.deltaIdRemaps.set(deltaId, suffixed)
+      if (!resolvedMessages.some((m) => m.id === suffixed)) {
+        ctx.appendResponseSlot(
+          targetForSuffix,
+          { id: suffixed, type: 'response', content: '', timestamp: Date.now() },
+          { onlyIfAbsent: true },
+        )
+      }
+      deltaId = suffixed
+    }
+  }
+
+  // #4889 — post-tool continuation split. The server reuses ONE messageId for
+  // an entire assistant turn even when text → tool → text → tool → text. The
+  // earlier branches only fire on the first delta / non-response slot;
+  // subsequent text chunks would otherwise concatenate into the same
+  // response.content with no separator — producing `…filing.Filing now.` and
+  // losing paragraph breaks.
+  //
+  // Detect the boundary by checking whether a tool_use was appended AFTER the
+  // currently-resolved response slot. If so, materialize a fresh continuation
+  // slot at the end (`<deltaId>-cont-<ts>`) and remap the ORIGINAL incoming
+  // messageId directly to the new slot (single-hop, never chained). Skipped
+  // while the session is replaying — replayed history is reassembled
+  // server-side and must not be re-split on the client.
+  {
+    const splitCapturedMessages = capturedSessionId ? ctx.getSessionMessages(capturedSessionId) : null
+    const splitSessionMessages =
+      splitCapturedMessages ||
+      (ctx.activeSessionId ? ctx.getSessionMessages(ctx.activeSessionId) : null) ||
+      null
+    const splitEffectiveId = splitCapturedMessages ? capturedSessionId : ctx.activeSessionId
+    const isReplaying = splitEffectiveId ? ctx.replayingSessions.has(splitEffectiveId) : false
+    if (!isReplaying) {
+      const splitMessages = splitSessionMessages ?? ctx.getFlatMessages()
+      // The continuation split writes through `appendResponseSlot`/
+      // `peelSlotContent`; pass the session id only when session state backs
+      // the resolved messages (else the flat path, mirroring both originals).
+      const splitTarget = splitSessionMessages ? splitEffectiveId : null
+      const slotIdx = splitMessages.findIndex((m) => m.id === deltaId)
+      if (slotIdx >= 0) {
+        const slot = splitMessages[slotIdx]!
+        // Buffered (not-yet-flushed) text counts as content for the split
+        // decision — otherwise a chunk that hasn't hit the 100ms flush yet
+        // would look empty and we'd append onto it.
+        const bufferedContent = ctx.pendingDeltas.get(deltaId)?.delta || ''
+        const hasContent = slot.type === 'response'
+          && (slot.content.length > 0 || bufferedContent.length > 0)
+        // Index-based scan instead of slice().some() — avoids allocating a
+        // tail array on every delta. This handler runs many times per turn and
+        // sessions can carry long histories, so this stays on the hot path
+        // lean.
+        let toolAfter = false
+        if (hasContent) {
+          for (let i = slotIdx + 1; i < splitMessages.length; i++) {
+            if (splitMessages[i]!.type === 'tool_use') {
+              toolAfter = true
+              break
+            }
+          }
+        }
+        // #4999 — mid-sentence fragmentation gate. The post-#4889 split only
+        // makes sense when the prior bubble's text reached a sentence boundary
+        // (the LLM finished a thought before invoking the tool); otherwise the
+        // tool interrupted mid-sentence and the post-tool delta is the same
+        // sentence continuing. Treat the prior slot as "sentence-complete"
+        // only when its trailing non-whitespace character is a sentence
+        // terminator (`.`, `!`, `?`) or a hard line break (`\n`). A bubble
+        // that ends with a word char, open paren, comma, colon, dash, etc.
+        // is mid-sentence — route the delta back to the existing slot so the
+        // sentence renders as one contiguous bubble (followed by the tool).
+        if (toolAfter) {
+          const priorFullForGate = slot.type === 'response' ? slot.content + bufferedContent : ''
+          // Trim trailing whitespace before inspecting the last char so e.g.
+          // `"...sentence.   "` still reads as sentence-complete.
+          const lastNonWs = priorFullForGate.replace(/\s+$/, '')
+          // Strip trailing closing punctuation/quotes that commonly follow a
+          // sentence terminator (`.")`, `."`, `!'`, `?)`, etc.) so the gate
+          // looks at the terminator itself, not the wrapper. #5014 — also
+          // strip CJK closing brackets (`」』）`) so a fullwidth-terminated
+          // sentence wrapped in CJK quotes still reads as sentence-complete.
+          const stripped = lastNonWs.replace(/[)\]}"'’”»›」』）]+$/, '')
+          const lastChar = stripped.charAt(stripped.length - 1)
+          // #5014 — recognize CJK fullwidth sentence terminators
+          // (`．` U+FF0E, `！` U+FF01, `？` U+FF1F) and the ideographic
+          // full stop (`。` U+3002) alongside ASCII.
+          const endsSentence =
+            lastChar === '.' ||
+            lastChar === '!' ||
+            lastChar === '?' ||
+            lastChar === '．' ||
+            lastChar === '！' ||
+            lastChar === '？' ||
+            lastChar === '。'
+          const endsHardBreak = /\n\s*$/.test(priorFullForGate)
+          if (!endsSentence && !endsHardBreak) {
+            toolAfter = false
+          }
+        }
+        if (toolAfter) {
+          // #4975 — mid-word peel. The LLM sometimes interrupts a text content
+          // block to call a tool, splitting a word across the boundary (e.g.
+          // `"...PR #3.Del"` → tool → `"egating..."`). The post-#4889 split
+          // would otherwise show "Del" in one bubble and "egating..." in
+          // another with the tool between. Detect the mid-word case (last char
+          // of the prior slot's full content is a word char AND the FIRST char
+          // of the incoming post-tool delta is also a word char — both sides
+          // of the boundary must be in a word, else the LLM emitted a normal
+          // word boundary and the peel would wrongly move a complete trailing
+          // word across the tool bubble) and peel the trailing partial word off
+          // the prior slot, seeding the continuation buffer with it. Result:
+          // the word reassembles in the continuation bubble.
+          const priorFull = slot.type === 'response' ? slot.content + bufferedContent : ''
+          const incomingDelta = msg.delta as string
+          const incomingStartsMidWord = /^[A-Za-z0-9_]/.test(incomingDelta)
+          const midWordMatch = incomingStartsMidWord ? priorFull.match(/[A-Za-z0-9_]+$/) : null
+          let priorTail = ''
+          if (midWordMatch && midWordMatch[0].length > 0) {
+            priorTail = midWordMatch[0]
+            // Peel the partial word off the prior slot. It may live in
+            // already-flushed `slot.content` and/or in the still-buffered
+            // `pendingDeltas[deltaId].delta` — strip from buffered first (it
+            // lives at the tail), then from flushed content if needed.
+            let remaining = priorTail.length
+            if (bufferedContent.length > 0) {
+              const peelFromBuf = Math.min(remaining, bufferedContent.length)
+              const newBuf = bufferedContent.slice(0, bufferedContent.length - peelFromBuf)
+              if (newBuf.length > 0) {
+                ctx.pendingDeltas.set(deltaId, {
+                  sessionId: capturedSessionId,
+                  delta: newBuf,
+                })
+              } else {
+                ctx.pendingDeltas.delete(deltaId)
+              }
+              remaining -= peelFromBuf
+            }
+            if (remaining > 0 && slot.type === 'response' && slot.content.length > 0) {
+              ctx.peelSlotContent(splitTarget, deltaId, remaining)
+            }
+          }
+          const contId = `${deltaId}-cont-${Date.now()}`
+          // Single-hop remap: write against the ORIGINAL incoming messageId so
+          // successive continuation splits overwrite this entry rather than
+          // building a chain. Keeps `deltaIdRemaps` size bounded by the count
+          // of distinct in-flight turn ids, and lets `stream_end`'s
+          // `deltaIdRemaps.delete(out.messageId)` clean up completely.
+          ctx.deltaIdRemaps.set(originalMessageId, contId)
+          const contMsg: ChatMessage = {
+            id: contId,
+            type: 'response',
+            content: '',
+            timestamp: Date.now(),
+          }
+          ctx.appendResponseSlot(splitTarget, contMsg)
+          deltaId = contId
+          // Seed the new continuation buffer with the peeled word so the first
+          // delta on `contId` carries the partial word as its prefix. The
+          // normal append below sees the existing buffer and concatenates
+          // correctly.
+          if (priorTail.length > 0) {
+            ctx.pendingDeltas.set(contId, {
+              sessionId: capturedSessionId,
+              delta: priorTail,
+            })
+          }
+        }
+      }
+    }
+  }
+
+  const existingDelta = ctx.pendingDeltas.get(deltaId)
+  ctx.pendingDeltas.set(deltaId, {
+    sessionId: capturedSessionId,
+    delta: (existingDelta?.delta || '') + (msg.delta as string),
+  })
+  ctx.scheduleFlush()
+}
+
+// ---------------------------------------------------------------------------
 // stream_end
 // ---------------------------------------------------------------------------
 

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -340,6 +340,8 @@ export type {
   ToolInputDeltaPayload,
   StreamStartPayload,
   StreamEndPayload,
+  StreamDeltaContext,
+  PendingDelta,
   ResultUsagePayload,
 } from './handlers'
 
@@ -445,6 +447,7 @@ export {
   handleToolResult,
   handleToolInputDelta,
   handleStreamStart,
+  sharedStreamDelta,
   handleStreamEnd,
   handleResultUsage,
 } from './handlers'


### PR DESCRIPTION
## Summary

`stream_delta` was the conspicuous holdout among the message handlers — its hot-path logic (post-tool continuation split #4889, single-hop `_deltaIdRemaps` remap, mid-sentence gate #4999/#5014, mid-word peel #4975) was duplicated between the dashboard `handleStreamDelta` and the app `case 'stream_delta'`. Every fix to this path (#4297 / #4889 / #4922 / #4975 / #5014) had to be applied twice.

This PR extracts the platform-neutral algorithm into `sharedStreamDelta` in `@chroxy/store-core`, following the established `sharedToolStart` / `sharedStreamEnd` pattern. Pure refactor — no behaviour change.

## Behavioural divergence found between the two originals

The issue described the two impls as "duplicated verbatim". They were **not**:

- The **dashboard** ran a #4297 empty-response-slot **reorder** pre-step and carried **flat-`messages` fallbacks** in the defensive-remap and continuation-split branches.
- The **app** had **neither** — it only ever operated on `sessionStates`, and had no terminal-data write.

To preserve both behaviours exactly, those divergent pieces are supplied by the call site through the context (see below). The dashboard keeps its reorder + flat fallback; the app keeps its session-only path. Neither platform's behaviour changed.

## `StreamDeltaContext` shape

```ts
interface StreamDeltaContext {
  activeSessionId: string | null
  getSessionMessages: (sessionId: string | null) => readonly ChatMessage[] | null
  getFlatMessages: () => readonly ChatMessage[]
  pendingDeltas: Map<string, PendingDelta>
  deltaIdRemaps: Map<string, string>
  postPermissionSplits: Set<string>
  replayingSessions: Set<string>
  appendTerminalDelta: (delta: string) => void
  reorderEmptyResponseSlot: (deltaId: string, capturedSessionId: string | null) => void
  appendResponseSlot: (targetSessionId: string | null, slot: ChatMessage, opts?: { onlyIfAbsent?: boolean }) => void
  peelSlotContent: (targetSessionId: string | null, deltaId: string, count: number) => void
  scheduleFlush: () => void
}
```

The shared fn reads/mutates the four module-local collections directly (identical on both platforms) and delegates every store write or platform-divergent op to a callback.

## What moved to store-core vs what stayed at the call sites

**Moved (platform-neutral):** original-id capture, #4297 reorder *dispatch*, post-permission `-post-` split, single-hop defensive `-response` remap, post-tool `-cont-` continuation split, #4999/#5014 mid-sentence gate, #4975 mid-word peel decision, buffered append + flush scheduling.

**Stayed at call sites (platform-specific):**
- dashboard: terminal-data write (`appendTerminalData`), the #4297 reorder *implementation* (session + flat shift), flat-`messages` fallbacks, `updateSession`/`set` writes, the 100ms timer handle.
- app: no-op terminal write, no-op reorder, session-only `updateSession` writes (no flat fallback), the 100ms timer handle.

The memory note `stream_id_collision` (symmetric defensive remap → suffixed `-response` id) is preserved: it's the `else` branch of `sharedStreamDelta` and covered by a dedicated unit test.

## Behaviour-preserving confirmation

All three suites pass **unchanged** — no pre-existing test changed its expected output:

- **store-core:** 1115 passed (1106 → +9 new `sharedStreamDelta` unit tests), `tsc --noEmit` clean
- **dashboard:** 2910 passed, `tsc --noEmit` clean
- **app:** 1586 passed (jest), `tsc --noEmit` clean

Net: ~740 lines removed from the two call sites, centralized into store-core.

## Test plan

- [x] `cd packages/store-core && npx vitest run && npx tsc --noEmit`
- [x] `cd packages/dashboard && npx vitest run && npx tsc --noEmit`
- [x] `cd packages/app && npx jest && npx tsc --noEmit` (app uses jest, not vitest)
- [x] New store-core unit suite covers: continuation split, single-hop remap (no chain), mid-sentence gate (ASCII + CJK fullwidth), mid-word coalescing (flushed + buffered), replay guard, defensive `-response` remap.
- [x] Existing dashboard/app integration suites (terminal side-effects, #4297 reorder, mid-word peel #4978 fixtures) retained as the wrapper safety net.

Closes #4981