### PR TITLE
feat(server): capture SDK task_id + cancelActivity() for subagents (#5269)

### DIFF
--- a/packages/server/src/activity-registry.js
+++ b/packages/server/src/activity-registry.js
@@ -97,6 +97,18 @@ export class ActivityRegistry {
   }
 
   /**
+   * #5269: a single entry by id (a defensive copy), or null. Used by the
+   * control-action path to map an `activityId` from the client back to a
+   * tracked node so it can decide whether/how the node is cancellable.
+   * @param {string} id
+   * @returns {ActivityEntry|null}
+   */
+  getEntry(id) {
+    const entry = this._entries.get(id)
+    return entry ? { ...entry } : null
+  }
+
+  /**
    * Build the `activity_snapshot` message for a fresh subscriber / resync.
    * Always returns a valid message (empty `entries` is the legitimate
    * "no in-flight activity" state, never omitted).

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -849,6 +849,26 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
+   * #5269 (Control Room Phase 2a): cancel a single in-flight activity node by
+   * its `activityId` (an `activity_snapshot`/`activity_delta` entry id).
+   *
+   * Default (base) behavior: not supported. Only providers that expose a
+   * per-task control surface override this — today that is the Agent-SDK path
+   * (`SdkSession`, which maps an `agent` node to the SDK's `query.stopTask`).
+   * Background shells and individual tool calls are NOT individually
+   * cancellable (chroxy does not own the OS process; see activity-registry.js),
+   * and CLI/TUI providers have no per-subagent control surface — they fall
+   * through to this default. Whole-turn interruption stays on the existing
+   * `interrupt()` path, unchanged.
+   *
+   * @param {string} _activityId
+   * @returns {Promise<{ ok: boolean, reason?: string, error?: string }>}
+   */
+  async cancelActivity(_activityId) {
+    return { ok: false, reason: 'not-supported' }
+  }
+
+  /**
    * #4307: emit the current pending-shells snapshot on the
    * `background_work_changed` event. Pulled into a helper so both
    * `trackBackgroundShell` and `clearBackgroundShell` use one shape.

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -324,7 +324,8 @@ export class SdkSession extends BaseSession {
     // captured from `task_started` system messages. cancelActivity() needs the
     // task_id to call query.stopTask(); the wire/activity layer only knows the
     // tool_use_id. Cleared per entry on the terminal `task_notification` and
-    // wholesale on turn finalize / destroy.
+    // wholesale at the start of each new turn (after `_callQuery`) and in
+    // destroy().
     this._taskIdByToolUseId = new Map()
 
     // Permission handling — delegated to PermissionManager

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -319,6 +319,14 @@ export class SdkSession extends BaseSession {
     this._thinkingLevel = null
     this._pendingInput = []
 
+    // #5269 (Control Room Phase 2a): map a Task subagent's tool_use_id (the id
+    // chroxy keys activity/agent nodes by) → the SDK's separate `task_id`,
+    // captured from `task_started` system messages. cancelActivity() needs the
+    // task_id to call query.stopTask(); the wire/activity layer only knows the
+    // tool_use_id. Cleared per entry on the terminal `task_notification` and
+    // wholesale on turn finalize / destroy.
+    this._taskIdByToolUseId = new Map()
+
     // Permission handling — delegated to PermissionManager
     this._permissions = new PermissionManager({ log })
     this._permissions.on('permission_request', (data) => {
@@ -689,6 +697,10 @@ export class SdkSession extends BaseSession {
         queryArgs.prompt = buildContentBlocks(promptWithSkills, attachments)
       }
       this._query = this._callQuery(queryArgs)
+      // #5269: a fresh turn — drop any task_id mappings left over from a prior
+      // turn (every subagent should clear via task_notification, but a turn
+      // aborted before its notifications would otherwise strand entries).
+      this._taskIdByToolUseId.clear()
 
       // _callQuery returned an iterable without throwing — the prepend
       // bucket is committed to this turn's prompt, so flip the flag (#3225).
@@ -735,6 +747,23 @@ export class SdkSession extends BaseSession {
               }
               // Fetch dynamic model list from SDK (non-blocking)
               this._fetchSupportedModels()
+            } else if (msg.subtype === 'task_started') {
+              // #5269: a Task subagent started. The SDK message carries BOTH
+              // the subagent's `task_id` (needed by query.stopTask) and the
+              // originating `tool_use_id` (the id chroxy keys agent nodes by).
+              // Capture the mapping so cancelActivity() can translate an
+              // activity id back to a stoppable task. No client-facing emit —
+              // the agent node already exists via agent_spawned.
+              this._captureTaskId(msg.tool_use_id, msg.task_id)
+              break
+            } else if (msg.subtype === 'task_notification') {
+              // #5269: a Task subagent reached a terminal state (completed /
+              // failed / stopped — the last one is what query.stopTask emits).
+              // Finalize the agent node promptly and drop the task mapping so a
+              // cancel feels responsive instead of waiting for the turn-end
+              // sweep. Idempotent (no-op if already finalized).
+              this._finalizeAgentByToolUseId(msg.tool_use_id)
+              break
             } else {
               // Forward non-init system events (e.g. /usage, /cost, other
               // slash command responses) as system messages to the client
@@ -1374,6 +1403,91 @@ export class SdkSession extends BaseSession {
   }
 
   /**
+   * #5269: record a Task subagent's `task_id ↔ tool_use_id` mapping. Tolerant
+   * of either id arriving missing (the SDK marks `tool_use_id` optional on
+   * task messages) and of `task_started` racing ahead of `agent_spawned` — the
+   * map is keyed by tool_use_id and read lazily at cancel time, so order does
+   * not matter.
+   * @param {unknown} toolUseId
+   * @param {unknown} taskId
+   * @private
+   */
+  _captureTaskId(toolUseId, taskId) {
+    if (typeof toolUseId !== 'string' || !toolUseId) return
+    if (typeof taskId !== 'string' || !taskId) return
+    this._taskIdByToolUseId.set(toolUseId, taskId)
+  }
+
+  /**
+   * #5269: finalize a Task subagent identified by its `tool_use_id` — drop the
+   * task-id mapping and, if the agent is still tracked, balance the
+   * `agent_spawned` with a matching `agent_completed` + `_activeAgents` delete
+   * so the activity node terminates immediately (the turn-end sweep would
+   * otherwise be the only finalizer on the SDK path). Idempotent.
+   * @param {unknown} toolUseId
+   * @private
+   */
+  _finalizeAgentByToolUseId(toolUseId) {
+    if (typeof toolUseId !== 'string' || !toolUseId) return
+    this._taskIdByToolUseId.delete(toolUseId)
+    if (this._activeAgents.has(toolUseId)) {
+      this._activeAgents.delete(toolUseId)
+      this.emit('agent_completed', { toolUseId })
+    }
+  }
+
+  /**
+   * #5269 (Control Room Phase 2a): cancel a single in-flight subagent by its
+   * activity id (which, for an `agent` node, IS the Task's `tool_use_id`).
+   * Translates the id to the SDK `task_id` and calls `query.stopTask()`. The
+   * SDK responds with a `task_notification` (status `stopped`), which
+   * `_finalizeAgentByToolUseId` turns into the terminal activity delta; we also
+   * finalize optimistically on success so the node clears without waiting.
+   *
+   * Only `agent` nodes are cancellable — shells/tools are not individually
+   * stoppable (chroxy doesn't own them). Returns a structured result rather
+   * than throwing so the WS handler can map it to a reply.
+   *
+   * @param {string} activityId
+   * @returns {Promise<{ ok: boolean, reason?: string, error?: string }>}
+   */
+  async cancelActivity(activityId) {
+    if (typeof activityId !== 'string' || !activityId) return { ok: false, reason: 'invalid-id' }
+    const entry = this._activity.getEntry(activityId)
+    if (!entry) return { ok: false, reason: 'not-found' }
+    if (entry.kind !== 'agent') {
+      // Shells and tool calls have no per-node cancel surface. Distinguish the
+      // shell case so the UI can explain "use Interrupt turn" rather than
+      // implying a transient error.
+      return { ok: false, reason: entry.kind === 'shell' ? 'shell-not-cancellable' : 'not-cancellable' }
+    }
+    // A finished agent isn't retained in the registry (terminal nodes are
+    // dropped on _end), so a stale cancel for one resolves as not-found above —
+    // no separate already-finished branch is reachable here.
+    const taskId = this._taskIdByToolUseId.get(activityId)
+    if (!taskId) {
+      // agent_spawned landed but task_started hasn't (or this SDK build doesn't
+      // emit task lifecycle messages) — we have no id to stop.
+      return { ok: false, reason: 'no-task-id' }
+    }
+    // Feature-detect stopTask (mirrors the supportedModels / setMaxThinkingTokens
+    // guards) — older SDK builds may not expose it even though interrupt() works.
+    if (!this._query || typeof this._query.stopTask !== 'function') {
+      return { ok: false, reason: 'not-supported' }
+    }
+    ;(this._log || log).info(`Cancelling subagent ${activityId} (task ${taskId})`)
+    try {
+      await this._query.stopTask(taskId)
+    } catch (err) {
+      ;(this._log || log).warn(`stopTask failed for ${activityId}: ${err.message}`)
+      return { ok: false, reason: 'stop-failed', error: err.message }
+    }
+    // Optimistic finalize — idempotent with the incoming task_notification.
+    this._finalizeAgentByToolUseId(activityId)
+    return { ok: true }
+  }
+
+  /**
    * Interrupt the current query.
    */
   async interrupt() {
@@ -1593,6 +1707,8 @@ export class SdkSession extends BaseSession {
     // #4881: clear so a teardown after interrupt() never leaks the flag past
     // this session instance. Mirrors CliSession.destroy() (#4602).
     this._intentionalStop = false
+    // #5269: drop subagent task-id mappings on teardown.
+    this._taskIdByToolUseId.clear()
 
     if (this._resultTimeout) {
       clearTimeout(this._resultTimeout)

--- a/packages/server/tests/sdk-session-cancel-activity.test.js
+++ b/packages/server/tests/sdk-session-cancel-activity.test.js
@@ -1,0 +1,244 @@
+import { describe, it, after, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { SdkSession } from '../src/sdk-session.js'
+import { BaseSession } from '../src/base-session.js'
+
+/**
+ * #5269 (Control Room Phase 2a): SdkSession control actions.
+ *
+ *   - task_id ↔ tool_use_id capture (_captureTaskId), order-independent
+ *   - prompt-side finalize (_finalizeAgentByToolUseId): drop mapping + emit
+ *     agent_completed so a cancelled/finished subagent node terminates promptly
+ *   - cancelActivity(activityId): agent node → query.stopTask(task_id), with a
+ *     structured result for every non-happy path (not the SDK throwing)
+ *   - BaseSession default cancelActivity is not-supported (CLI/TUI/byok inherit)
+ *
+ * State file points at a tmp dir (#4633 sandbox) so no test touches real state.
+ */
+
+let _globalTmpDir = null
+function tmpStateFile() {
+  if (!_globalTmpDir) _globalTmpDir = mkdtempSync(join(tmpdir(), 'sdk-cancel-activity-test-'))
+  return join(_globalTmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_globalTmpDir) rmSync(_globalTmpDir, { recursive: true, force: true })
+})
+
+function createSession(opts = {}) {
+  const stateFilePath = opts.stateFilePath || tmpStateFile()
+  const session = new SdkSession({ cwd: '/tmp', stateFilePath, ...opts })
+  session._testStateFilePath = stateFilePath
+  return session
+}
+
+// Seed an `agent` activity node for `toolUseId` directly via the registry (the
+// same node agent_spawned produces).
+function seedAgentNode(session, toolUseId, label = 'sub') {
+  session._activity.onAgentSpawned({ toolUseId, description: label, startedAt: Date.now() })
+}
+
+// A stand-in query. destroy() calls `_query.interrupt()`, so every mock must
+// carry it; spread `over` for stopTask variants.
+function mockQuery(over = {}) {
+  return { interrupt: async () => {}, ...over }
+}
+
+describe('SdkSession #5269 — task_id capture', () => {
+  it('captures task_id keyed by tool_use_id', () => {
+    const session = createSession()
+    session._captureTaskId('tu-1', 'task-1')
+    assert.equal(session._taskIdByToolUseId.get('tu-1'), 'task-1')
+    session.destroy()
+  })
+
+  it('ignores a missing tool_use_id or task_id (no phantom entries)', () => {
+    const session = createSession()
+    session._captureTaskId(undefined, 'task-1')
+    session._captureTaskId('tu-1', undefined)
+    session._captureTaskId('', 'task-1')
+    session._captureTaskId('tu-1', '')
+    assert.equal(session._taskIdByToolUseId.size, 0)
+    session.destroy()
+  })
+
+  it('is order-independent: task_started before agent_spawned still cancels', async () => {
+    const session = createSession()
+    // task_started lands first (mapping captured before the node exists)
+    session._captureTaskId('tu-1', 'task-1')
+    // then the agent node appears
+    seedAgentNode(session, 'tu-1')
+    const stopTask = mock.fn(async () => {})
+    session._query = mockQuery({ stopTask })
+    const res = await session.cancelActivity('tu-1')
+    assert.equal(res.ok, true)
+    assert.equal(stopTask.mock.callCount(), 1)
+    assert.equal(stopTask.mock.calls[0].arguments[0], 'task-1')
+    session.destroy()
+  })
+})
+
+describe('SdkSession #5269 — _finalizeAgentByToolUseId', () => {
+  it('drops the mapping and emits agent_completed when the agent is active', () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._activeAgents.set('tu-1', { toolUseId: 'tu-1' })
+    session._captureTaskId('tu-1', 'task-1')
+    const completed = []
+    session.on('agent_completed', (d) => completed.push(d))
+    session._finalizeAgentByToolUseId('tu-1')
+    assert.deepEqual(completed, [{ toolUseId: 'tu-1' }])
+    assert.equal(session._activeAgents.has('tu-1'), false)
+    assert.equal(session._taskIdByToolUseId.has('tu-1'), false)
+    session.destroy()
+  })
+
+  it('is idempotent — second call does not re-emit or throw', () => {
+    const session = createSession()
+    session._activeAgents.set('tu-1', { toolUseId: 'tu-1' })
+    let emits = 0
+    session.on('agent_completed', () => { emits++ })
+    session._finalizeAgentByToolUseId('tu-1')
+    session._finalizeAgentByToolUseId('tu-1')
+    assert.equal(emits, 1)
+    session.destroy()
+  })
+
+  it('no-ops for an unknown / empty tool_use_id', () => {
+    const session = createSession()
+    let emits = 0
+    session.on('agent_completed', () => { emits++ })
+    session._finalizeAgentByToolUseId('nope')
+    session._finalizeAgentByToolUseId('')
+    session._finalizeAgentByToolUseId(undefined)
+    assert.equal(emits, 0)
+    session.destroy()
+  })
+})
+
+describe('SdkSession #5269 — cancelActivity', () => {
+  it('cancels an agent node via query.stopTask and finalizes it', async () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._activeAgents.set('tu-1', { toolUseId: 'tu-1' })
+    session._captureTaskId('tu-1', 'task-1')
+    const stopTask = mock.fn(async () => {})
+    session._query = mockQuery({ stopTask })
+    const completed = []
+    session.on('agent_completed', (d) => completed.push(d))
+
+    const res = await session.cancelActivity('tu-1')
+
+    assert.deepEqual(res, { ok: true })
+    assert.equal(stopTask.mock.callCount(), 1)
+    assert.equal(stopTask.mock.calls[0].arguments[0], 'task-1')
+    // Optimistic finalize: node cleared, mapping dropped, agent_completed fired.
+    assert.deepEqual(completed, [{ toolUseId: 'tu-1' }])
+    assert.equal(session._taskIdByToolUseId.has('tu-1'), false)
+    session.destroy()
+  })
+
+  it('returns invalid-id for a non-string / empty id', async () => {
+    const session = createSession()
+    assert.deepEqual(await session.cancelActivity(''), { ok: false, reason: 'invalid-id' })
+    assert.deepEqual(await session.cancelActivity(undefined), { ok: false, reason: 'invalid-id' })
+    session.destroy()
+  })
+
+  it('returns not-found for an unknown activity id', async () => {
+    const session = createSession()
+    assert.deepEqual(await session.cancelActivity('nope'), { ok: false, reason: 'not-found' })
+    session.destroy()
+  })
+
+  it('refuses a shell node with shell-not-cancellable', async () => {
+    const session = createSession()
+    session._activity.onBackgroundWorkChanged({ pending: [{ shellId: 'sh-1', command: 'sleep 99', startedAt: Date.now() }] })
+    const res = await session.cancelActivity('shell:sh-1')
+    assert.deepEqual(res, { ok: false, reason: 'shell-not-cancellable' })
+    session.destroy()
+  })
+
+  it('refuses a plain tool node with not-cancellable', async () => {
+    const session = createSession()
+    session._activity.onToolStart({ toolUseId: 'tu-tool', name: 'Read', startedAt: Date.now() })
+    const res = await session.cancelActivity('tu-tool')
+    assert.deepEqual(res, { ok: false, reason: 'not-cancellable' })
+    session.destroy()
+  })
+
+  it('returns not-found for an agent that already finished (terminal nodes are dropped)', async () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._captureTaskId('tu-1', 'task-1')
+    session._activity.onAgentCompleted({ toolUseId: 'tu-1' }) // _end drops the entry
+    session._query = mockQuery({ stopTask: mock.fn(async () => {}) })
+    const res = await session.cancelActivity('tu-1')
+    assert.deepEqual(res, { ok: false, reason: 'not-found' })
+    session.destroy()
+  })
+
+  it('returns no-task-id when task_started was never seen', async () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._query = mockQuery({ stopTask: mock.fn(async () => {}) })
+    const res = await session.cancelActivity('tu-1')
+    assert.deepEqual(res, { ok: false, reason: 'no-task-id' })
+    session.destroy()
+  })
+
+  it('returns not-supported when the query lacks stopTask (older SDK)', async () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._captureTaskId('tu-1', 'task-1')
+    session._query = mockQuery() // no stopTask
+    const res = await session.cancelActivity('tu-1')
+    assert.deepEqual(res, { ok: false, reason: 'not-supported' })
+    session.destroy()
+  })
+
+  it('surfaces stop-failed (not a throw) when stopTask rejects', async () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._activeAgents.set('tu-1', { toolUseId: 'tu-1' })
+    session._captureTaskId('tu-1', 'task-1')
+    session._query = mockQuery({ stopTask: async () => { throw new Error('boom') } })
+    const res = await session.cancelActivity('tu-1')
+    assert.equal(res.ok, false)
+    assert.equal(res.reason, 'stop-failed')
+    assert.equal(res.error, 'boom')
+    // Failed stop must NOT finalize the node (it may still be running).
+    assert.equal(session._taskIdByToolUseId.has('tu-1'), true)
+    session.destroy()
+  })
+})
+
+describe('BaseSession #5269 — default cancelActivity is not-supported', () => {
+  it('returns not-supported on the base prototype', async () => {
+    const res = await BaseSession.prototype.cancelActivity.call({}, 'anything')
+    assert.deepEqual(res, { ok: false, reason: 'not-supported' })
+  })
+})
+
+describe('SdkSession #5269 — lifecycle clears the task map', () => {
+  it('destroy() clears stranded mappings', () => {
+    const session = createSession()
+    session._captureTaskId('tu-1', 'task-1')
+    assert.equal(session._taskIdByToolUseId.size, 1)
+    session.destroy()
+    assert.equal(session._taskIdByToolUseId.size, 0)
+  })
+
+  it('source wires task_started/task_notification through the capture/finalize helpers', () => {
+    // The dispatch lives inside the _callQuery async-iterator loop, which can't
+    // be driven in isolation; pin the wiring as a source-text contract (mirrors
+    // the #4881 finally-clear source assertion pattern).
+    const src = readFileSync(new URL('../src/sdk-session.js', import.meta.url), 'utf8')
+    assert.match(src, /subtype === 'task_started'[\s\S]*?_captureTaskId\(msg\.tool_use_id, msg\.task_id\)/)
+    assert.match(src, /subtype === 'task_notification'[\s\S]*?_finalizeAgentByToolUseId\(msg\.tool_use_id\)/)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #5269. Control Room epic #5159, Phase 2a (control actions) **keystone** — turns the read-only in-session activity tree into something the user can act on, starting with cancelling a single subagent.

## Feasibility (the issue's spike)

A pass over the SDK/CLI found that **only subagents and the whole turn are cancellable** from chroxy:

| Target | Cancellable? | Mechanism |
|--------|-------------|-----------|
| Subagent (Task) | ✅ yes | SDK `query.stopTask(task_id)` |
| Whole turn | ✅ already shipped | `session.interrupt()` |
| Background shell | ❌ no | chroxy doesn't own it — a shell id is a string parsed from claude's output; no PID/handle/kill API |
| Single tool call | ❌ no | no per-tool abort in the SDK |

So this PR wires **subagent cancel** and leaves whole-turn interrupt on the existing path. The UI (#5272) will deliberately not offer a kill affordance on shell/tool nodes.

**Spike result:** `stopTask` is on the SDK `Query` interface, and chroxy's `_query` is that same object (`interrupt`/`supportedModels`/`setMaxThinkingTokens` already work on it in prod despite the identical "streaming-input-mode only" type note). The call is therefore available; it's also **feature-detected** so an older SDK build degrades to `not-supported` rather than crashing. Runtime confirmation that `stopTask` actually stops a *live* subagent needs a billed session — left to smoke verification; the code degrades safely if the method is absent.

## Changes (`SdkSession` / `BaseSession` / `ActivityRegistry`)

- **task_id capture:** `task_started` system messages carry both `task_id` and the originating `tool_use_id`; capture into `_taskIdByToolUseId` keyed by `tool_use_id` (the id chroxy keys agent nodes by). Order-independent; cleared per-entry on the terminal `task_notification` and wholesale on turn-start/destroy.
- **prompt-side finalize:** `task_notification` (completed/failed/stopped) now finalizes the agent node promptly via `_finalizeAgentByToolUseId` (emits `agent_completed`) instead of waiting for the turn-end sweep — makes a cancel responsive. Idempotent.
- **`cancelActivity(activityId)`:** agent node → `query.stopTask(task_id)`, feature-detected. Returns a **structured result** for every path (`not-found` / `shell-not-cancellable` / `not-cancellable` / `no-task-id` / `not-supported` / `stop-failed`) rather than throwing, so the WS handler (#5271) can map it to a reply. Optimistic finalize on success (idempotent with the incoming notification); failed stop does NOT finalize.
- **`BaseSession.cancelActivity` default** → `not-supported`, so CLI/TUI and the byok session inherit a clean answer.
- **`ActivityRegistry.getEntry(id)`** for the id→node lookup.

## Tests

`tests/sdk-session-cancel-activity.test.js` — 18 cases: task_id capture (incl. order-independence + phantom-entry guards), finalize (emit + idempotency + no-op), and every `cancelActivity` branch (happy path calls `stopTask` with the right id + finalizes; shell/tool refusal; no-task-id; not-supported; stop-failed surfaces structured, doesn't finalize), the BaseSession default, and destroy-clears-the-map. Source-text assertion pins the loop wiring. 351 server tests green (activity/sdk/base/background suites), eslint + opt-forwarding + state-file lints clean.

## Scope
SdkSession (`claude-sdk`) only. `ClaudeByokSession` parity is a follow-up (same mechanism, separate message loop). Protocol message (#5270), WS handler (#5271), and dashboard UI (#5272) are separate issues.