### PR TITLE
Control Room polish: cell ellipsis (#5201) + full-width meta bar (#5203)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -176,6 +176,17 @@ describe('ControlRoomSection (#5175)', () => {
     expect(screen.queryByTestId('cr-note-row-no-it-all')).toBeNull()
   })
 
+  it('#5201: branch + onboarding cells carry the full text as a title for hover-reveal when ellipsis-truncated', () => {
+    render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    const branch = screen.getByTestId('cr-branch-medlens')
+    expect(branch).toHaveClass('cr-branch')
+    expect(branch).toHaveAttribute('title', 'docs/app-store-prep')
+    // onboarding cell carries its full value as a title too
+    const onboarding = screen.getByText('skipped — dirty tree')
+    expect(onboarding).toHaveClass('cr-onboarding')
+    expect(onboarding).toHaveAttribute('title', 'skipped — dirty tree')
+  })
+
   it('shows the live green dot only for live repos', () => {
     render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
     expect(screen.getByTestId('cr-live-dot-chroxy')).toBeTruthy()

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -277,10 +277,12 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now }: R
               title="Live agent here right now"
             />
           )}
-          <div className="cr-dim cr-mono" data-testid={`cr-branch-${repo.name}`}>{repo.branch}</div>
+          {/* #5201: long branch names ellipsis-truncate with the full value on
+              hover (title) instead of forcing the table wider / clipping. */}
+          <div className="cr-dim cr-mono cr-branch" data-testid={`cr-branch-${repo.name}`} title={repo.branch}>{repo.branch}</div>
         </td>
         <td><VerdictTag verdict={repo.verdict} /></td>
-        <td className="cr-onboarding">{repo.onboarding}</td>
+        <td className="cr-onboarding" title={repo.onboarding}>{repo.onboarding}</td>
         <TreeCell repo={repo} />
         <CountCell value={repo.worktrees} testid={`cr-wt-${repo.name}`} />
         <CountCell value={repo.openPRs} testid={`cr-prs-${repo.name}`} />

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -282,7 +282,11 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now }: R
           <div className="cr-dim cr-mono cr-branch" data-testid={`cr-branch-${repo.name}`} title={repo.branch}>{repo.branch}</div>
         </td>
         <td><VerdictTag verdict={repo.verdict} /></td>
-        <td className="cr-onboarding" title={repo.onboarding}>{repo.onboarding}</td>
+        {/* #5201: ellipsis-truncate on an inner block element, not the <td>
+            itself — text-overflow on display:table-cell is unreliable and can
+            still let long content widen the column. The branch cell already
+            wraps its text in a div for the same reason. */}
+        <td><div className="cr-onboarding" title={repo.onboarding}>{repo.onboarding}</div></td>
         <TreeCell repo={repo} />
         <CountCell value={repo.worktrees} testid={`cr-wt-${repo.name}`} />
         <CountCell value={repo.openPRs} testid={`cr-prs-${repo.name}`} />

--- a/packages/dashboard/src/components/HeaderOverflow.test.tsx
+++ b/packages/dashboard/src/components/HeaderOverflow.test.tsx
@@ -30,11 +30,20 @@ describe('Header overflow prevention (#2297, #3705 follow-up)', () => {
     expect(block![0]).toMatch(/grid-template-columns:\s*auto\s+minmax\(0,\s*1fr\)\s+auto/)
   })
 
