### PR TITLE
feat(server): encrypt credentials.json at rest with an OS-keychain key (#5154)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/blamechris/Projects/chroxy/node_modules

--- a/packages/server/node_modules
+++ b/packages/server/node_modules
@@ -1,0 +1,1 @@
+/Users/blamechris/Projects/chroxy/packages/server/node_modules

--- a/packages/server/src/credential-cipher.js
+++ b/packages/server/src/credential-cipher.js
@@ -119,7 +119,22 @@ export function decryptEnvelope(envelope, key) {
   }
   const nonce = new Uint8Array(Buffer.from(envelope.nonce, 'base64'))
   const box = new Uint8Array(Buffer.from(envelope.data, 'base64'))
-  const opened = nacl.secretbox.open(box, nonce, key)
+  // Guard the decoded lengths before handing them to tweetnacl: a malformed /
+  // truncated envelope can decode to a wrong-size nonce, and nacl.secretbox
+  // throws 'bad nonce size' rather than returning null — surface a predictable
+  // error instead. A short ciphertext (< the Poly1305 tag) likewise can't be a
+  // valid box.
+  if (nonce.length !== NONCE_BYTES || box.length <= nacl.secretbox.overheadLength) {
+    throw new Error('credential decryption failed (wrong key or corrupt data)')
+  }
+  // secretbox.open returns null on auth failure, but defensively wrap it so any
+  // unexpected throw from a corrupt envelope still becomes the same friendly error.
+  let opened
+  try {
+    opened = nacl.secretbox.open(box, nonce, key)
+  } catch {
+    opened = null
+  }
   if (!opened) {
     throw new Error('credential decryption failed (wrong key or corrupt data)')
   }

--- a/packages/server/src/credential-cipher.js
+++ b/packages/server/src/credential-cipher.js
@@ -1,0 +1,131 @@
+/**
+ * Envelope encryption for the credential store at rest (#5154).
+ *
+ * `credentials.json` holds the highest-value secrets chroxy persists — BYOK
+ * provider API keys and the Claude Code OAuth token. Mode 0600 keeps them
+ * owner-only, but a stolen disk image / backup / errant `cat` still exposes
+ * them in plaintext. This module encrypts the whole JSON blob with a random
+ * 32-byte data key that lives in the OS keychain — NOT next to the file — so a
+ * file-read alone is not enough to recover the secrets.
+ *
+ *   on disk:   { v: 1, alg: 'nacl-secretbox', nonce: <b64>, data: <b64> }
+ *   keychain:  service 'chroxy-cred-key', the base64 data key (one entry)
+ *
+ * Crypto: `nacl.secretbox` (XSalsa20-Poly1305 AEAD) — the same primitive the
+ * transport layer already uses, and `tweetnacl` is already a server dependency.
+ * The 24-byte nonce is random per write; the Poly1305 tag detects tampering on
+ * open (a wrong key or a flipped byte fails closed).
+ *
+ * Honest threat model: encryption only adds real protection because the key
+ * lives in the OS keychain (macOS Keychain / Linux libsecret), which a
+ * file-read attacker cannot reach. Where no keychain is available (Windows,
+ * headless Linux without `secret-tool`) there is nowhere safe to put the key,
+ * so the store falls back to today's 0600 plaintext and the server logs a
+ * one-time warning rather than inventing a machine-derived key (which would be
+ * obfuscation, not security). See docs/security for the full model.
+ *
+ * The keychain is dependency-injected (every export takes an optional
+ * `keychain` arg defaulting to the real module) so callers and tests stay
+ * deterministic regardless of the host's actual keychain.
+ */
+import nacl from 'tweetnacl'
+import { randomBytes } from 'node:crypto'
+import * as realKeychain from './keychain.js'
+
+/** Keychain service for the credential data key. Distinct from the primary
+ *  API-token entry (service 'chroxy') so the two never collide. */
+export const CRED_KEY_SERVICE = 'chroxy-cred-key'
+
+export const ENVELOPE_VERSION = 1
+const ALG = 'nacl-secretbox'
+const KEY_BYTES = 32 // nacl.secretbox key length
+const NONCE_BYTES = 24 // nacl.secretbox nonce length
+
+/**
+ * Is `obj` a well-formed encrypted envelope (vs. a legacy plaintext object)?
+ * Used by the store to decide decrypt-vs-passthrough on read.
+ */
+export function isEncryptedEnvelope(obj) {
+  return (
+    !!obj &&
+    typeof obj === 'object' &&
+    !Array.isArray(obj) &&
+    obj.v === ENVELOPE_VERSION &&
+    obj.alg === ALG &&
+    typeof obj.nonce === 'string' &&
+    typeof obj.data === 'string'
+  )
+}
+
+/**
+ * Read the existing data key from the keychain WITHOUT creating one. Returns a
+ * 32-byte Uint8Array, or null when no keychain is available or no key is stored
+ * (or the stored value is the wrong length — treated as absent).
+ */
+export function getMasterKey(keychain = realKeychain) {
+  if (!keychain.isKeychainAvailable()) return null
+  const stored = keychain.getToken(CRED_KEY_SERVICE)
+  if (!stored) return null
+  const buf = Buffer.from(stored, 'base64')
+  return buf.length === KEY_BYTES ? new Uint8Array(buf) : null
+}
+
+/**
+ * Get the data key from the keychain, generating and persisting a fresh one if
+ * none exists. Returns null when no keychain is available (caller must fall
+ * back to plaintext). A stored-but-malformed key is replaced (the old encrypted
+ * blob, if any, becomes undecryptable — acceptable: the alternative is a hard
+ * failure, and a corrupt keychain entry already means the secrets are lost).
+ */
+export function getOrCreateMasterKey(keychain = realKeychain) {
+  if (!keychain.isKeychainAvailable()) return null
+  const existing = getMasterKey(keychain)
+  if (existing) return existing
+  const key = randomBytes(KEY_BYTES)
+  keychain.setToken(Buffer.from(key).toString('base64'), CRED_KEY_SERVICE)
+  return new Uint8Array(key)
+}
+
+/**
+ * Encrypt a plain JS object into an envelope using `key` (32-byte Uint8Array).
+ * Pure: a fresh random nonce each call. Throws on a bad key length.
+ */
+export function encryptJson(plainObj, key) {
+  if (!(key instanceof Uint8Array) || key.length !== KEY_BYTES) {
+    throw new Error('credential cipher: key must be a 32-byte Uint8Array')
+  }
+  const nonce = new Uint8Array(randomBytes(NONCE_BYTES))
+  const message = new TextEncoder().encode(JSON.stringify(plainObj))
+  const box = nacl.secretbox(message, nonce, key)
+  return {
+    v: ENVELOPE_VERSION,
+    alg: ALG,
+    nonce: Buffer.from(nonce).toString('base64'),
+    data: Buffer.from(box).toString('base64'),
+  }
+}
+
+/**
+ * Decrypt an envelope back to its plain object using `key`. Throws when the key
+ * is wrong or the ciphertext was tampered with (Poly1305 verification fails),
+ * or when the envelope/JSON is malformed.
+ */
+export function decryptEnvelope(envelope, key) {
+  if (!isEncryptedEnvelope(envelope)) {
+    throw new Error('credential cipher: not a valid encrypted envelope')
+  }
+  if (!(key instanceof Uint8Array) || key.length !== KEY_BYTES) {
+    throw new Error('credential cipher: key must be a 32-byte Uint8Array')
+  }
+  const nonce = new Uint8Array(Buffer.from(envelope.nonce, 'base64'))
+  const box = new Uint8Array(Buffer.from(envelope.data, 'base64'))
+  const opened = nacl.secretbox.open(box, nonce, key)
+  if (!opened) {
+    throw new Error('credential decryption failed (wrong key or corrupt data)')
+  }
+  const parsed = JSON.parse(new TextDecoder().decode(opened))
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('credential cipher: decrypted payload is not a JSON object')
+  }
+  return parsed
+}

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -31,17 +31,62 @@
  * `Bearer` patterns, and SENSITIVE_KEYS in config.js masks the file path; this
  * module additionally never passes a raw value to any logger call.
  *
