### PR TITLE
feat(dashboard): tab close UX — hover/focus × + close-confirm dialog + Settings toggle (#5205, #5206)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -143,6 +143,8 @@ vi.mock('./store/connection', () => {
     serverErrors: [],
     connectionRetryCount: 0,
     terminalRawBuffer: '',
+    // #5206 — mirror the real default (session-close confirmation on).
+    confirmSessionClose: true,
     getActiveSessionState: () => ({
       messages: [],
       streamingMessageId: null,
@@ -533,6 +535,47 @@ describe('App', () => {
       render(<App />)
       fireEvent.keyDown(window, { key: 'w', metaKey: true })
       expect(destroySession).not.toHaveBeenCalled()
+    })
+
+    describe('#5206 session-close confirmation', () => {
+      it('clicking a tab × opens the confirm dialog instead of destroying immediately (default on)', () => {
+        const destroySession = vi.fn()
+        stateOverrides = { connectionPhase: 'connected', sessions: twoSessions, activeSessionId: 's1', destroySession, confirmSessionClose: true }
+        render(<App />)
+        const tab = screen.getByTestId('session-tab-s2')
+        fireEvent.click(within(tab).getByTestId('tab-close'))
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument()
+        expect(destroySession).not.toHaveBeenCalled()
+      })
+
+      it('confirming the dialog destroys the targeted session', () => {
+        const destroySession = vi.fn()
+        stateOverrides = { connectionPhase: 'connected', sessions: twoSessions, activeSessionId: 's1', destroySession, confirmSessionClose: true }
+        render(<App />)
+        fireEvent.click(within(screen.getByTestId('session-tab-s2')).getByTestId('tab-close'))
+        fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+        expect(destroySession).toHaveBeenCalledWith('s2')
+        expect(screen.queryByTestId('confirm-dialog')).toBeNull()
+      })
+
+      it('cancelling the dialog keeps the session', () => {
+        const destroySession = vi.fn()
+        stateOverrides = { connectionPhase: 'connected', sessions: twoSessions, activeSessionId: 's1', destroySession, confirmSessionClose: true }
+        render(<App />)
+        fireEvent.click(within(screen.getByTestId('session-tab-s2')).getByTestId('tab-close'))
+        fireEvent.click(screen.getByTestId('confirm-dialog-cancel'))
+        expect(destroySession).not.toHaveBeenCalled()
+        expect(screen.queryByTestId('confirm-dialog')).toBeNull()
+      })
+
+      it('closes immediately without a dialog when the setting is off', () => {
+        const destroySession = vi.fn()
+        stateOverrides = { connectionPhase: 'connected', sessions: twoSessions, activeSessionId: 's1', destroySession, confirmSessionClose: false }
+        render(<App />)
+        fireEvent.click(within(screen.getByTestId('session-tab-s2')).getByTestId('tab-close'))
+        expect(screen.queryByTestId('confirm-dialog')).toBeNull()
+        expect(destroySession).toHaveBeenCalledWith('s2')
+      })
     })
   })
 
@@ -1245,18 +1288,13 @@ describe('App', () => {
       })
       expect(screen.getByTestId('pasted-text-chips')).toBeInTheDocument()
 
-      // Confirm dialog returns true so handleCloseSession proceeds.
-      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-      try {
-        // Click the close (×) button on s1's tab. SessionBar hides the close
-        // button when only one session remains, so we need ≥2 sessions for
-        // this to render at all.
-        const s1Tab = screen.getByTestId('session-tab-s1')
-        const closeBtn = within(s1Tab).getByTestId('tab-close')
-        fireEvent.click(closeBtn)
-      } finally {
-        confirmSpy.mockRestore()
-      }
+      // Click the close (×) button on s1's tab. SessionBar hides the close
+      // button when only one session remains, so we need ≥2 sessions for
+      // this to render at all. #5206 — closing now opens the ConfirmDialog;
+      // confirm it to proceed with the teardown.
+      const s1Tab = screen.getByTestId('session-tab-s1')
+      fireEvent.click(within(s1Tab).getByTestId('tab-close'))
+      fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
       expect(destroySessionFn).toHaveBeenCalledWith('s1')
 
       // Simulate the store completing destruction: s1 is gone, s2 is active.

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -55,6 +55,7 @@ import { ConnectionAnnouncer } from './components/ConnectionAnnouncer'
 import { StdinDisabledBanner } from './components/StdinDisabledBanner'
 import { WelcomeScreen } from './components/WelcomeScreen'
 import { CreateSessionModal } from './components/CreateSessionModal'
+import { ConfirmDialog } from './components/ConfirmDialog'
 import { NotificationBanners } from './components/NotificationBanners'
 import { Toast, type ToastItem } from './components/Toast'
 import { FileBrowserPanel } from './components/FileBrowserPanel'
@@ -520,6 +521,7 @@ export function App() {
   const destroySession = useConnectionStore(s => s.destroySession)
   const renameSession = useConnectionStore(s => s.renameSession)
   const createSession = useConnectionStore(s => s.createSession)
+  const confirmSessionClose = useConnectionStore(s => s.confirmSessionClose)
   const setViewMode = useConnectionStore(s => s.setViewMode)
   const setModel = useConnectionStore(s => s.setModel)
   const setPermissionMode = useConnectionStore(s => s.setPermissionMode)
@@ -633,6 +635,9 @@ export function App() {
     setControlRoomOpen(false)
     setControlRoomActive(false)
   }, [])
+  // #5206 — the session id awaiting close-confirmation, or null when no
+  // confirm is pending. Drives the ConfirmDialog rendered near the modals.
+  const [closeConfirmSessionId, setCloseConfirmSessionId] = useState<string | null>(null)
 
   // #3073: copy chat transcript to clipboard with brief "Copied" feedback.
   const [transcriptCopied, setTranscriptCopied] = useState(false)
@@ -694,8 +699,9 @@ export function App() {
     switchSession(sessionId)
   }, [switchSession, activeSessionId])
 
