### PR TITLE
feat(app): React Native MultiQuestionForm for multi-question AskUserQuestion

### DIFF
--- a/packages/app/.maestro/chat-multi-question.yaml
+++ b/packages/app/.maestro/chat-multi-question.yaml
@@ -1,12 +1,12 @@
 appId: com.blamechris.chroxy
-name: ChatView mixed multi-question AskUserQuestion form (#4762)
+name: ChatView mixed multi-question AskUserQuestion form (#4762 / #4973)
 ---
 
-# #4762 — Mobile Maestro coverage for the mixed multi-question
+# #4762 / #4973 — Mobile Maestro coverage for the mixed multi-question
 # AskUserQuestion wire payload. Sibling to ask-user-question-multi.yaml
 # (which pins the all-single-select 4-question shape #4604 Chunk B).
 # This flow exercises the *mixed* wire shape #4735 / #4760 wired into
-# the dashboard's MultiQuestionForm:
+# the React Native MultiQuestionForm (#4973):
 #
 #   - Q[0]: single-select with model-supplied 'Other' label
 #   - Q[1]: multi-select (`multiSelect: true`)
@@ -17,45 +17,31 @@ name: ChatView mixed multi-question AskUserQuestion form (#4762)
 # seeding pattern is documented in CLAUDE.md → "Fixture Seeding for
 # Structured Renderers".
 #
-# Coverage today (MessageBubble only renders Q[0]):
+# Coverage (#4973 — the mobile React Native MultiQuestionForm now
+# renders all N questions for SDK-mode sessions; the mock session is
+# `provider: 'claude-sdk'`, so `allowMultiQuestion` is true):
 #
 #   - Pins the wire→render path for the mixed payload: a regression in
 #     handleUserQuestion's normalizeQuestion that mishandled
 #     multi-select or the model-supplied Other label on a sibling
 #     question would either (a) drop the whole `user_question`
 #     envelope at the `firstNormalized == null` guard or (b) corrupt
-#     Q[0]'s options. The `approval-question-0` wait + the
-#     `approval-button-approve` / `approval-button-deny` /
-#     `approval-button-Other` assertions catch both.
+#     a question's options. The `question-prompt-multi` wait + the
+#     per-question option assertions catch both.
+#   - Pins the interactive multi-question form (#4973 acceptance
+#     criteria): `question-prompt-multi` container,
+#     `question-multi-option-<idx>-<value>` per option, and the single
+#     `question-multi-submit` button.
 #   - Pins the model-supplied 'Other' branch on Q[0] — Q[0]'s third
 #     option uses the model-supplied 'Other' label (not the synthetic
 #     OTHER_OPTION_VALUE sentinel), so the testID resolves to
-#     `approval-button-Other` (value === label). A regression in
-#     normalizeQuestion that double-appended the sentinel would
-#     surface as `approval-button-__chroxy_other__` instead.
-#   - Pins the answered round-trip — taps Approve on Q[0] and asserts
-#     the bubble flips to answered state (options remain in tree,
-#     `approval-card-<id>` still resolves).
-#
-# Out of scope until the mobile multi-question renderer lands:
-#
-#   - The dashboard-equivalent `question-prompt-multi` /
-#     `question-multi-submit` testIDs (per the #4762 acceptance
-#     criteria) come from `packages/dashboard/src/components/
-#     QuestionPrompt.tsx`'s `MultiQuestionForm` — the mobile
-#     `MessageBubble` doesn't yet have a sibling React Native
-#     component. When that component lands the flow extends to:
-#       - Wait for `id: question-prompt-multi`
-#       - Tap `id: question-multi-option-0-approve` for Q[0]
-#       - Tap `id: question-multi-option-1-app` / `-server` for Q[1]
-#         (multi-select — multiple taps add to the array)
-#       - Tap `id: question-multi-option-2-auto-rollback` for Q[2]
-#       - Tap `id: question-multi-submit`
-#       - Assert post-answer summary chip shows the comma-joined
-#         multi-select labels (`Q2 — which areas to verify?: app, server`)
-#         per #4716 / #4735 readability.
-#   - For now the post-answer state pin is via the single-option
-#     `approval-button-<value>` route on Q[0] only.
+#     `question-multi-option-0-Other` (value === label).
+#   - Exercises every selection branch in one payload: single-select
+#     radio (Q[0] / Q[2]) and multi-select checkbox (Q[1] — two taps
+#     add `app` + `server` to the array).
+#   - Pins the post-answer summary chip showing the comma-joined
+#     multi-select labels per question (`Q2 — which areas to verify?:
+#     app, server`) per #4716 / #4735 readability.
 #
 # Tested devices: portrait iPhone (iOS 17+). Mirrors
 # ask-user-question.yaml / ask-user-question-multi.yaml. Requires the
@@ -134,48 +120,72 @@ name: ChatView mixed multi-question AskUserQuestion form (#4762)
 
 - hideKeyboard
 
-# Wait for Q[0]'s prompt to render — same selector as the single-
-# question flow because the mobile MessageBubble currently renders
-# Q[0] of every multi-question payload.
+# Wait for the interactive multi-question form container to render
+# (#4973). The mock session is `provider: 'claude-sdk'`, so the mobile
+# `allowMultiQuestion` gate is true and MessageBubble renders the
+# React Native MultiQuestionForm instead of the legacy Q[0]-only UI.
 - extendedWaitUntil:
     visible:
-      id: "approval-question-0"
+      id: "question-prompt-multi"
     timeout: 10000
 
-- takeScreenshot: chat-multi-question-prompt-rendered
+- takeScreenshot: chat-multi-question-form-rendered
 
-# Assert Q[0]'s options + Q[0]'s question text rendered.
-#   - 'approve' / 'deny' are the canonical lowercase labels (value ===
-#     label, see normalizeQuestion).
-#   - 'Other' is the model-supplied Other on Q[0] — testID resolves to
-#     `approval-button-Other` because the model-supplied label takes
-#     precedence over the synthetic OTHER_OPTION_VALUE sentinel.
-#   - 'Q1 — deploy to production?' pins the wire→render path for the
-#     question text field on the mixed payload.
+# Assert every question's options rendered with the parity testIDs.
+#   - Q[0] single-select: 'approve' / 'deny' (lowercase, value === label)
+#     plus the model-supplied 'Other' (value === label === 'Other').
+#   - Q[1] multi-select: 'app' / 'server' / 'dashboard'.
+#   - Q[2] single-select: 'auto-rollback' / 'manual-rollback' plus the
+#     synthetic `__chroxy_other__` sentinel appended by handleUserQuestion.
 - assertVisible:
-    id: "approval-button-approve"
+    id: "question-multi-option-0-approve"
 - assertVisible:
-    id: "approval-button-deny"
+    id: "question-multi-option-0-deny"
 - assertVisible:
-    id: "approval-button-Other"
+    id: "question-multi-option-0-Other"
+- assertVisible:
+    id: "question-multi-option-1-app"
+- assertVisible:
+    id: "question-multi-option-1-server"
+- assertVisible:
+    id: "question-multi-option-1-dashboard"
+- assertVisible:
+    id: "question-multi-option-2-auto-rollback"
+- assertVisible:
+    id: "question-multi-option-2-manual-rollback"
 - assertVisible: "Q1 — deploy to production?"
+- assertVisible: "Q2 — which areas to verify?"
+- assertVisible: "Q3 — rollback strategy?"
 
-# Tap Approve to round-trip the answered state on Q[0]. The mobile
-# `sendUserQuestionResponse` (widened in #4761 / PR #4859) accepts
-# both the legacy single-question string and the multi-question
-# `Record<string, string | string[]>` shape; Q[0]-only tap exercises
-# the string branch.
+# Answer every question: Q[0] approve (single-select radio), Q[1]
+# app + server (multi-select checkbox — two taps add to the array),
+# Q[2] auto-rollback (single-select radio).
 - tapOn:
-    id: "approval-button-approve"
+    id: "question-multi-option-0-approve"
+- tapOn:
+    id: "question-multi-option-1-app"
+- tapOn:
+    id: "question-multi-option-1-server"
+- tapOn:
+    id: "question-multi-option-2-auto-rollback"
+
+- takeScreenshot: chat-multi-question-form-filled
+
+# Submit the form. The mobile `sendUserQuestionResponse` (widened in
+# #4761 / PR #4859) serializes the per-question `answers` map (with
+# multi-select as a native `string[]`) plus a comma-joined `answer`
+# summary on the wire.
+- tapOn:
+    id: "question-multi-submit"
 - waitForAnimationToEnd
 
-- takeScreenshot: chat-multi-question-answered
+# Post-answer the form is replaced by the summary chip (#4973). Assert
+# the multi-select summary line shows the comma-joined labels per the
+# #4716 / #4735 readability AC.
+- extendedWaitUntil:
+    visible:
+      id: "question-multi-summary"
+    timeout: 10000
+- assertVisible: "Q2 — which areas to verify?: app, server"
 
-# Buttons remain in the tree post-answer (only their interactivity
-# changes). The answered state on Q[0] is the only pin we can make
-# today — extending to per-question post-answer summary chip lands
-# with the mobile MultiQuestionForm renderer (see header).
-- assertVisible:
-    id: "approval-button-approve"
-- assertVisible:
-    id: "approval-button-deny"
+- takeScreenshot: chat-multi-question-answered

--- a/packages/app/.maestro/mock-server.mjs
+++ b/packages/app/.maestro/mock-server.mjs
@@ -548,17 +548,17 @@ wss.on('connection', (ws) => {
           break
         }
 
-        // #4762: trigger phrase 'show-multi-question' emits the four
-        // wedge shapes #4735 / #4604 Chunk B require coverage for —
-        // mixed (single-select + multi-select + with-Other in one
-        // payload). The dashboard's MultiQuestionForm exercises every
-        // branch in a single payload because the dashboard renders
-        // all N questions inline (#4760 lifted the suppression for
-        // SDK-mode sessions). The mobile MessageBubble currently
-        // renders only `questions[0]` so this flow pins the wire→Q[0]
-        // path for the mixed payload — when the mobile multi-question
-        // renderer lands the flow extends to iterate every question
-        // (`approval-question-1` / `approval-question-2`).
+        // #4762 / #4973: trigger phrase 'show-multi-question' emits the
+        // mixed wedge shape #4735 / #4604 Chunk B require coverage for —
+        // single-select + multi-select + with-Other in one payload. Both
+        // the dashboard's MultiQuestionForm AND the mobile React Native
+        // MultiQuestionForm (#4973) render all N questions inline for
+        // SDK-mode sessions (#4760 / #4731 lifted the suppression). The
+        // mock session reports `provider: 'claude-sdk'`, so chat-multi-
+        // question.yaml drives the full interactive form: tap every
+        // `question-multi-option-<idx>-<value>`, submit via
+        // `question-multi-submit`, and assert the post-answer summary
+        // chip's comma-joined multi-select labels.
         //
         // The mixed shape exercises three independent wire branches
         // in a single payload:

--- a/packages/app/src/__tests__/store/connection.test.ts
+++ b/packages/app/src/__tests__/store/connection.test.ts
@@ -1849,6 +1849,67 @@ describe('markPromptAnsweredByRequestId', () => {
   });
 });
 
+describe('markPromptAnsweredMulti (#4973)', () => {
+  it('stores the structured answers map and a comma-joined summary on the active session message', () => {
+    const promptMsg = {
+      id: 'mq-1',
+      type: 'prompt' as const,
+      content: 'Q1?',
+      toolUseId: 'toolu_multi',
+      timestamp: 1,
+    };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: { ...createEmptySessionState(), messages: [promptMsg] },
+      },
+    });
+
+    const answers = {
+      'Q1 — deploy to production?': 'approve',
+      'Q2 — which areas to verify?': ['app', 'server'],
+    };
+    useConnectionStore.getState().markPromptAnsweredMulti('mq-1', answers);
+
+    const msg = useConnectionStore.getState().getActiveSessionState().messages[0] as any;
+    // Structured map preserved verbatim (multi-select stays a string[]).
+    expect(msg.answeredAnswers).toEqual(answers);
+    // Flat `answered` holds the human-readable comma-joined summary.
+    expect(msg.answered).toBe(
+      'Q1 — deploy to production?: approve | Q2 — which areas to verify?: app, server',
+    );
+    expect(typeof msg.answeredAt).toBe('number');
+  });
+
+  it('leaves other messages untouched', () => {
+    const promptMsg = {
+      id: 'mq-2',
+      type: 'prompt' as const,
+      content: 'Q?',
+      toolUseId: 'toolu_x',
+      timestamp: 1,
+    };
+    const otherMsg = {
+      id: 'resp-1',
+      type: 'response' as const,
+      content: 'Hi',
+      timestamp: 2,
+    };
+    useConnectionStore.setState({
+      activeSessionId: 's1',
+      sessionStates: {
+        s1: { ...createEmptySessionState(), messages: [promptMsg, otherMsg] },
+      },
+    });
+
+    useConnectionStore.getState().markPromptAnsweredMulti('mq-2', { 'Q?': 'yes' });
+
+    const msgs = useConnectionStore.getState().getActiveSessionState().messages;
+    expect((msgs[1] as any).answered).toBeUndefined();
+    expect((msgs[1] as any).answeredAnswers).toBeUndefined();
+  });
+});
+
 describe('inactivityWarning cleanup (#3899)', () => {
   const WARNING = { idleMs: 1_800_000, prefab: 'Status update?', receivedAt: 1 };
 

--- a/packages/app/src/components/ChatView.tsx
+++ b/packages/app/src/components/ChatView.tsx
@@ -20,6 +20,7 @@ import { ActivityGroup } from './chat/ActivityGroup';
 import { ToolDetailModal } from './chat/ToolDetailModal';
 import { MessageBubble } from './chat/MessageBubble';
 import type { SelectOptionValue } from './chat/MessageBubble';
+import type { MultiQuestionAnswersMap } from './chat/MultiQuestionForm';
 import { buildChatViewMessages } from '@chroxy/store-core';
 import { useConnectionStore } from '../store/connection';
 
@@ -39,6 +40,20 @@ export interface ChatViewProps {
    * `MessageBubble.SelectOptionValue` for the union type.
    */
   onSelectOption: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
+  /**
+   * #4973 — submit handler for the multi-question AskUserQuestion form.
+   * Fires with the per-question answers map; SessionScreen forwards it to
+   * `sendUserQuestionResponse` and records the structured summary.
+   */
+  onSubmitMultiQuestion?: (answersMap: MultiQuestionAnswersMap, messageId: string, toolUseId?: string) => void;
+  /**
+   * #4973 / #4735 — when true, multi-question AskUserQuestion payloads
+   * render the interactive `MultiQuestionForm`. SDK-mode sessions only;
+   * TUI / CLI sessions leave this false (permission-hook denies combined
+   * multi-question tool_uses). Mirrors the dashboard's
+   * `allowMultiQuestionForm` gate.
+   */
+  allowMultiQuestion?: boolean;
   isCliMode: boolean;
   selectedIds: Set<string>;
   isSelecting: boolean;
@@ -114,6 +129,8 @@ export function ChatView({
   scrollViewRef,
   claudeReady,
   onSelectOption,
+  onSubmitMultiQuestion,
+  allowMultiQuestion,
   isCliMode,
   selectedIds,
   isSelecting,
@@ -345,6 +362,8 @@ export function ChatView({
                 <MessageBubble
                   message={msg}
                   onSelectOption={onSelectOption}
+                  onSubmitMultiQuestion={onSubmitMultiQuestion}
+                  allowMultiQuestion={allowMultiQuestion}
                   isSelected={selectedIds.has(msg.id)}
                   isSelecting={isSelecting}
                   onLongPress={() => onToggleSelection(msg.id)}

--- a/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
@@ -199,4 +199,23 @@ describe('MessageBubble multi-question form (#4973)', () => {
     const toppings = first(tree, 'question-multi-summary-1');
     expect(toppings.props.children.join('')).toBe('Pick toppings: Cherry, Date');
   });
+
+  it('falls back to the flat answered summary when answeredAnswers is missing (answered elsewhere / rehydrated)', () => {
+    // No `answeredAnswers` — e.g. the prompt was answered on another
+    // client or rehydrated from history before the structured field
+    // existed. The chip must still show the flat `answered` summary
+    // rather than blank per-question lines.
+    const answered = multiQuestionPrompt({
+      answered: 'Q1 — deploy to production?: approve | Q2 — which areas to verify?: app, server',
+    });
+    const tree = render(answered, { allowMultiQuestion: true });
+    expect(present(tree, 'question-multi-summary')).toBe(true);
+    // No per-question structured rows (those need answeredAnswers).
+    expect(present(tree, 'question-multi-summary-0')).toBe(false);
+    // The flat summary line shows the comma-joined answer text.
+    const flat = first(tree, 'question-multi-summary-flat');
+    expect(flat.props.children).toBe(
+      'Q1 — deploy to production?: approve | Q2 — which areas to verify?: app, server',
+    );
+  });
 });

--- a/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
+++ b/packages/app/src/components/__tests__/MessageBubble.multiQuestion.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * MessageBubble multi-question integration — #4973
+ *
+ * Pins how MessageBubble wires the React Native `MultiQuestionForm`:
+ *
+ *   1. Renders the interactive form (`question-prompt-multi`) only when
+ *      the payload has > 1 question AND the session is SDK-mode
+ *      (`allowMultiQuestion`). TUI / CLI sessions fall back to the legacy
+ *      single-question Q[0] UI (`approval-button-<value>`).
+ *   2. Submitting the form forwards the per-question answers map (keyed by
+ *      question text, multi-select as `string[]`) to
+ *      `onSubmitMultiQuestion` with the message id + toolUseId.
+ *   3. Once answered, the form is replaced by the post-answer summary chip
+ *      (`question-multi-summary`) showing the comma-joined option LABELS
+ *      per question (mapped back from `answeredAnswers`).
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import { MessageBubble } from '../chat/MessageBubble';
+import type { ChatMessage } from '../../store/connection';
+
+function multiQuestionPrompt(overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: 'mq-1',
+    type: 'prompt',
+    content: 'Q1 — deploy to production?',
+    timestamp: Date.now(),
+    toolUseId: 'toolu_multi',
+    tool: 'AskUserQuestion',
+    options: [
+      { label: 'approve', value: 'approve' },
+      { label: 'deny', value: 'deny' },
+    ],
+    questions: [
+      {
+        question: 'Q1 — deploy to production?',
+        options: [
+          { label: 'approve', value: 'approve' },
+          { label: 'deny', value: 'deny' },
+        ],
+      },
+      {
+        question: 'Q2 — which areas to verify?',
+        multiSelect: true,
+        options: [
+          { label: 'app', value: 'app' },
+          { label: 'server', value: 'server' },
+          { label: 'dashboard', value: 'dashboard' },
+        ],
+      },
+      {
+        question: 'Q3 — rollback strategy?',
+        options: [
+          { label: 'auto-rollback', value: 'auto-rollback' },
+          { label: 'manual-rollback', value: 'manual-rollback' },
+        ],
+      },
+    ],
+    ...overrides,
+  } as ChatMessage;
+}
+
+function render(
+  message: ChatMessage,
+  props: {
+    allowMultiQuestion?: boolean;
+    onSubmitMultiQuestion?: jest.Mock;
+    onSelectOption?: jest.Mock;
+  } = {},
+) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(
+      <MessageBubble
+        message={message}
+        isSelected={false}
+        isSelecting={false}
+        onLongPress={() => {}}
+        onPress={() => {}}
+        onOpenDetail={() => {}}
+        onSelectOption={props.onSelectOption ?? jest.fn()}
+        onSubmitMultiQuestion={props.onSubmitMultiQuestion}
+        allowMultiQuestion={props.allowMultiQuestion}
+      />,
+    );
+  });
+  return tree;
+}
+
+// react-test-renderer surfaces a testID on both the composite and the
+// host node, so a single rendered element matches `findAllByProps` more
+// than once. Use presence (>= 1) for "is rendered" assertions and grab
+// the first match when reading props.
+function present(tree: renderer.ReactTestRenderer, testID: string): boolean {
+  return tree.root.findAllByProps({ testID }).length > 0;
+}
+
+function first(tree: renderer.ReactTestRenderer, testID: string) {
+  return tree.root.findAllByProps({ testID })[0];
+}
+
+function tap(tree: renderer.ReactTestRenderer, testID: string) {
+  act(() => {
+    first(tree, testID).props.onPress();
+  });
+}
+
+describe('MessageBubble multi-question form (#4973)', () => {
+  it('renders the interactive form for SDK-mode multi-question prompts', () => {
+    const tree = render(multiQuestionPrompt(), { allowMultiQuestion: true });
+    expect(present(tree, 'question-prompt-multi')).toBe(true);
+    expect(present(tree, 'question-multi-submit')).toBe(true);
+  });
+
+  it('falls back to the legacy single-question Q[0] UI when allowMultiQuestion is false', () => {
+    const tree = render(multiQuestionPrompt(), { allowMultiQuestion: false });
+    // No multi-question form...
+    expect(present(tree, 'question-prompt-multi')).toBe(false);
+    // ...but the legacy Q[0] option buttons still render.
+    expect(present(tree, 'approval-button-approve')).toBe(true);
+    expect(present(tree, 'approval-button-deny')).toBe(true);
+  });
+
+  it('forwards the answers map + message id + toolUseId on submit', () => {
+    const onSubmitMultiQuestion = jest.fn();
+    const tree = render(multiQuestionPrompt(), {
+      allowMultiQuestion: true,
+      onSubmitMultiQuestion,
+    });
+    tap(tree, 'question-multi-option-0-approve');
+    tap(tree, 'question-multi-option-1-app');
+    tap(tree, 'question-multi-option-1-server');
+    tap(tree, 'question-multi-option-2-auto-rollback');
+    tap(tree, 'question-multi-submit');
+    expect(onSubmitMultiQuestion).toHaveBeenCalledTimes(1);
+    expect(onSubmitMultiQuestion).toHaveBeenCalledWith(
+      {
+        'Q1 — deploy to production?': 'approve',
+        'Q2 — which areas to verify?': ['app', 'server'],
+        'Q3 — rollback strategy?': 'auto-rollback',
+      },
+      'mq-1',
+      'toolu_multi',
+    );
+  });
+
+  it('renders the post-answer summary chip with comma-joined option labels per question', () => {
+    // Simulate the answered state: `answered` holds the comma-joined
+    // summary; `answeredAnswers` holds the structured map the chip maps
+    // back to option labels.
+    const answered = multiQuestionPrompt({
+      answered: 'Q1 — deploy to production?: approve | Q2 — which areas to verify?: app, server',
+      answeredAnswers: {
+        'Q1 — deploy to production?': 'approve',
+        'Q2 — which areas to verify?': ['app', 'server'],
+        'Q3 — rollback strategy?': 'auto-rollback',
+      },
+    });
+    const tree = render(answered, { allowMultiQuestion: true });
+    // Interactive form is gone once answered.
+    expect(present(tree, 'question-prompt-multi')).toBe(false);
+    // Summary chip present.
+    expect(present(tree, 'question-multi-summary')).toBe(true);
+    // Q2's multi-select labels are comma-joined per the #4716 / #4735
+    // readability AC.
+    const q2 = first(tree, 'question-multi-summary-1');
+    const text = q2.props.children.join('');
+    expect(text).toBe('Q2 — which areas to verify?: app, server');
+  });
+
+  it('maps chosen values back to their option labels when value !== label', () => {
+    const answered = multiQuestionPrompt({
+      questions: [
+        {
+          question: 'Pick a fruit',
+          options: [
+            { label: 'Apple', value: 'a' },
+            { label: 'Banana', value: 'b' },
+          ],
+        },
+        {
+          question: 'Pick toppings',
+          multiSelect: true,
+          options: [
+            { label: 'Cherry', value: 'c' },
+            { label: 'Date', value: 'd' },
+          ],
+        },
+      ],
+      answered: 'summary',
+      answeredAnswers: {
+        'Pick a fruit': 'b',
+        'Pick toppings': ['c', 'd'],
+      },
+    });
+    const tree = render(answered, { allowMultiQuestion: true });
+    const fruit = first(tree, 'question-multi-summary-0');
+    expect(fruit.props.children.join('')).toBe('Pick a fruit: Banana');
+    const toppings = first(tree, 'question-multi-summary-1');
+    expect(toppings.props.children.join('')).toBe('Pick toppings: Cherry, Date');
+  });
+});

--- a/packages/app/src/components/__tests__/MultiQuestionForm.test.tsx
+++ b/packages/app/src/components/__tests__/MultiQuestionForm.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * MultiQuestionForm — #4973
+ *
+ * React Native multi-question AskUserQuestion form. Mobile sibling of the
+ * dashboard's `MultiQuestionForm` (`packages/dashboard/src/components/
+ * QuestionPrompt.tsx`). These tests pin the component's core behaviour:
+ *
+ *   1. Renders all N questions with the dashboard-parity testIDs
+ *      (`question-prompt-multi`, `question-multi-option-<idx>-<value>`,
+ *      `question-multi-submit`).
+ *   2. Single-select is a radio (latest choice replaces the previous).
+ *   3. Multi-select is a checkbox (taps toggle into / out of an array).
+ *   4. Submit is gated until every single-select question has a choice;
+ *      multi-select may be left empty.
+ *   5. The submit payload is the per-question answers map keyed by
+ *      question text, with single-select values as strings and
+ *      multi-select values as native `string[]` (the widened wire shape
+ *      #4761 / #4735 — no JSON encoding).
+ *   6. Submit fires at most once (one-shot guard, #3753 parity).
+ */
+import React from 'react';
+import renderer, { act } from 'react-test-renderer';
+import type { ChatMessageQuestion } from '@chroxy/store-core';
+import { MultiQuestionForm } from '../chat/MultiQuestionForm';
+import type { MultiQuestionAnswersMap } from '../chat/MultiQuestionForm';
+
+function mixedQuestions(): ChatMessageQuestion[] {
+  return [
+    {
+      question: 'Q1 — deploy to production?',
+      options: [
+        { label: 'approve', value: 'approve' },
+        { label: 'deny', value: 'deny' },
+      ],
+    },
+    {
+      question: 'Q2 — which areas to verify?',
+      multiSelect: true,
+      options: [
+        { label: 'app', value: 'app' },
+        { label: 'server', value: 'server' },
+        { label: 'dashboard', value: 'dashboard' },
+      ],
+    },
+    {
+      question: 'Q3 — rollback strategy?',
+      options: [
+        { label: 'auto-rollback', value: 'auto-rollback' },
+        { label: 'manual-rollback', value: 'manual-rollback' },
+      ],
+    },
+  ];
+}
+
+function render(questions: ChatMessageQuestion[], onSubmit: jest.Mock) {
+  let tree!: renderer.ReactTestRenderer;
+  act(() => {
+    tree = renderer.create(<MultiQuestionForm questions={questions} onSubmit={onSubmit} />);
+  });
+  return tree;
+}
+
+function tap(tree: renderer.ReactTestRenderer, testID: string) {
+  act(() => {
+    tree.root.findByProps({ testID }).props.onPress();
+  });
+}
+
+describe('MultiQuestionForm (#4973)', () => {
+  it('renders the container, every option, and the submit button with parity testIDs', () => {
+    const tree = render(mixedQuestions(), jest.fn());
+    // react-test-renderer surfaces a testID on both the composite and the
+    // host node, so assert presence (>= 1) rather than an exact count.
+    const has = (testID: string) =>
+      expect(tree.root.findAllByProps({ testID }).length).toBeGreaterThanOrEqual(1);
+    has('question-prompt-multi');
+    has('question-multi-submit');
+    // Per-question option testIDs: `question-multi-option-<idx>-<value>`.
+    has('question-multi-option-0-approve');
+    has('question-multi-option-1-app');
+    has('question-multi-option-1-server');
+    has('question-multi-option-2-auto-rollback');
+    // Each question's text renders.
+    has('question-multi-text-0');
+    has('question-multi-text-2');
+  });
+
+  it('disables submit until every single-select question is answered (multi-select may be empty)', () => {
+    const onSubmit = jest.fn();
+    const tree = render(mixedQuestions(), onSubmit);
+    const submit = () => tree.root.findByProps({ testID: 'question-multi-submit' });
+    // Initially disabled — Q1 and Q3 (single-select) have no choice.
+    expect(submit().props.accessibilityState.disabled).toBe(true);
+    tap(tree, 'question-multi-option-0-approve');
+    expect(submit().props.accessibilityState.disabled).toBe(true); // Q3 still unanswered
+    tap(tree, 'question-multi-option-2-auto-rollback');
+    // Both single-selects answered; Q2 multi-select left empty is fine.
+    expect(submit().props.accessibilityState.disabled).toBe(false);
+  });
+
+  it('single-select is a radio — the latest tap replaces the previous choice', () => {
+    const onSubmit = jest.fn();
+    const tree = render(mixedQuestions(), onSubmit);
+    tap(tree, 'question-multi-option-0-approve');
+    tap(tree, 'question-multi-option-0-deny'); // replaces 'approve'
+    tap(tree, 'question-multi-option-2-auto-rollback');
+    tap(tree, 'question-multi-submit');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const map: MultiQuestionAnswersMap = onSubmit.mock.calls[0][0];
+    expect(map['Q1 — deploy to production?']).toBe('deny');
+  });
+
+  it('multi-select toggles values into a native string[] (second tap removes)', () => {
+    const onSubmit = jest.fn();
+    const tree = render(mixedQuestions(), onSubmit);
+    tap(tree, 'question-multi-option-0-approve');
+    tap(tree, 'question-multi-option-2-auto-rollback');
+    // Q2 multi-select: add app + server + dashboard, then remove dashboard.
+    tap(tree, 'question-multi-option-1-app');
+    tap(tree, 'question-multi-option-1-server');
+    tap(tree, 'question-multi-option-1-dashboard');
+    tap(tree, 'question-multi-option-1-dashboard'); // toggle off
+    tap(tree, 'question-multi-submit');
+    const map: MultiQuestionAnswersMap = onSubmit.mock.calls[0][0];
+    const verify = map['Q2 — which areas to verify?'];
+    expect(Array.isArray(verify)).toBe(true);
+    expect(verify).toEqual(['app', 'server']);
+  });
+
+  it('emits the full answers map keyed by question text on submit', () => {
+    const onSubmit = jest.fn();
+    const tree = render(mixedQuestions(), onSubmit);
+    tap(tree, 'question-multi-option-0-approve');
+    tap(tree, 'question-multi-option-1-app');
+    tap(tree, 'question-multi-option-1-server');
+    tap(tree, 'question-multi-option-2-manual-rollback');
+    tap(tree, 'question-multi-submit');
+    expect(onSubmit).toHaveBeenCalledWith({
+      'Q1 — deploy to production?': 'approve',
+      'Q2 — which areas to verify?': ['app', 'server'],
+      'Q3 — rollback strategy?': 'manual-rollback',
+    });
+  });
+
+  it('an unanswered multi-select question emits an empty array', () => {
+    const onSubmit = jest.fn();
+    const tree = render(mixedQuestions(), onSubmit);
+    tap(tree, 'question-multi-option-0-approve');
+    tap(tree, 'question-multi-option-2-auto-rollback');
+    tap(tree, 'question-multi-submit');
+    const map: MultiQuestionAnswersMap = onSubmit.mock.calls[0][0];
+    expect(map['Q2 — which areas to verify?']).toEqual([]);
+  });
+
+  it('does not submit while a single-select question is unanswered', () => {
+    const onSubmit = jest.fn();
+    const tree = render(mixedQuestions(), onSubmit);
+    tap(tree, 'question-multi-option-0-approve'); // Q3 still unanswered
+    tap(tree, 'question-multi-submit');
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('fires onSubmit at most once even on a rapid double-tap (#3753 one-shot guard)', () => {
+    const onSubmit = jest.fn();
+    const tree = render(mixedQuestions(), onSubmit);
+    tap(tree, 'question-multi-option-0-approve');
+    tap(tree, 'question-multi-option-2-auto-rollback');
+    tap(tree, 'question-multi-submit');
+    tap(tree, 'question-multi-submit');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -141,6 +141,23 @@ export function MessageBubble({ message, onSelectOption, onSubmitMultiQuestion, 
     isPrompt && Array.isArray(message.questions) && message.questions.length > 1;
   const showMultiQuestionForm =
     isMultiQuestion && !!allowMultiQuestion && message.answered == null && !isExpired;
+  // #4973 — the per-question structured summary chip needs the
+  // `answeredAnswers` map (recorded by `markPromptAnsweredMulti` on the
+  // client that submitted). When a multi-question prompt is answered but
+  // that map is absent — e.g. it was answered on another client, or
+  // rehydrated from history before this field existed — fall back to the
+  // flat `message.answered` summary text (Copilot review) so the answer
+  // is never shown as blank.
+  const hasMultiQuestionAnswers =
+    isMultiQuestion &&
+    !!allowMultiQuestion &&
+    message.answered != null &&
+    message.answeredAnswers != null;
+  const showMultiQuestionFallbackSummary =
+    isMultiQuestion &&
+    !!allowMultiQuestion &&
+    message.answered != null &&
+    message.answeredAnswers == null;
   const showMultiQuestionSummary =
     isMultiQuestion && !!allowMultiQuestion && message.answered != null;
   // #4973 — per-question display labels for the post-answer summary chip.
@@ -148,7 +165,7 @@ export function MessageBubble({ message, onSelectOption, onSubmitMultiQuestion, 
   // `answeredAnswers` map) back to its option label(s), comma-joined for
   // multi-select. Falls back to the raw value when no matching option is
   // found (defensive — covers free-form values older servers might echo).
-  const multiQuestionAnswerLabels = showMultiQuestionSummary
+  const multiQuestionAnswerLabels = hasMultiQuestionAnswers
     ? (message.questions ?? []).map((q) => {
         const value = message.answeredAnswers?.[q.question];
         const toLabel = (v: string) =>
@@ -333,7 +350,7 @@ export function MessageBubble({ message, onSelectOption, onSubmitMultiQuestion, 
           }}
         />
       )}
-      {showMultiQuestionSummary && (
+      {hasMultiQuestionAnswers && (
         <View style={styles.multiQuestionSummary} testID="question-multi-summary">
           {message.questions!.map((q, i) => (
             <View key={`s-${i}`} style={styles.multiQuestionSummaryRow}>
@@ -346,6 +363,19 @@ export function MessageBubble({ message, onSelectOption, onSubmitMultiQuestion, 
               </Text>
             </View>
           ))}
+        </View>
+      )}
+      {showMultiQuestionFallbackSummary && (
+        // #4973 — answered elsewhere / rehydrated without the structured
+        // `answeredAnswers` map: render the flat comma-joined summary so
+        // the answer is never blank (Copilot review).
+        <View style={styles.multiQuestionSummary} testID="question-multi-summary">
+          <View style={styles.multiQuestionSummaryRow}>
+            <Icon name="check" size={14} color={COLORS.accentGreen} />
+            <Text style={styles.multiQuestionSummaryText} testID="question-multi-summary-flat">
+              {message.answered}
+            </Text>
+          </View>
         </View>
       )}
       {showOptionButtons && (

--- a/packages/app/src/components/chat/MessageBubble.tsx
+++ b/packages/app/src/components/chat/MessageBubble.tsx
@@ -24,6 +24,8 @@ import { ThinkingIndicator } from './ThinkingIndicator';
 import { ToolBubble } from './ToolBubble';
 import { StreamStallChip } from '../StreamStallChip';
 import { ResumeUnknownChip } from '../ResumeUnknownChip';
+import { MultiQuestionForm } from './MultiQuestionForm';
+import type { MultiQuestionAnswersMap } from './MultiQuestionForm';
 
 /**
  * #4755 — single-question Other / freeform answer payload (mobile parity
@@ -50,9 +52,25 @@ export type { OtherFreeformAnswer };
 
 export type SelectOptionValue = string | OtherFreeformAnswer;
 
-export function MessageBubble({ message, onSelectOption, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall }: {
+export function MessageBubble({ message, onSelectOption, onSubmitMultiQuestion, allowMultiQuestion, isSelected, isSelecting, onLongPress, onPress, onOpenDetail, onImagePress, onRetryStreamStall }: {
   message: ChatMessage;
   onSelectOption?: (value: SelectOptionValue, messageId: string, requestId?: string, toolUseId?: string) => void;
+  /**
+   * #4973 — submit handler for the multi-question form. Fires with the
+   * per-question answers map (`Record<string, string | string[]>`) plus
+   * the message + toolUseId so SessionScreen can forward it to
+   * `sendUserQuestionResponse` (widened in #4761) and record the
+   * comma-joined summary via `markPromptAnswered`.
+   */
+  onSubmitMultiQuestion?: (answersMap: MultiQuestionAnswersMap, messageId: string, toolUseId?: string) => void;
+  /**
+   * #4973 / #4735 — opt-in flag for SDK-mode sessions to render the
+   * interactive `MultiQuestionForm` instead of falling back to the legacy
+   * single-question Q[0] UI. TUI / CLI sessions leave this false because
+   * the permission-hook (#4648) denies combined multi-question tool_uses
+   * there. Mirrors the dashboard's `allowMultiQuestionForm` gate.
+   */
+  allowMultiQuestion?: boolean;
   isSelected: boolean;
   isSelecting: boolean;
   onLongPress: () => void;
@@ -110,6 +128,36 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
       setOtherText('');
     }
   }, [isPrompt, message.answered, otherActive]);
+  // #4973 — multi-question AskUserQuestion: render the interactive
+  // `MultiQuestionForm` (all N questions) instead of the legacy
+  // single-question Q[0] UI when (a) the payload carries more than one
+  // question, (b) the session is SDK-mode (`allowMultiQuestion`, mirrors
+  // the dashboard's `allowMultiQuestionForm` gate), and (c) the prompt is
+  // unanswered. Once answered we render the comma-joined summary chip
+  // instead. TUI / CLI sessions (`allowMultiQuestion` false) fall through
+  // to the legacy single-question render of Q[0] so the existing
+  // single-question pins keep passing.
+  const isMultiQuestion =
+    isPrompt && Array.isArray(message.questions) && message.questions.length > 1;
+  const showMultiQuestionForm =
+    isMultiQuestion && !!allowMultiQuestion && message.answered == null && !isExpired;
+  const showMultiQuestionSummary =
+    isMultiQuestion && !!allowMultiQuestion && message.answered != null;
+  // #4973 — per-question display labels for the post-answer summary chip.
+  // Maps each question's chosen value(s) (from the structured
+  // `answeredAnswers` map) back to its option label(s), comma-joined for
+  // multi-select. Falls back to the raw value when no matching option is
+  // found (defensive — covers free-form values older servers might echo).
+  const multiQuestionAnswerLabels = showMultiQuestionSummary
+    ? (message.questions ?? []).map((q) => {
+        const value = message.answeredAnswers?.[q.question];
+        const toLabel = (v: string) =>
+          q.options.find((o) => o.value === v)?.label ?? v;
+        if (Array.isArray(value)) return value.map(toLabel).join(', ');
+        if (typeof value === 'string') return toLabel(value);
+        return '';
+      })
+    : [];
   const hasOptions = isPrompt && !!message.options && message.options.length > 0;
   const answeredIsFreeText =
     hasOptions && message.answered != null &&
@@ -120,6 +168,9 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
   // another client answers while local Other mode is open).
   const showOptionButtons =
     hasOptions && !answeredIsFreeText &&
+    // #4973 — suppress the legacy Q[0] option buttons when the
+    // interactive multi-question form / summary is rendering.
+    !showMultiQuestionForm && !showMultiQuestionSummary &&
     (message.answered != null || !otherActive);
   const showFreetextInput = isPrompt && otherActive && !message.answered && !isExpired;
 
@@ -241,7 +292,13 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
           <PermissionCountdown expiresAt={message.expiresAt} onExpire={() => setIsExpired(true)} />
         )}
       </View>
-      {isPrompt && message.toolInput ? (
+      {/* #4973 — when the multi-question form / summary renders, suppress
+          the body content Text. The top-level `message.content` mirrors
+          Q[0]'s question (store-core handleUserQuestion), so rendering it
+          here would duplicate Q[0] above the form. The form / summary
+          renders every question itself. */}
+      {showMultiQuestionForm || showMultiQuestionSummary ? null :
+        isPrompt && message.toolInput ? (
         <PermissionDetailOrFallback tool={message.tool} toolInput={message.toolInput} fallback={message.content?.trim() || ''} />
       ) : !isUser && !isPrompt && !isError && !isSystem ? (
         <FormattedResponse content={message.content?.trim() || ''} messageTextStyle={styles.messageText} />
@@ -263,6 +320,31 @@ export function MessageBubble({ message, onSelectOption, isSelected, isSelecting
                 <Text style={styles.attachmentChipName} numberOfLines={1}>{att.name}</Text>
               </View>
             )
+          ))}
+        </View>
+      )}
+      {showMultiQuestionForm && (
+        <MultiQuestionForm
+          questions={message.questions!}
+          onSubmit={(answersMap) => {
+            if (submittedRef.current) return;
+            submittedRef.current = true;
+            onSubmitMultiQuestion?.(answersMap, message.id, message.toolUseId);
+          }}
+        />
+      )}
+      {showMultiQuestionSummary && (
+        <View style={styles.multiQuestionSummary} testID="question-multi-summary">
+          {message.questions!.map((q, i) => (
+            <View key={`s-${i}`} style={styles.multiQuestionSummaryRow}>
+              <Icon name="check" size={14} color={COLORS.accentGreen} />
+              <Text
+                style={styles.multiQuestionSummaryText}
+                testID={`question-multi-summary-${i}`}
+              >
+                {q.question}: {multiQuestionAnswerLabels[i]}
+              </Text>
+            </View>
           ))}
         </View>
       )}
@@ -555,6 +637,21 @@ const styles = StyleSheet.create({
     color: COLORS.textSecondary,
     fontSize: 14,
     fontStyle: 'italic',
+  },
+  multiQuestionSummary: {
+    marginTop: 10,
+    gap: 6,
+  },
+  multiQuestionSummaryRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 6,
+  },
+  multiQuestionSummaryText: {
+    flex: 1,
+    color: COLORS.textChatMessage,
+    fontSize: 14,
+    lineHeight: 20,
   },
   errorBubble: {
     backgroundColor: COLORS.accentRedLight,

--- a/packages/app/src/components/chat/MultiQuestionForm.tsx
+++ b/packages/app/src/components/chat/MultiQuestionForm.tsx
@@ -1,0 +1,222 @@
+/**
+ * MultiQuestionForm — React Native multi-question AskUserQuestion form
+ * (#4973). Mobile sibling of the dashboard's `MultiQuestionForm`
+ * (`packages/dashboard/src/components/QuestionPrompt.tsx`).
+ *
+ * Renders one selection control per question in a multi-question
+ * AskUserQuestion payload: a single-select radio row for single-select
+ * questions and a checkbox row for multi-select questions (`multiSelect:
+ * true`). A single Submit button at the bottom fires
+ * `onSubmit(answersMap)` with one entry per question, keyed by question
+ * text. Multi-select values are emitted as native `string[]` arrays of
+ * chosen option values (#4621 / #4735) — the wire schema
+ * (`UserQuestionResponseSchema`) and the store-layer
+ * `sendUserQuestionResponse` (widened in #4761 / PR #4859) accept the
+ * `Record<string, string | string[]>` shape directly, so no JSON
+ * encoding is required.
+ *
+ * #4735 / #4731 — the parent (`MessageBubble`) only renders this form
+ * for SDK-mode sessions (`allowMultiQuestion === true`). TUI / CLI
+ * sessions render the legacy single-question Q[0] UI because the
+ * permission-hook (#4648) denies combined multi-question tool_uses
+ * there; the dashboard mirrors this gate via `allowMultiQuestionForm`.
+ *
+ * testIDs (parity with the dashboard #4762 acceptance criteria):
+ *   - `question-prompt-multi` (container)
+ *   - `question-multi-option-<questionIndex>-<optionValue>` (each option)
+ *   - `question-multi-submit` (submit button)
+ */
+import React, { useState, useRef } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import type { ChatMessageQuestion } from '@chroxy/store-core';
+import { COLORS } from '../../constants/colors';
+
+/**
+ * #4735 — per-question answer payload emitted by the multi-question form.
+ * Values are either a string (single-select chosen value) or a string[]
+ * (multi-select chosen values). Mirrors the dashboard's
+ * `MultiQuestionAnswersMap`.
+ */
+export type MultiQuestionAnswersMap = Record<string, string | string[]>;
+
+export interface MultiQuestionFormProps {
+  questions: ChatMessageQuestion[];
+  onSubmit: (answersMap: MultiQuestionAnswersMap) => void;
+}
+
+export function MultiQuestionForm({ questions, onSubmit }: MultiQuestionFormProps) {
+  // State per question, indexed by question position so duplicate
+  // question texts don't collide: single-select holds the chosen value
+  // string, multi-select holds an array of chosen value strings.
+  const [singleSelectByIdx, setSingleSelectByIdx] = useState<Record<number, string>>({});
+  const [multiSelectByIdx, setMultiSelectByIdx] = useState<Record<number, string[]>>({});
+  // #3753 parity — one-shot send guard so a rapid double-tap on Submit
+  // (before the store round-trip flips `message.answered`) only fires
+  // one `user_question_response`.
+  const submittedRef = useRef(false);
+
+  const handleRadioSelect = (idx: number, value: string) => {
+    setSingleSelectByIdx((prev) => ({ ...prev, [idx]: value }));
+  };
+
+  const handleCheckboxToggle = (idx: number, value: string) => {
+    setMultiSelectByIdx((prev) => {
+      const curr = prev[idx] ?? [];
+      const next = curr.includes(value)
+        ? curr.filter((v) => v !== value)
+        : [...curr, value];
+      return { ...prev, [idx]: next };
+    });
+  };
+
+  // Submit enabled only when every single-select question has a choice.
+  // Multi-select is allowed to be empty (claude SDK accepts zero
+  // selections for multi-select) — parity with the dashboard's
+  // `canSubmit`.
+  const canSubmit = questions.every((q, idx) => {
+    if (q.multiSelect) return true;
+    return singleSelectByIdx[idx] != null;
+  });
+
+  const handleSubmit = () => {
+    if (submittedRef.current || !canSubmit) return;
+    submittedRef.current = true;
+    const answersMap: MultiQuestionAnswersMap = {};
+    questions.forEach((q, idx) => {
+      if (q.multiSelect) {
+        // #4621 / #4735 — emit multi-select as a native `string[]` via the
+        // widened wire shape; the server passes the array through to the
+        // SDK canUseTool callback unchanged.
+        answersMap[q.question] = multiSelectByIdx[idx] ?? [];
+      } else {
+        const chosen = singleSelectByIdx[idx];
+        if (chosen != null) answersMap[q.question] = chosen;
+      }
+    });
+    onSubmit(answersMap);
+  };
+
+  return (
+    <View style={styles.container} testID="question-prompt-multi">
+      {questions.map((q, idx) => {
+        const isMultiSelect = q.multiSelect === true;
+        const selectedSingle = singleSelectByIdx[idx];
+        const selectedMulti = multiSelectByIdx[idx] ?? [];
+        return (
+          <View key={`q-${idx}`} style={styles.questionRow} testID={`question-multi-row-${idx}`}>
+            <Text
+              style={styles.questionText}
+              // #4973 — per-question text anchor for Maestro / unit tests
+              // to assert each question rendered. Deliberately NOT
+              // `approval-question-<idx>` (that testID is owned by the
+              // bubble HEADER label in MessageBubble, and reusing it here
+              // would create a duplicate testID for Q[0]).
+              testID={`question-multi-text-${idx}`}
+            >
+              {q.question}
+            </Text>
+            <View
+              style={styles.optionsRow}
+              accessibilityRole={isMultiSelect ? 'none' : 'radiogroup'}
+            >
+              {q.options.map((opt) => {
+                const isChosen = isMultiSelect
+                  ? selectedMulti.includes(opt.value)
+                  : selectedSingle === opt.value;
+                return (
+                  <TouchableOpacity
+                    key={opt.value}
+                    testID={`question-multi-option-${idx}-${opt.value}`}
+                    accessibilityRole={isMultiSelect ? 'checkbox' : 'radio'}
+                    accessibilityState={{ checked: isChosen, selected: isChosen }}
+                    accessibilityLabel={opt.label}
+                    style={[styles.optionButton, isChosen && styles.optionButtonChosen]}
+                    onPress={() =>
+                      isMultiSelect
+                        ? handleCheckboxToggle(idx, opt.value)
+                        : handleRadioSelect(idx, opt.value)
+                    }
+                  >
+                    <Text style={[styles.optionText, isChosen && styles.optionTextChosen]}>
+                      {opt.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          </View>
+        );
+      })}
+      <TouchableOpacity
+        testID="question-multi-submit"
+        accessibilityRole="button"
+        accessibilityLabel="Submit answers"
+        accessibilityState={{ disabled: !canSubmit }}
+        disabled={!canSubmit}
+        style={[styles.submitButton, !canSubmit && styles.submitButtonDisabled]}
+        onPress={handleSubmit}
+      >
+        <Text style={styles.submitButtonText}>Submit</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 10,
+    gap: 14,
+  },
+  questionRow: {
+    gap: 8,
+  },
+  questionText: {
+    color: COLORS.textChatMessage,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  optionsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  optionButton: {
+    backgroundColor: COLORS.accentOrangeMedium,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    minHeight: 44,
+    justifyContent: 'center',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.accentOrangeBorderStrong,
+  },
+  optionButtonChosen: {
+    backgroundColor: COLORS.accentOrange,
+    borderColor: COLORS.accentOrange,
+  },
+  optionText: {
+    color: COLORS.accentOrange,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  optionTextChosen: {
+    color: '#fff',
+  },
+  submitButton: {
+    alignSelf: 'flex-start',
+    backgroundColor: COLORS.accentOrange,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    minHeight: 44,
+    justifyContent: 'center',
+    borderRadius: 8,
+  },
+  submitButtonDisabled: {
+    opacity: 0.4,
+  },
+  submitButtonText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/packages/app/src/components/chat/MultiQuestionForm.tsx
+++ b/packages/app/src/components/chat/MultiQuestionForm.tsx
@@ -45,9 +45,18 @@ export interface MultiQuestionFormProps {
 }
 
 export function MultiQuestionForm({ questions, onSubmit }: MultiQuestionFormProps) {
-  // State per question, indexed by question position so duplicate
-  // question texts don't collide: single-select holds the chosen value
-  // string, multi-select holds an array of chosen value strings.
+  // Local selection state is indexed by question POSITION so that while
+  // the form is open, two questions with identical text track their
+  // choices independently (single-select holds the chosen value string,
+  // multi-select holds an array of chosen value strings). NOTE: the
+  // emitted `answersMap` (see `handleSubmit`) is keyed by `q.question`
+  // text — this is the wire shape `UserQuestionResponseSchema` /
+  // `PermissionManager.respondToQuestion` consume, and it matches the
+  // dashboard's `MultiQuestionForm`. If a payload ever carried two
+  // questions with the exact same text, the later one would overwrite the
+  // earlier in the emitted map; that's an inherent constraint of the
+  // question-text-keyed wire contract (shared with the dashboard), not a
+  // mobile-only limitation.
   const [singleSelectByIdx, setSingleSelectByIdx] = useState<Record<number, string>>({});
   const [multiSelectByIdx, setMultiSelectByIdx] = useState<Record<number, string[]>>({});
   // #3753 parity — one-shot send guard so a rapid double-tap on Submit

--- a/packages/app/src/screens/SessionScreen.tsx
+++ b/packages/app/src/screens/SessionScreen.tsx
@@ -222,8 +222,27 @@ export function SessionScreen() {
   const sendPermissionResponse = useConnectionStore((s) => s.sendPermissionResponse);
   const sendUserQuestionResponse = useConnectionStore((s) => s.sendUserQuestionResponse);
   const markPromptAnswered = useConnectionStore((s) => s.markPromptAnswered);
+  const markPromptAnsweredMulti = useConnectionStore((s) => s.markPromptAnsweredMulti);
 
   const sessions = useConnectionStore((s) => s.sessions);
+  // #4973 / #4735 — allow the interactive multi-question form only for
+  // SDK-mode sessions. TUI / CLI sessions (`claude-tui` / `claude-cli`)
+  // leave it off because the permission-hook (#4648) denies combined
+  // multi-question tool_uses there and answers would misroute through
+  // `_pendingUserAnswer`; SDK / BYOK / Codex / Gemini sessions accept
+  // per-question answers natively (#4731). Mirrors the dashboard's
+  // `allowMultiQuestionForm` (App.tsx).
+  const activeSessionProvider = useConnectionStore((s) => {
+    const id = s.activeSessionId;
+    return id ? s.sessions.find((sess) => sess.sessionId === id)?.provider ?? null : null;
+  });
+  const allowMultiQuestion = useMemo(
+    () =>
+      activeSessionProvider != null &&
+      activeSessionProvider !== 'claude-tui' &&
+      activeSessionProvider !== 'claude-cli',
+    [activeSessionProvider],
+  );
   const viewingCachedSession = useConnectionStore((s) => s.viewingCachedSession);
   const exitCachedSession = useConnectionStore((s) => s.exitCachedSession);
   const savedConnection = useConnectionLifecycleStore((s) => s.savedConnection);
@@ -731,6 +750,26 @@ export function SessionScreen() {
       // the answered-state UI renders the user's actual answer.
       const summary = freeform ? value.freeformText : value;
       markPromptAnswered(messageId, summary);
+    }
+  };
+
+  // #4973 — submit handler for the multi-question AskUserQuestion form.
+  // Forwards the per-question answers map (`Record<string, string |
+  // string[]>`) to `sendUserQuestionResponse` (widened in #4761), which
+  // serializes the `answers` map + a comma-joined `answer` summary on the
+  // wire. On success we record the structured map via
+  // `markPromptAnsweredMulti` so the post-answer summary chip can map
+  // chosen values back to option labels. Mirrors the dashboard's
+  // App.tsx + `formatQuestionAnswerSummary` multi-question path (#4760).
+  const handleSubmitMultiQuestion = (
+    answersMap: Record<string, string | string[]>,
+    messageId: string,
+    toolUseId?: string,
+  ) => {
+    if (!toolUseId) return;
+    const sent = sendUserQuestionResponse(answersMap, toolUseId);
+    if (sent === 'sent') {
+      markPromptAnsweredMulti(messageId, answersMap);
     }
   };
 
@@ -1318,6 +1357,8 @@ export function SessionScreen() {
                   scrollViewRef={scrollViewRef}
                   claudeReady={claudeReady}
                   onSelectOption={handleSelectOption}
+                  onSubmitMultiQuestion={handleSubmitMultiQuestion}
+                  allowMultiQuestion={allowMultiQuestion}
                   isCliMode={isCliMode}
                   selectedIds={selectedIds}
                   isSelecting={isSelecting}
@@ -1349,6 +1390,8 @@ export function SessionScreen() {
               scrollViewRef={scrollViewRef}
               claudeReady={claudeReady}
               onSelectOption={handleSelectOption}
+              onSubmitMultiQuestion={handleSubmitMultiQuestion}
+              allowMultiQuestion={allowMultiQuestion}
               isCliMode={isCliMode}
               selectedIds={selectedIds}
               isSelecting={isSelecting}
@@ -1374,6 +1417,8 @@ export function SessionScreen() {
               scrollViewRef={scrollViewRef}
               claudeReady={claudeReady}
               onSelectOption={handleSelectOption}
+              onSubmitMultiQuestion={handleSubmitMultiQuestion}
+              allowMultiQuestion={allowMultiQuestion}
               isCliMode={isCliMode}
               selectedIds={selectedIds}
               isSelecting={isSelecting}

--- a/packages/app/src/store/connection.ts
+++ b/packages/app/src/store/connection.ts
@@ -1284,6 +1284,27 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }));
   },
 
