### PR TITLE
fix(server): bound Control Room survey probes + configurable runner gh enrichment (#5259, #5260)

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -78,6 +78,11 @@ const CONFIG_SCHEMA = {
   // containing a `.runner` config). Defaults to ~/github-runners when unset.
   // Mirrored by the CHROXY_RUNNER_ROOT env var.
   controlRoomRunnerRoot: 'string',
+  // #5260 (Control Room): whether the self-hosted runner survey enriches each
+  // runner with GitHub's view via `gh api` (online/busy/labels). Defaults to
+  // true. Set false for a faster local-only survey, or on hosts where `gh`
+  // isn't authenticated. Mirrored by the CHROXY_RUNNER_INCLUDE_GITHUB env var.
+  controlRoomRunnerIncludeGithub: 'boolean',
   maxSessions: 'number',
   maxHistory: 'number',
   maxMessages: 'number',
@@ -770,6 +775,8 @@ function envKeyForConfig(key) {
     controlRoomRoot: 'CHROXY_CONTROL_ROOM_ROOT',
     // #5253: discovery root for the Control Room self-hosted runner survey.
     controlRoomRunnerRoot: 'CHROXY_RUNNER_ROOT',
+    // #5260: toggle gh enrichment of the runner survey.
+    controlRoomRunnerIncludeGithub: 'CHROXY_RUNNER_INCLUDE_GITHUB',
     logFormat: 'CHROXY_LOG_FORMAT',
     sandbox: 'CHROXY_SANDBOX',
     resultTimeoutMs: 'CHROXY_RESULT_TIMEOUT_MS',

--- a/packages/server/src/control-room/runners.js
+++ b/packages/server/src/control-room/runners.js
@@ -47,6 +47,20 @@ export const DEFAULT_RUNNER_ROOT = join(homedir(), 'github-runners')
 export const DEFAULT_CONCURRENCY = 5
 
 /**
+ * #5259: bound every probe subprocess so a stuck `gh`/`launchctl`/`systemctl`
+ * (network blip, wedged service manager) rejects in finite time instead of
+ * hanging the survey forever — which would also pin the handler's per-client
+ * in-flight guard. The survey already tolerates a rejected probe (degrades to
+ * not-running / null GitHub view), so a timeout just guarantees it rejects.
+ * Kept consistent with the host survey (survey.js EXEC_TIMEOUT_MS).
+ */
+export const EXEC_TIMEOUT_MS = 20000
+/** Modest output cap for probe subprocesses (runner JSON is small). */
+const EXEC_MAX_BUFFER = 8 * 1024 * 1024
+/** Shared exec options for every probe. */
+const EXEC_OPTS = { timeout: EXEC_TIMEOUT_MS, maxBuffer: EXEC_MAX_BUFFER }
+
+/**
  * Parse a runner install's `.runner` config (JSON). The file GitHub writes is
  * UTF-8 with a BOM, which `JSON.parse` rejects — strip a leading BOM first.
  *
@@ -156,14 +170,14 @@ export async function probeService(execFn, service) {
   if (!service || !service.label) return stopped
   try {
     if (service.manager === 'launchd') {
-      const { stdout } = await execFn('launchctl', ['list', service.label], {})
+      const { stdout } = await execFn('launchctl', ['list', service.label], EXEC_OPTS)
       return parseLaunchctlList(stdout)
     }
     if (service.manager === 'systemd') {
       const { stdout } = await execFn('systemctl', [
         'show', service.label,
         '--property=ActiveState', '--property=MainPID', '--property=ExecMainStatus',
-      ], {})
+      ], EXEC_OPTS)
       return parseSystemctlShow(stdout)
     }
     return stopped
@@ -420,7 +434,7 @@ export async function surveyRunners(opts = {}) {
           const path = ghRunnersApiPath(group.target)
           if (!path) return new Map()
           try {
-            const { stdout } = await _execFile('gh', ['api', path], {})
+            const { stdout } = await _execFile('gh', ['api', path], EXEC_OPTS)
             return parseGhRunners(typeof stdout === 'string' ? stdout : '')
           } catch {
             return new Map()

--- a/packages/server/src/control-room/survey.js
+++ b/packages/server/src/control-room/survey.js
@@ -44,6 +44,15 @@ const execFileAsync = promisify(execFile)
 const EXEC_MAX_BUFFER = 16 * 1024 * 1024
 
 /**
+ * #5259: bound every git/gh probe so a stuck subprocess (network blip on `gh`,
+ * a wedged git) rejects in finite time instead of hanging the survey forever
+ * (which would also pin the handler's per-client in-flight guard). tryExec
+ * already degrades a rejected probe to null, so the timeout just guarantees the
+ * rejection. Kept consistent with the runner survey (runners.js EXEC_TIMEOUT_MS).
+ */
+const EXEC_TIMEOUT_MS = 20000
+
+/**
  * Cap for `gh pr list` (#5240). `gh pr list` defaults to 30, silently capping
  * the open-PR count AND the CI/review rollup. 200 covers even bot-heavy repos;
  * a repo past it is undercounted, but far less often than at the 30 default.
@@ -80,7 +89,7 @@ export const DEFAULT_THRESHOLDS = {
  */
 async function tryExec(execFn, file, args, cwd) {
   try {
-    const { stdout } = await execFn(file, args, { cwd, maxBuffer: EXEC_MAX_BUFFER })
+    const { stdout } = await execFn(file, args, { cwd, maxBuffer: EXEC_MAX_BUFFER, timeout: EXEC_TIMEOUT_MS })
     return typeof stdout === 'string' ? stdout.trim() : ''
   } catch {
     return null

--- a/packages/server/src/handlers/control-room-handlers.js
+++ b/packages/server/src/handlers/control-room-handlers.js
@@ -211,9 +211,14 @@ async function handleRunnerStatusRequest(ws, client, msg, ctx) {
   // Tests inject `ctx.surveyRunners` to stub the fs/exec calls.
   const surveyFn = typeof ctx?.surveyRunners === 'function' ? ctx.surveyRunners : surveyRunners
 
+  // #5260: gh enrichment is on by default; an operator disables it (faster,
+  // local-only survey, or no `gh` auth) by setting controlRoomRunnerIncludeGithub
+  // false. Only an explicit `false` turns it off — unset/undefined stays true.
+  const includeGithub = config.controlRoomRunnerIncludeGithub !== false
+
   runnerInFlight.add(client)
   try {
-    const snapshot = await surveyFn({ root })
+    const snapshot = await surveyFn({ root, includeGithub })
     ctx.send(ws, {
       type: 'runner_status_snapshot',
       requestId,

--- a/packages/server/tests/control-room-handlers.test.js
+++ b/packages/server/tests/control-room-handlers.test.js
@@ -305,6 +305,25 @@ describe('runner_status_request handler (#5253)', () => {
     assert.equal(opts.root, '/home/user/github-runners')
   })
 
+  it('#5260: enables gh enrichment by default (config key unset)', async () => {
+    await controlRoomHandlers.runner_status_request(ws, client, { type: 'runner_status_request' }, ctx)
+    const [opts] = ctx.surveyRunners.lastCall
+    assert.equal(opts.includeGithub, true, 'unset config defaults includeGithub to true')
+  })
+
+  it('#5260: disables gh enrichment when controlRoomRunnerIncludeGithub is false', async () => {
+    ctx = makeRunnerCtx({ config: { controlRoomRunnerIncludeGithub: false } })
+    await controlRoomHandlers.runner_status_request(ws, client, { type: 'runner_status_request' }, ctx)
+    const [opts] = ctx.surveyRunners.lastCall
+    assert.equal(opts.includeGithub, false)
+  })
+
+  it('#5260: a non-false value keeps enrichment on', async () => {
+    ctx = makeRunnerCtx({ config: { controlRoomRunnerIncludeGithub: true } })
+    await controlRoomHandlers.runner_status_request(ws, client, { type: 'runner_status_request' }, ctx)
+    assert.equal(ctx.surveyRunners.lastCall[0].includeGithub, true)
+  })
+
   it('reports a resolved default root when controlRoomRunnerRoot is unset', async () => {
     ctx = makeRunnerCtx({ config: {} })
     await controlRoomHandlers.runner_status_request(ws, client, { type: 'runner_status_request' }, ctx)

--- a/packages/server/tests/control-room-runners.test.js
+++ b/packages/server/tests/control-room-runners.test.js
@@ -33,6 +33,7 @@ import {
   ghRunnersApiPath,
   parseGhRunners,
   classifyRunner,
+  EXEC_TIMEOUT_MS,
 } from '../src/control-room/runners.js'
 
 // A Dirent-like for the injected readdir seam.
@@ -128,6 +129,14 @@ describe('control-room/runners — probeService', () => {
     const r = await probeService(exec, { manager: 'none', label: null })
     assert.equal(called, false)
     assert.deepEqual(r, { running: false, pid: null, lastExitCode: null })
+  })
+
+  it('#5259: bounds the probe with a timeout + maxBuffer so a wedged service manager rejects', async () => {
+    let opts = null
+    const exec = async (file, args, o) => { opts = o; return { stdout: '\t"PID" = 1;\n' } }
+    await probeService(exec, { manager: 'launchd', label: 'l' })
+    assert.equal(opts.timeout, EXEC_TIMEOUT_MS, 'launchctl probe must carry the bounded timeout')
+    assert.ok(typeof opts.maxBuffer === 'number' && opts.maxBuffer > 0, 'maxBuffer must be set')
   })
 })
 
@@ -357,5 +366,16 @@ describe('control-room/runners — surveyRunners (end-to-end)', () => {
     const aa1 = aa.runners.find(r => r.name === 'aa-1')
     assert.equal(aa1.verdict, 'idle') // running locally, no gh view
     assert.equal(aa1.githubStatus, null)
+  })
+
+  it('#5259: passes a bounded timeout to the gh enrichment call', async () => {
+    let ghOpts = null
+    const exec = async (file, args, o) => {
+      if (file === 'gh') { ghOpts = o; return { stdout: JSON.stringify({ runners: [] }) } }
+      return execFile(file, args)
+    }
+    await surveyRunners({ ...baseOpts(), _execFile: exec })
+    assert.ok(ghOpts, 'gh enrichment ran')
+    assert.equal(ghOpts.timeout, EXEC_TIMEOUT_MS, 'gh api call must carry the bounded timeout')
   })
 })

--- a/packages/server/tests/control-room-survey.test.js
+++ b/packages/server/tests/control-room-survey.test.js
@@ -600,4 +600,18 @@ describe('survey probes — exec robustness (#5240/#5241)', () => {
       )
     }
   })
+
+  it('#5259: every git/gh probe passes a bounded timeout so a stuck subprocess rejects', async () => {
+    const repo = '/r'
+    const { fn, calls } = capturingExec({ [repo]: cleanRepo() })
+    await surveyRepos([repo], { _execFile: fn, _now: now, _readFile: async () => { throw new Error() } })
+    const probeCalls = calls.filter((c) => c.file === 'git' || c.file === 'gh')
+    assert.ok(probeCalls.length > 0, 'at least one probe ran')
+    for (const c of probeCalls) {
+      assert.ok(
+        c.opts && typeof c.opts.timeout === 'number' && c.opts.timeout > 0,
+        `probe \`${c.file} ${c.args[0]}\` must pass a positive timeout (got ${c.opts && c.opts.timeout})`,
+      )
+    }
+  })
 })


### PR DESCRIPTION
Closes #5259
Closes #5260

Two follow-ups from the review of #5254, both in the Control Room survey path.

## #5259 — bound every probe with a timeout

Both surveys shelled out via promisified `execFile` with no `timeout`. A stuck subprocess (`gh` stalling on a network blip, a wedged `launchctl`/`systemctl`, a hung `git`) would make the survey **never resolve** — and because each handler holds a per-client in-flight guard for the survey's duration, that client could never run another survey of that kind until the socket closed.

Fix: a consistent **20s timeout** on every probe in both `control-room/runners.js` (`gh api`, `launchctl list`, `systemctl show`) and `control-room/survey.js` (git/gh), plus a modest 8MB `maxBuffer` on the runner probes. The surveys already tolerate a *rejected* probe (degrade to not-running / null GitHub view / null PR count); this just guarantees the rejection happens in bounded time.

## #5260 — make runner gh enrichment configurable

`surveyRunners({ includeGithub })` already supports a local-only survey (skip the per-project `gh api` call, classify from local service state alone, leave GitHub fields null) and was unit-tested — but the handler always enabled it, so operators without `gh` auth paid one failing `gh` call per project on every Refresh.

Fix: `controlRoomRunnerIncludeGithub` config key + `CHROXY_RUNNER_INCLUDE_GITHUB` env var (default **true**; only an explicit `false` disables), plumbed through `handleRunnerStatusRequest` into `surveyRunners({ root, includeGithub })`.

## Tests

- runner survey: probe carries `timeout === EXEC_TIMEOUT_MS` + maxBuffer; gh enrichment call carries the timeout.
- host survey: every git/gh probe passes a positive timeout (alongside the existing #5241 maxBuffer assertion).
- handler: `includeGithub` defaults to true (unset), is `false` only when explicitly configured false, stays true otherwise.

198 control-room + config tests pass; eslint clean.