-  const handleCloseSession = useCallback((sessionId: string) => {
-    if (!window.confirm('Close this session? The Claude process will be terminated.')) return
+  // The actual session teardown, shared by the confirm path and the
+  // no-confirm path (#5206).
+  const performCloseSession = useCallback((sessionId: string) => {
     // #3800: evict the per-session composer state (draft + collapsed-paste
     // blocks + next-id counter) so the refs further down don't leak the
     // pasted-text content for the lifetime of <App />. `handleSend` already
@@ -706,6 +712,18 @@ export function App() {
     evictSessionComposerState(sessionId)
     destroySession(sessionId)
   }, [destroySession])
+
+  const handleCloseSession = useCallback((sessionId: string) => {
+    // #5206 — gate the teardown behind a styled confirm dialog when the
+    // setting is enabled (the default). When disabled, close immediately.
+    // The Control Room tab closes via its own non-session path and never
+    // reaches here, so it stays exempt from the confirmation.
+    if (confirmSessionClose) {
+      setCloseConfirmSessionId(sessionId)
+      return
+    }
+    performCloseSession(sessionId)
+  }, [confirmSessionClose, performCloseSession])
 
   // #3567 / #3602: dedicated restart handler for the StdinDisabledBanner.
   // Creates a replacement session FIRST and then destroys the broken one so
@@ -2728,6 +2746,28 @@ export function App() {
         existingNames={sessions.map(s => s.name)}
         serverError={sessionCreateError ?? undefined}
         isCreating={isCreatingSession}
+      />
+
+      {/* #5206 — session-close confirmation. Shown only when the
+          confirmSessionClose setting is enabled (handleCloseSession gates it).
+          Confirm tears the session down; cancel/Escape/backdrop keep it. */}
+      <ConfirmDialog
+        open={closeConfirmSessionId !== null}
+        title="Close session?"
+        message={(() => {
+          const name = sessions.find(s => s.sessionId === closeConfirmSessionId)?.name
+          return name
+            ? `Close "${name}"? The Claude process will be terminated.`
+            : 'Close this session? The Claude process will be terminated.'
+        })()}
+        confirmLabel="Close session"
+        cancelLabel="Cancel"
+        danger
+        onConfirm={() => {
+          if (closeConfirmSessionId) performCloseSession(closeConfirmSessionId)
+          setCloseConfirmSessionId(null)
+        }}
+        onCancel={() => setCloseConfirmSessionId(null)}
       />
 
       {/* Toasts */}

--- a/packages/dashboard/src/components/ConfirmDialog.test.tsx
+++ b/packages/dashboard/src/components/ConfirmDialog.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * ConfirmDialog tests (#5206)
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { ConfirmDialog } from './ConfirmDialog'
+
+afterEach(cleanup)
+
+describe('ConfirmDialog', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <ConfirmDialog
+        open={false}
+        title="Close?"
+        message="Are you sure?"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.queryByTestId('confirm-dialog')).toBeNull()
+  })
+
+  it('renders title, message, and the default button labels when open', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="Close session?"
+        message="The Claude process will be terminated."
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Close session?')).toBeInTheDocument()
+    expect(screen.getByTestId('confirm-dialog-message')).toHaveTextContent(
+      'The Claude process will be terminated.'
+    )
+    expect(screen.getByTestId('confirm-dialog-confirm')).toHaveTextContent('Confirm')
+    expect(screen.getByTestId('confirm-dialog-cancel')).toHaveTextContent('Cancel')
+  })
+
+  it('uses custom button labels', () => {
+    render(
+      <ConfirmDialog
+        open
+        title="t"
+        message="m"
+        confirmLabel="Close session"
+        cancelLabel="Keep it"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByTestId('confirm-dialog-confirm')).toHaveTextContent('Close session')
+    expect(screen.getByTestId('confirm-dialog-cancel')).toHaveTextContent('Keep it')
+  })
+
+  it('applies the danger class to the confirm button when danger', () => {
+    render(
+      <ConfirmDialog open danger title="t" message="m" onConfirm={vi.fn()} onCancel={vi.fn()} />
+    )
+    expect(screen.getByTestId('confirm-dialog-confirm')).toHaveClass('btn-modal-danger')
+  })
+
+  it('uses the non-danger class by default', () => {
+    render(
+      <ConfirmDialog open title="t" message="m" onConfirm={vi.fn()} onCancel={vi.fn()} />
+    )
+    expect(screen.getByTestId('confirm-dialog-confirm')).toHaveClass('btn-modal-create')
+  })
+
+  it('fires onConfirm when the confirm button is clicked', () => {
+    const onConfirm = vi.fn()
+    render(
+      <ConfirmDialog open title="t" message="m" onConfirm={onConfirm} onCancel={vi.fn()} />
+    )
+    fireEvent.click(screen.getByTestId('confirm-dialog-confirm'))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onCancel when the cancel button is clicked', () => {
+    const onCancel = vi.fn()
+    render(
+      <ConfirmDialog open title="t" message="m" onConfirm={vi.fn()} onCancel={onCancel} />
+    )
+    fireEvent.click(screen.getByTestId('confirm-dialog-cancel'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onCancel when Escape is pressed (Modal contract)', () => {
+    const onCancel = vi.fn()
+    render(
+      <ConfirmDialog open title="t" message="m" onConfirm={vi.fn()} onCancel={onCancel} />
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/dashboard/src/components/ConfirmDialog.tsx
+++ b/packages/dashboard/src/components/ConfirmDialog.tsx
@@ -40,9 +40,12 @@ export function ConfirmDialog({
   return (
     <Modal open={open} onClose={onCancel} title={title} maxWidth="420px">
       <div className="confirm-dialog" data-testid="confirm-dialog">
-        <p className="confirm-dialog-message" data-testid="confirm-dialog-message">
+        {/* Neutral container (not <p>) so callers can pass richer block-level
+            content — lists, multiple paragraphs, etc. — without producing
+            invalid nested markup. Styled like body text via the CSS class. */}
+        <div className="confirm-dialog-message" data-testid="confirm-dialog-message">
           {message}
-        </p>
+        </div>
         <div className="modal-buttons">
           <button
             type="button"

--- a/packages/dashboard/src/components/ConfirmDialog.tsx
+++ b/packages/dashboard/src/components/ConfirmDialog.tsx
@@ -1,0 +1,67 @@
+/**
+ * ConfirmDialog — a small, reusable confirm/cancel dialog built on `Modal`.
+ *
+ * #5206 — introduced for the session-close confirmation, but deliberately
+ * generic (message, button labels, and a `danger` flavour are all props) so
+ * future destructive actions can reuse it instead of `window.confirm`, which
+ * is unstyleable, untestable, and unreliable inside the Tauri webview.
+ *
+ * Focus management, the Escape-to-close handler, the focus trap, and the
+ * backdrop click all come from `Modal`. Escape / backdrop resolve as a
+ * cancel (they call `onCancel`).
+ */
+import { Modal } from './Modal'
+
+export interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  /** Body text (or richer content) explaining what is about to happen. */
+  message: React.ReactNode
+  /** Confirm-button label. Defaults to "Confirm". */
+  confirmLabel?: string
+  /** Cancel-button label. Defaults to "Cancel". */
+  cancelLabel?: string
+  /** When true, the confirm button uses the destructive (red) styling. */
+  danger?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  danger = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Modal open={open} onClose={onCancel} title={title} maxWidth="420px">
+      <div className="confirm-dialog" data-testid="confirm-dialog">
+        <p className="confirm-dialog-message" data-testid="confirm-dialog-message">
+          {message}
+        </p>
+        <div className="modal-buttons">
+          <button
+            type="button"
+            className="btn-modal-cancel"
+            data-testid="confirm-dialog-cancel"
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            className={danger ? 'btn-modal-danger' : 'btn-modal-create'}
+            data-testid="confirm-dialog-confirm"
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/packages/dashboard/src/components/FocusIndicators.test.tsx
+++ b/packages/dashboard/src/components/FocusIndicators.test.tsx
@@ -51,6 +51,13 @@ describe('Focus indicators (#997)', () => {
     expect(componentsCss).toMatch(/\.tab-close:focus-visible/)
   })
 
+  it('reveals the tab × on hover AND keyboard focus within the tab (#5205)', () => {
+    // The × is opacity:0 by default; it must reveal on both pointer hover and
+    // keyboard focus anywhere in the tab so it's discoverable for both.
+    expect(componentsCss).toMatch(/\.session-tab:hover \.tab-close/)
+    expect(componentsCss).toMatch(/\.session-tab:focus-within \.tab-close/)
+  })
+
   it('has :focus-visible styles for new session button', () => {
     expect(componentsCss).toMatch(/\.btn-new-session:focus-visible/)
   })

--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -41,6 +41,8 @@ const mockSetTheme = vi.fn()
 const mockUpdateInputSettings = vi.fn()
 // #5184: spy for the cost-badge mode setter.
 const mockSetCostBadgeMode = vi.fn()
+// #5206: spy for the confirm-session-close setter.
+const mockSetConfirmSessionClose = vi.fn()
 
 // #3404 audit F1: settable so individual tests can override availableProviders
 // without redefining the whole mock.
@@ -57,6 +59,9 @@ function setMockState(extra: Record<string, unknown> = {}): void {
     // #5184: header cost-badge display mode default + setter spy.
     costBadgeMode: 'provider-model',
     setCostBadgeMode: mockSetCostBadgeMode,
+    // #5206: confirm-before-close setting default + setter spy.
+    confirmSessionClose: true,
+    setConfirmSessionClose: mockSetConfirmSessionClose,
     availableProviders: [],
     // Per-session promptEvaluator toggle defaults — overridden by the
     // Active session test cases. Default empty array + null id keeps the
@@ -245,6 +250,29 @@ describe('SettingsPanel', () => {
       const select = screen.getByTestId('cost-badge-mode-select')
       fireEvent.change(select, { target: { value: 'not-a-mode' } })
       expect(mockSetCostBadgeMode).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('confirm-before-close toggle (#5206)', () => {
+    it('reflects the enabled state from the store', () => {
+      setMockState({ confirmSessionClose: true })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const toggle = screen.getByTestId('confirm-session-close-toggle') as HTMLInputElement
+      expect(toggle.checked).toBe(true)
+    })
+
+    it('reflects the disabled state from the store', () => {
+      setMockState({ confirmSessionClose: false })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const toggle = screen.getByTestId('confirm-session-close-toggle') as HTMLInputElement
+      expect(toggle.checked).toBe(false)
+    })
+
+    it('calls setConfirmSessionClose when toggled', () => {
+      setMockState({ confirmSessionClose: true })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      fireEvent.click(screen.getByTestId('confirm-session-close-toggle'))
+      expect(mockSetConfirmSessionClose).toHaveBeenCalledWith(false)
     })
   })
 

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -618,6 +618,8 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   // (same localStorage pattern as theme / default provider).
   const costBadgeMode = useConnectionStore(s => s.costBadgeMode)
   const setCostBadgeMode = useConnectionStore(s => s.setCostBadgeMode)
+  const confirmSessionClose = useConnectionStore(s => s.confirmSessionClose)
+  const setConfirmSessionClose = useConnectionStore(s => s.setConfirmSessionClose)
   // Per-session promptEvaluator toggle. Lives in settings (not the header)
   // so the "Auto-evaluate prompts before send" label has room for a hint
   // line and doesn't crowd the model/permission selects. Only shown when
@@ -1118,6 +1120,27 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 Choose what the badge in the top bar displays — provider and
                 model, the running dollar cost, token count, percent of the
                 context window used, or the session-type tag.
+              </p>
+            </div>
+            {/* #5206: confirm-before-close toggle. When on (default), closing
+                a session tab prompts a confirmation so a session isn't
+                terminated by an accidental click. The Control Room tab is
+                exempt — it closes immediately. */}
+            <div className="settings-field settings-field-checkbox">
+              <label htmlFor="confirm-session-close">
+                <input
+                  id="confirm-session-close"
+                  type="checkbox"
+                  checked={confirmSessionClose}
+                  onChange={(e) => setConfirmSessionClose(e.target.checked)}
+                  data-testid="confirm-session-close-toggle"
+                />
+                Confirm before closing a session
+              </label>
+              <p className="settings-hint">
+                Ask for confirmation before closing a session tab so you don't
+                terminate a session by accident. Closing the Control Room tab
+                never asks.
               </p>
             </div>
             <div className="settings-field">

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -403,6 +403,10 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const raw = loadPersistedSetting('chroxy_cost_badge_mode', DEFAULT_COST_BADGE_MODE)
     return isCostBadgeMode(raw) ? raw : DEFAULT_COST_BADGE_MODE
   })(),
+  // #5206 — whether closing a session tab prompts a confirmation first.
+  // Defaults to enabled (string 'true'); only an explicit 'false' disables it,
+  // so a missing / corrupt value safely falls back to the protective default.
+  confirmSessionClose: loadPersistedSetting('chroxy_confirm_session_close', 'true') !== 'false',
   // #4052: BYOK credentials state. Server-of-truth lives in
   // ~/.chroxy/credentials.json or ANTHROPIC_API_KEY env var; the dashboard
   // mirrors the resolved status (set/missing) + a masked preview. Updates
@@ -549,6 +553,13 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   setCostBadgeMode: (mode: CostBadgeMode) => {
     set({ costBadgeMode: mode });
     try { localStorage.setItem('chroxy_cost_badge_mode', mode); } catch { /* noop */ }
+  },
+
+  // #5206 — toggle the session-close confirmation. Persisted as 'true'/'false'
+  // strings to match the loadPersistedSetting string contract.
+  setConfirmSessionClose: (enabled: boolean) => {
+    set({ confirmSessionClose: enabled });
+    try { localStorage.setItem('chroxy_confirm_session_close', enabled ? 'true' : 'false'); } catch { /* noop */ }
   },
 
   // #4052: BYOK credentials actions. The full key is never stored in the

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -421,6 +421,37 @@ describe('useConnectionStore', () => {
     });
   });
 
+  describe('confirmSessionClose (#5206)', () => {
+    it('defaults to enabled (true)', async () => {
+      const { useConnectionStore } = await import('./connection');
+      expect(useConnectionStore.getState().confirmSessionClose).toBe(true);
+    });
+
+    it('setConfirmSessionClose updates state and persists to localStorage', async () => {
+      const { useConnectionStore } = await import('./connection');
+      useConnectionStore.getState().setConfirmSessionClose(false);
+      expect(useConnectionStore.getState().confirmSessionClose).toBe(false);
+      expect(localStorage.getItem('chroxy_confirm_session_close')).toBe('false');
+      useConnectionStore.getState().setConfirmSessionClose(true);
+      expect(useConnectionStore.getState().confirmSessionClose).toBe(true);
+      expect(localStorage.getItem('chroxy_confirm_session_close')).toBe('true');
+    });
+
+    it('swallows a localStorage write failure (private mode / quota)', async () => {
+      const { useConnectionStore } = await import('./connection');
+      const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+      try {
+        expect(() => useConnectionStore.getState().setConfirmSessionClose(false)).not.toThrow();
+        expect(useConnectionStore.getState().confirmSessionClose).toBe(false);
+      } finally {
+        spy.mockRestore();
+        useConnectionStore.getState().setConfirmSessionClose(true);
+      }
+    });
+  });
+
   it('switchSession updates activeSessionId even without cached state', async () => {
     const { useConnectionStore } = await import('./connection');
 

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -941,6 +941,11 @@ export interface ConnectionState {
   costBadgeMode: CostBadgeMode;
   setCostBadgeMode: (mode: CostBadgeMode) => void;
 
+  // #5206: whether closing a session tab prompts a confirmation dialog first.
+  // Persisted to localStorage ('true'/'false'); defaults to enabled (true).
+  confirmSessionClose: boolean;
+  setConfirmSessionClose: (enabled: boolean) => void;
+
   // #4052: BYOK credentials state + actions. The raw key is NEVER stored
   // here — only the masked preview from the server's reply.
   byokCredentialsStatus: {

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1607,8 +1607,20 @@ button.sidebar-token-view-session-row:hover {
   transition: opacity 0.15s;
 }
 
-.session-tab:hover .tab-close {
+/* #5205 — reveal the × on hover OR keyboard focus anywhere within the tab
+ * (the tab div itself is focusable via tabIndex=0, so :focus-within fires when
+ * a keyboard user lands on the tab, not only once they reach the × button).
+ * Keeps the close affordance discoverable for both mouse and keyboard. */
+.session-tab:hover .tab-close,
+.session-tab:focus-within .tab-close {
   opacity: 1;
+}
+
+/* #5205 — subtle "expand slightly" affordance on hover/focus so the tab grows
+ * to make room for the revealed ×, matching the requested feel. */
+.session-tab:hover,
+.session-tab:focus-within {
+  padding-right: 14px;
 }
 
 .tab-close:hover {
@@ -5032,6 +5044,28 @@ button.sidebar-token-view-session-row:hover {
 }
 
 .btn-modal-create:hover { background: #3a8eef; }
+
+/* #5206 — destructive confirm button (e.g. "Close session"). Same shape as
+ * .btn-modal-create but red, signalling the action is irreversible. */
+.btn-modal-danger {
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: none;
+  background: var(--accent-red);
+  color: #fff;
+  font-size: var(--text-base);
+  cursor: pointer;
+  font-weight: 500;
+}
+.btn-modal-danger:hover { filter: brightness(1.1); }
+
+/* #5206 — ConfirmDialog body text. */
+.confirm-dialog-message {
+  margin: 0 0 14px;
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+  line-height: 1.5;
+}
 
 .form-error {
   color: var(--accent-red);


### PR DESCRIPTION
## Summary

Closes #5205 and #5206. Part of epic #5170 (Control Room v2 follow-ups, v0.9.44 feedback). Builds on the new Control Room top-level tab (#5204).

## #5205 — hover/focus-reveal × on tabs
The tab close (×) was already `opacity:0` and revealed on `:hover` / `.tab-close:focus-visible`. The gap was **keyboard focus on the tab itself**. Added:
- `.session-tab:focus-within .tab-close` → the × reveals when a keyboard user lands on the tab (the tab div is `tabIndex=0`), not only once they tab onto the × button.
- A subtle "expand slightly" (extra right padding) on `:hover` / `:focus-within`, matching the requested feel.

The × is already accessible (`aria-label`, real `<button>`, keyboard-reachable). The Control Room tab's × reuses the same rules.

## #5206 — close-confirm dialog + Settings toggle
`handleCloseSession` used a bare `window.confirm` — unstyleable, untestable, and unreliable in the Tauri webview. Replaced with a styled, **reusable** `ConfirmDialog`:
- **`ConfirmDialog`** (new) — built on `Modal` (focus trap, Escape, backdrop). Generic props: `message`, `confirmLabel`, `cancelLabel`, `danger`. Built generic so future destructive actions can reuse it (extensible, per the user's ask).
- **Setting** `confirmSessionClose` (default **on**) — persisted to `chroxy_confirm_session_close` ('true'/'false'); only an explicit `'false'` disables, so a corrupt value keeps the protective default. Mirrors the cost-badge #5184 persistence pattern.
- **App** — `handleCloseSession` opens the dialog when enabled, else closes immediately. Teardown extracted to `performCloseSession`. **The Control Room tab is exempt** (it closes via its own non-session path).
- **SettingsPanel** — a checkbox toggle to enable/disable.

## Tests
- New `ConfirmDialog` tests (render/labels/danger/confirm/cancel/Escape).
- Store tests (default on, setter persists, swallows write failure).
- SettingsPanel toggle tests (reflects state, calls setter).
- App-level gating tests (× opens dialog & no immediate destroy; confirm → destroy; cancel → keep; setting off → immediate).
- Updated the #3800 eviction test to drive the new dialog path.
- CSS pin for the #5205 hover + focus reveal.
- **3111 dashboard tests pass**, `tsc --noEmit` clean.

## Acceptance criteria
#5205:
- [x] Each tab shows a × on hover/focus (expands slightly)
- [x] Clicking × closes that tab
- [x] Accessible (aria-label, keyboard reachable)

#5206:
- [x] Closing a session tab prompts a confirm dialog (when enabled)
- [x] Settings toggle enables/disables the prompt; persisted; default enabled
- [x] Control Room tab close is exempt
- [x] Confirm terminates/closes the session; cancel keeps it