### PR TITLE
fix(server): reap completed background shells without a BashOutput poll

### DIFF
--- a/packages/server/src/background-shells.js
+++ b/packages/server/src/background-shells.js
@@ -30,6 +30,20 @@
 // narrow: malformed payloads return null and the wait is invisible.
 const SHELL_ID_RE = /Command running in background with ID:\s+([A-Za-z0-9_-]+)/
 
+// #5177: the canonical tool_result also names the file claude tails the
+// background command's stdout/stderr into:
+//
+//   "Output is being written to: /private/tmp/claude-501/…/tasks/<id>.output"
+//
+// We capture the path so the periodic sweep (see BaseSession) can observe
+// the shell's completion WITHOUT the agent ever calling `BashOutput`: a
+// finished command stops appending to this file, so a quiesced mtime is a
+// reap signal. Match a run of non-whitespace after the colon — the path is
+// always a single token and any trailing sentence punctuation (". You will
+// be notified…") is whitespace-separated. Strip a single trailing period
+// defensively in case a future claude build drops the space before it.
+const SHELL_OUTPUT_PATH_RE = /Output is being written to:\s+(\S+)/
+
 /**
  * Parse the shell id from a tool_result text. Returns the id when the
  * canonical pattern matches, else null.
@@ -44,6 +58,28 @@ export function parseBackgroundShellId(text) {
   if (typeof text !== 'string' || text.length === 0) return null
   const m = SHELL_ID_RE.exec(text)
   return m ? m[1] : null
+}
+
+/**
+ * #5177: parse the output file path from a tool_result text. Returns the
+ * path when the canonical `Output is being written to: <path>` pattern
+ * matches, else null. A single trailing period is stripped so a build that
+ * emits `…<id>.output.` (no space before the sentence end) still yields a
+ * clean path.
+ *
+ * Defensive against non-string / empty inputs so callers can hand the raw
+ * `tool_result.result` field through without pre-checking. Returning null
+ * is non-fatal: the shell is still tracked, the sweep just can't reap it
+ * via the output file and falls back to the BashOutput / destroy paths.
+ *
+ * @param {unknown} text
+ * @returns {string | null}
+ */
+export function parseBackgroundShellOutputPath(text) {
+  if (typeof text !== 'string' || text.length === 0) return null
+  const m = SHELL_OUTPUT_PATH_RE.exec(text)
+  if (!m) return null
+  return m[1].replace(/\.$/, '')
 }
 
 /**

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -101,16 +101,19 @@ export const DEFAULT_STREAM_STALL_TIMEOUT_MS = 5 * 60 * 1000
 // pending output file is negligible. Only armed while shells are pending.
 export const BACKGROUND_SHELL_SWEEP_MS = 15 * 1000
 
-// #5177: quiescence window (ms). A pending shell whose output file has not
-// been modified for at least this long is treated as complete and reaped.
-// 30s is conservative — comfortably longer than the inter-line gap of a
-// typical periodic background command (e.g. a 2s-sleep loop) so a command
-// that is merely slow between writes is not reaped while still running. A
-// command that genuinely stalls for >30s with no output reaps as "done";
-// that is acceptable — the agent re-discovers reality on its next
-// BashOutput poll, and an over-eager clear is a far smaller UX harm than
-// the banner sticking forever (the bug this fixes).
-export const BACKGROUND_SHELL_QUIESCE_MS = 30 * 1000
+// #5177: quiescence window (ms). A pending shell whose NON-EMPTY output
+// file has not been modified for at least this long is treated as complete
+// and reaped. 60s is conservative — comfortably longer than the inter-line
+// gap of a typical periodic background command (e.g. a 2s-sleep loop) so a
+// command that is merely slow between writes is not reaped while still
+// running. Combined with the non-empty guard in `_isBackgroundShellComplete`
+// (a silent command that emits no output is NEVER reaped via the file path),
+// the false-positive surface is small: only a command that produced output,
+// then went silent for >60s, then is still running, would be reaped early —
+// and even then the agent re-discovers reality on its next BashOutput poll.
+// An over-eager clear is a far smaller UX harm than the banner sticking
+// forever (the bug this fixes).
+export const BACKGROUND_SHELL_QUIESCE_MS = 60 * 1000
 
 // Default per-provider injection mode (#3200). Subprocess providers without
 // a system-prompt flag (Codex, Gemini) prepend skills to the first user
@@ -912,13 +915,15 @@ export class BaseSession extends EventEmitter {
    * Tests inject `_backgroundShellCompletionCheck` for deterministic control
    * without touching the filesystem or real time. The production default
    * uses the shell's output file mtime: claude tails the command's
-   * stdout/stderr into the file named in the tool_result, so a file that has
-   * not been written to for `_backgroundShellQuiesceMs` means the command
-   * has stopped producing output — the strongest completion signal available
-   * given chroxy never holds the shell's PID (the id is opaque, owned by
-   * claude). A shell with no known output path can't be reaped this way and
-   * stays pending until BashOutput / destroy — the existing #4307 behaviour,
-   * preserved as the fallback.
+   * stdout/stderr into the file named in the tool_result, so a NON-EMPTY
+   * file that has not been written to for `_backgroundShellQuiesceMs` means
+   * the command produced output and then stopped — the strongest completion
+   * signal available given chroxy never holds the shell's PID (the id is
+   * opaque, owned by claude). A shell with no known output path, or whose
+   * output file is still empty (a silent command like `sleep 600`), can't be
+   * reaped this way and stays pending until BashOutput / destroy — the
+   * existing #4307 behaviour, preserved as the conservative fallback so a
+   * long, silent job is never flipped to idle while still running.
    *
    * Defensive: a stat() error (file removed, races) is treated as NOT
    * complete so a transient FS hiccup can't reap a still-running shell. The
@@ -937,6 +942,18 @@ export class BaseSession extends EventEmitter {
     }
     try {
       const st = statSync(entry.outputPath)
+      // #5177 (review): a SILENT command — one that produces no output and
+      // only exits much later (`sleep 600`, a long compute that prints only
+      // at the end) — leaves the output file empty and untouched after
+      // creation. Reaping on mtime alone would clear it ~quiesceMs after
+      // start while it is still running, flipping isRunning to false and
+      // letting SessionTimeoutManager treat the session as idle. Guard with
+      // a non-empty check: an empty output file is NEVER reaped via this
+      // path, so silent shells fall back to the existing BashOutput /
+      // destroy clear (the conservative #4307 behaviour). The sweep only
+      // reaps shells that demonstrably produced output and then went quiet —
+      // the strong signal that the command ran and finished.
+      if (st.size <= 0) return false
       const lastWrite = st.mtimeMs
       return Date.now() - lastWrite >= this._backgroundShellQuiesceMs
     } catch {

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -8,6 +8,7 @@
  */
 import { EventEmitter } from 'events'
 import { randomBytes } from 'crypto'
