### PR TITLE
feat(dashboard): sort and filter the Control Room repo table (#5216)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -39,6 +39,9 @@ import {
   formatGeneratedAgo,
   sessionIdForRepoPath,
   HIGH_COUNT_THRESHOLD,
+  filterRepos,
+  sortRepos,
+  type RepoFilterKey,
 } from './ControlRoomSection'
 
 // Minimal SessionInfo factory — only the fields the repo→session mapping reads
@@ -278,6 +281,150 @@ describe('ControlRoomSection (#5175)', () => {
       />,
     )
     expect(screen.getByTestId('cr-no-repos')).toBeTruthy()
+  })
+})
+
+// Helper: read the DOM order of rendered repo rows (top-level rows only).
+function renderedRepoOrder(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('[data-testid^="cr-row-"]')).map((el) =>
+    (el.getAttribute('data-testid') ?? '').replace('cr-row-', ''),
+  )
+}
+
+describe('filterRepos (#5216)', () => {
+  const repos = makeSnapshot().repos
+
+  it('returns all repos (a copy) for an empty filter set', () => {
+    const out = filterRepos(repos, new Set())
+    expect(out.map((r) => r.name)).toEqual(['chroxy', 'medlens', 'no-it-all'])
+    expect(out).not.toBe(repos) // a copy, not the original array
+  })
+
+  it('dirty → only repos with a dirty tree', () => {
+    expect(filterRepos(repos, new Set<RepoFilterKey>(['dirty'])).map((r) => r.name)).toEqual(['medlens'])
+  })
+
+  it('live → only live repos', () => {
+    expect(filterRepos(repos, new Set<RepoFilterKey>(['live'])).map((r) => r.name)).toEqual(['chroxy'])
+  })
+
+  it('prs → repos with >0 open PRs (null counts as 0)', () => {
+    expect(filterRepos(repos, new Set<RepoFilterKey>(['prs'])).map((r) => r.name)).toEqual(['medlens', 'no-it-all'])
+  })
+
+  it('triage → only investigate/abandoned/recent verdicts', () => {
+    expect(filterRepos(repos, new Set<RepoFilterKey>(['triage'])).map((r) => r.name)).toEqual(['medlens'])
+  })
+
+  it('combines filters with AND (intersection)', () => {
+    // medlens is both dirty and has PRs.
+    expect(filterRepos(repos, new Set<RepoFilterKey>(['dirty', 'prs'])).map((r) => r.name)).toEqual(['medlens'])
+    // No repo is both dirty AND live (medlens is dirty-not-live, chroxy is live-not-dirty).
+    expect(filterRepos(repos, new Set<RepoFilterKey>(['dirty', 'live']))).toEqual([])
+  })
+})
+
+describe('sortRepos (#5216)', () => {
+  const repos = makeSnapshot().repos
+
+  it('default preserves server order and does not mutate the input', () => {
+    const out = sortRepos(repos, 'default')
+    expect(out.map((r) => r.name)).toEqual(['chroxy', 'medlens', 'no-it-all'])
+    expect(out).not.toBe(repos)
+    // original untouched
+    expect(repos.map((r) => r.name)).toEqual(['chroxy', 'medlens', 'no-it-all'])
+  })
+
+  it('recent sorts most-recently-touched first', () => {
+    // chroxy 11:47 > no-it-all 11:12 > medlens 2026-05-28
+    expect(sortRepos(repos, 'recent').map((r) => r.name)).toEqual(['chroxy', 'no-it-all', 'medlens'])
+  })
+
+  it('worktrees sorts highest count first', () => {
+    expect(sortRepos(repos, 'worktrees').map((r) => r.name)).toEqual(['medlens', 'chroxy', 'no-it-all'])
+  })
+
+  it('prs sorts highest open-PR count first, unknown (null) last', () => {
+    // medlens 16 > no-it-all 1 > chroxy null
+    expect(sortRepos(repos, 'prs').map((r) => r.name)).toEqual(['medlens', 'no-it-all', 'chroxy'])
+  })
+
+  it('verdict sorts by priority (live first, onboarded last)', () => {
+    expect(sortRepos(repos, 'verdict').map((r) => r.name)).toEqual(['chroxy', 'medlens', 'no-it-all'])
+  })
+
+  it('tree sorts most uncommitted changes first, ties broken by name', () => {
+    // medlens has 2 changes; chroxy & no-it-all are clean (0) → name tiebreak.
+    expect(sortRepos(repos, 'tree').map((r) => r.name)).toEqual(['medlens', 'chroxy', 'no-it-all'])
+  })
+})
+
+describe('ControlRoomSection sort/filter controls (#5216)', () => {
+  it('renders the controls bar with filter chips, a sort select, and a count', () => {
+    render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    expect(screen.getByTestId('cr-controls')).toBeTruthy()
+    expect(screen.getByTestId('cr-filter-dirty')).toBeTruthy()
+    expect(screen.getByTestId('cr-filter-live')).toBeTruthy()
+    expect(screen.getByTestId('cr-filter-prs')).toBeTruthy()
+    expect(screen.getByTestId('cr-filter-triage')).toBeTruthy()
+    expect(screen.getByTestId('cr-sort')).toBeTruthy()
+    // No filter active → plain "N repos" and no Clear button.
+    expect(screen.getByTestId('cr-visible-count')).toHaveTextContent('3 repos')
+    expect(screen.queryByTestId('cr-clear-filters')).toBeNull()
+  })
+
+  it('filtering by dirty narrows the table and updates the count', () => {
+    const { container } = render(
+      <ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />,
+    )
+    fireEvent.click(screen.getByTestId('cr-filter-dirty'))
+    expect(renderedRepoOrder(container)).toEqual(['medlens'])
+    expect(screen.getByTestId('cr-filter-dirty')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('cr-visible-count')).toHaveTextContent('1 of 3 repos')
+  })
+
+  it('Clear resets the filters', () => {
+    const { container } = render(
+      <ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />,
+    )
+    fireEvent.click(screen.getByTestId('cr-filter-dirty'))
+    fireEvent.click(screen.getByTestId('cr-clear-filters'))
+    expect(renderedRepoOrder(container)).toEqual(['chroxy', 'medlens', 'no-it-all'])
+    expect(screen.getByTestId('cr-visible-count')).toHaveTextContent('3 repos')
+    expect(screen.getByTestId('cr-filter-dirty')).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  it('shows a no-matches row (with a clear action) when filters exclude everything', () => {
+    const { container } = render(
+      <ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />,
+    )
+    // dirty + live → no repo matches both.
+    fireEvent.click(screen.getByTestId('cr-filter-dirty'))
+    fireEvent.click(screen.getByTestId('cr-filter-live'))
+    expect(renderedRepoOrder(container)).toEqual([])
+    expect(screen.getByTestId('cr-no-matches')).toBeTruthy()
+    fireEvent.click(screen.getByTestId('cr-no-matches-clear'))
+    expect(renderedRepoOrder(container)).toEqual(['chroxy', 'medlens', 'no-it-all'])
+  })
+
+  it('changing the sort reorders the rendered rows', () => {
+    const { container } = render(
+      <ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />,
+    )
+    fireEvent.change(screen.getByTestId('cr-sort'), { target: { value: 'worktrees' } })
+    expect(renderedRepoOrder(container)).toEqual(['medlens', 'chroxy', 'no-it-all'])
+  })
+
+  it('does not render the controls bar when there are no repos', () => {
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot({ repos: [], summary: { live: 0, onboarded: 0, abandoned: 0, investigate: 0, recent: 0 } })}
+        loading={false}
+        onRefresh={() => {}}
+        now={() => NOW}
+      />,
+    )
+    expect(screen.queryByTestId('cr-controls')).toBeNull()
   })
 })
 

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -31,7 +31,7 @@
  *   - recent      → warn  (amber)  — recent uncommitted work; eyeball before touching.
  *   - onboarded   → ok    (green)  — on the pull-model; just needs a checkout+pull.
  */
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { RepoStatus, RepoVerdict, ServerHostStatusSnapshotMessage } from '@chroxy/protocol'
 import type { ActivityState, SessionInfo } from '@chroxy/store-core'