+  // #4973 — record a multi-question form submission. Stores the
+  // comma-joined human-readable summary in `answered` (for chat history
+  // and legacy single-question renderers) AND the structured per-question
+  // answers map in `answeredAnswers` so the multi-question summary chip
+  // can map chosen values back to option labels without re-parsing the
+  // delimited summary string.
+  markPromptAnsweredMulti: (
+    messageId: string,
+    answers: Record<string, string | string[]>,
+  ) => {
+    const now = Date.now();
+    const summary = formatQuestionAnswerSummary(answers);
+    updateActiveSession((ss) => ({
+      messages: ss.messages.map((m) =>
+        m.id === messageId
+          ? { ...m, answered: summary, answeredAnswers: answers, answeredAt: now }
+          : m
+      ),
+    }));
+  },
+
   markPromptAnsweredByRequestId: (requestId: string, answer: string) => {
     const { sessionStates } = get();
     const now = Date.now();

--- a/packages/app/src/store/types.ts
+++ b/packages/app/src/store/types.ts
@@ -439,6 +439,15 @@ export interface MessageInputActions {
     toolUseId?: string,
   ) => 'sent' | 'queued' | false;
   markPromptAnswered: (messageId: string, answer: string) => void;
+  /**
+   * #4973 — record a multi-question form submission: stores the
+   * comma-joined summary in `answered` and the structured per-question
+   * answers map in `answeredAnswers`.
+   */
+  markPromptAnsweredMulti: (
+    messageId: string,
+    answers: Record<string, string | string[]>,
+  ) => void;
   markPromptAnsweredByRequestId: (requestId: string, answer: string) => void;
 }
 

