### PR TITLE
feat(app): render Task subagent agent_event nested sub-bubbles

### DIFF
--- a/packages/app/src/__tests__/store/agent-event-handler.test.ts
+++ b/packages/app/src/__tests__/store/agent-event-handler.test.ts
@@ -1,0 +1,155 @@
+/**
+ * agent_event handler tests — #5060
+ *
+ * Verifies the mobile message-handler's `case 'agent_event':` routes
+ * through the SHARED `handleAgentEvent` builder from @chroxy/store-core
+ * (the same one the dashboard uses), appending each child wire event to
+ * the parent Task tool_use bubble's `childAgentEvents[]`. Also pins the
+ * same-reference no-op idiom: an event whose parentToolUseId matches no
+ * bubble must not mutate (and must not churn) the messages array.
+ */
+import {
+  _testMessageHandler,
+  setStore,
+} from '../../store/message-handler';
+import { createEmptySessionState } from '../../store/utils';
+import type { ConnectionState } from '../../store/types';
+import type { ChatMessage } from '../../store/connection';
+
+jest.mock('../../store/persistence', () => ({
+  clearPersistedSession: jest.fn(() => Promise.resolve()),
+  persistSessionMessages: jest.fn(),
+  persistViewMode: jest.fn(),
+  persistActiveSession: jest.fn(),
+  persistTerminalBuffer: jest.fn(),
+  loadPersistedState: jest.fn(),
+  loadSessionMessages: jest.fn(),
+  clearPersistedState: jest.fn(),
+  _resetForTesting: jest.fn(),
+}));
+
+function createMockStore(initialState: Partial<ConnectionState>) {
+  let state = initialState as ConnectionState;
+  return {
+    getState: () => state,
+    setState: (
+      updater:
+        | Partial<ConnectionState>
+        | ((s: ConnectionState) => Partial<ConnectionState>),
+    ) => {
+      state = typeof updater === 'function'
+        ? { ...state, ...updater(state) }
+        : { ...state, ...updater };
+    },
+    subscribe: () => () => {},
+    destroy: () => {},
+  };
+}
+
+function createMockContext() {
+  return {
+    socket: { readyState: 1, send: jest.fn() } as any,
+    serverUrl: 'wss://test.example.com',
+    apiToken: 'test-token',
+    connectionId: 'test-conn-1',
+    reconnecting: false,
+    connectedAt: Date.now(),
+    isSessionSwitchReplay: false,
+    activeSessionIdAtConnect: null,
+  };
+}
+
+function taskBubble(toolUseId: string): ChatMessage {
+  return {
+    id: `m-${toolUseId}`,
+    type: 'tool_use',
+    sender: 'assistant',
+    content: 'Task',
+    tool: 'Task',
+    toolUseId,
+    timestamp: Date.now(),
+  } as ChatMessage;
+}
+
+function storeWithTask(toolUseId: string) {
+  const ss = createEmptySessionState();
+  ss.messages = [taskBubble(toolUseId)];
+  return createMockStore({
+    activeSessionId: 's1',
+    sessions: [{ sessionId: 's1', name: 'S1' } as any],
+    sessionStates: { s1: ss },
+  });
+}
+
+describe('agent_event handler (#5060)', () => {
+  it('appends a child wire event to the parent Task bubble childAgentEvents[]', () => {
+    const store = storeWithTask('parent-1');
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'agent_event',
+      sessionId: 's1',
+      parentToolUseId: 'parent-1',
+      eventType: 'tool_start',
+      payload: { toolUseId: 'child-1', tool: 'Read', input: { file_path: '/a' } },
+    });
+
+    const msgs = store.getState().sessionStates.s1.messages;
+    const parent = msgs.find((m) => m.toolUseId === 'parent-1')!;
+    expect(parent.childAgentEvents).toHaveLength(1);
+    expect(parent.childAgentEvents![0]!.type).toBe('tool_start');
+    expect(parent.childAgentEvents![0]!.payload.toolUseId).toBe('child-1');
+  });
+
+  it('accumulates multiple events in arrival order', () => {
+    const store = storeWithTask('parent-2');
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+
+    _testMessageHandler.handle({
+      type: 'agent_event',
+      sessionId: 's1',
+      parentToolUseId: 'parent-2',
+      eventType: 'tool_start',
+      payload: { toolUseId: 'c1', tool: 'Read' },
+    });
+    _testMessageHandler.handle({
+      type: 'agent_event',
+      sessionId: 's1',
+      parentToolUseId: 'parent-2',
+      eventType: 'tool_result',
+      payload: { toolUseId: 'c1', result: 'ok' },
+    });
+
+    const parent = store
+      .getState()
+      .sessionStates.s1.messages.find((m) => m.toolUseId === 'parent-2')!;
+    expect(parent.childAgentEvents).toHaveLength(2);
+    expect(parent.childAgentEvents!.map((e) => e.type)).toEqual([
+      'tool_start',
+      'tool_result',
+    ]);
+  });
+
+  it('same-reference no-op when parentToolUseId matches no bubble', () => {
+    const store = storeWithTask('parent-3');
+    setStore(store as any);
+    _testMessageHandler.setContext(createMockContext() as any);
+    const before = store.getState().sessionStates.s1.messages;
+
+    _testMessageHandler.handle({
+      type: 'agent_event',
+      sessionId: 's1',
+      parentToolUseId: 'does-not-exist',
+      eventType: 'tool_start',
+      payload: { toolUseId: 'cZ', tool: 'Read' },
+    });
+
+    // No matching bubble → builder returns the same array reference → no
+    // churn, and the parent bubble stays free of childAgentEvents.
+    const after = store.getState().sessionStates.s1.messages;
+    expect(after).toBe(before);
+    expect(after[0]!.childAgentEvents).toBeUndefined();
+  });
+});