- * NOTE (scope): the issue's "encrypted at rest with an OS-keychain-derived key"
- * requirement is intentionally NOT implemented here. The established chroxy
- * secret-at-rest baseline is the 0600 owner-only file (refusing anything more
- * permissive), shared with the primary-token fallback and the #4052 BYOK store.
- * Keychain-derived envelope encryption of the multi-key map is tracked as a
- * separable follow-up — see the PR body.
+ * At-rest encryption (#5154): on hosts with an OS keychain (macOS Keychain /
+ * Linux libsecret), the file is encrypted with a random data key stored in the
+ * keychain — see credential-cipher.js. The 0600 owner-only mode is retained as
+ * defense-in-depth even when encrypted. Where no keychain is available
+ * (Windows, headless Linux without `secret-tool`) the store falls back to 0600
+ * plaintext, since a key stored beside the file would be obfuscation, not
+ * security. `maybeEncryptCredentialsAtRest()` migrates a legacy plaintext file
+ * in place at startup once a keychain is present.
  */
 import { readFileSync, statSync, writeFileSync, chmodSync, renameSync, mkdirSync, unlinkSync, existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { homedir } from 'os'
 import { maskApiKey } from './byok-credentials.js'
+import * as realKeychain from './keychain.js'
+import {
+  CRED_KEY_SERVICE,
+  isEncryptedEnvelope,
+  decryptEnvelope,
+  encryptJson,
+  getMasterKey,
+  getOrCreateMasterKey,
+} from './credential-cipher.js'
+
+// A keychain stub that reports "no keychain here" — selects the plaintext
+// fallback path.
+const NO_KEYCHAIN = { isKeychainAvailable: () => false }
+
+// Explicit test injection (an in-memory keychain), or null to use the resolved
+// default. Takes precedence over the env escape hatch below.
+let _keychainOverride = null
+
+/**
+ * Resolve the keychain to use for at-rest encryption, evaluated lazily per call
+ * (NOT captured at import) so it never forces `keychain.js` into the module
+ * graph early — that would defeat `mock.module('child_process')` in the keychain
+ * unit tests.
+ *
+ *   1. an explicit test injection wins (the encryption suite's in-memory key);
+ *   2. else `CHROXY_CRED_DISABLE_KEYCHAIN=1` forces the plaintext fallback —
+ *      an operator escape hatch for hosts with an unreliable keychain, and the
+ *      switch the test bootstrap sets so suites never touch the real keychain;
+ *   3. else the real OS keychain.
+ */
+function activeKeychain() {
+  if (_keychainOverride) return _keychainOverride
+  if (process.env.CHROXY_CRED_DISABLE_KEYCHAIN === '1') return NO_KEYCHAIN
+  return realKeychain
+}
+
+/**
+ * Test seam: inject a keychain (e.g. an in-memory one to drive the encrypted
+ * path), or pass null to fall back to the resolved default.
+ */
+export function _setCredentialKeychainForTests(keychain) {
+  _keychainOverride = keychain || null
+}
 
 /**
  * The credential env vars the store manages, with display metadata. The order
@@ -149,7 +194,62 @@ function readStore() {
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return { data: {}, fileExists: true, error: `${file} is not a JSON object` }
   }
-  return { data: parsed, fileExists: true, error: null }
+
+  // #5154 — an encrypted envelope requires the keychain data key to decrypt.
+  // A plaintext object passes through unchanged (legacy / no-keychain host).
+  if (isEncryptedEnvelope(parsed)) {
+    const key = getMasterKey(activeKeychain())
+    if (!key) {
+      return {
+        data: {},
+        fileExists: true,
+        error: `${file} is encrypted but its decryption key is unavailable (OS keychain service "${CRED_KEY_SERVICE}" missing or unreadable)`,
+        encrypted: true,
+      }
+    }
+    try {
+      return { data: decryptEnvelope(parsed, key), fileExists: true, error: null, encrypted: true }
+    } catch (err) {
+      return { data: {}, fileExists: true, error: `${file} could not be decrypted: ${err.message}`, encrypted: true }
+    }
+  }
+
+  return { data: parsed, fileExists: true, error: null, encrypted: false }
+}
+
+/**
+ * Serialize + atomically write the store to `target`, encrypting the blob when
+ * a keychain-backed data key is available (#5154) and otherwise writing 0600
+ * plaintext. Preserves the temp-file → chmod 0600 → rename crash-safety and the
+ * post-write mode re-check (POSIX). `dir` is assumed to already exist (callers
+ * mkdir it). Shared by the set/delete/migrate paths.
+ */
+function writeStoreAtomically(target, nextObj) {
+  const key = getOrCreateMasterKey(activeKeychain())
+  const payload = key ? encryptJson(nextObj, key) : nextObj
+
+  const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`
+  let renamed = false
+  try {
+    writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 })
+    if (process.platform !== 'win32') chmodSync(tmp, 0o600)
+    if (process.platform === 'win32' && existsSync(target)) {
+      try { unlinkSync(target) } catch { /* */ }
+    }
+    renameSync(tmp, target)
+    renamed = true
+    if (process.platform !== 'win32') {
+      const perms = statSync(target).mode & 0o777
+      if (perms !== 0o600) {
+        try { unlinkSync(target) } catch { /* */ }
+        throw new Error(`credentials file ended up with mode ${perms.toString(8)} after write; refused`)
+      }
+    }
+  } finally {
+    if (!renamed && existsSync(tmp)) {
+      try { unlinkSync(tmp) } catch { /* */ }
+    }
+  }
 }
 
 /**
@@ -233,28 +333,7 @@ export function setStoredCredential(key, rawValue) {
   const legacyField = LEGACY_FIELD_BY_KEY[key]
   if (legacyField) next[legacyField] = value
 
-  const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`
-  let renamed = false
-  try {
-    writeFileSync(tmp, JSON.stringify(next, null, 2), { mode: 0o600 })
-    if (process.platform !== 'win32') chmodSync(tmp, 0o600)
-    if (process.platform === 'win32' && existsSync(target)) {
-      try { unlinkSync(target) } catch { /* */ }
-    }
-    renameSync(tmp, target)
-    renamed = true
-    if (process.platform !== 'win32') {
-      const perms = statSync(target).mode & 0o777
-      if (perms !== 0o600) {
-        try { unlinkSync(target) } catch { /* */ }
-        throw new Error(`credentials file ended up with mode ${perms.toString(8)} after write; refused`)
-      }
-    }
-  } finally {
-    if (!renamed && existsSync(tmp)) {
-      try { unlinkSync(tmp) } catch { /* */ }
-    }
-  }
+  writeStoreAtomically(target, next)
 }
 
 /**
@@ -286,20 +365,45 @@ export function deleteStoredCredential(key) {
     return
   }
 
-  const tmp = `${target}.tmp.${process.pid}.${Math.random().toString(36).slice(2, 10)}`
-  let renamed = false
+  writeStoreAtomically(target, next)
+}
+
+/**
+ * #5154 — encrypt a legacy plaintext credentials.json in place once an OS
+ * keychain is available. Mirrors the primary-token keychain migration in
+ * server-cli.js; call once at startup. Best-effort: never throws into boot.
+ *
+ * No-op (with a reason) when: the file is missing, no keychain is available
+ * (logs a one-time plaintext warning), the file is already encrypted, the file
+ * can't be safely read (bad mode / corrupt), or the store is empty.
+ *
+ * @param {{ log?: { info: Function, warn: Function } }} [opts]
+ * @returns {{ migrated: boolean, reason: string }}
+ */
+export function maybeEncryptCredentialsAtRest({ log } = {}) {
+  const file = credentialsFilePath()
+  if (!existsSync(file)) return { migrated: false, reason: 'no-file' }
+
+  if (!activeKeychain().isKeychainAvailable()) {
+    if (log) log.warn(`${file} is stored as plaintext — no OS keychain available to encrypt it at rest`)
+    return { migrated: false, reason: 'no-keychain' }
+  }
+
+  const { data, error, encrypted } = readStore()
+  if (error) {
+    if (log) log.warn(`Credentials at-rest encryption skipped: ${error}`)
+    return { migrated: false, reason: 'read-error' }
+  }
+  if (encrypted) return { migrated: false, reason: 'already-encrypted' }
+  if (Object.keys(data).length === 0) return { migrated: false, reason: 'empty' }
+
   try {
-    writeFileSync(tmp, JSON.stringify(next, null, 2), { mode: 0o600 })
-    if (process.platform !== 'win32') chmodSync(tmp, 0o600)
-    if (process.platform === 'win32' && existsSync(target)) {
-      try { unlinkSync(target) } catch { /* */ }
-    }
-    renameSync(tmp, target)
-    renamed = true
-  } finally {
-    if (!renamed && existsSync(tmp)) {
-      try { unlinkSync(tmp) } catch { /* */ }
-    }
+    writeStoreAtomically(file, data) // getOrCreateMasterKey → writes an envelope
+    if (log) log.info('Encrypted credentials.json at rest using an OS-keychain-backed key')
+    return { migrated: true, reason: 'migrated' }
+  } catch (err) {
+    if (log) log.warn(`Credentials at-rest encryption failed: ${err.message}`)
+    return { migrated: false, reason: 'write-error' }
   }
 }
 

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -64,9 +64,12 @@ let _keychainOverride = null
 
 /**
  * Resolve the keychain to use for at-rest encryption, evaluated lazily per call
- * (NOT captured at import) so it never forces `keychain.js` into the module
- * graph early — that would defeat `mock.module('child_process')` in the keychain
- * unit tests.
+ * (NOT captured at import). `keychain.js` is imported at the top of this file,
+ * but no OS-keychain call (or `process.env` read) happens until a store
+ * operation actually runs — so importing `credential-store.js` never triggers a
+ * `child_process` keychain probe at module-load time. (Test isolation against
+ * `mock.module('child_process')` is owned by `_setup.mjs`, which deliberately
+ * imports neither this module nor `keychain.js`.)
  *
  *   1. an explicit test injection wins (the encryption suite's in-memory key);
  *   2. else `CHROXY_CRED_DISABLE_KEYCHAIN=1` forces the plaintext fallback —

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -21,6 +21,7 @@ import { PairingManager } from './pairing.js'
 import { getLanIp } from './lan-ip.js'
 import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
+import { maybeEncryptCredentialsAtRest } from './credential-store.js'
 import { registerDockerProvider, resolveProviderLabel } from './providers.js'
 import { getSharedPool, isPoolEnabled } from './docker-byok-pool.js'
 import { getSharedPoolStats } from './docker-byok-pool-stats.js'
@@ -346,6 +347,15 @@ export async function startCliServer(config) {
   if (!NO_AUTH && !API_TOKEN) {
     console.error('[!] No API token configured. Run \'npx chroxy init\' first.') // intentional user-facing output
     process.exit(1)
+  }
+
+  // #5154 — encrypt a legacy plaintext credentials.json at rest once an OS
+  // keychain is available (mirrors the primary-token migration above).
+  // Best-effort: never blocks boot.
+  try {
+    maybeEncryptCredentialsAtRest({ log })
+  } catch (err) {
+    log.warn(`Credentials at-rest encryption check failed: ${err.message}`)
   }
 
   const banner = buildServerBanner({ version: SERVER_VERSION, provider: config.provider })

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -220,10 +220,11 @@ if (fs.promises) {
 // keychain analogue of the #4633 home-write contamination the fs guard above
 // blocks. Set the escape-hatch env so every server test exercises the
 // plaintext-0600 fallback (deterministic on every host, zero real-keychain
-// access). credential-store reads this lazily at call time, so — unlike
-// importing the module here — it does NOT pull keychain.js into the graph early
-// and therefore does not defeat `mock.module('child_process')` in the keychain
-// unit tests. The encryption suite injects an in-memory keychain via
+// access). Critically, this bootstrap sets an ENV flag rather than importing
+// credential-store/keychain: it must NOT pull `keychain.js` into the module
+// graph, or `keychain-mock.test.js` could no longer `mock.module('child_process')`
+// before it imports keychain. credential-store reads this flag lazily at call
+// time. The encryption suite injects an in-memory keychain via
 // `_setCredentialKeychainForTests(...)`, which takes precedence over this flag.
 process.env.CHROXY_CRED_DISABLE_KEYCHAIN = '1'
 

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -213,6 +213,20 @@ if (fs.promises) {
   }
 }
 
+// --- Default the credential-store to "no keychain" ----------------------------
+// #5154: the credential store encrypts credentials.json with an OS-keychain
+// data key when a keychain is available. On a developer's macOS box that means
+// tests would shell out to `security` and pollute the REAL login keychain — the
+// keychain analogue of the #4633 home-write contamination the fs guard above
+// blocks. Set the escape-hatch env so every server test exercises the
+// plaintext-0600 fallback (deterministic on every host, zero real-keychain
+// access). credential-store reads this lazily at call time, so — unlike
+// importing the module here — it does NOT pull keychain.js into the graph early
+// and therefore does not defeat `mock.module('child_process')` in the keychain
+// unit tests. The encryption suite injects an in-memory keychain via
+// `_setCredentialKeychainForTests(...)`, which takes precedence over this flag.
+process.env.CHROXY_CRED_DISABLE_KEYCHAIN = '1'
+
 // --- Diagnostic ---------------------------------------------------------------
 // Quiet by default; set CHROXY_TEST_SANDBOX_DEBUG=1 to see the protected
 // paths once per process.

--- a/packages/server/tests/credential-cipher.test.js
+++ b/packages/server/tests/credential-cipher.test.js
@@ -85,6 +85,22 @@ describe('credential-cipher: encrypt/decrypt round-trip', () => {
   it('rejects decrypting a non-envelope', () => {
     assert.throws(() => decryptEnvelope({ not: 'an envelope' }, key32()), /not a valid encrypted envelope/)
   })
+
+  it('fails predictably on a malformed nonce (no tweetnacl "bad nonce size" leak)', () => {
+    const key = key32()
+    const env = encryptJson({ x: 1 }, key)
+    // A too-short nonce would make tweetnacl throw 'bad nonce size'; we must
+    // surface the friendly decryption-failed error instead.
+    const badNonce = { ...env, nonce: Buffer.from('short').toString('base64') }
+    assert.throws(() => decryptEnvelope(badNonce, key), /decryption failed/)
+  })
+
+  it('fails predictably on truncated ciphertext', () => {
+    const key = key32()
+    const env = encryptJson({ x: 1 }, key)
+    const truncated = { ...env, data: Buffer.from('xx').toString('base64') }
+    assert.throws(() => decryptEnvelope(truncated, key), /decryption failed/)
+  })
 })
 
 describe('credential-cipher: master key via keychain', () => {

--- a/packages/server/tests/credential-cipher.test.js
+++ b/packages/server/tests/credential-cipher.test.js
@@ -1,0 +1,125 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { randomBytes } from 'node:crypto'
+import {
+  CRED_KEY_SERVICE,
+  ENVELOPE_VERSION,
+  isEncryptedEnvelope,
+  encryptJson,
+  decryptEnvelope,
+  getMasterKey,
+  getOrCreateMasterKey,
+} from '../src/credential-cipher.js'
+
+/**
+ * Tests for credential-cipher.js (#5154) — the envelope crypto + keychain
+ * data-key helpers. Pure crypto is exercised directly; the keychain is a tiny
+ * in-memory fake so nothing touches the real OS keychain.
+ */
+
+// In-memory keychain fake mirroring keychain.js's (getToken/setToken) shape.
+function fakeKeychain({ available = true } = {}) {
+  const store = new Map()
+  return {
+    isKeychainAvailable: () => available,
+    getToken: (service) => store.get(service) ?? null,
+    setToken: (token, service) => { store.set(service, token) },
+    _store: store,
+  }
+}
+
+const key32 = () => new Uint8Array(randomBytes(32))
+
+describe('credential-cipher: envelope shape', () => {
+  it('isEncryptedEnvelope accepts a well-formed envelope and rejects others', () => {
+    const env = encryptJson({ a: 1 }, key32())
+    assert.equal(isEncryptedEnvelope(env), true)
+    assert.equal(env.v, ENVELOPE_VERSION)
+    assert.equal(env.alg, 'nacl-secretbox')
+
+    assert.equal(isEncryptedEnvelope(null), false)
+    assert.equal(isEncryptedEnvelope({}), false)
+    assert.equal(isEncryptedEnvelope({ ANTHROPIC_API_KEY: 'sk-ant-x' }), false) // plaintext store
+    assert.equal(isEncryptedEnvelope([]), false)
+    assert.equal(isEncryptedEnvelope({ v: 1, alg: 'nacl-secretbox', nonce: 'x' }), false) // no data
+  })
+})
+
+describe('credential-cipher: encrypt/decrypt round-trip', () => {
+  it('round-trips an object', () => {
+    const key = key32()
+    const plain = { ANTHROPIC_API_KEY: 'sk-ant-abc', OPENAI_API_KEY: 'sk-openai-xyz' }
+    const env = decryptEnvelope(encryptJson(plain, key), key)
+    assert.deepEqual(env, plain)
+  })
+
+  it('uses a fresh nonce each call (ciphertext differs for the same input)', () => {
+    const key = key32()
+    const a = encryptJson({ x: 1 }, key)
+    const b = encryptJson({ x: 1 }, key)
+    assert.notEqual(a.nonce, b.nonce)
+    assert.notEqual(a.data, b.data)
+  })
+
+  it('fails to decrypt with the wrong key', () => {
+    const env = encryptJson({ secret: 'v' }, key32())
+    assert.throws(() => decryptEnvelope(env, key32()), /decryption failed/)
+  })
+
+  it('fails to decrypt tampered ciphertext (Poly1305 auth)', () => {
+    const key = key32()
+    const env = encryptJson({ secret: 'v' }, key)
+    // Flip a byte in the base64 ciphertext.
+    const buf = Buffer.from(env.data, 'base64')
+    buf[0] ^= 0xff
+    const tampered = { ...env, data: buf.toString('base64') }
+    assert.throws(() => decryptEnvelope(tampered, key), /decryption failed/)
+  })
+
+  it('rejects a bad key length on both encrypt and decrypt', () => {
+    assert.throws(() => encryptJson({}, new Uint8Array(16)), /32-byte/)
+    const env = encryptJson({}, key32())
+    assert.throws(() => decryptEnvelope(env, new Uint8Array(16)), /32-byte/)
+  })
+
+  it('rejects decrypting a non-envelope', () => {
+    assert.throws(() => decryptEnvelope({ not: 'an envelope' }, key32()), /not a valid encrypted envelope/)
+  })
+})
+
+describe('credential-cipher: master key via keychain', () => {
+  it('getMasterKey returns null when no keychain is available', () => {
+    assert.equal(getMasterKey(fakeKeychain({ available: false })), null)
+  })
+
+  it('getMasterKey returns null when no key is stored yet', () => {
+    assert.equal(getMasterKey(fakeKeychain()), null)
+  })
+
+  it('getOrCreateMasterKey creates, persists, and is stable across calls', () => {
+    const kc = fakeKeychain()
+    const k1 = getOrCreateMasterKey(kc)
+    assert.ok(k1 instanceof Uint8Array)
+    assert.equal(k1.length, 32)
+    // Persisted under the credential-key service (distinct from the api-token).
+    assert.ok(kc._store.has(CRED_KEY_SERVICE))
+    // Second call returns the SAME key (read back, not regenerated).
+    const k2 = getOrCreateMasterKey(kc)
+    assert.deepEqual([...k1], [...k2])
+    // getMasterKey now finds it too.
+    assert.deepEqual([...getMasterKey(kc)], [...k1])
+  })
+
+  it('getOrCreateMasterKey returns null (no creation) without a keychain', () => {
+    const kc = fakeKeychain({ available: false })
+    assert.equal(getOrCreateMasterKey(kc), null)
+    assert.equal(kc._store.size, 0)
+  })
+
+  it('a stored-but-malformed key is replaced', () => {
+    const kc = fakeKeychain()
+    kc.setToken(Buffer.from('too-short').toString('base64'), CRED_KEY_SERVICE)
+    const k = getOrCreateMasterKey(kc)
+    assert.equal(k.length, 32)
+  })
+})

--- a/packages/server/tests/credential-store-encryption.test.js
+++ b/packages/server/tests/credential-store-encryption.test.js
@@ -1,0 +1,162 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync, statSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getStoredCredential,
+  setStoredCredential,
+  deleteStoredCredential,
+  getCredentialsStatus,
+  maybeEncryptCredentialsAtRest,
+  _setCredentialKeychainForTests,
+} from '../src/credential-store.js'
+import { isEncryptedEnvelope } from '../src/credential-cipher.js'
+
+/**
+ * Encrypted-path tests for the credential store (#5154). An in-memory keychain
+ * fake drives the encrypted branch; HOME points at a tmpdir so the real
+ * ~/.chroxy is never touched. The shared bootstrap (_setup.mjs) defaults every
+ * suite to a no-keychain stub, so we install our in-memory one per test and
+ * restore the no-keychain default afterwards.
+ */
+
+const CRED_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'GEMINI_API_KEY', 'OPENAI_API_KEY']
+
+function inMemoryKeychain() {
+  const store = new Map()
+  return {
+    isKeychainAvailable: () => true,
+    getToken: (service) => store.get(service) ?? null,
+    setToken: (token, service) => { store.set(service, token) },
+    _store: store,
+  }
+}
+const noKeychain = { isKeychainAvailable: () => false }
+
+describe('credential-store at-rest encryption (#5154)', () => {
+  let tmpHome
+  let originalHome
+  let keychain
+  const savedEnv = {}
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-enc-test-'))
+    originalHome = process.env.HOME
+    process.env.HOME = tmpHome
+    for (const k of CRED_ENV_VARS) {
+      savedEnv[k] = process.env[k]
+      delete process.env[k]
+    }
+    keychain = inMemoryKeychain()
+    _setCredentialKeychainForTests(keychain)
+  })
+
+  afterEach(() => {
+    // Clear the injection so the bootstrap env default (no keychain) governs
+    // again — sibling suites stay on the plaintext path.
+    _setCredentialKeychainForTests(null)
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    for (const k of CRED_ENV_VARS) {
+      if (savedEnv[k] === undefined) delete process.env[k]
+      else process.env[k] = savedEnv[k]
+    }
+    try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }
+  })
+
+  function credPath() {
+    return join(tmpHome, '.chroxy', 'credentials.json')
+  }
+  function onDisk() {
+    return JSON.parse(readFileSync(credPath(), 'utf8'))
+  }
+
+  it('writes an encrypted envelope (not plaintext) when a keychain is available', () => {
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-secret-value')
+    const raw = onDisk()
+    assert.equal(isEncryptedEnvelope(raw), true)
+    // The raw secret must NOT appear anywhere on disk.
+    assert.ok(!readFileSync(credPath(), 'utf8').includes('sk-ant-secret-value'))
+    // A data key was stored in the (fake) keychain.
+    assert.ok(keychain._store.has('chroxy-cred-key'))
+    // …but it still round-trips through the API.
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-secret-value')
+  })
+
+  it('keeps the encrypted file at mode 0600', () => {
+    setStoredCredential('OPENAI_API_KEY', 'sk-openai-abc')
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(credPath()).mode & 0o777, 0o600)
+    }
+  })
+
+  it('round-trips multiple keys and re-encrypts on each write', () => {
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-one')
+    setStoredCredential('OPENAI_API_KEY', 'sk-openai-two')
+    assert.equal(isEncryptedEnvelope(onDisk()), true)
+    const status = getCredentialsStatus()
+    assert.equal(status.fileError, null)
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-one')
+    assert.equal(getStoredCredential('OPENAI_API_KEY'), 'sk-openai-two')
+  })
+
+  it('delete rewrites the (still encrypted) store and preserves siblings', () => {
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-keep')
+    setStoredCredential('OPENAI_API_KEY', 'sk-openai-drop')
+    deleteStoredCredential('OPENAI_API_KEY')
+    assert.equal(isEncryptedEnvelope(onDisk()), true)
+    assert.equal(getStoredCredential('OPENAI_API_KEY'), null)
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-keep')
+  })
+
+  it('surfaces a clear error (no plaintext leak) when the key is gone', () => {
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-locked')
+    // Simulate a lost keychain entry (e.g. different machine / wiped keychain).
+    keychain._store.delete('chroxy-cred-key')
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), null)
+    const status = getCredentialsStatus()
+    assert.match(status.fileError, /encrypted but its decryption key is unavailable/)
+  })
+
+  describe('maybeEncryptCredentialsAtRest', () => {
+    function writePlaintext(obj) {
+      mkdirSync(join(tmpHome, '.chroxy'), { recursive: true, mode: 0o700 })
+      writeFileSync(credPath(), JSON.stringify(obj, null, 2), { mode: 0o600 })
+      if (process.platform !== 'win32') chmodSync(credPath(), 0o600)
+    }
+
+    it('encrypts a legacy plaintext file in place', () => {
+      writePlaintext({ ANTHROPIC_API_KEY: 'sk-ant-legacy', anthropicApiKey: 'sk-ant-legacy' })
+      const res = maybeEncryptCredentialsAtRest()
+      assert.equal(res.migrated, true)
+      assert.equal(res.reason, 'migrated')
+      assert.equal(isEncryptedEnvelope(onDisk()), true)
+      assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-legacy')
+    })
+
+    it('is idempotent — already-encrypted files are left alone', () => {
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-x')
+      const res = maybeEncryptCredentialsAtRest()
+      assert.equal(res.migrated, false)
+      assert.equal(res.reason, 'already-encrypted')
+    })
+
+    it('no-ops when there is no file', () => {
+      const res = maybeEncryptCredentialsAtRest()
+      assert.equal(res.migrated, false)
+      assert.equal(res.reason, 'no-file')
+    })
+
+    it('warns and leaves plaintext when no keychain is available', () => {
+      writePlaintext({ ANTHROPIC_API_KEY: 'sk-ant-plain', anthropicApiKey: 'sk-ant-plain' })
+      _setCredentialKeychainForTests(noKeychain)
+      const warns = []
+      const res = maybeEncryptCredentialsAtRest({ log: { info: () => {}, warn: (m) => warns.push(m) } })
+      assert.equal(res.migrated, false)
+      assert.equal(res.reason, 'no-keychain')
+      assert.equal(isEncryptedEnvelope(onDisk()), false) // still plaintext
+      assert.ok(warns.some((m) => /plaintext/.test(m)))
+    })
+  })
+})


