### PR TITLE
feat(protocol): add Control Room activity tree schemas (#5161)

### DIFF
--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -31,4 +31,5 @@ export declare const CLIENT_CAPABILITIES: {
 export declare const MIN_PROTOCOL_VERSION = 1;
 export * from './schemas/index.ts';
 export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
+export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, } from './schemas/server.ts';
 export * from './error-categories.ts';

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -284,6 +284,235 @@ export declare const ServerBackgroundWorkChangedSchema: z.ZodObject<{
         startedAt: z.ZodNumber;
     }, z.core.$strip>>;
 }, z.core.$strip>;
+/**
+ * Current schema version for the activity-tree wire contract. Carried on both
+ * `activity_snapshot` and `activity_delta` so consumers can branch on it if a
+ * future, additive field-set revision lands. Bump only for a deliberate shape
+ * change; additive optional fields do NOT require a bump (Zod strips unknowns,
+ * so older clients stay compatible).
+ */
+export declare const ACTIVITY_SCHEMA_VERSION = 1;
+/**
+ * Kind of activity entry. The session→agent→tool hierarchy is expressed via
+ * `parentId`, but `kind` lets a consumer pick an icon / renderer without
+ * walking the tree:
+ *   - `'agent'` — a Task subagent (the `Task` tool's spawned worker). Maps to
+ *     the existing `agent_spawned` / `agent_event` signal (#5016/#5060/#5061).
+ *   - `'shell'` — a backgrounded `Bash` shell (`run_in_background: true`). Maps
+ *     to the existing `pendingBackgroundShells` model (#4307).
+ *   - `'tool'` — any other long-running tool call surfaced as its own node.
+ *
+ * Declared as a named enum (not inlined) so #5162/#5163 can import it for
+ * exhaustive switch handling.
+ */
+export declare const ActivityKindSchema: z.ZodEnum<{
+    tool: "tool";
+    agent: "agent";
+    shell: "shell";
+}>;
+/**
+ * Lifecycle status of an activity entry:
+ *   - `'running'` — actively executing.
+ *   - `'blocked'` — alive but waiting on something (e.g. a pending permission
+ *     prompt or user input). Distinct from `running` so the Control Room can
+ *     flag "needs attention" without inferring it from elapsed time.
+ *   - `'done'`   — finished successfully.
+ *   - `'failed'` — finished with an error / non-zero exit.
+ *
+ * `done` and `failed` are terminal; `endedAt` MUST be set once an entry reaches
+ * either (enforced by `ActivityEntrySchema` below).
+ */
+export declare const ActivityStatusSchema: z.ZodEnum<{
+    running: "running";
+    blocked: "blocked";
+    done: "done";
+    failed: "failed";
+}>;
+/**
+ * Reference that lets a consumer locate the live output stream for an entry so
+ * the Control Room can drill into it. Optional because not every entry has a
+ * separately-addressable stream (a synthetic grouping node may not), and absent
+ * on older servers.
+ *
+ * Modelled as a `{ kind, id }` pair rather than a bare string so the consumer
+ * knows WHICH existing stream channel to subscribe against without parsing the
+ * id:
+ *   - `'tool_use'` — `id` is the tool_use id; output arrives as the existing
+ *     `agent_event` stream keyed by `parentToolUseId` (#5016).
+ *   - `'shell'` — `id` is the short shell token (e.g. `brk57kt6pm`); output is
+ *     fetched via the existing `BashOutput` / background-shell path (#4307).
+ *   - `'message'` — `id` is a `stream_start` messageId; output arrives as the
+ *     existing `stream_delta` stream for that message.
+ *
+ * A consumer that doesn't recognise a future `kind` (added additively in a
+ * later revision) should treat the entry as "no drill-in available" rather
+ * than erroring.
+ */
+export declare const ActivityOutputRefSchema: z.ZodObject<{
+    kind: z.ZodEnum<{
+        message: "message";
+        shell: "shell";
+        tool_use: "tool_use";
+    }>;
+    id: z.ZodString;
+}, z.core.$strip>;
+/**
+ * The shared activity-entry shape — one node in the activity tree.
+ *
+ * Fields:
+ *   - `id`        — stable, server-assigned id for this entry. Consumers key the
+ *                   tree off it; deltas reference it; it MUST survive status
+ *                   flips so an `updated` delta lands on the right node.
+ *   - `kind`      — see `ActivityKindSchema`.
+ *   - `label`     — human-readable description (e.g. the Task prompt summary,
+ *                   the Bash command text, or the tool name). May be empty for
+ *                   an entry whose label isn't known yet.
+ *   - `status`    — see `ActivityStatusSchema`.
+ *   - `startedAt` — server wall-clock (ms epoch) when the entry began. Server
+ *                   clock so the Control Room can render elapsed time without
+ *                   trusting the client clock (same rationale as #4307's
+ *                   `startedAt`). Allowed to be 0 so a clock-skewed dev box
+ *                   doesn't bounce the message.
+ *   - `endedAt?`  — server wall-clock (ms epoch) when the entry reached a
+ *                   terminal status. REQUIRED once `status` is `done`/`failed`
+ *                   and FORBIDDEN while `running`/`blocked` (refined below) so
+ *                   "ended but no end time" / "running but has end time" can't
+ *                   reach a consumer.
+ *   - `parentId?` — id of the parent entry, expressing the session→agent→tool
+ *                   hierarchy. Absent / undefined for a top-level entry (a child
+ *                   of the session root). A consumer MUST treat an unknown
+ *                   `parentId` (parent not in the tree) as a top-level entry
+ *                   rather than dropping the node.
+ *   - `outputRef?`— see `ActivityOutputRefSchema`.
+ *
+ * `startedAt` / `endedAt` follow the ms-typed-field discipline at the top of
+ * this file (integer, finite, non-negative) but are wall-clock epochs not
+ * durations, so they are NOT bounded by `MAX_SANE_DURATION_MS` — a 2026 epoch
+ * (~1.7e12) is far past that 24h ceiling.
+ */
+export declare const ActivityEntrySchema: z.ZodObject<{
+    id: z.ZodString;
+    kind: z.ZodEnum<{
+        tool: "tool";
+        agent: "agent";
+        shell: "shell";
+    }>;
+    label: z.ZodString;
+    status: z.ZodEnum<{
+        running: "running";
+        blocked: "blocked";
+        done: "done";
+        failed: "failed";
+    }>;
+    startedAt: z.ZodNumber;
+    endedAt: z.ZodOptional<z.ZodNumber>;
+    parentId: z.ZodOptional<z.ZodString>;
+    outputRef: z.ZodOptional<z.ZodObject<{
+        kind: z.ZodEnum<{
+            message: "message";
+            shell: "shell";
+            tool_use: "tool_use";
+        }>;
+        id: z.ZodString;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+/**
+ * #5161 — full current activity tree for a session. Emitted on subscribe /
+ * resync. The complete `entries` array is on the wire (a flat list; the tree is
+ * reconstructed from `parentId`) so a late-joining or reconnecting client
+ * reaches canonical state in one message without replaying deltas.
+ *
+ * `entries` is ordered server-side but consumers MUST NOT depend on the order
+ * for correctness (they reconstruct the tree from `id`/`parentId`). An empty
+ * array is the valid "session has no in-flight activity" state — never omitted.
+ */
+export declare const ServerActivitySnapshotSchema: z.ZodObject<{
+    type: z.ZodLiteral<"activity_snapshot">;
+    sessionId: z.ZodString;
+    schemaVersion: z.ZodNumber;
+    entries: z.ZodArray<z.ZodObject<{
+        id: z.ZodString;
+        kind: z.ZodEnum<{
+            tool: "tool";
+            agent: "agent";
+            shell: "shell";
+        }>;
+        label: z.ZodString;
+        status: z.ZodEnum<{
+            running: "running";
+            blocked: "blocked";
+            done: "done";
+            failed: "failed";
+        }>;
+        startedAt: z.ZodNumber;
+        endedAt: z.ZodOptional<z.ZodNumber>;
+        parentId: z.ZodOptional<z.ZodString>;
+        outputRef: z.ZodOptional<z.ZodObject<{
+            kind: z.ZodEnum<{
+                message: "message";
+                shell: "shell";
+                tool_use: "tool_use";
+            }>;
+            id: z.ZodString;
+        }, z.core.$strip>>;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
+/**
+ * #5161 — incremental change to a single activity entry. Emitted as work
+ * progresses so subscribed clients don't pay the full-snapshot cost on every
+ * status flip.
+ *
+ * `op` discriminates the change:
+ *   - `'started'` — a new entry appeared; `entry` is the full node.
+ *   - `'updated'` — an existing entry changed (status / label / endedAt / etc.);
+ *     `entry` is the full, current node (not a partial patch) so a consumer that
+ *     missed the `started` delta can still upsert by `entry.id`. Upsert-by-id is
+ *     the intended reducer behaviour — a `started` for an id already present, or
+ *     an `updated` for an id not yet present, both resolve to "replace the node".
+ *   - `'ended'`   — the entry reached a terminal status; `entry.status` is
+ *     `done`/`failed` and `entry.endedAt` is set (enforced by the entry schema
+ *     plus the refinement below).
+ *
+ * Carrying the full entry on every op (rather than a partial diff) keeps the
+ * reducer trivial and makes each delta self-healing against a dropped earlier
+ * delta — the deliberate tradeoff for a small, infrequently-changing tree.
+ */
+export declare const ServerActivityDeltaSchema: z.ZodObject<{
+    type: z.ZodLiteral<"activity_delta">;
+    sessionId: z.ZodString;
+    schemaVersion: z.ZodNumber;
+    op: z.ZodEnum<{
+        started: "started";
+        updated: "updated";
+        ended: "ended";
+    }>;
+    entry: z.ZodObject<{
+        id: z.ZodString;
+        kind: z.ZodEnum<{
+            tool: "tool";
+            agent: "agent";
+            shell: "shell";
+        }>;
+        label: z.ZodString;
+        status: z.ZodEnum<{
+            running: "running";
+            blocked: "blocked";
+            done: "done";
+            failed: "failed";
+        }>;
+        startedAt: z.ZodNumber;
+        endedAt: z.ZodOptional<z.ZodNumber>;
+        parentId: z.ZodOptional<z.ZodString>;
+        outputRef: z.ZodOptional<z.ZodObject<{
+            kind: z.ZodEnum<{
+                message: "message";
+                shell: "shell";
+                tool_use: "tool_use";
+            }>;
+            id: z.ZodString;
+        }, z.core.$strip>>;
+    }, z.core.$strip>;
+}, z.core.$strip>;
 export declare const ServerClientFocusChangedSchema: z.ZodObject<{
     type: z.ZodLiteral<"client_focus_changed">;
     clientId: z.ZodString;
@@ -748,8 +977,8 @@ export declare const ServerWebTaskCreatedSchema: z.ZodObject<{
         status: z.ZodEnum<{
             pending: "pending";
             running: "running";
-            completed: "completed";
             failed: "failed";
+            completed: "completed";
         }>;
         createdAt: z.ZodNumber;
         updatedAt: z.ZodNumber;
@@ -766,8 +995,8 @@ export declare const ServerWebTaskUpdatedSchema: z.ZodObject<{
         status: z.ZodEnum<{
             pending: "pending";
             running: "running";
-            completed: "completed";
             failed: "failed";
+            completed: "completed";
         }>;
         createdAt: z.ZodNumber;
         updatedAt: z.ZodNumber;
@@ -812,8 +1041,8 @@ export declare const ServerWebTaskListSchema: z.ZodObject<{
         status: z.ZodEnum<{
             pending: "pending";
             running: "running";
-            completed: "completed";
             failed: "failed";
+            completed: "completed";
         }>;
         createdAt: z.ZodNumber;
         updatedAt: z.ZodNumber;
@@ -891,3 +1120,9 @@ export type ServerSkillTrustGrantInvalidAuthorMessage = z.infer<typeof ServerSki
 export type ServerByokCredentialsStatusMessage = z.infer<typeof ServerByokCredentialsStatusSchema>;
 export type ServerCredentialsStatusMessage = z.infer<typeof ServerCredentialsStatusSchema>;
 export type ServerCredentialTestResultMessage = z.infer<typeof ServerCredentialTestResultSchema>;
+export type ActivityKind = z.infer<typeof ActivityKindSchema>;
+export type ActivityStatus = z.infer<typeof ActivityStatusSchema>;
+export type ActivityOutputRef = z.infer<typeof ActivityOutputRefSchema>;
+export type ActivityEntry = z.infer<typeof ActivityEntrySchema>;
+export type ServerActivitySnapshotMessage = z.infer<typeof ServerActivitySnapshotSchema>;
+export type ServerActivityDeltaMessage = z.infer<typeof ServerActivityDeltaSchema>;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -344,16 +344,26 @@ export declare const ActivityStatusSchema: z.ZodEnum<{
  *   - `'message'` — `id` is a `stream_start` messageId; output arrives as the
  *     existing `stream_delta` stream for that message.
  *
- * A consumer that doesn't recognise a future `kind` (added additively in a
- * later revision) should treat the entry as "no drill-in available" rather
- * than erroring.
+ * `kind` is an OPEN, non-empty string — deliberately NOT a closed `z.enum`. A
+ * future server may introduce a new channel kind additively, and a strict enum
+ * would reject the WHOLE activity message at an older client's schema boundary
+ * (the exact opposite of this contract's forward-compat intent). With an open
+ * string, an unrecognised kind parses cleanly and the consumer switches on the
+ * known values below, treating anything else as "no drill-in available". The
+ * three values defined today are:
+ *   - `'tool_use'` — `id` is the tool_use id; output arrives as the existing
+ *     `agent_event` stream keyed by `parentToolUseId` (#5016).
+ *   - `'shell'` — `id` is the short shell token (e.g. `brk57kt6pm`); output is
+ *     fetched via the existing `BashOutput` / background-shell path (#4307).
+ *   - `'message'` — `id` is a `stream_start` messageId; output arrives as the
+ *     existing `stream_delta` stream for that message.
+ *
+ * `ACTIVITY_OUTPUT_REF_KINDS` exports the known set so #5162/#5163 can branch
+ * exhaustively without re-declaring the literals.
  */
+export declare const ACTIVITY_OUTPUT_REF_KINDS: readonly ["tool_use", "shell", "message"];
 export declare const ActivityOutputRefSchema: z.ZodObject<{
-    kind: z.ZodEnum<{
-        message: "message";
-        shell: "shell";
-        tool_use: "tool_use";
-    }>;
+    kind: z.ZodString;
     id: z.ZodString;
 }, z.core.$strip>;
 /**
@@ -408,11 +418,7 @@ export declare const ActivityEntrySchema: z.ZodObject<{
     endedAt: z.ZodOptional<z.ZodNumber>;
     parentId: z.ZodOptional<z.ZodString>;
     outputRef: z.ZodOptional<z.ZodObject<{
-        kind: z.ZodEnum<{
-            message: "message";
-            shell: "shell";
-            tool_use: "tool_use";
-        }>;
+        kind: z.ZodString;
         id: z.ZodString;
     }, z.core.$strip>>;
 }, z.core.$strip>;
@@ -448,11 +454,7 @@ export declare const ServerActivitySnapshotSchema: z.ZodObject<{
         endedAt: z.ZodOptional<z.ZodNumber>;
         parentId: z.ZodOptional<z.ZodString>;
         outputRef: z.ZodOptional<z.ZodObject<{
-            kind: z.ZodEnum<{
-                message: "message";
-                shell: "shell";
-                tool_use: "tool_use";
-            }>;
+            kind: z.ZodString;
             id: z.ZodString;
         }, z.core.$strip>>;
     }, z.core.$strip>>;
@@ -504,11 +506,7 @@ export declare const ServerActivityDeltaSchema: z.ZodObject<{
         endedAt: z.ZodOptional<z.ZodNumber>;
         parentId: z.ZodOptional<z.ZodString>;
         outputRef: z.ZodOptional<z.ZodObject<{
-            kind: z.ZodEnum<{
-                message: "message";
-                shell: "shell";
-                tool_use: "tool_use";
-            }>;
+            kind: z.ZodString;
             id: z.ZodString;
         }, z.core.$strip>>;
     }, z.core.$strip>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -369,6 +369,216 @@ export const ServerBackgroundWorkChangedSchema = z.object({
     sessionId: z.string(),
     pending: z.array(ServerPendingBackgroundShellSchema),
 });
+// ───────────────────────────────────────────────────────────────────────────
+// Control Room activity tree (#5159 epic, #5161 protocol contract)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Wire contract for the per-session "activity tree": the live map of every
+// in-flight process inside a chroxy-managed session — Task subagents, Bash
+// `run_in_background` shells, and long-running tool calls — each with a status,
+// elapsed time, and a parent→child hierarchy (session → agent → tool).
+//
+// This file defines ONLY the schemas/types (issue #5161). The server emitter
+// (#5160), store-core reducer (#5162), and dashboard panel (#5163) consume
+// these. The shape is deliberately minimal-but-complete so all three
+// downstream consumers can build on it without a wire change.
+//
+// Two message types form the contract:
+//   - `activity_snapshot` — the full current tree for a session. Emitted on
+//     subscribe / resync so a late-joining client gets canonical state in one
+//     message (mirrors the `background_work_changed` full-snapshot philosophy:
+//     a client never has to reconcile deltas against a separate snapshot to be
+//     correct).
+//   - `activity_delta` — an incremental change to a single entry (started /
+//     updated / ended). Emitted as work progresses so an already-subscribed
+//     client doesn't pay the full-snapshot cost on every status flip.
+//
+// Forward/back compat: both messages carry a `schemaVersion` (currently 1) so a
+// future field-set change can be signalled without a wire-shape break, and all
+// schemas strip unknown fields (Zod default) so an older client parsing a newer
+// server's payload silently ignores fields it doesn't recognise. Older clients
+// that predate these message types ignore the unknown `type` entirely at the
+// dispatch layer.
+/**
+ * Current schema version for the activity-tree wire contract. Carried on both
+ * `activity_snapshot` and `activity_delta` so consumers can branch on it if a
+ * future, additive field-set revision lands. Bump only for a deliberate shape
+ * change; additive optional fields do NOT require a bump (Zod strips unknowns,
+ * so older clients stay compatible).
+ */
+export const ACTIVITY_SCHEMA_VERSION = 1;
+/**
+ * Kind of activity entry. The session→agent→tool hierarchy is expressed via
+ * `parentId`, but `kind` lets a consumer pick an icon / renderer without
+ * walking the tree:
+ *   - `'agent'` — a Task subagent (the `Task` tool's spawned worker). Maps to
+ *     the existing `agent_spawned` / `agent_event` signal (#5016/#5060/#5061).
+ *   - `'shell'` — a backgrounded `Bash` shell (`run_in_background: true`). Maps
+ *     to the existing `pendingBackgroundShells` model (#4307).
+ *   - `'tool'` — any other long-running tool call surfaced as its own node.
+ *
+ * Declared as a named enum (not inlined) so #5162/#5163 can import it for
+ * exhaustive switch handling.
+ */
+export const ActivityKindSchema = z.enum(['agent', 'shell', 'tool']);
+/**
+ * Lifecycle status of an activity entry:
+ *   - `'running'` — actively executing.
+ *   - `'blocked'` — alive but waiting on something (e.g. a pending permission
+ *     prompt or user input). Distinct from `running` so the Control Room can
+ *     flag "needs attention" without inferring it from elapsed time.
+ *   - `'done'`   — finished successfully.
+ *   - `'failed'` — finished with an error / non-zero exit.
+ *
+ * `done` and `failed` are terminal; `endedAt` MUST be set once an entry reaches
+ * either (enforced by `ActivityEntrySchema` below).
+ */
+export const ActivityStatusSchema = z.enum(['running', 'blocked', 'done', 'failed']);
+/**
+ * Reference that lets a consumer locate the live output stream for an entry so
+ * the Control Room can drill into it. Optional because not every entry has a
+ * separately-addressable stream (a synthetic grouping node may not), and absent
+ * on older servers.
+ *
+ * Modelled as a `{ kind, id }` pair rather than a bare string so the consumer
+ * knows WHICH existing stream channel to subscribe against without parsing the
+ * id:
+ *   - `'tool_use'` — `id` is the tool_use id; output arrives as the existing
+ *     `agent_event` stream keyed by `parentToolUseId` (#5016).
+ *   - `'shell'` — `id` is the short shell token (e.g. `brk57kt6pm`); output is
+ *     fetched via the existing `BashOutput` / background-shell path (#4307).
+ *   - `'message'` — `id` is a `stream_start` messageId; output arrives as the
+ *     existing `stream_delta` stream for that message.
+ *
+ * A consumer that doesn't recognise a future `kind` (added additively in a
+ * later revision) should treat the entry as "no drill-in available" rather
+ * than erroring.
+ */
+export const ActivityOutputRefSchema = z.object({
+    kind: z.enum(['tool_use', 'shell', 'message']),
+    id: z.string().min(1),
+});
+/**
+ * The shared activity-entry shape — one node in the activity tree.
+ *
+ * Fields:
+ *   - `id`        — stable, server-assigned id for this entry. Consumers key the
+ *                   tree off it; deltas reference it; it MUST survive status
+ *                   flips so an `updated` delta lands on the right node.
+ *   - `kind`      — see `ActivityKindSchema`.
+ *   - `label`     — human-readable description (e.g. the Task prompt summary,
+ *                   the Bash command text, or the tool name). May be empty for
+ *                   an entry whose label isn't known yet.
+ *   - `status`    — see `ActivityStatusSchema`.
+ *   - `startedAt` — server wall-clock (ms epoch) when the entry began. Server
+ *                   clock so the Control Room can render elapsed time without
+ *                   trusting the client clock (same rationale as #4307's
+ *                   `startedAt`). Allowed to be 0 so a clock-skewed dev box
+ *                   doesn't bounce the message.
+ *   - `endedAt?`  — server wall-clock (ms epoch) when the entry reached a
+ *                   terminal status. REQUIRED once `status` is `done`/`failed`
+ *                   and FORBIDDEN while `running`/`blocked` (refined below) so
+ *                   "ended but no end time" / "running but has end time" can't
+ *                   reach a consumer.
+ *   - `parentId?` — id of the parent entry, expressing the session→agent→tool
+ *                   hierarchy. Absent / undefined for a top-level entry (a child
+ *                   of the session root). A consumer MUST treat an unknown
+ *                   `parentId` (parent not in the tree) as a top-level entry
+ *                   rather than dropping the node.
+ *   - `outputRef?`— see `ActivityOutputRefSchema`.
+ *
+ * `startedAt` / `endedAt` follow the ms-typed-field discipline at the top of
+ * this file (integer, finite, non-negative) but are wall-clock epochs not
+ * durations, so they are NOT bounded by `MAX_SANE_DURATION_MS` — a 2026 epoch
+ * (~1.7e12) is far past that 24h ceiling.
+ */
+export const ActivityEntrySchema = z.object({
+    id: z.string().min(1),
+    kind: ActivityKindSchema,
+    label: z.string(),
+    status: ActivityStatusSchema,
+    startedAt: z.number().int().nonnegative().finite(),
+    endedAt: z.number().int().nonnegative().finite().optional(),
+    parentId: z.string().min(1).optional(),
+    outputRef: ActivityOutputRefSchema.optional(),
+}).superRefine((entry, ctx) => {
+    const terminal = entry.status === 'done' || entry.status === 'failed';
+    if (terminal && entry.endedAt === undefined) {
+        ctx.addIssue({
+            code: 'custom',
+            path: ['endedAt'],
+            message: 'endedAt is required when status is "done" or "failed"',
+        });
+    }
+    if (!terminal && entry.endedAt !== undefined) {
+        ctx.addIssue({
+            code: 'custom',
+            path: ['endedAt'],
+            message: 'endedAt must be absent while status is "running" or "blocked"',
+        });
+    }
+    if (entry.endedAt !== undefined && entry.endedAt < entry.startedAt) {
+        ctx.addIssue({
+            code: 'custom',
+            path: ['endedAt'],
+            message: 'endedAt must be >= startedAt',
+        });
+    }
+});
+/**
+ * #5161 — full current activity tree for a session. Emitted on subscribe /
+ * resync. The complete `entries` array is on the wire (a flat list; the tree is
+ * reconstructed from `parentId`) so a late-joining or reconnecting client
+ * reaches canonical state in one message without replaying deltas.
+ *
+ * `entries` is ordered server-side but consumers MUST NOT depend on the order
+ * for correctness (they reconstruct the tree from `id`/`parentId`). An empty
+ * array is the valid "session has no in-flight activity" state — never omitted.
+ */
+export const ServerActivitySnapshotSchema = z.object({
+    type: z.literal('activity_snapshot'),
+    sessionId: z.string(),
+    schemaVersion: z.number().int().positive(),
+    entries: z.array(ActivityEntrySchema),
+});
+/**
+ * #5161 — incremental change to a single activity entry. Emitted as work
+ * progresses so subscribed clients don't pay the full-snapshot cost on every
+ * status flip.
+ *
+ * `op` discriminates the change:
+ *   - `'started'` — a new entry appeared; `entry` is the full node.
+ *   - `'updated'` — an existing entry changed (status / label / endedAt / etc.);
+ *     `entry` is the full, current node (not a partial patch) so a consumer that
+ *     missed the `started` delta can still upsert by `entry.id`. Upsert-by-id is
+ *     the intended reducer behaviour — a `started` for an id already present, or
+ *     an `updated` for an id not yet present, both resolve to "replace the node".
+ *   - `'ended'`   — the entry reached a terminal status; `entry.status` is
+ *     `done`/`failed` and `entry.endedAt` is set (enforced by the entry schema
+ *     plus the refinement below).
+ *
+ * Carrying the full entry on every op (rather than a partial diff) keeps the
+ * reducer trivial and makes each delta self-healing against a dropped earlier
+ * delta — the deliberate tradeoff for a small, infrequently-changing tree.
+ */
+export const ServerActivityDeltaSchema = z.object({
+    type: z.literal('activity_delta'),
+    sessionId: z.string(),
+    schemaVersion: z.number().int().positive(),
+    op: z.enum(['started', 'updated', 'ended']),
+    entry: ActivityEntrySchema,
+}).superRefine((msg, ctx) => {
+    if (msg.op === 'ended') {
+        const terminal = msg.entry.status === 'done' || msg.entry.status === 'failed';
+        if (!terminal) {
+            ctx.addIssue({
+                code: 'custom',
+                path: ['entry', 'status'],
+                message: 'an "ended" delta must carry a terminal entry status ("done" or "failed")',
+            });
+        }
+    }
+});
 export const ServerClientFocusChangedSchema = z.object({
     type: z.literal('client_focus_changed'),
     clientId: z.string(),

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -450,12 +450,26 @@ export const ActivityStatusSchema = z.enum(['running', 'blocked', 'done', 'faile
  *   - `'message'` — `id` is a `stream_start` messageId; output arrives as the
  *     existing `stream_delta` stream for that message.
  *
- * A consumer that doesn't recognise a future `kind` (added additively in a
- * later revision) should treat the entry as "no drill-in available" rather
- * than erroring.
+ * `kind` is an OPEN, non-empty string — deliberately NOT a closed `z.enum`. A
+ * future server may introduce a new channel kind additively, and a strict enum
+ * would reject the WHOLE activity message at an older client's schema boundary
+ * (the exact opposite of this contract's forward-compat intent). With an open
+ * string, an unrecognised kind parses cleanly and the consumer switches on the
+ * known values below, treating anything else as "no drill-in available". The
+ * three values defined today are:
+ *   - `'tool_use'` — `id` is the tool_use id; output arrives as the existing
+ *     `agent_event` stream keyed by `parentToolUseId` (#5016).
+ *   - `'shell'` — `id` is the short shell token (e.g. `brk57kt6pm`); output is
+ *     fetched via the existing `BashOutput` / background-shell path (#4307).
+ *   - `'message'` — `id` is a `stream_start` messageId; output arrives as the
+ *     existing `stream_delta` stream for that message.
+ *
+ * `ACTIVITY_OUTPUT_REF_KINDS` exports the known set so #5162/#5163 can branch
+ * exhaustively without re-declaring the literals.
  */
+export const ACTIVITY_OUTPUT_REF_KINDS = ['tool_use', 'shell', 'message'];
 export const ActivityOutputRefSchema = z.object({
-    kind: z.enum(['tool_use', 'shell', 'message']),
+    kind: z.string().min(1),
     id: z.string().min(1),
 });
 /**

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -44,5 +44,19 @@ export * from './schemas/index.ts'
 // line for any future type alias whose existence is a public contract.
 export type { ServerErrorEnvelopeMessage } from './schemas/server.ts'
 
+// #5161: pin the Control Room activity-tree contract at the package entry point
+// so #5160/#5162/#5163 import `ActivityEntry` / `ServerActivitySnapshotMessage`
+// / `ServerActivityDeltaMessage` etc. as a stable public contract — the named
+// re-export makes `tsc --build` fail loudly if any alias is removed from
+// `./schemas/server.ts` (same rationale as the #4192 line above).
+export type {
+  ActivityKind,
+  ActivityStatus,
+  ActivityOutputRef,
+  ActivityEntry,
+  ServerActivitySnapshotMessage,
+  ServerActivityDeltaMessage,
+} from './schemas/server.ts'
+
 // Re-export client-side error-category detection (#3151)
 export * from './error-categories.ts'

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -486,12 +486,27 @@ export const ActivityStatusSchema = z.enum(['running', 'blocked', 'done', 'faile
  *   - `'message'` — `id` is a `stream_start` messageId; output arrives as the
  *     existing `stream_delta` stream for that message.
  *
- * A consumer that doesn't recognise a future `kind` (added additively in a
- * later revision) should treat the entry as "no drill-in available" rather
- * than erroring.
+ * `kind` is an OPEN, non-empty string — deliberately NOT a closed `z.enum`. A
+ * future server may introduce a new channel kind additively, and a strict enum
+ * would reject the WHOLE activity message at an older client's schema boundary
+ * (the exact opposite of this contract's forward-compat intent). With an open
+ * string, an unrecognised kind parses cleanly and the consumer switches on the
+ * known values below, treating anything else as "no drill-in available". The
+ * three values defined today are:
+ *   - `'tool_use'` — `id` is the tool_use id; output arrives as the existing
+ *     `agent_event` stream keyed by `parentToolUseId` (#5016).
+ *   - `'shell'` — `id` is the short shell token (e.g. `brk57kt6pm`); output is
+ *     fetched via the existing `BashOutput` / background-shell path (#4307).
+ *   - `'message'` — `id` is a `stream_start` messageId; output arrives as the
+ *     existing `stream_delta` stream for that message.
+ *
+ * `ACTIVITY_OUTPUT_REF_KINDS` exports the known set so #5162/#5163 can branch
+ * exhaustively without re-declaring the literals.
  */
+export const ACTIVITY_OUTPUT_REF_KINDS = ['tool_use', 'shell', 'message'] as const
+
 export const ActivityOutputRefSchema = z.object({
-  kind: z.enum(['tool_use', 'shell', 'message']),
+  kind: z.string().min(1),
   id: z.string().min(1),
 })
 

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -401,6 +401,224 @@ export const ServerBackgroundWorkChangedSchema = z.object({
   pending: z.array(ServerPendingBackgroundShellSchema),
 })
 
+// ───────────────────────────────────────────────────────────────────────────
+// Control Room activity tree (#5159 epic, #5161 protocol contract)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Wire contract for the per-session "activity tree": the live map of every
+// in-flight process inside a chroxy-managed session — Task subagents, Bash
+// `run_in_background` shells, and long-running tool calls — each with a status,
+// elapsed time, and a parent→child hierarchy (session → agent → tool).
+//
+// This file defines ONLY the schemas/types (issue #5161). The server emitter
+// (#5160), store-core reducer (#5162), and dashboard panel (#5163) consume
+// these. The shape is deliberately minimal-but-complete so all three
+// downstream consumers can build on it without a wire change.
+//
+// Two message types form the contract:
+//   - `activity_snapshot` — the full current tree for a session. Emitted on
+//     subscribe / resync so a late-joining client gets canonical state in one
+//     message (mirrors the `background_work_changed` full-snapshot philosophy:
+//     a client never has to reconcile deltas against a separate snapshot to be
+//     correct).
+//   - `activity_delta` — an incremental change to a single entry (started /
+//     updated / ended). Emitted as work progresses so an already-subscribed
+//     client doesn't pay the full-snapshot cost on every status flip.
+//
+// Forward/back compat: both messages carry a `schemaVersion` (currently 1) so a
+// future field-set change can be signalled without a wire-shape break, and all
+// schemas strip unknown fields (Zod default) so an older client parsing a newer
+// server's payload silently ignores fields it doesn't recognise. Older clients
+// that predate these message types ignore the unknown `type` entirely at the
+// dispatch layer.
+
+/**
+ * Current schema version for the activity-tree wire contract. Carried on both
+ * `activity_snapshot` and `activity_delta` so consumers can branch on it if a
+ * future, additive field-set revision lands. Bump only for a deliberate shape
+ * change; additive optional fields do NOT require a bump (Zod strips unknowns,
+ * so older clients stay compatible).
+ */
+export const ACTIVITY_SCHEMA_VERSION = 1
+
+/**
+ * Kind of activity entry. The session→agent→tool hierarchy is expressed via
+ * `parentId`, but `kind` lets a consumer pick an icon / renderer without
+ * walking the tree:
+ *   - `'agent'` — a Task subagent (the `Task` tool's spawned worker). Maps to
+ *     the existing `agent_spawned` / `agent_event` signal (#5016/#5060/#5061).
+ *   - `'shell'` — a backgrounded `Bash` shell (`run_in_background: true`). Maps
+ *     to the existing `pendingBackgroundShells` model (#4307).
+ *   - `'tool'` — any other long-running tool call surfaced as its own node.
+ *
+ * Declared as a named enum (not inlined) so #5162/#5163 can import it for
+ * exhaustive switch handling.
+ */
+export const ActivityKindSchema = z.enum(['agent', 'shell', 'tool'])
+
+/**
+ * Lifecycle status of an activity entry:
+ *   - `'running'` — actively executing.
+ *   - `'blocked'` — alive but waiting on something (e.g. a pending permission
+ *     prompt or user input). Distinct from `running` so the Control Room can
+ *     flag "needs attention" without inferring it from elapsed time.
+ *   - `'done'`   — finished successfully.
+ *   - `'failed'` — finished with an error / non-zero exit.
+ *
+ * `done` and `failed` are terminal; `endedAt` MUST be set once an entry reaches
+ * either (enforced by `ActivityEntrySchema` below).
+ */
+export const ActivityStatusSchema = z.enum(['running', 'blocked', 'done', 'failed'])
+
+/**
+ * Reference that lets a consumer locate the live output stream for an entry so
+ * the Control Room can drill into it. Optional because not every entry has a
+ * separately-addressable stream (a synthetic grouping node may not), and absent
+ * on older servers.
+ *
+ * Modelled as a `{ kind, id }` pair rather than a bare string so the consumer
+ * knows WHICH existing stream channel to subscribe against without parsing the
+ * id:
+ *   - `'tool_use'` — `id` is the tool_use id; output arrives as the existing
+ *     `agent_event` stream keyed by `parentToolUseId` (#5016).
+ *   - `'shell'` — `id` is the short shell token (e.g. `brk57kt6pm`); output is
+ *     fetched via the existing `BashOutput` / background-shell path (#4307).
+ *   - `'message'` — `id` is a `stream_start` messageId; output arrives as the
+ *     existing `stream_delta` stream for that message.
+ *
+ * A consumer that doesn't recognise a future `kind` (added additively in a
+ * later revision) should treat the entry as "no drill-in available" rather
+ * than erroring.
+ */
+export const ActivityOutputRefSchema = z.object({
+  kind: z.enum(['tool_use', 'shell', 'message']),
+  id: z.string().min(1),
+})
+
+/**
+ * The shared activity-entry shape — one node in the activity tree.
+ *
+ * Fields:
+ *   - `id`        — stable, server-assigned id for this entry. Consumers key the
+ *                   tree off it; deltas reference it; it MUST survive status
+ *                   flips so an `updated` delta lands on the right node.
+ *   - `kind`      — see `ActivityKindSchema`.
+ *   - `label`     — human-readable description (e.g. the Task prompt summary,
+ *                   the Bash command text, or the tool name). May be empty for
+ *                   an entry whose label isn't known yet.
+ *   - `status`    — see `ActivityStatusSchema`.
+ *   - `startedAt` — server wall-clock (ms epoch) when the entry began. Server
+ *                   clock so the Control Room can render elapsed time without
+ *                   trusting the client clock (same rationale as #4307's
+ *                   `startedAt`). Allowed to be 0 so a clock-skewed dev box
+ *                   doesn't bounce the message.
+ *   - `endedAt?`  — server wall-clock (ms epoch) when the entry reached a
+ *                   terminal status. REQUIRED once `status` is `done`/`failed`
+ *                   and FORBIDDEN while `running`/`blocked` (refined below) so
+ *                   "ended but no end time" / "running but has end time" can't
+ *                   reach a consumer.
+ *   - `parentId?` — id of the parent entry, expressing the session→agent→tool
+ *                   hierarchy. Absent / undefined for a top-level entry (a child
+ *                   of the session root). A consumer MUST treat an unknown
+ *                   `parentId` (parent not in the tree) as a top-level entry
+ *                   rather than dropping the node.
+ *   - `outputRef?`— see `ActivityOutputRefSchema`.
+ *
+ * `startedAt` / `endedAt` follow the ms-typed-field discipline at the top of
+ * this file (integer, finite, non-negative) but are wall-clock epochs not
+ * durations, so they are NOT bounded by `MAX_SANE_DURATION_MS` — a 2026 epoch
+ * (~1.7e12) is far past that 24h ceiling.
+ */
+export const ActivityEntrySchema = z.object({
+  id: z.string().min(1),
+  kind: ActivityKindSchema,
+  label: z.string(),
+  status: ActivityStatusSchema,
+  startedAt: z.number().int().nonnegative().finite(),
+  endedAt: z.number().int().nonnegative().finite().optional(),
+  parentId: z.string().min(1).optional(),
+  outputRef: ActivityOutputRefSchema.optional(),
+}).superRefine((entry, ctx) => {
+  const terminal = entry.status === 'done' || entry.status === 'failed'
+  if (terminal && entry.endedAt === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['endedAt'],
+      message: 'endedAt is required when status is "done" or "failed"',
+    })
+  }
+  if (!terminal && entry.endedAt !== undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['endedAt'],
+      message: 'endedAt must be absent while status is "running" or "blocked"',
+    })
+  }
+  if (entry.endedAt !== undefined && entry.endedAt < entry.startedAt) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['endedAt'],
+      message: 'endedAt must be >= startedAt',
+    })
+  }
+})
+
+/**
+ * #5161 — full current activity tree for a session. Emitted on subscribe /
+ * resync. The complete `entries` array is on the wire (a flat list; the tree is
+ * reconstructed from `parentId`) so a late-joining or reconnecting client
+ * reaches canonical state in one message without replaying deltas.
+ *
+ * `entries` is ordered server-side but consumers MUST NOT depend on the order
+ * for correctness (they reconstruct the tree from `id`/`parentId`). An empty
+ * array is the valid "session has no in-flight activity" state — never omitted.
+ */
+export const ServerActivitySnapshotSchema = z.object({
+  type: z.literal('activity_snapshot'),
+  sessionId: z.string(),
+  schemaVersion: z.number().int().positive(),
+  entries: z.array(ActivityEntrySchema),
+})
+
+/**
+ * #5161 — incremental change to a single activity entry. Emitted as work
+ * progresses so subscribed clients don't pay the full-snapshot cost on every
+ * status flip.
+ *
+ * `op` discriminates the change:
+ *   - `'started'` — a new entry appeared; `entry` is the full node.
+ *   - `'updated'` — an existing entry changed (status / label / endedAt / etc.);
+ *     `entry` is the full, current node (not a partial patch) so a consumer that
+ *     missed the `started` delta can still upsert by `entry.id`. Upsert-by-id is
+ *     the intended reducer behaviour — a `started` for an id already present, or
+ *     an `updated` for an id not yet present, both resolve to "replace the node".
+ *   - `'ended'`   — the entry reached a terminal status; `entry.status` is
+ *     `done`/`failed` and `entry.endedAt` is set (enforced by the entry schema
+ *     plus the refinement below).
+ *
+ * Carrying the full entry on every op (rather than a partial diff) keeps the
+ * reducer trivial and makes each delta self-healing against a dropped earlier
+ * delta — the deliberate tradeoff for a small, infrequently-changing tree.
+ */
+export const ServerActivityDeltaSchema = z.object({
+  type: z.literal('activity_delta'),
+  sessionId: z.string(),
+  schemaVersion: z.number().int().positive(),
+  op: z.enum(['started', 'updated', 'ended']),
+  entry: ActivityEntrySchema,
+}).superRefine((msg, ctx) => {
+  if (msg.op === 'ended') {
+    const terminal = msg.entry.status === 'done' || msg.entry.status === 'failed'
+    if (!terminal) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['entry', 'status'],
+        message: 'an "ended" delta must carry a terminal entry status ("done" or "failed")',
+      })
+    }
+  }
+})
+
 export const ServerClientFocusChangedSchema = z.object({
   type: z.literal('client_focus_changed'),
   clientId: z.string(),
@@ -1238,3 +1456,11 @@ export type ServerByokCredentialsStatusMessage = z.infer<typeof ServerByokCreden
 // #3855: generalized provider-credential status + test-result payloads.
 export type ServerCredentialsStatusMessage = z.infer<typeof ServerCredentialsStatusSchema>
 export type ServerCredentialTestResultMessage = z.infer<typeof ServerCredentialTestResultSchema>
+// #5161: Control Room activity-tree wire contract. Consumed by the server
+// emitter (#5160), store-core reducer (#5162), and dashboard panel (#5163).
+export type ActivityKind = z.infer<typeof ActivityKindSchema>
+export type ActivityStatus = z.infer<typeof ActivityStatusSchema>
+export type ActivityOutputRef = z.infer<typeof ActivityOutputRefSchema>
+export type ActivityEntry = z.infer<typeof ActivityEntrySchema>
+export type ServerActivitySnapshotMessage = z.infer<typeof ServerActivitySnapshotSchema>
+export type ServerActivityDeltaMessage = z.infer<typeof ServerActivityDeltaSchema>

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -46,6 +46,8 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
+  'activity_snapshot', // #5161 schema-only — Control Room activity tree wire contract. No handler yet: the server emitter is #5160, the store-core reducer is #5162, and the dashboard panel that consumes it is #5163. Becomes dashboard-handled (move to PLATFORM_SPECIFIC) when #5163 lands; mobile parity is a Phase-2 fast-follow per epic #5159.
+  'activity_delta',    // #5161 schema-only — see activity_snapshot above. Handler lands with the dashboard Control Room panel (#5163).
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
   // 'session_usage' is now handled by both dashboard (#4073) and mobile

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -1770,4 +1770,249 @@ describe('@chroxy/protocol schemas', () => {
       assert.ok(!result.success)
     })
   })
+
+  describe('Control Room activity tree (#5161)', () => {
+    const runningEntry = {
+      id: 'act-1',
+      kind: 'agent',
+      label: 'Refactor auth module',
+      status: 'running',
+      startedAt: 1_700_000_000_000,
+    }
+
+    const terminalEntry = {
+      id: 'act-2',
+      kind: 'shell',
+      label: 'npm test',
+      status: 'done',
+      startedAt: 1_700_000_000_000,
+      endedAt: 1_700_000_005_000,
+      parentId: 'act-1',
+      outputRef: { kind: 'shell', id: 'brk57kt6pm' },
+    }
+
+    describe('ActivityEntrySchema', () => {
+      it('validates a well-formed running entry (no endedAt)', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse(runningEntry)
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.kind, 'agent')
+        assert.equal(result.data.endedAt, undefined)
+      })
+
+      it('validates a terminal entry with endedAt, parentId, outputRef', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse(terminalEntry)
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.parentId, 'act-1')
+        assert.equal(result.data.outputRef.kind, 'shell')
+      })
+
+      it('accepts all three kinds', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        for (const kind of ['agent', 'shell', 'tool']) {
+          const result = ActivityEntrySchema.safeParse({ ...runningEntry, kind })
+          assert.ok(result.success, `kind ${kind} should validate`)
+        }
+      })
+
+      it('rejects an unknown kind', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse({ ...runningEntry, kind: 'process' })
+        assert.ok(!result.success, 'unknown kind must reject')
+      })
+
+      it('accepts all four statuses (with endedAt where terminal)', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        assert.ok(ActivityEntrySchema.safeParse({ ...runningEntry, status: 'running' }).success)
+        assert.ok(ActivityEntrySchema.safeParse({ ...runningEntry, status: 'blocked' }).success)
+        assert.ok(ActivityEntrySchema.safeParse({ ...runningEntry, status: 'done', endedAt: 1_700_000_001_000 }).success)
+        assert.ok(ActivityEntrySchema.safeParse({ ...runningEntry, status: 'failed', endedAt: 1_700_000_001_000 }).success)
+      })
+
+      it('rejects a done/failed entry without endedAt', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        assert.ok(!ActivityEntrySchema.safeParse({ ...runningEntry, status: 'done' }).success, 'done requires endedAt')
+        assert.ok(!ActivityEntrySchema.safeParse({ ...runningEntry, status: 'failed' }).success, 'failed requires endedAt')
+      })
+
+      it('rejects a running/blocked entry that carries endedAt', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const running = ActivityEntrySchema.safeParse({ ...runningEntry, status: 'running', endedAt: 1_700_000_001_000 })
+        const blocked = ActivityEntrySchema.safeParse({ ...runningEntry, status: 'blocked', endedAt: 1_700_000_001_000 })
+        assert.ok(!running.success, 'running must not carry endedAt')
+        assert.ok(!blocked.success, 'blocked must not carry endedAt')
+      })
+
+      it('rejects endedAt earlier than startedAt', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse({
+          ...runningEntry,
+          status: 'done',
+          startedAt: 1_700_000_005_000,
+          endedAt: 1_700_000_000_000,
+        })
+        assert.ok(!result.success, 'endedAt must be >= startedAt')
+      })
+
+      it('allows startedAt of 0 (clock-skew tolerance)', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse({ ...runningEntry, startedAt: 0 })
+        assert.ok(result.success, 'startedAt=0 must validate')
+      })
+
+      it('allows an empty label', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse({ ...runningEntry, label: '' })
+        assert.ok(result.success, 'empty label must validate (label not known yet)')
+      })
+
+      it('rejects an empty id', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse({ ...runningEntry, id: '' })
+        assert.ok(!result.success, 'id must be non-empty')
+      })
+
+      it('rejects a non-integer startedAt', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse({ ...runningEntry, startedAt: 1.5 })
+        assert.ok(!result.success, 'startedAt must be an integer ms epoch')
+      })
+
+      it('rejects an unknown outputRef kind', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse({
+          ...runningEntry,
+          outputRef: { kind: 'pty', id: 'x' },
+        })
+        assert.ok(!result.success, 'unknown outputRef kind must reject')
+      })
+
+      it('strips unknown fields for forward compat', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse({ ...runningEntry, futureField: { x: 1 } })
+        assert.ok(result.success, 'unknown fields must not reject (newer server, older client)')
+        assert.equal(result.data.futureField, undefined, 'Zod strips unknown fields')
+      })
+    })
+
+    describe('ServerActivitySnapshotSchema', () => {
+      it('validates a snapshot with entries', async () => {
+        const { ServerActivitySnapshotSchema, ACTIVITY_SCHEMA_VERSION } = await import('../src/schemas/server.ts')
+        const result = ServerActivitySnapshotSchema.safeParse({
+          type: 'activity_snapshot',
+          sessionId: 'sess-1',
+          schemaVersion: ACTIVITY_SCHEMA_VERSION,
+          entries: [runningEntry, terminalEntry],
+        })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.entries.length, 2)
+      })
+
+      it('validates an empty-tree snapshot', async () => {
+        const { ServerActivitySnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivitySnapshotSchema.safeParse({
+          type: 'activity_snapshot',
+          sessionId: 'sess-1',
+          schemaVersion: 1,
+          entries: [],
+        })
+        assert.ok(result.success, 'empty entries is the valid no-activity state')
+      })
+
+      it('rejects a wrong type literal', async () => {
+        const { ServerActivitySnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivitySnapshotSchema.safeParse({
+          type: 'activity', sessionId: 'sess-1', schemaVersion: 1, entries: [],
+        })
+        assert.ok(!result.success)
+      })
+
+      it('rejects a missing entries array', async () => {
+        const { ServerActivitySnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivitySnapshotSchema.safeParse({
+          type: 'activity_snapshot', sessionId: 'sess-1', schemaVersion: 1,
+        })
+        assert.ok(!result.success, 'entries must never be omitted')
+      })
+
+      it('rejects a non-positive schemaVersion', async () => {
+        const { ServerActivitySnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivitySnapshotSchema.safeParse({
+          type: 'activity_snapshot', sessionId: 'sess-1', schemaVersion: 0, entries: [],
+        })
+        assert.ok(!result.success, 'schemaVersion must be a positive int')
+      })
+
+      it('propagates entry-level refinements (terminal without endedAt)', async () => {
+        const { ServerActivitySnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivitySnapshotSchema.safeParse({
+          type: 'activity_snapshot',
+          sessionId: 'sess-1',
+          schemaVersion: 1,
+          entries: [{ ...runningEntry, status: 'done' }],
+        })
+        assert.ok(!result.success, 'invalid entry inside the array must reject the whole snapshot')
+      })
+    })
+
+    describe('ServerActivityDeltaSchema', () => {
+      it('validates a started delta', async () => {
+        const { ServerActivityDeltaSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivityDeltaSchema.safeParse({
+          type: 'activity_delta', sessionId: 'sess-1', schemaVersion: 1, op: 'started', entry: runningEntry,
+        })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.op, 'started')
+      })
+
+      it('validates an updated delta', async () => {
+        const { ServerActivityDeltaSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivityDeltaSchema.safeParse({
+          type: 'activity_delta', sessionId: 'sess-1', schemaVersion: 1, op: 'updated',
+          entry: { ...runningEntry, status: 'blocked' },
+        })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+      })
+
+      it('validates an ended delta carrying a terminal entry', async () => {
+        const { ServerActivityDeltaSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivityDeltaSchema.safeParse({
+          type: 'activity_delta', sessionId: 'sess-1', schemaVersion: 1, op: 'ended', entry: terminalEntry,
+        })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+      })
+
+      it('rejects an ended delta whose entry is non-terminal', async () => {
+        const { ServerActivityDeltaSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivityDeltaSchema.safeParse({
+          type: 'activity_delta', sessionId: 'sess-1', schemaVersion: 1, op: 'ended', entry: runningEntry,
+        })
+        assert.ok(!result.success, 'an ended op requires a done/failed entry')
+      })
+
+      it('rejects an unknown op', async () => {
+        const { ServerActivityDeltaSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivityDeltaSchema.safeParse({
+          type: 'activity_delta', sessionId: 'sess-1', schemaVersion: 1, op: 'removed', entry: runningEntry,
+        })
+        assert.ok(!result.success, 'op must be started/updated/ended')
+      })
+
+      it('strips unknown top-level fields for forward compat', async () => {
+        const { ServerActivityDeltaSchema } = await import('../src/schemas/server.ts')
+        const result = ServerActivityDeltaSchema.safeParse({
+          type: 'activity_delta', sessionId: 'sess-1', schemaVersion: 1, op: 'started',
+          entry: runningEntry, futureField: 'x',
+        })
+        assert.ok(result.success)
+        assert.equal(result.data.futureField, undefined)
+      })
+    })
+
+    it('ACTIVITY_SCHEMA_VERSION is 1', async () => {
+      const { ACTIVITY_SCHEMA_VERSION } = await import('../src/schemas/server.ts')
+      assert.equal(ACTIVITY_SCHEMA_VERSION, 1)
+    })
+  })
 })

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -1879,13 +1879,36 @@ describe('@chroxy/protocol schemas', () => {
         assert.ok(!result.success, 'startedAt must be an integer ms epoch')
       })
 
-      it('rejects an unknown outputRef kind', async () => {
+      it('accepts a future/unknown outputRef kind (open string for forward compat)', async () => {
+        // #5161 (Copilot review): outputRef.kind is an OPEN non-empty string,
+        // not a closed enum — a newer server introducing a new channel kind
+        // must NOT reject the whole message at an older client. The consumer
+        // switches on the known kinds and degrades to "no drill-in" otherwise.
         const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
         const result = ActivityEntrySchema.safeParse({
           ...runningEntry,
           outputRef: { kind: 'pty', id: 'x' },
         })
-        assert.ok(!result.success, 'unknown outputRef kind must reject')
+        assert.ok(result.success, 'unknown outputRef kind must parse (degrade gracefully, not reject)')
+        assert.equal(result.data.outputRef.kind, 'pty')
+      })
+
+      it('accepts all three known outputRef kinds', async () => {
+        const { ActivityEntrySchema, ACTIVITY_OUTPUT_REF_KINDS } = await import('../src/schemas/server.ts')
+        assert.deepEqual([...ACTIVITY_OUTPUT_REF_KINDS], ['tool_use', 'shell', 'message'])
+        for (const kind of ACTIVITY_OUTPUT_REF_KINDS) {
+          const result = ActivityEntrySchema.safeParse({ ...runningEntry, outputRef: { kind, id: 'x' } })
+          assert.ok(result.success, `known outputRef kind ${kind} should validate`)
+        }
+      })
+
+      it('rejects an empty outputRef id', async () => {
+        const { ActivityEntrySchema } = await import('../src/schemas/server.ts')
+        const result = ActivityEntrySchema.safeParse({
+          ...runningEntry,
+          outputRef: { kind: 'shell', id: '' },
+        })
+        assert.ok(!result.success, 'outputRef.id must be non-empty')
       })
 
       it('strips unknown fields for forward compat', async () => {

--- a/packages/server/src/ws-server.js
+++ b/packages/server/src/ws-server.js
@@ -389,6 +389,8 @@ function _isSecureRequest(req) {
  *   { type: 'agent_completed', sessionId, agentId, parentToolId }       — background agent completed
  *   { type: 'agent_event', sessionId, parentToolUseId, eventType, payload } — Task subagent intermediate wire event re-emit (#5016, transient; eventType is one of `tool_start` / `tool_input_delta` / `tool_result` / `stream_delta`)
  *   { type: 'background_work_changed', sessionId, pending } — pending background shells snapshot changed (#4307, transient; `pending: [{ shellId, command, startedAt }, …]`)
+ *   { type: 'activity_snapshot', sessionId, schemaVersion, entries } — Control Room full activity tree for a session, on subscribe/resync (#5161 schema; emitter #5160; `entries: [{ id, kind, label, status, startedAt, endedAt?, parentId?, outputRef? }, …]`)
+ *   { type: 'activity_delta', sessionId, schemaVersion, op, entry } — Control Room incremental activity-entry change (#5161 schema; emitter #5160; `op` is one of `started` / `updated` / `ended`; `entry` is the full node)
  *   { type: 'provider_list', providers }                — available providers
  *   { type: 'byok_credentials_status', requestId?, status, source, masked?, reason? } — BYOK credentials state for the dashboard (#4052)
  *   { type: 'credentials_status', requestId?, credentials: [{ key, provider, label, kind, status, source, masked?, oauth }], fileExists?, fileError? } — generalized provider-credential status for the dashboard (#3855); masked, value-free; sent to requester + broadcast after set/delete


### PR DESCRIPTION
## Summary

Defines the **wire contract** for the Control Room activity tree in `@chroxy/protocol` — the foundation the server emitter (#5160), store-core reducer (#5162), and dashboard panel (#5163) all build on. Schema-only; no emitter / reducer / UI here.

### Activity entry shape
One node in the per-session activity tree:
- `id` — stable server-assigned id (deltas reference it; survives status flips)
- `kind` — `'agent'` (Task subagent) | `'shell'` (backgrounded Bash) | `'tool'`
- `label` — human-readable description (may be empty when not yet known)
- `status` — `'running'` | `'blocked'` | `'done'` | `'failed'`
- `startedAt` — server wall-clock ms epoch (server clock, not client)
- `endedAt?` — set iff terminal (`done`/`failed`)
- `parentId?` — session→agent→tool hierarchy; absent = top-level
- `outputRef?` — `{ kind: 'tool_use' | 'shell' | 'message', id }` to locate the live output stream (reuses existing `agent_event` / background-shell / `stream_delta` channels)

### Messages
- **`activity_snapshot`** — full current tree for a session (subscribe/resync). Flat `entries` array; empty array is the valid no-activity state. Mirrors the `background_work_changed` full-snapshot philosophy so a late joiner is canonical in one message.
- **`activity_delta`** — incremental `started` / `updated` / `ended` change. Carries the **full entry** per op (not a partial patch) so the reducer is trivial and each delta self-heals against a dropped earlier one.

### Safety / compat
- `superRefine` guards: `endedAt` required iff terminal, forbidden while running/blocked, `endedAt >= startedAt`; an `ended` delta must carry a terminal entry.
- `schemaVersion` (`ACTIVITY_SCHEMA_VERSION = 1`) on both messages + Zod's default unknown-field stripping, so older clients ignore newer payloads gracefully and unknown message types are skipped at the dispatch layer.
- Exported Zod schemas + inferred TS types, pinned as a public contract at the package entry point.

### Tests / coverage
- Added a `Control Room activity tree (#5161)` block to `schemas.test.js` (entry refinements, all kinds/statuses, snapshot/delta happy + reject paths, forward-compat field stripping).
- Documented both messages in the `ws-server.js` Server→Client contract and added them to `INTENTIONALLY_UNHANDLED` in `handler-coverage.test.js` (handlers land with #5162/#5163).
- `tsc` clean; `packages/protocol` tests green (183 pass).

Closes #5161
Part of #5159