### PR TITLE
feat(dashboard): fold per-session activity into Control Room, retire v1 panel (#5176)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -276,9 +276,6 @@ export function App() {
   const sessions = useConnectionStore(s => s.sessions)
   const sessionStates = useConnectionStore(s => s.sessionStates)
   const activeSessionId = useConnectionStore(s => s.activeSessionId)
-  // #5163 (epic #5159) — Control Room activity tree, rendered by the sidebar
-  // panel slot's Control Room view.
-  const activity = useConnectionStore(s => s.activity)
   const viewMode = useConnectionStore(s => s.viewMode)
   const availableModels = useConnectionStore(s => s.availableModels)
   const availableModelsProvider = useConnectionStore(s => s.availableModelsProvider)
@@ -2219,7 +2216,6 @@ export function App() {
           searchConversations={searchConversations}
           clearSearchResults={clearSearchResults}
           sessions={sessions}
-          activity={activity}
           initialPanelHeight={loadPersistedSidebarPanelHeight() ?? 200}
           initialPanelView={loadPersistedSidebarPanelView()}
           initialPanelCollapsed={loadPersistedSidebarPanelCollapsed()}

--- a/packages/dashboard/src/components/ActivityTree.test.tsx
+++ b/packages/dashboard/src/components/ActivityTree.test.tsx
@@ -1,10 +1,13 @@
 /**
- * ControlRoomPanel tests (#5163, epic #5159).
+ * ActivityTree tests (#5176, epic #5170).
  *
- * Covers the read-only live tree rendering: hierarchy/indentation, status
- * badges, live + frozen elapsed timers, the blocked-state highlight, and
- * expand-to-output. The store wiring is covered separately in
- * dispatch-control-room-activity.test.ts.
+ * The reusable per-session activity tree extracted from the retired Control
+ * Room v1 sidebar panel. Covers the read-only live tree rendering:
+ * hierarchy/indentation, status badges, live + frozen elapsed timers, the
+ * blocked-state highlight, expand-to-output, and the session-scoped expansion
+ * reset (id collision guard). The store wiring is covered separately in
+ * dispatch-control-room-activity.test.ts; the drill-down integration into the
+ * Control Room section is covered in ControlRoomSection.test.tsx.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
@@ -15,7 +18,7 @@ import {
   type ActivityEntry,
   type ActivityState,
 } from '@chroxy/store-core'
-import { ControlRoomPanel, controlRoomCollapsedMetric, formatElapsed } from './ControlRoomPanel'
+import { ActivityTree, formatElapsed } from './ActivityTree'
 
 const SESSION_ID = 'sess-1'
 
@@ -44,14 +47,14 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-describe('ControlRoomPanel (#5163)', () => {
-  it('renders the empty state when there is no active session', () => {
-    render(<ControlRoomPanel activity={createEmptyActivityState()} activeSessionId={null} />)
+describe('ActivityTree (#5176)', () => {
+  it('renders the empty state when there is no session', () => {
+    render(<ActivityTree activity={createEmptyActivityState()} sessionId={null} />)
     expect(screen.getByTestId('control-room-empty')).toHaveTextContent('No active session')
   })
 
-  it('renders the empty state when the active session has no activity', () => {
-    render(<ControlRoomPanel activity={createEmptyActivityState()} activeSessionId={SESSION_ID} />)
+  it('renders the empty state when the session has no activity', () => {
+    render(<ActivityTree activity={createEmptyActivityState()} sessionId={SESSION_ID} />)
     expect(screen.getByTestId('control-room-empty')).toHaveTextContent('No activity in flight')
   })
 
@@ -61,7 +64,7 @@ describe('ControlRoomPanel (#5163)', () => {
       entry('b', { status: 'done', endedAt: 2000, label: 'Done thing' }),
       entry('c', { status: 'failed', endedAt: 3000, label: 'Failed thing' }),
     ])
-    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+    render(<ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 1000} />)
 
     expect(screen.getByTestId('control-room-entry-label-a')).toHaveTextContent('Run a search')
     expect(screen.getByTestId('control-room-status-a')).toHaveTextContent('Running')
@@ -76,7 +79,7 @@ describe('ControlRoomPanel (#5163)', () => {
       entry('parent', { kind: 'agent' }),
       entry('child', { kind: 'tool', parentId: 'parent' }),
     ])
-    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+    render(<ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 1000} />)
 
     const parentToggle = screen.getByTestId('control-room-entry-toggle-parent')
     const childToggle = screen.getByTestId('control-room-entry-toggle-child')
@@ -90,7 +93,7 @@ describe('ControlRoomPanel (#5163)', () => {
       entry('live', { status: 'running', startedAt: 0 }),
       entry('done', { status: 'done', startedAt: 0, endedAt: 5000 }),
     ])
-    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 10_000} />)
+    render(<ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 10_000} />)
     // Live entry: 10s elapsed against the injected clock.
     expect(screen.getByTestId('control-room-elapsed-live')).toHaveTextContent('10s')
     // Terminal entry: frozen at endedAt - startedAt = 5s, ignoring the clock.
@@ -101,7 +104,7 @@ describe('ControlRoomPanel (#5163)', () => {
     vi.useFakeTimers()
     let clock = 1000
     const activity = buildActivity([entry('live', { status: 'running', startedAt: 1000 })])
-    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => clock} />)
+    render(<ActivityTree activity={activity} sessionId={SESSION_ID} now={() => clock} />)
     expect(screen.getByTestId('control-room-elapsed-live')).toHaveTextContent('0s')
 
     act(() => {
@@ -113,7 +116,7 @@ describe('ControlRoomPanel (#5163)', () => {
 
   it('highlights blocked entries with the blocked class', () => {
     const activity = buildActivity([entry('blk', { status: 'blocked', label: 'Waiting on you' })])
-    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+    render(<ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 1000} />)
     const toggle = screen.getByTestId('control-room-entry-toggle-blk')
     expect(toggle.className).toContain('control-room-entry-blocked')
     expect(toggle).toHaveAttribute('data-status', 'blocked')
@@ -123,7 +126,7 @@ describe('ControlRoomPanel (#5163)', () => {
     const activity = buildActivity([
       entry('a', { outputRef: { kind: 'tool_use', id: 'tool-42' } }),
     ])
-    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+    render(<ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 1000} />)
     expect(screen.queryByTestId('control-room-output-a')).toBeNull()
 
     fireEvent.click(screen.getByTestId('control-room-entry-toggle-a'))
@@ -135,25 +138,25 @@ describe('ControlRoomPanel (#5163)', () => {
     expect(screen.queryByTestId('control-room-output-a')).toBeNull()
   })
 
-  it('resets expansion state when the active session changes (id collision guard)', () => {
+  it('resets expansion state when the session changes (id collision guard)', () => {
     // Two sessions each have an entry with the SAME id 'a' (ids are only
     // unique within a session). Expanding it in session 1 must NOT carry over
     // and auto-expand the colliding id when switching to session 2.
     const s1 = buildActivity([entry('a', { outputRef: { kind: 'tool_use', id: 't1' } })], 's1')
     const s2 = buildActivity([entry('a', { outputRef: { kind: 'tool_use', id: 't2' } })], 's2')
     const { rerender } = render(
-      <ControlRoomPanel activity={s1} activeSessionId="s1" now={() => 1000} />,
+      <ActivityTree activity={s1} sessionId="s1" now={() => 1000} />,
     )
     fireEvent.click(screen.getByTestId('control-room-entry-toggle-a'))
     expect(screen.getByTestId('control-room-output-a')).toBeInTheDocument()
 
-    rerender(<ControlRoomPanel activity={s2} activeSessionId="s2" now={() => 1000} />)
+    rerender(<ActivityTree activity={s2} sessionId="s2" now={() => 1000} />)
     expect(screen.queryByTestId('control-room-output-a')).toBeNull()
   })
 
   it('shows a "no linked output" message when an entry has no outputRef', () => {
     const activity = buildActivity([entry('a')])
-    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 1000} />)
+    render(<ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 1000} />)
     fireEvent.click(screen.getByTestId('control-room-entry-toggle-a'))
     expect(screen.getByTestId('control-room-output-empty-a')).toHaveTextContent('No linked output yet')
   })
@@ -162,7 +165,7 @@ describe('ControlRoomPanel (#5163)', () => {
     vi.useFakeTimers()
     const setIntervalSpy = vi.spyOn(window, 'setInterval')
     const activity = buildActivity([entry('done', { status: 'done', endedAt: 2000 })])
-    render(<ControlRoomPanel activity={activity} activeSessionId={SESSION_ID} now={() => 5000} />)
+    render(<ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 5000} />)
     expect(setIntervalSpy).not.toHaveBeenCalled()
     setIntervalSpy.mockRestore()
   })
@@ -178,30 +181,5 @@ describe('formatElapsed', () => {
 
   it('clamps negative input to 0', () => {
     expect(formatElapsed(-1000)).toBe('0s')
-  })
-})
-
-describe('controlRoomCollapsedMetric', () => {
-  it('returns null when no active session', () => {
-    expect(controlRoomCollapsedMetric(createEmptyActivityState(), null)).toBeNull()
-  })
-
-  it('returns null when nothing is live', () => {
-    const activity = buildActivity([entry('done', { status: 'done', endedAt: 2000 })])
-    expect(controlRoomCollapsedMetric(activity, SESSION_ID)).toBeNull()
-  })
-
-  it('counts live entries and blocked entries', () => {
-    const activity = buildActivity([
-      entry('a', { status: 'running' }),
-      entry('b', { status: 'blocked' }),
-      entry('c', { status: 'done', endedAt: 2000 }),
-    ])
-    expect(controlRoomCollapsedMetric(activity, SESSION_ID)).toBe('2 live · 1 blocked')
-  })
-
-  it('omits the blocked suffix when nothing is blocked', () => {
-    const activity = buildActivity([entry('a', { status: 'running' })])
-    expect(controlRoomCollapsedMetric(activity, SESSION_ID)).toBe('1 live')
   })
 })

--- a/packages/dashboard/src/components/ActivityTree.tsx
+++ b/packages/dashboard/src/components/ActivityTree.tsx
@@ -34,6 +34,10 @@ export interface ActivityTreeProps {
   now?: () => number
 }
 
+// Stable empty tree for the null-session case so we don't allocate a new array
+// each render (keeps the `hasLiveEntry` / render path referentially cheap).
+const EMPTY_TREE: readonly ActivityTreeNode[] = []
+
 // Kind → glyph. Kept ASCII-ish so it renders in a small font without needing
 // an icon font. Mirrors the kinds in the protocol `ActivityKindSchema`
 // (agent / shell / tool).
@@ -241,7 +245,10 @@ function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand }: EntryTree
 }
 
 export function ActivityTree({ activity, sessionId, now = Date.now }: ActivityTreeProps) {
-  const tree = selectActivityTree(activity, sessionId ?? '')
+  // Only query the reducer for a real session — a null id has no tree, and
+  // selecting with an empty-string id would do pointless work (and could match
+  // a degenerate "" session key). The empty-state branch below renders for null.
+  const tree = sessionId !== null ? selectActivityTree(activity, sessionId) : EMPTY_TREE
   const live = hasLiveEntry(tree)
   const tick = useTick(live, now)
 

--- a/packages/dashboard/src/components/ActivityTree.tsx
+++ b/packages/dashboard/src/components/ActivityTree.tsx
@@ -1,19 +1,18 @@
 /**
- * ControlRoomPanel (#5163, epic #5159) — the v1 user-facing surface of the
- * Control Room: a read-only live tree of everything in flight inside the
- * active session (subagents, background shells, long-running tools), each with
- * a status badge, a live-ticking elapsed timer, a kind icon, and an
- * expand-to-output affordance.
+ * ActivityTree (#5176, epic #5170) — the reusable, read-only live tree of a
+ * single session's in-flight work (subagents, background shells, long-running
+ * tools), each with a kind icon, status badge, a live-ticking elapsed timer,
+ * and an expand-to-output affordance.
  *
- * Slots into the sidebar panel slot (#4303) alongside the token view. It reads
- * the per-session activity state off the connection store (fed by the
- * store-core reducer from `activity_snapshot` / `activity_delta`) and renders
- * the tree via `selectActivityTree` so the dashboard and future mobile parity
- * share one tree-building implementation.
+ * This is the presentational core extracted from the retired Control Room v1
+ * sidebar panel (`ControlRoomPanel`, #5163). The same tree now drills down
+ * inside the main-tab `ControlRoomSection` (#5176): when an operator expands a
+ * repo row, the repo's active chroxy session is mapped to its activity tree and
+ * rendered here. Keeping one implementation means the v1 reducer / protocol /
+ * `selectActivityTree` stay the single source of truth for the tree shape.
  *
- * v1 is READ-ONLY: no cancel/kill/jump-to-intervene actions. Control actions,
- * the cross-session aggregate view, and mobile parity are tracked phase-2
- * fast-follows on the epic (#5159), not this panel.
+ * v1 is READ-ONLY: no cancel/kill/jump-to-intervene actions. Control actions
+ * and mobile parity are tracked phase-2 fast-follows on the epic (#5159).
  *
  * Blocked-on-input entries are visually prominent and tie into the dashboard's
  * intervention convention (#4891): a blocked entry pulses the same accent the
@@ -23,11 +22,11 @@ import { useCallback, useEffect, useState } from 'react'
 import type { ActivityEntry, ActivityState, ActivityTreeNode } from '@chroxy/store-core'
 import { selectActivityTree } from '@chroxy/store-core'
 
-export interface ControlRoomPanelProps {
+export interface ActivityTreeProps {
   /** Whole-store activity state (one tree per session). */
   activity: ActivityState
-  /** Active session whose tree is rendered. Null → empty state. */
-  activeSessionId: string | null
+  /** Session whose tree is rendered. Null → renders the empty state. */
+  sessionId: string | null
   /**
    * Injectable clock for deterministic tests. Defaults to `Date.now`. Used by
    * the elapsed timer; production passes nothing.
@@ -35,9 +34,9 @@ export interface ControlRoomPanelProps {
   now?: () => number
 }
 
-// Kind → glyph. Kept ASCII-ish so it renders in the sidebar's small font
-// without needing an icon font. Mirrors the kinds in the protocol
-// `ActivityKindSchema` (agent / shell / tool).
+// Kind → glyph. Kept ASCII-ish so it renders in a small font without needing
+// an icon font. Mirrors the kinds in the protocol `ActivityKindSchema`
+// (agent / shell / tool).
 const KIND_ICON: Record<ActivityEntry['kind'], string> = {
   agent: '◆',
   shell: '$',
@@ -241,19 +240,19 @@ function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand }: EntryTree
   )
 }
 
-export function ControlRoomPanel({ activity, activeSessionId, now = Date.now }: ControlRoomPanelProps) {
-  const tree = selectActivityTree(activity, activeSessionId ?? '')
+export function ActivityTree({ activity, sessionId, now = Date.now }: ActivityTreeProps) {
+  const tree = selectActivityTree(activity, sessionId ?? '')
   const live = hasLiveEntry(tree)
   const tick = useTick(live, now)
 
   const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => new Set())
-  // Copilot review: `ActivityEntry.id` is only unique WITHIN a session, so the
-  // expansion set must be scoped to the active session — otherwise switching
-  // sessions could auto-expand a colliding id in the new session or carry UI
-  // state across unrelated sessions. Reset on every active-session change.
+  // `ActivityEntry.id` is only unique WITHIN a session, so the expansion set
+  // must be scoped to the rendered session — otherwise switching sessions could
+  // auto-expand a colliding id in the new session or carry UI state across
+  // unrelated sessions. Reset on every session change.
   useEffect(() => {
     setExpandedIds(new Set())
-  }, [activeSessionId])
+  }, [sessionId])
   const handleToggleExpand = useCallback((id: string) => {
     setExpandedIds((prev) => {
       const next = new Set(prev)
@@ -263,7 +262,7 @@ export function ControlRoomPanel({ activity, activeSessionId, now = Date.now }: 
     })
   }, [])
 
-  if (activeSessionId === null) {
+  if (sessionId === null) {
     return (
       <div className="control-room-panel" data-testid="control-room-panel">
         <div className="control-room-empty" data-testid="control-room-empty">
@@ -294,33 +293,4 @@ export function ControlRoomPanel({ activity, activeSessionId, now = Date.now }: 
       />
     </div>
   )
-}
-
-/**
- * Collapsed-panel header metric for the Control Room (decision #4 in #4303):
- * a one-glance count of live (running/blocked) entries in the active session's
- * tree, so the operator sees in-flight work without expanding the panel.
- * Returns null when nothing is live so the slot can hide the metric.
- */
-export function controlRoomCollapsedMetric(
-  activity: ActivityState,
-  activeSessionId: string | null,
-): string | null {
-  if (activeSessionId === null) return null
-  const tree = selectActivityTree(activity, activeSessionId)
-  let live = 0
-  let blocked = 0
-  function walk(nodes: readonly ActivityTreeNode[]): void {
-    for (const node of nodes) {
-      if (!isTerminal(node.entry.status)) {
-        live += 1
-        if (node.entry.status === 'blocked') blocked += 1
-      }
-      walk(node.children)
-    }
-  }
-  walk(tree)
-  if (live === 0) return null
-  if (blocked > 0) return `${live} live · ${blocked} blocked`
-  return `${live} live`
 }

--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -311,6 +311,18 @@ describe('sessionIdForRepoPath (#5176)', () => {
     expect(sessionIdForRepoPath('/Users/me/Projects/chroxy', sessions)).toBe('s-deep')
   })
 
+  it('matches across Windows backslash vs forward-slash separators (mirrors server pathKey)', () => {
+    // The server's repo.path may arrive backslash-separated on Windows while a
+    // session cwd is forward-slash (or vice versa); normalization folds both.
+    const sessions = [makeSession('s-win', 'C:/Users/me/Projects/chroxy')]
+    expect(sessionIdForRepoPath('C:\\Users\\me\\Projects\\chroxy', sessions)).toBe('s-win')
+  })
+
+  it('matches a nested Windows cwd under a backslash repo path', () => {
+    const sessions = [makeSession('s-wt', 'C:\\Users\\me\\Projects\\chroxy\\wt')]
+    expect(sessionIdForRepoPath('C:/Users/me/Projects/chroxy', sessions)).toBe('s-wt')
+  })
+
   it('returns null when no session maps to the repo', () => {
     const sessions = [makeSession('s-other', '/Users/me/Projects/medlens')]
     expect(sessionIdForRepoPath('/Users/me/Projects/chroxy', sessions)).toBeNull()

--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -17,6 +17,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import type { ServerHostStatusSnapshotMessage } from '@chroxy/protocol'
+import type { ActivityEntry, ActivityState, SessionInfo } from '@chroxy/store-core'
+import { applyActivitySnapshot, createEmptyActivityState } from '@chroxy/store-core'
 
 // The component reads the store as a fallback when props are omitted; these
 // render tests always pass explicit props, so the store-selector path only
@@ -35,8 +37,46 @@ vi.mock('../store/connection', () => ({
 import {
   ControlRoomSection,
   formatGeneratedAgo,
+  sessionIdForRepoPath,
   HIGH_COUNT_THRESHOLD,
 } from './ControlRoomSection'
+
+// Minimal SessionInfo factory — only the fields the repo→session mapping reads
+// (`sessionId`, `cwd`) matter; the rest satisfy the type.
+function makeSession(sessionId: string, cwd: string): SessionInfo {
+  return {
+    sessionId,
+    name: sessionId,
+    cwd,
+    type: 'cli',
+    hasTerminal: false,
+    model: null,
+    permissionMode: null,
+    isBusy: false,
+    createdAt: 0,
+    conversationId: null,
+  }
+}
+
+function buildActivity(sessionId: string, entries: ActivityEntry[]): ActivityState {
+  return applyActivitySnapshot(createEmptyActivityState(), {
+    type: 'activity_snapshot',
+    sessionId,
+    schemaVersion: 1,
+    entries,
+  })
+}
+
+function activityEntry(id: string, over: Partial<ActivityEntry> = {}): ActivityEntry {
+  return {
+    id,
+    kind: 'agent',
+    label: `Label ${id}`,
+    status: 'running',
+    startedAt: 1000,
+    ...over,
+  }
+}
 
 afterEach(() => cleanup())
 
@@ -246,5 +286,111 @@ describe('formatGeneratedAgo (#5175)', () => {
   })
   it('clamps a future / clock-skewed timestamp to "just now"', () => {
     expect(formatGeneratedAgo(base + 60_000, base)).toBe('generated just now')
+  })
+})
+
+describe('sessionIdForRepoPath (#5176)', () => {
+  it('maps a repo path to the session whose cwd matches exactly', () => {
+    const sessions = [
+      makeSession('s-chroxy', '/Users/me/Projects/chroxy'),
+      makeSession('s-other', '/Users/me/Projects/medlens'),
+    ]
+    expect(sessionIdForRepoPath('/Users/me/Projects/chroxy', sessions)).toBe('s-chroxy')
+  })
+
+  it('tolerates a trailing-slash mismatch between repo path and cwd', () => {
+    const sessions = [makeSession('s-chroxy', '/Users/me/Projects/chroxy/')]
+    expect(sessionIdForRepoPath('/Users/me/Projects/chroxy', sessions)).toBe('s-chroxy')
+  })
+
+  it('falls back to the deepest nested cwd under the repo path (e.g. a worktree)', () => {
+    const sessions = [
+      makeSession('s-shallow', '/Users/me/Projects/chroxy/pkg'),
+      makeSession('s-deep', '/Users/me/Projects/chroxy/pkg/server'),
+    ]
+    expect(sessionIdForRepoPath('/Users/me/Projects/chroxy', sessions)).toBe('s-deep')
+  })
+
+  it('returns null when no session maps to the repo', () => {
+    const sessions = [makeSession('s-other', '/Users/me/Projects/medlens')]
+    expect(sessionIdForRepoPath('/Users/me/Projects/chroxy', sessions)).toBeNull()
+  })
+
+  it('does not treat a sibling repo with a shared prefix as nested', () => {
+    // /chroxy-2 starts with /chroxy but is NOT under /chroxy/.
+    const sessions = [makeSession('s-sibling', '/Users/me/Projects/chroxy-2')]
+    expect(sessionIdForRepoPath('/Users/me/Projects/chroxy', sessions)).toBeNull()
+  })
+})
+
+describe('ControlRoomSection activity drill-down (#5176)', () => {
+  const NOW_TICK = () => 5000
+
+  it('renders a drill-down toggle only for repos with a mapped active session', () => {
+    const sessions = [makeSession('s-chroxy', '/Users/me/Projects/chroxy')]
+    const activity = buildActivity('s-chroxy', [activityEntry('a1')])
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={NOW_TICK}
+        sessions={sessions}
+        activity={activity}
+      />,
+    )
+    // chroxy has a mapped session → disclosure toggle present.
+    expect(screen.getByTestId('cr-drill-toggle-chroxy')).toBeTruthy()
+    // medlens / no-it-all have no session → no toggle.
+    expect(screen.queryByTestId('cr-drill-toggle-medlens')).toBeNull()
+    expect(screen.queryByTestId('cr-drill-toggle-no-it-all')).toBeNull()
+  })
+
+  it('reveals the mapped session activity tree when a repo row is expanded', () => {
+    const sessions = [makeSession('s-chroxy', '/Users/me/Projects/chroxy')]
+    const activity = buildActivity('s-chroxy', [
+      activityEntry('a1', { label: 'build agent', status: 'running' }),
+      activityEntry('a2', { kind: 'shell', label: 'tail logs', status: 'blocked' }),
+    ])
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={NOW_TICK}
+        sessions={sessions}
+        activity={activity}
+      />,
+    )
+    // Collapsed by default — no tree yet.
+    expect(screen.queryByTestId('cr-activity-row-chroxy')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('cr-drill-toggle-chroxy'))
+
+    // Expanded: the activity tree renders the session's entries with status.
+    expect(screen.getByTestId('cr-activity-row-chroxy')).toBeTruthy()
+    expect(screen.getByTestId('control-room-tree')).toBeTruthy()
+    expect(screen.getByTestId('control-room-entry-label-a1')).toHaveTextContent('build agent')
+    expect(screen.getByTestId('control-room-status-a1')).toHaveTextContent('Running')
+    expect(screen.getByTestId('control-room-entry-label-a2')).toHaveTextContent('tail logs')
+    expect(screen.getByTestId('control-room-status-a2')).toHaveTextContent('Blocked')
+  })
+
+  it('shows the empty "no activity" state for a mapped session with no in-flight work', () => {
+    const sessions = [makeSession('s-chroxy', '/Users/me/Projects/chroxy')]
+    const activity = createEmptyActivityState()
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={NOW_TICK}
+        sessions={sessions}
+        activity={activity}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('cr-drill-toggle-chroxy'))
+    expect(screen.getByTestId('cr-activity-row-chroxy')).toBeTruthy()
+    expect(screen.getByTestId('control-room-empty')).toHaveTextContent('No activity in flight')
   })
 })

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -97,14 +97,22 @@ function isoDate(iso: string): string {
 }
 
 /**
- * Normalize a filesystem path for comparison: strip a single trailing slash
- * (but keep root "/"). The host survey's `repo.path` and a session's `cwd` come
- * from independent sources (server-side `git` walk vs. the session's launch
- * cwd) and one may carry a trailing slash the other doesn't.
+ * Normalize a filesystem path for comparison: convert backslashes to forward
+ * slashes, then strip a single trailing slash (but keep root "/"). The host
+ * survey's `repo.path` and a session's `cwd` come from independent sources
+ * (server-side `git` walk vs. the session's launch cwd) and one may carry a
+ * trailing slash the other doesn't.
+ *
+ * This deliberately mirrors the server's own Control Room binding normalization
+ * (`pathKey` in `packages/server/src/control-room/survey.js`) so the dashboard
+ * decides "this repo has a live session" on exactly the same key the server
+ * used to derive the repo's `live` verdict — including the backslash → slash
+ * fold that lets the drill-down resolve on Windows.
  */
 function normalizePath(path: string): string {
-  if (path.length > 1 && path.endsWith('/')) return path.slice(0, -1)
-  return path
+  const slashed = path.replace(/\\/g, '/')
+  if (slashed.length > 1 && slashed.endsWith('/')) return slashed.slice(0, -1)
+  return slashed
 }
 
 /**

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -9,8 +9,15 @@
  *
  * Lives in the dashboard's MAIN content tab bar (the wide area where Chat /
  * Output / Files / System / Envs / Snapshots live) — the fleet table is too
- * wide for the narrow sidebar. The old sidebar activity panel
- * (ControlRoomPanel) is a separate, unrelated surface retired in #5176.
+ * wide for the narrow sidebar.
+ *
+ * #5176 (epic #5170): the Control Room v1 per-session activity tree (the old
+ * sidebar `ControlRoomPanel`, retired here) is folded in as a per-repo
+ * drill-down. Each repo row maps its filesystem `path` to the active chroxy
+ * session whose `cwd` matches (`sessionIdForRepoPath`); expanding the row
+ * reveals that session's live activity tree (subagents / shells / tools) via
+ * the reused `ActivityTree` + v1 `selectActivityTree`. So nothing the v1 panel
+ * surfaced is lost — it just moved into the Control Room next to the verdict.
  *
  * Data flow: the Refresh button dispatches `host_status_request` via the store's
  * `requestHostStatus` action; the server replies with one `host_status_snapshot`
@@ -24,8 +31,12 @@
  *   - recent      → warn  (amber)  — recent uncommitted work; eyeball before touching.
  *   - onboarded   → ok    (green)  — on the pull-model; just needs a checkout+pull.
  */
+import { useCallback, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { RepoStatus, RepoVerdict, ServerHostStatusSnapshotMessage } from '@chroxy/protocol'
+import type { ActivityState, SessionInfo } from '@chroxy/store-core'
+import { createEmptyActivityState } from '@chroxy/store-core'
+import { ActivityTree } from './ActivityTree'
 
 // Verdict → semantic accent. The three buckets map onto the dashboard's
 // ok/warn/bad theme accents (green/amber/red). A single named map keeps the tag
@@ -83,6 +94,51 @@ function isoDate(iso: string): string {
   // Defensive: if it doesn't look like an ISO date, render it verbatim.
   const m = /^(\d{4}-\d{2}-\d{2})/.exec(iso)
   return m ? m[1]! : iso
+}
+
+/**
+ * Normalize a filesystem path for comparison: strip a single trailing slash
+ * (but keep root "/"). The host survey's `repo.path` and a session's `cwd` come
+ * from independent sources (server-side `git` walk vs. the session's launch
+ * cwd) and one may carry a trailing slash the other doesn't.
+ */
+function normalizePath(path: string): string {
+  if (path.length > 1 && path.endsWith('/')) return path.slice(0, -1)
+  return path
+}
+
+/**
+ * Map a repo (by its filesystem `path`) to the session id of the active chroxy
+ * session whose `cwd` matches that path — the link that lets the Control Room
+ * drill down into a repo's live activity tree.
+ *
+ * Match precedence:
+ *   1. Exact (normalized) `cwd === repo.path`.
+ *   2. A session whose `cwd` is nested under `repo.path` (e.g. a worktree or
+ *      subdir launch) — closest (longest) match wins so a session in
+ *      `/repo/sub` prefers `/repo/sub` over `/repo`.
+ *
+ * Returns null when no session maps to the repo. Exported for direct unit
+ * testing of the mapping rule.
+ */
+export function sessionIdForRepoPath(repoPath: string, sessions: readonly SessionInfo[]): string | null {
+  const target = normalizePath(repoPath)
+  // Exact match first.
+  for (const s of sessions) {
+    if (normalizePath(s.cwd) === target) return s.sessionId
+  }
+  // Nested fallback: pick the session whose cwd is the deepest path under the
+  // repo (a `${target}/...` prefix). Longest cwd wins the tie.
+  let best: { sessionId: string; depth: number } | null = null
+  const prefix = target === '/' ? '/' : `${target}/`
+  for (const s of sessions) {
+    const cwd = normalizePath(s.cwd)
+    if (cwd.startsWith(prefix)) {
+      const depth = cwd.length
+      if (best === null || depth > best.depth) best = { sessionId: s.sessionId, depth }
+    }
+  }
+  return best ? best.sessionId : null
 }
 
 interface SummaryChip {
@@ -164,12 +220,46 @@ function AttributionCell({ attribution }: { attribution: boolean | null }) {
   )
 }
 
-function RepoRows({ repo }: { repo: RepoStatus }) {
+interface RepoRowsProps {
+  repo: RepoStatus
+  /** Whole-store activity state, for the drill-down tree. */
+  activity: ActivityState
+  /** Active sessions, used to map this repo's path → its session id. */
+  sessions: readonly SessionInfo[]
+  /** Whether this repo's activity drill-down is expanded. */
+  expanded: boolean
+  /** Toggle the drill-down for this repo (keyed by repo.path). */
+  onToggleExpand: (path: string) => void
+  /** Injectable clock for the activity tree's elapsed timers (tests). */
+  now?: () => number
+}
+
+function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now }: RepoRowsProps) {
+  // Map repo → its active chroxy session (by cwd). When a session is found the
+  // name cell becomes a disclosure toggle that reveals that session's live
+  // activity tree (subagents / shells / tools — the retired v1 panel's view).
+  const sessionId = sessionIdForRepoPath(repo.path, sessions)
+  const drillable = sessionId !== null
+
   return (
     <>
-      <tr data-testid={`cr-row-${repo.name}`}>
+      <tr data-testid={`cr-row-${repo.name}`} className={repo.live ? 'cr-row-live' : undefined}>
         <td>
-          <b data-testid={`cr-name-${repo.name}`}>{repo.name}</b>
+          {drillable ? (
+            <button
+              type="button"
+              className="cr-drill-toggle"
+              data-testid={`cr-drill-toggle-${repo.name}`}
+              aria-expanded={expanded}
+              onClick={() => onToggleExpand(repo.path)}
+              title={expanded ? 'Hide live activity' : 'Show live activity'}
+            >
+              <span className="cr-drill-chevron" aria-hidden="true">{expanded ? '▼' : '▶'}</span>
+              <b data-testid={`cr-name-${repo.name}`}>{repo.name}</b>
+            </button>
+          ) : (
+            <b data-testid={`cr-name-${repo.name}`}>{repo.name}</b>
+          )}
           {repo.live && (
             <span
               className="cr-live-dot"
@@ -193,6 +283,18 @@ function RepoRows({ repo }: { repo: RepoStatus }) {
         <tr className="cr-act" data-testid={`cr-note-row-${repo.name}`}>
           <td colSpan={8}>
             <span className="cr-arrow" aria-hidden="true">↳</span> {repo.note}
+          </td>
+        </tr>
+      )}
+      {drillable && expanded && (
+        <tr className="cr-activity-row" data-testid={`cr-activity-row-${repo.name}`}>
+          <td colSpan={8}>
+            <div className="cr-activity-drill">
+              <div className="cr-activity-heading" data-testid={`cr-activity-heading-${repo.name}`}>
+                Live activity · {repo.name}
+              </div>
+              <ActivityTree activity={activity} sessionId={sessionId} now={now} />
+            </div>
           </td>
         </tr>
       )}
@@ -239,26 +341,59 @@ export interface ControlRoomSectionProps {
   connected?: boolean
   /** Refresh action. Defaults to the store's `requestHostStatus`. */
   onRefresh?: () => void
+  /**
+   * Whole-store activity state (one tree per session) for the per-repo
+   * drill-down. Defaults to the store's `activity`. Injectable for tests.
+   */
+  activity?: ActivityState
+  /**
+   * Active sessions, used to map a repo's `path` → its session id for the
+   * drill-down. Defaults to the store's `sessions`. Injectable for tests.
+   */
+  sessions?: readonly SessionInfo[]
   /** Injectable clock (epoch ms) for the "generated Nm ago" string. */
   now?: () => number
 }
+
+// Stable empty-activity default so the `activity` prop falling back to its
+// default doesn't allocate a new object each render.
+const EMPTY_ACTIVITY: ActivityState = createEmptyActivityState()
 
 export function ControlRoomSection({
   snapshot: snapshotProp,
   loading: loadingProp,
   connected: connectedProp,
   onRefresh: onRefreshProp,
+  activity: activityProp,
+  sessions: sessionsProp,
   now = Date.now,
 }: ControlRoomSectionProps = {}) {
   const storeSnapshot = useConnectionStore((s) => s.hostStatus)
   const storeLoading = useConnectionStore((s) => s.hostStatusLoading)
   const storeConnected = useConnectionStore((s) => s.connectionPhase === 'connected')
   const requestHostStatus = useConnectionStore((s) => s.requestHostStatus)
+  const storeActivity = useConnectionStore((s) => s.activity)
+  const storeSessions = useConnectionStore((s) => s.sessions)
 
   const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
   const loading = loadingProp !== undefined ? loadingProp : storeLoading
   const connected = connectedProp !== undefined ? connectedProp : storeConnected
   const onRefresh = onRefreshProp ?? requestHostStatus
+  const activity = activityProp ?? storeActivity ?? EMPTY_ACTIVITY
+  const sessions = sessionsProp ?? storeSessions ?? []
+
+  // Per-repo drill-down expansion, keyed by repo.path. A repo's row reveals its
+  // active session's live activity tree (subagents / shells / tools) when
+  // toggled — the per-session view folded in from the retired v1 panel (#5176).
+  const [expandedRepos, setExpandedRepos] = useState<ReadonlySet<string>>(() => new Set())
+  const handleToggleRepo = useCallback((path: string) => {
+    setExpandedRepos((prev) => {
+      const next = new Set(prev)
+      if (next.has(path)) next.delete(path)
+      else next.add(path)
+      return next
+    })
+  }, [])
 
   // Gate the refresh on connection state: a dropped request would otherwise
   // spin/no-op silently. Disabled while a refresh is in flight or disconnected.
@@ -369,7 +504,17 @@ export function ControlRoomSection({
                     <td colSpan={8} className="cr-dim">No repos found under {snapshot.root}.</td>
                   </tr>
                 ) : (
-                  snapshot.repos.map((repo) => <RepoRows key={repo.path} repo={repo} />)
+                  snapshot.repos.map((repo) => (
+                    <RepoRows
+                      key={repo.path}
+                      repo={repo}
+                      activity={activity}
+                      sessions={sessions}
+                      expanded={expandedRepos.has(repo.path)}
+                      onToggleExpand={handleToggleRepo}
+                      now={now}
+                    />
+                  ))
                 )}
               </tbody>
             </table>

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -5,13 +5,12 @@
  * Collapsible with Cmd+B toggle.
  */
 import { useState, useCallback, useRef, useMemo } from 'react'
-import type { ActivityState, CumulativeUsage, SessionInfo, SessionVisualStatus } from '@chroxy/store-core'
-import { createEmptyActivityState, formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
+import type { CumulativeUsage, SessionInfo, SessionVisualStatus } from '@chroxy/store-core'
+import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
 import { SidebarPanelSlot, type SidebarPanelView } from './SidebarPanelSlot'
 import { SidebarTokenView, tokenViewCollapsedMetric } from './SidebarTokenView'
-import { ControlRoomPanel, controlRoomCollapsedMetric } from './ControlRoomPanel'
 import type { SearchResult } from '../store/types'
 import {
   persistSidebarPanelHeight,
@@ -85,10 +84,6 @@ export interface SidebarProps {
   // #4303 — full sessions list (used by the bottom slot's token view).
   // Optional so existing tests + callers don't break; defaults to [].
   sessions?: SessionInfo[]
-  // #5163 (epic #5159) — Control Room activity state for the bottom slot's
-  // Control Room view. Optional so existing tests/callers default to an empty
-  // tree (the panel renders its "no activity" empty state).
-  activity?: ActivityState
   // #4303 — initial state for the bottom panel slot (loaded from
   // localStorage in App.tsx; defaults applied here).
   initialPanelHeight?: number
@@ -102,11 +97,6 @@ export interface SidebarProps {
   onReorderRepos?: (orderedRepoPaths: string[]) => void
   onReorderSessions?: (repoPath: string, orderedSessionIds: string[]) => void
 }
-
-// #5163 — stable empty-activity default so the `activity` prop falling back to
-// its default doesn't allocate a new object each render (which would break the
-// panelViews useMemo referential check below).
-const EMPTY_ACTIVITY: ActivityState = createEmptyActivityState()
 
 function abbreviateTunnel(url: string): string {
   try {
@@ -138,7 +128,6 @@ export function Sidebar({
   clearSearchResults,
   onWidthChange,
   sessions = [],
-  activity = EMPTY_ACTIVITY,
   initialPanelHeight = 200,
   initialPanelView = null,
   initialPanelCollapsed = false,
@@ -199,17 +188,10 @@ export function Sidebar({
       ),
       collapsedHeaderMetric: () => tokenViewCollapsedMetric(sessions),
     },
-    {
-      // #5163 (epic #5159) — Control Room: live read-only tree of the active
-      // session's in-flight subagents / background shells / tools.
-      id: 'control-room',
-      label: 'Control Room',
-      render: () => (
-        <ControlRoomPanel activity={activity} activeSessionId={activeSessionId} />
-      ),
-      collapsedHeaderMetric: () => controlRoomCollapsedMetric(activity, activeSessionId),
-    },
-  ]), [sessions, activeSessionId, onSessionClick, activity])
+    // #5176 (epic #5170) — the Control Room v1 sidebar panel was retired here;
+    // the per-session activity tree now drills down inside the main-tab
+    // ControlRoomSection (mapped repo → active session → activity tree).
+  ]), [sessions, activeSessionId, onSessionClick])
 
   const toggleRepo = useCallback((path: string) => {
     setCollapsed(prev => ({ ...prev, [path]: !prev[path] }))

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8515,6 +8515,54 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-purple);
 }
 
+/* #5176 — per-repo activity drill-down inside the Control Room table. The repo
+   name cell becomes a disclosure toggle; expanding reveals the active session's
+   live activity tree (folded in from the retired v1 sidebar panel). */
+.cr-drill-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.cr-drill-toggle:hover .cr-drill-chevron,
+.cr-drill-toggle:focus-visible .cr-drill-chevron {
+  color: var(--accent-purple);
+}
+
+.cr-drill-chevron {
+  font-size: 9px;
+  color: var(--text-muted);
+  width: 10px;
+  flex: 0 0 auto;
+}
+
+.cr-activity-row td {
+  padding-top: 0;
+  padding-bottom: 12px;
+}
+
+.cr-activity-drill {
+  border-left: 2px solid var(--accent-purple);
+  padding-left: 10px;
+  margin-left: 4px;
+}
+
+.cr-activity-heading {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+}
+
 .cr-num {
   text-align: center;
 }


### PR DESCRIPTION
## What

Final issue of epic #5170 (Control Room v2), **A6**. Retires the Control Room v1 per-session activity sidebar panel and folds its live tree (running subagents / background shells / tools) into the main-tab **Control Room** section as a per-repo drill-down — so the per-session activity is **not lost**, it just moves next to each repo's verdict.

## How

- **Reusable `ActivityTree`** — extracted the v1 panel's presentational tree (kind icons, status badges, live/frozen elapsed timers, the blocked-state highlight, expand-to-output, session-scoped expansion reset for the id-collision guard). Same rendering the old panel showed.
- **Retire the old panel** — removed `ControlRoomPanel` + its sidebar registration and the now-dead `activity` prop/wiring from `Sidebar` and `App`.
- **Drill-down in `ControlRoomSection`** — each repo row maps its filesystem `path` -> the active chroxy session whose `cwd` matches (`sessionIdForRepoPath`: exact match, trailing-slash tolerant, with a deepest-nested-cwd fallback for worktree/subdir launches). Repos with a mapped session get a disclosure toggle that reveals that session's live `ActivityTree`.

## v1 infra stays consumed (not orphaned)

The store-core activity reducer / protocol / `selectActivityTree` are unchanged and remain wired: `message-handler` still dispatches `activity_snapshot` / `activity_delta` into the store's `activity` slice, and `ControlRoomSection` reads `s.activity` + `s.sessions` to build the drill-down. `dispatch-control-room-activity.test.ts` stays green.

## Tests

- `ActivityTree.test.tsx` — rendering ported from the retired panel test (hierarchy, badges, timers, blocked highlight, expand-to-output, session-change expansion reset, no-interval-when-terminal).
- `ControlRoomSection.test.tsx` — `sessionIdForRepoPath` mapping rule (exact / trailing-slash / nested / sibling-prefix / none) + the section drill-down (toggle only for mapped repos, tree reveal on expand, empty state).
- Full dashboard suite: 3068 passing. `tsc --noEmit` clean. `vite build` passes.

Closes #5176