### PR TITLE
fix(server): SIGKILL escalation + bounded buffer in streaming execInEnvironment

### DIFF
--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -299,8 +299,14 @@ export class DockerBackend {
             // promise otherwise only settles on `close`; a child stuck in an
             // uninterruptible state would leave it pending forever. Cleared on
             // close via settle(); unref'd so it never holds the loop open.
+            //
+            // Gate on `!settled` (the `close` hasn't fired) rather than
+            // `!child.killed`: Node flips `child.killed` to true the moment a
+            // signal is *delivered*, even if the process keeps running, so a
+            // `!child.killed` guard would skip the SIGKILL on exactly the
+            // stuck-child case this is meant to handle.
             killTimer = setTimeout(() => {
-              if (child && !child.killed) {
+              if (!settled && child) {
                 try { child.kill('SIGKILL') } catch { /* already gone */ }
               }
             }, STREAM_SIGKILL_GRACE_MS)

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -6,6 +6,44 @@ const log = createLogger('docker-backend')
 const DEFAULT_CONTAINER_CLI_PATH = '/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js'
 
 /**
+ * #5127 — Cap on the per-stream buffer the streaming execInEnvironment path
+ * retains for the resolved value / failure tail. The buffered execFile path
+ * rejects past Node's 1 MB maxBuffer; the streaming path used to accumulate
+ * without limit, so a postCreateCommand that printed hundreds of MB grew the
+ * daemon's retained buffer unbounded.
+ *
+ * We keep the LAST N bytes (the tail) because the failure event only surfaces
+ * a 4 KiB tail (POST_CREATE_OUTPUT_CAP_BYTES in docker-byok-session.js) and
+ * diagnostic info (the actual exception, exit codes) lands at the end. 256 KiB
+ * is comfortably larger than the 4 KiB failure tail while staying bounded.
+ *
+ * onData STILL fires for every chunk — streaming is not truncated, only the
+ * retained accumulator is capped.
+ */
+const STREAM_RETAINED_BUFFER_CAP_BYTES = 256 * 1024
+
+/**
+ * #5126 — Grace period after a SIGTERM-on-timeout before escalating to
+ * SIGKILL. A child that ignores SIGTERM (or is stuck uninterruptibly) would
+ * otherwise leave the streaming promise pending forever, since it only settles
+ * on the subsequent `close`.
+ */
+const STREAM_SIGKILL_GRACE_MS = 5_000
+
+/**
+ * Append `chunk` to `buf` keeping at most `cap` UTF-16 code units (the tail).
+ * Uses string length as a cheap proxy for byte size — exact byte accounting
+ * isn't required since the value is a diagnostic tail and the downstream
+ * failure event re-caps to 4 KiB. A multibyte sequence clipped at the cut
+ * boundary decodes to U+FFFD, which is acceptable for a tail.
+ */
+function appendCapped(buf, chunk, cap = STREAM_RETAINED_BUFFER_CAP_BYTES) {
+  const next = buf + chunk
+  if (next.length <= cap) return next
+  return next.slice(next.length - cap)
+}
+
+/**
  * Env vars explicitly forwarded into the container during streamCliInEnvironment.
  * Mirrors the allowlist in docker-sdk-session.js — keep both in sync.
  *
@@ -236,11 +274,16 @@ export class DockerBackend {
         let settled = false
         let timedOut = false
         let timer = null
+        // #5126 — SIGKILL escalation timer, armed only after the SIGTERM-on-
+        // timeout fires. Cleared on close so a child that exits promptly never
+        // gets force-killed.
+        let killTimer = null
 
         const settle = (fn, arg) => {
           if (settled) return
           settled = true
           if (timer) clearTimeout(timer)
+          if (killTimer) clearTimeout(killTimer)
           fn(arg)
         }
 
@@ -252,6 +295,16 @@ export class DockerBackend {
             if (child && !child.killed) {
               try { child.kill('SIGTERM') } catch { /* already gone */ }
             }
+            // #5126 — Escalate to SIGKILL if the child ignores SIGTERM. The
+            // promise otherwise only settles on `close`; a child stuck in an
+            // uninterruptible state would leave it pending forever. Cleared on
+            // close via settle(); unref'd so it never holds the loop open.
+            killTimer = setTimeout(() => {
+              if (child && !child.killed) {
+                try { child.kill('SIGKILL') } catch { /* already gone */ }
+              }
+            }, STREAM_SIGKILL_GRACE_MS)
+            if (killTimer && typeof killTimer.unref === 'function') killTimer.unref()
           }, timeout)
           // Don't let the timeout keep the event loop alive on its own.
           if (timer && typeof timer.unref === 'function') timer.unref()