--- a/packages/store-core/src/types.ts
+++ b/packages/store-core/src/types.ts
@@ -141,6 +141,17 @@ export interface ChatMessage {
    */
   toolInputPartialTruncated?: boolean;
   answered?: string;
+  /**
+   * #4973 — structured per-question answers map recorded when the user
+   * submits a multi-question AskUserQuestion form. Keyed by question text,
+   * with single-select values as a `string` and multi-select values as a
+   * `string[]` of chosen option values. The flat `answered` field still
+   * holds the comma-joined human-readable summary (for chat history /
+   * legacy renderers); this field lets the multi-question summary chip
+   * map chosen values back to their option labels per question without
+   * re-parsing the delimited summary string.
+   */
+  answeredAnswers?: Record<string, string | string[]>;
   /** Timestamp when the user answered a permission prompt */
   answeredAt?: number;
   expiresAt?: number;


### PR DESCRIPTION
## Summary

Implements the React Native `MultiQuestionForm` for the mobile app — the multi-question `AskUserQuestion` form, mirroring the dashboard's existing `MultiQuestionForm` (`packages/dashboard/src/components/QuestionPrompt.tsx`). This completes the remaining mobile acceptance criteria from #4762 that PR #4965 could not satisfy because no mobile equivalent existed.

Closes #4973

## What changed

- **New `packages/app/src/components/chat/MultiQuestionForm.tsx`** — renders all N questions inline: a radio row for single-select, a checkbox row for multi-select (`multiSelect: true`), and a single Submit button. Parity testIDs per the AC: `question-prompt-multi` (container), `question-multi-option-<questionIndex>-<optionValue>` (each option), `question-multi-submit` (submit). One-shot submit guard (#3753 parity). 44pt min touch targets.
- **`MessageBubble.tsx`** — renders the interactive form for multi-question payloads only when the session is SDK-mode (`allowMultiQuestion`); TUI / CLI sessions fall back to the legacy single-question Q[0] UI. Post-answer, the form is replaced by a summary chip showing the comma-joined option **labels** per question (mapped back from the structured `answeredAnswers` map). Suppresses the duplicated Q[0] body text when the form / summary renders.
- **`SessionScreen.tsx`** — computes `allowMultiQuestion` from the active session's provider (not `claude-tui` / `claude-cli`), mirroring the dashboard's `allowMultiQuestionForm`. New `handleSubmitMultiQuestion` forwards the per-question answers map through `sendUserQuestionResponse` (widened in #4761 / #4859) and records it via the new `markPromptAnsweredMulti` store action.
- **`connection.ts` / `store/types.ts`** — new `markPromptAnsweredMulti` action stores the comma-joined summary in `answered` AND the structured map in `answeredAnswers`.
- **`store-core/src/types.ts`** — new optional `answeredAnswers?: Record<string, string | string[]>` field on `ChatMessage`.
- **`ChatView.tsx`** — plumbs `onSubmitMultiQuestion` + `allowMultiQuestion` through to `MessageBubble`.
- **`.maestro/chat-multi-question.yaml`** — extended to drive the full interactive form (tap every option across all three questions, submit, assert the post-answer summary chip `Q2 — which areas to verify?: app, server`). Mock-server comment updated to reflect the landed renderer (the `show-multi-question` fixture already emits the correct mixed payload, and the mock session is `provider: 'claude-sdk'`).

## Test coverage — jest vs simulator

**Covered by jest (primary automated proof, all passing locally):**
- `MultiQuestionForm.test.tsx` — testID rendering, single-select radio (latest replaces), multi-select checkbox toggle (into / out of array), submit gating (disabled until every single-select answered; multi-select may be empty), exact submit payload shape (per-question map, multi-select as native `string[]`), empty multi-select → `[]`, one-shot guard.
- `MessageBubble.multiQuestion.test.tsx` — form renders only when `allowMultiQuestion`, legacy fallback otherwise, submit forwards `(answersMap, messageId, toolUseId)`, post-answer summary chip with comma-joined labels + value→label mapping.
- `connection.test.ts` — `markPromptAnsweredMulti` stores the structured map + comma-joined summary and leaves other messages untouched.

**Needs a manual simulator run (cannot run headlessly here):** the `chat-multi-question.yaml` Maestro flow requires a booted iOS simulator + Metro + the dev client + mock-server. The flow is updated as code and ready to run; the live run on iPhone 15 Pro + iPhone SE 3 (the last #4762 AC checkbox) remains for manual verification.

Type-check is clean for all changed files.