### PR TITLE
chore: enforce zero-attribution (includeCoAuthoredBy: false)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,6 @@
         ]
       }
     ]
-  }
+  },
+  "includeCoAuthoredBy": false
 }


### PR DESCRIPTION
Adds `"includeCoAuthoredBy": false` to this repo's `.claude/settings.json` so no commit gets an AI Co-Authored-By trailer — project-level enforcement of the global zero-attribution policy. Settings-only, additive merge.