### PR TITLE
fix(server): credential atomic-replace retries a Windows held-handle lock (#5258)

### DIFF
--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -62,6 +62,12 @@ import {
 // fallback path.
 const NO_KEYCHAIN = { isKeychainAvailable: () => false }
 
+// #5258: Windows rename-failure codes that indicate a held handle (antivirus /
+// Windows Search) on the destination, not a genuine I/O error. Mirrors
+// session-state-persistence.WINDOWS_LOCK_CODES — replaceFileAtomically retries
+// once on these.
+const CRED_WINDOWS_LOCK_CODES = new Set(['EPERM', 'EACCES', 'EBUSY', 'EEXIST'])
+
 // #5242: logger for the recoverable encrypted-but-keychain-unavailable warning.
 // Injectable for tests. Credentials are NEVER passed to it — only the key NAME
 // and the fact of the failure (the logger.js redactor scrubs sk-ant/Bearer too).
@@ -280,15 +286,50 @@ function readStore() {
  * sibling `writeFileRestricted` (platform.js), which goes straight from
  * `writeFileSync(tmp)` to `renameSync`.
  *
+ * #5258: on Windows an antivirus / Windows Search held handle on `target` can
+ * make the atomic replace fail with EPERM/EACCES/EBUSY/EEXIST even though
+ * renameSync normally replaces atomically. We mirror
+ * session-state-persistence._rotateToBak's one-shot retry: snapshot the live
+ * target, clear it, then retry the rename once. The unlink happens ONLY after
+ * the atomic attempt already failed (never a pre-delete — that was the #5243
+ * data-loss bug), and the snapshot lets us restore the live credentials if the
+ * retry ALSO fails, so a crash can't leave zero credentials.
+ *
  * fs ops are injectable for testing (defaults are the real fs calls).
  *
  * @param {string} tmp - source temp path.
  * @param {string} target - destination path.
- * @param {{ rename?: Function }} [deps]
+ * @param {{ rename?: Function, unlink?: Function, readFile?: Function, writeFile?: Function, platform?: string }} [deps]
  */
 export function replaceFileAtomically(tmp, target, deps = {}) {
-  const { rename = renameSync } = deps
-  rename(tmp, target)
+  const {
+    rename = renameSync,
+    unlink = unlinkSync,
+    readFile = readFileSync,
+    writeFile = writeFileSync,
+    platform = process.platform,
+  } = deps
+  try {
+    rename(tmp, target)
+    return
+  } catch (err) {
+    // Non-Windows, or an error that isn't a Windows held-handle lock: surface
+    // it unchanged (no unlink — preserves the #5243 no-pre-delete guarantee).
+    if (platform !== 'win32' || !err || !CRED_WINDOWS_LOCK_CODES.has(err.code)) throw err
+    let snapshot = null
+    try { snapshot = readFile(target) } catch { /* target may already be gone */ }
+    try { unlink(target) } catch { /* best-effort — target may be gone */ }
+    try {
+      rename(tmp, target)
+    } catch (retryErr) {
+      // Retry still failed — restore the live bytes (if captured) so the prior
+      // credentials survive, then surface the error to the caller.
+      if (snapshot !== null) {
+        try { writeFile(target, snapshot, { mode: 0o600 }) } catch { /* best-effort restore */ }
+      }
+      throw retryErr
+    }
+  }
 }
 
 /**

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -292,8 +292,13 @@ function readStore() {
  * session-state-persistence._rotateToBak's one-shot retry: snapshot the live
  * target, clear it, then retry the rename once. The unlink happens ONLY after
  * the atomic attempt already failed (never a pre-delete — that was the #5243
- * data-loss bug), and the snapshot lets us restore the live credentials if the
- * retry ALSO fails, so a crash can't leave zero credentials.
+ * data-loss bug). The in-memory snapshot lets us restore the live credentials
+ * if the *retry* also fails. It does NOT make the unlink→re-rename window
+ * crash-safe: a hard process crash in that window leaves `target` gone with the
+ * new payload only on the on-disk `.tmp` (no automated reader recovers it). To
+ * keep that window from ever destroying the only copy, we refuse to unlink when
+ * the snapshot read failed but the file is still present (see below) — so the
+ * worst pre-crash state is "live file intact, replace not applied".
  *
  * fs ops are injectable for testing (defaults are the real fs calls).
  *
@@ -316,8 +321,15 @@ export function replaceFileAtomically(tmp, target, deps = {}) {
     // Non-Windows, or an error that isn't a Windows held-handle lock: surface
     // it unchanged (no unlink — preserves the #5243 no-pre-delete guarantee).
     if (platform !== 'win32' || !err || !CRED_WINDOWS_LOCK_CODES.has(err.code)) throw err
+    // Snapshot the live target so we can restore it if the retry also fails.
     let snapshot = null
     try { snapshot = readFile(target) } catch { /* target may already be gone */ }
+    // If the snapshot failed but the target is still on disk (e.g. readFile threw
+    // EACCES/EPERM because the same held handle is blocking the read), unlinking
+    // it here would destroy the only copy with no way to restore — re-introducing
+    // the #5243 data-loss path. Keep the live file intact and surface the ORIGINAL
+    // lock error instead; the caller is no worse off than before the retry.
+    if (snapshot === null && existsSync(target)) throw err
     try { unlink(target) } catch { /* best-effort — target may be gone */ }
     try {
       rename(tmp, target)

--- a/packages/server/tests/credential-store-atomic-replace.test.js
+++ b/packages/server/tests/credential-store-atomic-replace.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, renameSync } from 'node:fs'
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync, renameSync, unlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -71,6 +71,62 @@ describe('credential-store — replaceFileAtomically (#5243)', () => {
 
     assert.ok(existsSync(target), 'live target must still exist after a failed replace')
     assert.equal(readFileSync(target, 'utf8'), 'LIVE-CREDENTIALS', 'live content must be preserved')
+  })
+
+  it('#5258: win32 retries once after a held-handle lock (EEXIST) and succeeds', () => {
+    const target = join(dir, 'c.json')
+    const tmp = join(dir, 'c.json.tmp')
+    writeFileSync(target, 'OLD')
+    writeFileSync(tmp, 'NEW')
+    let attempts = 0
+    let unlinkedTarget = false
+    replaceFileAtomically(tmp, target, {
+      platform: 'win32',
+      rename: (from, to) => {
+        attempts++
+        if (attempts === 1) { const e = new Error('EEXIST: handle held'); e.code = 'EEXIST'; throw e }
+        renameSync(from, to)
+      },
+      unlink: (p) => { if (p === target) unlinkedTarget = true; unlinkSync(p) },
+    })
+    assert.equal(attempts, 2, 'exactly one retry')
+    assert.ok(unlinkedTarget, 'target unlinked before the retry (after the atomic attempt, not before)')
+    assert.equal(readFileSync(target, 'utf8'), 'NEW')
+  })
+
+  it('#5258: win32 restores the live file if the retry also fails', () => {
+    const target = join(dir, 'c.json')
+    const tmp = join(dir, 'c.json.tmp')
+    writeFileSync(target, 'LIVE')
+    writeFileSync(tmp, 'NEW')
+    // Both the atomic attempt and the post-unlink retry fail (handle never
+    // releases). Default unlink/readFile/writeFile are real fs, so this
+    // exercises the snapshot → unlink → restore path end-to-end.
+    assert.throws(() => {
+      replaceFileAtomically(tmp, target, {
+        platform: 'win32',
+        rename: () => { const e = new Error('EBUSY: locked'); e.code = 'EBUSY'; throw e },
+      })
+    }, /EBUSY/)
+    assert.ok(existsSync(target), 'live file restored after retry failure')
+    assert.equal(readFileSync(target, 'utf8'), 'LIVE', 'prior credentials survive a doubly-failed replace')
+  })
+
+  it('#5258: win32 does NOT retry a non-lock error (e.g. ENOSPC) — surfaces immediately', () => {
+    const target = join(dir, 'c.json')
+    const tmp = join(dir, 'c.json.tmp')
+    writeFileSync(target, 'LIVE')
+    writeFileSync(tmp, 'NEW')
+    let unlinkCalled = false
+    assert.throws(() => {
+      replaceFileAtomically(tmp, target, {
+        platform: 'win32',
+        rename: () => { const e = new Error('ENOSPC: disk full'); e.code = 'ENOSPC'; throw e },
+        unlink: () => { unlinkCalled = true },
+      })
+    }, /ENOSPC/)
+    assert.equal(unlinkCalled, false, 'a non-lock error must not trigger the destructive retry')
+    assert.ok(existsSync(target), 'live file untouched')
   })
 })
 

