### PR TITLE
feat(dashboard): render child permission_request as nested sub-bubble

### DIFF
--- a/packages/dashboard/src/components/ChildAgentEventList.test.tsx
+++ b/packages/dashboard/src/components/ChildAgentEventList.test.tsx
@@ -8,12 +8,34 @@
  * Render tests focus on what users see: collapsed by default, expands
  * on click, surfaces input summary + result text.
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { ChildAgentEventList, __reduceEventsForTest } from './ChildAgentEventList'
+import type { PermissionDecision } from '../store/types'
+
+// #5061 — the component reads `resolvedPermissions` and calls
+// `sendPermissionResponse` from the connection store. Mock it so the
+// nested permission affordance can be tested without booting Zustand.
+type MockStore = {
+  resolvedPermissions: Record<string, PermissionDecision>
+  sendPermissionResponse: (requestId: string, decision: PermissionDecision) => void
+}
+const sendPermissionResponseMock = vi.fn()
+let mockStoreState: MockStore = {
+  resolvedPermissions: {},
+  sendPermissionResponse: sendPermissionResponseMock,
+}
+vi.mock('../store/connection', () => ({
+  useConnectionStore: <T,>(selector: (s: MockStore) => T): T => selector(mockStoreState),
+}))
 
 afterEach(() => {
   cleanup()
+  sendPermissionResponseMock.mockReset()
+  mockStoreState = {
+    resolvedPermissions: {},
+    sendPermissionResponse: sendPermissionResponseMock,
+  }
 })
 
 describe('reduceEvents (#5016)', () => {
@@ -102,11 +124,11 @@ describe('reduceEvents (#5016)', () => {
   it('ignores unknown event types (forward-compat against future server emits)', () => {
     const out = __reduceEventsForTest([
       { type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } },
-      { type: 'permission_request', payload: { tool: 'Bash' } },
       { type: 'something_new', payload: { foo: 'bar' } },
     ])
     expect(out.tools).toHaveLength(1)
     expect(out.assistantText).toBe('')
+    expect(out.permissions).toHaveLength(0)
   })
 
   it('replays of tool_start preserve resolved state on the row', () => {
@@ -119,6 +141,61 @@ describe('reduceEvents (#5016)', () => {
     expect(out.tools).toHaveLength(1)
     expect(out.tools[0]?.hasResult).toBe(true)
     expect(out.tools[0]?.result).toBe('done')
+  })
+
+  // #5061 — child permission_request / permission_resolved relay.
+  it('surfaces one permission row per child permission_request', () => {
+    const out = __reduceEventsForTest([
+      { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash', description: 'run ls' } },
+    ])
+    expect(out.permissions).toHaveLength(1)
+    expect(out.permissions[0]?.requestId).toBe('p1')
+    expect(out.permissions[0]?.tool).toBe('Bash')
+    expect(out.permissions[0]?.description).toBe('run ls')
+    expect(out.permissions[0]?.serverDecision).toBeUndefined()
+  })
+
+  it('ignores a permission_request without a string requestId', () => {
+    const out = __reduceEventsForTest([
+      { type: 'permission_request', payload: { tool: 'Bash' } },
+    ])
+    expect(out.permissions).toHaveLength(0)
+  })
+
+  it('settles a permission row when permission_resolved relays a decision', () => {
+    const out = __reduceEventsForTest([
+      { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+      { type: 'permission_resolved', payload: { requestId: 'p1', decision: 'deny' } },
+    ])
+    expect(out.permissions).toHaveLength(1)
+    expect(out.permissions[0]?.serverDecision).toBe('deny')
+  })
+
+  it('synthesises a permission row when permission_resolved arrives first (out-of-order relay)', () => {
+    const out = __reduceEventsForTest([
+      { type: 'permission_resolved', payload: { requestId: 'pX', decision: 'allow' } },
+    ])
+    expect(out.permissions).toHaveLength(1)
+    expect(out.permissions[0]?.requestId).toBe('pX')
+    expect(out.permissions[0]?.serverDecision).toBe('allow')
+  })
+
+  it('treats a permission_resolved without a decision as denied', () => {
+    const out = __reduceEventsForTest([
+      { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+      { type: 'permission_resolved', payload: { requestId: 'p1' } },
+    ])
+    expect(out.permissions[0]?.serverDecision).toBe('denied')
+  })
+
+  it('replayed permission_request preserves a prior server resolution', () => {
+    const out = __reduceEventsForTest([
+      { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+      { type: 'permission_resolved', payload: { requestId: 'p1', decision: 'allow' } },
+      { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+    ])
+    expect(out.permissions).toHaveLength(1)
+    expect(out.permissions[0]?.serverDecision).toBe('allow')
   })
 })
 
@@ -202,6 +279,111 @@ describe('ChildAgentEventList render (#5016)', () => {
       </div>,
     )
     fireEvent.click(screen.getByTestId('child-agent-tool-c1'))
+    // No throw — stopPropagation is working.
+  })
+})
+
+describe('ChildAgentEventList nested permission affordance (#5061)', () => {
+  it('renders a permission row with Allow / Deny buttons', () => {
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash', description: 'run ls' } },
+        ]}
+        parentToolUseId="tu-parent-perm-1"
+      />,
+    )
+    expect(screen.getByTestId('child-agent-permission-p1')).toHaveTextContent('Bash')
+    expect(screen.getByTestId('child-agent-permission-p1')).toHaveTextContent('run ls')
+    expect(screen.getByTestId('child-agent-permission-allow-p1')).toBeInTheDocument()
+    expect(screen.getByTestId('child-agent-permission-deny-p1')).toBeInTheDocument()
+  })
+
+  it('mounts even when there are no tool rows or stream text', () => {
+    // A child whose only event is a permission_request must still render
+    // (the parent ToolBubble mounts us because childAgentEvents is non-empty).
+    const { container } = render(
+      <ChildAgentEventList
+        events={[
+          { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+        ]}
+        parentToolUseId="tu-parent-perm-2"
+      />,
+    )
+    expect(container.firstChild).not.toBeNull()
+    expect(screen.getByTestId('child-agent-permission-p1')).toBeInTheDocument()
+  })
+
+  it('Allow calls sendPermissionResponse with allow', () => {
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+        ]}
+        parentToolUseId="tu-parent-perm-3"
+      />,
+    )
+    fireEvent.click(screen.getByTestId('child-agent-permission-allow-p1'))
+    expect(sendPermissionResponseMock).toHaveBeenCalledWith('p1', 'allow')
+  })
+
+  it('Deny calls sendPermissionResponse with deny', () => {
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+        ]}
+        parentToolUseId="tu-parent-perm-4"
+      />,
+    )
+    fireEvent.click(screen.getByTestId('child-agent-permission-deny-p1'))
+    expect(sendPermissionResponseMock).toHaveBeenCalledWith('p1', 'deny')
+  })
+
+  it('shows answered state (no buttons) when the store has a recorded decision', () => {
+    mockStoreState.resolvedPermissions = { p1: 'allow' }
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+        ]}
+        parentToolUseId="tu-parent-perm-5"
+      />,
+    )
+    expect(screen.getByTestId('child-agent-permission-answer-p1')).toHaveTextContent('Allowed')
+    expect(screen.queryByTestId('child-agent-permission-allow-p1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('child-agent-permission-deny-p1')).not.toBeInTheDocument()
+  })
+
+  it('shows Denied answered state from a server permission_resolved relay', () => {
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+          { type: 'permission_resolved', payload: { requestId: 'p1', decision: 'deny' } },
+        ]}
+        parentToolUseId="tu-parent-perm-6"
+      />,
+    )
+    expect(screen.getByTestId('child-agent-permission-answer-p1')).toHaveTextContent('Denied')
+    expect(screen.queryByTestId('child-agent-permission-allow-p1')).not.toBeInTheDocument()
+  })
+
+  it('clicking a permission button does not propagate to the parent bubble', () => {
+    const onContainerClick = () => {
+      throw new Error('outer onClick should not fire')
+    }
+    render(
+      <div onClick={onContainerClick} role="presentation">
+        <ChildAgentEventList
+          events={[
+            { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+          ]}
+          parentToolUseId="tu-parent-perm-7"
+        />
+      </div>,
+    )
+    fireEvent.click(screen.getByTestId('child-agent-permission-allow-p1'))
     // No throw — stopPropagation is working.
   })
 })

