### PR TITLE
feat(server): support multi-file dockerComposeFile overlay merge

### DIFF
--- a/packages/server/src/byok-compose-state.js
+++ b/packages/server/src/byok-compose-state.js
@@ -31,6 +31,21 @@ import { writeFileRestricted } from './platform.js'
 const STATE_VERSION = 1
 
 /**
+ * #5124 — A persisted compose file may be a single path or an array of paths
+ * (base + override overlay). Valid when it's a non-empty string, or a
+ * non-empty array of non-empty strings.
+ * @param {*} composeFile
+ * @returns {boolean}
+ */
+function isValidComposeFile(composeFile) {
+  if (typeof composeFile === 'string') return composeFile.length > 0
+  if (Array.isArray(composeFile)) {
+    return composeFile.length > 0 && composeFile.every((f) => typeof f === 'string' && f.length > 0)
+  }
+  return false
+}
+
+/**
  * Default on-disk location, mirroring environment-manager.js's
  * `~/.chroxy/environments.json`. Honors CHROXY_CONFIG_DIR like the rest of
  * the docker-byok stack does.
@@ -65,15 +80,18 @@ export class ByokComposeStateStore {
    *
    * @param {object} entry
    * @param {string} entry.projectId   - Compose project id (chroxy-byok-<hex>).
-   * @param {string} entry.composeFile - Absolute path to the compose file.
+   * @param {string|string[]} entry.composeFile - Absolute path to the compose
+   *   file, or an ARRAY of paths for a base + override overlay (#5124). The
+   *   boot sweep replays the same `-f` set so the merged config — and thus the
+   *   stack torn down — matches the one brought up.
    * @param {string} entry.cwd         - Working directory the stack runs in.
    */
   record({ projectId, composeFile, cwd } = {}) {
     if (!projectId || typeof projectId !== 'string') {
       throw new Error('record() requires a non-empty projectId')
     }
-    if (!composeFile || typeof composeFile !== 'string') {
-      throw new Error('record() requires a non-empty composeFile')
+    if (!isValidComposeFile(composeFile)) {
+      throw new Error('record() requires a non-empty composeFile (string or array of strings)')
     }
     if (!cwd || typeof cwd !== 'string') {
       throw new Error('record() requires a non-empty cwd')
@@ -98,7 +116,7 @@ export class ByokComposeStateStore {
 
   /**
    * Snapshot of all recorded stacks (insertion order).
-   * @returns {Array<{projectId:string, composeFile:string, cwd:string, createdAt:string}>}
+   * @returns {Array<{projectId:string, composeFile:string|string[], cwd:string, createdAt:string}>}
    */
   list() {
     return Array.from(this._stacks.values()).map((s) => ({ ...s }))
@@ -143,7 +161,7 @@ export class ByokComposeStateStore {
         if (
           !entry
           || typeof entry.projectId !== 'string' || !entry.projectId
-          || typeof entry.composeFile !== 'string' || !entry.composeFile
+          || !isValidComposeFile(entry.composeFile)
           || typeof entry.cwd !== 'string' || !entry.cwd
         ) {
           continue

--- a/packages/server/src/byok-compose-state.js
+++ b/packages/server/src/byok-compose-state.js
@@ -46,6 +46,18 @@ function isValidComposeFile(composeFile) {
 }
 
 /**
+ * #5124 — Defensive copy so the store never aliases a caller-provided array.
+ * Strings are immutable and returned as-is; arrays are shallow-cloned so a
+ * later mutation by the caller can't change persisted state (or what a prior
+ * `list()` consumer sees).
+ * @param {string|string[]} composeFile
+ * @returns {string|string[]}
+ */
+function cloneComposeFile(composeFile) {
+  return Array.isArray(composeFile) ? [...composeFile] : composeFile
+}
+
+/**
  * Default on-disk location, mirroring environment-manager.js's
  * `~/.chroxy/environments.json`. Honors CHROXY_CONFIG_DIR like the rest of
  * the docker-byok stack does.
@@ -98,7 +110,7 @@ export class ByokComposeStateStore {
     }
     this._stacks.set(projectId, {
       projectId,
-      composeFile,
+      composeFile: cloneComposeFile(composeFile),
       cwd,
       createdAt: new Date().toISOString(),
     })
@@ -119,7 +131,7 @@ export class ByokComposeStateStore {
    * @returns {Array<{projectId:string, composeFile:string|string[], cwd:string, createdAt:string}>}
    */
   list() {
-    return Array.from(this._stacks.values()).map((s) => ({ ...s }))
+    return Array.from(this._stacks.values()).map((s) => ({ ...s, composeFile: cloneComposeFile(s.composeFile) }))
   }
 
   _persist() {

--- a/packages/server/src/docker-byok-session.js
+++ b/packages/server/src/docker-byok-session.js
@@ -89,9 +89,10 @@
  *     is treated as if the operator passed `composeFile`, and the primary
  *     service is taken from devcontainer.json's `service` field. The same
  *     compose lifecycle (up / attach / down) and pooling-disabled posture
- *     as the explicit `composeFile` opt applies. Arrays use the FIRST
- *     file (compose overlay merge is not yet supported — the extras are
- *     logged, not silently dropped).
+ *     as the explicit `composeFile` opt applies. Arrays are threaded
+ *     through in full as a base + override overlay — `_composeUp`/
+ *     `_composeDown` emit one `-f <file>` per entry in declared order so
+ *     compose merges them (later files override earlier ones). (#5124)
  *
  * Snapshot / restore (#5023)
  * --------------------------
@@ -1227,14 +1228,17 @@ export class DockerByokSession extends ClaudeByokSession {
    * #5078 — Resolve a devcontainer.json `dockerComposeFile` declaration
    * into the session's compose opts. When present (and no explicit
    * `composeFile` constructor opt was passed), sets `_composeFile` to the
-   * primary compose file resolved relative to the devcontainer.json dir,
+   * compose file(s) resolved relative to the devcontainer.json dir,
    * picks the primary service from devcontainer.json's `service` field,
    * and disables pooling (compose stacks own their container lifecycle).
    *
-   * The devcontainer spec allows an ARRAY of compose files (base +
-   * overrides). The current backend `_composeUp` shells a single `-f`;
-   * we attach to the FIRST file and warn that overlays are not yet
-   * merged, rather than silently dropping the extras.
+   * #5124 — The devcontainer spec allows an ARRAY of compose files (a base
+   * file plus one or more overrides). Compose merges them via a repeated
+   * `-f` flag in declared order, so we thread the FULL resolved array (each
+   * entry resolved relative to the devcontainer.json dir) through to the
+   * backend `_composeUp`/`_composeDown` rather than attaching only to the
+   * first file. A single declared file resolves to a lone string for
+   * backward compatibility.
    *
    * No-op when the overlay declares no compose file or an explicit
    * `composeFile` constructor opt already won.
@@ -1246,13 +1250,11 @@ export class DockerByokSession extends ClaudeByokSession {
       return
     }
     const dcDir = config.dir || cwd
-    const files = config.dockerComposeFile
-    if (files.length > 1) {
-      log.warn(
-        `devcontainer.json dockerComposeFile lists ${files.length} files; only the first ("${files[0]}") is used (compose overlay merge is not yet supported)`,
-      )
-    }
-    this._composeFile = resolve(dcDir, files[0])
+    const files = config.dockerComposeFile.map((f) => resolve(dcDir, f))
+    // Thread the full set so `_composeUp` emits `-f <base> -f <override>`
+    // in declared order. A lone file stays a plain string so single-file
+    // callers and persisted state are unaffected.
+    this._composeFile = files.length === 1 ? files[0] : files
     // Primary service: devcontainer.json `service` field wins; otherwise
     // fall back to the first service the backend reports.
     if (!this._composeService && config.service) {

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -744,9 +744,10 @@ export class DockerBackend {
 
   // #5124: `composeFile` may be a single path or an ARRAY of paths
   // (devcontainer.json `dockerComposeFile` base + overrides). Normalise a
-  // lone string to a single-element array and drop empty entries so every
-  // call site emits `-f <file>` flags in declared order. Backward-compatible:
-  // existing single-file callers pass a string and get one `-f`.
+  // lone string to a single-element array and drop non-string/empty entries
+  // so every call site emits `-f <file>` flags in declared order.
+  // Backward-compatible: existing single-file callers pass a string and get
+  // one `-f`.
   _composeFileList(composeFile) {
     const files = Array.isArray(composeFile) ? composeFile : [composeFile]
     return files.filter((f) => typeof f === 'string' && f.length > 0)
@@ -765,9 +766,18 @@ export class DockerBackend {
       // #5124: compose merges a base + overrides via a repeated `-f` flag in
       // DECLARED ORDER (later files override earlier ones), so we emit one
       // `-f <file>` per entry rather than a single `-f`.
+      const files = this._composeFileList(composeFile)
+      // Fail fast on an empty/invalid file set rather than letting
+      // `docker compose up` silently fall back to a default compose file in
+      // cwd. The pre-#5124 single-`-f` path errored on an undefined file, so
+      // this preserves that fail-fast contract for the array path too.
+      if (files.length === 0) {
+        reject(new Error('docker compose up requires at least one compose file'))
+        return
+      }
       const args = ['compose']
       if (envFile) args.push('--env-file', envFile)
-      for (const file of this._composeFileList(composeFile)) {
+      for (const file of files) {
         args.push('-f', file)
       }
       args.push('-p', project, 'up', '-d')

--- a/packages/server/src/environments/backends/docker.js
+++ b/packages/server/src/environments/backends/docker.js
@@ -742,6 +742,16 @@ export class DockerBackend {
     })
   }
 
+  // #5124: `composeFile` may be a single path or an ARRAY of paths
+  // (devcontainer.json `dockerComposeFile` base + overrides). Normalise a
+  // lone string to a single-element array and drop empty entries so every
+  // call site emits `-f <file>` flags in declared order. Backward-compatible:
+  // existing single-file callers pass a string and get one `-f`.
+  _composeFileList(composeFile) {
+    const files = Array.isArray(composeFile) ? composeFile : [composeFile]
+    return files.filter((f) => typeof f === 'string' && f.length > 0)
+  }
+
   _composeUp(composeFile, project, cwd, envFile) {
     return new Promise((resolve, reject) => {
       // `docker compose --env-file <path>` (before the subcommand) sets the
@@ -751,9 +761,16 @@ export class DockerBackend {
       // compose file. The file is short-lived (tmpfile created + unlinked
       // by the caller) and lives at 0600 so the key never appears in `ps`
       // output. (#5079)
+      //
+      // #5124: compose merges a base + overrides via a repeated `-f` flag in
+      // DECLARED ORDER (later files override earlier ones), so we emit one
+      // `-f <file>` per entry rather than a single `-f`.
       const args = ['compose']
       if (envFile) args.push('--env-file', envFile)
-      args.push('-f', composeFile, '-p', project, 'up', '-d')
+      for (const file of this._composeFileList(composeFile)) {
+        args.push('-f', file)
+      }
+      args.push('-p', project, 'up', '-d')
       this._execFile('docker', args, { encoding: 'utf-8', timeout: 120_000, cwd }, (err, _stdout, stderr) => {
         if (err) {
           reject(new Error(stderr ? stderr.trim() : err.message))
@@ -766,9 +783,14 @@ export class DockerBackend {
 
   _composeDown(composeFile, project, cwd) {
     return new Promise((resolve) => {
-      this._execFile('docker', [
-        'compose', '-f', composeFile, '-p', project, 'down', '--remove-orphans',
-      ], { encoding: 'utf-8', timeout: 30_000, cwd }, (err) => {
+      // #5124: tear the stack down with the SAME `-f` file set used to bring
+      // it up, in declared order, so the merged config resolves identically.
+      const args = ['compose']
+      for (const file of this._composeFileList(composeFile)) {
+        args.push('-f', file)
+      }
+      args.push('-p', project, 'down', '--remove-orphans')
+      this._execFile('docker', args, { encoding: 'utf-8', timeout: 30_000, cwd }, (err) => {
         if (err) log.warn(`docker compose down failed: ${err.message}`)
         resolve()
       })

--- a/packages/server/tests/byok-compose-state.test.js
+++ b/packages/server/tests/byok-compose-state.test.js
@@ -104,6 +104,21 @@ describe('ByokComposeStateStore', () => {
     assert.deepEqual(b.list()[0].composeFile, files)
   })
 
+  it('does not alias the caller-provided compose-file array (#5124)', () => {
+    const store = new ByokComposeStateStore({ statePath })
+    const files = ['/proj/base.yml', '/proj/override.yml']
+    store.record({ projectId: 'p1', composeFile: files, cwd: '/proj' })
+
+    // Mutating the caller's array after record() must NOT change stored state.
+    files.push('/proj/sneaky.yml')
+    assert.deepEqual(store.list()[0].composeFile, ['/proj/base.yml', '/proj/override.yml'])
+
+    // Mutating the array returned by list() must NOT change stored state either.
+    const returned = store.list()[0].composeFile
+    returned.push('/proj/also-sneaky.yml')
+    assert.deepEqual(store.list()[0].composeFile, ['/proj/base.yml', '/proj/override.yml'])
+  })
+
   it('rejects an empty or non-string compose-file array (#5124)', () => {
     const store = new ByokComposeStateStore({ statePath })
     assert.throws(() => store.record({ projectId: 'p', composeFile: [], cwd: '/a' }), /composeFile/)

--- a/packages/server/tests/byok-compose-state.test.js
+++ b/packages/server/tests/byok-compose-state.test.js
@@ -91,6 +91,26 @@ describe('ByokComposeStateStore', () => {
     assert.throws(() => store.record({ projectId: 'p', composeFile: '/a' }), /cwd/)
   })
 
+  it('records and round-trips a compose-file overlay array (#5124)', () => {
+    const a = new ByokComposeStateStore({ statePath })
+    const files = ['/proj/docker-compose.yml', '/proj/docker-compose.override.yml']
+    a.record({ projectId: 'overlay', composeFile: files, cwd: '/proj' })
+
+    const raw = JSON.parse(readFileSync(statePath, 'utf-8'))
+    assert.deepEqual(raw.stacks[0].composeFile, files)
+
+    // Survives a reload so the boot sweep replays the same `-f` set.
+    const b = new ByokComposeStateStore({ statePath })
+    assert.deepEqual(b.list()[0].composeFile, files)
+  })
+
+  it('rejects an empty or non-string compose-file array (#5124)', () => {
+    const store = new ByokComposeStateStore({ statePath })
+    assert.throws(() => store.record({ projectId: 'p', composeFile: [], cwd: '/a' }), /composeFile/)
+    assert.throws(() => store.record({ projectId: 'p', composeFile: ['/a', ''], cwd: '/a' }), /composeFile/)
+    assert.throws(() => store.record({ projectId: 'p', composeFile: ['/a', 5], cwd: '/a' }), /composeFile/)
+  })
+
   it('load() ignores a corrupt state file but does not crash', () => {
     writeFileSync(statePath, 'this is not json')
     const store = new ByokComposeStateStore({ statePath })

--- a/packages/server/tests/docker-byok-session.test.js
+++ b/packages/server/tests/docker-byok-session.test.js
@@ -3962,7 +3962,7 @@ describe('DockerByokSession — devcontainer build / compose (#5078)', () => {
     }
   })
 
-  it('dockerComposeFile (array) uses the first file and resolves relative to devcontainer dir', async () => {
+  it('dockerComposeFile (array) threads the full overlay set, each resolved relative to devcontainer dir, in order (#5124)', async () => {
     const cwd = makeDevcontainerCwd({
       dockerComposeFile: ['../base.yml', 'override.yml'],
       service: 'app',
@@ -3974,8 +3974,33 @@ describe('DockerByokSession — devcontainer build / compose (#5078)', () => {
       session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
       await session.start()
       const call = backend.createCalls[0]
-      // ../base.yml from <cwd>/.devcontainer resolves to <cwd>/base.yml
-      assert.equal(call.composeFile, join(cwd, 'base.yml'))
+      // ../base.yml from <cwd>/.devcontainer resolves to <cwd>/base.yml;
+      // override.yml resolves to <cwd>/.devcontainer/override.yml. Both are
+      // threaded in declared order (base first) for compose's later-wins
+      // overlay merge.
+      assert.deepEqual(call.composeFile, [
+        join(cwd, 'base.yml'),
+        join(cwd, '.devcontainer', 'override.yml'),
+      ])
+      await session.destroy()
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  it('dockerComposeFile (single-element array) resolves to a lone string for backward compat (#5124)', async () => {
+    const cwd = makeDevcontainerCwd({
+      dockerComposeFile: ['solo.yml'],
+      service: 'app',
+    })
+    try {
+      const _execFile = execFileStub({ info: { stdout: 'ok' } })
+      const backend = composeBackendStub()
+      const session = new DockerByokSession({ cwd, useDevcontainer: true, _execFile, _dockerBackend: backend })
+      session._client = { messages: { stream: () => ({ async *[Symbol.asyncIterator]() {} }) } }
+      await session.start()
+      const call = backend.createCalls[0]
+      assert.equal(call.composeFile, join(cwd, '.devcontainer', 'solo.yml'))
       await session.destroy()
     } finally {
       rmSync(cwd, { recursive: true, force: true })

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -406,6 +406,31 @@ describe('DockerBackend.createComposeEnvironment()', () => {
     assert.deepEqual(fFlagFiles, ['/proj/docker-compose.yml'])
   })
 
+  it('fails fast with a clear error when composeFile normalises to an empty set (#5124)', async () => {
+    let upCalled = false
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) { upCalled = true }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    // An array with no usable entries must not silently run `docker compose up`
+    // with zero `-f` flags (which would fall back to a default compose file).
+    await assert.rejects(
+      () => backend.createComposeEnvironment({
+        envId: 'env-empty',
+        cwd: '/proj',
+        composeFile: ['', null],
+        composeProject: 'chroxy-env-empty',
+        containerUser: 'chroxy',
+      }),
+      /requires at least one compose file/
+    )
+    assert.equal(upCalled, false, 'docker compose up must not run with an empty file set')
+  })
+
   it('calls compose down and re-throws when primary container not found', async () => {
     let downCalled = false
     function mockExec(_cmd, args, opts, cb) {

--- a/packages/server/tests/environments/backends/docker.test.js
+++ b/packages/server/tests/environments/backends/docker.test.js
@@ -342,6 +342,70 @@ describe('DockerBackend.createComposeEnvironment()', () => {
     assert.equal(upArgs.indexOf('--env-file'), -1, '--env-file must be absent when not requested')
   })
 
+  it('emits a `-f` flag per compose file in declared order when composeFile is an array (#5124)', async () => {
+    let upArgs = null
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) { upArgs = [...args]; cb(null, '', ''); return }
+      if (args[0] === 'compose' && args.includes('ps')) {
+        cb(null, '{"ID":"ctr-1","Service":"app","State":"running"}\n', '')
+        return
+      }
+      if (args[0] === 'exec') { cb(null, '/usr/local\n', ''); return }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    await backend.createComposeEnvironment({
+      envId: 'env-overlay',
+      cwd: '/proj',
+      composeFile: ['/proj/docker-compose.yml', '/proj/docker-compose.override.yml'],
+      composeProject: 'chroxy-env-overlay',
+      containerUser: 'chroxy',
+    })
+
+    assert.ok(upArgs, 'compose up should have been called')
+    // Each declared file becomes its own `-f <file>` token, and the base
+    // file MUST precede the override so compose's later-wins merge applies.
+    const fFlagFiles = upArgs.reduce((acc, tok, i) => {
+      if (tok === '-f') acc.push(upArgs[i + 1])
+      return acc
+    }, [])
+    assert.deepEqual(fFlagFiles, ['/proj/docker-compose.yml', '/proj/docker-compose.override.yml'])
+  })
+
+  it('emits a single `-f` flag when composeFile is a lone string (backward-compat, #5124)', async () => {
+    let upArgs = null
+    function mockExec(_cmd, args, opts, cb) {
+      if (typeof opts === 'function') { cb = opts; opts = {} }
+      if (args[0] === 'compose' && args.includes('up')) { upArgs = [...args]; cb(null, '', ''); return }
+      if (args[0] === 'compose' && args.includes('ps')) {
+        cb(null, '{"ID":"ctr-1","Service":"app","State":"running"}\n', '')
+        return
+      }
+      if (args[0] === 'exec') { cb(null, '/usr/local\n', ''); return }
+      cb(null, '', '')
+    }
+    mockExec.calls = []
+
+    const backend = new DockerBackend({ _execFile: mockExec })
+    await backend.createComposeEnvironment({
+      envId: 'env-single',
+      cwd: '/proj',
+      composeFile: '/proj/docker-compose.yml',
+      composeProject: 'chroxy-env-single',
+      containerUser: 'chroxy',
+    })
+
+    assert.ok(upArgs, 'compose up should have been called')
+    const fFlagFiles = upArgs.reduce((acc, tok, i) => {
+      if (tok === '-f') acc.push(upArgs[i + 1])
+      return acc
+    }, [])
+    assert.deepEqual(fFlagFiles, ['/proj/docker-compose.yml'])
+  })
+
   it('calls compose down and re-throws when primary container not found', async () => {
     let downCalled = false
     function mockExec(_cmd, args, opts, cb) {
@@ -419,6 +483,26 @@ describe('DockerBackend.destroyComposeEnvironment()', () => {
     assert.ok(downCall, 'should call docker compose down')
     assert.ok(downCall.args.includes('--remove-orphans'))
     assert.ok(downCall.args.includes('chroxy-test-project'))
+  })
+
+  it('tears down with the SAME `-f` file set used to bring the stack up, in order (#5124)', async () => {
+    const mockExec = createMockExecFile()
+    const backend = new DockerBackend({ _execFile: mockExec })
+
+    await backend.destroyComposeEnvironment({
+      composeFile: ['/proj/docker-compose.yml', '/proj/docker-compose.override.yml'],
+      composeProject: 'chroxy-overlay-down',
+      cwd: '/proj',
+    })
+
+    const downCall = mockExec.calls.find(c => c.args[0] === 'compose' && c.args.includes('down'))
+    assert.ok(downCall, 'should call docker compose down')
+    const fFlagFiles = downCall.args.reduce((acc, tok, i) => {
+      if (tok === '-f') acc.push(downCall.args[i + 1])
+      return acc
+    }, [])
+    assert.deepEqual(fFlagFiles, ['/proj/docker-compose.yml', '/proj/docker-compose.override.yml'])
+    assert.ok(downCall.args.includes('--remove-orphans'))
   })
 
   it('resolves even when compose down fails (best-effort)', async () => {


### PR DESCRIPTION
## Summary

The devcontainer spec allows `dockerComposeFile` to be an **array** of compose files (a base file plus one or more overrides), which Docker Compose merges via repeated `-f` flags in declared order — later files override earlier ones (`docker compose -f base.yml -f override.yml ...`).

PR #5123 (M7) parsed the full array but used **only the first file**, warn-logging the extras. This wires true overlay merge.

## What changed

- **`_composeUp` / `_composeDown`** (`environments/backends/docker.js`) accept `string | string[]` and emit one `-f <file>` per entry. A new `_composeFileList` helper normalises a lone string to a single-element array and drops empty entries, so existing single-file callers are unaffected.
- **`DockerByokSession._resolveDevContainerCompose`** threads the FULL file array through `_composeFile`, each entry resolved relative to the devcontainer.json dir. A single declared file resolves to a plain string for backward compat.
- The **"only the first file is used" warning is removed** now that merge is wired.
- **`byok-compose-state`** `record()`/`_load()` accept a compose-file array (validated as a non-empty array of non-empty strings) so the boot sweep tears the stack down with the same `-f` set it was brought up with — no orphaned stack.

## argv shape (one `-f` per file)

Base + override array `['/proj/base.yml', '/proj/override.yml']` produces:

```
docker compose [--env-file <f>] -f /proj/base.yml -f /proj/override.yml -p <project> up -d
docker compose -f /proj/base.yml -f /proj/override.yml -p <project> down --remove-orphans
```

Order is preserved (override semantics depend on it). Down replays the same set as up.

## Callers checked for compat

- `createComposeEnvironment` / `destroyComposeEnvironment` (backend) — pass `composeFile` straight through to the now array-aware `_composeUp`/`_composeDown`.
- `environment-manager.js` `_createComposeEnvironment` / sweep — pass a single string; unchanged (94 tests pass).
- `byok-compose-state.js` `record` + `sweepOrphanedComposeStacks` — now accept arrays.
- `_composePrimaryContainerId` / `_composeServices` — only take `-p <project>`, never `composeFile`; unaffected.
- `k8s.js` compose methods are `notImplemented` no-ops; unaffected.

## Test plan

- Two-file array -> two `-f` flags in declared order, asserted via the `_execFile` seam, for both `up` and `down`.
- Single-file string path produces exactly one `-f` (backward-compat).
- `_resolveDevContainerCompose` threads the full overlay set, each resolved relative to the devcontainer dir, in order; single-element array collapses to a lone string.
- Overlay array round-trips through `byok-compose-state` persistence; empty / non-string arrays are rejected.

`node --test` on `docker.test.js`, `docker-byok-session.test.js`, `devcontainer-config.test.js`, `byok-compose-state.test.js`, `environment-manager.test.js` — all pass. `lint-tests-state-file-path.sh` and `lint-session-opt-forwarding.sh` both OK.

Closes #5124