### PR TITLE
feat(dashboard): clickable Investigate verdict launches a pre-seeded session (#5202)

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -88,7 +88,7 @@ import { ConsolePage } from './components/ConsolePage'
 import { EnvironmentPanel } from './components/EnvironmentPanel'
 import { SnapshotsPanel } from './components/SnapshotsPanel'
 import { PoolStatsPanel } from './components/PoolStatsPanel'
-import { ControlRoomSection } from './components/ControlRoomSection'
+import { ControlRoomSection, type RepoInvestigateRequest } from './components/ControlRoomSection'
 
 /** Server-injected config from <meta name="chroxy-config"> tag */
 interface ChroxyConfig {
@@ -638,6 +638,11 @@ export function App() {
   // #5206 — the session id awaiting close-confirmation, or null when no
   // confirm is pending. Drives the ConfirmDialog rendered near the modals.
   const [closeConfirmSessionId, setCloseConfirmSessionId] = useState<string | null>(null)
+  // #5202 — when an Investigate verdict launches a session, the reason note is
+  // stashed here at click time and seeded into the new session's composer once
+  // the server confirms the session (the create-confirm effect). A ref (not
+  // state) so it survives without re-renders and is read at the transition.
+  const pendingSeedPromptRef = useRef<string | null>(null)
 
   // #3073: copy chat transcript to clipboard with brief "Copied" feedback.
   const [transcriptCopied, setTranscriptCopied] = useState(false)
@@ -909,6 +914,19 @@ export function App() {
       setShowCreateSession(false)
       setIsCreatingSession(false)
       setSessionCreateError(null)
+      // #5202 — if this create was launched from an Investigate verdict, seed
+      // the freshly-created session's composer with the reason note and drop
+      // out of the Control Room so the operator lands in the new session. We
+      // write the per-session draft ref too so the draft-restore effect (which
+      // runs after this one on the same activeSessionId change) reads the seed
+      // rather than clobbering it with an empty draft.
+      if (pendingSeedPromptRef.current) {
+        const reason = pendingSeedPromptRef.current
+        inputDraftsRef.current.set(activeSessionId, reason)
+        setInputDraftValue(reason)
+        setControlRoomActive(false)
+        pendingSeedPromptRef.current = null
+      }
     }
   }, [activeSessionId, isCreatingSession])
 
@@ -1402,6 +1420,19 @@ export function App() {
 
   const handleNewSession = useCallback(() => {
     setPendingCwd(null)
+    // #5202 — a plain new session carries no investigation seed; clear any
+    // stale one so it can't leak into this session's composer.
+    pendingSeedPromptRef.current = null
+    setShowCreateSession(true)
+  }, [])
+
+  // #5202 — open the create-session picker pre-filled for an Investigate
+  // action: cwd = the repo path, and the reason note stashed for seeding into
+  // the new session's composer once it's created. The user still picks
+  // model/provider/options in the modal before creating.
+  const handleInvestigate = useCallback((req: RepoInvestigateRequest) => {
+    pendingSeedPromptRef.current = req.reason || null
+    setPendingCwd(req.cwd)
     setShowCreateSession(true)
   }, [])
 
@@ -2361,7 +2392,7 @@ export function App() {
             even with zero sessions. */}
         {controlRoomActive && connectionPhase !== 'connecting' && (
           <div className="main-content" data-testid="control-room-main">
-            <ControlRoomSection />
+            <ControlRoomSection onInvestigate={handleInvestigate} />
           </div>
         )}
 
@@ -2739,7 +2770,7 @@ export function App() {
       {/* Modals */}
       <CreateSessionModal
         open={showCreateSession}
-        onClose={() => { setShowCreateSession(false); setIsCreatingSession(false); setSessionCreateError(null) }}
+        onClose={() => { setShowCreateSession(false); setIsCreatingSession(false); setSessionCreateError(null); pendingSeedPromptRef.current = null }}
         onCreate={handleCreateSession}
         initialCwd={pendingCwd}
         knownCwds={knownCwds}

--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -440,6 +440,20 @@ describe('ControlRoomSection investigate action (#5202)', () => {
     expect(tag).toHaveClass('cr-tag-action')
   })
 
+  it('gives the investigate button a per-row accessible name including the repo', () => {
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+        onInvestigate={() => {}}
+      />,
+    )
+    const tag = screen.getByTestId('cr-verdict-investigate')
+    expect(tag).toHaveAttribute('aria-label', expect.stringContaining('medlens'))
+  })
+
   it('calls onInvestigate with the repo cwd, name, and reason note on click', () => {
     const onInvestigate = vi.fn()
     render(

--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -417,3 +417,90 @@ describe('ControlRoomSection activity drill-down (#5176)', () => {
     expect(screen.getByTestId('control-room-empty')).toHaveTextContent('No activity in flight')
   })
 })
+
+describe('ControlRoomSection investigate action (#5202)', () => {
+  it('renders the investigate verdict as a non-interactive span when no handler is wired', () => {
+    render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    const tag = screen.getByTestId('cr-verdict-investigate')
+    expect(tag.tagName).toBe('SPAN')
+  })
+
+  it('renders the investigate verdict as a button when onInvestigate is provided', () => {
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+        onInvestigate={() => {}}
+      />,
+    )
+    const tag = screen.getByTestId('cr-verdict-investigate')
+    expect(tag.tagName).toBe('BUTTON')
+    expect(tag).toHaveClass('cr-tag-action')
+  })
+
+  it('calls onInvestigate with the repo cwd, name, and reason note on click', () => {
+    const onInvestigate = vi.fn()
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+        onInvestigate={onInvestigate}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('cr-verdict-investigate'))
+    expect(onInvestigate).toHaveBeenCalledWith({
+      cwd: '/Users/me/Projects/medlens',
+      name: 'medlens',
+      reason: '172 worktrees — likely a leak/runaway.',
+    })
+  })
+
+  it('passes an empty reason when the repo has no note', () => {
+    const onInvestigate = vi.fn()
+    const snap = makeSnapshot({
+      repos: [
+        {
+          name: 'noteless',
+          path: '/Users/me/Projects/noteless',
+          branch: 'main',
+          verdict: 'investigate',
+          live: false,
+          tree: { state: 'dirty', untracked: 1, modified: 0, staged: 0 },
+          worktrees: 99,
+          openPRs: null,
+          attribution: null,
+          onboarding: 'skipped',
+          lastTouched: '2026-05-28T11:00:00.000Z',
+          // no note
+        },
+      ],
+    })
+    render(
+      <ControlRoomSection snapshot={snap} loading={false} onRefresh={() => {}} now={() => NOW} onInvestigate={onInvestigate} />,
+    )
+    fireEvent.click(screen.getByTestId('cr-verdict-investigate'))
+    expect(onInvestigate).toHaveBeenCalledWith({
+      cwd: '/Users/me/Projects/noteless',
+      name: 'noteless',
+      reason: '',
+    })
+  })
+
+  it('leaves non-actionable verdicts (live, onboarded) as plain spans even with a handler', () => {
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+        onInvestigate={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('cr-verdict-live').tagName).toBe('SPAN')
+    expect(screen.getByTestId('cr-verdict-onboarded').tagName).toBe('SPAN')
+  })
+})

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -62,6 +62,29 @@ const VERDICT_LABEL: Record<RepoVerdict, string> = {
 }
 
 /**
+ * #5202 — payload emitted when an operator clicks an actionable verdict tag.
+ * The host wires this to the create-session flow: it opens the picker
+ * pre-filled with `cwd` and seeds `reason` into the new session's composer.
+ */
+export interface RepoInvestigateRequest {
+  /** Absolute path of the repo — becomes the new session's cwd. */
+  cwd: string
+  /** Repo display name, for labelling the action and session. */
+  name: string
+  /** The investigation reason (the repo's `↳` note) to seed the composer with. */
+  reason: string
+}
+
+/**
+ * #5202 — which verdicts are clickable "control actions". Start with
+ * `investigate` only; extend this map per-verdict as more actions land (e.g.
+ * `abandoned` → review-and-clean) so the click wiring grows in one place.
+ */
+const ACTIONABLE_VERDICTS: Partial<Record<RepoVerdict, true>> = {
+  investigate: true,
+}
+
+/**
  * A worktree or open-PR count at or above this threshold renders in the "bad"
  * colour — the brief flags runaway worktree/PR counts (e.g. 172 worktrees =
  * leak) so the operator's eye lands on them. Kept low enough to surface a
@@ -164,8 +187,37 @@ const SUMMARY_CHIPS: readonly SummaryChip[] = [
   { key: 'recent', label: 'Recent / your call', accent: 'warn' },
 ]
 
-function VerdictTag({ verdict }: { verdict: RepoVerdict }) {
+function VerdictTag({
+  repo,
+  onInvestigate,
+}: {
+  repo: RepoStatus
+  /** #5202 — when provided and the verdict is actionable, the tag is a button. */
+  onInvestigate?: (req: RepoInvestigateRequest) => void
+}) {
+  const { verdict } = repo
   const accent = VERDICT_ACCENT[verdict]
+  // #5202 — the only wired action today is Investigate. Keep the dispatch
+  // table-driven so adding e.g. an `abandoned` action is a one-line change.
+  const actionable = ACTIONABLE_VERDICTS[verdict] === true && !!onInvestigate
+
+  if (actionable) {
+    return (
+      <button
+        type="button"
+        className={`cr-tag cr-tag-${accent} cr-tag-action`}
+        data-testid={`cr-verdict-${verdict}`}
+        data-accent={accent}
+        title={`Investigate ${repo.name} — open a session in ${repo.path}`}
+        onClick={() =>
+          onInvestigate!({ cwd: repo.path, name: repo.name, reason: repo.note ?? '' })
+        }
+      >
+        {VERDICT_LABEL[verdict]}
+      </button>
+    )
+  }
+
   return (
     <span
       className={`cr-tag cr-tag-${accent}`}
@@ -240,9 +292,11 @@ interface RepoRowsProps {
   onToggleExpand: (path: string) => void
   /** Injectable clock for the activity tree's elapsed timers (tests). */
   now?: () => number
+  /** #5202 — investigate action, forwarded to the verdict tag. */
+  onInvestigate?: (req: RepoInvestigateRequest) => void
 }
 
-function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now }: RepoRowsProps) {
+function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onInvestigate }: RepoRowsProps) {
   // Map repo → its active chroxy session (by cwd). When a session is found the
   // name cell becomes a disclosure toggle that reveals that session's live
   // activity tree (subagents / shells / tools — the retired v1 panel's view).
@@ -281,7 +335,7 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now }: R
               hover (title) instead of forcing the table wider / clipping. */}
           <div className="cr-dim cr-mono cr-branch" data-testid={`cr-branch-${repo.name}`} title={repo.branch}>{repo.branch}</div>
         </td>