-  it('.header-meta is the right-aligned second row holding the cost/token cluster (#5200)', () => {
+  it('.header-meta is the full-width second row; the status bar fills it and space-betweens its own groups (#5200/#5203)', () => {
+    // #5203: the container no longer right-aligns its child (the old #5200
+    // `justify-content: flex-end`). The status bar now spans the full row
+    // (`.status-bar { width: 100% }`) and distributes its own left/right
+    // groups via `space-between`, so the container is a plain flex parent.
     const block = css.match(/\.header-meta\s*\{[^}]*\}/s)
     expect(block).toBeTruthy()
     expect(block![0]).toMatch(/display:\s*flex/)
-    expect(block![0]).toMatch(/justify-content:\s*flex-end/)
+    expect(block![0]).not.toMatch(/justify-content:\s*flex-end/)
+    // the bar itself owns the full width + the space-between split
+    const barBlock = css.match(/\.header-meta \.status-bar\s*\{[^}]*\}/s)
+    expect(barBlock).toBeTruthy()
+    expect(barBlock![0]).toMatch(/width:\s*100%/)
+    expect(barBlock![0]).toMatch(/justify-content:\s*space-between/)
   })
 
   it('#header has overflow: visible (native selects render outside header bounds)', () => {

--- a/packages/dashboard/src/components/SidebarCostBadge.test.tsx
+++ b/packages/dashboard/src/components/SidebarCostBadge.test.tsx
@@ -196,8 +196,8 @@ describe('SidebarCostBadge mode union (#5184)', () => {
     )
   })
 
-  it('defaults to provider-model', () => {
-    expect(DEFAULT_COST_BADGE_MODE).toBe('provider-model')
+  it('defaults to cost (#5203: identity moved to the header-meta left group)', () => {
+    expect(DEFAULT_COST_BADGE_MODE).toBe('cost')
   })
 
   it('has a human-readable label for every mode', () => {
@@ -247,8 +247,8 @@ describe('formatCostBadgeContent per mode (#5184)', () => {
       .toBe('Claude Code (SDK)')
   })
 
-  it('defaults to provider-model when mode is omitted', () => {
-    expect(formatCostBadgeContent(full)).toBe('Claude Code (SDK) · Sonnet 4.6')
+  it('defaults to cost when mode is omitted (#5203)', () => {
+    expect(formatCostBadgeContent(full)).toBe('$0.2903')
   })
 
   it('cost: legacy "$0.2903" 4-decimal form', () => {
@@ -302,11 +302,11 @@ describe('SidebarCostBadge render (#5184)', () => {
     expect(badge.getAttribute('aria-label')).toBe('Total session cost')
   })
 
-  it('defaults to provider-model when no mode prop is given', () => {
-    render(<SidebarCostBadge provider="claude-sdk" model="Sonnet 4.6" />)
+  it('defaults to cost when no mode prop is given (#5203)', () => {
+    render(<SidebarCostBadge provider="claude-sdk" model="Sonnet 4.6" cost={0.2903} />)
     const badge = screen.getByTestId('sidebar-cost-badge')
-    expect(badge.getAttribute('data-cost-badge-mode')).toBe('provider-model')
-    expect(badge.textContent).toBe('Claude Code (SDK) · Sonnet 4.6')
+    expect(badge.getAttribute('data-cost-badge-mode')).toBe('cost')
+    expect(badge.textContent).toBe('$0.2903')
   })
 
   it('appends an extra className alongside the base cost-badge class', () => {

--- a/packages/dashboard/src/components/StatusBar.test.tsx
+++ b/packages/dashboard/src/components/StatusBar.test.tsx
@@ -13,9 +13,26 @@ describe('StatusBar', () => {
     expect(screen.getByTestId('status-bar')).toBeInTheDocument()
   })
 
-  it('does not render model (model shown in header dropdown)', () => {
+  it('renders no model element when no model prop is given', () => {
     const { container } = render(<StatusBar />)
     expect(container.querySelector('.status-model')).toBeNull()
+  })
+
+  it('#5203: renders the model in the left identity group, metrics on the right', () => {
+    const { container } = render(<StatusBar provider="claude-sdk" model="Sonnet 4.6" cost={0.29} />)
+    const left = container.querySelector('.status-bar-left')
+    const right = container.querySelector('.status-bar-right')
+    expect(left).toBeTruthy()
+    expect(right).toBeTruthy()
+    // identity (provider badge + model) sits in the LEFT group
+    expect(left?.querySelector('.status-provider')).toBeTruthy()
+    const modelEl = left?.querySelector('.status-model')
+    expect(modelEl).toBeTruthy()
+    expect(modelEl).toHaveTextContent('Sonnet 4.6')
+    expect(modelEl).toHaveAttribute('title', 'Sonnet 4.6')
+    // metrics (cost badge) sit in the RIGHT group, not the left
+    expect(right?.querySelector('.status-cost')).toBeTruthy()
+    expect(left?.querySelector('.status-cost')).toBeNull()
   })
 
   it('shows formatted cost with 4 decimal places', () => {

--- a/packages/dashboard/src/components/StatusBar.tsx
+++ b/packages/dashboard/src/components/StatusBar.tsx
@@ -104,10 +104,11 @@ export function StatusBar({
         : ''
 
   return (
+    // #5203: two groups — LEFT is the session identity (type badge + model
+    // name), RIGHT is the metrics (configurable cost badge + token meter).
+    // `.status-bar` spans the full second-row width and space-betweens them.
     <div className="status-bar" data-testid="status-bar">
-      {isBusy && (
-        <span className="busy-indicator" data-testid="busy-indicator" />
-      )}
+    <div className="status-bar-group status-bar-left">
       {prov && (
         <span
           className="status-provider"
@@ -118,6 +119,16 @@ export function StatusBar({
         >
           {prov.short}
         </span>
+      )}
+      {model && (
+        <span className="status-model" data-testid="status-model" title={model}>
+          {model}
+        </span>
+      )}
+    </div>
+    <div className="status-bar-group status-bar-right">
+      {isBusy && (
+        <span className="busy-indicator" data-testid="busy-indicator" />
       )}
       {costBadgeMode ? (
         // #5184: configurable badge. The display mode comes from Settings
@@ -199,6 +210,7 @@ export function StatusBar({
           {agentCount} {agentCount === 1 ? 'agent' : 'agents'}
         </span>
       )}
+    </div>
     </div>
   )
 }

--- a/packages/dashboard/src/components/StatusBar.tsx
+++ b/packages/dashboard/src/components/StatusBar.tsx
@@ -41,7 +41,7 @@ export interface StatusBarProps {
    * legacy `$X.XXXX` span. Left undefined by callers that don't wire the
    * setting (and by the existing test suite) so the legacy behaviour stays
    * the render fallback. The live app always passes the store value, whose
-   * own default is `provider-model`.
+   * own default is `cost` (#5203).
    */
   costBadgeMode?: CostBadgeMode
 }
@@ -132,7 +132,7 @@ export function StatusBar({
       )}
       {costBadgeMode ? (
         // #5184: configurable badge. The display mode comes from Settings
-        // (store-backed, default `provider-model`); the host still owns the
+        // (store-backed, default `cost` since #5203); the host still owns the
         // tooltip so the hover breakdown is unchanged. `className` adds
         // `status-cost` so existing layout/selectors keep working.
         <SidebarCostBadge

--- a/packages/dashboard/src/lib/cost-badge-mode.ts
+++ b/packages/dashboard/src/lib/cost-badge-mode.ts
@@ -31,8 +31,11 @@ export type CostBadgeMode =
   | 'context-pct'
   | 'session-type'
 
-/** Default mode — what a fresh install / unset localStorage shows. */
-export const DEFAULT_COST_BADGE_MODE: CostBadgeMode = 'provider-model'
+/** Default mode — what a fresh install / unset localStorage shows.
+ * #5203: defaults to `cost` because the two-row header's left identity group
+ * now owns provider/model, so the right-side badge defaulting to provider-model
+ * would duplicate it. Still fully switchable in Settings. */
+export const DEFAULT_COST_BADGE_MODE: CostBadgeMode = 'cost'
 
 /**
  * Exhaustive list of modes. The `Record<CostBadgeMode, true>` keying makes

--- a/packages/dashboard/src/lib/cost-badge-mode.ts
+++ b/packages/dashboard/src/lib/cost-badge-mode.ts
@@ -9,8 +9,8 @@
  * so existing component-level imports keep working.
  *
  * Modes:
- *   - `provider-model`  (DEFAULT) — "Claude Code (SDK) · Sonnet 4.6"
- *   - `cost`            — the dollar cost ("$0.2903"), the legacy behaviour
+ *   - `cost`            (DEFAULT) — the dollar cost ("$0.2903"), the legacy behaviour
+ *   - `provider-model`  — "Claude Code (SDK) · Sonnet 4.6"
  *   - `tokens`          — total input+output tokens for the turn ("30.0k tokens")
  *   - `context-pct`     — percent of the model context window used ("45%")
  *   - `session-type`    — the SDK/CLI/TUI/BYOK session-type tag ("SDK")
@@ -78,7 +78,7 @@ export const COST_BADGE_MODE_LABELS: Record<CostBadgeMode, string> = {
 const NBSP = ' '
 
 export interface CostBadgeContentInput {
-  /** Which piece of info to render. Defaults to `provider-model`. */
+  /** Which piece of info to render. Defaults to `DEFAULT_COST_BADGE_MODE` (`cost`). */
   mode?: CostBadgeMode
   /** Total session cost in USD (drives `cost` mode). */
   cost?: number | null

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -391,9 +391,9 @@ describe('useConnectionStore', () => {
 
   // #5184: header cost-badge display mode — default, setter, persistence.
   describe('costBadgeMode (#5184)', () => {
-    it('defaults to provider-model', async () => {
+    it('defaults to cost (#5203)', async () => {
       const { useConnectionStore } = await import('./connection');
-      expect(useConnectionStore.getState().costBadgeMode).toBe('provider-model');
+      expect(useConnectionStore.getState().costBadgeMode).toBe('cost');
     });
 
     it('setCostBadgeMode updates state and persists to localStorage', async () => {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -374,14 +374,50 @@
   flex-shrink: 0;
 }
 
-/* #5200: the status bar (provider badge + cost + token meter) now lives on
-   its own row (.header-meta), right-aligned with the full header width — so
-   it rarely needs to shrink. min-width: 0 + the cost badge's ellipsis keep
-   it graceful if the window is ever narrower than the cluster. */
+/* #5200/#5203: the status bar lives on its own row (.header-meta) and spans
+   the FULL header width, space-betweening two groups — identity (type badge +
+   model) on the left, metrics (configurable cost badge + token meter) on the
+   right. */
+.header-meta {
+  /* override the #5200 flex-end: the status-bar fills the row and distributes
+     its own groups */
+  justify-content: stretch;
+}
+
 .header-meta .status-bar {
+  width: 100%;
+  justify-content: space-between;
   flex-shrink: 1;
   min-width: 0;
   white-space: nowrap;
+}
+
+/* #5203: left/right groups inside the status bar. */
+.status-bar-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.status-bar-left {
+  /* identity can truncate (model name) before the metrics group does */
+  flex-shrink: 1;
+  overflow: hidden;
+}
+
+.status-bar-right {
+  flex-shrink: 0;
+}
+
+/* #5203: the model name in the left identity group. */
+.status-model {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 .logo {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8645,6 +8645,19 @@ button.sidebar-token-view-session-row:hover {
   white-space: nowrap;
 }
 
+/* #5201: the text-heavy columns ellipsis-truncate (full value on hover via the
+   cell's title attr) so a long branch / onboarding string shrinks the column
+   instead of forcing the whole table wider than the viewport and clipping the
+   right-hand columns off-edge. The .cr-table-wrap still scrolls horizontally
+   as a fallback when even the truncated table doesn't fit. */
+.cr-branch,
+.cr-onboarding {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Verdict tags */
 .cr-tag {
   display: inline-block;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -107,11 +107,13 @@
   gap: 16px;
 }
 
-/* #5200: row 2 — the cost/token cluster on its own line, right-aligned, with
-   the full header width to itself so it never collides with the selectors. */
+/* #5200/#5203: row 2 — the status bar on its own line with the full header
+   width to itself so it never collides with the selectors. The bar fills the
+   row (`.status-bar { width: 100% }`) and distributes its own left/right groups
+   via `space-between`, so this container just lays it out as a single flex
+   child with no extra justification. */
 .header-meta {
   display: flex;
-  justify-content: flex-end;
   align-items: center;
   min-width: 0;
 }
@@ -378,12 +380,6 @@
    the FULL header width, space-betweening two groups — identity (type badge +
    model) on the left, metrics (configurable cost badge + token meter) on the
    right. */
-.header-meta {
-  /* override the #5200 flex-end: the status-bar fills the row and distributes
-     its own groups */
-  justify-content: stretch;
-}
-
 .header-meta .status-bar {
   width: 100%;
   justify-content: space-between;


### PR DESCRIPTION
Closes #5201. Closes #5203.

**#5201** — Control Room table branch/onboarding cells ellipsis-truncate (`max-width`) with the full value in a `title` (hover-reveal); `.cr-table-wrap` keeps `overflow-x: auto` as a fallback.

**#5203** — the second-row meta bar spans the full header width and space-betweens two groups: **LEFT** = identity (type badge + model name), **RIGHT** = metrics (configurable cost badge + token meter). Cost-badge default flips provider-model → **cost** (identity now lives on the left; still switchable in Settings).

3078 dashboard tests pass; tsc + build clean.