### PR TITLE
fix(server): warn when an encrypted credential resolves null on keychain-unavailable (#5242)

### DIFF
--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -46,6 +46,7 @@ import { join, dirname } from 'path'
 import { homedir } from 'os'
 import { maskApiKey } from './byok-credentials.js'
 import * as realKeychain from './keychain.js'
+import { createLogger } from './logger.js'
 import {
   CRED_KEY_SERVICE,
   isEncryptedEnvelope,
@@ -58,6 +59,41 @@ import {
 // A keychain stub that reports "no keychain here" — selects the plaintext
 // fallback path.
 const NO_KEYCHAIN = { isKeychainAvailable: () => false }
+
+// #5242: logger for the recoverable encrypted-but-keychain-unavailable warning.
+// Injectable for tests. Credentials are NEVER passed to it — only the key NAME
+// and the fact of the failure (the logger.js redactor scrubs sk-ant/Bearer too).
+let _log = createLogger('credentials')
+export function _setCredentialLoggerForTests(logger) {
+  _log = logger || createLogger('credentials')
+}
+
+// #5242: keys we've already warned about, so the spawn path (which calls
+// resolveCredential on every child launch) warns once per key, not per spawn.
+const _keychainUnavailableWarned = new Set()
+export function _resetKeychainWarningsForTests() {
+  _keychainUnavailableWarned.clear()
+}
+
+/**
+ * #5242: emit a one-time warning that an ENCRYPTED credential exists on disk but
+ * its keychain data key is currently unavailable (locked keychain, transient
+ * `security`/`secret-tool` failure, denied/timed-out unlock prompt) — a
+ * RECOVERABLE condition distinct from a corrupt/bad-mode file. Without this, the
+ * spawn path (resolveCredential → buildSpawnEnv) silently launches a subprocess
+ * provider unauthenticated despite a valid credential on disk. The warning makes
+ * that observable; the value is never logged.
+ *
+ * @param {string} key
+ */
+function warnKeychainUnavailableOnce(key) {
+  if (_keychainUnavailableWarned.has(key)) return
+  _keychainUnavailableWarned.add(key)
+  _log.warn(
+    `${key} is stored (encrypted) but its OS keychain data key is currently unavailable — resolving as unset. ` +
+    `A spawned child may launch unauthenticated. Unlock the OS keychain (or re-store the credential) and retry.`,
+  )
+}
 
 // Explicit test injection (an in-memory keychain), or null to use the resolved
 // default. Takes precedence over the env escape hatch below.
@@ -266,8 +302,15 @@ function writeStoreAtomically(target, nextObj) {
  */
 export function getStoredCredential(key) {
   if (!isKnownCredentialKey(key)) return null
-  const { data, error } = readStore()
-  if (error) return null
+  const { data, error, encrypted } = readStore()
+  if (error) {
+    // #5242: a read error with `encrypted: true` is the RECOVERABLE
+    // keychain-unavailable case (not corruption). Emit a one-time warning so a
+    // silent unauthenticated spawn is observable; other read errors (bad
+    // mode/JSON) are already surfaced via getCredentialsStatus.fileError.
+    if (encrypted) warnKeychainUnavailableOnce(key)
+    return null
+  }
   const canonical = data[key]
   if (typeof canonical === 'string' && canonical.length > 0) return canonical
   const legacyField = LEGACY_FIELD_BY_KEY[key]

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -240,16 +240,24 @@ function readStore() {
   if (isEncryptedEnvelope(parsed)) {
     const key = getMasterKey(activeKeychain())
     if (!key) {
+      // #5242: the RECOVERABLE case — the envelope is intact but the keychain
+      // data key can't be fetched (locked keychain, transient probe failure).
+      // `keychainUnavailable` distinguishes it from a decrypt-throw corruption
+      // below so the spawn-path warning only fires for this recoverable branch.
       return {
         data: {},
         fileExists: true,
         error: `${file} is encrypted but its decryption key is unavailable (OS keychain service "${CRED_KEY_SERVICE}" missing or unreadable)`,
         encrypted: true,
+        keychainUnavailable: true,
       }
     }
     try {
       return { data: decryptEnvelope(parsed, key), fileExists: true, error: null, encrypted: true }
     } catch (err) {
+      // The data key was present but decryption failed — a corrupt/invalid
+      // envelope, NOT a keychain-availability problem. No keychainUnavailable
+      // flag, so this does not trigger the keychain-unavailable warning.
       return { data: {}, fileExists: true, error: `${file} could not be decrypted: ${err.message}`, encrypted: true }
     }
   }
@@ -302,13 +310,15 @@ function writeStoreAtomically(target, nextObj) {
  */
 export function getStoredCredential(key) {
   if (!isKnownCredentialKey(key)) return null
-  const { data, error, encrypted } = readStore()
+  const { data, error, keychainUnavailable } = readStore()
   if (error) {
-    // #5242: a read error with `encrypted: true` is the RECOVERABLE
-    // keychain-unavailable case (not corruption). Emit a one-time warning so a
-    // silent unauthenticated spawn is observable; other read errors (bad
-    // mode/JSON) are already surfaced via getCredentialsStatus.fileError.
-    if (encrypted) warnKeychainUnavailableOnce(key)
+    // #5242: a read error with `keychainUnavailable: true` is the RECOVERABLE
+    // case — an intact encrypted envelope whose keychain data key can't be
+    // fetched right now. Emit a one-time warning so a silent unauthenticated
+    // spawn is observable. Other read errors (bad mode/JSON, or a corrupt
+    // envelope that fails to decrypt) are already surfaced via
+    // getCredentialsStatus.fileError and are NOT the recoverable case.
+    if (keychainUnavailable) warnKeychainUnavailableOnce(key)
     return null
   }
   const canonical = data[key]

--- a/packages/server/tests/credential-store-spawn-warning.test.js
+++ b/packages/server/tests/credential-store-spawn-warning.test.js
@@ -1,0 +1,120 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getStoredCredential,
+  setStoredCredential,
+  resolveCredential,
+  _setCredentialKeychainForTests,
+  _setCredentialLoggerForTests,
+  _resetKeychainWarningsForTests,
+} from '../src/credential-store.js'
+
+/**
+ * #5242 — the spawn path must not SILENTLY resolve an encrypted credential to
+ * null when the keychain data key is momentarily unavailable (locked keychain,
+ * transient security/secret-tool failure). That recoverable case used to launch
+ * a subprocess provider unauthenticated with zero diagnostic. We now emit a
+ * one-time warning. Resolution semantics are unchanged (still `unset`) — this is
+ * purely observability; the write/availability policy is #5230.
+ *
+ * In-memory keychain + tmp HOME — the real ~/.chroxy and OS keychain are never
+ * touched.
+ */
+
+const CRED_ENV_VARS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN', 'GEMINI_API_KEY', 'OPENAI_API_KEY']
+
+function inMemoryKeychain() {
+  const store = new Map()
+  return {
+    isKeychainAvailable: () => true,
+    getToken: (service) => store.get(service) ?? null,
+    setToken: (token, service) => { store.set(service, token) },
+    _store: store,
+  }
+}
+
+function capturingLogger() {
+  const warns = []
+  return { warn: (m) => warns.push(m), info: () => {}, error: () => {}, debug: () => {}, _warns: warns }
+}
+
+describe('credential-store — encrypted-keychain-unavailable warning (#5242)', () => {
+  let tmpHome, originalHome, logger
+  const savedEnv = {}
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), 'chroxy-cred-warn-'))
+    originalHome = process.env.HOME
+    process.env.HOME = tmpHome
+    for (const k of CRED_ENV_VARS) { savedEnv[k] = process.env[k]; delete process.env[k] }
+    logger = capturingLogger()
+    _setCredentialLoggerForTests(logger)
+    _resetKeychainWarningsForTests()
+  })
+
+  afterEach(() => {
+    _setCredentialKeychainForTests(null)
+    _setCredentialLoggerForTests(null)
+    _resetKeychainWarningsForTests()
+    if (originalHome) process.env.HOME = originalHome
+    else delete process.env.HOME
+    for (const k of CRED_ENV_VARS) { if (savedEnv[k] === undefined) delete process.env[k]; else process.env[k] = savedEnv[k] }
+    try { rmSync(tmpHome, { recursive: true, force: true }) } catch { /* */ }
+  })
+
+  // Write an encrypted credential with one keychain, then swap to an EMPTY
+  // (available, but no data key) keychain so readStore hits the
+  // encrypted-but-key-unavailable branch.
+  function writeEncryptedThenLoseKey() {
+    const k1 = inMemoryKeychain()
+    _setCredentialKeychainForTests(k1)
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-secret-value')
+    // A different keychain instance: available, but the data key isn't there.
+    _setCredentialKeychainForTests(inMemoryKeychain())
+  }
+
+  it('warns once when an encrypted credential can not be decrypted (keychain unavailable)', () => {
+    writeEncryptedThenLoseKey()
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), null)
+    assert.equal(logger._warns.length, 1, 'should warn exactly once')
+    assert.match(logger._warns[0], /ANTHROPIC_API_KEY/)
+    assert.match(logger._warns[0], /keychain/i)
+    // The secret value must never appear in the warning.
+    assert.ok(!logger._warns[0].includes('sk-ant-secret-value'))
+  })
+
+  it('dedupes: repeated resolves on the spawn path warn once per key', () => {
+    writeEncryptedThenLoseKey()
+    resolveCredential('ANTHROPIC_API_KEY')
+    resolveCredential('ANTHROPIC_API_KEY')
+    resolveCredential('ANTHROPIC_API_KEY')
+    assert.equal(logger._warns.length, 1, 'one warning despite three resolves')
+  })
+
+  it('resolveCredential still returns {value:null, source:unset} (semantics unchanged)', () => {
+    writeEncryptedThenLoseKey()
+    assert.deepEqual(resolveCredential('ANTHROPIC_API_KEY'), { value: null, source: 'unset' })
+  })
+
+  it('does NOT warn for a non-encrypted read error (bad JSON)', () => {
+    const file = join(tmpHome, '.chroxy', 'credentials.json')
+    mkdirSync(join(tmpHome, '.chroxy'), { recursive: true })
+    writeFileSync(file, '{not json', { mode: 0o600 })
+    if (process.platform !== 'win32') chmodSync(file, 0o600)
+    _setCredentialKeychainForTests(inMemoryKeychain())
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), null)
+    assert.equal(logger._warns.length, 0, 'a corrupt-file error is not the recoverable keychain case')
+  })
+
+  it('does NOT warn when the credential resolves successfully', () => {
+    const k1 = inMemoryKeychain()
+    _setCredentialKeychainForTests(k1)
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-ok')
+    // Same keychain still holds the data key → decrypts fine.
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-ok')
+    assert.equal(logger._warns.length, 0)
+  })
+})

