### PR TITLE
feat(dashboard): surface Running indicator on left projects/explorer header

### DIFF
--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -168,6 +168,31 @@ describe('Sidebar', () => {
     expect(screen.getByTestId('sidebar-footer')).toHaveTextContent('3')
   })
 
+  // #5183 — the Running indicator is surfaced on the left projects/explorer
+  // header (in addition to the footer), reusing the serverStatus signal.
+  it('shows Running indicator on the projects header when connected', () => {
+    renderSidebar({ serverStatus: 'connected' })
+    const header = screen.getByTestId('sidebar-projects-header')
+    expect(header).toHaveTextContent('Running')
+    const dot = screen.getByTestId('sidebar-projects-status-dot')
+    expect(dot).toHaveClass('connected')
+  })
+
+  it('shows Reconnecting on the projects header when reconnecting', () => {
+    renderSidebar({ serverStatus: 'reconnecting' })
+    const header = screen.getByTestId('sidebar-projects-header')
+    expect(header).toHaveTextContent('Reconnecting')
+    expect(screen.getByTestId('sidebar-projects-status-dot')).toHaveClass('reconnecting')
+  })
+
+  it('shows Stopped on the projects header when disconnected', () => {
+    renderSidebar({ serverStatus: 'disconnected' })
+    const header = screen.getByTestId('sidebar-projects-header')
+    expect(header).toHaveTextContent('Stopped')
+    expect(header).not.toHaveTextContent('Running')
+    expect(screen.getByTestId('sidebar-projects-status-dot')).toHaveClass('disconnected')
+  })
+
   it('renders collapsed state when isOpen is false', () => {
     renderSidebar({ isOpen: false })
     const sidebar = screen.getByTestId('sidebar')

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -667,6 +667,24 @@ export function Sidebar({
             />
           )}
 
+          {/* #5183 — Projects/explorer header. Surfaces the daemon Running
+              state (reusing the same `serverStatus` signal the footer uses)
+              at the top of the left explorer where the user looks first,
+              not just buried in the footer. */}
+          <div className="sidebar-projects-header" data-testid="sidebar-projects-header">
+            <span className="sidebar-projects-title">Projects</span>
+            <span
+              className={`sidebar-status-dot ${serverStatus}`}
+              data-testid="sidebar-projects-status-dot"
+              title={
+                serverStatus === 'connected' ? 'Server running'
+                  : serverStatus === 'reconnecting' ? 'Reconnecting to server...'
+                    : 'Server stopped'
+              }
+            />
+            <span className="sidebar-projects-status-label">{statusLabel}</span>
+          </div>
+
           {/* Repo tree */}
           <div className="sidebar-tree" role="tree" aria-label="Repository sessions" ref={treeRef} onKeyDown={handleTreeKeyDown}>
             {filteredRepos.map(repo => {

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -676,10 +676,17 @@ export function Sidebar({
             <span
               className={`sidebar-status-dot ${serverStatus}`}
               data-testid="sidebar-projects-status-dot"
+              // Decorative — the adjacent status label already announces the
+              // state, so hide the dot from screen readers to avoid a
+              // redundant/ambiguous announcement (Copilot review).
+              aria-hidden="true"
+              // Reuse the SAME tooltip wording as the footer dot so the two
+              // indicators don't disagree when both are visible (Copilot
+              // review).
               title={
-                serverStatus === 'connected' ? 'Server running'
+                serverStatus === 'connected' ? 'Server connected'
                   : serverStatus === 'reconnecting' ? 'Reconnecting to server...'
-                    : 'Server stopped'
+                    : 'Server disconnected'
               }
             />
             <span className="sidebar-projects-status-label">{statusLabel}</span>

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -432,6 +432,29 @@
   border-color: var(--accent-blue);
 }
 
+/* #5183 — Projects/explorer header with the daemon Running indicator. */
+.sidebar-projects-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.sidebar-projects-title {
+  font-weight: 600;
+}
+
+.sidebar-projects-status-label {
+  margin-left: auto;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
 .sidebar-tree {
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
## Summary

Part of epic #5170 (Control Room v2). Surfaces the daemon **Running** state on the LEFT projects/explorer sidebar, where the user looks first, instead of only in the sidebar footer.

Adds a "Projects" header at the top of the repo tree with a status dot + label (Running / Reconnecting / Stopped). It reuses the **existing `serverStatus` signal** (derived in `App.tsx` from `isConnected`/`isReconnecting`, the same source the footer's status label uses) — no new running-state source was invented. The dot reuses the existing `.sidebar-status-dot` style classes (`connected`/`reconnecting`/`disconnected`) for visual consistency.

## Scope notes

- This is the D2 half of the split described in the issue. The TOP status dot ("Connected to tunnel", #5182) is intentionally **not** touched here.
- The footer running state is left in place per the issue ("ADD it there"). It now appears in both the explorer header and the footer; if the footer one should be removed, that can be a follow-up.

## Changes

- `Sidebar.tsx` — new `.sidebar-projects-header` above the repo tree, with status dot + `statusLabel` (reused).
- `components.css` — styles for the header.
- `Sidebar.test.tsx` — 3 tests asserting the indicator reflects connected/reconnecting/disconnected.

## Testing

- `npm test` (dashboard): 2998 passed (153 files), including 3 new tests.
- `npm run typecheck`: clean.

Closes #5183