@@ -260,7 +313,9 @@ export class DockerBackend {
         if (child.stdout) {
           child.stdout.setEncoding('utf-8')
           child.stdout.on('data', (chunk) => {
-            stdout += chunk
+            // #5127 — retain a bounded tail, not the full stream. onData still
+            // fires for every chunk below (streaming is never truncated).
+            stdout = appendCapped(stdout, chunk)
             // Never let an onData throw escape and orphan the child.
             try { onData(chunk, 'stdout') } catch { /* listener error — ignore */ }
           })
@@ -268,7 +323,7 @@ export class DockerBackend {
         if (child.stderr) {
           child.stderr.setEncoding('utf-8')
           child.stderr.on('data', (chunk) => {
-            stderr += chunk
+            stderr = appendCapped(stderr, chunk)
             try { onData(chunk, 'stderr') } catch { /* listener error — ignore */ }
           })
         }

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -1243,6 +1243,199 @@ describe('DockerBackend.execInEnvironment()', () => {
     const result = await p
     assert.equal(result.stdout, 'hello\n')
   })
+
+  // ───────────────────────────────────────────────────────────────────────
+  // #5126 — SIGKILL escalation when a child ignores SIGTERM on timeout.
+  // ───────────────────────────────────────────────────────────────────────
+
+  // A child that records every signal it receives but NEVER flips `killed`
+  // (i.e. it ignores SIGTERM) and never emits `close` on its own.
+  function makeStubbornChild() {
+    const child = new EventEmitter()
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.killed = false
+    child.signals = []
+    child.kill = (sig) => {
+      child.signals.push(sig)
+      // Deliberately do NOT set child.killed — simulate a process that
+      // ignores SIGTERM. SIGKILL would normally be uncatchable; we let the
+      // backend's escalation path do its thing and assert on the signal log.
+    }
+    return child
+  }
+
+  it('#5126: escalates to SIGKILL when the child ignores SIGTERM, and the promise rejects', async () => {
+    // Deterministic: stub setTimeout so the 5s grace timer runs synchronously.
+    const stubborn = makeStubbornChild()
+    const backend = new DockerBackend({ _spawn: () => stubborn })
+
+    const realSetTimeout = global.setTimeout
+    // Run the SHORTEST timer (the timeout) on a real micro-delay, but make the
+    // grace timer (the longer 5s one) fire immediately so we don't wait 5s.
+    global.setTimeout = (fn, ms, ...rest) => {
+      if (ms >= 1000) {
+        // The SIGKILL grace timer — fire on next tick instead of after 5s.
+        const t = realSetTimeout(fn, 0, ...rest)
+        if (t && typeof t.unref === 'function') t.unref()
+        return t
+      }
+      return realSetTimeout(fn, ms, ...rest)
+    }
+
+    let caught
+    try {
+      const p = backend.execInEnvironment('ctr-abc', {
+        cmd: 'hangs-forever',
+        timeout: 5,
+        onData: () => {},
+      })
+      // Let timeout fire (SIGTERM) then the (now-immediate) grace timer (SIGKILL).
+      await new Promise((r) => realSetTimeout(r, 30))
+      assert.deepEqual(
+        stubborn.signals,
+        ['SIGTERM', 'SIGKILL'],
+        'must SIGTERM first, then escalate to SIGKILL after grace',
+      )
+      // The real docker process would now close from the SIGKILL.
+      stubborn.emit('close', null, 'SIGKILL')
+      await p
+      assert.fail('expected rejection on timeout')
+    } catch (err) {
+      caught = err
+    } finally {
+      global.setTimeout = realSetTimeout
+    }
+    assert.match(caught.message, /timed out after 5ms/)
+    assert.equal(caught.killed, true)
+  })
+
+  it('#5126: grace timer is cleared on a prompt close (no SIGKILL on a child that honours SIGTERM)', async () => {
+    // Detect any attempt to arm a >=1s timer (the SIGKILL grace) and whether it
+    // ever fires. The grace is 5s in production; the child closes promptly after
+    // SIGTERM, so settle() must clear the armed grace timer before it fires.
+    const realSetTimeout = global.setTimeout
+    const realClearTimeout = global.clearTimeout
+    let graceFired = false
+    let graceArmed = false
+    let graceCleared = false
+    let graceHandle = null
+    global.setTimeout = (fn, ms, ...rest) => {
+      if (ms >= 1000) {
+        graceArmed = true
+        graceHandle = realSetTimeout(() => { graceFired = true; fn() }, ms, ...rest)
+        if (graceHandle && typeof graceHandle.unref === 'function') graceHandle.unref()
+        return graceHandle
+      }
+      return realSetTimeout(fn, ms, ...rest)
+    }
+    global.clearTimeout = (t) => {
+      if (t && t === graceHandle) graceCleared = true
+      return realClearTimeout(t)
+    }
+
+    const { backend, fakeChild } = makeStreamingBackend()
+    fakeChild.signals = []
+    const realKill = fakeChild.kill
+    fakeChild.kill = (sig) => { fakeChild.signals.push(sig); realKill(sig) }
+
+    let caught
+    try {
+      const p = backend.execInEnvironment('ctr-abc', {
+        cmd: 'hangs-then-dies',
+        timeout: 5,
+        onData: () => {},
+      })
+      // Timeout fires -> SIGTERM + grace armed. Child honours it and closes
+      // before the 5s grace fires, so settle() must clear the grace timer.
+      await new Promise((r) => realSetTimeout(r, 20))
+      assert.ok(fakeChild.signals.includes('SIGTERM'), 'SIGTERM sent on timeout')
+      assert.ok(graceArmed, 'grace timer must be armed after SIGTERM')
+      fakeChild.emit('close', null, 'SIGTERM')
+      await p
+      assert.fail('expected rejection on timeout')
+    } catch (err) {
+      caught = err
+    } finally {
+      global.setTimeout = realSetTimeout
+      global.clearTimeout = realClearTimeout
+    }
+    assert.match(caught.message, /timed out after 5ms/)
+    assert.ok(graceCleared, 'grace timer must be cleared once the child closes')
+    assert.ok(!graceFired, 'grace timer must not fire when the child closes promptly')
+    assert.ok(!fakeChild.signals.includes('SIGKILL'), 'no SIGKILL when SIGTERM is honoured')
+  })
+
+  // ───────────────────────────────────────────────────────────────────────
+  // #5127 — bounded retained buffer (maxBuffer parity). onData still fires
+  // for every chunk; only the accumulator is capped to a last-N tail.
+  // ───────────────────────────────────────────────────────────────────────
+
+  it('#5127: caps the retained stdout buffer while still delivering every chunk to onData', async () => {
+    const { backend, fakeChild } = makeStreamingBackend()
+    const seen = []
+    const p = backend.execInEnvironment('ctr-abc', {
+      cmd: 'spammy-setup.sh',
+      onData: (chunk, stream) => seen.push([stream, chunk]),
+    })
+
+    // The retained cap is 256 KiB. Emit well past it as many discrete chunks so
+    // we can assert (a) every chunk reached onData and (b) the resolved buffer
+    // is bounded to the tail.
+    const CAP = 256 * 1024
+    const chunk = 'x'.repeat(64 * 1024) // 64 KiB per chunk
+    const numChunks = 10 // 640 KiB total — 2.5x the cap
+    const tailMarker = 'TAIL-MARKER-END\n'
+    for (let i = 0; i < numChunks; i++) {
+      fakeChild.stdout.write(chunk)
+    }
+    fakeChild.stdout.write(tailMarker)
+    await new Promise((r) => setImmediate(r))
+    fakeChild.emit('close', 0, null)
+
+    const result = await p
+
+    // (a) Every emitted chunk reached onData — streaming is NOT truncated.
+    const stdoutChunks = seen.filter(([s]) => s === 'stdout')
+    assert.equal(stdoutChunks.length, numChunks + 1, 'onData fires for every chunk past the cap')
+    const totalStreamed = stdoutChunks.reduce((n, [, c]) => n + c.length, 0)
+    assert.equal(totalStreamed, numChunks * chunk.length + tailMarker.length, 'full bytes streamed via onData')
+
+    // (b) The retained buffer is bounded to the cap.
+    assert.ok(result.stdout.length <= CAP, `retained stdout (${result.stdout.length}) must be <= cap (${CAP})`)
+    assert.ok(result.stdout.length > 0, 'retained buffer is non-empty')
+    // (c) The TAIL is kept (diagnostic info lands at the end).
+    assert.ok(result.stdout.endsWith(tailMarker), 'the last bytes (the diagnostic tail) are retained')
+  })
+
+  it('#5127: failure tail is preserved off the bounded buffer on non-zero exit', async () => {
+    const { backend, fakeChild } = makeStreamingBackend()
+    const p = backend.execInEnvironment('ctr-abc', {
+      cmd: 'broken-spammy-setup.sh',
+      onData: () => {},
+    })
+
+    const filler = 'y'.repeat(64 * 1024)
+    for (let i = 0; i < 8; i++) {
+      fakeChild.stderr.write(filler) // 512 KiB of noise — past the 256 KiB cap
+    }
+    fakeChild.stderr.write('ERR: the actual failure line\n')
+    await new Promise((r) => setImmediate(r))
+    fakeChild.emit('close', 1, null)
+
+    let caught
+    try {
+      await p
+      assert.fail('expected rejection on non-zero exit')
+    } catch (err) {
+      caught = err
+    }
+    const CAP = 256 * 1024
+    assert.ok(caught.stderr.length <= CAP, 'failure stderr is bounded to the cap')
+    assert.match(caught.stderr, /ERR: the actual failure line/, 'failure tail survives the cap')
+    assert.match(caught.message, /ERR: the actual failure line/, 'message derives from the bounded tail')
+    assert.equal(caught.code, 1)
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -1248,8 +1248,13 @@ describe('DockerBackend.execInEnvironment()', () => {
   // #5126 — SIGKILL escalation when a child ignores SIGTERM on timeout.
   // ───────────────────────────────────────────────────────────────────────
 
-  // A child that records every signal it receives but NEVER flips `killed`
-  // (i.e. it ignores SIGTERM) and never emits `close` on its own.
+  // A child that records every signal it receives and flips `killed=true` on
+  // the FIRST signal — matching real Node `ChildProcess.kill()` semantics,
+  // where `killed` means "a signal was delivered", NOT "the process exited".
+  // The process keeps running (never emits `close` on its own), simulating a
+  // stuck child that ignores SIGTERM. Because `killed` is true after SIGTERM,
+  // this stub would expose any escalation logic that (wrongly) gates SIGKILL
+  // on `!child.killed` — such logic would never fire SIGKILL.
   function makeStubbornChild() {
     const child = new EventEmitter()
     child.stdout = new PassThrough()
@@ -1258,9 +1263,7 @@ describe('DockerBackend.execInEnvironment()', () => {
     child.signals = []
     child.kill = (sig) => {
       child.signals.push(sig)
-      // Deliberately do NOT set child.killed — simulate a process that
-      // ignores SIGTERM. SIGKILL would normally be uncatchable; we let the
-      // backend's escalation path do its thing and assert on the signal log.
+      child.killed = true // Node sets this on signal delivery, not on exit.
     }
     return child
   }


### PR DESCRIPTION
## Summary

Hardens the streaming `onData` branch of `DockerBackend.execInEnvironment` (added in #5125) to match the robustness of the buffered `execFile` path. Both fixes touch the same function and are shipped together.

## #5126 — SIGKILL escalation

On timeout the child is SIGTERM'd and the promise previously settled only on the subsequent `close`. A child that ignores SIGTERM (stuck `apt-get` / `npm install`) left the promise pending forever.

- After SIGTERM-on-timeout, arm a 5s SIGKILL grace timer that force-kills the child if it has not closed.
- The grace timer is `unref`'d (never holds the loop open) and cleared on `close` via the idempotent `settle()`.
- The SIGKILL-then-close sequence does not double-settle (`settle()` guards on `settled`).

### AC
- [x] After the SIGTERM-on-timeout, schedule a SIGKILL grace timer (5s) that force-kills the child if it has not closed.
- [x] The grace timer is `unref`'d and cleared on `close`.
- [x] Test: a child that ignores SIGTERM is SIGKILL'd and the promise rejects.

## #5127 — bounded retained buffer (maxBuffer parity)

The streaming path accumulated stdout/stderr unbounded; a postCreateCommand printing hundreds of MB grew the daemon's retained buffer without limit (the buffered path rejects past Node's 1 MB maxBuffer).

- Retain at most a 256 KiB tail per stream — comfortably larger than the 4 KiB `POST_CREATE_OUTPUT_CAP_BYTES` failure tail the error event surfaces, while staying bounded.
- `onData(chunk, stream)` STILL fires for every chunk — streaming is not truncated, only the retained accumulator is capped.
- The failure tail (#5067) is preserved off the bounded buffer.

### AC
- [x] The streaming path retains at most a bounded buffer (last-N tail).
- [x] `onData` still fires for every chunk regardless of the cap.
- [x] Test: a streamed command producing more than the cap still resolves/rejects with a bounded buffer and full onData chunk delivery.

## Test plan

`cd packages/server && node --test tests/environments/backends/docker.test.js tests/docker-byok-session.test.js`

- docker backend suite: 64 tests pass (5 new: SIGKILL escalation, grace-timer-cleared-on-close, bounded stdout buffer + full onData delivery, failure tail off the bounded buffer)
- docker-byok-session suite (the streaming caller): 148 tests pass — no regression to M8 streaming or marker idempotency
- `./scripts/lint-tests-state-file-path.sh` and `./scripts/lint-session-opt-forwarding.sh` both pass