### PR TITLE
fix(dashboard): Control Room tab visibility + header cluster overflow + model dropdown width

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -220,6 +220,9 @@ function ViewSwitcher({
       >
         <button className={`view-tab${viewMode === 'chat' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('chat'); setSplitMode(null); persistSplitMode(null) }} type="button">Chat</button>
         <button className={`view-tab${viewMode === 'terminal' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('terminal'); setSplitMode(null); persistSplitMode(null) }} type="button">Output</button>
+        {/* #5197: Control Room sits right after Output (marquee feature) so it's
+            always visible instead of overflowing off the end of the tab bar. */}
+        <button className={`view-tab${viewMode === 'control-room' ? ' active' : ''}`} onClick={() => { setViewMode('control-room'); setSplitMode(null); persistSplitMode(null) }} type="button">Control Room</button>
         <button
           className={`view-tab${splitMode ? ' active' : ''}`}
           onClick={() => { const next: SplitDirection | null = splitMode ? null : 'horizontal'; setSplitMode(next); persistSplitMode(next) }}
@@ -235,7 +238,6 @@ function ViewSwitcher({
         <button className={`view-tab${viewMode === 'environments' ? ' active' : ''}`} onClick={() => { setViewMode('environments'); setSplitMode(null); persistSplitMode(null) }} type="button">Envs</button>
         <button className={`view-tab${viewMode === 'snapshots' ? ' active' : ''}`} onClick={() => { setViewMode('snapshots'); setSplitMode(null); persistSplitMode(null) }} type="button">Snapshots</button>
         <button className={`view-tab${viewMode === 'pool' ? ' active' : ''}`} onClick={() => { setViewMode('pool'); setSplitMode(null); persistSplitMode(null) }} type="button">Pool</button>
-        <button className={`view-tab${viewMode === 'control-room' ? ' active' : ''}`} onClick={() => { setViewMode('control-room'); setSplitMode(null); persistSplitMode(null) }} type="button">Control Room</button>
         <div className="view-switch-spacer" />
         <button className={`view-tab view-tab-right${checkpointsOpen ? ' active' : ''}`} onClick={() => setCheckpointsOpen(prev => !prev)} type="button" title="Toggle checkpoint timeline">Checkpoints</button>
         <button className={`view-tab${viewMode === 'diff' ? ' active' : ''}`} onClick={() => setViewMode('diff')} type="button">Diff</button>

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -16,11 +16,14 @@ import { resolve } from 'path'
 const css = readFileSync(resolve(__dirname, '../theme/components.css'), 'utf-8')
 
 describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
-  it('#header is a 3-column grid (auto | 1fr | auto) so zones cannot overlap', () => {
+  it('#header is a 3-column grid (auto | 1fr | minmax(0,auto)) so zones cannot overlap', () => {
     const block = css.match(/#header\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
     expect(block![0]).toMatch(/display:\s*grid/)
-    expect(block![0]).toMatch(/grid-template-columns:\s*auto\s+minmax\(0,\s*1fr\)\s+auto/)
+    // #5197: the right column is minmax(0, auto) — it can shrink below its
+    // content's max width so the cost badge truncates rather than the whole
+    // cluster clipping off the right edge of the window.
+    expect(block![0]).toMatch(/grid-template-columns:\s*auto\s+minmax\(0,\s*1fr\)\s+minmax\(0,\s*auto\)/)
   })
 
   it('#header has overflow: visible (native selects render outside header bounds)', () => {
@@ -40,18 +43,19 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(block![0]).not.toMatch(/flex-shrink:/)
   })
 
-  it('.header-right is a flex container, content-pinned so it never collapses its children (#5180)', () => {
+  it('.header-right is a flex container that can shrink (min-width: 0) so the cluster never clips off-window (#5180/#5197)', () => {
     const block = css.match(/\.header-right\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
     expect(block![0]).toMatch(/display:\s*flex/)
-    // #5180: the right cluster must keep its intrinsic width so the bell,
-    // ⋯ overflow, cost badge and tokens sit side-by-side instead of
-    // shrinking on top of one another (the occlusion symptom). The grid's
-    // `auto` track plus `min-width: max-content` pin the column to its
-    // content. Strip CSS comments before asserting on declarations so
-    // explanatory prose mentioning `flex-shrink` doesn't trip the regex.
+    // #5197: `min-width: max-content` (the #5180 fix) stopped sibling
+    // overlap but made the cluster overflow the WINDOW edge once the
+    // provider/model cost badge got long. `min-width: 0` lets the column
+    // yield; overlap is still prevented by per-child `flex-shrink: 0` (next
+    // test) while the squeeze is absorbed by the cost badge truncating.
+    // Strip CSS comments so explanatory prose doesn't trip the regex.
     const decls = block![0].replace(/\/\*[\s\S]*?\*\//g, '')
-    expect(decls).toMatch(/min-width:\s*max-content/)
+    expect(decls).toMatch(/min-width:\s*0/)
+    expect(decls).not.toMatch(/min-width:\s*max-content/)
   })
 
   it('every direct child of .header-right is flex-shrink: 0 so no control overlaps a sibling (#5180)', () => {
@@ -60,14 +64,23 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(block![0]).toMatch(/flex-shrink:\s*0/)
   })
 
-  it('.header-right .status-bar (a flex item inside header-right) gets flex-shrink: 0 + nowrap', () => {
-    // status-bar IS a flex item here (header-right is display: flex), so
-    // flex-shrink: 0 is the right primitive — without it, the cost +
-    // token text could truncate to "718 toke...".
+  it('.header-right .status-bar may shrink (#5197) so the cost badge truncates while the token meter stays fixed', () => {
+    // #5197: status-bar is the ONE right-cluster child allowed to shrink
+    // (flex-shrink: 1 + min-width: 0) so the long provider/model cost badge
+    // can ellipsis-truncate instead of pushing the token count off-screen.
     const block = css.match(/\.header-right \.status-bar\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
-    expect(block![0]).toMatch(/flex-shrink:\s*0/)
+    expect(block![0]).toMatch(/flex-shrink:\s*1/)
+    expect(block![0]).toMatch(/min-width:\s*0/)
     expect(block![0]).toMatch(/white-space:\s*nowrap/)
+    // The squeeze is absorbed by the cost badge (truncates), NOT the token
+    // meter or provider tag (both fixed) — so "61 / 200.0k tokens" is never
+    // clipped.
+    const cost = css.match(/\.status-cost\s*\{[^}]*\}/s)
+    expect(cost![0]).toMatch(/text-overflow:\s*ellipsis/)
+    expect(cost![0]).toMatch(/flex-shrink:\s*1/)
+    const meter = css.match(/\.status-context-meter\s*\{[^}]*\}/s)
+    expect(meter![0]).toMatch(/flex-shrink:\s*0/)
   })
 
   it('.header-center has min-width: 0 and overflow: hidden so its column can shrink without spilling', () => {
@@ -98,12 +111,13 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(model).toBeTruthy()
     expect(permission).toBeTruthy()
     expect(thinking).toBeTruthy()
-    // #5181: the model select is content-aware (width: auto) with a small
-    // min-width floor so short ids ("Auto") don't float in an over-wide
-    // box, and a 240px max-width cap so long ids truncate-with-ellipsis
-    // in place rather than overflowing onto the right cluster.
+    // #5197: a native <select> with `width: auto` does NOT grow to its
+    // label in WebKit — it collapses to min-width and truncates the rest
+    // ("Sonnet 4.6" → "Sonnet …"). The floor must fit the common model
+    // labels (160px shows "Sonnet 4.6"); the 240px cap still truncates
+    // pathologically long ids.
     expect(model![0]).toMatch(/width:\s*auto/)
-    expect(model![0]).toMatch(/min-width:\s*90px/)
+    expect(model![0]).toMatch(/min-width:\s*160px/)
     expect(model![0]).toMatch(/max-width:\s*240px/)
     expect(permission![0]).toMatch(/min-width:\s*110px/)
     expect(permission![0]).toMatch(/max-width:\s*160px/)

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -81,7 +81,11 @@
    own cell with explicit gap; only the center column flexes. */
 #header {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  /* #5197: the right column is `minmax(0, auto)` (not bare `auto`) so it can
+     shrink below its content's max width when the window is narrow — letting
+     the cost badge truncate in place instead of the whole cluster (token
+     count + usage bar) clipping off the right edge of the window. */
+  grid-template-columns: auto minmax(0, 1fr) minmax(0, auto);
   align-items: center;
   gap: 16px;
   padding: 10px 16px;
@@ -147,7 +151,12 @@
    overflowing the grid column onto its neighbours. */
 .header-center select[data-kind="model"] {
   width: auto;
-  min-width: 90px;
+  /* #5197: a native <select> with `width: auto` does NOT grow to its label
+     in WebKit — it collapses to `min-width` and ellipsis-truncates the rest
+     (the "Sonnet 4.6" → "Sonnet …" bug). The floor must therefore fit the
+     common model labels; 160px shows "Sonnet 4.6" / "Opus 4.8" in full while
+     the 240px cap still truncates pathologically long ids. */
+  min-width: 160px;
   max-width: 240px;
 }
 .header-center select[data-kind="permission"] {
@@ -180,10 +189,10 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   flex-shrink: 1;
-  /* #5181: mirror the model <select>'s responsive sizing so the
-     read-only TUI pill sits cleanly in the same slot — content-aware
-     width with a small floor and the same 240px truncation cap. */
-  min-width: 90px;
+  /* #5181 + #5197: mirror the model <select>'s sizing so the read-only TUI
+     pill sits cleanly in the same slot — 160px floor (fits "Sonnet 4.6")
+     with the same 240px truncation cap. */
+  min-width: 160px;
   max-width: 240px;
   display: inline-block;
 }
@@ -332,8 +341,12 @@
      the per-child `flex-shrink: 0` below guarantees no individual control
      gets clipped. The center column's `minmax(0, 1fr)` absorbs the
      remaining space, so it (not the right cluster) is what yields when
-     the window narrows. */
-  min-width: max-content;
+     the window narrows.
+     #5197: but `max-content` made the cluster overflow the WINDOW edge once
+     the provider/model cost badge got long — so allow the column to shrink
+     (`min-width: 0`) and push the yield down into the cost badge, which
+     truncates, while the small fixed controls below keep `flex-shrink: 0`. */
+  min-width: 0;
 }
 
 /* #5180: every direct control in the right cluster keeps its intrinsic
@@ -342,13 +355,14 @@
   flex-shrink: 0;
 }
 
-/* Status bar lives inside header-right (cost + tokens). It must NOT shrink
-   below its content — token count truncating to "718 toke..." was the
-   visible symptom. The 3-column grid above already protects the right
-   zone from the center, so the status bar is free to take whatever width
-   its content needs. */
+/* #5197: the status bar (provider badge + cost + token meter) is the ONE
+   right-cluster child allowed to shrink, so the long provider/model cost
+   badge can truncate instead of shoving the token count off-screen. The
+   token meter and provider badge inside it stay fixed (rules below); only
+   the cost badge absorbs the squeeze. */
 .header-right .status-bar {
-  flex-shrink: 0;
+  flex-shrink: 1;
+  min-width: 0;
   white-space: nowrap;
 }
 
@@ -4117,6 +4131,8 @@ button.sidebar-token-view-session-row:hover {
   border-radius: 3px;
   padding: 1px 6px;
   cursor: help;
+  /* #5197: the SDK/provider tag stays fixed; only the cost text truncates. */
+  flex-shrink: 0;
 }
 .status-provider[data-provider="sdk"] {
   color: var(--accent-orange);
@@ -4134,7 +4150,15 @@ button.sidebar-token-view-session-row:hover {
 .status-cost {
   color: var(--accent-green);
   font-family: var(--font-mono);
-  min-width: 60px;
+  /* #5197: the cost badge (esp. provider/model mode, e.g.
+     "Claude Code (SDK) · Sonnet 4.6") is the flexible element of the right
+     cluster — it truncates with an ellipsis when space is tight so the token
+     count and usage bar stay on-screen. */
+  min-width: 0;
+  flex-shrink: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .status-context {
@@ -4156,6 +4180,9 @@ button.sidebar-token-view-session-row:hover {
   gap: 6px;
   color: var(--text-muted);
   font-family: var(--font-mono);
+  /* #5197: the token count + usage bar never shrink — only the cost badge
+     does — so "61 / 200.0k tokens" is never clipped. */
+  flex-shrink: 0;
 }
 
 /* #5179: stacked variant — label on top, fill bar beneath it, both


### PR DESCRIPTION
Closes #5197

Three regressions found in the running v0.9.43 app after epic #5170 (user feedback + screenshots):

## 1. Control Room tab unreachable
A5 appended the "Control Room" tab to the end of an already-full tab bar, so it overflowed off the right edge ("Co…›"). **Moved it to right after Output** — the marquee feature is now always visible.

## 2. Top-right cluster clipped off the window edge
C2 over-corrected with `.header-right { min-width: max-content }` + children `flex-shrink: 0` — the cluster never yielded, so the long provider/model cost badge ("Claude Code (SDK) · Sonnet 4.6") pushed the token count + usage bar off the window's right edge. Now:
- grid col3 = `minmax(0, auto)` and `.header-right { min-width: 0 }` (column can shrink)
- `.status-bar` shrinks (`flex-shrink: 1; min-width: 0`); `.status-cost` truncates with ellipsis
- `.status-context-meter` + `.status-provider` stay `flex-shrink: 0` — the **token count is never clipped**, only the cost badge truncates when tight

## 3. Model dropdown over-truncated
C3's `width: auto` doesn't grow a native WebKit `<select>` — it collapsed to `min-width: 90px` and truncated "Sonnet 4.6" → "Sonnet …". Raised `min-width` to **160px** (fits common model labels); 240px cap still truncates pathological ids.

## Tests
Updated the `HeaderOverflow.test.tsx` CSS-pinning assertions to the new invariants (incl. new checks that the cost badge truncates while the token meter stays fixed). Full dashboard suite: 3070 passing; tsc + vite build clean.

Note: autonomous screenshot verification was blocked (the dev window won't come to foreground under automation), so these are verified by code + tests + build; visual confirm pending in the running app.