### PR TITLE
chore(release): bump version to 0.9.44 (Control Room v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Sidebar token-usage view: cache-hit ratio + per-session breakdown (#4303):** the bottom sidebar panel's token view now surfaces a cache-hit ratio in the aggregate strip (`cacheRead / (input + cacheRead + cacheCreation)` — the visible signal of prompt-caching effectiveness, hidden when there's no input surface) and a per-session breakdown sorted by total tokens. Per-session rows are click-to-activate (parity with the sidebar tree) and float the active session to the top with `aria-current`. claude-tui sessions remain excluded from the per-session list since they expose no token counts. Pure helper `cacheHitRatio(usage)` is unit-tested independently of React.
+
 ## [0.9.44] - 2026-06-05
 
 Control Room v2: a navigable host/repo status section plus a round of top-bar polish.
 
 ### Added
 
-- **Control Room section (epic #5159 / #5170):** a new main-content tab that surveys every managed repo (config `repos` ∪ auto-discovered git repos under a configurable root, default `~/Projects`) and renders a host/fleet status table — triage verdict (live / investigate / likely-abandoned / recent / onboarded), tree state, worktree count, open PRs, attribution, last-touched, and live-agent detection (a chroxy session bound to the repo, or a dirty-tree + recently-touched heuristic). On-demand Refresh snapshot over a new `host_status_request` / `host_status_snapshot` WS contract (#5171–#5175). Per-session activity (running agents/shells/tools) folds in as a per-repo drill-down (#5176), replacing the v1 sidebar panel.
+- **Control Room section (epic #5159 / #5170):** a new main-content view that surveys every managed repo (config `repos` ∪ auto-discovered git repos under a configurable root, default `~/Projects`) and renders a host/fleet status table — triage verdict (live / investigate / likely-abandoned / recent / onboarded), tree state, worktree count, open PRs, attribution, last-touched, and live-agent detection (a chroxy session bound to the repo, or a dirty-tree + recently-touched heuristic). Launched from a button in the sidebar bottom-panel slot header (#5200); the wide table opens in the main content area. On-demand Refresh snapshot over a new `host_status_request` / `host_status_snapshot` WS contract (#5171–#5175). Per-session activity (running agents/shells/tools) folds in as a per-repo drill-down (#5176), replacing the v1 sidebar panel.
 - **Configurable header cost badge (#5184):** the badge display is chosen in Settings — provider/model (default), cost, tokens, % context used, or session-type — persisted locally.
 - **Running indicator on the projects/explorer header (#5183).**
 
 ### Changed
 
 - **Top status dot now reflects Connected (tunnel), not Running (#5182).**
-- **Top-bar layout pass (#5179–#5181 + #5197):** token usage bar sits under the token count; right-cluster spacing reworked so controls no longer occlude one another; model dropdown is responsive and the cost badge truncates so the token count never clips; the Control Room tab sits after Output so it's always visible.
+- **Top-bar layout pass (#5179–#5181 + #5197 + #5200):** the header is now two stacked rows — the model/permission selectors on top, the cost/token cluster on its own row below — so the main bar is never crowded and the permission selector is no longer pushed past overflow; the token usage bar sits under the token count; the model dropdown is responsive and the cost badge truncates so the token count never clips. The Control Room moved off the top tab bar to a sidebar launcher (#5200), freeing the tab row.
 
 ### Fixed
 
 - **Background-work banner no longer sticks forever (#5177 / #5178):** completed background shells are reaped (output-file quiesce sweep) so the "Waiting on background work" indicator clears instead of hanging after the command exits.
-
-## [Unreleased]
-
-### Added
-
-- **Sidebar token-usage view: cache-hit ratio + per-session breakdown (#4303):** the bottom sidebar panel's token view now surfaces a cache-hit ratio in the aggregate strip (`cacheRead / (input + cacheRead + cacheCreation)` — the visible signal of prompt-caching effectiveness, hidden when there's no input surface) and a per-session breakdown sorted by total tokens. Per-session rows are click-to-activate (parity with the sidebar tree) and float the active session to the top with `aria-current`. claude-tui sessions remain excluded from the per-session list since they expose no token counts. Pure helper `cacheHitRatio(usage)` is unit-tested independently of React.
 
 ## [0.9.43] - 2026-06-03
 
@@ -138,8 +138,6 @@ Single-fix release. Voice input on macOS desktop finally produces transcripts �
 ### Follow-up issues filed during this sweep
 
 - #4986 — `speech.rs` 3-second SIGTERM kill-fallback in `stop()` previously masked this bug (helper "exited cleanly" via SIGKILL after Tauri timed out). The fallback should log a warning when it fires, so future bugs of this shape don't slip past local testing.
-
-
 
 ## [0.9.41] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.44] - 2026-06-05
+
+Control Room v2: a navigable host/repo status section plus a round of top-bar polish.
+
+### Added
+
+- **Control Room section (epic #5159 / #5170):** a new main-content tab that surveys every managed repo (config `repos` ∪ auto-discovered git repos under a configurable root, default `~/Projects`) and renders a host/fleet status table — triage verdict (live / investigate / likely-abandoned / recent / onboarded), tree state, worktree count, open PRs, attribution, last-touched, and live-agent detection (a chroxy session bound to the repo, or a dirty-tree + recently-touched heuristic). On-demand Refresh snapshot over a new `host_status_request` / `host_status_snapshot` WS contract (#5171–#5175). Per-session activity (running agents/shells/tools) folds in as a per-repo drill-down (#5176), replacing the v1 sidebar panel.
+- **Configurable header cost badge (#5184):** the badge display is chosen in Settings — provider/model (default), cost, tokens, % context used, or session-type — persisted locally.
+- **Running indicator on the projects/explorer header (#5183).**
+
+### Changed
+
+- **Top status dot now reflects Connected (tunnel), not Running (#5182).**
+- **Top-bar layout pass (#5179–#5181 + #5197):** token usage bar sits under the token count; right-cluster spacing reworked so controls no longer occlude one another; model dropdown is responsive and the cost badge truncates so the token count never clips; the Control Room tab sits after Output so it's always visible.
+
+### Fixed
+
+- **Background-work banner no longer sticks forever (#5177 / #5178):** completed background shells are reaped (output-file quiesce sweep) so the "Waiting on background work" indicator clears instead of hanging after the command exits.
+
 ## [Unreleased]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chroxy",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chroxy",
-      "version": "0.9.43",
+      "version": "0.9.44",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -16872,7 +16872,7 @@
     },
     "packages/app": {
       "name": "@chroxy/app",
-      "version": "0.9.43",
+      "version": "0.9.44",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16925,7 +16925,7 @@
     },
     "packages/dashboard": {
       "name": "@chroxy/dashboard",
-      "version": "0.9.43",
+      "version": "0.9.44",
       "dependencies": {
         "@chroxy/protocol": "*",
         "@chroxy/store-core": "*",
@@ -17035,11 +17035,11 @@
     },
     "packages/desktop": {
       "name": "@chroxy/desktop",
-      "version": "0.9.43"
+      "version": "0.9.44"
     },
     "packages/protocol": {
       "name": "@chroxy/protocol",
-      "version": "0.9.43",
+      "version": "0.9.44",
       "dependencies": {
         "zod": "^4.3.6"
       },
@@ -17050,7 +17050,7 @@
     },
     "packages/server": {
       "name": "@chroxy/server",
-      "version": "0.9.43",
+      "version": "0.9.44",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -17112,7 +17112,7 @@
     },
     "packages/store-core": {
       "name": "@chroxy/store-core",
-      "version": "0.9.43",
+      "version": "0.9.44",
       "dependencies": {
         "@chroxy/protocol": "*",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chroxy",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "private": true,
   "description": "Remote terminal for Claude Code from your phone",
   "workspaces": [

--- a/packages/app/app.json
+++ b/packages/app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Chroxy",
     "slug": "chroxy",
-    "version": "0.9.43",
+    "version": "0.9.44",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",

--- a/packages/app/ios/Chroxy/Info.plist
+++ b/packages/app/ios/Chroxy/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.9.43</string>
+    <string>0.9.44</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/app",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "description": "Chroxy mobile app",
   "main": "index.js",
   "scripts": {

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/dashboard",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -220,9 +220,10 @@ function ViewSwitcher({
       >
         <button className={`view-tab${viewMode === 'chat' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('chat'); setSplitMode(null); persistSplitMode(null) }} type="button">Chat</button>
         <button className={`view-tab${viewMode === 'terminal' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('terminal'); setSplitMode(null); persistSplitMode(null) }} type="button">Output</button>
-        {/* #5197: Control Room sits right after Output (marquee feature) so it's
-            always visible instead of overflowing off the end of the tab bar. */}
-        <button className={`view-tab${viewMode === 'control-room' ? ' active' : ''}`} onClick={() => { setViewMode('control-room'); setSplitMode(null); persistSplitMode(null) }} type="button">Control Room</button>
+        {/* #5200: the Control Room is launched from the bottom sidebar panel
+            slot (its header "Control Room" button), not a top tab — the wide
+            host/repo table gets the full main content area. The 'control-room'
+            viewMode still renders below; it just has no top-tab entry now. */}
         <button
           className={`view-tab${splitMode ? ' active' : ''}`}
           onClick={() => { const next: SplitDirection | null = splitMode ? null : 'horizontal'; setSplitMode(next); persistSplitMode(next) }}
@@ -2213,6 +2214,7 @@ export function App() {
           onFilterChange={setSidebarFilter}
           onSessionClick={handleSwitchSession}
           onResumeSession={resumeConversation}
+          onOpenControlRoom={() => { setViewMode('control-room'); setSplitMode(null); persistSplitMode(null) }}
           onNewSession={(cwd) => {
             setPendingCwd(cwd || null)
             setShowCreateSession(true)

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -2016,6 +2016,11 @@ export function App() {
 
       {/* Header */}
       <header id="header">
+        {/* #5200: two-row header — row 1 (.header-main) is the 3-column main
+            bar (logo/status | model+permission selects | bell + ⋯); the
+            cost/token cluster moved to row 2 (.header-meta) so the main bar
+            is never crowded and the permission selector isn't pushed out. */}
+        <div className="header-main">
         <div className="header-left">
           <span className="logo">Chroxy</span>
           {/* #4630 — version + status-dot were bare spans with no
@@ -2166,6 +2171,9 @@ export function App() {
             ]
             return <HeaderOverflowMenu items={overflowItems} />
           })()}
+        </div>
+        </div>
+        <div className="header-meta">
           <StatusBar
             cost={sessionCost ?? undefined}
             context={formatContext(contextUsage)}

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -16,14 +16,25 @@ import { resolve } from 'path'
 const css = readFileSync(resolve(__dirname, '../theme/components.css'), 'utf-8')
 
 describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
-  it('#header is a 3-column grid (auto | 1fr | minmax(0,auto)) so zones cannot overlap', () => {
+  it('#header is a flex column (two rows: .header-main + .header-meta) (#5200)', () => {
     const block = css.match(/#header\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/display:\s*flex/)
+    expect(block![0]).toMatch(/flex-direction:\s*column/)
+  })
+
+  it('.header-main is the 3-column main bar grid (auto | 1fr | auto) so zones cannot overlap (#5200)', () => {
+    const block = css.match(/\.header-main\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
     expect(block![0]).toMatch(/display:\s*grid/)
-    // #5197: the right column is minmax(0, auto) — it can shrink below its
-    // content's max width so the cost badge truncates rather than the whole
-    // cluster clipping off the right edge of the window.
-    expect(block![0]).toMatch(/grid-template-columns:\s*auto\s+minmax\(0,\s*1fr\)\s+minmax\(0,\s*auto\)/)
+    expect(block![0]).toMatch(/grid-template-columns:\s*auto\s+minmax\(0,\s*1fr\)\s+auto/)
+  })
+
+  it('.header-meta is the right-aligned second row holding the cost/token cluster (#5200)', () => {
+    const block = css.match(/\.header-meta\s*\{[^}]*\}/s)
+    expect(block).toBeTruthy()
+    expect(block![0]).toMatch(/display:\s*flex/)
+    expect(block![0]).toMatch(/justify-content:\s*flex-end/)
   })
 
   it('#header has overflow: visible (native selects render outside header bounds)', () => {
@@ -64,11 +75,12 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(block![0]).toMatch(/flex-shrink:\s*0/)
   })
 
-  it('.header-right .status-bar may shrink (#5197) so the cost badge truncates while the token meter stays fixed', () => {
-    // #5197: status-bar is the ONE right-cluster child allowed to shrink
-    // (flex-shrink: 1 + min-width: 0) so the long provider/model cost badge
-    // can ellipsis-truncate instead of pushing the token count off-screen.
-    const block = css.match(/\.header-right \.status-bar\s*\{[^}]*\}/s)
+  it('.header-meta .status-bar may shrink (#5200) so the cost badge truncates while the token meter stays fixed', () => {
+    // #5200: status-bar lives on its own row (.header-meta) now. It can still
+    // shrink (flex-shrink: 1 + min-width: 0) so the long provider/model cost
+    // badge ellipsis-truncates rather than the token count clipping if the
+    // window is ever narrower than the cluster.
+    const block = css.match(/\.header-meta \.status-bar\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
     expect(block![0]).toMatch(/flex-shrink:\s*1/)
     expect(block![0]).toMatch(/min-width:\s*0/)

--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -117,6 +117,20 @@ describe('Sidebar', () => {
     expect(onResumeSession).toHaveBeenCalledWith('c1')
   })
 
+  it('#5200: shows a Control Room launcher in the panel slot that calls onOpenControlRoom', () => {
+    const onOpenControlRoom = vi.fn()
+    renderSidebar({ onOpenControlRoom })
+    const launcher = screen.getByTestId('sidebar-panel-slot-launcher-control-room')
+    expect(launcher).toBeInTheDocument()
+    fireEvent.click(launcher)
+    expect(onOpenControlRoom).toHaveBeenCalledTimes(1)
+  })
+
+  it('#5200: no Control Room launcher when onOpenControlRoom is not provided', () => {
+    renderSidebar()
+    expect(screen.queryByTestId('sidebar-panel-slot-launcher-control-room')).toBeNull()
+  })
+
   it('calls onNewSession when new session button clicked', () => {
     const onNewSession = vi.fn()
     renderSidebar({ onNewSession })

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -9,7 +9,7 @@ import type { CumulativeUsage, SessionInfo, SessionVisualStatus } from '@chroxy/
 import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
-import { SidebarPanelSlot, type SidebarPanelView } from './SidebarPanelSlot'
+import { SidebarPanelSlot, type SidebarPanelView, type SidebarPanelLauncher } from './SidebarPanelSlot'
 import { SidebarTokenView, tokenViewCollapsedMetric } from './SidebarTokenView'
 import type { SearchResult } from '../store/types'
 import {
@@ -96,6 +96,10 @@ export interface SidebarProps {
   // them up.
   onReorderRepos?: (orderedRepoPaths: string[]) => void
   onReorderSessions?: (repoPath: string, orderedSessionIds: string[]) => void
+  // #5200 — open the Control Room (a wide host/repo table) in the main
+  // content area, launched from the bottom panel slot's header. Optional so
+  // existing tests/callers don't need to wire it.
+  onOpenControlRoom?: () => void
 }
 
 function abbreviateTunnel(url: string): string {
@@ -133,6 +137,7 @@ export function Sidebar({
   initialPanelCollapsed = false,
   onReorderRepos,
   onReorderSessions,
+  onOpenControlRoom,
 }: SidebarProps) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
   const [focusedIndex, setFocusedIndex] = useState(0)
@@ -192,6 +197,15 @@ export function Sidebar({
     // the per-session activity tree now drills down inside the main-tab
     // ControlRoomSection (mapped repo → active session → activity tree).
   ]), [sessions, activeSessionId, onSessionClick])
+
+  // #5200 — Control Room launcher in the slot header. The host/repo table is
+  // wide, so the launcher opens it in the main content area (via
+  // onOpenControlRoom) rather than rendering in the narrow slot.
+  const panelLaunchers = useMemo<SidebarPanelLauncher[]>(() => (
+    onOpenControlRoom
+      ? [{ id: 'control-room', label: 'Control Room', title: 'Open the Control Room', onClick: onOpenControlRoom }]
+      : []
+  ), [onOpenControlRoom])
 
   const toggleRepo = useCallback((path: string) => {
     setCollapsed(prev => ({ ...prev, [path]: !prev[path] }))
@@ -934,6 +948,7 @@ export function Sidebar({
               want simultaneously with whatever lives in the slot). */}
           <SidebarPanelSlot
             views={panelViews}
+            launchers={panelLaunchers}
             selectedViewId={panelView}
             onSelectView={handlePanelViewChange}
             collapsed={panelCollapsed}

--- a/packages/dashboard/src/components/SidebarPanelSlot.test.tsx
+++ b/packages/dashboard/src/components/SidebarPanelSlot.test.tsx
@@ -27,6 +27,33 @@ const baseProps = {
 }
 
 describe('SidebarPanelSlot (#4303)', () => {
+  describe('launchers (#5200)', () => {
+    it('renders launcher buttons in the header and fires onClick (no in-slot body)', () => {
+      const onClick = vi.fn()
+      render(
+        <SidebarPanelSlot
+          {...baseProps}
+          views={[makeView('tokens', 'Tokens', 'Token body')]}
+          launchers={[{ id: 'control-room', label: 'Control Room', onClick }]}
+        />,
+      )
+      const btn = screen.getByTestId('sidebar-panel-slot-launcher-control-room')
+      expect(btn).toBeInTheDocument()
+      expect(btn).toHaveTextContent('Control Room')
+      fireEvent.click(btn)
+      expect(onClick).toHaveBeenCalledTimes(1)
+      // It is NOT a view — no body is rendered for it; the token view stays.
+      expect(screen.getByTestId('view-body-tokens')).toBeInTheDocument()
+    })
+
+    it('renders no launcher region when launchers is omitted', () => {
+      render(
+        <SidebarPanelSlot {...baseProps} views={[makeView('tokens', 'Tokens', 'Token body')]} />,
+      )
+      expect(screen.queryByTestId('sidebar-panel-slot-launcher-control-room')).toBeNull()
+    })
+  })
+
   describe('view selection', () => {
     it('renders nothing when zero views registered', () => {
       const { container } = render(

--- a/packages/dashboard/src/components/SidebarPanelSlot.tsx
+++ b/packages/dashboard/src/components/SidebarPanelSlot.tsx
@@ -29,8 +29,24 @@ export interface SidebarPanelView {
   collapsedHeaderMetric?: () => ReactNode
 }
 
+/**
+ * A launcher is an action button shown in the slot header next to the view
+ * tabs. Unlike a view, it does NOT render a body in the slot — clicking it
+ * fires `onClick` (e.g. to open a wide view in the main content area). Added
+ * for #5200: the Control Room (a wide host/repo table) is launched from here
+ * rather than crammed into the narrow slot.
+ */
+export interface SidebarPanelLauncher {
+  id: string
+  label: string
+  onClick: () => void
+  title?: string
+}
+
 export interface SidebarPanelSlotProps {
   views: SidebarPanelView[]
+  /** Optional action buttons in the header that open something elsewhere. */
+  launchers?: SidebarPanelLauncher[]
   selectedViewId: string | null
   onSelectView: (viewId: string) => void
   collapsed: boolean
@@ -49,6 +65,7 @@ const HEADER_HEIGHT_PX = 28
 
 export function SidebarPanelSlot({
   views,
+  launchers,
   selectedViewId,
   onSelectView,
   collapsed,
@@ -240,6 +257,22 @@ export function SidebarPanelSlot({
             )
           })}
         </div>
+        {launchers && launchers.length > 0 && (
+          <div className="sidebar-panel-slot-launchers">
+            {launchers.map((l) => (
+              <button
+                key={l.id}
+                type="button"
+                className="sidebar-panel-slot-launcher"
+                data-testid={`sidebar-panel-slot-launcher-${l.id}`}
+                title={l.title ?? l.label}
+                onClick={l.onClick}
+              >
+                {l.label}
+              </button>
+            ))}
+          </div>
+        )}
         {collapsed && activeView?.collapsedHeaderMetric && (
           <div
             className="sidebar-panel-slot-collapsed-metric"

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -937,6 +937,33 @@
   background: var(--bg-muted, color-mix(in srgb, var(--text-secondary) 10%, transparent));
 }
 
+/* #5200: launcher buttons in the slot header (e.g. "Control Room") — an
+   action that opens a wide view in the main content area rather than
+   rendering in the narrow slot. Accented so it reads as an action, not a
+   passive view tab. */
+.sidebar-panel-slot-launchers {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 6px;
+}
+
+.sidebar-panel-slot-launcher {
+  background: transparent;
+  border: 1px solid var(--border-primary, color-mix(in srgb, var(--text-secondary) 22%, transparent));
+  padding: 3px 8px;
+  color: var(--accent-blue);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.sidebar-panel-slot-launcher:hover {
+  background: color-mix(in srgb, var(--accent-blue) 14%, transparent);
+}
+
 .sidebar-panel-slot-collapsed-metric {
   font-size: 11px;
   color: var(--text-secondary);

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -79,15 +79,14 @@
    native select dropdowns), causing Skills to underlap the gear button and
    long model names to underlap the status dot. Grid gives each zone its
    own cell with explicit gap; only the center column flexes. */
+/* #5200: the header is now two stacked rows — .header-main (selectors) on
+   top and .header-meta (cost/token cluster) below — so the main bar is never
+   crowded. #header is the flex-column wrapper; the 3-column grid moved to
+   .header-main. */
 #header {
-  display: grid;
-  /* #5197: the right column is `minmax(0, auto)` (not bare `auto`) so it can
-     shrink below its content's max width when the window is narrow — letting
-     the cost badge truncate in place instead of the whole cluster (token
-     count + usage bar) clipping off the right edge of the window. */
-  grid-template-columns: auto minmax(0, 1fr) minmax(0, auto);
-  align-items: center;
-  gap: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
   padding: 10px 16px;
   background: var(--bg-header);
   border-bottom: 1px solid var(--border-primary);
@@ -95,6 +94,26 @@
   overflow: visible;
   position: relative;
   z-index: 10;
+}
+
+/* #5200: row 1 — the 3-column main bar (logo/status | model+permission
+   selects | bell + ⋯). With the cost/token cluster gone to row 2, the
+   center column has room for every selector again (the permission select
+   was being pushed past overflow:hidden before). */
+.header-main {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+}
+
+/* #5200: row 2 — the cost/token cluster on its own line, right-aligned, with
+   the full header width to itself so it never collides with the selectors. */
+.header-meta {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  min-width: 0;
 }
 
 .header-left {
@@ -355,12 +374,11 @@
   flex-shrink: 0;
 }
 
-/* #5197: the status bar (provider badge + cost + token meter) is the ONE
-   right-cluster child allowed to shrink, so the long provider/model cost
-   badge can truncate instead of shoving the token count off-screen. The
-   token meter and provider badge inside it stay fixed (rules below); only
-   the cost badge absorbs the squeeze. */
-.header-right .status-bar {
+/* #5200: the status bar (provider badge + cost + token meter) now lives on
+   its own row (.header-meta), right-aligned with the full header width — so
+   it rarely needs to shrink. min-width: 0 + the cost badge's ellipsis keep
+   it graceful if the window is ever narrower than the cluster. */
+.header-meta .status-bar {
   flex-shrink: 1;
   min-width: 0;
   white-space: nowrap;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -73,16 +73,16 @@
 }
 
 /* ---- Header ---- */
-/* Header is a 3-column grid (auto | 1fr | auto). Switching from flex
-   space-between fixed a class of overlap bugs: with flex, header-center
-   could spill into header-right's space (overflow: visible was needed for
-   native select dropdowns), causing Skills to underlap the gear button and
-   long model names to underlap the status dot. Grid gives each zone its
-   own cell with explicit gap; only the center column flexes. */
-/* #5200: the header is now two stacked rows — .header-main (selectors) on
-   top and .header-meta (cost/token cluster) below — so the main bar is never
-   crowded. #header is the flex-column wrapper; the 3-column grid moved to
-   .header-main. */
+/* #5200: the header is two stacked rows — #header is the flex-column wrapper;
+   row 1 (.header-main) is the 3-column main bar (selectors), row 2
+   (.header-meta) holds the cost/token cluster below it — so the main bar is
+   never crowded.
+   History: .header-main's 3-column grid (auto | 1fr | auto) replaced an
+   earlier flex space-between layout that let header-center spill into
+   header-right's space (overflow: visible is needed for native select
+   dropdowns), causing Skills to underlap the gear button and long model
+   names to underlap the status dot. The grid gives each zone its own cell
+   with explicit gap; only the center column flexes. */
 #header {
   display: flex;
   flex-direction: column;

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/desktop",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "private": true,
   "description": "Chroxy desktop tray app (Tauri)",
   "scripts": {

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "chroxy-desktop"
-version = "0.9.43"
+version = "0.9.44"
 dependencies = [
  "base64 0.22.1",
  "cocoa",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chroxy-desktop"
-version = "0.9.43"
+version = "0.9.44"
 edition = "2021"
 description = "Chroxy desktop tray app"
 

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Chroxy",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "identifier": "com.chroxy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/protocol",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "private": true,
   "description": "Shared WebSocket protocol constants and types for Chroxy",
   "type": "module",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chroxy/server",
-      "version": "0.9.43",
+      "version": "0.9.44",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/server",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "description": "Chroxy server daemon and CLI",
   "type": "module",
   "main": "src/cli.js",

--- a/packages/store-core/package.json
+++ b/packages/store-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chroxy/store-core",
-  "version": "0.9.43",
+  "version": "0.9.44",
   "private": true,
   "description": "Shared store logic for Chroxy app and dashboard",
   "type": "module",


### PR DESCRIPTION
Cuts **0.9.44** — the Control Room v2 epic (#5170) plus the post-release UI follow-ups found while verifying the installed app:

- **Version bump** to 0.9.44 across all package files (`scripts/bump-version.sh`) + CHANGELOG.
- **Two-row header (#5200):** the cost/token cluster moved to its own row below the model/permission selectors — the main bar is no longer crowded and the Approve selector is visible again.
- **Sidebar Control Room launcher (#5200):** the Control Room opens from a launcher button in the bottom panel slot header (next to Tokens); the wide host/repo table renders in the main content area. The crowded top tab was removed.

Built + installed locally as a signed .app and screenshot-verified (two-row header, launcher).