### PR TITLE
feat(dashboard): cache-hit ratio + per-session breakdown in sidebar token view (#4303)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sidebar token-usage view: cache-hit ratio + per-session breakdown (#4303):** the bottom sidebar panel's token view now surfaces a cache-hit ratio in the aggregate strip (`cacheRead / (input + cacheRead + cacheCreation)` — the visible signal of prompt-caching effectiveness, hidden when there's no input surface) and a per-session breakdown sorted by total tokens. Per-session rows are click-to-activate (parity with the sidebar tree) and float the active session to the top with `aria-current`. claude-tui sessions remain excluded from the per-session list since they expose no token counts. Pure helper `cacheHitRatio(usage)` is unit-tested independently of React.
+
 ## [0.9.43] - 2026-06-03
 
 Two-day backlog-sweep release: 52 PRs landed. The headline additions are two brand-new features — a `docker-byok` container provider that sandboxes file/Bash tool execution inside a Docker container while the model loop stays host-side, and a `Task` subagent tool in `claude-byok` that lets the model delegate work to focused child agents. The rest is the v0.9.40 / v0.9.41 / v0.9.42 follow-up tail: ResumeUnknownChip mobile parity + escalation, SESSION_NOT_FOUND consumer wiring, intervention notifications widget, voice-permission reset affordance, extended Tauri menu bar, a real Windows CI runner, the auto-tag release-PR safety net, and a stack of polish across both dashboard and store-core.

--- a/docs/architecture/reference.md
+++ b/docs/architecture/reference.md
@@ -473,7 +473,9 @@ The web dashboard is a React + Vite SPA served by the Node.js server. It shares 
 | `src/components/InputBar.tsx` | Text input with slash commands, file attachments |
 | `src/components/TerminalView.tsx` | xterm.js terminal emulator |
 | `src/components/MultiTerminalView.tsx` | Multi-tab terminal container |
-| `src/components/Sidebar.tsx` | Session list, navigation, resize |
+| `src/components/Sidebar.tsx` | Session list, navigation, resize; hosts the pluggable bottom panel slot |
+| `src/components/SidebarPanelSlot.tsx` | Pluggable bottom-panel slot (tab strip, collapse, drag/keyboard resize) — see "Sidebar panel slot" below |
+| `src/components/SidebarTokenView.tsx` | First slot occupant: token-usage view (aggregate totals, cache-hit ratio, per-provider + per-session breakdown) |
 | `src/components/SessionBar.tsx` | Session tab strip |
 | `src/components/StatusBar.tsx` | Connection status, cost, model info |
 | `src/components/FooterBar.tsx` | Bottom bar with actions |
@@ -533,6 +535,38 @@ The web dashboard is a React + Vite SPA served by the Node.js server. It shares 
 | `src/utils/image-utils.ts` | Image processing utilities |
 | **Theme** | |
 | `src/theme/tokens.ts` | Generated design tokens (colors, spacing) |
+
+#### Sidebar panel slot (#4303)
+
+The left sidebar is split into two stacked sections: the existing session tree
+on top and a **pluggable panel slot** (`SidebarPanelSlot`) below it. The slot
+manages the tab strip, collapse toggle, collapsed-header live metric, and
+drag/keyboard resize so individual views don't have to.
+
+Views are registered **declaratively** — adding one is a one-entry append to the
+`panelViews` array in `Sidebar.tsx`, with no changes to slot code. Each view is a
+`SidebarPanelView`:
+
+```ts
+interface SidebarPanelView {
+  id: string                                 // stable id, used for persistence + selection
+  label: string                              // tab strip label
+  render: () => ReactNode                    // body, rendered only when selected
+  collapsedHeaderMetric?: () => ReactNode    // one live metric shown when the panel is collapsed
+}
+```
+
+Slot state — selected view id, collapsed flag, and height — is persisted through
+the existing scoped-persistence layer (`chroxy_persist_sidebar_panel_{view,collapsed,height}`)
+so it survives reload. A stale `selectedViewId` (e.g. a view removed in a later
+build) falls back to the first registered view rather than rendering empty.
+
+The **token-usage view** (`SidebarTokenView`) is the first occupant: it reads the
+in-memory `cumulativeUsage` carried on each `SessionInfo` (no new wire/event work)
+and renders aggregate totals, a cache-hit ratio, a per-provider breakdown, and a
+click-to-activate per-session breakdown. claude-tui sessions surface `—` with a
+tooltip since their PTY interface exposes no token counts. Future occupants (MCP
+status, skills registry, slash-command palette, etc.) slot in the same way.
 
 ### Store Core (`packages/store-core/`)
 

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -179,10 +179,16 @@ export function Sidebar({
     {
       id: 'tokens',
       label: 'Tokens',
-      render: () => <SidebarTokenView sessions={sessions} />,
+      render: () => (
+        <SidebarTokenView
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSessionClick={onSessionClick}
+        />
+      ),
       collapsedHeaderMetric: () => tokenViewCollapsedMetric(sessions),
     },
-  ]), [sessions])
+  ]), [sessions, activeSessionId, onSessionClick])
 
   const toggleRepo = useCallback((path: string) => {
     setCollapsed(prev => ({ ...prev, [path]: !prev[path] }))

--- a/packages/dashboard/src/components/SidebarTokenView.test.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.test.tsx
@@ -1,12 +1,13 @@
 /**
  * SidebarTokenView v0 tests (#4303).
  */
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, cleanup, screen, fireEvent } from '@testing-library/react'
 import type { SessionInfo, CumulativeUsage } from '@chroxy/store-core'
 import {
   SidebarTokenView,
   aggregateUsage,
+  cacheHitRatio,
   tokenViewCollapsedMetric,
 } from './SidebarTokenView'
 
@@ -21,6 +22,22 @@ function makeUsage(input: number, output: number, costUsd = 0): CumulativeUsage 
     cacheReadTokens: 0,
     cacheCreationTokens: 0,
     costUsd,
+    turnsBilled: 1,
+  }
+}
+
+function makeUsageWithCache(
+  input: number,
+  output: number,
+  cacheRead: number,
+  cacheCreation: number,
+): CumulativeUsage {
+  return {
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: cacheRead,
+    cacheCreationTokens: cacheCreation,
+    costUsd: 0,
     turnsBilled: 1,
   }
 }
