### PR TITLE
feat(server): cancel_activity WS handler + auth gating (#5271)

### DIFF
--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -529,6 +529,83 @@ function handleInterrupt(ws, client, msg, ctx) {
   }
 }
 
+/**
+ * #5271 (Control Room Phase 2a): cancel a single in-flight activity node
+ * (currently a Task subagent) in a session. Authority mirrors `interrupt` —
+ * acting on your own session, NOT a privilege escalation — so resolveSession's
+ * standard binding check is the only gate: a pairing-bound client may cancel
+ * activity in its OWN bound session but not another's. Whole-turn interruption
+ * stays on the `interrupt` message.
+ *
+ * The session does the work via `cancelActivity(activityId)`, which returns a
+ * structured `{ ok, reason }` (never throws). On success the terminal
+ * `activity_delta` is broadcast through the existing agent_completed → registry
+ * path, so the tree updates live with no extra reply here. Only failures are
+ * surfaced to the caller, as a `session_error` (the same envelope interrupt
+ * uses for binding/stale-id problems).
+ */
+async function handleCancelActivity(ws, client, msg, ctx) {
+  const entry = resolveSession(ctx, msg, client)
+  if (!entry) {
+    // Disambiguate a binding mismatch from a truly-missing session, exactly as
+    // handleInterrupt/handleInput do (Copilot review #4979) — a bound client
+    // aiming at another session must see SESSION_TOKEN_MISMATCH, not a stale-id
+    // drop.
+    if (msg.sessionId && client.boundSessionId && client.boundSessionId !== msg.sessionId) {
+      log.info(`cancel_activity rejected: session-token mismatch sessionId=${msg.sessionId} boundSessionId=${client.boundSessionId} client=${client.id}`)
+      ctx.send(ws, {
+        type: 'session_error',
+        ...buildSessionTokenMismatchPayload({
+          sessionManager: ctx.sessionManager,
+          boundSessionId: client.boundSessionId,
+        }),
+      })
+      return
+    }
+    const sid = msg.sessionId || client.activeSessionId
+    log.info(`cancel_activity dropped: session not found sessionId=${sid} client=${client.id}`)
+    ctx.send(ws, {
+      type: 'session_error',
+      code: 'SESSION_NOT_FOUND',
+      message: `Session not found: ${sid}`,
+      attemptedSessionId: sid,
+    })
+    return
+  }
+
+  const session = entry.session
+  if (typeof session.cancelActivity !== 'function') {
+    // Defensive: every BaseSession defines it (defaulting to not-supported),
+    // but guard so a provider that somehow lacks it can't crash the handler.
+    ctx.send(ws, {
+      type: 'session_error',
+      code: 'CANCEL_ACTIVITY_FAILED',
+      message: 'This session does not support cancelling activity',
+      reason: 'not-supported',
+      activityId: msg.activityId,
+    })
+    return
+  }
+
+  const result = await session.cancelActivity(msg.activityId)
+  if (!result || result.ok !== true) {
+    const reason = (result && result.reason) || 'unknown'
+    log.info(`cancel_activity ${msg.activityId} not actioned (${reason}) client=${client.id}`)
+    ctx.send(ws, {
+      type: 'session_error',
+      code: 'CANCEL_ACTIVITY_FAILED',
+      message: `Could not cancel activity: ${reason}`,
+      reason,
+      activityId: msg.activityId,
+    })
+    return
+  }
+  // Success: the node's terminal activity_delta is broadcast via the session's
+  // agent_completed → registry path; no extra reply needed (mirrors interrupt,
+  // which also acks via the resulting stream change, not a dedicated message).
+  log.info(`cancel_activity ${msg.activityId} actioned by ${client.id}`)
+}
+
 function handleResumeBudget(ws, client, msg, ctx) {
   const budgetSessionId = msg.sessionId || client.activeSessionId
   if (!budgetSessionId || !resolveSession(ctx, msg, client)) {
@@ -742,6 +819,7 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
 export const inputHandlers = {
   input: handleInput,
   interrupt: handleInterrupt,
+  cancel_activity: handleCancelActivity,
   resume_budget: handleResumeBudget,
   register_push_token: handleRegisterPushToken,
   notification_prefs_get: handleNotificationPrefsGet,

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -563,6 +563,14 @@ async function handleCancelActivity(ws, client, msg, ctx) {
       return
     }
     const sid = msg.sessionId || client.activeSessionId
+    if (!sid) {
+      // No id at all to act on — emit the canonical "No active session"
+      // envelope (mirrors handleInput) rather than a misleading
+      // "Session not found: undefined" with a null attemptedSessionId.
+      log.info(`cancel_activity dropped: no active session client=${client.id}`)
+      sendSessionError(ws, ctx, 'No active session')
+      return
+    }
     log.info(`cancel_activity dropped: session not found sessionId=${sid} client=${client.id}`)
     ctx.send(ws, {
       type: 'session_error',

--- a/packages/server/tests/handlers/cancel-activity-handler.test.js
+++ b/packages/server/tests/handlers/cancel-activity-handler.test.js
@@ -112,6 +112,20 @@ describe('cancel_activity handler (#5271)', () => {
     assert.equal(reply.attemptedSessionId, 'gone')
   })
 
+  it('emits "No active session" (not SESSION_NOT_FOUND) when there is no id to act on', async () => {
+    const ctx = makeCtx(new Map())
+    const client = makeClient({ activeSessionId: null }) // no sessionId, no activeSessionId
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1' }, ctx)
+
+    const reply = last(ctx)
+    assert.equal(reply.type, 'session_error')
+    assert.equal(reply.message, 'No active session')
+    // Must NOT mislabel a no-id case as a stale-id SESSION_NOT_FOUND drop.
+    assert.equal(reply.code, undefined)
+    assert.equal(reply.attemptedSessionId, undefined)
+  })
+
   it('lets a pairing-bound client cancel activity in its OWN session', async () => {
     const sessions = new Map()
     const { entry, cancelActivity } = entryWithCancel({ ok: true })

--- a/packages/server/tests/handlers/cancel-activity-handler.test.js
+++ b/packages/server/tests/handlers/cancel-activity-handler.test.js
@@ -1,0 +1,143 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { inputHandlers } from '../../src/handlers/input-handlers.js'
+import { createSpy } from '../test-helpers.js'
+
+/**
+ * #5271 (Control Room Phase 2a): cancel_activity WS handler.
+ *
+ * Authority mirrors `interrupt` — acting on your own session, not an
+ * escalation — so a pairing-bound client may cancel activity in its OWN bound
+ * session but a cross-session attempt yields SESSION_TOKEN_MISMATCH. On success
+ * the terminal activity_delta is broadcast by the session (not by this handler),
+ * so the handler stays silent; only failures surface as a session_error.
+ */
+
+function makeCtx(sessions = new Map(), overrides = {}) {
+  const sent = []
+  return {
+    send: createSpy((ws, msg) => { sent.push(msg) }),
+    broadcast: createSpy(),
+    broadcastToSession: createSpy(),
+    sessionManager: {
+      getSession: createSpy((id) => sessions.get(id)),
+    },
+    _sent: sent,
+    ...overrides,
+  }
+}
+
+function makeClient(overrides = {}) {
+  return { id: 'client-1', activeSessionId: null, ...overrides }
+}
+
+function makeWs() { return {} }
+
+// A session entry whose session exposes a cancelActivity returning `result`.
+function entryWithCancel(result, cwd = '/work') {
+  const cancelActivity = createSpy(async () => result)
+  return { entry: { session: { cancelActivity }, name: 'S', cwd }, cancelActivity }
+}
+
+const last = (ctx) => ctx._sent[ctx._sent.length - 1] ?? null
+
+describe('cancel_activity handler (#5271)', () => {
+  it('calls session.cancelActivity with the activityId and stays silent on success', async () => {
+    const sessions = new Map()
+    const { entry, cancelActivity } = entryWithCancel({ ok: true })
+    sessions.set('s1', entry)
+    const ctx = makeCtx(sessions)
+    const client = makeClient({ activeSessionId: 's1' })
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1' }, ctx)
+
+    assert.equal(cancelActivity.calls.length, 1)
+    assert.equal(cancelActivity.calls[0][0], 'tu-1')
+    // No session_error on success — the activity_delta is the confirmation.
+    assert.equal(ctx._sent.length, 0)
+  })
+
+  it('surfaces a structured failure (no-task-id) as a CANCEL_ACTIVITY_FAILED session_error', async () => {
+    const sessions = new Map()
+    const { entry } = entryWithCancel({ ok: false, reason: 'no-task-id' })
+    sessions.set('s1', entry)
+    const ctx = makeCtx(sessions)
+    const client = makeClient({ activeSessionId: 's1' })
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1' }, ctx)
+
+    const reply = last(ctx)
+    assert.equal(reply.type, 'session_error')
+    assert.equal(reply.code, 'CANCEL_ACTIVITY_FAILED')
+    assert.equal(reply.reason, 'no-task-id')
+    assert.equal(reply.activityId, 'tu-1')
+  })
+
+  it('surfaces a shell-not-cancellable refusal with its reason', async () => {
+    const sessions = new Map()
+    const { entry } = entryWithCancel({ ok: false, reason: 'shell-not-cancellable' })
+    sessions.set('s1', entry)
+    const ctx = makeCtx(sessions)
+    const client = makeClient({ activeSessionId: 's1' })
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'shell:sh-1' }, ctx)
+
+    const reply = last(ctx)
+    assert.equal(reply.code, 'CANCEL_ACTIVITY_FAILED')
+    assert.equal(reply.reason, 'shell-not-cancellable')
+  })
+
+  it('rejects a session whose provider lacks cancelActivity', async () => {
+    const sessions = new Map()
+    sessions.set('s1', { session: {}, name: 'S', cwd: '/work' }) // no cancelActivity
+    const ctx = makeCtx(sessions)
+    const client = makeClient({ activeSessionId: 's1' })
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1' }, ctx)
+
+    const reply = last(ctx)
+    assert.equal(reply.code, 'CANCEL_ACTIVITY_FAILED')
+    assert.equal(reply.reason, 'not-supported')
+  })
+
+  it('returns SESSION_NOT_FOUND for an unknown session id (no binding)', async () => {
+    const ctx = makeCtx(new Map())
+    const client = makeClient({ activeSessionId: 'gone' })
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1' }, ctx)
+
+    const reply = last(ctx)
+    assert.equal(reply.type, 'session_error')
+    assert.equal(reply.code, 'SESSION_NOT_FOUND')
+    assert.equal(reply.attemptedSessionId, 'gone')
+  })
+
+  it('lets a pairing-bound client cancel activity in its OWN session', async () => {
+    const sessions = new Map()
+    const { entry, cancelActivity } = entryWithCancel({ ok: true })
+    sessions.set('bound-1', entry)
+    const ctx = makeCtx(sessions)
+    const client = makeClient({ boundSessionId: 'bound-1', activeSessionId: 'bound-1' })
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1', sessionId: 'bound-1' }, ctx)
+
+    assert.equal(cancelActivity.calls.length, 1)
+    assert.equal(ctx._sent.length, 0)
+  })
+
+  it('rejects a bound client aiming at ANOTHER session with SESSION_TOKEN_MISMATCH', async () => {
+    const sessions = new Map()
+    const { entry, cancelActivity } = entryWithCancel({ ok: true })
+    sessions.set('other', entry)
+    const ctx = makeCtx(sessions)
+    const client = makeClient({ boundSessionId: 'bound-1', activeSessionId: 'bound-1' })
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1', sessionId: 'other' }, ctx)
+
+    const reply = last(ctx)
+    assert.equal(reply.type, 'session_error')
+    assert.equal(reply.code, 'SESSION_TOKEN_MISMATCH')
+    // The cross-session cancel must NOT have run.
+    assert.equal(cancelActivity.calls.length, 0)
+  })
+})

--- a/packages/server/tests/ws-schema-coverage.test.js
+++ b/packages/server/tests/ws-schema-coverage.test.js
@@ -87,12 +87,8 @@ describe('WS protocol schema coverage', () => {
     const handlerTypes = new Set([...registeredMessageTypes, ...SCHEMA_EXEMPT])
     const schemaOnly = [...schemaTypes].filter((t) => !handlerTypes.has(t))
 
-    // Known schema-only types, in two categories:
-    //   1. Handled at the connection/auth layer (ws-server.js) before messages
-    //      reach the handler registry (auth, pair, key_exchange, ping, encrypted).
-    //   2. Temporary: the schema landed ahead of its handler and the type is
-    //      currently unhandled (cancel_activity, see #5270/#5271). Each such
-    //      entry carries its own removal note below.
+    // These are known schema-only types handled at the connection/auth layer
+    // (ws-server.js) before messages reach the handler registry.
     const KNOWN_PRE_REGISTRY = new Set([
       'auth',          // handled in ws-auth.js before registry dispatch
       'pair',          // pairing flow, handled at connection layer
@@ -102,11 +98,8 @@ describe('WS protocol schema coverage', () => {
       // #5174 (epic #5170): host_status_request now has a real handler
       // (control-room-handlers.js), so it is covered by the forward
       // schema-coverage check and no longer belongs in KNOWN_PRE_REGISTRY.
-      // #5270 (Control Room Phase 2a): cancel_activity schema lands ahead of
-      // its handler. TEMPORARY — remove this entry in #5271 when the
-      // cancel_activity WS handler is registered (it will then be covered by
-      // the forward check above).
-      'cancel_activity',
+      // #5271 (Control Room Phase 2a): cancel_activity likewise now has a real
+      // handler (input-handlers.js), so its temporary entry was removed here.
     ])
 
     const unexplained = schemaOnly.filter((t) => !KNOWN_PRE_REGISTRY.has(t))


### PR DESCRIPTION
## Summary

Closes #5271. Control Room epic #5159, Phase 2a. Wires the `cancel_activity` protocol message (#5270) to the session's `cancelActivity()` (#5269) — completing the server side of subagent cancellation.

## Change

- **`handleCancelActivity`** mirrors `handleInterrupt`'s session resolution + binding handling. `resolveSession` is the only gate: cancel is the **same authority class as `interrupt`/`input`** (acting on your own session, not a privilege escalation), so a pairing-bound client may cancel activity in **its own** bound session, while a cross-session attempt yields the canonical `SESSION_TOKEN_MISMATCH` envelope. It deliberately does **not** use the auto-mode / credential-write bound-rejection.
- Calls `session.cancelActivity(activityId)` (structured `{ ok, reason }`, never throws). **On success the handler stays silent** — the terminal `activity_delta` is already broadcast via the `agent_completed → registry` path (mirrors `interrupt`, which acks via the stream change, not a dedicated message). **Failures** (`not-found`, `not-supported`, `no-task-id`, `shell-not-cancellable`, `stop-failed`, …) surface as a `session_error` with `code: CANCEL_ACTIVITY_FAILED` + the `reason` — so **no new server message type/schema** is needed.
- Registered `cancel_activity` in the input handler map. The schema (#5270) is now covered by the **forward** schema-coverage check, so the **TEMPORARY `KNOWN_PRE_REGISTRY` entry added in #5270 is removed** (as that PR instructed).

## Tests

`tests/handlers/cancel-activity-handler.test.js`:
- success → calls `cancelActivity('tu-1')` and sends nothing
- structured failures (`no-task-id`, `shell-not-cancellable`) and a provider lacking `cancelActivity` → `CANCEL_ACTIVITY_FAILED` with the reason
- unknown session → `SESSION_NOT_FOUND`
- **bound client cancels its own session** (allowed), but a **cross-session attempt is rejected `SESSION_TOKEN_MISMATCH` and never runs the cancel**

87 tests green (handler + input-handlers + ws-schema-coverage); eslint + opt-forwarding + state-file lints clean.

## Chain
Builds on #5269 (`session.cancelActivity`, merged) and #5270 (`cancel_activity` schema, merged). Dashboard UI is #5272.