### PR TITLE
fix(store-core): guard stream_delta handler against malformed payloads

### DIFF
--- a/packages/store-core/src/handlers/handlers.test.ts
+++ b/packages/store-core/src/handlers/handlers.test.ts
@@ -8155,4 +8155,95 @@ describe('sharedStreamDelta (#4981)', () => {
     expect(suffixed!.content).toBe('hi')
     expect(h.deltaIdRemaps.get('resp-collide')).toBe('resp-collide-response')
   })
+
+  // -------------------------------------------------------------------------
+  // #5130 — malformed-payload hardening. ServerStreamDeltaSchema declares
+  // `messageId` and `delta` as required `z.string()`, so these arms only fire
+  // for payloads that bypassed Zod parse. Valid payloads (covered by every
+  // test above) are unaffected.
+  // -------------------------------------------------------------------------
+
+  it('#5130: non-string messageId early-returns without poisoning any collection', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'Hello')
+    // messageId is a number — must not become a Map/Set key.
+    h.send({ messageId: 123 as unknown as string, delta: 'world' })
+    h.flush()
+    // No buffering happened, content untouched.
+    expect(h.pendingDeltas.size).toBe(0)
+    expect(h.deltaIdRemaps.size).toBe(0)
+    expect(h.postPermissionSplits.size).toBe(0)
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses).toHaveLength(1)
+    expect(responses[0]!.content).toBe('Hello')
+    // No non-string key leaked into pendingDeltas.
+    for (const key of h.pendingDeltas.keys()) {
+      expect(typeof key).toBe('string')
+    }
+  })
+
+  it('#5130: missing messageId early-returns', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'Hello')
+    h.send({ delta: 'world' })
+    h.flush()
+    expect(h.pendingDeltas.size).toBe(0)
+    expect(h.deltaIdRemaps.size).toBe(0)
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses[0]!.content).toBe('Hello')
+  })
+
+  it('#5130: missing delta does NOT append the literal "undefined"', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'Hello')
+    h.send({ messageId: 'resp-1' }) // delta absent
+    h.flush()
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses).toHaveLength(1)
+    // The literal "undefined" must NOT have been concatenated.
+    expect(responses[0]!.content).toBe('Hello')
+    expect(responses[0]!.content).not.toContain('undefined')
+    expect(h.pendingDeltas.size).toBe(0)
+  })
+
+  it('#5130: non-string delta does NOT append (early-return, nothing buffered)', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'Hello')
+    h.send({ messageId: 'resp-1', delta: { foo: 'bar' } as unknown as string })
+    h.flush()
+    const responses = h.messages.filter((m) => m.type === 'response')
+    expect(responses[0]!.content).toBe('Hello')
+    expect(responses[0]!.content).not.toContain('[object Object]')
+    expect(h.pendingDeltas.size).toBe(0)
+  })
+
+  it('#5130: non-string sessionId falls back to the active session (no Map-key coercion)', () => {
+    const h = makeHarness('s1')
+    h.seedResponse('resp-1', 'Hello ')
+    // Call the handler directly to override the harness's spread sessionId with
+    // a non-string value. The captured sessionId should fall back to the
+    // active session ('s1'), and the delta should buffer + flush normally.
+    sharedStreamDelta(
+      { messageId: 'resp-1', delta: 'world', sessionId: 42 as unknown as string },
+      {
+        activeSessionId: 's1',
+        pendingDeltas: h.pendingDeltas,
+        deltaIdRemaps: h.deltaIdRemaps,
+        postPermissionSplits: h.postPermissionSplits,
+        replayingSessions: h.replayingSessions,
+        getSessionMessages: (id) => (id === 's1' ? h.messages : null),
+        getFlatMessages: () => [],
+        appendTerminalDelta: () => {},
+        reorderEmptyResponseSlot: () => {},
+        appendResponseSlot: () => {},
+        peelSlotContent: () => {},
+        scheduleFlush: () => {},
+      },
+    )
+    // The buffered entry's sessionId must be the active-session fallback, not 42.
+    const buffered = h.pendingDeltas.get('resp-1')
+    expect(buffered).toBeDefined()
+    expect(buffered!.sessionId).toBe('s1')
+    expect(buffered!.delta).toBe('world')
+  })
 })

