### PR TITLE
feat(server): chroxy credentials rekey — rotate the at-rest data key (#5229)

### DIFF
--- a/packages/server/src/cli.js
+++ b/packages/server/src/cli.js
@@ -20,6 +20,7 @@ import { registerServiceCommand } from './cli/service-cmd.js'
 import { registerUpdateCommand } from './cli/update-cmd.js'
 import { registerStatusCommand } from './cli/status-cmd.js'
 import { registerWorktreeCommand } from './cli/worktree-gc-cmd.js'
+import { registerCredentialsCommand } from './cli/credentials-cmd.js'
 
 const require = createRequire(import.meta.url)
 const { version } = require('../package.json')
@@ -42,5 +43,6 @@ registerServiceCommand(program)
 registerUpdateCommand(program)
 registerStatusCommand(program)
 registerWorktreeCommand(program)
+registerCredentialsCommand(program)
 
 program.parse()

--- a/packages/server/src/cli/credentials-cmd.js
+++ b/packages/server/src/cli/credentials-cmd.js
@@ -1,0 +1,59 @@
+/**
+ * `chroxy credentials` CLI subcommands.
+ *
+ * `rekey` (#5229) rotates the at-rest credential data key: it mints a fresh
+ * OS-keychain data key, re-encrypts ~/.chroxy/credentials.json under it
+ * atomically (temp → chmod 0600 → rename), and replaces the old keychain entry
+ * in place. Use it after a suspected keychain compromise, or to periodically
+ * rotate the key, WITHOUT re-entering any provider credentials.
+ */
+import { rekeyCredentialStore } from '../credential-store.js'
+import { createLogger } from '../logger.js'
+
+const REKEY_MESSAGES = {
+  rekeyed: 'Rotated the credential data key and re-encrypted credentials.json.',
+  'no-keychain': 'No OS keychain available — nothing to rotate (credentials are stored as plaintext 0600).',
+  'no-file': 'No credentials.json found — nothing to rotate.',
+  empty: 'credentials.json holds no credentials — nothing to rotate.',
+  'read-error': 'Could not read credentials.json safely — aborted without changing anything.',
+  'write-error': 'Re-encryption failed — the keychain key was rolled back; the existing store is unchanged.',
+}
+
+/**
+ * Run `chroxy credentials rekey`. Returns the {@link rekeyCredentialStore}
+ * result. `deps` is a test seam (`write`, `log`, `rekey`).
+ */
+export async function runCredentialsRekey(options = {}, deps = {}) {
+  const out = deps.write || console.log
+  const log = deps.log || createLogger('credentials')
+  const rekey = deps.rekey || rekeyCredentialStore
+  const result = rekey({ log })
+
+  if (options.json) {
+    out(JSON.stringify(result, null, 2))
+  } else {
+    const msg = REKEY_MESSAGES[result.reason] || result.reason
+    out(`${result.rekeyed ? '✓' : '•'} ${msg}`)
+  }
+  return result
+}
+
+export function registerCredentialsCommand(program) {
+  const creds = program
+    .command('credentials')
+    .description('Manage stored provider credentials')
+
+  creds
+    .command('rekey')
+    .description('Rotate the at-rest credential data key and re-encrypt credentials.json')
+    .option('--json', 'Output machine-readable JSON')
+    .action(async (options) => {
+      const result = await runCredentialsRekey(options)
+      // Signal failure to scripts/CI only when we INTENDED to rotate but
+      // couldn't (the store was readable yet the swap failed). Benign no-ops
+      // (no-file, empty, no-keychain) exit 0.
+      if (!result.rekeyed && (result.reason === 'read-error' || result.reason === 'write-error')) {
+        process.exitCode = 1
+      }
+    })
+}

--- a/packages/server/src/cli/credentials-cmd.js
+++ b/packages/server/src/cli/credentials-cmd.js
@@ -12,7 +12,7 @@ import { createLogger } from '../logger.js'
 
 const REKEY_MESSAGES = {
   rekeyed: 'Rotated the credential data key and re-encrypted credentials.json.',
-  'no-keychain': 'No OS keychain available — nothing to rotate (credentials are stored as plaintext 0600).',
+  'no-keychain': 'No OS keychain available to hold a data key — nothing to rotate.',
   'no-file': 'No credentials.json found — nothing to rotate.',
   empty: 'credentials.json holds no credentials — nothing to rotate.',
   'read-error': 'Could not read credentials.json safely — aborted without changing anything.',

--- a/packages/server/src/credential-cipher.js
+++ b/packages/server/src/credential-cipher.js
@@ -88,6 +88,38 @@ export function getOrCreateMasterKey(keychain = realKeychain) {
 }
 
 /**
+ * #5229 — generate a FRESH data key, persist it to the keychain (replacing any
+ * existing `chroxy-cred-key` entry), and return it as a 32-byte Uint8Array.
+ * Returns null when no keychain is available. Unlike getOrCreateMasterKey this
+ * always mints a new key — callers use it to rotate, and are responsible for
+ * re-encrypting the store under the returned key (and for rolling back via
+ * setMasterKey if that write fails).
+ */
+export function rotateMasterKey(keychain = realKeychain) {
+  if (!keychain.isKeychainAvailable()) return null
+  const key = randomBytes(KEY_BYTES)
+  keychain.setToken(Buffer.from(key).toString('base64'), CRED_KEY_SERVICE)
+  return new Uint8Array(key)
+}
+
+/**
+ * #5229 — restore a specific data key to the keychain (the rekey rollback seam).
+ * Pass a 32-byte Uint8Array to set it, or null to delete the entry entirely
+ * (used when the store had no prior key — i.e. was plaintext — before a failed
+ * rotation). Throws on a wrong-length key.
+ */
+export function setMasterKey(key, keychain = realKeychain) {
+  if (key == null) {
+    keychain.deleteToken(CRED_KEY_SERVICE)
+    return
+  }
+  if (!(key instanceof Uint8Array) || key.length !== KEY_BYTES) {
+    throw new Error('credential cipher: key must be a 32-byte Uint8Array')
+  }
+  keychain.setToken(Buffer.from(key).toString('base64'), CRED_KEY_SERVICE)
+}
+
+/**
  * Encrypt a plain JS object into an envelope using `key` (32-byte Uint8Array).
  * Pure: a fresh random nonce each call. Throws on a bad key length.
  */

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -53,6 +53,8 @@ import {
   encryptJson,
   getMasterKey,
   getOrCreateMasterKey,
+  rotateMasterKey,
+  setMasterKey,
 } from './credential-cipher.js'
 
 // A keychain stub that reports "no keychain here" — selects the plaintext
@@ -408,6 +410,63 @@ export function maybeEncryptCredentialsAtRest({ log } = {}) {
   } catch (err) {
     if (log) log.warn(`Credentials at-rest encryption failed: ${err.message}`)
     return { migrated: false, reason: 'write-error' }
+  }
+}
+
+/**
+ * #5229 — rotate the at-rest credential data key. Generates a fresh keychain
+ * data key, re-encrypts the existing store under it, and atomically replaces
+ * credentials.json (temp → chmod 0600 → rename, via writeStoreAtomically). The
+ * single keychain entry (service `chroxy-cred-key`) is overwritten in place, so
+ * no stale key is left dangling.
+ *
+ * Crash-safety: the new key is written to the keychain first, then the store is
+ * re-encrypted with the standard atomic write. If that write throws (disk full,
+ * permission, mode re-check), the keychain is rolled back to the prior key (or
+ * deleted, if the store had been plaintext) so the existing on-disk envelope
+ * stays decryptable. The only unrecoverable window is a hard process crash
+ * between the keychain swap and the file rename — unavoidable without a second
+ * key slot, and vanishingly small.
+ *
+ * No-op (with a reason) when: no keychain is available (nowhere to hold a key),
+ * the file is missing, the store can't be safely read (bad mode / corrupt /
+ * undecryptable), or the store is empty.
+ *
+ * @param {{ log?: { info: Function, warn: Function } }} [opts]
+ * @returns {{ rekeyed: boolean, reason: string }}
+ */
+export function rekeyCredentialStore({ log } = {}) {
+  const file = credentialsFilePath()
+  const keychain = activeKeychain()
+
+  if (!keychain.isKeychainAvailable()) {
+    if (log) log.warn('Credential rekey skipped — no OS keychain available to hold a data key')
+    return { rekeyed: false, reason: 'no-keychain' }
+  }
+  if (!existsSync(file)) return { rekeyed: false, reason: 'no-file' }
+
+  // Decrypt the current store up front: a read error (bad mode / corrupt /
+  // undecryptable) must abort BEFORE we touch the keychain, so we never strand
+  // a readable store behind a rotated key.
+  const { data, error } = readStore()
+  if (error) {
+    if (log) log.warn(`Credential rekey skipped: ${error}`)
+    return { rekeyed: false, reason: 'read-error' }
+  }
+  if (Object.keys(data).length === 0) return { rekeyed: false, reason: 'empty' }
+
+  // Capture the prior key for rollback (null when the store was plaintext).
+  const previousKey = getMasterKey(keychain)
+  rotateMasterKey(keychain) // keychain now holds the new key
+  try {
+    writeStoreAtomically(file, data) // getOrCreateMasterKey → encrypts under the new key
+    if (log) log.info('Rotated the credential data key and re-encrypted credentials.json')
+    return { rekeyed: true, reason: 'rekeyed' }
+  } catch (err) {
+    // Roll the keychain back so the still-on-disk envelope stays decryptable.
+    setMasterKey(previousKey, keychain)
+    if (log) log.warn(`Credential rekey failed: ${err.message}`)
+    return { rekeyed: false, reason: 'write-error' }
   }
 }
 

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -420,13 +420,23 @@ export function maybeEncryptCredentialsAtRest({ log } = {}) {
  * single keychain entry (service `chroxy-cred-key`) is overwritten in place, so
  * no stale key is left dangling.
  *
- * Crash-safety: the new key is written to the keychain first, then the store is
- * re-encrypted with the standard atomic write. If that write throws (disk full,
- * permission, mode re-check), the keychain is rolled back to the prior key (or
- * deleted, if the store had been plaintext) so the existing on-disk envelope
- * stays decryptable. The only unrecoverable window is a hard process crash
- * between the keychain swap and the file rename — unavoidable without a second
- * key slot, and vanishingly small.
+ * Crash-safety: the keychain rotation and the re-encrypting atomic write share a
+ * single try/catch failure domain. If either throws (disk full, permission, OS
+ * keychain write failure, mode re-check), the keychain is rolled back to the
+ * prior key (or deleted, if the store had been plaintext) so the existing on-disk
+ * envelope stays decryptable.
+ *
+ * One narrow exception to "envelope stays decryptable": writeStoreAtomically does
+ * a post-rename 0600 mode re-check, and on failure it unlinks the just-renamed
+ * target before throwing. In that single case the rollback restores the old key
+ * but there is no longer a file to decrypt — the new envelope was already removed.
+ * This is a defensive last resort (the file landed with unexpected perms, which
+ * shouldn't happen given the temp file is created mode 0600); the secrets remain
+ * recoverable from the provider, and the operator can re-run rekey/migrate.
+ *
+ * The only other unrecoverable window is a hard process crash between the keychain
+ * swap and the file rename — unavoidable without a second key slot, and
+ * vanishingly small.
  *
  * No-op (with a reason) when: no keychain is available (nowhere to hold a key),
  * the file is missing, the store can't be safely read (bad mode / corrupt /
@@ -457,14 +467,26 @@ export function rekeyCredentialStore({ log } = {}) {
 
   // Capture the prior key for rollback (null when the store was plaintext).
   const previousKey = getMasterKey(keychain)
-  rotateMasterKey(keychain) // keychain now holds the new key
+  // Treat the keychain rotation AND the re-encrypting file write as one failure
+  // domain: if EITHER throws we roll the keychain back to previousKey so the
+  // still-on-disk envelope stays decryptable. rotateMasterKey lives inside the
+  // try because its keychain write can throw (e.g. execFileSync to the OS
+  // keychain fails) and a partially-applied rotation would otherwise strand the
+  // existing envelope behind an uncaught error.
   try {
+    rotateMasterKey(keychain) // keychain now holds the new key
     writeStoreAtomically(file, data) // getOrCreateMasterKey → encrypts under the new key
     if (log) log.info('Rotated the credential data key and re-encrypted credentials.json')
     return { rekeyed: true, reason: 'rekeyed' }
   } catch (err) {
     // Roll the keychain back so the still-on-disk envelope stays decryptable.
-    setMasterKey(previousKey, keychain)
+    // Best-effort: if rollback itself throws, surface the original error reason
+    // rather than masking it with a secondary keychain failure.
+    try {
+      setMasterKey(previousKey, keychain)
+    } catch (rollbackErr) {
+      if (log) log.warn(`Credential rekey rollback failed: ${rollbackErr.message}`)
+    }
     if (log) log.warn(`Credential rekey failed: ${err.message}`)
     return { rekeyed: false, reason: 'write-error' }
   }

--- a/packages/server/tests/credential-rekey.test.js
+++ b/packages/server/tests/credential-rekey.test.js
@@ -1,0 +1,223 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, chmodSync, mkdirSync, rmSync, statSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getStoredCredential,
+  setStoredCredential,
+  rekeyCredentialStore,
+  _setCredentialKeychainForTests,
+} from '../src/credential-store.js'
+import {
+  CRED_KEY_SERVICE,
+  isEncryptedEnvelope,
+  decryptEnvelope,
+  getMasterKey,
+  rotateMasterKey,
+  setMasterKey,
+} from '../src/credential-cipher.js'
+import { runCredentialsRekey } from '../src/cli/credentials-cmd.js'
+
+/**
+ * Credential data-key rotation / rekey (#5229). An in-memory keychain fake
+ * drives the encrypted path; HOME points at a tmpdir so the real ~/.chroxy is
+ * never touched (the _setup.mjs sandbox would otherwise throw). The fake
+ * includes deleteToken so the rollback-to-plaintext path is exercised.
+ */
+
+const CRED_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'GEMINI_API_KEY', 'OPENAI_API_KEY']
+
+function inMemoryKeychain() {
+  const store = new Map()
+  return {
+    isKeychainAvailable: () => true,
+    getToken: (service) => store.get(service) ?? null,
+    setToken: (token, service) => { store.set(service, token) },
+    deleteToken: (service) => { store.delete(service) },
+    _store: store,
+  }
+}
+const noKeychain = { isKeychainAvailable: () => false }
+
+describe('credential data-key rekey (#5229)', () => {
+  let tmpHome
+  let originalHome
+  let keychain
+  const savedEnv = {}
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-rekey-test-'))
+    originalHome = process.env.HOME
+    process.env.HOME = tmpHome
+    for (const k of CRED_ENV_VARS) {
+      savedEnv[k] = process.env[k]
+      delete process.env[k]
+    }
+    keychain = inMemoryKeychain()
+    _setCredentialKeychainForTests(keychain)
+  })
+
+  afterEach(() => {
+    _setCredentialKeychainForTests(null)
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    for (const k of CRED_ENV_VARS) {
+      if (savedEnv[k] === undefined) delete process.env[k]
+      else process.env[k] = savedEnv[k]
+    }
+    // Restore mode in case a rollback test left the dir read-only.
+    try { chmodSync(join(tmpHome, '.chroxy'), 0o700) } catch { /* */ }
+    try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }
+  })
+
+  const credDir = () => join(tmpHome, '.chroxy')
+  const credPath = () => join(credDir(), 'credentials.json')
+  const onDisk = () => JSON.parse(readFileSync(credPath(), 'utf8'))
+
+  // ---- cipher key-rotation primitives ----
+
+  it('rotateMasterKey mints a fresh 32-byte key, persists it, and replaces any prior entry', () => {
+    const first = rotateMasterKey(keychain)
+    assert.ok(first instanceof Uint8Array)
+    assert.equal(first.length, 32)
+    const firstStored = keychain.getToken(CRED_KEY_SERVICE)
+    assert.equal(Buffer.from(firstStored, 'base64').length, 32)
+
+    const second = rotateMasterKey(keychain)
+    assert.notDeepEqual([...second], [...first]) // a genuinely new key
+    assert.notEqual(keychain.getToken(CRED_KEY_SERVICE), firstStored) // entry replaced in place
+  })
+
+  it('rotateMasterKey returns null when no keychain is available', () => {
+    assert.equal(rotateMasterKey(noKeychain), null)
+  })
+
+  it('setMasterKey sets a given key and deletes the entry on null', () => {
+    const key = rotateMasterKey(keychain)
+    setMasterKey(null, keychain)
+    assert.equal(keychain.getToken(CRED_KEY_SERVICE), null)
+    setMasterKey(key, keychain)
+    assert.equal(Buffer.from(keychain.getToken(CRED_KEY_SERVICE), 'base64').length, 32)
+    assert.throws(() => setMasterKey(new Uint8Array(8), keychain), /32-byte/)
+  })
+
+  // ---- rekeyCredentialStore ----
+
+  it('rotates the data key, re-encrypts the store, and preserves the credentials', () => {
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-secret-value')
+    setStoredCredential('OPENAI_API_KEY', 'sk-openai-abc')
+    assert.ok(isEncryptedEnvelope(onDisk()))
+    const oldKey = getMasterKey(keychain)
+    const oldStored = keychain.getToken(CRED_KEY_SERVICE)
+
+    const res = rekeyCredentialStore()
+    assert.deepEqual(res, { rekeyed: true, reason: 'rekeyed' })
+
+    // Keychain entry was replaced with a different key.
+    assert.notEqual(keychain.getToken(CRED_KEY_SERVICE), oldStored)
+    // File is still an encrypted envelope, and the credentials round-trip.
+    assert.ok(isEncryptedEnvelope(onDisk()))
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-secret-value')
+    assert.equal(getStoredCredential('OPENAI_API_KEY'), 'sk-openai-abc')
+    // The OLD key can no longer decrypt the rotated file.
+    assert.throws(() => decryptEnvelope(onDisk(), oldKey), /decryption failed/)
+    // Mode stayed 0600.
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(credPath()).mode & 0o777, 0o600)
+    }
+  })
+
+  it('encrypts a legacy plaintext store under a fresh key (previous key was absent)', () => {
+    mkdirSync(credDir(), { recursive: true, mode: 0o700 })
+    writeFileSync(credPath(), JSON.stringify({ ANTHROPIC_API_KEY: 'sk-ant-plain' }), { mode: 0o600 })
+    assert.ok(!isEncryptedEnvelope(onDisk()))
+    assert.equal(getMasterKey(keychain), null) // no data key yet
+
+    const res = rekeyCredentialStore()
+    assert.deepEqual(res, { rekeyed: true, reason: 'rekeyed' })
+    assert.ok(isEncryptedEnvelope(onDisk()))
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-plain')
+  })
+
+  it('is a no-op with reason no-keychain when no keychain is available', () => {
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-secret-value') // encrypted under the in-memory keychain
+    _setCredentialKeychainForTests(noKeychain)
+    const before = readFileSync(credPath(), 'utf8')
+    assert.deepEqual(rekeyCredentialStore(), { rekeyed: false, reason: 'no-keychain' })
+    assert.equal(readFileSync(credPath(), 'utf8'), before) // untouched
+  })
+
+  it('is a no-op with reason no-file when there is no credentials.json', () => {
+    assert.deepEqual(rekeyCredentialStore(), { rekeyed: false, reason: 'no-file' })
+  })
+
+  it('is a no-op with reason empty for an empty store', () => {
+    mkdirSync(credDir(), { recursive: true, mode: 0o700 })
+    writeFileSync(credPath(), JSON.stringify({}), { mode: 0o600 })
+    assert.deepEqual(rekeyCredentialStore(), { rekeyed: false, reason: 'empty' })
+  })
+
+  it('aborts with reason read-error (and leaves the key untouched) on a bad-mode file', (t) => {
+    if (process.platform === 'win32') return t.skip('mode bits not enforced on win32')
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-secret-value')
+    const keyBefore = keychain.getToken(CRED_KEY_SERVICE)
+    chmodSync(credPath(), 0o644) // refused by readStore's 0600 boundary
+    assert.deepEqual(rekeyCredentialStore(), { rekeyed: false, reason: 'read-error' })
+    assert.equal(keychain.getToken(CRED_KEY_SERVICE), keyBefore) // key never rotated
+  })
+
+  it('rolls the keychain key back on a write failure so the existing store stays readable', (t) => {
+    if (process.platform === 'win32') return t.skip('dir-permission write failure not reproducible on win32')
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-secret-value')
+    const keyBefore = keychain.getToken(CRED_KEY_SERVICE)
+    // Make the atomic temp-write fail: a read-only parent dir can't hold the tmp file.
+    chmodSync(credDir(), 0o500)
+    const res = rekeyCredentialStore()
+    chmodSync(credDir(), 0o700) // restore so the assertions below can read
+
+    assert.deepEqual(res, { rekeyed: false, reason: 'write-error' })
+    // Key rolled back to the original, so the unchanged on-disk envelope decrypts.
+    assert.equal(keychain.getToken(CRED_KEY_SERVICE), keyBefore)
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-secret-value')
+  })
+
+  // ---- `chroxy credentials rekey` CLI runner (deps-injected, no real keychain) ----
+
+  describe('runCredentialsRekey CLI', () => {
+    const noopLog = { info() {}, warn() {} }
+
+    it('prints a human success line and leaves exit code unset on rekeyed', async () => {
+      const lines = []
+      const prevExit = process.exitCode
+      const res = await runCredentialsRekey({}, {
+        write: (s) => lines.push(s),
+        log: noopLog,
+        rekey: () => ({ rekeyed: true, reason: 'rekeyed' }),
+      })
+      assert.deepEqual(res, { rekeyed: true, reason: 'rekeyed' })
+      assert.match(lines.join('\n'), /^✓ Rotated the credential data key/)
+      assert.equal(process.exitCode, prevExit) // success doesn't set a failure code
+    })
+
+    it('emits JSON when --json is passed', async () => {
+      const lines = []
+      await runCredentialsRekey({ json: true }, {
+        write: (s) => lines.push(s),
+        log: noopLog,
+        rekey: () => ({ rekeyed: false, reason: 'no-file' }),
+      })
+      assert.deepEqual(JSON.parse(lines.join('\n')), { rekeyed: false, reason: 'no-file' })
+    })
+
+    it('maps a benign no-op (no-keychain) to a bullet line', async () => {
+      const lines = []
+      await runCredentialsRekey({}, {
+        write: (s) => lines.push(s),
+        log: noopLog,
+        rekey: () => ({ rekeyed: false, reason: 'no-keychain' }),
+      })
+      assert.match(lines.join('\n'), /^• No OS keychain available/)
+    })
+  })
+})


