### PR TITLE
feat(dashboard): persist Control Room sort/filter across reloads (#5226)

### DIFF
--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -81,7 +81,12 @@ function activityEntry(id: string, over: Partial<ActivityEntry> = {}): ActivityE
   }
 }
 
-afterEach(() => cleanup())
+afterEach(() => {
+  cleanup()
+  // #5226 persists filters/sort to localStorage — clear so view state from one
+  // case never leaks into the next (which assumes the default unfiltered view).
+  try { localStorage.clear() } catch { /* noop */ }
+})
 
 const NOW = Date.parse('2026-06-04T12:00:00.000Z')
 
@@ -425,6 +430,66 @@ describe('ControlRoomSection sort/filter controls (#5216)', () => {
       />,
     )
     expect(screen.queryByTestId('cr-controls')).toBeNull()
+  })
+})
+
+describe('ControlRoomSection sort/filter persistence (#5226)', () => {
+  it('persists an active filter to localStorage', () => {
+    render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    fireEvent.click(screen.getByTestId('cr-filter-dirty'))
+    expect(localStorage.getItem('chroxy_cr_filters')).toBe('dirty')
+  })
+
+  it('persists the chosen sort to localStorage', () => {
+    render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    fireEvent.change(screen.getByTestId('cr-sort'), { target: { value: 'worktrees' } })
+    expect(localStorage.getItem('chroxy_cr_sort')).toBe('worktrees')
+  })
+
+  it('restores persisted filter + sort on a fresh mount', () => {
+    localStorage.setItem('chroxy_cr_filters', 'dirty')
+    localStorage.setItem('chroxy_cr_sort', 'worktrees')
+    const { container } = render(
+      <ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />,
+    )
+    // dirty filter restored → only medlens, and chip shows pressed.
+    expect(screen.getByTestId('cr-filter-dirty')).toHaveAttribute('aria-pressed', 'true')
+    expect(renderedRepoOrder(container)).toEqual(['medlens'])
+    // sort restored → the select reflects it.
+    expect((screen.getByTestId('cr-sort') as HTMLSelectElement).value).toBe('worktrees')
+  })
+
+  it('round-trips through unmount/remount (a reload survives)', () => {
+    const first = render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    fireEvent.click(screen.getByTestId('cr-filter-live'))
+    first.unmount()
+    // Re-mount fresh (simulating a page reload reading from localStorage).
+    render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    expect(screen.getByTestId('cr-filter-live')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('cr-visible-count')).toHaveTextContent('1 of 3 repos')
+  })
+
+  it('ignores garbage / unknown persisted values, falling back to defaults', () => {
+    localStorage.setItem('chroxy_cr_filters', 'dirty,bogus,,live')
+    localStorage.setItem('chroxy_cr_sort', 'not-a-real-sort')
+    const { container } = render(
+      <ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />,
+    )
+    // Only the valid keys (dirty, live) survive — and they AND to nothing here.
+    expect(screen.getByTestId('cr-filter-dirty')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('cr-filter-live')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.queryByTestId('cr-filter-prs')).toHaveAttribute('aria-pressed', 'false')
+    // Invalid sort → default (server order).
+    expect((screen.getByTestId('cr-sort') as HTMLSelectElement).value).toBe('default')
+    expect(renderedRepoOrder(container)).toEqual([]) // dirty AND live matches nothing
+  })
+
+  it('clearing filters empties the persisted value', () => {
+    render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)
+    fireEvent.click(screen.getByTestId('cr-filter-dirty'))
+    expect(localStorage.getItem('chroxy_cr_filters')).toBe('dirty')
+    fireEvent.click(screen.getByTestId('cr-clear-filters'))
+    expect(localStorage.getItem('chroxy_cr_filters')).toBe('')
   })
 })
 

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -31,7 +31,7 @@
  *   - recent      → warn  (amber)  — recent uncommitted work; eyeball before touching.
  *   - onboarded   → ok    (green)  — on the pull-model; just needs a checkout+pull.
  */
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { RepoStatus, RepoVerdict, ServerHostStatusSnapshotMessage } from '@chroxy/protocol'
 import type { ActivityState, SessionInfo } from '@chroxy/store-core'