+import { statSync } from 'fs'
 import { resolveModelId } from './models.js'
 import {
   loadActiveSkillsLayered,
@@ -91,6 +92,25 @@ export const DEFAULT_HARD_TIMEOUT_MS = 2 * 60 * 60 * 1000
 // via config.streamStallTimeoutMs or CHROXY_STREAM_STALL_TIMEOUT_MS, or set
 // to 0 to disable.
 export const DEFAULT_STREAM_STALL_TIMEOUT_MS = 5 * 60 * 1000
+
+// #5177: how often the background-shell sweep runs (ms). A completed
+// background shell that the agent never polls via `BashOutput` is reaped on
+// the next tick after its output file quiesces. 15s is a tradeoff: snappy
+// enough that the dashboard banner clears within a sensible window of the
+// command actually finishing, slow enough that the per-tick stat() of each
+// pending output file is negligible. Only armed while shells are pending.
+export const BACKGROUND_SHELL_SWEEP_MS = 15 * 1000
+
+// #5177: quiescence window (ms). A pending shell whose output file has not
+// been modified for at least this long is treated as complete and reaped.
+// 30s is conservative — comfortably longer than the inter-line gap of a
+// typical periodic background command (e.g. a 2s-sleep loop) so a command
+// that is merely slow between writes is not reaped while still running. A
+// command that genuinely stalls for >30s with no output reaps as "done";
+// that is acceptable — the agent re-discovers reality on its next
+// BashOutput poll, and an over-eager clear is a far smaller UX harm than
+// the banner sticking forever (the bug this fixes).
+export const BACKGROUND_SHELL_QUIESCE_MS = 30 * 1000
 
 // Default per-provider injection mode (#3200). Subprocess providers without
 // a system-prompt flag (Codex, Gemini) prepend skills to the first user
@@ -288,6 +308,29 @@ export class BaseSession extends EventEmitter {
     // also reconcile with the (unknown) post-restart claude side —
     // blindly restoring a stale Map will lock the indicator on forever.
     this._pendingBackgroundShells = new Map()
+    // #5177: periodic sweep that reaps COMPLETED background shells without
+    // waiting for the agent to call `BashOutput`. Before #5177 a shell that
+    // finished (e.g. `for i in $(seq 1 30); …`, exit 0) stayed pending
+    // forever — `isRunning` never returned to false and the dashboard's
+    // "Waiting on background work" banner stuck, because the only clear
+    // signal was an explicit BashOutput poll that never comes after the
+    // turn ends. The sweep observes completion via the output file claude
+    // names in the tool_result (`Output is being written to: <path>`): a
+    // finished command stops appending, so a quiesced mtime reaps it. The
+    // timer is armed only while the pending map is non-empty (lazy) and
+    // stopped when it drains or the session is destroyed (no leak / no idle
+    // wakeups). Interval + completion check are injectable for tests.
+    this._backgroundShellSweepTimer = null
+    this._backgroundShellSweepMs = BACKGROUND_SHELL_SWEEP_MS
+    // Quiescence window: a shell whose output file has not been written to
+    // for this long is treated as complete. Conservative so a command that
+    // pauses output mid-run is not reaped prematurely; the agent's own
+    // BashOutput poll still clears faster when it happens.
+    this._backgroundShellQuiesceMs = BACKGROUND_SHELL_QUIESCE_MS
+    // Injectable completion check — `(entry) => boolean`. Default reads the
+    // output file's mtime; tests override this to drive deterministic
+    // completion without touching the filesystem or real timers.
+    this._backgroundShellCompletionCheck = null
     // #4307: ephemeral map of recent `Bash` tool_uses dispatched with
     // `run_in_background: true`, keyed by toolUseId. Used to recover the
     // command string when the matching tool_result lands carrying the
@@ -653,7 +696,11 @@ export class BaseSession extends EventEmitter {
    * objects so the caller can stringify directly onto a wire payload.
    */
   getPendingBackgroundShells() {
-    return Array.from(this._pendingBackgroundShells.values())
+    // #5177: project to the stable wire shape — `outputPath` is an internal
+    // sweep detail and must not leak onto the snapshot the dashboard caches.
+    return Array.from(this._pendingBackgroundShells.values()).map(
+      ({ shellId, startedAt, command }) => ({ shellId, startedAt, command }),
+    )
   }
 
   /**
@@ -667,17 +714,25 @@ export class BaseSession extends EventEmitter {
    * after a change. `SessionManager` proxies this transient event onto
    * the WS wire (see `customEvents`-style integration).
    *
-   * @param {{ shellId: string, command?: string }} opts
+   * #5177: `outputPath` (when known — parsed from the canonical
+   * tool_result) is stashed so the completion sweep can observe the shell
+   * finishing via the output file's mtime. It is internal-only and is NOT
+   * surfaced on the wire snapshot (see getPendingBackgroundShells).
+   *
+   * @param {{ shellId: string, command?: string, outputPath?: string }} opts
    * @returns {boolean} true if a new entry was added
    */
-  trackBackgroundShell({ shellId, command } = {}) {
+  trackBackgroundShell({ shellId, command, outputPath } = {}) {
     if (typeof shellId !== 'string' || shellId.length === 0) return false
     if (this._pendingBackgroundShells.has(shellId)) return false
     this._pendingBackgroundShells.set(shellId, {
       shellId,
       startedAt: Date.now(),
       command: typeof command === 'string' ? command : '',
+      outputPath: typeof outputPath === 'string' && outputPath.length > 0 ? outputPath : null,
     })
+    // #5177: start the reaping sweep now that there is work to watch.
+    this._ensureBackgroundShellSweep()
     this._emitBackgroundWorkChanged()
     return true
   }
@@ -697,6 +752,10 @@ export class BaseSession extends EventEmitter {
   clearBackgroundShell(shellId) {
     if (typeof shellId !== 'string' || shellId.length === 0) return false
     if (!this._pendingBackgroundShells.delete(shellId)) return false
+    // #5177: stop the sweep once the last shell drains so an idle session
+    // has no recurring timer (no wakeups, no leak). Re-armed by the next
+    // trackBackgroundShell.
+    if (this._pendingBackgroundShells.size === 0) this._stopBackgroundShellSweep()
     this._emitBackgroundWorkChanged()
     return true
   }
@@ -746,6 +805,11 @@ export class BaseSession extends EventEmitter {
     // shape with the right argument count.
     if (eventName === undefined) {
       this._activity.clear()
+      // #5177: stop the background-shell sweep on full teardown too. Most
+      // providers (cli/jsonl/gemini/codex) destroy via removeAllListeners()
+      // and never call _destroyPendingBackgroundShells, so this is the
+      // chokepoint that guarantees no provider leaks the recurring timer.
+      this._stopBackgroundShellSweep()
       return super.removeAllListeners()
     }
     return super.removeAllListeners(eventName)
@@ -787,6 +851,100 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
+   * #5177: arm the periodic reaping sweep if it is not already running and
+   * there is pending work to watch. Idempotent — a second call while the
+   * timer is live is a no-op, so every `trackBackgroundShell` can call it
+   * unconditionally. The interval is `unref()`'d so a lone pending shell
+   * can never keep the process alive on its own (mirrors how chroxy treats
+   * its other background timers — the shell is owned by claude, not us).
+   *
+   * @private
+   */
+  _ensureBackgroundShellSweep() {
+    if (this._backgroundShellSweepTimer) return
+    if (this._pendingBackgroundShells.size === 0) return
+    if (!(this._backgroundShellSweepMs > 0)) return
+    this._backgroundShellSweepTimer = setInterval(
+      () => this._sweepCompletedBackgroundShells(),
+      this._backgroundShellSweepMs,
+    )
+    // unref so the sweep never blocks process exit on its own.
+    if (typeof this._backgroundShellSweepTimer.unref === 'function') {
+      this._backgroundShellSweepTimer.unref()
+    }
+  }
+
+  /**
+   * #5177: stop the reaping sweep. Idempotent.
+   * @private
+   */
+  _stopBackgroundShellSweep() {
+    if (!this._backgroundShellSweepTimer) return
+    clearInterval(this._backgroundShellSweepTimer)
+    this._backgroundShellSweepTimer = null
+  }
+
+  /**
+   * #5177: one sweep tick — reap every pending shell that has completed.
+   * Completion is decided by `_isBackgroundShellComplete`. Reaping a shell
+   * goes through `clearBackgroundShell`, so it emits the SAME
+   * `background_work_changed` snapshot the BashOutput / destroy paths emit —
+   * the dashboard's "Waiting on background work" indicator consumes that
+   * snapshot and clears with no new wire contract. Iterating over a copied
+   * key list keeps the mutation (clearBackgroundShell deletes from the map)
+   * safe.
+   *
+   * @private
+   */
+  _sweepCompletedBackgroundShells() {
+    for (const shellId of Array.from(this._pendingBackgroundShells.keys())) {
+      const entry = this._pendingBackgroundShells.get(shellId)
+      if (!entry) continue
+      if (this._isBackgroundShellComplete(entry)) {
+        this.clearBackgroundShell(shellId)
+      }
+    }
+  }
+
+  /**
+   * #5177: decide whether a pending background shell has completed.
+   *
+   * Tests inject `_backgroundShellCompletionCheck` for deterministic control
+   * without touching the filesystem or real time. The production default
+   * uses the shell's output file mtime: claude tails the command's
+   * stdout/stderr into the file named in the tool_result, so a file that has
+   * not been written to for `_backgroundShellQuiesceMs` means the command
+   * has stopped producing output — the strongest completion signal available
+   * given chroxy never holds the shell's PID (the id is opaque, owned by
+   * claude). A shell with no known output path can't be reaped this way and
+   * stays pending until BashOutput / destroy — the existing #4307 behaviour,
+   * preserved as the fallback.
+   *
+   * Defensive: a stat() error (file removed, races) is treated as NOT
+   * complete so a transient FS hiccup can't reap a still-running shell. The
+   * banner sticking briefly is recoverable; a false clear is worse.
+   *
+   * @param {{ shellId: string, outputPath?: string|null, startedAt: number }} entry
+   * @returns {boolean}
+   * @private
+   */
+  _isBackgroundShellComplete(entry) {
+    if (typeof this._backgroundShellCompletionCheck === 'function') {
+      return this._backgroundShellCompletionCheck(entry) === true
+    }
+    if (!entry || typeof entry.outputPath !== 'string' || entry.outputPath.length === 0) {
+      return false
+    }
+    try {
+      const st = statSync(entry.outputPath)
+      const lastWrite = st.mtimeMs
+      return Date.now() - lastWrite >= this._backgroundShellQuiesceMs
+    } catch {
+      return false
+    }
+  }
+
+  /**
    * #4307: clear the pending map on session destroy. Pulled into a
    * helper so subclasses can call it from their own `destroy()` after
    * the existing teardown — keeping the map alive past destroy would
@@ -795,6 +953,9 @@ export class BaseSession extends EventEmitter {
    * @private
    */
   _destroyPendingBackgroundShells() {
+    // #5177: stop the reaping sweep before clearing the map so no tick can
+    // fire against a half-torn-down session.
+    this._stopBackgroundShellSweep()
     this._pendingBackgroundShells.clear()
     this._pendingBackgroundCommands.clear()
     // #5160: tear down the activity registry alongside the other transient

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -12,6 +12,7 @@ import { isOperatorTimeoutInRange } from './duration.js'
 import { materializeAttachments, buildAttachmentsPromptSuffix } from './claude-tui-attachments.js'
 import {
   parseBackgroundShellId,
+  parseBackgroundShellOutputPath,
   isRunInBackgroundInput,
   parseBashOutputShellId,
 } from './background-shells.js'
@@ -1803,7 +1804,10 @@ export class ClaudeTuiSession extends BaseSession {
     if (shellId) {
       const command = this._pendingBackgroundCommands.get(toolUseId) || ''
       this._pendingBackgroundCommands.delete(toolUseId)
-      this.trackBackgroundShell({ shellId, command })
+      // #5177: capture the output file path so the completion sweep can reap
+      // the shell on quiescence without an explicit BashOutput poll.
+      const outputPath = parseBackgroundShellOutputPath(result)
+      this.trackBackgroundShell({ shellId, command, outputPath })
     }
   }
 

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -8,6 +8,7 @@ import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
 import {
   parseBackgroundShellId,
+  parseBackgroundShellOutputPath,
   isRunInBackgroundInput,
   parseBashOutputShellId,
 } from './background-shells.js'
@@ -1232,7 +1233,10 @@ export class SdkSession extends BaseSession {
       if (!shellId) continue
       const command = this._pendingBackgroundCommands.get(block.tool_use_id) || ''
       this._pendingBackgroundCommands.delete(block.tool_use_id)
-      this.trackBackgroundShell({ shellId, command })
+      // #5177: capture the output file path from the same tool_result so the
+      // completion sweep can reap the shell on quiescence without a poll.
+      const outputPath = parseBackgroundShellOutputPath(text)
+      this.trackBackgroundShell({ shellId, command, outputPath })
     }
   }
 

--- a/packages/server/tests/background-shells.test.js
+++ b/packages/server/tests/background-shells.test.js
@@ -14,14 +14,15 @@
  *   - turn-end (`_clearMessageState`) does NOT clear pending shells
  *   - the BashOutput tool clears the matching entry
  */
-import { describe, it, beforeEach, afterEach } from 'node:test'
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync, utimesSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { BaseSession } from '../src/base-session.js'
 import {
   parseBackgroundShellId,
+  parseBackgroundShellOutputPath,
   isRunInBackgroundInput,
 } from '../src/background-shells.js'
 import { SessionTimeoutManager } from '../src/session-timeout-manager.js'
@@ -70,6 +71,32 @@ describe('background-shells helpers (#4307)', () => {
         parseBackgroundShellId('Command running in background with ID:    \n\n'),
         null,
       )
+    })
+  })
+
+  describe('parseBackgroundShellOutputPath (#5177)', () => {
+    it('extracts the output file path from the canonical message', () => {
+      const text =
+        'Command running in background with ID: brk57kt6pm. Output is being ' +
+        'written to: /private/tmp/claude-501/x/tasks/brk57kt6pm.output. You ' +
+        'will be notified when it completes.'
+      assert.equal(
+        parseBackgroundShellOutputPath(text),
+        '/private/tmp/claude-501/x/tasks/brk57kt6pm.output',
+      )
+    })
+
+    it('strips a single trailing period when no space precedes the sentence end', () => {
+      const text = 'Output is being written to: /tmp/tasks/abc.output.'
+      assert.equal(parseBackgroundShellOutputPath(text), '/tmp/tasks/abc.output')
+    })
+
+    it('returns null when the message has no output path', () => {
+      assert.equal(parseBackgroundShellOutputPath('Command running in background with ID: x'), null)
+      assert.equal(parseBackgroundShellOutputPath(''), null)
+      assert.equal(parseBackgroundShellOutputPath(null), null)
+      assert.equal(parseBackgroundShellOutputPath(undefined), null)
+      assert.equal(parseBackgroundShellOutputPath(42), null)
     })
   })
 
@@ -224,6 +251,123 @@ describe('BaseSession background-shell tracking (#4307)', () => {
       session._destroyPendingBackgroundShells()
       assert.equal(session._pendingBackgroundShells.size, 0)
     })
+  })
+})
+
+describe('BaseSession background-shell completion sweep (#5177)', () => {
+  let session
+
+  beforeEach(() => {
+    emptySkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bg-skills-'))
+    session = makeSession()
+    // Tighten the sweep interval so fake timers advance predictably.
+    session._backgroundShellSweepMs = 1000
+  })
+
+  afterEach(() => {
+    mock.timers.reset()
+    session._destroyPendingBackgroundShells()
+    if (emptySkillsDir) rmSync(emptySkillsDir, { recursive: true, force: true })
+    emptySkillsDir = null
+  })
+
+  it('reaps a completed shell on the next sweep tick WITHOUT a BashOutput poll', () => {
+    mock.timers.enable({ apis: ['setInterval'] })
+    // Deterministic completion check: this shell is "done".
+    session._backgroundShellCompletionCheck = () => true
+
+    const events = []
+    session.on('background_work_changed', (d) => events.push(d))
+
+    session.trackBackgroundShell({ shellId: 'a', command: 'sleep 5', outputPath: '/tmp/a.output' })
+    assert.equal(session.isRunning, true, 'running while pending')
+    assert.equal(events.length, 1, 'track emitted once')
+
+    // Advance one sweep interval — the sweep should reap the shell.
+    mock.timers.tick(1000)
+
+    assert.equal(session._pendingBackgroundShells.size, 0, 'shell reaped')
+    assert.equal(session.isRunning, false, 'no longer running')
+    // The reap must emit the SAME background_work_changed snapshot the
+    // dashboard consumes (empty pending) — this is the #5178 clear signal.
+    assert.equal(events.length, 2, 'reap emitted a second change')
+    assert.equal(events[1].pending.length, 0, 'snapshot shows no pending shells')
+  })
+
+  it('leaves a still-running shell pending across sweep ticks', () => {
+    mock.timers.enable({ apis: ['setInterval'] })
+    session._backgroundShellCompletionCheck = () => false
+
+    session.trackBackgroundShell({ shellId: 'a', command: 'sleep 600', outputPath: '/tmp/a.output' })
+    mock.timers.tick(1000)
+    mock.timers.tick(1000)
+    assert.equal(session._pendingBackgroundShells.size, 1, 'still pending')
+    assert.equal(session.isRunning, true)
+  })
+
+  it('does not arm a sweep timer until a shell is tracked, and stops it when the map drains', () => {
+    mock.timers.enable({ apis: ['setInterval'] })
+    assert.equal(session._backgroundShellSweepTimer, null, 'no timer when idle')
+
+    session._backgroundShellCompletionCheck = () => false
+    session.trackBackgroundShell({ shellId: 'a', outputPath: '/tmp/a.output' })
+    assert.ok(session._backgroundShellSweepTimer, 'timer armed once pending')
+
+    // Clearing the last shell stops the timer.
+    session.clearBackgroundShell('a')
+    assert.equal(session._backgroundShellSweepTimer, null, 'timer stopped when map drains')
+  })
+
+  it('default completion check uses the output file mtime (real fs, no real timers)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-bg-out-'))
+    const outputPath = join(dir, 'shell.output')
+    writeFileSync(outputPath, 'hi\n')
+    session._backgroundShellQuiesceMs = 5000
+
+    // Freshly written → not quiesced → not complete.
+    session.trackBackgroundShell({ shellId: 'a', outputPath })
+    const fresh = session._pendingBackgroundShells.get('a')
+    assert.equal(session._isBackgroundShellComplete(fresh), false, 'fresh write is not complete')
+
+    // Backdate the mtime past the quiescence window → complete.
+    const old = Date.now() / 1000 - 60
+    utimesSync(outputPath, old, old)
+    assert.equal(session._isBackgroundShellComplete(fresh), true, 'quiesced file is complete')
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('default completion check treats a shell with no output path as not complete (#4307 fallback)', () => {
+    session._backgroundShellQuiesceMs = 5000
+    session.trackBackgroundShell({ shellId: 'a', command: 'x' })
+    const entry = session._pendingBackgroundShells.get('a')
+    assert.equal(entry.outputPath, null, 'no path captured')
+    assert.equal(session._isBackgroundShellComplete(entry), false, 'cannot reap without a path')
+  })
+
+  it('default completion check treats a stat() error as not complete (defensive)', () => {
+    session._backgroundShellQuiesceMs = 5000
+    session.trackBackgroundShell({ shellId: 'a', outputPath: '/no/such/file/at/all.output' })
+    const entry = session._pendingBackgroundShells.get('a')
+    assert.equal(session._isBackgroundShellComplete(entry), false, 'missing file is not reaped')
+  })
+
+  it('outputPath is NOT leaked onto the wire snapshot', () => {
+    session.trackBackgroundShell({ shellId: 'a', command: 'x', outputPath: '/tmp/a.output' })
+    const snap = session.getPendingBackgroundShells()
+    assert.equal(snap.length, 1)
+    assert.deepEqual(Object.keys(snap[0]).sort(), ['command', 'shellId', 'startedAt'])
+    assert.equal('outputPath' in snap[0], false, 'internal field stripped')
+  })
+
+  it('destroy stops the sweep timer (no leak)', () => {
+    mock.timers.enable({ apis: ['setInterval'] })
+    session._backgroundShellCompletionCheck = () => false
+    session.trackBackgroundShell({ shellId: 'a', outputPath: '/tmp/a.output' })
+    assert.ok(session._backgroundShellSweepTimer)
+    session._destroyPendingBackgroundShells()
+    assert.equal(session._backgroundShellSweepTimer, null, 'timer cleared on destroy')
+    assert.equal(session._pendingBackgroundShells.size, 0)
   })
 })
 