--- a/packages/dashboard/src/components/ChildAgentEventList.test.tsx
+++ b/packages/dashboard/src/components/ChildAgentEventList.test.tsx
@@ -188,6 +188,22 @@ describe('reduceEvents (#5016)', () => {
     expect(out.permissions[0]?.serverDecision).toBe('denied')
   })
 
+  it('normalises an unrecognised decision value to denied (fail-safe)', () => {
+    const out = __reduceEventsForTest([
+      { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+      { type: 'permission_resolved', payload: { requestId: 'p1', decision: 'bogus' } },
+    ])
+    expect(out.permissions[0]?.serverDecision).toBe('denied')
+  })
+
+  it('accepts the allowAlways wire decision verbatim', () => {
+    const out = __reduceEventsForTest([
+      { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+      { type: 'permission_resolved', payload: { requestId: 'p1', decision: 'allowAlways' } },
+    ])
+    expect(out.permissions[0]?.serverDecision).toBe('allowAlways')
+  })
+
   it('replayed permission_request preserves a prior server resolution', () => {
     const out = __reduceEventsForTest([
       { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
@@ -367,6 +383,19 @@ describe('ChildAgentEventList nested permission affordance (#5061)', () => {
     )
     expect(screen.getByTestId('child-agent-permission-answer-p1')).toHaveTextContent('Denied')
     expect(screen.queryByTestId('child-agent-permission-allow-p1')).not.toBeInTheDocument()
+  })
+
+  it('shows Allowed for an allowAlways server relay', () => {
+    render(
+      <ChildAgentEventList
+        events={[
+          { type: 'permission_request', payload: { requestId: 'p1', tool: 'Bash' } },
+          { type: 'permission_resolved', payload: { requestId: 'p1', decision: 'allowAlways' } },
+        ]}
+        parentToolUseId="tu-parent-perm-aa"
+      />,
+    )
+    expect(screen.getByTestId('child-agent-permission-answer-p1')).toHaveTextContent('Allowed')
   })
 
   it('clicking a permission button does not propagate to the parent bubble', () => {

--- a/packages/dashboard/src/components/ChildAgentEventList.tsx
+++ b/packages/dashboard/src/components/ChildAgentEventList.tsx
@@ -35,10 +35,31 @@
  *   reducer trivial (append) and lets us style nested rows distinctly
  *   ("this is sub-tool progress, not top-level work").
  *
+ * Child permission requests (#5061):
+ *   - When the subagent fires an MCP tool under `approve` mode, the
+ *     child's `PermissionManager` raises a `permission_request` that the
+ *     parent relays to the dashboard as
+ *     `agent_event{eventType: 'permission_request'}` (byok-session.js
+ *     #5056). The relay also registers the child's `requestId` in the
+ *     WsServer `permissionSessionMap` against the PARENT session id, and
+ *     records `requestId -> childSession` in the parent's routing table.
+ *   - The reducer surfaces one permission row per pending request; the
+ *     row carries inline Allow / Deny affordances. Tapping a button
+ *     calls the store's `sendPermissionResponse(requestId, decision)` —
+ *     the exact same wire path a top-level prompt uses. ws-permissions
+ *     authorises against the parent session id, the parent forwards the
+ *     decision to the child that actually holds the pending entry. No new
+ *     trust boundary (see byok-session.js authority note).
+ *   - The resolved decision is read from the store
+ *     (`resolvedPermissions[requestId]`) so a tab switch that remounts
+ *     this list preserves the answered state, and a server-side
+ *     `permission_resolved` relay (timeout / abort / auto) also flips the
+ *     row to its terminal state via the reducer.
+ *
  * What this does NOT render in v2:
- *   - `permission_request` from the child (the server gates these on
- *     the parent's permission manager today; deferred until the child
- *     gets its own per-launch permission_mode override surface).
+ *   - An "Allow for Session" affordance — session-scoped rules are a
+ *     parent-session concept; the child's permission is a transient
+ *     per-dispatch decision, so the nested row offers Allow / Deny only.
  *   - Errors from the child are surfaced via the parent's Task
  *     tool_result `is_error: true` content (the byok-session.js
  *     fold), so a child error renders in the parent bubble's normal
@@ -48,6 +69,8 @@
 import { useMemo, useState } from 'react'
 import type { ChildAgentEvent } from '@chroxy/store-core'
 import { formatToolName, getInputSummary, getPartialSummary } from '@chroxy/store-core'
+import { useConnectionStore } from '../store/connection'
+import type { PermissionDecision } from '../store/types'
 
 interface ChildAgentEventListProps {
   events: ChildAgentEvent[]
@@ -77,6 +100,31 @@ interface ChildToolRow {
 }
 
 /**
+ * One pending (or server-resolved) permission request raised by the
+ * child agent and relayed up as `agent_event{eventType:
+ * 'permission_request'}`. The row carries inline Allow / Deny
+ * affordances; the answered state is read from the dashboard store, but
+ * a `permission_resolved` relay (timeout / abort / auto) records a
+ * terminal `serverDecision` here too so the row settles even when the
+ * user never tapped a button.
+ */
+interface ChildPermissionRow {
+  /** Permission requestId — store key + wire key for the response. */
+  requestId: string
+  /** Tool the child wants to run (`Bash`, an MCP tool, etc.). */
+  tool: string
+  /** Human-readable description from the child's PermissionManager. */
+  description: string
+  /**
+   * Terminal decision relayed by the server via `permission_resolved`
+   * (e.g. `'deny'` on timeout/abort). Distinct from the user's own
+   * decision in `resolvedPermissions` — either flips the row to its
+   * answered state.
+   */
+  serverDecision?: PermissionDecision | 'denied'
+}
+
+/**
  * Reduce the flat `agent_event` log into a structured per-tool list +
  * one concatenated assistant-text block (or null when the child
  * produced no streaming text). Pure — recomputed via `useMemo` when
@@ -94,9 +142,12 @@ interface ChildToolRow {
 function reduceEvents(events: ChildAgentEvent[]): {
   tools: ChildToolRow[]
   assistantText: string
+  permissions: ChildPermissionRow[]
 } {
   const tools: ChildToolRow[] = []
   const byId = new Map<string, ChildToolRow>()
+  const permissions: ChildPermissionRow[] = []
+  const permById = new Map<string, ChildPermissionRow>()
   let assistantText = ''
   // Track the messageId of the last stream_delta we appended so we can
   // insert a blank-line boundary on transition. Without this, multi-
@@ -170,13 +221,46 @@ function reduceEvents(events: ChildAgentEvent[]): {
         assistantText += delta
         if (messageId) lastStreamMessageId = messageId
       }
+    } else if (ev.type === 'permission_request') {
+      // #5061: child raised a permission prompt (relayed via agent_event).
+      const requestId = typeof p.requestId === 'string' ? p.requestId : null
+      if (!requestId) continue
+      const tool = typeof p.tool === 'string' ? p.tool : 'tool'
+      const description = typeof p.description === 'string' ? p.description : ''
+      const existing = permById.get(requestId)
+      if (existing) {
+        // Idempotent replay — refresh display fields, keep terminal state.
+        existing.tool = tool
+        existing.description = description || existing.description
+        continue
+      }
+      const row: ChildPermissionRow = { requestId, tool, description }
+      permById.set(requestId, row)
+      permissions.push(row)
+    } else if (ev.type === 'permission_resolved') {
+      // #5061: server-side resolution (user response echo, timeout, abort,
+      // auto-mode). Settle the matching row so the affordance disappears
+      // even when no local decision was recorded.
+      const requestId = typeof p.requestId === 'string' ? p.requestId : null
+      if (!requestId) continue
+      const decision = typeof p.decision === 'string' ? p.decision : 'denied'
+      let row = permById.get(requestId)
+      if (!row) {
+        // Defensive: resolved arrived without a preceding request (replay
+        // gap / out-of-order relay). Synthesise so the terminal state is
+        // still visible rather than dropping it silently.
+        row = { requestId, tool: 'tool', description: '' }
+        permById.set(requestId, row)
+        permissions.push(row)
+      }
+      row.serverDecision = decision as PermissionDecision | 'denied'
     }
     // Unknown types fall through silently and are NOT rendered.
-    // Adding a new surface (e.g. nested permission_request rows) means
-    // adding an explicit branch above AND a styled row in the JSX —
-    // a generic "unknown event" line would just be noise to users.
+    // Adding a new surface means adding an explicit branch above AND a
+    // styled row in the JSX — a generic "unknown event" line would just
+    // be noise to users.
   }
-  return { tools, assistantText }
+  return { tools, assistantText, permissions }
 }
 
 export function ChildAgentEventList({ events, parentToolUseId }: ChildAgentEventListProps) {
@@ -185,7 +269,18 @@ export function ChildAgentEventList({ events, parentToolUseId }: ChildAgentEvent
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
   const toggle = (id: string) => setExpanded((s) => ({ ...s, [id]: !s[id] }))
 
-  if (reduced.tools.length === 0 && !reduced.assistantText) {
+  // #5061: locally-recorded decisions (so an answered nested prompt stays
+  // answered across remounts), plus the wire path for responses. The
+  // response routes through the parent session id exactly like a top-level
+  // prompt — the server's #5056 routing table forwards it to the child.
+  const resolvedPermissions = useConnectionStore((s) => s.resolvedPermissions)
+  const sendPermissionResponse = useConnectionStore((s) => s.sendPermissionResponse)
+
+  if (
+    reduced.tools.length === 0
+    && !reduced.assistantText
+    && reduced.permissions.length === 0
+  ) {
     // Render nothing — the parent ToolBubble only mounts us when
     // there is at least one event, so this branch is the
     // safety-net for an all-`stream_delta`-empty payload.
@@ -248,6 +343,66 @@ export function ChildAgentEventList({ events, parentToolUseId }: ChildAgentEvent
                 onClick={(e) => e.stopPropagation()}
               >
                 <pre>{row.result}</pre>
+              </div>
+            )}
+          </div>
+        )
+      })}
+      {reduced.permissions.map((perm) => {
+        // The row is answered when EITHER the user recorded a local
+        // decision OR the server relayed a terminal resolution.
+        const localDecision = resolvedPermissions?.[perm.requestId] ?? null
+        const answered = localDecision ?? perm.serverDecision ?? null
+        const answerLabel = answered === 'deny' || answered === 'denied'
+          ? 'Denied'
+          : answered
+            ? 'Allowed'
+            : null
+        return (
+          <div
+            key={perm.requestId}
+            className={`child-agent-permission${answered ? ' answered' : ''}`}
+            data-testid={`child-agent-permission-${perm.requestId}`}
+            onClick={(e) => e.stopPropagation()}
+            role="presentation"
+          >
+            <div className="child-agent-permission-desc">
+              <span className="child-agent-permission-tool">{perm.tool}</span>
+              {perm.description ? `: ${perm.description}` : ': Permission requested'}
+            </div>
+            {answered ? (
+              <div
+                className="child-agent-permission-answer"
+                data-testid={`child-agent-permission-answer-${perm.requestId}`}
+              >
+                {answerLabel}
+              </div>
+            ) : (
+              <div className="child-agent-permission-buttons">
+                <button
+                  className="btn-allow"
+                  type="button"
+                  data-testid={`child-agent-permission-allow-${perm.requestId}`}
+                  aria-label={`Allow ${perm.tool} for subagent`}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    sendPermissionResponse(perm.requestId, 'allow')
+                  }}
+                >
+                  Allow
+                </button>
+                <button
+                  className="btn-deny"
+                  type="button"
+                  data-testid={`child-agent-permission-deny-${perm.requestId}`}
+                  aria-label={`Deny ${perm.tool} for subagent`}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    sendPermissionResponse(perm.requestId, 'deny')
+                  }}
+                >
+                  Deny
+                </button>
               </div>
             )}
           </div>

--- a/packages/dashboard/src/components/ChildAgentEventList.tsx
+++ b/packages/dashboard/src/components/ChildAgentEventList.tsx
@@ -70,7 +70,6 @@ import { useMemo, useState } from 'react'
 import type { ChildAgentEvent } from '@chroxy/store-core'
 import { formatToolName, getInputSummary, getPartialSummary } from '@chroxy/store-core'
 import { useConnectionStore } from '../store/connection'
-import type { PermissionDecision } from '../store/types'
 
 interface ChildAgentEventListProps {
   events: ChildAgentEvent[]
@@ -108,6 +107,20 @@ interface ChildToolRow {
  * terminal `serverDecision` here too so the row settles even when the
  * user never tapped a button.
  */
+/**
+ * Server-relayed terminal decision from `permission_resolved`. This is
+ * the WIRE decision set (`'allow' | 'allowAlways' | 'deny'`, see
+ * `PermissionResponseSchema` in @chroxy/protocol) plus a `'denied'`
+ * sentinel for resolutions that carry no explicit decision (timeout /
+ * abort / malformed relay), which we fail-safe to denied. Deliberately
+ * NOT `PermissionDecision` (a UI-only type that includes `'allowSession'`
+ * and excludes `'allowAlways'`) so the server set can't drift into it.
+ */
+type ServerPermissionDecision = 'allow' | 'allowAlways' | 'deny' | 'denied'
+
+/** Wire decisions the server may relay; anything else is treated as denied. */
+const WIRE_PERMISSION_DECISIONS = new Set<ServerPermissionDecision>(['allow', 'allowAlways', 'deny'])
+
 interface ChildPermissionRow {
   /** Permission requestId — store key + wire key for the response. */
   requestId: string
@@ -121,7 +134,7 @@ interface ChildPermissionRow {
    * decision in `resolvedPermissions` — either flips the row to its
    * answered state.
    */
-  serverDecision?: PermissionDecision | 'denied'
+  serverDecision?: ServerPermissionDecision
 }
 
 /**
@@ -243,7 +256,13 @@ function reduceEvents(events: ChildAgentEvent[]): {
       // even when no local decision was recorded.
       const requestId = typeof p.requestId === 'string' ? p.requestId : null
       if (!requestId) continue
-      const decision = typeof p.decision === 'string' ? p.decision : 'denied'
+      // Normalise to a known wire decision; anything unexpected (or a
+      // resolution with no decision: timeout / abort) fails safe to denied
+      // so an unrecognised value can never read as "Allowed".
+      const decision: ServerPermissionDecision =
+        WIRE_PERMISSION_DECISIONS.has(p.decision as ServerPermissionDecision)
+          ? (p.decision as ServerPermissionDecision)
+          : 'denied'
       let row = permById.get(requestId)
       if (!row) {
         // Defensive: resolved arrived without a preceding request (replay
@@ -253,7 +272,7 @@ function reduceEvents(events: ChildAgentEvent[]): {
         permById.set(requestId, row)
         permissions.push(row)
       }
-      row.serverDecision = decision as PermissionDecision | 'denied'
+      row.serverDecision = decision
     }
     // Unknown types fall through silently and are NOT rendered.
     // Adding a new surface means adding an explicit branch above AND a


### PR DESCRIPTION
## Summary

The Task subagent permission relay (server-side, #5056) forwards a child agent's `permission_request` to the parent's dashboard wire path as `agent_event{eventType: 'permission_request'}` and registers the `requestId` in the WsServer `permissionSessionMap` against the parent session id. The dashboard already stored these events in `childAgentEvents[]`, but `ChildAgentEventList` ignored unknown event types — so the nested prompt never rendered and the child's request silently timed out.

This wires the remaining dashboard side of #5061.

## Changes

- **Reducer (`reduceEvents`)** — surface one `ChildPermissionRow` per child `permission_request`, settling it on `permission_resolved` (user-response echo, timeout, abort, auto-mode) with a synthesised-row fallback for out-of-order relays. Idempotent on replay (a replayed `permission_request` preserves a prior server resolution).
- **Render** — inline Allow / Deny affordance per pending row, wired through the store's `sendPermissionResponse(requestId, decision)` — the exact same wire path a top-level prompt uses. The server routes the response from the parent session id to the child that actually holds the pending entry (#5056), so no new trust boundary is introduced. `stopPropagation` guards keep button clicks from collapsing the outer Task bubble.
- **Answered state** — read `resolvedPermissions` from the store so an answered nested prompt stays answered across tab-switch remounts; a server `permission_resolved` relay also flips the row to its terminal `Allowed` / `Denied` state.
- **No Allow-for-Session** — session-scoped rules are a parent-session concept; the child permission is a transient per-dispatch decision, so the nested row offers Allow / Deny only.

## Acceptance criteria

- [x] Decision: relay as `agent_event` (already shipped server-side in #5056) — dashboard consumes from `childAgentEvents[]`
- [x] Implementation matches the chosen surface
- [x] Dashboard renders the child permission affordance in the nested sub-bubble
- [x] Approve/deny round-trip wired (`sendPermissionResponse` → parent session → child routing table)
- [x] Tests for the relay path (reducer + render; 30 ChildAgentEventList tests, full dashboard suite 2923 passing, typecheck clean)

## Notes

This proceeds independently of #5017 (per-launch permission_mode override): the relay infrastructure that lands the data already shipped, so the dashboard rendering needs no further server work.

Closes #5061