### PR TITLE
fix(server): ratchet token usage for subscription CLI sessions (#5115)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1877,7 +1877,7 @@ export class SessionManager extends EventEmitter {
     if (!entry.cumulativeUsage) entry.cumulativeUsage = makeZeroCumulativeUsage()
     const u = resultData?.usage || {}
     const acc = entry.cumulativeUsage
-    // #5115: coerce to a finite number, defaulting to 0. Plain
+    // #5115: coerce each delta defensively before accumulating. Plain
     // `Number(x) || 0` does NOT reject Infinity (Infinity is truthy), so a
     // provider bug that reports Infinity tokens / cost would poison the
     // accumulator. Now that the usage gate lets `cost: null` / non-finite
@@ -1885,12 +1885,23 @@ export class SessionManager extends EventEmitter {
     // particular MUST drop a non-finite cost rather than add it — exactly
     // the cumulativeCost-poison guard called out in #5115's acceptance
     // criteria and #4088.
-    const finite = (x) => (Number.isFinite(x) ? x : 0)
-    acc.inputTokens += finite(Number(u.input_tokens))
-    acc.outputTokens += finite(Number(u.output_tokens))
-    acc.cacheReadTokens += finite(Number(u.cache_read_input_tokens))
-    acc.cacheCreationTokens += finite(Number(u.cache_creation_input_tokens))
-    acc.costUsd += finite(Number(resultData?.cost))
+    //
+    // Per-field coercion mirrors the restore-time clamp (restoreState's
+    // `nonNegFinite`) and CumulativeUsageSchema (@chroxy/protocol):
+    //   - Token fields are monotonic NON-NEGATIVE integer counters. A
+    //     negative provider delta (bug) would drive them below zero and
+    //     violate the schema's `.nonnegative()` contract, so drop any delta
+    //     that isn't a finite, >= 0 number.
+    //   - costUsd is finite but intentionally SIGNED — a refund / credit
+    //     adjustment turn (#4099) legitimately subtracts — so only reject
+    //     a non-finite cost.
+    const tokenDelta = (x) => (Number.isFinite(x) && x >= 0 ? x : 0)
+    const finiteCost = (x) => (Number.isFinite(x) ? x : 0)
+    acc.inputTokens += tokenDelta(Number(u.input_tokens))
+    acc.outputTokens += tokenDelta(Number(u.output_tokens))
+    acc.cacheReadTokens += tokenDelta(Number(u.cache_read_input_tokens))
+    acc.cacheCreationTokens += tokenDelta(Number(u.cache_creation_input_tokens))
+    acc.costUsd += finiteCost(Number(resultData?.cost))
     acc.turnsBilled += 1
     // Shallow-copy on emit so a subscriber that mutates the payload
     // can't corrupt the canonical accumulator (#4072 review-prep).

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1680,47 +1680,69 @@ export class SessionManager extends EventEmitter {
           })
         }
 
-        // Track cumulative cost and check budget on priced turn-terminal
-        // events. Both `result` (success path) AND `error` (failure path,
-        // partial spend surfaced by #5037) fold into the same cumulative
-        // tracker — otherwise the user-billed tokens on a failed turn
-        // would silently drop out of cumulativeUsage / sessionCost /
-        // budget gates (#5038).
+        // Track cumulative cost and token usage on turn-terminal events.
+        // Both `result` (success path) AND `error` (failure path, partial
+        // spend surfaced by #5037) fold into the same cumulative tracker —
+        // otherwise the user-billed tokens on a failed turn would silently
+        // drop out of cumulativeUsage / sessionCost / budget gates (#5038).
         //
