### PR TITLE
fix: untrack accidentally-committed node_modules symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Dependencies
-node_modules/
+# No trailing slash: must also match a `node_modules` SYMLINK (not just a real
+# directory), or an accidentally-created symlink slips past the ignore and can
+# be committed (see the #5154 worktree mishap that tracked self-referential
+# node_modules symlinks into main).
+node_modules
 
 # Environment
 .env

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/blamechris/Projects/chroxy/node_modules

--- a/packages/server/node_modules
+++ b/packages/server/node_modules
@@ -1,1 +1,0 @@
-/Users/blamechris/Projects/chroxy/packages/server/node_modules


### PR DESCRIPTION
## Problem

The #5154 PR (#5227, merged as `8e416bb12`) accidentally committed **`node_modules` symlinks** into `main`:

```
node_modules                  -> /Users/.../chroxy/node_modules   (self-referential)
packages/server/node_modules  -> /Users/.../chroxy/packages/server/node_modules
```

They came from the #5154 worktree workflow (worktrees have no hoisted `node_modules`, so symlinks were created to the main install). `.gitignore` listed `node_modules/` **with a trailing slash**, which matches only *directories* — a **symlink** named `node_modules` slipped past the ignore, so `git add -A` swept them into the commit.

On a fresh checkout/pull these materialise as **self-referential loops** that break the local install (`Too many levels of symbolic links`).

## Fix

- `git rm --cached` the two tracked symlinks (working-tree real installs untouched).
- `.gitignore`: `node_modules/` → `node_modules` (no trailing slash) so a *symlink* named `node_modules`, not just a real directory, is ignored too — prevents recurrence.

## Impact / safety

- **Working trees self-heal**: `npm ci` / `npm install` rebuilds the real directory; this PR's author already restored it locally.
- **CI was unaffected** — it runs `npm ci`, which removes the symlink and reinstalls before tests. (#5227's CI was green for this reason.)
- No source/behaviour changes; this is pure repo hygiene.

## Test plan

- `git check-ignore -v node_modules` now reports it ignored (was not, pre-fix).
- After the change, a real `node_modules` install shows clean `git status` (not tracked).