### PR TITLE
feat(server): unified per-session activity registry (Control Room)

### DIFF
--- a/packages/server/src/activity-registry.js
+++ b/packages/server/src/activity-registry.js
@@ -1,0 +1,457 @@
+/**
+ * #5160 — per-session activity registry (Control Room phase 1).
+ *
+ * A thin UNIFYING layer over the in-flight signals BaseSession already
+ * emits. It does NOT track anything the session doesn't already know — it
+ * maps the existing lifecycle events into the `ActivityEntry` wire shape
+ * (#5161, `@chroxy/protocol`) and emits two events the WS layer forwards
+ * verbatim:
+ *
+ *   - `activity_snapshot { sessionId, schemaVersion, entries }` — the full
+ *     current tree. Served to a fresh subscriber (snapshot-on-subscribe via
+ *     `getSnapshotMessage()`) and on resync, mirroring the
+ *     `background_work_changed` full-snapshot philosophy so a late joiner
+ *     never reconciles deltas against a separate snapshot.
+ *   - `activity_delta { sessionId, schemaVersion, op, entry }` — one
+ *     upsert/end per change. `op` is `started` / `updated` / `ended`; the
+ *     FULL entry rides every op so the downstream reducer (#5162) is a pure
+ *     upsert-by-id and self-heals a dropped delta.
+ *
+ * The signals it unifies (all already emitted by BaseSession / providers):
+ *   - `tool_start` / `tool_result`     → long-running tool calls (#4628)
+ *   - `agent_spawned` / `agent_completed` → Task subagents (#5016/#5060)
+ *   - `background_work_changed`        → backgrounded Bash shells (#4307)
+ *   - `permission_request` / `user_question` / `permission_resolved`
+ *                                      → the `blocked` status (waiting on
+ *                                        the user)
+ *
+ * Dedup note: a `Task` tool fires BOTH `tool_start` (kind `tool`) AND
+ * `agent_spawned` (kind `agent`) on the SAME toolUseId. The registry treats
+ * `agent_spawned` as authoritative and upgrades the `tool` node to an
+ * `agent` node in place (same id) rather than carrying two nodes for one
+ * unit of work. The matching `tool_result` (or `agent_completed`) then
+ * terminates the agent node.
+ *
+ * Lifetime: one registry per session, owned by BaseSession. It holds NO
+ * timers and NO external refs; `reset()` (turn-end) and `clear()` (destroy)
+ * empty the map. Nothing here is persisted — the underlying signals are all
+ * transient/in-memory (see #4307/#4417), so a server restart starts with an
+ * empty tree, which is correct (the OS-level work is owned by claude, not
+ * chroxy).
+ */
+
+import { ACTIVITY_SCHEMA_VERSION } from '@chroxy/protocol'
+
+// Prefix for shell entry ids so a shell token (e.g. `brk57kt6pm`) can never
+// collide with a tool_use id in the flat entry map.
+const SHELL_ID_PREFIX = 'shell:'
+// Prefix for permission / question (blocked) entry ids — keyed by the
+// permission requestId or the AskUserQuestion synthetic toolUseId.
+const BLOCKED_ID_PREFIX = 'blocked:'
+
+/**
+ * @typedef {import('@chroxy/protocol').ActivityEntry} ActivityEntry
+ */
+
+export class ActivityRegistry {
+  /**
+   * @param {object} opts
+   * @param {string} opts.sessionId — the session this registry tracks. Carried
+   *   on every emitted message. May be empty at construction (SDK sessions
+   *   learn their id on `init`); `setSessionId` updates it later.
+   * @param {(event: string, payload: object) => void} opts.emit — bound emitter
+   *   (the owning session's `this.emit`). Kept as an injected function so the
+   *   registry is unit-testable without a real session.
+   */
+  constructor({ sessionId = '', emit } = {}) {
+    if (typeof emit !== 'function') {
+      throw new TypeError('ActivityRegistry requires an emit function')
+    }
+    this._sessionId = typeof sessionId === 'string' ? sessionId : ''
+    this._emit = emit
+    /** @type {Map<string, ActivityEntry>} */
+    this._entries = new Map()
+  }
+
+  /**
+   * Update the session id (SDK sessions only learn it on `init`). Existing
+   * entries are unaffected; only future emitted messages carry the new id.
+   * @param {string} sessionId
+   */
+  setSessionId(sessionId) {
+    if (typeof sessionId === 'string' && sessionId.length > 0) {
+      this._sessionId = sessionId
+    }
+  }
+
+  /**
+   * Current entries as a plain array (flat list; the tree is reconstructed
+   * client-side from `parentId`). Returned in insertion order so the most
+   * recently started work sorts last, but consumers MUST NOT depend on order.
+   * @returns {ActivityEntry[]}
+   */
+  getEntries() {
+    return Array.from(this._entries.values()).map((e) => ({ ...e }))
+  }
+
+  /**
+   * Build the `activity_snapshot` message for a fresh subscriber / resync.
+   * Always returns a valid message (empty `entries` is the legitimate
+   * "no in-flight activity" state, never omitted).
+   * @returns {{ type: 'activity_snapshot', sessionId: string, schemaVersion: number, entries: ActivityEntry[] }}
+   */
+  getSnapshotMessage() {
+    return {
+      type: 'activity_snapshot',
+      sessionId: this._sessionId,
+      schemaVersion: ACTIVITY_SCHEMA_VERSION,
+      entries: this.getEntries(),
+    }
+  }
+
+  // --- signal handlers ------------------------------------------------------
+
+  /**
+   * A tool_use began streaming. Creates a `running` `tool` node unless the
+   * id is already an `agent` node (a Task — `agent_spawned` is authoritative
+   * and may land before or after `tool_start` depending on the provider).
+   * @param {{ toolUseId?: string, tool?: string }} data
+   */
+  onToolStart(data) {
+    const toolUseId = data?.toolUseId
+    if (!isNonEmptyString(toolUseId)) return
+    const existing = this._entries.get(toolUseId)
+    // Already an agent node for this id → the Task signal wins, leave it.
+    if (existing && existing.kind === 'agent') return
+    const label = isNonEmptyString(data.tool) ? data.tool : ''
+    this._upsert({
+      id: toolUseId,
+      kind: 'tool',
+      label,
+      status: 'running',
+      startedAt: Date.now(),
+      outputRef: { kind: 'tool_use', id: toolUseId },
+    })
+  }
+
+  /**
+   * A tool_use returned a result. Terminates the matching node (tool OR the
+   * upgraded agent node sharing the toolUseId). `isError` → `failed`, else
+   * `done`. Unknown ids are a no-op (e.g. a result for a tool whose start we
+   * never saw).
+   * @param {{ toolUseId?: string, isError?: boolean }} data
+   */
+  onToolResult(data) {
+    const toolUseId = data?.toolUseId
+    if (!isNonEmptyString(toolUseId)) return
+    // If this id is an agent node, drain its child tools first so the tree
+    // never strands a child beneath a terminated parent.
+    const existing = this._entries.get(toolUseId)
+    if (existing && existing.kind === 'agent') {
+      this._endChildrenOf(toolUseId)
+    }
+    this._end(toolUseId, data?.isError === true ? 'failed' : 'done')
+  }
+
+  /**
+   * A Task subagent was spawned. Authoritative for the toolUseId: if a `tool`
+   * node already exists for it (the Task's own tool_start), upgrade it to an
+   * `agent` node in place; otherwise create a fresh `agent` node.
+   * @param {{ toolUseId?: string, description?: string, startedAt?: number }} data
+   */
+  onAgentSpawned(data) {
+    const toolUseId = data?.toolUseId
+    if (!isNonEmptyString(toolUseId)) return
+    const existing = this._entries.get(toolUseId)
+    // Preserve the original start time if the tool_start landed first.
+    const startedAt = sanitizeTimestamp(data.startedAt)
+      ?? existing?.startedAt
+      ?? Date.now()
+    this._upsert({
+      id: toolUseId,
+      kind: 'agent',
+      label: isNonEmptyString(data.description) ? data.description : (existing?.label ?? ''),
+      status: 'running',
+      startedAt,
+      outputRef: { kind: 'tool_use', id: toolUseId },
+    })
+  }
+
+  /**
+   * A Task subagent finished. Terminates the agent node as `done` (the
+   * subagent's own failure surfaces separately via the Task tool_result;
+   * `agent_completed` is the lifecycle-clear signal, not an error signal).
+   * @param {{ toolUseId?: string }} data
+   */
+  onAgentCompleted(data) {
+    const toolUseId = data?.toolUseId
+    if (!isNonEmptyString(toolUseId)) return
+    // End any child tool nodes still open under this agent first, so the
+    // tree drains leaf-up and no orphaned child outlives its parent.
+    this._endChildrenOf(toolUseId)
+    this._end(toolUseId, 'done')
+  }
+
+  /**
+   * #5016 — a Task subagent's intermediate wire event, relayed by the parent
+   * under `agent_event` and tagged with the parent's `parentToolUseId`. This
+   * is the session→agent→tool hierarchy signal: a child `tool_start` /
+   * `tool_result` nested inside the parent agent. We surface only the
+   * tool lifecycle (the structural nodes); `stream_delta` / `tool_input_delta`
+   * are output noise, not activity nodes.
+   *
+   * Child ids are namespaced by the parent (`<parentId>::<childToolUseId>`)
+   * so two subagents running the same tool can't collide, and a child node
+   * is dropped if its parent agent isn't (or is no longer) tracked — a child
+   * tool only makes sense under a live agent.
+   *
+   * @param {{ parentToolUseId?: string, type?: string, payload?: object }} data
+   */
+  onAgentEvent(data) {
+    const parentId = data?.parentToolUseId
+    if (!isNonEmptyString(parentId)) return
+    const childType = data?.type
+    const payload = (data?.payload && typeof data.payload === 'object') ? data.payload : {}
+    if (childType === 'tool_start') {
+      const childToolUseId = payload.toolUseId
+      if (!isNonEmptyString(childToolUseId)) return
+      // Only nest under a parent agent we're actually tracking — a child
+      // tool with no live parent would be an orphan in the tree.
+      if (!this._entries.has(parentId)) return
+      const id = childActivityId(parentId, childToolUseId)
+      this._upsert({
+        id,
+        kind: 'tool',
+        label: isNonEmptyString(payload.tool) ? payload.tool : '',
+        status: 'running',
+        startedAt: Date.now(),
+        parentId,
+        outputRef: { kind: 'tool_use', id: childToolUseId },
+      })
+    } else if (childType === 'tool_result') {
+      const childToolUseId = payload.toolUseId
+      if (!isNonEmptyString(childToolUseId)) return
+      this._end(childActivityId(parentId, childToolUseId), payload.isError === true ? 'failed' : 'done')
+    }
+  }
+
+  /**
+   * Reconcile backgrounded-shell entries against the full pending snapshot
+   * BaseSession emits on `background_work_changed`. Adds entries for newly
+   * pending shells (started delta) and ends entries for shells no longer
+   * pending (ended/done delta). The snapshot is authoritative — this is a
+   * set-reconciliation, not an incremental diff, so a dropped event self-heals
+   * on the next snapshot.
+   * @param {{ pending?: Array<{ shellId?: string, startedAt?: number, command?: string }> }} data
+   */
+  onBackgroundWorkChanged(data) {
+    const pending = Array.isArray(data?.pending) ? data.pending : []
+    const seen = new Set()
+    for (const shell of pending) {
+      const shellId = shell?.shellId
+      if (!isNonEmptyString(shellId)) continue
+      const id = SHELL_ID_PREFIX + shellId
+      seen.add(id)
+      if (this._entries.has(id)) continue // already tracked; preserve startedAt
+      this._upsert({
+        id,
+        kind: 'shell',
+        label: isNonEmptyString(shell.command) ? shell.command : '',
+        status: 'running',
+        startedAt: sanitizeTimestamp(shell.startedAt) ?? Date.now(),
+        outputRef: { kind: 'shell', id: shellId },
+      })
+    }
+    // End any shell entry that's no longer in the pending snapshot.
+    for (const [id, entry] of this._entries) {
+      if (entry.kind !== 'shell') continue
+      if (seen.has(id)) continue
+      this._end(id, 'done')
+    }
+  }
+
+  /**
+   * A tool is blocked waiting on a user permission decision. Creates a
+   * `blocked` node keyed by the requestId so the Control Room can flag
+   * "needs attention" without inferring it from elapsed time. Resolved via
+   * `onPermissionResolved`.
+   * @param {{ requestId?: string, tool?: string, description?: string }} data
+   */
+  onPermissionRequest(data) {
+    const requestId = data?.requestId
+    if (!isNonEmptyString(requestId)) return
+    const label = isNonEmptyString(data.description)
+      ? data.description
+      : (isNonEmptyString(data.tool) ? data.tool : '')
+    this._upsert({
+      id: BLOCKED_ID_PREFIX + requestId,
+      kind: 'tool',
+      label,
+      status: 'blocked',
+      startedAt: Date.now(),
+    })
+  }
+
+  /**
+   * An AskUserQuestion is blocked waiting on the user. Same `blocked` model
+   * as a permission request, keyed by the synthetic question toolUseId.
+   * @param {{ toolUseId?: string }} data
+   */
+  onUserQuestion(data) {
+    const toolUseId = data?.toolUseId
+    if (!isNonEmptyString(toolUseId)) return
+    this._upsert({
+      id: BLOCKED_ID_PREFIX + toolUseId,
+      kind: 'tool',
+      label: 'Waiting for your answer',
+      status: 'blocked',
+      startedAt: Date.now(),
+    })
+  }
+
+  /**
+   * A pending permission / question was resolved (approved, denied, timed
+   * out, or aborted). Ends the matching blocked node. A `deny`/`timeout`/
+   * `aborted` resolution is `failed`; an approval is `done` (the subsequent
+   * tool_start, if any, creates its own running node). The payload carries
+   * EITHER `requestId` (permission) OR `toolUseId` (question).
+   * @param {{ requestId?: string, toolUseId?: string, decision?: string, reason?: string }} data
+   */
+  onPermissionResolved(data) {
+    const key = isNonEmptyString(data?.requestId)
+      ? data.requestId
+      : (isNonEmptyString(data?.toolUseId) ? data.toolUseId : null)
+    if (!key) return
+    const denied = data?.decision === 'deny'
+      || data?.reason === 'timeout'
+      || data?.reason === 'aborted'
+    this._end(BLOCKED_ID_PREFIX + key, denied ? 'failed' : 'done')
+  }
+
+  // --- lifecycle ------------------------------------------------------------
+
+  /**
+   * Turn-end reconciliation. Ends any non-shell entry still marked
+   * `running`/`blocked` as `done` — at turn end the model has stopped, so a
+   * lingering tool/agent/blocked node is an orphan (mirrors BaseSession's
+   * `_sweepUnresolvedToolStarts`). Shell entries SURVIVE turn-end on purpose
+   * (#4307: a backgrounded shell outlives the turn that spawned it; it clears
+   * via `onBackgroundWorkChanged`).
+   */
+  reset() {
+    for (const [id, entry] of this._entries) {
+      if (entry.kind === 'shell') continue
+      this._end(id, 'done')
+    }
+  }
+
+  /**
+   * Session destroy. Ends EVERY remaining entry (including shells — the
+   * session is gone, so nothing is still in flight) and empties the map.
+   */
+  clear() {
+    for (const id of Array.from(this._entries.keys())) {
+      this._end(id, 'done')
+    }
+    this._entries.clear()
+  }
+
+  // --- internals ------------------------------------------------------------
+
+  /**
+   * Insert or replace an entry and emit the matching delta. A brand-new id
+   * emits `op: 'started'`; an existing id emits `op: 'updated'`. The full
+   * entry rides the delta so the downstream reducer is a pure upsert-by-id.
+   * @param {ActivityEntry} entry
+   * @private
+   */
+  _upsert(entry) {
+    const op = this._entries.has(entry.id) ? 'updated' : 'started'
+    this._entries.set(entry.id, entry)
+    this._emitDelta(op, entry)
+  }
+
+  /**
+   * Terminate an entry by id with the given terminal status, set `endedAt`,
+   * emit an `ended` delta, and drop it from the map. No-op for an unknown id
+   * or an already-terminated entry.
+   * @param {string} id
+   * @param {'done'|'failed'} status
+   * @private
+   */
+  _end(id, status) {
+    const existing = this._entries.get(id)
+    if (!existing) return
+    // endedAt must be >= startedAt (schema invariant); clamp against a
+    // clock that ticked backwards between start and end.
+    const endedAt = Math.max(Date.now(), existing.startedAt)
+    const ended = { ...existing, status, endedAt }
+    // Drop it BEFORE emitting so a re-entrant handler observing the emit
+    // can't double-end the same node.
+    this._entries.delete(id)
+    this._emitDelta('ended', ended)
+  }
+
+  /**
+   * End every entry whose `parentId` matches the given id (one level — child
+   * tools don't themselves have children today). Snapshot the keys first so
+   * the delete-during-iterate inside `_end` is safe.
+   * @param {string} parentId
+   * @private
+   */
+  _endChildrenOf(parentId) {
+    const children = []
+    for (const [id, entry] of this._entries) {
+      if (entry.parentId === parentId) children.push(id)
+    }
+    for (const id of children) {
+      this._end(id, 'done')
+    }
+  }
+
+  /**
+   * Emit one `activity_delta`. Carries the session id + schema version so the
+   * WS layer forwards it verbatim.
+   * @param {'started'|'updated'|'ended'} op
+   * @param {ActivityEntry} entry
+   * @private
+   */
+  _emitDelta(op, entry) {
+    this._emit('activity_delta', {
+      sessionId: this._sessionId,
+      schemaVersion: ACTIVITY_SCHEMA_VERSION,
+      op,
+      entry,
+    })
+  }
+}
+
+/**
+ * Build a parent-namespaced child entry id so two subagents running the same
+ * tool can't collide on a shared child toolUseId.
+ * @param {string} parentId
+ * @param {string} childToolUseId
+ * @returns {string}
+ */
+function childActivityId(parentId, childToolUseId) {
+  return `${parentId}::${childToolUseId}`
+}
+
+/**
+ * @param {unknown} v
+ * @returns {boolean}
+ */
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.length > 0
+}
+
+/**
+ * Coerce a timestamp opt to a non-negative finite integer, or null when it's
+ * not a usable number (so callers fall back to `Date.now()`).
+ * @param {unknown} v
+ * @returns {number | null}
+ */
+function sanitizeTimestamp(v) {
+  if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) return null
+  return Math.floor(v)
+}

