### PR TITLE
fix(server): verify worktree prune actually reclaimed each entry (#5246)

### DIFF
--- a/packages/server/src/worktree-gc.js
+++ b/packages/server/src/worktree-gc.js
@@ -248,12 +248,38 @@ export function applyPlan(repoPath, plan, deps = {}) {
     } catch (err) {
       pruneError = (err && err.message) || String(err)
     }
+
+    // #5246: verify per-entry that prune actually reclaimed the worktree. The
+    // plan classifies an unlocked worktree as 'prune' when `dirGone` is true,
+    // and `dirGone` includes `!exists(e.path)` — but `existsSync` returns false
+    // on ANY stat error (an unmounted/temporarily-unavailable mount, a TOCTOU
+    // race), not only genuine absence. `git worktree prune` correctly leaves a
+    // still-present worktree intact, so reporting ok:true off the back of the
+    // single global prune would over-count reclamations. Re-list the worktrees
+    // and only claim success for items whose admin ref is genuinely gone.
+    let remaining = null
+    if (!pruneError) {
+      try {
+        remaining = new Set(parseWorktreeList(git(repoPath, ['worktree', 'list', '--porcelain'])).map(e => e.path))
+      } catch {
+        // Can't verify — fall back to best-effort (the prune call succeeded).
+        remaining = null
+      }
+    }
+
     for (const item of pruneItems) {
       const unlockErr = unlockErrors.get(item.path)
       if (unlockErr) {
         results.push({ path: item.path, action: 'prune', ok: false, error: `unlock failed (entry still locked): ${unlockErr}` })
       } else if (pruneError) {
         results.push({ path: item.path, action: 'prune', ok: false, error: pruneError })
+      } else if (remaining && remaining.has(item.path)) {
+        results.push({
+          path: item.path,
+          action: 'prune',
+          ok: false,
+          error: 'still present after prune (not reclaimed) — a transient stat failure likely misclassified a present worktree as dir-gone',
+        })
       } else {
         results.push({ path: item.path, action: 'prune', ok: true })
       }

--- a/packages/server/tests/worktree-gc.test.js
+++ b/packages/server/tests/worktree-gc.test.js
@@ -231,6 +231,53 @@ describe('worktree-gc unit: applyPlan prune reporting (injected git)', () => {
     }, { git })
     assert.equal(results[0].ok, true)
   })
+
+  // #5246: a transient stat failure can misclassify a PRESENT worktree as
+  // dir-gone → 'prune'. `git worktree prune` leaves it intact, so applyPlan
+  // must NOT report ok:true for it. Verified by re-listing worktrees after the
+  // prune and checking the entry is genuinely gone.
+  it('reports a prune item as not-ok when the worktree is still present after prune (#5246)', () => {
+    const git = (cwd, args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        // The "reclaimed" path is STILL listed → prune reclaimed nothing.
+        return 'worktree /repo\nHEAD a\nbranch refs/heads/main\n\nworktree /repo/wt/present\nHEAD b\nbranch refs/heads/x\n'
+      }
+      return '' // prune succeeds
+    }
+    const results = applyPlan('/repo', {
+      items: [{ path: '/repo/wt/present', action: 'prune', locked: false }],
+    }, { git })
+    assert.equal(results[0].ok, false)
+    assert.match(results[0].error, /still present after prune/)
+  })
+
+  it('reports prune ok when the worktree is genuinely gone after prune (#5246)', () => {
+    const git = (cwd, args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        // Only the main worktree remains — the pruned entry is gone.
+        return 'worktree /repo\nHEAD a\nbranch refs/heads/main\n'
+      }
+      return ''
+    }
+    const results = applyPlan('/repo', {
+      items: [{ path: '/repo/wt/gone', action: 'prune', locked: false }],
+    }, { git })
+    assert.equal(results[0].ok, true)
+  })
+
+  it('falls back to ok (best-effort) when the post-prune re-list fails (#5246)', () => {
+    const git = (cwd, args) => {
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        const e = new Error('fatal: re-list failed'); e.code = 1; throw e
+      }
+      return '' // prune succeeds
+    }
+    const results = applyPlan('/repo', {
+      items: [{ path: '/repo/wt/gone', action: 'prune', locked: false }],
+    }, { git })
+    // Can't verify, but prune succeeded — don't manufacture a failure.
+    assert.equal(results[0].ok, true)
+  })
 })
 
 describe('worktree-gc unit: readLockReasonFromAdmin (injected fs)', () => {


### PR DESCRIPTION
Closes #5246.

## The bug (inflated reclaim count)

`applyPlan` reported **every** prune item `ok: true` whenever the single global `git worktree prune` call succeeded — with no per-entry check that the entry was actually reclaimed.

The plan classifies an unlocked worktree as `prune` when `dirGone = e.prunable || !exists(e.path)`. But `existsSync` returns `false` on **any** stat error (an unmounted/temporarily-unavailable mount, a TOCTOU race), not only genuine absence. Under a transient stat failure a *present* worktree is classified `prune`; `git worktree prune` correctly leaves it intact (reclaims nothing) — yet the old code still reported `ok: true`, so the reaper incremented `summary.reclaimed` and pushed the path into `summary.removed[]`, reporting a reclamation that never happened.

**No data loss** — nothing was wrongly deleted; impact is misleading reporting only.

## Fix

After the global prune, re-list worktrees (`git worktree list --porcelain`) and report a prune item `ok: true` only when its admin ref is genuinely gone from the list; otherwise mark it `ok: false` with a clear reason. If the re-list itself fails we fall back to best-effort (the prune call's success), so we never manufacture a spurious failure.

## Tests

`worktree-gc.test.js` (injected git seam):
- a still-present worktree after prune → `ok: false` ("still present after prune") — **mutation-catching** (the old unconditional `ok: true` fails this),
- a genuinely-gone worktree → `ok: true`,
- a failed post-prune re-list → falls back to `ok: true`.

Existing applyPlan/prune tests stay green (25 total).