### PR TITLE
test(server): worktree gc CLI coverage for the config-discovered repo set (#5221)

### DIFF
--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -309,4 +309,63 @@ describe('worktree-gc CLI (runWorktreeGc against a real repo)', () => {
     assert.equal(existsSync(cleanDead), false)
     assert.equal(existsSync(dirtyDead), true)
   })
+
+  it('#5221 scans the config.repos set when no --repo is given', async () => {
+    const { collectWorktreeGc } = await import('../src/cli/worktree-gc-cmd.js')
+    // A config that lists the temp repo explicitly — exercises the
+    // readConfigSoft → resolveRepoSet({ repos }) path (vs the --repo shortcut).
+    const configPath = join(repo, 'config.json')
+    writeFileSync(configPath, JSON.stringify({ repos: [{ name: 'cfg-repo', path: repo }] }))
+
+    const report = collectWorktreeGc(
+      {}, // no --repo
+      {
+        configPath,
+        withSizes: false,
+        planDeps: { kill: fakeKill },
+        // Stub auto-discovery so the default ~/Projects root isn't walked —
+        // isolates the assertion to the explicit config.repos entry.
+        repoSetSeams: { _readdir: () => [] },
+      },
+    )
+    assert.equal(report.repoCount, 1)
+    assert.equal(report.reclaimableCount, 1) // clean-dead
+    assert.equal(report.skippedCount, 1) // dirty-dead
+    assert.ok(report.repos.some((r) => r.path === repo), 'config repo was not scanned')
+  })
+})
+
+describe('worktree-gc CLI (config controlRoomRoot auto-discovery, #5221)', () => {
+  let root, repo, cleanDead
+
+  beforeEach(() => {
+    // A dedicated discovery root holding one repo, so resolveRepoSet's
+    // auto-discovery has a deterministic tree to walk (not all of tmpdir).
+    root = mkdtempSync(join(tmpdir(), 'chroxy-wtgc-root-'))
+    repo = join(root, 'project-a')
+    mkdirSync(repo, { recursive: true })
+    git(repo, ['init', '--initial-branch=main', '.'])
+    git(repo, ['config', 'user.email', 'test@test'])
+    git(repo, ['config', 'user.name', 'Test'])
+    git(repo, ['commit', '--allow-empty', '-m', 'init'])
+    cleanDead = join(repo, '.claude', 'worktrees', 'clean-dead')
+    git(repo, ['worktree', 'add', '--detach', cleanDead, 'HEAD'])
+    git(repo, ['worktree', 'lock', '--reason', `claude agent a1 (pid ${DEAD_PID})`, cleanDead])
+  })
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }))
+
+  it('discovers repos under config.controlRoomRoot when no --repo is given', async () => {
+    const { collectWorktreeGc } = await import('../src/cli/worktree-gc-cmd.js')
+    const configPath = join(root, 'config.json')
+    writeFileSync(configPath, JSON.stringify({ controlRoomRoot: root }))
+
+    const report = collectWorktreeGc(
+      {},
+      { configPath, withSizes: false, planDeps: { kill: fakeKill } },
+    )
+    assert.ok(report.repoCount >= 1, 'no repos discovered under controlRoomRoot')
+    assert.ok(report.repos.some((r) => r.path === repo), 'project-a was not discovered')
+    assert.equal(report.reclaimableCount, 1)
+  })
 })

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -364,8 +364,11 @@ describe('worktree-gc CLI (config controlRoomRoot auto-discovery, #5221)', () =>
       {},
       { configPath, withSizes: false, planDeps: { kill: fakeKill } },
     )
-    assert.ok(report.repoCount >= 1, 'no repos discovered under controlRoomRoot')
-    assert.ok(report.repos.some((r) => r.path === repo), 'project-a was not discovered')
-    assert.equal(report.reclaimableCount, 1)
+    // Exact count: the temp root holds exactly one repo, so a stronger guard
+    // than `>= 1` catches a regression that unions in the default ~/Projects set.
+    assert.equal(report.repoCount, 1)
+    assert.equal(report.repos[0].path, repo, 'project-a was not the discovered repo')
+    assert.equal(report.reclaimableCount, 1) // clean-dead
+    assert.equal(report.skippedCount, 0) // only a clean-dead worktree in this fixture
   })
 })


### PR DESCRIPTION
## Summary

Closes #5221. Test-only follow-up from the #5220 review.

The `chroxy worktree gc` CLI tests covered only the `--repo` shortcut. This adds coverage for the **no-`--repo`** path that resolves the repo set from config (the `readConfigSoft → resolveRepoSet` branch in `collectWorktreeGc`):

- **`config.repos` explicit entry** — verifies an explicitly-listed repo is scanned. Stubs auto-discovery via the `_readdir` seam so the default `~/Projects` root isn't walked, isolating the assertion to the configured repo.
- **`config.controlRoomRoot` auto-discovery** — a dedicated temp root holding one repo (with a dead-pid-locked clean worktree) is discovered and reported reclaimable.

(Surfaced incidentally: with `config.repos` set but no `controlRoomRoot`, the command scans `config.repos ∪ ~/Projects` — intended, matching the Control Room repo-set resolver. The first test stubs that discovery for determinism.)

## Tests
- 2 new tests; **22 worktree-gc tests pass**. No production code changed. Sandbox-safe (temp dirs only).

## Acceptance criteria
- [x] CLI test covers the config-discovered repo set (`config.repos` + `controlRoomRoot`)