### PR TITLE
feat(server): K8s resource quotas (CPU/mem requests & limits)

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -314,6 +314,54 @@ the per-call value always wins. With no caller override and no config block,
 the manager omits the field entirely and the K8s backend falls back to the
 `hostPath` strategy (single-node clusters).
 
+### Kubernetes resource quotas (CPU / memory requests & limits)
+
+When the K8s environment backend is active, every Pod it creates carries CPU and
+memory **requests** (what the scheduler reserves and the pod is guaranteed) and
+**limits** (the hard ceiling enforced by the kernel/cgroup). This keeps a single
+runaway session from starving the node (`#3195`).
+
+If a `createEnvironment` call does not specify resources, the backend applies
+these built-in defaults:
+
+| Dimension | Request | Limit |
+|-----------|---------|-------|
+| CPU       | `500m`  | `2`   |
+| Memory    | `512Mi` | `4Gi` |
+
+All values are standard [Kubernetes resource quantities](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/):
+CPU as a decimal number or milli-cpu (`500m`, `1`, `2`), memory as a binary-SI
+quantity (`512Mi`, `2Gi`) or bytes. Docker-style memory suffixes (`512m`, `2g`)
+are normalised to their binary-SI equivalents (`512Mi`, `2Gi`). Malformed
+quantities are rejected before any Pod or Secret is created.
+
+Per-create callers can override any field via the structured `resources` opt:
+
+```js
+await environmentManager.create({
+  name: 'big-build',
+  cwd: '/path/to/project',
+  resources: {
+    cpu: '1',          // requests.cpu
+    memory: '1Gi',     // requests.memory
+    cpuLimit: '4',     // limits.cpu
+    memoryLimit: '8Gi' // limits.memory
+  },
+})
+```
+
+Unset fields fall back to the legacy flat `memoryLimit`/`cpuLimit` opts (applied
+to both the request and the limit for that dimension) and then to the defaults
+above. The structured `resources` opt always wins where both are present.
+
+Docker and other non-K8s backends ignore the `resources` opt entirely.
+
+Operators can also change the cluster-wide defaults when constructing the
+backend: pass `defaultResources` as a partial `{ cpu, memory, cpuLimit,
+memoryLimit }` object (merged over the built-ins) to raise/lower them, or
+`defaultResources: null` to disable defaults so only explicit per-call values
+produce a `resources` block.
+
 ## Examples
 
 ### Using Config File Only

