### PR TITLE
feat(dashboard): top-bar layout pass — token bar, cluster occlusion, model dropdown, status dot

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -2139,6 +2139,85 @@ describe('App', () => {
     })
   })
 
+  // #5182 (D1) — the top-bar status dot must track the CONNECTED state
+  // (the app's WS/tunnel connection), not a daemon "running" state. It is
+  // driven by `connectionPhase`: green `.connected` only when
+  // connectionPhase === 'connected', and a non-connected class otherwise.
+  // The separate "Running" indicator lives on the sidebar/explorer header
+  // (#5192) and is deliberately not wired into this dot.
+  describe('top status dot reflects Connected state (#5182)', () => {
+    const oneSession = [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null }]
+
+    it('is .connected (green) when connectionPhase is connected', () => {
+      stateOverrides = { connectionPhase: 'connected', sessions: oneSession, activeSessionId: 's1' }
+      const { container } = render(<App />)
+      const dot = container.querySelector('#header .status-dot')
+      expect(dot, 'header status-dot must exist').toBeTruthy()
+      expect(dot!.classList.contains('connected'), 'dot must be .connected when connected').toBe(true)
+      expect(dot!.getAttribute('aria-label')).toMatch(/connected/i)
+    })
+
+    it('is NOT .connected when disconnected', () => {
+      stateOverrides = { connectionPhase: 'disconnected', sessions: [], activeSessionId: null }
+      const { container } = render(<App />)
+      const dot = container.querySelector('#header .status-dot')
+      expect(dot, 'header status-dot must exist').toBeTruthy()
+      expect(dot!.classList.contains('connected'), 'dot must NOT be .connected when disconnected').toBe(false)
+      expect(dot!.classList.contains('disconnected')).toBe(true)
+    })
+
+    it('shows the connecting state (not connected) while reconnecting', () => {
+      stateOverrides = { connectionPhase: 'reconnecting', sessions: oneSession, activeSessionId: 's1' }
+      const { container } = render(<App />)
+      const dot = container.querySelector('#header .status-dot')
+      expect(dot!.classList.contains('connected')).toBe(false)
+      expect(dot!.classList.contains('reconnecting')).toBe(true)
+    })
+  })
+
+  // #5180 (C2) — every control in the top bar must be present (and thus
+  // not occluded into nonexistence) when connected: the model dropdown,
+  // the permission (Approve) select, the notification bell, the ⋯
+  // overflow trigger, the cost badge, and the token/status cluster. This
+  // is the render-level guard that pairs with the CSS layout fix (the
+  // right cluster is content-pinned and its children never shrink to
+  // overlap one another).
+  describe('top-bar controls all render without occlusion (#5180)', () => {
+    const connectedModelState = {
+      connectionPhase: 'connected' as const,
+      sessions: [{ sessionId: 's1', name: 'Test', cwd: '/tmp', type: 'cli' as const, hasTerminal: true, model: 'sonnet', permissionMode: 'approve', isBusy: false, createdAt: Date.now(), conversationId: null }],
+      activeSessionId: 's1',
+      availableModels: [
+        { id: 'sonnet', label: 'Sonnet 4.6', fullId: 'claude-sonnet-4-6', contextWindow: 200000 },
+        { id: 'opus', label: 'Opus 4.7', fullId: 'claude-opus-4-7', contextWindow: 200000 },
+      ],
+      availablePermissionModes: [
+        { id: 'approve', label: 'Approve' },
+        { id: 'auto', label: 'Auto Approve' },
+      ],
+    }
+
+    it('renders the model dropdown, permission select, bell, overflow, and cost slot together', () => {
+      stateOverrides = connectedModelState
+      const { container } = render(<App />)
+      const header = container.querySelector('#header')
+      expect(header, '#header must render').toBeTruthy()
+      // Model dropdown (header-center)
+      expect(within(header as HTMLElement).getByTestId('chat-settings-trigger')).toBeInTheDocument()
+      // Permission-mode (Approve) select
+      expect(header!.querySelector('select[data-kind="permission"]'), 'permission select must render').toBeTruthy()
+      // Notification bell trigger
+      expect(within(header as HTMLElement).getByTestId('notifications-widget-trigger')).toBeInTheDocument()
+      // Overflow (⋯) trigger
+      expect(within(header as HTMLElement).getByTestId('header-overflow-trigger')).toBeInTheDocument()
+      // Cost slot (legacy .status-cost or configurable badge — at least one)
+      const costSlot = header!.querySelector('.status-cost, [data-testid="sidebar-cost-badge"]')
+      expect(costSlot, 'cost slot must render').toBeTruthy()
+      // Status bar cluster (tokens live here)
+      expect(within(header as HTMLElement).getByTestId('status-bar')).toBeInTheDocument()
+    })
+  })
+
   // #4695 / #5062 — discoverable chrome-level "New Session" entry point.
   //
   // The per-project sidebar button (`sidebar-new-session-<path>`) and the

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2043,6 +2043,15 @@ export function App() {
             )
           })()}
           {(() => {
+            // #5182 (D1) — the top-bar dot reflects CONNECTED state (the
+            // app's WS/tunnel connection), NOT a daemon "running" state.
+            // It is driven purely by `connectionPhase` (the connected
+            // signal) plus the tunnel-warming gate below, mirroring the
+            // FooterBar's "Connected" dot exactly. The separate "Running"
+            // indicator lives on the left projects/explorer header (#5192)
+            // and is intentionally NOT wired here. The dot only turns
+            // green (`.connected`) when `connectionPhase === 'connected'`
+            // AND the tunnel is ready — i.e. genuinely connected end-to-end.
             const warming = serverPhase === 'tunnel_warming' || serverPhase === 'tunnel_verifying' || (isConnected && !tunnelReady && serverPhase == null)
             const phase = warming ? 'connecting' : connectionPhase
             const STATUS_LABELS: Record<string, string> = {

--- a/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
+++ b/packages/dashboard/src/components/ChatSettingsDropdown.test.tsx
@@ -164,6 +164,64 @@ describe('ChatSettingsDropdown', () => {
   })
 
   // #3888 — header model-picker tooltip surfaces model + context-window
+  // #5181 (C3): the model dropdown must be robust to any-length model
+  // name. The actual truncation is CSS (`text-overflow: ellipsis` +
+  // min/max-width keyed off `data-kind="model"`), which jsdom doesn't
+  // apply — so these tests pin the contract the CSS relies on: the
+  // `data-kind="model"` selector hook is present, short and long labels
+  // both render without disturbing the option set, and the full model id
+  // stays discoverable via title/aria-label so a visually-truncated
+  // label is never lost to AT users.
+  describe('#5181 — responsive model dropdown', () => {
+    it('model select carries the data-kind="model" sizing hook', () => {
+      renderDropdown()
+      const modelSelect = screen.getByTestId('chat-settings-trigger')
+      expect(modelSelect.getAttribute('data-kind')).toBe('model')
+    })
+
+    it('renders a very long model label without dropping options', () => {
+      const longModels = [
+        {
+          id: 'long',
+          label: 'Claude Opus 4.7 Extended Thinking (1M context, preview build)',
+          fullId: 'claude-opus-4-7-extended-thinking-1m-preview',
+          contextWindow: 1_000_000,
+        },
+        { id: 'short', label: 'Auto', fullId: 'auto' },
+      ]
+      renderDropdown({ availableModels: longModels, activeModel: 'long', defaultModelId: null })
+      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
+      // Default option + both models present — the long label doesn't
+      // crowd out or collapse the others.
+      expect(modelSelect.querySelectorAll('option').length).toBe(3)
+      expect(modelSelect.value).toBe('long')
+    })
+
+    it('renders a very short model label cleanly', () => {
+      const shortModels = [{ id: 'auto', label: 'Auto', fullId: 'auto' }]
+      renderDropdown({ availableModels: shortModels, activeModel: 'auto', defaultModelId: null })
+      const modelSelect = screen.getByTestId('chat-settings-trigger') as HTMLSelectElement
+      expect(modelSelect.value).toBe('auto')
+    })
+
+    it('keeps the full model id in title + aria-label so a truncated label stays discoverable', () => {
+      const longModels = [
+        {
+          id: 'long',
+          label: 'Claude Opus 4.7 Extended',
+          fullId: 'claude-opus-4-7-extended-thinking-1m-preview',
+          contextWindow: 1_000_000,
+        },
+      ]
+      renderDropdown({ availableModels: longModels, activeModel: 'long', defaultModelId: null })
+      const modelSelect = screen.getByTestId('chat-settings-trigger')
+      const title = modelSelect.getAttribute('title') ?? ''
+      const aria = modelSelect.getAttribute('aria-label') ?? ''
+      expect(title).toContain('claude-opus-4-7-extended-thinking-1m-preview')
+      expect(aria).toContain('claude-opus-4-7-extended-thinking-1m-preview')
+    })
+  })
+
   describe('active-model tooltip (#3888)', () => {
     it('exposes model id and context-window via title attribute', () => {
       renderDropdown({ activeModel: 'opus' })

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -40,11 +40,24 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(block![0]).not.toMatch(/flex-shrink:/)
   })
 
-  it('.header-right is a flex container — sizing pinned by the grid `auto` track', () => {
+  it('.header-right is a flex container, content-pinned so it never collapses its children (#5180)', () => {
     const block = css.match(/\.header-right\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
     expect(block![0]).toMatch(/display:\s*flex/)
-    expect(block![0]).not.toMatch(/flex-shrink:/)
+    // #5180: the right cluster must keep its intrinsic width so the bell,
+    // ⋯ overflow, cost badge and tokens sit side-by-side instead of
+    // shrinking on top of one another (the occlusion symptom). The grid's
+    // `auto` track plus `min-width: max-content` pin the column to its
+    // content. Strip CSS comments before asserting on declarations so
+    // explanatory prose mentioning `flex-shrink` doesn't trip the regex.
+    const decls = block![0].replace(/\/\*[\s\S]*?\*\//g, '')
+    expect(decls).toMatch(/min-width:\s*max-content/)
+  })
+
+  it('every direct child of .header-right is flex-shrink: 0 so no control overlaps a sibling (#5180)', () => {
+    const block = css.match(/\.header-right > \*\s*\{[^}]*\}/s)
+    expect(block, '.header-right > * rule must exist').toBeTruthy()
+    expect(block![0]).toMatch(/flex-shrink:\s*0/)
   })
 
   it('.header-right .status-bar (a flex item inside header-right) gets flex-shrink: 0 + nowrap', () => {
@@ -85,7 +98,12 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(model).toBeTruthy()
     expect(permission).toBeTruthy()
     expect(thinking).toBeTruthy()
-    expect(model![0]).toMatch(/min-width:\s*180px/)
+    // #5181: the model select is content-aware (width: auto) with a small
+    // min-width floor so short ids ("Auto") don't float in an over-wide
+    // box, and a 240px max-width cap so long ids truncate-with-ellipsis
+    // in place rather than overflowing onto the right cluster.
+    expect(model![0]).toMatch(/width:\s*auto/)
+    expect(model![0]).toMatch(/min-width:\s*90px/)
     expect(model![0]).toMatch(/max-width:\s*240px/)
     expect(permission![0]).toMatch(/min-width:\s*110px/)
     expect(permission![0]).toMatch(/max-width:\s*160px/)
@@ -145,8 +163,27 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     // 100/140 floor was only valid when all three selects shared one rule.
     const block = css.match(/@media \(max-width: 600px\)\s*\{[\s\S]*?\n\}/)
     expect(block).toBeTruthy()
-    expect(block![0]).toMatch(/select\[data-kind="model"\]\s*\{\s*min-width:\s*120px;\s*max-width:\s*160px/)
+    // #5181: model floor relaxed to 80px at narrow widths so short ids
+    // aren't padded into a wide box; the 160px cap keeps long ids from
+    // pushing the right cluster off-screen on phones.
+    expect(block![0]).toMatch(/select\[data-kind="model"\]\s*\{\s*min-width:\s*80px;\s*max-width:\s*160px/)
     expect(block![0]).toMatch(/select\[data-kind="permission"\]\s*\{\s*min-width:\s*80px;\s*max-width:\s*110px/)
     expect(block![0]).toMatch(/select\[data-kind="thinking"\]\s*\{\s*min-width:\s*60px;\s*max-width:\s*80px/)
+  })
+
+  // #5179 (C1): the token meter stacks the fill bar beneath the label.
+  it('.status-context-meter--stacked is a column so the bar sits under the label (#5179)', () => {
+    const block = css.match(/\.status-context-meter--stacked\s*\{[^}]*\}/s)
+    expect(block, '.status-context-meter--stacked rule must exist').toBeTruthy()
+    expect(block![0]).toMatch(/flex-direction:\s*column/)
+    // align-items: stretch lets the bar span the label width and anchor
+    // to the same left edge instead of floating at a fixed inline width.
+    expect(block![0]).toMatch(/align-items:\s*stretch/)
+  })
+
+  it('the stacked meter bar spans the column width instead of the inline 50px floor (#5179)', () => {
+    const block = css.match(/\.status-context-meter--stacked \.status-context-bar\s*\{[^}]*\}/s)
+    expect(block, 'stacked bar override rule must exist').toBeTruthy()
+    expect(block![0]).toMatch(/width:\s*auto/)
   })
 })

--- a/packages/dashboard/src/components/StatusBar.test.tsx
+++ b/packages/dashboard/src/components/StatusBar.test.tsx
@@ -305,6 +305,59 @@ describe('StatusBar', () => {
       expect(screen.queryByTestId('status-context-meter')).not.toBeInTheDocument()
     })
 
+    // #5179 (C1): the fill bar sits BENEATH the `used / total tokens`
+    // label, not inline to its left. We assert both the stacked layout
+    // hook (`status-context-meter--stacked`) AND the DOM order (label
+    // before bar) so the visual stacking can't silently regress.
+    describe('#5179 — fill bar stacked beneath the token label', () => {
+      it('applies the stacked layout class to the meter', () => {
+        render(
+          <StatusBar
+            contextPercent={30}
+            inputTokens={60000}
+            outputTokens={0}
+            contextWindow={200_000}
+          />,
+        )
+        const meter = screen.getByTestId('status-context-meter')
+        expect(meter.className).toContain('status-context-meter--stacked')
+      })
+
+      it('renders the label BEFORE the bar in DOM order (label on top, bar below)', () => {
+        render(
+          <StatusBar
+            contextPercent={30}
+            inputTokens={60000}
+            outputTokens={0}
+            contextWindow={200_000}
+          />,
+        )
+        const meter = screen.getByTestId('status-context-meter')
+        const children = Array.from(meter.children)
+        const labelIdx = children.findIndex(c =>
+          c.classList.contains('status-context-label'))
+        const barIdx = children.findIndex(c =>
+          c.classList.contains('status-context-bar'))
+        expect(labelIdx).toBeGreaterThanOrEqual(0)
+        expect(barIdx).toBeGreaterThanOrEqual(0)
+        // Label must come first so it stacks on top of the bar.
+        expect(labelIdx).toBeLessThan(barIdx)
+      })
+
+      it('keeps the progressbar a11y semantics intact in the stacked layout', () => {
+        render(
+          <StatusBar
+            contextPercent={45}
+            inputTokens={90000}
+            outputTokens={0}
+            contextWindow={200_000}
+          />,
+        )
+        const bar = screen.getByRole('progressbar', { name: /context window usage/i })
+        expect(bar.getAttribute('aria-valuenow')).toBe('45')
+      })
+    })
+
     it('inherits the contextTooltip on the meter (same in/out breakdown as the text chip)', () => {
       render(
         <StatusBar

--- a/packages/dashboard/src/components/StatusBar.tsx
+++ b/packages/dashboard/src/components/StatusBar.tsx
@@ -145,12 +145,27 @@ export function StatusBar({
         </span>
       )}
       {showMeter ? (
+        // #5179: stack the fill bar BENEATH the `used / total tokens`
+        // label rather than inline to its left. The label reads first
+        // (it's the at-a-glance number); the bar is a secondary, visual
+        // reinforcement that aligns to the label's left edge and spans
+        // the label width. `status-context-meter--stacked` flips the
+        // flex direction to column so the two children stack.
         <span
-          className="status-context-meter"
+          className="status-context-meter status-context-meter--stacked"
           data-testid="status-context-meter"
           title={contextTip}
           aria-label={contextTip}
         >
+          <span
+            className="status-context-label"
+            data-testid="status-context-label"
+          >
+            {formatTokensCompact(usedTokens)}
+            {' / '}
+            {formatTokensCompact(contextWindow)}
+            {' tokens'}
+          </span>
           <span
             className={`status-context-bar${meterClass}`}
             role="progressbar"
@@ -163,15 +178,6 @@ export function StatusBar({
               className="status-context-fill"
               style={{ width: `${meterFillWidth}%` }}
             />
-          </span>
-          <span
-            className="status-context-label"
-            data-testid="status-context-label"
-          >
-            {formatTokensCompact(usedTokens)}
-            {' / '}
-            {formatTokensCompact(contextWindow)}
-            {' tokens'}
           </span>
         </span>
       ) : (

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -135,8 +135,19 @@
    permission and thinking selects too, where it visually crowded the
    right zone (icons + cost) for no reason — those selects' longest
    labels are "Accept Edits" and "Default" respectively. */
+/* #5181: responsive model dropdown. The previous hard `min-width: 180px`
+   was a forcing function that surfaced two bugs: short ids ("Auto")
+   looked cramped/floating inside an over-wide box, and the `max-width`
+   alone didn't stop very long ids from pushing the right-zone cluster
+   under the sidebar at narrow widths. Switch to content-aware sizing:
+   `width: auto` lets the select size to its label, a small `min-width`
+   floor keeps short labels legible without padding them into a wide
+   empty box, and the `max-width` cap (combined with the select's own
+   `text-overflow: ellipsis`) truncates long ids in place instead of
+   overflowing the grid column onto its neighbours. */
 .header-center select[data-kind="model"] {
-  min-width: 180px;
+  width: auto;
+  min-width: 90px;
   max-width: 240px;
 }
 .header-center select[data-kind="permission"] {
@@ -169,7 +180,10 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   flex-shrink: 1;
-  min-width: 180px;
+  /* #5181: mirror the model <select>'s responsive sizing so the
+     read-only TUI pill sits cleanly in the same slot — content-aware
+     width with a small floor and the same 240px truncation cap. */
+  min-width: 90px;
   max-width: 240px;
   display: inline-block;
 }
@@ -309,12 +323,23 @@
   display: flex;
   gap: 8px;
   align-items: center;
-  min-width: 0;
-  /* As a grid item, this column is sized by `grid-template-columns: ... auto`
-     on #header — it pins to content width automatically. No flex-shrink
-     needed (would be a no-op anyway since this isn't a flex item). The
-     `min-width: 0` here lets the inner flex distribute children correctly
-     without forcing a horizontal scroll. */
+  /* #5180: the right cluster (bell, ⋯ overflow, cost badge, tokens) is
+     content-pinned by the grid's `auto` track. Each child must keep its
+     own width so they sit side-by-side instead of collapsing on top of
+     one another — the occlusion symptom was a child shrinking to zero
+     and the next one painting over it. `min-width: max-content` stops
+     the column from being squeezed narrower than its children need, and
+     the per-child `flex-shrink: 0` below guarantees no individual control
+     gets clipped. The center column's `minmax(0, 1fr)` absorbs the
+     remaining space, so it (not the right cluster) is what yields when
+     the window narrows. */
+  min-width: max-content;
+}
+
+/* #5180: every direct control in the right cluster keeps its intrinsic
+   width — none may shrink and overlap a sibling. */
+.header-right > * {
+  flex-shrink: 0;
 }
 
 /* Status bar lives inside header-right (cost + tokens). It must NOT shrink
@@ -4133,6 +4158,16 @@ button.sidebar-token-view-session-row:hover {
   font-family: var(--font-mono);
 }
 
+/* #5179: stacked variant — label on top, fill bar beneath it, both
+   left-aligned to the same edge. `align-items: stretch` lets the bar
+   span the full label width so the bar visually anchors to the number
+   it describes instead of floating at a fixed 50px to its left. */
+.status-context-meter--stacked {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 3px;
+}
+
 .status-context-bar {
   display: inline-block;
   width: 50px;
@@ -4141,6 +4176,13 @@ button.sidebar-token-view-session-row:hover {
   border-radius: 3px;
   overflow: hidden;
   flex-shrink: 0;
+}
+
+/* In the stacked layout the bar spans the label width (set by the
+   column's stretch) rather than the inline 50px floor. */
+.status-context-meter--stacked .status-context-bar {
+  display: block;
+  width: auto;
 }
 
 .status-context-fill {
@@ -5100,14 +5142,14 @@ button.sidebar-token-view-session-row:hover {
   }
   /* Narrow-viewport floors: relaxed across all kinds (#3705) so the grid's
      center column can shrink without overflow. Per-kind ratios preserved. */
-  .header-center select[data-kind="model"] { min-width: 120px; max-width: 160px; }
+  .header-center select[data-kind="model"] { min-width: 80px; max-width: 160px; }
   .header-center select[data-kind="permission"] { min-width: 80px; max-width: 110px; }
   .header-center select[data-kind="thinking"] { min-width: 60px; max-width: 80px; }
   /* #4464: match the model <select>'s narrow-viewport floors. Without
      this rule the read-only badge keeps the 180–240px desktop floor and
      overflows the header center column on phone widths. */
   .header-center .chat-settings-readonly-badge {
-    min-width: 120px;
+    min-width: 80px;
     max-width: 160px;
     font-size: var(--text-sm);
     padding: 3px 6px;


### PR DESCRIPTION
Coherent design pass over the dashboard top bar (epic #5170 — Control Room v2). All four issues touch the same header (`App.tsx` `#header`, `StatusBar`, `ChatSettingsDropdown`, the cost/overflow cluster), so they ship in one PR to avoid layout conflicts.

## What changed

### C1 (#5179) — token bar under the "x / 200k tokens" text
The context meter previously rendered the fill bar inline, to the left of the label. New `status-context-meter--stacked` modifier flips the meter to a column: the `used / total tokens` label renders first (on top) and the bar sits beneath it, spanning the label width (`align-items: stretch`, bar `width: auto`).

### C2 (#5180) — top-right cluster occlusion
`header-right` is now content-pinned with `min-width: max-content`, and every direct child (`bell`, `⋯` overflow, status bar with cost + tokens) gets `flex-shrink: 0`. This stops controls collapsing on top of one another (the occlusion symptom). The center column's `minmax(0, 1fr)` is what yields when the window narrows, never the right cluster.

### C3 (#5181) — responsive model dropdown
Removed the fixed `min-width: 180px` forcing-function floor. The model `<select>` is now content-aware (`width: auto`) with a small 90px floor so short ids ("Auto") don't float in an over-wide box, and the 240px cap + the select's existing `text-overflow: ellipsis` truncates long ids in place instead of pushing the right cluster off-screen. Narrow-viewport floors and the read-only TUI pill mirror the same sizing.

### D1 (#5182) — top status dot reflects Connected (tunnel), not Running
Made the dot's binding explicit: it tracks `connectionPhase` (the WS/tunnel connection) and is green (`.connected`) only when genuinely connected end-to-end, decoupled from any daemon "running" state. The separate "Running" indicator lives on the left projects/explorer header (#5192) and is deliberately not wired here.

## Verification
- `npm test` — 153 files, 3037 tests green
- `tsc --noEmit` clean; `vite build` passes
- Visual: rendered the header against the built CSS at short / long / minimal model-name widths — token bar stacks under the text, long ids truncate with ellipsis without disturbing neighbors, all right-cluster controls stay visible side-by-side, green connected dot present.

## Tests added/updated
- `StatusBar.test.tsx` — stacked-meter class + label-before-bar DOM order + a11y intact
- `ChatSettingsDropdown.test.tsx` — `data-kind="model"` hook, short/long label rendering, full id discoverable via title/aria-label
- `App.test.tsx` — status-dot connected vs disconnected vs reconnecting binding; all top-bar controls render together
- `HeaderOverflow.test.tsx` — CSS-audit updated for the new sizing + stacked-meter rules

Closes #5179. Closes #5180. Closes #5181. Closes #5182.