### PR TITLE
feat(store-core): platform-agnostic Control Room activity reducer

### DIFF
--- a/packages/store-core/src/activity-reducer.test.ts
+++ b/packages/store-core/src/activity-reducer.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ActivityEntry,
+  ServerActivitySnapshotMessage,
+  ServerActivityDeltaMessage,
+} from '@chroxy/protocol'
+import {
+  MAX_TERMINAL_ENTRIES_PER_SESSION,
+  createEmptyActivityState,
+  applyActivitySnapshot,
+  applyActivityDelta,
+  clearSessionActivity,
+  selectSessionEntries,
+  selectActivityTree,
+  type ActivityState,
+  type ActivityTreeNode,
+} from './activity-reducer'
+
+const T0 = 1_800_000_000_000
+
+function entry(over: Partial<ActivityEntry> & Pick<ActivityEntry, 'id'>): ActivityEntry {
+  return {
+    id: over.id,
+    kind: over.kind ?? 'tool',
+    label: over.label ?? `label-${over.id}`,
+    status: over.status ?? 'running',
+    startedAt: over.startedAt ?? T0,
+    endedAt: over.endedAt,
+    parentId: over.parentId,
+    outputRef: over.outputRef,
+  }
+}
+
+function terminal(id: string, over: Partial<ActivityEntry> = {}): ActivityEntry {
+  return entry({ id, status: 'done', endedAt: T0 + 1000, ...over })
+}
+
+function snapshot(sessionId: string, entries: ActivityEntry[]): ServerActivitySnapshotMessage {
+  return { type: 'activity_snapshot', sessionId, schemaVersion: 1, entries }
+}
+
+function delta(
+  sessionId: string,
+  op: ServerActivityDeltaMessage['op'],
+  e: ActivityEntry,
+): ServerActivityDeltaMessage {
+  return { type: 'activity_delta', sessionId, schemaVersion: 1, op, entry: e }
+}
+
+function ids(state: ActivityState, sessionId: string): string[] {
+  return selectSessionEntries(state, sessionId).map((e) => e.id)
+}
+
+describe('createEmptyActivityState', () => {
+  it('returns an empty bySession map', () => {
+    expect(createEmptyActivityState()).toEqual({ bySession: {} })
+  })
+})
+
+describe('applyActivitySnapshot', () => {
+  it('replaces the session state with normalized entries in wire order', () => {
+    const s = applyActivitySnapshot(createEmptyActivityState(), snapshot('s1', [
+      entry({ id: 'a' }),
+      entry({ id: 'b' }),
+    ]))
+    expect(ids(s, 's1')).toEqual(['a', 'b'])
+    expect(s.bySession.s1!.byId.a!.label).toBe('label-a')
+  })
+
+  it('REPLACES (not merges) prior state for that session', () => {
+    let s = applyActivitySnapshot(createEmptyActivityState(), snapshot('s1', [entry({ id: 'a' })]))
+    s = applyActivitySnapshot(s, snapshot('s1', [entry({ id: 'b' })]))
+    expect(ids(s, 's1')).toEqual(['b'])
+  })
+
+  it('leaves other sessions untouched', () => {
+    let s = applyActivitySnapshot(createEmptyActivityState(), snapshot('s1', [entry({ id: 'a' })]))
+    s = applyActivitySnapshot(s, snapshot('s2', [entry({ id: 'x' })]))
+    expect(ids(s, 's1')).toEqual(['a'])
+    expect(ids(s, 's2')).toEqual(['x'])
+  })
+
+  it('handles an empty snapshot as the valid "no activity" state', () => {
+    let s = applyActivitySnapshot(createEmptyActivityState(), snapshot('s1', [entry({ id: 'a' })]))
+    s = applyActivitySnapshot(s, snapshot('s1', []))
+    expect(ids(s, 's1')).toEqual([])
+  })
+
+  it('resolves duplicate ids in one snapshot last-writer-wins', () => {
+    const s = applyActivitySnapshot(createEmptyActivityState(), snapshot('s1', [
+      entry({ id: 'a', label: 'first' }),
+      entry({ id: 'a', label: 'second' }),
+    ]))
+    expect(ids(s, 's1')).toEqual(['a'])
+    expect(s.bySession.s1!.byId.a!.label).toBe('second')
+  })
+})
+
+describe('applyActivityDelta — upsert by id', () => {
+  it('started adds a new entry', () => {
+    const s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: 'a' })))
+    expect(ids(s, 's1')).toEqual(['a'])
+    expect(s.bySession.s1!.byId.a!.status).toBe('running')
+  })
+
+  it('updated upserts an existing entry (full replace)', () => {
+    let s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: 'a', label: 'old' })))
+    s = applyActivityDelta(s, delta('s1', 'updated', entry({ id: 'a', status: 'blocked', label: 'new' })))
+    expect(s.bySession.s1!.byId.a!.status).toBe('blocked')
+    expect(s.bySession.s1!.byId.a!.label).toBe('new')
+  })
+
+  it('updated for an unknown id creates the entry (self-healing dropped started)', () => {
+    const s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'updated', entry({ id: 'a', label: 'recovered' })))
+    expect(ids(s, 's1')).toEqual(['a'])
+    expect(s.bySession.s1!.byId.a!.label).toBe('recovered')
+  })
+
+  it('ended upserts the terminal entry and keeps it', () => {
+    let s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: 'a' })))
+    s = applyActivityDelta(s, delta('s1', 'ended', terminal('a', { status: 'failed' })))
+    expect(s.bySession.s1!.byId.a!.status).toBe('failed')
+    expect(s.bySession.s1!.byId.a!.endedAt).toBe(T0 + 1000)
+    expect(ids(s, 's1')).toEqual(['a'])
+  })
+
+  it('started for a known id replaces it (op is advisory)', () => {
+    let s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: 'a', label: 'v1' })))
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'a', label: 'v2' })))
+    expect(ids(s, 's1')).toEqual(['a'])
+    expect(s.bySession.s1!.byId.a!.label).toBe('v2')
+  })
+
+  it('seeds a session that had no prior state', () => {
+    const s = applyActivityDelta(createEmptyActivityState(), delta('newsession', 'started', entry({ id: 'a' })))
+    expect(ids(s, 'newsession')).toEqual(['a'])
+  })
+})
+
+describe('idempotency / out-of-order / duplicates', () => {
+  it('a stale non-terminal updated after ended does NOT un-terminate', () => {
+    let s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'ended', terminal('a', { status: 'done' })))
+    s = applyActivityDelta(s, delta('s1', 'updated', entry({ id: 'a', status: 'running' })))
+    expect(s.bySession.s1!.byId.a!.status).toBe('done')
+    expect(s.bySession.s1!.byId.a!.endedAt).toBe(T0 + 1000)
+  })
+
+  it('a duplicate ended is idempotent (value-stable)', () => {
+    const d = delta('s1', 'ended', terminal('a', { status: 'done' }))
+    const s = applyActivityDelta(createEmptyActivityState(), d)
+    const after = applyActivityDelta(s, d)
+    // Equal endedAt is a last-writer-wins restate (may be a new ref) but the
+    // observable state is unchanged: still one terminal entry, same fields.
+    expect(ids(after, 's1')).toEqual(['a'])
+    expect(after.bySession.s1!.byId.a).toEqual(s.bySession.s1!.byId.a)
+  })
+
+  it('a strictly-older duplicate ended is a true no-op (same ref)', () => {
+    const s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'ended', terminal('a', { status: 'done', endedAt: T0 + 2000 })))
+    const after = applyActivityDelta(s, delta('s1', 'ended', terminal('a', { status: 'done', endedAt: T0 + 1000 })))
+    expect(after).toBe(s)
+  })
+
+  it('an out-of-order older terminal does not overwrite a newer terminal', () => {
+    let s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'ended', terminal('a', { status: 'failed', endedAt: T0 + 5000 })))
+    s = applyActivityDelta(s, delta('s1', 'ended', terminal('a', { status: 'done', endedAt: T0 + 1000 })))
+    expect(s.bySession.s1!.byId.a!.status).toBe('failed')
+    expect(s.bySession.s1!.byId.a!.endedAt).toBe(T0 + 5000)
+  })
+
+  it('a newer terminal does overwrite an older terminal', () => {
+    let s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'ended', terminal('a', { status: 'done', endedAt: T0 + 1000 })))
+    s = applyActivityDelta(s, delta('s1', 'ended', terminal('a', { status: 'failed', endedAt: T0 + 5000 })))
+    expect(s.bySession.s1!.byId.a!.status).toBe('failed')
+  })
+
+  it('a no-op upsert returns the same top-level state reference', () => {
+    let s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'ended', terminal('a')))
+    const next = applyActivityDelta(s, delta('s1', 'updated', entry({ id: 'a', status: 'running' })))
+    expect(next).toBe(s)
+  })
+
+  it('does not mutate the input state (immutability)', () => {
+    const s0 = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: 'a' })))
+    const before = JSON.stringify(s0)
+    applyActivityDelta(s0, delta('s1', 'started', entry({ id: 'b' })))
+    expect(JSON.stringify(s0)).toBe(before)
+  })
+})
+
+describe('terminal-retention prune', () => {
+  it('keeps at most N most-recently-ended terminal entries, evicting oldest', () => {
+    let s = createEmptyActivityState()
+    for (let i = 0; i < 5; i++) {
+      s = applyActivityDelta(s, delta('s1', 'ended', terminal(`t${i}`, { endedAt: T0 + i * 100 })), 3)
+    }
+    // 5 terminal entries, cap 3 → oldest two (t0, t1) evicted.
+    expect(ids(s, 's1')).toEqual(['t2', 't3', 't4'])
+  })
+
+  it('never prunes running / blocked entries', () => {
+    let s = createEmptyActivityState()
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'live1', status: 'running' })), 1)
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'live2', status: 'blocked' })), 1)
+    s = applyActivityDelta(s, delta('s1', 'ended', terminal('done1', { endedAt: T0 + 100 })), 1)
+    s = applyActivityDelta(s, delta('s1', 'ended', terminal('done2', { endedAt: T0 + 200 })), 1)
+    const remaining = ids(s, 's1')
+    expect(remaining).toContain('live1')
+    expect(remaining).toContain('live2')
+    expect(remaining).toContain('done2') // newest terminal kept
+    expect(remaining).not.toContain('done1') // oldest terminal pruned (cap 1)
+  })
+
+  it('prune also applies on snapshot', () => {
+    const entries: ActivityEntry[] = []
+    for (let i = 0; i < 5; i++) entries.push(terminal(`t${i}`, { endedAt: T0 + i * 100 }))
+    const s = applyActivitySnapshot(createEmptyActivityState(), snapshot('s1', entries), 2)
+    expect(ids(s, 's1')).toEqual(['t3', 't4'])
+  })
+
+  it('disables pruning for a negative cap', () => {
+    let s = createEmptyActivityState()
+    for (let i = 0; i < 5; i++) {
+      s = applyActivityDelta(s, delta('s1', 'ended', terminal(`t${i}`, { endedAt: T0 + i })), -1)
+    }
+    expect(ids(s, 's1')).toHaveLength(5)
+  })
+
+  it('uses the documented default cap when none is passed', () => {
+    expect(MAX_TERMINAL_ENTRIES_PER_SESSION).toBeGreaterThan(0)
+    let s = createEmptyActivityState()
+    for (let i = 0; i < MAX_TERMINAL_ENTRIES_PER_SESSION + 5; i++) {
+      s = applyActivityDelta(s, delta('s1', 'ended', terminal(`t${i}`, { endedAt: T0 + i })))
+    }
+    expect(ids(s, 's1')).toHaveLength(MAX_TERMINAL_ENTRIES_PER_SESSION)
+  })
+})
+
+describe('multi-session isolation', () => {
+  it('deltas and snapshots only affect their own session', () => {
+    let s = createEmptyActivityState()
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'a' })))
+    s = applyActivityDelta(s, delta('s2', 'started', entry({ id: 'a' }))) // same id, different session
+    s = applyActivityDelta(s, delta('s1', 'ended', terminal('a')))
+    expect(s.bySession.s1!.byId.a!.status).toBe('done')
+    expect(s.bySession.s2!.byId.a!.status).toBe('running')
+  })
+
+  it('clearSessionActivity drops only the target session', () => {
+    let s = createEmptyActivityState()
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'a' })))
+    s = applyActivityDelta(s, delta('s2', 'started', entry({ id: 'b' })))
+    s = clearSessionActivity(s, 's1')
+    expect(s.bySession.s1).toBeUndefined()
+    expect(ids(s, 's2')).toEqual(['b'])
+  })
+
+  it('clearSessionActivity is a no-op (same ref) for an unknown session', () => {
+    const s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: 'a' })))
+    expect(clearSessionActivity(s, 'nope')).toBe(s)
+  })
+})
+
+describe('selectActivityTree — hierarchy build', () => {
+  it('returns empty for an unknown session', () => {
+    expect(selectActivityTree(createEmptyActivityState(), 'nope')).toEqual([])
+  })
+
+  it('builds parent → child hierarchy from parentId', () => {
+    let s = createEmptyActivityState()
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'root', kind: 'agent' })))
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'child1', parentId: 'root' })))
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'child2', parentId: 'root' })))
+    const tree = selectActivityTree(s, 's1')
+    expect(tree).toHaveLength(1)
+    expect(tree[0]!.entry.id).toBe('root')
+    expect(tree[0]!.children.map((c) => c.entry.id)).toEqual(['child1', 'child2'])
+  })
+
+  it('builds nested grandchildren', () => {
+    let s = createEmptyActivityState()
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'a' })))
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'b', parentId: 'a' })))
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'c', parentId: 'b' })))
+    const tree = selectActivityTree(s, 's1')
+    expect(tree[0]!.children[0]!.children[0]!.entry.id).toBe('c')
+  })
+
+  it('treats an unknown parentId as a root (never drops the node)', () => {
+    const s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: 'orphan', parentId: 'ghost' })))
+    const tree = selectActivityTree(s, 's1')
+    expect(tree).toHaveLength(1)
+    expect(tree[0]!.entry.id).toBe('orphan')
+  })
+
+  it('treats a self-parenting entry as a root', () => {
+    const s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: 'self', parentId: 'self' })))
+    const tree = selectActivityTree(s, 's1')
+    expect(tree).toHaveLength(1)
+    expect(tree[0]!.entry.id).toBe('self')
+    expect(tree[0]!.children).toEqual([])
+  })
+
+  it('does not infinite-loop on a parent cycle (a→b→a)', () => {
+    let s = createEmptyActivityState()
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'a', parentId: 'b' })))
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'b', parentId: 'a' })))
+    const tree = selectActivityTree(s, 's1')
+    // Every entry reachable exactly once; no throw / hang.
+    const flat: string[] = []
+    const walk = (nodes: readonly ActivityTreeNode[]): void => {
+      for (const n of nodes) {
+        flat.push(n.entry.id)
+        walk(n.children)
+      }
+    }
+    walk(tree)
+    expect(flat.sort()).toEqual(['a', 'b'])
+  })
+
+  it('orders roots and children by first-seen insertion order regardless of arrival', () => {
+    // Child arrives before parent; snapshot order is authoritative.
+    const s = applyActivitySnapshot(createEmptyActivityState(), snapshot('s1', [
+      entry({ id: 'p' }),
+      entry({ id: 'c2', parentId: 'p' }),
+      entry({ id: 'c1', parentId: 'p' }),
+    ]))
+    const tree = selectActivityTree(s, 's1')
+    expect(tree[0]!.children.map((c) => c.entry.id)).toEqual(['c2', 'c1'])
+  })
+
+  it('a child whose parent was pruned re-roots', () => {
+    let s = createEmptyActivityState()
+    // parent ends and gets pruned (cap 0 terminal kept), child stays running.
+    s = applyActivityDelta(s, delta('s1', 'ended', terminal('parent', { endedAt: T0 + 100 })), 0)
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'kid', parentId: 'parent', status: 'running' })), 0)
+    expect(s.bySession.s1!.byId.parent).toBeUndefined()
+    const tree = selectActivityTree(s, 's1')
+    expect(tree.map((n) => n.entry.id)).toEqual(['kid'])
+  })
+})
+
+describe('selectSessionEntries', () => {
+  it('returns the flat insertion-ordered list', () => {
+    let s = createEmptyActivityState()
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'b' })))
+    s = applyActivityDelta(s, delta('s1', 'started', entry({ id: 'a' })))
+    expect(selectSessionEntries(s, 's1').map((e) => e.id)).toEqual(['b', 'a'])
+  })
+
+  it('returns empty for an unknown session', () => {
+    expect(selectSessionEntries(createEmptyActivityState(), 'nope')).toEqual([])
+  })
+})

