### PR TITLE
feat(server): Rancher API adapter on top of K8s backend

### DIFF
--- a/docs/guides/k8s-rancher-backend.md
+++ b/docs/guides/k8s-rancher-backend.md
@@ -1,0 +1,110 @@
+# Kubernetes & Rancher Backends
+
+Chroxy's environment system runs each session's container environment through a
+pluggable *backend*. Beyond the default Docker backend, two cluster-oriented
+backends are available for remote / team deployments:
+
+- **`K8sBackend`** — talks directly to a Kubernetes API server (in-cluster
+  service account, or a kubeconfig file).
+- **`RancherBackend`** — an *optional* adapter that runs the exact same K8s
+  logic against a [Rancher](https://www.rancher.com/)-managed cluster, plus
+  Rancher's org model (Projects) on top.
+
+This guide covers when to pick each one and how to configure the Rancher
+adapter.
+
+## When to pick K8s vs Rancher
+
+| | `K8sBackend` (plain K8s) | `RancherBackend` (optional adapter) |
+|---|---|---|
+| **Authentication** | In-cluster service account, or kubeconfig | Rancher bearer token, proxied through the Rancher server |
+| **Connectivity** | Direct to the kube API server | Through `<rancher-url>/k8s/clusters/<clusterId>` |
+| **Namespace model** | Plain namespaces (assumed to pre-exist) | Plain namespaces **plus** Rancher Project binding (`ensureProjectNamespace`) |
+| **RBAC / quotas** | Whatever you define directly in K8s | Inherits the Rancher **Project**'s RBAC + resource quotas |
+| **Best for** | You run/operate the cluster directly, or use a managed kube control plane (EKS/GKE/AKS) and already manage kubeconfig/RBAC yourself | You self-host on Rancher and want org-level Projects, fleet management, and centralised RBAC without handing every operator raw kube credentials |
+
+**Rule of thumb:** if you don't run Rancher, use `K8sBackend`. The Rancher
+adapter is strictly additive and **opt-in** — when no Rancher connection is
+configured, nothing about Rancher is touched and the plain K8s path is the
+default.
+
+## How the Rancher adapter works
+
+Rancher is fundamentally an **auth/proxy layer in front of the Kubernetes API**.
+It exposes every downstream cluster's kube API under a per-cluster path:
+
+```
+https://<rancher-server>/k8s/clusters/<clusterId>
+```
+
+authenticated with a Rancher bearer token. `RancherBackend` therefore:
+
+1. Builds a standard `@kubernetes/client-node` client pointed at that proxy URL
+   with the bearer token (and optional CA bundle) — see
+   `buildRancherApi` in `packages/server/src/environments/backends/rancher.js`.
+2. Hands that client to `K8sBackend` via its injection seam, so **100% of the
+   pod / secret / exec logic is reused unchanged** — Rancher is transparent to
+   the rest of the backend.
+3. Adds `ensureProjectNamespace()`, which creates a namespace bound to a Rancher
+   **Project** via the `field.cattle.io/projectId: <clusterId>:<projectId>`
+   annotation. Rancher's controllers then apply the Project's RBAC and resource
+   quotas to that namespace.
+
+Because Project binding is expressed on a *standard* K8s Namespace annotation,
+there is no separate Rancher REST API to call — everything flows through the
+proxied kube API.
+
+## Configuration
+
+The Rancher connection is supplied as backend options:
+
+| Option | Required | Description |
+|---|---|---|
+| `rancherUrl` | yes | Rancher server base URL, e.g. `https://rancher.example.com` |
+| `clusterId` | yes | Downstream cluster ID, e.g. `c-m-abc123` (legacy `c-abcde` also accepted) |
+| `token` | yes | Rancher API bearer token (treat as a secret; **never logged**) |
+| `caData` | no | Base64-encoded PEM CA bundle for a self-signed Rancher server |
+| `skipTLSVerify` | no | Disable TLS verification (default `false`; **discouraged** — prefer `caData`) |
+| `defaultProjectId` | no | Default Rancher Project (`p-...`) for `ensureProjectNamespace` |
+
+All of the standard `K8sBackend` options (`namespace`, `sidecarImage`,
+`imagePullPolicy`, `connectMode`, …) are also accepted and forwarded.
+
+### Obtaining `clusterId` and `token`
+
+- **clusterId** — in the Rancher UI, open the cluster and copy the ID from the
+  URL, or run `kubectl get clusters.management.cattle.io` against the Rancher
+  local cluster. It looks like `c-m-abc123` or `c-abcde`.
+- **token** — Rancher UI → *Account & API Keys* → *Create API Key*. Scope it to
+  the cluster/project Chroxy needs. The token is shown once; store it in your
+  secret manager.
+- **projectId** — `kubectl get projects.management.cattle.io -n <clusterId>`, or
+  copy from the Project's URL in the Rancher UI. It looks like `p-xyz789`.
+
+## Security notes
+
+- **The bearer token is never logged and never copied onto the backend
+  instance.** It lives only inside the kube client's auth provider. Validation
+  errors deliberately omit the token value.
+- **TLS verification is on by default.** For a self-signed Rancher server,
+  supply `caData` (a base64-encoded CA bundle) rather than setting
+  `skipTLSVerify: true`. Disabling verification exposes the bearer token to
+  man-in-the-middle interception.
+- **Project-scoped namespaces inherit Rancher quotas/RBAC.** Prefer
+  `ensureProjectNamespace` over creating bare namespaces so that org-level
+  guardrails apply.
+- The `hostPath` workspace warnings from `K8sBackend` apply equally here — use
+  the PVC workspace strategy on shared/multi-tenant clusters.
+
+## Fallback behaviour
+
+The adapter degrades gracefully rather than failing hard:
+
+- If Rancher is **not configured** (`isRancherConfigured` is false), the plain
+  `K8sBackend` path is used — the default, unchanged behaviour.
+- If `ensureProjectNamespace` is called with a `projectId` but no usable
+  `clusterId` is available, it creates a **plain namespace without the project
+  binding** (and logs the degradation) rather than forming a malformed
+  annotation.
+- A `409 Conflict` (namespace already exists) is treated as success, so the call
+  is safe to retry.

--- a/docs/guides/k8s-rancher-backend.md
+++ b/docs/guides/k8s-rancher-backend.md
@@ -15,11 +15,11 @@ adapter.
 
 ## When to pick K8s vs Rancher
 
-| | `K8sBackend` (plain K8s) | `RancherBackend` (optional adapter) |
+| Aspect | `K8sBackend` (plain K8s) | `RancherBackend` (optional adapter) |
 |---|---|---|
 | **Authentication** | In-cluster service account, or kubeconfig | Rancher bearer token, proxied through the Rancher server |
 | **Connectivity** | Direct to the kube API server | Through `<rancher-url>/k8s/clusters/<clusterId>` |
-| **Namespace model** | Plain namespaces (assumed to pre-exist) | Plain namespaces **plus** Rancher Project binding (`ensureProjectNamespace`) |
+| **Namespace model** | Plain namespaces — the backend creates Pods/Secrets in a namespace it assumes already exists (it does not create namespaces) | Adds `ensureProjectNamespace`, which creates a namespace bound to a Rancher Project |
 | **RBAC / quotas** | Whatever you define directly in K8s | Inherits the Rancher **Project**'s RBAC + resource quotas |
 | **Best for** | You run/operate the cluster directly, or use a managed kube control plane (EKS/GKE/AKS) and already manage kubeconfig/RBAC yourself | You self-host on Rancher and want org-level Projects, fleet management, and centralised RBAC without handing every operator raw kube credentials |
 

--- a/packages/server/src/environments/backends/rancher.js
+++ b/packages/server/src/environments/backends/rancher.js
@@ -1,0 +1,301 @@
+import { KubeConfig, CoreV1Api } from '@kubernetes/client-node'
+import { K8sBackend } from './k8s.js'
+import { createLogger } from '../../logger.js'
+
+const log = createLogger('rancher-backend')
+
+/**
+ * Rancher cluster-ID format: `c-<short>` (legacy RKE) or `c-m-<random>` (Rancher
+ * v2 provisioned). We accept both by requiring a `c-` prefix followed by
+ * lowercase alphanumerics and hyphens. Validating up-front keeps a typo'd
+ * clusterId from being silently spliced into the proxy URL where it would
+ * surface as an opaque 404 from the Rancher server.
+ */
+const RANCHER_CLUSTER_ID = /^c-[a-z0-9-]+$/
+
+/**
+ * Rancher project-ID format: `p-<random>`. Used only when annotating a
+ * project-scoped namespace; never spliced into a URL.
+ */
+const RANCHER_PROJECT_ID = /^p-[a-z0-9-]+$/
+
+/** Annotation Rancher reads to bind a namespace to a project. */
+const PROJECT_ID_ANNOTATION = 'field.cattle.io/projectId'
+
+/**
+ * Builds the Rancher kube-API proxy path for a cluster.
+ *
+ * Rancher fronts each downstream cluster's Kubernetes API under
+ * `<rancherUrl>/k8s/clusters/<clusterId>`, authenticated with a Rancher bearer
+ * token. Pointing a standard `@kubernetes/client-node` client at this URL lets
+ * the entire K8sBackend operate unchanged — Rancher is purely an auth/proxy
+ * layer in front of the kube API.
+ *
+ * @param {string} rancherUrl - Rancher server base URL (trailing slash tolerated)
+ * @param {string} clusterId  - Rancher downstream cluster ID (e.g. `c-m-abc123`)
+ * @returns {string} Fully-qualified proxy URL
+ */
+function buildProxyUrl(rancherUrl, clusterId) {
+  const base = rancherUrl.replace(/\/+$/, '')
+  return `${base}/k8s/clusters/${clusterId}`
+}
+
+/**
+ * Validates the Rancher-specific connection options and normalises them.
+ *
+ * Enforced (all required unless noted):
+ *   - rancherUrl: non-empty http(s):// URL
+ *   - clusterId : matches the Rancher cluster-ID format
+ *   - token     : non-empty string (bearer token; never logged)
+ *   - caData    : optional, base64-encoded PEM bundle (string)
+ *   - skipTLSVerify: optional boolean (default false)
+ *
+ * @param {Object} opts
+ * @returns {{ rancherUrl: string, clusterId: string, token: string, caData?: string, skipTLSVerify: boolean }}
+ * @throws {Error} on any malformed option
+ */
+function validateRancherOptions({ rancherUrl, clusterId, token, caData, skipTLSVerify } = {}) {
+  if (typeof rancherUrl !== 'string' || rancherUrl.length === 0) {
+    throw new Error('RancherBackend: rancherUrl must be a non-empty string')
+  }
+  let parsed
+  try {
+    parsed = new URL(rancherUrl)
+  } catch {
+    throw new Error(`RancherBackend: rancherUrl is not a valid URL: ${rancherUrl}`)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`RancherBackend: rancherUrl must use http:// or https://, got ${parsed.protocol}`)
+  }
+
+  if (typeof clusterId !== 'string' || !RANCHER_CLUSTER_ID.test(clusterId)) {
+    throw new Error(`RancherBackend: clusterId must match the Rancher cluster-ID format (c-...), got "${clusterId}"`)
+  }
+
+  if (typeof token !== 'string' || token.length === 0) {
+    throw new Error('RancherBackend: token must be a non-empty bearer token string')
+  }
+
+  if (caData != null && (typeof caData !== 'string' || caData.length === 0)) {
+    throw new Error('RancherBackend: caData, when provided, must be a non-empty base64-encoded PEM string')
+  }
+
+  if (skipTLSVerify != null && typeof skipTLSVerify !== 'boolean') {
+    throw new Error(`RancherBackend: skipTLSVerify must be a boolean, got ${typeof skipTLSVerify}`)
+  }
+
+  return {
+    rancherUrl,
+    clusterId,
+    token,
+    caData: caData ?? undefined,
+    skipTLSVerify: skipTLSVerify ?? false,
+  }
+}
+
+/**
+ * Builds a CoreV1Api client pointed at the Rancher kube-API proxy.
+ *
+ * Uses `KubeConfig.loadFromClusterAndUser` so no kubeconfig file is needed:
+ * the cluster's server URL is the Rancher proxy endpoint and the user carries
+ * the Rancher bearer token. TLS verification is on by default; operators can
+ * supply a CA bundle (`caData`) for self-signed Rancher servers or, as a last
+ * resort, disable verification (`skipTLSVerify`).
+ *
+ * @param {{ rancherUrl: string, clusterId: string, token: string, caData?: string, skipTLSVerify: boolean }} cfg
+ * @returns {import('@kubernetes/client-node').CoreV1Api}
+ */
+function buildRancherApi(cfg) {
+  const kc = new KubeConfig()
+  const cluster = {
+    name: `rancher-${cfg.clusterId}`,
+    server: buildProxyUrl(cfg.rancherUrl, cfg.clusterId),
+    skipTLSVerify: cfg.skipTLSVerify,
+  }
+  if (cfg.caData) cluster.caData = cfg.caData
+  kc.loadFromClusterAndUser(cluster, {
+    name: `rancher-${cfg.clusterId}-user`,
+    token: cfg.token,
+  })
+  return kc.makeApiClient(CoreV1Api)
+}
+
+/**
+ * Returns true when the supplied options carry a complete Rancher connection
+ * config (URL + clusterId + token). EnvironmentManager / config wiring uses
+ * this to decide whether to instantiate a RancherBackend at all — when Rancher
+ * is not configured, the plain K8sBackend (in-cluster / kubeconfig) path is the
+ * default and nothing about Rancher is touched.
+ *
+ * Does NOT validate shape (that is `validateRancherOptions`'s job at construct
+ * time); it only checks presence so the default path stays untouched.
+ *
+ * @param {Object} [opts]
+ * @returns {boolean}
+ */
+export function isRancherConfigured(opts = {}) {
+  return Boolean(opts && opts.rancherUrl && opts.clusterId && opts.token)
+}
+
+/**
+ * Determine whether an API error means "already exists" (HTTP 409 Conflict).
+ * Mirrors `_isNotFound` in k8s.js but for the create-idempotency case.
+ */
+function isAlreadyExists(err) {
+  return err?.code === 409 ||
+    err?.statusCode === 409 ||
+    err?.response?.statusCode === 409 ||
+    err?.body?.code === 409 ||
+    err?.body?.reason === 'AlreadyExists'
+}
+
+/**
+ * RancherBackend — optional adapter that runs the full K8sBackend against a
+ * Rancher-managed cluster (#3196).
+ *
+ * Rancher is an auth/proxy layer in front of the Kubernetes API: it exposes
+ * every downstream cluster's kube API under `/k8s/clusters/<clusterId>` and
+ * authenticates with a Rancher bearer token. RancherBackend therefore reuses
+ * 100% of the K8sBackend pod/secret/exec logic and only changes how the kube
+ * client is constructed (Rancher proxy URL + bearer token + optional CA).
+ *
+ * It additionally layers Rancher's org model on top: `ensureProjectNamespace`
+ * creates a namespace bound to a Rancher Project via the
+ * `field.cattle.io/projectId` annotation, so quotas / RBAC defined at the
+ * project level apply to Chroxy's environments.
+ *
+ * Opt-in: this class is only instantiated when a Rancher connection is
+ * configured (`isRancherConfigured`). The default in-cluster / kubeconfig
+ * K8sBackend path is unchanged when Rancher is not configured.
+ */
+export class RancherBackend extends K8sBackend {
+  /**
+   * @param {Object} opts - All K8sBackend opts PLUS the Rancher connection block:
+   * @param {string}  opts.rancherUrl       - Rancher server base URL
+   * @param {string}  opts.clusterId        - Rancher downstream cluster ID (c-...)
+   * @param {string}  opts.token            - Rancher bearer token (never logged)
+   * @param {string}  [opts.caData]         - base64-encoded PEM CA bundle for the Rancher server
+   * @param {boolean} [opts.skipTLSVerify]  - Disable TLS verification (default false; discouraged)
+   * @param {string}  [opts.defaultProjectId] - Default Rancher project (p-...) for ensureProjectNamespace
+   * @param {object}  [opts._coreV1Api]     - Injected CoreV1Api for testing (bypasses Rancher kube-client build)
+   */
+  constructor(opts = {}) {
+    const {
+      rancherUrl, clusterId, token, caData, skipTLSVerify, defaultProjectId,
+      _coreV1Api,
+      ...k8sOpts
+    } = opts
+
+    if (_coreV1Api) {
+      // Test / pre-built-client seam: skip Rancher kube-client construction and
+      // hand the injected api straight to K8sBackend. We still record the
+      // Rancher identity fields (validated leniently) so ensureProjectNamespace
+      // can form the projectId annotation, but we tolerate their absence here so
+      // unit tests can exercise pod logic without a full Rancher config.
+      super({ ...k8sOpts, _coreV1Api })
+      this._rancher = {
+        rancherUrl,
+        clusterId,
+        defaultProjectId,
+      }
+    } else {
+      const cfg = validateRancherOptions({ rancherUrl, clusterId, token, caData, skipTLSVerify })
+      if (defaultProjectId != null && !RANCHER_PROJECT_ID.test(defaultProjectId)) {
+        throw new Error(`RancherBackend: defaultProjectId must match the Rancher project-ID format (p-...), got "${defaultProjectId}"`)
+      }
+      const api = buildRancherApi(cfg)
+      // Hand the Rancher-pointed client to K8sBackend via its injection seam so
+      // K8sBackend never constructs its own (in-cluster/kubeconfig) client.
+      super({ ...k8sOpts, _coreV1Api: api })
+      // Store only non-secret identity fields. The bearer token lives inside
+      // the kube client's auth provider and is never copied onto `this`.
+      this._rancher = {
+        rancherUrl: cfg.rancherUrl,
+        clusterId: cfg.clusterId,
+        defaultProjectId: defaultProjectId ?? undefined,
+      }
+      log.info(`RancherBackend connected to cluster ${cfg.clusterId} via ${cfg.rancherUrl} (proxy: /k8s/clusters/${cfg.clusterId})`)
+    }
+  }
+
+  /**
+   * Rancher cluster ID this backend is bound to (for diagnostics / annotation).
+   * @returns {string|undefined}
+   */
+  get clusterId() {
+    return this._rancher?.clusterId
+  }
+
+  /**
+   * Create (idempotently) a Kubernetes namespace bound to a Rancher Project.
+   *
+   * Rancher's project model is expressed on standard K8s Namespaces via the
+   * `field.cattle.io/projectId: <clusterId>:<projectId>` annotation — Rancher's
+   * controllers then apply the project's RBAC and resource quotas to the
+   * namespace. Creating the namespace through the proxied kube API (the same
+   * `_api` client every K8sBackend method uses) is all that is required; there
+   * is no separate Rancher REST call.
+   *
+   * Idempotent: a 409 Conflict (namespace already exists) is treated as success.
+   *
+   * Fallback: if Rancher is not configured with a usable clusterId (e.g. the
+   * test/injected-client path) the annotation is omitted and a plain namespace
+   * is created — this is the "falls back to plain K8s" behaviour from the AC.
+   *
+   * @param {string} namespace - RFC 1123 namespace name to create
+   * @param {Object} [opts]
+   * @param {string} [opts.projectId] - Rancher project ID (p-...); defaults to defaultProjectId
+   * @returns {Promise<{ namespace: string, projectId: string|null, created: boolean }>}
+   */
+  async ensureProjectNamespace(namespace, opts = {}) {
+    const ns = this._validateNamespace(this._resolveNamespace(namespace), 'ensureProjectNamespace')
+    const projectId = opts.projectId ?? this._rancher?.defaultProjectId ?? null
+    const clusterId = this._rancher?.clusterId
+
+    const metadata = { name: ns }
+
+    if (projectId != null) {
+      if (!RANCHER_PROJECT_ID.test(projectId)) {
+        throw new Error(`RancherBackend.ensureProjectNamespace: projectId must match the Rancher project-ID format (p-...), got "${projectId}"`)
+      }
+      if (!clusterId) {
+        // Project requested but we have no cluster ID to form the binding.
+        // Fall back to a plain namespace rather than creating a malformed
+        // annotation, and surface the degradation in the logs.
+        log.warn(`ensureProjectNamespace: projectId ${projectId} requested but no clusterId configured — creating plain namespace ${ns} without project binding`)
+      } else {
+        metadata.annotations = {
+          [PROJECT_ID_ANNOTATION]: `${clusterId}:${projectId}`,
+        }
+      }
+    }
+
+    const boundProjectId = metadata.annotations ? projectId : null
+    const body = { apiVersion: 'v1', kind: 'Namespace', metadata }
+
+    log.info(`Ensuring namespace ${ns}${boundProjectId ? ` bound to project ${boundProjectId}` : ''}`)
+    try {
+      await this._api.createNamespace({ body })
+      return { namespace: ns, projectId: boundProjectId, created: true }
+    } catch (err) {
+      if (isAlreadyExists(err)) {
+        log.info(`Namespace ${ns} already exists — treating as success`)
+        return { namespace: ns, projectId: boundProjectId, created: false }
+      }
+      // Do not include err details that could echo the request body / token.
+      log.warn(`Failed to create namespace ${ns}: ${err.message}`)
+      throw err
+    }
+  }
+}
+
+// Internal helpers exported for unit testing only.
+export const __test__ = {
+  buildProxyUrl,
+  validateRancherOptions,
+  buildRancherApi,
+  isAlreadyExists,
+  RANCHER_CLUSTER_ID,
+  RANCHER_PROJECT_ID,
+  PROJECT_ID_ANNOTATION,
+}

