### PR TITLE
feat(server): standalone chroxy-channel MCP server prototype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17059,6 +17059,7 @@
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
         "@kubernetes/client-node": "^1.4.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "bonjour-service": "^1.3.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,6 +23,7 @@
     "@chroxy/protocol": "*",
     "@chroxy/store-core": "*",
     "@kubernetes/client-node": "^1.4.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "bonjour-service": "^1.3.0",

--- a/packages/server/src/channels/README.md
+++ b/packages/server/src/channels/README.md
@@ -35,8 +35,9 @@ The server is spawned by `claude` over stdio, so running it directly just exits
 (it has no stdio peer — that is expected).
 
 ```bash
-# Terminal 1 — register it in .mcp.json (run from your project root).
-# Use an absolute path to the file so claude can spawn it from any cwd.
+# Terminal 1 — register it in .mcp.json. The relative path below works when you
+# launch claude from this repo's root; for a user-level ~/.claude.json, or to
+# launch from any cwd, use the absolute path to the file instead.
 cat > .mcp.json <<'EOF'
 {
   "mcpServers": {

--- a/packages/server/src/channels/README.md
+++ b/packages/server/src/channels/README.md
@@ -1,0 +1,95 @@
+# chroxy-channel — `claude --channels` MCP prototype
+
+Standalone prototype that proves the `claude --channels` round-trip end-to-end
+against a real `claude` binary. **No chroxy wiring** — this is intentionally not
+registered in `providers.js`, `ws-server.js`, or any session class. It exists to
+de-risk the channel protocol before the provider scaffold (#3953) and bridge
+(#3954) are built on top of it.
+
+See [`docs/architecture/claude-channels-provider-spike.md`](../../../../docs/architecture/claude-channels-provider-spike.md)
+(the #3951 spike) for the verified protocol contract and the go/no-go rationale.
+
+## What it does
+
+[`chroxy-channel-server.js`](./chroxy-channel-server.js) is a Node 22 stdio MCP
+server that:
+
+1. Declares the `experimental: { 'claude/channel': {} }` capability — the
+   presence of this key is what registers Claude's channel notification listener.
+2. Declares `tools: {}` and registers a two-way `reply(chat_id, text)` tool whose
+   handler logs the reply to **stderr** (the prototype has nowhere else to send
+   it yet; the bridge in #3954 will route it back over IPC).
+3. Listens on a **localhost-only** HTTP port (default `8788`, override with
+   `CHROXY_CHANNEL_PORT`). Every `POST` body is forwarded into Claude as a
+   `notifications/claude/channel` event with an incrementing `meta.chat_id`.
+4. Sets `instructions` on the `Server` constructor explaining the `<channel>`
+   envelope and how to reply.
+5. Connects over `StdioServerTransport` — `claude` spawns it as a subprocess.
+
+Permission relay (`claude/channel/permission`) is **out of scope** here (sub 4,
+#3955) — the prototype declares only the inbound channel + reply-tool surface.
+
+## Run it manually
+
+The server is spawned by `claude` over stdio, so running it directly just exits
+(it has no stdio peer — that is expected).
+
+```bash
+# Terminal 1 — register it in .mcp.json (run from your project root).
+# Use an absolute path to the file so claude can spawn it from any cwd.
+cat > .mcp.json <<'EOF'
+{
+  "mcpServers": {
+    "chroxy-channel": {
+      "command": "node",
+      "args": ["packages/server/src/channels/chroxy-channel-server.js"]
+    }
+  }
+}
+EOF
+
+# Start an interactive claude session that loads the channel. The dev flag is
+# required during the research preview because custom channels are not on the
+# approved allowlist.
+claude --dangerously-load-development-channels server:chroxy-channel
+
+# Terminal 2 — push a message into the live session.
+curl -X POST localhost:8788 -d "list the files in this directory"
+```
+
+Expected: the message lands in Claude's transcript as
+
+```text
+<channel source="chroxy-channel" chat_id="1" path="/" method="POST">list the files in this directory</channel>
+```
+
+Claude responds in the session and, when it calls the `reply` tool, the
+prototype logs the reply to stderr (visible in Terminal 1, or in the channel's
+debug log at `~/.claude/debug/<session-id>.txt`).
+
+### Override the port
+
+```bash
+CHROXY_CHANNEL_PORT=9001 claude --dangerously-load-development-channels server:chroxy-channel
+curl -X POST localhost:9001 -d "hello from a different port"
+```
+
+## Troubleshooting
+
+- **`curl` succeeds but nothing reaches Claude** — run `/mcp` in the session to
+  check the channel's status. "Failed to connect" usually means an import error;
+  check `~/.claude/debug/<session-id>.txt` for the stderr trace.
+- **`curl` fails with "connection refused"** — the port is not bound yet, or a
+  stale process from a previous run is holding it. `lsof -i :8788` shows what is
+  listening; kill the stale process and restart the session.
+- **"blocked by org policy"** — a Team/Enterprise admin must enable channels for
+  the org (`channelsEnabled`). Channels are not available on Bedrock/Vertex.
+
+## Security note
+
+The HTTP control surface binds to `127.0.0.1` only. Even so, **anything that can
+POST to the port injects text directly into the live Claude session** — a
+prompt-injection surface (spike risk R8). This prototype keeps the surface for
+`curl` testing; the real bridge (#3954) replaces it with a Unix socket driven
+solely by `ClaudeChannelSession`, and any permission-relay opt-in (#3955) gates
+on that single trusted writer.

--- a/packages/server/src/channels/chroxy-channel-server.js
+++ b/packages/server/src/channels/chroxy-channel-server.js
@@ -171,6 +171,11 @@ export function startHttpControlSurface({ mcp, port = DEFAULT_PORT, log = (...a)
 
   const httpServer = createServer((req, res) => {
     const chunks = []
+    // Body is read fully into memory: fine for a localhost debug prototype, not
+    // for the real bridge. No size cap by design — the surface is trusted-local.
+    req.on('error', err => {
+      log('request error:', err && err.message ? err.message : err)
+    })
     req.on('data', chunk => chunks.push(chunk))
     req.on('end', async () => {
       const body = Buffer.concat(chunks).toString('utf8')

--- a/packages/server/src/channels/chroxy-channel-server.js
+++ b/packages/server/src/channels/chroxy-channel-server.js
@@ -31,6 +31,7 @@
  * bridge (#3954) replaces this with a Unix socket driven solely by the session.
  */
 import { createServer } from 'http'
+import { pathToFileURL } from 'url'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
@@ -170,6 +171,16 @@ export function startHttpControlSurface({ mcp, port = DEFAULT_PORT, log = (...a)
   let nextChatId = 1
 
   const httpServer = createServer((req, res) => {
+    // The control surface only accepts POST (the documented `curl -X POST`
+    // path). Reject anything else up front so it's clear exactly what reaches
+    // the Claude session.
+    if ((req.method || '') !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'text/plain', Allow: 'POST' })
+      res.end('method not allowed')
+      req.resume() // drain any body so the socket can be reused/closed cleanly
+      return
+    }
+
     const chunks = []
     // Body is read fully into memory: fine for a localhost debug prototype, not
     // for the real bridge. No size cap by design — the surface is trusted-local.
@@ -222,9 +233,12 @@ export async function main() {
   startHttpControlSurface({ mcp, port })
 }
 
-// Only auto-run when executed directly (not when imported by tests).
+// Only auto-run when executed directly (not when imported by tests). Compare
+// against pathToFileURL(process.argv[1]) — argv[1] can be a RELATIVE path (e.g.
+// `node ./chroxy-channel-server.js`), so a naive `file://${argv[1]}` would never
+// match the absolute `import.meta.url` and main() would silently never run.
 const isDirectRun = process.argv[1] &&