@@ -144,6 +161,105 @@ describe('SidebarTokenView (#4303 v0)', () => {
   // @chroxy/store-core (#5058 / #5094); its unit tests now live in
   // store-core/src/cost-format.test.ts. The render-level assertions below
   // (today-total, by-provider) still exercise the formatter end-to-end.
+
+  describe('cacheHitRatio (pure)', () => {
+    it('returns null when there is no input surface', () => {
+      expect(cacheHitRatio(makeUsage(0, 0))).toBeNull()
+      expect(cacheHitRatio(makeUsageWithCache(0, 5000, 0, 0))).toBeNull()
+    })
+
+    it('computes cacheRead / (input + cacheRead + cacheCreation)', () => {
+      // cacheRead=80, input=10, cacheCreation=10 -> 80/100 = 0.8
+      expect(cacheHitRatio(makeUsageWithCache(10, 0, 80, 10))).toBeCloseTo(0.8)
+    })
+
+    it('is 0 when nothing was read from cache', () => {
+      expect(cacheHitRatio(makeUsageWithCache(100, 0, 0, 0))).toBe(0)
+    })
+
+    it('does not count output tokens in the denominator', () => {
+      // Large output should not dilute the ratio.
+      expect(cacheHitRatio(makeUsageWithCache(50, 1_000_000, 50, 0))).toBeCloseTo(0.5)
+    })
+  })
+
+  describe('cache-hit row render', () => {
+    it('renders the cache-hit row when there is an input surface', () => {
+      const sessions = [
+        makeSession('s1', 'claude-byok', makeUsageWithCache(20, 10, 80, 0)),
+      ]
+      render(<SidebarTokenView sessions={sessions} />)
+      // 80 / (20 + 80 + 0) = 80%
+      expect(screen.getByTestId('sidebar-token-view-cache-hit')).toHaveTextContent('80%')
+    })
+
+    it('hides the cache-hit row when there is no input surface', () => {
+      const sessions = [makeSession('sub', 'claude-sdk', makeUsage(0, 0, 0))]
+      render(<SidebarTokenView sessions={sessions} />)
+      expect(screen.queryByTestId('sidebar-token-view-cache-hit')).toBeNull()
+    })
+  })
+
+  describe('per-session breakdown', () => {
+    it('lists tracked sessions sorted by tokens desc', () => {
+      const sessions = [
+        makeSession('small', 'claude-sdk', makeUsage(100, 50)),
+        makeSession('big', 'claude-byok', makeUsage(5000, 1000, 0.2)),
+      ]
+      render(<SidebarTokenView sessions={sessions} />)
+      const list = screen.getByTestId('sidebar-token-view-by-session')
+      const rows = list.querySelectorAll('[data-testid^="sidebar-token-view-session-"]')
+      expect(rows[0]).toHaveTextContent('big')
+      expect(rows[1]).toHaveTextContent('small')
+    })
+
+    it('excludes untracked (TUI) sessions from the per-session list', () => {
+      const sessions = [
+        makeSession('sdk', 'claude-sdk', makeUsage(100, 50)),
+        makeSession('tui', 'claude-tui', makeUsage(0, 0)),
+      ]
+      render(<SidebarTokenView sessions={sessions} />)
+      expect(screen.getByTestId('sidebar-token-view-session-sdk')).toBeInTheDocument()
+      expect(screen.queryByTestId('sidebar-token-view-session-tui')).toBeNull()
+    })
+
+    it('hides the section entirely when no tracked sessions exist', () => {
+      const sessions = [makeSession('tui', 'claude-tui', makeUsage(0, 0))]
+      render(<SidebarTokenView sessions={sessions} />)
+      expect(screen.queryByTestId('sidebar-token-view-by-session')).toBeNull()
+    })
+
+    it('floats the active session to the top and marks it current', () => {
+      const sessions = [
+        makeSession('big', 'claude-byok', makeUsage(5000, 1000)),
+        makeSession('active', 'claude-sdk', makeUsage(10, 5)),
+      ]
+      render(<SidebarTokenView sessions={sessions} activeSessionId="active" />)
+      const list = screen.getByTestId('sidebar-token-view-by-session')
+      const rows = list.querySelectorAll('[data-testid^="sidebar-token-view-session-"]')
+      // Active session floats to top despite lower token count.
+      expect(rows[0]).toHaveTextContent('active')
+      const activeRow = screen.getByTestId('sidebar-token-view-session-active')
+      expect(activeRow.getAttribute('aria-current')).toBe('true')
+    })
+
+    it('renders rows as buttons and activates on click when handler supplied', () => {
+      const onSessionClick = vi.fn()
+      const sessions = [makeSession('s1', 'claude-sdk', makeUsage(100, 50))]
+      render(<SidebarTokenView sessions={sessions} onSessionClick={onSessionClick} />)
+      const row = screen.getByTestId('sidebar-token-view-session-s1')
+      expect(row.tagName).toBe('BUTTON')
+      fireEvent.click(row)
+      expect(onSessionClick).toHaveBeenCalledWith('s1')
+    })
+
+    it('renders static (non-button) rows when no click handler is supplied', () => {
+      const sessions = [makeSession('s1', 'claude-sdk', makeUsage(100, 50))]
+      render(<SidebarTokenView sessions={sessions} />)
+      const row = screen.getByTestId('sidebar-token-view-session-s1')
+      expect(row.tagName).toBe('LI')
+    })
+  })
 
   describe('tokenViewCollapsedMetric', () => {
     it('returns the same total as the expanded view', () => {

--- a/packages/dashboard/src/components/SidebarTokenView.tsx
+++ b/packages/dashboard/src/components/SidebarTokenView.tsx
@@ -69,6 +69,26 @@ function addUsage(a: CumulativeUsage, b: CumulativeUsage): CumulativeUsage {
 }
 
 /**
+ * Cache-hit ratio = cacheRead / (input + cacheRead + cacheCreation).
+ *
+ * "Input" on the wire is split three ways: brand-new input tokens, tokens
+ * read from the prompt cache (cacheRead), and tokens written into the cache
+ * (cacheCreation). The ratio of cacheRead to the total input surface is the
+ * visible signal of prompt-caching effectiveness (decision in #4303 token
+ * view). Returns null when there's no input surface at all so the renderer
+ * can hide the row rather than show a meaningless 0%.
+ */
+export function cacheHitRatio(usage: CumulativeUsage): number | null {
+  const denom = usage.inputTokens + usage.cacheReadTokens + usage.cacheCreationTokens
+  if (denom <= 0) return null
+  return usage.cacheReadTokens / denom
+}
+
+function formatPercent(ratio: number): string {
+  return `${Math.round(ratio * 100)}%`
+}
+
+/**
  * Aggregate `cumulativeUsage` across sessions, grouped by provider.
  *
  * Untracked providers (currently just claude-tui) are excluded from the
@@ -299,11 +319,47 @@ const TUI_UNTRACKED_EXPLANATION =
 export interface SidebarTokenViewProps {
   /** All known sessions across active + resumable + background. */
   sessions: SessionInfo[]
+  /** Currently-active session id, so its per-session row can be highlighted. */
+  activeSessionId?: string | null
+  /**
+   * Click-to-activate parity with the sidebar tree (decision in #4303): a
+   * click on a per-session row activates that session. Omitting it renders
+   * the rows as static (no click affordance).
+   */
+  onSessionClick?: (sessionId: string) => void
 }
 
-export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
+export function SidebarTokenView({
+  sessions,
+  activeSessionId = null,
+  onSessionClick,
+}: SidebarTokenViewProps) {
   const agg = useMemo(() => aggregateUsage(sessions), [sessions])
   const totalTokens = agg.totals.inputTokens + agg.totals.outputTokens
+  const hitRatio = cacheHitRatio(agg.totals)
+
+  // Per-session rows: tracked providers only (untracked providers have no
+  // tokens to show), sorted by total tokens desc. The active session is
+  // highlighted and floated to the top so the user's current context is
+  // always visible without scrolling.
+  const sessionRows = useMemo(() => {
+    return sessions
+      .filter((s) => !UNTRACKED_PROVIDERS.has(s.provider ?? 'unknown'))
+      .map((s) => {
+        const usage = s.cumulativeUsage ?? EMPTY_USAGE
+        return {
+          session: s,
+          tokens: usage.inputTokens + usage.outputTokens,
+          costUsd: usage.costUsd,
+        }
+      })
+      .sort((a, b) => {
+        const aActive = a.session.sessionId === activeSessionId
+        const bActive = b.session.sessionId === activeSessionId
+        if (aActive !== bActive) return aActive ? -1 : 1
+        return b.tokens - a.tokens
+      })
+  }, [sessions, activeSessionId])
 
   return (
     <div className="sidebar-token-view" data-testid="sidebar-token-view">
@@ -323,6 +379,17 @@ export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
             {formatTokens(agg.totals.inputTokens)} · {formatTokens(agg.totals.outputTokens)}
           </span>
         </div>
+        {hitRatio !== null && (
+          <div className="sidebar-token-view-aggregate-row">
+            <span className="sidebar-token-view-label">Cache hit</span>
+            <span
+              className="sidebar-token-view-value-secondary"
+              data-testid="sidebar-token-view-cache-hit"
+            >
+              {formatPercent(hitRatio)}
+            </span>
+          </div>
+        )}
         {agg.totals.costUsd > 0 && (
           <div className="sidebar-token-view-aggregate-row">
             <span className="sidebar-token-view-label">
@@ -386,6 +453,59 @@ export function SidebarTokenView({ sessions }: SidebarTokenViewProps) {
           </ul>
         )}
       </div>
+
+      {sessionRows.length > 0 && (
+        <div className="sidebar-token-view-section" data-testid="sidebar-token-view-by-session">
+          <div className="sidebar-token-view-section-header">By session</div>
+          <ul className="sidebar-token-view-session-list">
+            {sessionRows.map(({ session, tokens, costUsd }) => {
+              const isActive = session.sessionId === activeSessionId
+              const tokensLabel = (
+                <span className="sidebar-token-view-session-tokens">
+                  {formatTokens(tokens)}
+                  {costUsd > 0 && (
+                    <span className="sidebar-token-view-provider-cost">
+                      {' '}({formatCostBadge(costUsd)})
+                    </span>
+                  )}
+                </span>
+              )
+              const rowClass = `sidebar-token-view-session-row${isActive ? ' active' : ''}`
+              const testId = `sidebar-token-view-session-${session.sessionId}`
+              // Click-to-activate parity with the sidebar tree (#4303). When no
+              // handler is supplied, render a static row instead of a button so
+              // we don't advertise an affordance that does nothing.
+              if (onSessionClick) {
+                return (
+                  <li key={session.sessionId}>
+                    <button
+                      type="button"
+                      className={rowClass}
+                      data-testid={testId}
+                      aria-current={isActive ? 'true' : undefined}
+                      onClick={() => onSessionClick(session.sessionId)}
+                    >
+                      <span className="sidebar-token-view-session-name">{session.name}</span>
+                      {tokensLabel}
+                    </button>
+                  </li>
+                )
+              }
+              return (
+                <li
+                  key={session.sessionId}
+                  className={rowClass}
+                  data-testid={testId}
+                  aria-current={isActive ? 'true' : undefined}
+                >
+                  <span className="sidebar-token-view-session-name">{session.name}</span>
+                  {tokensLabel}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1029,6 +1029,12 @@
   color: inherit;
   font: inherit;
   text-align: left;
+}
+
+/* Only the <button> variant (rendered when click-to-activate is wired) is
+ * interactive — the static <li> variant must NOT show a pointer cursor or a
+ * hover affordance, or it advertises a click that does nothing. */
+button.sidebar-token-view-session-row {
   cursor: pointer;
 }
 

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1002,6 +1002,62 @@
   font-size: 11px;
 }
 
+/* #4303 per-session breakdown. Rows are buttons when click-to-activate is
+ * wired (parity with the sidebar tree), so reset button chrome to match the
+ * provider-row layout. */
+.sidebar-token-view-session-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar-token-view-session-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+  font-size: 12px;
+  background: none;
+  border: 0;
+  padding: 2px 4px;
+  margin: 0;
+  border-radius: 4px;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+button.sidebar-token-view-session-row:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.06));
+}
+
+.sidebar-token-view-session-row.active {
+  background: var(--bg-selected, rgba(255, 255, 255, 0.1));
+  font-weight: 600;
+}
+
+.sidebar-token-view-session-row:focus-visible {
+  outline: 1px dotted var(--text-muted);
+  outline-offset: 2px;
+}
+
+.sidebar-token-view-session-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.sidebar-token-view-session-tokens {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
 .sidebar-status-dot {
   width: 6px;
   height: 6px;


### PR DESCRIPTION
## Summary

Builds on the merged slot + token-view v0 (#4304) to extend the token-usage view — the first occupant of the pluggable sidebar panel slot from #4303.

- **Cache-hit ratio** in the aggregate strip: `cacheRead / (input + cacheRead + cacheCreation)` — the visible signal of prompt-caching effectiveness. The pure `cacheHitRatio()` helper returns `null` (row hidden) when there's no input surface, so it never renders a misleading 0%.
- **Per-session breakdown** sorted by total tokens desc. Rows are **click-to-activate** (parity with the sidebar tree) when an `onSessionClick` handler is supplied, otherwise rendered as static `<li>`. The active session floats to the top and carries `aria-current`.
- claude-tui sessions stay excluded from the per-session list (decision #1 — no token counts to show).
- Wires `activeSessionId` + `onSessionClick` through the `Sidebar` view registry.

## Docs
- `docs/architecture/reference.md` gains a **"Sidebar panel slot"** section documenting the declarative `SidebarPanelView` registration shape and the token view as first occupant.
- CHANGELOG `Unreleased` entry added.

## Tests
- New pure-helper tests for `cacheHitRatio` (null when no input surface, output excluded from denominator, etc.).
- New render tests: cache-hit row show/hide, per-session sort, untracked exclusion, active-float + `aria-current`, button vs static row, click activation.
- 42 SidebarTokenView tests pass; full dashboard suite **2938 passing**; `tsc --noEmit` clean; css-audit clean.

## Scope note
#4303 was planned as a 3-PR effort; PR 1 (#4304) landed the slot infra + token view v0. This PR adds the cache-hit ratio and per-session breakdown criteria. The remaining server-heavy items (time-series `usage-history.json`, 7d/30d aggregates, sparkline, API-equiv cost toggle, per-tool drill-down) are tracked as follow-ups and noted in the issue's own PR-2/PR-3 plan.

Closes #4303