### PR TITLE
fix(server): credentials-safe warn logging on credential replace win32 retry (#5264)

### DIFF
--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -331,14 +331,15 @@ export function replaceFileAtomically(tmp, target, deps = {}) {
     _log.warn(`credentials atomic replace hit a Windows held-handle lock (${err.code}); attempting one-shot retry`)
     // Snapshot the live target so we can restore it if the retry also fails.
     let snapshot = null
-    try { snapshot = readFile(target) } catch { /* target may already be gone */ }
+    let snapshotErr = null
+    try { snapshot = readFile(target) } catch (readErr) { snapshotErr = readErr /* target may already be gone */ }
     // If the snapshot failed but the target is still on disk (e.g. readFile threw
     // EACCES/EPERM because the same held handle is blocking the read), unlinking
     // it here would destroy the only copy with no way to restore — re-introducing
     // the #5243 data-loss path. Keep the live file intact and surface the ORIGINAL
     // lock error instead; the caller is no worse off than before the retry.
     if (snapshot === null && existsSync(target)) {
-      _log.warn(`credentials atomic replace could not snapshot the live target before retry (${err.code}); leaving it intact and surfacing the lock error`)
+      _log.warn(`credentials atomic replace could not snapshot the live target before retry (lock ${err.code}, read ${snapshotErr?.code || 'unknown'}); leaving it intact and surfacing the lock error`)
       throw err
     }
     try { unlink(target) } catch { /* best-effort — target may be gone */ }
@@ -354,7 +355,7 @@ export function replaceFileAtomically(tmp, target, deps = {}) {
           // Worst case: target deleted, retry failed, restore failed → no
           // credentials on disk. Leave a breadcrumb (codes only) so the thrown
           // error isn't the sole signal that a restore was even attempted.
-          _log.warn(`credentials atomic replace failed to restore the prior file after a failed retry (${restoreErr?.code || restoreErr?.message || 'unknown'})`)
+          _log.warn(`credentials atomic replace failed to restore the prior file after a failed retry (${restoreErr?.code || 'unknown'})`)
         }
       }
       throw retryErr

--- a/packages/server/src/credential-store.js
+++ b/packages/server/src/credential-store.js
@@ -300,6 +300,10 @@ function readStore() {
  * the snapshot read failed but the file is still present (see below) — so the
  * worst pre-crash state is "live file intact, replace not applied".
  *
+ * #5264: the win32 retry/refuse/restore branches emit credentials-safe
+ * `_log.warn` breadcrumbs (error codes only — never values or snapshot bytes)
+ * for observability parity with `_rotateToBak`.
+ *
  * fs ops are injectable for testing (defaults are the real fs calls).
  *
  * @param {string} tmp - source temp path.
@@ -321,6 +325,10 @@ export function replaceFileAtomically(tmp, target, deps = {}) {
     // Non-Windows, or an error that isn't a Windows held-handle lock: surface
     // it unchanged (no unlink — preserves the #5243 no-pre-delete guarantee).
     if (platform !== 'win32' || !err || !CRED_WINDOWS_LOCK_CODES.has(err.code)) throw err
+    // #5264: surface the recovery attempt for observability parity with
+    // session-state-persistence._rotateToBak. Only the error code is logged —
+    // never the credential value or any snapshot bytes (module invariant).
+    _log.warn(`credentials atomic replace hit a Windows held-handle lock (${err.code}); attempting one-shot retry`)
     // Snapshot the live target so we can restore it if the retry also fails.
     let snapshot = null
     try { snapshot = readFile(target) } catch { /* target may already be gone */ }
@@ -329,7 +337,10 @@ export function replaceFileAtomically(tmp, target, deps = {}) {
     // it here would destroy the only copy with no way to restore — re-introducing
     // the #5243 data-loss path. Keep the live file intact and surface the ORIGINAL
     // lock error instead; the caller is no worse off than before the retry.
-    if (snapshot === null && existsSync(target)) throw err
+    if (snapshot === null && existsSync(target)) {
+      _log.warn(`credentials atomic replace could not snapshot the live target before retry (${err.code}); leaving it intact and surfacing the lock error`)
+      throw err
+    }
     try { unlink(target) } catch { /* best-effort — target may be gone */ }
     try {
       rename(tmp, target)
@@ -337,7 +348,14 @@ export function replaceFileAtomically(tmp, target, deps = {}) {
       // Retry still failed — restore the live bytes (if captured) so the prior
       // credentials survive, then surface the error to the caller.
       if (snapshot !== null) {
-        try { writeFile(target, snapshot, { mode: 0o600 }) } catch { /* best-effort restore */ }
+        try {
+          writeFile(target, snapshot, { mode: 0o600 })
+        } catch (restoreErr) {
+          // Worst case: target deleted, retry failed, restore failed → no
+          // credentials on disk. Leave a breadcrumb (codes only) so the thrown
+          // error isn't the sole signal that a restore was even attempted.
+          _log.warn(`credentials atomic replace failed to restore the prior file after a failed retry (${restoreErr?.code || restoreErr?.message || 'unknown'})`)
+        }
       }
       throw retryErr
     }

--- a/packages/server/tests/credential-store-atomic-replace.test.js
+++ b/packages/server/tests/credential-store-atomic-replace.test.js
@@ -7,6 +7,7 @@ import {
   replaceFileAtomically,
   setStoredCredential,
   getStoredCredential,
+  _setCredentialLoggerForTests,
 } from '../src/credential-store.js'
 
 /**
@@ -184,5 +185,102 @@ describe('credential-store — set overwrites an existing file safely (#5243)', 
     // existing file. The store must end up with the new value and stay readable.
     setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-second')
     assert.equal(getStoredCredential('ANTHROPIC_API_KEY'), 'sk-ant-second')
+  })
+})
+
+describe('credential-store — replaceFileAtomically win32 warn logging (#5264)', () => {
+  let dir
+  let warnings
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-cred-warn-'))
+    warnings = []
+    // Capture-only logger. warn() records the message so we can assert on it;
+    // the other levels are no-ops. The credential value must never appear here.
+    _setCredentialLoggerForTests({
+      warn: (m) => warnings.push(m),
+      info: () => {},
+      error: () => {},
+      debug: () => {},
+    })
+  })
+  afterEach(() => {
+    _setCredentialLoggerForTests(null)
+    try { rmSync(dir, { recursive: true, force: true }) } catch { /* */ }
+  })
+
+  it('warns once on entering the retry after a held-handle lock, then succeeds (no value leaked)', () => {
+    const target = join(dir, 'c.json')
+    const tmp = join(dir, 'c.json.tmp')
+    writeFileSync(target, 'LIVE-SECRET-VALUE')
+    writeFileSync(tmp, 'NEW')
+    let attempts = 0
+    replaceFileAtomically(tmp, target, {
+      platform: 'win32',
+      rename: (from, to) => {
+        attempts++
+        if (attempts === 1) { const e = new Error('EBUSY: handle held'); e.code = 'EBUSY'; throw e }
+        renameSync(from, to)
+      },
+    })
+    assert.equal(attempts, 2, 'one retry')
+    const retryWarns = warnings.filter((w) => /one-shot retry/.test(w))
+    assert.equal(retryWarns.length, 1, 'exactly one retry warn')
+    assert.match(retryWarns[0], /EBUSY/, 'logs the error code')
+    // No restore warn on the success path.
+    assert.equal(warnings.filter((w) => /restore/.test(w)).length, 0)
+    // The credential value must never reach the logger.
+    assert.ok(!warnings.some((w) => w.includes('LIVE-SECRET-VALUE')), 'credential value never logged')
+  })
+
+  it('warns on the refuse-to-unlink safety stop when the snapshot read fails', () => {
+    const target = join(dir, 'c.json')
+    const tmp = join(dir, 'c.json.tmp')
+    writeFileSync(target, 'LIVE')
+    writeFileSync(tmp, 'NEW')
+    assert.throws(() => {
+      replaceFileAtomically(tmp, target, {
+        platform: 'win32',
+        rename: () => { const e = new Error('EPERM: locked'); e.code = 'EPERM'; throw e },
+        readFile: () => { const e = new Error('EACCES: read blocked'); e.code = 'EACCES'; throw e },
+        unlink: () => { throw new Error('unlink must not be called') },
+      })
+    }, /EPERM/)
+    assert.equal(warnings.filter((w) => /could not snapshot/.test(w)).length, 1, 'one refuse-to-unlink warn')
+    assert.match(warnings.find((w) => /could not snapshot/.test(w)), /EPERM/)
+  })
+
+  it('warns when the restore also fails after a failed retry (codes only)', () => {
+    const target = join(dir, 'c.json')
+    const tmp = join(dir, 'c.json.tmp')
+    writeFileSync(target, 'LIVE')
+    writeFileSync(tmp, 'NEW')
+    assert.throws(() => {
+      replaceFileAtomically(tmp, target, {
+        platform: 'win32',
+        rename: () => { const e = new Error('EBUSY: locked'); e.code = 'EBUSY'; throw e },
+        // Snapshot succeeds (captures live bytes), unlink succeeds, retry fails,
+        // and the restore write fails too — the worst-case silent path.
+        readFile: () => Buffer.from('LIVE'),
+        unlink: () => {},
+        writeFile: () => { const e = new Error('ENOSPC: disk full'); e.code = 'ENOSPC'; throw e },
+      })
+    }, /EBUSY/)
+    const restoreWarns = warnings.filter((w) => /failed to restore/.test(w))
+    assert.equal(restoreWarns.length, 1, 'one failed-restore warn')
+    assert.match(restoreWarns[0], /ENOSPC/, 'logs the restore error code')
+  })
+
+  it('does not warn at all on a clean non-win32 failure (no retry path entered)', () => {
+    const target = join(dir, 'c.json')
+    const tmp = join(dir, 'c.json.tmp')
+    writeFileSync(target, 'LIVE')
+    writeFileSync(tmp, 'NEW')
+    assert.throws(() => {
+      replaceFileAtomically(tmp, target, {
+        platform: 'linux',
+        rename: () => { const e = new Error('EBUSY: locked'); e.code = 'EBUSY'; throw e },
+      })
+    }, /EBUSY/)
+    assert.equal(warnings.length, 0, 'no win32 retry warns on a non-win32 platform')
   })
 })

