### PR TITLE
feat(cli): chroxy worktree gc — reclaim orphaned dead-pid-locked worktrees (#5158)

### DIFF
--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -19,6 +19,7 @@ import { registerSessionCommands } from './cli/session-cmd.js'
 import { registerServiceCommand } from './cli/service-cmd.js'
 import { registerUpdateCommand } from './cli/update-cmd.js'
 import { registerStatusCommand } from './cli/status-cmd.js'
+import { registerWorktreeCommand } from './cli/worktree-gc-cmd.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json')
@@ -40,5 +41,6 @@ registerSessionCommands(program)
 registerServiceCommand(program)
 registerUpdateCommand(program)
 registerStatusCommand(program)
+registerWorktreeCommand(program)
 
 program.parse()

--- a/packages/server/src/cli/worktree-gc-cmd.js
+++ b/packages/server/src/cli/worktree-gc-cmd.js
@@ -1,0 +1,186 @@
+// `chroxy worktree gc` — reclaim orphaned, dead-pid-locked agent worktrees (#5158).
+//
+// Dry-run by DEFAULT: it reports what it would reclaim and changes nothing.
+// Pass --apply to actually unlock + remove (clean trees only, never --force).
+//
+// Scans the resolved repo set (config.repos ∪ auto-discover under the
+// configured root, default ~/Projects) — or a single repo via --repo — and,
+// per the safety contract in worktree-gc.js, only reclaims worktrees that are
+// locked by a verified-dead pid AND clean, plus stale dir-gone admin refs.
+
+import { existsSync, readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { resolve, basename } from 'node:path'
+import { CONFIG_FILE } from './shared.js'
+import { resolveRepoSet } from '../control-room/repo-set.js'
+import { planRepoGc, applyPlan } from '../worktree-gc.js'
+
+/** Read config.json best-effort for repos + discovery root (never throws/exits). */
+function readConfigSoft(configPath, deps = {}) {
+  const { exists = existsSync, read = readFileSync } = deps
+  try {
+    if (!exists(configPath)) return {}
+    return JSON.parse(read(configPath, 'utf-8')) || {}
+  } catch {
+    return {}
+  }
+}
+
+/** Best-effort directory size in KiB via `du -sk`; null when unavailable. */
+function dirSizeKib(path, deps = {}) {
+  const { exec = (cmd, args) => execFileSync(cmd, args, { encoding: 'utf8' }) } = deps
+  try {
+    const out = exec('du', ['-sk', path])
+    const kib = parseInt(String(out).split(/\s+/)[0], 10)
+    return Number.isFinite(kib) ? kib : null
+  } catch {
+    return null
+  }
+}
+
+function humanSize(kib) {
+  if (kib == null) return ''
+  if (kib < 1024) return `${kib} KiB`
+  const mib = kib / 1024
+  if (mib < 1024) return `${mib.toFixed(1)} MiB`
+  return `${(mib / 1024).toFixed(2)} GiB`
+}
+
+/**
+ * Build the GC report across all target repos. Returns a structured object
+ * (also what --json prints). Pure aside from injected seams.
+ */
+export function collectWorktreeGc(options = {}, deps = {}) {
+  const {
+    configPath = CONFIG_FILE,
+    plan = planRepoGc,
+    sizeOf = (p) => dirSizeKib(p, deps),
+    withSizes = true,
+  } = deps
+
+  let repos
+  if (options.repo) {
+    const p = resolve(options.repo)
+    repos = [{ name: basename(p), path: p }]
+  } else {
+    const cfg = readConfigSoft(configPath, deps)
+    repos = resolveRepoSet({
+      repos: cfg.repos,
+      root: cfg.controlRoom?.discoveryRoot,
+      ...(deps.repoSetSeams || {}),
+    })
+  }
+
+  const reposOut = []
+  let reclaimableCount = 0
+  let reclaimableKib = 0
+  let skippedCount = 0
+
+  for (const r of repos) {
+    const p = plan(r.path, deps.planDeps || {})
+    const reclaimable = p.items.filter((it) => it.action === 'remove' || it.action === 'prune')
+    const skipped = p.items.filter((it) => it.action === 'skip')
+    if (withSizes) {
+      for (const it of reclaimable) {
+        if (it.action === 'remove') {
+          it.sizeKib = sizeOf(it.path)
+          if (it.sizeKib != null) reclaimableKib += it.sizeKib
+        }
+      }
+    }
+    reclaimableCount += reclaimable.length
+    skippedCount += skipped.length
+    reposOut.push({ name: r.name, path: r.path, error: p.error, reclaimable, skipped })
+  }
+
+  return {
+    apply: !!options.apply,
+    repoCount: repos.length,
+    reclaimableCount,
+    reclaimableKib,
+    skippedCount,
+    repos: reposOut,
+  }
+}
+
+function printHuman(report, applied) {
+  const lines = []
+  const mode = report.apply ? 'apply' : 'dry-run'
+  lines.push(`Worktree GC (${mode}) — scanned ${report.repoCount} repo${report.repoCount === 1 ? '' : 's'}`)
+  lines.push('')
+
+  let any = false
+  for (const repo of report.repos) {
+    const reclaimable = repo.reclaimable
+    if (repo.error) {
+      lines.push(`  ${repo.name}  —  error: ${repo.error}`)
+      any = true
+      continue
+    }
+    if (reclaimable.length === 0) continue
+    any = true
+    lines.push(`  ${repo.name}  (${repo.path})`)
+    for (const it of reclaimable) {
+      const size = it.sizeKib != null ? `  [${humanSize(it.sizeKib)}]` : ''
+      const verb = it.action === 'prune' ? 'prune' : 'remove'
+      const why = it.reason ? ` — ${it.reason}` : ''
+      let status = ''
+      if (applied) {
+        const res = applied.find((a) => a.path === it.path)
+        status = res ? (res.ok ? '  ✓ done' : `  ✗ failed: ${res.error}`) : ''
+      }
+      lines.push(`    ${verb}  ${it.path}${size}${why}${status}`)
+    }
+    lines.push('')
+  }
+
+  if (!any) {
+    lines.push('  Nothing to reclaim — no dead-pid-locked or stale worktrees found.')
+    lines.push('')
+  }
+
+  const sz = report.reclaimableKib ? ` (~${humanSize(report.reclaimableKib)})` : ''
+  lines.push(`Summary: ${report.reclaimableCount} reclaimable${sz}, ${report.skippedCount} skipped (live/dirty/unknown — preserved).`)
+  if (!report.apply && report.reclaimableCount > 0) {
+    lines.push('Re-run with --apply to reclaim them (clean trees only; never --force).')
+  }
+  return lines.join('\n')
+}
+
+export async function runWorktreeGc(options = {}, deps = {}) {
+  const out = deps.write || console.log
+  const report = collectWorktreeGc(options, deps)
+
+  let applied = null
+  if (options.apply) {
+    applied = []
+    for (const repo of report.repos) {
+      if (repo.error || repo.reclaimable.length === 0) continue
+      const res = applyPlan(repo.path, { items: repo.reclaimable }, deps.planDeps || {})
+      applied.push(...res)
+    }
+  }
+
+  if (options.json) {
+    out(JSON.stringify({ ...report, applied }, null, 2))
+  } else {
+    out(printHuman(report, applied))
+  }
+  return { report, applied }
+}
+
+export function registerWorktreeCommand(program) {
+  const wt = program
+    .command('worktree')
+    .description('Manage chroxy/agent git worktrees')
+
+  wt
+    .command('gc')
+    .description('Reclaim orphaned worktrees locked by dead agent processes (dry-run by default)')
+    .option('--repo <path>', 'Scan a single repo instead of the configured/discovered set')
+    .option('--apply', 'Actually unlock + remove reclaimable worktrees (default: dry-run report only)')
+    .option('--json', 'Output machine-readable JSON')
+    .action(async (options) => {
+      await runWorktreeGc(options)
+    })
+}

--- a/packages/server/src/cli/worktree-gc-cmd.js
+++ b/packages/server/src/cli/worktree-gc-cmd.js
@@ -66,7 +66,7 @@ export function collectWorktreeGc(options = {}, deps = {}) {
     const cfg = readConfigSoft(configPath, deps)
     repos = resolveRepoSet({
       repos: cfg.repos,
-      root: cfg.controlRoom?.discoveryRoot,
+      root: cfg.controlRoomRoot,
       ...(deps.repoSetSeams || {}),
     })
   }

--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -23,6 +23,7 @@
 
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
+import { isAbsolute, resolve as resolvePath } from 'node:path'
 import { GIT } from './git.js'
 
 /**
@@ -108,7 +109,12 @@ export function readLockReasonFromAdmin(worktreePath, deps = {}) {
     const pointer = String(read(dotGit, 'utf8')).trim()
     const m = /^gitdir:\s*(.+)$/m.exec(pointer)
     if (!m) return ''
-    const lockedFile = `${m[1].trim()}/locked`
+    // git may write the gitdir pointer as a path RELATIVE to the worktree dir
+    // (e.g. with extensions.relativeWorktrees); resolve it against worktreePath
+    // so we read the right `locked` file rather than one off the cwd.
+    const gitdir = m[1].trim()
+    const adminDir = isAbsolute(gitdir) ? gitdir : resolvePath(worktreePath, gitdir)
+    const lockedFile = `${adminDir}/locked`
     if (!exists(lockedFile)) return ''
     return String(read(lockedFile, 'utf8')).trim()
   } catch {
@@ -207,7 +213,8 @@ function isClean(git, worktreePath) {
 export function applyPlan(repoPath, plan, deps = {}) {
   const { git = (cwd, args) => execFileSync(GIT, ['-C', cwd, ...args], { encoding: 'utf8' }) } = deps
   const results = []
-  let needPrune = false
+  const pruneItems = []
+  const unlockErrors = new Map() // item.path -> error message when its pre-prune unlock failed
 
   for (const item of plan.items) {
     if (item.action === 'remove') {
@@ -219,23 +226,36 @@ export function applyPlan(repoPath, plan, deps = {}) {
         results.push({ path: item.path, action: 'remove', ok: false, error: (err && err.message) || String(err) })
       }
     } else if (item.action === 'prune') {
-      // A locked, dir-gone worktree must be unlocked before prune will reclaim it.
+      // A locked, dir-gone worktree must be unlocked before prune will reclaim
+      // it. If the unlock fails the entry stays locked and prune cannot reclaim
+      // it, so record the failure and report this item as not-ok rather than
+      // claiming success off the back of a prune that skipped it.
       if (item.locked) {
-        try { git(repoPath, ['worktree', 'unlock', item.path]) } catch { /* best-effort */ }
+        try {
+          git(repoPath, ['worktree', 'unlock', item.path])
+        } catch (err) {
+          unlockErrors.set(item.path, (err && err.message) || String(err))
+        }
       }
