### PR TITLE
feat(server): namespace-level ResourceQuota / LimitRange ensure (per-tenant)

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -421,9 +421,11 @@ At least one field is required. `cpu`/`memory` become the LimitRange
 
 Both blocks accept the same quantity grammar as the per-pod `resources` opt
 (CPU as a decimal/milli-cpu string, memory as a binary-SI quantity; Docker-style
-suffixes are normalised). Malformed quantities are rejected at startup. The ensure
-is idempotent (read-or-create, already-exists swallowed) and cached per process,
-so it adds a single API roundtrip the first time a tenant namespace is used.
+suffixes are normalised). Malformed quantities are rejected at startup. Each
+configured object's ensure is idempotent (read-or-create, already-exists
+swallowed) and cached per process, so it adds one read (plus a create if the
+object is missing) per configured object the first time a tenant namespace is
+used, and nothing on subsequent calls for that namespace.
 
 ## Examples
 

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -362,6 +362,69 @@ memoryLimit }` object (merged over the built-ins) to raise/lower them, or
 `defaultResources: null` to disable defaults so only explicit per-call values
 produce a `resources` block.
 
+### Kubernetes per-tenant namespace caps (`ResourceQuota` / `LimitRange`)
+
+The pod-level `resources` block above limits each individual Pod. Now that the
+K8s backend gives every tenant their own namespace (`#3194`), you can also set
+**namespace-level** guardrails that apply to the tenant as a whole (`#5142`).
+Both are **opt-in**; when unset the namespace-ensure path is unchanged. They are
+only applied to per-tenant namespaces — never to the static default namespace.
+
+**`environments.k8s.namespaceQuota`** ensures an idempotent `ResourceQuota` that
+caps the AGGREGATE resources a tenant may consume across ALL their Pods:
+
+```json
+{
+  "environments": {
+    "backend": "k8s",
+    "k8s": {
+      "namespaceQuota": {
+        "cpu": "8",          // aggregate requests.cpu cap
+        "memory": "16Gi",    // aggregate requests.memory cap
+        "cpuLimit": "16",    // aggregate limits.cpu cap
+        "memoryLimit": "32Gi", // aggregate limits.memory cap
+        "pods": 10           // max Pods in the namespace
+      }
+    }
+  }
+}
+```
+
+At least one field is required. `cpu`/`memory` map to the aggregate `requests.*`
+keys, `cpuLimit`/`memoryLimit` to the aggregate `limits.*` keys, and `pods` to
+the object-count quota. With a quota in place, Pods that lack their own
+requests/limits will be REJECTED by the cluster — pair it with a `LimitRange`
+(below) or the backend's own `defaultResources` so every Pod carries values.
+
+**`environments.k8s.namespaceLimitRange`** ensures an idempotent `LimitRange`
+that supplies cluster-level DEFAULT requests/limits, so Pods created without
+explicit resources inherit namespace defaults (defence-in-depth on top of the
+backend's own `defaultResources`):
+
+```json
+{
+  "environments": {
+    "k8s": {
+      "namespaceLimitRange": {
+        "cpu": "250m",       // defaultRequest.cpu
+        "memory": "256Mi",   // defaultRequest.memory
+        "cpuLimit": "1",     // default.cpu (the limit)
+        "memoryLimit": "1Gi" // default.memory (the limit)
+      }
+    }
+  }
+}
+```
+
+At least one field is required. `cpu`/`memory` become the LimitRange
+`defaultRequest`, while `cpuLimit`/`memoryLimit` become the `default` (limit).
+
+Both blocks accept the same quantity grammar as the per-pod `resources` opt
+(CPU as a decimal/milli-cpu string, memory as a binary-SI quantity; Docker-style
+suffixes are normalised). Malformed quantities are rejected at startup. The ensure
+is idempotent (read-or-create, already-exists swallowed) and cached per process,
+so it adds a single API roundtrip the first time a tenant namespace is used.
+
 ## Examples
 
 ### Using Config File Only

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -965,6 +965,10 @@ export async function buildEnvironmentBackend(config, { _execFile, _loadBackends
       sidecarImage: k8s.sidecarImage,
       imagePullPolicy: k8s.imagePullPolicy,
       connectMode: k8s.connectMode,
+      // Per-tenant namespace-level guardrails (#5142). Both opt-in; the backend
+      // validates the quantity strings and throws on a malformed block.
+      namespaceQuota: k8s.namespaceQuota,
+      namespaceLimitRange: k8s.namespaceLimitRange,
     })
     return { backend, type }
   }