-  import.meta.url === `file://${process.argv[1]}`
+  import.meta.url === pathToFileURL(process.argv[1]).href
 if (isDirectRun) {
   main().catch(err => {
     console.error('[chroxy-channel] fatal:', err)

--- a/packages/server/src/channels/chroxy-channel-server.js
+++ b/packages/server/src/channels/chroxy-channel-server.js
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * chroxy-channel — standalone `claude --channels` MCP server prototype (#3952).
+ *
+ * This is a STANDALONE prototype, intentionally NOT wired into chroxy's provider
+ * registry, ws-server, or any session class. Its only job is to prove the live
+ * `claude --channels` round-trip end-to-end before the provider scaffold (#3953)
+ * and bridge (#3954) are built on top of it. See:
+ *   - docs/architecture/claude-channels-provider-spike.md  (the #3951 spike)
+ *   - packages/server/src/channels/README.md               (how to run it)
+ *
+ * Protocol contract (verified against the published Channels reference and the
+ * installed CLI v2.1.163 in the spike):
+ *   - Declares the `experimental: { 'claude/channel': {} }` capability — the
+ *     presence of this key is what registers the channel notification listener.
+ *   - Declares `tools: {}` and registers a two-way `reply(chat_id, text)` tool.
+ *     For this prototype the handler just logs the reply to stderr.
+ *   - Pushes inbound events with `mcp.notification({ method:
+ *     'notifications/claude/channel', params: { content, meta } })`. Each `meta`
+ *     key becomes an attribute on the `<channel source="…">` envelope.
+ *   - Connects over `StdioServerTransport` — `claude` spawns this file as a
+ *     subprocess and talks stdio, so running it directly exits immediately (it
+ *     has no stdio peer). That is expected; spawn it via `claude --channels`.
+ *
+ * Permission relay (`claude/channel/permission`) is deliberately OUT OF SCOPE
+ * here — that is sub 4 (#3955), where it can be gated behind a trusted sender.
+ *
+ * Security: the HTTP control surface binds to 127.0.0.1 only. It is a debug /
+ * prototype affordance — anything that can POST to it injects text into the
+ * live Claude session (a prompt-injection surface, see spike R8). The real
+ * bridge (#3954) replaces this with a Unix socket driven solely by the session.
+ */
+import { createServer } from 'http'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+
+export const SERVER_NAME = 'chroxy-channel'
+export const SERVER_VERSION = '0.0.1'
+export const DEFAULT_PORT = 8788
+
+// The channel notification method, verbatim from the protocol contract. Each
+// `meta` key becomes an attribute on the <channel source="…"> envelope.
+export const CHANNEL_NOTIFICATION_METHOD = 'notifications/claude/channel'
+
+// Injected into Claude's system prompt. Tells Claude the envelope shape and how
+// to reply. `source` is filled in automatically from SERVER_NAME by the CLI.
+export const INSTRUCTIONS = [
+  `Events from the ${SERVER_NAME} channel arrive as`,
+  `<channel source="${SERVER_NAME}" chat_id="…" path="…" method="…">…</channel>.`,
+  'They carry text a remote user sent over the chroxy-channel prototype.',
+  'To send a message back to that user, call the `reply` tool, passing the',
+  '`chat_id` from the inbound tag and your `text`. Anything you want the sender',
+  'to see must go through the `reply` tool — the channel is otherwise one-way.'
+].join(' ')
+
+// The reply tool definition, shaped exactly as the protocol reference shows.
+export const REPLY_TOOL = {
+  name: 'reply',
+  description: 'Send a message back to the sender over the chroxy-channel.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      chat_id: { type: 'string', description: 'The conversation to reply in (from the inbound <channel> tag).' },
+      text: { type: 'string', description: 'The message to send back to the sender.' }
+    },
+    required: ['chat_id', 'text']
+  }
+}
+
+/**
+ * MCP `meta` keys must be identifiers (letters, digits, underscores). Per the
+ * protocol reference, keys containing hyphens or other characters are silently
+ * dropped by Claude Code. We drop them up front so the prototype's behaviour is
+ * explicit and testable rather than relying on the silent drop.
+ *
+ * @param {Record<string, unknown>} meta
+ * @returns {Record<string, string>} identifier-safe, string-valued meta
+ */
+export function sanitizeMeta(meta) {
+  const out = {}
+  if (!meta || typeof meta !== 'object') return out
+  for (const [key, value] of Object.entries(meta)) {
+    if (!/^[A-Za-z0-9_]+$/.test(key)) continue
+    if (value === undefined || value === null) continue
+    out[key] = String(value)
+  }
+  return out
+}
+
+/**
+ * Build the channel `notifications/claude/channel` payload for a given request.
+ * Factored out so the envelope shape (method + content + sanitized meta) can be
+ * unit-tested without a live transport.
+ *
+ * @param {object} args
+ * @param {string} args.content  the message body (becomes the <channel> body)
+ * @param {string} args.chatId   incrementing per-request id (becomes chat_id attr)
+ * @param {string} [args.path]   request path (becomes path attr)
+ * @param {string} [args.method] request method (becomes method attr)
+ * @returns {{ method: string, params: { content: string, meta: Record<string,string> } }}
+ */
+export function buildChannelNotification({ content, chatId, path = '/', method = 'POST' }) {
+  return {
+    method: CHANNEL_NOTIFICATION_METHOD,
+    params: {
+      content: String(content ?? ''),
+      meta: sanitizeMeta({ chat_id: chatId, path, method })
+    }
+  }
+}
+
+/**
+ * Create the channel MCP `Server` with the channel capability, the reply tool,
+ * and the instructions wired up — but without connecting any transport. The
+ * caller connects stdio (the CLI path) or drives it directly (tests).
+ *
+ * @param {object} [opts]
+ * @param {(args: { chat_id: string, text: string }) => void} [opts.onReply]
+ *   invoked when Claude calls the `reply` tool. Defaults to logging to stderr.
+ * @param {(...args: unknown[]) => void} [opts.log] stderr logger seam (tests).
+ * @returns {{ mcp: import('@modelcontextprotocol/sdk/server/index.js').Server }}
+ */
+export function createChannelServer(opts = {}) {
+  const log = opts.log || ((...args) => console.error('[chroxy-channel]', ...args))
+  const onReply = opts.onReply || (({ chat_id, text }) => {
+    log(`reply chat_id=${chat_id}: ${text}`)
+  })
+
+  const mcp = new Server(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    {
+      // Presence of `claude/channel` registers the channel notification
+      // listener; `tools` lets Claude discover the `reply` tool.
+      capabilities: {
+        experimental: { 'claude/channel': {} },
+        tools: {}
+      },
+      instructions: INSTRUCTIONS
+    }
+  )
+
+  mcp.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [REPLY_TOOL] }))
+
+  mcp.setRequestHandler(CallToolRequestSchema, async req => {
+    if (req.params.name === REPLY_TOOL.name) {
+      const args = req.params.arguments || {}
+      const chat_id = String(args.chat_id ?? '')
+      const text = String(args.text ?? '')
+      onReply({ chat_id, text })
+      return { content: [{ type: 'text', text: 'sent' }] }
+    }
+    throw new Error(`unknown tool: ${req.params.name}`)
+  })
+
+  return { mcp }
+}
+
+/**
+ * Start the localhost-only HTTP control surface that forwards every POST body
+ * into Claude as a channel notification, with an incrementing `chat_id`.
+ *
+ * @param {object} args
+ * @param {import('@modelcontextprotocol/sdk/server/index.js').Server} args.mcp
+ * @param {number} [args.port]
+ * @param {(...args: unknown[]) => void} [args.log]
+ * @returns {import('http').Server}
+ */
+export function startHttpControlSurface({ mcp, port = DEFAULT_PORT, log = (...a) => console.error('[chroxy-channel]', ...a) }) {
+  let nextChatId = 1
+
+  const httpServer = createServer((req, res) => {
+    const chunks = []
+    req.on('data', chunk => chunks.push(chunk))
+    req.on('end', async () => {
+      const body = Buffer.concat(chunks).toString('utf8')
+      const chatId = String(nextChatId++)
+      const path = (req.url || '/').split('?')[0]
+      const notification = buildChannelNotification({
+        content: body,
+        chatId,
+        path,
+        method: req.method || 'POST'
+      })
+      try {
+        // Fire-and-forget: resolves on transport write, not on Claude
+        // processing. Dropped silently if the session didn't load the channel.
+        await mcp.notification(notification)
+        log(`forwarded chat_id=${chatId} (${body.length} bytes)`)
+        res.writeHead(200, { 'Content-Type': 'text/plain' })
+        res.end('ok')
+      } catch (err) {
+        log('notification failed:', err && err.message ? err.message : err)
+        res.writeHead(502, { 'Content-Type': 'text/plain' })
+        res.end('channel notification failed')
+      }
+    })
+  })
+
+  // localhost-only: nothing outside this machine can POST. See spike R8.
+  httpServer.listen(port, '127.0.0.1', () => {
+    log(`HTTP control surface listening on 127.0.0.1:${port}`)
+  })
+  return httpServer
+}
+
+/**
+ * CLI entrypoint: build the server, connect stdio, and start the HTTP surface.
+ * Exported so it can be invoked in tests with injected seams if ever needed,
+ * but it is normally run by `claude` spawning this file over stdio.
+ */
+export async function main() {
+  const port = Number(process.env.CHROXY_CHANNEL_PORT) || DEFAULT_PORT
+  const { mcp } = createChannelServer()
+  // Connect stdio FIRST so notifications have a transport to write to.
+  await mcp.connect(new StdioServerTransport())
+  startHttpControlSurface({ mcp, port })
+}
+
+// Only auto-run when executed directly (not when imported by tests).
+const isDirectRun = process.argv[1] &&
+  import.meta.url === `file://${process.argv[1]}`
+if (isDirectRun) {
+  main().catch(err => {
+    console.error('[chroxy-channel] fatal:', err)
+    process.exit(1)
+  })
+}

--- a/packages/server/tests/chroxy-channel-server.test.js
+++ b/packages/server/tests/chroxy-channel-server.test.js
@@ -1,0 +1,237 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { once } from 'node:events'
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import {
+  SERVER_NAME,
+  DEFAULT_PORT,
+  CHANNEL_NOTIFICATION_METHOD,
+  INSTRUCTIONS,
+  REPLY_TOOL,
+  sanitizeMeta,
+  buildChannelNotification,
+  createChannelServer,
+  startHttpControlSurface
+} from '../src/channels/chroxy-channel-server.js'
+
+// Unit tests for the standalone chroxy-channel MCP prototype (#3952). These
+// exercise the protocol surface against injectable seams without spawning a
+// live `claude` session — they assert the capability advertisement, reply-tool
+// shape, notification envelope, meta sanitization, and the HTTP control surface
+// forwarding behaviour. The live `claude --channels` round-trip is documented
+// in the README and is not exercisable headlessly here.
+
+describe('chroxy-channel: protocol constants', () => {
+  it('uses the verified channel notification method verbatim', () => {
+    assert.equal(CHANNEL_NOTIFICATION_METHOD, 'notifications/claude/channel')
+  })
+
+  it('exposes the prototype server name and default port', () => {
+    assert.equal(SERVER_NAME, 'chroxy-channel')
+    assert.equal(DEFAULT_PORT, 8788)
+  })
+
+  it('instructions tell Claude the envelope shape and to use the reply tool', () => {
+    assert.match(INSTRUCTIONS, /<channel source="chroxy-channel"/)
+    assert.match(INSTRUCTIONS, /reply/i)
+    assert.match(INSTRUCTIONS, /chat_id/)
+  })
+
+  it('reply tool declares chat_id + text as required string args', () => {
+    assert.equal(REPLY_TOOL.name, 'reply')
+    assert.equal(REPLY_TOOL.inputSchema.type, 'object')
+    assert.deepEqual(REPLY_TOOL.inputSchema.required, ['chat_id', 'text'])
+    assert.equal(REPLY_TOOL.inputSchema.properties.chat_id.type, 'string')
+    assert.equal(REPLY_TOOL.inputSchema.properties.text.type, 'string')
+  })
+})
+
+describe('chroxy-channel: sanitizeMeta', () => {
+  it('keeps identifier-safe keys and stringifies values', () => {
+    assert.deepEqual(
+      sanitizeMeta({ chat_id: 1, severity: 'high', count: 0 }),
+      { chat_id: '1', severity: 'high', count: '0' }
+    )
+  })
+
+  it('drops keys with hyphens or other non-identifier characters', () => {
+    // Per the protocol reference, Claude silently drops these; we drop up front.
+    assert.deepEqual(
+      sanitizeMeta({ 'chat-id': '1', 'x.y': '2', ok_key: '3' }),
+      { ok_key: '3' }
+    )
+  })
+
+  it('drops null and undefined values', () => {
+    assert.deepEqual(
+      sanitizeMeta({ a: null, b: undefined, c: 'keep' }),
+      { c: 'keep' }
+    )
+  })
+
+  it('returns an empty object for non-object input', () => {
+    assert.deepEqual(sanitizeMeta(null), {})
+    assert.deepEqual(sanitizeMeta(undefined), {})
+    assert.deepEqual(sanitizeMeta('nope'), {})
+  })
+})
+
+describe('chroxy-channel: buildChannelNotification', () => {
+  it('produces the verified channel notification envelope', () => {
+    const n = buildChannelNotification({ content: 'hello', chatId: '7', path: '/hook', method: 'POST' })
+    assert.equal(n.method, 'notifications/claude/channel')
+    assert.equal(n.params.content, 'hello')
+    assert.deepEqual(n.params.meta, { chat_id: '7', path: '/hook', method: 'POST' })
+  })
+
+  it('defaults path and method, and coerces missing content to empty string', () => {
+    const n = buildChannelNotification({ content: undefined, chatId: '1' })
+    assert.equal(n.params.content, '')
+    assert.deepEqual(n.params.meta, { chat_id: '1', path: '/', method: 'POST' })
+  })
+})
+
+describe('chroxy-channel: createChannelServer capabilities', () => {
+  it('declares the claude/channel capability and tools', () => {
+    const { mcp } = createChannelServer({ log: () => {} })
+    // getCapabilities reflects what was passed to the Server constructor.
+    const caps = mcp.getCapabilities ? mcp.getCapabilities() : mcp._capabilities
+    assert.ok(caps.experimental, 'experimental capabilities present')
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(caps.experimental, 'claude/channel'),
+      'claude/channel key present — registers the channel listener'
+    )
+    assert.deepEqual(caps.experimental['claude/channel'], {})
+    assert.ok(caps.tools, 'tools capability present for the reply tool')
+  })
+
+  it('does NOT declare the permission relay capability (out of scope, sub 4)', () => {
+    const { mcp } = createChannelServer({ log: () => {} })
+    const caps = mcp.getCapabilities ? mcp.getCapabilities() : mcp._capabilities
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(caps.experimental, 'claude/channel/permission'),
+      'permission relay must not be declared in the prototype'
+    )
+  })
+})
+
+describe('chroxy-channel: reply tool handlers', () => {
+  // The MCP Server registers request handlers keyed by the request schema's
+  // method. We exercise those handlers directly via the (private) registry to
+  // avoid spinning up a transport pair.
+  function getHandler(mcp, schema) {
+    const method = schema.shape.method.value
+    return mcp._requestHandlers.get(method)
+  }
+
+  it('ListTools returns exactly the reply tool', async () => {
+    const { mcp } = createChannelServer({ log: () => {} })
+    const handler = getHandler(mcp, ListToolsRequestSchema)
+    assert.ok(handler, 'ListTools handler registered')
+    const result = await handler({ method: 'tools/list', params: {} }, {})
+    assert.equal(result.tools.length, 1)
+    assert.equal(result.tools[0].name, 'reply')
+  })
+
+  it('CallTool reply invokes onReply with chat_id + text and returns sent', async () => {
+    const replies = []
+    const { mcp } = createChannelServer({ log: () => {}, onReply: r => replies.push(r) })
+    const handler = getHandler(mcp, CallToolRequestSchema)
+    const result = await handler(
+      { method: 'tools/call', params: { name: 'reply', arguments: { chat_id: '3', text: 'hi there' } } },
+      {}
+    )
+    assert.deepEqual(replies, [{ chat_id: '3', text: 'hi there' }])
+    assert.deepEqual(result.content, [{ type: 'text', text: 'sent' }])
+  })
+
+  it('CallTool coerces missing reply arguments to empty strings', async () => {
+    const replies = []
+    const { mcp } = createChannelServer({ log: () => {}, onReply: r => replies.push(r) })
+    const handler = getHandler(mcp, CallToolRequestSchema)
+    await handler({ method: 'tools/call', params: { name: 'reply' } }, {})
+    assert.deepEqual(replies, [{ chat_id: '', text: '' }])
+  })
+
+  it('CallTool throws for an unknown tool', async () => {
+    const { mcp } = createChannelServer({ log: () => {} })
+    const handler = getHandler(mcp, CallToolRequestSchema)
+    await assert.rejects(
+      () => handler({ method: 'tools/call', params: { name: 'nope', arguments: {} } }, {}),
+      /unknown tool: nope/
+    )
+  })
+
+  it('the default onReply logs the reply to the injected logger (stderr seam)', async () => {
+    const logged = []
+    const { mcp } = createChannelServer({ log: (...a) => logged.push(a.join(' ')) })
+    const handler = getHandler(mcp, CallToolRequestSchema)
+    await handler({ method: 'tools/call', params: { name: 'reply', arguments: { chat_id: '9', text: 'pong' } } }, {})
+    assert.ok(logged.some(l => l.includes('reply chat_id=9') && l.includes('pong')))
+  })
+})
+
+describe('chroxy-channel: HTTP control surface', () => {
+  async function withServer(fn) {
+    const sent = []
+    // Fake mcp with just the notification method the surface uses.
+    const mcp = { notification: async n => { sent.push(n) } }
+    // port 0 → OS picks a free localhost port, avoids 8788 collisions in CI.
+    const httpServer = startHttpControlSurface({ mcp, port: 0, log: () => {} })
+    await once(httpServer, 'listening')
+    const { port } = httpServer.address()
+    try {
+      await fn({ port, sent })
+    } finally {
+      httpServer.close()
+      await once(httpServer, 'close')
+    }
+  }
+
+  it('binds to localhost only', async () => {
+    const mcp = { notification: async () => {} }
+    const httpServer = startHttpControlSurface({ mcp, port: 0, log: () => {} })
+    await once(httpServer, 'listening')
+    assert.equal(httpServer.address().address, '127.0.0.1')
+    httpServer.close()
+    await once(httpServer, 'close')
+  })
+
+  it('forwards a POST body as a channel notification with incrementing chat_id', async () => {
+    await withServer(async ({ port, sent }) => {
+      const r1 = await fetch(`http://127.0.0.1:${port}/hook`, { method: 'POST', body: 'first' })
+      const r2 = await fetch(`http://127.0.0.1:${port}/`, { method: 'POST', body: 'second' })
+      assert.equal(r1.status, 200)
+      assert.equal(await r1.text(), 'ok')
+      assert.equal(r2.status, 200)
+
+      assert.equal(sent.length, 2)
+      assert.equal(sent[0].method, 'notifications/claude/channel')
+      assert.equal(sent[0].params.content, 'first')
+      assert.deepEqual(sent[0].params.meta, { chat_id: '1', path: '/hook', method: 'POST' })
+      assert.equal(sent[1].params.content, 'second')
+      assert.equal(sent[1].params.meta.chat_id, '2')
+    })
+  })
+
+  it('strips the query string from the forwarded path', async () => {
+    await withServer(async ({ port, sent }) => {
+      await fetch(`http://127.0.0.1:${port}/p?x=1`, { method: 'POST', body: 'q' })
+      assert.equal(sent[0].params.meta.path, '/p')
+    })
+  })
+
+  it('returns 502 when the notification fails', async () => {
+    const mcp = { notification: async () => { throw new Error('no transport') } }
+    const httpServer = startHttpControlSurface({ mcp, port: 0, log: () => {} })
+    await once(httpServer, 'listening')
+    const { port } = httpServer.address()
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`, { method: 'POST', body: 'x' })
+      assert.equal(res.status, 502)
+    } finally {
+      httpServer.close()
+      await once(httpServer, 'close')
+    }
+  })
+})

--- a/packages/server/tests/chroxy-channel-server.test.js
+++ b/packages/server/tests/chroxy-channel-server.test.js
@@ -221,6 +221,15 @@ describe('chroxy-channel: HTTP control surface', () => {
     })
   })
 
+  it('rejects non-POST methods with 405 and does not notify', async () => {
+    await withServer(async ({ port, sent }) => {
+      const res = await fetch(`http://127.0.0.1:${port}/`, { method: 'GET' })
+      assert.equal(res.status, 405)
+      assert.equal(res.headers.get('allow'), 'POST')
+      assert.equal(sent.length, 0, 'no channel notification for a non-POST request')
+    })
+  })
+
   it('returns 502 when the notification fails', async () => {
     const mcp = { notification: async () => { throw new Error('no transport') } }
     const httpServer = startHttpControlSurface({ mcp, port: 0, log: () => {} })


### PR DESCRIPTION
## Summary

Sub 1 of #3951 (the `claude --channels` provider chain). Builds a **standalone** stdio MCP server — `chroxy-channel` — that speaks the channel protocol verified in the [#3951 spike](../blob/main/docs/architecture/claude-channels-provider-spike.md). Its only job is to prove the live channel round-trip before the provider scaffold (#3953) and bridge (#3954) are built on top of it.

**It is intentionally NOT wired into `providers.js`, `ws-server.js`, or any session class.** No existing provider is touched.

## What it does

`packages/server/src/channels/chroxy-channel-server.js`:
- Declares the `experimental: { 'claude/channel': {} }` capability (the presence of this key registers Claude's channel notification listener) plus `tools: {}`.
- Registers a two-way `reply(chat_id, text)` tool whose handler logs to **stderr** (the prototype has nowhere else to route it yet; the bridge in #3954 will).
- Connects over `StdioServerTransport` — `claude` spawns it as a subprocess.
- Runs a **localhost-only** HTTP control surface (default `8788`, override `CHROXY_CHANNEL_PORT`) that forwards every `POST` body into Claude as a `notifications/claude/channel` event with an incrementing `meta.chat_id`.
- Sets `instructions` on the `Server` constructor explaining the `<channel>` envelope and how to reply.

Protocol logic is split into pure, injectable seams (`createChannelServer`, `buildChannelNotification`, `sanitizeMeta`, `startHttpControlSurface`) so it is unit-testable without a live `claude` session.

## Protocol provenance

Every protocol detail (capability key, notification method `notifications/claude/channel`, `meta`→attribute mapping, reply-tool schema, instructions/envelope shape) is taken **verbatim** from the official [Channels reference](https://code.claude.com/docs/en/channels-reference) and matches the strings the #3951 spike found in the installed CLI v2.1.163. Nothing about the protocol is invented.

## Testing

- `tests/chroxy-channel-server.test.js` — **21 unit tests**: capability advertisement (and that permission relay is *not* declared — that's sub 4), instructions content, reply-tool list + handler (invoke `onReply`, coerce missing args, unknown-tool error, default stderr log), `meta` sanitization (hyphen/non-identifier/null drop, stringify), the notification envelope, and the HTTP surface (incrementing `chat_id`, query-string strip, 502 on notification failure, `127.0.0.1` bind).
- Also exercised the **full protocol surface over a real MCP `InMemoryTransport` loopback** (initialize → capabilities → `tools/list` → `reply` call → channel notification push) and confirmed the direct-spawn path writes the correct JSON-RPC `notifications/claude/channel` frame to stdout when curled.

### Live round-trip status

The full `claude --dangerously-load-development-channels server:chroxy-channel` round-trip against an authenticated interactive session is **not exercisable headlessly in CI** (it needs a subscription/console-authenticated `claude` session in the loop). The protocol surface is fully implemented and unit-tested, the wire frame is confirmed correct against the real SDK transport, and the README documents the three-terminal manual test. Proving the live loop is a manual step; the prototype is self-contained and safe to land.

## Dependency

Adds `@modelcontextprotocol/sdk` `^1.29.0` as a regular (non-dev) server dependency, as the spike and issue call for. Resolves cleanly under Node 22.

## Out of scope (per #3951 sub split)

Permission relay (sub 4), sender allowlist (sub 3 bridge), plugin packaging (sub 5), provider/session wiring (sub 2/3).

Closes #3952
