### PR TITLE
feat(server): K8s git-clone workspace strategy (phase 1)

### DIFF
--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -165,6 +165,195 @@ function validateWorkspacePVC(workspacePVC, cwd) {
   }
 }
 
+/** Default git image used by the clone init container — overridable via opts. */
+const DEFAULT_GIT_IMAGE = 'alpine/git:latest'
+
+/** Default mount path the workspace volume is exposed at inside the Pod. */
+const DEFAULT_WORKSPACE_MOUNT_PATH = '/workspace'
+
+/**
+ * Reject argv values that git would interpret as an option rather than a
+ * positional argument (argument-injection hardening, #3193).
+ *
+ * git-clone argv is NOT passed through a shell — the init container runs
+ * `command: ['git']` with an explicit `args` array — so classic shell
+ * metacharacter injection (`;`, `|`, `$()`, backticks) is structurally
+ * impossible. The residual risk is *argument* injection: a value beginning
+ * with `-` (e.g. `--upload-pack=…`, `--config=…`) would be parsed by git as a
+ * flag. We reject any value whose first character is `-`; the clone argv also
+ * uses `--` to terminate option parsing as belt-and-braces.
+ *
+ * @param {string} value
+ * @param {string} field - Field name for the error message
+ * @throws {Error} If the value starts with '-'
+ */
+function rejectGitOptionLike(value, field) {
+  if (typeof value === 'string' && value.startsWith('-')) {
+    throw new Error(
+      `createEnvironment: opts.gitRepo.${field} must not start with "-" ` +
+      '(rejected to prevent git argument injection)',
+    )
+  }
+}
+
+/**
+ * Validate + normalise `opts.gitRepo` for createEnvironment (#3193).
+ *
+ * The git-clone workspace strategy (Phase 1) provisions the Pod's workspace by
+ * cloning a repo into an `emptyDir` volume via an init container, instead of
+ * mounting a host path (`opts.cwd`) or referencing a pre-provisioned PVC
+ * (`opts.workspacePVC`). It is the K8s-native answer to "the pod is on a remote
+ * node and can't see the operator's filesystem" without requiring an
+ * out-of-band PVC seed step.
+ *
+ * Accepts:
+ *   - `undefined` / `null` — git-clone strategy not requested.
+ *   - A non-empty string — shorthand for `{ url: <string> }`.
+ *   - `{ url, branch?, commit?, depth?, mountPath? }` — `url` is required and
+ *     must be a non-empty string. `branch` / `commit` pin the checkout. `depth`
+ *     (positive integer) requests a shallow clone. `mountPath` overrides the
+ *     pod-side mount (default `/workspace`).
+ *
+ * Enforces mutual exclusion with the other two workspace strategies (`opts.cwd`
+ * and `opts.workspacePVC`): exactly one strategy may be chosen. The alternative
+ * — a silent precedence rule — would hide operator intent.
+ *
+ * branch + commit may both be supplied: git supports `clone --branch <branch>`
+ * followed by a `checkout <commit>`, so the clone fetches the branch tip and a
+ * second step pins the exact commit.
+ *
+ * @param {*} gitRepo - Raw opts.gitRepo value
+ * @param {*} cwd     - opts.cwd value (mutual-exclusion check)
+ * @param {*} workspacePVC - opts.workspacePVC value (mutual-exclusion check)
+ * @returns {{ url: string, branch: string|null, commit: string|null, depth: number|null, mountPath: string }|null}
+ *   Normalised descriptor, or null when no git-clone strategy was requested.
+ * @throws {Error} If the value is malformed or conflicts with another strategy.
+ */
+function validateGitRepo(gitRepo, cwd, workspacePVC) {
+  if (gitRepo == null) return null
+
+  // Normalise the string shorthand to the object form.
+  const spec = typeof gitRepo === 'string' ? { url: gitRepo } : gitRepo
+
+  if (typeof spec !== 'object' || Array.isArray(spec)) {
+    throw new Error(
+      'createEnvironment: opts.gitRepo must be a non-empty URL string or ' +
+      'an object with a url property',
+    )
+  }
+  if (typeof spec.url !== 'string' || spec.url.length === 0) {
+    throw new Error(
+      'createEnvironment: opts.gitRepo.url must be a non-empty string',
+    )
+  }
+  rejectGitOptionLike(spec.url, 'url')
+
+  if (spec.branch != null) {
+    if (typeof spec.branch !== 'string' || spec.branch.length === 0) {
+      throw new Error('createEnvironment: opts.gitRepo.branch must be a non-empty string')
+    }
+    rejectGitOptionLike(spec.branch, 'branch')
+  }
+
+  if (spec.commit != null) {
+    if (typeof spec.commit !== 'string' || spec.commit.length === 0) {
+      throw new Error('createEnvironment: opts.gitRepo.commit must be a non-empty string')
+    }
+    rejectGitOptionLike(spec.commit, 'commit')
+  }
+
+  let depth = null
+  if (spec.depth != null) {
+    if (!Number.isInteger(spec.depth) || spec.depth < 1) {
+      throw new Error('createEnvironment: opts.gitRepo.depth must be a positive integer')
+    }
+    depth = spec.depth
+  }
+
+  let mountPath = DEFAULT_WORKSPACE_MOUNT_PATH
+  if (spec.mountPath != null) {
+    if (typeof spec.mountPath !== 'string' || spec.mountPath.length === 0) {
+      throw new Error('createEnvironment: opts.gitRepo.mountPath must be a non-empty string')
+    }
+    mountPath = spec.mountPath
+  }
+
+  // Mutual exclusion with the other two strategies.
+  if (cwd != null && cwd !== '') {
+    throw new Error(
+      'createEnvironment: opts.cwd and opts.gitRepo are mutually exclusive — ' +
+      'choose exactly one workspace strategy (hostPath, PVC, or git-clone)',
+    )
+  }
+  if (workspacePVC != null) {
+    throw new Error(
+      'createEnvironment: opts.workspacePVC and opts.gitRepo are mutually exclusive — ' +
+      'choose exactly one workspace strategy (hostPath, PVC, or git-clone)',
+    )
+  }
+
+  return { url: spec.url, branch: spec.branch ?? null, commit: spec.commit ?? null, depth, mountPath }
+}
+
+/**
+ * Build the git-clone init container spec(s) for the git-clone workspace
+ * strategy (#3193).
+ *
+ * Each container runs `git` with an explicit argv array (never a shell string),
+ * cloning `descriptor.url` into the shared `emptyDir` workspace volume mounted
+ * at `descriptor.mountPath`. Branch / commit pinning and shallow depth are
+ * honoured:
+ *   - `--branch <branch>` checks out the named branch/tag at clone time.
+ *   - `--depth <n>` requests a shallow clone.
+ *   - `commit` pins the exact SHA via a SECOND init container running
+ *     `git -C <dir> checkout --detach <commit>`. K8s runs init containers
+ *     sequentially over the shared emptyDir, so the clone completes before the
+ *     checkout starts. Splitting into two containers keeps every value in an
+ *     argv slot — no shell is ever invoked, so neither the URL nor the SHA can
+ *     be interpreted as a command.
+ *
+ * @param {{ url: string, branch: string|null, commit: string|null, depth: number|null, mountPath: string }} descriptor
+ * @param {string} gitImage - Image providing the `git` binary
+ * @returns {Array<object>} One or two init container specs (clone, optional checkout)
+ */
+function buildGitCloneInitContainers(descriptor, gitImage) {
+  const { url, branch, commit, depth, mountPath } = descriptor
+
+  const cloneArgs = ['clone']
+  if (depth != null) {
+    cloneArgs.push('--depth', String(depth))
+  }
+  if (branch != null) {
+    cloneArgs.push('--branch', branch)
+  }
+  // `--` terminates option parsing so url/mountPath can never be read as flags.
+  cloneArgs.push('--', url, mountPath)
+
+  const volumeMount = { name: 'workspace', mountPath }
+
+  const containers = [{
+    name: 'git-clone',
+    image: gitImage,
+    command: ['git'],
+    args: cloneArgs,
+    volumeMounts: [volumeMount],
+  }]
+
+  if (commit != null) {
+    containers.push({
+      name: 'git-checkout',
+      image: gitImage,
+      command: ['git'],
+      // `-C <dir>` runs git in the cloned tree; `checkout --detach` pins the
+      // exact commit. `--` terminates option parsing before the SHA.
+      args: ['-C', mountPath, 'checkout', '--detach', '--', commit],
+      volumeMounts: [volumeMount],
+    })
+  }
+
+  return containers
+}
+
 /**
  * K8sBackend implements the Backend interface (see types.js) using the
  * Kubernetes API via @kubernetes/client-node.
@@ -204,6 +393,9 @@ export class K8sBackend {
    * @param {boolean} [opts.inCluster]                  - Force in-cluster auth (default: auto-detect via KUBERNETES_SERVICE_HOST)
    * @param {string}  [opts.kubeconfigPath]             - Path to kubeconfig file (overrides default search)
    * @param {string}  [opts.sidecarImage]               - Sidecar image to use in createEnvironment (default: chroxy-pod-agent:latest)
+   * @param {string}  [opts.gitImage]                   - Image providing `git` for the git-clone workspace
+   *   init container (default: alpine/git:latest). Used only when a createEnvironment call passes
+   *   `opts.gitRepo` (#3193).
    * @param {'Always'|'IfNotPresent'|'Never'} [opts.imagePullPolicy] - imagePullPolicy applied to all
    *   containers in the Pod spec. When unset the field is omitted and Kubernetes applies its own default
    *   ('Always' for :latest tags, 'IfNotPresent' otherwise). Set to 'IfNotPresent' for air-gapped
@@ -218,13 +410,14 @@ export class K8sBackend {
    * @param {Function} [opts._setTimeout]               - Override setTimeout for deterministic testing
    * @param {Function} [opts._clearTimeout]             - Override clearTimeout for deterministic testing
    */