### PR DESCRIPTION
Closes #5229.

## Summary

The at-rest credential scheme (#5154) stored one long-lived random data key in the OS keychain (`chroxy-cred-key`) and **never rotated it** — no path to recover from a suspected keychain compromise without re-entering every credential. This adds rotation.

- **`credential-cipher.js`** — `rotateMasterKey()` mints a fresh 32-byte key and replaces the single keychain entry in place; `setMasterKey(key|null)` is the rollback seam (set a given key, or delete the entry).
- **`credential-store.js`** — `rekeyCredentialStore()`:
  1. Decrypts the current store **up front** — a read error (bad mode / corrupt / undecryptable) aborts *before* the keychain is touched, so a readable store is never stranded behind a rotated key.
  2. Rotates the key, then re-encrypts via the existing `writeStoreAtomically` (**temp → chmod 0600 → rename**).
  3. On a write failure, **rolls the keychain back** to the prior key (or deletes it, if the store had been plaintext) so the unchanged on-disk envelope stays decryptable.
  4. No-ops with a reason on `no-keychain` / `no-file` / `empty`.
- **CLI** — `chroxy credentials rekey [--json]`, mirroring `chroxy worktree gc`. Exits non-zero only on `read-error` / `write-error`.

## Crash-safety note (for review)

Rekey spans two stores (file + keychain), so it can't be fully atomic. The key is swapped first, then the file is re-encrypted atomically; **all caught write failures roll the keychain back** (tested). The only unrecoverable window is a hard process crash between the keychain swap and the file rename — unavoidable without a second key slot, and vanishingly small. The single keychain entry is overwritten, so no stale key is left dangling.

## Test plan (13 tests, all green)

- Key-rotation primitives (`rotateMasterKey` mints/replaces/null-on-no-keychain; `setMasterKey` set/delete/length-guard).
- Full rekey round-trip: keychain entry changes, file stays an envelope, creds preserved, **old key can no longer decrypt**, mode 0600.
- Legacy plaintext store → encrypted under a fresh key.
- Every no-op reason (`no-keychain`, `no-file`, `empty`).
- `read-error` on a bad-mode file leaves the key **untouched**.
- **Write-failure rollback**: read-only dir → `write-error`, key rolled back, existing store still readable.
- CLI runner output + `--json` + benign-noop formatting via the deps seam.

Also passes both CI lints (test stateFilePath, opt-forwarding) + eslint.

## Acceptance criteria

- [x] A documented way to rotate the credential data key (`chroxy credentials rekey`)
- [x] Rekey re-encrypts the store under the new key atomically (temp → chmod 0600 → rename)
- [x] Old keychain entry is replaced, not left dangling (single entry, overwritten)

## Note

Chose a CLI command (local admin op) over a WS handler — rotation shouldn't be reachable over the tunnel/token surface. Verified registration via `--help`; the actual rotation was **not** run here (it would rotate the real keychain key).