--- a/packages/server/src/environments/backends/rancher.js
+++ b/packages/server/src/environments/backends/rancher.js
@@ -188,10 +188,18 @@ export class RancherBackend extends K8sBackend {
 
     if (_coreV1Api) {
       // Test / pre-built-client seam: skip Rancher kube-client construction and
-      // hand the injected api straight to K8sBackend. We still record the
-      // Rancher identity fields (validated leniently) so ensureProjectNamespace
-      // can form the projectId annotation, but we tolerate their absence here so
-      // unit tests can exercise pod logic without a full Rancher config.
+      // hand the injected api straight to K8sBackend. The Rancher identity
+      // fields are optional here (so unit tests can exercise inherited pod logic
+      // without a full Rancher config), but when present they are validated to
+      // the same format rules as the live path — a malformed clusterId /
+      // defaultProjectId would otherwise be spliced verbatim into the
+      // `field.cattle.io/projectId` annotation.
+      if (clusterId != null && !RANCHER_CLUSTER_ID.test(clusterId)) {
+        throw new Error(`RancherBackend: clusterId must match the Rancher cluster-ID format (c-...), got "${clusterId}"`)
+      }
+      if (defaultProjectId != null && !RANCHER_PROJECT_ID.test(defaultProjectId)) {
+        throw new Error(`RancherBackend: defaultProjectId must match the Rancher project-ID format (p-...), got "${defaultProjectId}"`)
+      }
       super({ ...k8sOpts, _coreV1Api })
       this._rancher = {
         rancherUrl,
@@ -237,6 +245,12 @@ export class RancherBackend extends K8sBackend {
    * is no separate Rancher REST call.
    *
    * Idempotent: a 409 Conflict (namespace already exists) is treated as success.
+   * Because the namespace already existed, we did NOT apply the project
+   * annotation in this call, so the returned `projectId` is `null` even when a
+   * binding was requested — the caller must not assume the pre-existing
+   * namespace carries the requested Rancher Project binding (it may have a
+   * different binding, or none). Verifying/patching the annotation on an
+   * existing namespace is intentionally out of scope here (see #5144).
    *
    * Fallback: if Rancher is not configured with a usable clusterId (e.g. the
    * test/injected-client path) the annotation is omitted and a plain namespace
@@ -246,6 +260,10 @@ export class RancherBackend extends K8sBackend {
    * @param {Object} [opts]
    * @param {string} [opts.projectId] - Rancher project ID (p-...); defaults to defaultProjectId
    * @returns {Promise<{ namespace: string, projectId: string|null, created: boolean }>}
+   *   `projectId` reflects the binding this call actually applied: the requested
+   *   project when the namespace was freshly created with the annotation, or
+   *   `null` when the namespace already existed (binding unverified) or no
+   *   project was requested.
    */
   async ensureProjectNamespace(namespace, opts = {}) {
     const ns = this._validateNamespace(this._resolveNamespace(namespace), 'ensureProjectNamespace')
@@ -279,8 +297,15 @@ export class RancherBackend extends K8sBackend {
       return { namespace: ns, projectId: boundProjectId, created: true }
     } catch (err) {
       if (isAlreadyExists(err)) {
-        log.info(`Namespace ${ns} already exists — treating as success`)
-        return { namespace: ns, projectId: boundProjectId, created: false }
+        // The namespace pre-existed, so this call did not apply the annotation.
+        // Report projectId:null so callers don't assume a binding we didn't make
+        // (the existing namespace may carry a different binding, or none).
+        if (boundProjectId) {
+          log.warn(`Namespace ${ns} already exists — project binding ${boundProjectId} NOT applied (pre-existing namespace; binding unverified)`)
+        } else {
+          log.info(`Namespace ${ns} already exists — treating as success`)
+        }
+        return { namespace: ns, projectId: null, created: false }
       }
       // Do not include err details that could echo the request body / token.
       log.warn(`Failed to create namespace ${ns}: ${err.message}`)

--- a/packages/server/tests/environments/backends/rancher.test.js
+++ b/packages/server/tests/environments/backends/rancher.test.js
@@ -208,6 +208,24 @@ describe('RancherBackend constructor', () => {
     const backend = new RancherBackend({ _coreV1Api: api, namespace: 'team-a', clusterId: 'c-m-1' })
     assert.equal(backend._namespace, 'team-a')
   })
+
+  it('validates clusterId on the injected-client seam when provided (rejects malformed)', () => {
+    assert.throws(
+      () => new RancherBackend({ _coreV1Api: createMockApi(), clusterId: 'bad' }),
+      /cluster-ID format/,
+    )
+  })
+
+  it('validates defaultProjectId on the injected-client seam when provided (rejects malformed)', () => {
+    assert.throws(
+      () => new RancherBackend({ _coreV1Api: createMockApi(), clusterId: 'c-m-1', defaultProjectId: 'bad' }),
+      /project-ID format/,
+    )
+  })
+
+  it('tolerates omitted Rancher identity on the injected-client seam', () => {
+    assert.doesNotThrow(() => new RancherBackend({ _coreV1Api: createMockApi() }))
+  })
 })
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -241,12 +259,15 @@ describe('ensureProjectNamespace', () => {
     assert.equal(result.projectId, 'p-default')
   })
 
-  it('is idempotent — a 409 AlreadyExists is treated as success (created:false)', async () => {
+  it('is idempotent — a 409 AlreadyExists is treated as success (created:false) and does NOT claim an unverified binding', async () => {
     const api = createMockApi({ createNamespace: () => { throw makeConflictError() } })
     const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-abc123' })
 
+    // Even though a projectId was requested, the namespace pre-existed so this
+    // call did not apply the annotation — projectId must come back null so the
+    // caller does not assume a binding we didn't make.
     const result = await backend.ensureProjectNamespace('team-alpha', { projectId: 'p-xyz789' })
-    assert.deepEqual(result, { namespace: 'team-alpha', projectId: 'p-xyz789', created: false })
+    assert.deepEqual(result, { namespace: 'team-alpha', projectId: null, created: false })
   })
 
   it('rethrows non-conflict API errors', async () => {

--- a/packages/server/tests/environments/backends/rancher.test.js
+++ b/packages/server/tests/environments/backends/rancher.test.js
@@ -1,0 +1,328 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  RancherBackend,
+  isRancherConfigured,
+  __test__,
+} from '../../../src/environments/backends/rancher.js'
+
+const { buildProxyUrl, validateRancherOptions, isAlreadyExists, PROJECT_ID_ANNOTATION } = __test__
+
+// ─── Mock CoreV1Api factory ───────────────────────────────────────────────────
+//
+// Mirrors the K8s test fake: records calls and returns configured results.
+// RancherBackend only adds createNamespace on top of the K8s surface, so we
+// only need that method plus the pod/secret methods K8sBackend touches.
+function createMockApi({ createNamespace, createPod, createSecret } = {}) {
+  const calls = { createNamespace: [], create: [], createSecret: [] }
+  const api = {
+    createNamespace: createNamespace
+      ? async (args) => { calls.createNamespace.push(args); return createNamespace(args) }
+      : async (args) => { calls.createNamespace.push(args); return {} },
+    createNamespacedPod: createPod
+      ? async (args) => { calls.create.push(args); return createPod(args) }
+      : async (args) => { calls.create.push(args); return {} },
+    createNamespacedSecret: createSecret
+      ? async (args) => { calls.createSecret.push(args); return createSecret(args) }
+      : async (args) => { calls.createSecret.push(args); return {} },
+  }
+  api.calls = calls
+  return api
+}
+
+function makeConflictError() {
+  return Object.assign(new Error('namespaces "x" already exists'), { code: 409 })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validateRancherOptions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validateRancherOptions', () => {
+  const ok = { rancherUrl: 'https://rancher.example.com', clusterId: 'c-m-abc123', token: 'tok' }
+
+  it('accepts a complete, well-formed config and defaults skipTLSVerify to false', () => {
+    const cfg = validateRancherOptions(ok)
+    assert.equal(cfg.rancherUrl, ok.rancherUrl)
+    assert.equal(cfg.clusterId, ok.clusterId)
+    assert.equal(cfg.token, ok.token)
+    assert.equal(cfg.skipTLSVerify, false)
+    assert.equal(cfg.caData, undefined)
+  })
+
+  it('accepts legacy c-<short> cluster IDs', () => {
+    assert.doesNotThrow(() => validateRancherOptions({ ...ok, clusterId: 'c-abcde' }))
+  })
+
+  it('throws on missing rancherUrl', () => {
+    assert.throws(() => validateRancherOptions({ ...ok, rancherUrl: undefined }), /rancherUrl must be a non-empty string/)
+  })
+
+  it('throws on a non-URL rancherUrl', () => {
+    assert.throws(() => validateRancherOptions({ ...ok, rancherUrl: 'not a url' }), /not a valid URL/)
+  })
+
+  it('throws on a non-http(s) rancherUrl protocol', () => {
+    assert.throws(() => validateRancherOptions({ ...ok, rancherUrl: 'ftp://rancher.example.com' }), /must use http/)
+  })
+
+  it('throws on a malformed clusterId', () => {
+    assert.throws(() => validateRancherOptions({ ...ok, clusterId: 'm-abc123' }), /cluster-ID format/)
+  })
+
+  it('throws on a missing/empty token', () => {
+    assert.throws(() => validateRancherOptions({ ...ok, token: '' }), /non-empty bearer token/)
+  })
+
+  it('throws on a non-string caData', () => {
+    assert.throws(() => validateRancherOptions({ ...ok, caData: 123 }), /caData/)
+  })
+
+  it('throws on a non-boolean skipTLSVerify', () => {
+    assert.throws(() => validateRancherOptions({ ...ok, skipTLSVerify: 'yes' }), /skipTLSVerify must be a boolean/)
+  })
+
+  it('never echoes the token in error messages', () => {
+    try {
+      validateRancherOptions({ ...ok, clusterId: 'bad', token: 'SUPER-SECRET-TOKEN' })
+      assert.fail('expected throw')
+    } catch (err) {
+      assert.ok(!err.message.includes('SUPER-SECRET-TOKEN'), 'token must not appear in error')
+    }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildProxyUrl
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildProxyUrl', () => {
+  it('forms the Rancher kube-API proxy path', () => {
+    assert.equal(
+      buildProxyUrl('https://rancher.example.com', 'c-m-abc123'),
+      'https://rancher.example.com/k8s/clusters/c-m-abc123',
+    )
+  })
+
+  it('tolerates a trailing slash on the base URL', () => {
+    assert.equal(
+      buildProxyUrl('https://rancher.example.com/', 'c-m-abc123'),
+      'https://rancher.example.com/k8s/clusters/c-m-abc123',
+    )
+  })
+
+  it('collapses multiple trailing slashes', () => {
+    assert.equal(
+      buildProxyUrl('https://rancher.example.com///', 'c-m-x'),
+      'https://rancher.example.com/k8s/clusters/c-m-x',
+    )
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isRancherConfigured (opt-in gate)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isRancherConfigured', () => {
+  it('is false for empty / undefined opts (default K8s path)', () => {
+    assert.equal(isRancherConfigured(), false)
+    assert.equal(isRancherConfigured({}), false)
+    assert.equal(isRancherConfigured({ namespace: 'default' }), false)
+  })
+
+  it('is false when any of url/clusterId/token is missing', () => {
+    assert.equal(isRancherConfigured({ rancherUrl: 'https://r', clusterId: 'c-m-1' }), false)
+    assert.equal(isRancherConfigured({ rancherUrl: 'https://r', token: 't' }), false)
+    assert.equal(isRancherConfigured({ clusterId: 'c-m-1', token: 't' }), false)
+  })
+
+  it('is true only when url + clusterId + token are all present', () => {
+    assert.equal(isRancherConfigured({ rancherUrl: 'https://r', clusterId: 'c-m-1', token: 't' }), true)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isAlreadyExists
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('isAlreadyExists', () => {
+  it('matches the various 409 shapes the kube client surfaces', () => {
+    assert.equal(isAlreadyExists({ code: 409 }), true)
+    assert.equal(isAlreadyExists({ statusCode: 409 }), true)
+    assert.equal(isAlreadyExists({ response: { statusCode: 409 } }), true)
+    assert.equal(isAlreadyExists({ body: { code: 409 } }), true)
+    assert.equal(isAlreadyExists({ body: { reason: 'AlreadyExists' } }), true)
+  })
+
+  it('does not match unrelated errors', () => {
+    assert.equal(isAlreadyExists({ code: 404 }), false)
+    assert.equal(isAlreadyExists(new Error('boom')), false)
+    assert.equal(isAlreadyExists(null), false)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// constructor — kube-client construction & opt-in default safety
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RancherBackend constructor', () => {
+  it('validates Rancher options when no client is injected (rejects bad clusterId without touching a real cluster)', () => {
+    assert.throws(
+      () => new RancherBackend({ rancherUrl: 'https://r', clusterId: 'bad', token: 't' }),
+      /cluster-ID format/,
+    )
+  })
+
+  it('builds a real kube client pointed at the Rancher proxy when given a full config (no network call at construct time)', () => {
+    const backend = new RancherBackend({
+      rancherUrl: 'https://rancher.example.com',
+      clusterId: 'c-m-abc123',
+      token: 'secret-token',
+    })
+    assert.equal(backend.clusterId, 'c-m-abc123')
+    // The kube client exists and is the object K8sBackend methods use.
+    assert.ok(backend._api, 'expected a CoreV1Api on the backend')
+    // The bearer token must NOT be copied onto the instance identity block.
+    assert.equal(backend._rancher.token, undefined)
+    assert.ok(!JSON.stringify(backend._rancher).includes('secret-token'))
+  })
+
+  it('rejects a malformed defaultProjectId', () => {
+    assert.throws(
+      () => new RancherBackend({
+        rancherUrl: 'https://r', clusterId: 'c-m-1', token: 't', defaultProjectId: 'bad',
+      }),
+      /project-ID format/,
+    )
+  })
+
+  it('accepts an injected CoreV1Api seam and skips Rancher client construction', () => {
+    const api = createMockApi()
+    const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-abc123', namespace: 'team-a' })
+    assert.equal(backend._api, api)
+    assert.equal(backend.clusterId, 'c-m-abc123')
+  })
+
+  it('forwards K8s opts (namespace) to the K8sBackend base', () => {
+    const api = createMockApi()
+    const backend = new RancherBackend({ _coreV1Api: api, namespace: 'team-a', clusterId: 'c-m-1' })
+    assert.equal(backend._namespace, 'team-a')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ensureProjectNamespace — project-scoped namespace creation (core AC)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ensureProjectNamespace', () => {
+  it('creates a namespace annotated with field.cattle.io/projectId (<clusterId>:<projectId>)', async () => {
+    const api = createMockApi()
+    const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-abc123' })
+
+    const result = await backend.ensureProjectNamespace('team-alpha', { projectId: 'p-xyz789' })
+
+    assert.equal(api.calls.createNamespace.length, 1)
+    const body = api.calls.createNamespace[0].body
+    assert.equal(body.kind, 'Namespace')
+    assert.equal(body.metadata.name, 'team-alpha')
+    assert.equal(body.metadata.annotations[PROJECT_ID_ANNOTATION], 'c-m-abc123:p-xyz789')
+    assert.deepEqual(result, { namespace: 'team-alpha', projectId: 'p-xyz789', created: true })
+  })
+
+  it('uses the constructor defaultProjectId when no per-call projectId is given', async () => {
+    const api = createMockApi()
+    const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-abc123' })
+    backend._rancher.defaultProjectId = 'p-default'
+
+    const result = await backend.ensureProjectNamespace('team-beta')
+
+    const body = api.calls.createNamespace[0].body
+    assert.equal(body.metadata.annotations[PROJECT_ID_ANNOTATION], 'c-m-abc123:p-default')
+    assert.equal(result.projectId, 'p-default')
+  })
+
+  it('is idempotent — a 409 AlreadyExists is treated as success (created:false)', async () => {
+    const api = createMockApi({ createNamespace: () => { throw makeConflictError() } })
+    const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-abc123' })
+
+    const result = await backend.ensureProjectNamespace('team-alpha', { projectId: 'p-xyz789' })
+    assert.deepEqual(result, { namespace: 'team-alpha', projectId: 'p-xyz789', created: false })
+  })
+
+  it('rethrows non-conflict API errors', async () => {
+    const api = createMockApi({ createNamespace: () => { throw Object.assign(new Error('forbidden'), { code: 403 }) } })
+    const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-abc123' })
+    await assert.rejects(
+      () => backend.ensureProjectNamespace('team-alpha', { projectId: 'p-xyz789' }),
+      /forbidden/,
+    )
+  })
+
+  it('falls back to a plain namespace (no project binding) when no projectId is available', async () => {
+    const api = createMockApi()
+    const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-abc123' })
+
+    const result = await backend.ensureProjectNamespace('plain-ns')
+
+    const body = api.calls.createNamespace[0].body
+    assert.equal(body.metadata.annotations, undefined)
+    assert.equal(result.projectId, null)
+    assert.equal(result.created, true)
+  })
+
+  it('falls back to a plain namespace when a projectId is requested but no clusterId is configured', async () => {
+    const api = createMockApi()
+    // No clusterId — e.g. injected-client test path with partial Rancher identity.
+    const backend = new RancherBackend({ _coreV1Api: api })
+
+    const result = await backend.ensureProjectNamespace('plain-ns', { projectId: 'p-xyz789' })
+
+    const body = api.calls.createNamespace[0].body
+    assert.equal(body.metadata.annotations, undefined, 'must not form a malformed annotation without clusterId')
+    assert.equal(result.projectId, null)
+  })
+
+  it('rejects a malformed per-call projectId', async () => {
+    const api = createMockApi()
+    const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-abc123' })
+    await assert.rejects(
+      () => backend.ensureProjectNamespace('team-alpha', { projectId: 'bad' }),
+      /project-ID format/,
+    )
+  })
+
+  it('validates the namespace against RFC 1123 (reuses K8sBackend validation)', async () => {
+    const api = createMockApi()
+    const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-abc123' })
+    await assert.rejects(
+      () => backend.ensureProjectNamespace('Bad_NS', { projectId: 'p-xyz789' }),
+      /RFC 1123/,
+    )
+    assert.equal(api.calls.createNamespace.length, 0, 'no API call for an invalid namespace')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inherited K8sBackend behaviour still works through the Rancher proxy client
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('RancherBackend inherits K8sBackend', () => {
+  it('is an instanceof K8sBackend (so EnvironmentManager treats it identically)', async () => {
+    const { K8sBackend } = await import('../../../src/environments/backends/k8s.js')
+    const backend = new RancherBackend({ _coreV1Api: createMockApi(), clusterId: 'c-m-1' })
+    assert.ok(backend instanceof K8sBackend)
+  })
+
+  it('createEnvironment uses the injected (Rancher proxy) api and honours the namespace', async () => {
+    const api = createMockApi()
+    const backend = new RancherBackend({ _coreV1Api: api, clusterId: 'c-m-1', namespace: 'team-a' })
+
+    await backend.createEnvironment({ envId: 'e1' })
+
+    // Secret + Pod created in the configured namespace via the same client.
+    assert.equal(api.calls.createSecret.length, 1)
+    assert.equal(api.calls.createSecret[0].namespace, 'team-a')
+    assert.equal(api.calls.create.length, 1)
+    assert.equal(api.calls.create[0].namespace, 'team-a')
+  })
+})


### PR DESCRIPTION
## Summary

Adds an **optional** `RancherBackend` that runs the full `K8sBackend` against a Rancher-managed cluster (#3196, part of epic #2450).

Rancher is fundamentally an **auth/proxy layer in front of the Kubernetes API**: it exposes each downstream cluster's kube API under `<rancher-url>/k8s/clusters/<clusterId>`, authenticated with a Rancher bearer token. The adapter therefore only changes **how the kube client is constructed** and reuses 100% of the existing pod/secret/exec logic.

## What it does

- `RancherBackend extends K8sBackend`. Builds the kube client via `KubeConfig.loadFromClusterAndUser` pointed at the Rancher proxy URL with bearer-token auth + optional CA bundle, handed down through K8sBackend's existing `_coreV1Api` injection seam — fully unit-testable without a real Rancher/cluster.
- `ensureProjectNamespace(ns, { projectId })` — project-scoped namespace creation. Creates a standard K8s Namespace annotated `field.cattle.io/projectId: <clusterId>:<projectId>`, which is exactly how Rancher binds a namespace to a Project (RBAC + quotas inherited). No separate Rancher REST API needed — it flows through the proxied kube API.
- **Opt-in.** `isRancherConfigured(opts)` gates instantiation. When Rancher is not configured, the default in-cluster / kubeconfig K8s path is unchanged.
- **Graceful fallback** (AC: "falls back to plain K8s if Rancher API is unavailable"): when a `projectId` is requested but no usable `clusterId` is available, it creates a plain namespace (no malformed annotation) and logs the degradation. A `409 Conflict` is treated as success (idempotent, safe to retry).

## Security

- Bearer token is validated but **never logged and never copied onto the instance** — it lives only inside the kube client's auth provider. Validation errors deliberately omit the token value.
- TLS verification **on by default**; `caData` for self-signed Rancher servers, `skipTLSVerify` documented as discouraged.

## Docs

`docs/guides/k8s-rancher-backend.md` — when to pick K8s vs Rancher, configuration table, and security notes.

## Tests

`packages/server/tests/environments/backends/rancher.test.js` (33 tests, all green): option validation (incl. token never echoed), proxy URL construction, opt-in gating, 409-shape detection, constructor (real client build + injected seam + token-not-leaked), project-namespace annotation, defaultProjectId, idempotency, non-conflict rethrow, fallback paths, RFC 1123 namespace reuse, and `instanceof K8sBackend` + inherited `createEnvironment` through the proxy client.

Both server lint scripts pass (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`).

## Out of scope / follow-up

Config-level backend *selection* (`environments.rancher` block in `config.js`) is not wired here because backend selection isn't config-driven even for `K8sBackend` yet (both are instantiated via the `EnvironmentManager` `backend` injection seam). Tracked as follow-up.

## Live validation

No real Rancher/cluster available in CI — expected. The kube-client construction (`loadFromClusterAndUser` → proxy URL + bearer token) is unit-verified but the end-to-end proxy round-trip against a live Rancher server remains for manual validation.

Closes #3196