@@ -981,6 +985,9 @@ export async function buildEnvironmentBackend(config, { _execFile, _loadBackends
       sidecarImage: k8s.sidecarImage,
       imagePullPolicy: k8s.imagePullPolicy,
       connectMode: k8s.connectMode,
+      // Per-tenant namespace-level guardrails (#5142), shared with the plain K8s path.
+      namespaceQuota: k8s.namespaceQuota,
+      namespaceLimitRange: k8s.namespaceLimitRange,
       // Rancher connection block. Token is resolved from a secret-friendly
       // source and never logged.
       rancherUrl: rancher.rancherUrl,

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -645,12 +645,29 @@ export class K8sBackend {
     // at the first createEnvironment call (mirrors defaultResources).
     //   - undefined/null → feature off (no quota / limitrange ensured)
     //   - object         → validated + cached spec, ensured per tenant namespace
-    this._namespaceQuotaSpec = (namespaceQuota == null)
-      ? null
-      : buildResourceQuotaSpec(namespaceQuota)
-    this._namespaceLimitRangeSpec = (namespaceLimitRange == null)
-      ? null
-      : buildLimitRangeSpec(namespaceLimitRange)
+    // Re-scope any builder failure to the constructor option (mirrors how
+    // defaultResources wraps buildResourceBlock above) — the builders blame
+    // `namespaceQuota.*` via _validateResourceQuantity's `createEnvironment:`
+    // prefix, which points at the wrong call site for constructor config. The
+    // original error is preserved as `cause`.
+    if (namespaceQuota == null) {
+      this._namespaceQuotaSpec = null
+    } else {
+      try {
+        this._namespaceQuotaSpec = buildResourceQuotaSpec(namespaceQuota)
+      } catch (err) {
+        throw new Error(`K8sBackend: opts.namespaceQuota is invalid — ${err.message}`, { cause: err })
+      }
+    }
+    if (namespaceLimitRange == null) {
+      this._namespaceLimitRangeSpec = null
+    } else {
+      try {
+        this._namespaceLimitRangeSpec = buildLimitRangeSpec(namespaceLimitRange)
+      } catch (err) {
+        throw new Error(`K8sBackend: opts.namespaceLimitRange is invalid — ${err.message}`, { cause: err })
+      }
+    }
     // Namespaces whose ResourceQuota / LimitRange we have already ensured this
     // process, so repeated createEnvironment calls for the same tenant skip the
     // read/create roundtrip (mirrors _ensuredNamespaces).

--- a/packages/server/src/environments/backends/k8s.js
+++ b/packages/server/src/environments/backends/k8s.js
@@ -567,6 +567,22 @@ export class K8sBackend {
    *   An object is merged over the built-in {@link DEFAULT_RESOURCES} (so partial overrides are fine)
    *   and validated at construction. Pass `null` to disable defaults entirely — then only explicit
    *   per-call resource values produce a `resources` block. Omit to use the built-in defaults.
+   * @param {Object|null} [opts.namespaceQuota] - Per-tenant aggregate ResourceQuota spec (#5142).
+   *   When set, a namespace-scoped `ResourceQuota` capping the tenant's TOTAL CPU/memory (and
+   *   optionally Pod count) across all their Pods is ensured (idempotent create) whenever a tenant
+   *   namespace is ensured. Shape: `{ cpu, memory, cpuLimit, memoryLimit, pods }` — `cpu`/`memory`
+   *   map to aggregate `requests.*`, `cpuLimit`/`memoryLimit` to aggregate `limits.*`, `pods` to the
+   *   max object count. At least one field is required. Quantities are validated at construction.
+   *   Distinct from per-pod `defaultResources` (#3195), which limits each individual Pod. Omit (or
+   *   `null`) to skip — the namespace-ensure path is unchanged. Never applied to the static default
+   *   namespace.
+   * @param {Object|null} [opts.namespaceLimitRange] - Per-tenant LimitRange defaults (#5142).
+   *   When set, a namespace-scoped `LimitRange` is ensured so Pods created WITHOUT explicit
+   *   requests/limits inherit namespace defaults at the cluster level (defence-in-depth on top of
+   *   `defaultResources`). Same flat shape as `defaultResources`: `{ cpu, memory, cpuLimit,
+   *   memoryLimit }` — `cpu`/`memory` become `defaultRequest.*`, `cpuLimit`/`memoryLimit` become
+   *   `default.*`. At least one field required. Quantities validated at construction. Omit (or
+   *   `null`) to skip. Never applied to the static default namespace.
    * @param {'portforward'|'clusterip'} [opts.connectMode='portforward'] - How to reach the sidecar
    * @param {object}  [opts._coreV1Api]                 - Injected CoreV1Api for testing
    * @param {object}  [opts._portForward]               - Injected PortForward for testing
@@ -578,7 +594,7 @@ export class K8sBackend {
    * @param {Function} [opts._clearTimeout]             - Override clearTimeout for deterministic testing
    */
   constructor({ namespace, namespaceFor, inCluster, kubeconfigPath, sidecarImage, gitImage, imagePullPolicy,
-    defaultResources, connectMode, _coreV1Api, _portForward, _dialWs, _net,
+    defaultResources, namespaceQuota, namespaceLimitRange, connectMode, _coreV1Api, _portForward, _dialWs, _net,
     _reconnectDelays, _maxRetries, _maxStdinBufferBytes,
     _setTimeout: setTimeoutImpl, _clearTimeout: clearTimeoutImpl } = {}) {
     validateImagePullPolicy(imagePullPolicy, 'constructor opts')
@@ -622,6 +638,25 @@ export class K8sBackend {
     } else {
       throw new TypeError('K8sBackend: opts.defaultResources must be an object or null')
     }
+
+    // Namespace-level (per-tenant) ResourceQuota / LimitRange (#5142). These are
+    // OPT-IN: when unset the namespace-ensure path is unchanged. Build the canonical
+    // K8s spec up-front so a malformed quantity surfaces at construction rather than
+    // at the first createEnvironment call (mirrors defaultResources).
+    //   - undefined/null → feature off (no quota / limitrange ensured)
+    //   - object         → validated + cached spec, ensured per tenant namespace
+    this._namespaceQuotaSpec = (namespaceQuota == null)
+      ? null
+      : buildResourceQuotaSpec(namespaceQuota)
+    this._namespaceLimitRangeSpec = (namespaceLimitRange == null)
+      ? null
+      : buildLimitRangeSpec(namespaceLimitRange)
+    // Namespaces whose ResourceQuota / LimitRange we have already ensured this
+    // process, so repeated createEnvironment calls for the same tenant skip the
+    // read/create roundtrip (mirrors _ensuredNamespaces).
+    this._ensuredQuotas = new Set()
+    this._ensuredLimitRanges = new Set()
+
     this._connectMode = connectMode ?? 'portforward'
 
     if (_coreV1Api) {
@@ -778,6 +813,119 @@ export class K8sBackend {
       log.info(`Namespace ${ns} already exists (concurrent create)`)
     }
     this._ensuredNamespaces.add(ns)
+  }
+
+  /**
+   * Idempotently ensure a per-tenant `ResourceQuota` exists in `ns` (#5142).
+   *
+   * A namespace-scoped ResourceQuota caps the AGGREGATE CPU/memory (and
+   * optionally Pod count) a tenant may consume across ALL their Pods — distinct
+   * from the per-pod requests/limits #3195 sets on each container. It is the
+   * tenant-level guardrail that becomes meaningful now that #3194 gives every
+   * tenant their own namespace.
+   *
+   * Opt-in + safe by construction:
+   *   - No-op when the backend was constructed without `namespaceQuota`.
+   *   - No-op for the static default namespace (treated as cluster bootstrap,
+   *     chroxy is unlikely to hold RBAC there) — mirrors ensureNamespace.
+   *   - Read-or-create, idempotent, safe to call repeatedly/concurrently: a 404
+   *     read triggers a create; a 409 AlreadyExists on create is swallowed.
+   *   - Once ensured, the namespace is cached so subsequent calls are a no-op.
+   *
+   * @param {string} ns - A namespace name already validated as an RFC 1123 label
+   * @returns {Promise<void>}
+   */
+  async ensureResourceQuota(ns) {
+    if (this._namespaceQuotaSpec == null) return
+    if (this._ensuredQuotas.has(ns)) return
+    // Never touch the static default namespace — assumed pre-existing, and chroxy
+    // may lack RBAC to write ResourceQuota objects there.
+    if (ns === this._namespace) {
+      this._ensuredQuotas.add(ns)
+      return
+    }
+
+    const name = 'chroxy-quota'
+    try {
+      await this._api.readNamespacedResourceQuota({ name, namespace: ns })
+      this._ensuredQuotas.add(ns)
+      return
+    } catch (err) {
+      if (!_isNotFound(err)) throw err
+      // 404 → fall through and create it.
+    }
+
+    const body = {
+      apiVersion: 'v1',
+      kind: 'ResourceQuota',
+      metadata: {
+        name,
+        labels: { 'app.kubernetes.io/managed-by': 'chroxy' },
+      },
+      spec: { hard: this._namespaceQuotaSpec },
+    }
+    try {
+      log.info(`Creating ResourceQuota ${name} in namespace ${ns}`)
+      await this._api.createNamespacedResourceQuota({ namespace: ns, body })
+    } catch (err) {
+      // Another creator won the race (or it already existed) — AlreadyExists is
+      // success for an idempotent ensure, not an error.
+      if (!_isAlreadyExists(err)) throw err
+      log.info(`ResourceQuota ${name} already exists in ${ns} (concurrent create)`)
+    }
+    this._ensuredQuotas.add(ns)
+  }
+
+  /**
+   * Idempotently ensure a per-tenant `LimitRange` exists in `ns` (#5142).
+   *
+   * A namespace-scoped LimitRange supplies cluster-level DEFAULT requests/limits
+   * so Pods created WITHOUT explicit resources inherit sane values — a
+   * defence-in-depth layer on top of the backend's own DEFAULT_RESOURCES.
+   *
+   * Same opt-in + idempotency semantics as {@link ensureResourceQuota}:
+   *   - No-op when constructed without `namespaceLimitRange`.
+   *   - No-op for the static default namespace.
+   *   - Read-or-create (404 → create, 409 → swallowed), cached per process.
+   *
+   * @param {string} ns - A namespace name already validated as an RFC 1123 label
+   * @returns {Promise<void>}
+   */
+  async ensureLimitRange(ns) {
+    if (this._namespaceLimitRangeSpec == null) return
+    if (this._ensuredLimitRanges.has(ns)) return
+    if (ns === this._namespace) {
+      this._ensuredLimitRanges.add(ns)
+      return
+    }
+
+    const name = 'chroxy-limits'
+    try {
+      await this._api.readNamespacedLimitRange({ name, namespace: ns })
+      this._ensuredLimitRanges.add(ns)
+      return
+    } catch (err) {
+      if (!_isNotFound(err)) throw err
+      // 404 → fall through and create it.
+    }
+
+    const body = {
+      apiVersion: 'v1',
+      kind: 'LimitRange',
+      metadata: {
+        name,
+        labels: { 'app.kubernetes.io/managed-by': 'chroxy' },
+      },
+      spec: { limits: [this._namespaceLimitRangeSpec] },
+    }
+    try {
+      log.info(`Creating LimitRange ${name} in namespace ${ns}`)
+      await this._api.createNamespacedLimitRange({ namespace: ns, body })
+    } catch (err) {
+      if (!_isAlreadyExists(err)) throw err
+      log.info(`LimitRange ${name} already exists in ${ns} (concurrent create)`)
+    }
+    this._ensuredLimitRanges.add(ns)
   }
 
   /**
@@ -989,6 +1137,12 @@ export class K8sBackend {
     // Ensure the tenant namespace exists before provisioning any resource in it
     // (#3194). Idempotent + cached; a no-op for the static default namespace.
     await this.ensureNamespace(ns)
+    // Ensure per-tenant namespace-level guardrails (#5142). Both are opt-in
+    // (no-op unless the backend was constructed with namespaceQuota /
+    // namespaceLimitRange) and idempotent + cached. Run after ensureNamespace so
+    // the namespace is guaranteed to exist before the quota/limitrange is written.
+    await this.ensureResourceQuota(ns)
+    await this.ensureLimitRange(ns)
     const podName = `chroxy-env-${envId}`
     const secretName = `chroxy-token-${envId}`
     // K8sBackend ALWAYS runs the chroxy-pod-agent sidecar — the sidecar is
@@ -2746,4 +2900,114 @@ export function buildResourceBlock(resources, legacyCpuLimit, legacyMemoryLimit,
   if (Object.keys(requests).length > 0) block.requests = requests
   if (Object.keys(limits).length > 0) block.limits = limits
   return block
+}
+
+/**
+ * Map a tenant-friendly quota spec to the K8s `ResourceQuota.spec.hard` keys
+ * (#5142).
+ *
+ * The operator supplies a small, intention-revealing object; this builder
+ * translates it into the canonical `hard` map the API server understands and
+ * validates every quantity through the same grammar the per-pod path uses
+ * (`_validateResourceQuantity`). CPU/memory values become the standard
+ * `requests.*` / `limits.*` aggregate keys, and the pod count maps to the
+ * `pods` object-count quota.
+ *
+ *   { cpu, memory }             → requests.cpu / requests.memory
+ *   { cpuLimit, memoryLimit }   → limits.cpu   / limits.memory
+ *   { pods }                    → pods         (max object count, integer)
+ *
+ * @param {Object} spec
+ * @param {string} [spec.cpu]         - Aggregate CPU request cap (e.g. "8")
+ * @param {string} [spec.memory]      - Aggregate memory request cap (e.g. "16Gi")
+ * @param {string} [spec.cpuLimit]    - Aggregate CPU limit cap (e.g. "16")
+ * @param {string} [spec.memoryLimit] - Aggregate memory limit cap (e.g. "32Gi")
+ * @param {number} [spec.pods]        - Max number of Pods in the namespace
+ * @returns {Object} A `ResourceQuota.spec.hard` map (at least one entry)
+ * @throws {Error} If the spec is malformed or yields no caps
+ */
+export function buildResourceQuotaSpec(spec) {
+  if (spec == null || typeof spec !== 'object' || Array.isArray(spec)) {
+    throw new Error('K8sBackend: namespaceQuota must be an object')
+  }
+  const hard = {}
+  if (spec.cpu != null) {
+    hard['requests.cpu'] = _validateResourceQuantity(spec.cpu, 'cpu', 'namespaceQuota.cpu')
+  }
+  if (spec.memory != null) {
+    hard['requests.memory'] = _validateResourceQuantity(spec.memory, 'memory', 'namespaceQuota.memory')
+  }
+  if (spec.cpuLimit != null) {
+    hard['limits.cpu'] = _validateResourceQuantity(spec.cpuLimit, 'cpu', 'namespaceQuota.cpuLimit')
+  }
+  if (spec.memoryLimit != null) {
+    hard['limits.memory'] = _validateResourceQuantity(spec.memoryLimit, 'memory', 'namespaceQuota.memoryLimit')
+  }
+  if (spec.pods != null) {
+    if (!Number.isInteger(spec.pods) || spec.pods < 1) {
+      throw new Error('K8sBackend: namespaceQuota.pods must be a positive integer')
+    }
+    // ResourceQuota `hard` values are all quantity strings, including counts.
+    hard.pods = String(spec.pods)
+  }
+  if (Object.keys(hard).length === 0) {
+    throw new Error(
+      'K8sBackend: namespaceQuota must set at least one of ' +
+      'cpu, memory, cpuLimit, memoryLimit, pods',
+    )
+  }
+  return hard
+}
+
+/**
+ * Map a tenant-friendly LimitRange spec to a single container-scoped
+ * `LimitRange.spec.limits[]` entry (#5142).
+ *
+ * A LimitRange supplies *namespace-level* defaults so Pods created WITHOUT
+ * explicit requests/limits inherit sane values at the cluster level — a
+ * defence-in-depth layer on top of the backend's own DEFAULT_RESOURCES. The
+ * operator supplies the same flat shape as `defaultResources`; this builder
+ * splits it into the `default` (limits) and `defaultRequest` (requests) maps a
+ * container-type LimitRange item expects, validating every quantity.
+ *
+ *   { cpu, memory }           → defaultRequest.cpu / defaultRequest.memory
+ *   { cpuLimit, memoryLimit } → default.cpu        / default.memory
+ *
+ * @param {Object} spec
+ * @param {string} [spec.cpu]         - Default CPU request (e.g. "250m")
+ * @param {string} [spec.memory]      - Default memory request (e.g. "256Mi")
+ * @param {string} [spec.cpuLimit]    - Default CPU limit (e.g. "1")
+ * @param {string} [spec.memoryLimit] - Default memory limit (e.g. "1Gi")
+ * @returns {{ type: 'Container', default?: Object, defaultRequest?: Object }}
+ *   A single LimitRange item (at least one of default/defaultRequest set)
+ * @throws {Error} If the spec is malformed or yields no defaults
+ */
+export function buildLimitRangeSpec(spec) {
+  if (spec == null || typeof spec !== 'object' || Array.isArray(spec)) {
+    throw new Error('K8sBackend: namespaceLimitRange must be an object')
+  }
+  const defaultRequest = {}
+  const defaultLimit = {}
+  if (spec.cpu != null) {
+    defaultRequest.cpu = _validateResourceQuantity(spec.cpu, 'cpu', 'namespaceLimitRange.cpu')
+  }
+  if (spec.memory != null) {
+    defaultRequest.memory = _validateResourceQuantity(spec.memory, 'memory', 'namespaceLimitRange.memory')
+  }
+  if (spec.cpuLimit != null) {
+    defaultLimit.cpu = _validateResourceQuantity(spec.cpuLimit, 'cpu', 'namespaceLimitRange.cpuLimit')
+  }
+  if (spec.memoryLimit != null) {
+    defaultLimit.memory = _validateResourceQuantity(spec.memoryLimit, 'memory', 'namespaceLimitRange.memoryLimit')
+  }
+  const item = { type: 'Container' }
+  if (Object.keys(defaultLimit).length > 0) item.default = defaultLimit
+  if (Object.keys(defaultRequest).length > 0) item.defaultRequest = defaultRequest
+  if (item.default == null && item.defaultRequest == null) {
+    throw new Error(
+      'K8sBackend: namespaceLimitRange must set at least one of ' +
+      'cpu, memory, cpuLimit, memoryLimit',
+    )
+  }
+  return item
 }

--- a/packages/server/tests/config-backend-selection.test.js
+++ b/packages/server/tests/config-backend-selection.test.js
@@ -100,6 +100,8 @@ describe('buildEnvironmentBackend (#5144)', () => {
           sidecarImage: 'agent:1',
           imagePullPolicy: 'IfNotPresent',
           connectMode: 'clusterip',
+          namespaceQuota: { cpu: '8', memory: '16Gi', pods: 10 },
+          namespaceLimitRange: { cpu: '250m', cpuLimit: '1' },
           // workspace lives here too but is wired separately via the manager;
           // it should NOT be passed into the K8sBackend constructor here.
           workspace: { claimName: 'pvc' },
@@ -115,6 +117,8 @@ describe('buildEnvironmentBackend (#5144)', () => {
     assert.equal(backend.opts.sidecarImage, 'agent:1')
     assert.equal(backend.opts.imagePullPolicy, 'IfNotPresent')
     assert.equal(backend.opts.connectMode, 'clusterip')
+    assert.deepEqual(backend.opts.namespaceQuota, { cpu: '8', memory: '16Gi', pods: 10 })
+    assert.deepEqual(backend.opts.namespaceLimitRange, { cpu: '250m', cpuLimit: '1' })
     assert.ok(!('workspace' in backend.opts))
   })
 
@@ -132,7 +136,12 @@ describe('buildEnvironmentBackend (#5144)', () => {
     const config = {
       environments: {
         backend: 'rancher',
-        k8s: { namespace: 'chroxy', connectMode: 'clusterip' },
+        k8s: {
+          namespace: 'chroxy',
+          connectMode: 'clusterip',
+          namespaceQuota: { cpu: '8', memory: '16Gi' },
+          namespaceLimitRange: { cpuLimit: '1' },
+        },
         rancher: {
           rancherUrl: 'https://rancher.example.com',
           clusterId: 'c-m-abc123',
@@ -149,6 +158,8 @@ describe('buildEnvironmentBackend (#5144)', () => {
     // k8s knobs flow through
     assert.equal(backend.opts.namespace, 'chroxy')
     assert.equal(backend.opts.connectMode, 'clusterip')
+    assert.deepEqual(backend.opts.namespaceQuota, { cpu: '8', memory: '16Gi' })
+    assert.deepEqual(backend.opts.namespaceLimitRange, { cpuLimit: '1' })
     // rancher block flows through
     assert.equal(backend.opts.rancherUrl, 'https://rancher.example.com')
     assert.equal(backend.opts.clusterId, 'c-m-abc123')

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -5,6 +5,8 @@ import {
   K8sBackend,
   sanitizeNamespaceLabel,
   buildResourceBlock,
+  buildResourceQuotaSpec,
+  buildLimitRangeSpec,
   DEFAULT_RESOURCES,
 } from '../../../src/environments/backends/k8s.js'
 
@@ -22,12 +24,18 @@ import {
  * @param {Function} [opts.readNs]       - Override for `readNamespace` (ensureNamespace probe)
  * @param {Function} [opts.createNs]     - Override for `createNamespace` (ensureNamespace create)
  * @param {Function} [opts.listPods]     - Override for `listNamespacedPod` (listEnvironments)
+ * @param {Function} [opts.readQuota]    - Override for `readNamespacedResourceQuota` (ensureResourceQuota probe)
+ * @param {Function} [opts.createQuota]  - Override for `createNamespacedResourceQuota` (ensureResourceQuota create)
+ * @param {Function} [opts.readLimitRange]   - Override for `readNamespacedLimitRange` (ensureLimitRange probe)
+ * @param {Function} [opts.createLimitRange] - Override for `createNamespacedLimitRange` (ensureLimitRange create)
  */
 function createMockApi({ createPod, deletePod, readPod, createSecret, deleteSecret, readSecret,
-  readNs, createNs, listPods } = {}) {
+  readNs, createNs, listPods,
+  readQuota, createQuota, readLimitRange, createLimitRange } = {}) {
   const calls = {
     create: [], delete: [], read: [], createSecret: [], deleteSecret: [], readSecret: [],
     readNs: [], createNs: [], listPods: [],
+    readQuota: [], createQuota: [], readLimitRange: [], createLimitRange: [],
   }
 
   const api = {
@@ -69,6 +77,25 @@ function createMockApi({ createPod, deletePod, readPod, createSecret, deleteSecr
     listNamespacedPod: listPods
       ? async (args) => { calls.listPods.push(args); return listPods(args) }
       : async (args) => { calls.listPods.push(args); return { items: [] } },
+
+    // Namespace-level ResourceQuota / LimitRange lifecycle (#5142). Default read
+    // resolves so the object is treated as already-existing — when the feature is
+    // enabled and no override is given, ensure does NOT attempt a create.
+    readNamespacedResourceQuota: readQuota
+      ? async (args) => { calls.readQuota.push(args); return readQuota(args) }
+      : async (args) => { calls.readQuota.push(args); return {} },
+
+    createNamespacedResourceQuota: createQuota
+      ? async (args) => { calls.createQuota.push(args); return createQuota(args) }
+      : async (args) => { calls.createQuota.push(args); return {} },
+
+    readNamespacedLimitRange: readLimitRange
+      ? async (args) => { calls.readLimitRange.push(args); return readLimitRange(args) }
+      : async (args) => { calls.readLimitRange.push(args); return {} },
+
+    createNamespacedLimitRange: createLimitRange
+      ? async (args) => { calls.createLimitRange.push(args); return createLimitRange(args) }
+      : async (args) => { calls.createLimitRange.push(args); return {} },
   }
 
   api.calls = calls
@@ -5045,5 +5072,371 @@ describe('K8sBackend namespace isolation (#3194)', () => {
     )
     assert.equal(api.calls.create.length, 0)
     assert.equal(api.calls.createSecret.length, 0)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Namespace-level ResourceQuota / LimitRange (#5142)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildResourceQuotaSpec() (#5142)', () => {
+  it('maps cpu/memory to aggregate requests.* keys', () => {
+    const hard = buildResourceQuotaSpec({ cpu: '8', memory: '16Gi' })
+    assert.deepEqual(hard, { 'requests.cpu': '8', 'requests.memory': '16Gi' })
+  })
+
+  it('maps cpuLimit/memoryLimit to aggregate limits.* keys', () => {
+    const hard = buildResourceQuotaSpec({ cpuLimit: '16', memoryLimit: '32Gi' })
+    assert.deepEqual(hard, { 'limits.cpu': '16', 'limits.memory': '32Gi' })
+  })
+
+  it('maps pods to a stringified count quota', () => {
+    const hard = buildResourceQuotaSpec({ pods: 5 })
+    assert.deepEqual(hard, { pods: '5' })
+  })
+
+  it('combines every dimension', () => {
+    const hard = buildResourceQuotaSpec({
+      cpu: '4', memory: '8Gi', cpuLimit: '8', memoryLimit: '16Gi', pods: 10,
+    })
+    assert.deepEqual(hard, {
+      'requests.cpu': '4',
+      'requests.memory': '8Gi',
+      'limits.cpu': '8',
+      'limits.memory': '16Gi',
+      pods: '10',
+    })
+  })
+
+  it('normalises Docker-style memory suffixes via the shared validator', () => {
+    const hard = buildResourceQuotaSpec({ memory: '16g' })
+    assert.equal(hard['requests.memory'], '16Gi')
+  })
+
+  it('throws on a malformed CPU quantity', () => {
+    assert.throws(() => buildResourceQuotaSpec({ cpu: 'lots' }), /not a valid K8s CPU quantity/)
+  })
+
+  it('throws on a malformed memory quantity', () => {
+    assert.throws(() => buildResourceQuotaSpec({ memory: '8 gigabytes' }), /not a valid K8s memory quantity/)
+  })
+
+  it('throws on a non-positive / non-integer pods count', () => {
+    assert.throws(() => buildResourceQuotaSpec({ pods: 0 }), /positive integer/)
+    assert.throws(() => buildResourceQuotaSpec({ pods: 2.5 }), /positive integer/)
+    assert.throws(() => buildResourceQuotaSpec({ pods: -1 }), /positive integer/)
+  })
+
+  it('throws when no cap is set', () => {
+    assert.throws(() => buildResourceQuotaSpec({}), /at least one of/)
+  })
+
+  it('throws on a non-object spec', () => {
+    assert.throws(() => buildResourceQuotaSpec(null), /must be an object/)
+    assert.throws(() => buildResourceQuotaSpec([]), /must be an object/)
+    assert.throws(() => buildResourceQuotaSpec('8'), /must be an object/)
+  })
+})
+
+describe('buildLimitRangeSpec() (#5142)', () => {
+  it('maps cpu/memory to defaultRequest.*', () => {
+    const item = buildLimitRangeSpec({ cpu: '250m', memory: '256Mi' })
+    assert.deepEqual(item, {
+      type: 'Container',
+      defaultRequest: { cpu: '250m', memory: '256Mi' },
+    })
+  })
+
+  it('maps cpuLimit/memoryLimit to default.*', () => {
+    const item = buildLimitRangeSpec({ cpuLimit: '1', memoryLimit: '1Gi' })
+    assert.deepEqual(item, {
+      type: 'Container',
+      default: { cpu: '1', memory: '1Gi' },
+    })
+  })
+
+  it('combines requests + limits in one container item', () => {
+    const item = buildLimitRangeSpec({ cpu: '250m', memory: '256Mi', cpuLimit: '1', memoryLimit: '1Gi' })
+    assert.deepEqual(item, {
+      type: 'Container',
+      default: { cpu: '1', memory: '1Gi' },
+      defaultRequest: { cpu: '250m', memory: '256Mi' },
+    })
+  })
+
+  it('normalises Docker-style memory suffixes via the shared validator', () => {
+    const item = buildLimitRangeSpec({ memoryLimit: '1g' })
+    assert.equal(item.default.memory, '1Gi')
+  })
+
+  it('throws on a malformed quantity', () => {
+    assert.throws(() => buildLimitRangeSpec({ cpu: 'nope' }), /not a valid K8s CPU quantity/)
+  })
+
+  it('throws when no default is set', () => {
+    assert.throws(() => buildLimitRangeSpec({}), /at least one of/)
+  })
+
+  it('throws on a non-object spec', () => {
+    assert.throws(() => buildLimitRangeSpec(null), /must be an object/)
+    assert.throws(() => buildLimitRangeSpec([]), /must be an object/)
+  })
+})
+
+describe('K8sBackend constructor namespaceQuota / namespaceLimitRange validation (#5142)', () => {
+  it('validates namespaceQuota at construction (fails fast on bad quantity)', () => {
+    assert.throws(
+      () => new K8sBackend({ _coreV1Api: createMockApi(), namespaceQuota: { cpu: 'bad' } }),
+      /not a valid K8s CPU quantity/,
+    )
+  })
+
+  it('validates namespaceLimitRange at construction (fails fast on bad quantity)', () => {
+    assert.throws(
+      () => new K8sBackend({ _coreV1Api: createMockApi(), namespaceLimitRange: { memoryLimit: 'bad' } }),
+      /not a valid K8s memory quantity/,
+    )
+  })
+
+  it('rejects an empty namespaceQuota object at construction', () => {
+    assert.throws(
+      () => new K8sBackend({ _coreV1Api: createMockApi(), namespaceQuota: {} }),
+      /at least one of/,
+    )
+  })
+
+  it('accepts a valid namespaceQuota / namespaceLimitRange', () => {
+    assert.doesNotThrow(() => new K8sBackend({
+      _coreV1Api: createMockApi(),
+      namespaceQuota: { cpu: '8', memory: '16Gi', pods: 10 },
+      namespaceLimitRange: { cpu: '250m', cpuLimit: '1' },
+    }))
+  })
+
+  it('treats null / omitted as feature-off (no spec stored)', () => {
+    const off = new K8sBackend({ _coreV1Api: createMockApi() })
+    assert.equal(off._namespaceQuotaSpec, null)
+    assert.equal(off._namespaceLimitRangeSpec, null)
+    const explicitNull = new K8sBackend({
+      _coreV1Api: createMockApi(), namespaceQuota: null, namespaceLimitRange: null,
+    })
+    assert.equal(explicitNull._namespaceQuotaSpec, null)
+    assert.equal(explicitNull._namespaceLimitRangeSpec, null)
+  })
+})
+
+describe('K8sBackend.ensureResourceQuota() / ensureLimitRange() (#5142)', () => {
+  const QUOTA = { cpu: '8', memory: '16Gi', pods: 10 }
+  const LIMITS = { cpu: '250m', memory: '256Mi', cpuLimit: '1', memoryLimit: '1Gi' }
+
+  // ─── opt-in / no-op when unconfigured ──────────────────────────────────────
+
+  it('is a no-op when neither quota nor limitrange is configured', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.ensureResourceQuota('chroxy-user-x')
+    await backend.ensureLimitRange('chroxy-user-x')
+
+    assert.equal(api.calls.readQuota.length, 0)
+    assert.equal(api.calls.createQuota.length, 0)
+    assert.equal(api.calls.readLimitRange.length, 0)
+    assert.equal(api.calls.createLimitRange.length, 0)
+  })
+
+  it('createEnvironment never touches quota/limitrange when feature is off', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api })
+
+    await backend.createEnvironment({ envId: 'e1', image: 'a', userId: 'bob' })
+
+    assert.equal(api.calls.readQuota.length, 0)
+    assert.equal(api.calls.createQuota.length, 0)
+    assert.equal(api.calls.readLimitRange.length, 0)
+    assert.equal(api.calls.createLimitRange.length, 0)
+  })
+
+  // ─── ResourceQuota idempotent ensure ───────────────────────────────────────
+
+  it('ensureResourceQuota creates the quota when it does not exist (404 → create)', async () => {
+    const api = createMockApi({ readQuota: () => { throw make404Error() } })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceQuota: QUOTA })
+
+    await backend.ensureResourceQuota('chroxy-user-bob')
+
+    assert.equal(api.calls.readQuota.length, 1)
+    assert.equal(api.calls.createQuota.length, 1)
+    assert.equal(api.calls.createQuota[0].namespace, 'chroxy-user-bob')
+    const body = api.calls.createQuota[0].body
+    assert.equal(body.kind, 'ResourceQuota')
+    assert.equal(body.metadata.name, 'chroxy-quota')
+    assert.equal(body.metadata.labels['app.kubernetes.io/managed-by'], 'chroxy')
+    assert.deepEqual(body.spec.hard, {
+      'requests.cpu': '8', 'requests.memory': '16Gi', pods: '10',
+    })
+  })
+
+  it('ensureResourceQuota does NOT create when it already exists (read succeeds)', async () => {
+    const api = createMockApi() // default readQuota resolves
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceQuota: QUOTA })
+
+    await backend.ensureResourceQuota('chroxy-user-bob')
+
+    assert.equal(api.calls.readQuota.length, 1)
+    assert.equal(api.calls.createQuota.length, 0)
+  })
+
+  it('ensureResourceQuota swallows 409 AlreadyExists on concurrent create', async () => {
+    const make409 = () => Object.assign(new Error('Conflict'), { code: 409 })
+    const api = createMockApi({
+      readQuota: () => { throw make404Error() },
+      createQuota: () => { throw make409() },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceQuota: QUOTA })
+
+    await backend.ensureResourceQuota('chroxy-user-race')
+    assert.equal(api.calls.createQuota.length, 1)
+  })
+
+  it('ensureResourceQuota re-throws a non-404 read error', async () => {
+    const make500 = () => Object.assign(new Error('boom'), { code: 500 })
+    const api = createMockApi({ readQuota: () => { throw make500() } })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceQuota: QUOTA })
+
+    await assert.rejects(() => backend.ensureResourceQuota('chroxy-user-x'), /boom/)
+  })
+
+  it('ensureResourceQuota re-throws a non-409 create error', async () => {
+    const make500 = () => Object.assign(new Error('denied'), { code: 500 })
+    const api = createMockApi({
+      readQuota: () => { throw make404Error() },
+      createQuota: () => { throw make500() },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceQuota: QUOTA })
+
+    await assert.rejects(() => backend.ensureResourceQuota('chroxy-user-x'), /denied/)
+  })
+
+  it('ensureResourceQuota caches per process — second call is a no-op', async () => {
+    const api = createMockApi({ readQuota: () => { throw make404Error() } })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceQuota: QUOTA })
+
+    await backend.ensureResourceQuota('chroxy-user-cache')
+    await backend.ensureResourceQuota('chroxy-user-cache')
+
+    assert.equal(api.calls.readQuota.length, 1)
+    assert.equal(api.calls.createQuota.length, 1)
+  })
+
+  it('ensureResourceQuota never touches the static default namespace', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api, namespaceQuota: QUOTA })
+
+    await backend.ensureResourceQuota('default')
+
+    assert.equal(api.calls.readQuota.length, 0)
+    assert.equal(api.calls.createQuota.length, 0)
+  })
+
+  // ─── LimitRange idempotent ensure ──────────────────────────────────────────
+
+  it('ensureLimitRange creates the limitrange when it does not exist (404 → create)', async () => {
+    const api = createMockApi({ readLimitRange: () => { throw make404Error() } })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceLimitRange: LIMITS })
+
+    await backend.ensureLimitRange('chroxy-user-bob')
+
+    assert.equal(api.calls.readLimitRange.length, 1)
+    assert.equal(api.calls.createLimitRange.length, 1)
+    const body = api.calls.createLimitRange[0].body
+    assert.equal(body.kind, 'LimitRange')
+    assert.equal(body.metadata.name, 'chroxy-limits')
+    assert.equal(body.metadata.labels['app.kubernetes.io/managed-by'], 'chroxy')
+    assert.deepEqual(body.spec.limits, [{
+      type: 'Container',
+      default: { cpu: '1', memory: '1Gi' },
+      defaultRequest: { cpu: '250m', memory: '256Mi' },
+    }])
+  })
+
+  it('ensureLimitRange does NOT create when it already exists (read succeeds)', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceLimitRange: LIMITS })
+
+    await backend.ensureLimitRange('chroxy-user-bob')
+
+    assert.equal(api.calls.readLimitRange.length, 1)
+    assert.equal(api.calls.createLimitRange.length, 0)
+  })
+
+  it('ensureLimitRange swallows 409 AlreadyExists on concurrent create', async () => {
+    const make409 = () => Object.assign(new Error('Conflict'), { code: 409 })
+    const api = createMockApi({
+      readLimitRange: () => { throw make404Error() },
+      createLimitRange: () => { throw make409() },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceLimitRange: LIMITS })
+
+    await backend.ensureLimitRange('chroxy-user-race')
+    assert.equal(api.calls.createLimitRange.length, 1)
+  })
+
+  it('ensureLimitRange caches per process — second call is a no-op', async () => {
+    const api = createMockApi({ readLimitRange: () => { throw make404Error() } })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceLimitRange: LIMITS })
+
+    await backend.ensureLimitRange('chroxy-user-cache')
+    await backend.ensureLimitRange('chroxy-user-cache')
+
+    assert.equal(api.calls.readLimitRange.length, 1)
+    assert.equal(api.calls.createLimitRange.length, 1)
+  })
+
+  it('ensureLimitRange never touches the static default namespace', async () => {
+    const api = createMockApi()
+    const backend = new K8sBackend({ namespace: 'default', _coreV1Api: api, namespaceLimitRange: LIMITS })
+
+    await backend.ensureLimitRange('default')
+
+    assert.equal(api.calls.readLimitRange.length, 0)
+    assert.equal(api.calls.createLimitRange.length, 0)
+  })
+
+  // ─── composition with ensureNamespace via createEnvironment ─────────────────
+
+  it('createEnvironment ensures namespace → quota → limitrange → secret → pod, in order', async () => {
+    const order = []
+    const api = createMockApi({
+      readNs: () => { throw make404Error() },
+      createNs: () => { order.push('createNs'); return {} },
+      readQuota: () => { throw make404Error() },
+      createQuota: () => { order.push('createQuota'); return {} },
+      readLimitRange: () => { throw make404Error() },
+      createLimitRange: () => { order.push('createLimitRange'); return {} },
+      createSecret: () => { order.push('createSecret'); return {} },
+      createPod: () => { order.push('createPod'); return {} },
+    })
+    const backend = new K8sBackend({
+      _coreV1Api: api, namespaceQuota: QUOTA, namespaceLimitRange: LIMITS,
+    })
+
+    await backend.createEnvironment({ envId: 'e1', image: 'a', userId: 'carol' })
+
+    assert.deepEqual(order, [
+      'createNs', 'createQuota', 'createLimitRange', 'createSecret', 'createPod',
+    ])
+    assert.equal(api.calls.createQuota[0].namespace, 'chroxy-user-carol')
+    assert.equal(api.calls.createLimitRange[0].namespace, 'chroxy-user-carol')
+  })
+
+  it('createEnvironment ensures only the quota when only namespaceQuota is set', async () => {
+    const api = createMockApi({ readQuota: () => { throw make404Error() } })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceQuota: QUOTA })
+
+    await backend.createEnvironment({ envId: 'e1', image: 'a', userId: 'bob' })
+
+    assert.equal(api.calls.createQuota.length, 1)
+    assert.equal(api.calls.readLimitRange.length, 0)
+    assert.equal(api.calls.createLimitRange.length, 0)
   })
 })

