### PR TITLE
chore: coverage-audit cleanup — fix smoke tooling + Control Room smoke coverage

### DIFF
--- a/.claude/commands/agentic-audit.md
+++ b/.claude/commands/agentic-audit.md
@@ -1,0 +1,144 @@
+# /agentic-audit
+
+Launch a panel of specialized agents to audit a pull request from multiple perspectives before merge.
+
+## Arguments
+
+- `$ARGUMENTS` - PR number (optional, defaults to current branch's PR), plus optional agent count (default: 5). Examples:
+  - `42` (PR #42, 5 agents)
+  - `42 7` (PR #42, 7 agents)
+  - `3` (PR #3 or 3 agents — resolved by checking if a PR with that number exists)
+
+## Instructions
+
+### 1. Gather PR Context
+
+```bash
+PR_NUM=${1:-$(gh pr view --json number -q .number)}
+AGENT_COUNT=${2:-5}  # min: 3, max: 8
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# PR metadata
+gh pr view ${PR_NUM} --json title,body,headRefName,baseRefName,files,additions,deletions
+
+# Full diff
+gh pr diff ${PR_NUM}
+
+# Changed file list
+gh pr view ${PR_NUM} --json files -q '.files[].path'
+```
+
+Build a context bundle for agents containing: PR title, description, branch names, full diff, and the list of changed files.
+
+### 2. Select Agents
+
+Pick AGENT_COUNT agents from the roster. Always include the core 3. Fill remaining slots from the extended roster based on what the diff touches.
+
+#### Core (always included)
+
+| Agent | Lens | Personality |
+|-------|------|-------------|
+| Skeptic | Correctness, false assumptions, logic errors, what will break | Cynical engineer who has seen too many PRs ship bugs. Reads every line of the diff looking for what's wrong. |
+| Builder | Completeness, missing edge cases, integration gaps, unfinished work | Pragmatic dev who has to maintain this code. Finds what's missing, incomplete, or will cause follow-up PRs. |
+| Minimalist | Over-engineering, unnecessary changes, scope creep, simpler alternatives | Believes the best PR is the smallest PR. Finds what to cut and proposes leaner approaches. |
+
+#### Extended (pick by relevance to the diff)
+
+| Agent | Lens | Include When |
+|-------|------|--------------|
+| Guardian | Failure modes, race conditions, data integrity, error handling | Changes touch concurrency, state management, data persistence, or error paths |
+| Operator | UX impact, user-facing regressions, accessibility, error states | Changes touch UI, user flows, or output formatting |
+| Futurist | Tech debt introduced, maintainability cost, extensibility impact | Changes introduce new patterns, abstractions, or architectural decisions |
+| Adversary | Security holes, input validation, auth bypass, injection vectors | Changes touch auth, user input, API boundaries, or external data |
+| Tester | Test coverage, untested paths, edge cases, test quality | Changes include complex logic, new features, or modify existing tests |
+
+### 3. Launch Agents
+
+Launch all agents in parallel using the Task tool. Each agent receives the full PR context bundle and their persona.
+
+**Agent prompt:**
+
+```
+You are "{AGENT_NAME}" — {PERSONALITY}
+
+Audit this pull request from the lens of **{LENS}**.
+
+## PR Context
+- **Title**: {PR_TITLE}
+- **Branch**: {HEAD} → {BASE}
+- **Changed files**: {FILE_LIST}
+
+## Diff
+{FULL_DIFF}
+
+## PR Description
+{PR_BODY}
+
+## Your Review
+1. Rate the PR overall 1–5
+2. List your top findings (up to 5), each with:
+   - Severity: critical / major / minor / nit
+   - File and line reference
+   - What's wrong and why it matters
+   - Suggested fix (concrete, not vague)
+3. Note anything done well worth preserving
+4. One-paragraph verdict
+
+## Rules
+- Review the DIFF, but also read surrounding code in changed files for context.
+- Be specific. Reference exact lines. "This might be a problem" is useless.
+- Be opinionated. Strong views, loosely held.
+- 3/5 = adequate, would merge with minor comments. 5/5 = exemplary. 1/5 = should not merge.
+```
+
+Run agents as foreground Task calls. If more than 4 agents, batch: first 4 in parallel, then the rest.
+
+### 4. Synthesize and Report
+
+After all agents return, output a single synthesis directly to the user (no files written):
+
+```markdown
+## Agentic Audit: PR #{PR_NUM} — {TITLE}
+
+**Agents**: {count} | **Aggregate**: {average}/5
+
+### Agent Panel
+| Agent | Rating | Top Finding |
+|-------|--------|-------------|
+| Skeptic | X/5 | One-line summary |
+| Builder | X/5 | One-line summary |
+| ... | ... | ... |
+
+### Consensus Findings
+Issues where 3+ agents agree. These are high-confidence and should be addressed.
+
+1. **{Finding}** (Skeptic, Builder, Guardian) — {description + file:line}
+2. ...
+
+### Contested Points
+Where agents disagree. Present both sides, assess who's right.
+
+### Action Items
+Prioritized list of recommended changes before merge, ordered by severity.
+
+### Verdict
+One paragraph: merge as-is, merge with changes, or rework needed.
+```
+
+### 5. Offer Next Steps
+
+After presenting the synthesis, ask the user:
+
+> Want me to fix any of the findings? I can address them as commits on this branch.
+
+## Rating Scale
+
+| Rating | Meaning |
+|:------:|---------|
+| 5 | Exemplary — would merge without comment |
+| 4 | Good — minor issues, none blocking |
+| 3 | Adequate — merge with changes |
+| 2 | Concerning — significant issues to resolve first |
+| 1 | Do not merge — needs rework |
+
+<!-- skill-templates: agentic-audit 3f616c3 2026-06-06 -->

--- a/.claude/commands/autonomous-dev-flow.md
+++ b/.claude/commands/autonomous-dev-flow.md
@@ -307,8 +307,7 @@ If `NEEDS_SMOKE_TEST` is true:
 
 1. **Rebuild dashboard** if needed:
    ```bash
-   cd packages/server
-   PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run dashboard:build
+   PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run build -w @chroxy/dashboard
    ```
 2. **Run `/smoke-test`** — this launches the app, opens a headless browser, and verifies key UI elements
 3. **Check results:**

--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -99,7 +99,7 @@ gh api repos/${REPO}/actions/runs/${RUN_ID}/jobs --jq '.jobs[] | select(.conclus
 Chroxy-specific patterns:
 - `npm test` failures in server tests → check for missing test fixtures or mock setup issues
 - `npx tsc --noEmit` failures in app → TypeScript strict mode violations (check for `any` types, platform-specific issues)
-- `npm run dashboard:build` failures → Vite build errors, missing CSS, or theme issues
+- `npm run build -w @chroxy/dashboard` failures → Vite build errors, missing CSS, or theme issues
 - `npx jest` failures in dashboard tests → component rendering or mock issues
 - WebSocket protocol test failures → check WS message format or auth flow issues
 

--- a/.claude/commands/project-audit.md
+++ b/.claude/commands/project-audit.md
@@ -1,0 +1,531 @@
+# /project-audit
+
+Launch a comprehensive multi-agent audit of the entire project. Agents with diverse perspectives analyze the codebase in parallel, then findings are synthesized into a master assessment with actionable recommendations.
+
+Unlike `/swarm-audit` (which audits a specific document or topic), this skill audits the **whole project holistically** — architecture, code quality, security, testing, and more — with agent selection automatically tuned to the project type.
+
+## Arguments
+
+- `$ARGUMENTS` - Optional configuration. Space-separated tokens:
+  - `agents=N` — Number of agents (default: 6, min: 4, max: 12)
+  - `focus=AREA[,AREA,...]` — Comma-separated focus areas to emphasize (e.g., `focus=security,performance`)
+  - `output=DIR` — Output directory for reports (default: `docs/project-audit/`)
+  - `verbosity=brief|standard|detailed` — Report depth (default: `standard`)
+  - `skip=AGENT[,AGENT,...]` — Comma-separated agent nicknames to exclude
+  - `include=AGENT[,AGENT,...]` — Force-include specific optional agents by nickname
+
+Examples:
+```
+/project-audit
+/project-audit agents=8 focus=security,performance
+/project-audit output=audits/pre-release verbosity=detailed
+/project-audit agents=10 include=deployer,auditor
+/project-audit focus=testing skip=scout
+```
+
+## Instructions
+
+### 1. Parse Arguments
+
+```
+AGENT_COUNT = extract from agents=N (default: 6, clamp to 4–12)
+FOCUS_AREAS = extract from focus=X,Y (default: empty — auto-detect all)
+OUTPUT_DIR  = extract from output=DIR (default: docs/project-audit/)
+VERBOSITY   = extract from verbosity=X (default: standard)
+SKIP_AGENTS = extract from skip=X,Y (default: empty)
+INCLUDE_AGENTS = extract from include=X,Y (default: empty)
+```
+
+### 2. Auto-Discover Project Profile
+
+Before selecting agents, build a project profile by scanning the repository. This determines which optional agents are relevant.
+
+**Scan these signals (read files, do NOT guess):**
+
+| Signal | How to Detect | What It Tells Us |
+|--------|---------------|------------------|
+| Languages | File extensions, package files (`package.json`, `Cargo.toml`, `go.mod`, `requirements.txt`, `Gemfile`, `*.csproj`, `pom.xml`, `build.gradle`) | Primary language(s) and ecosystem |
+| Framework | Config files, imports (`next.config.js`, `angular.json`, `django`, `flask`, `rails`, `spring`) | Framework-specific concerns |
+| Frontend | `src/**/*.tsx`, `src/**/*.vue`, `src/**/*.svelte`, HTML templates, CSS/SCSS files | Include UX agent |
+| Tests | `tests/`, `__tests__/`, `spec/`, `*.test.*`, `*.spec.*`, test config files | Testing maturity, include Testing agent |
+| CI/CD | `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `Dockerfile`, `docker-compose.yml`, `.circleci/` | Include DevOps agent |
+| Dependencies | Lock files, dependency count, outdated indicators | Include Dependencies agent |
+| Docs | `docs/`, `README.md`, API docs, inline doc coverage | Include Documentation agent |
+| Security surface | Auth modules, crypto usage, env files, secrets patterns, network code | Elevate Security agent priority |
+| Performance indicators | Database queries, caching layers, async patterns, worker threads | Include Performance agent |
+| API surface | REST routes, GraphQL schemas, gRPC protos, OpenAPI specs | API design concerns |
+| Project size | File count, LOC estimate, directory depth | Calibrate agent depth |
+
+**Build the profile object (mental model, not written):**
+
+```
+PROJECT_PROFILE = {
+  name: <from package.json, Cargo.toml, etc. or directory name>,
+  languages: [...],
+  frameworks: [...],
+  has_frontend: bool,
+  has_tests: bool,
+  test_coverage_estimate: low|medium|high,
+  has_ci: bool,
+  has_docker: bool,
+  dependency_count: approximate,
+  has_docs: bool,
+  has_api: bool,
+  security_surface: low|medium|high,
+  performance_critical: bool,
+  project_size: small|medium|large,
+  repo_age: <from git log --reverse>,
+}
+```
+
+**IMPORTANT:** Spend real effort on discovery. Read `package.json`, `README.md`, config files, and sample source files. The better the profile, the more relevant the audit. Do NOT skip this step or guess from file names alone.
+
+### 3. Select Agent Panel
+
+Choose AGENT_COUNT agents. Always include all 5 core agents. Fill remaining slots from the optional roster based on the project profile, FOCUS_AREAS, INCLUDE_AGENTS, and SKIP_AGENTS.
+
+#### Core Panel (always included)
+
+| Agent | Nickname | Lens | Personality |
+|-------|----------|------|-------------|
+| Code Quality | "Craftsman" | Code standards, consistency, naming, error handling, anti-patterns, tech debt | Meticulous senior engineer who has maintained codebases for decades. Reads every line. Spots inconsistencies others miss. Cares deeply about readability and maintainability. |
+| Architecture | "Architect" | System design, modularity, coupling, cohesion, separation of concerns, scalability patterns | Principal engineer who designs systems for 10x growth. Evaluates whether the structure will hold as the project evolves. Identifies hidden coupling and missing abstractions. |
+| Security | "Sentinel" | Vulnerabilities, input validation, auth flows, secrets management, dependency CVEs, attack surface | Paranoid security engineer who assumes every input is hostile. Checks for injection, XSS, CSRF, path traversal, credential leaks, and insecure defaults. Cross-references dependencies against known CVEs. |
+| Testing | "Inspector" | Test coverage, test quality, edge cases, test architecture, CI reliability | QA architect who believes untested code is broken code. Evaluates not just coverage percentage but test quality — are the right things being tested? Are edge cases covered? Are tests brittle or robust? |
+| Feature Completeness | "Strategist" | Feature gaps, user journey completeness, error states, edge case handling, polish level | Product-minded engineer who thinks from the user's perspective. Identifies missing features, incomplete flows, poor error messages, and rough edges that hurt the user experience. |
+
+**Chroxy core-agent weighting:**
+- **Sentinel** weights the bearer-token authority model (primary / pairing-bound / hook-secret classes — see `docs/security/bearer-token-authority.md`), transport E2E encryption, and credentials.json at-rest encryption. Every new HTTP route or WS handler that touches session state is in scope.
+- **Inspector** weights the two mandatory CI lints — test `stateFilePath` isolation (`lint-tests-state-file-path.sh`) and `BaseSession` opt-forwarding (`lint-session-opt-forwarding.sh`) — plus the three test layers: server/protocol `node:test`, dashboard/store-core `vitest`, and the visual/E2E smoke layer (Playwright dashboard smoke + Maestro mobile flows).
+- **Strategist** weights mobile UX: reconnect/ConnectionPhase resilience, touch targets, plan-approval and AskUserQuestion flows, and offline behavior.
+
+#### Optional Roster (auto-selected based on project profile)
+
+| Agent | Nickname | Lens | Auto-Include When | Personality |
+|-------|----------|------|-------------------|-------------|
+| Performance | "Profiler" | Bottlenecks, memory leaks, N+1 queries, caching opportunities, bundle size, lazy loading | `performance_critical` OR `has_frontend` OR large project | Performance engineer who profiles everything. Finds N+1 queries, unnecessary re-renders, missing indexes, bloated bundles, and synchronous operations that should be async. |
+| UX/DX | "Advocate" | User experience (if frontend), developer experience (if library/tool), API ergonomics, error messages | `has_frontend` OR project is a library/CLI tool | Designer-developer hybrid who obsesses over the experience. For frontend: accessibility, responsiveness, loading states. For libraries: API intuitiveness, documentation clarity, error message helpfulness. |
+| DevOps/CI | "Deployer" | CI pipeline, deployment strategy, environment parity, monitoring, alerting, infrastructure as code | `has_ci` OR `has_docker` | SRE who has been paged at 3am too many times. Evaluates CI reliability, deployment safety (rollback?), environment consistency, log quality, and monitoring coverage. |
+| Documentation | "Chronicler" | README quality, API docs, inline comments, architecture decision records, onboarding experience | `has_docs` is false OR project is a library | Technical writer who judges documentation by whether a new team member can onboard in a day. Evaluates README completeness, API documentation, code comments, and whether architecture decisions are recorded. |
+| Dependency Health | "Auditor" | Outdated dependencies, CVEs, license compliance, dependency weight, vendoring strategy | `dependency_count` > 20 OR `security_surface` is high | Supply chain security expert who treats every dependency as a liability. Checks for outdated packages, known vulnerabilities, license conflicts, unnecessary dependencies, and whether the dependency tree is well-managed. |
+| Competitive Analysis | "Scout" | Industry standards, competing projects, missing table-stakes features, differentiation | Project is a product or library (not internal tooling) | Product strategist who knows the competitive landscape. Compares against similar projects and industry standards. Identifies table-stakes features that are missing and areas where the project could differentiate. |
+| API Design | "Contract" | API consistency, REST/GraphQL conventions, versioning, error formats, pagination, rate limiting | `has_api` | API design purist who has read every RFC. Evaluates endpoint naming, HTTP method usage, error response consistency, pagination patterns, versioning strategy, and whether the API is self-documenting. |
+
+**Chroxy domain-specific optional agents:**
+
+| Agent | Nickname | Lens | Auto-Include When | Personality |
+|-------|----------|------|-------------------|-------------|
+| Expo Expert | "Expo Expert" | Expo SDK lifecycle, RN constraints, dev-client vs Expo Go, native modules (expo-speech-recognition, expo-secure-store), EAS builds, OTA | audit touches `packages/app` | Mobile engineer who has shipped many Expo apps and knows where the native seams bite. Flags dev-build-only assumptions and SDK-upgrade hazards. |
+| Tunneler | "Tunneler" | Cloudflare tunnels (Quick + Named), DNS/TLS, WebSocket proxying, HTTP+WS upgrade, reconnect/health-check reliability | audit touches `tunnel/` or `ws-server.js` | Network SRE who has debugged flaky tunnels at 3am. Knows WsServer must be an HTTP+WS upgrade (not standalone WS) and that the app health-checks before connecting. |
+| Protocol Steward | "Steward" | Zod schema consistency and wire-contract drift across server ↔ dashboard ↔ app, schemaVersion bounds, prototype-pollution hardening | audit touches `packages/protocol` or `packages/store-core` | Contract purist who diffs every emitter against every consumer of the WS protocol. Catches a server field that no schema validates and a schema no client reads. |
+| Tauri Smith | "Smith" | Tauri v2 packaging, CSP/nonce, launchd cwd, code-signing/notarization, Rust↔web bridge | audit touches `packages/desktop` | Desktop-platform engineer who knows Tauri-spawned servers run with `cwd=/` and a minimal PATH, and that signing belongs in `build.rs`. |
+
+#### Selection Algorithm
+
+```
+1. Start with 5 core agents
+2. Remove any core agents in SKIP_AGENTS (minimum 3 core agents — refuse if user tries to skip more)
+3. Force-add any agents in INCLUDE_AGENTS
+4. For remaining slots (AGENT_COUNT - current count):
+   a. Score each optional agent by relevance to PROJECT_PROFILE
+   b. Boost score +2 for agents whose lens matches a FOCUS_AREA
+   c. Select highest-scoring agents until slots are filled
+5. Remove any optional agents in SKIP_AGENTS
+6. Final panel size may be less than AGENT_COUNT if SKIP reduces it
+```
+
+**Tell the user which agents were selected and why** before launching the swarm.
+
+### 4. Create Output Directory
+
+```bash
+mkdir -p "${OUTPUT_DIR}"
+```
+
+If the directory already contains a previous audit, warn the user and ask whether to overwrite or create a timestamped subdirectory (e.g., `docs/project-audit/YYYY-MM-DD/`).
+
+### 5. Launch Agent Swarm
+
+Launch ALL agents in parallel using the Task tool. Each agent receives:
+
+1. The full project profile (languages, frameworks, size, etc.)
+2. Their specific persona, lens, and evaluation criteria
+3. Instructions to explore the actual codebase thoroughly
+4. A structured report format to follow
+
+**Agent prompt template:**
+
+```
+You are **"{NICKNAME}"** — {PERSONALITY}
+
+You are auditing a project from the lens of **{LENS}**.
+
+## Project Profile
+{PROJECT_PROFILE_SUMMARY}
+
+## Your Audit Scope
+
+You MUST explore the codebase thoroughly. Read source files, configuration, tests, and documentation. Do NOT base your audit on file names alone.
+
+### Exploration Strategy
+1. Start with entry points: main files, index files, app entry, CLI entry
+2. Trace key flows end-to-end (at least 2-3 major flows)
+3. Read configuration and build files
+4. Sample at least 5-10 source files across different modules
+5. Read test files to understand what IS and ISN'T tested
+6. Check for patterns: are conventions consistent across the codebase?
+
+### Report Structure
+
+#### Executive Summary
+2-3 sentences: overall assessment from your lens.
+
+#### Ratings
+
+Rate each area on your lens (1-5 scale):
+
+| Area | Rating | Evidence |
+|------|--------|----------|
+| {area relevant to lens} | X/5 | Specific file:line references |
+| ... | ... | ... |
+
+#### Top Findings
+Rank your top 5-8 findings by severity. Each finding MUST include:
+1. **Severity**: Critical / Major / Minor / Nitpick
+2. **Finding**: Clear description
+3. **Evidence**: Specific file paths and line numbers. Quote relevant code.
+4. **Impact**: What goes wrong if this isn't fixed
+5. **Recommendation**: Concrete fix (not "consider improving")
+
+#### Strengths
+What this project does WELL from your lens. Be specific — cite files and patterns.
+
+#### Actionable Recommendations
+Ordered list of concrete next steps. Each item must be specific enough to become a GitHub issue. Include:
+- What to do (imperative verb)
+- Where to do it (file paths)
+- Why it matters (impact)
+- Effort estimate: S (< 1 hour) / M (1-4 hours) / L (4-16 hours) / XL (> 16 hours)
+
+#### Overall Rating
+Single rating X.X/5 with one-paragraph justification.
+
+## Rules
+- READ actual source code. Verify everything against the codebase.
+- Be specific. "This might be a problem" is worthless. "src/auth.js:42 uses MD5 for password hashing" is useful.
+- Rate honestly. 3/5 means "adequate." 5/5 means "exemplary — I would showcase this." 1/5 means "actively harmful."
+- Be opinionated. Strong views, loosely held. Do not hedge everything.
+- Your recommendations must be actionable enough to become GitHub issues.
+
+## Verbosity: {VERBOSITY}
+- brief: Top 5 findings only, minimal evidence, skip Strengths section
+- standard: Full report as described above
+- detailed: Full report plus additional deep-dives into any area rated <= 2/5. Include code snippets for every finding.
+```
+
+**Batching:** Launch agents in parallel batches. First batch of up to 5 agents, then remaining agents in a second batch. Do NOT run agents in the background — use foreground Task calls so output returns directly.
+
+### 6. Write Individual Reports
+
+After all agents return, write each report to its own file:
+
+```
+${OUTPUT_DIR}/
+  00-master-assessment.md    <- You write this (step 7)
+  01-craftsman.md            <- Code Quality
+  02-architect.md            <- Architecture
+  03-sentinel.md             <- Security
+  04-inspector.md            <- Testing
+  05-strategist.md           <- Feature Completeness
+  06-{nickname}.md           <- Optional agents
+  ...
+```
+
+Each file starts with:
+
+```markdown
+# {Nickname}'s Audit: {Project Name}
+
+**Agent**: {Nickname} — {one-line personality summary}
+**Lens**: {lens description}
+**Overall Rating**: X.X / 5
+**Date**: {today}
+**Verbosity**: {verbosity level}
+
+---
+```
+
+### 7. Write Master Assessment
+
+Create `00-master-assessment.md` that synthesizes ALL agent findings into a unified assessment.
+
+#### Required Sections
+
+**a. Project Profile Summary**
+
+Concise overview: name, languages, frameworks, size, what it does, project maturity.
+
+**b. Auditor Panel**
+
+| Agent | Lens | Rating | Key Finding |
+|-------|------|--------|-------------|
+| Craftsman | Code Quality | X.X/5 | One-sentence headline |
+| Architect | Architecture | X.X/5 | One-sentence headline |
+| ... | ... | ... | ... |
+
+**Aggregate Rating**: Weighted average (core agents 1.0x, optional agents 0.8x).
+
+**c. Risk Heatmap**
+
+ASCII grid mapping identified risks by likelihood vs. impact:
+
+```
+                    IMPACT
+            Low      Medium     High     Critical
+         ┌────────┬──────────┬────────┬──────────┐
+  Likely  │        │          │ ██ R3  │ ██ R1    │
+         ├────────┼──────────┼────────┼──────────┤
+ Possible │        │ ░░ R5    │ ░░ R4  │ ██ R2    │
+         ├────────┼──────────┼────────┼──────────┤
+ Unlikely │ ·· R7  │ ·· R6    │        │ ░░ R8    │
+         └────────┴──────────┴────────┴──────────┘
+
+██ = Immediate action   ░░ = Plan to address   ·· = Monitor
+```
+
+Map each risk ID (R1, R2, ...) to a description below the grid.
+
+**d. Consensus Findings**
+
+Findings where 3+ agents independently identified the same issue. These are highest confidence. For each:
+- What agents agree on
+- Supporting evidence from multiple reports
+- Recommended action
+- Priority: P0 (fix now) / P1 (fix this sprint) / P2 (fix this quarter) / P3 (backlog)
+
+**e. Contested Points**
+
+Findings where agents disagree. Present each position with the agent's name. Include your synthesis of who is right and why — do not just list opinions.
+
+**f. Strengths**
+
+What the project does well, as identified across multiple agents. Grouped by theme.
+
+**g. Critical Path: Top 10 Recommendations**
+
+Synthesized and deduplicated from all agent recommendations. Ordered by priority, not by agent. Each recommendation includes:
+
+| # | Recommendation | Priority | Effort | Agents | Impact |
+|---|---------------|----------|--------|--------|--------|
+| 1 | Imperative description | P0-P3 | S/M/L/XL | Who flagged it | What improves |
+| 2 | ... | ... | ... | ... | ... |
+
+**h. Implementation Roadmap**
+
+Group the top 10 into a phased plan:
+
+**Phase 1 — Immediate (this week):** P0 items, quick wins (S/M effort)
+**Phase 2 — Short-term (this month):** P1 items, medium effort
+**Phase 3 — Medium-term (this quarter):** P2 items, larger efforts
+**Phase 4 — Long-term (backlog):** P3 items, strategic improvements
+
+For each phase, list:
+- What to do (linked to recommendation #)
+- Dependencies (which items unblock others)
+- Expected outcome
+
+**i. Final Verdict**
+
+One of:
+- **Ship It** — Project is solid. Address minor findings at your pace.
+- **Ship With Fixes** — Project is good but has specific issues that should be fixed before/alongside the next release.
+- **Needs Work** — Significant issues identified. Address Phase 1 items before expanding scope.
+- **Rethink** — Fundamental concerns raised. Consider architectural changes before further investment.
+
+One-paragraph justification with the aggregate rating.
+
+**j. Appendix: Agent Reports**
+
+Table linking to each individual report file.
+
+| Agent | File | Rating |
+|-------|------|--------|
+| Craftsman | [01-craftsman.md](./01-craftsman.md) | X.X/5 |
+| ... | ... | ... |
+
+### 8. Optionally Generate Issues
+
+After writing the master assessment, ask the user:
+
+> "Would you like me to create GitHub issues for the top N recommendations? I can create them with appropriate labels and link them to the audit."
+
+If yes, use this format for each issue:
+
+```bash
+gh issue create \
+  --title "type(scope): recommendation title" \
+  --label "enhancement" \
+  --label "from-audit" \
+  --body "$(cat <<'EOF'
+## Context
+
+Identified during project audit on {DATE}.
+**Source:** {OUTPUT_DIR}/00-master-assessment.md — Recommendation #{N}
+**Priority:** {P0-P3}
+**Effort:** {S/M/L/XL}
+
+## Agents Who Flagged This
+
+{List of agents and their specific findings}
+
+## Description
+
+{Detailed description of what needs to change and why}
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Evidence
+
+{File:line references from agent reports}
+EOF
+)"
+```
+
+**Chroxy issue/commit conventions:** create issues with a `from-audit` label. Title findings as `type(scope): summary` using chroxy's types (feat/fix/refactor/docs/test/chore/style/perf) and scopes (server/app/desktop/tunnel/ws/cli/ci/docs). Per the Zero Attribution Policy, **never** add any AI/Claude attribution to issues, commits, or PR bodies.
+
+### 9. Commit Results
+
+Stage and commit all audit files:
+
+```bash
+git add "${OUTPUT_DIR}/"
+git commit -m "docs: project audit (${AGENT_COUNT} agents, aggregate ${AGGREGATE_RATING}/5)
+
+Agents: ${AGENT_NICKNAMES_COMMA_SEPARATED}
+Verdict: ${VERDICT}
+Top finding: ${TOP_CONSENSUS_FINDING_SUMMARY}
+"
+```
+
+Do NOT push unless explicitly asked.
+
+### 10. Report to User
+
+Output a concise summary:
+
+```markdown
+## Project Audit Complete
+
+| Metric | Value |
+|--------|-------|
+| Agents | ${AGENT_COUNT} (${CORE_COUNT} core + ${OPTIONAL_COUNT} optional) |
+| Aggregate Rating | ${AGGREGATE_RATING} / 5 |
+| Verdict | ${VERDICT} |
+| Reports | ${OUTPUT_DIR}/ |
+
+### Agent Ratings
+
+| Agent | Rating | Top Finding |
+|-------|--------|-------------|
+| Craftsman | X.X/5 | ... |
+| ... | ... | ... |
+
+### Top 3 Consensus Findings
+1. ...
+2. ...
+3. ...
+
+### Top Contested Point
+...
+
+### Recommended Next Action
+...
+```
+
+## Configuration
+
+### Rating Scale
+
+| Rating | Meaning |
+|:------:|---------|
+| 5/5 | Exemplary. Would showcase this as a reference implementation. |
+| 4/5 | Good. Minor issues that do not block progress. |
+| 3/5 | Adequate. Works but has gaps worth addressing. |
+| 2/5 | Concerning. Significant issues that will cause problems at scale. |
+| 1/5 | Fundamentally broken. Needs rethinking, not patching. |
+
+**Chroxy grading criteria:**
+- **Sentinel** weights the bearer-token authority model, transport E2E encryption, and credentials.json at-rest encryption (OS-keychain key); any new endpoint touching session state must be checked against `docs/security/bearer-token-authority.md`.
+- **Profiler** weights WebSocket streaming and large-output handling (stream parsing, background-shell reaping, message-id collisions).
+- **Inspector** weights the mandatory CI lints (test `stateFilePath` isolation, `BaseSession` opt-forwarding) and gives extra weight to the visual-smoke / Maestro layers, which lag the unit layer.
+- **Advocate** (if included) weights mobile reconnect resilience and touch ergonomics; **Tunneler** weights tunnel/WS reliability under drops.
+
+### Agent Behavior Rules
+
+- Agents MUST read actual source code — at least 5-10 files across different modules
+- Agents MUST provide file:line references for every finding
+- Agents MUST rate each area independently with evidence
+- Agents MUST end with actionable recommendations that could become GitHub issues
+- Agents MUST include effort estimates (S/M/L/XL) for every recommendation
+- Agents should be opinionated, not diplomatic — strong views, loosely held
+- Agents should acknowledge strengths, not just problems — a balanced audit is more credible
+
+### Verbosity Levels
+
+| Level | Individual Reports | Master Assessment |
+|-------|-------------------|-------------------|
+| brief | Top 5 findings, minimal evidence, no Strengths section | Ratings table, consensus findings, top 5 recommendations |
+| standard | Full report as specified | Full report as specified |
+| detailed | Full report + deep-dives on low-rated areas with code snippets | Full report + expanded implementation roadmap with code examples |
+
+## Customization
+
+### Adding Custom Agent Personas
+
+To add a custom agent, include it in your `INCLUDE_AGENTS` with a description in the arguments. Or, to make it permanent, create a `.claude/audit-agents.json` file:
+
+```json
+{
+  "custom_agents": [
+    {
+      "nickname": "Regulator",
+      "lens": "GDPR compliance, data privacy, consent flows, data retention",
+      "personality": "Privacy lawyer turned engineer who reads every data flow for compliance violations.",
+      "auto_include_when": "Project handles personal data or has EU users",
+      "detect_signals": ["gdpr", "privacy", "consent", "personal data", "user data"]
+    }
+  ]
+}
+```
+
+### Project-Level Defaults
+
+Create `.claude/audit-config.json` to set defaults for this project:
+
+```json
+{
+  "default_agents": 8,
+  "default_focus": ["security", "performance"],
+  "default_verbosity": "detailed",
+  "always_include": ["deployer", "auditor"],
+  "always_skip": ["scout"],
+  "output_dir": "docs/audits/"
+}
+```
+
+## Examples
+
+```
+/project-audit
+/project-audit agents=8
+/project-audit focus=security
+/project-audit agents=10 focus=security,performance verbosity=detailed
+/project-audit output=audits/pre-launch agents=12
+/project-audit skip=scout,chronicler
+/project-audit include=deployer verbosity=brief
+```
+
+<!-- skill-templates: project-audit aae4d65 2026-06-06 -->

--- a/.claude/commands/smoke-test.md
+++ b/.claude/commands/smoke-test.md
@@ -75,8 +75,9 @@ for arg in $ARGUMENTS; do
 done
 
 # Rebuild dashboard before testing (source changes not visible without rebuild)
-cd packages/server
-npm run dashboard:build
+# The dashboard is its own workspace package (@chroxy/dashboard); the server
+# serves its compiled dist/. There is no `dashboard:build` script.
+npm run build -w @chroxy/dashboard
 
 # Run the smoke test
 cd packages/server && node tests/smoke-test.mjs $PW_FLAGS
@@ -114,14 +115,14 @@ Output a summary table:
 |---|-------|--------|-------|
 | 1 | Dashboard loads | PASS | HTTP 200, WS connects |
 | 2 | Session creation | PASS | Ctrl+N modal opens |
-| 3 | Keyboard shortcuts | PASS | `?` help, `Ctrl+K` palette |
+| 3 | Keyboard shortcuts | PASS | `?` help overlay |
 
 **Screenshots reviewed:** N
 **Visual issues found:** M (describe any issues)
 
 If the test failed, check:
 - Is the server running? (`curl http://localhost:8765/health`)
-- Did the dashboard rebuild? (`npm run dashboard:build`)
+- Did the dashboard rebuild? (`npm run build -w @chroxy/dashboard`)
 - Are there console errors in the browser? (check screenshots or run with `--headed`)
 ```
 
@@ -219,8 +220,9 @@ Organize checks into logical groups:
 | Category | What to Verify |
 |----------|---------------|
 | Dashboard Core | Page loads (HTTP 200), WS connects, version badge, sidebar, session tabs, full-width layout, input bar |
-| Session Creation | Ctrl+N opens modal, session name input, CWD combobox, provider picker (SDK/CLI options) |
-| Keyboard Shortcuts | `?` opens help overlay, `Ctrl+K` command palette, `Ctrl+N` new session |
+| Session Creation | Ctrl+N opens modal, session name input, CWD combobox, provider picker visible (logs option labels) |
+| Keyboard Shortcuts | `?` opens help overlay, `Ctrl+N` new session |
+| Control Room | Sidebar launcher opens the Control Room, `control-room-section` + top-level tab render, repo table or empty state shows, sort/filter controls present (with data), refresh stays stable (best-effort) |
 | Health | No critical console errors |
 
 ## Critical Rules
@@ -231,6 +233,6 @@ Organize checks into logical groups:
 4. **Stable selectors** — Use aria labels and roles, not brittle CSS class names that change with refactors.
 5. **Visual verification is the point** — The automated checks catch DOM presence. Reading screenshots catches visual regressions (z-index, color, spacing).
 6. **Idempotent** — Safe to run repeatedly. Don't create persistent state (sessions, data, etc.) that would affect the next run.
-7. **Rebuild dashboard before testing** — Dashboard serves compiled Vite bundles. Source changes are NOT visible without `npm run dashboard:build`.
+7. **Rebuild dashboard before testing** — Dashboard serves compiled Vite bundles. Source changes are NOT visible without `npm run build -w @chroxy/dashboard`.
 8. **`?` shortcut quirk** — Test fails if textarea has focus (keystroke goes to input, not shortcut handler). Click body first to ensure focus is not in the input bar.
 <!-- skill-templates: smoke-test 21fa678 2026-06-03 -->

--- a/.claude/skill-profile.md
+++ b/.claude/skill-profile.md
@@ -129,7 +129,7 @@ Mindset: "Will this code work reliably over a cellular connection through a tunn
 - **Run:** `cd packages/server && node tests/smoke-test.mjs [--headed]`
 - **Screenshots:** `packages/server/tests/screenshots/` (gitignored)
 - **Requires:** `playwright` as dev dependency, Chromium installed via `npx playwright install chromium`
-- **Rebuild dashboard before testing:** `cd packages/server && npm run dashboard:build`
+- **Rebuild dashboard before testing:** `npm run build -w @chroxy/dashboard`
 
 ### Test Categories
 
@@ -181,8 +181,7 @@ Any PR touching dashboard source files, React components, CSS, or theme files tr
 
 #### UI Rebuild Command
 ```bash
-cd packages/server
-PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run dashboard:build
+PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm run build -w @chroxy/dashboard
 ```
 Dashboard serves compiled Vite bundles — source changes are NOT visible without rebuild.
 

--- a/.claude/skills.lock
+++ b/.claude/skills.lock
@@ -5,6 +5,10 @@
       "hash": "ebdb14e",
       "installed": "2026-06-02"
     },
+    "agentic-audit": {
+      "hash": "3f616c3",
+      "installed": "2026-06-06"
+    },
     "autonomous-dev-flow": {
       "hash": "ebdb14e",
       "installed": "2026-06-02"
@@ -80,6 +84,10 @@
     "tackle-issues": {
       "hash": "21fa678",
       "installed": "2026-06-03"
+    },
+    "project-audit": {
+      "hash": "aae4d65",
+      "installed": "2026-06-06"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,18 +65,24 @@ npx chroxy tunnel setup
 3. Review open PRs, **separated by author** so external contributions don't get lost in your own queue:
    - Yours: `gh pr list --state open --author @me`
    - **External:** `gh pr list --state open --search "-author:@me"` — flag any results for review attention before starting new marathons (an open external PR may already cover an issue you'd otherwise queue)
-4. Check for skill template updates: `~/Projects/skill-templates/sync.sh chroxy`
+4. Check for skill drift: `/skill outdated` (then `/skill update [name]` to refresh)
 
-### Skill Templates
+### Skills (pull-based registry)
 
-Reusable skill templates (check-pr, agent-review, etc.) are maintained in the private repo `blamechris/skill-templates`. When the sync script reports drift, review the generic template and customization notes, then update local skills as needed.
+Skills live in the `blamechris/skill-templates` **registry** and install **on demand** via the
+`/skill` client — think `npm`/`brew` for `.claude/commands/*.md`. There is no push-deploy and no
+`sync.sh`; the old push/`customizations/` workflow is retired.
 
-```
-~/Projects/skill-templates/
-├── generic/           # Gold standard templates
-├── customizations/    # Per-repo adaptation notes (chroxy.md)
-└── sync.sh           # Drift detection
-```
+- **`/skill add <name>`** — resolve from the registry → fetch `generic/<name>.md` → fill its
+  `{{CUSTOMIZE: ...}}` markers from this repo's `CLAUDE.md` + `.claude/skill-profile.md` + code →
+  write a version-stamped `.claude/commands/<name>.md` → record in `.claude/skills.lock`.
+- **`/skill list` / `outdated` / `update [name]` / `remove <name>`** — manage installed skills.
+- **Install-on-miss is a rule:** if `/X` is requested but absent from `.claude/commands/`, run
+  `/skill add X` first, then invoke it.
+
+This repo carries `.claude/skill-profile.md` (the customization profile) and `.claude/skills.lock`
+(what's installed, at which template hash). Maintainers edit templates in the registry's `generic/`
+and run its `scripts/build-index.sh`; consumers pick changes up on the next `/skill update`.
 
 ## Git Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Skills live in the `blamechris/skill-templates` **registry** and install **on de
 - **`/skill add <name>`** — resolve from the registry → fetch `generic/<name>.md` → fill its
   `{{CUSTOMIZE: ...}}` markers from this repo's `CLAUDE.md` + `.claude/skill-profile.md` + code →
   write a version-stamped `.claude/commands/<name>.md` → record in `.claude/skills.lock`.
-- **`/skill list` / `outdated` / `update [name]` / `remove <name>`** — manage installed skills.
+- **`/skill list` / `/skill outdated` / `/skill update [name]` / `/skill remove <name>`** — manage installed skills.
 - **Install-on-miss is a rule:** if `/X` is requested but absent from `.claude/commands/`, run
   `/skill add X` first, then invoke it.
 

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -623,7 +623,7 @@ export function createHttpHandler(server) {
       const distDir = existsSync(workspaceDist) ? workspaceDist : bundleDist
       if (!existsSync(distDir) && !createHttpHandler._distMissWarned) {
         createHttpHandler._distMissWarned = true
-        log.warn(`Dashboard dist directory not found: ${distDir} — run "npm run dashboard:build"`)
+        log.warn(`Dashboard dist directory not found: ${distDir} — run "npm run build -w @chroxy/dashboard"`)
       }
       const relPath = dashUrl.pathname.replace(/^\/dashboard\/?/, '') || 'index.html'
 
@@ -675,7 +675,7 @@ export function createHttpHandler(server) {
         res.end(html)
       } else {
         res.writeHead(404)
-        res.end('Dashboard not built. Run: npm run dashboard:build')
+        res.end('Dashboard not built. Run: npm run build -w @chroxy/dashboard')
       }
       return
     }

--- a/packages/server/tests/smoke-test.mjs
+++ b/packages/server/tests/smoke-test.mjs
@@ -332,6 +332,83 @@ async function run() {
       }
     }
 
+    // ---- Control Room ----
+    log('')
+    log('--- Control Room ---')
+
+    // Open the Control Room from the sidebar panel-slot launcher (#5200/#5204).
+    const crLauncher = await page.$('[data-testid="sidebar-panel-slot-launcher-control-room"]')
+    if (crLauncher && await crLauncher.isVisible()) {
+      await crLauncher.click()
+      await page.waitForTimeout(600)
+
+      // The section owns the main content area when active.
+      const crSection = await page.$('[data-testid="control-room-section"]')
+      if (crSection && await crSection.isVisible()) {
+        pass('Control Room opens', 'launcher → control-room-section visible')
+        await screenshot(page, '06-control-room')
+      } else {
+        fail('Control Room opens', 'control-room-section not visible after launcher click')
+      }
+
+      // It registers a session-independent top-level tab (#5204).
+      const crTab = await page.$('[data-testid="control-room-tab"]')
+      if (crTab && await crTab.isVisible()) {
+        pass('Control Room tab present')
+      } else {
+        fail('Control Room tab present', 'control-room-tab not found')
+      }
+
+      // Renders either the populated repo table or the empty/not-yet-surveyed state.
+      const crTable = await page.$('[data-testid="cr-table"]')
+      const crEmpty = await page.$('[data-testid="cr-empty"]')
+      const tableVisible = crTable && await crTable.isVisible()
+      const emptyVisible = crEmpty && await crEmpty.isVisible()
+      if (tableVisible) {
+        pass('Control Room renders', 'repo table (cr-table)')
+      } else if (emptyVisible) {
+        pass('Control Room renders', 'empty/not-yet-surveyed state (cr-empty)')
+      } else {
+        fail('Control Room renders', 'neither cr-table nor cr-empty visible')
+      }
+
+      // With a populated table, the sort/filter controls (#5225) should also render.
+      if (tableVisible) {
+        const crControls = await page.$('[data-testid="cr-controls"]')
+        if (crControls && await crControls.isVisible()) {
+          pass('Control Room sort/filter controls')
+        } else {
+          fail('Control Room sort/filter controls', 'cr-controls not visible with a populated table')
+        }
+      }
+
+      // Best-effort: trigger a refresh (read-only git/gh survey) and screenshot the result.
+      // Non-fatal — the survey can be slow or rate-limited; we only verify the button wires up
+      // and the section stays mounted afterward, not any specific repo data.
+      try {
+        const refreshBtn = await page.$(
+          '[data-testid="cr-refresh"]:not([disabled]), [data-testid="cr-empty-refresh"]:not([disabled])'
+        )
+        if (refreshBtn) {
+          await refreshBtn.click()
+          await page.waitForTimeout(4000)
+          await screenshot(page, '07-control-room-survey')
+          const stillThere = await page.$('[data-testid="control-room-section"]')
+          if (stillThere && await stillThere.isVisible()) {
+            pass('Control Room refresh', 'section stable after survey request')
+          } else {
+            fail('Control Room refresh', 'section disappeared after refresh')
+          }
+        } else {
+          log('  (refresh button disabled/absent — skipping survey trigger)')
+        }
+      } catch (e) {
+        log(`  (refresh trigger skipped: ${e.message})`)
+      }
+    } else {
+      fail('Control Room opens', 'sidebar-panel-slot-launcher-control-room not found')
+    }
+
     // ---- Console errors ----
     log('')
     log('--- Health ---')
@@ -363,9 +440,20 @@ async function run() {
   if (browser) await browser.close()
   if (managedServer) {
     log('Stopping managed server...')
-    managedServer.kill('SIGTERM')
-    await new Promise(r => setTimeout(r, 1000))
-    if (managedServer.exitCode === null) managedServer.kill('SIGKILL')
+    // Give the server time to flush session-state.json on SIGTERM before escalating.
+    // SIGKILL bypasses the flush handler and can wipe state (feedback_sigterm_not_sigkill):
+    // wait for a clean exit, only force-kill if the process is genuinely hung.
+    await new Promise((resolve) => {
+      const grace = setTimeout(() => {
+        if (managedServer.exitCode === null && managedServer.signalCode === null) {
+          log('  server did not exit within 8s of SIGTERM — escalating to SIGKILL')
+          managedServer.kill('SIGKILL')
+        }
+        resolve()
+      }, 8000)
+      managedServer.once('exit', () => { clearTimeout(grace); resolve() })
+      managedServer.kill('SIGTERM')
+    })
   }
 
   process.exit(failed > 0 ? 1 : 0)
@@ -374,6 +462,7 @@ async function run() {
 run().catch(err => {
   console.error('Fatal:', err)
   if (browser) browser.close()
+  // SIGTERM (never SIGKILL) so the server flushes session-state on the way out.
   if (managedServer) managedServer.kill('SIGTERM')
   process.exit(1)
 })

--- a/packages/server/tests/smoke-test.mjs
+++ b/packages/server/tests/smoke-test.mjs
@@ -444,14 +444,16 @@ async function run() {
     // SIGKILL bypasses the flush handler and can wipe state (feedback_sigterm_not_sigkill):
     // wait for a clean exit, only force-kill if the process is genuinely hung.
     await new Promise((resolve) => {
+      // Resolve only once the child has actually exited so we never leave a
+      // zombie/port-holding process behind. The 'exit' listener fires for both
+      // the graceful SIGTERM flush and a forced SIGKILL.
+      managedServer.once('exit', () => { clearTimeout(grace); resolve() })
       const grace = setTimeout(() => {
         if (managedServer.exitCode === null && managedServer.signalCode === null) {
           log('  server did not exit within 8s of SIGTERM — escalating to SIGKILL')
           managedServer.kill('SIGKILL')
         }
-        resolve()
       }, 8000)
-      managedServer.once('exit', () => { clearTimeout(grace); resolve() })
       managedServer.kill('SIGTERM')
     })
   }
@@ -462,7 +464,9 @@ async function run() {
 run().catch(err => {
   console.error('Fatal:', err)
   if (browser) browser.close()
-  // SIGTERM (never SIGKILL) so the server flushes session-state on the way out.
+  // Fatal path: send only SIGTERM (no SIGKILL escalation here) so the server
+  // gets a chance to flush session-state on the way out. The graceful cleanup
+  // path above is the one that may escalate to SIGKILL if the process hangs.
   if (managedServer) managedServer.kill('SIGTERM')
   process.exit(1)
 })


### PR DESCRIPTION
## Summary

Cleanup surfaced by a 5-agent **coverage audit** of the Control Room v2 commit window (the full report is local, gitignored at `docs/audit-results/`). Three buckets, all verified:

### 🔴 Smoke tooling was silently broken
- The `/smoke-test` skill rebuilt via `npm run dashboard:build` — a script that **no longer exists** since the dashboard became its own `@chroxy/dashboard` workspace. Replaced with `npm run build -w @chroxy/dashboard` across the smoke-test / fix-ci / autonomous-dev-flow skills, `skill-profile.md`, and the server's `dist`-missing warnings (`http-routes.js`).
- The skill **advertised checks it never ran** (`Ctrl+K` palette, "SDK/CLI provider options"). Docs reconciled with the actual test.

### 🟢 Control Room smoke coverage (the biggest E2E gap)
- New Playwright checks: open Control Room via the sidebar launcher → assert section, session-independent top-level tab, repo table-or-empty state, sort/filter controls, best-effort refresh.
- **Verified live: 17/17 passing**, real 25-repo survey table rendered (screenshot in the local report).
- Hardened shutdown: wait for a clean `SIGTERM` flush (≤8s) before escalating to `SIGKILL`, so a smoke run can't wipe `session-state.json` (per project memory).

### 🧹 Skill registry housekeeping
- Rewrote CLAUDE.md's skill workflow to the pull-based `/skill` registry; retired the dead `sync.sh` / `customizations/` references.
- Installed `project-audit` + `agentic-audit` skills, customized for chroxy (both pass `skill-lint.sh`).

## Test plan
- [x] `node --check` on the modified smoke test
- [x] Live smoke run: 17/17 PASS, Control Room table rendered against real repos
- [x] `session-state.json` byte-identical before/after the run (graceful shutdown works)
- [x] `skill-lint.sh` clean on both new skills

## Note
Skill drift was **triple-checked and is a false alarm** — the 14 "outdated" skills carry an old commit-stamp, not changed content (templates have 0 commits since install). No bulk `skill update` performed.