-  constructor({ namespace, inCluster, kubeconfigPath, sidecarImage, imagePullPolicy,
+  constructor({ namespace, inCluster, kubeconfigPath, sidecarImage, gitImage, imagePullPolicy,
     connectMode, _coreV1Api, _portForward, _dialWs, _net,
     _reconnectDelays, _maxRetries, _maxStdinBufferBytes,
     _setTimeout: setTimeoutImpl, _clearTimeout: clearTimeoutImpl } = {}) {
     validateImagePullPolicy(imagePullPolicy, 'constructor opts')
     this._namespace = namespace ?? 'default'
     this._sidecarImage = sidecarImage ?? DEFAULT_SIDECAR_IMAGE
+    this._gitImage = gitImage ?? DEFAULT_GIT_IMAGE
     this._imagePullPolicy = imagePullPolicy ?? null
     this._connectMode = connectMode ?? 'portforward'
 
@@ -368,6 +561,21 @@ export class K8sBackend {
    *        - `opts.cwd` and `opts.workspacePVC` are mutually exclusive — passing
    *          both throws.  Operators must explicitly choose one strategy.
    *
+   * 3. git-clone (Phase 1, #3193) — pass `opts.gitRepo`:
+   *      `opts.gitRepo = { url, branch?, commit?, depth?, mountPath? }` (or a bare
+   *      URL string) provisions an ephemeral `emptyDir` workspace that a
+   *      `git clone` init container populates before the main container starts.
+   *      This is the K8s-native answer to "the Pod runs on a remote node that
+   *      can't see the operator's filesystem" without requiring an out-of-band
+   *      PVC seed step. Branch / commit pinning and shallow `depth` are honoured.
+   *      The git binary comes from the constructor `gitImage` (default
+   *      `alpine/git:latest`).
+   *
+   *      Persistence caveat: `emptyDir` is tied to the Pod lifecycle — when the
+   *      Pod is deleted the cloned tree is gone. PVC-backed persistence for the
+   *      git-clone strategy is the explicit follow-up (#3385); until then a
+   *      git-clone workspace is for ephemeral, single-Pod sessions only.
+   *
    * **Security warning — hostPath privilege escalation:**
    *   `hostPath` volumes (used for both `opts.cwd` and `opts.mounts`) give the
    *   Pod direct access to the underlying node's filesystem. This is a
@@ -400,6 +608,14 @@ export class K8sBackend {
    * @param {string}   opts.workspacePVC.claimName   - Name of a pre-provisioned PVC in the target namespace
    * @param {string}   [opts.workspacePVC.mountPath] - Pod-side mount path (default: `/workspace`)
    * @param {boolean}  [opts.workspacePVC.readOnly]  - Mount the PVC read-only (default: false)
+   * @param {string|Object} [opts.gitRepo]  - git-clone workspace strategy (#3193). A bare URL string is
+   *   shorthand for `{ url }`. Provisions an `emptyDir` workspace populated by a `git clone` init container.
+   *   Mutually exclusive with `opts.cwd` and `opts.workspacePVC` — passing more than one throws.
+   * @param {string}   opts.gitRepo.url        - Repo URL to clone (required; must not start with "-")
+   * @param {string}   [opts.gitRepo.branch]   - Branch/tag to check out at clone time (`--branch`)
+   * @param {string}   [opts.gitRepo.commit]   - Exact commit SHA to pin via a follow-up checkout init container
+   * @param {number}   [opts.gitRepo.depth]    - Positive integer for a shallow clone (`--depth`)
+   * @param {string}   [opts.gitRepo.mountPath] - Pod-side workspace mount path (default: `/workspace`)
    * @param {string}   [opts.image]        - Overrides the constructor sidecarImage
    * @param {string}   [opts.memoryLimit]  - K8s memory quantity string (e.g. "2Gi").
    *   Applied to both `resources.limits.memory` and `resources.requests.memory`.
@@ -429,14 +645,18 @@ export class K8sBackend {
       envId, cwd, containerEnv, namespace,
       memoryLimit, cpuLimit, forwardPorts, mounts,
       imagePullPolicy: callImagePullPolicy,
-      workspacePVC,
+      workspacePVC, gitRepo,
     } = opts
     validateImagePullPolicy(callImagePullPolicy, 'createEnvironment opts')
-    // Workspace-strategy validation (#3385): `opts.cwd` (hostPath) and
-    // `opts.workspacePVC` (PVC) are two competing strategies for what to mount
-    // at /workspace. Accept either, never both — the alternative would be
-    // a silent precedence rule that hides operator intent.
+    // Workspace-strategy validation: three mutually-exclusive strategies decide
+    // what backs /workspace:
+    //   - opts.cwd          → hostPath volume      (single-node clusters, #3316)
+    //   - opts.workspacePVC → persistentVolumeClaim (multi-node clusters, #3385)
+    //   - opts.gitRepo      → git-clone init container into an emptyDir (#3193)
+    // Accept exactly one — passing more than one throws. The alternative would
+    // be a silent precedence rule that hides operator intent.
     validateWorkspacePVC(workspacePVC, cwd)
+    const gitClone = validateGitRepo(gitRepo, cwd, workspacePVC)
     const ns = this._validateNamespace(this._resolveNamespace(namespace), 'createEnvironment')
     const podName = `chroxy-env-${envId}`
     const secretName = `chroxy-token-${envId}`
@@ -504,15 +724,32 @@ export class K8sBackend {
     const imagePullPolicy = callImagePullPolicy || this._imagePullPolicy
 
     // 4. Build volumes + volumeMounts
-    // 4a. Workspace volume — one of two mutually-exclusive strategies (#3385):
-    //   - `opts.cwd`          → hostPath volume (single-node clusters)
-    //   - `opts.workspacePVC` → persistentVolumeClaim volume (multi-node clusters)
+    // 4a. Workspace volume — one of three mutually-exclusive strategies:
+    //   - `opts.cwd`          → hostPath volume (single-node clusters, #3316)
+    //   - `opts.workspacePVC` → persistentVolumeClaim volume (multi-node clusters, #3385)
+    //   - `opts.gitRepo`      → emptyDir populated by a git-clone init container (#3193)
     //   See the createEnvironment JSDoc for the strategy comparison and migration
-    //   guidance. validateWorkspacePVC() above already rejected the both-set case.
+    //   guidance. The validators above already rejected any both-set combination.
     const volumes = []
     const volumeMounts = []
+    // Init containers populate the workspace before the main container starts
+    // (git-clone strategy). Empty for the other strategies.
+    const initContainers = []
 
-    if (workspacePVC) {
+    if (gitClone) {
+      // git-clone strategy: an emptyDir is shared between the clone init
+      // container(s) and the main container. The init container clones the repo
+      // into the emptyDir; the main container then sees the populated tree.
+      // emptyDir is ephemeral — PVC-backed persistence is the explicit
+      // follow-up (#3385); see the createEnvironment JSDoc.
+      volumes.push({ name: 'workspace', emptyDir: {} })
+      volumeMounts.push({ name: 'workspace', mountPath: gitClone.mountPath })
+      const cloneContainers = buildGitCloneInitContainers(gitClone, this._gitImage)
+      if (imagePullPolicy) {
+        for (const c of cloneContainers) c.imagePullPolicy = imagePullPolicy
+      }
+      initContainers.push(...cloneContainers)
+    } else if (workspacePVC) {
       const mountPath = workspacePVC.mountPath || '/workspace'
       volumes.push({
         name: 'workspace',
@@ -625,6 +862,10 @@ export class K8sBackend {
     const podSpec = {
       restartPolicy: 'Never',
       containers: [containerSpec],
+    }
+
+    if (initContainers.length > 0) {
+      podSpec.initContainers = initContainers
     }
 
     if (volumes.length > 0) {

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -275,6 +275,19 @@ function validateGitRepo(gitRepo, cwd, workspacePVC) {
     if (typeof spec.mountPath !== 'string' || spec.mountPath.length === 0) {
       throw new Error('createEnvironment: opts.gitRepo.mountPath must be a non-empty string')
     }
+    // K8s requires volumeMount.mountPath to be absolute; a relative value would
+    // be rejected at Pod-create time with an opaque API error. Reject `.`/`..`
+    // segments too so the path can't escape the intended workspace root.
+    if (!spec.mountPath.startsWith('/')) {
+      throw new Error(
+        'createEnvironment: opts.gitRepo.mountPath must be an absolute path (start with "/")',
+      )
+    }
+    if (spec.mountPath.split('/').some((seg) => seg === '.' || seg === '..')) {
+      throw new Error(
+        'createEnvironment: opts.gitRepo.mountPath must not contain "." or ".." segments',
+      )
+    }
     mountPath = spec.mountPath
   }
 
@@ -575,6 +588,14 @@ export class K8sBackend {
    *      Pod is deleted the cloned tree is gone. PVC-backed persistence for the
    *      git-clone strategy is the explicit follow-up (#3385); until then a
    *      git-clone workspace is for ephemeral, single-Pod sessions only.
+   *
+   *      mountPath caveat (#3193 phase 1): the default `mountPath` of
+   *      `/workspace` aligns with `streamCliInEnvironment`'s host→Pod cwd
+   *      remap, so exec sessions land on the cloned tree automatically. A
+   *      NON-default `mountPath` is supported in the Pod manifest, but the cwd
+   *      remap still targets `/workspace` — callers that override `mountPath`
+   *      must pass the matching `cwd` to `streamCliInEnvironment` themselves.
+   *      Per-Pod workspace-root tracking is left as follow-up.
    *
    * **Security warning — hostPath privilege escalation:**
    *   `hostPath` volumes (used for both `opts.cwd` and `opts.mounts`) give the

--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -71,8 +71,8 @@
  *   K8sBackend — Docker and other backends silently ignore this field. A bare URL string is shorthand
  *   for `{ url }`. K8sBackend provisions an `emptyDir` workspace populated by a `git clone` init
  *   container. Mutually exclusive with `opts.cwd` and `opts.workspacePVC` (passing more than one
- *   throws — see `K8sBackend.validateGitRepo`). `emptyDir` is ephemeral; PVC-backed persistence for
- *   the git-clone strategy is the follow-up (#3385).
+ *   throws — see the `validateGitRepo` helper in k8s.js). `emptyDir` is ephemeral; PVC-backed
+ *   persistence for the git-clone strategy is the follow-up (#3385).
  * @param {string}  opts.gitRepo.url        - Repo URL to clone (required; must not start with "-").
  * @param {string}  [opts.gitRepo.branch]   - Branch/tag checked out at clone time.
  * @param {string}  [opts.gitRepo.commit]   - Exact commit SHA pinned via a follow-up checkout step.

--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -67,6 +67,17 @@
  *   target namespace. Required when `workspacePVC` is set; must be a non-empty string.
  * @param {string}  [opts.workspacePVC.mountPath] - Pod-side mount path (default: `/workspace`).
  * @param {boolean} [opts.workspacePVC.readOnly]  - Mount the PVC read-only (default: false).
+ * @param {string|Object} [opts.gitRepo] - git-clone workspace strategy (#3193). Honoured only by
+ *   K8sBackend — Docker and other backends silently ignore this field. A bare URL string is shorthand
+ *   for `{ url }`. K8sBackend provisions an `emptyDir` workspace populated by a `git clone` init
+ *   container. Mutually exclusive with `opts.cwd` and `opts.workspacePVC` (passing more than one
+ *   throws — see `K8sBackend.validateGitRepo`). `emptyDir` is ephemeral; PVC-backed persistence for
+ *   the git-clone strategy is the follow-up (#3385).
+ * @param {string}  opts.gitRepo.url        - Repo URL to clone (required; must not start with "-").
+ * @param {string}  [opts.gitRepo.branch]   - Branch/tag checked out at clone time.
+ * @param {string}  [opts.gitRepo.commit]   - Exact commit SHA pinned via a follow-up checkout step.
+ * @param {number}  [opts.gitRepo.depth]    - Positive integer for a shallow clone.
+ * @param {string}  [opts.gitRepo.mountPath] - Pod-side workspace mount path (default: `/workspace`).
  * @returns {Promise<{ containerId: string, containerCliPath: string }>}
  *   containerId — the full container ID string returned by the runtime
  *   containerCliPath — absolute path inside the container where the CLI binary was installed

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1410,6 +1410,35 @@ describe('K8sBackend.createEnvironment() — git-clone workspace strategy (#3193
     }
   })
 
+  it('throws when gitRepo.mountPath is relative (must be absolute)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+    await assert.rejects(
+      () => backend.createEnvironment({
+        envId: 'rel-mountpath',
+        image: 'agent:latest',
+        gitRepo: { url: 'https://example.com/r.git', mountPath: 'src' },
+      }),
+      /mountPath must be an absolute path/,
+    )
+    assert.equal(api.calls.create.length, 0)
+  })
+
+  it('throws when gitRepo.mountPath contains "." or ".." segments', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+    for (const bad of ['/work/../etc', '/work/./x']) {
+      await assert.rejects(
+        () => backend.createEnvironment({
+          envId: 'dotdot-mountpath',
+          image: 'agent:latest',
+          gitRepo: { url: 'https://example.com/r.git', mountPath: bad },
+        }),
+        /must not contain "\." or "\.\." segments/,
+      )
+    }
+  })
+
   it('throws when both opts.cwd and opts.gitRepo are set (mutually exclusive)', async () => {
     const api = createMockApi()
     const backend = new K8sBackend({ _coreV1Api: api })

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1105,6 +1105,355 @@ describe('K8sBackend.createEnvironment() — PVC workspace strategy (#3385)', ()
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.createEnvironment — git-clone workspace strategy (#3193)
+//
+// Phase 1: provision the Pod workspace by cloning the repo into an emptyDir via
+// a git-clone init container, since a remote-node Pod can't bind-mount the
+// operator's host filesystem. PVC-backed persistence is the follow-up (#3385).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend.createEnvironment() — git-clone workspace strategy (#3193)', () => {
+  it('provisions an emptyDir workspace + a git-clone init container', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-test',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://github.com/example/repo.git' },
+    })
+
+    const { body } = api.calls.create[0]
+    const volumes = body.spec.volumes
+    const wsVol = volumes.find(v => v.name === 'workspace')
+    assert.ok(wsVol, 'must have a volume named "workspace"')
+    assert.deepEqual(wsVol.emptyDir, {}, 'git-clone workspace must be an emptyDir')
+    assert.equal(wsVol.hostPath, undefined, 'git-clone workspace must NOT set hostPath')
+    assert.equal(wsVol.persistentVolumeClaim, undefined, 'git-clone workspace must NOT set a PVC')
+
+    const initContainers = body.spec.initContainers
+    assert.ok(Array.isArray(initContainers), 'spec.initContainers must be an array')
+    assert.equal(initContainers.length, 1, 'no commit pin → single clone init container')
+    const clone = initContainers[0]
+    assert.equal(clone.name, 'git-clone')
+    assert.deepEqual(clone.command, ['git'])
+    assert.deepEqual(
+      clone.args,
+      ['clone', '--', 'https://github.com/example/repo.git', '/workspace'],
+    )
+    const cloneMount = clone.volumeMounts.find(m => m.name === 'workspace')
+    assert.ok(cloneMount, 'init container must mount the workspace volume')
+    assert.equal(cloneMount.mountPath, '/workspace')
+  })
+
+  it('the main container also mounts the cloned workspace at /workspace', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-main-mount',
+      image: 'agent:latest',
+      gitRepo: 'https://github.com/example/repo.git', // string shorthand
+    })
+
+    const mounts = api.calls.create[0].body.spec.containers[0].volumeMounts
+    const wsMount = mounts.find(m => m.name === 'workspace')
+    assert.ok(wsMount, 'main container must mount the workspace volume')
+    assert.equal(wsMount.mountPath, '/workspace')
+  })
+
+  it('accepts a bare URL string as shorthand for { url }', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-shorthand',
+      image: 'agent:latest',
+      gitRepo: 'git@github.com:example/repo.git',
+    })
+
+    const clone = api.calls.create[0].body.spec.initContainers[0]
+    assert.deepEqual(clone.args, ['clone', '--', 'git@github.com:example/repo.git', '/workspace'])
+  })
+
+  it('honours branch pinning via --branch', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-branch',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://example.com/r.git', branch: 'develop' },
+    })
+
+    const clone = api.calls.create[0].body.spec.initContainers[0]
+    assert.deepEqual(
+      clone.args,
+      ['clone', '--branch', 'develop', '--', 'https://example.com/r.git', '/workspace'],
+    )
+  })
+
+  it('honours shallow depth via --depth', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-depth',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://example.com/r.git', depth: 1 },
+    })
+
+    const clone = api.calls.create[0].body.spec.initContainers[0]
+    assert.deepEqual(
+      clone.args,
+      ['clone', '--depth', '1', '--', 'https://example.com/r.git', '/workspace'],
+    )
+  })
+
+  it('pins an exact commit via a second checkout init container', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-commit',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://example.com/r.git', commit: 'deadbeef' },
+    })
+
+    const initContainers = api.calls.create[0].body.spec.initContainers
+    assert.equal(initContainers.length, 2, 'commit pin → clone + checkout init containers')
+    assert.equal(initContainers[0].name, 'git-clone')
+    const checkout = initContainers[1]
+    assert.equal(checkout.name, 'git-checkout')
+    assert.deepEqual(checkout.command, ['git'])
+    assert.deepEqual(
+      checkout.args,
+      ['-C', '/workspace', 'checkout', '--detach', '--', 'deadbeef'],
+    )
+    const checkoutMount = checkout.volumeMounts.find(m => m.name === 'workspace')
+    assert.ok(checkoutMount)
+    assert.equal(checkoutMount.mountPath, '/workspace')
+  })
+
+  it('combines branch + commit (clone branch tip, then pin commit)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-branch-commit',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://example.com/r.git', branch: 'main', commit: 'abc123' },
+    })
+
+    const initContainers = api.calls.create[0].body.spec.initContainers
+    assert.deepEqual(
+      initContainers[0].args,
+      ['clone', '--branch', 'main', '--', 'https://example.com/r.git', '/workspace'],
+    )
+    assert.deepEqual(
+      initContainers[1].args,
+      ['-C', '/workspace', 'checkout', '--detach', '--', 'abc123'],
+    )
+  })
+
+  it('honours a custom mountPath for clone, main mount, and checkout', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-mountpath',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://example.com/r.git', commit: 'c0ffee', mountPath: '/src' },
+    })
+
+    const { body } = api.calls.create[0]
+    assert.equal(
+      body.spec.containers[0].volumeMounts.find(m => m.name === 'workspace').mountPath,
+      '/src',
+    )
+    assert.deepEqual(
+      body.spec.initContainers[0].args,
+      ['clone', '--', 'https://example.com/r.git', '/src'],
+    )
+    assert.deepEqual(
+      body.spec.initContainers[1].args,
+      ['-C', '/src', 'checkout', '--detach', '--', 'c0ffee'],
+    )
+  })
+
+  it('uses the constructor gitImage for init containers', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api, gitImage: 'my-registry/git:2.44' })
+
+    await backend.createEnvironment({
+      envId: 'git-image',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://example.com/r.git', commit: 'x' },
+    })
+
+    const initContainers = api.calls.create[0].body.spec.initContainers
+    assert.equal(initContainers[0].image, 'my-registry/git:2.44')
+    assert.equal(initContainers[1].image, 'my-registry/git:2.44')
+  })
+
+  it('defaults the git image to alpine/git:latest', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-default-image',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://example.com/r.git' },
+    })
+
+    assert.equal(
+      api.calls.create[0].body.spec.initContainers[0].image,
+      'alpine/git:latest',
+    )
+  })
+
+  it('propagates imagePullPolicy to init containers', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api, imagePullPolicy: 'IfNotPresent' })
+
+    await backend.createEnvironment({
+      envId: 'git-pull-policy',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://example.com/r.git', commit: 'x' },
+    })
+
+    const initContainers = api.calls.create[0].body.spec.initContainers
+    assert.equal(initContainers[0].imagePullPolicy, 'IfNotPresent')
+    assert.equal(initContainers[1].imagePullPolicy, 'IfNotPresent')
+  })
+
+  it('git-clone workspace coexists with extra opts.mounts', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'git-plus-mounts',
+      image: 'agent:latest',
+      gitRepo: { url: 'https://example.com/r.git' },
+      mounts: ['/host/certs:/certs:ro'],
+    })
+
+    const volumes = api.calls.create[0].body.spec.volumes
+    assert.ok(volumes.find(v => v.name === 'workspace' && v.emptyDir))
+    assert.ok(volumes.find(v => v.name === 'extra-vol-0' && v.hostPath?.path === '/host/certs'))
+    assert.equal(volumes.length, 2)
+  })
+
+  // ─── Validation / mutual exclusion ───────────────────────────────────────
+
+  it('throws when gitRepo.url is missing', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+    await assert.rejects(
+      () => backend.createEnvironment({ envId: 'no-url', image: 'agent:latest', gitRepo: {} }),
+      /gitRepo\.url must be a non-empty string/,
+    )
+    assert.equal(api.calls.create.length, 0, 'no Pod created on validation failure')
+  })
+
+  it('throws when gitRepo.url starts with "-" (argument injection guard)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+    await assert.rejects(
+      () => backend.createEnvironment({
+        envId: 'inject-url',
+        image: 'agent:latest',
+        gitRepo: { url: '--upload-pack=touch /tmp/pwned' },
+      }),
+      /must not start with "-"/,
+    )
+  })
+
+  it('throws when gitRepo.branch starts with "-"', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+    await assert.rejects(
+      () => backend.createEnvironment({
+        envId: 'inject-branch',
+        image: 'agent:latest',
+        gitRepo: { url: 'https://example.com/r.git', branch: '--config=core.fsmonitor=evil' },
+      }),
+      /branch must not start with "-"/,
+    )
+  })
+
+  it('throws when gitRepo.commit starts with "-"', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+    await assert.rejects(
+      () => backend.createEnvironment({
+        envId: 'inject-commit',
+        image: 'agent:latest',
+        gitRepo: { url: 'https://example.com/r.git', commit: '--evil' },
+      }),
+      /commit must not start with "-"/,
+    )
+  })
+
+  it('throws when gitRepo.depth is not a positive integer', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+    for (const bad of [0, -1, 1.5, '1']) {
+      await assert.rejects(
+        () => backend.createEnvironment({
+          envId: 'bad-depth',
+          image: 'agent:latest',
+          gitRepo: { url: 'https://example.com/r.git', depth: bad },
+        }),
+        /depth must be a positive integer/,
+      )
+    }
+  })
+
+  it('throws when both opts.cwd and opts.gitRepo are set (mutually exclusive)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+    await assert.rejects(
+      () => backend.createEnvironment({
+        envId: 'cwd-and-git',
+        image: 'agent:latest',
+        cwd: '/home/user/proj',
+        gitRepo: { url: 'https://example.com/r.git' },
+      }),
+      /cwd and opts\.gitRepo are mutually exclusive/,
+    )
+    assert.equal(api.calls.create.length, 0)
+  })
+
+  it('throws when both opts.workspacePVC and opts.gitRepo are set (mutually exclusive)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+    await assert.rejects(
+      () => backend.createEnvironment({
+        envId: 'pvc-and-git',
+        image: 'agent:latest',
+        workspacePVC: { claimName: 'my-pvc' },
+        gitRepo: { url: 'https://example.com/r.git' },
+      }),
+      /workspacePVC and opts\.gitRepo are mutually exclusive/,
+    )
+    assert.equal(api.calls.create.length, 0)
+  })
+
+  it('omits initContainers when no git-clone strategy is requested', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'no-git', image: 'agent:latest' })
+
+    assert.equal(
+      api.calls.create[0].body.spec.initContainers, undefined,
+      'initContainers must be absent without a git-clone strategy',
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
 // K8sBackend.createEnvironment — resource limits (#3316)
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Implements the **git-clone workspace strategy (Phase 1)** for `K8sBackend`, part of the Rancher/K8s orchestration epic (#2450).

A K8s Pod runs on a remote node and can't bind-mount the operator's host filesystem the way the Docker backend does. Phase 1 provisions the Pod's workspace by **cloning the repo into an ephemeral `emptyDir`** via a `git clone` init container, then mounting that volume into the main container at `/workspace`.

### What's added
- `opts.gitRepo` on `K8sBackend.createEnvironment` — a bare URL string (shorthand for `{ url }`) or `{ url, branch?, commit?, depth?, mountPath? }`.
- An `emptyDir` `workspace` volume mounted at `/workspace` (or a custom `mountPath`) in both the init container(s) and the main container, so exec sessions chdir to `/workspace` over the cloned tree.
- **Branch pinning** via `git clone --branch`; **shallow clone** via `--depth`.
- **Exact commit pinning** via a second `git checkout --detach` init container (init containers run sequentially over the shared `emptyDir`, so the clone completes first).
- **Mutual exclusion** with `opts.cwd` (hostPath) and `opts.workspacePVC` — passing more than one strategy throws, so operator intent is never silently overridden.
- Constructor `gitImage` option (default `alpine/git:latest`); `imagePullPolicy` propagates to init containers.

### Security
Every value is passed as an **argv token** — the init container runs `command: ['git']` with an explicit `args` array, so there is no shell and classic metacharacter injection is structurally impossible. The residual *argument*-injection vector (a value beginning with `-` that git would parse as a flag, e.g. `--upload-pack=…`) is rejected, and the argv uses `--` to terminate git option parsing as belt-and-braces.

### Tests
20 new unit tests against the injected `CoreV1Api` (no real cluster): manifest/argv construction for clone, branch, depth, commit (two init containers), branch+commit, custom mountPath, gitImage, imagePullPolicy propagation, coexistence with extra mounts, string shorthand, and all validation / mutual-exclusion / argument-injection guards. Full backend + manager suite: 400 passing. `lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`, and eslint all clean.

### Acceptance criteria (#3193)
- [x] `createEnvironment(spec)` accepts `gitRepo`
- [x] Pod init container runs `git clone <gitRepo> /workspace`
- [x] Subsequent exec sessions chdir to `/workspace` (workspace volume mounted there in the main container; existing `streamCliInEnvironment` cwd remap unchanged)
- [x] Branch / commit pinning supported in spec
- [x] Tests: mocked git-clone init container creation

### Not in this PR
- **PVC-backed persistence for the git-clone strategy** is the explicit follow-up (#3385). `emptyDir` is ephemeral, so a git-clone workspace is single-Pod only for now — documented in the `createEnvironment` JSDoc.
- No real-cluster validation was performed (no cluster available); everything is exercised against an injected K8s API. The argv/manifest construction, branch/commit/depth logic, mutual exclusion, and error handling are fully unit-tested. Live `git clone` behaviour inside a scheduled Pod remains for cluster validation.

Closes #3193