### PR TITLE
feat(server): register claude-channel provider scaffold

### DIFF
--- a/packages/server/src/claude-channel-session.js
+++ b/packages/server/src/claude-channel-session.js
@@ -1,0 +1,180 @@
+import { homedir } from 'os'
+import { join } from 'path'
+import { BaseSession } from './base-session.js'
+import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
+
+// Minimum `claude` CLI version that ships the `--channels` MCP transport.
+// Verified present in v2.1.163 (the locally-installed CLI) and documented
+// from v2.1.80+; permission relay needs ≥ v2.1.81 but that surface lands
+// with sub 4 (#3955), so the scaffold gates on the channel-transport floor
+// only. See docs/architecture/claude-channels-provider-spike.md.
+export const CLAUDE_CHANNEL_MIN_VERSION = '2.1.80'
+
+/**
+ * ClaudeChannelSession — provider scaffold for the `claude --channels` MCP
+ * transport (#3953, parent #3951). Research preview.
+ *
+ * This is intentionally a NO-OP session: `start()` throws "not yet
+ * implemented" so the bridge wiring (spawn + IPC round-trip) can land in
+ * isolation as sub 3 (#3954). Everything the dashboard and `chroxy doctor`
+ * need to LIST and reason about the provider — capabilities, displayLabel,
+ * dataDir, preflight (binary + minVersion + credentials), model metadata,
+ * and auth/billing detail — is fully wired here so the registry surface can
+ * be reviewed without any PTY spawning or MCP child process.
+ *
+ * Auth/billing mirrors `claude-tui`: a subscription/console-authenticated
+ * interactive `claude` session. The channel path bypasses programmatic
+ * credit metering for the same reason the TUI path does — the events arrive
+ * in a real interactive session, not a `claude -p` subprocess. It does NOT
+ * accept ANTHROPIC_API_KEY.
+ *
+ * Capability honesty (see the spike's matrix): channels win on `streaming`
+ * and a documented permission contract, but do NOT solve model switch or
+ * permission-mode switch — those stay `false`, same gap `claude-tui` has.
+ */
+export class ClaudeChannelSession extends BaseSession {
+  // Single source of truth for the scaffold's "not yet implemented" error
+  // so start()/sendMessage()/interrupt() stay in lockstep and tests can
+  // assert on the same string.
+  static get NOT_IMPLEMENTED_MESSAGE() {
+    return 'claude-channel provider not yet implemented (bridge wiring lands in #3954, see #3951)'
+  }
+
+  static get displayLabel() {
+    return 'Claude Code (Channel · subscription · research preview)'
+  }
+
+  static get dataDir() {
+    return join(homedir(), '.claude')
+  }
+
+  static get capabilities() {
+    return {
+      // Permissions land in sub 4 (#3955) via the first-party
+      // `claude/channel/permission` relay — declared true here so the
+      // capability matrix matches the spike + #3953, but the actual
+      // round-trip is not wired until the bridge exists.
+      permissions: true,
+      // Verdicts round-trip over IPC, not in-process — same as claude-tui.
+      inProcessPermissions: false,
+      // Channel surface does not expose model switching (spike R5).
+      modelSwitch: false,
+      // No documented channel mechanism for permission-mode switch (initially).
+      permissionModeSwitch: false,
+      planMode: false,
+      resume: false,
+      terminal: false,
+      thinkingLevel: false,
+      // Channel notifications stream as they arrive — the headline win
+      // over claude-tui's deliver-on-complete model.
+      streaming: true,
+      tools: true,
+    }
+  }
+
+  static get preflight() {
+    return {
+      label: 'Claude Channel',
+      binary: {
+        name: 'claude',
+        args: ['--version'],
+        // Gate on the channel-transport floor. The doctor's checkBinary
+        // comparator parses the leading semver out of `claude --version`
+        // (e.g. "2.1.163 (Claude Code)") and fails below this.
+        minVersion: CLAUDE_CHANNEL_MIN_VERSION,
+        candidates: [
+          join(homedir(), '.local/bin/claude'),
+          '/opt/homebrew/bin/claude',
+          '/usr/local/bin/claude',
+          join(homedir(), '.claude/local/node_modules/.bin/claude'),
+          join(homedir(), '.npm-global/bin/claude'),
+        ],
+        installHint: `install Claude Code CLI ≥ ${CLAUDE_CHANNEL_MIN_VERSION} (research preview — channels)`,
+      },
+      credentials: {
+        envVars: [],
+        hint: 'run `claude login` (subscription required — this provider does NOT accept ANTHROPIC_API_KEY)',
+        optional: true,
+      },
+    }
+  }
+
+  /**
+   * Resolve runtime auth state for the dashboard (#4769 pattern).
+   *
+   * Same path as claude-tui: subscription via OAuth/Keychain, never the
+   * API key. Marked ready up front because the on-disk OAuth probe can't
+   * see Keychain credentials. Detail flags the research-preview status and
+   * the credit-metering bypass so the dashboard billing panel reads true.
+   *
+   * @returns {{ready:boolean, source:string, envVar:string|null, envVars:string[], hint:string, detail:string}}
+   */
+  static resolveAuth() {
+    const envVars = this.preflight.credentials.envVars
+    return {
+      ready: true,
+      source: 'oauth',
+      envVar: null,
+      envVars,
+      hint: 'run `claude login` if not yet authed',
+      detail: 'Claude subscription (channel MCP — bypasses programmatic credit metering · research preview)',
+    }
+  }
+
+  static getFallbackModels() {
+    return FALLBACK_MODELS
+  }
+
+  static getAllowedModels() {
+    return [...ALLOWED_MODEL_IDS]
+  }
+
+  static getModelMetadata(modelId) {
+    if (typeof modelId !== 'string' || modelId.length === 0) return null
+    const fullId = modelId
+    const id = claudeDeriveId(fullId)
+    return { id, label: id, fullId, contextWindow: resolveClaudeContextWindow(fullId), description: '' }
+  }
+
+  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs } = {}) {
+    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-channel', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs })
+  }
+
+  /**
+   * Scaffold no-op. The live bridge — spawn `claude --channels`, wire the
+   * stdio MCP child + IPC socket, normalize outbound events — is sub 3
+   * (#3954). Throwing here (rather than spawning anything) is the whole
+   * point of #3953: `chroxy --provider claude-channel` fails fast with a
+   * clear message, no PTY, no MCP child.
+   */
+  async start() {
+    throw new Error(ClaudeChannelSession.NOT_IMPLEMENTED_MESSAGE)
+  }
+
+  /**
+   * Required by the ProviderSession interface (validateProviderClass).
+   * Unlike start/destroy/setModel/setPermissionMode, BaseSession does not
+   * provide sendMessage/interrupt — each provider owns them — so the
+   * scaffold must define them or the registry validator rejects the class.
+   * Both throw the same not-implemented error until the bridge (#3954)
+   * gives them something to do. They should never be reached anyway: start()
+   * throws first, so no session ever becomes ready enough to message.
+   */
+  async sendMessage() {
+    throw new Error(ClaudeChannelSession.NOT_IMPLEMENTED_MESSAGE)
+  }
+
+  interrupt() {
+    throw new Error(ClaudeChannelSession.NOT_IMPLEMENTED_MESSAGE)
+  }
+
+  /**
+   * Safe no-op teardown. There is nothing to tear down (start() never
+   * spawns anything), and destroy() must not throw — SessionManager calls
+   * it on cleanup paths where a throw would mask the original error.
+   */
+  destroy() {
+    this._destroying = true
+    this._processReady = false
+  }
+}

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -46,8 +46,14 @@ export function parseLeadingSemver(str) {
  * Compare two semver values. `found` may be a string or a parsed
  * `[major, minor, patch]` tuple; `required` is a semver string. Returns a
  * negative number when `found` < `required`, 0 when equal (on the numeric
- * core), positive when greater. An unparseable `found` sorts as less-than
- * so a malformed version never silently satisfies a floor. (#3953)
+ * core), positive when greater.
+ *
+ * Both sides fail CLOSED: an unparseable `found` OR an unparseable
+ * `required` sorts as less-than (returns negative) so the floor is treated
+ * as NOT satisfied. This matters for `required` too — a provider that
+ * accidentally supplies a non-`major.minor.patch` floor (e.g. ">=2.1.80"
+ * or "2.1.80-beta") must not silently disable minVersion enforcement
+ * (Copilot review on #3953). (#3953)
  *
  * @param {string | [number, number, number]} found
  * @param {string} required
@@ -56,7 +62,10 @@ export function parseLeadingSemver(str) {
 export function compareSemver(found, required) {
   const a = Array.isArray(found) ? found : parseLeadingSemver(found)
   const b = parseLeadingSemver(required)
-  if (!a || !b) return a ? 1 : -1
+  // Fail closed on either side: a malformed floor (b) or version (a) is
+  // treated as "not satisfied" so an enforcement gate can never pass by
+  // accident. Returns negative (found < required) in every invalid case.
+  if (!a || !b) return -1
   for (let i = 0; i < 3; i++) {
     if (a[i] !== b[i]) return a[i] - b[i]
   }

--- a/packages/server/src/doctor.js
+++ b/packages/server/src/doctor.js
@@ -26,6 +26,44 @@ const CONFIG_FILE = join(homedir(), '.chroxy', 'config.json')
 const DEFAULT_PROVIDER = 'claude-sdk'
 
 /**
+ * Parse the leading `major.minor.patch` semver out of an arbitrary version
+ * string (e.g. "2.1.163 (Claude Code)" → [2, 1, 163]). Returns null when no
+ * leading semver is present so callers can degrade gracefully rather than
+ * hard-fail on an unexpected version format. Pre-release / build suffixes
+ * are ignored — only the numeric core is compared. (#3953)
+ *
+ * @param {string} str
+ * @returns {[number, number, number] | null}
+ */
+export function parseLeadingSemver(str) {
+  if (typeof str !== 'string') return null
+  const m = str.trim().match(/^v?(\d+)\.(\d+)\.(\d+)/)
+  if (!m) return null
+  return [Number(m[1]), Number(m[2]), Number(m[3])]
+}
+
+/**
+ * Compare two semver values. `found` may be a string or a parsed
+ * `[major, minor, patch]` tuple; `required` is a semver string. Returns a
+ * negative number when `found` < `required`, 0 when equal (on the numeric
+ * core), positive when greater. An unparseable `found` sorts as less-than
+ * so a malformed version never silently satisfies a floor. (#3953)
+ *
+ * @param {string | [number, number, number]} found
+ * @param {string} required
+ * @returns {number}
+ */
+export function compareSemver(found, required) {
+  const a = Array.isArray(found) ? found : parseLeadingSemver(found)
+  const b = parseLeadingSemver(required)
+  if (!a || !b) return a ? 1 : -1
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i]
+  }
+  return 0
+}
+
+/**
  * Detect whether the server is running inside a bundled .app (Tauri) or
  * under the supervisor process. In either case, the end user cannot fix
  * a missing dependency / broken install themselves by running `npm install`
@@ -244,6 +282,11 @@ function checkProvider(providerName) {
       required: true,
       candidates: spec.binary.candidates || [],
       installHint: spec.binary.installHint || `install ${spec.binary.name}`,
+      // #3953: providers may declare a minimum binary version (e.g.
+      // claude-channel needs `claude` ≥ 2.1.80 for the --channels MCP
+      // transport). checkBinary parses the leading semver out of the
+      // version output and fails when it's below the floor.
+      minVersion: spec.binary.minVersion || null,
     })
     bin.provider = providerName
     out.push(bin)
@@ -282,13 +325,36 @@ function checkProvider(providerName) {
  *
  * Exported for tests — callers in production should use `runDoctorChecks`.
  */
-export function checkBinary(name, args, { parseVersion, required, installHint, candidates = [] }) {
+export function checkBinary(name, args, { parseVersion, required, installHint, candidates = [], minVersion = null }) {
   const resolved = resolveBinary(name, candidates)
   try {
     const output = execFileSync(resolved, args, {
       encoding: 'utf-8', timeout: 5000, stdio: ['ignore', 'pipe', 'pipe'],
     })
-    return { name, status: 'pass', message: parseVersion(output) }
+    const message = parseVersion(output)
+    // #3953: when the provider declares a minimum version, parse the
+    // leading semver out of the (already pretty-printed) version message
+    // and fail the check below the floor. If the version can't be parsed
+    // we don't block the user — we surface a warn so a format change in
+    // the upstream CLI doesn't hard-fail an otherwise-working install.
+    if (minVersion) {
+      const found = parseLeadingSemver(message)
+      if (found === null) {
+        return {
+          name,
+          status: 'warn',
+          message: `${message} — could not parse version to verify ≥ ${minVersion}`,
+        }
+      }
+      if (compareSemver(found, minVersion) < 0) {
+        return {
+          name,
+          status: required ? 'fail' : 'warn',
+          message: `${message} — requires ${name} ≥ ${minVersion}; ${installHint}`,
+        }
+      }
+    }
+    return { name, status: 'pass', message }
   } catch (err) {
     if (err.killed || err.signal === 'SIGTERM') {
       // Timeout — binary exists but hung

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -16,6 +16,7 @@
 import { CliSession } from './cli-session.js'
 import { SdkSession } from './sdk-session.js'
 import { ClaudeTuiSession } from './claude-tui-session.js'
+import { ClaudeChannelSession } from './claude-channel-session.js'
 import { ClaudeByokSession } from './byok-session.js'
 import { DeepSeekSession } from './deepseek-session.js'
 import { GeminiSession } from './gemini-session.js'
@@ -33,6 +34,12 @@ const PROVIDERS = {
   'claude-cli': CliSession,
   'claude-sdk': SdkSession,
   'claude-tui': ClaudeTuiSession,
+  // #3953 — research-preview `claude --channels` MCP transport. Scaffold
+  // only: ClaudeChannelSession.start() throws until the bridge lands in
+  // #3954. Registered so the dashboard can list it + `chroxy doctor` runs
+  // its preflight; gated as a preview option (never default — server-cli's
+  // default stays `claude-sdk`).
+  'claude-channel': ClaudeChannelSession,
   'claude-byok': ClaudeByokSession,
   'deepseek': DeepSeekSession,
   'gemini': GeminiSession,

--- a/packages/server/tests/claude-channel-session.test.js
+++ b/packages/server/tests/claude-channel-session.test.js
@@ -1,0 +1,183 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { ClaudeChannelSession, CLAUDE_CHANNEL_MIN_VERSION } from '../src/claude-channel-session.js'
+import { BaseSession } from '../src/base-session.js'
+import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+
+// #3953 — provider scaffold for the `claude --channels` MCP transport.
+// The session is intentionally a no-op (start() throws); these tests pin
+// the static surface the dashboard + `chroxy doctor` rely on, and confirm
+// start() fails fast without spawning anything.
+describe('ClaudeChannelSession scaffold (#3953)', () => {
+  it('extends BaseSession', () => {
+    assert.ok(ClaudeChannelSession.prototype instanceof BaseSession)
+  })
+
+  it('start() rejects with the not-implemented error and spawns nothing', async () => {
+    const session = new ClaudeChannelSession({ cwd: process.cwd() })
+    await assert.rejects(
+      () => session.start(),
+      /not yet implemented/i,
+    )
+    // No PTY / MCP child was created — the scaffold has no process handles.
+    assert.equal(session._processReady, false)
+  })
+
+  it('start() error references the bridge sub-issue (#3954)', async () => {
+    const session = new ClaudeChannelSession({ cwd: process.cwd() })
+    await assert.rejects(() => session.start(), /#3954/)
+  })
+
+  it('sendMessage() rejects with the not-implemented error', async () => {
+    const session = new ClaudeChannelSession({ cwd: process.cwd() })
+    await assert.rejects(() => session.sendMessage('hello'), /not yet implemented/i)
+  })
+
+  it('interrupt() throws the not-implemented error', () => {
+    const session = new ClaudeChannelSession({ cwd: process.cwd() })
+    assert.throws(() => session.interrupt(), /not yet implemented/i)
+  })
+
+  it('destroy() is a safe no-op (does not throw)', () => {
+    const session = new ClaudeChannelSession({ cwd: process.cwd() })
+    assert.doesNotThrow(() => session.destroy())
+    assert.equal(session._destroying, true)
+    assert.equal(session._processReady, false)
+  })
+
+  it('exposes a research-preview displayLabel', () => {
+    assert.equal(typeof ClaudeChannelSession.displayLabel, 'string')
+    assert.match(ClaudeChannelSession.displayLabel, /channel/i)
+    assert.match(ClaudeChannelSession.displayLabel, /research preview/i)
+    assert.match(ClaudeChannelSession.displayLabel, /subscription/i)
+  })
+
+  it('dataDir points at ~/.claude (shared with the other Claude providers)', () => {
+    assert.equal(ClaudeChannelSession.dataDir, join(homedir(), '.claude'))
+  })
+
+  describe('capabilities matrix (from the spike)', () => {
+    const caps = ClaudeChannelSession.capabilities
+
+    it('declares permissions true (channel/permission relay — sub 4)', () => {
+      assert.equal(caps.permissions, true)
+    })
+
+    it('verdicts round-trip over IPC, not in-process', () => {
+      assert.equal(caps.inProcessPermissions, false)
+    })
+
+    it('streams (the headline win over claude-tui)', () => {
+      assert.equal(caps.streaming, true)
+    })
+
+    it('renders tool calls', () => {
+      assert.equal(caps.tools, true)
+    })
+
+    // The deliberately-honest cells: channels do NOT solve these.
+    it('does not claim model switch / permission-mode switch / plan / resume / terminal / thinking', () => {
+      assert.equal(caps.modelSwitch, false)
+      assert.equal(caps.permissionModeSwitch, false)
+      assert.equal(caps.planMode, false)
+      assert.equal(caps.resume, false)
+      assert.equal(caps.terminal, false)
+      assert.equal(caps.thinkingLevel, false)
+    })
+  })
+
+  describe('preflight', () => {
+    const pf = ClaudeChannelSession.preflight
+
+    it('checks the `claude` binary', () => {
+      assert.equal(pf.binary.name, 'claude')
+      assert.deepEqual(pf.binary.args, ['--version'])
+      assert.ok(Array.isArray(pf.binary.candidates) && pf.binary.candidates.length > 0)
+    })
+
+    it('declares the channel-transport minimum version', () => {
+      assert.equal(pf.binary.minVersion, CLAUDE_CHANNEL_MIN_VERSION)
+      assert.equal(CLAUDE_CHANNEL_MIN_VERSION, '2.1.80')
+    })
+
+    it('install hint mentions the version floor', () => {
+      assert.match(pf.binary.installHint, new RegExp(CLAUDE_CHANNEL_MIN_VERSION))
+    })
+
+    it('credentials are optional and do NOT accept ANTHROPIC_API_KEY', () => {
+      assert.deepEqual(pf.credentials.envVars, [])
+      assert.equal(pf.credentials.optional, true)
+      assert.match(pf.credentials.hint, /claude login/)
+      assert.match(pf.credentials.hint, /ANTHROPIC_API_KEY/)
+    })
+  })
+
+  describe('resolveAuth (#4769 pattern)', () => {
+    it('reports ready via subscription OAuth, mentioning research preview', () => {
+      const auth = ClaudeChannelSession.resolveAuth()
+      assert.equal(auth.ready, true)
+      assert.equal(auth.source, 'oauth')
+      assert.equal(auth.envVar, null)
+      assert.deepEqual(auth.envVars, [])
+      assert.match(auth.detail, /subscription/i)
+      assert.match(auth.detail, /research preview/i)
+      assert.match(auth.detail, /bypasses programmatic credit metering/i)
+    })
+  })
+
+  describe('model metadata (reused from claude-tui)', () => {
+    it('returns the same non-empty fallback model list as claude-tui', () => {
+      const models = ClaudeChannelSession.getFallbackModels()
+      assert.ok(Array.isArray(models) && models.length > 0)
+      assert.deepEqual(models, ClaudeTuiSession.getFallbackModels())
+    })
+
+    it('returns a non-empty allowed-model list', () => {
+      const allowed = ClaudeChannelSession.getAllowedModels()
+      assert.ok(Array.isArray(allowed) && allowed.length > 0)
+    })
+
+    it('derives model metadata for a valid id', () => {
+      const meta = ClaudeChannelSession.getModelMetadata('claude-sonnet-4-5-20250929')
+      assert.ok(meta)
+      assert.equal(typeof meta.id, 'string')
+      assert.equal(meta.fullId, 'claude-sonnet-4-5-20250929')
+      assert.equal(typeof meta.contextWindow, 'number')
+    })
+
+    it('returns null for an empty/invalid model id', () => {
+      assert.equal(ClaudeChannelSession.getModelMetadata(''), null)
+      assert.equal(ClaudeChannelSession.getModelMetadata(null), null)
+    })
+  })
+
+  describe('constructor / BaseSession opt forwarding', () => {
+    it('defaults provider to claude-channel', () => {
+      const session = new ClaudeChannelSession({ cwd: process.cwd() })
+      assert.equal(session._provider, 'claude-channel')
+    })
+
+    it('forwards BaseSession opts through super() (middle-layer trap guard)', () => {
+      const session = new ClaudeChannelSession({
+        cwd: '/tmp/some-cwd',
+        model: 'claude-opus-4-1-20250805',
+        permissionMode: 'acceptEdits',
+        chroxyContextHint: true,
+        sessionPreamble: 'be terse',
+      })
+      assert.equal(session.cwd, '/tmp/some-cwd')
+      assert.equal(session.model, 'claude-opus-4-1-20250805')
+      assert.equal(session.permissionMode, 'acceptEdits')
+      assert.equal(session.chroxyContextHint, true)
+      assert.equal(session.sessionPreamble, 'be terse')
+    })
+
+    it('constructs with no args (every opt optional)', () => {
+      const session = new ClaudeChannelSession()
+      assert.ok(session instanceof ClaudeChannelSession)
+      assert.equal(session._provider, 'claude-channel')
+    })
+  })
+})

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -303,6 +303,28 @@ describe('parseLeadingSemver / compareSemver helpers (#3953)', () => {
   it('sorts an unparseable found-version as less-than the floor', () => {
     assert.ok(compareSemver('garbage', '2.1.80') < 0)
   })
+
+  // Copilot review on #3953: a malformed `required` floor must also fail
+  // closed, otherwise a provider that supplies ">=2.1.80" / "2.1.80-beta"
+  // would silently disable minVersion enforcement (compareSemver returning
+  // positive → "satisfied").
+  it('fails closed when the required floor has no parseable leading semver', () => {
+    // No leading `major.minor.patch` → parseLeadingSemver returns null →
+    // fail closed (less-than), so the floor is never silently satisfied.
+    assert.ok(compareSemver('2.1.163', '>=2.1.80') < 0)
+    assert.ok(compareSemver('2.1.163', 'v2') < 0)
+    assert.ok(compareSemver('2.1.163', 'not-a-version') < 0)
+    // Both sides invalid is still less-than.
+    assert.ok(compareSemver('garbage', 'also-garbage') < 0)
+  })
+
+  it('still satisfies a floor that carries a pre-release/build suffix after a valid core', () => {
+    // "2.1.80-beta" HAS a parseable leading core (2.1.80), so a higher
+    // found version legitimately satisfies it — the suffix is ignored, not
+    // treated as unparseable.
+    assert.ok(compareSemver('2.1.163', '2.1.80-beta') > 0)
+    assert.ok(compareSemver('2.1.80', '2.1.80-beta') === 0)
+  })
 })
 
 describe('runDoctorChecks — bundled .app context (issue #2897)', () => {

--- a/packages/server/tests/doctor.test.js
+++ b/packages/server/tests/doctor.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, parse as parsePath, relative } from 'node:path'
-import { runDoctorChecks, checkBinary, isBundledOrSupervisedContext } from '../src/doctor.js'
+import { runDoctorChecks, checkBinary, isBundledOrSupervisedContext, parseLeadingSemver, compareSemver } from '../src/doctor.js'
 
 /**
  * Integration tests for doctor.js.
@@ -211,6 +211,97 @@ describe('runDoctorChecks', () => {
         process.env.PATH = originalPath
       }
     }
+  })
+})
+
+// #3953 — provider preflight can declare a minimum binary version (e.g.
+// claude-channel needs `claude` ≥ 2.1.80). checkBinary parses the leading
+// semver and fails below the floor.
+describe('checkBinary minVersion gate (#3953)', () => {
+  it('passes when the binary version meets the floor', () => {
+    // Node prints `v22.x.y`; any floor at-or-below the running Node passes.
+    const result = checkBinary('node', ['--version'], {
+      parseVersion: (out) => out.trim(),
+      required: true,
+      candidates: [process.execPath],
+      installHint: 'install node',
+      minVersion: '18.0.0',
+    })
+    assert.equal(result.status, 'pass',
+      `expected pass for floor 18.0.0 vs running ${process.versions.node}, got ${result.status}: ${result.message}`)
+  })
+
+  it('fails when the binary version is below the floor', () => {
+    // A floor far above any plausible Node major forces the fail branch.
+    const result = checkBinary('node', ['--version'], {
+      parseVersion: (out) => out.trim(),
+      required: true,
+      candidates: [process.execPath],
+      installHint: 'install node ≥ 999.0.0',
+      minVersion: '999.0.0',
+    })
+    assert.equal(result.status, 'fail')
+    assert.match(result.message, /requires node ≥ 999\.0\.0/)
+    assert.match(result.message, /install node ≥ 999\.0\.0/)
+  })
+
+  it('downgrades a below-floor optional binary to warn (not fail)', () => {
+    const result = checkBinary('node', ['--version'], {
+      parseVersion: (out) => out.trim(),
+      required: false,
+      candidates: [process.execPath],
+      installHint: 'install node',
+      minVersion: '999.0.0',
+    })
+    assert.equal(result.status, 'warn')
+  })
+
+  it('warns (does not hard-fail) when the version cannot be parsed', () => {
+    const result = checkBinary('node', ['--version'], {
+      // Intentionally return an unparseable version string.
+      parseVersion: () => 'some weird build identifier',
+      required: true,
+      candidates: [process.execPath],
+      installHint: 'install node',
+      minVersion: '2.1.80',
+    })
+    assert.equal(result.status, 'warn')
+    assert.match(result.message, /could not parse version/)
+  })
+
+  it('ignores minVersion when not declared (back-compat)', () => {
+    const result = checkBinary('node', ['--version'], {
+      parseVersion: (out) => out.trim(),
+      required: true,
+      candidates: [process.execPath],
+      installHint: 'install node',
+    })
+    assert.equal(result.status, 'pass')
+  })
+})
+
+describe('parseLeadingSemver / compareSemver helpers (#3953)', () => {
+  it('parses a leading semver out of a decorated version string', () => {
+    assert.deepEqual(parseLeadingSemver('2.1.163 (Claude Code)'), [2, 1, 163])
+    assert.deepEqual(parseLeadingSemver('v22.14.0'), [22, 14, 0])
+  })
+
+  it('returns null for unparseable input', () => {
+    assert.equal(parseLeadingSemver('not a version'), null)
+    assert.equal(parseLeadingSemver(''), null)
+    assert.equal(parseLeadingSemver(null), null)
+  })
+
+  it('orders versions correctly', () => {
+    assert.ok(compareSemver('2.1.79', '2.1.80') < 0)
+    assert.ok(compareSemver('2.1.80', '2.1.80') === 0)
+    assert.ok(compareSemver('2.1.163', '2.1.80') > 0)
+    assert.ok(compareSemver('3.0.0', '2.9.9') > 0)
+    assert.ok(compareSemver('2.0.0', '2.1.0') < 0)
+  })
+
+  it('sorts an unparseable found-version as less-than the floor', () => {
+    assert.ok(compareSemver('garbage', '2.1.80') < 0)
   })
 })
 

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -670,6 +670,68 @@ describe('Provider Registry', () => {
   })
 })
 
+// #3953 — claude-channel provider scaffold. Registered in providers.js so
+// the dashboard can list it + `chroxy doctor` runs its preflight; the
+// session itself is a no-op until the bridge lands in #3954.
+describe('claude-channel provider scaffold (#3953)', () => {
+  it('is registered and resolvable via getProvider', async () => {
+    const { ClaudeChannelSession } = await import('../src/claude-channel-session.js')
+    assert.equal(getProvider('claude-channel'), ClaudeChannelSession)
+  })
+
+  it('appears in listProviders() with the expected capability matrix', () => {
+    const list = listProviders()
+    const entry = list.find(p => p.name === 'claude-channel')
+    assert.ok(entry, 'claude-channel must appear in listProviders()')
+    assert.equal(entry.capabilities.permissions, true)
+    assert.equal(entry.capabilities.inProcessPermissions, false)
+    assert.equal(entry.capabilities.modelSwitch, false)
+    assert.equal(entry.capabilities.permissionModeSwitch, false)
+    assert.equal(entry.capabilities.planMode, false)
+    assert.equal(entry.capabilities.resume, false)
+    assert.equal(entry.capabilities.terminal, false)
+    assert.equal(entry.capabilities.thinkingLevel, false)
+    assert.equal(entry.capabilities.streaming, true)
+    assert.equal(entry.capabilities.tools, true)
+    // Derived: scaffold does not implement setPermissionRules.
+    assert.equal(entry.capabilities.sessionRules, false)
+  })
+
+  it('exposes auth detail mentioning subscription + research preview', () => {
+    const list = listProviders()
+    const entry = list.find(p => p.name === 'claude-channel')
+    assert.ok(entry?.auth)
+    assert.equal(entry.auth.ready, true)
+    assert.equal(entry.auth.source, 'oauth')
+    assert.match(entry.auth.detail, /research preview/i)
+    assert.match(entry.auth.detail, /channel/i)
+  })
+
+  it('passes validateProviderClass (no inProcessPermissions methods required)', async () => {
+    const { validateProviderClass } = await import('../src/providers.js')
+    const { ClaudeChannelSession } = await import('../src/claude-channel-session.js')
+    // Should not throw — start/destroy/sendMessage/interrupt/setModel/
+    // setPermissionMode all inherited from BaseSession.
+    validateProviderClass(ClaudeChannelSession, 'claude-channel')
+  })
+
+  it('exposes a non-empty displayLabel via resolveProviderLabel', async () => {
+    const { resolveProviderLabel } = await import('../src/providers.js')
+    const label = resolveProviderLabel('claude-channel')
+    assert.match(label, /channel/i)
+  })
+
+  it('shares the ~/.claude dataDir without duplicating it in getProviderDataDirs', async () => {
+    const { getProviderDataDirs } = await import('../src/providers.js')
+    const { homedir } = await import('node:os')
+    const { join } = await import('node:path')
+    const dirs = getProviderDataDirs()
+    const claudeDir = join(homedir(), '.claude')
+    assert.equal(dirs.filter(d => d === claudeDir).length, 1,
+      '~/.claude must appear exactly once even with claude-channel registered')
+  })
+})
+
 describe('Docker Provider Naming (#2475)', () => {
   it('registerDockerProvider skips when environments not enabled', async () => {
     const before = listProviders().length


### PR DESCRIPTION
## Summary

Sub 2 of the `claude --channels` provider chain (parent #3951, spike `docs/architecture/claude-channels-provider-spike.md`). Lands a **no-op** `ClaudeChannelSession` registered as the `claude-channel` provider so the dashboard can list it and `chroxy doctor` runs a sane preflight — **without** any of the bridge wiring (spawn + IPC round-trip), which is sub 3 (#3954).

This is deliberately split from the bridge so the registry/scaffold surface can be reviewed in isolation.

## What changed

- **New `packages/server/src/claude-channel-session.js`** (`extends BaseSession`):
  - `start()` / `sendMessage()` / `interrupt()` throw a single not-implemented message (one `static NOT_IMPLEMENTED_MESSAGE` source of truth); `destroy()` is a safe no-op (must not throw on cleanup paths).
  - Static surface fully wired: `displayLabel` (research preview · subscription), `dataDir` (`~/.claude`), `capabilities` matrix, `preflight` (claude binary + `minVersion: 2.1.80` + optional subscription creds — does **not** accept `ANTHROPIC_API_KEY`), model metadata reused from claude-tui, and `resolveAuth()` reporting `ready:true, source:'oauth'` with research-preview billing detail.
  - Capability honesty per the spike: `streaming:true` (the win over claude-tui), but `modelSwitch`/`permissionModeSwitch:false` — channels don't solve those.
- **`providers.js`**: import + register `claude-channel` between `claude-tui` and `claude-byok`. Gated as a preview option; default provider stays `claude-sdk`.
- **`doctor.js`**: extend the preflight runner so a provider's `binary.minVersion` is enforced — new `parseLeadingSemver` + `compareSemver` helpers; `checkBinary` warns (not hard-fails) on an unparseable version.
- Constructor forwards **every** BaseSession opt via `super()` (opt-forwarding lint passes — the middle-layer trap).

## Acceptance (#3953)

- [x] `claude-channel` appears in `listProviders()` with the correct capability matrix.
- [x] `getProviderAuthInfo('claude-channel', …)` returns `ready:true, source:'oauth', detail:'…research preview…'`.
- [x] `chroxy --provider claude-channel` fails fast with the not-implemented error (no PTY, no MCP child).
- [x] Other providers unchanged; `~/.claude` dataDir not duplicated.
- [x] Tests cover scaffold + registry surface + the minVersion comparator.

## Notes for the reviewer

- The issue body referenced `isHostClaudeCli` / `describeBillingIdentity` in `providers.js`; those were removed by the #4769 auth-resolution refactor (each provider now owns `static resolveAuth`). This PR follows the **current** pattern (mirrors `claude-tui`), which achieves the same AC.
- The issue offered two options for the version gate; option 1 (preflight-runner `minVersion`) was easy to extend, so that's implemented here rather than punting the probe to sub 3.

## Testing

- `tests/claude-channel-session.test.js`, additions to `tests/providers.test.js` and `tests/doctor.test.js` — all green.
- `lint-tests-state-file-path.sh` and `lint-session-opt-forwarding.sh` both pass (7 subclasses forward all 19 BaseSession opts).

## Not in this PR (sub 3 — #3954)

The live bridge: `node-pty` spawn of `claude --channels`, Unix-socket IPC, `sendMessage` round-trip, outbound event normalization via `event-normalizer.js`.

Closes #3953