### PR TITLE
feat(server): control-room repo-set resolver + configurable discovery root

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -67,6 +67,12 @@ const CONFIG_SCHEMA = {
   costBudget: 'number',
   externalUrl: 'string',
   repos: 'array',
+  // #5172 (Control Room v2): filesystem root the Host Status survey scans
+  // for auto-discovered git repos. resolveRepoSet (control-room/repo-set.js)
+  // unions any explicit `repos[]` entries with the immediate subdirectories
+  // of this root that contain a `.git` entry. Defaults to ~/Projects when
+  // unset. Mirrored by the CHROXY_CONTROL_ROOM_ROOT env var.
+  controlRoomRoot: 'string',
   maxSessions: 'number',
   maxHistory: 'number',
   maxMessages: 'number',
@@ -737,6 +743,8 @@ function envKeyForConfig(key) {
     maxMessages: 'CHROXY_MAX_MESSAGES',
     showToken: 'CHROXY_SHOW_TOKEN',
     repos: 'CHROXY_REPOS',
+    // #5172: discovery root for the Control Room Host Status repo survey.
+    controlRoomRoot: 'CHROXY_CONTROL_ROOM_ROOT',
     logFormat: 'CHROXY_LOG_FORMAT',
     sandbox: 'CHROXY_SANDBOX',
     resultTimeoutMs: 'CHROXY_RESULT_TIMEOUT_MS',
@@ -1036,6 +1044,42 @@ export function writeReposToConfig(repos, configPath = DEFAULT_CONFIG_PATH) {
     // Start fresh if parse fails
   }
   existing.repos = repos
+  const dir = dirname(configPath)
+  mkdirSync(dir, { recursive: true })
+  writeFileRestricted(configPath, JSON.stringify(existing, null, 2))
+}
+
+/**
+ * Read the Control Room discovery root from a config file (#5172).
+ * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
+ * @returns {string|undefined} The configured root, or undefined if missing/invalid.
+ */
+export function readControlRoomRootFromConfig(configPath = DEFAULT_CONFIG_PATH) {
+  try {
+    if (!existsSync(configPath)) return undefined
+    const raw = JSON.parse(readFileSync(configPath, 'utf-8'))
+    return typeof raw.controlRoomRoot === 'string' ? raw.controlRoomRoot : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Write the Control Room discovery root to a config file, preserving other
+ * fields (#5172).
+ * @param {string} root - Absolute path to the discovery root.
+ * @param {string} [configPath] - Path to config.json. Defaults to ~/.chroxy/config.json.
+ */
+export function writeControlRoomRootToConfig(root, configPath = DEFAULT_CONFIG_PATH) {
+  let existing = {}
+  try {
+    if (existsSync(configPath)) {
+      existing = JSON.parse(readFileSync(configPath, 'utf-8'))
+    }
+  } catch {
+    // Start fresh if parse fails
+  }
+  existing.controlRoomRoot = root
   const dir = dirname(configPath)
   mkdirSync(dir, { recursive: true })
   writeFileRestricted(configPath, JSON.stringify(existing, null, 2))

--- a/packages/server/src/control-room/repo-set.js
+++ b/packages/server/src/control-room/repo-set.js
@@ -6,8 +6,8 @@
  * under a configurable discovery root.
  *
  * Pure server utility — no protocol dependency. The filesystem access is fully
- * injectable (`_readdir` / `_stat` / `_realpath`) so tests never touch the real
- * disk or the user's home directory.
+ * injectable (`_readdir` / `_stat` / `_exists` / `_realpath`) so tests never
+ * touch the real disk or the user's home directory.
  */
 
 import { readdirSync, statSync, existsSync, realpathSync } from 'fs'
@@ -26,9 +26,11 @@ function defaultFs() {
     // List immediate directory entries as names (strings).
     readdir: dir => readdirSync(dir),
     // Return { isDirectory(): boolean } for a path. Used to check that a
-    // discovered entry is a directory and that its `.git` is a dir/file.
+    // discovered entry is a directory.
     stat: p => statSync(p),
-    // Whether a path exists (the `.git` entry check).
+    // Whether a path exists. Used for the `.git` entry check (a `.git`
+    // directory for a clone or a `.git` file for a worktree/submodule both
+    // count — existence alone qualifies).
     exists: p => existsSync(p),
     // Canonical absolute path used as the de-dupe key. Falls back to the
     // input on failure (e.g. a symlink target that no longer resolves).
@@ -44,7 +46,9 @@ function defaultFs() {
  *
  * @param {string} root - Discovery root (absolute path).
  * @param {object} fs - Filesystem seam (see defaultFs()).
- * @returns {Array<{ name: string, path: string }>} Discovered repos (basename + realpath).
+ * @returns {Array<{ name: string, path: string }>} Discovered repos: `name` is
+ *   the basename, `path` is the joined `root/entry` directory path (NOT the
+ *   realpath — realpath is only computed later as the de-dupe key).
  */
 function discoverRepos(root, fs) {
   let entries

--- a/packages/server/src/control-room/repo-set.js
+++ b/packages/server/src/control-room/repo-set.js
@@ -1,0 +1,158 @@
+/**
+ * Control Room v2 (#5172) — repo-set resolver.
+ *
+ * Resolves the set of repos the Host Status survey covers: the de-duped union
+ * of explicit `config.repos[]` entries and git repositories auto-discovered
+ * under a configurable discovery root.
+ *
+ * Pure server utility — no protocol dependency. The filesystem access is fully
+ * injectable (`_readdir` / `_stat` / `_realpath`) so tests never touch the real
+ * disk or the user's home directory.
+ */
+
+import { readdirSync, statSync, existsSync, realpathSync } from 'fs'
+import { join, basename, resolve } from 'path'
+import { homedir } from 'os'
+
+/** Default discovery root when none is configured. */
+export const DEFAULT_CONTROL_ROOM_ROOT = join(homedir(), 'Projects')
+
+/**
+ * Default filesystem injection seam. Real `fs`/`path` access lives here so the
+ * resolver body never references the modules directly — tests pass a fake.
+ */
+function defaultFs() {
+  return {
+    // List immediate directory entries as names (strings).
+    readdir: dir => readdirSync(dir),
+    // Return { isDirectory(): boolean } for a path. Used to check that a
+    // discovered entry is a directory and that its `.git` is a dir/file.
+    stat: p => statSync(p),
+    // Whether a path exists (the `.git` entry check).
+    exists: p => existsSync(p),
+    // Canonical absolute path used as the de-dupe key. Falls back to the
+    // input on failure (e.g. a symlink target that no longer resolves).
+    realpath: p => realpathSync(p),
+  }
+}
+
+/**
+ * Auto-discover git repos that are immediate subdirectories of `root`.
+ *
+ * Only entries that (a) are directories and (b) contain a `.git` entry (either
+ * a directory for a normal clone or a file for a worktree/submodule) qualify.
+ *
+ * @param {string} root - Discovery root (absolute path).
+ * @param {object} fs - Filesystem seam (see defaultFs()).
+ * @returns {Array<{ name: string, path: string }>} Discovered repos (basename + realpath).
+ */
+function discoverRepos(root, fs) {
+  let entries
+  try {
+    entries = fs.readdir(root)
+  } catch {
+    // Missing/unreadable root — nothing to discover.
+    return []
+  }
+
+  const found = []
+  for (const entry of entries) {
+    const dirPath = join(root, entry)
+
+    // Must be a directory.
+    let st
+    try {
+      st = fs.stat(dirPath)
+    } catch {
+      continue
+    }
+    if (!st || !st.isDirectory()) continue
+
+    // Must contain a `.git` entry (dir for a clone, file for a worktree).
+    const gitPath = join(dirPath, '.git')
+    try {
+      if (!fs.exists(gitPath)) continue
+    } catch {
+      continue
+    }
+
+    found.push({ name: basename(dirPath), path: dirPath })
+  }
+  return found
+}
+
+/**
+ * Resolve the absolute, canonical path for a repo entry, used as the de-dupe
+ * key. Falls back to a non-canonical absolute path when realpath fails so a
+ * not-yet-existing config entry still de-dupes against itself.
+ *
+ * @param {string} p - A repo path.
+ * @param {object} fs - Filesystem seam.
+ * @returns {string} The de-dupe key.
+ */
+function dedupeKey(p, fs) {
+  const absolute = resolve(p)
+  try {
+    return fs.realpath(absolute)
+  } catch {
+    return absolute
+  }
+}
+
+/**
+ * Resolve the de-duped set of repos for the Host Status survey.
+ *
+ * The result is the union of:
+ *   - explicit `repos[]` entries (`{ path, name? }`), and
+ *   - git repos auto-discovered under `root` (default ~/Projects).
+ *
+ * De-duplication is by realpath; config entries win over discovered ones on a
+ * collision (config order is preserved, discovered repos append after).
+ *
+ * @param {object} [opts]
+ * @param {Array<{ path: string, name?: string }>} [opts.repos] - Explicit config repos.
+ * @param {string} [opts.root] - Discovery root. Defaults to DEFAULT_CONTROL_ROOM_ROOT.
+ * @param {Function} [opts._readdir] - Override for reading a directory (returns string[]).
+ * @param {Function} [opts._stat] - Override for stat (returns { isDirectory() }).
+ * @param {Function} [opts._exists] - Override for existence check (returns boolean).
+ * @param {Function} [opts._realpath] - Override for realpath (returns string).
+ * @returns {Array<{ name: string, path: string }>} De-duped repo set.
+ */
+export function resolveRepoSet(opts = {}) {
+  const { repos = [], root, _readdir, _stat, _exists, _realpath } = opts
+
+  const base = defaultFs()
+  const fs = {
+    readdir: _readdir || base.readdir,
+    stat: _stat || base.stat,
+    exists: _exists || base.exists,
+    realpath: _realpath || base.realpath,
+  }
+
+  const effectiveRoot = root || DEFAULT_CONTROL_ROOM_ROOT
+
+  const seen = new Set()
+  const out = []
+
+  // Config repos first so they win de-dupe collisions and keep their order.
+  for (const repo of Array.isArray(repos) ? repos : []) {
+    if (!repo || typeof repo.path !== 'string' || repo.path.length === 0) continue
+    const key = dedupeKey(repo.path, fs)
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push({
+      name: typeof repo.name === 'string' && repo.name.length > 0 ? repo.name : basename(repo.path),
+      path: repo.path,
+    })
+  }
+
+  // Auto-discovered repos append after, skipping any already covered by config.
+  for (const repo of discoverRepos(effectiveRoot, fs)) {
+    const key = dedupeKey(repo.path, fs)
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(repo)
+  }
+
+  return out
+}

--- a/packages/server/tests/control-room-repo-set.test.js
+++ b/packages/server/tests/control-room-repo-set.test.js
@@ -1,0 +1,148 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { join } from 'path'
+import { homedir } from 'os'
+
+import { resolveRepoSet, DEFAULT_CONTROL_ROOM_ROOT } from '../src/control-room/repo-set.js'
+
+/**
+ * Build a fake filesystem seam from a declarative tree description.
+ *
+ * @param {Object<string, string[]>} dirs - Map of dir path → entry names.
+ * @param {Set<string>} gitPaths - Paths that exist as a `.git` entry.
+ * @param {Object<string, string>} [realpaths] - Optional path → canonical override.
+ * @returns {{ _readdir, _stat, _exists, _realpath }}
+ */
+function fakeFs(dirs, gitPaths, realpaths = {}) {
+  return {
+    _readdir: dir => {
+      if (!(dir in dirs)) throw new Error(`ENOENT: ${dir}`)
+      return dirs[dir]
+    },
+    _stat: p => {
+      // Anything we listed as a directory key is a directory; subdir entries
+      // (children listed under a parent) are directories too.
+      const isDir = p in dirs || Object.values(dirs).some((entries, i) => {
+        const parent = Object.keys(dirs)[i]
+        return entries.some(e => join(parent, e) === p)
+      })
+      return { isDirectory: () => isDir }
+    },
+    _exists: p => gitPaths.has(p),
+    _realpath: p => realpaths[p] || p,
+  }
+}
+
+describe('resolveRepoSet', () => {
+  it('returns config-only repos when discovery root is empty', () => {
+    const fs = fakeFs({ '/root': [] }, new Set())
+    const result = resolveRepoSet({
+      repos: [{ path: '/work/alpha', name: 'alpha' }, { path: '/work/beta' }],
+      root: '/root',
+      ...fs,
+    })
+    assert.deepEqual(result, [
+      { name: 'alpha', path: '/work/alpha' },
+      { name: 'beta', path: '/work/beta' },
+    ])
+  })
+
+  it('derives name from basename when config entry omits name', () => {
+    const fs = fakeFs({ '/root': [] }, new Set())
+    const result = resolveRepoSet({ repos: [{ path: '/work/my-repo' }], root: '/root', ...fs })
+    assert.deepEqual(result, [{ name: 'my-repo', path: '/work/my-repo' }])
+  })
+
+  it('returns scan-only repos that contain a .git entry', () => {
+    const dirs = { '/root': ['repo-a', 'repo-b', 'not-a-repo', 'file.txt'] }
+    const gitPaths = new Set(['/root/repo-a/.git', '/root/repo-b/.git'])
+    const result = resolveRepoSet({ repos: [], root: '/root', ...fakeFs(dirs, gitPaths) })
+    assert.deepEqual(result, [
+      { name: 'repo-a', path: '/root/repo-a' },
+      { name: 'repo-b', path: '/root/repo-b' },
+    ])
+  })
+
+  it('treats a .git file (worktree/submodule) as a repo', () => {
+    const dirs = { '/root': ['wt'] }
+    const gitPaths = new Set(['/root/wt/.git']) // _exists returns true regardless of file vs dir
+    const result = resolveRepoSet({ repos: [], root: '/root', ...fakeFs(dirs, gitPaths) })
+    assert.deepEqual(result, [{ name: 'wt', path: '/root/wt' }])
+  })
+
+  it('unions config and discovered repos', () => {
+    const dirs = { '/root': ['scanned'] }
+    const gitPaths = new Set(['/root/scanned/.git'])
+    const result = resolveRepoSet({
+      repos: [{ path: '/work/configured', name: 'configured' }],
+      root: '/root',
+      ...fakeFs(dirs, gitPaths),
+    })
+    assert.deepEqual(result, [
+      { name: 'configured', path: '/work/configured' },
+      { name: 'scanned', path: '/root/scanned' },
+    ])
+  })
+
+  it('de-dupes by realpath, config entry winning over discovered', () => {
+    // /root/shared (discovered) and /work/shared (config) realpath to the same
+    // canonical path -> only the config entry survives, keeping its name.
+    const dirs = { '/root': ['shared'] }
+    const gitPaths = new Set(['/root/shared/.git'])
+    const realpaths = {
+      '/root/shared': '/canonical/shared',
+      '/work/shared': '/canonical/shared',
+    }
+    const result = resolveRepoSet({
+      repos: [{ path: '/work/shared', name: 'my-shared' }],
+      root: '/root',
+      ...fakeFs(dirs, gitPaths, realpaths),
+    })
+    assert.deepEqual(result, [{ name: 'my-shared', path: '/work/shared' }])
+  })
+
+  it('de-dupes duplicate config entries by realpath', () => {
+    const realpaths = { '/a/repo': '/canon/repo', '/b/repo': '/canon/repo' }
+    const fs = fakeFs({ '/root': [] }, new Set(), realpaths)
+    const result = resolveRepoSet({
+      repos: [{ path: '/a/repo', name: 'first' }, { path: '/b/repo', name: 'second' }],
+      root: '/root',
+      ...fs,
+    })
+    assert.deepEqual(result, [{ name: 'first', path: '/a/repo' }])
+  })
+
+  it('skips config entries with missing or invalid path', () => {
+    const fs = fakeFs({ '/root': [] }, new Set())
+    const result = resolveRepoSet({
+      repos: [{ path: '/ok', name: 'ok' }, { name: 'no-path' }, null, { path: '' }],
+      root: '/root',
+      ...fs,
+    })
+    assert.deepEqual(result, [{ name: 'ok', path: '/ok' }])
+  })
+
+  it('returns empty when root is unreadable and no config repos', () => {
+    const fs = fakeFs({}, new Set()) // /root not present -> _readdir throws
+    const result = resolveRepoSet({ repos: [], root: '/root', ...fs })
+    assert.deepEqual(result, [])
+  })
+
+  it('uses the default root (~/Projects) when none provided', () => {
+    assert.equal(DEFAULT_CONTROL_ROOM_ROOT, join(homedir(), 'Projects'))
+
+    const calls = []
+    const result = resolveRepoSet({
+      repos: [],
+      _readdir: dir => {
+        calls.push(dir)
+        return [] // empty default root
+      },
+      _stat: () => ({ isDirectory: () => true }),
+      _exists: () => false,
+      _realpath: p => p,
+    })
+    assert.deepEqual(result, [])
+    assert.deepEqual(calls, [DEFAULT_CONTROL_ROOM_ROOT])
+  })
+})

--- a/packages/server/tests/control-room-repo-set.test.js
+++ b/packages/server/tests/control-room-repo-set.test.js
@@ -8,24 +8,31 @@ import { resolveRepoSet, DEFAULT_CONTROL_ROOM_ROOT } from '../src/control-room/r
 /**
  * Build a fake filesystem seam from a declarative tree description.
  *
+ * Every listed child entry is a directory by default. Pass `filePaths` to mark
+ * specific child paths as plain files so the resolver's `isDirectory()` guard is
+ * genuinely exercised (a non-directory must be rejected even if it had a `.git`).
+ *
  * @param {Object<string, string[]>} dirs - Map of dir path → entry names.
  * @param {Set<string>} gitPaths - Paths that exist as a `.git` entry.
- * @param {Object<string, string>} [realpaths] - Optional path → canonical override.
+ * @param {object} [extra]
+ * @param {Object<string, string>} [extra.realpaths] - Optional path → canonical override.
+ * @param {Set<string>} [extra.filePaths] - Child paths that are plain files, not directories.
  * @returns {{ _readdir, _stat, _exists, _realpath }}
  */
-function fakeFs(dirs, gitPaths, realpaths = {}) {
+function fakeFs(dirs, gitPaths, { realpaths = {}, filePaths = new Set() } = {}) {
   return {
     _readdir: dir => {
       if (!(dir in dirs)) throw new Error(`ENOENT: ${dir}`)
       return dirs[dir]
     },
     _stat: p => {
-      // Anything we listed as a directory key is a directory; subdir entries
-      // (children listed under a parent) are directories too.
-      const isDir = p in dirs || Object.values(dirs).some((entries, i) => {
-        const parent = Object.keys(dirs)[i]
-        return entries.some(e => join(parent, e) === p)
-      })
+      // Explicit files are not directories; everything else listed as a dir key
+      // or as a child entry under a parent is a directory.
+      const isFile = filePaths.has(p)
+      const isChild = Object.entries(dirs).some(([parent, entries]) =>
+        entries.some(e => join(parent, e) === p),
+      )
+      const isDir = !isFile && (p in dirs || isChild)
       return { isDirectory: () => isDir }
     },
     _exists: p => gitPaths.has(p),
@@ -56,11 +63,31 @@ describe('resolveRepoSet', () => {
   it('returns scan-only repos that contain a .git entry', () => {
     const dirs = { '/root': ['repo-a', 'repo-b', 'not-a-repo', 'file.txt'] }
     const gitPaths = new Set(['/root/repo-a/.git', '/root/repo-b/.git'])
-    const result = resolveRepoSet({ repos: [], root: '/root', ...fakeFs(dirs, gitPaths) })
+    // file.txt is a plain file so the isDirectory() guard rejects it before the
+    // .git check; not-a-repo is a directory but has no .git.
+    const result = resolveRepoSet({
+      repos: [],
+      root: '/root',
+      ...fakeFs(dirs, gitPaths, { filePaths: new Set(['/root/file.txt']) }),
+    })
     assert.deepEqual(result, [
       { name: 'repo-a', path: '/root/repo-a' },
       { name: 'repo-b', path: '/root/repo-b' },
     ])
+  })
+
+  it('skips a non-directory entry even when a .git path would match', () => {
+    // Proves the isDirectory() guard is independent of the .git existence check:
+    // file.txt is rejected purely because it is not a directory, despite having
+    // a matching .git entry in the fake fs.
+    const dirs = { '/root': ['file.txt'] }
+    const gitPaths = new Set(['/root/file.txt/.git'])
+    const result = resolveRepoSet({
+      repos: [],
+      root: '/root',
+      ...fakeFs(dirs, gitPaths, { filePaths: new Set(['/root/file.txt']) }),
+    })
+    assert.deepEqual(result, [])
   })
 
   it('treats a .git file (worktree/submodule) as a repo', () => {
@@ -96,14 +123,14 @@ describe('resolveRepoSet', () => {
     const result = resolveRepoSet({
       repos: [{ path: '/work/shared', name: 'my-shared' }],
       root: '/root',
-      ...fakeFs(dirs, gitPaths, realpaths),
+      ...fakeFs(dirs, gitPaths, { realpaths }),
     })
     assert.deepEqual(result, [{ name: 'my-shared', path: '/work/shared' }])
   })
 
   it('de-dupes duplicate config entries by realpath', () => {
     const realpaths = { '/a/repo': '/canon/repo', '/b/repo': '/canon/repo' }
-    const fs = fakeFs({ '/root': [] }, new Set(), realpaths)
+    const fs = fakeFs({ '/root': [] }, new Set(), { realpaths })
     const result = resolveRepoSet({
       repos: [{ path: '/a/repo', name: 'first' }, { path: '/b/repo', name: 'second' }],
       root: '/root',


### PR DESCRIPTION
## Summary

Implements **#5172** (A2, part of Control Room v2 epic #5170): a pure server utility that resolves the set of repos the Host Status survey will cover.

`resolveRepoSet(opts)` returns a de-duped `{ name, path }[]` = union of explicit `config.repos[]` entries and git repos auto-discovered under a configurable root.

## What's included

- **`packages/server/src/control-room/repo-set.js`**
  - `resolveRepoSet(opts)` — unions config repos with auto-discovered repos.
  - Auto-discovery: only immediate subdirectories of the root that contain a `.git` entry (dir for a clone, file for a worktree/submodule). `name` = basename.
  - De-dupe by realpath; config entries win over discovered ones on a collision and keep their declared order/name.
  - **Injection seam**: `_readdir` / `_stat` / `_exists` / `_realpath` overrides defaulting to `fs`, so tests never touch real disk or `~`.
  - `DEFAULT_CONTROL_ROOM_ROOT` = `~/Projects`.
- **`config.js`** — new `controlRoomRoot` string key (schema + `CHROXY_CONTROL_ROOM_ROOT` env mapping, wired the same way as `repos`/`CHROXY_REPOS`), plus `readControlRoomRootFromConfig` / `writeControlRoomRootToConfig` helpers mirroring the existing repos helpers.
- **Tests** (`tests/control-room-repo-set.test.js`) — fully faked fs: config-only, scan-only, `.git` file, union, realpath de-dupe (config wins), duplicate config entries, invalid entries skipped, unreadable root, default-root behaviour.

## Testing

- `control-room-repo-set.test.js`: 10/10 pass.
- `config.test.js`: 80/80 pass.
- `lint-tests-state-file-path.sh` and `lint-session-opt-forwarding.sh`: pass.

Closes #5172