--- a/packages/store-core/src/activity-reducer.ts
+++ b/packages/store-core/src/activity-reducer.ts
@@ -1,0 +1,298 @@
+/**
+ * Control Room activity reducer (#5162, epic #5159).
+ *
+ * Platform-agnostic reducer that builds and maintains the per-session
+ * "activity tree" — the live map of in-flight subagents (`agent`),
+ * background shells (`shell`), and long-running tool calls (`tool`) — from the
+ * `activity_snapshot` + `activity_delta` wire contract (#5161). The dashboard
+ * Control Room panel (#5163) and future mobile parity both consume THIS one
+ * implementation so the two surfaces can't drift apart.
+ *
+ * Wire contract recap (see `@chroxy/protocol` `schemas/server.ts`):
+ *   - `activity_snapshot` carries the FULL current entry list for a session.
+ *     Applying it REPLACES that session's activity state (canonical resync).
+ *   - `activity_delta` carries the FULL entry on every op (`started` / `updated`
+ *     / `ended`) — never a partial patch — so each delta is self-healing: the
+ *     reducer is a pure upsert-by-id and a dropped earlier delta is recovered by
+ *     the next one. `op` is advisory; correctness comes from `entry`.
+ *
+ * State shape is normalized (`byId`) plus a flat `order` array recording
+ * first-seen insertion order, so the selector can reconstruct a deterministically
+ * ordered tree from `id` / `parentId` without depending on wire order (which the
+ * protocol explicitly says consumers MUST NOT rely on).
+ */
+
+import type {
+  ActivityEntry,
+  ServerActivitySnapshotMessage,
+  ServerActivityDeltaMessage,
+} from '@chroxy/protocol'
+
+/**
+ * Default retention cap for ended (terminal) entries kept per session. Running /
+ * blocked entries are never pruned — they're the live tree. Once an entry
+ * reaches `done` / `failed` it becomes a candidate for pruning; we keep only the
+ * `MAX_TERMINAL_ENTRIES_PER_SESSION` most-recently-ended ones (by `endedAt`,
+ * tie-broken by insertion order) so a long-lived session's tree doesn't grow
+ * unbounded as work completes. A child whose parent was pruned re-roots
+ * gracefully (the selector treats an unknown `parentId` as top-level), matching
+ * the protocol's "unknown parentId → top-level, never drop" rule.
+ */
+export const MAX_TERMINAL_ENTRIES_PER_SESSION = 50
+
+/** One session's normalized activity state. */
+export interface SessionActivityState {
+  /** Entries keyed by `ActivityEntry.id`. */
+  readonly byId: Readonly<Record<string, ActivityEntry>>
+  /**
+   * First-seen insertion order of ids. Used as the stable ordering key for the
+   * selector's tree (and tie-breaker for terminal pruning) so the rendered tree
+   * is deterministic regardless of wire-arrival order. Pruned ids are removed.
+   */
+  readonly order: readonly string[]
+}
+
+/** The full reducer state: one `SessionActivityState` per session id. */
+export interface ActivityState {
+  readonly bySession: Readonly<Record<string, SessionActivityState>>
+}
+
+/** A node in the rendered activity tree: an entry plus its ordered children. */
+export interface ActivityTreeNode {
+  readonly entry: ActivityEntry
+  readonly children: readonly ActivityTreeNode[]
+}
+
+const EMPTY_SESSION: SessionActivityState = Object.freeze({
+  byId: Object.freeze({}),
+  order: Object.freeze([]),
+})
+
+/** Fresh, empty reducer state. */
+export function createEmptyActivityState(): ActivityState {
+  return { bySession: {} }
+}
+
+function isTerminal(entry: ActivityEntry): boolean {
+  return entry.status === 'done' || entry.status === 'failed'
+}
+
+/**
+ * Decide whether `incoming` should replace `existing` for the same id.
+ *
+ * Pure upsert would let a delayed/duplicate non-terminal `updated` arriving
+ * AFTER an `ended` un-terminate the entry. Guard against that:
+ *   - An already-terminal entry is NOT overwritten by a non-terminal incoming
+ *     entry (a stale `running`/`blocked` after `done`/`failed`). The terminal
+ *     state wins — the entry stays ended.
+ *   - Two terminal entries: keep the later one (by `endedAt`); a duplicate /
+ *     out-of-order terminal with an older `endedAt` is ignored. Equal `endedAt`
+ *     takes the incoming (last-writer-wins for an identical terminal restate).
+ *   - Otherwise (no existing, or a forward non-terminal→non-terminal /
+ *     non-terminal→terminal transition) the incoming entry wins.
+ */
+function shouldReplace(existing: ActivityEntry | undefined, incoming: ActivityEntry): boolean {
+  if (existing === undefined) return true
+
+  const existingTerminal = isTerminal(existing)
+  const incomingTerminal = isTerminal(incoming)
+
+  if (existingTerminal && !incomingTerminal) {
+    // Stale non-terminal update after the entry already ended — ignore it.
+    return false
+  }
+
+  if (existingTerminal && incomingTerminal) {
+    // Both terminal: keep whichever ended later; ignore an older duplicate.
+    const existingEnd = existing.endedAt ?? 0
+    const incomingEnd = incoming.endedAt ?? 0
+    return incomingEnd >= existingEnd
+  }
+
+  // existing is non-terminal: any incoming (newer running/blocked, or the
+  // terminal transition) wins.
+  return true
+}
+
+/**
+ * Upsert `entry` into a session state, applying the {@link shouldReplace} guard
+ * and the terminal-retention prune. Returns a NEW `SessionActivityState`
+ * (immutable update) — or the SAME reference if nothing changed (so callers can
+ * cheaply skip re-renders).
+ */
+function upsertEntry(
+  session: SessionActivityState,
+  entry: ActivityEntry,
+  maxTerminal: number,
+): SessionActivityState {
+  const existing = session.byId[entry.id]
+  if (!shouldReplace(existing, entry)) return session
+
+  const byId: Record<string, ActivityEntry> = { ...session.byId, [entry.id]: entry }
+  const order = existing === undefined ? [...session.order, entry.id] : session.order
+
+  return pruneTerminal({ byId, order }, maxTerminal)
+}
+
+/**
+ * Enforce the terminal-retention rule: keep at most `maxTerminal` ended entries
+ * per session, evicting the oldest-ended first. Running / blocked entries are
+ * always kept. A negative / non-finite `maxTerminal` disables pruning. Returns
+ * the SAME reference if nothing was pruned.
+ */
+function pruneTerminal(session: SessionActivityState, maxTerminal: number): SessionActivityState {
+  if (!Number.isFinite(maxTerminal) || maxTerminal < 0) return session
+
+  const terminalIds: string[] = []
+  for (const id of session.order) {
+    const e = session.byId[id]
+    if (e !== undefined && isTerminal(e)) terminalIds.push(id)
+  }
+  if (terminalIds.length <= maxTerminal) return session
+
+  // Oldest-ended-first ordering. `endedAt` is guaranteed present on terminal
+  // entries by the protocol schema; fall back to insertion order on ties.
+  const orderIndex = new Map(session.order.map((id, idx) => [id, idx]))
+  const sorted = [...terminalIds].sort((a, b) => {
+    const ea = session.byId[a]!.endedAt ?? 0
+    const eb = session.byId[b]!.endedAt ?? 0
+    if (ea !== eb) return ea - eb
+    return (orderIndex.get(a) ?? 0) - (orderIndex.get(b) ?? 0)
+  })
+
+  const evictCount = terminalIds.length - maxTerminal
+  const evicted = new Set(sorted.slice(0, evictCount))
+
+  const byId: Record<string, ActivityEntry> = {}
+  for (const id of session.order) {
+    if (!evicted.has(id)) byId[id] = session.byId[id]!
+  }
+  const order = session.order.filter((id) => !evicted.has(id))
+
+  return { byId, order }
+}
+
+/**
+ * Apply an `activity_snapshot`: REPLACE the target session's activity state with
+ * the snapshot's entries (normalized by id, first-seen order = wire order, then
+ * pruned to the retention cap). Other sessions are untouched.
+ *
+ * Duplicate ids within one snapshot resolve last-writer-wins (a malformed
+ * server snapshot shouldn't crash the reducer).
+ */
+export function applyActivitySnapshot(
+  state: ActivityState,
+  message: ServerActivitySnapshotMessage,
+  maxTerminal: number = MAX_TERMINAL_ENTRIES_PER_SESSION,
+): ActivityState {
+  const byId: Record<string, ActivityEntry> = {}
+  const order: string[] = []
+  for (const entry of message.entries) {
+    if (!(entry.id in byId)) order.push(entry.id)
+    byId[entry.id] = entry
+  }
+
+  const session = pruneTerminal({ byId, order }, maxTerminal)
+  return {
+    bySession: { ...state.bySession, [message.sessionId]: session },
+  }
+}
+
+/**
+ * Apply an `activity_delta`: upsert the carried entry into its session by id.
+ * `op` is advisory — the FULL entry drives the result, so a `started` for a
+ * known id, an `updated` for an unknown id, and a re-sent `ended` all converge.
+ * Out-of-order / duplicate deltas are idempotent via {@link shouldReplace}.
+ * Returns the SAME state reference if the upsert was a no-op.
+ */
+export function applyActivityDelta(
+  state: ActivityState,
+  message: ServerActivityDeltaMessage,
+  maxTerminal: number = MAX_TERMINAL_ENTRIES_PER_SESSION,
+): ActivityState {
+  const current = state.bySession[message.sessionId] ?? EMPTY_SESSION
+  const next = upsertEntry(current, message.entry, maxTerminal)
+  if (next === current) return state
+  return {
+    bySession: { ...state.bySession, [message.sessionId]: next },
+  }
+}
+
+/**
+ * Drop a session's activity state entirely (e.g. on session close / unsubscribe).
+ * Returns the SAME state reference if the session wasn't present.
+ */
+export function clearSessionActivity(state: ActivityState, sessionId: string): ActivityState {
+  if (!(sessionId in state.bySession)) return state
+  const bySession = { ...state.bySession }
+  delete bySession[sessionId]
+  return { bySession }
+}
+
+/** A session's flat, insertion-ordered entry list (selector helper). */
+export function selectSessionEntries(state: ActivityState, sessionId: string): readonly ActivityEntry[] {
+  const session = state.bySession[sessionId]
+  if (session === undefined) return []
+  return session.order.map((id) => session.byId[id]!).filter((e): e is ActivityEntry => e !== undefined)
+}
+
+/**
+ * Build the renderable activity tree for a session: an array of ordered root
+ * nodes, each with ordered `children`, reconstructed from `id` / `parentId`.
+ *
+ * Ordering at every level follows first-seen insertion order (the `order`
+ * array), so the tree is deterministic regardless of wire-arrival order. An
+ * entry whose `parentId` is unknown (parent not in the tree — e.g. pruned, or a
+ * delta arriving before its parent) is treated as a ROOT rather than dropped,
+ * per the protocol's forward-compat rule. Self-parenting / cycles are broken by
+ * only attaching a child whose parent was already placed via the ordered walk;
+ * any entry that can't be attached falls back to a root, so every entry is
+ * always reachable exactly once.
+ */
+export function selectActivityTree(state: ActivityState, sessionId: string): readonly ActivityTreeNode[] {
+  const session = state.bySession[sessionId]
+  if (session === undefined) return []
+
+  const childrenByParent = new Map<string, ActivityEntry[]>()
+  const roots: ActivityEntry[] = []
+
+  for (const id of session.order) {
+    const entry = session.byId[id]
+    if (entry === undefined) continue
+    const parentId = entry.parentId
+    if (parentId !== undefined && parentId !== entry.id && parentId in session.byId) {
+      const bucket = childrenByParent.get(parentId)
+      if (bucket === undefined) childrenByParent.set(parentId, [entry])
+      else bucket.push(entry)
+    } else {
+      // No parent, self-parent, or unknown parent → root.
+      roots.push(entry)
+    }
+  }
+
+  // Guard against cycles (A→B→A): only descend into ids not already on the
+  // walk, so a cycle can't infinitely recurse. Any entry trapped in a pure
+  // cycle (every member has a known parent, so none is a root) would otherwise
+  // be unreachable — after the root walk we promote each still-unvisited entry
+  // to its own root so EVERY entry appears exactly once.
+  const visited = new Set<string>()
+  function build(entry: ActivityEntry): ActivityTreeNode {
+    visited.add(entry.id)
+    const kids = childrenByParent.get(entry.id) ?? []
+    const children: ActivityTreeNode[] = []
+    for (const kid of kids) {
+      if (visited.has(kid.id)) continue
+      children.push(build(kid))
+    }
+    return { entry, children }
+  }
+
+  const result = roots.map((entry) => build(entry))
+  for (const id of session.order) {
+    if (visited.has(id)) continue
+    const entry = session.byId[id]
+    if (entry === undefined) continue
+    result.push(build(entry))
+  }
+  return result
+}

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -205,6 +205,26 @@ export {
   applyOrphanDeltas,
 } from './orphan-deltas'
 
