### PR TITLE
fix(store-core): harden Control Room activity reducer against prototype-pollution wire keys

### DIFF
--- a/packages/store-core/src/activity-reducer.test.ts
+++ b/packages/store-core/src/activity-reducer.test.ts
@@ -352,3 +352,51 @@ describe('selectSessionEntries', () => {
     expect(selectSessionEntries(createEmptyActivityState(), 'nope')).toEqual([])
   })
 })
+
+describe('prototype-key safety (wire-controlled ids/sessionIds)', () => {
+  // `byId` / `bySession` are keyed off wire strings. Plain `{}` + `in` would
+  // misdetect inherited Object.prototype members as present and let
+  // `obj["__proto__"] = entry` mutate the prototype. These lock in the
+  // null-prototype hardening.
+  const PROTO_KEYS = ['__proto__', 'toString', 'constructor', 'hasOwnProperty']
+
+  for (const key of PROTO_KEYS) {
+    it(`delta appends an id of "${key}" to order and upserts it`, () => {
+      let s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: key, label: 'v1' })))
+      expect(selectSessionEntries(s, 's1').map((e) => e.id)).toEqual([key])
+      // a second started for the same proto-key id replaces in place (no dupe in order)
+      s = applyActivityDelta(s, delta('s1', 'started', entry({ id: key, label: 'v2' })))
+      expect(selectSessionEntries(s, 's1').map((e) => e.id)).toEqual([key])
+      expect(selectSessionEntries(s, 's1')[0]!.label).toBe('v2')
+    })
+
+    it(`snapshot dedupes a proto-key id "${key}" via own-property check`, () => {
+      const s = applyActivitySnapshot(createEmptyActivityState(), snapshot('s1', [
+        entry({ id: key, label: 'first' }),
+        entry({ id: key, label: 'second' }),
+        entry({ id: 'normal' }),
+      ]))
+      expect(selectSessionEntries(s, 's1').map((e) => e.id)).toEqual([key, 'normal'])
+      expect(selectSessionEntries(s, 's1')[0]!.label).toBe('second')
+    })
+
+    it(`a parentId of "${key}" that is not a real entry re-roots the child`, () => {
+      const s = applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: 'child', parentId: key })))
+      const tree = selectActivityTree(s, 's1')
+      expect(tree.map((n) => n.entry.id)).toEqual(['child'])
+    })
+
+    it(`a sessionId of "${key}" is isolated and clearable`, () => {
+      let s = applyActivityDelta(createEmptyActivityState(), delta(key, 'started', entry({ id: 'a' })))
+      expect(selectSessionEntries(s, key).map((e) => e.id)).toEqual(['a'])
+      s = clearSessionActivity(s, key)
+      expect(selectSessionEntries(s, key)).toEqual([])
+    })
+  }
+
+  it('does not pollute Object.prototype when an id is "__proto__"', () => {
+    applyActivityDelta(createEmptyActivityState(), delta('s1', 'started', entry({ id: '__proto__', label: 'x' })))
+    // If the prototype were mutated, {}.label would be 'x'.
+    expect(({} as Record<string, unknown>).label).toBeUndefined()
+  })
+})

--- a/packages/store-core/src/activity-reducer.ts
+++ b/packages/store-core/src/activity-reducer.ts
@@ -63,14 +63,34 @@ export interface ActivityTreeNode {
   readonly children: readonly ActivityTreeNode[]
 }
 
