### PR TITLE
feat(server): config-driven environment backend selection (k8s/rancher)

### DIFF
--- a/packages/server/src/cli/shared.js
+++ b/packages/server/src/cli/shared.js
@@ -54,6 +54,7 @@ export function addServerOptions(cmd) {
     .option('--dangerously-skip-permissions', 'TUI provider only: spawn claude with --dangerously-skip-permissions and disable chroxy permission gating (mirrors `chroxy resume` flag)')
     .option('-v, --verbose', 'Show detailed config sources and validation info')
     .option('--environments', 'Enable environment isolation providers (e.g. docker)')
+    .option('--environment-backend <backend>', 'Environment backend: docker (default), k8s, or rancher')
 }
 
 /**
@@ -127,7 +128,24 @@ export function loadAndMergeConfig(options, extraOverrides = {}) {
   if (options.legacyCli) cliOverrides.legacyCli = true
   if (options.provider !== undefined) cliOverrides.provider = options.provider
   if (options.logFormat !== undefined) cliOverrides.logFormat = options.logFormat
-  if (options.environments) cliOverrides.environments = { enabled: true }
+  // #5144: the `environments` key is an object whose sub-blocks (k8s, rancher,
+  // workspace) normally live in the config file. mergeConfig replaces a whole
+  // top-level key on CLI override, so a naive `cliOverrides.environments =
+  // { enabled: true }` would WIPE a file-configured k8s/rancher block. Layer
+  // the CLI-supplied environment sub-fields over a shallow copy of the file's
+  // block instead, so `--environments` / `--environment-backend` compose with
+  // file config rather than clobbering it.
+  const fileEnv = (fileConfig.environments && typeof fileConfig.environments === 'object' && !Array.isArray(fileConfig.environments))
+    ? fileConfig.environments
+    : {}
+  let envOverride = null
+  if (options.environments) {
+    envOverride = { ...fileEnv, enabled: true }
+  }
+  if (options.environmentBackend !== undefined) {
+    envOverride = { ...(envOverride || fileEnv), backend: options.environmentBackend }
+  }
+  if (envOverride) cliOverrides.environments = envOverride
   // #4209 / #4246: only forward when the flag was explicitly passed.
   // Commander sets the property to `true` when present and leaves it
   // `undefined` when absent, so we never write a coerced `false` that

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -186,6 +186,153 @@ const CONFIG_SCHEMA = {
 const SENSITIVE_KEYS = ['apiToken', 'pushToken']
 
 /**
+ * #5144: recognised values for `environments.backend`. 'docker' is the default
+ * when the key is absent so existing single-node setups are unchanged.
+ */
+const ENVIRONMENT_BACKENDS = new Set(['docker', 'k8s', 'rancher'])
+
+/** #5144: valid Kubernetes imagePullPolicy values (mirrors k8s.js). */
+const VALID_K8S_PULL_POLICIES = new Set(['Always', 'IfNotPresent', 'Never'])
+
+/** #5144: valid K8sBackend connectMode values (mirrors k8s.js). */
+const VALID_K8S_CONNECT_MODES = new Set(['portforward', 'clusterip'])
+
+/**
+ * #5144: Rancher cluster-/project-ID formats. Kept in sync with the canonical
+ * regexes in rancher.js (RANCHER_CLUSTER_ID / RANCHER_PROJECT_ID). Duplicated
+ * here rather than imported to keep config.js free of any cluster-client
+ * dependency (rancher.js eagerly imports @kubernetes/client-node), so loading
+ * config never pulls in the kube SDK.
+ */
+const RANCHER_CLUSTER_ID_RE = /^c-[a-z0-9-]+$/
+const RANCHER_PROJECT_ID_RE = /^p-[a-z0-9-]+$/
+
+/**
+ * #5144: validate the `environments.k8s` connection sub-block at config-load
+ * time. The `workspace` sub-block has its own validation (#4556); this covers
+ * the remaining fields the wiring layer forwards to `K8sBackend`. Every field
+ * is optional — only the fields actually present are checked — so a partial
+ * block (or one carrying only `workspace`) passes cleanly.
+ *
+ * Pushes human-readable warnings onto `warnings`; never throws.
+ *
+ * @param {object} k8s - The `environments.k8s` object (already known to be a plain object)
+ * @param {string[]} warnings - Accumulator the caller logs/returns
+ */
+function validateK8sBlock(k8s, warnings) {
+  const stringFields = ['namespace', 'kubeconfigPath', 'sidecarImage']
+  for (const field of stringFields) {
+    if (Object.prototype.hasOwnProperty.call(k8s, field) && typeof k8s[field] !== 'string') {
+      warnings.push(
+        `Invalid type for 'environments.k8s.${field}': expected string, got ${Array.isArray(k8s[field]) ? 'array' : typeof k8s[field]}`,
+      )
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(k8s, 'inCluster') && typeof k8s.inCluster !== 'boolean') {
+    warnings.push(
+      `Invalid type for 'environments.k8s.inCluster': expected boolean, got ${typeof k8s.inCluster}`,
+    )
+  }
+  if (Object.prototype.hasOwnProperty.call(k8s, 'imagePullPolicy')) {
+    const v = k8s.imagePullPolicy
+    if (typeof v !== 'string' || !VALID_K8S_PULL_POLICIES.has(v)) {
+      warnings.push(
+        `Invalid value for 'environments.k8s.imagePullPolicy': '${v}' (must be one of: ${[...VALID_K8S_PULL_POLICIES].join(', ')})`,
+      )
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(k8s, 'connectMode')) {
+    const v = k8s.connectMode
+    if (typeof v !== 'string' || !VALID_K8S_CONNECT_MODES.has(v)) {
+      warnings.push(
+        `Invalid value for 'environments.k8s.connectMode': '${v}' (must be one of: ${[...VALID_K8S_CONNECT_MODES].join(', ')})`,
+      )
+    }
+  }
+}
+
+/**
+ * #5144: validate the `environments.rancher` connection block at config-load
+ * time. Mirrors `validateRancherOptions` in rancher.js (URL shape, cluster-ID
+ * format, presence of a bearer token) so the operator sees the same error at
+ * startup that RancherBackend's constructor would throw — without ever logging
+ * the token value itself.
+ *
+ * Gated on `isRancherConfigured` semantics: a block missing any of rancherUrl /
+ * clusterId / token is treated as "Rancher not yet configured" and only its
+ * top-level shape (must be a plain object) is checked. This keeps a
+ * half-filled-in block from spamming warnings during setup while still
+ * catching a genuinely malformed complete config.
+ *
+ * Pushes human-readable warnings onto `warnings`; never throws. The token value
+ * is never echoed into a warning.
+ *
+ * @param {*} rancher - The `environments.rancher` value (any type)
+ * @param {string[]} warnings - Accumulator the caller logs/returns
+ */
+function validateRancherBlock(rancher, warnings) {
+  if (typeof rancher !== 'object' || rancher === null || Array.isArray(rancher)) {
+    warnings.push(
+      `Invalid type for 'environments.rancher': expected object, got ${Array.isArray(rancher) ? 'array' : typeof rancher}`,
+    )
+    return
+  }
+
+  const { rancherUrl, clusterId, token, caData, skipTLSVerify, defaultProjectId } = rancher
+
+  // Presence gate (mirrors isRancherConfigured): unless all three identity
+  // fields are present, treat as "not configured yet" — only shape was checked.
+  const configured = Boolean(rancherUrl && clusterId && token)
+  if (!configured) return
+
+  if (typeof rancherUrl !== 'string' || rancherUrl.length === 0) {
+    warnings.push(`Invalid value for 'environments.rancher.rancherUrl': must be a non-empty string`)
+  } else {
+    let parsed
+    try {
+      parsed = new URL(rancherUrl)
+    } catch {
+      parsed = null
+      warnings.push(`Invalid URL format for 'environments.rancher.rancherUrl': ${rancherUrl}`)
+    }
+    if (parsed && parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      warnings.push(
+        `Invalid value for 'environments.rancher.rancherUrl': must use http:// or https://, got '${parsed.protocol}'`,
+      )
+    }
+  }
+
+  if (typeof clusterId !== 'string' || !RANCHER_CLUSTER_ID_RE.test(clusterId)) {
+    warnings.push(
+      `Invalid value for 'environments.rancher.clusterId': must match the Rancher cluster-ID format (c-...), got '${clusterId}'`,
+    )
+  }
+
+  if (typeof token !== 'string' || token.length === 0) {
+    // Never echo the token value.
+    warnings.push(`Invalid value for 'environments.rancher.token': must be a non-empty bearer token string`)
+  }
+
+  if (caData != null && (typeof caData !== 'string' || caData.length === 0)) {
+    warnings.push(
+      `Invalid value for 'environments.rancher.caData': when provided, must be a non-empty base64-encoded PEM string`,
+    )
+  }
+
+  if (skipTLSVerify != null && typeof skipTLSVerify !== 'boolean') {
+    warnings.push(
+      `Invalid type for 'environments.rancher.skipTLSVerify': expected boolean, got ${typeof skipTLSVerify}`,
+    )
+  }
+
+  if (defaultProjectId != null && (typeof defaultProjectId !== 'string' || !RANCHER_PROJECT_ID_RE.test(defaultProjectId))) {
+    warnings.push(
+      `Invalid value for 'environments.rancher.defaultProjectId': must match the Rancher project-ID format (p-...), got '${defaultProjectId}'`,
+    )
+  }
+}
+
+/**
  * Return a copy of config with sensitive fields replaced by '***'.
  * Use this whenever the config object is serialized to logs or debug output.
  *
@@ -357,8 +504,31 @@ export function validateConfig(config, verbose = false) {
   // operators without any k8s key, or with other k8s settings but no
   // workspace block) passes through untouched.
   if (config.environments && typeof config.environments === 'object' && !Array.isArray(config.environments)) {
+    // #5144: backend selector. One of 'docker' (default) | 'k8s' | 'rancher'.
+    // When absent the wiring layer falls back to Docker, so the common
+    // single-node setup is unchanged. A bad value is warn-only (not fatal):
+    // the wiring layer treats an unrecognised selector as Docker, mirroring
+    // the "drop bad value, keep the safe default" contract used elsewhere.
+    if (Object.prototype.hasOwnProperty.call(config.environments, 'backend')) {
+      const backend = config.environments.backend
+      if (typeof backend !== 'string') {
+        warnings.push(
+          `Invalid type for 'environments.backend': expected string, got ${Array.isArray(backend) ? 'array' : typeof backend}`,
+        )
+      } else if (!ENVIRONMENT_BACKENDS.has(backend)) {
+        warnings.push(
+          `Invalid value for 'environments.backend': '${backend}' (must be one of: ${[...ENVIRONMENT_BACKENDS].join(', ')})`,
+        )
+      }
+    }
+
     const k8sBlock = config.environments.k8s
     if (k8sBlock && typeof k8sBlock === 'object' && !Array.isArray(k8sBlock)) {
+      // #5144: validate the K8s connection sub-block (the `workspace` block
+      // below already had its own validation from #4556). Only fields the
+      // wiring layer actually forwards to K8sBackend are checked; each is
+      // optional so a partial block (or just the workspace sub-block) passes.
+      validateK8sBlock(k8sBlock, warnings)
       if (Object.prototype.hasOwnProperty.call(k8sBlock, 'workspace')) {
         const ws = k8sBlock.workspace
         if (typeof ws !== 'object' || ws === null || Array.isArray(ws)) {
@@ -391,6 +561,18 @@ export function validateConfig(config, verbose = false) {
           }
         }
       }
+    }
+
+    // #5144: validate the Rancher connection block. Mirrors
+    // `validateRancherOptions` in rancher.js so an operator never sees one
+    // message at config-load time and a different one when RancherBackend is
+    // constructed. Gated on `isRancherConfigured` (presence of rancherUrl +
+    // clusterId + token): a block that does not yet carry a complete Rancher
+    // config is treated as "Rancher not configured" and only its shape (object,
+    // not array) is checked — partial blocks during setup don't spam warnings.
+    const rancherBlock = config.environments.rancher
+    if (rancherBlock !== undefined) {
+      validateRancherBlock(rancherBlock, warnings)
     }
   }
 
@@ -648,6 +830,143 @@ export function resolveSkipPermissions(config) {
     source: null,
     deprecationWarning: null,
   }
+}
+
+/**
+ * #5144: resolve the selected environment backend from a merged config object.
+ *
+ * Returns 'docker' for an absent, malformed, or unrecognised
+ * `environments.backend` (validateConfig already surfaces the warning), so the
+ * wiring layer never crashes on a typo and the default single-node path is
+ * preserved. Pure — no side effects, no logging.
+ *
+ * @param {object|null|undefined} config - Merged config
+ * @returns {'docker'|'k8s'|'rancher'}
+ */
+export function resolveEnvironmentBackend(config) {
+  const selected = config?.environments?.backend
+  if (typeof selected === 'string' && ENVIRONMENT_BACKENDS.has(selected)) {
+    return selected
+  }
+  return 'docker'
+}
+
+/**
+ * #5144: resolve a Rancher bearer token from a secret-friendly source.
+ *
+ * Precedence (highest first):
+ *   1. `tokenEnv` — name of an env var holding the token (e.g. RANCHER_TOKEN).
+ *      Keeps the secret out of the on-disk config file.
+ *   2. `tokenFile` — path to a file whose trimmed contents are the token
+ *      (e.g. a mounted secret).
+ *   3. `token` — inline token (discouraged but supported for parity with
+ *      validateRancherOptions).
+ *
+ * The resolved value is never logged. Returns `undefined` when none resolve so
+ * the caller / RancherBackend constructor produces the canonical "token must be
+ * a non-empty bearer token string" error.
+ *
+ * @param {object} rancher - The `environments.rancher` block
+ * @returns {string|undefined}
+ */
+export function resolveRancherToken(rancher = {}) {
+  if (typeof rancher.tokenEnv === 'string' && rancher.tokenEnv.length > 0) {
+    const fromEnv = process.env[rancher.tokenEnv]
+    if (typeof fromEnv === 'string' && fromEnv.length > 0) return fromEnv
+  }
+  if (typeof rancher.tokenFile === 'string' && rancher.tokenFile.length > 0) {
+    try {
+      const fromFile = readFileSync(rancher.tokenFile, 'utf-8').trim()
+      if (fromFile.length > 0) return fromFile
+    } catch {
+      // Fall through to inline token / undefined. Do not log the path's
+      // contents; the eventual "token required" error is enough signal.
+    }
+  }
+  if (typeof rancher.token === 'string' && rancher.token.length > 0) return rancher.token
+  return undefined
+}
+
+/**
+ * #5144: construct the environment backend selected by config.
+ *
+ * - 'docker' (default): `new DockerBackend({ _execFile })` — unchanged behaviour.
+ * - 'k8s'             : `new K8sBackend({ ...environments.k8s })`.
+ * - 'rancher'         : `new RancherBackend({ ...environments.k8s, ...rancher })`
+ *                       with the token resolved from a secret-friendly source.
+ *
+ * Backend modules are imported lazily so loading config never eagerly pulls in
+ * `@kubernetes/client-node` (only the K8s/Rancher paths need it). The selected
+ * backend's construction validates its own options and throws on a malformed
+ * block — the caller (server-cli) surfaces that as a fatal startup error.
+ *
+ * @param {object} config - Merged config
+ * @param {object} [deps] - Injection seam for testing
+ * @param {Function} [deps._execFile] - Forwarded to DockerBackend
+ * @param {Function} [deps._loadBackends] - Override the lazy module loader
+ *   (returns `{ DockerBackend, K8sBackend, RancherBackend }`). Lets unit tests
+ *   assert which class is instantiated with which options without importing the
+ *   kube SDK.
+ * @returns {Promise<{ backend: object, type: 'docker'|'k8s'|'rancher' }>}
+ */
+export async function buildEnvironmentBackend(config, { _execFile, _loadBackends } = {}) {
+  const type = resolveEnvironmentBackend(config)
+  const envs = config?.environments || {}
+
+  const loadBackends = _loadBackends || (async () => {
+    if (type === 'docker') {
+      const { DockerBackend } = await import('./environments/backends/docker.js')
+      return { DockerBackend }
+    }
+    if (type === 'k8s') {
+      const { K8sBackend } = await import('./environments/backends/k8s.js')
+      return { K8sBackend }
+    }
+    const { RancherBackend } = await import('./environments/backends/rancher.js')
+    return { RancherBackend }
+  })
+
+  const mods = await loadBackends()
+
+  if (type === 'k8s') {
+    const k8s = (envs.k8s && typeof envs.k8s === 'object' && !Array.isArray(envs.k8s)) ? envs.k8s : {}
+    const backend = new mods.K8sBackend({
+      namespace: k8s.namespace,
+      inCluster: k8s.inCluster,
+      kubeconfigPath: k8s.kubeconfigPath,
+      sidecarImage: k8s.sidecarImage,
+      imagePullPolicy: k8s.imagePullPolicy,
+      connectMode: k8s.connectMode,
+    })
+    return { backend, type }
+  }
+
+  if (type === 'rancher') {
+    const k8s = (envs.k8s && typeof envs.k8s === 'object' && !Array.isArray(envs.k8s)) ? envs.k8s : {}
+    const rancher = (envs.rancher && typeof envs.rancher === 'object' && !Array.isArray(envs.rancher)) ? envs.rancher : {}
+    const token = resolveRancherToken(rancher)
+    const backend = new mods.RancherBackend({
+      // K8s connection/runtime knobs shared with the plain K8s path.
+      namespace: k8s.namespace,
+      inCluster: k8s.inCluster,
+      kubeconfigPath: k8s.kubeconfigPath,
+      sidecarImage: k8s.sidecarImage,
+      imagePullPolicy: k8s.imagePullPolicy,
+      connectMode: k8s.connectMode,
+      // Rancher connection block. Token is resolved from a secret-friendly
+      // source and never logged.
+      rancherUrl: rancher.rancherUrl,
+      clusterId: rancher.clusterId,
+      token,
+      caData: rancher.caData,
+      skipTLSVerify: rancher.skipTLSVerify,
+      defaultProjectId: rancher.defaultProjectId,
+    })
+    return { backend, type }
+  }
+
+  const backend = new mods.DockerBackend({ _execFile })
+  return { backend, type }
 }
 
 const DEFAULT_CONFIG_PATH = join(homedir(), '.chroxy', 'config.json')

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -278,11 +278,19 @@ function validateRancherBlock(rancher, warnings) {
     return
   }
 
-  const { rancherUrl, clusterId, token, caData, skipTLSVerify, defaultProjectId } = rancher
+  const { rancherUrl, clusterId, token, tokenEnv, tokenFile, caData, skipTLSVerify, defaultProjectId } = rancher
 
-  // Presence gate (mirrors isRancherConfigured): unless all three identity
-  // fields are present, treat as "not configured yet" — only shape was checked.
-  const configured = Boolean(rancherUrl && clusterId && token)
+  // A token can come from any of three secret-friendly sources (resolved by
+  // `resolveRancherToken` at construct time). Presence of ANY source counts
+  // toward "configured" so a block using `tokenEnv` / `tokenFile` is still
+  // validated here (Copilot review #5148) — not just inline `token`.
+  const hasTokenSource = Boolean(token || tokenEnv || tokenFile)
+
+  // Presence gate (mirrors isRancherConfigured): unless rancherUrl + clusterId
+  // are present AND a token source is configured, treat the block as "not
+  // configured yet" — only the top-level shape was checked above. This keeps a
+  // half-filled-in block from spamming warnings during setup.
+  const configured = Boolean(rancherUrl && clusterId && hasTokenSource)
   if (!configured) return
 
   if (typeof rancherUrl !== 'string' || rancherUrl.length === 0) {
@@ -308,10 +316,24 @@ function validateRancherBlock(rancher, warnings) {
     )
   }
 
-  if (typeof token !== 'string' || token.length === 0) {
-    // Never echo the token value.
-    warnings.push(`Invalid value for 'environments.rancher.token': must be a non-empty bearer token string`)
+  // Token sources. Validate the SHAPE of each provided source (never the value
+  // — the token is never echoed). Only warn "missing token" when NO source is
+  // present; an inline `token` is no longer required when `tokenEnv` /
+  // `tokenFile` is set (Copilot review #5148).
+  if (token != null && (typeof token !== 'string' || token.length === 0)) {
+    warnings.push(`Invalid value for 'environments.rancher.token': when provided, must be a non-empty bearer token string`)
   }
+  if (tokenEnv != null && (typeof tokenEnv !== 'string' || tokenEnv.length === 0)) {
+    warnings.push(`Invalid value for 'environments.rancher.tokenEnv': when provided, must be a non-empty env-var name`)
+  }
+  if (tokenFile != null && (typeof tokenFile !== 'string' || tokenFile.length === 0)) {
+    warnings.push(`Invalid value for 'environments.rancher.tokenFile': when provided, must be a non-empty file path`)
+  }
+  // NB: a "missing token" warning is unreachable here — the `configured` gate
+  // above already requires at least one token source, so a block with no token
+  // source short-circuits as "not configured yet" without warning (the intended
+  // setup-friendly behaviour). The shape checks above only fire on a block that
+  // is otherwise complete.
 
   if (caData != null && (typeof caData !== 'string' || caData.length === 0)) {
     warnings.push(
@@ -512,8 +534,14 @@ export function validateConfig(config, verbose = false) {
     if (Object.prototype.hasOwnProperty.call(config.environments, 'backend')) {
       const backend = config.environments.backend
       if (typeof backend !== 'string') {
+        // Deliberately an "Invalid value" (not "Invalid type") warning: the
+        // wiring layer (`resolveEnvironmentBackend`) treats anything
+        // unrecognised as Docker, so a typo must NOT be fatal.
+        // `loadAndMergeConfig` escalates only "Invalid type" warnings to a hard
+        // exit, which would contradict the documented "malformed → docker"
+        // fallback (Copilot review #5148).
         warnings.push(
-          `Invalid type for 'environments.backend': expected string, got ${Array.isArray(backend) ? 'array' : typeof backend}`,
+          `Invalid value for 'environments.backend': expected one of ${[...ENVIRONMENT_BACKENDS].join(', ')}, got ${Array.isArray(backend) ? 'array' : typeof backend}`,
         )
       } else if (!ENVIRONMENT_BACKENDS.has(backend)) {
         warnings.push(

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -30,7 +30,7 @@ import { loadModelsCache, getModels } from './models.js'
 // environment-manager.js itself remains behind the dynamic import below
 // (`if (config?.environments?.enabled)`).
 import { UNREACHABLE_STATUSES } from './environment-statuses.js'
-import { resolveSkipPermissions } from './config.js'
+import { resolveSkipPermissions, buildEnvironmentBackend } from './config.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -419,7 +419,25 @@ export async function startCliServer(config) {
       // Docker / other backends silently ignore the field at runtime.
       log.info(`EnvironmentManager: K8s workspace PVC configured (claim: ${workspacePVCDefault.claimName}, mount: ${mountPath})${readOnlyTag} — active only on K8sBackend; ignored by Docker and other backends`)
     }
-    environmentManager = new EnvironmentManager({ workspacePVCDefault })
+    // #5144: config-driven backend selection. `environments.backend` picks
+    // docker (default) | k8s | rancher; the selected backend's options come
+    // from `environments.k8s` / `environments.rancher` (Rancher token resolved
+    // from a secret-friendly source and never logged). The factory imports the
+    // backend module lazily so a Docker deployment never pulls in the kube SDK,
+    // and throws on a malformed k8s/rancher block — surfaced here as a fatal
+    // startup error rather than a silent fall-through to Docker.
+    let backend
+    try {
+      const built = await buildEnvironmentBackend(config)
+      backend = built.backend
+      if (built.type !== 'docker') {
+        log.info(`EnvironmentManager: using '${built.type}' backend (from environments.backend)`)
+      }
+    } catch (err) {
+      log.error(`EnvironmentManager: failed to construct '${config?.environments?.backend || 'docker'}' backend — ${err.message}`)
+      throw err
+    }
+    environmentManager = new EnvironmentManager({ backend, workspacePVCDefault })
     await logEnvironmentManagerReconnectResult(environmentManager, log)
   }
 

--- a/packages/server/tests/cli-environment-backend.test.js
+++ b/packages/server/tests/cli-environment-backend.test.js
@@ -1,0 +1,109 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { Command } from 'commander'
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { addServerOptions, loadAndMergeConfig } from '../src/cli/shared.js'
+
+/**
+ * #5144 — `--environment-backend` CLI flag wiring on `chroxy start` / `dev`.
+ *
+ * The flag selects the environment backend (docker | k8s | rancher) and must
+ * compose with — not clobber — a file-configured `environments` block
+ * (k8s/rancher sub-blocks normally live in config.json).
+ */
+describe('--environment-backend flag (#5144)', () => {
+  function makeServerCmd() {
+    const program = new Command()
+    program.exitOverride()
+    const cmd = program.command('start').helpOption(false).action(() => {})
+    addServerOptions(cmd)
+    return { program, cmd }
+  }
+
+  it('registers --environment-backend as a recognised option', () => {
+    const { cmd } = makeServerCmd()
+    const optNames = cmd.options.map((o) => o.long)
+    assert.ok(optNames.includes('--environment-backend'), `got: ${optNames.join(', ')}`)
+  })
+
+  it('help text names docker/k8s/rancher', () => {
+    const { cmd } = makeServerCmd()
+    const opt = cmd.options.find((o) => o.long === '--environment-backend')
+    assert.ok(opt)
+    assert.match(opt.description, /docker/)
+    assert.match(opt.description, /k8s/)
+    assert.match(opt.description, /rancher/)
+  })
+
+  it('parses to options.environmentBackend (camelCased)', () => {
+    const { program } = makeServerCmd()
+    program.parse(['node', 'chroxy', 'start', '--environment-backend', 'rancher'])
+    const opts = program.commands.find((c) => c.name() === 'start').opts()
+    assert.equal(opts.environmentBackend, 'rancher')
+  })
+
+  it('absent flag leaves options.environmentBackend undefined (config-file precedence preserved)', () => {
+    const { program } = makeServerCmd()
+    program.parse(['node', 'chroxy', 'start'])
+    const opts = program.commands.find((c) => c.name() === 'start').opts()
+    assert.equal(opts.environmentBackend, undefined)
+  })
+})
+
+describe('loadAndMergeConfig environments composition (#5144)', () => {
+  let tempDir
+  let configPath
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'chroxy-env-backend-'))
+    configPath = join(tempDir, 'config.json')
+  })
+  afterEach(() => { rmSync(tempDir, { recursive: true, force: true }) })
+
+  function writeConfig(obj) {
+    writeFileSync(configPath, JSON.stringify(obj))
+  }
+
+  it('--environment-backend overrides the file value but keeps file sub-blocks', () => {
+    writeConfig({
+      apiToken: 'tok',
+      environments: {
+        enabled: true,
+        backend: 'docker',
+        k8s: { namespace: 'chroxy' },
+        rancher: { rancherUrl: 'https://rancher.example.com', clusterId: 'c-m-a', token: 't' },
+      },
+    })
+    const config = loadAndMergeConfig({ config: configPath, environmentBackend: 'rancher' })
+    assert.equal(config.environments.backend, 'rancher')
+    // File sub-blocks survive the CLI override.
+    assert.equal(config.environments.k8s.namespace, 'chroxy')
+    assert.equal(config.environments.rancher.clusterId, 'c-m-a')
+    // `enabled` survives too.
+    assert.equal(config.environments.enabled, true)
+  })
+
+  it('--environments alone preserves a file-configured k8s block', () => {
+    writeConfig({
+      apiToken: 'tok',
+      environments: { k8s: { workspace: { claimName: 'pvc' } } },
+    })
+    const config = loadAndMergeConfig({ config: configPath, environments: true })
+    assert.equal(config.environments.enabled, true)
+    assert.equal(config.environments.k8s.workspace.claimName, 'pvc')
+  })
+
+  it('file backend value is used when no CLI flag is given', () => {
+    writeConfig({ apiToken: 'tok', environments: { enabled: true, backend: 'k8s' } })
+    const config = loadAndMergeConfig({ config: configPath })
+    assert.equal(config.environments.backend, 'k8s')
+  })
+
+  it('default path (no environments block at all) is unchanged', () => {
+    writeConfig({ apiToken: 'tok' })
+    const config = loadAndMergeConfig({ config: configPath })
+    assert.equal(config.environments, undefined)
+  })
+})

--- a/packages/server/tests/config-backend-selection.test.js
+++ b/packages/server/tests/config-backend-selection.test.js
@@ -1,0 +1,224 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  resolveEnvironmentBackend,
+  resolveRancherToken,
+  buildEnvironmentBackend,
+} from '../src/config.js'
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+/**
+ * #5144 — config-driven environment backend selection.
+ *
+ * `buildEnvironmentBackend` is exercised with an injected `_loadBackends`
+ * factory so no real `@kubernetes/client-node` / Docker is touched: the fake
+ * backend classes simply record the options they were constructed with, and the
+ * tests assert which class was instantiated for each `environments.backend`
+ * value and that the right options flowed through.
+ */
+
+// Fake backend classes — each captures its constructor opts for assertion.
+class FakeDockerBackend {
+  constructor(opts = {}) { this.kind = 'docker'; this.opts = opts }
+}
+class FakeK8sBackend {
+  constructor(opts = {}) { this.kind = 'k8s'; this.opts = opts }
+}
+class FakeRancherBackend {
+  constructor(opts = {}) { this.kind = 'rancher'; this.opts = opts }
+}
+
+const fakeLoader = async () => ({
+  DockerBackend: FakeDockerBackend,
+  K8sBackend: FakeK8sBackend,
+  RancherBackend: FakeRancherBackend,
+})
+
+describe('resolveEnvironmentBackend (#5144)', () => {
+  it('defaults to docker when environments is absent', () => {
+    assert.equal(resolveEnvironmentBackend({}), 'docker')
+    assert.equal(resolveEnvironmentBackend(undefined), 'docker')
+    assert.equal(resolveEnvironmentBackend(null), 'docker')
+  })
+
+  it('defaults to docker when backend is absent', () => {
+    assert.equal(resolveEnvironmentBackend({ environments: { enabled: true } }), 'docker')
+  })
+
+  it('returns the selected backend for each valid value', () => {
+    assert.equal(resolveEnvironmentBackend({ environments: { backend: 'docker' } }), 'docker')
+    assert.equal(resolveEnvironmentBackend({ environments: { backend: 'k8s' } }), 'k8s')
+    assert.equal(resolveEnvironmentBackend({ environments: { backend: 'rancher' } }), 'rancher')
+  })
+
+  it('falls back to docker on an unrecognised value (warning surfaced by validateConfig)', () => {
+    assert.equal(resolveEnvironmentBackend({ environments: { backend: 'nomad' } }), 'docker')
+    assert.equal(resolveEnvironmentBackend({ environments: { backend: 42 } }), 'docker')
+  })
+})
+
+describe('buildEnvironmentBackend (#5144)', () => {
+  it('constructs DockerBackend by default and forwards _execFile', async () => {
+    const execFile = () => {}
+    const { backend, type } = await buildEnvironmentBackend(
+      { environments: { enabled: true } },
+      { _execFile: execFile, _loadBackends: fakeLoader },
+    )
+    assert.equal(type, 'docker')
+    assert.ok(backend instanceof FakeDockerBackend)
+    assert.equal(backend.opts._execFile, execFile)
+  })
+
+  it('constructs DockerBackend for an explicit docker selector', async () => {
+    const { backend, type } = await buildEnvironmentBackend(
+      { environments: { backend: 'docker' } },
+      { _loadBackends: fakeLoader },
+    )
+    assert.equal(type, 'docker')
+    assert.ok(backend instanceof FakeDockerBackend)
+  })
+
+  it('constructs DockerBackend for an unrecognised selector (safe default)', async () => {
+    const { backend, type } = await buildEnvironmentBackend(
+      { environments: { backend: 'nomad' } },
+      { _loadBackends: fakeLoader },
+    )
+    assert.equal(type, 'docker')
+    assert.ok(backend instanceof FakeDockerBackend)
+  })
+
+  it('constructs K8sBackend and forwards the k8s connection options', async () => {
+    const config = {
+      environments: {
+        backend: 'k8s',
+        k8s: {
+          namespace: 'chroxy',
+          inCluster: true,
+          kubeconfigPath: '/k/config',
+          sidecarImage: 'agent:1',
+          imagePullPolicy: 'IfNotPresent',
+          connectMode: 'clusterip',
+          // workspace lives here too but is wired separately via the manager;
+          // it should NOT be passed into the K8sBackend constructor here.
+          workspace: { claimName: 'pvc' },
+        },
+      },
+    }
+    const { backend, type } = await buildEnvironmentBackend(config, { _loadBackends: fakeLoader })
+    assert.equal(type, 'k8s')
+    assert.ok(backend instanceof FakeK8sBackend)
+    assert.equal(backend.opts.namespace, 'chroxy')
+    assert.equal(backend.opts.inCluster, true)
+    assert.equal(backend.opts.kubeconfigPath, '/k/config')
+    assert.equal(backend.opts.sidecarImage, 'agent:1')
+    assert.equal(backend.opts.imagePullPolicy, 'IfNotPresent')
+    assert.equal(backend.opts.connectMode, 'clusterip')
+    assert.ok(!('workspace' in backend.opts))
+  })
+
+  it('constructs K8sBackend with empty opts when no k8s block is configured', async () => {
+    const { backend, type } = await buildEnvironmentBackend(
+      { environments: { backend: 'k8s' } },
+      { _loadBackends: fakeLoader },
+    )
+    assert.equal(type, 'k8s')
+    assert.ok(backend instanceof FakeK8sBackend)
+    assert.equal(backend.opts.namespace, undefined)
+  })
+
+  it('constructs RancherBackend and forwards both k8s and rancher options', async () => {
+    const config = {
+      environments: {
+        backend: 'rancher',
+        k8s: { namespace: 'chroxy', connectMode: 'clusterip' },
+        rancher: {
+          rancherUrl: 'https://rancher.example.com',
+          clusterId: 'c-m-abc123',
+          token: 'inline-token',
+          caData: 'YmFzZTY0',
+          skipTLSVerify: true,
+          defaultProjectId: 'p-xyz',
+        },
+      },
+    }
+    const { backend, type } = await buildEnvironmentBackend(config, { _loadBackends: fakeLoader })
+    assert.equal(type, 'rancher')
+    assert.ok(backend instanceof FakeRancherBackend)
+    // k8s knobs flow through
+    assert.equal(backend.opts.namespace, 'chroxy')
+    assert.equal(backend.opts.connectMode, 'clusterip')
+    // rancher block flows through
+    assert.equal(backend.opts.rancherUrl, 'https://rancher.example.com')
+    assert.equal(backend.opts.clusterId, 'c-m-abc123')
+    assert.equal(backend.opts.token, 'inline-token')
+    assert.equal(backend.opts.caData, 'YmFzZTY0')
+    assert.equal(backend.opts.skipTLSVerify, true)
+    assert.equal(backend.opts.defaultProjectId, 'p-xyz')
+  })
+
+  it('resolves the Rancher token from an env var (secret-friendly source)', async () => {
+    process.env.CHROXY_TEST_RANCHER_TOKEN = 'env-sourced-token'
+    try {
+      const config = {
+        environments: {
+          backend: 'rancher',
+          rancher: {
+            rancherUrl: 'https://rancher.example.com',
+            clusterId: 'c-m-abc123',
+            tokenEnv: 'CHROXY_TEST_RANCHER_TOKEN',
+          },
+        },
+      }
+      const { backend } = await buildEnvironmentBackend(config, { _loadBackends: fakeLoader })
+      assert.equal(backend.opts.token, 'env-sourced-token')
+    } finally {
+      delete process.env.CHROXY_TEST_RANCHER_TOKEN
+    }
+  })
+})
+
+describe('resolveRancherToken (#5144)', () => {
+  let tempDir
+  beforeEach(() => { tempDir = mkdtempSync(join(tmpdir(), 'chroxy-rancher-token-')) })
+  afterEach(() => { rmSync(tempDir, { recursive: true, force: true }) })
+
+  it('prefers tokenEnv over tokenFile and inline token', () => {
+    process.env.CHROXY_TEST_TKN = 'from-env'
+    const file = join(tempDir, 'tok')
+    writeFileSync(file, 'from-file\n')
+    try {
+      const tok = resolveRancherToken({ tokenEnv: 'CHROXY_TEST_TKN', tokenFile: file, token: 'inline' })
+      assert.equal(tok, 'from-env')
+    } finally {
+      delete process.env.CHROXY_TEST_TKN
+    }
+  })
+
+  it('falls back to tokenFile (trimmed) when tokenEnv is unset', () => {
+    const file = join(tempDir, 'tok')
+    writeFileSync(file, '  from-file-trimmed  \n')
+    const tok = resolveRancherToken({ tokenEnv: 'CHROXY_TEST_UNSET_VAR', tokenFile: file, token: 'inline' })
+    assert.equal(tok, 'from-file-trimmed')
+  })
+
+  it('falls back to inline token when neither env nor file resolve', () => {
+    const tok = resolveRancherToken({ tokenFile: join(tempDir, 'does-not-exist'), token: 'inline' })
+    assert.equal(tok, 'inline')
+  })
+
+  it('returns undefined when no source resolves', () => {
+    assert.equal(resolveRancherToken({}), undefined)
+    assert.equal(resolveRancherToken({ tokenEnv: 'CHROXY_TEST_NONE' }), undefined)
+  })
+
+  it('ignores an empty env var value and falls through', () => {
+    process.env.CHROXY_TEST_EMPTY = ''
+    try {
+      assert.equal(resolveRancherToken({ tokenEnv: 'CHROXY_TEST_EMPTY', token: 'inline' }), 'inline')
+    } finally {
+      delete process.env.CHROXY_TEST_EMPTY
+    }
+  })
+})

--- a/packages/server/tests/config-range-validation.test.js
+++ b/packages/server/tests/config-range-validation.test.js
@@ -250,10 +250,14 @@ describe('validateConfig environments.backend (#5144)', () => {
     assert.ok(result.warnings.some(w => /environments\.backend/.test(w) && /nomad/.test(w)))
   })
 
-  it('warns when backend is not a string', () => {
+  it('warns (warn-only, not fatal "Invalid type") when backend is not a string', () => {
     const result = validateConfig({ environments: { backend: 123 } })
     assert.equal(result.valid, false)
-    assert.ok(result.warnings.some(w => /environments\.backend/.test(w) && /string/.test(w)))
+    const w = result.warnings.find(x => /environments\.backend/.test(x))
+    assert.ok(w, `expected environments.backend warning, got: ${result.warnings.join('; ')}`)
+    // Must NOT use the "Invalid type" prefix — loadAndMergeConfig escalates
+    // those to a fatal exit, which would break the "malformed → docker" fallback.
+    assert.ok(!w.startsWith('Invalid type'), `backend warning must not be fatal: ${w}`)
   })
 
   it('passes when the backend key is absent (default path unchanged)', () => {
@@ -392,5 +396,47 @@ describe('validateConfig environments.rancher block (#5144)', () => {
       environments: { rancher: { ...fullRancher, clusterId: 'bogus' } },
     })
     assert.ok(!result.warnings.some(w => w.includes('token-secret-xyz')))
+  })
+
+  it('validates a block configured via tokenEnv (no inline token) — surfaces malformed clusterId', () => {
+    const result = validateConfig({
+      environments: {
+        rancher: { rancherUrl: 'https://rancher.example.com', clusterId: 'bogus', tokenEnv: 'RANCHER_TOKEN' },
+      },
+    })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /environments\.rancher\.clusterId/.test(w)))
+  })
+
+  it('does NOT warn "missing token" when only tokenFile is set on a complete block', () => {
+    const result = validateConfig({
+      environments: {
+        rancher: { ...fullRancher, token: undefined, tokenFile: '/run/secrets/rancher-token' },
+      },
+    })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('warns when tokenEnv is an empty string on an otherwise complete block', () => {
+    const result = validateConfig({
+      environments: { rancher: { ...fullRancher, tokenEnv: '' } },
+    })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /tokenEnv/.test(w)))
+  })
+
+  it('warns when tokenFile is the wrong type on an otherwise complete block', () => {
+    const result = validateConfig({
+      environments: { rancher: { ...fullRancher, tokenFile: 42 } },
+    })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /tokenFile/.test(w)))
+  })
+
+  it('treats a block with rancherUrl+clusterId but no token source as "not configured" (no warnings)', () => {
+    const result = validateConfig({
+      environments: { rancher: { rancherUrl: 'https://rancher.example.com', clusterId: 'c-m-abc' } },
+    })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
   })
 })

