### PR TITLE
feat(dashboard): Control Room panel — live read-only activity tree

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -274,6 +274,9 @@ export function App() {
   const sessions = useConnectionStore(s => s.sessions)
   const sessionStates = useConnectionStore(s => s.sessionStates)
   const activeSessionId = useConnectionStore(s => s.activeSessionId)
+  // #5163 (epic #5159) — Control Room activity tree, rendered by the sidebar
+  // panel slot's Control Room view.
+  const activity = useConnectionStore(s => s.activity)
   const viewMode = useConnectionStore(s => s.viewMode)
   const availableModels = useConnectionStore(s => s.availableModels)
   const availableModelsProvider = useConnectionStore(s => s.availableModelsProvider)
@@ -2189,6 +2192,7 @@ export function App() {
           searchConversations={searchConversations}
           clearSearchResults={clearSearchResults}
           sessions={sessions}
+          activity={activity}
           initialPanelHeight={loadPersistedSidebarPanelHeight() ?? 200}
           initialPanelView={loadPersistedSidebarPanelView()}
           initialPanelCollapsed={loadPersistedSidebarPanelCollapsed()}

--- a/packages/dashboard/src/components/ControlRoomPanel.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomPanel.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * ControlRoomPanel tests (#5163, epic #5159).
+ *
+ * Covers the read-only live tree rendering: hierarchy/indentation, status
+ * badges, live + frozen elapsed timers, the blocked-state highlight, and
+ * expand-to-output. The store wiring is covered separately in
+ * dispatch-control-room-activity.test.ts.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react'
+import {
+  applyActivitySnapshot,
+  createEmptyActivityState,
+  type ActivityEntry,
+  type ActivityState,
+} from '@chroxy/store-core'
+import { ControlRoomPanel, controlRoomCollapsedMetric, formatElapsed } from './ControlRoomPanel'
+
+const SESSION_ID = 'sess-1'
+
+function buildActivity(entries: ActivityEntry[], sessionId = SESSION_ID): ActivityState {
+  return applyActivitySnapshot(createEmptyActivityState(), {
+    type: 'activity_snapshot',
+    sessionId,
+    schemaVersion: 1,
+    entries,
+  })
+}
+
+function entry(id: string, over: Partial<ActivityEntry> = {}): ActivityEntry {
+  return {
+    id,
+    kind: 'agent',
+    label: `Label ${id}`,
+    status: 'running',
+    startedAt: 1000,
+    ...over,
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('ControlRoomPanel (#5163)', () => {
+  it('renders the empty state when there is no active session', () => {
+    render(<ControlRoomPanel activity={createEmptyActivityState()} activeSessionId={null} />)
+    expect(screen.getByTestId('control-room-empty')).toHaveTextContent('No active session')
+  })
+
+  it('renders the empty state when the active session has no activity', () => {
+    render(<ControlRoomPanel activity={createEmptyActivityState()} activeSessionId={SESSION_ID} />)
+    expect(screen.getByTestId('control-room-empty')).toHaveTextContent('No activity in flight')
+  })
+
+  it('renders the tree with labels and status badges', () => {
+    const activity = buildActivity([
+      entry('a', { status: 'running', label: 'Run a search' }),
+      entry('b', { status: 'done', endedAt: 2000, label: 'Done thing' }),
+      entry('c', { status: 'failed', endedAt: 3000, label: 'Failed thing' }),
+    ])
+    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+
+    expect(screen.getByTestId('control-room-entry-label-a')).toHaveTextContent('Run a search')
+    expect(screen.getByTestId('control-room-status-a')).toHaveTextContent('Running')
+    expect(screen.getByTestId('control-room-status-b')).toHaveTextContent('Done')
+    expect(screen.getByTestId('control-room-status-c')).toHaveTextContent('Failed')
+    // Accessible status label, not just colour.
+    expect(screen.getByTestId('control-room-status-a')).toHaveAttribute('aria-label', 'Status: Running')
+  })
+
+  it('indents children below their parent', () => {
+    const activity = buildActivity([
+      entry('parent', { kind: 'agent' }),
+      entry('child', { kind: 'tool', parentId: 'parent' }),
+    ])
+    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+
+    const parentToggle = screen.getByTestId('control-room-entry-toggle-parent')
+    const childToggle = screen.getByTestId('control-room-entry-toggle-child')
+    const parentPad = Number.parseInt(parentToggle.style.paddingLeft || '0', 10)
+    const childPad = Number.parseInt(childToggle.style.paddingLeft || '0', 10)
+    expect(childPad).toBeGreaterThan(parentPad)
+  })
+
+  it('freezes elapsed for terminal entries at endedAt and ticks for live ones', () => {
+    const activity = buildActivity([
+      entry('live', { status: 'running', startedAt: 0 }),
+      entry('done', { status: 'done', startedAt: 0, endedAt: 5000 }),
+    ])
+    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 10_000} />)
+    // Live entry: 10s elapsed against the injected clock.
+    expect(screen.getByTestId('control-room-elapsed-live')).toHaveTextContent('10s')
+    // Terminal entry: frozen at endedAt - startedAt = 5s, ignoring the clock.
+    expect(screen.getByTestId('control-room-elapsed-done')).toHaveTextContent('5s')
+  })
+
+  it('live-ticks the elapsed timer for running entries', () => {
+    vi.useFakeTimers()
+    let clock = 1000
+    const activity = buildActivity([entry('live', { status: 'running', startedAt: 1000 })])
+    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => clock} />)
+    expect(screen.getByTestId('control-room-elapsed-live')).toHaveTextContent('0s')
+
+    act(() => {
+      clock = 4000
+      vi.advanceTimersByTime(1000)
+    })
+    expect(screen.getByTestId('control-room-elapsed-live')).toHaveTextContent('3s')
+  })
+
+  it('highlights blocked entries with the blocked class', () => {
+    const activity = buildActivity([entry('blk', { status: 'blocked', label: 'Waiting on you' })])
+    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+    const toggle = screen.getByTestId('control-room-entry-toggle-blk')
+    expect(toggle.className).toContain('control-room-entry-blocked')
+    expect(toggle).toHaveAttribute('data-status', 'blocked')
+  })
+
+  it('expands an entry to show its output ref', () => {
+    const activity = buildActivity([
+      entry('a', { outputRef: { kind: 'tool_use', id: 'tool-42' } }),
+    ])
+    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+    expect(screen.queryByTestId('control-room-output-a')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('control-room-entry-toggle-a'))
+    expect(screen.getByTestId('control-room-output-a')).toBeInTheDocument()
+    expect(screen.getByTestId('control-room-output-ref-a')).toHaveTextContent('tool_use: tool-42')
+
+    // Toggling again collapses it.
+    fireEvent.click(screen.getByTestId('control-room-entry-toggle-a'))
+    expect(screen.queryByTestId('control-room-output-a')).toBeNull()
+  })
+
+  it('shows a "no linked output" message when an entry has no outputRef', () => {
+    const activity = buildActivity([entry('a')])
+    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+    fireEvent.click(screen.getByTestId('control-room-entry-toggle-a'))
+    expect(screen.getByTestId('control-room-output-empty-a')).toHaveTextContent('No linked output yet')
+  })
+
+  it('does not start an interval when nothing is live (terminal-only tree)', () => {
+    vi.useFakeTimers()
+    const setIntervalSpy = vi.spyOn(window, 'setInterval')
+    const activity = buildActivity([entry('done', { status: 'done', endedAt: 2000 })])
+    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 5000} />)
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+    setIntervalSpy.mockRestore()
+  })
+})
+
+describe('formatElapsed', () => {
+  it('formats seconds, minutes, and hours', () => {
+    expect(formatElapsed(0)).toBe('0s')
+    expect(formatElapsed(5000)).toBe('5s')
+    expect(formatElapsed(65_000)).toBe('1:05')
+    expect(formatElapsed(3_661_000)).toBe('1:01:01')
+  })
+
+  it('clamps negative input to 0', () => {
+    expect(formatElapsed(-1000)).toBe('0s')
+  })
+})
+
+describe('controlRoomCollapsedMetric', () => {
+  it('returns null when no active session', () => {
+    expect(controlRoomCollapsedMetric(createEmptyActivityState(), null)).toBeNull()
+  })
+
+  it('returns null when nothing is live', () => {
+    const activity = buildActivity([entry('done', { status: 'done', endedAt: 2000 })])
+    expect(controlRoomCollapsedMetric(activity, SESSION_ID)).toBeNull()
+  })
+
+  it('counts live entries and blocked entries', () => {
+    const activity = buildActivity([
+      entry('a', { status: 'running' }),
+      entry('b', { status: 'blocked' }),
+      entry('c', { status: 'done', endedAt: 2000 }),
+    ])
+    expect(controlRoomCollapsedMetric(activity, SESSION_ID)).toBe('2 live · 1 blocked')
+  })
+
+  it('omits the blocked suffix when nothing is blocked', () => {
+    const activity = buildActivity([entry('a', { status: 'running' })])
+    expect(controlRoomCollapsedMetric(activity, SESSION_ID)).toBe('1 live')
+  })
+})