-        <td><VerdictTag verdict={repo.verdict} /></td>
+        <td><VerdictTag repo={repo} onInvestigate={onInvestigate} /></td>
         {/* #5201: ellipsis-truncate on an inner block element, not the <td>
             itself — text-overflow on display:table-cell is unreliable and can
             still let long content widen the column. The branch cell already
@@ -367,6 +421,12 @@ export interface ControlRoomSectionProps {
   sessions?: readonly SessionInfo[]
   /** Injectable clock (epoch ms) for the "generated Nm ago" string. */
   now?: () => number
+  /**
+   * #5202 — invoked when an operator clicks an actionable verdict tag
+   * (currently Investigate). The host opens the create-session picker
+   * pre-filled with the repo cwd and seeds the reason into the composer.
+   */
+  onInvestigate?: (req: RepoInvestigateRequest) => void
 }
 
 // Stable empty-activity default so the `activity` prop falling back to its
@@ -381,6 +441,7 @@ export function ControlRoomSection({
   activity: activityProp,
   sessions: sessionsProp,
   now = Date.now,
+  onInvestigate,
 }: ControlRoomSectionProps = {}) {
   const storeSnapshot = useConnectionStore((s) => s.hostStatus)
   const storeLoading = useConnectionStore((s) => s.hostStatusLoading)
@@ -527,6 +588,7 @@ export function ControlRoomSection({
                       expanded={expandedRepos.has(repo.path)}
                       onToggleExpand={handleToggleRepo}
                       now={now}
+                      onInvestigate={onInvestigate}
                     />
                   ))
                 )}

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -208,6 +208,10 @@ function VerdictTag({
         className={`cr-tag cr-tag-${accent} cr-tag-action`}
         data-testid={`cr-verdict-${verdict}`}
         data-accent={accent}
+        // #5202 — the visible label is just "Investigate", identical on every
+        // row; give screen readers a per-row accessible name (the title tooltip
+        // is not a reliable accessible-name source).
+        aria-label={`Investigate ${repo.name} — open a session in ${repo.path}`}
         title={`Investigate ${repo.name} — open a session in ${repo.path}`}
         onClick={() =>
           onInvestigate!({ cwd: repo.path, name: repo.name, reason: repo.note ?? '' })

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8774,3 +8774,23 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-red);
 }
 
+/* #5202 — an actionable verdict tag rendered as a <button> (e.g. Investigate).
+ * Inherits the .cr-tag look; resets button chrome and adds a clickable
+ * affordance (pointer, hover lift, focus ring) so it reads as interactive. */
+.cr-tag-action {
+  cursor: pointer;
+  font: inherit;
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 11px;
+  transition: filter 0.12s, box-shadow 0.12s;
+}
+.cr-tag-action:hover {
+  filter: brightness(1.12);
+  box-shadow: 0 0 0 1px currentColor inset;
+}
+.cr-tag-action:focus-visible {
+  outline: 2px solid var(--border-focus);
+  outline-offset: 1px;
+}
+


### PR DESCRIPTION
## Summary

Closes #5202. Part of epic #5170 (Control Room v2) — the first phase-2 "control action" (observe → act).

The Control Room verdict tags were static labels. This makes **Investigate** clickable: clicking it opens the create-session picker pre-filled with the repo's path as `cwd` and seeds the repo's `↳` reason note into the new session's composer once it's created.

## Flow
1. Operator clicks the **Investigate** tag on a repo row.
2. The create-session modal opens, **cwd pre-filled** with that repo's path.
3. Operator picks model / provider / options and creates (the reason is held until then).
4. The new session opens in that folder with the reason **pre-seeded as an editable composer draft** (not auto-sent), and the view drops out of the Control Room into the new session.

## Implementation
- **`ControlRoomSection`** — `VerdictTag` renders a `<button>` (was `<span>`) when the verdict is actionable **and** an `onInvestigate` handler is wired; otherwise it stays a non-interactive span (no dead clicks). Driven by an `ACTIONABLE_VERDICTS` table — investigate-only today, so adding e.g. `abandoned → review-and-clean` later is a one-line change (the extensibility the issue asked for). Emits `{ cwd, name, reason }`.
- **App** — `handleInvestigate` stashes the reason in `pendingSeedPromptRef` and opens the modal with `pendingCwd`. The existing create-confirm effect (which already fires when the new `activeSessionId` lands) seeds the composer: it writes both `inputDraftValue` and the per-session `inputDraftsRef` (so the draft-restore effect that runs right after doesn't clobber the seed with an empty draft), then `setControlRoomActive(false)`. The ref is cleared on modal cancel and on plain new-session so a stale reason can't leak into an unrelated session.
- **CSS** — `.cr-tag-action` adds a clickable affordance (pointer, hover lift, focus ring) over the existing `.cr-tag` look.

## Tests
- 5 new `ControlRoomSection` tests: span when no handler; button + `cr-tag-action` when wired; click payload `{cwd,name,reason}`; empty reason when the repo has no note; non-actionable verdicts (live/onboarded) stay spans.
- **3116 dashboard tests pass**, `tsc --noEmit` clean.

## Acceptance criteria
- [x] Investigate tag is clickable (keyboard-accessible button)
- [x] Click opens create-session pre-filled with the repo cwd + investigation reason
- [x] Creating starts a session in that repo seeded with the reason
- [x] Non-actionable verdicts remain non-interactive (no dead clicks)