### PR TITLE
feat(protocol): cancel_activity client→server message (#5270)

### DIFF
--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -69,6 +69,11 @@ export declare const InputSchema: z.ZodObject<{
 export declare const InterruptSchema: z.ZodObject<{
     type: z.ZodLiteral<"interrupt">;
 }, z.core.$loose>;
+export declare const CancelActivitySchema: z.ZodObject<{
+    type: z.ZodLiteral<"cancel_activity">;
+    activityId: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
 export declare const SetModelSchema: z.ZodObject<{
     type: z.ZodLiteral<"set_model">;
     model: z.ZodString;
@@ -594,6 +599,10 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"interrupt">;
 }, z.core.$loose>, z.ZodObject<{
+    type: z.ZodLiteral<"cancel_activity">;
+    activityId: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"set_model">;
     model: z.ZodString;
 }, z.core.$loose>, z.ZodObject<{
@@ -924,6 +933,7 @@ export type AuthMessage = z.infer<typeof AuthSchema>;
 export type PairMessage = z.infer<typeof PairSchema>;
 export type InputMessage = z.infer<typeof InputSchema>;
 export type InterruptMessage = z.infer<typeof InterruptSchema>;
+export type CancelActivityMessage = z.infer<typeof CancelActivitySchema>;
 export type SetModelMessage = z.infer<typeof SetModelSchema>;
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>;
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -58,6 +58,16 @@ export const InputSchema = z.object({
 export const InterruptSchema = z.object({
     type: z.literal('interrupt'),
 }).passthrough();
+// #5270 (Control Room Phase 2a): cancel a single in-flight activity node
+// (currently a Task subagent) by its activity-tree entry id. `sessionId` is
+// optional — the server resolves the target session from it or the caller's
+// bound/active session, mirroring `interrupt`. Whole-turn interruption stays on
+// the `interrupt` message; this is the per-node control action.
+export const CancelActivitySchema = z.object({
+    type: z.literal('cancel_activity'),
+    activityId: z.string().min(1).max(512),
+    sessionId: z.string().optional(),
+}).passthrough();
 export const SetModelSchema = z.object({
     type: z.literal('set_model'),
     model: z.string().max(256),
@@ -696,6 +706,7 @@ export const EncryptedEnvelopeSchema = z.object({
 export const ClientMessageSchema = z.discriminatedUnion('type', [
     InputSchema,
     InterruptSchema,
+    CancelActivitySchema,
     SetModelSchema,
     SetPermissionModeSchema,
     SetThinkingLevelSchema,

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -66,7 +66,7 @@ export const InterruptSchema = z.object({
 export const CancelActivitySchema = z.object({
     type: z.literal('cancel_activity'),
     activityId: z.string().min(1).max(512),
-    sessionId: z.string().optional(),
+    sessionId: z.string().max(256).optional(),
 }).passthrough();
 export const SetModelSchema = z.object({
     type: z.literal('set_model'),

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -68,6 +68,17 @@ export const InterruptSchema = z.object({
   type: z.literal('interrupt'),
 }).passthrough()
 
+// #5270 (Control Room Phase 2a): cancel a single in-flight activity node
+// (currently a Task subagent) by its activity-tree entry id. `sessionId` is
+// optional — the server resolves the target session from it or the caller's
+// bound/active session, mirroring `interrupt`. Whole-turn interruption stays on
+// the `interrupt` message; this is the per-node control action.
+export const CancelActivitySchema = z.object({
+  type: z.literal('cancel_activity'),
+  activityId: z.string().min(1).max(512),
+  sessionId: z.string().optional(),
+}).passthrough()
+
 export const SetModelSchema = z.object({
   type: z.literal('set_model'),
   model: z.string().max(256),
@@ -808,6 +819,7 @@ export const EncryptedEnvelopeSchema = z.object({
 export const ClientMessageSchema = z.discriminatedUnion('type', [
   InputSchema,
   InterruptSchema,
+  CancelActivitySchema,
   SetModelSchema,
   SetPermissionModeSchema,
   SetThinkingLevelSchema,
@@ -890,6 +902,7 @@ export type AuthMessage = z.infer<typeof AuthSchema>
 export type PairMessage = z.infer<typeof PairSchema>
 export type InputMessage = z.infer<typeof InputSchema>
 export type InterruptMessage = z.infer<typeof InterruptSchema>
+export type CancelActivityMessage = z.infer<typeof CancelActivitySchema>
 export type SetModelMessage = z.infer<typeof SetModelSchema>
 export type SetPermissionModeMessage = z.infer<typeof SetPermissionModeSchema>
 export type SetPermissionRulesMessage = z.infer<typeof SetPermissionRulesSchema>

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -76,7 +76,7 @@ export const InterruptSchema = z.object({
 export const CancelActivitySchema = z.object({
   type: z.literal('cancel_activity'),
   activityId: z.string().min(1).max(512),
-  sessionId: z.string().optional(),
+  sessionId: z.string().max(256).optional(),
 }).passthrough()
 
 export const SetModelSchema = z.object({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -35,6 +35,30 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(!result.success, 'Should reject data over 100k chars')
   })
 
+  // #5270 (Control Room Phase 2a): cancel_activity client→server message.
+  it('validates cancel_activity with an activityId (sessionId optional)', async () => {
+    const { CancelActivitySchema } = await import('../src/schemas/client.ts')
+    const minimal = CancelActivitySchema.safeParse({ type: 'cancel_activity', activityId: 'tu-1' })
+    assert.ok(minimal.success, 'Should validate with just activityId')
+    const withSession = CancelActivitySchema.safeParse({ type: 'cancel_activity', activityId: 'tu-1', sessionId: 'sess-1' })
+    assert.ok(withSession.success, 'Should validate with sessionId too')
+  })
+
+  it('rejects cancel_activity missing or with an empty activityId', async () => {
+    const { CancelActivitySchema } = await import('../src/schemas/client.ts')
+    assert.ok(!CancelActivitySchema.safeParse({ type: 'cancel_activity' }).success, 'missing activityId rejected')
+    assert.ok(!CancelActivitySchema.safeParse({ type: 'cancel_activity', activityId: '' }).success, 'empty activityId rejected')
+    assert.ok(!CancelActivitySchema.safeParse({ type: 'cancel_activity', activityId: 'x'.repeat(513) }).success, 'over-long activityId rejected')
+  })
+
+  it('resolves cancel_activity through the ClientMessageSchema union by discriminator', async () => {
+    const { ClientMessageSchema } = await import('../src/schemas/client.ts')
+    const result = ClientMessageSchema.safeParse({ type: 'cancel_activity', activityId: 'tu-1' })
+    assert.ok(result.success, 'union should route cancel_activity to CancelActivitySchema')
+    // The discriminated union must NOT collapse it to a different member.
+    assert.equal(result.data.type, 'cancel_activity')
+  })
+
   it('validates server auth_ok message', async () => {
     const { ServerAuthOkSchema } = await import('../src/schemas/server.ts')
     const result = ServerAuthOkSchema.safeParse({

--- a/packages/protocol/tests/schemas.test.js
+++ b/packages/protocol/tests/schemas.test.js
@@ -49,6 +49,7 @@ describe('@chroxy/protocol schemas', () => {
     assert.ok(!CancelActivitySchema.safeParse({ type: 'cancel_activity' }).success, 'missing activityId rejected')
     assert.ok(!CancelActivitySchema.safeParse({ type: 'cancel_activity', activityId: '' }).success, 'empty activityId rejected')
     assert.ok(!CancelActivitySchema.safeParse({ type: 'cancel_activity', activityId: 'x'.repeat(513) }).success, 'over-long activityId rejected')
+    assert.ok(!CancelActivitySchema.safeParse({ type: 'cancel_activity', activityId: 'tu-1', sessionId: 'x'.repeat(257) }).success, 'over-long sessionId rejected')
   })
 
   it('resolves cancel_activity through the ClientMessageSchema union by discriminator', async () => {

--- a/packages/server/tests/ws-schema-coverage.test.js
+++ b/packages/server/tests/ws-schema-coverage.test.js
@@ -87,8 +87,12 @@ describe('WS protocol schema coverage', () => {
     const handlerTypes = new Set([...registeredMessageTypes, ...SCHEMA_EXEMPT])
     const schemaOnly = [...schemaTypes].filter((t) => !handlerTypes.has(t))
 
-    // These are known schema-only types handled at the connection/auth layer
-    // (ws-server.js) before messages reach the handler registry.
+    // Known schema-only types, in two categories:
+    //   1. Handled at the connection/auth layer (ws-server.js) before messages
+    //      reach the handler registry (auth, pair, key_exchange, ping, encrypted).
+    //   2. Temporary: the schema landed ahead of its handler and the type is
+    //      currently unhandled (cancel_activity, see #5270/#5271). Each such
+    //      entry carries its own removal note below.
     const KNOWN_PRE_REGISTRY = new Set([
       'auth',          // handled in ws-auth.js before registry dispatch
       'pair',          // pairing flow, handled at connection layer

--- a/packages/server/tests/ws-schema-coverage.test.js
+++ b/packages/server/tests/ws-schema-coverage.test.js
@@ -98,6 +98,11 @@ describe('WS protocol schema coverage', () => {
       // #5174 (epic #5170): host_status_request now has a real handler
       // (control-room-handlers.js), so it is covered by the forward
       // schema-coverage check and no longer belongs in KNOWN_PRE_REGISTRY.
+      // #5270 (Control Room Phase 2a): cancel_activity schema lands ahead of
+      // its handler. TEMPORARY — remove this entry in #5271 when the
+      // cancel_activity WS handler is registered (it will then be covered by
+      // the forward check above).
+      'cancel_activity',
     ])
 
     const unexplained = schemaOnly.filter((t) => !KNOWN_PRE_REGISTRY.has(t))


### PR DESCRIPTION
## Summary

Closes #5270. Control Room epic #5159, Phase 2a. The per-node control-action message the WS handler (#5271) and dashboard (#5272) build on; the keystone server logic (`session.cancelActivity`) landed in #5269 (PR #5273).

## Change

- **`CancelActivitySchema`** `{ type: 'cancel_activity', activityId, sessionId? }` mirroring `InterruptSchema`. `activityId` is the activity-tree entry id (1–512 chars, required); `sessionId` optional — the server resolves the target from it or the caller's bound/active session, exactly like `interrupt`. Whole-turn interruption stays on the `interrupt` message; this is the per-node action.
- Added to the `ClientMessageSchema` discriminated union + exported `CancelActivityMessage` (flows through the `export *` chain). Rebuilt `dist`.

## Tests

`schemas.test.js`:
- validates with just `activityId`, and with `sessionId` too
- rejects missing / empty / over-512-char `activityId`
- resolves through `ClientMessageSchema` by discriminator (not collapsed to another member)

## Cross-PR note (read before merging #5271)

The handler arrives in **#5271**. Until then `cancel_activity` is a schema with **no registered handler**, which `ws-schema-coverage.test.js`'s reverse check would flag — so it's added to `KNOWN_PRE_REGISTRY` with a **TEMPORARY** marker. **#5271 MUST remove that entry** when it registers the real handler (the forward schema-coverage check then covers it). This is the only wart from splitting the schema and handler across two issues.