--- a/packages/server/tests/config-range-validation.test.js
+++ b/packages/server/tests/config-range-validation.test.js
@@ -222,3 +222,175 @@ describe('validateConfig environments.k8s.workspace (#4556)', () => {
     assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
   })
 })
+
+/**
+ * #5144 — config-driven backend selection. Validates the `environments.backend`
+ * selector and the `environments.k8s` connection sub-block (the `workspace`
+ * sub-block is covered by the #4556 suite above).
+ */
+describe('validateConfig environments.backend (#5144)', () => {
+  it('accepts docker', () => {
+    const result = validateConfig({ environments: { backend: 'docker' } })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('accepts k8s', () => {
+    const result = validateConfig({ environments: { backend: 'k8s' } })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('accepts rancher (without a configured rancher block — selector alone is fine)', () => {
+    const result = validateConfig({ environments: { backend: 'rancher' } })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('warns on an unrecognised backend value', () => {
+    const result = validateConfig({ environments: { backend: 'nomad' } })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /environments\.backend/.test(w) && /nomad/.test(w)))
+  })
+
+  it('warns when backend is not a string', () => {
+    const result = validateConfig({ environments: { backend: 123 } })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /environments\.backend/.test(w) && /string/.test(w)))
+  })
+
+  it('passes when the backend key is absent (default path unchanged)', () => {
+    const result = validateConfig({ environments: { enabled: true } })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+})
+
+describe('validateConfig environments.k8s connection block (#5144)', () => {
+  it('accepts a full valid k8s block', () => {
+    const config = {
+      environments: {
+        backend: 'k8s',
+        k8s: {
+          namespace: 'chroxy',
+          inCluster: true,
+          kubeconfigPath: '/home/user/.kube/config',
+          sidecarImage: 'chroxy-pod-agent:latest',
+          imagePullPolicy: 'IfNotPresent',
+          connectMode: 'clusterip',
+        },
+      },
+    }
+    const result = validateConfig(config)
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('warns when namespace is not a string', () => {
+    const result = validateConfig({ environments: { k8s: { namespace: 5 } } })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /environments\.k8s\.namespace/.test(w) && /string/.test(w)))
+  })
+
+  it('warns when inCluster is not a boolean', () => {
+    const result = validateConfig({ environments: { k8s: { inCluster: 'yes' } } })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /environments\.k8s\.inCluster/.test(w) && /boolean/.test(w)))
+  })
+
+  it('warns on an invalid imagePullPolicy', () => {
+    const result = validateConfig({ environments: { k8s: { imagePullPolicy: 'Sometimes' } } })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /imagePullPolicy/.test(w) && /Sometimes/.test(w)))
+  })
+
+  it('warns on an invalid connectMode', () => {
+    const result = validateConfig({ environments: { k8s: { connectMode: 'tunnel' } } })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /connectMode/.test(w) && /tunnel/.test(w)))
+  })
+
+  it('passes when k8s block has only a workspace sub-block (other fields absent)', () => {
+    const result = validateConfig({ environments: { k8s: { workspace: { claimName: 'pvc' } } } })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+})
+
+describe('validateConfig environments.rancher block (#5144)', () => {
+  const fullRancher = {
+    rancherUrl: 'https://rancher.example.com',
+    clusterId: 'c-m-abc123',
+    token: 'token-secret-xyz',
+  }
+
+  it('accepts a complete valid rancher block', () => {
+    const result = validateConfig({ environments: { backend: 'rancher', rancher: { ...fullRancher } } })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('accepts an optional caData / skipTLSVerify / defaultProjectId', () => {
+    const result = validateConfig({
+      environments: {
+        rancher: { ...fullRancher, caData: 'YmFzZTY0', skipTLSVerify: true, defaultProjectId: 'p-xyz' },
+      },
+    })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('treats a partial block (no token) as "not configured" — no warnings', () => {
+    const result = validateConfig({
+      environments: { rancher: { rancherUrl: 'https://rancher.example.com', clusterId: 'c-m-abc' } },
+    })
+    assert.equal(result.valid, true, `warnings: ${result.warnings.join('; ')}`)
+  })
+
+  it('warns on a malformed rancherUrl when the block is complete', () => {
+    const result = validateConfig({
+      environments: { rancher: { ...fullRancher, rancherUrl: 'not-a-url' } },
+    })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /environments\.rancher\.rancherUrl/.test(w)))
+  })
+
+  it('warns on a non-http(s) rancherUrl protocol', () => {
+    const result = validateConfig({
+      environments: { rancher: { ...fullRancher, rancherUrl: 'ftp://rancher.example.com' } },
+    })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /environments\.rancher\.rancherUrl/.test(w) && /http/.test(w)))
+  })
+
+  it('warns on a clusterId that does not match the Rancher format', () => {
+    const result = validateConfig({
+      environments: { rancher: { ...fullRancher, clusterId: 'bogus' } },
+    })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /environments\.rancher\.clusterId/.test(w)))
+  })
+
+  it('warns on a malformed defaultProjectId', () => {
+    const result = validateConfig({
+      environments: { rancher: { ...fullRancher, defaultProjectId: 'bad' } },
+    })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /defaultProjectId/.test(w)))
+  })
+
+  it('warns when caData is an empty string', () => {
+    const result = validateConfig({
+      environments: { rancher: { ...fullRancher, caData: '' } },
+    })
+    // empty caData means "configured? false" since token present but caData
+    // empty -> still configured (url+cluster+token present). caData '' triggers.
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /caData/.test(w)))
+  })
+
+  it('warns when rancher is not an object', () => {
+    const result = validateConfig({ environments: { rancher: 'https://rancher.example.com' } })
+    assert.equal(result.valid, false)
+    assert.ok(result.warnings.some(w => /environments\.rancher/.test(w) && /object/.test(w)))
+  })
+
+  it('never echoes the token value in a warning', () => {
+    const result = validateConfig({
+      environments: { rancher: { ...fullRancher, clusterId: 'bogus' } },
+    })
+    assert.ok(!result.warnings.some(w => w.includes('token-secret-xyz')))
+  })
+})


