### PR TITLE
fix(ci): bump-version.sh scaffolds new CHANGELOG section below [Unreleased] (#5207)

### DIFF
--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -292,8 +292,21 @@ EOF
     return 1
   }
 
-  # The pending [Unreleased] entry must be preserved (not buried/dropped).
-  grep -q "A pending entry not yet released" "$dir/CHANGELOG.md" || return 1
+  # The pending [Unreleased] entry must be preserved (not buried/dropped) AND
+  # stay above the new version header — i.e. the new section must land below the
+  # [Unreleased] *body*, not immediately after the `## [Unreleased]` line (which
+  # would push the pending entry under the cut release). Assert by line number,
+  # not just existence, so a regression that splices after the header line fails.
+  local pending_line
+  pending_line=$(grep -n "A pending entry not yet released" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
+  [ -n "$pending_line" ] || {
+    echo "    pending [Unreleased] entry was dropped" >&2
+    return 1
+  }
+  [ "$pending_line" -lt "$new_line" ] || {
+    echo "    pending [Unreleased] entry landed below the new section (line $pending_line vs $new_line)" >&2
+    return 1
+  }
 }
 
 test_preserves_header_preamble() {

--- a/scripts/__tests__/bump-version.test.sh
+++ b/scripts/__tests__/bump-version.test.sh
@@ -247,6 +247,55 @@ test_scaffolds_new_section() {
   [ "$new_line" -lt "$prev_line" ]
 }
 
+test_inserts_after_unreleased_section() {
+  # #5207 — when the CHANGELOG has an [Unreleased] section on top, the new
+  # versioned section must land directly BELOW it (and its body), not above —
+  # preserving Keep-a-Changelog ordering and not burying pending entries.
+  local dir
+  dir=$(mktemp -d)
+  trap "rm -rf '$dir'" RETURN
+  build_fake_repo "$dir" "0.1.0"
+  install_bump_script "$dir"
+  cat > "$dir/CHANGELOG.md" <<'EOF'
+# Changelog
+
+The format is based on [Keep a Changelog]; [Unreleased] stays on top.
+
+## [Unreleased]
+
+### Added
+
+- A pending entry not yet released
+
+## [0.1.0] - 2026-01-01
+
+### Added
+
+- Initial release
+EOF
+
+  (cd "$dir" && PATH="$NOCARGO_PATH" ./scripts/bump-version.sh 0.2.0) > /dev/null 2>&1 || return 1
+
+  grep -q "^## \[0.2.0\] - " "$dir/CHANGELOG.md" || return 1
+
+  # Ordering must be: [Unreleased] < [0.2.0] < [0.1.0]
+  local unrel_line new_line prev_line
+  unrel_line=$(grep -n "^## \[Unreleased\]" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
+  new_line=$(grep -n "^## \[0.2.0\]" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
+  prev_line=$(grep -n "^## \[0.1.0\]" "$dir/CHANGELOG.md" | head -1 | cut -d: -f1)
+  [ "$unrel_line" -lt "$new_line" ] || {
+    echo "    new section landed above [Unreleased] (line $new_line vs $unrel_line)" >&2
+    return 1
+  }
+  [ "$new_line" -lt "$prev_line" ] || {
+    echo "    new section landed below the prior release (line $new_line vs $prev_line)" >&2
+    return 1
+  }
+
+  # The pending [Unreleased] entry must be preserved (not buried/dropped).
+  grep -q "A pending entry not yet released" "$dir/CHANGELOG.md" || return 1
+}
+
 test_preserves_header_preamble() {
   local dir
   dir=$(mktemp -d)
@@ -594,6 +643,8 @@ echo "Running bump-version.sh tests"
 echo "============================="
 run_test "scaffolds a new CHANGELOG section with today's date" \
   test_scaffolds_new_section
+run_test "inserts the new section below [Unreleased], above the prior release (#5207)" \
+  test_inserts_after_unreleased_section
 run_test "preserves the Keep-a-Changelog header preamble" \
   test_preserves_header_preamble
 run_test "is idempotent when a section for the new version already exists" \

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -319,16 +319,34 @@ if [ "$SKIP_CHANGELOG" -eq 0 ] && [ -f "$CHANGELOG" ]; then
 
 EOF
 
-    # Insert the new section before the first `## [` line. The header (title +
-    # "Keep a Changelog" preamble) sits above that line and must be preserved.
+    # Insert the new section before the first *versioned* `## [` header — i.e.
+    # the first `## [` that is NOT `## [Unreleased]`. This keeps the new release
+    # directly BELOW the [Unreleased] section (and its body), preserving the
+    # Keep-a-Changelog ordering the file documents ([Unreleased] on top,
+    # releases descending). The header (title + preamble) and any [Unreleased]
+    # section above the first versioned header are preserved. #5207 — before
+    # this fix the entry landed above [Unreleased], inverting the order and
+    # burying pending [Unreleased] entries. When there is no [Unreleased]
+    # section the first `## [` IS a versioned header, so the placement is
+    # unchanged.
     track_tmp "$CHANGELOG.tmp"
     awk -v entry_file="$CHANGELOG.entry.tmp" '
-      !inserted && /^## \[/ {
+      !inserted && /^## \[/ && !/^## \[Unreleased\]/ {
         while ((getline line < entry_file) > 0) print line
         close(entry_file)
         inserted = 1
       }
       { print }
+      END {
+        # No versioned release header existed (only [Unreleased], or none at
+        # all) — append the new section at the end so it still lands below
+        # [Unreleased] rather than silently vanishing (the post-grep verify
+        # would otherwise fail the bump).
+        if (!inserted) {
+          while ((getline line < entry_file) > 0) print line
+          close(entry_file)
+        }
+      }
     ' "$CHANGELOG" > "$CHANGELOG.tmp" && mv "$CHANGELOG.tmp" "$CHANGELOG"
     rm -f "$CHANGELOG.entry.tmp"
 


### PR DESCRIPTION
## Summary

Closes #5207. From-review follow-up of PR #5199 (0.9.44 release bump).

`scripts/bump-version.sh` scaffolded the new version's CHANGELOG section by inserting it **before the first `## [` header**. Since `[Unreleased]` is the first such header, the new release block landed **above** `[Unreleased]` — inverting the Keep-a-Changelog ordering the file documents in its own preamble (`[Unreleased]` on top, releases descending) and burying any pending `[Unreleased]` entries under the cut release. In PR #5199 this had to be corrected by hand (`f095d76bb`).

## Fix

Insert before the first **versioned** `## [` header (skip `## [Unreleased]`), so the new section lands directly below `[Unreleased]` (and its body), above the previous release. An `END` block appends the section when only `[Unreleased]` (or no `## [`) exists, so it still lands and the post-scaffold `grep` verify passes. When there is no `[Unreleased]` section, the first `## [` is already a versioned header, so placement is unchanged.

## Tests

- New `test_inserts_after_unreleased_section`: asserts ordering `[Unreleased] < [new] < [prior]` and that a pending `[Unreleased]` entry is preserved.
- Existing 13 tests still pass (the no-`[Unreleased]` fixtures exercise the unchanged path). **14 passed, 0 failed.**

## Acceptance criteria
- [x] inserts the new section directly below the `[Unreleased]` section (and its body)
- [x] when there is no `[Unreleased]` section, behaviour is unchanged
- [x] a test covers the ordering