--- a/packages/dashboard/src/components/ControlRoomPanel.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomPanel.test.tsx
@@ -135,6 +135,22 @@ describe('ControlRoomPanel (#5163)', () => {
     expect(screen.queryByTestId('control-room-output-a')).toBeNull()
   })
 
+  it('resets expansion state when the active session changes (id collision guard)', () => {
+    // Two sessions each have an entry with the SAME id 'a' (ids are only
+    // unique within a session). Expanding it in session 1 must NOT carry over
+    // and auto-expand the colliding id when switching to session 2.
+    const s1 = buildActivity([entry('a', { outputRef: { kind: 'tool_use', id: 't1' } })], 's1')
+    const s2 = buildActivity([entry('a', { outputRef: { kind: 'tool_use', id: 't2' } })], 's2')
+    const { rerender } = render(
+      <ControlRoomPanel activity={s1} activeSessionId="s1" now={() => 1000} />,
+    )
+    fireEvent.click(screen.getByTestId('control-room-entry-toggle-a'))
+    expect(screen.getByTestId('control-room-output-a')).toBeInTheDocument()
+
+    rerender(<ControlRoomPanel activity={s2} activeSessionId="s2" now={() => 1000} />)
+    expect(screen.queryByTestId('control-room-output-a')).toBeNull()
+  })
+
   it('shows a "no linked output" message when an entry has no outputRef', () => {
     const activity = buildActivity([entry('a')])
     render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)

--- a/packages/dashboard/src/components/ControlRoomPanel.tsx
+++ b/packages/dashboard/src/components/ControlRoomPanel.tsx
@@ -247,6 +247,13 @@ export function ControlRoomPanel({ activity, activeSessionId, now = Date.now }: 
   const tick = useTick(live, now)
 
   const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => new Set())
+  // Copilot review: `ActivityEntry.id` is only unique WITHIN a session, so the
+  // expansion set must be scoped to the active session — otherwise switching
+  // sessions could auto-expand a colliding id in the new session or carry UI
+  // state across unrelated sessions. Reset on every active-session change.
+  useEffect(() => {
+    setExpandedIds(new Set())
+  }, [activeSessionId])
   const handleToggleExpand = useCallback((id: string) => {
     setExpandedIds((prev) => {
       const next = new Set(prev)

--- a/packages/dashboard/src/components/ControlRoomPanel.tsx
+++ b/packages/dashboard/src/components/ControlRoomPanel.tsx
@@ -1,0 +1,319 @@
+/**
+ * ControlRoomPanel (#5163, epic #5159) — the v1 user-facing surface of the
+ * Control Room: a read-only live tree of everything in flight inside the
+ * active session (subagents, background shells, long-running tools), each with
+ * a status badge, a live-ticking elapsed timer, a kind icon, and an
+ * expand-to-output affordance.
+ *
+ * Slots into the sidebar panel slot (#4303) alongside the token view. It reads
+ * the per-session activity state off the connection store (fed by the
+ * store-core reducer from `activity_snapshot` / `activity_delta`) and renders
+ * the tree via `selectActivityTree` so the dashboard and future mobile parity
+ * share one tree-building implementation.
+ *
+ * v1 is READ-ONLY: no cancel/kill/jump-to-intervene actions. Control actions,
+ * the cross-session aggregate view, and mobile parity are tracked phase-2
+ * fast-follows on the epic (#5159), not this panel.
+ *
+ * Blocked-on-input entries are visually prominent and tie into the dashboard's
+ * intervention convention (#4891): a blocked entry pulses the same accent the
+ * intervention surface uses so the operator's eye lands on "this needs you".
+ */
+import { useCallback, useEffect, useState } from 'react'
+import type { ActivityEntry, ActivityState, ActivityTreeNode } from '@chroxy/store-core'
+import { selectActivityTree } from '@chroxy/store-core'
+
+export interface ControlRoomPanelProps {
+  /** Whole-store activity state (one tree per session). */
+  activity: ActivityState
+  /** Active session whose tree is rendered. Null → empty state. */
+  activeSessionId: string | null
+  /**
+   * Injectable clock for deterministic tests. Defaults to `Date.now`. Used by
+   * the elapsed timer; production passes nothing.
+   */
+  now?: () => number
+}
+
+// Kind → glyph. Kept ASCII-ish so it renders in the sidebar's small font
+// without needing an icon font. Mirrors the kinds in the protocol
+// `ActivityKindSchema` (agent / shell / tool).
+const KIND_ICON: Record<ActivityEntry['kind'], string> = {
+  agent: '◆',
+  shell: '$',
+  tool: '⚙',
+}
+
+const KIND_LABEL: Record<ActivityEntry['kind'], string> = {
+  agent: 'Subagent',
+  shell: 'Background shell',
+  tool: 'Tool',
+}
+
+const STATUS_LABEL: Record<ActivityEntry['status'], string> = {
+  running: 'Running',
+  blocked: 'Blocked',
+  done: 'Done',
+  failed: 'Failed',
+}
+
+function isTerminal(status: ActivityEntry['status']): boolean {
+  return status === 'done' || status === 'failed'
+}
+
+/**
+ * Format an elapsed duration (ms) as a compact `h:mm:ss` / `m:ss` / `Ns`
+ * string. Negative input (clock skew between server `startedAt` and the client
+ * clock) clamps to 0 so the timer never shows a negative value.
+ */
+export function formatElapsed(ms: number): string {
+  const totalSec = Math.max(0, Math.floor(ms / 1000))
+  const sec = totalSec % 60
+  const min = Math.floor(totalSec / 60) % 60
+  const hr = Math.floor(totalSec / 3600)
+  if (hr > 0) return `${hr}:${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`
+  if (min > 0) return `${min}:${String(sec).padStart(2, '0')}`
+  return `${sec}s`
+}
+
+/**
+ * Whether ANY entry in the tree is still live (running/blocked). Drives the
+ * shared ticking interval: we only run a timer while something is in flight, so
+ * a tree of only-terminal entries doesn't keep a 1s interval alive (no
+ * memory-leaking interval — #4304 panel convention).
+ */
+function hasLiveEntry(nodes: readonly ActivityTreeNode[]): boolean {
+  for (const node of nodes) {
+    if (!isTerminal(node.entry.status)) return true
+    if (hasLiveEntry(node.children)) return true
+  }
+  return false
+}
+
+/**
+ * Live-ticking "now" that only runs an interval while `enabled`. Returns the
+ * current clock value, refreshed every second. When disabled (no live
+ * entries), no interval is created and the last value is held — terminal
+ * entries freeze their elapsed at `endedAt` anyway, so the held value is
+ * irrelevant to them. The interval is always cleared on unmount / dep change,
+ * so it can't leak.
+ */
+function useTick(enabled: boolean, now: () => number): number {
+  const [tick, setTick] = useState(() => now())
+  useEffect(() => {
+    if (!enabled) return
+    // Refresh immediately so a freshly-enabled timer doesn't show a stale
+    // value for up to a second, then tick every second.
+    setTick(now())
+    const id = window.setInterval(() => setTick(now()), 1000)
+    return () => window.clearInterval(id)
+  }, [enabled, now])
+  return tick
+}
+
+interface EntryRowProps {
+  entry: ActivityEntry
+  depth: number
+  now: number
+  expanded: boolean
+  onToggleExpand: (id: string) => void
+}
+
+function EntryRow({ entry, depth, now, expanded, onToggleExpand }: EntryRowProps) {
+  const terminal = isTerminal(entry.status)
+  const blocked = entry.status === 'blocked'
+  // Terminal entries freeze elapsed at endedAt; live entries tick from `now`.
+  const elapsedMs = (terminal && entry.endedAt !== undefined ? entry.endedAt : now) - entry.startedAt
+
+  const rowClass =
+    `control-room-entry status-${entry.status}` + (blocked ? ' control-room-entry-blocked' : '')
+
+  return (
+    <li
+      className="control-room-entry-row"
+      data-testid={`control-room-entry-${entry.id}`}
+    >
+      <button
+        type="button"
+        className={rowClass}
+        // Indent children by depth. paddingLeft keeps the whole row clickable
+        // (vs a margin that would leave dead gutter).
+        style={{ paddingLeft: 6 + depth * 14 }}
+        aria-expanded={expanded}
+        data-status={entry.status}
+        data-testid={`control-room-entry-toggle-${entry.id}`}
+        onClick={() => onToggleExpand(entry.id)}
+        title={`${KIND_LABEL[entry.kind]} · ${STATUS_LABEL[entry.status]}`}
+      >
+        <span className="control-room-entry-icon" aria-hidden="true">
+          {KIND_ICON[entry.kind]}
+        </span>
+        <span className="control-room-entry-label" data-testid={`control-room-entry-label-${entry.id}`}>
+          {entry.label || KIND_LABEL[entry.kind]}
+        </span>
+        <span
+          className={`control-room-status-badge status-${entry.status}`}
+          data-testid={`control-room-status-${entry.id}`}
+          // The badge's colour is the only signal of status; an explicit label
+          // keeps it accessible to screen readers and colour-blind users.
+          role="status"
+          aria-label={`Status: ${STATUS_LABEL[entry.status]}`}
+        >
+          {STATUS_LABEL[entry.status]}
+        </span>
+        <span
+          className="control-room-entry-elapsed"
+          data-testid={`control-room-elapsed-${entry.id}`}
+          // Elapsed is decorative against the label; give SR users context.
+          aria-label={`Elapsed ${formatElapsed(elapsedMs)}`}
+        >
+          {formatElapsed(elapsedMs)}
+        </span>
+      </button>
+      {expanded && (
+        <div
+          className="control-room-entry-output"
+          data-testid={`control-room-output-${entry.id}`}
+        >
+          <div className="control-room-output-row">
+            <span className="control-room-output-key">Kind</span>
+            <span className="control-room-output-val">{KIND_LABEL[entry.kind]}</span>
+          </div>
+          <div className="control-room-output-row">
+            <span className="control-room-output-key">Status</span>
+            <span className="control-room-output-val">{STATUS_LABEL[entry.status]}</span>
+          </div>
+          {entry.outputRef ? (
+            <div className="control-room-output-row">
+              <span className="control-room-output-key">Output</span>
+              <span
+                className="control-room-output-val control-room-output-ref"
+                data-testid={`control-room-output-ref-${entry.id}`}
+              >
+                {entry.outputRef.kind}: {entry.outputRef.id}
+              </span>
+            </div>
+          ) : (
+            <div className="control-room-output-empty" data-testid={`control-room-output-empty-${entry.id}`}>
+              No linked output yet
+            </div>
+          )}
+        </div>
+      )}
+    </li>
+  )
+}
+
+interface EntryTreeProps {
+  nodes: readonly ActivityTreeNode[]
+  depth: number
+  now: number
+  expandedIds: ReadonlySet<string>
+  onToggleExpand: (id: string) => void
+}
+
+function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand }: EntryTreeProps) {
+  return (
+    <ul className="control-room-entry-list" data-testid={depth === 0 ? 'control-room-tree' : undefined}>
+      {nodes.map((node) => (
+        <li key={node.entry.id} className="control-room-entry-group">
+          <ul className="control-room-entry-list-inner">
+            <EntryRow
+              entry={node.entry}
+              depth={depth}
+              now={now}
+              expanded={expandedIds.has(node.entry.id)}
+              onToggleExpand={onToggleExpand}
+            />
+          </ul>
+          {node.children.length > 0 && (
+            <EntryTree
+              nodes={node.children}
+              depth={depth + 1}
+              now={now}
+              expandedIds={expandedIds}
+              onToggleExpand={onToggleExpand}
+            />
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export function ControlRoomPanel({ activity, activeSessionId, now = Date.now }: ControlRoomPanelProps) {
+  const tree = selectActivityTree(activity, activeSessionId ?? '')
+  const live = hasLiveEntry(tree)
+  const tick = useTick(live, now)
+
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => new Set())
+  const handleToggleExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  if (activeSessionId === null) {
+    return (
+      <div className="control-room-panel" data-testid="control-room-panel">
+        <div className="control-room-empty" data-testid="control-room-empty">
+          No active session
+        </div>
+      </div>
+    )
+  }
+
+  if (tree.length === 0) {
+    return (
+      <div className="control-room-panel" data-testid="control-room-panel">
+        <div className="control-room-empty" data-testid="control-room-empty">
+          No activity in flight
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="control-room-panel" data-testid="control-room-panel">
+      <EntryTree
+        nodes={tree}
+        depth={0}
+        now={tick}
+        expandedIds={expandedIds}
+        onToggleExpand={handleToggleExpand}
+      />
+    </div>
+  )
+}
+
+/**
+ * Collapsed-panel header metric for the Control Room (decision #4 in #4303):
+ * a one-glance count of live (running/blocked) entries in the active session's
+ * tree, so the operator sees in-flight work without expanding the panel.
+ * Returns null when nothing is live so the slot can hide the metric.
+ */
+export function controlRoomCollapsedMetric(
+  activity: ActivityState,
+  activeSessionId: string | null,
+): string | null {
+  if (activeSessionId === null) return null
+  const tree = selectActivityTree(activity, activeSessionId)
+  let live = 0
+  let blocked = 0
+  function walk(nodes: readonly ActivityTreeNode[]): void {
+    for (const node of nodes) {
+      if (!isTerminal(node.entry.status)) {
+        live += 1
+        if (node.entry.status === 'blocked') blocked += 1
+      }
+      walk(node.children)
+    }
+  }
+  walk(tree)
+  if (live === 0) return null
+  if (blocked > 0) return `${live} live · ${blocked} blocked`
+  return `${live} live`
+}

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -5,12 +5,13 @@
  * Collapsible with Cmd+B toggle.
  */
 import { useState, useCallback, useRef, useMemo } from 'react'
-import type { CumulativeUsage, SessionInfo, SessionVisualStatus } from '@chroxy/store-core'
-import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
+import type { ActivityState, CumulativeUsage, SessionInfo, SessionVisualStatus } from '@chroxy/store-core'
+import { createEmptyActivityState, formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
 import { SidebarPanelSlot, type SidebarPanelView } from './SidebarPanelSlot'
 import { SidebarTokenView, tokenViewCollapsedMetric } from './SidebarTokenView'
+import { ControlRoomPanel, controlRoomCollapsedMetric } from './ControlRoomPanel'
 import type { SearchResult } from '../store/types'
 import {
   persistSidebarPanelHeight,
@@ -84,6 +85,10 @@ export interface SidebarProps {
   // #4303 — full sessions list (used by the bottom slot's token view).
   // Optional so existing tests + callers don't break; defaults to [].
   sessions?: SessionInfo[]
+  // #5163 (epic #5159) — Control Room activity state for the bottom slot's
+  // Control Room view. Optional so existing tests/callers default to an empty
+  // tree (the panel renders its "no activity" empty state).
+  activity?: ActivityState
   // #4303 — initial state for the bottom panel slot (loaded from
   // localStorage in App.tsx; defaults applied here).
   initialPanelHeight?: number
@@ -97,6 +102,11 @@ export interface SidebarProps {
   onReorderRepos?: (orderedRepoPaths: string[]) => void
   onReorderSessions?: (repoPath: string, orderedSessionIds: string[]) => void
 }
+
+// #5163 — stable empty-activity default so the `activity` prop falling back to
+// its default doesn't allocate a new object each render (which would break the
+// panelViews useMemo referential check below).
+const EMPTY_ACTIVITY: ActivityState = createEmptyActivityState()
 
 function abbreviateTunnel(url: string): string {
   try {
@@ -128,6 +138,7 @@ export function Sidebar({
   clearSearchResults,
   onWidthChange,
   sessions = [],
+  activity = EMPTY_ACTIVITY,
   initialPanelHeight = 200,
   initialPanelView = null,
   initialPanelCollapsed = false,
@@ -188,7 +199,17 @@ export function Sidebar({
       ),
       collapsedHeaderMetric: () => tokenViewCollapsedMetric(sessions),
     },
-  ]), [sessions, activeSessionId, onSessionClick])
+    {
+      // #5163 (epic #5159) — Control Room: live read-only tree of the active
+      // session's in-flight subagents / background shells / tools.
+      id: 'control-room',
+      label: 'Control Room',
+      render: () => (
+        <ControlRoomPanel activity={activity} activeSessionId={activeSessionId} />
+      ),
+      collapsedHeaderMetric: () => controlRoomCollapsedMetric(activity, activeSessionId),
+    },
+  ]), [sessions, activeSessionId, onSessionClick, activity])
 
   const toggleRepo = useCallback((path: string) => {
     setCollapsed(prev => ({ ...prev, [path]: !prev[path] }))

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -127,6 +127,9 @@ import {
   // narrowing lets the post-detection `as { otherLabel, freeformText }`
   // casts drop out.
   isFreeformAnswer,
+  // #5163 (epic #5159): seed the Control Room activity state empty so the
+  // reducer can apply snapshots/deltas immutably from the first message.
+  createEmptyActivityState,
 } from '@chroxy/store-core';
 import { decrypt, DIRECTION_SERVER, type EncryptedEnvelope } from './crypto';
 import {
@@ -358,6 +361,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   sessions: [],
   activeSessionId: null,
   sessionStates: {},
+  // #5163 (epic #5159): Control Room activity tree, fed by the store-core
+  // reducer from activity_snapshot / activity_delta.
+  activity: createEmptyActivityState(),
   claudeReady: false,
   streamingMessageId: null,
   activeModel: null,
@@ -1355,6 +1361,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       sessions: [],
       activeSessionId: null,
       sessionStates: {},
+      // #5163: drop the Control Room tree on disconnect/forget — a fresh
+      // connection re-seeds it from activity_snapshot on subscribe.
+      activity: createEmptyActivityState(),
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -1381,6 +1390,9 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       sessions: [],
       activeSessionId: null,
       sessionStates: {},
+      // #5163: drop the Control Room tree on disconnect/forget — a fresh
+      // connection re-seeds it from activity_snapshot on subscribe.
+      activity: createEmptyActivityState(),
       wsUrl: null,
       apiToken: null,
       serverMode: null,

--- a/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
+++ b/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
@@ -205,6 +205,35 @@ describe('Control Room activity dispatch (#5163)', () => {
     expect(store.getState().activity).toBe(after)
   })
 
+  it('bumps lastClientActivityAt and clears inactivityWarning on activity_delta', () => {
+    // Seed the active session with a stale activity timestamp + an outstanding
+    // inactivity warning, then deliver a delta. The handler treats the delta as
+    // activity-bearing: it bumps lastClientActivityAt and clears the warning.
+    const seeded = createEmptySessionState()
+    store.setState({
+      sessionStates: {
+        [SESSION_ID]: {
+          ...seeded,
+          lastClientActivityAt: 1,
+          inactivityWarning: { idleMs: 1000, prefab: 'quiet', receivedAt: 1 },
+        },
+      },
+    })
+    handleMessage(delta('started', runningEntry('z')), ctx() as never)
+    const ss = store.getState().sessionStates[SESSION_ID]!
+    expect(ss.lastClientActivityAt).toBeGreaterThan(1)
+    expect(ss.inactivityWarning).toBeNull()
+  })
+
+  it('does NOT bump activity on activity_snapshot (resync, not fresh work)', () => {
+    const seeded = createEmptySessionState()
+    store.setState({
+      sessionStates: { [SESSION_ID]: { ...seeded, lastClientActivityAt: 1 } },
+    })
+    handleMessage(snapshot([runningEntry('a')]), ctx() as never)
+    expect(store.getState().sessionStates[SESSION_ID]!.lastClientActivityAt).toBe(1)
+  })
+
   it('clears a session activity tree when session_list drops it', () => {
     handleMessage(snapshot([runningEntry('a')], SESSION_ID), ctx() as never)
     handleMessage(snapshot([runningEntry('b')], OTHER_SESSION_ID), ctx() as never)

--- a/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
+++ b/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Integration test for the Control Room activity wiring (#5163, epic #5159).
+ *
+ * Guards the wire path between the dashboard message handler and the store-core
+ * activity reducer:
+ *   - `activity_snapshot` REPLACES the target session's tree.
+ *   - `activity_delta` upserts the carried entry by id (self-healing).
+ *   - malformed payloads are dropped (Zod safeParse) without crashing.
+ *   - a no-op delta short-circuits without re-allocating `activity`.
+ *   - `session_list` removal drops a closed session's activity tree.
+ *
+ * The reducer + selector have their own unit tests in store-core
+ * (activity-reducer.test.ts); this file covers ONLY the handler glue.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./crypto', () => ({
+  createKeyPair: vi.fn(() => ({ publicKey: 'mock-pub', secretKey: 'mock-sec' })),
+  deriveSharedKey: vi.fn(),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  generateConnectionSalt: vi.fn(() => 'mock-salt'),
+  deriveConnectionKey: vi.fn(() => new Uint8Array(32)),
+  DIRECTION_CLIENT: 0,
+  DIRECTION_SERVER: 1,
+}))
+
+vi.mock('./persistence', () => ({
+  clearPersistedSession: vi.fn(),
+}))
+
+import {
+  handleMessage,
+  setStore,
+  clearDeltaBuffers,
+  clearPermissionSplits,
+  stopHeartbeat,
+  resetReplayFlags,
+} from './message-handler'
+import {
+  createEmptyActivityState,
+  selectActivityTree,
+  type ActivityEntry,
+} from '@chroxy/store-core'
+import { createEmptySessionState } from './utils'
+import type { ConnectionState } from './types'
+
+const SESSION_ID = 'sess-cr-1'
+const OTHER_SESSION_ID = 'sess-cr-2'
+
+function createMockStore(initial: Partial<ConnectionState>) {
+  let state = initial as ConnectionState
+  return {
+    getState: () => state,
+    setState: (s: Partial<ConnectionState> | ((prev: ConnectionState) => Partial<ConnectionState>)) => {
+      const patch = typeof s === 'function' ? s(state) : s
+      state = { ...state, ...patch }
+    },
+  }
+}
+
+function createMockSocket(): WebSocket {
+  return {
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: WebSocket.OPEN,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+function baseState(): Partial<ConnectionState> {
+  return {
+    connectionPhase: 'connected',
+    socket: null,
+    sessions: [],
+    activeSessionId: SESSION_ID,
+    sessionStates: { [SESSION_ID]: createEmptySessionState() },
+    activity: createEmptyActivityState(),
+    messages: [],
+  }
+}
+
+function runningEntry(id: string, over: Partial<ActivityEntry> = {}): ActivityEntry {
+  return {
+    id,
+    kind: 'agent',
+    label: `entry-${id}`,
+    status: 'running',
+    startedAt: 1000,
+    ...over,
+  }
+}
+
+function snapshot(entries: ActivityEntry[], sessionId = SESSION_ID) {
+  return { type: 'activity_snapshot', sessionId, schemaVersion: 1, entries }
+}
+
+function delta(op: 'started' | 'updated' | 'ended', entry: ActivityEntry, sessionId = SESSION_ID) {
+  return { type: 'activity_delta', sessionId, schemaVersion: 1, op, entry }
+}
+
+describe('Control Room activity dispatch (#5163)', () => {
+  let store: ReturnType<typeof createMockStore>
+  let mockSocket: WebSocket
+
+  const ctx = () => ({
+    url: 'wss://t',
+    token: 'tok',
+    socket: mockSocket,
+    isReconnect: false,
+    silent: false,
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    mockSocket = createMockSocket()
+    store = createMockStore(baseState())
+    setStore(store)
+  })
+
+  afterEach(() => {
+    stopHeartbeat()
+    clearDeltaBuffers()
+    clearPermissionSplits()
+    resetReplayFlags()
+  })
+
+  it('applies activity_snapshot, replacing the session tree', () => {
+    handleMessage(snapshot([runningEntry('a'), runningEntry('b')]), ctx() as never)
+    const tree = selectActivityTree(store.getState().activity, SESSION_ID)
+    expect(tree.map((n) => n.entry.id)).toEqual(['a', 'b'])
+
+    // A second snapshot REPLACES (not merges) the prior entries.
+    handleMessage(snapshot([runningEntry('c')]), ctx() as never)
+    const tree2 = selectActivityTree(store.getState().activity, SESSION_ID)
+    expect(tree2.map((n) => n.entry.id)).toEqual(['c'])
+  })
+
+  it('applies activity_delta upserts by id (started then ended)', () => {
+    handleMessage(delta('started', runningEntry('x')), ctx() as never)
+    expect(selectActivityTree(store.getState().activity, SESSION_ID).map((n) => n.entry.status)).toEqual([
+      'running',
+    ])
+
+    handleMessage(
+      delta('ended', runningEntry('x', { status: 'done', endedAt: 5000 })),
+      ctx() as never,
+    )
+    const tree = selectActivityTree(store.getState().activity, SESSION_ID)
+    expect(tree).toHaveLength(1)
+    expect(tree[0]!.entry.status).toBe('done')
+    expect(tree[0]!.entry.endedAt).toBe(5000)
+  })
+
+  it('builds parent→child hierarchy from a delta with parentId', () => {
+    handleMessage(delta('started', runningEntry('parent', { kind: 'agent' })), ctx() as never)
+    handleMessage(
+      delta('started', runningEntry('child', { kind: 'tool', parentId: 'parent' })),
+      ctx() as never,
+    )
+    const tree = selectActivityTree(store.getState().activity, SESSION_ID)
+    expect(tree).toHaveLength(1)
+    expect(tree[0]!.entry.id).toBe('parent')
+    expect(tree[0]!.children.map((c) => c.entry.id)).toEqual(['child'])
+  })
+
+  it('keeps per-session trees isolated', () => {
+    handleMessage(snapshot([runningEntry('a')], SESSION_ID), ctx() as never)
+    handleMessage(snapshot([runningEntry('b')], OTHER_SESSION_ID), ctx() as never)
+    expect(selectActivityTree(store.getState().activity, SESSION_ID).map((n) => n.entry.id)).toEqual(['a'])
+    expect(selectActivityTree(store.getState().activity, OTHER_SESSION_ID).map((n) => n.entry.id)).toEqual([
+      'b',
+    ])
+  })
+
+  it('drops a malformed activity_snapshot without crashing or mutating state', () => {
+    const before = store.getState().activity
+    // Missing required `entries` array.
+    handleMessage({ type: 'activity_snapshot', sessionId: SESSION_ID, schemaVersion: 1 }, ctx() as never)
+    expect(store.getState().activity).toBe(before)
+  })
+
+  it('drops a malformed activity_delta (terminal status without endedAt)', () => {
+    const before = store.getState().activity
+    handleMessage(
+      delta('ended', { id: 'bad', kind: 'tool', label: 'b', status: 'done', startedAt: 1 }),
+      ctx() as never,
+    )
+    expect(store.getState().activity).toBe(before)
+  })
+
+  it('short-circuits a no-op delta without re-allocating activity state', () => {
+    // End the entry, then send a STALE running update for the same id. The
+    // reducer's terminal-precedence guard rejects it (returns the same state
+    // reference), and the handler must NOT call set() for that no-op.
+    handleMessage(delta('started', runningEntry('y')), ctx() as never)
+    handleMessage(delta('ended', runningEntry('y', { status: 'done', endedAt: 5000 })), ctx() as never)
+    const after = store.getState().activity
+    handleMessage(delta('updated', runningEntry('y', { status: 'running' })), ctx() as never)
+    expect(store.getState().activity).toBe(after)
+  })
+
+  it('clears a session activity tree when session_list drops it', () => {
+    handleMessage(snapshot([runningEntry('a')], SESSION_ID), ctx() as never)
+    handleMessage(snapshot([runningEntry('b')], OTHER_SESSION_ID), ctx() as never)
+
+    // session_list now only lists OTHER_SESSION_ID — SESSION_ID is removed.
+    handleMessage(
+      {
+        type: 'session_list',
+        sessions: [{ sessionId: OTHER_SESSION_ID, name: 'keep', cwd: '/tmp', provider: 'claude-cli' }],
+      },
+      ctx() as never,
+    )
+
+    expect(selectActivityTree(store.getState().activity, SESSION_ID)).toEqual([])
+    expect(selectActivityTree(store.getState().activity, OTHER_SESSION_ID).map((n) => n.entry.id)).toEqual([
+      'b',
+    ])
+  })
+})

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1848,6 +1848,16 @@ function handleActivitySnapshot(msg: Record<string, unknown>, get: MsgGet, set: 
  * into its session by id. `op` is advisory — the full entry drives the result,
  * so a dropped earlier delta is self-healed by the next one. Validated +
  * no-op-short-circuited like the snapshot handler above.
+ *
+ * Copilot review: an `activity_delta` is a genuine live state change (a
+ * background shell / subagent / tool started, progressed, or ended), so it
+ * also counts as activity-bearing — bump `lastClientActivityAt` and clear any
+ * outstanding `inactivityWarning` for the delta's session so the "Working… last
+ * activity Ns ago" indicator and the inactivity chip don't go stale while only
+ * Control Room traffic is flowing. Gated on `_replayingSessions` exactly like
+ * the dispatch-level bump (#4466) so a session switch's history replay doesn't
+ * reset the timestamp. NOTE: `activity_snapshot` deliberately does NOT bump —
+ * it's a full-state resync emitted on subscribe / reconnect, not fresh work.
  */
 function handleActivityDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const parsed = ServerActivityDeltaSchema.safeParse(msg);
@@ -1856,6 +1866,15 @@ function handleActivityDelta(msg: Record<string, unknown>, get: MsgGet, set: Msg
   const next = applyActivityDelta(prev, parsed.data);
   if (next === prev) return;
   set({ activity: next });
+
+  const sessionId = parsed.data.sessionId;
+  if (get().sessionStates[sessionId] && !_replayingSessions.has(sessionId)) {
+    updateSession(sessionId, (ss) => {
+      const patch: Partial<SessionState> = { lastClientActivityAt: Date.now() };
+      if (ss.inactivityWarning) patch.inactivityWarning = null;
+      return patch;
+    });
+  }
 }
 
 /**

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -103,13 +103,19 @@ import {
   handleUserQuestion as sharedUserQuestion,
   applyOrphanDeltas,
   isActivityEvent,
+  // #5163 (epic #5159): Control Room activity reducer — snapshot replace +
+  // self-healing delta upsert + terminal-retention prune. The dashboard
+  // panel and future mobile parity both consume this one implementation.
+  applyActivitySnapshot,
+  applyActivityDelta,
+  clearSessionActivity,
   // #5039: pre-formatted partial-cost sub-line used by the `case 'error'`
   // branch so the toast and the mobile Alert share copy.
   formatPartialCostLine,
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerNotificationPrefsSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerNotificationPrefsSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema } from '@chroxy/protocol/schemas'
 import {
   createKeyPair,
   deriveSharedKey,
@@ -1817,6 +1823,42 @@ function handleServerShutdown(msg: Record<string, unknown>, _get: MsgGet, set: M
 }
 
 /**
+ * #5163 (epic #5159) — Control Room `activity_snapshot`: REPLACE the target
+ * session's activity tree with the snapshot's entries via the store-core
+ * reducer. Emitted on subscribe / resync so a late-joining or reconnecting
+ * client reaches canonical state in one message.
+ *
+ * The wire shape is validated with the protocol Zod schema (same defensive
+ * pattern as the credential-status handlers) so a malformed payload is dropped
+ * rather than crashing the reducer. `applyActivityDelta`/`applyActivitySnapshot`
+ * return the SAME state reference on a no-op, so the equality short-circuit
+ * below skips a needless re-render.
+ */
+function handleActivitySnapshot(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerActivitySnapshotSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const prev = get().activity;
+  const next = applyActivitySnapshot(prev, parsed.data);
+  if (next === prev) return;
+  set({ activity: next });
+}
+
+/**
+ * #5163 (epic #5159) — Control Room `activity_delta`: upsert the carried entry
+ * into its session by id. `op` is advisory — the full entry drives the result,
+ * so a dropped earlier delta is self-healed by the next one. Validated +
+ * no-op-short-circuited like the snapshot handler above.
+ */
+function handleActivityDelta(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerActivityDeltaSchema.safeParse(msg);
+  if (!parsed.success) return;
+  const prev = get().activity;
+  const next = applyActivityDelta(prev, parsed.data);
+  if (next === prev) return;
+  set({ activity: next });
+}
+
+/**
  * Map of message type → handler function for the simplest, most self-contained
  * cases. handleMessage() dispatches to this map first; unmatched types fall
  * through to the legacy switch statement below.
@@ -1867,6 +1909,9 @@ const HANDLERS: Record<string, Handler> = {
   budget_resumed: handleBudgetResumed,
   server_error: handleServerError,
   server_shutdown: handleServerShutdown,
+  // #5163 (epic #5159): Control Room live activity tree.
+  activity_snapshot: handleActivitySnapshot,
+  activity_delta: handleActivityDelta,
 };
 
 // ---------------------------------------------------------------------------
@@ -2110,6 +2155,13 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           delete newStates[id];
         }
         patch.sessionStates = newStates;
+        // #5163: drop the Control Room activity tree for any session that
+        // dropped out of the list so a closed session's tree doesn't linger.
+        let nextActivity = get().activity;
+        for (const id of removedIds) {
+          nextActivity = clearSessionActivity(nextActivity, id);
+        }
+        if (nextActivity !== get().activity) patch.activity = nextActivity;
         // If the active session was removed, switch to next available
         if (initialActiveId && removedIds.includes(initialActiveId)) {
           const remaining = Object.keys(newStates);

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -65,6 +65,13 @@ export type {
   // dashboard-local GitStatusEntry. Same shape (path + status union) — was
   // missed by the #3132 dedup sweep that moved DiffFile/Hunk/HunkLine.
   GitFileStatus,
+  // #5163 (epic #5159): Control Room activity state. The reducer + selector
+  // live in store-core (#5162); the dashboard holds one `ActivityState` on
+  // the connection store and the Control Room panel renders it via
+  // `selectActivityTree`.
+  ActivityState,
+  ActivityEntry,
+  ActivityTreeNode,
 } from '@chroxy/store-core';
 
 // Import for local use in SessionState/ConnectionState definitions below
@@ -514,6 +521,16 @@ export interface ConnectionState {
   sessions: SessionInfo[];
   activeSessionId: string | null;
   sessionStates: Record<string, SessionState>;
+
+  /**
+   * #5163 (epic #5159) — Control Room activity state: the per-session live
+   * tree of in-flight subagents / background shells / long-running tools,
+   * fed by `activity_snapshot` + `activity_delta` through the store-core
+   * reducer. The Control Room sidebar panel renders the active session's
+   * tree via `selectActivityTree(activity, activeSessionId)`. Read-only in
+   * v1 — control actions are a tracked phase-2 follow-up on the epic.
+   */
+  activity: import('@chroxy/store-core').ActivityState;
 
   // Legacy flat state (used when server doesn't send session_list, i.e. PTY mode)
   claudeReady: boolean;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1064,6 +1064,179 @@ button.sidebar-token-view-session-row:hover {
   flex-shrink: 0;
 }
 
+/* #5163 (epic #5159) — Control Room panel: live read-only activity tree. */
+.control-room-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.control-room-empty {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-style: italic;
+  padding: 4px 2px;
+}
+
+.control-room-entry-list,
+.control-room-entry-list-inner {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.control-room-entry-row {
+  display: flex;
+  flex-direction: column;
+}
+
+.control-room-entry {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 3px 6px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.control-room-entry:hover,
+.control-room-entry:focus-visible {
+  background: var(--bg-tertiary);
+}
+
+.control-room-entry-icon {
+  flex-shrink: 0;
+  width: 12px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.control-room-entry-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.control-room-entry-elapsed {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+}
+
+.control-room-status-badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.control-room-status-badge.status-running {
+  color: var(--accent-blue);
+  background: var(--accent-blue-light);
+  border-color: var(--accent-blue-border);
+}
+
+.control-room-status-badge.status-done {
+  color: var(--accent-green);
+  background: var(--accent-green-light);
+  border-color: var(--accent-green-border);
+}
+
+.control-room-status-badge.status-failed {
+  color: var(--accent-red);
+  background: var(--accent-red-light);
+  border-color: var(--accent-red-border);
+}
+
+.control-room-status-badge.status-blocked {
+  color: var(--accent-orange);
+  background: var(--accent-orange-medium);
+  border-color: var(--accent-orange-border-strong);
+}
+
+/* Blocked-on-input entries are visually prominent and tie into the
+   intervention surface (#4891): a steady amber accent + left rule so the
+   operator's eye lands on "this needs you". A subtle pulse draws attention
+   without the motion being distracting; respects reduced-motion below. */
+.control-room-entry-blocked {
+  background: var(--accent-orange-light);
+  border-color: var(--accent-orange-border);
+  border-left: 3px solid var(--accent-orange);
+  animation: control-room-blocked-pulse 2s ease-in-out infinite;
+}
+
+.control-room-entry-blocked:hover,
+.control-room-entry-blocked:focus-visible {
+  background: var(--accent-orange-subtle);
+}
+
+@keyframes control-room-blocked-pulse {
+  0%, 100% { border-left-color: var(--accent-orange); }
+  50% { border-left-color: var(--accent-orange-border-strong); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .control-room-entry-blocked {
+    animation: none;
+  }
+}
+
+.control-room-entry-output {
+  margin: 2px 6px 4px 18px;
+  padding: 4px 8px;
+  background: var(--bg-tertiary);
+  border-radius: 4px;
+  font-size: 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.control-room-output-row {
+  display: flex;
+  gap: 8px;
+}
+
+.control-room-output-key {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  min-width: 48px;
+}
+
+.control-room-output-val {
+  color: var(--text-secondary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.control-room-output-ref {
+  font-family: var(--font-mono, monospace);
+}
+
+.control-room-output-empty {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 .sidebar-status-dot {
   width: 6px;
   height: 6px;

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -46,8 +46,9 @@ const INTENTIONALLY_UNHANDLED = new Set([
   'rate_limited',       // rate limit signals, handled at connection layer
   'extension_message',  // extension framework, routed to extension handlers not main switch
   'stdin_dropped_totals', // #3544 transient counter event — surface is the SessionInfo.stdinForwardingDisabled flag from session_list (#3567/#3593), not the wire event; live counter consumers tracked in #3573
-  'activity_snapshot', // #5161 schema-only — Control Room activity tree wire contract. No handler yet: the server emitter is #5160, the store-core reducer is #5162, and the dashboard panel that consumes it is #5163. Becomes dashboard-handled (move to PLATFORM_SPECIFIC) when #5163 lands; mobile parity is a Phase-2 fast-follow per epic #5159.
-  'activity_delta',    // #5161 schema-only — see activity_snapshot above. Handler lands with the dashboard Control Room panel (#5163).
+  // 'activity_snapshot' / 'activity_delta' removed — the dashboard now handles
+  // them (Control Room panel #5163); they moved to PLATFORM_SPECIFIC as
+  // 'dashboard'. Mobile parity is a Phase-2 fast-follow per epic #5159.
   // 'session_stopped' removed — both handlers now implement case 'session_stopped': (dashboard #4878, mobile #4879)
   'prompt_evaluator_skip_pattern_changed', // #3639 server emits the broadcast; dashboard exposure (toggle UI + receipt handler) is a deferred follow-up — until then the surface is the per-session promptEvaluatorSkipPattern field on session_list. Pairs with the parent epic #3068.
   // 'session_usage' is now handled by both dashboard (#4073) and mobile
@@ -107,6 +108,8 @@ const PLATFORM_SPECIFIC = {
   // Coverage test passes because each handler has a
   // `case 'multi_question_intervention':` clause.
   'session_activity': 'dashboard', // server-broadcast busy/idle flips (#4639) — dashboard syncs sessionStates[id].isIdle so the Working banner survives tab swap; mobile app exposure tracked alongside the rest of the dashboard-only handlers
+  'activity_snapshot': 'dashboard', // Control Room live activity tree (#5161 schema / #5160 server / #5162 reducer / #5163 dashboard panel) — dashboard-only for v1; mobile parity is a Phase-2 fast-follow per epic #5159
+  'activity_delta': 'dashboard',    // Control Room activity delta — see activity_snapshot above; dashboard-only for v1, mobile parity is Phase-2 per epic #5159
   // 'agent_event' (#5016) is now handled by both dashboard and mobile
   // app (#5060 — mobile renders the same nested sub-bubbles inside the
   // parent Task tool_call). No PLATFORM_SPECIFIC entry needed; the

--- a/packages/store-core/src/index.ts
+++ b/packages/store-core/src/index.ts
@@ -215,6 +215,17 @@ export type {
   ActivityTreeNode,
 } from './activity-reducer'
 
+// #5163: re-export the wire-level activity types from the protocol through the
+// store-core surface so the dashboard panel + future mobile parity consume the
+// activity entry/kind/status types from the same single import as the reducer
+// and selector (rather than reaching into @chroxy/protocol directly).
+export type {
+  ActivityEntry,
+  ActivityKind,
+  ActivityStatus,
+  ActivityOutputRef,
+} from '@chroxy/protocol'
+
 export {
   MAX_TERMINAL_ENTRIES_PER_SESSION,
   createEmptyActivityState,


### PR DESCRIPTION
## Summary

Final piece of **Control Room v1** (epic #5159): the dashboard now puts the live activity tree on screen. A read-only **Control Room** panel in the sidebar panel slot (#4303) surfaces the active session's in-flight subagents, background shells, and long-running tools, driven by the store-core activity reducer (#5162).

## What v1 ships

- **Store wiring.** `activity_snapshot` / `activity_delta` are dispatched through the dashboard message handler into the store-core reducer (`applyActivitySnapshot` / `applyActivityDelta`). One `ActivityState` lives on the connection store. Snapshot replaces a session's tree; delta upserts the carried entry by id (self-healing). Payloads are validated with the protocol Zod schemas (`safeParse`) so malformed messages are dropped, not crashed; no-op reductions short-circuit the `set()`.
- **Lifecycle.** A session's activity tree is cleared when `session_list` drops it; the whole tree resets on disconnect / forget / server switch.
- **Panel.** `ControlRoomPanel` renders the tree via `selectActivityTree`: parent→child hierarchy with indented children, a kind icon (agent / shell / tool), a status badge (running / blocked / done / failed — each with an accessible `aria-label`, since colour alone isn't a signal), and a live-ticking elapsed timer. Terminal entries freeze their elapsed at `endedAt`. The 1s interval only runs while something is live and is always cleared on unmount / dep change, so it can't leak.
- **Blocked prominence.** Blocked-on-input entries get an amber accent + left rule and a reduced-motion-aware pulse, consistent with the intervention surface (#4891), so the operator's eye lands on "this needs you".
- **Expand-to-output.** Expanding an entry shows its `outputRef` (kind + id), or a "no linked output yet" note when none is attached.
- **Slot registration.** Registered as a second sidebar-slot view alongside the token view, with a collapsed-header live/blocked count metric.
- Wire-level activity types are re-exported through `@chroxy/store-core` so the panel imports them from the same surface as the reducer/selector.

## Deferred to phase-2 (tracked on epic #5159)

- Control actions (cancel/kill a shell or subagent, jump-to-intervene) — needs bearer-token auth gating
- Cross-session aggregate "mission control" view
- Mobile parity (RN Control Room)

## Testing

- `ControlRoomPanel.test.tsx` — tree/hierarchy/indentation, labels, status badges + aria-labels, live + frozen elapsed timers, the no-interval-when-idle guard, blocked highlight, expand-to-output, collapsed metric, `formatElapsed`.
- `dispatch-control-room-activity.test.ts` — snapshot replace, delta upsert (started→ended), parent/child build, per-session isolation, malformed-payload drop, no-op short-circuit, session-removal cleanup.
- Full dashboard suite green (2990 tests); `tsc --noEmit` clean for dashboard + store-core.

Closes #5163
Part of #5159 (Control Room v1 complete)