### PR TITLE
fix(server): background-shell mtime sweep is advisory, not a liveness reap (#5247)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -101,18 +101,15 @@ export const DEFAULT_STREAM_STALL_TIMEOUT_MS = 5 * 60 * 1000
 // pending output file is negligible. Only armed while shells are pending.
 export const BACKGROUND_SHELL_SWEEP_MS = 15 * 1000
 
-// #5177: quiescence window (ms). A pending shell whose NON-EMPTY output
-// file has not been modified for at least this long is treated as complete
-// and reaped. 60s is conservative — comfortably longer than the inter-line
-// gap of a typical periodic background command (e.g. a 2s-sleep loop) so a
-// command that is merely slow between writes is not reaped while still
-// running. Combined with the non-empty guard in `_isBackgroundShellComplete`
-// (a silent command that emits no output is NEVER reaped via the file path),
-// the false-positive surface is small: only a command that produced output,
-// then went silent for >60s, then is still running, would be reaped early —
-// and even then the agent re-discovers reality on its next BashOutput poll.
-// An over-eager clear is a far smaller UX harm than the banner sticking
-// forever (the bug this fixes).
+// #5177: quiescence window (ms). A pending shell whose NON-EMPTY output file
+// has not been modified for at least this long is treated as QUIESCED.
+// #5247: quiescence is ADVISORY — it clears the dashboard "Waiting on
+// background work" banner but does NOT reap the shell or flip `isRunning`,
+// because a non-empty-then-idle output file is indistinguishable from a live
+// dev server / file-watcher / `tail -f` that logged once and now waits. The
+// old behaviour (reap + flip isRunning on quiescence) idle-timed those live
+// sessions out — re-opening #4307. Liveness is released only by a BashOutput
+// poll or destroy. 60s is still a reasonable banner-clear delay.
 export const BACKGROUND_SHELL_QUIESCE_MS = 60 * 1000
 
 // Default per-provider injection mode (#3200). Subprocess providers without
@@ -686,6 +683,16 @@ export class BaseSession extends EventEmitter {
    * indistinguishable from a finished session — `_isBusy` had cleared
    * at turn-end. Now it stays "running" until the agent acknowledges
    * the shell (via a `BashOutput` call) or the session is destroyed.
+   *
+   * #5247: the map size counts shells the mtime sweep has marked
+   * `quiesced` too. The sweep is ADVISORY — it clears the dashboard
+   * banner (see `getPendingBackgroundShells`) but must NOT flip liveness,
+   * because mtime quiescence can't tell "finished" from "idle but alive"
+   * (a dev server that logs once then waits for connections). Letting it
+   * flip `isRunning` reaped live processes and let `SessionTimeoutManager`
+   * time the session out as idle — re-opening #4307. Liveness authority is
+   * therefore BashOutput / destroy only, exactly as #4307 intended; the
+   * sweep just affects what the banner shows.
    */
   get isRunning() {
     if (this._isBusy) return true
@@ -701,9 +708,13 @@ export class BaseSession extends EventEmitter {
   getPendingBackgroundShells() {
     // #5177: project to the stable wire shape — `outputPath` is an internal
     // sweep detail and must not leak onto the snapshot the dashboard caches.
-    return Array.from(this._pendingBackgroundShells.values()).map(
-      ({ shellId, startedAt, command }) => ({ shellId, startedAt, command }),
-    )
+    // #5247: a shell the mtime sweep marked `quiesced` (output went idle) is
+    // dropped from this banner snapshot — the dashboard "Waiting on background
+    // work" indicator clears — but it stays in `_pendingBackgroundShells` so
+    // `isRunning` is unaffected (the sweep is advisory; see isRunning).
+    return Array.from(this._pendingBackgroundShells.values())
+      .filter((e) => !e.quiesced)
+      .map(({ shellId, startedAt, command }) => ({ shellId, startedAt, command }))
   }
 
   /**
@@ -900,34 +911,58 @@ export class BaseSession extends EventEmitter {
    * @private
    */
   _sweepCompletedBackgroundShells() {
+    let changed = false
+    let anyActive = false
     for (const shellId of Array.from(this._pendingBackgroundShells.keys())) {
       const entry = this._pendingBackgroundShells.get(shellId)
       if (!entry) continue
+      if (entry.quiesced) continue // already advisory-cleared from the banner
       if (this._isBackgroundShellComplete(entry)) {
-        this.clearBackgroundShell(shellId)
+        // #5247: ADVISORY only — mark the shell quiesced so it drops out of the
+        // banner snapshot, but DO NOT clearBackgroundShell / remove it from the
+        // map. mtime quiescence can't distinguish "finished" from "idle but
+        // alive" (a dev server that logs once then waits), so flipping liveness
+        // here reaped live processes and let SessionTimeoutManager idle-time the
+        // session out — re-opening #4307. Real liveness is released only by a
+        // BashOutput poll or destroy.
+        entry.quiesced = true
+        changed = true
+      } else {
+        anyActive = true
       }
     }
+    // The banner snapshot changed (a shell dropped out) — emit the same
+    // background_work_changed the BashOutput / destroy paths emit so the
+    // dashboard indicator clears with no new wire contract.
+    if (changed) this._emitBackgroundWorkChanged()
+    // Nothing left that could still transition → stop the recurring stat()
+    // sweep. A future trackBackgroundShell re-arms it. (clearBackgroundShell
+    // also stops it when the map fully drains via BashOutput / destroy.)
+    if (!anyActive) this._stopBackgroundShellSweep()
   }
 
   /**
-   * #5177: decide whether a pending background shell has completed.
+   * #5177: decide whether a pending background shell's output has QUIESCED —
+   * i.e. it can be dropped from the dashboard banner.
+   *
+   * #5247: this is NOT "the command finished". Its NON-EMPTY-then-idle output
+   * file is indistinguishable from a live-but-quiet process (a dev server that
+   * logs "listening on :3000" then waits, a file watcher, `tail -f`, a build in
+   * a long silent link phase). chroxy never holds the shell's PID (the id is
+   * opaque, owned by claude), so mtime quiescence is the best the BANNER can do
+   * — and the caller (`_sweepCompletedBackgroundShells`) treats a `true` here as
+   * ADVISORY (clears the banner only). Liveness / `SessionTimeoutManager` is
+   * governed solely by BashOutput / destroy (#4307), so a false "quiesced" here
+   * can no longer idle-time a live session out.
    *
    * Tests inject `_backgroundShellCompletionCheck` for deterministic control
-   * without touching the filesystem or real time. The production default
-   * uses the shell's output file mtime: claude tails the command's
-   * stdout/stderr into the file named in the tool_result, so a NON-EMPTY
-   * file that has not been written to for `_backgroundShellQuiesceMs` means
-   * the command produced output and then stopped — the strongest completion
-   * signal available given chroxy never holds the shell's PID (the id is
-   * opaque, owned by claude). A shell with no known output path, or whose
-   * output file is still empty (a silent command like `sleep 600`), can't be
-   * reaped this way and stays pending until BashOutput / destroy — the
-   * existing #4307 behaviour, preserved as the conservative fallback so a
-   * long, silent job is never flipped to idle while still running.
+   * without touching the filesystem or real time. A shell with no known output
+   * path, or whose output file is still empty (a silent command like
+   * `sleep 600`), is never marked quiesced via this path and stays in the
+   * banner until BashOutput / destroy.
    *
-   * Defensive: a stat() error (file removed, races) is treated as NOT
-   * complete so a transient FS hiccup can't reap a still-running shell. The
-   * banner sticking briefly is recoverable; a false clear is worse.
+   * Defensive: a stat() error (file removed, races) is treated as NOT quiesced
+   * so a transient FS hiccup can't drop a shell from the banner early.
    *
    * @param {{ shellId: string, outputPath?: string|null, startedAt: number }} entry
    * @returns {boolean}

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -327,10 +327,10 @@ export class BaseSession extends EventEmitter {
     // pauses output mid-run is not reaped prematurely; the agent's own
     // BashOutput poll still clears faster when it happens.
     this._backgroundShellQuiesceMs = BACKGROUND_SHELL_QUIESCE_MS
-    // Injectable completion check — `(entry) => boolean`. Default reads the
+    // Injectable quiescence check — `(entry) => boolean`. Default reads the
     // output file's mtime; tests override this to drive deterministic
-    // completion without touching the filesystem or real timers.
-    this._backgroundShellCompletionCheck = null
+    // quiescence without touching the filesystem or real timers.
+    this._backgroundShellQuiesceCheck = null
     // #4307: ephemeral map of recent `Bash` tool_uses dispatched with
     // `run_in_background: true`, keyed by toolUseId. Used to recover the
     // command string when the matching tool_result lands carrying the
@@ -879,7 +879,7 @@ export class BaseSession extends EventEmitter {
     if (this._pendingBackgroundShells.size === 0) return
     if (!(this._backgroundShellSweepMs > 0)) return
     this._backgroundShellSweepTimer = setInterval(
-      () => this._sweepCompletedBackgroundShells(),
+      () => this._sweepQuiescedBackgroundShells(),
       this._backgroundShellSweepMs,
     )
     // unref so the sweep never blocks process exit on its own.
@@ -899,25 +899,25 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
-   * #5177: one sweep tick — reap every pending shell that has completed.
-   * Completion is decided by `_isBackgroundShellComplete`. Reaping a shell
-   * goes through `clearBackgroundShell`, so it emits the SAME
-   * `background_work_changed` snapshot the BashOutput / destroy paths emit —
-   * the dashboard's "Waiting on background work" indicator consumes that
-   * snapshot and clears with no new wire contract. Iterating over a copied
-   * key list keeps the mutation (clearBackgroundShell deletes from the map)
-   * safe.
+   * #5177: one sweep tick — mark every pending shell whose output has quiesced.
+   * Quiescence is decided by `_isBackgroundShellQuiesced`. #5247: this is
+   * ADVISORY — a quiesced shell is dropped from the banner snapshot (via the
+   * `quiesced` flag, NOT `clearBackgroundShell`) so it stays in the map and
+   * `isRunning` is unaffected. The emitted `background_work_changed` snapshot is
+   * the SAME shape the BashOutput / destroy paths emit, so the dashboard's
+   * "Waiting on background work" indicator clears with no new wire contract.
+   * Iterating over a copied key list keeps the mutation safe.
    *
    * @private
    */
-  _sweepCompletedBackgroundShells() {
+  _sweepQuiescedBackgroundShells() {
     let changed = false
     let anyActive = false
     for (const shellId of Array.from(this._pendingBackgroundShells.keys())) {
       const entry = this._pendingBackgroundShells.get(shellId)
       if (!entry) continue
       if (entry.quiesced) continue // already advisory-cleared from the banner
-      if (this._isBackgroundShellComplete(entry)) {
+      if (this._isBackgroundShellQuiesced(entry)) {
         // #5247: ADVISORY only — mark the shell quiesced so it drops out of the
         // banner snapshot, but DO NOT clearBackgroundShell / remove it from the
         // map. mtime quiescence can't distinguish "finished" from "idle but
@@ -950,12 +950,12 @@ export class BaseSession extends EventEmitter {
    * logs "listening on :3000" then waits, a file watcher, `tail -f`, a build in
    * a long silent link phase). chroxy never holds the shell's PID (the id is
    * opaque, owned by claude), so mtime quiescence is the best the BANNER can do
-   * — and the caller (`_sweepCompletedBackgroundShells`) treats a `true` here as
+   * — and the caller (`_sweepQuiescedBackgroundShells`) treats a `true` here as
    * ADVISORY (clears the banner only). Liveness / `SessionTimeoutManager` is
    * governed solely by BashOutput / destroy (#4307), so a false "quiesced" here
    * can no longer idle-time a live session out.
    *
-   * Tests inject `_backgroundShellCompletionCheck` for deterministic control
+   * Tests inject `_backgroundShellQuiesceCheck` for deterministic control
    * without touching the filesystem or real time. A shell with no known output
    * path, or whose output file is still empty (a silent command like
    * `sleep 600`), is never marked quiesced via this path and stays in the
@@ -968,9 +968,9 @@ export class BaseSession extends EventEmitter {
    * @returns {boolean}
    * @private
    */
-  _isBackgroundShellComplete(entry) {
-    if (typeof this._backgroundShellCompletionCheck === 'function') {
-      return this._backgroundShellCompletionCheck(entry) === true
+  _isBackgroundShellQuiesced(entry) {
+    if (typeof this._backgroundShellQuiesceCheck === 'function') {
+      return this._backgroundShellQuiesceCheck(entry) === true
     }
     if (!entry || typeof entry.outputPath !== 'string' || entry.outputPath.length === 0) {
       return false

--- a/packages/server/tests/background-shells.test.js
+++ b/packages/server/tests/background-shells.test.js
@@ -271,27 +271,49 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
     emptySkillsDir = null
   })
 
-  it('reaps a completed shell on the next sweep tick WITHOUT a BashOutput poll', () => {
+  it('#5247: the sweep is advisory — clears the banner but does NOT flip isRunning', () => {
     mock.timers.enable({ apis: ['setInterval'] })
-    // Deterministic completion check: this shell is "done".
+    // Deterministic completion check: this shell's output has "quiesced".
     session._backgroundShellCompletionCheck = () => true
 
     const events = []
     session.on('background_work_changed', (d) => events.push(d))
 
-    session.trackBackgroundShell({ shellId: 'a', command: 'sleep 5', outputPath: '/tmp/a.output' })
+    session.trackBackgroundShell({ shellId: 'a', command: 'npm run dev', outputPath: '/tmp/a.output' })
     assert.equal(session.isRunning, true, 'running while pending')
     assert.equal(events.length, 1, 'track emitted once')
 
-    // Advance one sweep interval — the sweep should reap the shell.
+    // Advance one sweep interval — the sweep marks the shell quiesced.
     mock.timers.tick(1000)
 
-    assert.equal(session._pendingBackgroundShells.size, 0, 'shell reaped')
-    assert.equal(session.isRunning, false, 'no longer running')
-    // The reap must emit the SAME background_work_changed snapshot the
-    // dashboard consumes (empty pending) — this is the #5178 clear signal.
-    assert.equal(events.length, 2, 'reap emitted a second change')
-    assert.equal(events[1].pending.length, 0, 'snapshot shows no pending shells')
+    // The banner clears: the snapshot drops the quiesced shell, emitting the
+    // SAME background_work_changed the dashboard consumes.
+    assert.equal(events.length, 2, 'sweep emitted a banner change')
+    assert.equal(events[1].pending.length, 0, 'banner snapshot shows no pending shells')
+    assert.equal(session.getPendingBackgroundShells().length, 0, 'banner empty')
+
+    // But liveness is NOT flipped: the shell stays in the map and isRunning is
+    // still true — mtime quiescence can't tell a finished command from a live,
+    // idle dev server, so SessionTimeoutManager must not idle-time it out
+    // (#5247 / #4307). The OLD code reaped here and flipped isRunning false.
+    assert.equal(session._pendingBackgroundShells.size, 1, 'shell retained for liveness')
+    assert.equal(session.isRunning, true, 'still running after an advisory sweep')
+
+    // The recurring stat() sweep stops once nothing can still transition.
+    assert.equal(session._backgroundShellSweepTimer, null, 'sweep stops when all quiesced')
+  })
+
+  it('#5247: an authoritative clear (BashOutput / destroy) releases liveness after a sweep', () => {
+    mock.timers.enable({ apis: ['setInterval'] })
+    session._backgroundShellCompletionCheck = () => true
+    session.trackBackgroundShell({ shellId: 'a', outputPath: '/tmp/a.output' })
+    mock.timers.tick(1000) // advisory quiesce — banner clears, liveness retained
+    assert.equal(session.isRunning, true, 'sweep alone keeps it running')
+
+    // The agent polls BashOutput → clearBackgroundShell → liveness released.
+    assert.equal(session.clearBackgroundShell('a'), true)
+    assert.equal(session._pendingBackgroundShells.size, 0)
+    assert.equal(session.isRunning, false, 'now idle once the shell is acknowledged')
   })
 
   it('leaves a still-running shell pending across sweep ticks', () => {

--- a/packages/server/tests/background-shells.test.js
+++ b/packages/server/tests/background-shells.test.js
@@ -273,8 +273,8 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
 
   it('#5247: the sweep is advisory — clears the banner but does NOT flip isRunning', () => {
     mock.timers.enable({ apis: ['setInterval'] })
-    // Deterministic completion check: this shell's output has "quiesced".
-    session._backgroundShellCompletionCheck = () => true
+    // Deterministic quiescence check: this shell's output has "quiesced".
+    session._backgroundShellQuiesceCheck = () => true
 
     const events = []
     session.on('background_work_changed', (d) => events.push(d))
@@ -305,7 +305,7 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
 
   it('#5247: an authoritative clear (BashOutput / destroy) releases liveness after a sweep', () => {
     mock.timers.enable({ apis: ['setInterval'] })
-    session._backgroundShellCompletionCheck = () => true
+    session._backgroundShellQuiesceCheck = () => true
     session.trackBackgroundShell({ shellId: 'a', outputPath: '/tmp/a.output' })
     mock.timers.tick(1000) // advisory quiesce — banner clears, liveness retained
     assert.equal(session.isRunning, true, 'sweep alone keeps it running')
@@ -318,7 +318,7 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
 
   it('leaves a still-running shell pending across sweep ticks', () => {
     mock.timers.enable({ apis: ['setInterval'] })
-    session._backgroundShellCompletionCheck = () => false
+    session._backgroundShellQuiesceCheck = () => false
 
     session.trackBackgroundShell({ shellId: 'a', command: 'sleep 600', outputPath: '/tmp/a.output' })
     mock.timers.tick(1000)
@@ -331,7 +331,7 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
     mock.timers.enable({ apis: ['setInterval'] })
     assert.equal(session._backgroundShellSweepTimer, null, 'no timer when idle')
 
-    session._backgroundShellCompletionCheck = () => false
+    session._backgroundShellQuiesceCheck = () => false
     session.trackBackgroundShell({ shellId: 'a', outputPath: '/tmp/a.output' })
     assert.ok(session._backgroundShellSweepTimer, 'timer armed once pending')
 
@@ -340,7 +340,7 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
     assert.equal(session._backgroundShellSweepTimer, null, 'timer stopped when map drains')
   })
 
-  it('default completion check uses the output file mtime (real fs, no real timers)', () => {
+  it('default quiescence check uses the output file mtime (real fs, no real timers)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'chroxy-bg-out-'))
     const outputPath = join(dir, 'shell.output')
     writeFileSync(outputPath, 'hi\n')
@@ -349,17 +349,17 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
     // Freshly written → not quiesced → not complete.
     session.trackBackgroundShell({ shellId: 'a', outputPath })
     const fresh = session._pendingBackgroundShells.get('a')
-    assert.equal(session._isBackgroundShellComplete(fresh), false, 'fresh write is not complete')
+    assert.equal(session._isBackgroundShellQuiesced(fresh), false, 'fresh write is not quiesced')
 
-    // Backdate the mtime past the quiescence window → complete.
+    // Backdate the mtime past the quiescence window → quiesced.
     const old = Date.now() / 1000 - 60
     utimesSync(outputPath, old, old)
-    assert.equal(session._isBackgroundShellComplete(fresh), true, 'quiesced file is complete')
+    assert.equal(session._isBackgroundShellQuiesced(fresh), true, 'idle file is quiesced')
 
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('default completion check does NOT reap a silent shell whose output file is empty (#5177 review)', () => {
+  it('default quiescence check does NOT reap a silent shell whose output file is empty (#5177 review)', () => {
     // A silent command (e.g. `sleep 600`) leaves an empty, quiesced output
     // file. Reaping on mtime alone would flip isRunning to false while it is
     // still running; the non-empty guard prevents that.
@@ -374,7 +374,7 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
     session.trackBackgroundShell({ shellId: 'a', outputPath })
     const entry = session._pendingBackgroundShells.get('a')
     assert.equal(
-      session._isBackgroundShellComplete(entry),
+      session._isBackgroundShellQuiesced(entry),
       false,
       'empty output file is never reaped (silent shell stays pending)',
     )
@@ -382,19 +382,19 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it('default completion check treats a shell with no output path as not complete (#4307 fallback)', () => {
+  it('default quiescence check treats a shell with no output path as not quiesced (#4307 fallback)', () => {
     session._backgroundShellQuiesceMs = 5000
     session.trackBackgroundShell({ shellId: 'a', command: 'x' })
     const entry = session._pendingBackgroundShells.get('a')
     assert.equal(entry.outputPath, null, 'no path captured')
-    assert.equal(session._isBackgroundShellComplete(entry), false, 'cannot reap without a path')
+    assert.equal(session._isBackgroundShellQuiesced(entry), false, 'cannot reap without a path')
   })
 
-  it('default completion check treats a stat() error as not complete (defensive)', () => {
+  it('default quiescence check treats a stat() error as not quiesced (defensive)', () => {
     session._backgroundShellQuiesceMs = 5000
     session.trackBackgroundShell({ shellId: 'a', outputPath: '/no/such/file/at/all.output' })
     const entry = session._pendingBackgroundShells.get('a')
-    assert.equal(session._isBackgroundShellComplete(entry), false, 'missing file is not reaped')
+    assert.equal(session._isBackgroundShellQuiesced(entry), false, 'missing file is not reaped')
   })
 
   it('outputPath is NOT leaked onto the wire snapshot', () => {
@@ -407,7 +407,7 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
 
   it('destroy stops the sweep timer (no leak)', () => {
     mock.timers.enable({ apis: ['setInterval'] })
-    session._backgroundShellCompletionCheck = () => false
+    session._backgroundShellQuiesceCheck = () => false
     session.trackBackgroundShell({ shellId: 'a', outputPath: '/tmp/a.output' })
     assert.ok(session._backgroundShellSweepTimer)
     session._destroyPendingBackgroundShells()


### PR DESCRIPTION
Closes #5247.

## The bug (premature session timeout — re-opens #4307)

`_isBackgroundShellComplete` declared a background shell "complete" whenever its output file was **non-empty AND mtime-idle for 60s**, and the sweep then called `clearBackgroundShell` — flipping `isRunning` to false. `SessionTimeoutManager` skips sessions only while `isRunning` is true, so the session could then be idle-timed-out **while the OS process is still alive**.

mtime quiescence can't distinguish *finished* from *idle but alive*. A dev server that logs `listening on :3000` then waits for connections, a file watcher, `tail -f`, or a build in a long silent link phase all write once and go quiet — and got reaped at 60s, silently re-introducing the exact premature-timeout #4307's pending-shell clause was added to prevent.

## Fix (issue option 1 — advisory sweep)

The sweep is now **advisory**: it marks the shell `quiesced` (dropping it from the dashboard "Waiting on background work" banner) but **keeps it in `_pendingBackgroundShells`**, so `isRunning` stays true. Liveness is released only by a **BashOutput poll or destroy** — exactly #4307's authority.

- `getPendingBackgroundShells()` filters out `quiesced` entries → the banner still clears (#5177 preserved).
- `isRunning` counts the map (incl. quiesced) → no false idle flip.
- The sweep stops once nothing can still transition; a new shell re-arms it.
- Corrected the misleading docstrings (the old "the strong signal that the command ran and finished" claim) and the `BACKGROUND_SHELL_QUIESCE_MS` comment.

## Tests

- **`#5247`: the sweep is advisory** — after a sweep the banner snapshot empties but `_pendingBackgroundShells.size === 1` and `isRunning === true`. **Mutation-catching**: the old reap-and-flip code fails these assertions.
- **`#5247`: authoritative clear releases liveness** — a BashOutput `clearBackgroundShell` after the sweep flips `isRunning` false.
- Existing `_isBackgroundShellComplete` (quiescence detection), silent-shell, no-path, and stat-error tests unchanged.

660 base/sdk/tui/session-manager tests + 94 background-shell/timeout/activity tests pass; both server lints + eslint clean.

## Tradeoff (documented)

A genuinely-finished background command that the agent never polls now keeps the session alive until destroy — this is #4307's original (shipped, accepted) behaviour. The premature-timeout of a *live* process is the worse harm and is what this fixes.