### PR TITLE
feat(protocol): add host_status request/snapshot wire contract (#5171)

### DIFF
--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -32,4 +32,6 @@ export declare const MIN_PROTOCOL_VERSION = 1;
 export * from './schemas/index.ts';
 export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
 export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, } from './schemas/server.ts';
+export type { RepoVerdict, RepoTree, RepoStatus, HostStatusSummary, ServerHostStatusSnapshotMessage, } from './schemas/server.ts';
+export type { HostStatusRequestMessage } from './schemas/client.ts';
 export * from './error-categories.ts';

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -561,6 +561,10 @@ export declare const EvaluateDraftSchema: z.ZodObject<{
     sessionId: z.ZodOptional<z.ZodString>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>;
+export declare const HostStatusRequestSchema: z.ZodObject<{
+    type: z.ZodLiteral<"host_status_request">;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
 export declare const EncryptedEnvelopeSchema: z.ZodObject<{
     type: z.ZodLiteral<"encrypted">;
     d: z.ZodString;
@@ -905,6 +909,9 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     draft: z.ZodString;
     sessionId: z.ZodOptional<z.ZodString>;
     requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>, z.ZodObject<{
+    type: z.ZodLiteral<"host_status_request">;
+    requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$strip>], "type">;
 export type AuthMessage = z.infer<typeof AuthSchema>;
 export type PairMessage = z.infer<typeof PairSchema>;
@@ -915,5 +922,6 @@ export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>;
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>;
 export type PermissionResponseMessage = z.infer<typeof PermissionResponseSchema>;
 export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>;
+export type HostStatusRequestMessage = z.infer<typeof HostStatusRequestSchema>;
 export type ClientMessage = z.infer<typeof ClientMessageSchema>;
 export type EncryptedEnvelope = z.infer<typeof EncryptedEnvelopeSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -665,6 +665,16 @@ export const EvaluateDraftSchema = z.object({
     // specific Evaluate click that triggered it.
     requestId: z.string().max(128).optional(),
 });
+// #5171: Control Room v2 — request a Host/Repo Status survey. The server runs
+// the survey across `config.repos ∪ auto-discovered repos under the configured
+// root` and replies with a single `host_status_snapshot` (see server.ts). This
+// is a pull (the Refresh button) — the snapshot is not pushed on a timer. The
+// optional `requestId` lets the dashboard correlate a particular Refresh click
+// to the snapshot it produced (same pattern as `evaluate_draft` above).
+export const HostStatusRequestSchema = z.object({
+    type: z.literal('host_status_request'),
+    requestId: z.string().max(128).optional(),
+});
 // -- Encrypted envelope --
 export const EncryptedEnvelopeSchema = z.object({
     type: z.literal('encrypted'),
@@ -749,4 +759,5 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
     DestroyEnvironmentSchema,
     GetEnvironmentSchema,
     EvaluateDraftSchema,
+    HostStatusRequestSchema,
 ]);

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -511,6 +511,163 @@ export declare const ServerActivityDeltaSchema: z.ZodObject<{
         }, z.core.$strip>>;
     }, z.core.$strip>;
 }, z.core.$strip>;
+/**
+ * Verdict for a repo — the survey's classification of "what is this repo's
+ * current state". Drives the colour-coded tag in the Control Room table:
+ *   - `'live'`        — actively worked (a chroxy session is/was recently running).
+ *   - `'investigate'` — ambiguous state worth a human look (e.g. dirty tree on a
+ *                       repo with no recent activity).
+ *   - `'abandoned'`   — likely abandoned (no recent activity, nothing in flight).
+ *   - `'recent'`      — touched recently but not classified as live.
+ *   - `'onboarded'`   — set up / onboarded (has the expected chroxy scaffolding)
+ *                       but not currently active.
+ *
+ * Declared as a named enum so downstream consumers can switch exhaustively.
+ */
+export declare const RepoVerdictSchema: z.ZodEnum<{
+    live: "live";
+    investigate: "investigate";
+    abandoned: "abandoned";
+    recent: "recent";
+    onboarded: "onboarded";
+}>;
+/**
+ * Working-tree cleanliness summary for a repo:
+ *   - `state`     — `'clean'` (nothing to commit) or `'dirty'` (anything staged,
+ *                   modified, or untracked).
+ *   - `untracked` — count of untracked files.
+ *   - `modified`  — count of tracked-but-modified (unstaged) files.
+ *   - `staged`    — count of staged (index) changes.
+ *
+ * Counts are non-negative integers. `state` is carried explicitly (rather than
+ * derived from the counts) so the server's notion of clean/dirty is the
+ * authority — e.g. a repo may be "dirty" for a reason the three counts don't
+ * capture, and the consumer should not re-derive it.
+ */
+export declare const RepoTreeSchema: z.ZodObject<{
+    state: z.ZodEnum<{
+        clean: "clean";
+        dirty: "dirty";
+    }>;
+    untracked: z.ZodNumber;
+    modified: z.ZodNumber;
+    staged: z.ZodNumber;
+}, z.core.$strip>;
+/**
+ * One row in the Host/Repo Status table.
+ *
+ * Fields:
+ *   - `name`        — display name for the repo (typically the directory name).
+ *   - `path`        — absolute path on the host.
+ *   - `branch`      — current branch (or detached-HEAD description).
+ *   - `verdict`     — see `RepoVerdictSchema`.
+ *   - `live`        — true while a chroxy session is actively running in this
+ *                     repo. Distinct from `verdict === 'live'`: `verdict` is the
+ *                     survey's classification (may persist after the session
+ *                     ends), `live` is the instantaneous "session running now"
+ *                     state that drives the green dot.
+ *   - `tree`        — see `RepoTreeSchema`.
+ *   - `worktrees`   — count of git worktrees attached to this repo.
+ *   - `openPRs`     — number of open PRs, or `null` when unknown (e.g. no GitHub
+ *                     remote, or the lookup was skipped/failed). `null` ≠ 0.
+ *   - `attribution` — whether commits carry the expected author attribution, or
+ *                     `null` when not evaluated. `null` ≠ false.
+ *   - `onboarding`  — human-readable onboarding state (free-form so the survey
+ *                     can describe partial/odd setups without a wire change).
+ *   - `lastTouched` — ISO-8601 timestamp of the most recent activity used to
+ *                     classify the verdict.
+ *   - `note?`       — optional annotation rendered as the `↳` sub-row under the
+ *                     repo (e.g. "dirty tree, last touched 3 weeks ago").
+ */
+export declare const RepoStatusSchema: z.ZodObject<{
+    name: z.ZodString;
+    path: z.ZodString;
+    branch: z.ZodString;
+    verdict: z.ZodEnum<{
+        live: "live";
+        investigate: "investigate";
+        abandoned: "abandoned";
+        recent: "recent";
+        onboarded: "onboarded";
+    }>;
+    live: z.ZodBoolean;
+    tree: z.ZodObject<{
+        state: z.ZodEnum<{
+            clean: "clean";
+            dirty: "dirty";
+        }>;
+        untracked: z.ZodNumber;
+        modified: z.ZodNumber;
+        staged: z.ZodNumber;
+    }, z.core.$strip>;
+    worktrees: z.ZodNumber;
+    openPRs: z.ZodNullable<z.ZodNumber>;
+    attribution: z.ZodNullable<z.ZodBoolean>;
+    onboarding: z.ZodString;
+    lastTouched: z.ZodString;
+    note: z.ZodOptional<z.ZodString>;
+}, z.core.$strip>;
+/**
+ * Aggregate counts across the surveyed repos, one per verdict bucket. Carried
+ * alongside `repos` so the Control Room's summary chips don't have to re-tally
+ * the array (and stay consistent with the server's own count even if a future
+ * server truncates the `repos` list). All non-negative integers.
+ */
+export declare const HostStatusSummarySchema: z.ZodObject<{
+    live: z.ZodNumber;
+    onboarded: z.ZodNumber;
+    abandoned: z.ZodNumber;
+    investigate: z.ZodNumber;
+    recent: z.ZodNumber;
+}, z.core.$strip>;
+/**
+ * #5171 — full Host/Repo Status snapshot. Emitted in reply to a
+ * `host_status_request` (see client.ts). Carries the survey root, the aggregate
+ * `summary`, and the per-repo `repos` rows. `generatedAt` is the ISO-8601 time
+ * the survey ran so the Control Room can render "generated Nm ago" and detect a
+ * stale snapshot. An empty `repos` array is the valid "no repos found under the
+ * root" state — never omitted.
+ */
+export declare const ServerHostStatusSnapshotSchema: z.ZodObject<{
+    type: z.ZodLiteral<"host_status_snapshot">;
+    generatedAt: z.ZodString;
+    root: z.ZodString;
+    summary: z.ZodObject<{
+        live: z.ZodNumber;
+        onboarded: z.ZodNumber;
+        abandoned: z.ZodNumber;
+        investigate: z.ZodNumber;
+        recent: z.ZodNumber;
+    }, z.core.$strip>;
+    repos: z.ZodArray<z.ZodObject<{
+        name: z.ZodString;
+        path: z.ZodString;
+        branch: z.ZodString;
+        verdict: z.ZodEnum<{
+            live: "live";
+            investigate: "investigate";
+            abandoned: "abandoned";
+            recent: "recent";
+            onboarded: "onboarded";
+        }>;
+        live: z.ZodBoolean;
+        tree: z.ZodObject<{
+            state: z.ZodEnum<{
+                clean: "clean";
+                dirty: "dirty";
+            }>;
+            untracked: z.ZodNumber;
+            modified: z.ZodNumber;
+            staged: z.ZodNumber;
+        }, z.core.$strip>;
+        worktrees: z.ZodNumber;
+        openPRs: z.ZodNullable<z.ZodNumber>;
+        attribution: z.ZodNullable<z.ZodBoolean>;
+        onboarding: z.ZodString;
+        lastTouched: z.ZodString;
+        note: z.ZodOptional<z.ZodString>;
+    }, z.core.$strip>>;
+}, z.core.$strip>;
 export declare const ServerClientFocusChangedSchema: z.ZodObject<{
     type: z.ZodLiteral<"client_focus_changed">;
     clientId: z.ZodString;
@@ -1124,3 +1281,8 @@ export type ActivityOutputRef = z.infer<typeof ActivityOutputRefSchema>;
 export type ActivityEntry = z.infer<typeof ActivityEntrySchema>;
 export type ServerActivitySnapshotMessage = z.infer<typeof ServerActivitySnapshotSchema>;
 export type ServerActivityDeltaMessage = z.infer<typeof ServerActivityDeltaSchema>;
+export type RepoVerdict = z.infer<typeof RepoVerdictSchema>;
+export type RepoTree = z.infer<typeof RepoTreeSchema>;
+export type RepoStatus = z.infer<typeof RepoStatusSchema>;
+export type HostStatusSummary = z.infer<typeof HostStatusSummarySchema>;
+export type ServerHostStatusSnapshotMessage = z.infer<typeof ServerHostStatusSnapshotSchema>;

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -593,6 +593,138 @@ export const ServerActivityDeltaSchema = z.object({
         }
     }
 });