+// #5162 (epic #5159): platform-agnostic Control Room activity reducer. The
+// dashboard panel (#5163) and future mobile parity both derive the per-session
+// activity tree from this one implementation (snapshot replace + self-healing
+// upsert-by-id deltas + terminal-retention prune + tree selector).
+export type {
+  SessionActivityState,
+  ActivityState,
+  ActivityTreeNode,
+} from './activity-reducer'
+
+export {
+  MAX_TERMINAL_ENTRIES_PER_SESSION,
+  createEmptyActivityState,
+  applyActivitySnapshot,
+  applyActivityDelta,
+  clearSessionActivity,
+  selectSessionEntries,
+  selectActivityTree,
+} from './activity-reducer'
+
 // #4242: cheap structural gate for `JSON.parse` on streaming
 // `tool_input_delta` accumulators. Amortises N-1 throws on long
 // streams (every Bash invocation, every Edit).


### PR DESCRIPTION
## Summary

Adds a platform-agnostic **activity reducer** to `@chroxy/store-core` that builds and maintains the per-session activity tree from the `activity_snapshot` + `activity_delta` wire contract (#5161). The dashboard Control Room panel (#5163) and future mobile parity both consume this single implementation, so the two surfaces can't drift.

Reducer/state-shape only — does NOT build the dashboard panel (#5163).

## Exported API

- `createEmptyActivityState()` → `ActivityState`
- `applyActivitySnapshot(state, msg, maxTerminal?)` — REPLACE a session's state with the snapshot entries (normalized by id, wire order preserved, terminal-pruned). Other sessions untouched.
- `applyActivityDelta(state, msg, maxTerminal?)` — upsert the full carried entry by id. `op` is advisory; each delta carries the full entry so a dropped `started`/`updated`/`ended` self-heals on the next one.
- `clearSessionActivity(state, sessionId)` — drop one session (close/unsubscribe).
- `selectSessionEntries(state, sessionId)` — flat insertion-ordered list.
- `selectActivityTree(state, sessionId)` → `ActivityTreeNode[]` — ordered root+children tree.
- Types: `ActivityState`, `SessionActivityState`, `ActivityTreeNode`.
- `MAX_TERMINAL_ENTRIES_PER_SESSION` (default 50).

## State shape (for #5163)

`ActivityState = { bySession: Record<sessionId, { byId: Record<id, ActivityEntry>, order: string[] }> }`. Normalized `byId` + flat `order` (first-seen insertion order) so the tree is deterministic regardless of wire-arrival order.

## Idempotency / correctness

- A stale **non-terminal** `updated` arriving after an `ended` does NOT un-terminate the entry (terminal wins).
- Two terminals: keep the later `endedAt`; an older/duplicate terminal is ignored.
- Unknown / self / cyclic `parentId` re-roots the node rather than dropping it (matches the protocol's forward-compat rule); the tree build is cycle-safe.
- Immutable updates throughout; no-op upserts return the same reference for cheap re-render skipping.

## Prune rule (for #5163)

Keep at most `MAX_TERMINAL_ENTRIES_PER_SESSION` (default 50) ended (`done`/`failed`) entries per session, evicting oldest-ended-first (by `endedAt`, tie-broken by insertion order). Running/blocked entries are never pruned. Applied on both snapshot and delta. A child whose parent was pruned re-roots gracefully.

## Tests

37 vitest cases: snapshot replace + isolation + dup-id, started/updated/ended upserts, self-healing dropped deltas, out-of-order/duplicate idempotency, terminal prune (incl. snapshot path + disable + default cap), multi-session isolation, hierarchy build (nested, unknown/self/cyclic parents, insertion-order, pruned-parent re-root). Full store-core suite (1157) green; `tsc --noEmit` clean.

Closes #5162
Part of #5159