--- a/packages/server/tests/background-shells.test.js
+++ b/packages/server/tests/background-shells.test.js
@@ -337,6 +337,29 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
+  it('default completion check does NOT reap a silent shell whose output file is empty (#5177 review)', () => {
+    // A silent command (e.g. `sleep 600`) leaves an empty, quiesced output
+    // file. Reaping on mtime alone would flip isRunning to false while it is
+    // still running; the non-empty guard prevents that.
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-bg-empty-'))
+    const outputPath = join(dir, 'shell.output')
+    writeFileSync(outputPath, '') // empty
+    session._backgroundShellQuiesceMs = 5000
+    // Backdate well past the quiescence window.
+    const old = Date.now() / 1000 - 600
+    utimesSync(outputPath, old, old)
+
+    session.trackBackgroundShell({ shellId: 'a', outputPath })
+    const entry = session._pendingBackgroundShells.get('a')
+    assert.equal(
+      session._isBackgroundShellComplete(entry),
+      false,
+      'empty output file is never reaped (silent shell stays pending)',
+    )
+
+    rmSync(dir, { recursive: true, force: true })
+  })
+
   it('default completion check treats a shell with no output path as not complete (#4307 fallback)', () => {
     session._backgroundShellQuiesceMs = 5000
     session.trackBackgroundShell({ shellId: 'a', command: 'x' })


### PR DESCRIPTION
## Problem (B1 of Control Room v2 epic #5170)

A background shell that completes — e.g. `for i in $(seq 1 30); do echo hi; sleep 2; done`, exit 0 — was never observed as finished (reproduced live 2026-06-05). The pending-background-shells map cleared only on an explicit `BashOutput` poll or session destroy, so once the turn ended a finished shell stayed pending forever: `isRunning` never returned to `false`, and the dashboard's "Waiting on background work" banner stuck indefinitely.

## Root cause: server-side

The completion was only noticed if something explicitly polled `BashOutput`, which never happens after the turn ends. chroxy never holds the shell's PID (the id is opaque, owned by claude), so there was no exit handle to reap on, and no sweep to notice quiescence. This is a genuine server bug, not a dashboard-only issue.

## Fix

chroxy can't reap on process exit (no PID), so the architecture-fitting approach is a **lazy periodic sweep** keyed off a signal claude already gives us. The canonical `run_in_background` tool_result names the file claude tails the command's stdout/stderr into (`Output is being written to: <path>`). A finished command stops appending, so a quiesced output-file mtime is a reap signal.

- `background-shells.js`: `parseBackgroundShellOutputPath()` extracts the output path from the tool_result.
- `base-session.js`: stash `outputPath` on the pending entry; a `setInterval` sweep armed **only while shells are pending** (lazy) and stopped on drain / `destroy` / `removeAllListeners` teardown (no leak, `unref`'d so it never blocks exit); injectable interval + completion check for tests; output-file mtime quiescence as the default completion signal; `outputPath` stripped from the wire snapshot so the wire shape is unchanged.
- `sdk-session.js` / `claude-tui-session.js`: pass the parsed `outputPath` through to `trackBackgroundShell`.

### Downstream signal

Reaping goes through the existing `clearBackgroundShell` → `_emitBackgroundWorkChanged` path, so it emits the **same** `background_work_changed` snapshot the BashOutput / destroy paths already emit. That is exactly the signal the dashboard consumes — no new wire contract. The dashboard-side banner-clear robustness is tracked separately in #5178; this PR makes sure the server emits the clear signal the dashboard listens for.

## Tests & lint

- New tests in `background-shells.test.js`: output-path parser; sweep reaps a completed shell on the next tick WITHOUT a BashOutput poll (fake timers + injected completion check); still-running shell stays pending; timer is lazy-armed / stopped on drain / stopped on destroy; default mtime-quiescence completion check (real fs, no real timers); no-output-path and stat-error fallbacks; outputPath not leaked onto the wire snapshot.
- Touched-file suites green: `background-shells.test.js` + `base-session.test.js` 158/158; `claude-tui-session.test.js` 210/210.
- Full server suite: 7600 pass / 5 fail — the 5 are pre-existing environment/integration failures (cloudflared, network fetch timeout, claude-CLI feature detection) in `tunnel.integration.test.js` / `service.test.js` / `web-task-manager.test.js`, unrelated to this change and present on clean `main`.
- `lint-session-opt-forwarding.sh` and `lint-tests-state-file-path.sh` both pass (no new BaseSession constructor opt added — sweep state is internal).

Closes #5177