-        // Single-counting guarantee: the `Number.isFinite(data?.cost)`
-        // predicate below — NOT result/error mutual exclusion — is what
-        // ensures we account each priced turn exactly once.
-        //   - Happy path: a single `result` (with finite cost) per turn.
-        //   - byok-session error path: a single `error` (with finite cost
-        //     for the partial spend, see #5037).
+        // Two independent gates (#5115):
+        //   1. COST gate — `Number.isFinite(data?.cost)`. Drives _trackCost
+        //      (the $ accumulator + budget thresholds). Subscription-billed
+        //      runs report `total_cost_usd: null`, so this stays zero for
+        //      them (no dollar budget applies to a flat subscription).
+        //   2. USAGE gate — finite cost OR finite `usage.input_tokens`.
+        //      Drives _trackUsage (the cumulativeUsage token accumulator
+        //      that lights up the dashboard header meter). A subscription
+        //      `claude -p` turn carries real token counts with `cost: null`
+        //      (#5095 / #5108 verified cli-session forwards the full usage
+        //      payload verbatim), so the meter must ratchet on tokens, not
+        //      cost. _trackUsage itself drops a non-finite cost via an
+        //      explicit Number.isFinite coercion, so cumulativeCost is never
+        //      poisoned even when this gate passes on tokens alone.
+        //
+        // Single-counting guarantee: each priced/usage-bearing turn folds
+        // in exactly once.
+        //   - Happy path: a single `result` (finite cost AND usage) per turn.
+        //   - Subscription path: a single `result` (cost null, finite
+        //     input_tokens) per turn → counted via the usage gate.
+        //   - byok-session error path: a single `error` (finite cost for the
+        //     partial spend, see #5037).
         //   - Stream-stall path (sdk-session._handleStreamStall and
         //     cli-session._handleStreamStall — the latter calls
         //     _emitInterruptedTurnResult for the synthetic `result` and
         //     then emits the `error` itself): emits BOTH a synthetic
         //     `result` AND `error` for the same turn — but the synthetic
-        //     `result` carries `cost: null`, so the Number.isFinite gate
-        //     filters it. The `error` half is plain stream-stall metadata
-        //     (no cost field), also filtered.
-        // No emit topology change is needed to add new failure paths as
-        // long as they keep this invariant (priced terminal ⇒ exactly one
-        // event with a finite cost per turn).
+        //     `result` carries `cost: null` AND `usage: null`, so BOTH gates
+        //     filter it. The `error` half is plain stream-stall metadata
+        //     (no cost / no usage field), also filtered by both gates.
+        // No emit topology change is needed to add new failure paths as long
+        // as they keep this invariant (terminal turn ⇒ at most one event
+        // carrying a finite cost and/or finite input_tokens).
         //
         // Number.isFinite also guards against NaN / Infinity (provider
         // bugs) poisoning cumulative totals or triggering spurious budget
         // events (#4088 review).
-        if ((event === 'result' || event === 'error') && Number.isFinite(data?.cost)) {
-          const sessionEntry = this._sessions.get(sessionId)
-          const model = session.currentModel || sessionEntry?.model || null
-          this._trackCost(sessionId, data.cost, model)
-          // #4072: also accumulate token usage for cumulative-display.
-          // Gated on the same `Number.isFinite(data.cost)` predicate so
-          // subscription-only providers (cost: null) stay zero (no badge
-          // in UI) and NaN/Infinity can't poison the accumulator.
+        if (event === 'result' || event === 'error') {
+          const hasFiniteCost = Number.isFinite(data?.cost)
+          const hasFiniteTokens = Number.isFinite(data?.usage?.input_tokens)
+          if (hasFiniteCost) {
+            const sessionEntry = this._sessions.get(sessionId)
+            const model = session.currentModel || sessionEntry?.model || null
+            this._trackCost(sessionId, data.cost, model)
+          }
+          // #4072 / #5115: accumulate token usage for cumulative-display.
+          // Runs when EITHER cost OR input_tokens is finite, so
+          // subscription-only providers (cost: null, finite tokens) ratchet
+          // the header meter (#5115) while NaN/Infinity-only payloads still
+          // can't poison the accumulator.
           //
           // #5038: an errored turn DOES count as a billed turn — the user
           // was charged for the partial work — so `turnsBilled` ticks
           // exactly as it would on the success path.
-          this._trackUsage(sessionId, data)
+          if (hasFiniteCost || hasFiniteTokens) {
+            this._trackUsage(sessionId, data)
+          }
         }
       })
     }
