### PR TITLE
fix(server): gate provider-credential writes behind primary token (#5155)

### DIFF
--- a/docs/security/bearer-token-authority.md
+++ b/docs/security/bearer-token-authority.md
@@ -71,6 +71,15 @@ When `ws-auth.js` accepts a pair-issued token, it sets `client.boundSessionId` o
 
 Bound tokens cannot create, destroy, switch, or list sibling sessions. They can chat into their bound session and answer permissions for it. That's it.
 
+### Host-level writes a bound token must NOT reach
+
+Two host-level mutations are gated against bound tokens even though they arrive on the same WS surface, because each one escalates beyond a single session's scope:
+
+- **Auto permission mode** (`set_permission_mode` with `mode: 'auto'`, [`settings-handlers.js`](../../packages/server/src/handlers/settings-handlers.js)) — flipping a session to auto-approve is a privilege escalation, so a bound token is rejected with `AUTO_MODE_FORBIDDEN_BOUND_CLIENT`. Only the primary token (and only when `allowAutoPermissionMode` is set in the local config) can enable it.
+- **Provider credential writes** (`set_credential` / `delete_credential` and the BYOK `byok_set_credentials` / `byok_clear_credentials`, [`settings-handlers.js`](../../packages/server/src/handlers/settings-handlers.js) — `rejectCredentialWriteIfBound`) — a bound token can READ masked, value-free status, but writing lets the caller swap in a key it controls (billing redirection) or clear keys (DoS). That integrity risk is distinct from "use the credentials a session already resolves", so writes are rejected with `CREDENTIAL_WRITE_FORBIDDEN_BOUND_CLIENT` (#5155). Reads stay open to any authenticated client.
+
+Both gates branch on `client.boundSessionId` and reject via `sendError` (a generic `error` message) — the canonical pattern for "this operation requires host-level authority" on the WS path. New credential-touching or config-mutating handlers should follow it (see §8).
+
 ## 5. Per-Session Hook Secrets
 
 Each `CliSession` mints a 32-byte hex secret in its constructor ([`cli-session.js`](../../packages/server/src/cli-session.js) ~line 193) and exports it to the spawned `claude` CLI subprocess as `CHROXY_HOOK_SECRET`. The CLI uses it on outbound `POST /permission` callbacks.
@@ -104,6 +113,7 @@ Each step here tightened a real bug. Read the PRs in order if extending any of t
 - **#4788 / #4794** — closed gaps where bound tokens could resolve cross-session permissions
 - **#4798** — unified `SESSION_TOKEN_MISMATCH` payload across WS and HTTP error surfaces
 - **#4820** — P0 fix for cross-session `permission_response` hijack on the WS path; the review of that PR is what motivated this doc (issue #4830)
+- **#5155** — gated provider-credential WRITES (set/delete/clear, both the #3855 generalized and #4052 BYOK paths) behind host-level authority; bound tokens can read masked status but not overwrite or clear keys
 
 ## 8. Adding a New Endpoint or Message Type — Checklist
 

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -466,6 +466,35 @@ function handleListProviders(ws, client, msg, ctx) {
 }
 
 /**
+ * #5155: gate credential WRITES (set/delete/clear) behind the primary token.
+ *
+ * Reads are safe (status is masked, value-free) and stay open to every
+ * authenticated client. But a WRITE lets the caller swap in or clear the
+ * operator's provider keys — a pairing-bound (share-a-session) token doing so is
+ * a billing-redirection / integrity / DoS risk distinct from "use the existing
+ * credentials". So credential mutations now require host-level authority: a
+ * pairing-issued session token (client.boundSessionId set) is rejected, exactly
+ * like the auto-permission-mode escalation gate above. Only the primary API
+ * token (or an unbound linking-mode pairing token, both with boundSessionId
+ * unset) can write.
+ *
+ * Returns true and sends the rejection if the client is bound (caller must
+ * early-return); false to proceed. See docs/security/bearer-token-authority.md.
+ *
+ * @param {object} ws
+ * @param {object} client
+ * @param {object} msg
+ * @returns {boolean} true if the write was rejected.
+ */
+function rejectCredentialWriteIfBound(ws, client, msg) {
+  if (!client?.boundSessionId) return false
+  loggerForSession('ws', client.boundSessionId).warn(`Client ${client.id} (bound to ${client.boundSessionId}) attempted to modify provider credentials — rejected`)
+  sendError(ws, msg?.requestId, 'CREDENTIAL_WRITE_FORBIDDEN_BOUND_CLIENT',
+    'Pairing-issued session tokens cannot modify provider credentials. Use the primary API token from a device with physical access to this machine.')
+  return true
+}
+
+/**
  * BYOK credentials handlers (#4052).
  *
  * Three message types: get status, set the key, clear the key. The full
@@ -474,9 +503,9 @@ function handleListProviders(ws, client, msg, ctx) {
  * success replies go back to the calling ws AND broadcast to all
  * authenticated clients so additional dashboards / tabs stay in sync.
  *
- * Auth posture: any authenticated WS client can call these. chroxy isn't
- * multi-tenant — the user controls their own credentials file. The
- * existing WS auth gate is sufficient.
+ * Auth posture: status reads are open to any authenticated WS client. WRITES
+ * (set/clear) require host-level authority — a pairing-bound session token is
+ * rejected via `rejectCredentialWriteIfBound` (#5155).
  */
 function handleByokGetCredentialsStatus(ws, client, msg, ctx) {
   const status = getAnthropicApiKeyStatus()
@@ -484,6 +513,7 @@ function handleByokGetCredentialsStatus(ws, client, msg, ctx) {
 }
 
 function handleByokSetCredentials(ws, client, msg, ctx) {
+  if (rejectCredentialWriteIfBound(ws, client, msg)) return
   // Trim leading/trailing whitespace — pastes often carry surrounding
   // spaces/newlines that would otherwise be persisted into the credentials
   // file and silently fail when the SDK tries to use the key.
@@ -519,6 +549,7 @@ function handleByokSetCredentials(ws, client, msg, ctx) {
 }
 
 function handleByokClearCredentials(ws, client, msg, ctx) {
+  if (rejectCredentialWriteIfBound(ws, client, msg)) return
   try {
     clearAnthropicApiKey()
   } catch (err) {
@@ -541,16 +572,14 @@ function handleByokClearCredentials(ws, client, msg, ctx) {
  * reply with the same masked `credentials_status` snapshot the status query
  * returns.
  *
- * Auth posture: identical to the BYOK handlers — any authenticated WS client
- * (primary or pairing-bound token) reaches these because chroxy isn't
- * multi-tenant and the operator owns their own credential file. The WS auth
- * gate in ws-server.js (`client.authenticated`) is the access control; these
- * handlers never run for an unauthenticated connection. Per the bearer-token
- * authority doc, credential management is global state — but unlike the
- * privilege-escalating auto-mode flip, reading/writing one's own provider keys
- * is within the authority both token classes already hold (a bound token can
- * already use whatever credentials a session resolves), so no bound-token
- * rejection is required here.
+ * Auth posture (#5155): status reads are open to any authenticated WS client
+ * (the snapshot is masked and value-free). WRITES (set/delete) require
+ * host-level authority — a pairing-bound session token is rejected via
+ * `rejectCredentialWriteIfBound`, mirroring the auto-permission-mode escalation
+ * gate. Overwriting the operator's provider keys is a billing/integrity/DoS
+ * vector distinct from "use the existing credentials a session resolves", so a
+ * bound token must not be able to swap or clear them. See
+ * docs/security/bearer-token-authority.md.
  */
 const CREDENTIAL_OAUTH_HELPERS = Object.freeze({
   hasClaudeOAuthCreds,
@@ -574,6 +603,7 @@ function handleGetCredentialsStatus(ws, client, msg, ctx) {
 }
 
 function handleSetCredential(ws, client, msg, ctx) {
+  if (rejectCredentialWriteIfBound(ws, client, msg)) return
   const key = typeof msg?.key === 'string' ? msg.key : ''
   if (!isKnownCredentialKey(key)) {
     sendError(ws, msg?.requestId, 'INVALID_REQUEST', `Unknown credential key: ${key}`)
@@ -597,6 +627,7 @@ function handleSetCredential(ws, client, msg, ctx) {
 }
 
 function handleDeleteCredential(ws, client, msg, ctx) {
+  if (rejectCredentialWriteIfBound(ws, client, msg)) return
   const key = typeof msg?.key === 'string' ? msg.key : ''
   if (!isKnownCredentialKey(key)) {
     sendError(ws, msg?.requestId, 'INVALID_REQUEST', `Unknown credential key: ${key}`)

--- a/packages/server/tests/credential-handlers.test.js
+++ b/packages/server/tests/credential-handlers.test.js
@@ -182,4 +182,63 @@ describe('credential WS handlers (#3855)', () => {
       assert.equal(reply.type, 'error')
     })
   })
+
+  // #5155: credential WRITES require host-level authority. A pairing-bound
+  // session token (client.boundSessionId set) can READ masked status but must
+  // NOT be able to overwrite or clear the operator's provider keys — that's a
+  // billing-redirection / DoS vector. Reads stay open for the bound client.
+  describe('#5155 bound-client write gate', () => {
+    const boundClient = { id: 'c-bound', boundSessionId: 'sess-1' }
+
+    it('rejects set_credential from a pairing-bound client and does not write', () => {
+      const ws = makeWs()
+      const ctx = makeCtx()
+      settingsHandlers.set_credential(ws, boundClient, {
+        type: 'set_credential', key: 'OPENAI_API_KEY', value: 'sk-openai-evil', requestId: 'rb1',
+      }, ctx)
+      const reply = lastReply(ws, ctx)
+      assert.equal(reply.type, 'error')
+      assert.equal(reply.code, 'CREDENTIAL_WRITE_FORBIDDEN_BOUND_CLIENT')
+      assert.equal(reply.requestId, 'rb1')
+      // The write must NOT have happened.
+      assert.equal(getStoredCredential('OPENAI_API_KEY'), null)
+      assert.equal(ctx.broadcast.mock.callCount(), 0)
+    })
+
+    it('rejects delete_credential from a pairing-bound client and leaves the value intact', () => {
+      setStoredCredential('GEMINI_API_KEY', 'gem-keep')
+      const ws = makeWs()
+      const ctx = makeCtx()
+      settingsHandlers.delete_credential(ws, boundClient, {
+        type: 'delete_credential', key: 'GEMINI_API_KEY', requestId: 'rb2',
+      }, ctx)
+      const reply = lastReply(ws, ctx)
+      assert.equal(reply.type, 'error')
+      assert.equal(reply.code, 'CREDENTIAL_WRITE_FORBIDDEN_BOUND_CLIENT')
+      // The live value must survive.
+      assert.equal(getStoredCredential('GEMINI_API_KEY'), 'gem-keep')
+    })
+
+    it('still allows a pairing-bound client to READ masked status', () => {
+      setStoredCredential('ANTHROPIC_API_KEY', 'sk-ant-readable')
+      const ws = makeWs()
+      const ctx = makeCtx()
+      settingsHandlers.get_credentials_status(ws, boundClient, { type: 'get_credentials_status', requestId: 'rb3' }, ctx)
+      const reply = lastReply(ws, ctx)
+      assert.equal(reply.type, 'credentials_status')
+      const anth = reply.credentials.find((c) => c.key === 'ANTHROPIC_API_KEY')
+      assert.equal(anth.status, 'set')
+    })
+
+    it('still allows the primary (unbound) client to write', () => {
+      const ws = makeWs()
+      const ctx = makeCtx()
+      settingsHandlers.set_credential(ws, { id: 'c-primary' }, {
+        type: 'set_credential', key: 'OPENAI_API_KEY', value: 'sk-openai-ok', requestId: 'rb4',
+      }, ctx)
+      const reply = lastReply(ws, ctx)
+      assert.equal(reply.type, 'credentials_status')
+      assert.equal(getStoredCredential('OPENAI_API_KEY'), 'sk-openai-ok')
+    })
+  })
 })

--- a/packages/server/tests/handlers/byok-credentials-handlers.test.js
+++ b/packages/server/tests/handlers/byok-credentials-handlers.test.js
@@ -223,4 +223,46 @@ describe('byok credentials handlers (#4052)', () => {
       }
     })
   })
+
+  // #5155: BYOK credential WRITES require host-level authority. A pairing-bound
+  // session token (client.boundSessionId set) can READ masked status but must
+  // NOT be able to set or clear the operator's key.
+  describe('#5155 bound-client write gate', () => {
+    const boundClient = { id: 'c-bound', boundSessionId: 'sess-1' }
+    const credPath = () => join(tmpHome, '.chroxy', 'credentials.json')
+
+    it('rejects byok_set_credentials from a pairing-bound client and writes nothing', () => {
+      const longKey = 'sk-ant-api03-' + 'f'.repeat(95)
+      const ws = makeWs()
+      const ctx = makeCtx()
+      settingsHandlers.byok_set_credentials(ws, boundClient, { requestId: 'rb1', anthropicApiKey: longKey }, ctx)
+      const reply = ws._messages[0]
+      assert.equal(reply.type, 'error')
+      assert.equal(reply.code, 'CREDENTIAL_WRITE_FORBIDDEN_BOUND_CLIENT')
+      assert.equal(reply.requestId, 'rb1')
+      assert.equal(existsSync(credPath()), false, 'no credentials file written')
+      assert.equal(ctx.broadcast.calls.length, 0)
+    })
+
+    it('rejects byok_clear_credentials from a pairing-bound client and leaves the file intact', () => {
+      // Seed via an unbound (primary) client.
+      const longKey = 'sk-ant-api03-' + 'g'.repeat(95)
+      settingsHandlers.byok_set_credentials(makeWs(), { id: 'c-primary' }, { anthropicApiKey: longKey }, makeCtx())
+      assert.ok(existsSync(credPath()), 'precondition: file exists after set')
+
+      const ws = makeWs()
+      const ctx = makeCtx()
+      settingsHandlers.byok_clear_credentials(ws, boundClient, { requestId: 'rb2' }, ctx)
+      const reply = ws._messages[0]
+      assert.equal(reply.type, 'error')
+      assert.equal(reply.code, 'CREDENTIAL_WRITE_FORBIDDEN_BOUND_CLIENT')
+      assert.ok(existsSync(credPath()), 'credentials file must survive a rejected clear')
+    })
+
+    it('still allows a pairing-bound client to READ status', () => {
+      const ctx = makeCtx()
+      settingsHandlers.byok_get_credentials_status(makeWs(), boundClient, { requestId: 'rb3' }, ctx)
+      assert.equal(ctx._sent[0].type, 'byok_credentials_status')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes #5155.

A pairing-bound (share-a-session) token could **overwrite** the operator's provider credentials — `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, `GEMINI_API_KEY`, `OPENAI_API_KEY`. Reading is safe (status is masked, value-free), but a write lets a bound client swap in a key it controls (**billing redirection**) or clear keys (**DoS**) — an integrity risk distinct from "use the credentials a session already resolves". This posture was inherited from the #4052 BYOK handlers and generalized by the #3855 Provider Credentials pane.

**Decision (per maintainer):** gate credential **writes** behind host-level authority, mirroring the existing auto-permission-mode escalation gate.

## Change

Credential **writes** now require an unbound token (primary, or unbound linking-mode pairing token). A bound client (`client.boundSessionId` set) is rejected with `CREDENTIAL_WRITE_FORBIDDEN_BOUND_CLIENT`. Reads stay open to any authenticated client.

- New `rejectCredentialWriteIfBound(ws, client, msg)` guard, applied to all four write handlers:
  - `set_credential`, `delete_credential` (#3855 generalized path)
  - `byok_set_credentials`, `byok_clear_credentials` (#4052 BYOK path)
- Reuses the exact rejection convention of the auto-mode gate (`sendError` → generic `error` message, early return, session-scoped warn log).
- Rewrote the two stale JSDoc blocks that previously asserted "no bound-token rejection is required here".
- Recorded the decision in `docs/security/bearer-token-authority.md` (new §4 subsection "Host-level writes a bound token must NOT reach" + audit-chain entry).

No protocol/schema or dispatch changes — rejections use the existing generic `error` message type.

## Tests

`credential-handlers.test.js` + `handlers/byok-credentials-handlers.test.js` — new `#5155 bound-client write gate` blocks on both paths:
- bound client → `set`/`delete`/`clear` rejected with `CREDENTIAL_WRITE_FORBIDDEN_BOUND_CLIENT`, **and the write/clear does not happen** (value/file intact)
- bound client can **still read** masked status
- primary (unbound) client can **still write** (regression guard)

29 tests pass; eslint clean (the one `dirReal` warning is pre-existing, unrelated).