--- a/packages/server/tests/credential-store-atomic-replace.test.js
+++ b/packages/server/tests/credential-store-atomic-replace.test.js
@@ -246,7 +246,9 @@ describe('credential-store — replaceFileAtomically win32 warn logging (#5264)'
       })
     }, /EPERM/)
     assert.equal(warnings.filter((w) => /could not snapshot/.test(w)).length, 1, 'one refuse-to-unlink warn')
-    assert.match(warnings.find((w) => /could not snapshot/.test(w)), /EPERM/)
+    const snapshotWarn = warnings.find((w) => /could not snapshot/.test(w))
+    assert.match(snapshotWarn, /EPERM/, 'logs the original lock code')
+    assert.match(snapshotWarn, /EACCES/, 'logs the snapshot-read code that actually triggered this branch')
   })
 
   it('warns when the restore also fails after a failed retry (codes only)', () => {


### PR DESCRIPTION
## Summary

Closes #5264 (follow-up from the #5261 review).

`credential-store.replaceFileAtomically`'s win32 held-handle retry path was **completely silent**. Unlike its reference `session-state-persistence._rotateToBak`, it logged nothing when entering the retry, when refusing to unlink, or when a restore failed — so the worst case (target deleted → retry failed → restore failed → zero credentials on disk) surfaced only as the thrown error, with no breadcrumb that a restore was even attempted.

## Change

Add credentials-safe `_log.warn` breadcrumbs on the three win32 recovery branches:

| Branch | Warn |
|--------|------|
| Entering the one-shot retry after a Windows lock code | `…hit a Windows held-handle lock (CODE); attempting one-shot retry` |
| Refuse-to-unlink safety stop (snapshot read failed, target still present) | `…could not snapshot the live target before retry (CODE); leaving it intact…` |
| Restore also failed after a failed retry | `…failed to restore the prior file after a failed retry (CODE)` |

**Only error codes are logged — never the credential value or snapshot bytes**, preserving the module invariant that raw values never reach any logger. A capture-only test logger asserts the credential value never appears in any warn.

## Tests

`credential-store-atomic-replace.test.js` — 4 new cases (12 total, all pass):
- warns once on entering the retry then succeeds, and the value is never leaked
- warns on the refuse-to-unlink safety stop when the snapshot read fails
- warns when the restore also fails after a failed retry (codes only)
- does **not** warn at all on a non-win32 failure (retry path never entered)

No behaviour change — observability only. The #5261 data-loss guarantees (atomic-first, no pre-delete, refuse-to-unlink) are untouched.