### PR TITLE
fix(server): credential store must not unlink the live file before rename (#5243)

### DIFF
--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -222,6 +222,30 @@ function readStore() {
 }
 
 /**
+ * Atomically move `tmp` over `target`.
+ *
+ * #5243: relies on `renameSync`'s atomic replace — on win32 Node's
+ * `fs.renameSync` uses `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING |
+ * MOVEFILE_WRITE_THROUGH` since v16 (see platform.js), so it already replaces an
+ * existing target without a separate delete. The previous win32 path
+ * `unlinkSync(target)` immediately BEFORE the rename — a crash in that window
+ * left no `credentials.json` at all (the live file deleted, the replacement
+ * never moved in). We now never pre-delete the live file; this matches the
+ * sibling `writeFileRestricted` (platform.js), which goes straight from
+ * `writeFileSync(tmp)` to `renameSync`.
+ *
+ * fs ops are injectable for testing (defaults are the real fs calls).
+ *
+ * @param {string} tmp - source temp path.
+ * @param {string} target - destination path.
+ * @param {{ rename?: Function }} [deps]
+ */
+export function replaceFileAtomically(tmp, target, deps = {}) {
+  const { rename = renameSync } = deps
+  rename(tmp, target)
+}
+
+/**
  * Serialize + atomically write the store to `target`, encrypting the blob when
  * a keychain-backed data key is available (#5154) and otherwise writing 0600
  * plaintext. Preserves the temp-file → chmod 0600 → rename crash-safety and the
@@ -237,10 +261,8 @@ function writeStoreAtomically(target, nextObj) {
   try {
     writeFileSync(tmp, JSON.stringify(payload, null, 2), { mode: 0o600 })
     if (process.platform !== 'win32') chmodSync(tmp, 0o600)
-    if (process.platform === 'win32' && existsSync(target)) {
-      try { unlinkSync(target) } catch { /* */ }
-    }
-    renameSync(tmp, target)
+    // #5243: atomic replace — never unlink the live target first.
+    replaceFileAtomically(tmp, target)
     renamed = true
     if (process.platform !== 'win32') {
       const perms = statSync(target).mode & 0o777

--- a/packages/server/tests/credential-store-atomic-replace.test.js
+++ b/packages/server/tests/credential-store-atomic-replace.test.js
@@ -1,0 +1,102 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, renameSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  replaceFileAtomically,
+  setStoredCredential,
+  getStoredCredential,
+} from '../src/credential-store.js'
+
+/**
+ * #5243 — credential-store atomic replace.
+ *
+ * The win32 write path used to `unlinkSync(target)` immediately BEFORE the
+ * rename, so a crash in that window destroyed the live `credentials.json`
+ * before the replacement was moved in (data loss). `replaceFileAtomically`
+ * now relies on `renameSync`'s atomic replace and never pre-deletes the live
+ * file. These tests pin:
+ *   - a real overwrite replaces the target's content via a single rename
+ *   - a FAILED replace leaves the live target intact (no pre-delete) — the
+ *     core data-loss guarantee, platform-independent
+ *   - the end-to-end set path overwrites an existing credentials file safely
+ *
+ * HOME points at a tmpdir so the real ~/.chroxy/credentials.json is untouched.
+ */
+
+describe('credential-store — replaceFileAtomically (#5243)', () => {
+  let dir
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'chroxy-cred-atomic-')) })
+  afterEach(() => { try { rmSync(dir, { recursive: true, force: true }) } catch { /* */ } })
+
+  it('replaces an existing target with the temp file content via one rename', () => {
+    const target = join(dir, 'creds.json')
+    const tmp = join(dir, 'creds.json.tmp')
+    writeFileSync(target, 'OLD')
+    writeFileSync(tmp, 'NEW')
+
+    let renameCalls = 0
+    replaceFileAtomically(tmp, target, {
+      rename: (from, to) => { renameCalls++; assert.equal(from, tmp); assert.equal(to, target); renameSync(from, to) },
+    })
+    assert.equal(renameCalls, 1, 'exactly one rename')
+    assert.equal(readFileSync(target, 'utf8'), 'NEW')
+    assert.ok(!existsSync(tmp), 'temp file moved away')
+  })
+
+  it('uses the real fs by default (no injected deps)', () => {
+    const target = join(dir, 'd.json')
+    const tmp = join(dir, 'd.json.tmp')
+    writeFileSync(target, 'OLD')
+    writeFileSync(tmp, 'NEW')
+    replaceFileAtomically(tmp, target)
+    assert.equal(readFileSync(target, 'utf8'), 'NEW')
+  })
+
+  it('a failed replace leaves the live target intact — never pre-deletes it (#5243 core guarantee)', () => {
+    const target = join(dir, 'creds.json')
+    const tmp = join(dir, 'creds.json.tmp')
+    writeFileSync(target, 'LIVE-CREDENTIALS')
+    writeFileSync(tmp, 'REPLACEMENT')
+
+    // Simulate the rename failing (a lock, a crash-equivalent). The old code
+    // would have already unlinked `target` by this point; the new code must
+    // not have touched it.
+    assert.throws(() => {
+      replaceFileAtomically(tmp, target, {
+        rename: () => { throw new Error('EBUSY: target locked') },
+      })
+    }, /EBUSY/)
+
+    assert.ok(existsSync(target), 'live target must still exist after a failed replace')
+    assert.equal(readFileSync(target, 'utf8'), 'LIVE-CREDENTIALS', 'live content must be preserved')
+  })
+})
+
+describe('credential-store — set overwrites an existing file safely (#5243)', () => {
+  let tmpHome, originalHome
+  const CRED_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'GEMINI_API_KEY', 'OPENAI_API_KEY']
+  const saved = {}
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-set-'))
+    originalHome = process.env.HOME
+    process.env.HOME = tmpHome
+    for (const k of CRED_ENV_VARS) { saved[k] = process.env[k]; delete process.env[k] }
+  })
+  afterEach(() => {
+    process.env.HOME = originalHome
+    for (const k of CRED_ENV_VARS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k] }
+    try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }
+  })
+
+  it('overwriting a credential preserves a readable store at every step', () => {
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-first')
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-first')
+    // Overwrite — exercises writeStoreAtomically → replaceFileAtomically over an
+    // existing file. The store must end up with the new value and stay readable.
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-second')
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-second')
+  })
+})

