### PR TITLE
feat(dashboard): Control Room as a session-independent top-level tab (#5204)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -125,7 +125,10 @@ function formatContext(usage: { inputTokens: number; outputTokens: number } | nu
   return `${formatTokensCompact(total)} tokens`
 }
 
-type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool' | 'control-room'
+// #5204 — 'control-room' is no longer a per-session viewMode; the Control
+// Room is a dedicated session-independent top-level tab (see `controlRoomOpen`
+// / `controlRoomActive` in App).
+type ViewMode = 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool'
 
 /** Scrollable tab bar with arrow buttons when overflowing */
 function ViewSwitcher({
@@ -220,10 +223,10 @@ function ViewSwitcher({
       >
         <button className={`view-tab${viewMode === 'chat' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('chat'); setSplitMode(null); persistSplitMode(null) }} type="button">Chat</button>
         <button className={`view-tab${viewMode === 'terminal' && !splitMode ? ' active' : ''}`} onClick={() => { setViewMode('terminal'); setSplitMode(null); persistSplitMode(null) }} type="button">Output</button>
-        {/* #5200: the Control Room is launched from the bottom sidebar panel
-            slot (its header "Control Room" button), not a top tab — the wide
-            host/repo table gets the full main content area. The 'control-room'
-            viewMode still renders below; it just has no top-tab entry now. */}
+        {/* #5200/#5204: the Control Room is launched from the bottom sidebar
+            panel slot (its header "Control Room" button) and opens as its own
+            session-independent top-level tab in the SessionBar strip — not a
+            per-session view tab here. */}
         <button
           className={`view-tab${splitMode ? ' active' : ''}`}
           onClick={() => { const next: SplitDirection | null = splitMode ? null : 'horizontal'; setSplitMode(next); persistSplitMode(next) }}
@@ -609,6 +612,27 @@ export function App() {
   } | null>(null)
   const [splitMode, setSplitMode] = useState<SplitDirection | null>(() => loadPersistedSplitMode())
   const [checkpointsOpen, setCheckpointsOpen] = useState(false)
+  // #5204 — Control Room top-level tab. `controlRoomOpen` is whether the
+  // pinned tab exists in the SessionBar strip; `controlRoomActive` is whether
+  // it's the focused view. Both are local (not persisted) — opening the CR is
+  // cheap (the host/repo snapshot lives in the store, so closing/reopening
+  // doesn't wipe it) and it should not survive a reload. Switching to a
+  // session deactivates it; switching back re-activates without re-fetching.
+  const [controlRoomOpen, setControlRoomOpen] = useState(false)
+  const [controlRoomActive, setControlRoomActive] = useState(false)
+  const openControlRoom = useCallback(() => {
+    setControlRoomOpen(true)
+    setControlRoomActive(true)
+    setSplitMode(null)
+    persistSplitMode(null)
+  }, [])
+  const closeControlRoom = useCallback(() => {
+    // Closing is non-destructive: the tab disappears and we fall back to the
+    // prior session (activeSessionId is untouched). The store-held snapshot
+    // survives, so reopening re-renders from cache.
+    setControlRoomOpen(false)
+    setControlRoomActive(false)
+  }, [])
 
   // #3073: copy chat transcript to clipboard with brief "Copied" feedback.
   const [transcriptCopied, setTranscriptCopied] = useState(false)
@@ -661,6 +685,10 @@ export function App() {
   }, [activeSessionId])
 
   const handleSwitchSession = useCallback((sessionId: string) => {
+    // #5204 — clicking any session tab returns from the Control Room view.
+    // This must run even when the clicked session is already the active one
+    // (CR is overlaid on top of it), so it sits before the no-op early return.
+    setControlRoomActive(false)
     if (sessionId === activeSessionId) return
     setIsSwitchingSession(true)
     switchSession(sessionId)
@@ -2214,7 +2242,7 @@ export function App() {
           onFilterChange={setSidebarFilter}
           onSessionClick={handleSwitchSession}
           onResumeSession={resumeConversation}
-          onOpenControlRoom={() => { setViewMode('control-room'); setSplitMode(null); persistSplitMode(null) }}
+          onOpenControlRoom={openControlRoom}
           onNewSession={(cwd) => {
             setPendingCwd(cwd || null)
             setShowCreateSession(true)
@@ -2238,8 +2266,10 @@ export function App() {
 
       {/* Main content wrapper (when sidebar present) */}
       <div className={sidebarRepos.length > 0 ? 'main-wrapper' : undefined}>
-        {/* Session bar */}
-        {sessionTabs.length > 0 && (
+        {/* Session bar. #5204 — also rendered when the Control Room tab is
+            open even if there are no sessions, so the pinned CR tab (and its
+            close) is always reachable. */}
+        {(sessionTabs.length > 0 || controlRoomOpen) && (
           <SessionBar
             sessions={sessionTabs}
             onSwitch={handleSwitchSession}
@@ -2247,6 +2277,12 @@ export function App() {
             onRename={renameSession}
             onNewSession={handleNewSession}
             onReorder={handleReorderTabs}
+            controlRoom={{
+              open: controlRoomOpen,
+              active: controlRoomActive,
+              onActivate: openControlRoom,
+              onClose: closeControlRoom,
+            }}
           />
         )}
 
@@ -2300,8 +2336,19 @@ export function App() {
           </div>
         )}
 
+        {/* #5204 — Control Room top-level view. Session-independent: it
+            renders in place of the session UI / welcome screen while active,
+            and switching back to a session restores it untouched. Takes
+            precedence over the welcome screen so the operator can open the CR
+            even with zero sessions. */}
+        {controlRoomActive && connectionPhase !== 'connecting' && (
+          <div className="main-content" data-testid="control-room-main">
+            <ControlRoomSection />
+          </div>
+        )}
+
         {/* Welcome screen — shown when connected but no sessions */}
-        {showWelcome && (
+        {showWelcome && !controlRoomActive && (
           <WelcomeScreen
             onNewSession={handleNewSession}
             recentSessions={recentSessions}
@@ -2321,8 +2368,9 @@ export function App() {
           />
         )}
 
-        {/* Normal session UI */}
-        {!showWelcome && (
+        {/* Normal session UI. #5204 — suppressed while the Control Room tab
+            is active (the CR view above takes the main content area). */}
+        {!showWelcome && !controlRoomActive && (
           <>
             {/* View switcher */}
             <ViewSwitcher
@@ -2464,9 +2512,8 @@ export function App() {
                 {viewMode === 'pool' && connectionPhase !== 'connecting' && !isSwitchingSession && (
                   <PoolStatsPanel />
                 )}
-                {viewMode === 'control-room' && connectionPhase !== 'connecting' && (
-                  <ControlRoomSection />
-                )}
+                {/* #5204 — the Control Room moved out of the per-session view
+                    area into a dedicated top-level tab (rendered above). */}
               </div>
               {checkpointsOpen && (
                 <div className="checkpoint-panel">

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -1269,5 +1269,83 @@ describe('SessionBar', () => {
       const crTab = screen.getByTestId('control-room-tab')
       expect(crTab.getAttribute('draggable')).not.toBe('true')
     })
+
+    it('does not activate the CR tab when Enter/Space bubbles from its close ×', () => {
+      const onActivate = vi.fn()
+      const onClose = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: false, onActivate, onClose }}
+        />
+      )
+      // A key event originating on the close button must not reach the tab's
+      // activate handler (guarded by target === currentTarget).
+      const closeBtn = screen.getByTestId('control-room-tab-close')
+      fireEvent.keyDown(closeBtn, { key: 'Enter' })
+      fireEvent.keyDown(closeBtn, { key: ' ' })
+      expect(onActivate).not.toHaveBeenCalled()
+    })
+
+    it('clears the active session tab selection while the CR tab is active (single selected tab)', () => {
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: true, onActivate: vi.fn(), onClose: vi.fn() }}
+        />
+      )
+      // s1 is the active session, but the CR tab is the focused view — only
+      // the CR tab should report aria-selected, never two tabs at once.
+      const crTab = screen.getByTestId('control-room-tab')
+      const sessionTab = screen.getByTestId('session-tab-s1')
+      expect(crTab).toHaveAttribute('aria-selected', 'true')
+      expect(sessionTab).toHaveAttribute('aria-selected', 'false')
+      expect(sessionTab.className).not.toContain('active')
+      const selected = screen
+        .getAllByRole('tab')
+        .filter(t => t.getAttribute('aria-selected') === 'true')
+      expect(selected).toHaveLength(1)
+    })
+
+    it('restores the active session selection when the CR tab is open but not active', () => {
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: false, onActivate: vi.fn(), onClose: vi.fn() }}
+        />
+      )
+      const sessionTab = screen.getByTestId('session-tab-s1')
+      expect(sessionTab).toHaveAttribute('aria-selected', 'true')
+      expect(sessionTab.className).toContain('active')
+    })
+
+    it('fires onSwitch when clicking the underlying-active session while CR is active', () => {
+      const onSwitch = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={onSwitch}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: true, onActivate: vi.fn(), onClose: vi.fn() }}
+        />
+      )
+      // Clicking the active session while CR is overlaid must return to it.
+      fireEvent.click(screen.getByTestId('session-tab-s1'))
+      expect(onSwitch).toHaveBeenCalledWith('s1')
+    })
   })
 })

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -1108,4 +1108,166 @@ describe('SessionBar', () => {
       expect(tabA.getAttribute('aria-describedby')).toBe(null)
     })
   })
+
+  describe('#5204 Control Room top-level tab', () => {
+    it('does not render the CR tab when controlRoom is omitted', () => {
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+        />
+      )
+      expect(screen.queryByTestId('control-room-tab')).toBeNull()
+    })
+
+    it('does not render the CR tab when open is false', () => {
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: false, active: false, onActivate: vi.fn(), onClose: vi.fn() }}
+        />
+      )
+      expect(screen.queryByTestId('control-room-tab')).toBeNull()
+    })
+
+    it('renders the pinned CR tab when open, before the session tabs', () => {
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: false, onActivate: vi.fn(), onClose: vi.fn() }}
+        />
+      )
+      const tablist = screen.getByRole('tablist')
+      const tabs = within(tablist).getAllByRole('tab')
+      // CR tab is rendered first (pinned left), ahead of the session pills.
+      expect(tabs[0]).toBe(screen.getByTestId('control-room-tab'))
+      expect(screen.getByText('Control Room')).toBeInTheDocument()
+    })
+
+    it('marks the CR tab aria-selected when active', () => {
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: true, onActivate: vi.fn(), onClose: vi.fn() }}
+        />
+      )
+      const crTab = screen.getByTestId('control-room-tab')
+      expect(crTab).toHaveAttribute('aria-selected', 'true')
+      expect(crTab.className).toContain('active')
+    })
+
+    it('calls onActivate when an inactive CR tab is clicked', () => {
+      const onActivate = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: false, onActivate, onClose: vi.fn() }}
+        />
+      )
+      fireEvent.click(screen.getByTestId('control-room-tab'))
+      expect(onActivate).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onActivate when the already-active CR tab is clicked', () => {
+      const onActivate = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: true, onActivate, onClose: vi.fn() }}
+        />
+      )
+      fireEvent.click(screen.getByTestId('control-room-tab'))
+      expect(onActivate).not.toHaveBeenCalled()
+    })
+
+    it('activates the CR tab via Enter / Space keys', () => {
+      const onActivate = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: false, onActivate, onClose: vi.fn() }}
+        />
+      )
+      const crTab = screen.getByTestId('control-room-tab')
+      fireEvent.keyDown(crTab, { key: 'Enter' })
+      fireEvent.keyDown(crTab, { key: ' ' })
+      expect(onActivate).toHaveBeenCalledTimes(2)
+    })
+
+    it('closes the CR tab via its × without activating (stopPropagation)', () => {
+      const onActivate = vi.fn()
+      const onClose = vi.fn()
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: false, onActivate, onClose }}
+        />
+      )
+      fireEvent.click(screen.getByTestId('control-room-tab-close'))
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(onActivate).not.toHaveBeenCalled()
+    })
+
+    it('CR tab close is always shown even with a single session (exempt from showClose gate)', () => {
+      render(
+        <SessionBar
+          sessions={[{ sessionId: 's1', name: 'Default', isBusy: false, isActive: true }]}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: false, onActivate: vi.fn(), onClose: vi.fn() }}
+        />
+      )
+      // The single session tab has no close (showClose=false), but the CR tab does.
+      expect(screen.getByTestId('control-room-tab-close')).toBeInTheDocument()
+    })
+
+    it('CR tab is not draggable (not a session)', () => {
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          onReorder={vi.fn()}
+          controlRoom={{ open: true, active: false, onActivate: vi.fn(), onClose: vi.fn() }}
+        />
+      )
+      const crTab = screen.getByTestId('control-room-tab')
+      expect(crTab.getAttribute('draggable')).not.toBe('true')
+    })
+  })
 })

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -277,6 +277,10 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
             tabIndex={0}
             onClick={() => { if (!controlRoom.active) controlRoom.onActivate() }}
             onKeyDown={e => {
+              // Only act on key events that originate on the tab itself, not
+              // ones bubbling up from the close × button — otherwise pressing
+              // Enter/Space to close the tab would also re-activate it.
+              if (e.target !== e.currentTarget) return
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault()
                 if (!controlRoom.active) controlRoom.onActivate()
@@ -304,18 +308,23 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
           const isDragOver = dragOverId === session.sessionId && draggingId !== null && draggingId !== session.sessionId
           const isLifted = keyboardLiftId === session.sessionId
           const reorderDisabled = !onReorder
+          // #5204 — while the Control Room tab is the focused view, it is the
+          // single selected tab in the tablist. Suppress the active session's
+          // selected state so we never report two aria-selected tabs (and the
+          // dual-active highlight) at once.
+          const isActive = session.isActive && !controlRoom?.active
           return (
           <div
             key={session.sessionId}
             className={
-              `session-tab${session.isActive ? ' active' : ''}` +
+              `session-tab${isActive ? ' active' : ''}` +
               `${isDragging ? ' dragging' : ''}` +
               `${isDragOver ? ' drag-over' : ''}` +
               `${isLifted ? ' lifted' : ''}`
             }
             data-testid={`session-tab-${session.sessionId}`}
             role="tab"
-            aria-selected={session.isActive}
+            aria-selected={isActive}
             // #4951 — aria-grabbed (and aria-dropeffect) were removed in
             // WAI-ARIA 1.1; the lift state is conveyed via the `lifted`
             // CSS class (visual) + the live-region announcement (SR).
@@ -395,7 +404,10 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               setDragOverId(null)
             }}
             onClick={() => {
-              if (!session.isActive) onSwitch(session.sessionId)
+              // Use the CR-aware `isActive`: while the Control Room is the
+              // focused view, even the underlying-active session should fire
+              // onSwitch so clicking it returns from the CR to that session.
+              if (!isActive) onSwitch(session.sessionId)
             }}
             onKeyDown={e => {
               if (renamingId === session.sessionId) return
@@ -466,7 +478,7 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               }
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault()
-                if (!session.isActive) onSwitch(session.sessionId)
+                if (!isActive) onSwitch(session.sessionId)
               } else if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
                 e.preventDefault()
                 const tabs = (e.currentTarget.parentElement as HTMLElement)?.querySelectorAll<HTMLElement>('[role="tab"]')

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -47,6 +47,25 @@ export interface SessionTabData {
   stdinForwardingDisabled?: boolean
 }
 
+/**
+ * #5204 — the Control Room is a special, session-independent top-level tab
+ * that lives in the same strip as the session pills. It is NOT a session:
+ * it can't be renamed, dragged, or reordered, and its close is always
+ * available (and exempt from the session close-confirmation, #5206). When
+ * `open`, it renders as a pinned tab at the left of the strip; clicking it
+ * activates the host/repo table view, clicking its × closes it.
+ */
+export interface ControlRoomTabState {
+  /** Whether the Control Room tab exists in the strip. */
+  open: boolean
+  /** Whether the Control Room tab is the focused view. */
+  active: boolean
+  /** Focus the Control Room tab (show the host/repo table). */
+  onActivate: () => void
+  /** Close the Control Room tab (returns to the prior session; no confirm). */
+  onClose: () => void
+}
+
 export interface SessionBarProps {
   sessions: SessionTabData[]
   onSwitch: (sessionId: string) => void
@@ -60,6 +79,11 @@ export interface SessionBarProps {
    * callers continue to compile without reorder support.
    */
   onReorder?: (nextOrder: string[]) => void
+  /**
+   * #5204 — optional Control Room top-level tab. When provided and
+   * `open`, a pinned non-session tab renders at the left of the strip.
+   */
+  controlRoom?: ControlRoomTabState
 }
 
 function shortenModel(model: string): string {
@@ -121,7 +145,7 @@ export function reorderTabs(ids: string[], fromIndex: number, toIndex: number): 
   return next
 }
 
-export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession, onReorder }: SessionBarProps) {
+export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession, onReorder, controlRoom }: SessionBarProps) {
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
@@ -240,6 +264,41 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
   return (
     <div className="session-bar" data-testid="session-bar">
       <div className="session-tabs" role="tablist">
+        {/* #5204 — pinned, session-independent Control Room tab. Rendered
+            first so it sits at the left edge; not draggable / not renamable /
+            not a drop target, and its close is always shown (exempt from the
+            session close-confirmation). */}
+        {controlRoom?.open && (
+          <div
+            className={`session-tab control-room-tab${controlRoom.active ? ' active' : ''}`}
+            data-testid="control-room-tab"
+            role="tab"
+            aria-selected={controlRoom.active}
+            tabIndex={0}
+            onClick={() => { if (!controlRoom.active) controlRoom.onActivate() }}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                if (!controlRoom.active) controlRoom.onActivate()
+              }
+            }}
+          >
+            <span className="control-room-tab-icon" aria-hidden="true">⌘</span>
+            <span className="tab-name">Control Room</span>
+            <button
+              className="tab-close"
+              data-testid="control-room-tab-close"
+              aria-label="Close Control Room"
+              onClick={e => {
+                e.stopPropagation()
+                controlRoom.onClose()
+              }}
+              type="button"
+            >
+              &times;
+            </button>
+          </div>
+        )}
         {sessions.map(session => {
           const isDragging = draggingId === session.sessionId
           const isDragOver = dragOverId === session.sessionId && draggingId !== null && draggingId !== session.sessionId

--- a/packages/dashboard/src/store/persistence.ts
+++ b/packages/dashboard/src/store/persistence.ts
@@ -92,8 +92,11 @@ const MAX_MESSAGES = 100;
 /** Max terminal buffer size to persist (characters, ~50 KB for ASCII) */
 const MAX_TERMINAL_SIZE = 50_000;
 
-/** Valid view modes — used to validate persisted values */
-const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments', 'snapshots', 'pool', 'control-room'] as const;
+/** Valid view modes — used to validate persisted values.
+ * #5204 — 'control-room' removed: it's a top-level tab now, not a view mode.
+ * Any stale persisted 'control-room' value fails validation and falls back to
+ * the default, which is the desired behaviour. */
+const VALID_VIEW_MODES = ['chat', 'terminal', 'files', 'diff', 'system', 'console', 'environments', 'snapshots', 'pool'] as const;
 type ViewMode = (typeof VALID_VIEW_MODES)[number];
 
 function sessionMessagesKey(sessionId: string): string {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -703,8 +703,9 @@ export interface ConnectionState {
   // pairing_refreshed so the dashboard can auto-refresh the QR code (#2916).
   pairingRefreshedCount: number;
 
-  // View mode
-  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool' | 'control-room';
+  // View mode. #5204 — 'control-room' removed: the Control Room is now a
+  // session-independent top-level tab in App, not a per-session view mode.
+  viewMode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool';
 
   // Input settings
   inputSettings: InputSettings;
@@ -723,7 +724,7 @@ export interface ConnectionState {
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;
-  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool' | 'control-room') => void;
+  setViewMode: (mode: 'chat' | 'terminal' | 'files' | 'diff' | 'system' | 'console' | 'environments' | 'snapshots' | 'pool') => void;
   addMessage: (message: ChatMessage) => void;
   addUserMessage: (text: string, attachments?: MessageAttachment[], opts?: { clientMessageId?: string }) => void;
   appendTerminalData: (data: string) => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1490,6 +1490,26 @@ button.sidebar-token-view-session-row:hover {
   outline-offset: -2px;
 }
 
+/* #5204 — the pinned, session-independent Control Room tab. Distinct
+ * blue-accented styling so it reads as a different kind of tab from the
+ * session pills, and a left margin/divider separating it from sessions. */
+.control-room-tab {
+  border-color: color-mix(in srgb, var(--accent-blue) 35%, transparent);
+  color: var(--text-secondary);
+  margin-right: 4px;
+  padding-right: 8px;
+}
+.control-room-tab.active {
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border-color: var(--accent-blue);
+}
+.control-room-tab-icon {
+  pointer-events: none;
+  color: var(--accent-blue);
+  font-size: var(--text-sm);
+}
+
 .tab-name {
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary

Closes #5204. Part of epic #5170 (Control Room v2).

The Control Room was a per-session `viewMode` (`'control-room'`), so the host/repo table was tied to the active session's content area (the "Default" tab). This makes it a **dedicated, session-independent top-level tab** in the SessionBar strip, per the user's v0.9.44 feedback.

## Behaviour

- **Launcher opens/focuses a pinned CR tab** at the left of the session strip (distinct blue-accent styling, ⌘ glyph).
- **Session-independent** — clicking any session tab returns to that session exactly as it was; clicking the CR tab returns to the table. Switching does not re-fetch.
- **Closeable & non-destructive** — the CR tab's × closes it and falls back to the prior session (`activeSessionId` untouched). The host/repo snapshot lives in the Zustand store, so close→reopen re-renders from cache — no polled-state wipe (directly addresses the user's "don't wipe the polling" concern).
- **Reachable with zero sessions** — the SessionBar renders when the CR tab is open even if there are no session pills.
- **Exempt from the session close gate** — the CR × is always shown and bypasses the upcoming session close-confirmation (#5206).

## Implementation

- `SessionBar`: new optional `controlRoom` prop (`{ open, active, onActivate, onClose }`) renders a pinned **non-session** tab — not draggable, renamable, or a drop target.
- `App`: `controlRoomOpen` / `controlRoomActive` local state (not persisted — opening is cheap and shouldn't survive reload). `handleSwitchSession` deactivates the CR before its no-op early return so clicking the active session still returns from the CR.
- Removed `'control-room'` from the `ViewMode` union (App, `store/types.ts`, persisted `VALID_VIEW_MODES`); any stale persisted value fails validation and falls back to the default.

## Tests

- 12 new `SessionBar` tests (render/activate/close/keyboard/exemptions/not-draggable).
- Full dashboard suite: **3088 passed**, `tsc --noEmit` clean.

## Acceptance criteria
- [x] Launcher opens/focuses a dedicated Control Room top-level tab
- [x] CR tab is independent of sessions; switching away/back preserves both
- [x] Closing the CR tab returns to the prior session without wiping state
- [x] Reopening re-renders the table (from the store-cached snapshot)