@@ -1855,11 +1877,20 @@ export class SessionManager extends EventEmitter {
     if (!entry.cumulativeUsage) entry.cumulativeUsage = makeZeroCumulativeUsage()
     const u = resultData?.usage || {}
     const acc = entry.cumulativeUsage
-    acc.inputTokens += Number(u.input_tokens) || 0
-    acc.outputTokens += Number(u.output_tokens) || 0
-    acc.cacheReadTokens += Number(u.cache_read_input_tokens) || 0
-    acc.cacheCreationTokens += Number(u.cache_creation_input_tokens) || 0
-    acc.costUsd += Number(resultData?.cost) || 0
+    // #5115: coerce to a finite number, defaulting to 0. Plain
+    // `Number(x) || 0` does NOT reject Infinity (Infinity is truthy), so a
+    // provider bug that reports Infinity tokens / cost would poison the
+    // accumulator. Now that the usage gate lets `cost: null` / non-finite
+    // cost through (so subscription tokens ratchet), the cost line in
+    // particular MUST drop a non-finite cost rather than add it — exactly
+    // the cumulativeCost-poison guard called out in #5115's acceptance
+    // criteria and #4088.
+    const finite = (x) => (Number.isFinite(x) ? x : 0)
+    acc.inputTokens += finite(Number(u.input_tokens))
+    acc.outputTokens += finite(Number(u.output_tokens))
+    acc.cacheReadTokens += finite(Number(u.cache_read_input_tokens))
+    acc.cacheCreationTokens += finite(Number(u.cache_creation_input_tokens))
+    acc.costUsd += finite(Number(resultData?.cost))
     acc.turnsBilled += 1
     // Shallow-copy on emit so a subscriber that mutates the payload
     // can't corrupt the canonical accumulator (#4072 review-prep).

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2922,6 +2922,28 @@ describe('SessionManager._trackUsage (#4072)', () => {
     assert.equal(got.costUsd, 0, 'Infinity cost must not poison cumulativeCost')
   })
 
+  it('clamps NEGATIVE token deltas to 0 (monotonic counter contract, #5115 review)', () => {
+    // Token fields are non-negative monotonic counters per
+    // CumulativeUsageSchema (@chroxy/protocol). A provider bug emitting a
+    // negative delta must NOT drive the running total below zero. costUsd
+    // stays signed (refund/credit turns subtract, #4099).
+    const { mgr } = makeWiredManager()
+    mgr._trackUsage('s1', { usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 200 } })
+    // Provider bug: a turn reports negative tokens.
+    mgr._trackUsage('s1', {
+      usage: { input_tokens: -10, output_tokens: -5, cache_read_input_tokens: -1, cache_creation_input_tokens: -3 },
+      cost: -0.25,
+    })
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.inputTokens, 100, 'negative input delta dropped, total holds')
+    assert.equal(got.outputTokens, 50, 'negative output delta dropped')
+    assert.equal(got.cacheReadTokens, 200, 'negative cache-read delta dropped')
+    assert.equal(got.cacheCreationTokens, 0, 'negative cache-creation delta dropped')
+    assert.ok(got.inputTokens >= 0 && got.outputTokens >= 0, 'counters never go negative')
+    // costUsd is the one signed field — the -0.25 refund IS applied.
+    assert.ok(Math.abs(got.costUsd - (-0.25)) < 1e-9, `signed costUsd applies the refund; got ${got.costUsd}`)
+  })
+
   it('does NOT accumulate when both `cost` and `usage.input_tokens` are non-finite (#4088 / #5115)', () => {
     // Neither gate passes: NaN cost (cost gate fails) and no finite
     // input_tokens (usage gate fails). Nothing is tracked, nothing emits.

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2835,27 +2835,47 @@ describe('SessionManager._trackUsage (#4072)', () => {
     assert.ok(Math.abs(events[0].data.cumulativeUsage.costUsd - 0.000375) < 1e-9)
   })
 
-  it('does NOT accumulate when result has no `cost` (subscription-only providers)', () => {
+  it('DOES accumulate tokens when result has usage but no `cost` (subscription-only providers, #5115)', () => {
+    // #5115: a subscription-billed `claude -p` turn reports
+    // `total_cost_usd: null` but carries real token counts. The usage gate
+    // re-keys on finite `usage.input_tokens` so the dashboard header meter
+    // ratchets even though the cost accumulator stays at 0.
     const { mgr, session } = makeWiredManager()
     const events = captureSessionUsage(mgr)
-    // claude-tui-style result — usage may be absent or present, but no cost.
+    // claude-tui-style result — usage present, but no cost field.
     session.emit('result', { usage: { input_tokens: 1000, output_tokens: 500 } })
-    assert.equal(events.length, 0, 'no session_usage event without cost')
+    assert.equal(events.length, 1, 'usage with finite input_tokens fires session_usage')
     const got = mgr.getCumulativeUsage('s1')
-    assert.equal(got.turnsBilled, 0, 'turnsBilled stays zero')
-    assert.equal(got.inputTokens, 0, 'tokens stay zero')
+    assert.equal(got.turnsBilled, 1, 'a subscription turn IS a billed turn')
+    assert.equal(got.inputTokens, 1000, 'tokens ratchet')
+    assert.equal(got.outputTokens, 500)
+    assert.equal(got.costUsd, 0, 'cost accumulator stays zero — no cost to add')
   })
 
-  it('does NOT accumulate when result has `cost: null` (claude-tui subscription shape)', () => {
-    // #4072 review: claude-tui emits `cost: null` to mean "subscription-
-    // billed, not measured." The gate is `typeof cost === 'number'` so
-    // null skips (typeof null === 'object'). Locking this down prevents
-    // a regression where someone changes claude-tui back to `cost: 0`,
-    // which would silently tick `turnsBilled` for non-billed sessions.
+  it('DOES accumulate tokens when result has `cost: null` but finite usage (#5115)', () => {
+    // #5115: claude-tui emits `cost: null` to mean "subscription-billed,
+    // not measured" — but the usage payload still carries real tokens. The
+    // token accumulator must ratchet (header meter) while the cost
+    // accumulator stays at 0 (no dollar budget on a flat subscription).
+    const { mgr, session } = makeWiredManager()
+    const events = captureSessionUsage(mgr)
+    session.emit('result', { cost: null, usage: { input_tokens: 250, output_tokens: 80 } })
+    assert.equal(events.length, 1, 'cost: null with finite usage fires session_usage')
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.turnsBilled, 1)
+    assert.equal(got.inputTokens, 250)
+    assert.equal(got.costUsd, 0, 'null cost must not poison cumulativeCost')
+  })
+
+  it('does NOT accumulate when result has `cost: null` AND `usage: null` (interrupted/stall shape)', () => {
+    // #4072 / #5115: a synthetic interrupted-turn result
+    // (_emitInterruptedTurnResult) carries BOTH `cost: null` and
+    // `usage: null`. With no finite cost and no finite input_tokens, both
+    // gates filter it — the stall path stays single-counted.
     const { mgr, session } = makeWiredManager()
     const events = captureSessionUsage(mgr)
     session.emit('result', { cost: null, usage: null })
-    assert.equal(events.length, 0, 'cost: null must not fire session_usage')
+    assert.equal(events.length, 0, 'cost: null + usage: null must not fire session_usage')
     const got = mgr.getCumulativeUsage('s1')
     assert.equal(got.turnsBilled, 0)
   })
@@ -2876,24 +2896,42 @@ describe('SessionManager._trackUsage (#4072)', () => {
     assert.equal(got.costUsd, 0)
   })
 
-  it('does NOT accumulate when `cost` is NaN (provider bug, #4088 review)', () => {
+  it('accumulates tokens but NOT cost when `cost` is NaN with finite usage (#4088 / #5115)', () => {
+    // #4088: a NaN cost is a provider bug and must never poison the cost
+    // accumulator. #5115: but if the usage payload carries finite tokens,
+    // those ARE legitimate and ratchet the token meter. The usage gate keys
+    // on input_tokens; _trackUsage coerces the NaN cost to 0.
     const { mgr, session } = makeWiredManager()
     const events = captureSessionUsage(mgr)
     session.emit('result', { cost: NaN, usage: { input_tokens: 100 } })
-    assert.equal(events.length, 0, 'NaN cost must not pass the gate')
+    assert.equal(events.length, 1, 'finite usage fires session_usage even with NaN cost')
     const got = mgr.getCumulativeUsage('s1')
-    assert.equal(got.turnsBilled, 0)
-    assert.equal(got.inputTokens, 0)
+    assert.equal(got.turnsBilled, 1)
+    assert.equal(got.inputTokens, 100)
+    assert.equal(got.costUsd, 0, 'NaN cost must not poison cumulativeCost')
   })
 
-  it('does NOT accumulate when `cost` is Infinity (provider bug, #4088 review)', () => {
+  it('accumulates tokens but NOT cost when `cost` is Infinity with finite usage (#4088 / #5115)', () => {
     const { mgr, session } = makeWiredManager()
     const events = captureSessionUsage(mgr)
     session.emit('result', { cost: Infinity, usage: { input_tokens: 100 } })
-    assert.equal(events.length, 0, 'Infinity cost must not pass the gate')
+    assert.equal(events.length, 1, 'finite usage fires session_usage even with Infinity cost')
+    const got = mgr.getCumulativeUsage('s1')
+    assert.equal(got.turnsBilled, 1)
+    assert.equal(got.inputTokens, 100)
+    assert.equal(got.costUsd, 0, 'Infinity cost must not poison cumulativeCost')
+  })
+
+  it('does NOT accumulate when both `cost` and `usage.input_tokens` are non-finite (#4088 / #5115)', () => {
+    // Neither gate passes: NaN cost (cost gate fails) and no finite
+    // input_tokens (usage gate fails). Nothing is tracked, nothing emits.
+    const { mgr, session } = makeWiredManager()
+    const events = captureSessionUsage(mgr)
+    session.emit('result', { cost: NaN, usage: { output_tokens: 50 } })
+    assert.equal(events.length, 0, 'NaN cost + no input_tokens passes neither gate')
     const got = mgr.getCumulativeUsage('s1')
     assert.equal(got.turnsBilled, 0)
-    assert.equal(got.inputTokens, 0)
+    assert.equal(got.outputTokens, 0)
   })
 
   it('handles missing usage object on result gracefully (no NaN)', () => {
@@ -3371,9 +3409,11 @@ describe('SessionManager._trackCost integration with result events (#4086)', () 
     assert.equal(usageEvents.length, 0)
   })
 
-  it('error event with NaN / Infinity `cost` does NOT poison cumulative totals (#5038)', () => {
-    // Same defensive gate as the result path (#4088) — NaN / Infinity
-    // would poison cumulativeUsage and trigger spurious budget events.
+  it('error event with NaN / Infinity `cost` does NOT poison cumulative cost (#5038 / #4088)', () => {
+    // #4088: NaN / Infinity cost must never poison the cost accumulator or
+    // trigger spurious budget events. #5115: but finite tokens on the same
+    // error payload ARE legitimate partial spend and ratchet the token
+    // meter — the usage gate keys on input_tokens, the cost gate on cost.
     const { mgr, session } = makeWired({ budget: 1.0 })
     const costUpdates = captureSessionEvents(mgr, 'cost_update')
     session.emit('error', {
@@ -3384,9 +3424,13 @@ describe('SessionManager._trackCost integration with result events (#4086)', () 
       messageId: 'm', message: 'boom', code: 'STREAM_ERROR',
       cost: Infinity, usage: { input_tokens: 999 },
     })
-    assert.equal(mgr.getSessionCost('s1'), 0)
-    assert.equal(costUpdates.length, 0)
-    assert.equal(mgr.getCumulativeUsage('s1').inputTokens, 0)
+    // Cost accumulator stays clean — neither error ticked the budget.
+    assert.equal(mgr.getSessionCost('s1'), 0, 'NaN / Infinity cost must not poison cumulativeCost')
+    assert.equal(costUpdates.length, 0, 'non-finite cost must not fire cost_update')
+    assert.equal(mgr.getCumulativeUsage('s1').costUsd, 0)
+    // #5115: tokens ratchet (both errors carried finite input_tokens).
+    assert.equal(mgr.getCumulativeUsage('s1').inputTokens, 1998)
+    assert.equal(mgr.getCumulativeUsage('s1').turnsBilled, 2)
   })
 })
 
@@ -3466,19 +3510,20 @@ describe('SessionManager cost-threshold soft warning (#4075)', () => {
     assert.equal(crossings.length, 1, 'still no re-fire')
   })
 
-  it('does NOT fire for subscription-billed sessions (cost stays at 0)', () => {
+  it('does NOT fire the COST threshold for subscription-billed sessions, but DOES ratchet tokens (#5115)', () => {
     const { mgr, session } = makeMgr({ threshold: 0.001 })
     const crossings = captureCrossings(mgr)
-    // claude-tui-like flow: cost is null on the result event. The wired
-    // result handler gates _trackUsage on `Number.isFinite(data.cost)`
-    // (#4088), so subscription-billed sessions never increment the
-    // accumulator OR fire the threshold. From the badge's perspective
-    // both surfaces stay at 0 — no clutter.
+    // claude-tui-like flow: cost is null on the result event but the usage
+    // payload carries real tokens. #5115: the usage gate keys on
+    // input_tokens so the token meter ratchets, while costUsd stays at 0 —
+    // so the dollar-denominated soft threshold never crosses (no $ budget
+    // applies to a flat subscription). Both invariants hold simultaneously.
     session.emit('result', { usage: { input_tokens: 1000, output_tokens: 500 }, cost: null })
     session.emit('result', { usage: { input_tokens: 1000, output_tokens: 500 }, cost: null })
-    assert.equal(crossings.length, 0, 'subscription sessions must never trigger the threshold')
-    assert.equal(mgr.getCumulativeUsage('s1').costUsd, 0)
-    assert.equal(mgr.getCumulativeUsage('s1').inputTokens, 0, 'tokens are not tracked when cost is null')
+    assert.equal(crossings.length, 0, 'subscription sessions must never trigger the COST threshold')
+    assert.equal(mgr.getCumulativeUsage('s1').costUsd, 0, 'costUsd stays at 0 — no cost to add')
+    assert.equal(mgr.getCumulativeUsage('s1').inputTokens, 2000, 'tokens ARE tracked even when cost is null (#5115)')
+    assert.equal(mgr.getCumulativeUsage('s1').turnsBilled, 2)
   })
 
   it('is disabled when threshold is 0', () => {


### PR DESCRIPTION
## Summary

Subscription-billed `claude -p` turns report `total_cost_usd: null` but carry real token counts (verified in #5108: `cli-session.js` forwards the full `usage` payload verbatim). `session-manager._trackUsage` was reached only through a single `Number.isFinite(data.cost)` gate, so on a subscription turn the gate short-circuited and `cumulativeUsage` stayed at zero — the dashboard header token meter never lit up for CLI-mode subscription users.

## The decision (#5115 open question)

**Yes** — re-gate the usage accumulator on tokens, not cost. The turn-terminal accounting is now split into two independent gates:

1. **COST gate** — `Number.isFinite(data.cost)` (unchanged). Drives `_trackCost` (the dollar accumulator + budget thresholds). Subscription runs stay at `$0` — no dollar budget applies to a flat subscription.
2. **USAGE gate** — finite cost **OR** finite `usage.input_tokens`. Drives `_trackUsage` (the token accumulator behind the meter). Subscription turns now ratchet tokens via the token half of the gate.

## Cost-poison hardening

`_trackUsage` previously did `acc.costUsd += Number(cost) || 0`. That accepts `Infinity` (Infinity is truthy), so now that the usage gate lets non-finite-cost payloads through, an `Infinity` cost would poison `cumulativeCost`. Swapped to an explicit `Number.isFinite` coercion for every accumulated field. This directly satisfies the acceptance criterion "ensure the cost accumulator still skips non-finite cost."

## Single-counting

Preserved. The synthetic interrupted-turn result (`_emitInterruptedTurnResult`) carries both `cost: null` AND `usage: null`, so neither gate fires for the stream-stall path. A regression test pins this.

## Tests

- New: subscription `result` with `usage` and no cost / `cost: null` ratchets `inputTokens` + `turnsBilled` while `costUsd` stays 0.
- New: NaN / Infinity cost with finite usage ratchets tokens but never poisons `costUsd`.
- New: `cost: null` + `usage: null` (interrupted shape) fires nothing.
- New: NaN cost with no `input_tokens` passes neither gate.
- Updated the error-path and cost-threshold tests to the new semantics (cost threshold still never fires for subscription; tokens now ratchet).
- Full `session-manager.test.js`: 196/196 pass. Lints (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`) pass.

## Acceptance criteria

- [x] Re-gate `_trackUsage` on finite `usage.input_tokens` (in addition to cost).
- [x] Cost accumulator skips non-finite cost (no NaN/Infinity poison).
- [x] Regression test: `result` with `usage` but `cost: null` ticks `cumulativeUsage.inputTokens`.
- [ ] Live smoke-test of the header meter on a real `--use-claude-headless` session — not exercisable in this environment (needs a running server + real subscription `claude -p`). Verified the full wire path by code inspection: `_trackUsage` → `session_usage` event → dashboard `message-handler` → `SidebarTokenView`, which renders `inputTokens + outputTokens` and shows cost only `if costUsd > 0`. So the token meter lights up while cost stays hidden.

Closes #5115