### PR TITLE
fix(server): make permission requestIds globally unique

### DIFF
--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -48,7 +48,9 @@ export class PermissionManager extends EventEmitter {
     // own pending id against a child's (#5121). The counter is retained for
     // human-readable ordering in logs; global uniqueness comes from the
     // nonce. The id is opaque to all consumers — nothing parses its shape.
-    this._idNonce = randomUUID().slice(0, 8)
+    // Full 128-bit UUID (dashes stripped so the nonce stays a single id
+    // segment) — 32 bits would be birthday-bound vulnerable at scale.
+    this._idNonce = randomUUID().replace(/-/g, '')
     this._lastPermissionData = new Map() // requestId -> emitted permission_request payload
 
     // Session-scoped permission rules

--- a/packages/server/src/permission-manager.js
+++ b/packages/server/src/permission-manager.js
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events'
+import { randomUUID } from 'crypto'
 import { createLogger } from './logger.js'
 
 const _fallbackLog = createLogger('permission-manager')
@@ -39,6 +40,15 @@ export class PermissionManager extends EventEmitter {
     this._pendingPermissions = new Map() // requestId -> { resolve, input }
     this._permissionTimers = new Map()   // requestId -> timer
     this._permissionCounter = 0
+    // Per-instance (per-session) nonce so requestIds are globally unique
+    // across sessions. Without it the id was `perm-${counter}-${ms}` with a
+    // counter that restarts at 0 every session — two sessions could mint the
+    // same id (same counter + same millisecond), and the parent-level
+    // subagent routing table (byok-session.js) would then alias a parent's
+    // own pending id against a child's (#5121). The counter is retained for
+    // human-readable ordering in logs; global uniqueness comes from the
+    // nonce. The id is opaque to all consumers — nothing parses its shape.
+    this._idNonce = randomUUID().slice(0, 8)
     this._lastPermissionData = new Map() // requestId -> emitted permission_request payload
 
     // Session-scoped permission rules
@@ -161,7 +171,7 @@ export class PermissionManager extends EventEmitter {
     }
 
     return new Promise((resolve) => {
-      const requestId = `perm-${++this._permissionCounter}-${Date.now()}`
+      const requestId = `perm-${this._idNonce}-${++this._permissionCounter}-${Date.now()}`
       this._pendingPermissions.set(requestId, {
         resolve,
         input: input || {},
@@ -229,7 +239,7 @@ export class PermissionManager extends EventEmitter {
     return new Promise((resolve) => {
       const questionInput = input || {}
       this._waitingForAnswer = true
-      const toolUseId = `ask-${++this._permissionCounter}-${Date.now()}`
+      const toolUseId = `ask-${this._idNonce}-${++this._permissionCounter}-${Date.now()}`
       // #3975: stash toolUseId on the pending entry so clearAll() can
       // emit it on the cleared-variant permission_resolved. Without
       // toolUseId the sdk-session re-emit gate at sdk-session.js:281
@@ -531,7 +541,7 @@ export class PermissionManager extends EventEmitter {
    */
   requestMcpTrust(server) {
     return new Promise((resolve) => {
-      const requestId = `mcp-trust-${++this._permissionCounter}-${Date.now()}`
+      const requestId = `mcp-trust-${this._idNonce}-${++this._permissionCounter}-${Date.now()}`
       const argv0 = Array.isArray(server.args) && server.args.length > 0 ? server.args[0] : ''
       const input = {
         mcpServer: {

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -64,11 +64,13 @@ describe('PermissionManager', () => {
       pm.handlePermission('Bash', { command: 'pwd' }, null, 'approve')
 
       assert.notEqual(events[0].requestId, events[1].requestId)
-      // Both ids share this manager's nonce (the segment between perm- and
-      // the counter), proving the nonce is per-instance, not per-request.
-      const nonceA = events[0].requestId.split('-')[1]
-      const nonceB = events[1].requestId.split('-')[1]
-      assert.equal(nonceA, nonceB)
+      // Both ids share this manager's nonce, proving the nonce is
+      // per-instance, not per-request. Extract it by stripping the `perm-`
+      // prefix and the trailing `-<counter>-<ms>` rather than indexing a
+      // fixed segment, so the assertion stays valid if the nonce format
+      // changes (it remains opaque to consumers either way).
+      const nonceOf = (id) => id.replace(/^perm-/, '').replace(/-\d+-\d+$/, '')
+      assert.equal(nonceOf(events[0].requestId), nonceOf(events[1].requestId))
     })
   })
 

--- a/packages/server/tests/permission-manager.test.js
+++ b/packages/server/tests/permission-manager.test.js
@@ -26,6 +26,52 @@ describe('PermissionManager', () => {
 
   // -- Permission requests --
 
+  // #5121: requestIds must be globally unique across sessions so the
+  // parent-level subagent routing table (byok-session.js) can never alias
+  // a parent's own pending requestId against a child's. Each manager mints
+  // a per-instance nonce; the id is opaque to all consumers.
+  describe('requestId global uniqueness (#5121)', () => {
+    it('two managers do not mint the same requestId even with identical counters', () => {
+      const a = createManager()
+      const b = createManager()
+      try {
+        const aEvents = []
+        const bEvents = []
+        a.on('permission_request', (d) => aEvents.push(d))
+        b.on('permission_request', (d) => bEvents.push(d))
+
+        // Same tool/input/counter position in each manager — only the
+        // per-instance nonce keeps the ids apart.
+        a.handlePermission('Bash', { command: 'ls' }, null, 'approve')
+        b.handlePermission('Bash', { command: 'ls' }, null, 'approve')
+
+        assert.ok(aEvents[0].requestId)
+        assert.ok(bEvents[0].requestId)
+        assert.notEqual(aEvents[0].requestId, bEvents[0].requestId)
+        assert.match(aEvents[0].requestId, /^perm-/)
+        assert.match(bEvents[0].requestId, /^perm-/)
+      } finally {
+        a.destroy()
+        b.destroy()
+      }
+    })
+
+    it('a single manager mints distinct requestIds with a stable nonce', () => {
+      const events = []
+      pm.on('permission_request', (d) => events.push(d))
+
+      pm.handlePermission('Bash', { command: 'ls' }, null, 'approve')
+      pm.handlePermission('Bash', { command: 'pwd' }, null, 'approve')
+
+      assert.notEqual(events[0].requestId, events[1].requestId)
+      // Both ids share this manager's nonce (the segment between perm- and
+      // the counter), proving the nonce is per-instance, not per-request.
+      const nonceA = events[0].requestId.split('-')[1]
+      const nonceB = events[1].requestId.split('-')[1]
+      assert.equal(nonceA, nonceB)
+    })
+  })
+
   describe('handlePermission', () => {
     it('emits permission_request and creates entry in pending map', () => {
       const events = []


### PR DESCRIPTION
## Summary

`PermissionManager` minted permission requestIds as `perm-${counter}-${Date.now()}` (`packages/server/src/permission-manager.js`). The counter is **per-instance (per-session)** and restarts at 0 for every session, so requestIds were not globally unique across sessions.

PR #5120 added a parent-level subagent routing table (`_subagentPermissionRouting`: `childRequestId -> child session`) so a dashboard Approve/Deny on the parent can be forwarded to a Task subagent's PermissionManager. Because `respondToPermission` consults that table **first**, a child id that collides with a parent's own pending id (same counter value **and** same millisecond) would route the parent's response to the child instead of resolving the parent's own pending entry. Astronomically unlikely, but the routing key should not be able to alias at all (#5121).

## Fix / new id shape

- Generate a per-instance nonce once in the constructor: `this._idNonce = randomUUID().slice(0, 8)`.
- Embed it in every minted id:
  - `perm-${nonce}-${counter}-${ms}`
  - `ask-${nonce}-${counter}-${ms}` (AskUserQuestion toolUseId)
  - `mcp-trust-${nonce}-${counter}-${ms}` (MCP trust requestId — shares the same `_pendingPermissions` map + respond/route path, so it carried the same risk)

The counter is retained purely for human-readable log ordering; **global uniqueness comes from the nonce**.

## Consumers checked for opacity

Grepped every consumer of `requestId` / `perm-` across server, store-core, dashboard, app, protocol:

- `byok-session.js` `_subagentPermissionRouting` — uses the id only as a Map key (opaque). ✅
- `ws-permissions.js` — already mints its own `perm-${randomUUID()}` and treats ids opaquely. ✅
- Client stores (app/dashboard/store-core) — treat permission requestIds as opaque string keys; the `.split('-')[1]` parsing found in tests parses a **different** id (`nextMessageId`/client message counter), not permission requestIds. ✅
- No code parses the `perm-N-T` shape (no split-on-`-`, no counter/timestamp extraction). ✅
- Test assertions on the id are `/^perm-/` and `perm-[0-9a-f-]+` only — both still hold. ✅

## Routing-alias confirmation

Each session's PermissionManager now has its own nonce, so a child's minted requestId can never equal a parent's pending requestId. The routing key (`childRequestId`) therefore cannot alias the parent's own pending id under any timing.

## Persistence / migration

Pending permissions and `_lastPermissionData` live only in in-memory Maps; the requestId is **not** serialized to `session-state.json`. On reconnect the manager re-emits live data with a freshly generated nonce. No persisted-state migration is needed.

## Test plan

- `node --test tests/permission-manager.test.js tests/byok-session.test.js tests/ws-permissions.test.js tests/ws-permissions-binding-integration.test.js` (with `--test-force-exit`): **271 tests, 271 pass, 0 fail**.
- Added regression tests under `requestId global uniqueness (#5121)`: two managers with identical counter positions mint distinct ids; a single manager mints distinct ids while sharing a stable per-instance nonce.
- `./scripts/lint-tests-state-file-path.sh` and `./scripts/lint-session-opt-forwarding.sh`: both pass.

## Acceptance criteria

- [x] Permission requestIds are globally unique across sessions (per-session nonce).
- [x] The `_subagentPermissionRouting` key can never alias a parent's own pending requestId.
- [x] Existing permission tests still pass.

Closes #5121