### PR DESCRIPTION
## Summary

Adds operator-facing config to **select and configure** the cluster environment backends that previously could only be wired via the `EnvironmentManager` `backend` injection seam (never from config/CLI). Spun out of #3196 / PR #5143.

- `environments.backend`: `'docker'` (default) | `'k8s'` | `'rancher'`. Absent/malformed/unrecognised → Docker, so existing single-node setups are unchanged.
- `environments.k8s` connection block validated at config-load time (`namespace`, `inCluster`, `kubeconfigPath`, `sidecarImage`, `imagePullPolicy`, `connectMode`). The `workspace` sub-block validation from #4556 is preserved untouched.
- `environments.rancher` block validated mirroring `validateRancherOptions` in `rancher.js` (URL shape, cluster-ID format, token presence, optional `caData`/`skipTLSVerify`/`defaultProjectId`), gated on `isRancherConfigured` semantics so a half-filled-in block during setup doesn't spam warnings.
- `buildEnvironmentBackend(config)` factory constructs the selected backend with **lazy** module imports — a Docker deployment never pulls in `@kubernetes/client-node`. Wired into `server-cli.js` so `EnvironmentManager` receives the selected backend.
- `--environment-backend <backend>` CLI flag. It **composes with** a file-configured `environments` block instead of clobbering it (fixed the latent whole-object-replace behaviour for `--environments` too).

## Security

- The Rancher bearer **token is resolved from a secret-friendly source** — `tokenEnv` (env var name) > `tokenFile` (path to a mounted secret) > inline `token` — and is **never logged**: validation warnings deliberately omit the token value, and the token is not copied onto the backend instance (it lives only inside the kube client's auth provider, per RancherBackend).

## Tests

- `config-range-validation.test.js`: backend selector + k8s connection block + rancher block validation (including "token never echoed").
- `config-backend-selection.test.js`: `resolveEnvironmentBackend` defaults/precedence, `buildEnvironmentBackend` instantiates the correct class with the right options for each value (via an injected `_loadBackends` seam — no kube SDK / Docker touched), and `resolveRancherToken` source precedence.
- `cli-environment-backend.test.js`: flag registration/parsing + `loadAndMergeConfig` composition (CLI override keeps file sub-blocks; default path unchanged).

## Scope note

No live cluster available (expected). This is a config-parsing/validation/wiring change, unit-tested end-to-end via injection seams. Construction against a real K8s/Rancher cluster (actual pod creation, project-scoped namespaces) still needs live validation.

Closes #5144