### PR TITLE
fix(dashboard): Control Room from-review follow-ups (#5214, #5211, #5210)

### DIFF
--- a/packages/dashboard/src/App.test.tsx
+++ b/packages/dashboard/src/App.test.tsx
@@ -2326,4 +2326,30 @@ describe('App', () => {
       expect(screen.getByTestId('create-session-modal-mock')).toBeInTheDocument()
     })
   })
+
+  describe('#5211 Control Room view vs disconnected/startup screens', () => {
+    const sessionWithCwd = [
+      { sessionId: 's1', name: 'One', cwd: '/tmp/a', type: 'cli', hasTerminal: true, model: null, permissionMode: null, isBusy: false, createdAt: Date.now(), conversationId: null },
+    ]
+
+    it('keeps the CR view and suppresses the disconnected screen when the connection drops while CR is active', () => {
+      stateOverrides = { connectionPhase: 'connected', sessions: sessionWithCwd, activeSessionId: 's1' }
+      const { rerender } = render(<App />)
+      // Open the Control Room via the sidebar launcher (sessions-with-cwd
+      // render the sidebar, which hosts the launcher).
+      fireEvent.click(screen.getByTestId('sidebar-panel-slot-launcher-control-room'))
+      expect(screen.getByTestId('control-room-main')).toBeInTheDocument()
+
+      // Connection drops with no sessions left — the disconnected screen would
+      // normally render. controlRoomActive is local state and survives the
+      // rerender, so the CR is still active.
+      stateOverrides = { connectionPhase: 'disconnected', sessions: [], activeSessionId: null }
+      rerender(<App />)
+
+      // #5211 — the CR owns the main area; the disconnected screen does NOT
+      // also render (mutually exclusive).
+      expect(screen.getByTestId('control-room-main')).toBeInTheDocument()
+      expect(screen.queryByTestId('disconnected-screen')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -821,6 +821,9 @@ export function App() {
         })
       },
       openCreateSessionAt: (cwd) => {
+        // #5214 — opening the picker at a context-menu cwd is not an
+        // Investigate launch; clear any stashed seed so it can't leak.
+        pendingSeedPromptRef.current = null
         setPendingCwd(cwd)
         setShowCreateSession(true)
       },
@@ -879,6 +882,11 @@ export function App() {
         recordMruCommand(cmd.id)
         // Override commands that need App-level state
         if (cmd.id === 'new-session') {
+          // #5214 — a plain new session: reset cwd and clear any stashed
+          // Investigate seed so it can't leak into this session's composer
+          // (matches handleNewSession; this path previously diverged on both).
+          setPendingCwd(null)
+          pendingSeedPromptRef.current = null
           setShowCreateSession(true)
         } else if (cmd.id === 'toggle-sidebar') {
           setSidebarOpen(prev => !prev)
@@ -2293,6 +2301,9 @@ export function App() {
           onResumeSession={resumeConversation}
           onOpenControlRoom={openControlRoom}
           onNewSession={(cwd) => {
+            // #5214 — sidebar new-session is not an Investigate launch; clear
+            // any stashed seed so it can't leak into this session's composer.
+            pendingSeedPromptRef.current = null
             setPendingCwd(cwd || null)
             setShowCreateSession(true)
           }}
@@ -2346,8 +2357,12 @@ export function App() {
           onRestart={handleRestartSession}
         />
 
-        {/* Startup error screen — shown when server failed to start (Tauri) */}
-        {isStartupError && (
+        {/* Startup error screen — shown when server failed to start (Tauri).
+            #5211 — suppressed while the Control Room tab is active so the two
+            don't double-render; the CR shows its own not-connected affordance
+            (disabled Refresh + hint) and the operator can close it to reach
+            this screen. */}
+        {isStartupError && !controlRoomActive && (
           <StartupErrorScreen
             error={connectionError}
             logs={serverStartupLogs}
@@ -2356,8 +2371,11 @@ export function App() {
           />
         )}
 
-        {/* Disconnected screen — shown when not connected with no error (e.g. server stopped) */}
-        {connectionPhase === 'disconnected' && !connectionError && !isConnected && sessions.length === 0 && (
+        {/* Disconnected screen — shown when not connected with no error (e.g.
+            server stopped). #5211 — suppressed while the Control Room tab is
+            active (mutually exclusive with the CR view, which renders its own
+            not-connected state). */}
+        {connectionPhase === 'disconnected' && !connectionError && !isConnected && sessions.length === 0 && !controlRoomActive && (
           <div className="startup-error-screen" data-testid="disconnected-screen">
             <div className="startup-error-content">
               <h2 className="startup-error-title">Disconnected</h2>
@@ -2390,7 +2408,11 @@ export function App() {
             and switching back to a session restores it untouched. Takes
             precedence over the welcome screen so the operator can open the CR
             even with zero sessions. */}
-        {controlRoomActive && connectionPhase !== 'connecting' && (
+        {/* #5211 — the CR owns the main area whenever active (any connection
+            phase). It renders its own empty/loading + not-connected states, so
+            it stays put across reconnects instead of blanking or
+            double-rendering with the disconnected/startup screens. */}
+        {controlRoomActive && (
           <div className="main-content" data-testid="control-room-main">
             <ControlRoomSection onInvestigate={handleInvestigate} />
           </div>

--- a/packages/dashboard/src/components/SessionBar.test.tsx
+++ b/packages/dashboard/src/components/SessionBar.test.tsx
@@ -1270,6 +1270,30 @@ describe('SessionBar', () => {
       expect(crTab.getAttribute('draggable')).not.toBe('true')
     })
 
+    it('#5210 arrows off the CR tab onto an adjacent session tab and back', () => {
+      render(
+        <SessionBar
+          sessions={makeSessions()}
+          onSwitch={vi.fn()}
+          onClose={vi.fn()}
+          onRename={vi.fn()}
+          onNewSession={vi.fn()}
+          controlRoom={{ open: true, active: true, onActivate: vi.fn(), onClose: vi.fn() }}
+        />
+      )
+      const crTab = screen.getByTestId('control-room-tab')
+      const firstSession = screen.getByTestId('session-tab-s1')
+      // The CR tab is pinned first; ArrowRight moves to the first session tab.
+      crTab.focus()
+      fireEvent.keyDown(crTab, { key: 'ArrowRight' })
+      expect(document.activeElement).toBe(firstSession)
+      // And ArrowLeft from the first session tab returns to the CR tab
+      // (the session tabs' own roving ladder), proving the boundary is
+      // traversable both ways.
+      fireEvent.keyDown(firstSession, { key: 'ArrowLeft' })
+      expect(document.activeElement).toBe(crTab)
+    })
+
     it('does not activate the CR tab when Enter/Space bubbles from its close ×', () => {
       const onActivate = vi.fn()
       const onClose = vi.fn()

--- a/packages/dashboard/src/components/SessionBar.tsx
+++ b/packages/dashboard/src/components/SessionBar.tsx
@@ -284,6 +284,19 @@ export function SessionBar({ sessions, onSwitch, onClose, onRename, onNewSession
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault()
                 if (!controlRoom.active) controlRoom.onActivate()
+              } else if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+                // #5210 — mirror the session tabs' roving-tabindex arrow ladder
+                // so a keyboard user who arrows onto the CR tab can arrow back
+                // off it (it shares role="tab" with the session pills). Without
+                // this, focus would be stranded here.
+                e.preventDefault()
+                const tabs = (e.currentTarget.parentElement as HTMLElement)?.querySelectorAll<HTMLElement>('[role="tab"]')
+                if (!tabs) return
+                const idx = Array.from(tabs).indexOf(e.currentTarget)
+                const next = e.key === 'ArrowRight'
+                  ? (idx + 1) % tabs.length
+                  : (idx - 1 + tabs.length) % tabs.length
+                tabs[next]?.focus()
               }
             }}
           >


### PR DESCRIPTION
## Summary

Three narrow gaps surfaced by the reviews of #5204 (CR top-level tab) and #5202 (Investigate action). Closes #5214. Closes #5211. Closes #5210.

### #5214 — Investigate seed can't leak into an unrelated session
PR #5213 cleared `pendingSeedPromptRef` on the modal `onClose` and `handleNewSession`, but three other create-session openers bypassed `handleNewSession`. Each now clears the ref:
- command-palette `new-session` (also now resets `pendingCwd`, fixing a pre-existing divergence)
- sidebar `onNewSession(cwd)`
- `openCreateSessionAt` (context-menu "open session at cwd")

### #5211 — CR view ⟂ disconnected/startup-error screens
The CR view (`controlRoomActive`) didn't mutually exclude the disconnected / startup-error screens, so a mid-session disconnect double-rendered the table beneath a "Disconnected" banner. Now:
- The CR owns the main content area whenever active (any connection phase) and renders its own not-connected affordance (the existing disabled Refresh + "not connected" hint).
- The disconnected and startup-error screens are suppressed while CR is active.

### #5210 — CR tab keyboard roving isn't a dead end
The session tabs implement an ArrowLeft/ArrowRight roving-tabindex ladder; the CR tab shares `role="tab"` but only handled Enter/Space, stranding keyboard focus once it landed there. The CR tab's `onKeyDown` now handles the arrows the same way, so focus traverses the CR/session boundary both ways.

## Tests
- **#5210:** SessionBar — ArrowRight off the CR tab focuses the first session tab; ArrowLeft returns to the CR tab.
- **#5211:** App — open the CR via the sidebar launcher, drop the connection with zero sessions, assert `control-room-main` stays and `disconnected-screen` does not render.
- **#5214:** covered by the inline clears. A full create-flow E2E isn't drivable in `App.test` (CreateSessionModal is mocked without an `onCreate` seam; modal behavior lives in the CreateSessionModal*.test suites). The three openers now clear the ref symmetrically with `handleNewSession`.
- **3119 dashboard tests pass**, `tsc --noEmit` clean.

## Acceptance criteria
- #5214: [x] all create-session entry points clear the seed unless Investigate · [x] command-palette resets `pendingCwd` · [~] E2E test (see note above)
- #5211: [x] CR + disconnected/startup mutually exclusive · [x] CR shows a sensible state when down · [x] verified across phases
- #5210: [x] CR tab handles Arrow keys · [x] can arrow off and back · [x] test covers the boundary