### PR DESCRIPTION
## Summary

`credentials.json` holds the **highest-value secrets** chroxy persists — BYOK provider API keys (Anthropic/OpenAI/Gemini) and the Claude Code OAuth token. Mode `0600` keeps them owner-only, but a stolen disk image, a backup, or an errant `cat` still exposes them in plaintext. This PR encrypts the whole blob with a random 32-byte data key stored in the **OS keychain** — not beside the file — so a file read alone can't recover the secrets.

## How it works

```
on disk:  ~/.chroxy/credentials.json  →  { v: 1, alg: 'nacl-secretbox', nonce: <b64>, data: <b64> }
keychain: service 'chroxy-cred-key'   →  the base64 data key  (one entry, distinct from the api-token)
```

- **`credential-cipher.js`** (new) — `nacl.secretbox` (XSalsa20-Poly1305 AEAD) envelope + keychain data-key helpers (`getMasterKey` / `getOrCreateMasterKey`). Crypto reuses `tweetnacl` (already a server dep). Fresh random 24-byte nonce per write; the Poly1305 tag fails closed on tamper or wrong key. The keychain is dependency-injected throughout.
- **`credential-store.js`** — decrypt-on-read, encrypt-on-write through a shared atomic helper (temp → `chmod 0600` → rename, post-write mode recheck preserved). `0600` is retained as defense-in-depth even when encrypted. `maybeEncryptCredentialsAtRest()` migrates a legacy plaintext file in place. The keychain is resolved **lazily per call**, never captured at import.
- **`server-cli.js`** — best-effort startup migration hook (never blocks boot), mirroring the existing primary-token keychain migration.

