### PR TITLE
feat(dashboard): audible intervention ping + all-device alert consistency (#4891)

### DIFF
--- a/docs/guides/intervention-alerts.md
+++ b/docs/guides/intervention-alerts.md
@@ -1,0 +1,87 @@
+# Intervention alerts
+
+When the agent needs an **intervention** — a permission request, a question
+(`AskUserQuestion`), or any blocked-on-input state — Chroxy alerts you on every
+connected device so the session doesn't stall while you're heads-down on other
+work. This page documents which surfaces alert you, when they fire, and how to
+turn each one off.
+
+## What counts as an intervention
+
+- A **permission request** (a tool wants to run and needs allow / deny).
+- A **question** the agent asked and is waiting on.
+- Any prompt that blocks the turn until you respond.
+
+These all surface to clients as a permission/question prompt with a `requestId`
+and an expiry. Completion and error notifications are separate categories (see
+the per-category toggles in **Settings → Notifications**).
+
+## Which surfaces alert you
+
+| Surface | Signal | Fires when |
+| --- | --- | --- |
+| **Web / desktop dashboard** | Audible ping (two-note chirp) | An intervention arrives, even if the tab is minimized or sitting idle in the background |
+| **Web / desktop dashboard** | OS notification | An intervention arrives **and the window is not focused** |
+| **Web / desktop dashboard** | Notifications widget (bell icon) | Always — a durable read/unread inbox of every intervention |
+| **Mobile app** | Push notification with sound | An intervention arrives while the app is backgrounded or closed |
+| **Mobile app** | In-app alert | An intervention arrives while the app is foregrounded |
+
+All connected devices are alerted, not just the actively-focused one. The server
+fans an intervention out to every client subscribed to (or viewing) the session
+via `_broadcastToSession`, and to every registered push token via the push
+manager. Push for the `permission` category bypasses rate limiting so a blocking
+intervention always gets through.
+
+### Why the dashboard has both a chirp and an OS notification
+
+The OS notification only fires when the window is **unfocused**, and on many
+desktop configurations it makes no sound. The audible chirp closes that gap: it
+fires on **every** intervention regardless of focus, so a tab you've tabbed away
+from (but not minimized) still pulls you back, and minimized/background tabs
+still chirp as long as the page's JavaScript is running.
+
+## Dedupe and throttle (no alert storm)
+
+- Each intervention chirps **at most once**, keyed by its `requestId`. A
+  re-render or reconnect replay of the same request never re-chirps.
+- A burst of interventions arriving together (multiple sessions blocking at
+  once, or a reconnect replaying several prompts) collapses into a **single**
+  chirp via a short cooldown. New requests seen during the cooldown are still
+  recorded so they never re-fire once it lifts.
+- The same intervention reaching you on several devices alerts on each device
+  independently — each surface is the right alert for that device's context.
+
+## How to disable each surface
+
+| Surface | Where to turn it off |
+| --- | --- |
+| Dashboard chirp | **Settings → Dashboard → "Play a sound when the agent needs input"** (per-device, persisted in this browser/tab's local storage). Defaults on. |
+| Dashboard OS notification | Revoke the browser/OS notification permission for the dashboard origin. |
+| Per-category push / in-app | **Settings → Notifications** — toggle the **Permission requests** / **Waiting for input** categories off. |
+| Quiet hours | **Settings → Notifications → Quiet hours** — mutes pushes during a daily window. Operator-blocking categories (permission, session errors) bypass quiet hours by default; uncheck them in the bypass list to silence them at night too. |
+
+### Accessibility / "reduce sound"
+
+The dashboard chirp is synthesized with the Web Audio API (no bundled asset).
+If the browser blocks autoplay, has no audio device, or the page hasn't yet
+received a user gesture to resume the audio context, the chirp **fails soft** —
+it simply doesn't sound, and the OS notification + Notifications widget remain
+the durable signal. Mute the chirp entirely via the Settings toggle above if you
+prefer a silent dashboard.
+
+## Implementation pointers
+
+- Dashboard audio ping: `packages/dashboard/src/hooks/useInterventionPing.ts`
+  (dedupe + throttle + mute, fed the same derived prompt list as the OS
+  notification hook).
+- Dashboard OS notification: `packages/dashboard/src/hooks/usePermissionNotification.ts`.
+- Mute toggle + persistence: **Settings → Dashboard** in
+  `packages/dashboard/src/components/SettingsPanel.tsx`, persisted via
+  `persistInterventionPing` / `loadPersistedInterventionPing` in
+  `packages/dashboard/src/store/persistence.ts`.
+- Server fan-out: `_broadcastToSession` in `packages/server/src/ws-server.js`;
+  push in `packages/server/src/push.js` (the `permission` category bypasses rate
+  limiting).
+- Mobile push sound: `packages/app/src/notifications.ts`.
+- Notification preferences (per-category mute, quiet hours):
+  `packages/server/src/notification-prefs.js`.

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -73,10 +73,11 @@ import { useTauriMenuEvents } from './hooks/useTauriMenuEvents'
 import { isTauri } from './utils/tauri'
 import { startServer, revealInFinder } from './hooks/useTauriIPC'
 import { usePermissionNotification, type PermissionPromptInfo } from './hooks/usePermissionNotification'
+import { useInterventionPing } from './hooks/useInterventionPing'
 import { useShortcutDispatch } from './hooks/useShortcutDispatch'
 import { useChatMessages, toChatViewMessage } from './hooks/useChatMessages'
 import { SplitPane, type SplitDirection } from './components/SplitPane'
-import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed, loadPersistedSidebarRepoOrder, loadPersistedSidebarSessionOrder, persistSidebarRepoOrder, persistSidebarSessionOrder, persistSessionTabOrder, loadPersistedSessionTabOrder } from './store/persistence'
+import { persistSidebarWidth, loadPersistedSidebarWidth, persistSplitMode, loadPersistedSplitMode, persistShowConsoleTab, loadPersistedShowConsoleTab, persistInterventionPing, loadPersistedInterventionPing, loadPersistedSidebarPanelHeight, loadPersistedSidebarPanelView, loadPersistedSidebarPanelCollapsed, loadPersistedSidebarRepoOrder, loadPersistedSidebarSessionOrder, persistSidebarRepoOrder, persistSidebarSessionOrder, persistSessionTabOrder, loadPersistedSessionTabOrder } from './store/persistence'
 import { applyOrderById } from './utils/reorderById'
 import { DiffViewerPanel } from './components/DiffViewerPanel'
 import { AgentMonitorPanel } from './components/AgentMonitorPanel'
@@ -446,6 +447,17 @@ export function App() {
     [storeMessages],
   )
   usePermissionNotification(permissionPrompts)
+  // #4891 — audible intervention ping enable/mute. Defaults on; persisted
+  // per-device in localStorage. Toggled via Settings → Dashboard.
+  const [interventionPingEnabled, setInterventionPingEnabled] = useState(() => {
+    return loadPersistedInterventionPing()
+  })
+  // #4891 — audible ping on incoming intervention (permission request /
+  // question / blocked-on-input). Reuses the same derived prompt list as the
+  // OS-notification hook so both surfaces fire on identical events. The hook
+  // dedupes by requestId and throttles bursts; `enabled` honors the operator
+  // mute toggle (Settings → Dashboard, persisted per-device).
+  useInterventionPing(permissionPrompts, { enabled: interventionPingEnabled })
 
   // #3698 — derive the user-message history for the InputBar's terminal-
   // style Up/Down navigation. Oldest-first (matches the natural arrival
@@ -2546,6 +2558,11 @@ export function App() {
         onToggleConsoleTab={(show) => {
           setShowConsoleTab(show)
           persistShowConsoleTab(show)
+        }}
+        interventionPingEnabled={interventionPingEnabled}
+        onToggleInterventionPing={(enabled) => {
+          setInterventionPingEnabled(enabled)
+          persistInterventionPing(enabled)
         }}
       />
 

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -256,6 +256,44 @@ describe('SettingsPanel', () => {
     expect(screen.queryByLabelText('Show Console tab')).toBeNull()
   })
 
+  // #4891 — audible intervention ping toggle
+  it('renders the intervention-ping toggle when onToggleInterventionPing is provided', () => {
+    const onToggle = vi.fn()
+    render(
+      <SettingsPanel
+        isOpen={true}
+        onClose={vi.fn()}
+        interventionPingEnabled={true}
+        onToggleInterventionPing={onToggle}
+      />
+    )
+
+    const checkbox = screen.getByTestId('intervention-ping-toggle') as HTMLInputElement
+    expect(checkbox).toBeTruthy()
+    expect(checkbox.checked).toBe(true)
+
+    fireEvent.click(checkbox)
+    expect(onToggle).toHaveBeenCalledWith(false)
+  })
+
+  it('reflects the muted state on the intervention-ping toggle', () => {
+    render(
+      <SettingsPanel
+        isOpen={true}
+        onClose={vi.fn()}
+        interventionPingEnabled={false}
+        onToggleInterventionPing={vi.fn()}
+      />
+    )
+    const checkbox = screen.getByTestId('intervention-ping-toggle') as HTMLInputElement
+    expect(checkbox.checked).toBe(false)
+  })
+
+  it('does not render the intervention-ping toggle when handler is absent', () => {
+    render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+    expect(screen.queryByTestId('intervention-ping-toggle')).toBeNull()
+  })
+
   // #3404 audit F1
   describe('Provider auth status section', () => {
     it('hides the section when the server has not surfaced any auth field', () => {

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -131,6 +131,11 @@ export interface SettingsPanelProps {
   onClose: () => void
   showConsoleTab?: boolean
   onToggleConsoleTab?: (show: boolean) => void
+  // #4891 — audible intervention ping enable/mute. Optional so existing
+  // call sites / tests that don't wire it stay valid; the row only renders
+  // when the handler is provided.
+  interventionPingEnabled?: boolean
+  onToggleInterventionPing?: (enabled: boolean) => void
 }
 
 /**
@@ -592,7 +597,7 @@ function ThemeSwatches({ theme }: { theme: ThemeDefinition }) {
   )
 }
 
-export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsoleTab }: SettingsPanelProps) {
+export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsoleTab, interventionPingEnabled, onToggleInterventionPing }: SettingsPanelProps) {
   const backdropRef = useRef<HTMLDivElement>(null)
   const activeTheme = useConnectionStore(s => s.activeTheme)
   const setTheme = useConnectionStore(s => s.setTheme)
@@ -1616,18 +1621,46 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
             )}
           </section>
 
-          {onToggleConsoleTab && (
-            <section className="settings-section">
+          {(onToggleConsoleTab || onToggleInterventionPing) && (
+            <section className="settings-section" data-testid="dashboard-section">
               <h3>Dashboard</h3>
-              <div className="settings-field">
-                <label htmlFor="show-console-tab">Show Console tab</label>
-                <input
-                  id="show-console-tab"
-                  type="checkbox"
-                  checked={showConsoleTab ?? false}
-                  onChange={(e) => onToggleConsoleTab(e.target.checked)}
-                />
-              </div>
+              {onToggleConsoleTab && (
+                <div className="settings-field">
+                  <label htmlFor="show-console-tab">Show Console tab</label>
+                  <input
+                    id="show-console-tab"
+                    type="checkbox"
+                    checked={showConsoleTab ?? false}
+                    onChange={(e) => onToggleConsoleTab(e.target.checked)}
+                  />
+                </div>
+              )}
+              {/* #4891 — audible intervention ping toggle. Plays a short
+                  chirp in this tab whenever the agent needs input (permission
+                  request / question), even when the tab is minimized or
+                  idle in the background. Defaults on; mute is per-device. */}
+              {onToggleInterventionPing && (
+                <div className="settings-field settings-field-checkbox">
+                  <label htmlFor="intervention-ping-toggle">
+                    <input
+                      id="intervention-ping-toggle"
+                      type="checkbox"
+                      checked={interventionPingEnabled ?? true}
+                      onChange={(e) => onToggleInterventionPing(e.target.checked)}
+                      data-testid="intervention-ping-toggle"
+                    />
+                    Play a sound when the agent needs input
+                  </label>
+                  <p className="settings-hint">
+                    A short chirp plays in this browser tab whenever a session
+                    needs an intervention (permission prompt or question) — so
+                    you get pulled back in even with the tab minimized or idle.
+                    Applies to this device only. Repeat alerts for the same
+                    request are deduped, and bursts across multiple sessions
+                    are throttled into a single ping.
+                  </p>
+                </div>
+              )}
             </section>
           )}
 

--- a/packages/dashboard/src/hooks/useInterventionPing.test.ts
+++ b/packages/dashboard/src/hooks/useInterventionPing.test.ts
@@ -1,0 +1,228 @@
+/**
+ * useInterventionPing tests (#4891)
+ *
+ * Verifies the dashboard audio ping:
+ *   - fires once when a new intervention (permission prompt / question) arrives
+ *   - respects the mute toggle (`enabled: false` => silent)
+ *   - dedupes by requestId (no repeat ping for the same intervention)
+ *   - throttles a burst of simultaneous interventions into a single chirp
+ *   - skips answered / expired prompts
+ *   - re-pings a re-requested id after it's pruned
+ *   - fails soft when Web Audio is unavailable (no throw)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import {
+  useInterventionPing,
+  THROTTLE_MS,
+  __resetInterventionPingAudioContextForTests,
+} from './useInterventionPing'
+
+// --- AudioContext mock --------------------------------------------------
+// jsdom has no Web Audio API. We install a minimal mock that records every
+// oscillator start() so a single chirp (two notes) is observable as "two
+// oscillators started", and a fresh chirp increments the count.
+
+let oscillatorStarts = 0
+let createdContexts = 0
+
+function makeMockAudioContext() {
+  return class MockAudioContext {
+    state: 'suspended' | 'running' = 'running'
+    currentTime = 0
+    destination = {}
+    constructor() {
+      createdContexts++
+    }
+    resume() {
+      this.state = 'running'
+      return Promise.resolve()
+    }
+    createGain() {
+      return {
+        connect: vi.fn(),
+        gain: {
+          setValueAtTime: vi.fn(),
+          exponentialRampToValueAtTime: vi.fn(),
+        },
+      }
+    }
+    createOscillator() {
+      return {
+        type: 'sine',
+        frequency: { setValueAtTime: vi.fn() },
+        connect: vi.fn(),
+        start: () => { oscillatorStarts++ },
+        stop: vi.fn(),
+      }
+    }
+  }
+}
+
+/** A chirp plays two notes => two oscillator starts. */
+function chirpCount() {
+  return oscillatorStarts / 2
+}
+
+function makePrompt(
+  overrides: Partial<{
+    id: string
+    requestId: string
+    tool: string
+    description: string
+    expiresAt: number
+    answered: string | undefined
+  }> = {},
+) {
+  return {
+    id: 'perm-1',
+    requestId: 'req-1',
+    tool: 'Bash',
+    description: 'Run: npm install',
+    expiresAt: Date.now() + 60000,
+    answered: undefined,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  oscillatorStarts = 0
+  createdContexts = 0
+  __resetInterventionPingAudioContextForTests()
+  // @ts-expect-error — install mock
+  globalThis.window.AudioContext = makeMockAudioContext()
+  // @ts-expect-error — ensure prefixed fallback is absent
+  delete globalThis.window.webkitAudioContext
+})
+
+afterEach(() => {
+  __resetInterventionPingAudioContextForTests()
+  vi.restoreAllMocks()
+})
+
+describe('useInterventionPing', () => {
+  it('fires a single chirp when a new intervention arrives', () => {
+    renderHook(() => useInterventionPing([makePrompt()], { enabled: true }))
+    expect(chirpCount()).toBe(1)
+  })
+
+  it('does not ping when muted (enabled: false)', () => {
+    renderHook(() => useInterventionPing([makePrompt()], { enabled: false }))
+    expect(chirpCount()).toBe(0)
+    // No AudioContext should even be constructed while muted.
+    expect(createdContexts).toBe(0)
+  })
+
+  it('does not ping for already-answered prompts', () => {
+    renderHook(() =>
+      useInterventionPing([makePrompt({ answered: 'allow' })], { enabled: true }),
+    )
+    expect(chirpCount()).toBe(0)
+  })
+
+  it('does not ping for expired prompts', () => {
+    renderHook(() =>
+      useInterventionPing([makePrompt({ expiresAt: Date.now() - 1000 })], { enabled: true }),
+    )
+    expect(chirpCount()).toBe(0)
+  })
+
+  it('dedupes — same requestId does not re-ping on re-render', () => {
+    const { rerender } = renderHook(
+      ({ p }) => useInterventionPing(p, { enabled: true }),
+      { initialProps: { p: [makePrompt()] } },
+    )
+    expect(chirpCount()).toBe(1)
+    // New array instance, same requestId — effect reruns but must not re-ping.
+    rerender({ p: [makePrompt()] })
+    expect(chirpCount()).toBe(1)
+  })
+
+  it('throttles a burst of simultaneous interventions into one chirp', () => {
+    renderHook(() =>
+      useInterventionPing(
+        [
+          makePrompt({ id: 'a', requestId: 'req-a' }),
+          makePrompt({ id: 'b', requestId: 'req-b' }),
+          makePrompt({ id: 'c', requestId: 'req-c' }),
+        ],
+        { enabled: true },
+      ),
+    )
+    // Three new interventions in one tick collapse to a single chirp.
+    expect(chirpCount()).toBe(1)
+  })
+
+  it('does not re-ping a throttled id once the cooldown lifts', () => {
+    vi.useFakeTimers()
+    const base = Date.now()
+    vi.setSystemTime(base)
+    const { rerender } = renderHook(
+      ({ p }) => useInterventionPing(p, { enabled: true }),
+      {
+        initialProps: {
+          p: [
+            makePrompt({ id: 'a', requestId: 'req-a', expiresAt: base + 60000 }),
+            makePrompt({ id: 'b', requestId: 'req-b', expiresAt: base + 60000 }),
+          ],
+        },
+      },
+    )
+    expect(chirpCount()).toBe(1)
+    // Advance past the throttle window; the same ids are still present but
+    // were already recorded as pinged, so no new chirp fires.
+    vi.setSystemTime(base + 5000)
+    rerender({
+      p: [
+        makePrompt({ id: 'a', requestId: 'req-a', expiresAt: base + 60000 }),
+        makePrompt({ id: 'b', requestId: 'req-b', expiresAt: base + 60000 }),
+      ],
+    })
+    expect(chirpCount()).toBe(1)
+    vi.useRealTimers()
+  })
+
+  it('re-pings a re-requested id after it is pruned (past the throttle window)', () => {
+    vi.useFakeTimers()
+    const base = Date.now()
+    vi.setSystemTime(base)
+    const { rerender } = renderHook(
+      ({ p }) => useInterventionPing(p, { enabled: true }),
+      { initialProps: { p: [makePrompt({ requestId: 'req-1', expiresAt: base + 60000 })] } },
+    )
+    expect(chirpCount()).toBe(1)
+    // Intervention answered/removed — id pruned.
+    rerender({ p: [] })
+    // Advance past the throttle cooldown so the re-request is audible
+    // (a re-request inside the cooldown is intentionally throttled).
+    vi.setSystemTime(base + THROTTLE_MS + 1)
+    // Same requestId reappears (re-requested) — should ping again.
+    rerender({ p: [makePrompt({ requestId: 'req-1', expiresAt: base + 60000 + THROTTLE_MS })] })
+    expect(chirpCount()).toBe(2)
+    vi.useRealTimers()
+  })
+
+  it('still prunes stale ids while muted so unmuting does not replay old ids', () => {
+    const { rerender } = renderHook(
+      ({ p, enabled }) => useInterventionPing(p, { enabled }),
+      { initialProps: { p: [makePrompt({ requestId: 'req-1' })], enabled: false } },
+    )
+    expect(chirpCount()).toBe(0)
+    // While still muted the prompt is answered/removed (id pruned).
+    rerender({ p: [], enabled: false })
+    // Unmute with a brand-new intervention — should ping (proves the set
+    // didn't leak a stale id that would suppress later, and that unmuting
+    // does not replay the already-gone req-1).
+    rerender({ p: [makePrompt({ requestId: 'req-2' })], enabled: true })
+    expect(chirpCount()).toBe(1)
+  })
+
+  it('fails soft when Web Audio is unavailable (no throw, no chirp)', () => {
+    // @ts-expect-error — remove the constructor
+    delete globalThis.window.AudioContext
+    expect(() =>
+      renderHook(() => useInterventionPing([makePrompt()], { enabled: true })),
+    ).not.toThrow()
+    expect(chirpCount()).toBe(0)
+  })
+})

--- a/packages/dashboard/src/hooks/useInterventionPing.test.ts
+++ b/packages/dashboard/src/hooks/useInterventionPing.test.ts
@@ -98,6 +98,14 @@ beforeEach(() => {
 afterEach(() => {
   __resetInterventionPingAudioContextForTests()
   vi.restoreAllMocks()
+  // Restore real timers in case a test enabled fake timers and threw before
+  // its own cleanup, and remove the global Web Audio mock so it can't leak
+  // into unrelated dashboard tests that expect jsdom's default (#4891 review).
+  vi.useRealTimers()
+  // @ts-expect-error — remove mock
+  delete globalThis.window.AudioContext
+  // @ts-expect-error — remove prefixed fallback if a test added it
+  delete globalThis.window.webkitAudioContext
 })
 
 describe('useInterventionPing', () => {

--- a/packages/dashboard/src/hooks/useInterventionPing.ts
+++ b/packages/dashboard/src/hooks/useInterventionPing.ts
@@ -123,11 +123,13 @@ function playChirp(): void {
     // interventions don't grow the audio graph / retain orphaned nodes (#4891
     // review). onended fires when the last oscillator reaches its stop time.
     const lastOsc = oscs[oscs.length - 1]
-    lastOsc.onended = () => {
-      for (const osc of oscs) {
-        try { osc.disconnect() } catch { /* already gone */ }
+    if (lastOsc) {
+      lastOsc.onended = () => {
+        for (const osc of oscs) {
+          try { osc.disconnect() } catch { /* already gone */ }
+        }
+        try { gain.disconnect() } catch { /* already gone */ }
       }
-      try { gain.disconnect() } catch { /* already gone */ }
     }
   } catch {
     // Audio unavailable — fail soft.

--- a/packages/dashboard/src/hooks/useInterventionPing.ts
+++ b/packages/dashboard/src/hooks/useInterventionPing.ts
@@ -106,18 +106,29 @@ function playChirp(): void {
     // Two ascending notes (A5 → E6) — recognizable "attention" interval
     // without being alarming.
     const freqs = [880, 1318.51]
-    freqs.forEach((freq, i) => {
+    const oscs = freqs.map((freq, i) => {
       const osc = ctx.createOscillator()
       osc.type = 'sine'
       osc.frequency.setValueAtTime(freq, now + i * noteSec)
       osc.connect(gain)
       osc.start(now + i * noteSec)
       osc.stop(now + (i + 1) * noteSec)
+      return osc
     })
     // Fade the shared gain out at the end of the second note so the next
     // chirp re-ramps from silence.
     gain.gain.setValueAtTime(0.15, now + freqs.length * noteSec - 0.02)
     gain.gain.exponentialRampToValueAtTime(0.0001, now + freqs.length * noteSec)
+    // Disconnect the per-chirp nodes once the final note finishes so repeated
+    // interventions don't grow the audio graph / retain orphaned nodes (#4891
+    // review). onended fires when the last oscillator reaches its stop time.
+    const lastOsc = oscs[oscs.length - 1]
+    lastOsc.onended = () => {
+      for (const osc of oscs) {
+        try { osc.disconnect() } catch { /* already gone */ }
+      }
+      try { gain.disconnect() } catch { /* already gone */ }
+    }
   } catch {
     // Audio unavailable — fail soft.
   }

--- a/packages/dashboard/src/hooks/useInterventionPing.ts
+++ b/packages/dashboard/src/hooks/useInterventionPing.ts
@@ -1,0 +1,179 @@
+/**
+ * useInterventionPing (#4891) — play a short audible ping in the dashboard
+ * when an intervention (permission request / question / blocked-on-input)
+ * arrives, so the operator gets pulled back in while heads-down on other
+ * work — even when the dashboard tab is minimized or sitting idle in the
+ * background.
+ *
+ * Companion to `usePermissionNotification` (which fires the OS notification
+ * when the window is unfocused). This hook owns the *audio* surface, which
+ * the OS notification path never carried — the dashboard previously relied
+ * purely on the OS default notification sound, which is silent on many
+ * desktop configurations and never fires at all when the page is focused
+ * but the operator's attention is elsewhere.
+ *
+ * Design notes:
+ *   - **No bundled asset.** The ping is synthesized with the Web Audio API
+ *     (a short two-note oscillator chirp). This keeps the bundle lean and
+ *     sidesteps `<audio>` autoplay restrictions in the messiest way
+ *     possible: Web Audio still requires a user gesture to *resume* a
+ *     suspended `AudioContext`, but we fail soft — if the context can't
+ *     start (autoplay blocked, no audio device, unsupported browser) the
+ *     hook silently no-ops rather than throwing. The OS notification +
+ *     in-app NotificationsWidget remain the durable signal.
+ *   - **Mute respect.** `enabled === false` short-circuits before any audio
+ *     work. The caller persists this in localStorage (see App.tsx) and
+ *     exposes a toggle in Settings → Dashboard.
+ *   - **Dedupe.** Each intervention is pinged at most once, keyed by
+ *     `requestId`. Stale ids (prompt answered/expired/removed) are pruned
+ *     so a re-request of the same id can ping again — mirrors
+ *     `usePermissionNotification`'s `notifiedRef` contract.
+ *   - **Throttle.** A single audio ping covers a *batch* of new
+ *     interventions arriving in the same tick (e.g. several sessions
+ *     blocking at once, or the same intervention echoed across reconnect).
+ *     A short cooldown (`THROTTLE_MS`) collapses rapid-fire arrivals into
+ *     one chirp so a broadcasting fleet of sessions can't trigger an alert
+ *     storm. New ids are still recorded as "pinged" during the cooldown so
+ *     they don't re-fire once it lifts.
+ */
+import { useEffect, useRef } from 'react'
+import type { PermissionPromptInfo } from './usePermissionNotification'
+
+/**
+ * Minimum gap between audible pings. Multiple interventions landing inside
+ * this window collapse into a single chirp. 3s is long enough to dedupe a
+ * burst (multi-session block, reconnect replay) without feeling like the
+ * alert was dropped for genuinely separate events.
+ */
+export const THROTTLE_MS = 3000
+
+/** Total chirp duration — two short notes. Kept brief + non-annoying. */
+const NOTE_MS = 120
+
+export interface UseInterventionPingOptions {
+  /** When false, the hook never plays audio (operator muted it). */
+  enabled: boolean
+}
+
+/**
+ * Lazily-created shared AudioContext. Created on first ping (inside the
+ * effect, i.e. after React commit, never during module eval) so we don't
+ * spin one up for users who keep the ping muted. Reused across pings so we
+ * don't leak a context per intervention.
+ */
+let sharedContext: AudioContext | null = null
+
+function getAudioContext(): AudioContext | null {
+  if (typeof window === 'undefined') return null
+  // Safari historically exposed only the prefixed constructor.
+  const Ctor =
+    window.AudioContext ||
+    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+  if (!Ctor) return null
+  if (sharedContext === null) {
+    try {
+      sharedContext = new Ctor()
+    } catch {
+      return null
+    }
+  }
+  return sharedContext
+}
+
+/**
+ * Synthesize and play a short two-note chirp. Fully defensive: any failure
+ * (suspended/blocked context, no audio device, GC'd nodes) is swallowed so
+ * a missing sound never breaks the intervention flow.
+ */
+function playChirp(): void {
+  const ctx = getAudioContext()
+  if (!ctx) return
+  try {
+    // Browsers suspend the context until a user gesture. Attempt to resume;
+    // if it stays suspended (autoplay policy) the scheduled notes simply
+    // never sound — no throw, no console spam.
+    if (ctx.state === 'suspended') {
+      void ctx.resume().catch(() => {})
+    }
+    const now = ctx.currentTime
+    const gain = ctx.createGain()
+    gain.connect(ctx.destination)
+    // Gentle envelope so the notes don't click on/off.
+    gain.gain.setValueAtTime(0.0001, now)
+    gain.gain.exponentialRampToValueAtTime(0.15, now + 0.01)
+
+    const noteSec = NOTE_MS / 1000
+    // Two ascending notes (A5 → E6) — recognizable "attention" interval
+    // without being alarming.
+    const freqs = [880, 1318.51]
+    freqs.forEach((freq, i) => {
+      const osc = ctx.createOscillator()
+      osc.type = 'sine'
+      osc.frequency.setValueAtTime(freq, now + i * noteSec)
+      osc.connect(gain)
+      osc.start(now + i * noteSec)
+      osc.stop(now + (i + 1) * noteSec)
+    })
+    // Fade the shared gain out at the end of the second note so the next
+    // chirp re-ramps from silence.
+    gain.gain.setValueAtTime(0.15, now + freqs.length * noteSec - 0.02)
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + freqs.length * noteSec)
+  } catch {
+    // Audio unavailable — fail soft.
+  }
+}
+
+export function useInterventionPing(
+  prompts: PermissionPromptInfo[],
+  options: UseInterventionPingOptions,
+): void {
+  const { enabled } = options
+  const pingedRef = useRef(new Set<string>())
+  const lastPingAtRef = useRef(0)
+
+  useEffect(() => {
+    // Always prune stale ids so a re-requested intervention can ping again,
+    // even while muted (keeps the dedupe set bounded + correct for the
+    // moment the operator unmutes mid-session).
+    const activeIds = new Set(prompts.map(p => p.requestId))
+    for (const id of pingedRef.current) {
+      if (!activeIds.has(id)) pingedRef.current.delete(id)
+    }
+
+    if (!enabled) return
+
+    const now = Date.now()
+    let hasNewIntervention = false
+
+    for (const prompt of prompts) {
+      // Skip answered / expired prompts — they no longer need the operator.
+      // `expiresAt` is wall-clock at receipt time (see
+      // usePermissionNotification for the clock-domain rationale).
+      if (prompt.answered) continue
+      if (prompt.expiresAt <= now) continue
+      // Dedupe: already pinged this intervention.
+      if (pingedRef.current.has(prompt.requestId)) continue
+
+      // Record every genuinely-new intervention so it never re-fires, even
+      // if the throttle cooldown swallows the audible chirp this tick.
+      pingedRef.current.add(prompt.requestId)
+      hasNewIntervention = true
+    }
+
+    if (!hasNewIntervention) return
+
+    // Throttle: collapse a burst of new interventions into a single chirp.
+    if (now - lastPingAtRef.current < THROTTLE_MS) return
+    lastPingAtRef.current = now
+    playChirp()
+  }, [prompts, enabled])
+}
+
+/**
+ * Test-only escape hatch to drop the shared AudioContext between cases so a
+ * mocked constructor from one test doesn't leak into the next. Not used in
+ * production code paths.
+ */
+export function __resetInterventionPingAudioContextForTests(): void {
+  sharedContext = null
+}

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -20,6 +20,9 @@ const KEY_SPLIT_MODE = `${KEY_PREFIX}split_mode`;
 const KEY_ACTIVE_SERVER = `${KEY_PREFIX}active_server_id`;
 const KEY_THEME = `${KEY_PREFIX}theme`;
 const KEY_SHOW_CONSOLE_TAB = `${KEY_PREFIX}show_console_tab`;
+// #4891 — audible intervention ping. Defaults on; persisted per-device so a
+// muted browser tab stays muted across reload + Tauri restart.
+const KEY_INTERVENTION_PING = `${KEY_PREFIX}intervention_ping`;
 // #4303 — pluggable sidebar panel slot persistence
 const KEY_SIDEBAR_PANEL_HEIGHT = `${KEY_PREFIX}sidebar_panel_height`;
 const KEY_SIDEBAR_PANEL_VIEW = `${KEY_PREFIX}sidebar_panel_view`;
@@ -448,6 +451,31 @@ export function loadPersistedShowConsoleTab(): boolean {
     return localStorage.getItem(KEY_SHOW_CONSOLE_TAB) === 'true';
   } catch {
     return false;
+  }
+}
+
+/** Persist the intervention audio-ping enable/mute preference (#4891) */
+export function persistInterventionPing(enabled: boolean): void {
+  try {
+    localStorage.setItem(KEY_INTERVENTION_PING, String(enabled));
+  } catch {
+    // Storage not available
+  }
+}
+
+/**
+ * Load the persisted intervention audio-ping preference (#4891).
+ *
+ * Defaults to ON (returns true) when unset so the audible alert ships
+ * enabled out of the box — the whole point of the feature is to pull the
+ * operator back in. Only an explicit `'false'` mutes it. Falls back to ON
+ * if storage is unavailable so the alert never silently disappears.
+ */
+export function loadPersistedInterventionPing(): boolean {
+  try {
+    return localStorage.getItem(KEY_INTERVENTION_PING) !== 'false';
+  } catch {
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary

Adds an in-app **audio ping** to the web/desktop dashboard when the agent needs an intervention (permission request / question / blocked-on-input), and documents how interventions reach every connected device.

The dashboard previously fired only an OS notification when the window was *unfocused* — silent on many desktop setups and never firing when the tab is focused-but-ignored. This closes the audio gap so the operator gets pulled back in even with the tab minimized or idle.

### What changed
- **`useInterventionPing` hook** — synthesizes a short two-note chirp via the Web Audio API (no bundled asset). Fails soft when audio is unavailable/autoplay-blocked so a missing sound never breaks the flow. Not gated on window focus, so minimized/idle background tabs still chirp.
- **Dedupe + throttle** — pings each intervention at most once (keyed by `requestId`); collapses a burst across multiple sessions / reconnect replay into a single chirp (no alert storm).
- **Per-device mute toggle** — Settings → Dashboard → "Play a sound when the agent needs input", persisted in localStorage. Defaults on.
- **Docs** — `docs/guides/intervention-alerts.md`: which surfaces ping, when, dedupe/throttle, prefs/quiet-hours respect, and how to disable each surface.

### Why no server change
Part 2 of the AC (alert all connected devices, incl. idle/minimized/backgrounded) is already satisfied by existing primitives: `_broadcastToSession` reaches every subscribed/active client regardless of UI focus, and push (`permission` category, rate-limit-bypassing) covers backgrounded/closed apps. Quiet-hours gating already lives in `notification-prefs.js`. Modifying that fan-out would be gold-plating.

## Tests
- `useInterventionPing.test.ts` — 10 cases: fires once, respects mute, dedupes by requestId, throttles bursts, skips answered/expired, re-pings re-requested ids after the cooldown, prunes stale ids while muted, fails soft with no Web Audio.
- `SettingsPanel.test.tsx` — toggle renders/reflects state/fires handler/absent when unwired.
- Full dashboard suite green (2966 tests), `tsc --noEmit` clean, server lints green.

## Acceptance criteria
- [x] Audible ping in the dashboard with a mute/enable control
- [x] Interventions alert all connected devices (push backgrounded/closed; audio + OS notification for minimized tabs) — server fan-out pre-existing, dashboard audio added here
- [x] Respects existing notification preferences (per-category mute / quiet hours via existing prefs; chirp honors per-device mute)
- [x] Dedupe/throttle so the same intervention / multiple sessions don't storm
- [x] Behavior documented (`docs/guides/intervention-alerts.md`)

Closes #4891