+/**
+ * All dictionaries keyed off WIRE-controlled strings (`bySession` by
+ * `sessionId`, `byId` by `ActivityEntry.id`) use a null-prototype map so a
+ * malicious / accidental key like `"__proto__"`, `"toString"`, or
+ * `"constructor"` can't collide with an inherited `Object.prototype` member.
+ * On a plain `{}`, `"toString" in obj` is `true` even when unset (breaking
+ * upsert/order bookkeeping) and `obj["__proto__"] = entry` mutates the
+ * prototype rather than storing a value — both are closed off here. This
+ * matches the existing store-core hardening (`freeform-answer.ts`,
+ * `types.ts`'s `hasOwnProperty.call` guards). `hasKey` is the matching
+ * own-property check used instead of the `in` operator on these maps.
+ */
+function emptyRecord<V>(): Record<string, V> {
+  return Object.create(null) as Record<string, V>
+}
+
+function hasKey(obj: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key)
+}
+
 const EMPTY_SESSION: SessionActivityState = Object.freeze({
-  byId: Object.freeze({}),
+  byId: Object.freeze(emptyRecord<ActivityEntry>()),
   order: Object.freeze([]),
 })
 
 /** Fresh, empty reducer state. */
 export function createEmptyActivityState(): ActivityState {
-  return { bySession: {} }
+  return { bySession: emptyRecord<SessionActivityState>() }
 }
 
 function isTerminal(entry: ActivityEntry): boolean {
@@ -128,7 +148,9 @@ function upsertEntry(
   const existing = session.byId[entry.id]
   if (!shouldReplace(existing, entry)) return session
 
-  const byId: Record<string, ActivityEntry> = { ...session.byId, [entry.id]: entry }
+  const byId = emptyRecord<ActivityEntry>()
+  Object.assign(byId, session.byId)
+  byId[entry.id] = entry
   const order = existing === undefined ? [...session.order, entry.id] : session.order
 
   return pruneTerminal({ byId, order }, maxTerminal)
@@ -163,7 +185,7 @@ function pruneTerminal(session: SessionActivityState, maxTerminal: number): Sess
   const evictCount = terminalIds.length - maxTerminal
   const evicted = new Set(sorted.slice(0, evictCount))
 
-  const byId: Record<string, ActivityEntry> = {}
+  const byId = emptyRecord<ActivityEntry>()
   for (const id of session.order) {
     if (!evicted.has(id)) byId[id] = session.byId[id]!
   }
@@ -185,17 +207,18 @@ export function applyActivitySnapshot(
   message: ServerActivitySnapshotMessage,
   maxTerminal: number = MAX_TERMINAL_ENTRIES_PER_SESSION,
 ): ActivityState {
-  const byId: Record<string, ActivityEntry> = {}
+  const byId = emptyRecord<ActivityEntry>()
   const order: string[] = []
   for (const entry of message.entries) {
-    if (!(entry.id in byId)) order.push(entry.id)
+    if (!hasKey(byId, entry.id)) order.push(entry.id)
     byId[entry.id] = entry
   }
 
   const session = pruneTerminal({ byId, order }, maxTerminal)
-  return {
-    bySession: { ...state.bySession, [message.sessionId]: session },
-  }
+  const bySession = emptyRecord<SessionActivityState>()
+  Object.assign(bySession, state.bySession)
+  bySession[message.sessionId] = session
+  return { bySession }
 }
 
 /**
@@ -213,9 +236,10 @@ export function applyActivityDelta(
   const current = state.bySession[message.sessionId] ?? EMPTY_SESSION
   const next = upsertEntry(current, message.entry, maxTerminal)
   if (next === current) return state
-  return {
-    bySession: { ...state.bySession, [message.sessionId]: next },
-  }
+  const bySession = emptyRecord<SessionActivityState>()
+  Object.assign(bySession, state.bySession)
+  bySession[message.sessionId] = next
+  return { bySession }
 }
 
 /**
@@ -223,8 +247,9 @@ export function applyActivityDelta(
  * Returns the SAME state reference if the session wasn't present.
  */
 export function clearSessionActivity(state: ActivityState, sessionId: string): ActivityState {
-  if (!(sessionId in state.bySession)) return state
-  const bySession = { ...state.bySession }
+  if (!hasKey(state.bySession, sessionId)) return state
+  const bySession = emptyRecord<SessionActivityState>()
+  Object.assign(bySession, state.bySession)
   delete bySession[sessionId]
   return { bySession }
 }
@@ -260,7 +285,7 @@ export function selectActivityTree(state: ActivityState, sessionId: string): rea
     const entry = session.byId[id]
     if (entry === undefined) continue
     const parentId = entry.parentId
-    if (parentId !== undefined && parentId !== entry.id && parentId in session.byId) {
+    if (parentId !== undefined && parentId !== entry.id && hasKey(session.byId, parentId)) {
       const bucket = childrenByParent.get(parentId)
       if (bucket === undefined) childrenByParent.set(parentId, [entry])
       else bucket.push(entry)


### PR DESCRIPTION
## Context

Follow-up to #5162 / PR #5167 (Control Room store-core reducer). Copilot's review on #5167 arrived **after** the squash-merge landed, so its 10 valid prototype-pollution findings never made it onto main. This PR lands that hardening.

## Problem
`ActivityEntry.id` and `sessionId` come off the wire (`activity_snapshot` / `activity_delta`). Keying `byId` / `bySession` on those strings with plain `{}` objects means a `__proto__` / `constructor` / `prototype` key could pollute `Object.prototype` or collide with inherited members.

## Fix
- Every wire-keyed dictionary → null-prototype map via `emptyRecord()` (`Object.create(null)`).
- Replace the `in` operator with `hasOwnProperty.call` (`hasKey`).
- Matches existing store-core hardening precedent (`freeform-answer.ts`, `types.ts`).
- **+17 regression tests** covering `__proto__`/`toString`/`constructor`/`hasOwnProperty` as `id` / `parentId` / `sessionId` across snapshot/delta/clear/select, plus a no-`Object.prototype`-pollution assertion.

Store-core suite green (54 in the reducer file; full suite 1174), `tsc --noEmit` clean. These exact changes were reviewed by Copilot on #5167 (all 10 comments FIX).

Related to #5162, #5159.