### PR TITLE
fix(store-core): build the activity tree iteratively to avoid a deep-chain stack overflow (#5248)

### DIFF
--- a/packages/store-core/src/activity-reducer.test.ts
+++ b/packages/store-core/src/activity-reducer.test.ts
@@ -338,6 +338,32 @@ describe('selectActivityTree — hierarchy build', () => {
     const tree = selectActivityTree(s, 's1')
     expect(tree.map((n) => n.entry.id)).toEqual(['kid'])
   })
+
+  it('#5247: does not overflow the stack on a deep parentId chain', () => {
+    // A fully wire-controlled deep chain n0 ← n1 ← … would overflow a recursive
+    // descent (RangeError, ~5k deep) inside the Control Room render. The iterative
+    // build must handle it without throwing and still produce the full-depth tree.
+    const N = 20000
+    const entries = Array.from({ length: N }, (_, i) =>
+      entry({ id: `n${i}`, parentId: i === 0 ? undefined : `n${i - 1}` }),
+    )
+    const s = applyActivitySnapshot(createEmptyActivityState(), snapshot('s1', entries))
+
+    let tree: readonly ActivityTreeNode[] = []
+    expect(() => { tree = selectActivityTree(s, 's1') }).not.toThrow()
+
+    // One root, descending the full depth, each entry exactly once and in order.
+    expect(tree).toHaveLength(1)
+    let node: ActivityTreeNode | undefined = tree[0]
+    let depth = 0
+    while (node) {
+      expect(node.entry.id).toBe(`n${depth}`)
+      expect(node.children.length).toBeLessThanOrEqual(1)
+      depth += 1
+      node = node.children[0]
+    }
+    expect(depth).toBe(N)
+  })
 })
 
 describe('selectSessionEntries', () => {

--- a/packages/store-core/src/activity-reducer.test.ts
+++ b/packages/store-core/src/activity-reducer.test.ts
@@ -339,7 +339,7 @@ describe('selectActivityTree — hierarchy build', () => {
     expect(tree.map((n) => n.entry.id)).toEqual(['kid'])
   })
 
-  it('#5247: does not overflow the stack on a deep parentId chain', () => {
+  it('#5248: does not overflow the stack on a deep parentId chain', () => {
     // A fully wire-controlled deep chain n0 ← n1 ← … would overflow a recursive
     // descent (RangeError, ~5k deep) inside the Control Room render. The iterative
     // build must handle it without throwing and still produce the full-depth tree.

--- a/packages/store-core/src/activity-reducer.ts
+++ b/packages/store-core/src/activity-reducer.ts
@@ -303,10 +303,11 @@ export function selectActivityTree(state: ActivityState, sessionId: string): rea
   // Iterative (explicit-stack) DFS rather than recursion: a pathological deep
   // parentId chain (n0 ← n1 ← n2 ← …) is fully wire-controlled and would overflow
   // the JS call stack with a recursive descent, throwing RangeError inside the
-  // Control Room render that calls this directly (#5247). The heap-backed stack
-  // removes that ceiling. Output is identical to the former recursion: pre-order,
-  // children in bucket (first-seen) order, every entry visited exactly once;
-  // `visited` still breaks cycles (a child already on the walk is skipped).
+  // Control Room render that calls this directly (#5248). The heap-backed stack
+  // removes that ceiling. Output is identical to the former recursion: nodes are
+  // emitted in pre-order visitation order, children in bucket (first-seen) order,
+  // every entry visited exactly once; `visited` still breaks cycles (a child
+  // already on the walk is skipped).
   const visited = new Set<string>()
   // Post-order build: each frame collects its children into a mutable array and
   // only constructs the (readonly-`children`) node when its subtree is fully

--- a/packages/store-core/src/activity-reducer.ts
+++ b/packages/store-core/src/activity-reducer.ts
@@ -300,16 +300,40 @@ export function selectActivityTree(state: ActivityState, sessionId: string): rea
   // cycle (every member has a known parent, so none is a root) would otherwise
   // be unreachable — after the root walk we promote each still-unvisited entry
   // to its own root so EVERY entry appears exactly once.
+  // Iterative (explicit-stack) DFS rather than recursion: a pathological deep
+  // parentId chain (n0 ← n1 ← n2 ← …) is fully wire-controlled and would overflow
+  // the JS call stack with a recursive descent, throwing RangeError inside the
+  // Control Room render that calls this directly (#5247). The heap-backed stack
+  // removes that ceiling. Output is identical to the former recursion: pre-order,
+  // children in bucket (first-seen) order, every entry visited exactly once;
+  // `visited` still breaks cycles (a child already on the walk is skipped).
   const visited = new Set<string>()
-  function build(entry: ActivityEntry): ActivityTreeNode {
-    visited.add(entry.id)
-    const kids = childrenByParent.get(entry.id) ?? []
-    const children: ActivityTreeNode[] = []
-    for (const kid of kids) {
+  // Post-order build: each frame collects its children into a mutable array and
+  // only constructs the (readonly-`children`) node when its subtree is fully
+  // drained, appending it to its parent's collector. Children end up in kids
+  // (first-seen) order, every entry visited once, cycles broken by `visited`.
+  type Frame = { entry: ActivityEntry; kids: readonly ActivityEntry[]; i: number; children: ActivityTreeNode[] }
+  function build(rootEntry: ActivityEntry): ActivityTreeNode {
+    visited.add(rootEntry.id)
+    const stack: Frame[] = [
+      { entry: rootEntry, kids: childrenByParent.get(rootEntry.id) ?? [], i: 0, children: [] },
+    ]
+    for (;;) {
+      const frame = stack[stack.length - 1]!
+      if (frame.i >= frame.kids.length) {
+        stack.pop()
+        const node: ActivityTreeNode = { entry: frame.entry, children: frame.children }
+        const parent = stack[stack.length - 1]
+        if (parent === undefined) return node // root frame finished
+        parent.children.push(node)
+        continue
+      }
+      const kid = frame.kids[frame.i]!
+      frame.i += 1
       if (visited.has(kid.id)) continue
-      children.push(build(kid))
+      visited.add(kid.id)
+      stack.push({ entry: kid, kids: childrenByParent.get(kid.id) ?? [], i: 0, children: [] })
     }
-    return { entry, children }
   }
 
   const result = roots.map((entry) => build(entry))


### PR DESCRIPTION
Closes #5248.

## The bug (Control Room render DoS)

`selectActivityTree` built the render tree with a recursive `build()` — **one stack frame per parent→child level**. A fully wire-controlled deep `parentId` chain (`n0 ← n1 ← n2 ← …`) recurses as deep as the chain and throws `RangeError: Maximum call stack size exceeded` (~5k deep) **inside the Control Room render that calls `selectActivityTree(...)` directly** (`ActivityTree.tsx`), with no error boundary — crashing every connected dashboard/app client. The schema places no bound on `parentId` chain length (`ActivityEntrySchema.parentId = z.string().min(1).optional()`, `entries` array has no `.max()`), and `pruneTerminal` never evicts `running`/`blocked` entries, so a chain survives unpruned. Trigger: a compromised/buggy server, or a runaway subagent emitting a pathological chain.

## Fix

Convert `build()` to an **explicit-stack, post-order iterative traversal**. The output is **identical** to the former recursion — pre-order nodes, children in first-seen (`order`) sequence, every entry visited exactly once, cycles still broken by the `visited` set — but the heap-backed stack removes the call-depth ceiling. No schema/behavior change; purely the traversal.

## Tests

- New: a **20,000-deep** `parentId` chain no longer throws and yields the full-depth tree (one root, each node the single child of the prior, all `N` present in order).
- **Verified** the pre-fix recursive build `RangeError`s at that depth (standalone repro), so the test exercises a real overflow the fix prevents.
- Existing `selectActivityTree` tests (ordering, cycles, re-rooting, self-parent) still pass — output is unchanged.
- Full `store-core` suite **1175/1175**; `tsc --noEmit` clean.