### PR TITLE
feat(server): opt-in worktree auto-reaper on startup (#5158)

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -79,6 +79,11 @@ const CONFIG_SCHEMA = {
   showToken: 'boolean',
   logFormat: 'string',
   environments: 'object',
+  // #5158: worktree garbage-collection. `{ autoReap: boolean }` — when true,
+  // the server reclaims orphaned, dead-pid-locked agent worktrees on startup
+  // (clean trees only, never --force). Defaults to off; the `chroxy worktree
+  // gc` CLI is always available for manual/dry-run use.
+  worktreeGc: 'object',
   sandbox: 'object',
   // Optional allowlist of absolute directory paths that sessions may use
   // as their working directory. When set (non-empty array), session
@@ -607,6 +612,19 @@ export function validateConfig(config, verbose = false) {
     const rancherBlock = config.environments.rancher
     if (rancherBlock !== undefined) {
       validateRancherBlock(rancherBlock, warnings)
+    }
+  }
+
+  // #5158: worktree GC block. Only the shape (object, not array) and the
+  // `autoReap` boolean are checked; an unset block means "auto-reaper off".
+  if (config.worktreeGc !== undefined) {
+    if (typeof config.worktreeGc !== 'object' || config.worktreeGc === null || Array.isArray(config.worktreeGc)) {
+      warnings.push(`Invalid type for 'worktreeGc': expected object, got ${Array.isArray(config.worktreeGc) ? 'array' : typeof config.worktreeGc}`)
+    } else if (
+      Object.prototype.hasOwnProperty.call(config.worktreeGc, 'autoReap') &&
+      typeof config.worktreeGc.autoReap !== 'boolean'
+    ) {
+      warnings.push(`Invalid type for 'worktreeGc.autoReap': expected boolean, got ${typeof config.worktreeGc.autoReap}`)
     }
   }
 

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1039,10 +1039,10 @@ export async function startCliServer(config) {
   // now that the server is up. Fire-and-forget + lazily imported so a default
   // (disabled) boot pays nothing and a failure here never affects startup; the
   // reaper itself yields between repos so the sweep doesn't starve the loop.
-  if (config.worktreeGc?.autoReap) {
+  if (config.worktreeGc?.autoReap === true) {
     import('./worktree-reaper.js')
       .then(({ maybeAutoReapWorktrees }) => maybeAutoReapWorktrees(config, log))
-      .catch((err) => log.warn(`worktree auto-reaper failed: ${err.message}`))
+      .catch((err) => log.warn(`worktree auto-reaper failed: ${(err && err.message) || err}`))
   }
 
   console.log('\nPress Ctrl+C to stop.\n')

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1034,6 +1034,17 @@ export async function startCliServer(config) {
     })
   }
 
+  // #5158: opt-in worktree auto-reaper. When enabled, reclaim orphaned
+  // dead-pid-locked agent worktrees (clean trees only, never --force) once
+  // now that the server is up. Fire-and-forget + lazily imported so a default
+  // (disabled) boot pays nothing and a failure here never affects startup; the
+  // reaper itself yields between repos so the sweep doesn't starve the loop.
+  if (config.worktreeGc?.autoReap) {
+    import('./worktree-reaper.js')
+      .then(({ maybeAutoReapWorktrees }) => maybeAutoReapWorktrees(config, log))
+      .catch((err) => log.warn(`worktree auto-reaper failed: ${err.message}`))
+  }
+
   console.log('\nPress Ctrl+C to stop.\n')
 
   // Graceful shutdown.

--- a/packages/server/src/worktree-reaper.js
+++ b/packages/server/src/worktree-reaper.js
@@ -1,0 +1,99 @@
+// Opt-in worktree auto-reaper (#5158).
+//
+// When `config.worktreeGc.autoReap` is true, the server reclaims orphaned,
+// dead-pid-locked agent worktrees once on startup. It reuses the GC core
+// (planRepoGc/applyPlan), so the full safety contract holds unchanged: only
+// clean worktrees locked by a verified-dead pid (plus dir-gone stale refs) are
+// reclaimed, never --force, never the main worktree, never a dirty/live one.
+//
+// Default is OFF. The manual `chroxy worktree gc` CLI (dry-run by default) is
+// always available regardless of this setting.
+//
+// Scope mirrors the CLI: the resolved repo set (config.repos ∪ auto-discover
+// under config.controlRoomRoot). To keep an opt-in startup sweep from starving
+// the freshly-booted server's event loop, the orchestrator yields between
+// repos (each repo's git calls are still synchronous, but bounded).
+
+import { resolveRepoSet } from './control-room/repo-set.js'
+import { planRepoGc, applyPlan } from './worktree-gc.js'
+
+/**
+ * Reap one repo into the running summary. Sync (the GC core uses execFileSync).
+ */
+function reapOneRepo(repoPath, summary, planDeps) {
+  const plan = planRepoGc(repoPath, planDeps)
+  if (plan.error) {
+    summary.errors.push({ repo: repoPath, error: plan.error })
+    return
+  }
+  const reclaimable = plan.items.filter((it) => it.action === 'remove' || it.action === 'prune')
+  summary.skipped += plan.items.filter((it) => it.action === 'skip').length
+  if (reclaimable.length === 0) return
+  const results = applyPlan(repoPath, { items: reclaimable }, planDeps)
+  for (const res of results) {
+    if (res.ok) {
+      summary.reclaimed += 1
+      summary.removed.push(res.path)
+    } else {
+      summary.failed += 1
+      summary.errors.push({ repo: repoPath, path: res.path, error: res.error })
+    }
+  }
+}
+
+/**
+ * Reap a set of repos. `repos` is `[{ name, path }]`. Yields to the event loop
+ * between repos so a large sweep doesn't block a freshly-booted server.
+ * Returns a manifest summary. Pure aside from the injected GC seams (planDeps).
+ */
+export async function reapWorktrees({ repos = [], planDeps = {}, yieldFn } = {}) {
+  const summary = { repos: repos.length, reclaimed: 0, failed: 0, skipped: 0, removed: [], errors: [] }
+  const yieldToLoop = yieldFn || (() => new Promise((resolve) => setImmediate(resolve)))
+  for (const r of repos) {
+    await yieldToLoop()
+    reapOneRepo(r.path, summary, planDeps)
+  }
+  return summary
+}
+
+/**
+ * Startup entry point. No-op (returns null) unless `config.worktreeGc.autoReap`
+ * is true. Resolves the repo set the same way the CLI does, reaps, and logs a
+ * manifest. Best-effort: callers should fire-and-forget and not let a failure
+ * here affect boot.
+ *
+ * @param {object} config - merged server config
+ * @param {{ info: Function, warn: Function }} log - server logger
+ * @param {object} [deps] - test seams: resolveRepoSet, repoSetSeams, planDeps, yieldFn
+ */
+export async function maybeAutoReapWorktrees(config, log, deps = {}) {
+  if (!config || !config.worktreeGc || config.worktreeGc.autoReap !== true) return null
+
+  const resolve = deps.resolveRepoSet || resolveRepoSet
+  let repos
+  try {
+    repos = resolve({
+      repos: config.repos,
+      root: config.controlRoomRoot,
+      ...(deps.repoSetSeams || {}),
+    })
+  } catch (err) {
+    log.warn(`worktree auto-reap: repo discovery failed: ${(err && err.message) || err}`)
+    return null
+  }
+
+  const summary = await reapWorktrees({ repos, planDeps: deps.planDeps || {}, yieldFn: deps.yieldFn })
+
+  const base = `worktree auto-reap: reclaimed ${summary.reclaimed} worktree(s) across ${summary.repos} repo(s); ${summary.skipped} preserved (live/dirty/unknown)`
+  if (summary.failed > 0) {
+    log.warn(`${base}; ${summary.failed} failed`)
+    for (const e of summary.errors) {
+      log.warn(`  - ${e.path || e.repo}: ${e.error}`)
+    }
+  } else if (summary.reclaimed > 0) {
+    log.info(base)
+  } else {
+    log.info('worktree auto-reap: nothing to reclaim')
+  }
+  return summary
+}

--- a/packages/server/src/worktree-reaper.js
+++ b/packages/server/src/worktree-reaper.js
@@ -85,8 +85,12 @@ export async function maybeAutoReapWorktrees(config, log, deps = {}) {
   const summary = await reapWorktrees({ repos, planDeps: deps.planDeps || {}, yieldFn: deps.yieldFn })
 
   const base = `worktree auto-reap: reclaimed ${summary.reclaimed} worktree(s) across ${summary.repos} repo(s); ${summary.skipped} preserved (live/dirty/unknown)`
-  if (summary.failed > 0) {
-    log.warn(`${base}; ${summary.failed} failed`)
+  // Warn whenever anything went wrong — both per-item failures (counted in
+  // `failed`) and repo-level discovery/plan errors (recorded in `errors`
+  // without incrementing `failed`). Otherwise an unscannable repo would log a
+  // misleading "nothing to reclaim" info line and hide the failure.
+  if (summary.failed > 0 || summary.errors.length > 0) {
+    log.warn(`${base}; ${summary.failed} failed, ${summary.errors.length} error(s)`)
     for (const e of summary.errors) {
       log.warn(`  - ${e.path || e.repo}: ${e.error}`)
     }

--- a/packages/server/tests/config-worktree-gc.test.js
+++ b/packages/server/tests/config-worktree-gc.test.js
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { validateConfig } from '../src/config.js'
+
+/**
+ * #5158 — `worktreeGc: { autoReap: boolean }` config block gates the opt-in
+ * worktree auto-reaper. Validate the schema accepts a well-formed block and
+ * warns on the wrong shapes/types, without emitting an "Unknown config key".
+ */
+describe('config.worktreeGc (#5158)', () => {
+  it('accepts a well-formed { autoReap: true } block', () => {
+    const result = validateConfig({ worktreeGc: { autoReap: true } })
+    assert.equal(result.valid, true)
+    assert.equal(result.warnings.length, 0)
+  })
+
+  it('accepts an empty worktreeGc block (auto-reaper off)', () => {
+    const result = validateConfig({ worktreeGc: {} })
+    assert.equal(result.valid, true)
+    assert.equal(result.warnings.length, 0)
+  })
+
+  it('warns when autoReap is not a boolean', () => {
+    const result = validateConfig({ worktreeGc: { autoReap: 'yes' } })
+    assert.equal(result.valid, false)
+    assert.ok(
+      result.warnings.some((w) => w.includes('worktreeGc.autoReap') && w.includes('boolean')),
+      `expected a type warning for worktreeGc.autoReap, got: ${JSON.stringify(result.warnings)}`,
+    )
+  })
+
+  it('warns when worktreeGc is an array (wrong shape)', () => {
+    const result = validateConfig({ worktreeGc: [] })
+    assert.equal(result.valid, false)
+    assert.ok(
+      result.warnings.some((w) => w.includes('worktreeGc') && w.includes('object')),
+      `expected a shape warning for worktreeGc, got: ${JSON.stringify(result.warnings)}`,
+    )
+  })
+
+  it('does not flag worktreeGc as an unknown key', () => {
+    const result = validateConfig({ worktreeGc: { autoReap: false } })
+    const unknown = result.warnings.find((w) => w.includes('Unknown config key') && w.includes('worktreeGc'))
+    assert.equal(unknown, undefined)
+  })
+})

--- a/packages/server/tests/worktree-reaper.test.js
+++ b/packages/server/tests/worktree-reaper.test.js
@@ -1,0 +1,124 @@
+/**
+ * Tests for the opt-in worktree auto-reaper (#5158).
+ *
+ * Builds real temp git repos and drives reapWorktrees / maybeAutoReapWorktrees
+ * with an injected fake `kill` (so a fixed pid is "dead") and a stub logger.
+ * Asserts the reaper honours the GC safety contract (clean+dead-pid only, never
+ * dirty/live) and the opt-in gate (no-op unless config.worktreeGc.autoReap).
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { execFileSync } from 'child_process'
+import { GIT } from '../src/git.js'
+import { reapWorktrees, maybeAutoReapWorktrees } from '../src/worktree-reaper.js'
+
+const LIVE_PID = 4100002
+const DEAD_PID = 4100001
+const fakeKill = (pid) => {
+  if (pid === LIVE_PID) return true
+  const err = new Error('no such process')
+  err.code = 'ESRCH'
+  throw err
+}
+const planDeps = { kill: fakeKill }
+// Run the per-repo yield synchronously in tests (no real setImmediate wait).
+const yieldFn = () => Promise.resolve()
+
+const git = (cwd, args) => execFileSync(GIT, ['-C', cwd, ...args], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] })
+
+function makeLogger() {
+  const info = []
+  const warn = []
+  return { info: (m) => info.push(m), warn: (m) => warn.push(m), _info: info, _warn: warn }
+}
+
+describe('worktree-reaper', () => {
+  let root, repo, cleanDead, dirtyDead, live
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'chroxy-reaper-'))
+    repo = join(root, 'proj')
+    mkdirSync(repo, { recursive: true })
+    git(repo, ['init', '--initial-branch=main', '.'])
+    git(repo, ['config', 'user.email', 'test@test'])
+    git(repo, ['config', 'user.name', 'Test'])
+    git(repo, ['commit', '--allow-empty', '-m', 'init'])
+    cleanDead = join(repo, '.claude', 'worktrees', 'clean-dead')
+    dirtyDead = join(repo, '.claude', 'worktrees', 'dirty-dead')
+    live = join(repo, '.claude', 'worktrees', 'live')
+    git(repo, ['worktree', 'add', '--detach', cleanDead, 'HEAD'])
+    git(repo, ['worktree', 'lock', '--reason', `claude agent a1 (pid ${DEAD_PID})`, cleanDead])
+    git(repo, ['worktree', 'add', '--detach', dirtyDead, 'HEAD'])
+    writeFileSync(join(dirtyDead, 'scratch.txt'), 'wip')
+    git(repo, ['worktree', 'lock', '--reason', `claude agent a2 (pid ${DEAD_PID})`, dirtyDead])
+    git(repo, ['worktree', 'add', '--detach', live, 'HEAD'])
+    git(repo, ['worktree', 'lock', '--reason', `claude agent a3 (pid ${LIVE_PID})`, live])
+  })
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }))
+
+  it('reapWorktrees reclaims clean+dead, preserves dirty + live', async () => {
+    const summary = await reapWorktrees({ repos: [{ name: 'proj', path: repo }], planDeps, yieldFn })
+    assert.equal(summary.reclaimed, 1)
+    assert.equal(summary.failed, 0)
+    assert.equal(summary.skipped, 2) // dirty + live
+    assert.equal(existsSync(cleanDead), false)
+    assert.equal(existsSync(dirtyDead), true)
+    assert.equal(existsSync(live), true)
+  })
+
+  it('maybeAutoReapWorktrees is a no-op when autoReap is unset/false', async () => {
+    const log = makeLogger()
+    const r1 = await maybeAutoReapWorktrees({}, log, { planDeps, yieldFn })
+    const r2 = await maybeAutoReapWorktrees({ worktreeGc: {} }, log, { planDeps, yieldFn })
+    const r3 = await maybeAutoReapWorktrees({ worktreeGc: { autoReap: false } }, log, { planDeps, yieldFn })
+    assert.equal(r1, null)
+    assert.equal(r2, null)
+    assert.equal(r3, null)
+    assert.equal(log._info.length, 0)
+    // Nothing was touched.
+    assert.equal(existsSync(cleanDead), true)
+  })
+
+  it('maybeAutoReapWorktrees reaps when autoReap is true (config.repos scope)', async () => {
+    const log = makeLogger()
+    const summary = await maybeAutoReapWorktrees(
+      { worktreeGc: { autoReap: true }, repos: [{ name: 'proj', path: repo }] },
+      log,
+      // Stub discovery so the default ~/Projects root isn't walked.
+      { planDeps, yieldFn, repoSetSeams: { _readdir: () => [] } },
+    )
+    assert.equal(summary.reclaimed, 1)
+    assert.equal(existsSync(cleanDead), false)
+    assert.equal(existsSync(dirtyDead), true)
+    assert.ok(log._info.some((m) => /reclaimed 1 worktree/.test(m)), `info logs: ${JSON.stringify(log._info)}`)
+  })
+
+  it('logs "nothing to reclaim" when there is nothing dead+clean', async () => {
+    // Unlock + remove the clean-dead one up front so only dirty + live remain.
+    git(repo, ['worktree', 'unlock', cleanDead])
+    git(repo, ['worktree', 'remove', cleanDead])
+    const log = makeLogger()
+    const summary = await maybeAutoReapWorktrees(
+      { worktreeGc: { autoReap: true }, repos: [{ name: 'proj', path: repo }] },
+      log,
+      { planDeps, yieldFn, repoSetSeams: { _readdir: () => [] } },
+    )
+    assert.equal(summary.reclaimed, 0)
+    assert.ok(log._info.some((m) => /nothing to reclaim/.test(m)))
+  })
+
+  it('reports a repo-level git error without throwing', async () => {
+    const log = makeLogger()
+    const summary = await maybeAutoReapWorktrees(
+      { worktreeGc: { autoReap: true }, repos: [{ name: 'nope', path: join(root, 'does-not-exist') }] },
+      log,
+      { planDeps, yieldFn, repoSetSeams: { _readdir: () => [] } },
+    )
+    assert.equal(summary.reclaimed, 0)
+    assert.equal(summary.errors.length, 1)
+  })
+})

--- a/packages/server/tests/worktree-reaper.test.js
+++ b/packages/server/tests/worktree-reaper.test.js
@@ -120,5 +120,10 @@ describe('worktree-reaper', () => {
     )
     assert.equal(summary.reclaimed, 0)
     assert.equal(summary.errors.length, 1)
+    // A repo-level scan error must surface as a warn, not a misleading
+    // "nothing to reclaim" info line (Copilot #5224).
+    assert.equal(log._info.length, 0)
+    assert.ok(log._warn.some((m) => /error\(s\)/.test(m)), `warn logs: ${JSON.stringify(log._warn)}`)
+    assert.ok(log._warn.some((m) => /does-not-exist/.test(m)), `warn logs: ${JSON.stringify(log._warn)}`)
   })
 })


### PR DESCRIPTION
## Summary

Completes #5158. Follow-up to the manual `chroxy worktree gc` CLI (#5220): an **opt-in** auto-reaper so orphaned, dead-pid-locked agent worktrees are reclaimed automatically instead of needing a manual run.

## Policy (the decisions I made — flagged for your sign-off)
- **Off by default.** New config `worktreeGc: { autoReap: boolean }` (default `false`). A default boot pays *nothing* — the reaper module is lazily imported and only when the flag is set.
- **Opt-in, not default-on** — auto-deleting worktrees on every startup unprompted felt too aggressive; the operator turns it on after seeing the CLI surface the leak. (Say the word if you'd rather it default on.)
- **Scope = same as the CLI**: the resolved repo set (`config.repos` ∪ auto-discover under `controlRoomRoot`), so it actually catches leaks in discovered repos, not just configured ones.
- **Safety contract unchanged** — reuses the GC core (`planRepoGc`/`applyPlan`): clean trees only, dead-pid locks only, **never `--force`**, never the main worktree; dirty/live/unknown are preserved.
- **Best-effort + non-blocking**: fire-and-forget from `server-cli` startup; a failure never affects boot. The reaper **yields to the event loop between repos** so an opt-in sweep can't starve the freshly-booted server (the GC core itself is synchronous `execFileSync`).
- **Logged manifest**: `worktree auto-reap: reclaimed N worktree(s) across M repo(s); K preserved (live/dirty/unknown)` via the server logger (warns + per-item detail on failures).

## Files
- `src/worktree-reaper.js` — `reapWorktrees({ repos, planDeps, yieldFn })` and `maybeAutoReapWorktrees(config, log, deps)`, both dependency-injected.
- `src/config.js` — `worktreeGc` schema key + validation (object shape; `autoReap` boolean).
- `src/server-cli.js` — gated, lazily-imported, fire-and-forget startup hook (mirrors the #5081 docker-byok boot-sweep pattern).

## Tests (10 new)
- **Reaper** (real temp git repos): reclaims clean+dead, **preserves dirty + live**; opt-in gate (no-op + nothing touched when `autoReap` unset/false); "nothing to reclaim" log; per-repo git-error tolerance (no throw).
- **Config validation**: accepts `{ autoReap: true }` / empty block; warns on non-boolean `autoReap` and on array shape; not flagged as unknown key.
- 32 worktree/config tests pass; state-file + opt-forwarding lints green; `server-cli.js` imports clean.

## Acceptance criteria (#5158)
- [x] Stale-lock reaper reclaims dead-pid-locked clean worktrees automatically (opt-in)
- [x] Never `--force`; dirty/WIP preserved; only verified-dead pids; main worktree untouched
- [x] Logs a manifest of what was reclaimed
- [x] Manual `chroxy worktree gc` CLI remains (shipped in #5220)

Note: cleanup-on-exit / SIGKILL reaping (proposal #1) is naturally covered by the next startup's reaper; a dedicated in-process exit trap can be a follow-up if you want immediate reclamation rather than next-boot.