--- a/packages/server/src/environment-manager.js
+++ b/packages/server/src/environment-manager.js
@@ -105,6 +105,11 @@ export class EnvironmentManager extends EventEmitter {
    * @param {string} [opts.image] - Docker image (default: node:22-slim)
    * @param {string} [opts.memoryLimit] - Memory limit (default: 2g)
    * @param {string} [opts.cpuLimit] - CPU limit (default: 2)
+   * @param {Object} [opts.resources] - K8s-only: structured resource requests/limits
+   *   `{ cpu, memory, cpuLimit, memoryLimit }` (#3195). Forwarded verbatim to the backend;
+   *   only K8sBackend acts on it (DockerBackend and others ignore it). On K8s these values
+   *   take precedence over the flat `memoryLimit`/`cpuLimit` above; unset fields fall back to
+   *   the backend's configured defaults.
    * @param {string} [opts.containerUser] - Non-root user (default: chroxy)
    * @param {Object} [opts.workspacePVC] - K8s-only: mount a pre-provisioned
    *   PersistentVolumeClaim as the workspace instead of the host `cwd` directory.
@@ -120,7 +125,7 @@ export class EnvironmentManager extends EventEmitter {
    *   for any future dashboard/CLI input).
    * @returns {Promise<Object>} The created environment object
    */
-  async create({ name, cwd, image, memoryLimit, cpuLimit, containerUser, compose, primaryService, devcontainer, workspacePVC } = {}) {
+  async create({ name, cwd, image, memoryLimit, cpuLimit, resources, containerUser, compose, primaryService, devcontainer, workspacePVC } = {}) {
     if (!name?.trim()) throw new Error('Environment name is required')
     if (!cwd?.trim()) throw new Error('Environment cwd is required')
 
@@ -168,6 +173,10 @@ export class EnvironmentManager extends EventEmitter {
       image: resolvedImage,
       memoryLimit: resolvedMemory,
       cpuLimit: resolvedCpu,
+      // #3195: structured K8s resource requests/limits, forwarded verbatim.
+      // Only K8sBackend acts on it; the manager does no shape validation
+      // (that lives in K8sBackend.buildResourceBlock). undefined → backend defaults.
+      resources,
       containerUser: user,
       containerEnv: validatedEnv,
       forwardPorts: dcConfig.forwardPorts,

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -608,8 +608,16 @@ export class K8sBackend {
     } else if (typeof defaultResources === 'object' && !Array.isArray(defaultResources)) {
       const merged = { ...DEFAULT_RESOURCES, ...defaultResources }
       // Reuse the per-call builder purely to validate the merged quantities
-      // (defaults disabled so only the merged object is validated).
-      buildResourceBlock(merged, undefined, undefined, null)
+      // (defaults disabled so only the merged object is validated). Re-scope
+      // any failure to opts.defaultResources — buildResourceBlock blames
+      // `resources.*`/`createEnvironment`, which points at the wrong call
+      // site for constructor config (#3195 review) — preserving the
+      // underlying error as `cause`.
+      try {
+        buildResourceBlock(merged, undefined, undefined, null)
+      } catch (err) {
+        throw new Error(`K8sBackend: opts.defaultResources is invalid — ${err.message}`, { cause: err })
+      }
       this._defaultResources = merged
     } else {
       throw new TypeError('K8sBackend: opts.defaultResources must be an object or null')
@@ -2693,8 +2701,9 @@ function _validateResourceQuantity(value, kind, field) {
  *      disable defaults so only explicit per-call values produce a block.
  *
  * Every resolved quantity is validated against the K8s quantity grammar; an
- * invalid string throws before any API call so a bad value never leaks a
- * half-provisioned Secret.
+ * invalid string throws before the Pod/Secret are created — `createEnvironment`
+ * awaits `ensureNamespace()` first, so the tenant namespace may already exist,
+ * but no workload is provisioned with a bad value.
  *
  * @param {Object} [resources]            - opts.resources (structured form)
  * @param {string} [legacyCpuLimit]       - opts.cpuLimit (flat form)
@@ -2702,6 +2711,13 @@ function _validateResourceQuantity(value, kind, field) {
  * @param {Object|null} [defaults=DEFAULT_RESOURCES] - Per-field defaults, or null to disable
  * @returns {{ requests?: Object, limits?: Object }} A resources block (possibly empty)
  */
+function _resolveResourceField(structured, structuredLabel, legacy, legacyLabel, dflt, defaultLabel) {
+  if (structured != null) return { value: structured, field: structuredLabel }
+  if (legacy != null) return { value: legacy, field: legacyLabel }
+  if (dflt != null) return { value: dflt, field: defaultLabel }
+  return { value: null, field: null }
+}
+
 export function buildResourceBlock(resources, legacyCpuLimit, legacyMemoryLimit, defaults = DEFAULT_RESOURCES) {
   if (resources != null && (typeof resources !== 'object' || Array.isArray(resources))) {
     throw new Error('createEnvironment: opts.resources must be an object')
@@ -2709,18 +2725,22 @@ export function buildResourceBlock(resources, legacyCpuLimit, legacyMemoryLimit,
   const r = resources || {}
   const d = defaults || {}
 
-  // Resolve each of the four dimensions through the precedence chain.
-  const cpuRequest = r.cpu ?? legacyCpuLimit ?? d.cpu
-  const memRequest = r.memory ?? legacyMemoryLimit ?? d.memory
-  const cpuLimit = r.cpuLimit ?? legacyCpuLimit ?? d.cpuLimit
-  const memLimit = r.memoryLimit ?? legacyMemoryLimit ?? d.memoryLimit
+  // Resolve each of the four dimensions through the precedence chain,
+  // tracking which source actually supplied the value so a validation
+  // failure names the option the operator set (#3195 review) — the legacy
+  // flat opt or a constructor default — instead of always blaming
+  // `resources.*`.
+  const cpuRequest = _resolveResourceField(r.cpu, 'resources.cpu', legacyCpuLimit, 'cpuLimit', d.cpu, 'defaultResources.cpu')
+  const memRequest = _resolveResourceField(r.memory, 'resources.memory', legacyMemoryLimit, 'memoryLimit', d.memory, 'defaultResources.memory')
+  const cpuLimit = _resolveResourceField(r.cpuLimit, 'resources.cpuLimit', legacyCpuLimit, 'cpuLimit', d.cpuLimit, 'defaultResources.cpuLimit')
+  const memLimit = _resolveResourceField(r.memoryLimit, 'resources.memoryLimit', legacyMemoryLimit, 'memoryLimit', d.memoryLimit, 'defaultResources.memoryLimit')
 
   const requests = {}
   const limits = {}
-  if (cpuRequest != null) requests.cpu = _validateResourceQuantity(cpuRequest, 'cpu', 'resources.cpu')
-  if (memRequest != null) requests.memory = _validateResourceQuantity(memRequest, 'memory', 'resources.memory')
-  if (cpuLimit != null) limits.cpu = _validateResourceQuantity(cpuLimit, 'cpu', 'resources.cpuLimit')
-  if (memLimit != null) limits.memory = _validateResourceQuantity(memLimit, 'memory', 'resources.memoryLimit')
+  if (cpuRequest.value != null) requests.cpu = _validateResourceQuantity(cpuRequest.value, 'cpu', cpuRequest.field)
+  if (memRequest.value != null) requests.memory = _validateResourceQuantity(memRequest.value, 'memory', memRequest.field)
+  if (cpuLimit.value != null) limits.cpu = _validateResourceQuantity(cpuLimit.value, 'cpu', cpuLimit.field)
+  if (memLimit.value != null) limits.memory = _validateResourceQuantity(memLimit.value, 'memory', memLimit.field)
 
   const block = {}
   if (Object.keys(requests).length > 0) block.requests = requests

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -32,6 +32,29 @@ const DEFAULT_SIDECAR_IMAGE = 'chroxy-pod-agent:latest'
 const AGENT_PORT = 7681
 
 /**
+ * Default resource requests/limits applied to the sidecar container when a
+ * createEnvironment call does not specify its own (#3195).
+ *
+ * Requests are what the scheduler reserves (and what the pod is guaranteed);
+ * limits are the hard ceiling the kernel/cgroup enforces. The defaults keep a
+ * single runaway session from starving the node while leaving generous
+ * headroom for a real Claude Code workload:
+ *   - request 500m CPU / 512Mi memory — modest reservation so several
+ *     environments can be packed onto one node.
+ *   - limit   2 CPU  / 4Gi  memory — a session may burst well above its
+ *     request but is capped before it can consume the whole node.
+ *
+ * Operators override any field per-call via `opts.resources` (or the legacy
+ * `opts.memoryLimit`/`opts.cpuLimit`); see createEnvironment's JSDoc.
+ */
+export const DEFAULT_RESOURCES = Object.freeze({
+  cpu: '500m',
+  memory: '512Mi',
+  cpuLimit: '2',
+  memoryLimit: '4Gi',
+})
+
+/**
  * Default container CLI path — used to remap the host's absolute cli.js path
  * (passed by the SDK as args[0]) to a path that exists inside the Pod.
  * Mirrors DEFAULT_CONTAINER_CLI_PATH in docker.js.
@@ -538,6 +561,12 @@ export class K8sBackend {
    *   containers in the Pod spec. When unset the field is omitted and Kubernetes applies its own default
    *   ('Always' for :latest tags, 'IfNotPresent' otherwise). Set to 'IfNotPresent' for air-gapped
    *   clusters or local kind-based CI where images are loaded directly into the cluster.
+   * @param {Object|null} [opts.defaultResources] - Cluster-wide default resource requests/limits
+   *   applied to the sidecar container when a createEnvironment call does not override them (#3195).
+   *   Same shape as `createEnvironment`'s `opts.resources` (`{ cpu, memory, cpuLimit, memoryLimit }`).
+   *   An object is merged over the built-in {@link DEFAULT_RESOURCES} (so partial overrides are fine)
+   *   and validated at construction. Pass `null` to disable defaults entirely — then only explicit
+   *   per-call resource values produce a `resources` block. Omit to use the built-in defaults.
    * @param {'portforward'|'clusterip'} [opts.connectMode='portforward'] - How to reach the sidecar
    * @param {object}  [opts._coreV1Api]                 - Injected CoreV1Api for testing
    * @param {object}  [opts._portForward]               - Injected PortForward for testing
@@ -549,7 +578,7 @@ export class K8sBackend {
    * @param {Function} [opts._clearTimeout]             - Override clearTimeout for deterministic testing
    */
   constructor({ namespace, namespaceFor, inCluster, kubeconfigPath, sidecarImage, gitImage, imagePullPolicy,
-    connectMode, _coreV1Api, _portForward, _dialWs, _net,
+    defaultResources, connectMode, _coreV1Api, _portForward, _dialWs, _net,
     _reconnectDelays, _maxRetries, _maxStdinBufferBytes,
     _setTimeout: setTimeoutImpl, _clearTimeout: clearTimeoutImpl } = {}) {
     validateImagePullPolicy(imagePullPolicy, 'constructor opts')
@@ -566,6 +595,25 @@ export class K8sBackend {
     this._sidecarImage = sidecarImage ?? DEFAULT_SIDECAR_IMAGE
     this._gitImage = gitImage ?? DEFAULT_GIT_IMAGE
     this._imagePullPolicy = imagePullPolicy ?? null
+    // Default resource requests/limits applied to the sidecar container (#3195).
+    //   - undefined → use the module DEFAULT_RESOURCES
+    //   - an object → merge over DEFAULT_RESOURCES (operator-set cluster-wide defaults)
+    //   - null      → disable defaults entirely (only explicit per-call values apply)
+    // Validate any object form up-front so a malformed quantity surfaces at
+    // construction rather than at the first createEnvironment call.
+    if (defaultResources === null) {
+      this._defaultResources = null
+    } else if (defaultResources === undefined) {
+      this._defaultResources = { ...DEFAULT_RESOURCES }
+    } else if (typeof defaultResources === 'object' && !Array.isArray(defaultResources)) {
+      const merged = { ...DEFAULT_RESOURCES, ...defaultResources }
+      // Reuse the per-call builder purely to validate the merged quantities
+      // (defaults disabled so only the merged object is validated).
+      buildResourceBlock(merged, undefined, undefined, null)
+      this._defaultResources = merged
+    } else {
+      throw new TypeError('K8sBackend: opts.defaultResources must be an object or null')
+    }
     this._connectMode = connectMode ?? 'portforward'
 
     if (_coreV1Api) {
@@ -869,11 +917,24 @@ export class K8sBackend {
    * @param {number}   [opts.gitRepo.depth]    - Positive integer for a shallow clone (`--depth`)
    * @param {string}   [opts.gitRepo.mountPath] - Pod-side workspace mount path (default: `/workspace`)
    * @param {string}   [opts.image]        - Overrides the constructor sidecarImage
-   * @param {string}   [opts.memoryLimit]  - K8s memory quantity string (e.g. "2Gi").
-   *   Applied to both `resources.limits.memory` and `resources.requests.memory`.
+   * @param {Object}   [opts.resources]    - Structured resource requests/limits (#3195).
+   *   All four fields are optional K8s quantity strings, validated before any API call:
+   *     - `resources.cpu`         → `resources.requests.cpu`    (e.g. "500m", "1")
+   *     - `resources.memory`      → `resources.requests.memory` (e.g. "512Mi", "1Gi")
+   *     - `resources.cpuLimit`    → `resources.limits.cpu`      (e.g. "2")
+   *     - `resources.memoryLimit` → `resources.limits.memory`   (e.g. "4Gi")
+   *   Unset fields fall back to the legacy flat opts (below), then to the
+   *   constructor `defaultResources` (default {@link DEFAULT_RESOURCES}). Pass the
+   *   constructor `defaultResources: null` to omit defaults entirely.
+   * @param {string}   [opts.memoryLimit]  - Legacy flat K8s memory quantity string (e.g. "2Gi").
+   *   Applied to BOTH `resources.limits.memory` and `resources.requests.memory` for the
+   *   memory dimension (pre-#3195 behaviour). Superseded by `opts.resources.memory` /
+   *   `opts.resources.memoryLimit` when those are set.
    *   Accepts Docker-style suffixes ("g"/"m") and standard K8s suffixes ("Gi"/"Mi").
-   * @param {string}   [opts.cpuLimit]     - K8s CPU quantity string (e.g. "2" or "500m").
-   *   Applied to both `resources.limits.cpu` and `resources.requests.cpu`.
+   * @param {string}   [opts.cpuLimit]     - Legacy flat K8s CPU quantity string (e.g. "2" or "500m").
+   *   Applied to BOTH `resources.limits.cpu` and `resources.requests.cpu` for the CPU
+   *   dimension (pre-#3195 behaviour). Superseded by `opts.resources.cpu` /
+   *   `opts.resources.cpuLimit` when those are set.
    *   A plain integer or float (e.g. "2", "0.5") is valid K8s CPU quantity syntax.
    * @param {number[]|string[]} [opts.forwardPorts] - Extra ports to expose from the container
    *   (in addition to the built-in AGENT_PORT).  Each value may be a bare port number
@@ -902,7 +963,7 @@ export class K8sBackend {
   async createEnvironment(opts) {
     const {
       envId, cwd, containerEnv, namespace, userId, projectId,
-      memoryLimit, cpuLimit, forwardPorts, mounts,
+      memoryLimit, cpuLimit, resources: callResources, forwardPorts, mounts,
       imagePullPolicy: callImagePullPolicy,
       workspacePVC, gitRepo,
     } = opts
@@ -938,6 +999,14 @@ export class K8sBackend {
         parsedMounts.push(_parseMountString(mounts[i]))
       }
     }
+
+    // Build + validate the resources block up-front too (#3195). A malformed
+    // quantity throws here, BEFORE the Secret/Pod create, so a bad value never
+    // leaks a half-provisioned Secret. Defaults are applied unless the operator
+    // disabled them (constructor `defaultResources: null`).
+    const resources = buildResourceBlock(
+      callResources, cpuLimit, memoryLimit, this._defaultResources,
+    )
 
     // 1. Generate per-Pod auth token
     const agentToken = randomBytes(32).toString('base64url')
@@ -1068,27 +1137,9 @@ export class K8sBackend {
       }
     }
 
-    // 6. Build resource limits/requests.
-    //    Convert Docker-style suffixes (g → Gi, m → Mi) to K8s quantity strings.
-    //    A plain integer/float string (e.g. "2", "0.5") is already valid K8s CPU syntax.
-    //    Note: the g→Gi / m→Mi mapping errs generous (~7 % / ~5 % over SI).
-    //    See _normaliseMemoryQuantity JSDoc for details.
-    const resources = {}
-    if (memoryLimit || cpuLimit) {
-      const limits = {}
-      const requests = {}
-      if (memoryLimit) {
-        const mem = _normaliseMemoryQuantity(memoryLimit)
-        limits.memory = mem
-        requests.memory = mem
-      }
-      if (cpuLimit) {
-        limits.cpu = String(cpuLimit)
-        requests.cpu = String(cpuLimit)
-      }
-      resources.limits = limits
-      resources.requests = requests
-    }
+    // 6. Resources block (requests/limits) was built + validated up-front in
+    //    step 0 (`resources`). See buildResourceBlock for the precedence rules
+    //    and DEFAULT_RESOURCES for the defaults (#3195).
 
     // 7. Assemble container spec
     const containerSpec = {
@@ -2579,4 +2630,100 @@ function _normaliseMemoryQuantity(value) {
     const map = { g: 'Gi', G: 'Gi', m: 'Mi', M: 'Mi', k: 'Ki', K: 'Ki' }
     return num + (map[unit] || unit)
   })
+}
+
+// Valid Kubernetes CPU quantity: a plain decimal number ("2", "0.5", "1.5")
+// or a milli-cpu value with the `m` suffix ("500m", "1500m"). Exponent /
+// binary-SI suffixes are not meaningful for CPU and are rejected.
+const _CPU_QUANTITY_RE = /^(?:\d+(?:\.\d+)?|\.\d+|\d+m)$/
+
+// Valid Kubernetes memory quantity AFTER normalisation: a number with an
+// optional binary-SI ("Ki"/"Mi"/"Gi"/"Ti"/"Pi"/"Ei"), decimal-SI
+// ("k"/"M"/"G"/"T"/"P"/"E"), or exponent ("e6") suffix, or a bare byte count.
+// We normalise Docker-style lone-letter suffixes first, then validate.
+const _MEMORY_QUANTITY_RE =
+  /^(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+|Ki|Mi|Gi|Ti|Pi|Ei|[kKMGTPE])?$/
+
+/**
+ * Validate + normalise a single resource quantity string (#3195).
+ *
+ * @param {string} value    - The caller-supplied quantity (e.g. "500m", "2Gi")
+ * @param {'cpu'|'memory'} kind - Which quantity grammar to enforce
+ * @param {string} field    - Field label for the error message (e.g. "resources.cpu")
+ * @returns {string} The validated (and, for memory, normalised) quantity string
+ * @throws {Error} If `value` is not a string or is not a valid K8s quantity
+ */
+function _validateResourceQuantity(value, kind, field) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(
+      `createEnvironment: ${field} must be a non-empty K8s quantity string`,
+    )
+  }
+  const trimmed = value.trim()
+  if (kind === 'cpu') {
+    if (!_CPU_QUANTITY_RE.test(trimmed)) {
+      throw new Error(
+        `createEnvironment: ${field} "${value}" is not a valid K8s CPU quantity ` +
+        '(expected e.g. "500m", "1", "0.5")',
+      )
+    }
+    return trimmed
+  }
+  // memory
+  const normalised = _normaliseMemoryQuantity(trimmed)
+  if (!_MEMORY_QUANTITY_RE.test(normalised)) {
+    throw new Error(
+      `createEnvironment: ${field} "${value}" is not a valid K8s memory quantity ` +
+      '(expected e.g. "512Mi", "2Gi", "1G")',
+    )
+  }
+  return normalised
+}
+
+/**
+ * Build a Pod container `resources` block from caller opts + defaults (#3195).
+ *
+ * Resolution precedence per field (highest first):
+ *   1. The structured `opts.resources` object: `{ cpu, memory, cpuLimit, memoryLimit }`
+ *      where `cpu`/`memory` map to `requests` and `cpuLimit`/`memoryLimit` to `limits`.
+ *   2. The legacy flat opts `opts.cpuLimit` / `opts.memoryLimit` (applied to BOTH
+ *      the request and the limit for that dimension — the pre-#3195 behaviour).
+ *   3. The supplied `defaults` object (constructor `defaultResources`, itself
+ *      seeded from the module-level {@link DEFAULT_RESOURCES}). Pass `null` to
+ *      disable defaults so only explicit per-call values produce a block.
+ *
+ * Every resolved quantity is validated against the K8s quantity grammar; an
+ * invalid string throws before any API call so a bad value never leaks a
+ * half-provisioned Secret.
+ *
+ * @param {Object} [resources]            - opts.resources (structured form)
+ * @param {string} [legacyCpuLimit]       - opts.cpuLimit (flat form)
+ * @param {string} [legacyMemoryLimit]    - opts.memoryLimit (flat form)
+ * @param {Object|null} [defaults=DEFAULT_RESOURCES] - Per-field defaults, or null to disable
+ * @returns {{ requests?: Object, limits?: Object }} A resources block (possibly empty)
+ */
+export function buildResourceBlock(resources, legacyCpuLimit, legacyMemoryLimit, defaults = DEFAULT_RESOURCES) {
+  if (resources != null && (typeof resources !== 'object' || Array.isArray(resources))) {
+    throw new Error('createEnvironment: opts.resources must be an object')
+  }
+  const r = resources || {}
+  const d = defaults || {}
+
+  // Resolve each of the four dimensions through the precedence chain.
+  const cpuRequest = r.cpu ?? legacyCpuLimit ?? d.cpu
+  const memRequest = r.memory ?? legacyMemoryLimit ?? d.memory
+  const cpuLimit = r.cpuLimit ?? legacyCpuLimit ?? d.cpuLimit
+  const memLimit = r.memoryLimit ?? legacyMemoryLimit ?? d.memoryLimit
+
+  const requests = {}
+  const limits = {}
+  if (cpuRequest != null) requests.cpu = _validateResourceQuantity(cpuRequest, 'cpu', 'resources.cpu')
+  if (memRequest != null) requests.memory = _validateResourceQuantity(memRequest, 'memory', 'resources.memory')
+  if (cpuLimit != null) limits.cpu = _validateResourceQuantity(cpuLimit, 'cpu', 'resources.cpuLimit')
+  if (memLimit != null) limits.memory = _validateResourceQuantity(memLimit, 'memory', 'resources.memoryLimit')
+
+  const block = {}
+  if (Object.keys(requests).length > 0) block.requests = requests
+  if (Object.keys(limits).length > 0) block.limits = limits
+  return block
 }

--- a/packages/server/src/environments/backends/types.js
+++ b/packages/server/src/environments/backends/types.js
@@ -49,6 +49,11 @@
  * @param {string}   opts.image           - Docker image tag (already resolved to a default before this call)
  * @param {string}   opts.memoryLimit     - Docker memory limit string (e.g. "2g")
  * @param {string}   opts.cpuLimit        - Docker CPU limit string (e.g. "2")
+ * @param {Object}   [opts.resources]     - Structured K8s resource requests/limits (#3195):
+ *   `{ cpu, memory, cpuLimit, memoryLimit }` (all optional K8s quantity strings; `cpu`/`memory`
+ *   map to `requests`, `cpuLimit`/`memoryLimit` to `limits`). Honoured only by K8sBackend —
+ *   Docker and other backends silently ignore this field. When unset, K8sBackend falls back to
+ *   the legacy `opts.cpuLimit`/`opts.memoryLimit`, then to its configured defaults.
  * @param {string}   opts.containerUser   - Non-root username to create inside the container
  * @param {Object.<string,string>} [opts.containerEnv]  - Extra environment variables to inject (already sanitized)
  * @param {number[]|string[]} [opts.forwardPorts] - Ports to expose from the container

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -1,7 +1,12 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'events'
-import { K8sBackend, sanitizeNamespaceLabel } from '../../../src/environments/backends/k8s.js'
+import {
+  K8sBackend,
+  sanitizeNamespaceLabel,
+  buildResourceBlock,
+  DEFAULT_RESOURCES,
+} from '../../../src/environments/backends/k8s.js'
 
 // ─── Mock CoreV1Api factory ───────────────────────────────────────────────────
 
@@ -1508,10 +1513,13 @@ describe('K8sBackend.createEnvironment() — git-clone workspace strategy (#3193
 // K8sBackend.createEnvironment — resource limits (#3316)
 // ─────────────────────────────────────────────────────────────────────────────
 
+// These tests exercise the legacy flat `memoryLimit`/`cpuLimit` opts in
+// isolation, so the backend is constructed with `defaultResources: null` to
+// suppress the #3195 defaults that would otherwise fill the unset dimension.
 describe('K8sBackend.createEnvironment() — resource limits (#3316)', () => {
   it('sets resources.limits and resources.requests when memoryLimit is provided', async () => {
     const api = createMockApi()
-    const backend = new K8sBackend({ _coreV1Api: api })
+    const backend = new K8sBackend({ _coreV1Api: api, defaultResources: null })
 
     await backend.createEnvironment({
       envId: 'mem-only',
@@ -1528,7 +1536,7 @@ describe('K8sBackend.createEnvironment() — resource limits (#3316)', () => {
 
   it('sets resources.limits and resources.requests when cpuLimit is provided', async () => {
     const api = createMockApi()
-    const backend = new K8sBackend({ _coreV1Api: api })
+    const backend = new K8sBackend({ _coreV1Api: api, defaultResources: null })
 
     await backend.createEnvironment({
       envId: 'cpu-only',
@@ -1545,7 +1553,7 @@ describe('K8sBackend.createEnvironment() — resource limits (#3316)', () => {
 
   it('sets both memory and cpu limits when both are provided', async () => {
     const api = createMockApi()
-    const backend = new K8sBackend({ _coreV1Api: api })
+    const backend = new K8sBackend({ _coreV1Api: api, defaultResources: null })
 
     await backend.createEnvironment({
       envId: 'both-limits',
@@ -1563,7 +1571,7 @@ describe('K8sBackend.createEnvironment() — resource limits (#3316)', () => {
 
   it('normalises Docker-style memory suffix "g" to "Gi"', async () => {
     const api = createMockApi()
-    const backend = new K8sBackend({ _coreV1Api: api })
+    const backend = new K8sBackend({ _coreV1Api: api, defaultResources: null })
 
     await backend.createEnvironment({
       envId: 'mem-g',
@@ -1577,7 +1585,7 @@ describe('K8sBackend.createEnvironment() — resource limits (#3316)', () => {
 
   it('normalises Docker-style memory suffix "m" to "Mi"', async () => {
     const api = createMockApi()
-    const backend = new K8sBackend({ _coreV1Api: api })
+    const backend = new K8sBackend({ _coreV1Api: api, defaultResources: null })
 
     await backend.createEnvironment({
       envId: 'mem-m',
@@ -1589,14 +1597,243 @@ describe('K8sBackend.createEnvironment() — resource limits (#3316)', () => {
     assert.equal(resources.limits.memory, '512Mi', '"512m" must be normalised to "512Mi"')
   })
 
-  it('omits container.resources when neither memoryLimit nor cpuLimit is provided', async () => {
+  it('omits container.resources when no limits are set AND defaults disabled', async () => {
     const api = createMockApi()
-    const backend = new K8sBackend({ _coreV1Api: api })
+    const backend = new K8sBackend({ _coreV1Api: api, defaultResources: null })
 
     await backend.createEnvironment({ envId: 'no-limits', image: 'agent:latest' })
 
     const container = api.calls.create[0].body.spec.containers[0]
     assert.equal(container.resources, undefined, 'resources must be absent when no limits are set')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// K8sBackend.createEnvironment — structured resources + defaults (#3195)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('K8sBackend resource defaults (#3195)', () => {
+  it('applies DEFAULT_RESOURCES when no resource opts are given', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'defaults', image: 'agent:latest' })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    assert.deepEqual(resources, {
+      requests: { cpu: '500m', memory: '512Mi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    })
+  })
+
+  it('exposes the documented default quantities', () => {
+    assert.equal(DEFAULT_RESOURCES.cpu, '500m')
+    assert.equal(DEFAULT_RESOURCES.memory, '512Mi')
+    assert.equal(DEFAULT_RESOURCES.cpuLimit, '2')
+    assert.equal(DEFAULT_RESOURCES.memoryLimit, '4Gi')
+  })
+
+  it('constructor-level defaultResources merge over the built-in defaults', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({
+      _coreV1Api: api,
+      defaultResources: { cpu: '250m', memoryLimit: '8Gi' },
+    })
+
+    await backend.createEnvironment({ envId: 'merged-defaults', image: 'agent:latest' })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    // Overridden fields take the operator value; untouched fields keep the built-in.
+    assert.equal(resources.requests.cpu, '250m')
+    assert.equal(resources.requests.memory, '512Mi')
+    assert.equal(resources.limits.cpu, '2')
+    assert.equal(resources.limits.memory, '8Gi')
+  })
+
+  it('defaultResources: null omits the resources block entirely', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api, defaultResources: null })
+
+    await backend.createEnvironment({ envId: 'no-defaults', image: 'agent:latest' })
+
+    assert.equal(api.calls.create[0].body.spec.containers[0].resources, undefined)
+  })
+
+  it('rejects a malformed quantity in constructor defaultResources', () => {
+    assert.throws(
+      () => new K8sBackend({ _coreV1Api: createMockApi(), defaultResources: { cpu: 'not-a-cpu' } }),
+      /not a valid K8s CPU quantity/,
+    )
+  })
+
+  it('rejects a non-object defaultResources', () => {
+    assert.throws(
+      () => new K8sBackend({ _coreV1Api: createMockApi(), defaultResources: '500m' }),
+      /defaultResources must be an object or null/,
+    )
+  })
+})
+
+describe('K8sBackend structured resources opt (#3195)', () => {
+  it('maps resources.{cpu,memory} to requests and {cpuLimit,memoryLimit} to limits', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'structured',
+      image: 'agent:latest',
+      resources: { cpu: '250m', memory: '256Mi', cpuLimit: '1', memoryLimit: '1Gi' },
+    })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    assert.deepEqual(resources, {
+      requests: { cpu: '250m', memory: '256Mi' },
+      limits: { cpu: '1', memory: '1Gi' },
+    })
+  })
+
+  it('structured resources override the legacy flat opts', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'override-legacy',
+      image: 'agent:latest',
+      cpuLimit: '4',
+      memoryLimit: '8Gi',
+      resources: { cpuLimit: '1', memoryLimit: '1Gi' },
+    })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    // resources.* wins for limits; legacy flat opts still seed the requests for
+    // the dimensions structured-resources left unset (cpu/memory requests).
+    assert.equal(resources.limits.cpu, '1')
+    assert.equal(resources.limits.memory, '1Gi')
+    assert.equal(resources.requests.cpu, '4')
+    assert.equal(resources.requests.memory, '8Gi')
+  })
+
+  it('a partial structured resources fills the rest from defaults', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'partial',
+      image: 'agent:latest',
+      resources: { memoryLimit: '16Gi' },
+    })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(resources.limits.memory, '16Gi')   // explicit
+    assert.equal(resources.limits.cpu, '2')          // default
+    assert.equal(resources.requests.cpu, '500m')     // default
+    assert.equal(resources.requests.memory, '512Mi') // default
+  })
+
+  it('normalises Docker-style memory suffixes in structured resources', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({
+      envId: 'structured-norm',
+      image: 'agent:latest',
+      resources: { memory: '256m', memoryLimit: '2g' },
+    })
+
+    const { resources } = api.calls.create[0].body.spec.containers[0]
+    assert.equal(resources.requests.memory, '256Mi')
+    assert.equal(resources.limits.memory, '2Gi')
+  })
+
+  it('rejects a malformed CPU quantity before creating the Secret', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.rejects(
+      backend.createEnvironment({
+        envId: 'bad-cpu',
+        image: 'agent:latest',
+        resources: { cpu: '500x' },
+      }),
+      /not a valid K8s CPU quantity/,
+    )
+    // No Secret/Pod should have been created — validation runs before either call.
+    assert.equal(api.calls.createSecret.length, 0)
+    assert.equal(api.calls.create.length, 0)
+  })
+
+  it('rejects a malformed memory quantity', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.rejects(
+      backend.createEnvironment({
+        envId: 'bad-mem',
+        image: 'agent:latest',
+        resources: { memory: '512Megabytes' },
+      }),
+      /not a valid K8s memory quantity/,
+    )
+  })
+
+  it('rejects a non-object resources opt', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await assert.rejects(
+      backend.createEnvironment({
+        envId: 'bad-resources',
+        image: 'agent:latest',
+        resources: '500m',
+      }),
+      /opts\.resources must be an object/,
+    )
+  })
+})
+
+describe('buildResourceBlock() (#3195)', () => {
+  it('round-trips a full structured resources object', () => {
+    const block = buildResourceBlock(
+      { cpu: '500m', memory: '512Mi', cpuLimit: '2', memoryLimit: '4Gi' },
+      undefined, undefined, null,
+    )
+    assert.deepEqual(block, {
+      requests: { cpu: '500m', memory: '512Mi' },
+      limits: { cpu: '2', memory: '4Gi' },
+    })
+  })
+
+  it('returns an empty block when nothing is set and defaults are disabled', () => {
+    assert.deepEqual(buildResourceBlock(undefined, undefined, undefined, null), {})
+  })
+
+  it('legacy flat limit applies to both request and limit for its dimension', () => {
+    const block = buildResourceBlock(undefined, '2', undefined, null)
+    assert.deepEqual(block, { requests: { cpu: '2' }, limits: { cpu: '2' } })
+  })
+
+  it('accepts a variety of valid CPU quantities', () => {
+    for (const cpu of ['1', '0.5', '.5', '500m', '1500m', '2']) {
+      assert.doesNotThrow(() => buildResourceBlock({ cpu }, undefined, undefined, null), `cpu=${cpu}`)
+    }
+  })
+
+  it('rejects malformed CPU quantities', () => {
+    for (const cpu of ['', '500x', 'abc', '1Gi', '1.2.3', '500 m', '-1']) {
+      assert.throws(() => buildResourceBlock({ cpu }, undefined, undefined, null), `cpu=${cpu} should throw`)
+    }
+  })
+
+  it('accepts a variety of valid memory quantities (post-normalisation)', () => {
+    for (const memory of ['512Mi', '2Gi', '1G', '500M', '1024', '1.5Gi', '128974848', '64Mi', '1e6']) {
+      assert.doesNotThrow(() => buildResourceBlock({ memory }, undefined, undefined, null), `memory=${memory}`)
+    }
+  })
+
+  it('rejects malformed memory quantities', () => {
+    for (const memory of ['', '512Megabytes', 'abc', '2 Gi', '1.2.3Gi', 'Gi', '-512Mi']) {
+      assert.throws(() => buildResourceBlock({ memory }, undefined, undefined, null), `memory=${memory} should throw`)
+    }
   })
 })
 


### PR DESCRIPTION
## Summary

Adds CPU/memory **requests** and **limits** to the Pods the K8s backend creates so a runaway session can't consume the whole node (#3195).

- `K8sBackend.createEnvironment` gains a structured `resources` opt — `{ cpu, memory, cpuLimit, memoryLimit }` — where `cpu`/`memory` map to `resources.requests` and `cpuLimit`/`memoryLimit` to `resources.limits` on the container spec.
- **Sensible defaults** applied when unspecified (`DEFAULT_RESOURCES`): request `500m` CPU / `512Mi` memory, limit `2` CPU / `4Gi` memory. Operators can override cluster-wide via the constructor `defaultResources` opt (partial object, merged over the built-ins) or disable with `defaultResources: null`.
- **Validation**: every quantity is validated against the K8s quantity grammar (CPU and memory) *before* any Secret/Pod is created, so a malformed value never leaks a half-provisioned Secret. Docker-style memory suffixes (`2g`/`512m`) are normalised to binary-SI (`2Gi`/`512Mi`).
- **Precedence** per field: structured `resources` > legacy flat `memoryLimit`/`cpuLimit` > defaults. Legacy flat opts are fully preserved (still applied to both request and limit for their dimension).
- Plumbed the structured `resources` opt through `EnvironmentManager.create` (forwarded verbatim; only K8sBackend acts on it).
- Documented defaults + override surface in `CONFIG.md`; documented the new opt in the `types.js` Backend interface contract.

## Scope notes

- Namespace-level `ResourceQuota`/`LimitRange` objects are **not** in this issue's acceptance criteria (the AC covers pod-level requests/limits, defaults, docs, and spec round-trip) — left as a possible follow-up now that #3194 gives per-tenant namespaces.
- Fully unit-tested against the injected `CoreV1Api` fake — no real cluster required. Live-cluster validation (that the scheduler honours the requests and the kernel enforces the limits) is the only thing that can't be exercised here.

## Tests

New coverage in `tests/environments/backends/k8s.test.js`:
- default application + the documented default quantities
- constructor `defaultResources` merge / disable / malformed-quantity rejection / non-object rejection
- structured `resources` → requests/limits mapping, override of legacy flat opts, partial-fill-from-defaults, Docker-suffix normalisation
- malformed CPU/memory rejection before Secret creation, non-object `resources` rejection
- `buildResourceBlock` unit tests: round-trip, empty block, legacy flat behaviour, valid/malformed CPU & memory tables

All environment/K8s suites pass; both server lints (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`) pass.

Closes #3195