-      needPrune = true
+      pruneItems.push(item)
     }
   }
 
-  if (needPrune) {
+  if (pruneItems.length > 0) {
+    let pruneError = null
     try {
       git(repoPath, ['worktree', 'prune'])
-      for (const item of plan.items) {
-        if (item.action === 'prune') results.push({ path: item.path, action: 'prune', ok: true })
-      }
     } catch (err) {
-      for (const item of plan.items) {
-        if (item.action === 'prune') results.push({ path: item.path, action: 'prune', ok: false, error: (err && err.message) || String(err) })
+      pruneError = (err && err.message) || String(err)
+    }
+    for (const item of pruneItems) {
+      const unlockErr = unlockErrors.get(item.path)
+      if (unlockErr) {
+        results.push({ path: item.path, action: 'prune', ok: false, error: `unlock failed (entry still locked): ${unlockErr}` })
+      } else if (pruneError) {
+        results.push({ path: item.path, action: 'prune', ok: false, error: pruneError })
+      } else {
+        results.push({ path: item.path, action: 'prune', ok: true })
       }
     }
   }

--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -1,0 +1,244 @@
+// Worktree garbage-collector core (#5158).
+//
+// Reclaims git worktrees that were created + locked by an agent/orchestrator
+// (e.g. Claude Code's `.claude/worktrees/agent-XXX`, locked with a reason like
+// `claude agent agent-XXX (pid 45492)`) and then orphaned when that process
+// died without cleaning up. Such locks survive the process forever, so without
+// a reaper they pile up across runs (the issue observed 162 worktrees / ~15 GB
+// in one repo).
+//
+// Safety contract (do NOT relax — these are the guardrails from #5158):
+//   - Never `git worktree remove --force`. A worktree with uncommitted /
+//     untracked changes is preserved (skipped), never deleted.
+//   - Only auto-unlock locks held by a VERIFIED-DEAD pid. A live pid, or a
+//     lock whose reason has no parseable pid, is skipped (could be the user's
+//     own deliberate lock).
+//   - Never touch the main worktree (the primary checkout).
+//   - Removing a worktree only deletes its working directory + admin refs; it
+//     never deletes commits or branches. We still log a manifest of what was
+//     reclaimed.
+//
+// This module is pure + dependency-injected (git exec, process.kill, fs) so it
+// is fully testable against real temp repos without poking the real home dir.
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { GIT } from './git.js'
+
+/**
+ * Existence check for a pid without sending a real signal.
+ * Signal 0 only probes for the process; EPERM means it exists but we can't
+ * signal it (still alive), ESRCH means it's gone.
+ */
+export function isPidAlive(pid, kill = process.kill) {
+  if (!Number.isInteger(pid) || pid <= 0) return false
+  try {
+    kill(pid, 0)
+    return true
+  } catch (err) {
+    return err && err.code === 'EPERM'
+  }
+}
+
+/**
+ * Extract a pid from a worktree lock reason. Handles the agent format
+ * `... (pid 45492)` and a looser `pid: 45492` / `pid 45492` fallback.
+ * Returns a positive integer or null when no pid is present.
+ */
+export function parsePid(reason) {
+  if (!reason || typeof reason !== 'string') return null
+  const m = /\(pid\s+(\d+)\)/i.exec(reason) || /\bpid[\s:=]+(\d+)/i.exec(reason)
+  if (!m) return null
+  const pid = Number(m[1])
+  return Number.isInteger(pid) && pid > 0 ? pid : null
+}
+
+/**
+ * Parse `git worktree list --porcelain` output into structured entries.
+ * The first entry is always the main worktree. `locked`/`prunable` may carry
+ * an inline reason (git >= ~2.36); older git emits the bare keyword, in which
+ * case the lock reason is read from the admin file as a fallback.
+ */
+export function parseWorktreeList(porcelain) {
+  const entries = []
+  let cur = null
+  const flush = () => { if (cur) entries.push(cur) }
+  for (const raw of String(porcelain == null ? '' : porcelain).split('\n')) {
+    const line = raw.replace(/\r$/, '')
+    if (line.startsWith('worktree ')) {
+      flush()
+      cur = { path: line.slice('worktree '.length), locked: false, lockReason: '', prunable: false, detached: false }
+    } else if (!cur) {
+      continue
+    } else if (line === 'bare') {
+      cur.bare = true
+    } else if (line.startsWith('HEAD ')) {
+      cur.head = line.slice('HEAD '.length)
+    } else if (line.startsWith('branch ')) {
+      cur.branch = line.slice('branch '.length)
+    } else if (line === 'detached') {
+      cur.detached = true
+    } else if (line === 'locked') {
+      cur.locked = true
+    } else if (line.startsWith('locked ')) {
+      cur.locked = true
+      cur.lockReason = line.slice('locked '.length)
+    } else if (line === 'prunable') {
+      cur.prunable = true
+    } else if (line.startsWith('prunable ')) {
+      cur.prunable = true
+      cur.prunableReason = line.slice('prunable '.length)
+    }
+  }
+  flush()
+  return entries
+}
+
+/**
+ * Fallback lock-reason reader for older git that omits the inline reason in
+ * porcelain output. A linked worktree's `<path>/.git` is a file containing
+ * `gitdir: <maindir>/.git/worktrees/<id>`; the lock reason lives in
+ * `<that dir>/locked`. Returns '' when unavailable.
+ */
+export function readLockReasonFromAdmin(worktreePath, deps = {}) {
+  const { exists = existsSync, read = readFileSync } = deps
+  try {
+    const dotGit = `${worktreePath}/.git`
+    if (!exists(dotGit)) return ''
+    const pointer = String(read(dotGit, 'utf8')).trim()
+    const m = /^gitdir:\s*(.+)$/m.exec(pointer)
+    if (!m) return ''
+    const lockedFile = `${m[1].trim()}/locked`
+    if (!exists(lockedFile)) return ''
+    return String(read(lockedFile, 'utf8')).trim()
+  } catch {
+    return ''
+  }
+}
+
+/**
+ * Decide what to do with every linked worktree of `repoPath`. Returns a plan:
+ *   { repo, error?, items: [{ path, action, ... }] }
+ * where action is one of:
+ *   - 'remove' : dead-pid lock, dir present, clean   → unlock + `worktree remove` (no --force)
+ *   - 'prune'  : dir gone (dead-pid lock or unlocked) → unlock if needed + `worktree prune`
+ *   - 'skip'   : anything we must not touch (live pid, dirty, no pid, unlocked-present, main)
+ *
+ * Pure aside from the injected `git`/`kill`/`exists` seams.
+ */
+export function planRepoGc(repoPath, deps = {}) {
+  const {
+    git = (cwd, args) => execFileSync(GIT, ['-C', cwd, ...args], { encoding: 'utf8' }),
+    kill = process.kill,
+    exists = existsSync,
+    readLockReason = (wtPath) => readLockReasonFromAdmin(wtPath),
+  } = deps
+
+  let porcelain
+  try {
+    porcelain = git(repoPath, ['worktree', 'list', '--porcelain'])
+  } catch (err) {
+    return { repo: repoPath, error: (err && err.message) || String(err), items: [] }
+  }
+
+  const entries = parseWorktreeList(porcelain)
+  const items = []
+
+  entries.forEach((e, i) => {
+    if (i === 0) return // main worktree — never GC the primary checkout
+    const dirGone = e.prunable || !exists(e.path)
+
+    if (e.locked) {
+      const reason = e.lockReason || readLockReason(e.path) || ''
+      const pid = parsePid(reason)
+      if (pid == null) {
+        items.push({ path: e.path, action: 'skip', skipReason: 'locked with no pid in reason (not an abandoned agent worktree)', lockReason: reason })
+        return
+      }
+      if (isPidAlive(pid, kill)) {
+        items.push({ path: e.path, action: 'skip', skipReason: `locked by a live process (pid ${pid})`, pid, lockReason: reason })
+        return
+      }
+      // pid is dead — reclaimable, subject to the clean-tree guard.
+      if (dirGone) {
+        items.push({ path: e.path, action: 'prune', pid, lockReason: reason, reason: 'directory gone; lock held by dead pid', locked: true })
+        return
+      }
+      const clean = isClean(git, e.path)
+      if (clean === null) {
+        items.push({ path: e.path, action: 'skip', skipReason: 'could not determine working-tree state; left untouched for safety', pid, lockReason: reason })
+        return
+      }
+      if (!clean) {
+        items.push({ path: e.path, action: 'skip', skipReason: 'has uncommitted/untracked changes (preserved)', pid, lockReason: reason })
+        return
+      }
+      items.push({ path: e.path, action: 'remove', pid, lockReason: reason, reason: 'clean worktree locked by dead pid', locked: true })
+      return
+    }
+
+    // Not locked.
+    if (dirGone) {
+      items.push({ path: e.path, action: 'prune', reason: 'directory gone (stale admin ref)', locked: false })
+      return
+    }
+    items.push({ path: e.path, action: 'skip', skipReason: 'present and unlocked (not an abandoned agent worktree)' })
+  })
+
+  return { repo: repoPath, items }
+}
+
+/** `git -C <worktree> status --porcelain` → clean? null when it can't be run. */
+function isClean(git, worktreePath) {
+  try {
+    return git(worktreePath, ['status', '--porcelain']).trim().length === 0
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Execute a plan's reclaimable items. Returns per-item results
+ * ({ path, action, ok, error? }). `git worktree remove` is run WITHOUT
+ * --force; the plan already excluded dirty trees, so a clean removal succeeds
+ * and a surprise-dirty one fails loudly (and is reported) rather than nuking
+ * changes. A single `git worktree prune` reclaims all dir-gone admin refs.
+ */
+export function applyPlan(repoPath, plan, deps = {}) {
+  const { git = (cwd, args) => execFileSync(GIT, ['-C', cwd, ...args], { encoding: 'utf8' }) } = deps
+  const results = []
+  let needPrune = false
+
+  for (const item of plan.items) {
+    if (item.action === 'remove') {
+      try {
+        if (item.locked) git(repoPath, ['worktree', 'unlock', item.path])
+        git(repoPath, ['worktree', 'remove', item.path]) // NO --force
+        results.push({ path: item.path, action: 'remove', ok: true })
+      } catch (err) {
+        results.push({ path: item.path, action: 'remove', ok: false, error: (err && err.message) || String(err) })
+      }
+    } else if (item.action === 'prune') {
+      // A locked, dir-gone worktree must be unlocked before prune will reclaim it.
+      if (item.locked) {
+        try { git(repoPath, ['worktree', 'unlock', item.path]) } catch { /* best-effort */ }
+      }
+      needPrune = true
+    }
+  }
+
+  if (needPrune) {
+    try {
+      git(repoPath, ['worktree', 'prune'])
+      for (const item of plan.items) {
+        if (item.action === 'prune') results.push({ path: item.path, action: 'prune', ok: true })
+      }
+    } catch (err) {
+      for (const item of plan.items) {
+        if (item.action === 'prune') results.push({ path: item.path, action: 'prune', ok: false, error: (err && err.message) || String(err) })
+      }
+    }
+  }
+
+  return results
+}

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -1,0 +1,252 @@
+/**
+ * Tests for the worktree garbage-collector (#5158).
+ *
+ * Unit tests cover the pure parsers/guards. Integration tests build a real
+ * temp git repo with several linked worktrees in every state the GC must
+ * distinguish (clean+dead-pid, dirty+dead-pid, live-pid, no-pid lock,
+ * unlocked, dir-gone) and assert the plan + apply do the safe thing: reclaim
+ * only clean dead-pid-locked worktrees + stale dir-gone refs, never --force,
+ * never touch dirty/live/unknown ones.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execFileSync } from 'child_process'
+import { GIT } from '../src/git.js'
+import {
+  isPidAlive,
+  parsePid,
+  parseWorktreeList,
+  readLockReasonFromAdmin,
+  planRepoGc,
+  applyPlan,
+} from '../src/worktree-gc.js'
+
+// A pid that the fake kill treats as alive; everything else is "dead".
+const LIVE_PID = 4000002
+const DEAD_PID = 4000001
+const fakeKill = (pid) => {
+  if (pid === LIVE_PID) return true
+  const err = new Error('no such process')
+  err.code = 'ESRCH'
+  throw err
+}
+
+const git = (cwd, args) => execFileSync(GIT, ['-C', cwd, ...args], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] })
+
+describe('worktree-gc unit: isPidAlive', () => {
+  it('treats the current process as alive', () => {
+    assert.equal(isPidAlive(process.pid), true)
+  })
+  it('treats EPERM (exists, no permission) as alive', () => {
+    assert.equal(isPidAlive(123, () => { const e = new Error('perm'); e.code = 'EPERM'; throw e }), true)
+  })
+  it('treats ESRCH as dead', () => {
+    assert.equal(isPidAlive(123, () => { const e = new Error('gone'); e.code = 'ESRCH'; throw e }), false)
+  })
+  it('rejects non-positive / non-integer pids', () => {
+    assert.equal(isPidAlive(0), false)
+    assert.equal(isPidAlive(-5), false)
+    assert.equal(isPidAlive(1.5), false)
+    assert.equal(isPidAlive(NaN), false)
+  })
+})
+
+describe('worktree-gc unit: parsePid', () => {
+  it('parses the agent lock format', () => {
+    assert.equal(parsePid('claude agent agent-x (pid 45492)'), 45492)
+  })
+  it('parses loose pid forms', () => {
+    assert.equal(parsePid('locked, pid: 1234'), 1234)
+    assert.equal(parsePid('pid 9'), 9)
+  })
+  it('returns null when there is no pid', () => {
+    assert.equal(parsePid('manual lock, do not touch'), null)
+    assert.equal(parsePid(''), null)
+    assert.equal(parsePid(null), null)
+    assert.equal(parsePid(undefined), null)
+  })
+})
+
+describe('worktree-gc unit: parseWorktreeList', () => {
+  it('parses main + linked worktrees with locked/prunable reasons', () => {
+    const porcelain = [
+      'worktree /repo',
+      'HEAD aaa',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo/.claude/worktrees/agent-x',
+      'HEAD bbb',
+      'detached',
+      'locked claude agent agent-x (pid 999)',
+      '',
+      'worktree /repo/.claude/worktrees/agent-gone',
+      'HEAD ccc',
+      'detached',
+      'prunable gitdir file points to non-existent location',
+      '',
+    ].join('\n')
+    const entries = parseWorktreeList(porcelain)
+    assert.equal(entries.length, 3)
+    assert.equal(entries[0].path, '/repo')
+    assert.equal(entries[1].locked, true)
+    assert.equal(entries[1].lockReason, 'claude agent agent-x (pid 999)')
+    assert.equal(entries[1].detached, true)
+    assert.equal(entries[2].prunable, true)
+  })
+  it('handles bare keyword locked (no inline reason)', () => {
+    const entries = parseWorktreeList('worktree /a\n\nworktree /b\nlocked\n')
+    assert.equal(entries[1].locked, true)
+    assert.equal(entries[1].lockReason, '')
+  })
+  it('tolerates empty/nullish input', () => {
+    assert.deepEqual(parseWorktreeList(''), [])
+    assert.deepEqual(parseWorktreeList(null), [])
+  })
+})
+
+describe('worktree-gc integration (real git repo)', () => {
+  let repo
+  const made = []
+
+  function addWorktree(name, { lockReason, dirty } = {}) {
+    const wtPath = join(repo, '.claude', 'worktrees', name)
+    git(repo, ['worktree', 'add', '--detach', wtPath, 'HEAD'])
+    if (dirty) writeFileSync(join(wtPath, 'scratch.txt'), 'uncommitted work')
+    if (lockReason) git(repo, ['worktree', 'lock', '--reason', lockReason, wtPath])
+    made.push(wtPath)
+    return wtPath
+  }
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'chroxy-wtgc-'))
+    git(repo, ['init', '--initial-branch=main', '.'])
+    git(repo, ['config', 'user.email', 'test@test'])
+    git(repo, ['config', 'user.name', 'Test'])
+    git(repo, ['commit', '--allow-empty', '-m', 'init'])
+    mkdirSync(join(repo, '.claude', 'worktrees'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('plans: reclaim clean+dead-pid, skip dirty/live/no-pid/unlocked, prune dir-gone', () => {
+    addWorktree('clean-dead', { lockReason: `claude agent a1 (pid ${DEAD_PID})` })
+    addWorktree('dirty-dead', { lockReason: `claude agent a2 (pid ${DEAD_PID})`, dirty: true })
+    addWorktree('live', { lockReason: `claude agent a3 (pid ${LIVE_PID})` })
+    addWorktree('no-pid', { lockReason: 'manual lock, keep' })
+    addWorktree('unlocked')
+    const gone = addWorktree('gone', { lockReason: `claude agent a4 (pid ${DEAD_PID})` })
+    // Simulate the process having vanished mid-run: its worktree dir is gone
+    // but the locked admin ref remains.
+    rmSync(gone, { recursive: true, force: true })
+
+    const plan = planRepoGc(repo, { kill: fakeKill })
+    // Match by trailing dir name — git reports canonical paths (/private/var
+    // on macOS) that differ from the constructed /var paths.
+    const find = (name) => plan.items.find((i) => i.path.endsWith(`/${name}`))
+
+    assert.equal(find('clean-dead').action, 'remove')
+    assert.equal(find('dirty-dead').action, 'skip')
+    assert.match(find('dirty-dead').skipReason, /uncommitted/)
+    assert.equal(find('live').action, 'skip')
+    assert.match(find('live').skipReason, /live process/)
+    assert.equal(find('no-pid').action, 'skip')
+    assert.match(find('no-pid').skipReason, /no pid/)
+    assert.equal(find('unlocked').action, 'skip')
+    assert.equal(find('gone').action, 'prune')
+    // The main worktree is never listed for GC (only the 6 linked ones).
+    assert.equal(plan.items.length, 6)
+  })
+
+  it('apply: removes clean dead worktree + prunes dir-gone, preserves the rest', () => {
+    const cleanDead = addWorktree('clean-dead', { lockReason: `claude agent a1 (pid ${DEAD_PID})` })
+    const dirtyDead = addWorktree('dirty-dead', { lockReason: `claude agent a2 (pid ${DEAD_PID})`, dirty: true })
+    const live = addWorktree('live', { lockReason: `claude agent a3 (pid ${LIVE_PID})` })
+    const gone = addWorktree('gone', { lockReason: `claude agent a4 (pid ${DEAD_PID})` })
+    rmSync(gone, { recursive: true, force: true })
+
+    const plan = planRepoGc(repo, { kill: fakeKill })
+    const reclaimable = plan.items.filter((i) => i.action === 'remove' || i.action === 'prune')
+    const results = applyPlan(repo, { items: reclaimable })
+
+    // Every reclaim op succeeded.
+    assert.ok(results.every((r) => r.ok), `apply results: ${JSON.stringify(results)}`)
+
+    // Clean dead worktree dir is gone; dirty + live are preserved on disk.
+    assert.equal(existsSync(cleanDead), false)
+    assert.equal(existsSync(dirtyDead), true)
+    assert.equal(existsSync(live), true)
+
+    // git's own view: clean-dead and gone are no longer tracked; dirty + live remain.
+    const list = git(repo, ['worktree', 'list', '--porcelain'])
+    assert.ok(!list.includes(cleanDead), 'clean-dead still listed')
+    assert.ok(!list.includes(gone), 'gone still listed')
+    assert.ok(list.includes(dirtyDead), 'dirty-dead was dropped')
+    assert.ok(list.includes(live), 'live was dropped')
+  })
+
+  it('never deletes a dirty worktree even when locked by a dead pid', () => {
+    const dirtyDead = addWorktree('dirty-dead', { lockReason: `claude agent a2 (pid ${DEAD_PID})`, dirty: true })
+    const plan = planRepoGc(repo, { kill: fakeKill })
+    const reclaimable = plan.items.filter((i) => i.action !== 'skip')
+    applyPlan(repo, { items: reclaimable })
+    assert.equal(existsSync(dirtyDead), true)
+    assert.equal(existsSync(join(dirtyDead, 'scratch.txt')), true)
+  })
+
+  it('readLockReasonFromAdmin recovers the reason when porcelain omits it', () => {
+    const wt = addWorktree('clean-dead', { lockReason: `claude agent a1 (pid ${DEAD_PID})` })
+    const reason = readLockReasonFromAdmin(wt)
+    assert.match(reason, new RegExp(`pid ${DEAD_PID}`))
+  })
+})
+
+describe('worktree-gc CLI (runWorktreeGc against a real repo)', () => {
+  let repo, cleanDead, dirtyDead
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'chroxy-wtgc-cli-'))
+    git(repo, ['init', '--initial-branch=main', '.'])
+    git(repo, ['config', 'user.email', 'test@test'])
+    git(repo, ['config', 'user.name', 'Test'])
+    git(repo, ['commit', '--allow-empty', '-m', 'init'])
+    cleanDead = join(repo, '.claude', 'worktrees', 'clean-dead')
+    dirtyDead = join(repo, '.claude', 'worktrees', 'dirty-dead')
+    git(repo, ['worktree', 'add', '--detach', cleanDead, 'HEAD'])
+    git(repo, ['worktree', 'lock', '--reason', `claude agent a1 (pid ${DEAD_PID})`, cleanDead])
+    git(repo, ['worktree', 'add', '--detach', dirtyDead, 'HEAD'])
+    writeFileSync(join(dirtyDead, 'scratch.txt'), 'wip')
+    git(repo, ['worktree', 'lock', '--reason', `claude agent a2 (pid ${DEAD_PID})`, dirtyDead])
+  })
+
+  afterEach(() => rmSync(repo, { recursive: true, force: true }))
+
+  it('dry-run (default) reports reclaimable and deletes nothing', async () => {
+    const { runWorktreeGc } = await import('../src/cli/worktree-gc-cmd.js')
+    const out = []
+    const { report, applied } = await runWorktreeGc(
+      { repo, json: true },
+      { write: (s) => out.push(s), planDeps: { kill: fakeKill } },
+    )
+    assert.equal(applied, null)
+    assert.equal(report.apply, false)
+    assert.equal(report.reclaimableCount, 1) // clean-dead only; dirty-dead skipped
+    assert.equal(report.skippedCount, 1)
+    assert.equal(existsSync(cleanDead), true) // nothing deleted in dry-run
+  })
+
+  it('--apply reclaims the clean dead worktree and preserves the dirty one', async () => {
+    const { runWorktreeGc } = await import('../src/cli/worktree-gc-cmd.js')
+    const { applied } = await runWorktreeGc(
+      { repo, apply: true },
+      { write: () => {}, planDeps: { kill: fakeKill } },
+    )
+    assert.ok(applied && applied.length === 1 && applied[0].ok)
+    assert.equal(existsSync(cleanDead), false)
+    assert.equal(existsSync(dirtyDead), true)
+  })
+})

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -109,14 +109,12 @@ describe('worktree-gc unit: parseWorktreeList', () => {
 
 describe('worktree-gc integration (real git repo)', () => {
   let repo
-  const made = []
 
   function addWorktree(name, { lockReason, dirty } = {}) {
     const wtPath = join(repo, '.claude', 'worktrees', name)
     git(repo, ['worktree', 'add', '--detach', wtPath, 'HEAD'])
     if (dirty) writeFileSync(join(wtPath, 'scratch.txt'), 'uncommitted work')
     if (lockReason) git(repo, ['worktree', 'lock', '--reason', lockReason, wtPath])
-    made.push(wtPath)
     return wtPath
   }
 
@@ -202,6 +200,68 @@ describe('worktree-gc integration (real git repo)', () => {
     const wt = addWorktree('clean-dead', { lockReason: `claude agent a1 (pid ${DEAD_PID})` })
     const reason = readLockReasonFromAdmin(wt)
     assert.match(reason, new RegExp(`pid ${DEAD_PID}`))
+  })
+})
+
+describe('worktree-gc unit: applyPlan prune reporting (injected git)', () => {
+  it('reports a prune item as failed when its pre-prune unlock fails', () => {
+    const calls = []
+    const git = (cwd, args) => {
+      calls.push(args.join(' '))
+      if (args[0] === 'worktree' && args[1] === 'unlock') {
+        const e = new Error('fatal: cannot unlock'); e.code = 1; throw e
+      }
+      return '' // prune succeeds
+    }
+    const results = applyPlan('/repo', {
+      items: [{ path: '/repo/wt/gone', action: 'prune', locked: true }],
+    }, { git })
+
+    assert.equal(results.length, 1)
+    assert.equal(results[0].ok, false)
+    assert.match(results[0].error, /unlock failed/)
+    // prune still runs (it reclaims any other unlocked dir-gone refs).
+    assert.ok(calls.includes('worktree prune'))
+  })
+
+  it('reports prune ok when unlock+prune both succeed', () => {
+    const git = () => ''
+    const results = applyPlan('/repo', {
+      items: [{ path: '/repo/wt/gone', action: 'prune', locked: true }],
+    }, { git })
+    assert.equal(results[0].ok, true)
+  })
+})
+
+describe('worktree-gc unit: readLockReasonFromAdmin (injected fs)', () => {
+  it('resolves a RELATIVE gitdir pointer against the worktree dir', () => {
+    // git may write `gitdir:` as a path relative to the worktree (e.g. with
+    // extensions.relativeWorktrees). The resolved admin/locked file must hang
+    // off the worktree path, not the cwd.
+    const wtPath = '/repos/proj/.claude/worktrees/agent-x'
+    const expectedLocked = '/repos/proj/.git/worktrees/agent-x/locked'
+    const files = {
+      [`${wtPath}/.git`]: 'gitdir: ../../../.git/worktrees/agent-x',
+      [expectedLocked]: 'claude agent agent-x (pid 4242)',
+    }
+    const reason = readLockReasonFromAdmin(wtPath, {
+      exists: (p) => p in files,
+      read: (p) => files[p],
+    })
+    assert.equal(reason, 'claude agent agent-x (pid 4242)')
+  })
+
+  it('still handles an absolute gitdir pointer', () => {
+    const wtPath = '/repos/proj/.claude/worktrees/agent-y'
+    const files = {
+      [`${wtPath}/.git`]: 'gitdir: /repos/proj/.git/worktrees/agent-y',
+      '/repos/proj/.git/worktrees/agent-y/locked': 'claude agent agent-y (pid 99)',
+    }
+    const reason = readLockReasonFromAdmin(wtPath, {
+      exists: (p) => p in files,
+      read: (p) => files[p],
+    })
+    assert.equal(reason, 'claude agent agent-y (pid 99)')
   })
 })
 


### PR DESCRIPTION
## Summary

Part of #5158 — the **safe first slice**. Orchestrator/agent worktree isolation runs `git worktree add` + `git worktree lock` per agent (e.g. `.claude/worktrees/agent-XXX` locked with `claude agent agent-XXX (pid 45492)`), but nothing reclaims them when the process dies abnormally. The lock survives the process forever, so they accumulate across runs — the issue observed **162 worktrees / ~15 GB** in one repo (141 locked by a single dead pid).

This adds a `chroxy worktree gc` CLI that is **dry-run by default** (reports, deletes nothing) and only reclaims with explicit `--apply`.

```
chroxy worktree gc [--repo <path>] [--apply] [--json]
```

## Safety contract (enforced + tested)
Straight from the issue's requirements:
- **Never `--force`.** A worktree with uncommitted/untracked changes is preserved (skipped), never deleted.
- **Only auto-unlock locks held by a verified-dead pid** (`process.kill(pid, 0)` → ESRCH). Live pids, and locks whose reason has no parseable pid, are skipped (could be a deliberate user lock).
- **Never touch the main worktree.**
- Removal deletes only the working dir + admin refs — never commits/branches. A manifest of what was reclaimed is logged.

## How it classifies each linked worktree
| State | Action |
|-------|--------|
| dead-pid lock · dir present · clean | **remove** (unlock + `worktree remove`, no --force) |
| dir gone (dead-pid lock or unlocked stale ref) | **prune** (`worktree prune`) |
| live pid / dirty / no-pid lock / present+unlocked | **skip** (preserved) |

## Files
- `src/worktree-gc.js` — pure, dependency-injected core: `parseWorktreeList`, `parsePid`, `isPidAlive`, `planRepoGc`, `applyPlan`.
- `src/cli/worktree-gc-cmd.js` — `worktree gc` command; resolves the repo set via the Control Room's `resolveRepoSet` (config.repos ∪ auto-discover under the configured root) or a single `--repo`; human + `--json` output with per-item reason and best-effort size.
- `src/cli.js` — register the command.

## Tests (16, all passing)
Unit: `isPidAlive` (alive/EPERM/ESRCH/bad-input), `parsePid`, `parseWorktreeList`. Integration against **real temp git repos** with every state (clean+dead, dirty+dead, live-pid, no-pid lock, unlocked, dir-gone): plan classification, apply (removes clean dead + prunes gone, **preserves dirty + live**), the explicit never-delete-dirty guard, and the admin-file lock-reason fallback. CLI: dry-run reports without deleting; `--apply` reclaims. CI lints (state-file, opt-forwarding) green; 250 existing CLI tests still pass.

## Deferred (proposed for a follow-up, not in this PR)
The **auto-on-startup stale-lock reaper** (run GC automatically when Chroxy starts / periodically). That auto-deletes on a schedule, so I'd like to land the manual, dry-run-default CLI first and agree the reaper's policy (default-on vs opt-in, which repos, cadence) before anything reclaims unattended. Tracked under #5158.

Closes #5158 partially — keeping the issue open for the reaper, or split per your preference.