--- a/packages/server/tests/credential-store-atomic-replace.test.js
+++ b/packages/server/tests/credential-store-atomic-replace.test.js
@@ -75,19 +75,24 @@ describe('credential-store — replaceFileAtomically (#5243)', () => {
 })
 
 describe('credential-store — set overwrites an existing file safely (#5243)', () => {
-  let tmpHome, originalHome
+  // os.homedir() reads HOME on POSIX but USERPROFILE on win32, so point both at
+  // the tmp dir (and restore both) to keep the suite off the real home on every
+  // platform. Save/restore must delete a var that was originally unset rather
+  // than assign `undefined` (which would set the literal string "undefined").
+  let tmpHome
+  const HOME_ENV_VARS = ['HOME', 'USERPROFILE']
   const CRED_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'GEMINI_API_KEY', 'OPENAI_API_KEY']
   const saved = {}
+  const restoreEnv = (k) => { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k] }
 
   beforeEach(() => {
     tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-set-'))
-    originalHome = process.env.HOME
-    process.env.HOME = tmpHome
+    for (const k of HOME_ENV_VARS) { saved[k] = process.env[k]; process.env[k] = tmpHome }
     for (const k of CRED_ENV_VARS) { saved[k] = process.env[k]; delete process.env[k] }
   })
   afterEach(() => {
-    process.env.HOME = originalHome
-    for (const k of CRED_ENV_VARS) { if (saved[k] === undefined) delete process.env[k]; else process.env[k] = saved[k] }
+    for (const k of HOME_ENV_VARS) restoreEnv(k)
+    for (const k of CRED_ENV_VARS) restoreEnv(k)
     try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }
   })
 


### PR DESCRIPTION
Closes #5243.

## The bug (Windows data loss)

`writeStoreAtomically`'s win32 branch did `if (existsSync(target)) unlinkSync(target)` **immediately before** `renameSync(tmp, target)`. That deletes the live `credentials.json` before the replacement is moved into place — a crash/power-loss in the window between the unlink and the rename leaves **no credentials file at all** (the prior good file gone, the new one never renamed in).

## Fix

Extract `replaceFileAtomically(tmp, target)` and rely on `renameSync`'s atomic replace — on win32 Node's `fs.renameSync` uses `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH` since v16 (documented in `platform.js`), so it already replaces an existing target without a separate delete. This matches the sibling `writeFileRestricted`, which deliberately goes straight from `writeFileSync(tmp)` to `renameSync` with no pre-delete. The live file is never removed first.

## Tests

`tests/credential-store-atomic-replace.test.js`:
- replaces an existing target's content via exactly one rename (real fs + injected-spy),
- **a failed replace leaves the live target intact** (mutation-catching — the old code would have already unlinked it; platform-independent),
- end-to-end: overwriting a credential under a temp HOME keeps the store readable with the new value.

Existing `credential-store` + `credential-store-encryption` suites stay green (35 tests). HOME is pointed at a tmpdir; no real `~/.chroxy` state is touched.