### PR TITLE
feat(server): control-room git/gh survey + verdict + live-agent engine

### DIFF
--- a/packages/server/src/control-room/survey.js
+++ b/packages/server/src/control-room/survey.js
@@ -165,14 +165,17 @@ export function detectAttribution(contents) {
 
 /**
  * Normalise a repo path into a canonical comparison key for matching against
- * active session cwds. Strips a single trailing slash.
+ * active session cwds. Converts Windows backslashes to forward slashes (a
+ * session `cwd` on Windows uses `\\` separators) and strips a single trailing
+ * slash so prefix comparisons are separator-agnostic.
  *
  * @param {string} p - a path.
  * @returns {string} comparison key.
  */
 function pathKey(p) {
   if (typeof p !== 'string') return ''
-  return p.length > 1 && p.endsWith('/') ? p.slice(0, -1) : p
+  const slashed = p.replace(/\\/g, '/')
+  return slashed.length > 1 && slashed.endsWith('/') ? slashed.slice(0, -1) : slashed
 }
 
 /**
@@ -300,8 +303,18 @@ async function surveyOne(repo, ctx) {
       readSettings(readFn, repo.path),
     ])
 
+    // `git status --porcelain` is the authoritative tree probe. A null here
+    // means the command FAILED (path isn't a git repo, git unavailable, etc.)
+    // — distinct from a successful empty string (a genuinely clean tree). We
+    // must NOT fall back to parseTree('') in that case: it would paint a
+    // false `clean`/`onboarded` row. Surface it as a degraded `investigate`
+    // row instead so the Control Room flags it for a human look.
+    if (statusRaw === null) {
+      return degradedRepo(repo, now, new Error('git status probe failed (not a git repo or git unavailable)'))
+    }
+
     const branch = branchRaw && branchRaw.length > 0 ? branchRaw : 'unknown'
-    const tree = parseTree(statusRaw || '')
+    const tree = parseTree(statusRaw)
     const worktrees = countWorktrees(worktreeRaw || '')
     const openPRs = parseOpenPRs(prRaw)
     const attribution = detectAttribution(settingsRaw)

--- a/packages/server/src/control-room/survey.js
+++ b/packages/server/src/control-room/survey.js
@@ -1,0 +1,505 @@
+/**
+ * Control Room v2 (#5173) — host/repo git + gh survey + verdict engine.
+ *
+ * Given the resolved repo set (see `repo-set.js`), produces one `RepoStatus`
+ * per repo plus aggregate `summary` counts, shaped to the A1
+ * `host_status_snapshot` wire contract (minus the `type` field, which the WS
+ * handler in #5174 adds). The result conforms exactly to
+ * `ServerHostStatusSnapshotSchema` from `@chroxy/protocol`.
+ *
+ * Every external interaction is injectable so tests never touch real git / gh
+ * or the user's home directory:
+ *   - `_execFile(file, args, opts)` — async, resolves `{ stdout, stderr }`
+ *     (the promisified `child_process.execFile` shape). Rejected promises are
+ *     tolerated per-command.
+ *   - `_now()` — returns a `Date` (defaults to `new Date()`), for deterministic
+ *     verdict/threshold tests.
+ *   - `_readFile(path)` — async, resolves a string (for `.claude/settings.json`
+ *     attribution detection).
+ *
+ * Verdict classification (`'live' | 'investigate' | 'abandoned' | 'recent' |
+ * 'onboarded'`):
+ *   - live        — a live agent is present (chroxy session bound to the repo,
+ *                   or the dirty-tree-recently-touched heuristic).
+ *   - investigate — an excessive worktree count (likely a leak).
+ *   - recent      — dirty tree touched within the recent window, not live.
+ *   - abandoned   — dirty tree last touched long ago, not live.
+ *   - onboarded   — clean tree on the pull model.
+ */
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+import { resolveRepoSet } from './repo-set.js'
+
+const execFileAsync = promisify(execFile)
+
+/** Default concurrency cap for per-repo surveys. */
+export const DEFAULT_CONCURRENCY = 5
+
+/**
+ * Default verdict thresholds. All durations are in milliseconds.
+ *   - liveMs        — a dirty tree touched more recently than this is treated
+ *                     as having a live agent (heuristic). Default 15 min.
+ *   - recentMs      — a dirty tree touched more recently than this (but not
+ *                     live) is `recent`; older than this is `abandoned`.
+ *                     Default ~3 days.
+ *   - worktreeLeak  — a worktree count at or above this is `investigate`.
+ */
+export const DEFAULT_THRESHOLDS = {
+  liveMs: 15 * 60 * 1000,
+  recentMs: 3 * 24 * 60 * 60 * 1000,
+  worktreeLeak: 4,
+}
+
+/**
+ * Run a git/gh command, tolerating failure. Resolves trimmed stdout on success
+ * or `null` on any error (non-zero exit, missing binary, etc.).
+ *
+ * @param {Function} execFn - promisified execFile seam.
+ * @param {string} file - executable (e.g. 'git', 'gh').
+ * @param {string[]} args - argument vector.
+ * @param {string} cwd - working directory.
+ * @returns {Promise<string|null>} trimmed stdout, or null on error.
+ */
+async function tryExec(execFn, file, args, cwd) {
+  try {
+    const { stdout } = await execFn(file, args, { cwd })
+    return typeof stdout === 'string' ? stdout.trim() : ''
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse `git status --porcelain` output into a tree summary.
+ *
+ * Porcelain v1 lines are `XY <path>` where X is the index (staged) status and Y
+ * is the working-tree (unstaged) status. `??` marks an untracked file. A file
+ * may be counted in both staged and modified when it has changes in both the
+ * index and the working tree (e.g. `MM`).
+ *
+ * @param {string} porcelain - raw `git status --porcelain` stdout.
+ * @returns {{ state: 'clean'|'dirty', untracked: number, modified: number, staged: number }}
+ */
+export function parseTree(porcelain) {
+  const lines = (porcelain || '')
+    .split('\n')
+    .map(l => l.replace(/\r$/, ''))
+    .filter(l => l.length > 0)
+
+  let untracked = 0
+  let modified = 0
+  let staged = 0
+
+  for (const line of lines) {
+    if (line.startsWith('??')) {
+      untracked++
+      continue
+    }
+    const x = line[0]
+    const y = line[1]
+    if (x && x !== ' ' && x !== '?') staged++
+    if (y && y !== ' ' && y !== '?') modified++
+  }
+
+  const state = lines.length === 0 ? 'clean' : 'dirty'
+  return { state, untracked, modified, staged }
+}
+
+/**
+ * Count worktree entries from `git worktree list --porcelain` output.
+ *
+ * Each worktree is a record beginning with a `worktree <path>` line; records
+ * are separated by blank lines. The count includes the main worktree, so a
+ * repo with no extra worktrees reports 1.
+ *
+ * @param {string} porcelain - raw `git worktree list --porcelain` stdout.
+ * @returns {number} number of worktrees (>= 0).
+ */
+export function countWorktrees(porcelain) {
+  if (!porcelain) return 0
+  return porcelain.split('\n').filter(l => l.startsWith('worktree ')).length
+}
+
+/**
+ * Count open PRs from `gh pr list --json number` output.
+ *
+ * @param {string|null} json - raw stdout, or null if the command failed.
+ * @returns {number|null} count, or null when undeterminable (gh missing /
+ *   unauth / errored / unparseable).
+ */
+export function parseOpenPRs(json) {
+  if (json === null || json === undefined) return null
+  try {
+    const arr = JSON.parse(json)
+    return Array.isArray(arr) ? arr.length : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Detect project-level attribution policy from `.claude/settings.json`.
+ *
+ * @param {string|null} contents - raw settings.json text, or null if absent.
+ * @returns {boolean|null} `true` when `includeCoAuthoredBy` is explicitly
+ *   `false` (attribution suppressed — the expected pull-model setup),
+ *   `false` when explicitly `true`, `null` when the file is missing,
+ *   unparseable, or the key is absent.
+ */
+export function detectAttribution(contents) {
+  if (contents === null || contents === undefined) return null
+  let parsed
+  try {
+    parsed = JSON.parse(contents)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  if (typeof parsed.includeCoAuthoredBy !== 'boolean') return null
+  // `includeCoAuthoredBy: false` ⇒ attribution suppressed ⇒ true (expected).
+  return parsed.includeCoAuthoredBy === false
+}
+
+/**
+ * Normalise a repo path into a canonical comparison key for matching against
+ * active session cwds. Strips a single trailing slash.
+ *
+ * @param {string} p - a path.
+ * @returns {string} comparison key.
+ */
+function pathKey(p) {
+  if (typeof p !== 'string') return ''
+  return p.length > 1 && p.endsWith('/') ? p.slice(0, -1) : p
+}
+
+/**
+ * Whether any active chroxy-session cwd is bound to this repo path (exact match
+ * or a descendant of the repo directory).
+ *
+ * @param {string} repoPath - the repo's absolute path.
+ * @param {string[]} activeSessionCwds - cwds of active chroxy sessions.
+ * @returns {boolean}
+ */
+function hasBoundSession(repoPath, activeSessionCwds) {
+  const key = pathKey(repoPath)
+  if (!key) return false
+  for (const cwd of activeSessionCwds) {
+    const c = pathKey(cwd)
+    if (!c) continue
+    if (c === key || c.startsWith(key + '/')) return true
+  }
+  return false
+}
+
+/**
+ * Classify a repo into a verdict + derived `live`, `onboarding`, and `note`.
+ *
+ * @param {object} args
+ * @param {{ state: string }} args.tree
+ * @param {number} args.worktrees
+ * @param {Date|null} args.lastTouchedDate
+ * @param {boolean} args.sessionBound
+ * @param {Date} args.now
+ * @param {object} args.thresholds
+ * @returns {{ verdict: string, live: boolean, onboarding: string, note?: string }}
+ */
+function classify({ tree, worktrees, lastTouchedDate, sessionBound, now, thresholds }) {
+  const dirty = tree.state === 'dirty'
+  const ageMs = lastTouchedDate ? now.getTime() - lastTouchedDate.getTime() : null
+
+  // Live-agent detection: a bound chroxy session, OR the dirty-tree-recently-
+  // touched heuristic.
+  const heuristicLive = dirty && ageMs !== null && ageMs < thresholds.liveMs
+  const live = sessionBound || heuristicLive
+
+  if (live) {
+    const note = sessionBound
+      ? 'Active session here right now'
+      : 'Uncommitted work touched moments ago — likely a live agent'
+    return { verdict: 'live', live: true, onboarding: 'deferred (live)', note }
+  }
+
+  // Worktree leak takes precedence for a non-live repo — it's the clearest
+  // "needs a human look" signal.
+  if (worktrees >= thresholds.worktreeLeak) {
+    return {
+      verdict: 'investigate',
+      live: false,
+      onboarding: 'skipped — worktree leak',
+      note: `${worktrees} worktrees — likely a leak`,
+    }
+  }
+
+  if (dirty) {
+    const recent = ageMs !== null && ageMs < thresholds.recentMs
+    if (recent) {
+      return {
+        verdict: 'recent',
+        live: false,
+        onboarding: 'skipped — dirty tree',
+        note: `Uncommitted work last touched ${humanizeAge(ageMs)} ago, no live agent`,
+      }
+    }
+    return {
+      verdict: 'abandoned',
+      live: false,
+      onboarding: 'skipped — dirty tree',
+      note: `Uncommitted work last touched ${humanizeAge(ageMs)} ago, no live agent`,
+    }
+  }
+
+  // Clean tree, not live, no leak → onboarded on the pull model.
+  return { verdict: 'onboarded', live: false, onboarding: '✓ onboarded' }
+}
+
+/**
+ * Render a coarse human-readable age for a `↳` note. Best-effort, not exact.
+ *
+ * @param {number|null} ageMs
+ * @returns {string}
+ */
+function humanizeAge(ageMs) {
+  if (ageMs === null || ageMs === undefined) return 'an unknown time'
+  const sec = Math.floor(ageMs / 1000)
+  if (sec < 60) return `${sec}s`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h`
+  const days = Math.floor(hr / 24)
+  if (days < 7) return `${days}d`
+  const weeks = Math.floor(days / 7)
+  return `${weeks}w`
+}
+
+/**
+ * Survey one repo. A per-repo failure is contained: the worst case still
+ * returns a schema-valid degraded `RepoStatus` with a note.
+ *
+ * @param {{ name: string, path: string }} repo
+ * @param {object} ctx - { execFn, readFn, now, activeSessionCwds, thresholds }
+ * @returns {Promise<object>} a `RepoStatus`-shaped object.
+ */
+async function surveyOne(repo, ctx) {
+  const { execFn, readFn, now, activeSessionCwds, thresholds } = ctx
+  const cwd = repo.path
+
+  try {
+    const sessionBound = hasBoundSession(repo.path, activeSessionCwds)
+
+    // Run the independent git probes concurrently.
+    const [branchRaw, statusRaw, worktreeRaw, lastRaw, prRaw, settingsRaw] = await Promise.all([
+      tryExec(execFn, 'git', ['rev-parse', '--abbrev-ref', 'HEAD'], cwd),
+      tryExec(execFn, 'git', ['status', '--porcelain'], cwd),
+      tryExec(execFn, 'git', ['worktree', 'list', '--porcelain'], cwd),
+      tryExec(execFn, 'git', ['log', '-1', '--format=%cI'], cwd),
+      tryExec(execFn, 'gh', ['pr', 'list', '--json', 'number'], cwd),
+      readSettings(readFn, repo.path),
+    ])
+
+    const branch = branchRaw && branchRaw.length > 0 ? branchRaw : 'unknown'
+    const tree = parseTree(statusRaw || '')
+    const worktrees = countWorktrees(worktreeRaw || '')
+    const openPRs = parseOpenPRs(prRaw)
+    const attribution = detectAttribution(settingsRaw)
+
+    const lastTouchedDate = lastRaw ? parseIsoDate(lastRaw) : null
+    const lastTouched = lastTouchedDate ? lastTouchedDate.toISOString() : now.toISOString()
+
+    const { verdict, live, onboarding, note } = classify({
+      tree,
+      worktrees,
+      lastTouchedDate,
+      sessionBound,
+      now,
+      thresholds,
+    })
+
+    const status = {
+      name: repo.name,
+      path: repo.path,
+      branch,
+      verdict,
+      live,
+      tree,
+      worktrees,
+      openPRs,
+      attribution,
+      onboarding,
+      lastTouched,
+    }
+    if (note) status.note = note
+    return status
+  } catch (err) {
+    // Degraded — never fail the whole survey on one repo.
+    return degradedRepo(repo, now, err)
+  }
+}
+
+/**
+ * Read `.claude/settings.json` for a repo, tolerating absence/errors.
+ *
+ * @param {Function} readFn - async readFile seam.
+ * @param {string} repoPath
+ * @returns {Promise<string|null>}
+ */
+async function readSettings(readFn, repoPath) {
+  try {
+    const contents = await readFn(join(repoPath, '.claude', 'settings.json'), 'utf8')
+    return typeof contents === 'string' ? contents : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Parse an ISO date string into a `Date`, or null if invalid.
+ *
+ * @param {string} raw
+ * @returns {Date|null}
+ */
+function parseIsoDate(raw) {
+  const t = Date.parse(raw)
+  return Number.isFinite(t) ? new Date(t) : null
+}
+
+/**
+ * Build a schema-valid degraded `RepoStatus` for a repo whose survey threw.
+ *
+ * @param {{ name: string, path: string }} repo
+ * @param {Date} now
+ * @param {Error} [err]
+ * @returns {object}
+ */
+function degradedRepo(repo, now, err) {
+  return {
+    name: repo.name,
+    path: repo.path,
+    branch: 'unknown',
+    verdict: 'investigate',
+    live: false,
+    tree: { state: 'clean', untracked: 0, modified: 0, staged: 0 },
+    worktrees: 0,
+    openPRs: null,
+    attribution: null,
+    onboarding: 'skipped — survey failed',
+    lastTouched: now.toISOString(),
+    note: `Survey failed: ${err && err.message ? err.message : 'unknown error'}`,
+  }
+}
+
+/**
+ * Run `tasks` with a concurrency cap, preserving input order in the result.
+ *
+ * @template T
+ * @param {Array<() => Promise<T>>} tasks
+ * @param {number} cap
+ * @returns {Promise<T[]>}
+ */
+async function mapWithCap(tasks, cap) {
+  const results = new Array(tasks.length)
+  let cursor = 0
+  const limit = Math.max(1, Math.min(cap, tasks.length || 1))
+
+  async function worker() {
+    while (cursor < tasks.length) {
+      const i = cursor++
+      results[i] = await tasks[i]()
+    }
+  }
+
+  const workers = []
+  for (let i = 0; i < limit; i++) workers.push(worker())
+  await Promise.all(workers)
+  return results
+}
+
+/**
+ * Tally per-verdict summary counts across surveyed repos.
+ *
+ * @param {object[]} repos - `RepoStatus[]`.
+ * @returns {{ live, onboarded, abandoned, investigate, recent }}
+ */
+function summarize(repos) {
+  const summary = { live: 0, onboarded: 0, abandoned: 0, investigate: 0, recent: 0 }
+  for (const r of repos) {
+    if (r.verdict in summary) summary[r.verdict]++
+  }
+  return summary
+}
+
+/**
+ * Survey a list of repos and produce a `host_status_snapshot`-shaped result
+ * (minus the `type` field, which the WS handler adds).
+ *
+ * @param {Array<{ name: string, path: string }>} repoSet - resolved repo set.
+ * @param {object} [opts]
+ * @param {string[]} [opts.activeSessionCwds] - cwds of active chroxy sessions,
+ *   supplied by the WS handler (#5174) from SessionManager.
+ * @param {string} [opts.root] - the discovery root to report in the snapshot.
+ * @param {object} [opts.thresholds] - verdict thresholds (see DEFAULT_THRESHOLDS).
+ * @param {number} [opts.concurrency] - per-repo concurrency cap.
+ * @param {Function} [opts._execFile] - promisified execFile seam.
+ * @param {Function} [opts._now] - returns a `Date` for "now".
+ * @param {Function} [opts._readFile] - async readFile seam.
+ * @returns {Promise<{ generatedAt: string, root: string, summary: object, repos: object[] }>}
+ */
+export async function surveyRepos(repoSet, opts = {}) {
+  const {
+    activeSessionCwds = [],
+    root = '',
+    thresholds: thresholdOverrides = {},
+    concurrency = DEFAULT_CONCURRENCY,
+    _execFile = execFileAsync,
+    _now = () => new Date(),
+    _readFile = readFile,
+  } = opts
+
+  const now = _now()
+  const thresholds = { ...DEFAULT_THRESHOLDS, ...thresholdOverrides }
+  const ctx = {
+    execFn: _execFile,
+    readFn: _readFile,
+    now,
+    activeSessionCwds: Array.isArray(activeSessionCwds) ? activeSessionCwds : [],
+    thresholds,
+  }
+
+  const list = Array.isArray(repoSet) ? repoSet : []
+  const tasks = list.map(repo => () => surveyOne(repo, ctx))
+  const repos = await mapWithCap(tasks, concurrency)
+
+  return {
+    generatedAt: now.toISOString(),
+    root,
+    summary: summarize(repos),
+    repos,
+  }
+}
+
+/**
+ * Convenience: resolve the repo set (via `resolveRepoSet`) and survey it in one
+ * call. The WS handler (#5174) will typically call `resolveRepoSet` and
+ * `surveyRepos` separately so it can inject live session cwds, but this wrapper
+ * is handy for a one-shot survey from config.
+ *
+ * @param {object} [opts] - merged options for `resolveRepoSet` + `surveyRepos`.
+ * @returns {Promise<object>} snapshot-shaped result.
+ */
+export async function surveyHost(opts = {}) {
+  const repoSet = resolveRepoSet({
+    repos: opts.repos,
+    root: opts.root,
+    _readdir: opts._readdir,
+    _stat: opts._stat,
+    _exists: opts._exists,
+    _realpath: opts._realpath,
+  })
+  return surveyRepos(repoSet, {
+    ...opts,
+    root: opts.root || '',
+  })
+}

--- a/packages/server/tests/control-room-survey.test.js
+++ b/packages/server/tests/control-room-survey.test.js
@@ -259,12 +259,12 @@ describe('surveyRepos — per-repo error tolerance', () => {
   it('one repo whose _readFile/exec throw unexpectedly does not fail the survey', async () => {
     const ok = { name: 'ok', path: '/p/ok' }
     const bad = { name: 'bad', path: '/p/bad' }
-    // exec fake throws a non-Error for /p/bad branch to simulate an unexpected
-    // crash inside surveyOne (Promise.all rejection paths are tolerated, but
-    // we also exercise the outer try/catch via a throwing _readFile).
+    // The exec fake rejects for every command on /p/bad, so its git status
+    // probe returns null — surveyOne's core-probe-failure guard then yields a
+    // degraded `investigate` row (branch 'unknown') rather than a false-clean
+    // row. The /p/bad _readFile also throws, exercising the tolerant read path.
     const exec = async (file, args, opts) => {
       if (opts.cwd === '/p/bad') {
-        // throw synchronously-ish (rejected promise) for every command
         throw new Error('disk on fire')
       }
       const repo = cleanRepo()
@@ -283,6 +283,40 @@ describe('surveyRepos — per-repo error tolerance', () => {
     // still a valid RepoStatus (not dropped).
     assert.ok(badStatus)
     assert.equal(badStatus.branch, 'unknown')
+    // Core git probe failed → degraded `investigate`, NOT a false `onboarded`.
+    assert.equal(badStatus.verdict, 'investigate')
+  })
+
+  it('core git probe failure (status) yields a degraded investigate row, not onboarded', async () => {
+    const repo = { name: 'notgit', path: '/p/notgit' }
+    // `git status` fails (path is not a git repo). Other commands also fail.
+    const exec = makeExec({ '/p/notgit': {} }) // empty map → every command rejects
+    const out = await surveyRepos([repo], { _execFile: exec, _now: now, _readFile: async () => { throw new Error() } })
+    const r = out.repos[0]
+    assert.equal(r.verdict, 'investigate')
+    assert.equal(r.live, false)
+    assert.equal(r.branch, 'unknown')
+    // Did NOT fall through to a false-clean onboarded row.
+    assert.notEqual(r.verdict, 'onboarded')
+    assert.match(r.note, /git status probe failed/)
+    // Still a schema-valid RepoStatus.
+    const parsed = ServerHostStatusSnapshotSchema.safeParse({ type: 'host_status_snapshot', ...out })
+    assert.ok(parsed.success)
+  })
+
+  it('hasBoundSession matches a Windows-style backslash session cwd', async () => {
+    // Repo path uses backslashes (Windows); a bound session cwd under it must
+    // still register as live despite the separator difference.
+    const repo = { name: 'win', path: 'C:\\proj\\app' }
+    const exec = makeExec({ 'C:\\proj\\app': cleanRepo() })
+    const out = await surveyRepos([repo], {
+      _execFile: exec,
+      _now: now,
+      _readFile: async () => { throw new Error() },
+      activeSessionCwds: ['C:\\proj\\app\\packages\\server'],
+    })
+    assert.equal(out.repos[0].verdict, 'live')
+    assert.equal(out.repos[0].live, true)
   })
 })
 

--- a/packages/server/tests/control-room-survey.test.js
+++ b/packages/server/tests/control-room-survey.test.js
@@ -1,0 +1,364 @@
+/**
+ * #5173 — Control Room host/repo survey + verdict + live-agent engine.
+ *
+ * Pins the behaviour the WS handler (#5174) and dashboard build on:
+ *   - git status --porcelain → clean/dirty + untracked/modified/staged counts
+ *   - worktree count, branch, lastTouched parsing
+ *   - openPRs: count from gh json, null when gh missing/unauth/unparseable
+ *   - attribution: includeCoAuthoredBy:false → true, true → false, else null
+ *   - each verdict branch (live session-bound / live heuristic / investigate /
+ *     recent / abandoned / onboarded)
+ *   - per-repo error tolerance (one failing repo does not fail the survey)
+ *   - summary counts match the per-repo verdicts
+ *   - the snapshot validates against the @chroxy/protocol wire schema
+ *
+ * NEVER calls real git/gh or touches real ~/.chroxy / ~/.claude — all command
+ * output is canned via the `_execFile` / `_readFile` / `_now` injection seams.
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { ServerHostStatusSnapshotSchema } from '@chroxy/protocol'
+import {
+  surveyRepos,
+  parseTree,
+  countWorktrees,
+  parseOpenPRs,
+  detectAttribution,
+  DEFAULT_THRESHOLDS,
+} from '../src/control-room/survey.js'
+
+const NOW = new Date('2026-06-05T12:00:00.000Z')
+const now = () => new Date(NOW)
+
+function iso(msAgo) {
+  return new Date(NOW.getTime() - msAgo).toISOString()
+}
+
+/**
+ * Build an `_execFile` fake from a per-repo command map. The map is keyed by
+ * cwd → { branch, status, worktree, log, pr } strings (or an `Error` to reject,
+ * or `undefined` to reject as "command not found").
+ */
+function makeExec(byCwd) {
+  return async (file, args, opts) => {
+    const cwd = opts && opts.cwd
+    const repo = byCwd[cwd] || {}
+    const key = cmdKey(file, args)
+    const val = repo[key]
+    if (val instanceof Error) throw val
+    if (val === undefined) {
+      const e = new Error(`ENOENT: ${file}`)
+      throw e
+    }
+    return { stdout: val, stderr: '' }
+  }
+}
+
+function cmdKey(file, args) {
+  if (file === 'git' && args[0] === 'rev-parse') return 'branch'
+  if (file === 'git' && args[0] === 'status') return 'status'
+  if (file === 'git' && args[0] === 'worktree') return 'worktree'
+  if (file === 'git' && args[0] === 'log') return 'log'
+  if (file === 'gh') return 'pr'
+  return 'unknown'
+}
+
+/** A clean, onboarded repo command map. */
+function cleanRepo({ branch = 'main', log = iso(40 * 24 * 60 * 60 * 1000), pr = '[]', worktree = 'worktree /x\nHEAD abc\nbranch refs/heads/main\n' } = {}) {
+  return { branch, status: '', worktree, log, pr }
+}
+
+describe('parseTree', () => {
+  it('reports clean for empty porcelain', () => {
+    assert.deepEqual(parseTree(''), { state: 'clean', untracked: 0, modified: 0, staged: 0 })
+  })
+
+  it('counts untracked, modified, staged', () => {
+    const porcelain = [
+      '?? new.txt',
+      ' M edited.txt',
+      'M  staged.txt',
+      'MM both.txt',
+      'A  added.txt',
+    ].join('\n')
+    const t = parseTree(porcelain)
+    assert.equal(t.state, 'dirty')
+    assert.equal(t.untracked, 1)
+    // ' M' modified, 'MM' modified, => 2 modified
+    assert.equal(t.modified, 2)
+    // 'M ' staged, 'MM' staged, 'A ' staged => 3 staged
+    assert.equal(t.staged, 3)
+  })
+
+  it('tolerates CRLF line endings', () => {
+    const t = parseTree('?? a.txt\r\n M b.txt\r\n')
+    assert.equal(t.untracked, 1)
+    assert.equal(t.modified, 1)
+    assert.equal(t.state, 'dirty')
+  })
+})
+
+describe('countWorktrees', () => {
+  it('returns 0 for empty', () => {
+    assert.equal(countWorktrees(''), 0)
+  })
+  it('counts worktree records', () => {
+    const out = 'worktree /a\nHEAD x\n\nworktree /b\nHEAD y\n\nworktree /c\n'
+    assert.equal(countWorktrees(out), 3)
+  })
+})
+
+describe('parseOpenPRs', () => {
+  it('counts a json array', () => {
+    assert.equal(parseOpenPRs('[{"number":1},{"number":2}]'), 2)
+  })
+  it('returns 0 for empty array', () => {
+    assert.equal(parseOpenPRs('[]'), 0)
+  })
+  it('returns null when gh is missing (null input)', () => {
+    assert.equal(parseOpenPRs(null), null)
+  })
+  it('returns null for unparseable output', () => {
+    assert.equal(parseOpenPRs('not json — gh: command not found'), null)
+  })
+})
+
+describe('detectAttribution', () => {
+  it('includeCoAuthoredBy:false → true (attribution suppressed)', () => {
+    assert.equal(detectAttribution('{"includeCoAuthoredBy": false}'), true)
+  })
+  it('includeCoAuthoredBy:true → false', () => {
+    assert.equal(detectAttribution('{"includeCoAuthoredBy": true}'), false)
+  })
+  it('missing key → null', () => {
+    assert.equal(detectAttribution('{"other": 1}'), null)
+  })
+  it('missing file (null) → null', () => {
+    assert.equal(detectAttribution(null), null)
+  })
+  it('unparseable → null', () => {
+    assert.equal(detectAttribution('{ bad json'), null)
+  })
+})
+
+describe('surveyRepos — verdicts', () => {
+  it('onboarded: clean tree, not live, no leak', async () => {
+    const repo = { name: 'app', path: '/p/app' }
+    const exec = makeExec({ '/p/app': cleanRepo() })
+    const out = await surveyRepos([repo], { _execFile: exec, _now: now, _readFile: async () => { throw new Error('no file') } })
+    const r = out.repos[0]
+    assert.equal(r.verdict, 'onboarded')
+    assert.equal(r.live, false)
+    assert.equal(r.tree.state, 'clean')
+    assert.equal(r.onboarding, '✓ onboarded')
+    assert.equal(r.note, undefined)
+  })
+
+  it('live (session-bound): an active chroxy session cwd matches the repo', async () => {
+    const repo = { name: 'app', path: '/p/app' }
+    // clean tree but a session is bound → still live
+    const exec = makeExec({ '/p/app': cleanRepo() })
+    const out = await surveyRepos([repo], {
+      _execFile: exec,
+      _now: now,
+      _readFile: async () => { throw new Error('no file') },
+      activeSessionCwds: ['/p/app/packages/server'],
+    })
+    const r = out.repos[0]
+    assert.equal(r.verdict, 'live')
+    assert.equal(r.live, true)
+    assert.match(r.note, /Active session here/)
+    assert.equal(r.onboarding, 'deferred (live)')
+  })
+
+  it('live (heuristic): dirty tree touched within liveMs, no session', async () => {
+    const repo = { name: 'app', path: '/p/app' }
+    const exec = makeExec({
+      '/p/app': { branch: 'feat/x', status: ' M a.js', worktree: 'worktree /p/app\n', log: iso(60 * 1000), pr: '[]' },
+    })
+    const out = await surveyRepos([repo], { _execFile: exec, _now: now, _readFile: async () => { throw new Error() } })
+    const r = out.repos[0]
+    assert.equal(r.verdict, 'live')
+    assert.equal(r.live, true)
+    assert.match(r.note, /likely a live agent/)
+  })
+
+  it('investigate: excessive worktree count (leak), not live', async () => {
+    const repo = { name: 'app', path: '/p/app' }
+    const wt = Array.from({ length: DEFAULT_THRESHOLDS.worktreeLeak }, (_, i) => `worktree /p/app/wt${i}\n`).join('\n')
+    const exec = makeExec({
+      '/p/app': { branch: 'main', status: '', worktree: wt, log: iso(40 * 24 * 60 * 60 * 1000), pr: '[]' },
+    })
+    const out = await surveyRepos([repo], { _execFile: exec, _now: now, _readFile: async () => { throw new Error() } })
+    const r = out.repos[0]
+    assert.equal(r.verdict, 'investigate')
+    assert.equal(r.live, false)
+    assert.match(r.note, /worktrees — likely a leak/)
+  })
+
+  it('recent: dirty tree touched within recentMs but not live', async () => {
+    const repo = { name: 'app', path: '/p/app' }
+    const exec = makeExec({
+      '/p/app': { branch: 'feat/x', status: ' M a.js', worktree: 'worktree /p/app\n', log: iso(2 * 24 * 60 * 60 * 1000), pr: '[]' },
+    })
+    const out = await surveyRepos([repo], { _execFile: exec, _now: now, _readFile: async () => { throw new Error() } })
+    const r = out.repos[0]
+    assert.equal(r.verdict, 'recent')
+    assert.equal(r.live, false)
+    assert.match(r.note, /no live agent/)
+  })
+
+  it('abandoned: dirty tree last touched long ago, not live', async () => {
+    const repo = { name: 'app', path: '/p/app' }
+    const exec = makeExec({
+      '/p/app': { branch: 'feat/x', status: ' M a.js', worktree: 'worktree /p/app\n', log: iso(40 * 24 * 60 * 60 * 1000), pr: '[]' },
+    })
+    const out = await surveyRepos([repo], { _execFile: exec, _now: now, _readFile: async () => { throw new Error() } })
+    const r = out.repos[0]
+    assert.equal(r.verdict, 'abandoned')
+    assert.equal(r.live, false)
+    assert.match(r.note, /no live agent/)
+  })
+})
+
+describe('surveyRepos — gh tolerance', () => {
+  it('openPRs is null when gh is missing', async () => {
+    const repo = { name: 'app', path: '/p/app' }
+    const exec = makeExec({
+      // pr key omitted → exec fake rejects ("gh not found")
+      '/p/app': { branch: 'main', status: '', worktree: 'worktree /p/app\n', log: iso(1000) },
+    })
+    const out = await surveyRepos([repo], { _execFile: exec, _now: now, _readFile: async () => { throw new Error() } })
+    assert.equal(out.repos[0].openPRs, null)
+  })
+
+  it('openPRs counts PRs when gh works', async () => {
+    const repo = { name: 'app', path: '/p/app' }
+    const exec = makeExec({
+      '/p/app': { ...cleanRepo({ pr: '[{"number":7},{"number":9},{"number":11}]' }) },
+    })
+    const out = await surveyRepos([repo], { _execFile: exec, _now: now, _readFile: async () => { throw new Error() } })
+    assert.equal(out.repos[0].openPRs, 3)
+  })
+})
+
+describe('surveyRepos — attribution via _readFile', () => {
+  it('reads .claude/settings.json and detects suppressed attribution', async () => {
+    const repo = { name: 'app', path: '/p/app' }
+    const exec = makeExec({ '/p/app': cleanRepo() })
+    const readFile = async (path) => {
+      assert.match(path, /\.claude[\/\\]settings\.json$/)
+      return '{"includeCoAuthoredBy": false}'
+    }
+    const out = await surveyRepos([repo], { _execFile: exec, _now: now, _readFile: readFile })
+    assert.equal(out.repos[0].attribution, true)
+  })
+})
+
+describe('surveyRepos — per-repo error tolerance', () => {
+  it('one repo whose _readFile/exec throw unexpectedly does not fail the survey', async () => {
+    const ok = { name: 'ok', path: '/p/ok' }
+    const bad = { name: 'bad', path: '/p/bad' }
+    // exec fake throws a non-Error for /p/bad branch to simulate an unexpected
+    // crash inside surveyOne (Promise.all rejection paths are tolerated, but
+    // we also exercise the outer try/catch via a throwing _readFile).
+    const exec = async (file, args, opts) => {
+      if (opts.cwd === '/p/bad') {
+        // throw synchronously-ish (rejected promise) for every command
+        throw new Error('disk on fire')
+      }
+      const repo = cleanRepo()
+      return { stdout: repo[cmdKey(file, args)] ?? '', stderr: '' }
+    }
+    const readFile = async (path) => {
+      if (path.includes('/p/bad/')) throw new Error('boom')
+      throw new Error('no file')
+    }
+    const out = await surveyRepos([ok, bad], { _execFile: exec, _now: now, _readFile: readFile })
+    assert.equal(out.repos.length, 2)
+    const okStatus = out.repos.find(r => r.name === 'ok')
+    const badStatus = out.repos.find(r => r.name === 'bad')
+    assert.equal(okStatus.verdict, 'onboarded')
+    // bad repo: all git probes failed → branch unknown, clean tree fallback,
+    // still a valid RepoStatus (not dropped).
+    assert.ok(badStatus)
+    assert.equal(badStatus.branch, 'unknown')
+  })
+})
+
+describe('surveyRepos — summary + schema conformance', () => {
+  it('summary counts match per-repo verdicts and snapshot validates', async () => {
+    const repos = [
+      { name: 'onb', path: '/p/onb' },
+      { name: 'liv', path: '/p/liv' },
+      { name: 'rec', path: '/p/rec' },
+      { name: 'aba', path: '/p/aba' },
+      { name: 'inv', path: '/p/inv' },
+    ]
+    const wtLeak = Array.from({ length: 5 }, (_, i) => `worktree /p/inv/wt${i}\n`).join('\n')
+    const exec = makeExec({
+      '/p/onb': cleanRepo(),
+      '/p/liv': { branch: 'f', status: ' M a', worktree: 'worktree /p/liv\n', log: iso(30 * 1000), pr: '[]' },
+      '/p/rec': { branch: 'f', status: ' M a', worktree: 'worktree /p/rec\n', log: iso(2 * 24 * 60 * 60 * 1000), pr: '[]' },
+      '/p/aba': { branch: 'f', status: ' M a', worktree: 'worktree /p/aba\n', log: iso(40 * 24 * 60 * 60 * 1000), pr: '[]' },
+      '/p/inv': { branch: 'main', status: '', worktree: wtLeak, log: iso(40 * 24 * 60 * 60 * 1000), pr: '[]' },
+    })
+    const out = await surveyRepos(repos, {
+      _execFile: exec,
+      _now: now,
+      _readFile: async () => { throw new Error() },
+      root: '/p',
+    })
+
+    assert.deepEqual(out.summary, {
+      live: 1,
+      onboarded: 1,
+      abandoned: 1,
+      investigate: 1,
+      recent: 1,
+    })
+
+    // The handler adds `type`; the survey result is otherwise the full snapshot.
+    const snapshot = { type: 'host_status_snapshot', ...out }
+    const parsed = ServerHostStatusSnapshotSchema.safeParse(snapshot)
+    assert.ok(parsed.success, parsed.success ? '' : JSON.stringify(parsed.error.issues, null, 2))
+    assert.equal(out.root, '/p')
+    assert.match(out.generatedAt, /^2026-06-05T12:00:00/)
+  })
+
+  it('empty repo set yields a valid empty snapshot', async () => {
+    const out = await surveyRepos([], { _now: now, root: '/p' })
+    assert.deepEqual(out.repos, [])
+    assert.deepEqual(out.summary, { live: 0, onboarded: 0, abandoned: 0, investigate: 0, recent: 0 })
+    const parsed = ServerHostStatusSnapshotSchema.safeParse({ type: 'host_status_snapshot', ...out })
+    assert.ok(parsed.success)
+  })
+})
+
+describe('surveyRepos — concurrency cap', () => {
+  it('never exceeds the configured concurrency cap', async () => {
+    const repos = Array.from({ length: 12 }, (_, i) => ({ name: `r${i}`, path: `/p/r${i}` }))
+    let inFlight = 0
+    let maxInFlight = 0
+    const exec = async (file, args) => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise(r => setTimeout(r, 1))
+      inFlight--
+      // minimal valid output per command
+      const repo = cleanRepo()
+      return { stdout: repo[cmdKey(file, args)] ?? '', stderr: '' }
+    }
+    await surveyRepos(repos, {
+      _execFile: exec,
+      _now: now,
+      _readFile: async () => { throw new Error() },
+      concurrency: 3,
+    })
+    // Each repo fires up to 5 concurrent commands internally; the cap bounds
+    // how many repos run at once, so observed parallel commands stays bounded
+    // by cap * (commands per repo). The key invariant: not all 12 repos ran at
+    // once. With cap 3 and 5 cmds/repo, ceiling is 15 commands in flight.
+    assert.ok(maxInFlight <= 3 * 5, `maxInFlight=${maxInFlight}`)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the Control Room v2 host/repo survey engine (A3, part of epic #5170). Given the resolved repo set (from `resolveRepoSet`, #5186), it produces one `RepoStatus` per repo plus aggregate `summary` counts, shaped exactly to the A1 `host_status_snapshot` wire contract (#5185) — minus the `type` field, which the WS handler (#5174) adds.

New module: `packages/server/src/control-room/survey.js`, exporting `surveyRepos(repoSet, opts)`.

### Per repo
- **branch** — `git rev-parse --abbrev-ref HEAD`
- **tree** — `git status --porcelain` parsed into `{ state: clean|dirty, untracked, modified, staged }`
- **worktrees** — count from `git worktree list --porcelain`
- **lastTouched** — `git log -1 --format=%cI`, ISO-8601
- **openPRs** — `gh pr list --json` count; `null` when gh is missing / unauth / errors / unparseable (tolerated gracefully, `null` ≠ 0)
- **attribution** — project-level `.claude/settings.json` `includeCoAuthoredBy:false` → `true` (suppressed/expected), `true` → `false`, `null` when undeterminable
- **onboarding** — short human string (`✓ onboarded`, `skipped — dirty tree`, `deferred (live)`, etc.)
- **note** — optional `↳` annotation (e.g. `N worktrees — likely a leak`, `Active session here right now`)
- **verdict** — `live | investigate | abandoned | recent | onboarded`

### Verdict / live-agent logic
- **live** — a chroxy session bound to the repo (injected `activeSessionCwds`, supplied by the WS handler in #5174 from SessionManager) **OR** the dirty-tree-recently-touched heuristic (configurable `liveMs`, default 15 min)
- **investigate** — excessive worktree count (likely a leak)
- **recent** — dirty tree touched within the recent window, not live
- **abandoned** — dirty tree last touched long ago, not live
- **onboarded** — clean tree on the pull model

### Robustness
- Repos run concurrently with a small cap (default 5).
- A per-repo failure yields a schema-valid **degraded** `RepoStatus` with a note — it never fails the whole survey.

### Injection seams
All external interaction is injectable — `_execFile`, `_now`, `_readFile` — so tests never call real `git`/`gh` or touch real `~/.chroxy` / `~/.claude`.

## Tests
`packages/server/tests/control-room-survey.test.js` (27 cases): tree parsing (clean/dirty/CRLF), worktree count, openPRs parsing, attribution detection, each verdict branch, both live-agent paths (session-bound + heuristic), gh-missing → null, per-repo error tolerance, summary counts, concurrency cap, and schema conformance against `ServerHostStatusSnapshotSchema` from `@chroxy/protocol`.

- Full server suite green (no new failures vs `main`; the new module adds 0 regressions).
- `lint-tests-state-file-path.sh` and `lint-session-opt-forwarding.sh` pass.

Closes #5173