--- a/packages/app/src/components/__tests__/ChildAgentEventList.test.tsx
+++ b/packages/app/src/components/__tests__/ChildAgentEventList.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * ChildAgentEventList (mobile) tests — #5060
+ *
+ * Covers both the pure reducer (`__reduceEventsForTest`) and the
+ * rendered output. The reducer carries the load-bearing logic
+ * (per-tool row construction, stream_delta concatenation, defensive
+ * synthesis on out-of-order tool_result) and is a verbatim port of the
+ * dashboard's reducer, so most assertions live there — pinning parity.
+ * Render tests focus on what users see: collapsed by default, expands
+ * on tap, surfaces input summary + result text, pulse marker on
+ * unresolved rows, stream-text block, and stable testIDs.
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import type { ChildAgentEvent } from '@chroxy/store-core';
+import {
+  ChildAgentEventList,
+  __reduceEventsForTest,
+} from '../chat/ChildAgentEventList';
+
+function renderList(events: ChildAgentEvent[], parentToolUseId = 'tu-parent') {
+  let root!: renderer.ReactTestRenderer;
+  act(() => {
+    root = renderer.create(
+      <ChildAgentEventList events={events} parentToolUseId={parentToolUseId} />,
+    );
+  });
+  return root;
+}
+
+function findByTestId(root: renderer.ReactTestRenderer, id: string) {
+  return root.root.findAllByProps({ testID: id });
+}
+
+function tapRow(root: renderer.ReactTestRenderer, toolUseId: string) {
+  const [row] = findByTestId(root, `child-agent-tool-${toolUseId}`);
+  expect(row).toBeTruthy();
+  act(() => {
+    row!.props.onPress();
+  });
+}
+
+describe('reduceEvents (#5060) — mobile parity with dashboard', () => {
+  it('builds one row per child tool_start, in arrival order', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read', input: { file_path: '/a' } } },
+      { type: 'tool_start', payload: { toolUseId: 'c2', tool: 'Bash', input: { command: 'ls' } } },
+    ]);
+    expect(out.tools).toHaveLength(2);
+    expect(out.tools[0]?.toolUseId).toBe('c1');
+    expect(out.tools[0]?.toolName).toBe('Read');
+    expect(out.tools[1]?.toolUseId).toBe('c2');
+    expect(out.tools[1]?.toolName).toBe('Bash');
+  });
+
+  it('accumulates tool_input_delta partialJson onto the matching row', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+      { type: 'tool_input_delta', payload: { toolUseId: 'c1', partialJson: '{"file_path":' } },
+      { type: 'tool_input_delta', payload: { toolUseId: 'c1', partialJson: '"/a"}' } },
+    ]);
+    expect(out.tools[0]?.inputPartial).toBe('{"file_path":"/a"}');
+  });
+
+  it('marks a row resolved when tool_result arrives, captures result text', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+      { type: 'tool_result', payload: { toolUseId: 'c1', result: 'hello\nworld' } },
+    ]);
+    expect(out.tools[0]?.hasResult).toBe(true);
+    expect(out.tools[0]?.result).toBe('hello\nworld');
+  });
+
+  it('concatenates stream_delta chunks into assistantText', () => {
+    const out = __reduceEventsForTest([
+      { type: 'stream_delta', payload: { delta: 'Hello ' } },
+      { type: 'stream_delta', payload: { delta: 'world.' } },
+    ]);
+    expect(out.assistantText).toBe('Hello world.');
+    expect(out.tools).toHaveLength(0);
+  });
+
+  it('inserts a blank-line boundary when stream_delta messageId changes', () => {
+    const out = __reduceEventsForTest([
+      { type: 'stream_delta', payload: { messageId: 'r1', delta: 'First.' } },
+      { type: 'stream_delta', payload: { messageId: 'r2', delta: 'Second.' } },
+    ]);
+    expect(out.assistantText).toBe('First.\n\nSecond.');
+  });
+
+  it('does not insert a boundary on the very first stream_delta', () => {
+    const out = __reduceEventsForTest([
+      { type: 'stream_delta', payload: { messageId: 'r1', delta: 'Hi.' } },
+    ]);
+    expect(out.assistantText).toBe('Hi.');
+  });
+
+  it('synthesises a row when tool_result arrives without a preceding tool_start', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_result', payload: { toolUseId: 'cX', result: 'oops' } },
+    ]);
+    expect(out.tools).toHaveLength(1);
+    expect(out.tools[0]?.toolUseId).toBe('cX');
+    expect(out.tools[0]?.hasResult).toBe(true);
+  });
+
+  it('ignores tool_input_delta for an unknown toolUseId (pre-tool_start race)', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_input_delta', payload: { toolUseId: 'unknown', partialJson: 'x' } },
+    ]);
+    expect(out.tools).toHaveLength(0);
+  });
+
+  it('ignores stream_delta chunks without a string delta', () => {
+    const out = __reduceEventsForTest([
+      { type: 'stream_delta', payload: { delta: null } },
+      { type: 'stream_delta', payload: {} },
+      { type: 'stream_delta', payload: { delta: 'good' } },
+    ]);
+    expect(out.assistantText).toBe('good');
+  });
+
+  it('ignores unknown event types (forward-compat against future server emits)', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+      { type: 'permission_request', payload: { tool: 'Bash' } },
+      { type: 'something_new', payload: { foo: 'bar' } },
+    ]);
+    expect(out.tools).toHaveLength(1);
+    expect(out.assistantText).toBe('');
+  });
+
+  it('replays of tool_start preserve resolved state on the row', () => {
+    const out = __reduceEventsForTest([
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+      { type: 'tool_result', payload: { toolUseId: 'c1', result: 'done' } },
+      { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+    ]);
+    expect(out.tools).toHaveLength(1);
+    expect(out.tools[0]?.hasResult).toBe(true);
+    expect(out.tools[0]?.result).toBe('done');
+  });
+});
+
+describe('ChildAgentEventList render (#5060)', () => {
+  it('renders nothing when the events array is empty', () => {
+    const root = renderList([]);
+    expect(root.toJSON()).toBeNull();
+  });
+
+  it('shows the Subagent progress header and per-tool rows', () => {
+    const root = renderList(
+      [
+        { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read', input: { file_path: '/a' } } },
+        { type: 'tool_result', payload: { toolUseId: 'c1', result: 'hello' } },
+      ],
+      'tu-parent-2',
+    );
+    expect(findByTestId(root, 'child-agent-events-tu-parent-2')[0]).toBeTruthy();
+    expect(findByTestId(root, 'child-agent-events-header')[0]).toBeTruthy();
+    expect(findByTestId(root, 'child-agent-tool-c1')[0]).toBeTruthy();
+    const [input] = findByTestId(root, 'child-agent-tool-input-c1');
+    expect(input).toBeTruthy();
+    expect(input!.props.children).toContain('/a');
+  });
+
+  it('rows start collapsed; tapping a row expands the result', () => {
+    const root = renderList(
+      [
+        { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+        { type: 'tool_result', payload: { toolUseId: 'c1', result: 'hello' } },
+      ],
+      'tu-parent-3',
+    );
+    expect(findByTestId(root, 'child-agent-tool-result-c1')).toHaveLength(0);
+    tapRow(root, 'c1');
+    const [result] = findByTestId(root, 'child-agent-tool-result-c1');
+    expect(result).toBeTruthy();
+    expect(result!.props.children).toBe('hello');
+  });
+
+  it('surfaces a pulse marker on rows that have not resolved yet', () => {
+    const root = renderList(
+      [{ type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } }],
+      'tu-parent-4',
+    );
+    expect(findByTestId(root, 'child-agent-tool-pulse-c1')[0]).toBeTruthy();
+  });
+
+  it('does not surface a pulse marker once the row resolves', () => {
+    const root = renderList(
+      [
+        { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
+        { type: 'tool_result', payload: { toolUseId: 'c1', result: 'done' } },
+      ],
+      'tu-parent-4b',
+    );
+    expect(findByTestId(root, 'child-agent-tool-pulse-c1')).toHaveLength(0);
+  });
+
+  it('renders the child stream text block when stream_delta arrived', () => {
+    const root = renderList(
+      [
+        { type: 'stream_delta', payload: { delta: 'Hello ' } },
+        { type: 'stream_delta', payload: { delta: 'world.' } },
+      ],
+      'tu-parent-5',
+    );
+    const [stream] = findByTestId(root, 'child-agent-stream-text-tu-parent-5');
+    expect(stream).toBeTruthy();
+    expect(stream!.props.children).toBe('Hello world.');
+  });
+});

--- a/packages/app/src/components/chat/ActivityGroup.tsx
+++ b/packages/app/src/components/chat/ActivityGroup.tsx
@@ -13,6 +13,7 @@ import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
 import { ThinkingIndicator } from './ThinkingIndicator';
 import { TodoList, parseTodoList } from './TodoList';
+import { ChildAgentEventList } from './ChildAgentEventList';
 import {
   summarizeToolCounts,
   formatToolBreakdown,
@@ -104,37 +105,52 @@ function ActivityEntry({
           {hasResult ? (message.toolResult || '').slice(0, 60) : (message.content || '').slice(0, 40)}
         </Text>
       </View>
-      {expanded && (() => {
-        if (todoParsed) return <TodoList parsed={todoParsed} />
-        // #4203: prefer toolResult text when present; otherwise fall back to
-        // content (pre-result/pending state). When toolResult is undefined
-        // but images are attached (e.g. screenshot tool with no text body),
-        // the pre-#4203 expression resolved to an empty string and the
-        // expanded body was visually blank even though the row's image
-        // badge said 'N images'. Render an explicit placeholder so the
-        // user sees what's there. Inline image rendering can land later
-        // — the placeholder is the minimum signal.
-        const resultText = hasResult ? (message.toolResult || '') : (message.content || '')
-        if (resultText.length > 0) {
-          return (
-            <Text selectable style={styles.activityEntryExpanded}>
-              {resultText}
-            </Text>
-          )
-        }
-        if (imageCount > 0) {
-          return (
-            <Text style={styles.activityEntryExpanded}>
-              {imageCount === 1 ? '1 image attached (preview not yet rendered inline)' : `${imageCount} images attached (preview not yet rendered inline)`}
-            </Text>
-          )
-        }
-        return (
-          <Text style={styles.activityEntryExpanded}>
-            (no output)
-          </Text>
-        )
-      })()}
+      {expanded && (
+        <>
+          {(() => {
+            if (todoParsed) return <TodoList parsed={todoParsed} />
+            // #4203: prefer toolResult text when present; otherwise fall back to
+            // content (pre-result/pending state). When toolResult is undefined
+            // but images are attached (e.g. screenshot tool with no text body),
+            // the pre-#4203 expression resolved to an empty string and the
+            // expanded body was visually blank even though the row's image
+            // badge said 'N images'. Render an explicit placeholder so the
+            // user sees what's there. Inline image rendering can land later
+            // — the placeholder is the minimum signal.
+            const resultText = hasResult ? (message.toolResult || '') : (message.content || '')
+            if (resultText.length > 0) {
+              return (
+                <Text selectable style={styles.activityEntryExpanded}>
+                  {resultText}
+                </Text>
+              )
+            }
+            if (imageCount > 0) {
+              return (
+                <Text style={styles.activityEntryExpanded}>
+                  {imageCount === 1 ? '1 image attached (preview not yet rendered inline)' : `${imageCount} images attached (preview not yet rendered inline)`}
+                </Text>
+              )
+            }
+            return (
+              <Text style={styles.activityEntryExpanded}>
+                (no output)
+              </Text>
+            )
+          })()}
+          {/* #5060 — Task subagent nested progress. The child's
+              intermediate tool_start/tool_result/tool_input_delta/
+              stream_delta events arrive as `agent_event` and accumulate
+              in `childAgentEvents`, mirroring the dashboard's nested
+              sub-bubble rendering under the parent Task tool_call. */}
+          {message.childAgentEvents && message.childAgentEvents.length > 0 && message.toolUseId && (
+            <ChildAgentEventList
+              events={message.childAgentEvents}
+              parentToolUseId={message.toolUseId}
+            />
+          )}
+        </>
+      )}
     </TouchableOpacity>
   );
 }

--- a/packages/app/src/components/chat/ChildAgentEventList.tsx
+++ b/packages/app/src/components/chat/ChildAgentEventList.tsx
@@ -1,0 +1,298 @@
+/**
+ * ChildAgentEventList (mobile) — #5060
+ *
+ * React Native port of the dashboard's `ChildAgentEventList` (#5016).
+ * Renders the nested per-event timeline inside a Task tool_call bubble
+ * when the dispatched subagent has emitted intermediate progress
+ * (`tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`)
+ * via the server's `agent_event` re-emit path.
+ *
+ * The reducer (`reduceEvents`) is a verbatim port of the dashboard's
+ * load-bearing logic so the two platforms can't drift on how the flat
+ * `agent_event` log collapses into per-tool rows + a concatenated
+ * assistant-text block. Only the rendering layer differs (RN
+ * View/Text/Pressable vs. DOM div/span).
+ *
+ * Design (mirrors the dashboard):
+ *   - One row per `tool_start` / `tool_result` pair, keyed by the
+ *     child's `toolUseId`. `tool_input_delta` chunks accumulate onto
+ *     the row's `inputPartial`; `tool_result` resolves the row.
+ *   - `stream_delta` chunks concatenate into a single text block;
+ *     contiguous deltas inside the same `messageId` merge directly,
+ *     while a `messageId` transition inserts a blank line so multi-
+ *     round child output doesn't fuse unrelated paragraphs.
+ *   - Rows open collapsed and expand on tap. Default is "all
+ *     collapsed" so a Task with many child tools doesn't explode the
+ *     layout the first time the parent bubble expands.
+ *   - Unknown event types are silently ignored by the reducer.
+ *
+ * testIDs mirror the dashboard's data-testids so the mobile Maestro /
+ * jest assertions can reuse the same naming:
+ *   - child-agent-events-<parentToolUseId>
+ *   - child-agent-events-header
+ *   - child-agent-tool-<toolUseId>
+ *   - child-agent-tool-pulse-<toolUseId>
+ *   - child-agent-tool-input-<toolUseId>
+ *   - child-agent-tool-result-<toolUseId>
+ *   - child-agent-stream-text-<parentToolUseId>
+ */
+
+import React, { useMemo, useState } from 'react';
+import { View, Text, Pressable, StyleSheet, Platform, LayoutAnimation } from 'react-native';
+import type { ChildAgentEvent } from '@chroxy/store-core';
+import { formatToolName, getInputSummary, getPartialSummary } from '@chroxy/store-core';
+import { COLORS } from '../../constants/colors';
+
+interface ChildAgentEventListProps {
+  events: ChildAgentEvent[];
+  /** Parent Task tool_use id — scopes testIDs so sibling Tasks don't collide. */
+  parentToolUseId: string;
+}
+
+/**
+ * One row in the nested list — a tool_use from the child agent, with
+ * its accumulated input + final result text (when present).
+ */
+interface ChildToolRow {
+  toolUseId: string;
+  toolName: string;
+  input?: Record<string, unknown> | string;
+  inputPartial?: string;
+  result?: string;
+  serverName?: string;
+  hasResult: boolean;
+}
+
+/**
+ * Reduce the flat `agent_event` log into a structured per-tool list +
+ * one concatenated assistant-text block. Pure — recomputed via
+ * `useMemo` when `events` changes. Verbatim port of the dashboard's
+ * `reduceEvents` so the two stay in lockstep.
+ */
+function reduceEvents(events: ChildAgentEvent[]): {
+  tools: ChildToolRow[];
+  assistantText: string;
+} {
+  const tools: ChildToolRow[] = [];
+  const byId = new Map<string, ChildToolRow>();
+  let assistantText = '';
+  let lastStreamMessageId: string | null = null;
+  for (const ev of events) {
+    const p = ev.payload || {};
+    if (ev.type === 'tool_start') {
+      const toolUseId = typeof p.toolUseId === 'string' ? p.toolUseId : null;
+      if (!toolUseId) continue;
+      const toolName = typeof p.tool === 'string' ? p.tool : 'tool';
+      const serverName = typeof p.serverName === 'string' ? p.serverName : undefined;
+      const input =
+        (p.input && typeof p.input === 'object') || typeof p.input === 'string'
+          ? (p.input as Record<string, unknown> | string)
+          : undefined;
+      const existing = byId.get(toolUseId);
+      if (existing) {
+        // Idempotent — a replayed `tool_start` overwrites name/input
+        // but preserves the resolved state.
+        existing.toolName = toolName;
+        existing.input = input ?? existing.input;
+        existing.serverName = serverName ?? existing.serverName;
+        continue;
+      }
+      const row: ChildToolRow = {
+        toolUseId,
+        toolName,
+        input,
+        serverName,
+        hasResult: false,
+      };
+      byId.set(toolUseId, row);
+      tools.push(row);
+    } else if (ev.type === 'tool_input_delta') {
+      const toolUseId = typeof p.toolUseId === 'string' ? p.toolUseId : null;
+      const partialJson = typeof p.partialJson === 'string' ? p.partialJson : null;
+      if (!toolUseId || partialJson === null) continue;
+      const row = byId.get(toolUseId);
+      if (!row) continue;
+      row.inputPartial = (row.inputPartial || '') + partialJson;
+    } else if (ev.type === 'tool_result') {
+      const toolUseId = typeof p.toolUseId === 'string' ? p.toolUseId : null;
+      const result = typeof p.result === 'string' ? p.result : '';
+      if (!toolUseId) continue;
+      let row = byId.get(toolUseId);
+      if (!row) {
+        // Defensive: tool_result arrived without a preceding tool_start.
+        // Synthesise a row so the result is visible.
+        row = { toolUseId, toolName: 'tool', hasResult: false };
+        byId.set(toolUseId, row);
+        tools.push(row);
+      }
+      row.result = result;
+      row.hasResult = true;
+    } else if (ev.type === 'stream_delta') {
+      const delta = typeof p.delta === 'string' ? p.delta : null;
+      if (delta) {
+        const messageId = typeof p.messageId === 'string' ? p.messageId : null;
+        if (
+          messageId &&
+          lastStreamMessageId &&
+          messageId !== lastStreamMessageId &&
+          assistantText.length > 0
+        ) {
+          assistantText += '\n\n';
+        }
+        assistantText += delta;
+        if (messageId) lastStreamMessageId = messageId;
+      }
+    }
+    // Unknown types fall through silently and are NOT rendered.
+  }
+  return { tools, assistantText };
+}
+
+export function ChildAgentEventList({ events, parentToolUseId }: ChildAgentEventListProps) {
+  const reduced = useMemo(() => reduceEvents(events), [events]);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const toggle = (id: string) => {
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+    setExpanded((s) => ({ ...s, [id]: !s[id] }));
+  };
+
+  if (reduced.tools.length === 0 && !reduced.assistantText) {
+    // The parent ToolBubble only mounts us when there is at least one
+    // event; this branch is the safety-net for an all-empty payload.
+    return null;
+  }
+
+  return (
+    <View style={styles.list} testID={`child-agent-events-${parentToolUseId}`}>
+      <Text style={styles.header} testID="child-agent-events-header">
+        Subagent progress
+      </Text>
+      {reduced.tools.map((row) => {
+        const isExpanded = !!expanded[row.toolUseId];
+        const summary =
+          getInputSummary(row.input) ||
+          (row.inputPartial ? getPartialSummary(row.inputPartial) : '') ||
+          (row.inputPartial ? row.inputPartial.slice(0, 100) : '');
+        return (
+          <Pressable
+            key={row.toolUseId}
+            testID={`child-agent-tool-${row.toolUseId}`}
+            accessibilityRole="button"
+            accessibilityState={{ expanded: isExpanded }}
+            // Tapping a row must NOT bubble to the parent ToolBubble (which
+            // would collapse it). RN doesn't propagate Pressable presses to
+            // ancestor Touchables by default, so no explicit stopPropagation
+            // is needed — but we keep the handler row-scoped regardless.
+            onPress={() => toggle(row.toolUseId)}
+            style={[styles.row, isExpanded && styles.rowExpanded]}
+          >
+            <View style={styles.rowHeader}>
+              {!row.hasResult && (
+                <View
+                  style={styles.pulse}
+                  testID={`child-agent-tool-pulse-${row.toolUseId}`}
+                  accessibilityElementsHidden
+                  importantForAccessibility="no-hide-descendants"
+                />
+              )}
+              <Text style={styles.toolName}>{formatToolName(row.toolName, row.serverName)}</Text>
+              {!!summary && (
+                <Text
+                  style={styles.toolInput}
+                  testID={`child-agent-tool-input-${row.toolUseId}`}
+                  numberOfLines={1}
+                >
+                  {summary}
+                </Text>
+              )}
+            </View>
+            {isExpanded && row.result !== undefined && (
+              <Text
+                selectable
+                style={styles.toolResult}
+                testID={`child-agent-tool-result-${row.toolUseId}`}
+              >
+                {row.result}
+              </Text>
+            )}
+          </Pressable>
+        );
+      })}
+      {!!reduced.assistantText && (
+        <Text
+          selectable
+          style={styles.streamText}
+          testID={`child-agent-stream-text-${parentToolUseId}`}
+        >
+          {reduced.assistantText}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+// Exported for unit-test reach into the reducer without rendering RN.
+export { reduceEvents as __reduceEventsForTest };
+
+const styles = StyleSheet.create({
+  list: {
+    marginTop: 8,
+    paddingTop: 6,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: COLORS.backgroundCard,
+    gap: 4,
+  },
+  header: {
+    color: COLORS.textMuted,
+    fontSize: 10,
+    fontWeight: '600',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 2,
+  },
+  row: {
+    backgroundColor: COLORS.backgroundCard,
+    borderRadius: 6,
+    paddingVertical: 5,
+    paddingHorizontal: 8,
+  },
+  rowExpanded: {
+    backgroundColor: COLORS.backgroundCard,
+  },
+  rowHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+  },
+  pulse: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: COLORS.accentBlue,
+    opacity: 0.8,
+  },
+  toolName: {
+    color: COLORS.accentPurple,
+    fontSize: 11,
+    fontWeight: '600',
+  },
+  toolInput: {
+    flexShrink: 1,
+    color: COLORS.textMuted,
+    fontSize: 11,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+  },
+  toolResult: {
+    color: COLORS.textSecondary,
+    fontSize: 11,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    marginTop: 4,
+    lineHeight: 16,
+  },
+  streamText: {
+    color: COLORS.textSecondary,
+    fontSize: 12,
+    marginTop: 4,
+    lineHeight: 18,
+  },
+});

--- a/packages/app/src/components/chat/ToolBubble.tsx
+++ b/packages/app/src/components/chat/ToolBubble.tsx
@@ -13,6 +13,7 @@ import { Icon } from '../Icon';
 import { COLORS } from '../../constants/colors';
 import { formatToolName } from './chat-utils';
 import { TodoList, parseTodoList } from './TodoList';
+import { ChildAgentEventList } from './ChildAgentEventList';
 
 /**
  * #4081: while a `tool_use` is streaming its input via
@@ -179,11 +180,24 @@ export function ToolBubble({ message, isSelected, isSelecting, onToggleSelection
         </Text>
       </View>
       {expanded ? (
-        todoParsed ? (
-          <TodoList parsed={todoParsed} />
-        ) : (
-          <Text selectable style={styles.toolContentExpanded}>{content}</Text>
-        )
+        <>
+          {todoParsed ? (
+            <TodoList parsed={todoParsed} />
+          ) : (
+            <Text selectable style={styles.toolContentExpanded}>{content}</Text>
+          )}
+          {/* #5060 — Task subagent nested progress. The child's
+              intermediate tool_start/tool_result/tool_input_delta/
+              stream_delta events arrive as `agent_event` and accumulate
+              in `childAgentEvents`, mirroring the dashboard's nested
+              sub-bubble rendering under the parent Task tool_call. */}
+          {message.childAgentEvents && message.childAgentEvents.length > 0 && message.toolUseId && (
+            <ChildAgentEventList
+              events={message.childAgentEvents}
+              parentToolUseId={message.toolUseId}
+            />
+          )}
+        </>
       ) : (
         <Text
           testID="tool-collapsed-preview"

--- a/packages/app/src/store/message-handler.ts
+++ b/packages/app/src/store/message-handler.ts
@@ -101,6 +101,11 @@ import {
   handleAgentSpawned as sharedAgentSpawned,
   handleAgentCompleted as sharedAgentCompleted,
   handleBackgroundWorkChanged as sharedBackgroundWorkChanged,
+  // #5060 — Task subagent intermediate progress. Appends one entry to
+  // the parent Task tool_use bubble's `childAgentEvents[]`; the shared
+  // builder is the same one the dashboard uses so the two platforms
+  // can't drift on routing.
+  handleAgentEvent as sharedAgentEvent,
   handleAvailableModels as sharedAvailableModels,
   handleMcpServers as sharedMcpServers,
   handleCostUpdate as sharedCostUpdate,
@@ -1891,6 +1896,22 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         updateSession(builder.sessionId, (ss) => {
           const next = builder.applyTo(ss.activeAgents);
           return next === ss.activeAgents ? {} : { activeAgents: next };
+        });
+      }
+      break;
+    }
+
+    case 'agent_event': {
+      // #5060 — Task subagent intermediate progress. The shared builder
+      // appends one entry to the parent Task tool_use bubble's
+      // `childAgentEvents[]`. Same-reference no-op when the parent
+      // bubble isn't found (event arrived before tool_start, which the
+      // server's ordering guarantee prevents but is defended).
+      const builder = sharedAgentEvent(msg, get().activeSessionId);
+      if (builder.sessionId && get().sessionStates[builder.sessionId]) {
+        updateSession(builder.sessionId, (ss) => {
+          const next = builder.applyTo(ss.messages);
+          return next === ss.messages ? {} : { messages: next };
         });
       }
       break;

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -103,7 +103,11 @@ const PLATFORM_SPECIFIC = {
   // Coverage test passes because each handler has a
   // `case 'multi_question_intervention':` clause.
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
-  'agent_event': 'dashboard', // #5016 — Task subagent intermediate progress wire-event re-emit; dashboard renders nested sub-bubbles inside the parent Task tool_call. Mobile app rendering is the v2-deferred follow-up tracked in #5060.
+  // 'agent_event' (#5016) is now handled by both dashboard and mobile
+  // app (#5060 — mobile renders the same nested sub-bubbles inside the
+  // parent Task tool_call). No PLATFORM_SPECIFIC entry needed; the
+  // coverage test passes because both handlers have a
+  // `case 'agent_event':` clause.
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Brings the mobile app to parity with the dashboard (#5016) for Task subagent nested progress. The `agent_event` wire channel re-emits a child Task subagent's intermediate events (`tool_start` / `tool_result` / `tool_input_delta` / `stream_delta`) tagged with the parent's `toolUseId`. The dashboard already renders these as nested sub-bubbles inside the parent Task `tool_call`; the mobile app previously did not (`agent_event` was exempted as `'dashboard'` in `PLATFORM_SPECIFIC`). This PR adds the mobile handler + renderer and removes the exemption.

## Component approach

- **Handler** — added `case 'agent_event':` to `packages/app/src/store/message-handler.ts` that routes through the **shared** `handleAgentEvent` builder from `@chroxy/store-core` (the exact builder the dashboard uses, so there is no logic drift between platforms). Uses the same same-reference no-op idiom as the surrounding mobile cases — when the parent bubble isn't found, the builder returns the same `messages` reference and the case returns `{}` to skip the re-render.
- **Renderer** — new `packages/app/src/components/chat/ChildAgentEventList.tsx`, a React Native port of the dashboard's `ChildAgentEventList`. The `reduceEvents` reducer is a **verbatim port** of the dashboard's load-bearing logic (one row per child `tool_start`/`tool_result` keyed by `toolUseId`, `tool_input_delta` accumulation, `stream_delta` concatenation with `messageId` blank-line boundaries, defensive out-of-order `tool_result` synthesis, unknown-event skip). Only the render layer differs (RN `View`/`Text`/`Pressable` + `LayoutAnimation` vs. DOM). testIDs mirror the dashboard data-testids exactly (`child-agent-events-<id>`, `child-agent-events-header`, `child-agent-tool-<id>`, `child-agent-tool-pulse-<id>`, `child-agent-tool-input-<id>`, `child-agent-tool-result-<id>`, `child-agent-stream-text-<id>`).
- **Wiring** — `childAgentEvents` is surfaced under the parent's expansion in **both** mobile tool render paths: `ActivityGroup`/`ActivityEntry` (the production chat path for `tool_use` — `groupMessages` always wraps tool calls in activity groups) and `ToolBubble` (the secondary path). Both gate on `childAgentEvents.length > 0 && toolUseId`.
- **Coverage gate** — removed `'agent_event': 'dashboard'` from `PLATFORM_SPECIFIC` in `packages/protocol/tests/handler-coverage.test.js`. The coverage test now requires **both** platforms to have a `case 'agent_event':`, which it confirms by scanning each `message-handler` source.

## Acceptance criteria

- [x] `packages/app/src/store/message-handler.ts` handles `agent_event`
- [x] Mobile chat view surfaces nested sub-bubbles inside the parent Task `tool_call`
- [x] `PLATFORM_SPECIFIC['agent_event']` removed from `handler-coverage.test.js` (and the coverage test passes without it — proving both platforms cover it)
- [ ] **Manual smoke confirms parity** — **deferred to human.** A simulator + Metro can't run headless in this environment. Substituted with thorough unit tests + the handler-coverage gate (see Test plan). Steps for the human to run:
  1. Boot a sim (`xcrun simctl boot <device-id>`) and start Metro (`cd packages/app && npx expo start`).
  2. Drive a session where Claude dispatches a `Task` subagent that itself runs tools (Read/Bash/Grep) so the server emits `agent_event` frames.
  3. Expand the parent Task activity entry and confirm the "Subagent progress" header + nested rows appear, rows expand on tap to show results, in-flight rows show the pulse dot, and child streaming text renders — matching the dashboard.
  4. (Optional) extend the Maestro fixture harness: add an `agent_event`-emitting trigger phrase to `mock-server.mjs` and a `.maestro` flow asserting on the new testIDs.

## Test plan

- `cd packages/app && npx jest` — **113 suites / 1606 tests pass**, including the two new suites:
  - `src/components/__tests__/ChildAgentEventList.test.tsx` — reducer parity (per-tool rows, input-delta accumulation, result resolution, stream concatenation + messageId boundaries, out-of-order synthesis, unknown-event skip, replay) + render (empty → null, header + rows, collapsed-by-default → tap-to-expand result, pulse on unresolved/none on resolved, stream-text block).
  - `src/__tests__/store/agent-event-handler.test.ts` — handler appends to the parent Task bubble's `childAgentEvents[]`, accumulates in order, and is a same-reference no-op when `parentToolUseId` matches no bubble.
- `cd packages/app && npx tsc --noEmit` — clean.
- `cd packages/protocol && npm test` — 156 tests pass, including handler-coverage **without** the `agent_event` exemption.
- store-core untouched (import-only).