@@ -59,6 +59,128 @@ const VERDICT_LABEL: Record<RepoVerdict, string> = {
   abandoned: 'Likely abandoned',
   recent: 'Recent / your call',
   onboarded: 'Onboarded',
+}
+
+/**
+ * #5216 — repo-table filters. Each is an independent predicate the operator can
+ * toggle to narrow the survey to "what needs my attention". Mirrors the brief's
+ * facets: dirty · live · has-PRs · needs-triage.
+ *
+ *   - dirty   → working tree has uncommitted changes.
+ *   - live    → a chroxy session is running in the repo right now.
+ *   - prs     → the repo has at least one open PR (unknown `null` counts as 0).
+ *   - triage  → the verdict is one of the amber "a human should look" buckets
+ *               (investigate / abandoned / recent). LIVE (working now) and
+ *               onboarded (green, fine) are deliberately excluded.
+ */
+export type RepoFilterKey = 'dirty' | 'live' | 'prs' | 'triage'
+
+interface RepoFilterDef {
+  key: RepoFilterKey
+  label: string
+  test: (repo: RepoStatus) => boolean
+}
+
+// Order here is the order the filter chips render in.
+export const REPO_FILTERS: readonly RepoFilterDef[] = [
+  { key: 'dirty', label: 'Dirty', test: (r) => r.tree.state === 'dirty' },
+  { key: 'live', label: 'Live', test: (r) => r.live },
+  { key: 'prs', label: 'Has PRs', test: (r) => (r.openPRs ?? 0) > 0 },
+  {
+    key: 'triage',
+    label: 'Needs triage',
+    test: (r) => r.verdict === 'investigate' || r.verdict === 'abandoned' || r.verdict === 'recent',
+  },
+]
+
+/**
+ * #5216 — sort keys for the repo table. `default` preserves the server's order
+ * (the survey already returns repos in a sensible order); the rest are operator
+ * overrides. Every non-default sort breaks ties on `name` so the order is
+ * deterministic regardless of the incoming array order.
+ */
+export type RepoSortKey = 'default' | 'verdict' | 'name' | 'recent' | 'worktrees' | 'prs' | 'tree'
+
+export interface RepoSortOption {
+  key: RepoSortKey
+  label: string
+}
+
+export const REPO_SORT_OPTIONS: readonly RepoSortOption[] = [
+  { key: 'default', label: 'Server order' },
+  { key: 'verdict', label: 'Verdict (priority)' },
+  { key: 'name', label: 'Name (A–Z)' },
+  { key: 'recent', label: 'Last touched' },
+  { key: 'worktrees', label: 'Worktrees' },
+  { key: 'prs', label: 'Open PRs' },
+  { key: 'tree', label: 'Tree changes' },
+]
+
+// Verdict → sort weight (lower sorts first): the "stop, look now" buckets float
+// to the top, onboarded sinks. Drives the `verdict` sort.
+const VERDICT_PRIORITY: Record<RepoVerdict, number> = {
+  live: 0,
+  investigate: 1,
+  abandoned: 2,
+  recent: 3,
+  onboarded: 4,
+}
+
+/** Total uncommitted changes in a repo's tree (0 when clean). */
+function treeChangeCount(repo: RepoStatus): number {
+  if (repo.tree.state === 'clean') return 0
+  return repo.tree.untracked + repo.tree.modified + repo.tree.staged
+}
+
+/**
+ * Filter repos to those matching EVERY active filter (intersection / AND). An
+ * empty `active` set is the identity — all repos pass. Pure; returns a new
+ * array. Exported for direct unit testing.
+ */
+export function filterRepos(
+  repos: readonly RepoStatus[],
+  active: ReadonlySet<RepoFilterKey>,
+): RepoStatus[] {
+  if (active.size === 0) return repos.slice()
+  const predicates = REPO_FILTERS.filter((f) => active.has(f.key))
+  return repos.filter((repo) => predicates.every((f) => f.test(repo)))
+}
+
+/**
+ * Return a new array of repos ordered by `sortKey`. `default` keeps the server's
+ * incoming order (a stable copy). Every other key sorts descending on its metric
+ * with a `name` (then `path`) tiebreaker so the order is fully deterministic.
+ * Pure; never mutates the input. Exported for direct unit testing.
+ */
+export function sortRepos(repos: readonly RepoStatus[], sortKey: RepoSortKey): RepoStatus[] {
+  const copy = repos.slice()
+  if (sortKey === 'default') return copy
+
+  const byName = (a: RepoStatus, b: RepoStatus) =>
+    a.name.localeCompare(b.name) || a.path.localeCompare(b.path)
+
+  const compare: Record<Exclude<RepoSortKey, 'default'>, (a: RepoStatus, b: RepoStatus) => number> = {
+    // Ascending priority (live first), then name.
+    verdict: (a, b) => VERDICT_PRIORITY[a.verdict] - VERDICT_PRIORITY[b.verdict] || byName(a, b),
+    // A–Z.
+    name: (a, b) => byName(a, b),
+    // Most-recently-touched first. Unparseable timestamps sink (treated as 0).
+    recent: (a, b) => (parseTime(b.lastTouched) - parseTime(a.lastTouched)) || byName(a, b),
+    // Highest worktree count first.
+    worktrees: (a, b) => (b.worktrees - a.worktrees) || byName(a, b),
+    // Highest open-PR count first; unknown (`null`) sinks below 0.
+    prs: (a, b) => ((b.openPRs ?? -1) - (a.openPRs ?? -1)) || byName(a, b),
+    // Most uncommitted changes first.
+    tree: (a, b) => (treeChangeCount(b) - treeChangeCount(a)) || byName(a, b),
+  }
+
+  return copy.sort(compare[sortKey])
+}
+
+/** Parse an ISO timestamp to epoch ms, or 0 when unparseable (sinks in sorts). */
+function parseTime(iso: string): number {
+  const ms = Date.parse(iso)
+  return Number.isNaN(ms) ? 0 : ms
 }
 
 /**
@@ -474,6 +596,29 @@ export function ControlRoomSection({
     })
   }, [])
 
+  // #5216 — repo-table view controls. Filters narrow the table (AND across
+  // active filters); sort reorders it. Both are ephemeral view state (not
+  // persisted) so a refresh keeps the operator's current lens but a reload
+  // starts from the server's default order with no filters.
+  const [activeFilters, setActiveFilters] = useState<ReadonlySet<RepoFilterKey>>(() => new Set())
+  const [sortKey, setSortKey] = useState<RepoSortKey>('default')
+
+  const toggleFilter = useCallback((key: RepoFilterKey) => {
+    setActiveFilters((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }, [])
+  const clearFilters = useCallback(() => setActiveFilters(new Set()), [])
+
+  const allRepos = snapshot ? snapshot.repos : []
+  const visibleRepos = useMemo(
+    () => sortRepos(filterRepos(allRepos, activeFilters), sortKey),
+    [allRepos, activeFilters, sortKey],
+  )
+
   // Gate the refresh on connection state: a dropped request would otherwise
   // spin/no-op silently. Disabled while a refresh is in flight or disconnected.
   const refreshDisabled = loading || !connected
@@ -563,6 +708,56 @@ export function ControlRoomSection({
             local clone may just need a checkout+pull.
           </div>
 
+          {snapshot.repos.length > 0 && (
+            <div className="cr-controls" data-testid="cr-controls">
+              <div className="cr-filters" role="group" aria-label="Filter repos">
+                {REPO_FILTERS.map((f) => {
+                  const on = activeFilters.has(f.key)
+                  return (
+                    <button
+                      key={f.key}
+                      type="button"
+                      className={`cr-filter${on ? ' cr-filter-on' : ''}`}
+                      data-testid={`cr-filter-${f.key}`}
+                      aria-pressed={on}
+                      onClick={() => toggleFilter(f.key)}
+                    >
+                      {f.label}
+                    </button>
+                  )
+                })}
+                {activeFilters.size > 0 && (
+                  <button
+                    type="button"
+                    className="cr-filter-clear"
+                    data-testid="cr-clear-filters"
+                    onClick={clearFilters}
+                  >
+                    Clear
+                  </button>
+                )}
+              </div>
+              <label className="cr-sort-label">
+                Sort
+                <select
+                  className="cr-sort"
+                  data-testid="cr-sort"
+                  value={sortKey}
+                  onChange={(e) => setSortKey(e.target.value as RepoSortKey)}
+                >
+                  {REPO_SORT_OPTIONS.map((opt) => (
+                    <option key={opt.key} value={opt.key}>{opt.label}</option>
+                  ))}
+                </select>
+              </label>
+              <span className="cr-dim cr-visible-count" data-testid="cr-visible-count">
+                {activeFilters.size > 0
+                  ? `${visibleRepos.length} of ${snapshot.repos.length} repos`
+                  : `${snapshot.repos.length} repos`}
+              </span>
+            </div>
+          )}
+
           <section className="cr-table-wrap">
             <table className="cr-table" data-testid="cr-table">
               <thead>
@@ -582,8 +777,17 @@ export function ControlRoomSection({
                   <tr data-testid="cr-no-repos">
                     <td colSpan={8} className="cr-dim">No repos found under {snapshot.root}.</td>
                   </tr>
+                ) : visibleRepos.length === 0 ? (
+                  <tr data-testid="cr-no-matches">
+                    <td colSpan={8} className="cr-dim">
+                      No repos match the active filters.{' '}
+                      <button type="button" className="cr-link-btn" data-testid="cr-no-matches-clear" onClick={clearFilters}>
+                        Clear filters
+                      </button>
+                    </td>
+                  </tr>
                 ) : (
-                  snapshot.repos.map((repo) => (
+                  visibleRepos.map((repo) => (
                     <RepoRows
                       key={repo.path}
                       repo={repo}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -8625,6 +8625,95 @@ button.sidebar-token-view-session-row:hover {
   color: var(--accent-blue);
 }
 
+/* #5216 — repo-table view controls (filter chips + sort + visible count) */
+.cr-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  margin: 16px 0 0;
+}
+
+.cr-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.cr-filter {
+  appearance: none;
+  cursor: pointer;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+  line-height: 1.4;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+
+.cr-filter:hover {
+  border-color: var(--accent-blue);
+  color: var(--text-primary);
+}
+
+.cr-filter-on {
+  background: var(--accent-blue);
+  border-color: var(--accent-blue);
+  color: #fff;
+}
+
+.cr-filter-clear {
+  appearance: none;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  text-decoration: underline;
+  padding: 4px 6px;
+}
+
+.cr-filter-clear:hover {
+  color: var(--text-primary);
+}
+
+.cr-sort-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  color: var(--text-muted);
+}
+
+.cr-sort {
+  appearance: auto;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 12.5px;
+}
+
+.cr-visible-count {
+  margin-left: auto;
+  font-size: 12.5px;
+}
+
+.cr-link-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--accent-blue);
+  cursor: pointer;
+  text-decoration: underline;
+  font: inherit;
+  padding: 0;
+}
+
 /* Table */
 .cr-table-wrap {
   background: var(--bg-secondary);


### PR DESCRIPTION
## Summary

Adds a **view-controls bar** above the Control Room host/repo survey table — the first of the four remaining #5151 dashboard items tracked in #5216.

### Filter chips
Four independent facets the operator can toggle to narrow the survey to "what needs my attention":

| Chip | Matches |
|------|---------|
| **Dirty** | working tree has uncommitted changes |
| **Live** | a chroxy session is running in the repo right now |
| **Has PRs** | ≥1 open PR (unknown `null` counts as 0) |
| **Needs triage** | verdict ∈ {investigate, abandoned, recent} (LIVE and onboarded excluded) |

Filters combine with **AND** (each active chip further narrows). A **Clear** button and a `N of M repos` count surface the active lens. When filters exclude everything, a no-matches row offers an inline clear.

### Sort dropdown
`Server order` (default — preserves the survey's order) · `Verdict (priority)` · `Name (A–Z)` · `Last touched` · `Worktrees` · `Open PRs` · `Tree changes`. Every non-default sort breaks ties on `name` so the order is deterministic.

### Notes
- `filterRepos` / `sortRepos` are **pure and exported** for direct unit testing; `sortRepos` never mutates its input.
- View state is **ephemeral** (not persisted) — a Refresh keeps the operator's lens, a reload resets to the server's default order with no filters. (Persisting the preference can be a follow-up.)
- **No server/protocol changes** — operates entirely over data already in the `host_status_snapshot`.

## Scope
Covers **only** the first checkbox of #5216 (sort/filter). The other three — branch ahead/behind, PR CI/review state, and row actions — each need server-side plumbing and stay tracked in #5216.

## Test plan
- 19 new tests (pure `filterRepos`/`sortRepos` + DOM behaviour: chip toggle, AND combination, Clear, no-matches row, sort reorder, controls hidden when no repos).
- Full dashboard suite green: **3137 passed**.
- `tsc --noEmit` clean; `vite build` clean.

Related to #5216