--- a/packages/store-core/src/handlers/index.ts
+++ b/packages/store-core/src/handlers/index.ts
@@ -4765,17 +4765,39 @@ export function sharedStreamDelta(
   msg: Record<string, unknown>,
   ctx: StreamDeltaContext,
 ): void {
+  // #5130 — runtime guards against malformed/spoofed payloads. The wire schema
+  // (`ServerStreamDeltaSchema`) declares both `messageId` and `delta` as
+  // required `z.string()`, so a well-formed message always satisfies these
+  // guards and behaves EXACTLY as before. The guards only catch genuinely
+  // malformed payloads that bypassed Zod parse (e.g. a buggy producer or a
+  // dispatcher that skipped validation):
+  //
+  //   - non-string `messageId` would otherwise become a non-string key in
+  //     `deltaIdRemaps` / `pendingDeltas` / `postPermissionSplits`, poisoning
+  //     those collections. Early-return so no state is touched.
+  //   - non-string `delta` would otherwise stringify to the literal
+  //     `"undefined"` (or `"null"`, `"[object Object]"`, etc.) and append that
+  //     to a response slot's content. Early-return so nothing is buffered.
+  if (typeof msg.messageId !== 'string') return
+  if (typeof msg.delta !== 'string') return
+
   // Capture the ORIGINAL incoming messageId before any remap resolution.
   // The post-tool continuation split (#4889) writes its remap entry against
   // this id (not against the resolved `deltaId`) so successive splits
   // overwrite a single map entry instead of forming a chain — keeps
   // `deltaIdRemaps` bounded and eliminates the need for chained lookup.
-  const originalMessageId = msg.messageId as string
+  const originalMessageId = msg.messageId
   let deltaId = originalMessageId
-  const capturedSessionId = (msg.sessionId as string) || ctx.activeSessionId
+  // `sessionId` is an optional routing tag (not part of ServerStreamDeltaSchema)
+  // added at the broadcast layer. Guard it consistently with `handleStreamEnd`
+  // / `handleToolStart`: a non-string value falls back to the active session
+  // rather than coercing onto a Map key. `|| ctx.activeSessionId` also folds an
+  // empty string into the fallback, preserving the prior `(as string) ||` shape.
+  const capturedSessionId =
+    (typeof msg.sessionId === 'string' ? msg.sessionId : null) || ctx.activeSessionId
 
   // Forward delta text to terminal view (dashboard-only; app no-op).
-  if (typeof msg.delta === 'string' && msg.delta.length > 0) {
+  if (msg.delta.length > 0) {
     ctx.appendTerminalDelta(msg.delta)
   }
 
@@ -4945,7 +4967,7 @@ export function sharedStreamDelta(
           // the prior slot, seeding the continuation buffer with it. Result:
           // the word reassembles in the continuation bubble.
           const priorFull = slot.type === 'response' ? slot.content + bufferedContent : ''
-          const incomingDelta = msg.delta as string
+          const incomingDelta = msg.delta
           const incomingStartsMidWord = /^[A-Za-z0-9_]/.test(incomingDelta)
           const midWordMatch = incomingStartsMidWord ? priorFull.match(/[A-Za-z0-9_]+$/) : null
           let priorTail = ''
@@ -5006,7 +5028,7 @@ export function sharedStreamDelta(
   const existingDelta = ctx.pendingDeltas.get(deltaId)
   ctx.pendingDeltas.set(deltaId, {
     sessionId: capturedSessionId,
-    delta: (existingDelta?.delta || '') + (msg.delta as string),
+    delta: (existingDelta?.delta || '') + msg.delta,
   })
   ctx.scheduleFlush()
 }


### PR DESCRIPTION
## Summary

`sharedStreamDelta` in `packages/store-core/src/handlers/index.ts` (extracted in #5129) used `as string` casts for `msg.messageId`, `msg.sessionId`, and `msg.delta` instead of the `typeof === 'string'` guards used by sibling handlers (`handleStreamEnd`, `handleToolStart`). A malformed/spoofed payload that bypassed Zod parse could:

- introduce a non-string key into `deltaIdRemaps` / `pendingDeltas` / `postPermissionSplits`, or
- append the literal string `"undefined"` (or `"[object Object]"`) to a response slot's content when `delta` is missing/non-string.

This is the legitimate follow-up #5129 deliberately deferred (that PR was a pure refactor and had to keep behaviour identical).

## Guards added

- **`messageId`** — `typeof`-guarded at the top of the handler; non-string payloads early-return (no Map/Set poisoning).
- **`delta`** — `typeof`-guarded; missing/non-string `delta` early-returns and never appends `"undefined"`. Downstream `as string` casts on `msg.delta` removed (now narrowed to `string`).
- **`sessionId`** — typed fallback (`typeof msg.sessionId === 'string' ? msg.sessionId : null) || ctx.activeSessionId`), consistent with `handleStreamEnd` / `handleToolStart`. `sessionId` isn't even in `ServerStreamDeltaSchema` — it's an optional routing tag added at the broadcast layer.

## Valid payloads unchanged

`ServerStreamDeltaSchema` declares `messageId: z.string()` and `delta: z.string()` (both required), so any Zod-valid message always satisfies the new guards and flows through exactly as before. The early-return arms only fire for genuinely-malformed payloads. All pre-existing tests pass unchanged.

## Test plan

- `packages/store-core`: `npx vitest run` → 1120 passed (+5 new malformed-arm tests); `npx tsc --noEmit` clean
- `packages/dashboard`: `npx vitest run` → 2910 passed; `npx tsc --noEmit` clean
- `packages/app`: `npx jest` → 1586 passed; `npx tsc --noEmit` clean

New tests cover: non-string `messageId`, missing `messageId`, missing `delta` (no `"undefined"` appended), non-string `delta`, and non-string `sessionId` (active-session fallback, no Map-key coercion).

Closes #5130