### PR TITLE
fix(server): robust Control Room survey probes — gh --limit + exec maxBuffer (#5240, #5241)

### DIFF
--- a/packages/server/src/control-room/survey.js
+++ b/packages/server/src/control-room/survey.js
@@ -35,6 +35,21 @@ import { resolveRepoSet } from './repo-set.js'
 
 const execFileAsync = promisify(execFile)
 
+/**
+ * stdout cap for every git/gh probe (#5241). Node's execFile default is 1 MB,
+ * and overflow REJECTS — which `tryExec` turns into `null`, mislabelling a real
+ * repo with a large dirty/untracked tree (>1 MB of `git status --porcelain`) as
+ * "not a git repo". 16 MB is far beyond any realistic porcelain output.
+ */
+const EXEC_MAX_BUFFER = 16 * 1024 * 1024
+
+/**
+ * Cap for `gh pr list` (#5240). `gh pr list` defaults to 30, silently capping
+ * the open-PR count AND the CI/review rollup. 200 covers even bot-heavy repos;
+ * a repo past it is undercounted, but far less often than at the 30 default.
+ */
+const GH_PR_LIST_LIMIT = 200
+
 /** Default concurrency cap for per-repo surveys. */
 export const DEFAULT_CONCURRENCY = 5
 
@@ -65,7 +80,7 @@ export const DEFAULT_THRESHOLDS = {
  */
 async function tryExec(execFn, file, args, cwd) {
   try {
-    const { stdout } = await execFn(file, args, { cwd })
+    const { stdout } = await execFn(file, args, { cwd, maxBuffer: EXEC_MAX_BUFFER })
     return typeof stdout === 'string' ? stdout.trim() : ''
   } catch {
     return null
@@ -424,7 +439,8 @@ async function surveyOne(repo, ctx) {
       // origin remote → GitHub PRs URL (null for a non-GitHub / missing remote).
       tryExec(execFn, 'git', ['remote', 'get-url', 'origin'], cwd),
       // One gh call serves both the open-PR count and the CI/review rollup.
-      tryExec(execFn, 'gh', ['pr', 'list', '--json', 'number,reviewDecision,statusCheckRollup'], cwd),
+      // `--limit` is explicit: gh defaults to 30, which would silently cap both.
+      tryExec(execFn, 'gh', ['pr', 'list', '--limit', String(GH_PR_LIST_LIMIT), '--json', 'number,reviewDecision,statusCheckRollup'], cwd),
       readSettings(readFn, repo.path),
     ])
 

--- a/packages/server/tests/control-room-survey.test.js
+++ b/packages/server/tests/control-room-survey.test.js
@@ -562,3 +562,42 @@ describe('surveyRepos — concurrency cap', () => {
     assert.ok(maxInFlight <= 3 * 7, `maxInFlight=${maxInFlight}`)
   })
 })
+
+describe('survey probes — exec robustness (#5240/#5241)', () => {
+  // Wrap makeExec to capture every (file, args, opts) call while still returning
+  // clean-repo output.
+  function capturingExec(repoMap) {
+    const calls = []
+    const base = makeExec(repoMap)
+    const fn = async (file, args, opts) => {
+      calls.push({ file, args, opts })
+      return base(file, args, opts)
+    }
+    return { fn, calls }
+  }
+
+  it('#5240: gh pr list is invoked with an explicit --limit (not the silent 30 default)', async () => {
+    const repo = '/r'
+    const { fn, calls } = capturingExec({ [repo]: cleanRepo() })
+    await surveyRepos([repo], { _execFile: fn, _now: now, _readFile: async () => { throw new Error() } })
+    const ghCall = calls.find((c) => c.file === 'gh' && c.args[0] === 'pr' && c.args[1] === 'list')
+    assert.ok(ghCall, 'gh pr list was invoked')
+    const li = ghCall.args.indexOf('--limit')
+    assert.ok(li !== -1, `gh pr list missing --limit; args: ${JSON.stringify(ghCall.args)}`)
+    assert.ok(Number(ghCall.args[li + 1]) >= 100, `--limit should be a high cap, got ${ghCall.args[li + 1]}`)
+  })
+
+  it('#5241: every git/gh probe passes a maxBuffer well above Node\'s 1MB default', async () => {
+    const repo = '/r'
+    const { fn, calls } = capturingExec({ [repo]: cleanRepo() })
+    await surveyRepos([repo], { _execFile: fn, _now: now, _readFile: async () => { throw new Error() } })
+    const probeCalls = calls.filter((c) => c.file === 'git' || c.file === 'gh')
+    assert.ok(probeCalls.length > 0, 'at least one probe ran')
+    for (const c of probeCalls) {
+      assert.ok(
+        c.opts && typeof c.opts.maxBuffer === 'number' && c.opts.maxBuffer > 1024 * 1024,
+        `probe \`${c.file} ${c.args[0]}\` must pass maxBuffer > 1MB (got ${c.opts && c.opts.maxBuffer})`,
+      )
+    }
+  })
+})


### PR DESCRIPTION
Closes #5240. Closes #5241.

Two small robustness fixes to the git/gh probes in `control-room/survey.js`.

## #5240 — `gh pr list` was capped at 30

The probe ran `gh pr list --json …` with **no `--limit`**. `gh pr list` defaults to **30**, so for any repo with >30 open PRs both the open-PR count (`parseOpenPRs`) and the CI/review rollup (`parsePrChecks`) were silently truncated. Now passes `--limit 200`.

## #5241 — large `git status` mislabelled a repo as "not a git repo"

`tryExec` ran `execFile` with no `maxBuffer`, so Node's **1 MB** default rejected a `git status --porcelain` over 1 MB. `tryExec` turns the rejection into `null`, and `surveyOne` treats a null status as *"not a git repo or git unavailable"* — emitting a degraded `investigate` row with a (wrong) clean tree for a legitimate large dirty repo. Now passes `maxBuffer: 16 MB`, far beyond any realistic porcelain output.

```diff
-    const { stdout } = await execFn(file, args, { cwd })
+    const { stdout } = await execFn(file, args, { cwd, maxBuffer: EXEC_MAX_BUFFER }) // 16MB
...
-      tryExec(execFn, 'gh', ['pr', 'list', '--json', '…'], cwd),
+      tryExec(execFn, 'gh', ['pr', 'list', '--limit', String(GH_PR_LIST_LIMIT), '--json', '…'], cwd),
```

## Tests

Via the survey `_execFile` injection seam (capturing every `(file, args, opts)` call):
- the `gh pr list` invocation includes `--limit` with a high cap;
- every git/gh probe passes a `maxBuffer` > 1 MB.

**Mutation-verified**: reverting either fix fails its test. Full `control-room-survey` + `control-room-handlers` suites green (**66 tests**); both CI lints + eslint pass.