### PR TITLE
docs(security): reconcile keychain-unavailable fallback with #5154 scope (#5230)

### DIFF
--- a/docs/security/credentials-at-rest.md
+++ b/docs/security/credentials-at-rest.md
@@ -61,7 +61,7 @@ On hosts with no usable keychain — Windows, or headless Linux without `secret-
 
 It does **not** derive a key from machine identifiers and "encrypt" with that. Such a key is reconstructible on the same host that holds the file, so it would add only the *appearance* of protection — worse than honest plaintext, because it invites false confidence. Plaintext-`0600` is the same posture every other `~/.chroxy/` secret file uses.
 
-> **Reconciliation (#5230).** #5154's original scope said the keychain-less case should *refuse to store* rather than fall back to plaintext. The shipped behavior — and the recorded maintainer decision — is the `0600` plaintext fallback above, for the reasons in this section: a key stored beside the file is obfuscation not security, refuse-to-store would lock out every Windows / headless-Linux-without-`secret-tool` operator entirely, and it matches the existing primary-token fallback in `keychain.js`. #5154's "refuse to store" wording is superseded by this document.
+> **Reconciliation (#5230).** #5154's original scope said the keychain-less case should *refuse to store* rather than fall back to plaintext. The shipped behavior — and the recorded maintainer decision — is the `0600` plaintext fallback above, for the reasons in this section: a key stored beside the file is obfuscation not security, refuse-to-store would lock out every Windows / headless-Linux-without-`secret-tool` operator entirely, and it matches the existing primary-token fallback wired through `server-cli.js`, where `keychain.js` reports the keychain as unavailable (returns `null`) and the caller falls back to the `0600` config file. #5154's "refuse to store" wording is superseded by this document.
 
 ### Operator escape hatch
 

--- a/docs/security/credentials-at-rest.md
+++ b/docs/security/credentials-at-rest.md
@@ -61,6 +61,8 @@ On hosts with no usable keychain — Windows, or headless Linux without `secret-
 
 It does **not** derive a key from machine identifiers and "encrypt" with that. Such a key is reconstructible on the same host that holds the file, so it would add only the *appearance* of protection — worse than honest plaintext, because it invites false confidence. Plaintext-`0600` is the same posture every other `~/.chroxy/` secret file uses.
 
+> **Reconciliation (#5230).** #5154's original scope said the keychain-less case should *refuse to store* rather than fall back to plaintext. The shipped behavior — and the recorded maintainer decision — is the `0600` plaintext fallback above, for the reasons in this section: a key stored beside the file is obfuscation not security, refuse-to-store would lock out every Windows / headless-Linux-without-`secret-tool` operator entirely, and it matches the existing primary-token fallback in `keychain.js`. #5154's "refuse to store" wording is superseded by this document.
+
 ### Operator escape hatch
 
 `CHROXY_CRED_DISABLE_KEYCHAIN=1` forces the plaintext path even when a keychain is present. Use it only when the keychain is unreliable (e.g. flaky `secret-tool` in a container) and you accept plaintext-at-rest. Setting it does **not** decrypt an already-encrypted file; future writes and the startup migration use plaintext.


### PR DESCRIPTION
## Summary

Closes #5230.

#5154's original scope specified that the no-keychain case should **refuse to store** rather than fall back to plaintext. The shipped behavior (PR #5227) is the `0600` plaintext fallback with a one-time warning. #5230 tracked reconciling that divergence.

**Decision (per maintainer): keep the plaintext+0600 fallback.** Rationale (already in `credentials-at-rest.md` §5):
- A key stored beside the file would be obfuscation, not security.
- Refuse-to-store would lock out **every** Windows / headless-Linux-without-`secret-tool` operator entirely.
- It matches the existing primary-token fallback in `keychain.js`.

## Change

Docs-only. Adds a `Reconciliation (#5230)` note to `credentials-at-rest.md` §5 recording the maintainer decision and flagging #5154's "refuse to store" wording as superseded by this document. The doc and the implementation now explicitly agree.

No behavior change. (#5154 is closed; this PR's note + the issue comments are the durable paper trail.)

## Acceptance criteria (#5230)

- [x] Maintainer decision recorded (keep fallback)
- [x] #5154 wording and the implementation agree (note added; #5154's superseded wording flagged)
- [x] Refuse-to-store path not taken → no non-breaking-path work needed