--- a/packages/server/tests/credential-store-spawn-warning.test.js
+++ b/packages/server/tests/credential-store-spawn-warning.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, writeFileSync, chmodSync, mkdirSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { randomBytes } from 'node:crypto'
 import {
   getStoredCredential,
   setStoredCredential,
@@ -11,6 +12,7 @@ import {
   _setCredentialLoggerForTests,
   _resetKeychainWarningsForTests,
 } from '../src/credential-store.js'
+import { CRED_KEY_SERVICE } from '../src/credential-cipher.js'
 
 /**
  * #5242 — the spawn path must not SILENTLY resolve an encrypted credential to
@@ -116,5 +118,23 @@ describe('credential-store — encrypted-keychain-unavailable warning (#5242)', 
     // Same keychain still holds the data key → decrypts fine.
     assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-ok')
     assert.equal(logger._warns.length, 0)
+  })
+
+  // #5242 (review nitpick): an encrypted envelope that fails to DECRYPT — the
+  // keychain is available and HAS a data key, but it's the wrong key (or a
+  // corrupt envelope) — is NOT the recoverable keychain-unavailable case. The
+  // keychain-unavailable warning must not fire here; the error is already
+  // surfaced via getCredentialsStatus.fileError.
+  it('does NOT warn when an encrypted envelope fails to decrypt (corrupt/wrong key)', () => {
+    const k1 = inMemoryKeychain()
+    _setCredentialKeychainForTests(k1)
+    setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-corrupt-case')
+    // Swap to a keychain that IS available and DOES hold a data key, but a
+    // different one — so getMasterKey returns a key yet decryptEnvelope throws.
+    const k2 = inMemoryKeychain()
+    k2.setToken(Buffer.from(randomBytes(32)).toString('base64'), CRED_KEY_SERVICE)
+    _setCredentialKeychainForTests(k2)
+    assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), null)
+    assert.equal(logger._warns.length, 0, 'a decrypt failure is not the recoverable keychain-unavailable case')
   })
 })


### PR DESCRIPTION
Closes #5242.

## The bug (silent unauthenticated spawn)

`getStoredCredential()` does `const { data, error } = readStore(); if (error) return null`. But `readStore()` returns an `error` not only for a corrupt/bad-mode file but also for the **recoverable** case of an *encrypted* file whose keychain data key is momentarily unavailable (macOS keychain locked, `security`/`secret-tool` transiently failing, a denied/timed-out unlock prompt).

On the spawn path (`resolveCredential` → `buildSpawnEnv`), that null means the credential simply isn't injected and a subprocess provider (`cli-session`, `gemini-session`, `codex-session`) launches **unauthenticated despite a valid encrypted credential on disk** — with zero diagnostic, then hits the provider's missing-key error as if the credential were deleted.

## Fix (observability only)

`readStore` already tags the recoverable case with `encrypted: true`. When `getStoredCredential` sees `error && encrypted`, emit a **one-time, per-key** warning so the keyless spawn is observable. The warning carries only the key name + the fact of the failure — never the value (and `logger.js` redacts `sk-ant`/`Bearer` regardless).

**Resolution semantics are unchanged** — it still resolves as `unset`. Whether the store should refuse-to-store / fail-loud on keychain-unavailable is the *write/availability policy*, tracked separately in #5230; this PR is strictly the read/spawn observability gap.

## Tests

`tests/credential-store-spawn-warning.test.js` (in-memory keychain + tmp HOME — real `~/.chroxy` and OS keychain never touched):
- warns once when an encrypted credential can't be decrypted (keychain unavailable); the secret never appears in the message,
- dedupes: three `resolveCredential` calls on the spawn path → one warning,
- `resolveCredential` still returns `{ value: null, source: 'unset' }` (semantics unchanged),
- does **not** warn for a non-encrypted read error (bad JSON) — mutation-catching the `if (encrypted)` guard,
- does **not** warn on a successful resolve.

Existing credential-store + encryption suites stay green (36 tests).