## Threat model (honest)

Encryption only adds *real* protection because the key lives in the OS keychain (macOS Keychain / Linux libsecret), which a file-read attacker can't reach. Where **no keychain exists** (Windows, headless Linux without `secret-tool`), the store keeps today's `0600` plaintext and logs a one-time warning — rather than inventing a machine-derived key, which would be obfuscation, not security. `CHROXY_CRED_DISABLE_KEYCHAIN=1` is an operator escape hatch to force the plaintext path.

## Test plan

- **`credential-cipher.test.js`** — envelope shape, encrypt/decrypt round-trip, fresh-nonce, wrong-key + tampered-ciphertext both fail, bad key length, master-key lifecycle (create/persist/stable/replace-malformed).
- **`credential-store-encryption.test.js`** — encrypted-envelope-on-disk (secret never appears in the file), `0600` retained, multi-key round-trip, delete preserves siblings, **key-lost → clear error (no plaintext leak)**, and plaintext→encrypted migration (idempotent / no-file / no-keychain-warns).
- **`tests/_setup.mjs`** sets the escape-hatch env so **no suite touches the real OS keychain** — via env (read lazily), NOT a module import, so it does not pull `keychain.js` into the graph early and defeat `mock.module('child_process')` in the keychain unit tests.
- Verified green locally: **180/180** across the credential + keychain + config suites; the existing `credential-store.test.js` invariants (mode 0600, atomicity, precedence, masking) stay green on the plaintext-fallback path. Confirmed the only other full-suite failures (environment-handlers, web-task-manager, ws-server-file-ops) are **pre-existing on `main`** (environment-dependent), unrelated to this change.

Closes #5154