### PR TITLE
test(dashboard): clear "Waiting on background work" banner on completion (#5178)

### DIFF
--- a/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
+++ b/packages/dashboard/src/components/ActivityIndicator.pendingShells.test.tsx
@@ -148,6 +148,95 @@ describe('ActivityIndicator — pending background shells (#4418)', () => {
     expect(label.textContent).not.toMatch(/Waiting on background work/)
   })
 
+  it('clears the banner when a completion snapshot drops the previously-pending shell (#5178)', () => {
+    // B1 (#5187) reaps a finished background shell server-side and re-emits the
+    // `background_work_changed` snapshot WITHOUT it. The dashboard reconciles
+    // that snapshot via snapshot-replace, so the shell drops out of
+    // `pendingBackgroundShells` and the "Waiting on background work" banner
+    // must disappear. Without B1 the shell stayed pending forever and the
+    // banner stuck — this pins the clear path.
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'brk57kt6pm', command: 'npm run build', startedAt: now - 10_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    const { container, rerender } = render(<ActivityIndicator />)
+    // Banner is up while the shell is pending.
+    expect(screen.getByTestId('activity-indicator-label').textContent).toMatch(
+      /Waiting on background work/,
+    )
+
+    // Server reaps the shell and re-broadcasts an empty snapshot. The store's
+    // snapshot-replace reconciliation leaves `pendingBackgroundShells` empty.
+    ;(storeState.sessionStates as Record<string, { pendingBackgroundShells: unknown[] }>)[
+      'sess-1'
+    ]!.pendingBackgroundShells = []
+    rerender(<ActivityIndicator />)
+
+    // Banner must be gone — no stale entry left behind.
+    expect(screen.queryByTestId('activity-indicator-label')).toBeNull()
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('reconciles a multi-shell snapshot down to the survivors when one completes (#5178)', () => {
+    // Defensive reconciliation: a completion snapshot that still lists OTHER
+    // shells must keep the banner but drop only the finished one. The banner
+    // can only ever reflect shells present in the latest snapshot — no stale
+    // headline survives a shell's completion.
+    const now = Date.now()
+    storeState = {
+      activeSessionId: 'sess-1',
+      serverResultTimeoutMs: 30 * 60 * 1000,
+      sessionStates: {
+        'sess-1': {
+          isIdle: true,
+          lastClientActivityAt: now - 2_000,
+          messages: [],
+          activeTools: [],
+          activeAgents: [],
+          pendingBackgroundShells: [
+            { shellId: 'old01', command: 'sleep 60', startedAt: now - 30_000 },
+            { shellId: 'new02', command: 'npm test', startedAt: now - 5_000 },
+          ],
+          inactivityWarning: null,
+        },
+      },
+    }
+    const { rerender } = render(<ActivityIndicator />)
+    // Newest shell headlines while both are pending.
+    expect(screen.getByTestId('activity-indicator-label').textContent).toMatch(/npm test/)
+
+    // `npm test` finishes; the next snapshot lists only the still-running one.
+    ;(
+      storeState.sessionStates as Record<string, { pendingBackgroundShells: unknown[] }>
+    )['sess-1']!.pendingBackgroundShells = [
+      { shellId: 'old01', command: 'sleep 60', startedAt: now - 30_000 },
+    ]
+    rerender(<ActivityIndicator />)
+
+    // Banner stays up, now headlining the survivor — the completed shell is
+    // gone, not stuck as a stale headline.
+    const label = screen.getByTestId('activity-indicator-label')
+    expect(label.textContent).toMatch(/Waiting on background work/)
+    expect(label.textContent).toMatch(/sleep 60/)
+    expect(label.textContent).not.toMatch(/npm test/)
+    // Single survivor ⇒ no overflow disclosure.
+    expect(screen.queryByTestId('activity-indicator-more-badge')).toBeNull()
+  })
+
   it('renders nothing when idle with no pending background shells (regression)', () => {
     // Pre-#4418 behaviour: idle session renders nothing. Pin this so the new
     // surface only activates when shells are actually pending.


### PR DESCRIPTION
## Summary

B2 of the Control Room v2 epic (#5170). B1 (#5187) now reaps a finished background shell server-side and re-emits the `background_work_changed` snapshot without it. This PR confirms the dashboard half: the **"Waiting on background work" banner clears when the background shell completes**, and locks that behaviour in with tests.

## Finding: the dashboard already reconciles correctly

The reconciliation the issue asks for is already in place and is robust by construction:

- `handleBackgroundWorkChanged` (store-core) is a **full snapshot-replace** — each event carries the complete pending list, so the handler replaces `pendingBackgroundShells` wholesale (same-reference short-circuit only when nothing changed).
- Both wire paths use it: the live `background_work_changed` case and the `session_list` seed in `message-handler.ts`. So a removed/completed shell drops out on the next snapshot from either path.
- `ActivityIndicator` is a **pure projection** of `pendingBackgroundShells`: its idle branch renders the banner only when a `headlineShell` derived from the current list exists, and returns `null` otherwise. There is no separate accumulator that could retain a stale entry — the defensive guard ("banner can only show shells present in the latest snapshot") is inherent in the architecture.

The store-core handler tests already cover the snapshot "clear" path (empty `pending` → empty list). What was missing was a **rendered-banner** assertion, which this PR adds.

## Changes

Test-only (`ActivityIndicator.pendingShells.test.tsx`):

- A completion snapshot that drops the last pending shell **clears the banner entirely** — the stuck-banner regression this issue guards against.
- A snapshot that drops one of several shells **reconciles down to the survivors** — the completed shell is gone, not stuck as a stale headline, and the overflow disclosure collapses.

## Testing

- `npm test` (dashboard): 2993 passed (153 files), including the 2 new cases (22 in the pending-shells suite, was 20).
- `npm run typecheck`: clean.

Closes #5178