@@ -181,6 +181,60 @@ export function sortRepos(repos: readonly RepoStatus[], sortKey: RepoSortKey): R
 function parseTime(iso: string): number {
   const ms = Date.parse(iso)
   return Number.isNaN(ms) ? 0 : ms
+}
+
+/**
+ * #5226 — persist the operator's table lens (filters + sort) across reloads via
+ * localStorage, so a refresh doesn't drop back to the unfiltered server order.
+ * Values are validated against the known keys on read, so a stale/garbage entry
+ * (or one from a future build with a renamed key) degrades to the default
+ * instead of throwing. All access is try/catch-guarded — localStorage can throw
+ * (privacy mode, disabled storage) and a dashboard panel must never crash on it.
+ */
+const CR_FILTERS_STORAGE_KEY = 'chroxy_cr_filters'
+const CR_SORT_STORAGE_KEY = 'chroxy_cr_sort'
+
+const VALID_FILTER_KEYS: ReadonlySet<string> = new Set(REPO_FILTERS.map((f) => f.key))
+const VALID_SORT_KEYS: ReadonlySet<string> = new Set(REPO_SORT_OPTIONS.map((o) => o.key))
+
+function loadPersistedFilters(): ReadonlySet<RepoFilterKey> {
+  try {
+    const raw = localStorage.getItem(CR_FILTERS_STORAGE_KEY)
+    if (!raw) return new Set()
+    const keys = raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((k): k is RepoFilterKey => VALID_FILTER_KEYS.has(k))
+    return new Set(keys)
+  } catch {
+    return new Set()
+  }
+}
+
+function persistFilters(active: ReadonlySet<RepoFilterKey>): void {
+  try {
+    localStorage.setItem(CR_FILTERS_STORAGE_KEY, [...active].join(','))
+  } catch {
+    /* noop — storage unavailable */
+  }
+}
+
+function loadPersistedSort(): RepoSortKey {
+  try {
+    const raw = localStorage.getItem(CR_SORT_STORAGE_KEY)
+    if (raw && VALID_SORT_KEYS.has(raw)) return raw as RepoSortKey
+  } catch {
+    /* noop — storage unavailable */
+  }
+  return 'default'
+}
+
+function persistSort(sortKey: RepoSortKey): void {
+  try {
+    localStorage.setItem(CR_SORT_STORAGE_KEY, sortKey)
+  } catch {
+    /* noop — storage unavailable */
+  }
 }
 
 /**
@@ -597,11 +651,15 @@ export function ControlRoomSection({
   }, [])
 
   // #5216 — repo-table view controls. Filters narrow the table (AND across
-  // active filters); sort reorders it. Both are ephemeral view state (not
-  // persisted) so a refresh keeps the operator's current lens but a reload
-  // starts from the server's default order with no filters.
-  const [activeFilters, setActiveFilters] = useState<ReadonlySet<RepoFilterKey>>(() => new Set())
-  const [sortKey, setSortKey] = useState<RepoSortKey>('default')
+  // active filters); sort reorders it. #5226 — both are persisted to
+  // localStorage (lazy-initialised from it, written on change) so a reload
+  // keeps the operator's lens instead of snapping back to the unfiltered
+  // server order.
+  const [activeFilters, setActiveFilters] = useState<ReadonlySet<RepoFilterKey>>(loadPersistedFilters)
+  const [sortKey, setSortKey] = useState<RepoSortKey>(loadPersistedSort)
+
+  useEffect(() => { persistFilters(activeFilters) }, [activeFilters])
+  useEffect(() => { persistSort(sortKey) }, [sortKey])
 
   const toggleFilter = useCallback((key: RepoFilterKey) => {
     setActiveFilters((prev) => {


### PR DESCRIPTION
## Summary

The Control Room repo-table filters and sort (#5216) were ephemeral `useState`, so every reload snapped back to the unfiltered server order. This persists both to `localStorage` — lazy-initialised from it, written on change — so a reload keeps the operator's lens.

- `chroxy_cr_filters` — CSV of active filter keys; `chroxy_cr_sort` — the sort key.
- Values are **validated against the known keys on read**, so a stale/garbage entry (or one from a future build with a renamed key) degrades to the default instead of throwing or applying a bogus filter.
- All `localStorage` access is `try/catch`-guarded — it can throw (privacy mode / disabled storage) and a dashboard panel must never crash on it.

Closes #5226.

## Test plan

6 new tests: persist-on-change (filter + sort), restore-on-fresh-mount, survive unmount/remount (a reload), ignore garbage/unknown persisted values (→ defaults), clear empties the persisted value. The suite now clears `localStorage` in `afterEach` so view state never leaks between cases.

- Full dashboard suite green: **3143 passed**. `tsc --noEmit` clean.

## Note
Branched before #5231 (the node_modules-symlink untracking fix) landed; will rebase on updated `main` before merge so it doesn't reintroduce the tracked symlinks.