### PR TITLE
fix(server): worktree gc must not delete worktrees holding gitignored content (#5244)

### DIFF
--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -9,7 +9,10 @@
 //
 // Safety contract (do NOT relax — these are the guardrails from #5158):
 //   - Never `git worktree remove --force`. A worktree with uncommitted /
-//     untracked changes is preserved (skipped), never deleted.
+//     untracked / gitignored content is preserved (skipped), never deleted —
+//     `git worktree remove` (no --force) still deletes the whole directory
+//     INCLUDING gitignored files (node_modules, build/, a local .env), so the
+//     clean check counts ignored entries as not-clean (#5244).
 //   - Only auto-unlock locks held by a VERIFIED-DEAD pid. A live pid, or a
 //     lock whose reason has no parseable pid, is skipped (could be the user's
 //     own deliberate lock).
@@ -176,7 +179,7 @@ export function planRepoGc(repoPath, deps = {}) {
         return
       }
       if (!clean) {
-        items.push({ path: e.path, action: 'skip', skipReason: 'has uncommitted/untracked changes (preserved)', pid, lockReason: reason })
+        items.push({ path: e.path, action: 'skip', skipReason: 'has uncommitted/untracked/gitignored content (preserved)', pid, lockReason: reason })
         return
       }
       items.push({ path: e.path, action: 'remove', pid, lockReason: reason, reason: 'clean worktree locked by dead pid', locked: true })
@@ -194,10 +197,18 @@ export function planRepoGc(repoPath, deps = {}) {
   return { repo: repoPath, items }
 }
 
-/** `git -C <worktree> status --porcelain` → clean? null when it can't be run. */
+/**
+ * `git -C <worktree> status --porcelain --ignored` → clean? null when it can't
+ * be run. The `--ignored` flag is load-bearing (#5244): `git worktree remove`
+ * (run here WITHOUT --force) deletes the entire worktree directory including
+ * gitignored content — node_modules, build artifacts, a local `.env` — so a
+ * worktree that reads clean by tracked status alone can still hold precious
+ * un-versioned files. Treating any ignored entry (`!! ...`) as not-clean keeps
+ * such worktrees in the skip set instead of silently deleting their contents.
+ */
 function isClean(git, worktreePath) {
   try {
-    return git(worktreePath, ['status', '--porcelain']).trim().length === 0
+    return git(worktreePath, ['status', '--porcelain', '--ignored']).trim().length === 0
   } catch {
     return null
   }

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -11,7 +11,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, existsSync, writeFileSync, mkdirSync } from 'fs'
-import { join } from 'path'
+import { basename, join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { GIT } from '../src/git.js'
@@ -211,7 +211,8 @@ describe('worktree-gc integration (real git repo)', () => {
   it('#5244: never removes a worktree whose only content is gitignored (plans skip)', () => {
     addWorktree('ignored-dead', { lockReason: `claude agent a5 (pid ${DEAD_PID})`, ignored: true })
     const plan = planRepoGc(repo, { kill: fakeKill })
-    const item = plan.items.find((i) => i.path.endsWith('/ignored-dead'))
+    const item = plan.items.find((i) => basename(i.path) === 'ignored-dead')
+    assert.ok(item, 'expected a plan item for the ignored-dead worktree')
     // Tracked status is clean, but the gitignored node_modules/.env must keep it skipped.
     assert.equal(item.action, 'skip')
     assert.match(item.skipReason, /gitignored|ignored|untracked/)

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -110,10 +110,22 @@ describe('worktree-gc unit: parseWorktreeList', () => {
 describe('worktree-gc integration (real git repo)', () => {
   let repo
 
-  function addWorktree(name, { lockReason, dirty } = {}) {
+  function addWorktree(name, { lockReason, dirty, ignored } = {}) {
     const wtPath = join(repo, '.claude', 'worktrees', name)
     git(repo, ['worktree', 'add', '--detach', wtPath, 'HEAD'])
     if (dirty) writeFileSync(join(wtPath, 'scratch.txt'), 'uncommitted work')
+    if (ignored) {
+      // A worktree whose ONLY non-tracked content is gitignored: clean to
+      // `git status --porcelain`, but `git worktree remove` (no --force) would
+      // still delete the whole dir incl. these files (#5244). Commit the
+      // .gitignore so the only non-clean signal is the ignored entries.
+      writeFileSync(join(wtPath, '.gitignore'), 'node_modules/\n.env.local\n')
+      git(wtPath, ['add', '.gitignore'])
+      git(wtPath, ['commit', '-m', 'add gitignore'])
+      mkdirSync(join(wtPath, 'node_modules'), { recursive: true })
+      writeFileSync(join(wtPath, 'node_modules', '.env.local'), 'PRECIOUS local-only secret')
+      writeFileSync(join(wtPath, '.env.local'), 'TOKEN=secret')
+    }
     if (lockReason) git(repo, ['worktree', 'lock', '--reason', lockReason, wtPath])
     return wtPath
   }
@@ -194,6 +206,27 @@ describe('worktree-gc integration (real git repo)', () => {
     applyPlan(repo, { items: reclaimable })
     assert.equal(existsSync(dirtyDead), true)
     assert.equal(existsSync(join(dirtyDead, 'scratch.txt')), true)
+  })
+
+  it('#5244: never removes a worktree whose only content is gitignored (plans skip)', () => {
+    addWorktree('ignored-dead', { lockReason: `claude agent a5 (pid ${DEAD_PID})`, ignored: true })
+    const plan = planRepoGc(repo, { kill: fakeKill })
+    const item = plan.items.find((i) => i.path.endsWith('/ignored-dead'))
+    // Tracked status is clean, but the gitignored node_modules/.env must keep it skipped.
+    assert.equal(item.action, 'skip')
+    assert.match(item.skipReason, /gitignored|ignored|untracked/)
+  })
+
+  it('#5244: apply preserves an ignored-only worktree and its gitignored files', () => {
+    const ignoredDead = addWorktree('ignored-dead', { lockReason: `claude agent a5 (pid ${DEAD_PID})`, ignored: true })
+    const plan = planRepoGc(repo, { kill: fakeKill })
+    // Apply the FULL plan (mirrors the reaper): a regression would mark this
+    // 'remove' and applyPlan would delete the dir + the precious secret.
+    const reclaimable = plan.items.filter((i) => i.action !== 'skip')
+    applyPlan(repo, { items: reclaimable })
+    assert.equal(existsSync(ignoredDead), true)
+    assert.equal(existsSync(join(ignoredDead, 'node_modules', '.env.local')), true)
+    assert.equal(existsSync(join(ignoredDead, '.env.local')), true)
   })
 
   it('readLockReasonFromAdmin recovers the reason when porcelain omits it', () => {


### PR DESCRIPTION
Closes #5244.

## The bug (HIGH — silent data loss, auto-triggered)

`worktree-gc.js`'s `isClean()` ran `git status --porcelain` with **no `--ignored`**, so a worktree whose only non-tracked content was **gitignored** (`node_modules/`, `build/`, a local `.env.local`) read as *clean*. `planRepoGc` then marked it `action: 'remove'`, and `applyPlan` runs `git worktree remove` **without `--force`** — which still deletes the entire worktree directory, **including those gitignored files**. With `config.worktreeGc.autoReap` on (#5224), the startup reaper did this **automatically and silently**. Per the project's own *"Worktree node_modules hazard"* memory, agent worktrees routinely carry a populated `node_modules` and a local `.env`.

## Fix

`isClean()` now runs `git status --porcelain --ignored` and treats any ignored entry as **not clean**, so such worktrees are **skipped** instead of removed. Updated the module safety-contract comment and the skip reason to match.

```diff
-    return git(worktreePath, ['status', '--porcelain']).trim().length === 0
+    return git(worktreePath, ['status', '--porcelain', '--ignored']).trim().length === 0
```

## Tests (real temp git repos)

- A dead-pid-locked worktree whose only content is a gitignored `node_modules/.env.local` + `.env.local` is now planned **`skip`** (not `remove`).
- `applyPlan` over the full plan **preserves** the worktree directory and its gitignored files.
- **Mutation-verified**: reverting `--ignored` fails *both* new tests (the worktree and its "PRECIOUS local-only secret" get deleted). Full `worktree-gc.test.js`: **24/24** green; both CI lints pass.

No side-effecting commands were run against real state — everything is exercised against throwaway repos under `tmpdir()`.