+// ───────────────────────────────────────────────────────────────────────────
+// Host/Repo Status Control Room (#5170 epic, #5171 protocol contract)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Wire contract for the Host/Repo Status survey: a one-shot, pull-driven picture
+// of every repo the host knows about — `config.repos` unioned with repos
+// auto-discovered under a configurable root (default `~/Projects`). Each repo is
+// classified into a `verdict` (live / investigate / abandoned / recent /
+// onboarded) so the Control Room can colour-code the table and surface "needs
+// attention" repos without the client re-deriving the heuristic.
+//
+// This file defines ONLY the schemas/types (issue #5171). The server emitter,
+// store-core reducer, and dashboard panel consume these in sibling issues of the
+// #5170 epic.
+//
+// Flow: the client sends `host_status_request` (see client.ts) — typically the
+// Refresh button — and the server replies with exactly one
+// `host_status_snapshot`. There is no delta stream (unlike the activity tree):
+// the survey is cheap-enough-to-resend and the table is small, so a full
+// snapshot per refresh keeps both sides trivial.
+//
+// Forward/back compat: all schemas strip unknown fields (Zod default) so an
+// older client parsing a newer server's payload silently ignores fields it
+// doesn't recognise, and a client predating these message types ignores the
+// unknown `type` at the dispatch layer.
+/**
+ * Verdict for a repo — the survey's classification of "what is this repo's
+ * current state". Drives the colour-coded tag in the Control Room table:
+ *   - `'live'`        — actively worked (a chroxy session is/was recently running).
+ *   - `'investigate'` — ambiguous state worth a human look (e.g. dirty tree on a
+ *                       repo with no recent activity).
+ *   - `'abandoned'`   — likely abandoned (no recent activity, nothing in flight).
+ *   - `'recent'`      — touched recently but not classified as live.
+ *   - `'onboarded'`   — set up / onboarded (has the expected chroxy scaffolding)
+ *                       but not currently active.
+ *
+ * Declared as a named enum so downstream consumers can switch exhaustively.
+ */
+export const RepoVerdictSchema = z.enum([
+    'live',
+    'investigate',
+    'abandoned',
+    'recent',
+    'onboarded',
+]);
+/**
+ * Working-tree cleanliness summary for a repo:
+ *   - `state`     — `'clean'` (nothing to commit) or `'dirty'` (anything staged,
+ *                   modified, or untracked).
+ *   - `untracked` — count of untracked files.
+ *   - `modified`  — count of tracked-but-modified (unstaged) files.
+ *   - `staged`    — count of staged (index) changes.
+ *
+ * Counts are non-negative integers. `state` is carried explicitly (rather than
+ * derived from the counts) so the server's notion of clean/dirty is the
+ * authority — e.g. a repo may be "dirty" for a reason the three counts don't
+ * capture, and the consumer should not re-derive it.
+ */
+export const RepoTreeSchema = z.object({
+    state: z.enum(['clean', 'dirty']),
+    untracked: z.number().int().nonnegative().finite(),
+    modified: z.number().int().nonnegative().finite(),
+    staged: z.number().int().nonnegative().finite(),
+});
+/**
+ * One row in the Host/Repo Status table.
+ *
+ * Fields:
+ *   - `name`        — display name for the repo (typically the directory name).
+ *   - `path`        — absolute path on the host.
+ *   - `branch`      — current branch (or detached-HEAD description).
+ *   - `verdict`     — see `RepoVerdictSchema`.
+ *   - `live`        — true while a chroxy session is actively running in this
+ *                     repo. Distinct from `verdict === 'live'`: `verdict` is the
+ *                     survey's classification (may persist after the session
+ *                     ends), `live` is the instantaneous "session running now"
+ *                     state that drives the green dot.
+ *   - `tree`        — see `RepoTreeSchema`.
+ *   - `worktrees`   — count of git worktrees attached to this repo.
+ *   - `openPRs`     — number of open PRs, or `null` when unknown (e.g. no GitHub
+ *                     remote, or the lookup was skipped/failed). `null` ≠ 0.
+ *   - `attribution` — whether commits carry the expected author attribution, or
+ *                     `null` when not evaluated. `null` ≠ false.
+ *   - `onboarding`  — human-readable onboarding state (free-form so the survey
+ *                     can describe partial/odd setups without a wire change).
+ *   - `lastTouched` — ISO-8601 timestamp of the most recent activity used to
+ *                     classify the verdict.
+ *   - `note?`       — optional annotation rendered as the `↳` sub-row under the
+ *                     repo (e.g. "dirty tree, last touched 3 weeks ago").
+ */
+export const RepoStatusSchema = z.object({
+    name: z.string(),
+    path: z.string(),
+    branch: z.string(),
+    verdict: RepoVerdictSchema,
+    live: z.boolean(),
+    tree: RepoTreeSchema,
+    worktrees: z.number().int().nonnegative().finite(),
+    openPRs: z.number().int().nonnegative().finite().nullable(),
+    attribution: z.boolean().nullable(),
+    onboarding: z.string(),
+    lastTouched: z.string().datetime(),
+    note: z.string().optional(),
+});
+/**
+ * Aggregate counts across the surveyed repos, one per verdict bucket. Carried
+ * alongside `repos` so the Control Room's summary chips don't have to re-tally
+ * the array (and stay consistent with the server's own count even if a future
+ * server truncates the `repos` list). All non-negative integers.
+ */
+export const HostStatusSummarySchema = z.object({
+    live: z.number().int().nonnegative().finite(),
+    onboarded: z.number().int().nonnegative().finite(),
+    abandoned: z.number().int().nonnegative().finite(),
+    investigate: z.number().int().nonnegative().finite(),
+    recent: z.number().int().nonnegative().finite(),
+});
+/**
+ * #5171 — full Host/Repo Status snapshot. Emitted in reply to a
+ * `host_status_request` (see client.ts). Carries the survey root, the aggregate
+ * `summary`, and the per-repo `repos` rows. `generatedAt` is the ISO-8601 time
+ * the survey ran so the Control Room can render "generated Nm ago" and detect a
+ * stale snapshot. An empty `repos` array is the valid "no repos found under the
+ * root" state — never omitted.
+ */
+export const ServerHostStatusSnapshotSchema = z.object({
+    type: z.literal('host_status_snapshot'),
+    generatedAt: z.string().datetime(),
+    root: z.string(),
+    summary: HostStatusSummarySchema,
+    repos: z.array(RepoStatusSchema),
+});
 export const ServerClientFocusChangedSchema = z.object({
     type: z.literal('client_focus_changed'),
     clientId: z.string(),

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -58,5 +58,22 @@ export type {
   ServerActivityDeltaMessage,
 } from './schemas/server.ts'
 
+// #5171: pin the Host/Repo Status Control Room contract (#5170 epic) at the
+// package entry point so sibling issues import `RepoStatus` /
+// `ServerHostStatusSnapshotMessage` etc. as a stable public contract — the named
+// re-export makes `tsc --build` fail loudly if any alias is removed from
+// `./schemas/server.ts` (same rationale as the #4192 / #5161 lines above).
+export type {
+  RepoVerdict,
+  RepoTree,
+  RepoStatus,
+  HostStatusSummary,
+  ServerHostStatusSnapshotMessage,
+} from './schemas/server.ts'
+
+// #5171: the client→server request type is pinned at the entry point too so
+// consumers can import the alias without reaching into `./schemas/client.ts`.
+export type { HostStatusRequestMessage } from './schemas/client.ts'
+
 // Re-export client-side error-category detection (#3151)
 export * from './error-categories.ts'

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -773,6 +773,17 @@ export const EvaluateDraftSchema = z.object({
   requestId: z.string().max(128).optional(),
 })
 
+// #5171: Control Room v2 — request a Host/Repo Status survey. The server runs
+// the survey across `config.repos ∪ auto-discovered repos under the configured
+// root` and replies with a single `host_status_snapshot` (see server.ts). This
+// is a pull (the Refresh button) — the snapshot is not pushed on a timer. The
+// optional `requestId` lets the dashboard correlate a particular Refresh click
+// to the snapshot it produced (same pattern as `evaluate_draft` above).
+export const HostStatusRequestSchema = z.object({
+  type: z.literal('host_status_request'),
+  requestId: z.string().max(128).optional(),
+})
+
 // -- Encrypted envelope --
 
 export const EncryptedEnvelopeSchema = z.object({
@@ -859,6 +870,7 @@ export const ClientMessageSchema = z.discriminatedUnion('type', [
   DestroyEnvironmentSchema,
   GetEnvironmentSchema,
   EvaluateDraftSchema,
+  HostStatusRequestSchema,
 ])
 
 // -- Inferred TypeScript types --
@@ -872,5 +884,6 @@ export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>
 export type PermissionResponseMessage = z.infer<typeof PermissionResponseSchema>
 export type ExtensionMessage = z.infer<typeof ExtensionMessageSchema>
+export type HostStatusRequestMessage = z.infer<typeof HostStatusRequestSchema>
 export type ClientMessage = z.infer<typeof ClientMessageSchema>
 export type EncryptedEnvelope = z.infer<typeof EncryptedEnvelopeSchema>

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -634,6 +634,144 @@ export const ServerActivityDeltaSchema = z.object({
   }
 })
 
+// ───────────────────────────────────────────────────────────────────────────
+// Host/Repo Status Control Room (#5170 epic, #5171 protocol contract)
+// ───────────────────────────────────────────────────────────────────────────
+//
+// Wire contract for the Host/Repo Status survey: a one-shot, pull-driven picture
+// of every repo the host knows about — `config.repos` unioned with repos
+// auto-discovered under a configurable root (default `~/Projects`). Each repo is
+// classified into a `verdict` (live / investigate / abandoned / recent /
+// onboarded) so the Control Room can colour-code the table and surface "needs
+// attention" repos without the client re-deriving the heuristic.
+//
+// This file defines ONLY the schemas/types (issue #5171). The server emitter,
+// store-core reducer, and dashboard panel consume these in sibling issues of the
+// #5170 epic.
+//
+// Flow: the client sends `host_status_request` (see client.ts) — typically the
+// Refresh button — and the server replies with exactly one
+// `host_status_snapshot`. There is no delta stream (unlike the activity tree):
+// the survey is cheap-enough-to-resend and the table is small, so a full
+// snapshot per refresh keeps both sides trivial.
+//
+// Forward/back compat: all schemas strip unknown fields (Zod default) so an
+// older client parsing a newer server's payload silently ignores fields it
+// doesn't recognise, and a client predating these message types ignores the
+// unknown `type` at the dispatch layer.
+
+/**
+ * Verdict for a repo — the survey's classification of "what is this repo's
+ * current state". Drives the colour-coded tag in the Control Room table:
+ *   - `'live'`        — actively worked (a chroxy session is/was recently running).
+ *   - `'investigate'` — ambiguous state worth a human look (e.g. dirty tree on a
+ *                       repo with no recent activity).
+ *   - `'abandoned'`   — likely abandoned (no recent activity, nothing in flight).
+ *   - `'recent'`      — touched recently but not classified as live.
+ *   - `'onboarded'`   — set up / onboarded (has the expected chroxy scaffolding)
+ *                       but not currently active.
+ *
+ * Declared as a named enum so downstream consumers can switch exhaustively.
+ */
+export const RepoVerdictSchema = z.enum([
+  'live',
+  'investigate',
+  'abandoned',
+  'recent',
+  'onboarded',
+])
+
+/**
+ * Working-tree cleanliness summary for a repo:
+ *   - `state`     — `'clean'` (nothing to commit) or `'dirty'` (anything staged,
+ *                   modified, or untracked).
+ *   - `untracked` — count of untracked files.
+ *   - `modified`  — count of tracked-but-modified (unstaged) files.
+ *   - `staged`    — count of staged (index) changes.
+ *
+ * Counts are non-negative integers. `state` is carried explicitly (rather than
+ * derived from the counts) so the server's notion of clean/dirty is the
+ * authority — e.g. a repo may be "dirty" for a reason the three counts don't
+ * capture, and the consumer should not re-derive it.
+ */
+export const RepoTreeSchema = z.object({
+  state: z.enum(['clean', 'dirty']),
+  untracked: z.number().int().nonnegative().finite(),
+  modified: z.number().int().nonnegative().finite(),
+  staged: z.number().int().nonnegative().finite(),
+})
+
+/**
+ * One row in the Host/Repo Status table.
+ *
+ * Fields:
+ *   - `name`        — display name for the repo (typically the directory name).
+ *   - `path`        — absolute path on the host.
+ *   - `branch`      — current branch (or detached-HEAD description).
+ *   - `verdict`     — see `RepoVerdictSchema`.
+ *   - `live`        — true while a chroxy session is actively running in this
+ *                     repo. Distinct from `verdict === 'live'`: `verdict` is the
+ *                     survey's classification (may persist after the session
+ *                     ends), `live` is the instantaneous "session running now"
+ *                     state that drives the green dot.
+ *   - `tree`        — see `RepoTreeSchema`.
+ *   - `worktrees`   — count of git worktrees attached to this repo.
+ *   - `openPRs`     — number of open PRs, or `null` when unknown (e.g. no GitHub
+ *                     remote, or the lookup was skipped/failed). `null` ≠ 0.
+ *   - `attribution` — whether commits carry the expected author attribution, or
+ *                     `null` when not evaluated. `null` ≠ false.
+ *   - `onboarding`  — human-readable onboarding state (free-form so the survey
+ *                     can describe partial/odd setups without a wire change).
+ *   - `lastTouched` — ISO-8601 timestamp of the most recent activity used to
+ *                     classify the verdict.
+ *   - `note?`       — optional annotation rendered as the `↳` sub-row under the
+ *                     repo (e.g. "dirty tree, last touched 3 weeks ago").
+ */
+export const RepoStatusSchema = z.object({
+  name: z.string(),
+  path: z.string(),
+  branch: z.string(),
+  verdict: RepoVerdictSchema,
+  live: z.boolean(),
+  tree: RepoTreeSchema,
+  worktrees: z.number().int().nonnegative().finite(),
+  openPRs: z.number().int().nonnegative().finite().nullable(),
+  attribution: z.boolean().nullable(),
+  onboarding: z.string(),
+  lastTouched: z.string().datetime(),
+  note: z.string().optional(),
+})
+
+/**
+ * Aggregate counts across the surveyed repos, one per verdict bucket. Carried
+ * alongside `repos` so the Control Room's summary chips don't have to re-tally
+ * the array (and stay consistent with the server's own count even if a future
+ * server truncates the `repos` list). All non-negative integers.
+ */
+export const HostStatusSummarySchema = z.object({
+  live: z.number().int().nonnegative().finite(),
+  onboarded: z.number().int().nonnegative().finite(),
+  abandoned: z.number().int().nonnegative().finite(),
+  investigate: z.number().int().nonnegative().finite(),
+  recent: z.number().int().nonnegative().finite(),
+})
+
+/**
+ * #5171 — full Host/Repo Status snapshot. Emitted in reply to a
+ * `host_status_request` (see client.ts). Carries the survey root, the aggregate
+ * `summary`, and the per-repo `repos` rows. `generatedAt` is the ISO-8601 time
+ * the survey ran so the Control Room can render "generated Nm ago" and detect a
+ * stale snapshot. An empty `repos` array is the valid "no repos found under the
+ * root" state — never omitted.
+ */
+export const ServerHostStatusSnapshotSchema = z.object({
+  type: z.literal('host_status_snapshot'),
+  generatedAt: z.string().datetime(),
+  root: z.string(),
+  summary: HostStatusSummarySchema,
+  repos: z.array(RepoStatusSchema),
+})
+
 export const ServerClientFocusChangedSchema = z.object({
   type: z.literal('client_focus_changed'),
   clientId: z.string(),
@@ -1479,3 +1617,10 @@ export type ActivityOutputRef = z.infer<typeof ActivityOutputRefSchema>
 export type ActivityEntry = z.infer<typeof ActivityEntrySchema>
 export type ServerActivitySnapshotMessage = z.infer<typeof ServerActivitySnapshotSchema>
 export type ServerActivityDeltaMessage = z.infer<typeof ServerActivityDeltaSchema>
+// #5171: Host/Repo Status Control Room wire contract (#5170 epic). Consumed by
+// the server emitter, store-core reducer, and dashboard panel in sibling issues.
+export type RepoVerdict = z.infer<typeof RepoVerdictSchema>
+export type RepoTree = z.infer<typeof RepoTreeSchema>
+export type RepoStatus = z.infer<typeof RepoStatusSchema>
+export type HostStatusSummary = z.infer<typeof HostStatusSummarySchema>
+export type ServerHostStatusSnapshotMessage = z.infer<typeof ServerHostStatusSnapshotSchema>

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -2038,4 +2038,239 @@ describe('@chroxy/protocol schemas', () => {
       assert.equal(ACTIVITY_SCHEMA_VERSION, 1)
     })
   })
+
+  describe('Host/Repo Status Control Room (#5171)', () => {
+    const cleanRepo = {
+      name: 'chroxy',
+      path: '/Users/dev/Projects/chroxy',
+      branch: 'main',
+      verdict: 'live',
+      live: true,
+      tree: { state: 'clean', untracked: 0, modified: 0, staged: 0 },
+      worktrees: 2,
+      openPRs: 3,
+      attribution: true,
+      onboarding: 'fully onboarded',
+      lastTouched: '2026-06-05T12:00:00.000Z',
+    }
+
+    const dirtyRepo = {
+      name: 'old-experiment',
+      path: '/Users/dev/Projects/old-experiment',
+      branch: 'wip/spike',
+      verdict: 'investigate',
+      live: false,
+      tree: { state: 'dirty', untracked: 4, modified: 2, staged: 1 },
+      worktrees: 0,
+      openPRs: null,
+      attribution: null,
+      onboarding: 'not onboarded',
+      lastTouched: '2026-01-02T09:30:00.000Z',
+      note: 'dirty tree, last touched 5 months ago',
+    }
+
+    describe('RepoVerdictSchema', () => {
+      it('accepts every verdict', async () => {
+        const { RepoVerdictSchema } = await import('../src/schemas/server.ts')
+        for (const v of ['live', 'investigate', 'abandoned', 'recent', 'onboarded']) {
+          assert.ok(RepoVerdictSchema.safeParse(v).success, `verdict ${v} should validate`)
+        }
+      })
+
+      it('rejects an unknown verdict', async () => {
+        const { RepoVerdictSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!RepoVerdictSchema.safeParse('archived').success, 'unknown verdict must reject')
+      })
+    })
+
+    describe('RepoTreeSchema', () => {
+      it('validates a clean tree', async () => {
+        const { RepoTreeSchema } = await import('../src/schemas/server.ts')
+        const result = RepoTreeSchema.safeParse({ state: 'clean', untracked: 0, modified: 0, staged: 0 })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+      })
+
+      it('validates a dirty tree with counts', async () => {
+        const { RepoTreeSchema } = await import('../src/schemas/server.ts')
+        const result = RepoTreeSchema.safeParse({ state: 'dirty', untracked: 4, modified: 2, staged: 1 })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+      })
+
+      it('rejects an unknown state', async () => {
+        const { RepoTreeSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!RepoTreeSchema.safeParse({ state: 'conflicted', untracked: 0, modified: 0, staged: 0 }).success)
+      })
+
+      it('rejects negative counts', async () => {
+        const { RepoTreeSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!RepoTreeSchema.safeParse({ state: 'dirty', untracked: -1, modified: 0, staged: 0 }).success)
+      })
+
+      it('rejects non-integer counts', async () => {
+        const { RepoTreeSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!RepoTreeSchema.safeParse({ state: 'dirty', untracked: 1.5, modified: 0, staged: 0 }).success)
+      })
+    })
+
+    describe('RepoStatusSchema', () => {
+      it('validates a well-formed live repo', async () => {
+        const { RepoStatusSchema } = await import('../src/schemas/server.ts')
+        const result = RepoStatusSchema.safeParse(cleanRepo)
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.verdict, 'live')
+        assert.equal(result.data.note, undefined)
+      })
+
+      it('validates a repo with note and null openPRs/attribution', async () => {
+        const { RepoStatusSchema } = await import('../src/schemas/server.ts')
+        const result = RepoStatusSchema.safeParse(dirtyRepo)
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.openPRs, null)
+        assert.equal(result.data.attribution, null)
+        assert.equal(result.data.note, 'dirty tree, last touched 5 months ago')
+      })
+
+      it('accepts openPRs as a non-negative integer or null', async () => {
+        const { RepoStatusSchema } = await import('../src/schemas/server.ts')
+        assert.ok(RepoStatusSchema.safeParse({ ...cleanRepo, openPRs: 0 }).success)
+        assert.ok(RepoStatusSchema.safeParse({ ...cleanRepo, openPRs: null }).success)
+      })
+
+      it('rejects a negative openPRs', async () => {
+        const { RepoStatusSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!RepoStatusSchema.safeParse({ ...cleanRepo, openPRs: -1 }).success)
+      })
+
+      it('accepts attribution true / false / null', async () => {
+        const { RepoStatusSchema } = await import('../src/schemas/server.ts')
+        assert.ok(RepoStatusSchema.safeParse({ ...cleanRepo, attribution: true }).success)
+        assert.ok(RepoStatusSchema.safeParse({ ...cleanRepo, attribution: false }).success)
+        assert.ok(RepoStatusSchema.safeParse({ ...cleanRepo, attribution: null }).success)
+      })
+
+      it('rejects an unknown verdict', async () => {
+        const { RepoStatusSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!RepoStatusSchema.safeParse({ ...cleanRepo, verdict: 'archived' }).success)
+      })
+
+      it('rejects a non-ISO lastTouched', async () => {
+        const { RepoStatusSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!RepoStatusSchema.safeParse({ ...cleanRepo, lastTouched: 'yesterday' }).success)
+      })
+
+      it('rejects a non-boolean live', async () => {
+        const { RepoStatusSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!RepoStatusSchema.safeParse({ ...cleanRepo, live: 'yes' }).success)
+      })
+
+      it('strips unknown fields for forward compat', async () => {
+        const { RepoStatusSchema } = await import('../src/schemas/server.ts')
+        const result = RepoStatusSchema.safeParse({ ...cleanRepo, futureField: 'x' })
+        assert.ok(result.success)
+        assert.equal(result.data.futureField, undefined)
+      })
+    })
+
+    describe('ServerHostStatusSnapshotSchema', () => {
+      const snapshot = {
+        type: 'host_status_snapshot',
+        generatedAt: '2026-06-05T12:00:00.000Z',
+        root: '/Users/dev/Projects',
+        summary: { live: 1, onboarded: 0, abandoned: 0, investigate: 1, recent: 0 },
+        repos: [cleanRepo, dirtyRepo],
+      }
+
+      it('round-trips a full snapshot', async () => {
+        const { ServerHostStatusSnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerHostStatusSnapshotSchema.safeParse(snapshot)
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.repos.length, 2)
+        assert.equal(result.data.summary.investigate, 1)
+      })
+
+      it('accepts an empty repos array (no repos under root)', async () => {
+        const { ServerHostStatusSnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerHostStatusSnapshotSchema.safeParse({
+          ...snapshot,
+          repos: [],
+          summary: { live: 0, onboarded: 0, abandoned: 0, investigate: 0, recent: 0 },
+        })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+      })
+
+      it('rejects the wrong type literal', async () => {
+        const { ServerHostStatusSnapshotSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!ServerHostStatusSnapshotSchema.safeParse({ ...snapshot, type: 'host_status' }).success)
+      })
+
+      it('rejects a non-ISO generatedAt', async () => {
+        const { ServerHostStatusSnapshotSchema } = await import('../src/schemas/server.ts')
+        assert.ok(!ServerHostStatusSnapshotSchema.safeParse({ ...snapshot, generatedAt: '2026' }).success)
+      })
+
+      it('rejects a missing summary bucket', async () => {
+        const { ServerHostStatusSnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerHostStatusSnapshotSchema.safeParse({
+          ...snapshot,
+          summary: { live: 1, onboarded: 0, abandoned: 0, investigate: 1 },
+        })
+        assert.ok(!result.success, 'summary must carry all five buckets')
+      })
+
+      it('rejects an invalid repo inside repos', async () => {
+        const { ServerHostStatusSnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerHostStatusSnapshotSchema.safeParse({
+          ...snapshot,
+          repos: [{ ...cleanRepo, verdict: 'archived' }],
+        })
+        assert.ok(!result.success, 'an invalid repo must fail the whole snapshot')
+      })
+
+      it('strips unknown top-level fields for forward compat', async () => {
+        const { ServerHostStatusSnapshotSchema } = await import('../src/schemas/server.ts')
+        const result = ServerHostStatusSnapshotSchema.safeParse({ ...snapshot, futureField: 'x' })
+        assert.ok(result.success)
+        assert.equal(result.data.futureField, undefined)
+      })
+
+      it('is re-exported from the schemas entry point', async () => {
+        const mod = await import('../src/schemas/index.ts')
+        assert.ok(mod.ServerHostStatusSnapshotSchema, 'snapshot schema should be exported')
+        assert.ok(mod.RepoStatusSchema, 'RepoStatusSchema should be exported')
+        assert.ok(mod.HostStatusRequestSchema, 'HostStatusRequestSchema should be exported')
+      })
+    })
+
+    describe('HostStatusRequestSchema (client→server)', () => {
+      it('validates a bare request', async () => {
+        const { HostStatusRequestSchema } = await import('../src/schemas/client.ts')
+        const result = HostStatusRequestSchema.safeParse({ type: 'host_status_request' })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+      })
+
+      it('validates a request with requestId', async () => {
+        const { HostStatusRequestSchema } = await import('../src/schemas/client.ts')
+        const result = HostStatusRequestSchema.safeParse({ type: 'host_status_request', requestId: 'abc' })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.requestId, 'abc')
+      })
+
+      it('rejects the wrong type literal', async () => {
+        const { HostStatusRequestSchema } = await import('../src/schemas/client.ts')
+        assert.ok(!HostStatusRequestSchema.safeParse({ type: 'host_status' }).success)
+      })
+
+      it('rejects an over-long requestId', async () => {
+        const { HostStatusRequestSchema } = await import('../src/schemas/client.ts')
+        assert.ok(!HostStatusRequestSchema.safeParse({ type: 'host_status_request', requestId: 'x'.repeat(129) }).success)
+      })
+
+      it('is accepted by the ClientMessageSchema union', async () => {
+        const { ClientMessageSchema } = await import('../src/schemas/client.ts')
+        const result = ClientMessageSchema.safeParse({ type: 'host_status_request', requestId: 'r1' })
+        assert.ok(result.success, JSON.stringify(result.error?.issues))
+        assert.equal(result.data.type, 'host_status_request')
+      })
+    })
+  })
 })

--- a/packages/server/tests/ws-schema-coverage.test.js
+++ b/packages/server/tests/ws-schema-coverage.test.js
@@ -95,6 +95,12 @@ describe('WS protocol schema coverage', () => {
       'key_exchange',  // E2E encryption handshake, handled before dispatch
       'ping',          // keepalive, handled at connection layer
       'encrypted',     // envelope unwrapped before dispatch
+      // #5171 (epic #5170): the Host/Repo Status wire contract lands ahead of
+      // its server handler — A1 ships only the @chroxy/protocol schema so the
+      // dashboard/store-core siblings can build against a stable type. The
+      // server handler (the survey emitter) lands in a sibling #5170 issue,
+      // which removes this line and registers a real handler.
+      'host_status_request',
     ])
 
     const unexplained = schemaOnly.filter((t) => !KNOWN_PRE_REGISTRY.has(t))

--- a/smoke-test.md
+++ b/smoke-test.md
@@ -1,0 +1,31 @@
+# Control Room v2 — Smoke Test Checklist
+
+Verification checklist for epic #5170. Relaunch the app with `cd packages/desktop && cargo tauri dev`. References: the two screenshots shared in the planning thread + the HTML brief at `~/Obsidian/no-it-all/briefs/host-repo-status-2026-06-04.html`. Tick a box once visually confirmed.
+
+## A. Host/Repo Status Control Room
+- [ ] A Control Room section is reachable from chroxy nav
+- [ ] Summary chips: live / onboarded / likely-abandoned / investigate / recent
+- [ ] "How to read the verdict" callout present
+- [ ] Table columns: Repo/branch · Verdict · Onboarding · Tree · Wt · PRs · Attr · Last
+- [ ] Verdict tags color-coded (LIVE / Investigate / abandoned / recent / Onboarded) per the HTML brief
+- [ ] Live repos show a green dot; chroxy shows LIVE while a session runs
+- [ ] Annotated `↳` note rows under repos
+- [ ] Refresh button re-runs the survey; "generated Nm ago" updates
+- [ ] Repos = config.repos ∪ auto-discovered under ~/Projects (configurable root)
+- [ ] Per-session activity (running agents/shells/tools) still surfaced — drill into a live repo row (NOT lost)
+
+## B. Background-work banner bug
+- [ ] A finished background shell (e.g. a sleep loop) CLEARS the "Waiting on background work" banner (no longer sticks forever)
+
+## C. Top-bar layout
+- [ ] Token usage bar sits UNDER the "x / 200k tokens" text
+- [ ] Nothing after the Approve dropdown is hidden by the bell / ⋯ / cost badge / tokens cluster
+- [ ] Model dropdown handles short AND long model names without cramping or pushing neighbors under the sidebar
+
+## D. Status-dot semantics
+- [ ] Top green dot reflects CONNECTED (to tunnel), not "running"
+- [ ] A "Running" indicator appears in the left projects/explorer
+
+## E. Cost badge
+- [ ] Cost badge defaults to provider/model
+- [ ] Settings can switch it to cost / tokens / % context / session-type, and it persists


### PR DESCRIPTION
## Summary

A1 of the Control Room v2 epic (#5170): the `@chroxy/protocol` wire contract for the Host/Repo Status Control Room. Protocol-only — the server emitter, store-core reducer, and dashboard panel land in sibling issues.

### Schemas added
- **`host_status_request`** (client→server): `{ type, requestId? }` — pull-driven survey request (the Refresh button). Added to the `ClientMessageSchema` discriminated union.
- **`host_status_snapshot`** (server→client): `{ type, generatedAt(ISO), root, summary, repos[] }` — full survey reply. Modelled as a standalone schema, mirroring how `activity_snapshot` / `activity_delta` were added in #5161 (the server side has no discriminated union).
- **`RepoStatus`**, **`RepoTree`**, **`RepoVerdict`**, **`HostStatusSummary`** — supporting schemas + inferred TS types.

All new types are pinned at the package entry point (`src/index.ts`) as a stable public contract, matching the #4192 / #5161 pattern (so `tsc --build` fails loudly if an alias is removed).

### Design notes
- `openPRs` and `attribution` are nullable (`null` ≠ 0 / `null` ≠ false) to distinguish "unknown / not evaluated" from a real zero/false.
- ISO timestamps validated with `.datetime()`.
- All schemas strip unknown fields (Zod default) for forward-compat; tests assert this.
- No delta stream (unlike the activity tree): the survey is cheap to resend and the table is small, so a full snapshot per refresh keeps both sides trivial.

### Tests
Round-trip parse tests (valid + invalid) for every schema, plus `ClientMessageSchema` union acceptance and entry-point re-export checks. `npm test` in the protocol package: **214 passing**. `tsc` build clean; tracked `dist/` regenerated.

### Also in this PR
`smoke-test.md` at the repo root — the Control Room v2 verification checklist for epic #5170.

Closes #5171