### PR TITLE
feat(dashboard): make the header cost badge configurable in Settings

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -280,6 +280,8 @@ export function App() {
   const viewMode = useConnectionStore(s => s.viewMode)
   const availableModels = useConnectionStore(s => s.availableModels)
   const availableModelsProvider = useConnectionStore(s => s.availableModelsProvider)
+  // #5184: header cost-badge display mode (Settings-driven, persisted).
+  const costBadgeMode = useConnectionStore(s => s.costBadgeMode)
   const defaultModelId = useConnectionStore(s => s.defaultModelId)
   const availablePermissionModes = useConnectionStore(s => s.availablePermissionModes)
   const availableProviders = useConnectionStore(s => s.availableProviders)
@@ -1909,6 +1911,15 @@ export function App() {
     return (total / contextWindow) * 100
   }, [contextUsage, activeModel, availableModels])
 
+  // #5184: human-readable model label for the `provider-model` cost-badge
+  // mode. Prefer the server-supplied `label`; fall back to the raw model id
+  // so a model missing from `availableModels` still shows something.
+  const activeModelLabel = useMemo(() => {
+    if (!activeModel) return undefined
+    const modelInfo = availableModels.find(m => m.id === activeModel || m.fullId === activeModel)
+    return modelInfo?.label ?? activeModel
+  }, [activeModel, availableModels])
+
   const isConnected = connectionPhase === 'connected'
   const isReconnecting = connectionPhase === 'reconnecting' || connectionPhase === 'server_restarting'
   const isStartupError = connectionPhase === 'disconnected' && !!connectionError && sessions.length === 0