--- a/packages/server/tests/environments/backends/k8s.test.js
+++ b/packages/server/tests/environments/backends/k8s.test.js
@@ -5369,6 +5369,25 @@ describe('K8sBackend.ensureResourceQuota() / ensureLimitRange() (#5142)', () => 
     assert.equal(api.calls.createLimitRange.length, 0)
   })
 
+  it('ensureLimitRange re-throws a non-404 read error', async () => {
+    const make500 = () => Object.assign(new Error('boom'), { code: 500 })
+    const api = createMockApi({ readLimitRange: () => { throw make500() } })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceLimitRange: LIMITS })
+
+    await assert.rejects(() => backend.ensureLimitRange('chroxy-user-x'), /boom/)
+  })
+
+  it('ensureLimitRange re-throws a non-409 create error', async () => {
+    const make500 = () => Object.assign(new Error('denied'), { code: 500 })
+    const api = createMockApi({
+      readLimitRange: () => { throw make404Error() },
+      createLimitRange: () => { throw make500() },
+    })
+    const backend = new K8sBackend({ _coreV1Api: api, namespaceLimitRange: LIMITS })
+
+    await assert.rejects(() => backend.ensureLimitRange('chroxy-user-x'), /denied/)
+  })
+
   it('ensureLimitRange swallows 409 AlreadyExists on concurrent create', async () => {
     const make409 = () => Object.assign(new Error('Conflict'), { code: 409 })
     const api = createMockApi({


### PR DESCRIPTION
## Summary

Implements #5142 — idempotent, **opt-in** ensure of namespace-scoped `ResourceQuota` and `LimitRange` objects in each tenant namespace. This is the namespace-level (per-tenant aggregate) guardrail layer on top of the per-pod requests/limits added in #3195, now meaningful because #3194 gives every tenant their own namespace.

## What changed

- **`buildResourceQuotaSpec(spec)`** — maps a tenant-friendly flat spec `{ cpu, memory, cpuLimit, memoryLimit, pods }` to the canonical `ResourceQuota.spec.hard` map (`requests.*` / `limits.*` / `pods`), reusing the #3195 quantity validator (`_validateResourceQuantity`).
- **`buildLimitRangeSpec(spec)`** — maps `{ cpu, memory, cpuLimit, memoryLimit }` to a container-scoped `LimitRange` item (`defaultRequest` / `default`).
- **`ensureResourceQuota(ns)` / `ensureLimitRange(ns)`** — mirror `ensureNamespace`: read-or-create, `404 → create`, `409 AlreadyExists` swallowed, cached per process, never applied to the static default namespace.
- Both are invoked from `createEnvironment` after `ensureNamespace` (order: namespace → quota → limitrange → secret → pod). **No-op** unless the backend is constructed with `namespaceQuota` / `namespaceLimitRange`.
- Constructor validates the specs up-front, so a malformed quantity fails at startup rather than at first `createEnvironment`.
- Wired through `buildEnvironmentBackend` for the **k8s** and **rancher** config paths.
- Documented in `CONFIG.md`.

## Testing

Fully unit-testable behind the injected `CoreV1Api` fake — no real cluster required. Added coverage for:
- spec construction + quantity validation (both builders, incl. Docker-suffix normalisation, malformed/empty/non-object rejection)
- constructor fail-fast validation + feature-off (`null`/omitted) handling
- idempotent ensure: `404 → create`, already-exists read (no create), `409` swallow, non-404/non-409 re-throw, per-process cache, default-namespace skip
- composition via `createEnvironment` (ordering, only-quota / only-limitrange subsets, full no-op when feature off)
- config wiring assertions for k8s + rancher

All targeted suites pass (`k8s.test.js` 311 tests, plus config-backend-selection + rancher).

### Scope note

No live cluster is available in this environment (expected). The behaviour is fully exercised against the injected API fake. Live validation against a real cluster (that the quota actually rejects over-budget Pods, that the LimitRange defaults are applied by the admission controller) remains as a manual follow-up.

Closes #5142