--- a/packages/server/tests/credential-store-atomic-replace.test.js
+++ b/packages/server/tests/credential-store-atomic-replace.test.js
@@ -112,6 +112,31 @@ describe('credential-store — replaceFileAtomically (#5243)', () => {
     assert.equal(readFileSync(target, 'utf8'), 'LIVE', 'prior credentials survive a doubly-failed replace')
   })
 
+  it('#5258: win32 does NOT unlink when the snapshot read fails but the target still exists', () => {
+    const target = join(dir, 'c.json')
+    const tmp = join(dir, 'c.json.tmp')
+    writeFileSync(target, 'LIVE')
+    writeFileSync(tmp, 'NEW')
+    // The held handle also blocks the snapshot read (readFile throws EACCES) while
+    // the file is still present on disk. Unlinking it here would destroy the only
+    // copy with no restore possible — so we must surface the ORIGINAL lock error
+    // and leave the live file untouched (no unlink, no retry).
+    let unlinkCalled = false
+    let retryAttempts = 0
+    assert.throws(() => {
+      replaceFileAtomically(tmp, target, {
+        platform: 'win32',
+        rename: () => { retryAttempts++; const e = new Error('EPERM: locked'); e.code = 'EPERM'; throw e },
+        readFile: () => { const e = new Error('EACCES: read blocked'); e.code = 'EACCES'; throw e },
+        unlink: () => { unlinkCalled = true },
+      })
+    }, /EPERM/)
+    assert.equal(retryAttempts, 1, 'only the initial atomic attempt — no destructive retry')
+    assert.equal(unlinkCalled, false, 'must not unlink a present target it could not snapshot')
+    assert.ok(existsSync(target), 'live file untouched')
+    assert.equal(readFileSync(target, 'utf8'), 'LIVE', 'prior credentials survive when the snapshot fails')
+  })
+
   it('#5258: win32 does NOT retry a non-lock error (e.g. ENOSPC) — surfaces immediately', () => {
     const target = join(dir, 'c.json')
     const tmp = join(dir, 'c.json.tmp')


### PR DESCRIPTION
Closes #5258.

Follow-up from the review of #5255.

## Context

#5255 introduced `replaceFileAtomically(tmp, target)` as a bare `renameSync`. On Windows an antivirus / Windows Search held handle on the target can make even an atomic replace fail with `EPERM`/`EACCES`/`EBUSY`/`EEXIST`. The credential-store caller (`writeStoreAtomically`) has no retry of its own, so that surfaced as a hard write failure — whereas `session-state-persistence._rotateToBak` already handles exactly this with a one-shot retry.

## Fix

Mirror `_rotateToBak`'s pattern in `replaceFileAtomically`: on a Windows held-handle code, **snapshot** the live target, clear it, and **retry** the rename once; if the retry also fails, **restore** the snapshot so the prior credentials survive. Key safety property — the unlink happens **only after** the atomic attempt already failed, never as a pre-delete, so the #5243 no-data-loss guarantee is preserved. Non-Windows and non-lock errors surface unchanged (no unlink).

fs ops stay injectable; a new `platform` dep makes the win32 path testable on any host.

## Tests (`credential-store-atomic-replace.test.js`)

- win32 retries once after `EEXIST` and succeeds (asserts the unlink happens before the retry, i.e. after the atomic attempt),
- win32 restores the live file when the retry **also** fails (real fs — exercises snapshot → unlink → restore end-to-end),
- win32 does **not** retry a non-lock error (`ENOSPC`) — no destructive unlink,
- the existing #5243 guarantees (non-win32 throws without pre-delete) still hold.

38 credential-store tests pass; eslint clean.