@@ -2161,6 +2172,11 @@ export function App() {
             isBusy={!isIdle}
             agentCount={activeAgents.length}
             provider={sessions.find(s => s.sessionId === activeSessionId)?.provider}
+            // #5184: model label + Settings-driven badge mode. The mode is
+            // always defined (store default `provider-model`), so the
+            // StatusBar always renders the configurable badge in the app.
+            model={activeModelLabel}
+            costBadgeMode={costBadgeMode}
           />
         </div>
       </header>

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -39,6 +39,8 @@ vi.mock('../theme/theme-engine', () => ({
 
 const mockSetTheme = vi.fn()
 const mockUpdateInputSettings = vi.fn()
+// #5184: spy for the cost-badge mode setter.
+const mockSetCostBadgeMode = vi.fn()
 
 // #3404 audit F1: settable so individual tests can override availableProviders
 // without redefining the whole mock.
@@ -52,6 +54,9 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     setDefaultProvider: vi.fn(),
     inputSettings: { chatEnterToSend: true, terminalEnterToSend: false, voiceInputMode: 'continuous' },
     updateInputSettings: mockUpdateInputSettings,
+    // #5184: header cost-badge display mode default + setter spy.
+    costBadgeMode: 'provider-model',
+    setCostBadgeMode: mockSetCostBadgeMode,
     availableProviders: [],
     // Per-session promptEvaluator toggle defaults — overridden by the
     // Active session test cases. Default empty array + null id keeps the
@@ -118,6 +123,7 @@ vi.mock('../store/connection', () => ({
 
 beforeEach(() => {
   mockSetTheme.mockClear()
+  mockSetCostBadgeMode.mockClear()
   setMockState()
 })
 
@@ -200,6 +206,46 @@ describe('SettingsPanel', () => {
     const select = screen.getByLabelText('Send shortcut')
     fireEvent.change(select, { target: { value: 'cmd-enter' } })
     expect(mockUpdateInputSettings).toHaveBeenCalledWith({ chatEnterToSend: false })
+  })
+
+  // #5184: header cost-badge display mode select. Reads / writes through the
+  // store (mocked here) — the store layer owns the localStorage persistence,
+  // covered by the connection-store tests.
+  describe('cost-badge display mode (#5184)', () => {
+    it('renders the cost-badge mode selector with all five options', () => {
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const select = screen.getByTestId('cost-badge-mode-select') as HTMLSelectElement
+      expect(select).toBeInTheDocument()
+      const values = Array.from(select.options).map(o => o.value).sort()
+      expect(values).toEqual(['context-pct', 'cost', 'provider-model', 'session-type', 'tokens'])
+    })
+
+    it('reflects the persisted mode from the store', () => {
+      setMockState({ costBadgeMode: 'tokens' })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const select = screen.getByTestId('cost-badge-mode-select') as HTMLSelectElement
+      expect(select.value).toBe('tokens')
+    })
+
+    it('defaults the selector to provider-model', () => {
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const select = screen.getByTestId('cost-badge-mode-select') as HTMLSelectElement
+      expect(select.value).toBe('provider-model')
+    })
+
+    it('calls setCostBadgeMode when a new mode is chosen', () => {
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const select = screen.getByTestId('cost-badge-mode-select')
+      fireEvent.change(select, { target: { value: 'context-pct' } })
+      expect(mockSetCostBadgeMode).toHaveBeenCalledWith('context-pct')
+    })
+
+    it('ignores an invalid value rather than committing junk to the store', () => {
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const select = screen.getByTestId('cost-badge-mode-select')
+      fireEvent.change(select, { target: { value: 'not-a-mode' } })
+      expect(mockSetCostBadgeMode).not.toHaveBeenCalled()
+    })
   })
 
   it('closes on Escape key', () => {

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -13,6 +13,11 @@ import { getThemeById } from '../theme/themes'
 import type { ThemeDefinition } from '../theme/themes'
 import { PROVIDER_LABELS } from '../lib/provider-labels'
 import {
+  COST_BADGE_MODES,
+  COST_BADGE_MODE_LABELS,
+  isCostBadgeMode,
+} from './SidebarCostBadge'
+import {
   buildQuietHoursTimezoneList,
   formatPlatform,
   formatRelativeTime,
@@ -609,6 +614,10 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const availableProviders = useConnectionStore(s => s.availableProviders ?? [])
   const inputSettings = useConnectionStore(s => s.inputSettings)
   const updateInputSettings = useConnectionStore(s => s.updateInputSettings)
+  // #5184: header cost-badge display mode. Persisted via the store setter
+  // (same localStorage pattern as theme / default provider).
+  const costBadgeMode = useConnectionStore(s => s.costBadgeMode)
+  const setCostBadgeMode = useConnectionStore(s => s.setCostBadgeMode)
   // Per-session promptEvaluator toggle. Lives in settings (not the header)
   // so the "Auto-evaluate prompts before send" label has room for a hint
   // line and doesn't crowd the model/permission selects. Only shown when
@@ -971,6 +980,15 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
     setDefaultModel(e.target.value)
   }, [setDefaultModel])
 
+  // #5184: validate the select value through the shared guard before
+  // committing — a stray option (or a value injected by automated tooling)
+  // can't poison the union the way a bare cast would.
+  const handleCostBadgeModeChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    if (isCostBadgeMode(e.target.value)) {
+      setCostBadgeMode(e.target.value)
+    }
+  }, [setCostBadgeMode])
+
   const handleSendShortcutChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     updateInputSettings({ chatEnterToSend: e.target.value === 'enter' })
   }, [updateInputSettings])
@@ -1078,6 +1096,30 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 </select>
               </div>
             )}
+            {/* #5184: header cost-badge display mode. The badge in the
+                top bar (provider/model by default) can show cost, tokens,
+                % of context used, or the session-type tag instead. */}
+            <div className="settings-field">
+              <label htmlFor="cost-badge-mode">Header badge shows</label>
+              <select
+                id="cost-badge-mode"
+                aria-label="Header badge display"
+                value={costBadgeMode}
+                onChange={handleCostBadgeModeChange}
+                data-testid="cost-badge-mode-select"
+              >
+                {COST_BADGE_MODES.map(mode => (
+                  <option key={mode} value={mode}>
+                    {COST_BADGE_MODE_LABELS[mode]}
+                  </option>
+                ))}
+              </select>
+              <p className="settings-hint">
+                Choose what the badge in the top bar displays — provider and
+                model, the running dollar cost, token count, percent of the
+                context window used, or the session-type tag.
+              </p>
+            </div>
             <div className="settings-field">
               <label htmlFor="send-shortcut">Send message with</label>
               <select

--- a/packages/dashboard/src/components/SidebarCostBadge.test.tsx
+++ b/packages/dashboard/src/components/SidebarCostBadge.test.tsx
@@ -215,6 +215,16 @@ describe('SidebarCostBadge mode union (#5184)', () => {
     expect(isCostBadgeMode(undefined)).toBe(false)
     expect(isCostBadgeMode(42)).toBe(false)
   })
+
+  it('isCostBadgeMode rejects inherited Object.prototype keys (no prototype pollution)', () => {
+    // The guard must use hasOwnProperty, NOT `in` — otherwise a corrupt
+    // localStorage value of `toString` / `constructor` / `__proto__` would
+    // pass and get stored as a fake CostBadgeMode.
+    expect(isCostBadgeMode('toString')).toBe(false)
+    expect(isCostBadgeMode('constructor')).toBe(false)
+    expect(isCostBadgeMode('hasOwnProperty')).toBe(false)
+    expect(isCostBadgeMode('__proto__')).toBe(false)
+  })
 })
 
 describe('formatCostBadgeContent per mode (#5184)', () => {

--- a/packages/dashboard/src/components/SidebarCostBadge.test.tsx
+++ b/packages/dashboard/src/components/SidebarCostBadge.test.tsx
@@ -34,6 +34,15 @@ vi.mock('../store/connection', () => ({
 import { Sidebar } from './Sidebar'
 // #4123: formatters now live in store-core, not Sidebar.tsx.
 import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
+// #5184: the configurable header badge component + its pure formatter.
+import {
+  SidebarCostBadge,
+  formatCostBadgeContent,
+  isCostBadgeMode,
+  COST_BADGE_MODES,
+  COST_BADGE_MODE_LABELS,
+  DEFAULT_COST_BADGE_MODE,
+} from './SidebarCostBadge'
 
 afterEach(cleanup)
 
@@ -175,5 +184,126 @@ describe('Sidebar cost badge rendering (#4073)', () => {
   it('hides the badge when cumulativeUsage is undefined (older server)', () => {
     render(<Sidebar {...makeProps(undefined)} />)
     expect(screen.queryByTestId('sidebar-cost-badge-sess-1')).not.toBeInTheDocument()
+  })
+})
+
+// #5184: the header badge is now display-mode configurable. These tests pin
+// each mode's output, the default, and the defensive fallbacks.
+describe('SidebarCostBadge mode union (#5184)', () => {
+  it('exposes exactly the five documented modes', () => {
+    expect([...COST_BADGE_MODES].sort()).toEqual(
+      ['context-pct', 'cost', 'provider-model', 'session-type', 'tokens'],
+    )
+  })
+
+  it('defaults to provider-model', () => {
+    expect(DEFAULT_COST_BADGE_MODE).toBe('provider-model')
+  })
+
+  it('has a human-readable label for every mode', () => {
+    for (const mode of COST_BADGE_MODES) {
+      expect(typeof COST_BADGE_MODE_LABELS[mode]).toBe('string')
+      expect(COST_BADGE_MODE_LABELS[mode].length).toBeGreaterThan(0)
+    }
+  })
+
+  it('isCostBadgeMode accepts valid modes and rejects junk', () => {
+    expect(isCostBadgeMode('cost')).toBe(true)
+    expect(isCostBadgeMode('provider-model')).toBe(true)
+    expect(isCostBadgeMode('nonsense')).toBe(false)
+    expect(isCostBadgeMode('')).toBe(false)
+    expect(isCostBadgeMode(undefined)).toBe(false)
+    expect(isCostBadgeMode(42)).toBe(false)
+  })
+})
+
+describe('formatCostBadgeContent per mode (#5184)', () => {
+  const full = {
+    cost: 0.2903,
+    provider: 'claude-sdk',
+    model: 'Sonnet 4.6',
+    inputTokens: 25000,
+    outputTokens: 5000,
+    contextPercent: 45.4,
+  }
+
+  it('provider-model (default): "Claude Code (SDK) · Sonnet 4.6"', () => {
+    expect(formatCostBadgeContent({ ...full, mode: 'provider-model' }))
+      .toBe('Claude Code (SDK) · Sonnet 4.6')
+  })
+
+  it('provider-model falls back to provider label alone when no model', () => {
+    expect(formatCostBadgeContent({ ...full, mode: 'provider-model', model: null }))
+      .toBe('Claude Code (SDK)')
+  })
+
+  it('defaults to provider-model when mode is omitted', () => {
+    expect(formatCostBadgeContent(full)).toBe('Claude Code (SDK) · Sonnet 4.6')
+  })
+
+  it('cost: legacy "$0.2903" 4-decimal form', () => {
+    expect(formatCostBadgeContent({ ...full, mode: 'cost' })).toBe('$0.2903')
+  })
+
+  it('tokens: compact input+output total with a tokens suffix', () => {
+    expect(formatCostBadgeContent({ ...full, mode: 'tokens' })).toBe('30.0k tokens')
+  })
+
+  it('context-pct: rounded percent of the context window', () => {
+    expect(formatCostBadgeContent({ ...full, mode: 'context-pct' })).toBe('45%')
+  })
+
+  it('session-type: the provider short tag', () => {
+    expect(formatCostBadgeContent({ ...full, mode: 'session-type' })).toBe('SDK')
+    expect(formatCostBadgeContent({ ...full, mode: 'session-type', provider: 'claude-cli' }))
+      .toBe('CLI')
+  })
+
+  it('renders an NBSP placeholder when the mode datum is missing (no layout shift)', () => {
+    const NBSP = ' '
+    expect(formatCostBadgeContent({ mode: 'cost', cost: null })).toBe(NBSP)
+    expect(formatCostBadgeContent({ mode: 'tokens', inputTokens: 0, outputTokens: 0 })).toBe(NBSP)
+    expect(formatCostBadgeContent({ mode: 'context-pct', contextPercent: null })).toBe(NBSP)
+    expect(formatCostBadgeContent({ mode: 'session-type', provider: null })).toBe(NBSP)
+  })
+
+  it('cost guards against non-finite input', () => {
+    const NBSP = ' '
+    expect(formatCostBadgeContent({ mode: 'cost', cost: NaN })).toBe(NBSP)
+    expect(formatCostBadgeContent({ mode: 'cost', cost: Infinity })).toBe(NBSP)
+  })
+})
+
+describe('SidebarCostBadge render (#5184)', () => {
+  it('renders the mode content and stamps data-cost-badge-mode', () => {
+    render(
+      <SidebarCostBadge
+        mode="cost"
+        cost={0.2903}
+        provider="claude-sdk"
+        model="Sonnet 4.6"
+        title="Total session cost"
+      />,
+    )
+    const badge = screen.getByTestId('sidebar-cost-badge')
+    expect(badge.textContent).toBe('$0.2903')
+    expect(badge.getAttribute('data-cost-badge-mode')).toBe('cost')
+    expect(badge.getAttribute('title')).toBe('Total session cost')
+    expect(badge.getAttribute('aria-label')).toBe('Total session cost')
+  })
+
+  it('defaults to provider-model when no mode prop is given', () => {
+    render(<SidebarCostBadge provider="claude-sdk" model="Sonnet 4.6" />)
+    const badge = screen.getByTestId('sidebar-cost-badge')
+    expect(badge.getAttribute('data-cost-badge-mode')).toBe('provider-model')
+    expect(badge.textContent).toBe('Claude Code (SDK) · Sonnet 4.6')
+  })
+
+  it('appends an extra className alongside the base cost-badge class', () => {
+    const { container } = render(<SidebarCostBadge mode="session-type" provider="claude-cli" className="status-cost" />)
+    const el = container.querySelector('.cost-badge')
+    expect(el).not.toBeNull()
+    expect(el!.className).toContain('status-cost')
+    expect(el!.textContent).toBe('CLI')
   })
 })

--- a/packages/dashboard/src/components/SidebarCostBadge.tsx
+++ b/packages/dashboard/src/components/SidebarCostBadge.tsx
@@ -1,0 +1,147 @@
+/**
+ * SidebarCostBadge — the configurable header cost/info badge (#5184, epic #5170).
+ *
+ * The header badge used to be hard-wired to "<provider-short> $<cost>"
+ * (e.g. "SDK $0.2903"). Users liked the badge but wanted control over WHAT
+ * it shows, so the content is now driven by a `mode` chosen in Settings and
+ * persisted via the connection store (see `costBadgeMode`).
+ *
+ * Modes:
+ *   - `provider-model`  (DEFAULT) — "Claude Code (SDK) · Sonnet 4.6"
+ *   - `cost`            — the dollar cost ("$0.2903"), the legacy behaviour
+ *   - `tokens`          — total input+output tokens for the turn ("30.0k tokens")
+ *   - `context-pct`     — percent of the model context window used ("45%")
+ *   - `session-type`    — the SDK/CLI/TUI/BYOK session-type tag ("SDK")
+ *
+ * Pure / presentational: every input arrives via props so the badge is
+ * trivially testable and free of store coupling. The host (StatusBar) reads
+ * the mode + data from the store and forwards them.
+ */
+import { formatTokensCompact, getProviderInfo } from '@chroxy/store-core'
+
+/**
+ * Display modes for the header cost badge. Exported (with the matching
+ * runtime guard below) so the store rehydrate path and the Settings select
+ * can share a single source of truth — a new mode added to the union but
+ * not to `COST_BADGE_MODES` is a TS error, mirroring the `VoiceInputMode`
+ * pattern in store-core.
+ */
+export type CostBadgeMode =
+  | 'provider-model'
+  | 'cost'
+  | 'tokens'
+  | 'context-pct'
+  | 'session-type'
+
+/** Default mode — what a fresh install / unset localStorage shows. */
+export const DEFAULT_COST_BADGE_MODE: CostBadgeMode = 'provider-model'
+
+/**
+ * Exhaustive list of modes. The `Record<CostBadgeMode, true>` keying makes
+ * forgetting to list a new union member a compile error.
+ */
+const COST_BADGE_MODE_MAP: Record<CostBadgeMode, true> = {
+  'provider-model': true,
+  cost: true,
+  tokens: true,
+  'context-pct': true,
+  'session-type': true,
+}
+
+export const COST_BADGE_MODES = Object.keys(COST_BADGE_MODE_MAP) as CostBadgeMode[]
+
+/** Runtime guard — narrows an arbitrary string to a valid mode. */
+export function isCostBadgeMode(value: unknown): value is CostBadgeMode {
+  return typeof value === 'string' && value in COST_BADGE_MODE_MAP
+}
+
+/** Human-readable labels for the Settings select. */
+export const COST_BADGE_MODE_LABELS: Record<CostBadgeMode, string> = {
+  'provider-model': 'Provider / model',
+  cost: 'Cost ($)',
+  tokens: 'Token count',
+  'context-pct': '% of context used',
+  'session-type': 'Session type',
+}
+
+const NBSP = ' '
+
+export interface SidebarCostBadgeProps {
+  /** Which piece of info to render. Defaults to `provider-model`. */
+  mode?: CostBadgeMode
+  /** Total session cost in USD (drives `cost` mode). */
+  cost?: number | null
+  /** Provider id, e.g. `claude-sdk` (drives `provider-model` + `session-type`). */
+  provider?: string | null
+  /** Human-readable model label, e.g. `Sonnet 4.6` (drives `provider-model`). */
+  model?: string | null
+  /** Raw input tokens for the turn (drives `tokens`). */
+  inputTokens?: number | null
+  /** Raw output tokens for the turn (drives `tokens`). */
+  outputTokens?: number | null
+  /** Percent of the model context window used (drives `context-pct`). */
+  contextPercent?: number | null
+  /** Tooltip text — host computes the same tooltip it always did. */
+  title?: string
+  /** Extra class names appended to the base `cost-badge`. */
+  className?: string
+}
+
+/**
+ * Compute the badge text for a given mode. Returns NBSP when the requested
+ * datum is missing so the badge keeps its footprint (no layout shift) the
+ * same way the legacy `status-cost` span did.
+ */
+export function formatCostBadgeContent(props: SidebarCostBadgeProps): string {
+  const {
+    mode = DEFAULT_COST_BADGE_MODE,
+    cost,
+    provider,
+    model,
+    inputTokens,
+    outputTokens,
+    contextPercent,
+  } = props
+
+  switch (mode) {
+    case 'cost':
+      return cost != null && Number.isFinite(cost) ? `$${cost.toFixed(4)}` : NBSP
+    case 'tokens': {
+      const total = (inputTokens ?? 0) + (outputTokens ?? 0)
+      return total > 0 ? `${formatTokensCompact(total)} tokens` : NBSP
+    }
+    case 'context-pct':
+      return contextPercent != null && Number.isFinite(contextPercent)
+        ? `${Math.round(contextPercent)}%`
+        : NBSP
+    case 'session-type':
+      return provider ? getProviderInfo(provider).short : NBSP
+    case 'provider-model':
+    default: {
+      if (!provider) return model || NBSP
+      const label = getProviderInfo(provider).label
+      // "Claude Code (SDK) · Sonnet 4.6" — drop the separator + model when
+      // we have no model label yet (idle session before the first turn).
+      return model ? `${label} · ${model}` : label
+    }
+  }
+}
+
+export function SidebarCostBadge(props: SidebarCostBadgeProps) {
+  const { title, className } = props
+  const mode = props.mode ?? DEFAULT_COST_BADGE_MODE
+  const content = formatCostBadgeContent(props)
+  const cls = className ? `cost-badge ${className}` : 'cost-badge'
+
+  return (
+    <span
+      className={cls}
+      data-testid="sidebar-cost-badge"
+      data-cost-badge-mode={mode}
+      title={title}
+      aria-label={title}
+    >
+      {content}
+    </span>
+  )
+}

--- a/packages/dashboard/src/components/SidebarCostBadge.tsx
+++ b/packages/dashboard/src/components/SidebarCostBadge.tsx
@@ -6,125 +6,38 @@
  * it shows, so the content is now driven by a `mode` chosen in Settings and
  * persisted via the connection store (see `costBadgeMode`).
  *
- * Modes:
- *   - `provider-model`  (DEFAULT) — "Claude Code (SDK) · Sonnet 4.6"
- *   - `cost`            — the dollar cost ("$0.2903"), the legacy behaviour
- *   - `tokens`          — total input+output tokens for the turn ("30.0k tokens")
- *   - `context-pct`     — percent of the model context window used ("45%")
- *   - `session-type`    — the SDK/CLI/TUI/BYOK session-type tag ("SDK")
+ * The mode union, default, runtime guard, labels, and pure content formatter
+ * live in `lib/cost-badge-mode.ts` (a non-React module) so the store layer
+ * can import them without pulling this `.tsx` file into the non-UI graph.
+ * They're re-exported here so existing component-level imports keep working.
  *
- * Pure / presentational: every input arrives via props so the badge is
- * trivially testable and free of store coupling. The host (StatusBar) reads
- * the mode + data from the store and forwards them.
+ * This component is pure / presentational: every input arrives via props so
+ * the badge is trivially testable and free of store coupling. The host
+ * (StatusBar) reads the mode + data from the store and forwards them.
  */
-import { formatTokensCompact, getProviderInfo } from '@chroxy/store-core'
+import {
+  type CostBadgeContentInput,
+  DEFAULT_COST_BADGE_MODE,
+  formatCostBadgeContent,
+} from '../lib/cost-badge-mode'
 
-/**
- * Display modes for the header cost badge. Exported (with the matching
- * runtime guard below) so the store rehydrate path and the Settings select
- * can share a single source of truth — a new mode added to the union but
- * not to `COST_BADGE_MODES` is a TS error, mirroring the `VoiceInputMode`
- * pattern in store-core.
- */
-export type CostBadgeMode =
-  | 'provider-model'
-  | 'cost'
-  | 'tokens'
-  | 'context-pct'
-  | 'session-type'
+// Re-export the mode primitives so existing `from './SidebarCostBadge'`
+// imports (store, Settings, tests) continue to resolve.
+export {
+  type CostBadgeMode,
+  type CostBadgeContentInput,
+  DEFAULT_COST_BADGE_MODE,
+  COST_BADGE_MODES,
+  COST_BADGE_MODE_LABELS,
+  isCostBadgeMode,
+  formatCostBadgeContent,
+} from '../lib/cost-badge-mode'
 
-/** Default mode — what a fresh install / unset localStorage shows. */
-export const DEFAULT_COST_BADGE_MODE: CostBadgeMode = 'provider-model'
-
-/**
- * Exhaustive list of modes. The `Record<CostBadgeMode, true>` keying makes
- * forgetting to list a new union member a compile error.
- */
-const COST_BADGE_MODE_MAP: Record<CostBadgeMode, true> = {
-  'provider-model': true,
-  cost: true,
-  tokens: true,
-  'context-pct': true,
-  'session-type': true,
-}
-
-export const COST_BADGE_MODES = Object.keys(COST_BADGE_MODE_MAP) as CostBadgeMode[]
-
-/** Runtime guard — narrows an arbitrary string to a valid mode. */
-export function isCostBadgeMode(value: unknown): value is CostBadgeMode {
-  return typeof value === 'string' && value in COST_BADGE_MODE_MAP
-}
-
-/** Human-readable labels for the Settings select. */
-export const COST_BADGE_MODE_LABELS: Record<CostBadgeMode, string> = {
-  'provider-model': 'Provider / model',
-  cost: 'Cost ($)',
-  tokens: 'Token count',
-  'context-pct': '% of context used',
-  'session-type': 'Session type',
-}
-
-const NBSP = ' '
-
-export interface SidebarCostBadgeProps {
-  /** Which piece of info to render. Defaults to `provider-model`. */
-  mode?: CostBadgeMode
-  /** Total session cost in USD (drives `cost` mode). */
-  cost?: number | null
-  /** Provider id, e.g. `claude-sdk` (drives `provider-model` + `session-type`). */
-  provider?: string | null
-  /** Human-readable model label, e.g. `Sonnet 4.6` (drives `provider-model`). */
-  model?: string | null
-  /** Raw input tokens for the turn (drives `tokens`). */
-  inputTokens?: number | null
-  /** Raw output tokens for the turn (drives `tokens`). */
-  outputTokens?: number | null
-  /** Percent of the model context window used (drives `context-pct`). */
-  contextPercent?: number | null
+export interface SidebarCostBadgeProps extends CostBadgeContentInput {
   /** Tooltip text — host computes the same tooltip it always did. */
   title?: string
   /** Extra class names appended to the base `cost-badge`. */
   className?: string
-}
-
-/**
- * Compute the badge text for a given mode. Returns NBSP when the requested
- * datum is missing so the badge keeps its footprint (no layout shift) the
- * same way the legacy `status-cost` span did.
- */
-export function formatCostBadgeContent(props: SidebarCostBadgeProps): string {
-  const {
-    mode = DEFAULT_COST_BADGE_MODE,
-    cost,
-    provider,
-    model,
-    inputTokens,
-    outputTokens,
-    contextPercent,
-  } = props
-
-  switch (mode) {
-    case 'cost':
-      return cost != null && Number.isFinite(cost) ? `$${cost.toFixed(4)}` : NBSP
-    case 'tokens': {
-      const total = (inputTokens ?? 0) + (outputTokens ?? 0)
-      return total > 0 ? `${formatTokensCompact(total)} tokens` : NBSP
-    }
-    case 'context-pct':
-      return contextPercent != null && Number.isFinite(contextPercent)
-        ? `${Math.round(contextPercent)}%`
-        : NBSP
-    case 'session-type':
-      return provider ? getProviderInfo(provider).short : NBSP
-    case 'provider-model':
-    default: {
-      if (!provider) return model || NBSP
-      const label = getProviderInfo(provider).label
-      // "Claude Code (SDK) · Sonnet 4.6" — drop the separator + model when
-      // we have no model label yet (idle session before the first turn).
-      return model ? `${label} · ${model}` : label
-    }
-  }
 }
 
 export function SidebarCostBadge(props: SidebarCostBadgeProps) {

--- a/packages/dashboard/src/components/StatusBar.tsx
+++ b/packages/dashboard/src/components/StatusBar.tsx
@@ -8,6 +8,7 @@ import {
   contextTooltip,
   agentCountTooltip,
 } from '../lib/status-tooltips'
+import { SidebarCostBadge, type CostBadgeMode } from './SidebarCostBadge'
 
 export interface StatusBarProps {
   cost?: number
@@ -28,6 +29,21 @@ export interface StatusBarProps {
   isBusy?: boolean
   agentCount?: number
   provider?: string
+  /**
+   * #5184: human-readable model label (e.g. `Sonnet 4.6`) for the
+   * `provider-model` badge mode. Optional — when absent the badge shows the
+   * provider label alone.
+   */
+  model?: string
+  /**
+   * #5184: cost-badge display mode chosen in Settings. When provided the
+   * cost slot renders the configurable `SidebarCostBadge` instead of the
+   * legacy `$X.XXXX` span. Left undefined by callers that don't wire the
+   * setting (and by the existing test suite) so the legacy behaviour stays
+   * the render fallback. The live app always passes the store value, whose
+   * own default is `provider-model`.
+   */
+  costBadgeMode?: CostBadgeMode
 }
 
 // #4204 Copilot review: explicit non-breaking-space escape so the
@@ -47,7 +63,7 @@ export const STATUS_OVER_BUDGET_THRESHOLD = 100
 
 export function StatusBar({
   cost, context, contextPercent, inputTokens, outputTokens, contextWindow,
-  isBusy, agentCount, provider,
+  isBusy, agentCount, provider, model, costBadgeMode,
 }: StatusBarProps) {
   const prov = provider ? getProviderInfo(provider) : null
   // #4204 Copilot review: compute each chip's tooltip once so the
@@ -103,13 +119,31 @@ export function StatusBar({
           {prov.short}
         </span>
       )}
-      <span
-        className="status-cost"
-        title={costTip}
-        aria-label={costTip}
-      >
-        {cost != null ? `$${cost.toFixed(4)}` : NBSP}
-      </span>
+      {costBadgeMode ? (
+        // #5184: configurable badge. The display mode comes from Settings
+        // (store-backed, default `provider-model`); the host still owns the
+        // tooltip so the hover breakdown is unchanged. `className` adds
+        // `status-cost` so existing layout/selectors keep working.
+        <SidebarCostBadge
+          mode={costBadgeMode}
+          cost={cost}
+          provider={provider}
+          model={model}
+          inputTokens={inputTokens}
+          outputTokens={outputTokens}
+          contextPercent={contextPercent}
+          title={costTip}
+          className="status-cost"
+        />
+      ) : (
+        <span
+          className="status-cost"
+          title={costTip}
+          aria-label={costTip}
+        >
+          {cost != null ? `$${cost.toFixed(4)}` : NBSP}
+        </span>
+      )}
       {showMeter ? (
         <span
           className="status-context-meter"

--- a/packages/dashboard/src/lib/cost-badge-mode.ts
+++ b/packages/dashboard/src/lib/cost-badge-mode.ts
@@ -1,0 +1,132 @@
+/**
+ * Cost-badge display mode — the union, default, runtime guard, labels, and
+ * content formatter for the configurable header badge (#5184, epic #5170).
+ *
+ * Lives in `lib/` (a plain, non-React module) so the store layer
+ * (`store/connection.ts`, `store/types.ts`) can import the type + guard +
+ * default WITHOUT pulling a `.tsx` component (and its JSX runtime) into the
+ * non-UI dependency graph. `SidebarCostBadge.tsx` re-exports everything here
+ * so existing component-level imports keep working.
+ *
+ * Modes:
+ *   - `provider-model`  (DEFAULT) — "Claude Code (SDK) · Sonnet 4.6"
+ *   - `cost`            — the dollar cost ("$0.2903"), the legacy behaviour
+ *   - `tokens`          — total input+output tokens for the turn ("30.0k tokens")
+ *   - `context-pct`     — percent of the model context window used ("45%")
+ *   - `session-type`    — the SDK/CLI/TUI/BYOK session-type tag ("SDK")
+ */
+import { formatTokensCompact, getProviderInfo } from '@chroxy/store-core'
+
+/**
+ * Display modes for the header cost badge. Paired with the matching runtime
+ * guard below so the store rehydrate path and the Settings select share one
+ * source of truth — a new mode added to the union but not to
+ * `COST_BADGE_MODE_MAP` is a TS error, mirroring the `VoiceInputMode`
+ * pattern in store-core.
+ */
+export type CostBadgeMode =
+  | 'provider-model'
+  | 'cost'
+  | 'tokens'
+  | 'context-pct'
+  | 'session-type'
+
+/** Default mode — what a fresh install / unset localStorage shows. */
+export const DEFAULT_COST_BADGE_MODE: CostBadgeMode = 'provider-model'
+
+/**
+ * Exhaustive list of modes. The `Record<CostBadgeMode, true>` keying makes
+ * forgetting to list a new union member a compile error.
+ */
+const COST_BADGE_MODE_MAP: Record<CostBadgeMode, true> = {
+  'provider-model': true,
+  cost: true,
+  tokens: true,
+  'context-pct': true,
+  'session-type': true,
+}
+
+export const COST_BADGE_MODES = Object.keys(COST_BADGE_MODE_MAP) as CostBadgeMode[]
+
+/**
+ * Runtime guard — narrows an arbitrary value to a valid mode.
+ *
+ * Uses `Object.prototype.hasOwnProperty` (NOT the `in` operator) so inherited
+ * properties like `toString` / `constructor` / `__proto__` from a corrupt
+ * localStorage value can't masquerade as a valid `CostBadgeMode`.
+ */
+export function isCostBadgeMode(value: unknown): value is CostBadgeMode {
+  return typeof value === 'string'
+    && Object.prototype.hasOwnProperty.call(COST_BADGE_MODE_MAP, value)
+}
+
+/** Human-readable labels for the Settings select. */
+export const COST_BADGE_MODE_LABELS: Record<CostBadgeMode, string> = {
+  'provider-model': 'Provider / model',
+  cost: 'Cost ($)',
+  tokens: 'Token count',
+  'context-pct': '% of context used',
+  'session-type': 'Session type',
+}
+
+// Explicit non-breaking-space escape rather than a literal NBSP character —
+// keeps the source consistent with StatusBar.tsx (#4204) and avoids an
+// invisible character that's easy to miss or auto-reformat.
+const NBSP = ' '
+
+export interface CostBadgeContentInput {
+  /** Which piece of info to render. Defaults to `provider-model`. */
+  mode?: CostBadgeMode
+  /** Total session cost in USD (drives `cost` mode). */
+  cost?: number | null
+  /** Provider id, e.g. `claude-sdk` (drives `provider-model` + `session-type`). */
+  provider?: string | null
+  /** Human-readable model label, e.g. `Sonnet 4.6` (drives `provider-model`). */
+  model?: string | null
+  /** Raw input tokens for the turn (drives `tokens`). */
+  inputTokens?: number | null
+  /** Raw output tokens for the turn (drives `tokens`). */
+  outputTokens?: number | null
+  /** Percent of the model context window used (drives `context-pct`). */
+  contextPercent?: number | null
+}
+
+/**
+ * Compute the badge text for a given mode. Returns NBSP when the requested
+ * datum is missing so the badge keeps its footprint (no layout shift) the
+ * same way the legacy `status-cost` span did.
+ */
+export function formatCostBadgeContent(input: CostBadgeContentInput): string {
+  const {
+    mode = DEFAULT_COST_BADGE_MODE,
+    cost,
+    provider,
+    model,
+    inputTokens,
+    outputTokens,
+    contextPercent,
+  } = input
+
+  switch (mode) {
+    case 'cost':
+      return cost != null && Number.isFinite(cost) ? `$${cost.toFixed(4)}` : NBSP
+    case 'tokens': {
+      const total = (inputTokens ?? 0) + (outputTokens ?? 0)
+      return total > 0 ? `${formatTokensCompact(total)} tokens` : NBSP
+    }
+    case 'context-pct':
+      return contextPercent != null && Number.isFinite(contextPercent)
+        ? `${Math.round(contextPercent)}%`
+        : NBSP
+    case 'session-type':
+      return provider ? getProviderInfo(provider).short : NBSP
+    case 'provider-model':
+    default: {
+      if (!provider) return model || NBSP
+      const label = getProviderInfo(provider).label
+      // "Claude Code (SDK) · Sonnet 4.6" — drop the separator + model when
+      // we have no model label yet (idle session before the first turn).
+      return model ? `${label} · ${model}` : label
+    }
+  }
+}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -132,14 +132,15 @@ import {
   createEmptyActivityState,
 } from '@chroxy/store-core';
 import { decrypt, DIRECTION_SERVER, type EncryptedEnvelope } from './crypto';
-// #5184: header cost-badge mode union, default, and runtime guard. Lives
-// with the badge component (no store dependency) so the type, the rehydrate
-// validation, and the Settings select all share one source of truth.
+// #5184: header cost-badge mode union, default, and runtime guard. Lives in
+// a plain `lib/` module (no React dependency) so the store layer doesn't
+// import a `.tsx` component; the type, the rehydrate validation, and the
+// Settings select all share this one source of truth.
 import {
   DEFAULT_COST_BADGE_MODE,
   isCostBadgeMode,
   type CostBadgeMode,
-} from '../components/SidebarCostBadge';
+} from '../lib/cost-badge-mode';
 import {
   loadPersistedState,
   loadSessionList,

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -132,6 +132,14 @@ import {
   createEmptyActivityState,
 } from '@chroxy/store-core';
 import { decrypt, DIRECTION_SERVER, type EncryptedEnvelope } from './crypto';
+// #5184: header cost-badge mode union, default, and runtime guard. Lives
+// with the badge component (no store dependency) so the type, the rehydrate
+// validation, and the Settings select all share one source of truth.
+import {
+  DEFAULT_COST_BADGE_MODE,
+  isCostBadgeMode,
+  type CostBadgeMode,
+} from '../components/SidebarCostBadge';
 import {
   loadPersistedState,
   loadSessionList,
@@ -383,6 +391,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   activeTheme: loadPersistedSetting('chroxy_persist_theme', 'default'),
   defaultProvider: loadPersistedSetting('chroxy_default_provider', 'claude-sdk'),
   defaultModel: loadPersistedSetting('chroxy_default_model', ''),
+  // #5184: header cost-badge display mode. Validated through the badge's
+  // own `isCostBadgeMode` guard so a stale / corrupt localStorage value
+  // falls back to the default instead of poisoning the union.
+  costBadgeMode: (() => {
+    const raw = loadPersistedSetting('chroxy_cost_badge_mode', DEFAULT_COST_BADGE_MODE)
+    return isCostBadgeMode(raw) ? raw : DEFAULT_COST_BADGE_MODE
+  })(),
   // #4052: BYOK credentials state. Server-of-truth lives in
   // ~/.chroxy/credentials.json or ANTHROPIC_API_KEY env var; the dashboard
   // mirrors the resolved status (set/missing) + a masked preview. Updates
@@ -521,6 +536,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setDefaultModel: (model: string) => {
     set({ defaultModel: model });
     try { localStorage.setItem('chroxy_default_model', model); } catch { /* noop */ }
+  },
+
+  // #5184: persist the header cost-badge display mode. Mirrors the
+  // setTheme / setDefaultProvider pattern — immutable `set` + best-effort
+  // localStorage write that swallows quota / private-mode failures.
+  setCostBadgeMode: (mode: CostBadgeMode) => {
+    set({ costBadgeMode: mode });
+    try { localStorage.setItem('chroxy_cost_badge_mode', mode); } catch { /* noop */ }
   },
 
   // #4052: BYOK credentials actions. The full key is never stored in the

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -389,6 +389,38 @@ describe('useConnectionStore', () => {
     expect(typeof state.clearPlanState).toBe('function');
   });
 
+  // #5184: header cost-badge display mode — default, setter, persistence.
+  describe('costBadgeMode (#5184)', () => {
+    it('defaults to provider-model', async () => {
+      const { useConnectionStore } = await import('./connection');
+      expect(useConnectionStore.getState().costBadgeMode).toBe('provider-model');
+    });
+
+    it('setCostBadgeMode updates state and persists to localStorage', async () => {
+      const { useConnectionStore } = await import('./connection');
+      useConnectionStore.getState().setCostBadgeMode('tokens');
+      expect(useConnectionStore.getState().costBadgeMode).toBe('tokens');
+      expect(localStorage.getItem('chroxy_cost_badge_mode')).toBe('tokens');
+      // Restore so later tests in this file see the default again.
+      useConnectionStore.getState().setCostBadgeMode('provider-model');
+    });
+
+    it('swallows a localStorage write failure (private mode / quota)', async () => {
+      const { useConnectionStore } = await import('./connection');
+      const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+      try {
+        expect(() => useConnectionStore.getState().setCostBadgeMode('cost')).not.toThrow();
+        // State still updates even when the write fails.
+        expect(useConnectionStore.getState().costBadgeMode).toBe('cost');
+      } finally {
+        spy.mockRestore();
+        useConnectionStore.getState().setCostBadgeMode('provider-model');
+      }
+    });
+  });
+
   it('switchSession updates activeSessionId even without cached state', async () => {
     const { useConnectionStore } = await import('./connection');
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -13,6 +13,10 @@
 // puts it on the public surface but doesn't bring it into this file's
 // type-name scope).
 import type { PermissionMode } from '@chroxy/store-core'
+// #5184: header cost-badge display mode. Defined alongside the badge
+// component (which owns the union + runtime guard) — the store only needs
+// the type for its state slot.
+import type { CostBadgeMode } from '../components/SidebarCostBadge'
 
 // Re-export shared protocol types from store-core
 export type {
@@ -910,6 +914,12 @@ export interface ConnectionState {
   setDefaultProvider: (provider: string) => void;
   defaultModel: string;
   setDefaultModel: (model: string) => void;
+
+  // #5184: header cost-badge display mode (provider-model | cost | tokens |
+  // context-pct | session-type). Persisted to localStorage; defaults to
+  // 'provider-model'. Typed as `CostBadgeMode` at the component layer.
+  costBadgeMode: CostBadgeMode;
+  setCostBadgeMode: (mode: CostBadgeMode) => void;
 
   // #4052: BYOK credentials state + actions. The raw key is NEVER stored
   // here — only the masked preview from the server's reply.

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -13,10 +13,10 @@
 // puts it on the public surface but doesn't bring it into this file's
 // type-name scope).
 import type { PermissionMode } from '@chroxy/store-core'
-// #5184: header cost-badge display mode. Defined alongside the badge
-// component (which owns the union + runtime guard) — the store only needs
-// the type for its state slot.
-import type { CostBadgeMode } from '../components/SidebarCostBadge'
+// #5184: header cost-badge display mode. Defined in a plain lib module
+// (which owns the union + runtime guard) — the store only needs the type
+// for its state slot, and avoids importing a `.tsx` component here.
+import type { CostBadgeMode } from '../lib/cost-badge-mode'
 
 // Re-export shared protocol types from store-core
 export type {


### PR DESCRIPTION
## Summary

Part of epic #5170 (Control Room v2). The top-bar cost badge was hard-wired to `<provider> $<cost>` (e.g. "SDK $0.2903"). Users liked the badge but wanted control over what it displays, so its content is now driven by a display mode chosen in Settings and persisted across reloads. The default is **provider/model**.

## Display modes

| Mode | Example | Notes |
|------|---------|-------|
| `provider-model` (default) | `Claude Code (SDK) · Sonnet 4.6` | falls back to provider label alone when no model |
| `cost` | `$0.2903` | the legacy behaviour |
| `tokens` | `30.0k tokens` | input + output for the turn |
| `context-pct` | `45%` | percent of the model context window used |
| `session-type` | `SDK` | the SDK / CLI / TUI / BYOK tag |

## What changed

- **`SidebarCostBadge.tsx`** (new) — pure, presentational, mode-aware badge. Owns the `CostBadgeMode` union, the `isCostBadgeMode` runtime guard, `COST_BADGE_MODES`, labels, and `formatCostBadgeContent`. No store coupling.
- **Store** — `costBadgeMode` state + `setCostBadgeMode` setter, persisted under `chroxy_cost_badge_mode`, following the **existing** `setTheme` / `setDefaultProvider` localStorage pattern (the issue's required persistence mechanism). Rehydration validates through `isCostBadgeMode` so a corrupt value falls back to the default.
- **`StatusBar.tsx`** — renders the configurable badge when `costBadgeMode` is provided; keeps the legacy `$X.XXXX` span as the prop-undefined fallback so existing callers and the StatusBar test suite are unaffected. The badge keeps the `status-cost` class so existing CSS/layout applies unchanged.
- **`App.tsx`** — reads `costBadgeMode` from the store and passes it plus the active model label.
- **`SettingsPanel.tsx`** — adds a "Header badge shows" select listing all five modes, validated through `isCostBadgeMode` before committing.

## Tests

- Extended `SidebarCostBadge.test.tsx`: per-mode formatter output, the default, NBSP placeholders for missing data, non-finite guards, the union/guard, and component render.
- Extended `SettingsPanel.test.tsx`: selector renders all five options, reflects the persisted mode, defaults to provider-model, calls the setter, and ignores junk values.
- Extended `store.test.ts`: default, setter + localStorage persistence, and write-failure resilience.
- Full dashboard suite green (3017 tests), `tsc --noEmit` clean, `vite build` succeeds.

Closes #5184