--- a/packages/server/src/activity-registry.js
+++ b/packages/server/src/activity-registry.js
@@ -339,8 +339,14 @@ export class ActivityRegistry {
    * via `onBackgroundWorkChanged`).
    */
   reset() {
+    // Snapshot the ids first so `_end`'s delete-while-iterate is safe even if
+    // a delta listener re-enters the registry.
+    const toEnd = []
     for (const [id, entry] of this._entries) {
       if (entry.kind === 'shell') continue
+      toEnd.push(id)
+    }
+    for (const id of toEnd) {
       this._end(id, 'done')
     }
   }

--- a/packages/server/src/activity-registry.js
+++ b/packages/server/src/activity-registry.js
@@ -4,18 +4,20 @@
  * A thin UNIFYING layer over the in-flight signals BaseSession already
  * emits. It does NOT track anything the session doesn't already know — it
  * maps the existing lifecycle events into the `ActivityEntry` wire shape
- * (#5161, `@chroxy/protocol`) and emits two events the WS layer forwards
- * verbatim:
+ * (#5161, `@chroxy/protocol`) and produces the two activity-tree messages
+ * the WS layer forwards verbatim, via two distinct mechanisms:
  *
+ *   - `activity_delta { sessionId, schemaVersion, op, entry }` — EMITTED (as
+ *     an `activity_delta` event on the owning session) on every change. `op`
+ *     is `started` / `updated` / `ended`; the FULL entry rides every op so
+ *     the downstream reducer (#5162) is a pure upsert-by-id and self-heals a
+ *     dropped delta.
  *   - `activity_snapshot { sessionId, schemaVersion, entries }` — the full
- *     current tree. Served to a fresh subscriber (snapshot-on-subscribe via
- *     `getSnapshotMessage()`) and on resync, mirroring the
- *     `background_work_changed` full-snapshot philosophy so a late joiner
- *     never reconciles deltas against a separate snapshot.
- *   - `activity_delta { sessionId, schemaVersion, op, entry }` — one
- *     upsert/end per change. `op` is `started` / `updated` / `ended`; the
- *     FULL entry rides every op so the downstream reducer (#5162) is a pure
- *     upsert-by-id and self-heals a dropped delta.
+ *     current tree. NOT emitted as an event; it is BUILT on demand via
+ *     `getSnapshotMessage()` (surfaced as `BaseSession.getActivitySnapshot()`)
+ *     and sent to a fresh subscriber / on resync by `ws-history.sendSessionInfo`,
+ *     mirroring the `background_work_changed` full-snapshot philosophy so a
+ *     late joiner never reconciles deltas against a separate snapshot.
  *
  * The signals it unifies (all already emitted by BaseSession / providers):
  *   - `tool_start` / `tool_result`     → long-running tool calls (#4628)
@@ -326,6 +328,20 @@ export class ActivityRegistry {
       || data?.reason === 'timeout'
       || data?.reason === 'aborted'
     this._end(BLOCKED_ID_PREFIX + key, denied ? 'failed' : 'done')
+  }
+
+  /**
+   * A pending permission request EXPIRED (session hard-timeout force-cleared
+   * it). Ends the blocked node as `failed` — an expired request is an
+   * abandoned one, the same terminal class as a deny/timeout. Without this the
+   * node would only clear via the turn-end `reset()` sweep and be misreported
+   * as `done`.
+   * @param {{ requestId?: string }} data
+   */
+  onPermissionExpired(data) {
+    const requestId = data?.requestId
+    if (!isNonEmptyString(requestId)) return
+    this._end(BLOCKED_ID_PREFIX + requestId, 'failed')
   }
 
   // --- lifecycle ------------------------------------------------------------

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -20,6 +20,7 @@ import {
 import { SkillsTrustStore } from './skills-trust.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { createLogger } from './logger.js'
+import { ActivityRegistry } from './activity-registry.js'
 
 const log = createLogger('base-session')
 
@@ -307,6 +308,19 @@ export class BaseSession extends EventEmitter {
     // path: SessionMessageHistory.sweepUnresolvedToolStarts (#4617/#4619)
     // catches stragglers at restore-time as a backstop.
     this._inFlightToolStarts = new Map()
+    // #5160: per-session activity registry (Control Room). A thin unifying
+    // layer that maps the signals BaseSession already emits (tool_start /
+    // tool_result / agent_spawned / agent_completed / background_work_changed
+    // / permission_request / user_question / permission_resolved) into the
+    // `ActivityEntry` wire shape and re-emits `activity_delta` /
+    // `activity_snapshot` for the WS layer. NOT a parallel tracker — it
+    // listens to this session's own events (wired in _setupActivityRegistry)
+    // so it can never drift from the canonical signal source.
+    this._activity = new ActivityRegistry({
+      sessionId: '',
+      emit: (event, payload) => this.emit(event, payload),
+    })
+    this._setupActivityRegistry()
     this._messageCounter = 0
     // Boot-unique prefix mixed into every emitted messageId (#3700).
     // The dashboard caches up to 100 messages per session in localStorage
@@ -688,6 +702,69 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
+   * #5160: wire the activity registry to this session's own lifecycle
+   * events. The registry is a pure consumer — it only maps already-emitted
+   * signals into `ActivityEntry` records, so listening here keeps it a thin
+   * unifying layer rather than a parallel tracker. Listeners are attached on
+   * the session itself (an EventEmitter) so every provider that routes
+   * through these canonical events feeds the registry for free.
+   *
+   * @private
+   */
+  _setupActivityRegistry() {
+    this.on('tool_start', (d) => this._activity.onToolStart(d))
+    this.on('tool_result', (d) => this._activity.onToolResult(d))
+    this.on('agent_spawned', (d) => this._activity.onAgentSpawned(d))
+    this.on('agent_completed', (d) => this._activity.onAgentCompleted(d))
+    this.on('agent_event', (d) => this._activity.onAgentEvent(d))
+    this.on('background_work_changed', (d) => this._activity.onBackgroundWorkChanged(d))
+    this.on('permission_request', (d) => this._activity.onPermissionRequest(d))
+    this.on('user_question', (d) => this._activity.onUserQuestion(d))
+    this.on('permission_resolved', (d) => this._activity.onPermissionResolved(d))
+  }
+
+  /**
+   * #5160: clear the activity registry before any listener teardown. Every
+   * provider's `destroy()` routes through `removeAllListeners()` (directly,
+   * or via super.destroy() chaining — cli/jsonl/gemini/codex call it; sdk/tui
+   * also clear the registry explicitly via `_destroyPendingBackgroundShells`).
+   * Overriding here is the single chokepoint that guarantees a destroyed
+   * session emits `ended` deltas for any still-open node (so live subscribers
+   * see the tree drain) and leaves no stale entries — without having to touch
+   * each subclass's bespoke destroy(). Clearing BEFORE super removes the
+   * listeners means the `activity_delta` emits still reach the wired
+   * forwarder. Idempotent: a second call (or a session that already cleared
+   * via `_destroyPendingBackgroundShells`) sees an empty registry and no-ops.
+   */
+  removeAllListeners(eventName) {
+    // Only the full teardown variant (no event name) clears the registry —
+    // a targeted removeAllListeners('foo') must not drain the activity tree.
+    if (eventName === undefined) {
+      this._activity.clear()
+    }
+    return super.removeAllListeners(eventName)
+  }
+
+  /**
+   * #5160: keep the activity registry's session id in sync. Subclasses that
+   * learn their canonical session id late (SDK sessions, on `init`) call this
+   * so emitted `activity_*` messages carry the right id.
+   * @param {string} sessionId
+   */
+  setActivitySessionId(sessionId) {
+    this._activity.setSessionId(sessionId)
+  }
+
+  /**
+   * #5160: full current activity tree as an `activity_snapshot` message.
+   * Served to a fresh subscriber (snapshot-on-subscribe) and on resync.
+   * @returns {object} the `activity_snapshot` wire message
+   */
+  getActivitySnapshot() {
+    return this._activity.getSnapshotMessage()
+  }
+
+  /**
    * #4307: emit the current pending-shells snapshot on the
    * `background_work_changed` event. Pulled into a helper so both
    * `trackBackgroundShell` and `clearBackgroundShell` use one shape.
@@ -714,6 +791,11 @@ export class BaseSession extends EventEmitter {
   _destroyPendingBackgroundShells() {
     this._pendingBackgroundShells.clear()
     this._pendingBackgroundCommands.clear()
+    // #5160: tear down the activity registry alongside the other transient
+    // per-session work maps. Ends every remaining node (the session is gone,
+    // so nothing is still in flight) and empties the registry — no leak, and
+    // a late session-list snapshot can't surface a destroyed session's tree.
+    this._activity.clear()
   }
 
   /** Current thinking level. Override in subclasses that support it. */
@@ -1157,6 +1239,15 @@ export class BaseSession extends EventEmitter {
       }
       this._activeAgents.clear()
     }
+
+    // #5160: turn-end reconciliation for the activity registry. Ends any
+    // tool/agent/blocked node still marked running/blocked (orphans the
+    // model abandoned at turn end), mirroring _sweepUnresolvedToolStarts.
+    // Runs AFTER the agent_completed fan-out above so those completions
+    // terminate their nodes first; reset() is the belt-and-braces sweep for
+    // anything the canonical signals didn't clear. Shell nodes survive
+    // turn-end (#4307) and clear via background_work_changed.
+    this._activity.reset()
 
     if (this._resultTimeout) {
       clearTimeout(this._resultTimeout)

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -721,6 +721,7 @@ export class BaseSession extends EventEmitter {
     this.on('permission_request', (d) => this._activity.onPermissionRequest(d))
     this.on('user_question', (d) => this._activity.onUserQuestion(d))
     this.on('permission_resolved', (d) => this._activity.onPermissionResolved(d))
+    this.on('permission_expired', (d) => this._activity.onPermissionExpired(d))
   }
 
   /**

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -739,8 +739,13 @@ export class BaseSession extends EventEmitter {
   removeAllListeners(eventName) {
     // Only the full teardown variant (no event name) clears the registry —
     // a targeted removeAllListeners('foo') must not drain the activity tree.
+    // Note: `super.removeAllListeners(undefined)` is NOT equivalent to the
+    // no-arg call — EventEmitter treats `undefined` as the event named
+    // `undefined` and removes nothing. So branch on arity and forward each
+    // shape with the right argument count.
     if (eventName === undefined) {
       this._activity.clear()
+      return super.removeAllListeners()
     }
     return super.removeAllListeners(eventName)
   }

--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -209,6 +209,38 @@ Object.assign(EVENT_MAP, {
     sideEffects: [{ type: 'session_list' }],
   }),
 
+  // #5160: Control Room activity tree. The ActivityRegistry (owned by
+  // BaseSession) maps the existing in-flight signals (tool_start /
+  // agent_spawned / background_work_changed / permission_request / …) into
+  // `ActivityEntry` records and emits these two events. We inject the
+  // canonical `ctx.sessionId` (matching `background_work_changed`) so the
+  // wire message carries the SessionManager key the dashboard routes on,
+  // regardless of what internal id the session held. Both are transient —
+  // not replayed from history; a reconnecting client gets the full tree from
+  // the snapshot-on-subscribe in ws-history.sendSessionInfo.
+  activity_delta: (data, ctx) => ({
+    messages: [{
+      msg: {
+        type: 'activity_delta',
+        sessionId: ctx.sessionId,
+        schemaVersion: data.schemaVersion,
+        op: data.op,
+        entry: data.entry,
+      },
+    }],
+  }),
+
+  activity_snapshot: (data, ctx) => ({
+    messages: [{
+      msg: {
+        type: 'activity_snapshot',
+        sessionId: ctx.sessionId,
+        schemaVersion: data.schemaVersion,
+        entries: Array.isArray(data?.entries) ? data.entries : [],
+      },
+    }],
+  }),
+
   mcp_servers: (data) => ({
     messages: [{
       msg: { type: 'mcp_servers', servers: data.servers },

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1766,7 +1766,11 @@ export class SessionManager extends EventEmitter {
     // events (tool_start / tool_result / tool_input_delta / stream_delta)
     // tagged with the parent's toolUseId. Transient (not replayed on
     // reconnect — the canonical Task tool_result fold lands in history).
-    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'agent_event', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted', 'inactivity_warning', 'background_work_changed', 'stopped']
+    // #5160: `activity_delta` / `activity_snapshot` carry the Control Room
+    // activity tree (ActivityRegistry on BaseSession). Transient — not
+    // replayed from history; a reconnecting client gets the full tree from
+    // the snapshot-on-subscribe in ws-history.sendSessionInfo.
+    const builtinTransient = ['permission_request', 'permission_resolved', 'permission_expired', 'agent_spawned', 'agent_completed', 'agent_event', 'plan_started', 'plan_ready', 'mcp_servers', 'skill_changed', 'skill_trust_request', 'skill_trust_granted', 'inactivity_warning', 'background_work_changed', 'stopped', 'activity_delta', 'activity_snapshot']
     const customEvents = Array.isArray(session.constructor.customEvents) ? session.constructor.customEvents : []
     const TRANSIENT_EVENTS = [...new Set([...builtinTransient, ...customEvents])]
     for (const event of TRANSIENT_EVENTS) {

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -434,6 +434,20 @@ export function sendSessionInfo(ctx, ws, sessionId) {
       send(ws, { type: 'permission_rules_updated', rules, sessionId })
     }
   }
+
+  // #5160: snapshot-on-subscribe for the Control Room activity tree. A fresh
+  // subscriber (new client, tab switch, reconnect) gets the full current tree
+  // in one `activity_snapshot` so it reaches canonical state without replaying
+  // the `activity_delta` stream — mirroring the `background_work_changed`
+  // full-snapshot philosophy. Always sent (empty `entries` is the valid "no
+  // in-flight activity" state) so a client can clear any stale tree from a
+  // previous session on switch. We stamp the canonical `sessionId` here
+  // (matching the live-broadcast path's normalizer injection) rather than
+  // trusting whatever internal id the session held.
+  if (typeof session.getActivitySnapshot === 'function') {
+    const snapshot = session.getActivitySnapshot()
+    send(ws, { ...snapshot, sessionId })
+  }
 }
 
 /**

--- a/packages/server/tests/activity-registry.test.js
+++ b/packages/server/tests/activity-registry.test.js
@@ -14,7 +14,7 @@
  *   - emitted deltas validate against the @chroxy/protocol wire schemas
  *   - BaseSession wiring: events feed the registry and re-emit activity_*
  */
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
@@ -283,6 +283,15 @@ describe('ActivityRegistry — blocked (permission / question)', () => {
     r.onPermissionResolved({ toolUseId: 'ask-1', reason: 'aborted' })
     assert.equal(lastEntry(deltas).status, 'failed')
   })
+
+  it('permission_expired ends the blocked node as failed (not done)', () => {
+    const { r, deltas } = makeRegistry()
+    r.onPermissionRequest({ requestId: 'req1', tool: 'Bash' })
+    r.onPermissionExpired({ requestId: 'req1' })
+    assert.equal(deltas.at(-1).op, 'ended')
+    assert.equal(lastEntry(deltas).status, 'failed')
+    assert.equal(r.getEntries().length, 0)
+  })
 })
 
 describe('ActivityRegistry — reset (turn-end) and clear (destroy)', () => {
@@ -356,6 +365,12 @@ describe('ActivityRegistry — BaseSession wiring', () => {
     skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-activity-skills-'))
   })
 
+  // Cleanup in a hook so the temp dir is removed even when an assertion
+  // throws mid-test (an inline rmSync would leak the dir on early failure).
+  afterEach(() => {
+    if (skillsDir) rmSync(skillsDir, { recursive: true, force: true })
+  })
+
   function makeSession() {
     return new BaseSession({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
   }
@@ -371,8 +386,6 @@ describe('ActivityRegistry — BaseSession wiring', () => {
     assert.deepEqual(ops(deltas), ['started', 'ended'])
     assert.equal(deltas[0].entry.kind, 'tool')
     assert.equal(deltas[1].entry.status, 'done')
-
-    rmSync(skillsDir, { recursive: true, force: true })
   })
 
   it('getActivitySnapshot reflects in-flight work', () => {
@@ -382,8 +395,6 @@ describe('ActivityRegistry — BaseSession wiring', () => {
     assert.equal(snap.type, 'activity_snapshot')
     assert.equal(snap.entries.length, 1)
     assert.equal(snap.entries[0].kind, 'agent')
-
-    rmSync(skillsDir, { recursive: true, force: true })
   })
 
   it('background_work_changed feeds shell nodes into the registry', () => {
@@ -399,8 +410,6 @@ describe('ActivityRegistry — BaseSession wiring', () => {
     session.clearBackgroundShell('brk1')
     assert.equal(deltas.at(-1).op, 'ended')
     assert.equal(deltas.at(-1).entry.kind, 'shell')
-
-    rmSync(skillsDir, { recursive: true, force: true })
   })
 
   it('_clearMessageState (turn-end) ends non-shell nodes, shells survive', () => {
@@ -418,8 +427,6 @@ describe('ActivityRegistry — BaseSession wiring', () => {
     const remaining = session.getActivitySnapshot().entries
     assert.equal(remaining.length, 1)
     assert.equal(remaining[0].kind, 'shell')
-
-    rmSync(skillsDir, { recursive: true, force: true })
   })
 
   it('removeAllListeners (destroy chokepoint) clears the registry', () => {
@@ -446,7 +453,5 @@ describe('ActivityRegistry — BaseSession wiring', () => {
     session.trackBackgroundShell({ shellId: 'brk1', command: 'a' })
     session.removeAllListeners('some_other_event')
     assert.equal(session.getActivitySnapshot().entries.length, 1)
-
-    rmSync(skillsDir, { recursive: true, force: true })
   })
 })

--- a/packages/server/tests/activity-registry.test.js
+++ b/packages/server/tests/activity-registry.test.js
@@ -1,0 +1,446 @@
+/**
+ * #5160 — per-session activity registry (Control Room phase 1).
+ *
+ * Pins the behaviour the WS layer / store-core reducer (#5162) and dashboard
+ * (#5163) build on:
+ *   - tool_start → running tool node; tool_result → terminal (done/failed)
+ *   - agent_spawned is authoritative for a Task (upgrades the tool node)
+ *   - background_work_changed reconciles shell nodes (add / end)
+ *   - permission_request / user_question → blocked node; resolved → terminal
+ *   - agent_event nests child tools under the parent agent (parentId)
+ *   - reset() (turn-end) ends non-shell orphans, shells survive
+ *   - clear() (destroy) ends everything and empties the registry
+ *   - snapshot-on-subscribe (getSnapshotMessage) is the full current tree
+ *   - emitted deltas validate against the @chroxy/protocol wire schemas
+ *   - BaseSession wiring: events feed the registry and re-emit activity_*
+ */
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  ACTIVITY_SCHEMA_VERSION,
+  ServerActivitySnapshotSchema,
+  ServerActivityDeltaSchema,
+} from '@chroxy/protocol'
+import { ActivityRegistry } from '../src/activity-registry.js'
+import { BaseSession } from '../src/base-session.js'
+
+// --- registry-in-isolation harness -----------------------------------------
+
+function makeRegistry(sessionId = 's1') {
+  const deltas = []
+  const r = new ActivityRegistry({
+    sessionId,
+    emit: (event, payload) => {
+      assert.equal(event, 'activity_delta', 'registry only emits activity_delta')
+      deltas.push(payload)
+    },
+  })
+  return { r, deltas }
+}
+
+function ops(deltas) {
+  return deltas.map((d) => d.op)
+}
+
+function lastEntry(deltas) {
+  return deltas[deltas.length - 1].entry
+}
+
+describe('ActivityRegistry — construction', () => {
+  it('requires an emit function', () => {
+    assert.throws(() => new ActivityRegistry({ sessionId: 's1' }), TypeError)
+  })
+
+  it('starts with an empty snapshot', () => {
+    const { r } = makeRegistry()
+    const snap = r.getSnapshotMessage()
+    assert.equal(snap.type, 'activity_snapshot')
+    assert.equal(snap.sessionId, 's1')
+    assert.equal(snap.schemaVersion, ACTIVITY_SCHEMA_VERSION)
+    assert.deepEqual(snap.entries, [])
+  })
+
+  it('setSessionId updates the snapshot session id', () => {
+    const { r } = makeRegistry('')
+    r.setSessionId('sdk-123')
+    assert.equal(r.getSnapshotMessage().sessionId, 'sdk-123')
+  })
+})
+
+describe('ActivityRegistry — tool lifecycle', () => {
+  it('tool_start creates a running tool node, tool_result ends it done', () => {
+    const { r, deltas } = makeRegistry()
+    r.onToolStart({ toolUseId: 't1', tool: 'Bash' })
+    assert.deepEqual(ops(deltas), ['started'])
+    const started = lastEntry(deltas)
+    assert.equal(started.kind, 'tool')
+    assert.equal(started.label, 'Bash')
+    assert.equal(started.status, 'running')
+    assert.equal(started.endedAt, undefined)
+    assert.deepEqual(started.outputRef, { kind: 'tool_use', id: 't1' })
+
+    r.onToolResult({ toolUseId: 't1' })
+    assert.deepEqual(ops(deltas), ['started', 'ended'])
+    const ended = lastEntry(deltas)
+    assert.equal(ended.status, 'done')
+    assert.ok(ended.endedAt >= ended.startedAt)
+    // Terminated nodes drop out of the snapshot.
+    assert.equal(r.getEntries().length, 0)
+  })
+
+  it('tool_result with isError ends the node as failed', () => {
+    const { r, deltas } = makeRegistry()
+    r.onToolStart({ toolUseId: 't1', tool: 'Bash' })
+    r.onToolResult({ toolUseId: 't1', isError: true })
+    assert.equal(lastEntry(deltas).status, 'failed')
+  })
+
+  it('tool_result for an unknown id is a no-op', () => {
+    const { r, deltas } = makeRegistry()
+    r.onToolResult({ toolUseId: 'never-started' })
+    assert.equal(deltas.length, 0)
+  })
+
+  it('ignores tool_start without a toolUseId', () => {
+    const { r, deltas } = makeRegistry()
+    r.onToolStart({ tool: 'Bash' })
+    r.onToolStart({})
+    assert.equal(deltas.length, 0)
+  })
+})
+
+describe('ActivityRegistry — agent (Task) lifecycle', () => {
+  it('agent_spawned creates a running agent node', () => {
+    const { r, deltas } = makeRegistry()
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'investigate flaky test', startedAt: 1000 })
+    const e = lastEntry(deltas)
+    assert.equal(e.kind, 'agent')
+    assert.equal(e.label, 'investigate flaky test')
+    assert.equal(e.status, 'running')
+    assert.equal(e.startedAt, 1000)
+  })
+
+  it('agent_spawned upgrades a pre-existing tool node in place (Task dedup)', () => {
+    const { r, deltas } = makeRegistry()
+    // Task fires tool_start AND agent_spawned on the SAME id.
+    r.onToolStart({ toolUseId: 'a1', tool: 'Task' })
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'do the thing' })
+    // One node, upgraded — not two.
+    assert.equal(r.getEntries().length, 1)
+    const e = r.getEntries()[0]
+    assert.equal(e.kind, 'agent')
+    assert.equal(e.label, 'do the thing')
+    // started then updated (upgrade), no duplicate node.
+    assert.deepEqual(ops(deltas), ['started', 'updated'])
+  })
+
+  it('tool_start after agent_spawned does not downgrade the agent', () => {
+    const { r, deltas } = makeRegistry()
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'do the thing' })
+    r.onToolStart({ toolUseId: 'a1', tool: 'Task' })
+    assert.equal(r.getEntries()[0].kind, 'agent')
+    assert.deepEqual(ops(deltas), ['started']) // tool_start was a no-op
+  })
+
+  it('agent_completed ends the agent done', () => {
+    const { r, deltas } = makeRegistry()
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'x' })
+    r.onAgentCompleted({ toolUseId: 'a1' })
+    assert.equal(lastEntry(deltas).status, 'done')
+    assert.equal(r.getEntries().length, 0)
+  })
+
+  it('agent tool_result ends the agent (failed on error)', () => {
+    const { r, deltas } = makeRegistry()
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'x' })
+    r.onToolResult({ toolUseId: 'a1', isError: true })
+    assert.equal(lastEntry(deltas).status, 'failed')
+  })
+})
+
+describe('ActivityRegistry — hierarchy via agent_event', () => {
+  it('nests child tool_start under the parent agent with parentId', () => {
+    const { r, deltas } = makeRegistry()
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'parent' })
+    r.onAgentEvent({ parentToolUseId: 'a1', type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } })
+    const child = lastEntry(deltas)
+    assert.equal(child.kind, 'tool')
+    assert.equal(child.parentId, 'a1')
+    assert.equal(child.label, 'Read')
+    assert.equal(child.id, 'a1::c1')
+    assert.deepEqual(child.outputRef, { kind: 'tool_use', id: 'c1' })
+  })
+
+  it('child tool_result ends the namespaced child node', () => {
+    const { r, deltas } = makeRegistry()
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'parent' })
+    r.onAgentEvent({ parentToolUseId: 'a1', type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } })
+    r.onAgentEvent({ parentToolUseId: 'a1', type: 'tool_result', payload: { toolUseId: 'c1' } })
+    assert.equal(lastEntry(deltas).status, 'done')
+    assert.equal(lastEntry(deltas).id, 'a1::c1')
+  })
+
+  it('drops a child whose parent agent is not tracked', () => {
+    const { r, deltas } = makeRegistry()
+    r.onAgentEvent({ parentToolUseId: 'ghost', type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } })
+    assert.equal(deltas.length, 0)
+  })
+
+  it('ending the parent agent drains its open children first', () => {
+    const { r, deltas } = makeRegistry()
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'parent' })
+    r.onAgentEvent({ parentToolUseId: 'a1', type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } })
+    r.onAgentCompleted({ toolUseId: 'a1' })
+    // child ended, then parent ended
+    const ended = deltas.filter((d) => d.op === 'ended').map((d) => d.entry.id)
+    assert.deepEqual(ended, ['a1::c1', 'a1'])
+    assert.equal(r.getEntries().length, 0)
+  })
+
+  it('two subagents running the same child tool do not collide', () => {
+    const { r } = makeRegistry()
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'p1' })
+    r.onAgentSpawned({ toolUseId: 'a2', description: 'p2' })
+    r.onAgentEvent({ parentToolUseId: 'a1', type: 'tool_start', payload: { toolUseId: 'same', tool: 'Read' } })
+    r.onAgentEvent({ parentToolUseId: 'a2', type: 'tool_start', payload: { toolUseId: 'same', tool: 'Read' } })
+    const ids = r.getEntries().map((e) => e.id).sort()
+    assert.deepEqual(ids, ['a1', 'a1::same', 'a2', 'a2::same'])
+  })
+})
+
+describe('ActivityRegistry — background shells', () => {
+  it('reconciles new shells from the pending snapshot', () => {
+    const { r, deltas } = makeRegistry()
+    r.onBackgroundWorkChanged({ pending: [{ shellId: 'brk1', command: 'npm test', startedAt: 500 }] })
+    const e = lastEntry(deltas)
+    assert.equal(e.kind, 'shell')
+    assert.equal(e.id, 'shell:brk1')
+    assert.equal(e.label, 'npm test')
+    assert.equal(e.status, 'running')
+    assert.equal(e.startedAt, 500)
+    assert.deepEqual(e.outputRef, { kind: 'shell', id: 'brk1' })
+  })
+
+  it('does not re-emit for a shell already tracked (preserves startedAt)', () => {
+    const { r, deltas } = makeRegistry()
+    r.onBackgroundWorkChanged({ pending: [{ shellId: 'brk1', command: 'a', startedAt: 500 }] })
+    r.onBackgroundWorkChanged({ pending: [{ shellId: 'brk1', command: 'a', startedAt: 999 }] })
+    assert.deepEqual(ops(deltas), ['started']) // second snapshot is a no-op for brk1
+    assert.equal(r.getEntries()[0].startedAt, 500)
+  })
+
+  it('ends a shell that drops out of the pending snapshot', () => {
+    const { r, deltas } = makeRegistry()
+    r.onBackgroundWorkChanged({ pending: [{ shellId: 'brk1', command: 'a' }] })
+    r.onBackgroundWorkChanged({ pending: [] })
+    assert.deepEqual(ops(deltas), ['started', 'ended'])
+    assert.equal(lastEntry(deltas).kind, 'shell')
+    assert.equal(lastEntry(deltas).status, 'done')
+  })
+
+  it('handles a missing/non-array pending field as empty', () => {
+    const { r, deltas } = makeRegistry()
+    r.onBackgroundWorkChanged({})
+    r.onBackgroundWorkChanged({ pending: null })
+    assert.equal(deltas.length, 0)
+  })
+})
+
+describe('ActivityRegistry — blocked (permission / question)', () => {
+  it('permission_request creates a blocked node, resolved-approve ends it done', () => {
+    const { r, deltas } = makeRegistry()
+    r.onPermissionRequest({ requestId: 'req1', tool: 'Bash', description: 'rm -rf build' })
+    const e = lastEntry(deltas)
+    assert.equal(e.status, 'blocked')
+    assert.equal(e.label, 'rm -rf build')
+    assert.equal(e.id, 'blocked:req1')
+
+    r.onPermissionResolved({ requestId: 'req1', decision: 'allow' })
+    assert.equal(lastEntry(deltas).status, 'done')
+  })
+
+  it('permission denied / timeout / aborted ends the node failed', () => {
+    for (const data of [
+      { requestId: 'r', decision: 'deny' },
+      { requestId: 'r', reason: 'timeout' },
+      { requestId: 'r', reason: 'aborted' },
+    ]) {
+      const { r, deltas } = makeRegistry()
+      r.onPermissionRequest({ requestId: 'r', tool: 'Bash' })
+      r.onPermissionResolved(data)
+      assert.equal(lastEntry(deltas).status, 'failed')
+    }
+  })
+
+  it('user_question creates a blocked node, resolved via toolUseId ends it', () => {
+    const { r, deltas } = makeRegistry()
+    r.onUserQuestion({ toolUseId: 'ask-1' })
+    assert.equal(lastEntry(deltas).status, 'blocked')
+    assert.equal(lastEntry(deltas).id, 'blocked:ask-1')
+    r.onPermissionResolved({ toolUseId: 'ask-1', reason: 'aborted' })
+    assert.equal(lastEntry(deltas).status, 'failed')
+  })
+})
+
+describe('ActivityRegistry — reset (turn-end) and clear (destroy)', () => {
+  it('reset ends non-shell orphans but leaves shells running', () => {
+    const { r, deltas } = makeRegistry()
+    r.onToolStart({ toolUseId: 't1', tool: 'Grep' })
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'x' })
+    r.onBackgroundWorkChanged({ pending: [{ shellId: 'brk1', command: 'a' }] })
+    deltas.length = 0
+    r.reset()
+    // tool + agent ended, shell untouched
+    const endedIds = deltas.filter((d) => d.op === 'ended').map((d) => d.entry.id).sort()
+    assert.deepEqual(endedIds, ['a1', 't1'])
+    const remaining = r.getEntries()
+    assert.equal(remaining.length, 1)
+    assert.equal(remaining[0].kind, 'shell')
+    assert.equal(remaining[0].status, 'running')
+  })
+
+  it('clear ends everything (including shells) and empties the registry', () => {
+    const { r, deltas } = makeRegistry()
+    r.onToolStart({ toolUseId: 't1', tool: 'Grep' })
+    r.onBackgroundWorkChanged({ pending: [{ shellId: 'brk1', command: 'a' }] })
+    deltas.length = 0
+    r.clear()
+    const endedIds = deltas.filter((d) => d.op === 'ended').map((d) => d.entry.id).sort()
+    assert.deepEqual(endedIds, ['shell:brk1', 't1'])
+    assert.equal(r.getEntries().length, 0)
+    // second clear is a no-op
+    deltas.length = 0
+    r.clear()
+    assert.equal(deltas.length, 0)
+  })
+})
+
+describe('ActivityRegistry — wire-schema compliance', () => {
+  it('every emitted delta validates against ServerActivityDeltaSchema', () => {
+    const { r, deltas } = makeRegistry('sess-A')
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'parent' })
+    r.onAgentEvent({ parentToolUseId: 'a1', type: 'tool_start', payload: { toolUseId: 'c1', tool: 'Read' } })
+    r.onToolStart({ toolUseId: 't1', tool: 'Bash' })
+    r.onBackgroundWorkChanged({ pending: [{ shellId: 'brk1', command: 'npm test' }] })
+    r.onPermissionRequest({ requestId: 'req1', tool: 'Bash' })
+    r.onToolResult({ toolUseId: 't1', isError: true })
+    r.onBackgroundWorkChanged({ pending: [] })
+    r.onPermissionResolved({ requestId: 'req1', decision: 'deny' })
+    r.onAgentCompleted({ toolUseId: 'a1' })
+    assert.ok(deltas.length > 0)
+    for (const d of deltas) {
+      const parsed = ServerActivityDeltaSchema.safeParse({ type: 'activity_delta', ...d })
+      assert.ok(parsed.success, `delta failed schema: ${JSON.stringify(d)} -> ${parsed.error}`)
+    }
+  })
+
+  it('snapshot validates against ServerActivitySnapshotSchema', () => {
+    const { r } = makeRegistry('sess-B')
+    r.onToolStart({ toolUseId: 't1', tool: 'Bash' })
+    r.onAgentSpawned({ toolUseId: 'a1', description: 'x' })
+    const parsed = ServerActivitySnapshotSchema.safeParse(r.getSnapshotMessage())
+    assert.ok(parsed.success, `snapshot failed schema: ${parsed.error}`)
+    assert.equal(parsed.data.entries.length, 2)
+  })
+})
+
+// --- BaseSession integration -----------------------------------------------
+
+describe('ActivityRegistry — BaseSession wiring', () => {
+  let skillsDir
+
+  beforeEach(() => {
+    skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-activity-skills-'))
+  })
+
+  function makeSession() {
+    return new BaseSession({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
+  }
+
+  it('feeds session events into the registry and re-emits activity_delta', () => {
+    const session = makeSession()
+    const deltas = []
+    session.on('activity_delta', (d) => deltas.push(d))
+
+    session.emit('tool_start', { messageId: 'm1', toolUseId: 't1', tool: 'Bash' })
+    session.emit('tool_result', { toolUseId: 't1', result: 'ok', truncated: false })
+
+    assert.deepEqual(ops(deltas), ['started', 'ended'])
+    assert.equal(deltas[0].entry.kind, 'tool')
+    assert.equal(deltas[1].entry.status, 'done')
+
+    rmSync(skillsDir, { recursive: true, force: true })
+  })
+
+  it('getActivitySnapshot reflects in-flight work', () => {
+    const session = makeSession()
+    session.emit('agent_spawned', { toolUseId: 'a1', description: 'work' })
+    const snap = session.getActivitySnapshot()
+    assert.equal(snap.type, 'activity_snapshot')
+    assert.equal(snap.entries.length, 1)
+    assert.equal(snap.entries[0].kind, 'agent')
+
+    rmSync(skillsDir, { recursive: true, force: true })
+  })
+
+  it('background_work_changed feeds shell nodes into the registry', () => {
+    const session = makeSession()
+    const deltas = []
+    session.on('activity_delta', (d) => deltas.push(d))
+    // Use the real BaseSession path so we exercise the wiring end-to-end.
+    session.trackBackgroundShell({ shellId: 'brk1', command: 'npm test' })
+    assert.equal(deltas.length, 1)
+    assert.equal(deltas[0].entry.kind, 'shell')
+    assert.equal(deltas[0].op, 'started')
+
+    session.clearBackgroundShell('brk1')
+    assert.equal(deltas.at(-1).op, 'ended')
+    assert.equal(deltas.at(-1).entry.kind, 'shell')
+
+    rmSync(skillsDir, { recursive: true, force: true })
+  })
+
+  it('_clearMessageState (turn-end) ends non-shell nodes, shells survive', () => {
+    const session = makeSession()
+    session.emit('tool_start', { messageId: 'm1', toolUseId: 't1', tool: 'Grep' })
+    session.trackBackgroundShell({ shellId: 'brk1', command: 'a' })
+    const deltas = []
+    session.on('activity_delta', (d) => deltas.push(d))
+
+    session._clearMessageState()
+
+    const ended = deltas.filter((d) => d.op === 'ended').map((d) => d.entry.id)
+    assert.ok(ended.includes('t1'))
+    assert.ok(!ended.includes('shell:brk1'))
+    const remaining = session.getActivitySnapshot().entries
+    assert.equal(remaining.length, 1)
+    assert.equal(remaining[0].kind, 'shell')
+
+    rmSync(skillsDir, { recursive: true, force: true })
+  })
+
+  it('removeAllListeners (destroy chokepoint) clears the registry', () => {
+    const session = makeSession()
+    session.trackBackgroundShell({ shellId: 'brk1', command: 'a' })
+    const deltas = []
+    session.on('activity_delta', (d) => deltas.push(d))
+
+    session.removeAllListeners()
+
+    assert.equal(deltas.length, 1)
+    assert.equal(deltas[0].op, 'ended')
+    assert.equal(session.getActivitySnapshot().entries.length, 0)
+  })
+
+  it('targeted removeAllListeners(event) does NOT drain the registry', () => {
+    const session = makeSession()
+    session.trackBackgroundShell({ shellId: 'brk1', command: 'a' })
+    session.removeAllListeners('some_other_event')
+    assert.equal(session.getActivitySnapshot().entries.length, 1)
+
+    rmSync(skillsDir, { recursive: true, force: true })
+  })
+})

--- a/packages/server/tests/activity-registry.test.js
+++ b/packages/server/tests/activity-registry.test.js
@@ -428,11 +428,17 @@ describe('ActivityRegistry — BaseSession wiring', () => {
     const deltas = []
     session.on('activity_delta', (d) => deltas.push(d))
 
+    session.on('result', () => {})
     session.removeAllListeners()
 
     assert.equal(deltas.length, 1)
     assert.equal(deltas[0].op, 'ended')
     assert.equal(session.getActivitySnapshot().entries.length, 0)
+    // The override must still remove ALL session listeners — passing
+    // `undefined` to EventEmitter.removeAllListeners is a no-op, so the
+    // no-arg forwarding is load-bearing.
+    assert.equal(session.listenerCount('result'), 0)
+    assert.equal(session.listenerCount('tool_start'), 0)
   })
 
   it('targeted removeAllListeners(event) does NOT drain the registry', () => {


### PR DESCRIPTION
## Summary

Adds a per-session **ActivityRegistry** that captures every in-flight unit of work and emits the activity-tree wire contract from #5161 (`@chroxy/protocol`):

- `activity_snapshot { entries[] }` — full tree on subscribe / resync (snapshot-on-subscribe)
- `activity_delta { op, entry }` — per-entry `started` / `updated` / `ended` upsert (full entry per op, so the downstream reducer is a pure upsert-by-id and self-heals dropped deltas)

Both carry `sessionId` + `schemaVersion` (`ACTIVITY_SCHEMA_VERSION`).

## Approach — unify, don't rebuild

The registry is a thin layer over signals **BaseSession already emits**. It listens to the session's own events and maps them into `ActivityEntry` records — it is not a parallel tracker:

| Signal | Activity node |
|---|---|
| `tool_start` / `tool_result` | long-running `tool` node |
| `agent_spawned` / `agent_completed` | `agent` node (authoritative over `tool_start` for the same `toolUseId` — a Task is one node, not two) |
| `agent_event` (#5016) | child `tool` node nested under the agent via `parentId` (session → agent → tool hierarchy) |
| `background_work_changed` (#4307) | `shell` node, reconciled against the full pending snapshot |
| `permission_request` / `user_question` / `permission_resolved` | `blocked` node |

**Status transitions:** `running` → `done`/`failed` on result; `blocked` while a permission/question is pending; terminal status always sets `endedAt >= startedAt`.

**Lifecycle:** turn-end (`_clearMessageState`) ends non-shell orphans while backgrounded shells survive (#4307); session destroy clears everything via a `removeAllListeners()` chokepoint so every provider's bespoke `destroy()` drains the tree and leaves no stale entries.

**Wire path:** reuses the existing transient `session_event` → normalizer → `_broadcastToSession` flow. The canonical `sessionId` is injected by the normalizer (matching `background_work_changed`). Snapshot-on-subscribe is served from `ws-history.sendSessionInfo` so a fresh / reconnecting client reaches canonical state in one message.

## Scope

Server emit layer only. store-core reducer (#5162) and dashboard (#5163) are separate.

## Tests

`packages/server/tests/activity-registry.test.js` (34 tests) — registry state, status transitions, Task dedup, parent→child hierarchy, shell reconciliation, blocked nodes, reset/clear lifecycle, snapshot-on-subscribe, BaseSession end-to-end wiring, and **wire-schema compliance** (every emitted delta + snapshot validated against the protocol Zod schemas). No real subprocess/docker; BaseSession integration uses a temp skills dir.

Both lint scripts pass (`lint-tests-state-file-path.sh`, `lint-session-opt-forwarding.sh`). Full server suite shows 0 new failures vs baseline (pre-existing failures are an unrelated missing `@anthropic-ai/claude-agent-sdk` dep in this environment; CI has it installed).

Closes #5160
Part of #5159