### PR TITLE
feat(dashboard): cancel affordances on the Control Room activity tree (#5272)

### DIFF
--- a/packages/dashboard/src/components/ActivityTree.test.tsx
+++ b/packages/dashboard/src/components/ActivityTree.test.tsx
@@ -178,20 +178,26 @@ describe('ActivityTree control actions (#5272)', () => {
     expect(screen.queryByTestId('control-room-cancel-a')).toBeNull()
   })
 
-  it('shows a cancel button only on running SUBAGENT nodes', () => {
+  it('shows a cancel button only on non-terminal (running OR blocked) SUBAGENT nodes', () => {
     const activity = buildActivity([
       entry('agent-run', { kind: 'agent', status: 'running' }),
+      entry('agent-blocked', { kind: 'agent', status: 'blocked' }),
       entry('agent-done', { kind: 'agent', status: 'done', endedAt: 2000 }),
+      entry('agent-failed', { kind: 'agent', status: 'failed', endedAt: 2000 }),
       entry('shell-run', { kind: 'shell', status: 'running' }),
       entry('tool-run', { kind: 'tool', status: 'running' }),
     ])
     render(
       <ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 1000} onCancelActivity={() => {}} />,
     )
-    // Only the running agent is cancellable.
+    // Both the running AND the blocked agent are cancellable — a blocked subagent
+    // is stuck/waiting and is exactly what an operator wants to abort.
     expect(screen.getByTestId('control-room-cancel-agent-run')).toBeInTheDocument()
-    // Not the finished agent, nor shells/tools (chroxy can't cancel those).
+    expect(screen.getByTestId('control-room-cancel-agent-blocked')).toBeInTheDocument()
+    // Not the terminal agents (done / failed), nor shells/tools (chroxy can't
+    // cancel those).
     expect(screen.queryByTestId('control-room-cancel-agent-done')).toBeNull()
+    expect(screen.queryByTestId('control-room-cancel-agent-failed')).toBeNull()
     expect(screen.queryByTestId('control-room-cancel-shell-run')).toBeNull()
     expect(screen.queryByTestId('control-room-cancel-tool-run')).toBeNull()
   })

--- a/packages/dashboard/src/components/ActivityTree.test.tsx
+++ b/packages/dashboard/src/components/ActivityTree.test.tsx
@@ -171,6 +171,48 @@ describe('ActivityTree (#5176)', () => {
   })
 })
 
+describe('ActivityTree control actions (#5272)', () => {
+  it('renders no cancel buttons when onCancelActivity is not provided (read-only)', () => {
+    const activity = buildActivity([entry('a', { kind: 'agent', status: 'running' })])
+    render(<ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 1000} />)
+    expect(screen.queryByTestId('control-room-cancel-a')).toBeNull()
+  })
+
+  it('shows a cancel button only on running SUBAGENT nodes', () => {
+    const activity = buildActivity([
+      entry('agent-run', { kind: 'agent', status: 'running' }),
+      entry('agent-done', { kind: 'agent', status: 'done', endedAt: 2000 }),
+      entry('shell-run', { kind: 'shell', status: 'running' }),
+      entry('tool-run', { kind: 'tool', status: 'running' }),
+    ])
+    render(
+      <ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 1000} onCancelActivity={() => {}} />,
+    )
+    // Only the running agent is cancellable.
+    expect(screen.getByTestId('control-room-cancel-agent-run')).toBeInTheDocument()
+    // Not the finished agent, nor shells/tools (chroxy can't cancel those).
+    expect(screen.queryByTestId('control-room-cancel-agent-done')).toBeNull()
+    expect(screen.queryByTestId('control-room-cancel-shell-run')).toBeNull()
+    expect(screen.queryByTestId('control-room-cancel-tool-run')).toBeNull()
+  })
+
+  it('invokes onCancelActivity with the entry id (and does not toggle expansion)', () => {
+    const onCancel = vi.fn()
+    const activity = buildActivity([
+      entry('a', { kind: 'agent', status: 'running', outputRef: { kind: 'tool_use', id: 't' } }),
+    ])
+    render(
+      <ActivityTree activity={activity} sessionId={SESSION_ID} now={() => 1000} onCancelActivity={onCancel} />,
+    )
+    fireEvent.click(screen.getByTestId('control-room-cancel-a'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onCancel).toHaveBeenCalledWith('a')
+    // The cancel button is a sibling of the toggle, so clicking it must NOT
+    // expand the row's output.
+    expect(screen.queryByTestId('control-room-output-a')).toBeNull()
+  })
+})
+
 describe('formatElapsed', () => {
   it('formats seconds, minutes, and hours', () => {
     expect(formatElapsed(0)).toBe('0s')

--- a/packages/dashboard/src/components/ActivityTree.tsx
+++ b/packages/dashboard/src/components/ActivityTree.tsx
@@ -11,8 +11,12 @@
  * rendered here. Keeping one implementation means the v1 reducer / protocol /
  * `selectActivityTree` stay the single source of truth for the tree shape.
  *
- * v1 is READ-ONLY: no cancel/kill/jump-to-intervene actions. Control actions
- * and mobile parity are tracked phase-2 fast-follows on the epic (#5159).
+ * Control actions (#5272, epic #5159 Phase 2a): when an `onCancelActivity`
+ * callback is supplied, a Cancel button appears on running SUBAGENT nodes only.
+ * Background shells and tool calls are NOT individually cancellable (chroxy
+ * doesn't own those processes — see activity-registry.js / the #5269 server
+ * work), so they get no cancel affordance; whole-turn interruption lives on the
+ * section heading, not here. Without the callback the tree stays read-only.
  *
  * Blocked-on-input entries are visually prominent and tie into the dashboard's
  * intervention convention (#4891): a blocked entry pulses the same accent the
@@ -32,6 +36,12 @@ export interface ActivityTreeProps {
    * the elapsed timer; production passes nothing.
    */
   now?: () => number
+  /**
+   * #5272: cancel a running subagent node by its entry id. When omitted the tree
+   * is read-only (no cancel buttons). Only ever invoked for `agent` nodes that
+   * are still running.
+   */
+  onCancelActivity?: (activityId: string) => void
 }
 
 // Stable empty tree for the null-session case so we don't allocate a new array
@@ -120,9 +130,10 @@ interface EntryRowProps {
   now: number
   expanded: boolean
   onToggleExpand: (id: string) => void
+  onCancelActivity?: (activityId: string) => void
 }
 
-function EntryRow({ entry, depth, now, expanded, onToggleExpand }: EntryRowProps) {
+function EntryRow({ entry, depth, now, expanded, onToggleExpand, onCancelActivity }: EntryRowProps) {
   const terminal = isTerminal(entry.status)
   const blocked = entry.status === 'blocked'
   // Terminal entries freeze elapsed at endedAt; live entries tick from `now`.
@@ -131,48 +142,68 @@ function EntryRow({ entry, depth, now, expanded, onToggleExpand }: EntryRowProps
   const rowClass =
     `control-room-entry status-${entry.status}` + (blocked ? ' control-room-entry-blocked' : '')
 
+  // #5272: only running SUBAGENTS are individually cancellable. Shells/tools
+  // aren't (chroxy doesn't own them) and terminal nodes are already done, so
+  // they get no button. The cancel button is a SIBLING of the toggle button
+  // (not nested — that would be invalid HTML and swallow its own click).
+  const canCancel = onCancelActivity !== undefined && entry.kind === 'agent' && !terminal
+
   return (
     <li
       className="control-room-entry-row"
       data-testid={`control-room-entry-${entry.id}`}
     >
-      <button
-        type="button"
-        className={rowClass}
-        // Indent children by depth. paddingLeft keeps the whole row clickable
-        // (vs a margin that would leave dead gutter).
-        style={{ paddingLeft: 6 + depth * 14 }}
-        aria-expanded={expanded}
-        data-status={entry.status}
-        data-testid={`control-room-entry-toggle-${entry.id}`}
-        onClick={() => onToggleExpand(entry.id)}
-        title={`${KIND_LABEL[entry.kind]} · ${STATUS_LABEL[entry.status]}`}
-      >
-        <span className="control-room-entry-icon" aria-hidden="true">
-          {KIND_ICON[entry.kind]}
-        </span>
-        <span className="control-room-entry-label" data-testid={`control-room-entry-label-${entry.id}`}>
-          {entry.label || KIND_LABEL[entry.kind]}
-        </span>
-        <span
-          className={`control-room-status-badge status-${entry.status}`}
-          data-testid={`control-room-status-${entry.id}`}
-          // The badge's colour is the only signal of status; an explicit label
-          // keeps it accessible to screen readers and colour-blind users.
-          role="status"
-          aria-label={`Status: ${STATUS_LABEL[entry.status]}`}
+      <div className="control-room-entry-rowline">
+        <button
+          type="button"
+          className={rowClass}
+          // Indent children by depth. paddingLeft keeps the whole row clickable
+          // (vs a margin that would leave dead gutter).
+          style={{ paddingLeft: 6 + depth * 14 }}
+          aria-expanded={expanded}
+          data-status={entry.status}
+          data-testid={`control-room-entry-toggle-${entry.id}`}
+          onClick={() => onToggleExpand(entry.id)}
+          title={`${KIND_LABEL[entry.kind]} · ${STATUS_LABEL[entry.status]}`}
         >
-          {STATUS_LABEL[entry.status]}
-        </span>
-        <span
-          className="control-room-entry-elapsed"
-          data-testid={`control-room-elapsed-${entry.id}`}
-          // Elapsed is decorative against the label; give SR users context.
-          aria-label={`Elapsed ${formatElapsed(elapsedMs)}`}
-        >
-          {formatElapsed(elapsedMs)}
-        </span>
-      </button>
+          <span className="control-room-entry-icon" aria-hidden="true">
+            {KIND_ICON[entry.kind]}
+          </span>
+          <span className="control-room-entry-label" data-testid={`control-room-entry-label-${entry.id}`}>
+            {entry.label || KIND_LABEL[entry.kind]}
+          </span>
+          <span
+            className={`control-room-status-badge status-${entry.status}`}
+            data-testid={`control-room-status-${entry.id}`}
+            // The badge's colour is the only signal of status; an explicit label
+            // keeps it accessible to screen readers and colour-blind users.
+            role="status"
+            aria-label={`Status: ${STATUS_LABEL[entry.status]}`}
+          >
+            {STATUS_LABEL[entry.status]}
+          </span>
+          <span
+            className="control-room-entry-elapsed"
+            data-testid={`control-room-elapsed-${entry.id}`}
+            // Elapsed is decorative against the label; give SR users context.
+            aria-label={`Elapsed ${formatElapsed(elapsedMs)}`}
+          >
+            {formatElapsed(elapsedMs)}
+          </span>
+        </button>
+        {canCancel && (
+          <button
+            type="button"
+            className="control-room-cancel-btn"
+            data-testid={`control-room-cancel-${entry.id}`}
+            onClick={() => onCancelActivity!(entry.id)}
+            title={`Cancel ${entry.label || KIND_LABEL[entry.kind]}`}
+            aria-label={`Cancel subagent ${entry.label || ''}`.trim()}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
       {expanded && (
         <div
           className="control-room-entry-output"
@@ -213,9 +244,10 @@ interface EntryTreeProps {
   now: number
   expandedIds: ReadonlySet<string>
   onToggleExpand: (id: string) => void
+  onCancelActivity?: (activityId: string) => void
 }
 
-function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand }: EntryTreeProps) {
+function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand, onCancelActivity }: EntryTreeProps) {
   return (
     <ul className="control-room-entry-list" data-testid={depth === 0 ? 'control-room-tree' : undefined}>
       {nodes.map((node) => (
@@ -227,6 +259,7 @@ function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand }: EntryTree
               now={now}
               expanded={expandedIds.has(node.entry.id)}
               onToggleExpand={onToggleExpand}
+              onCancelActivity={onCancelActivity}
             />
           </ul>
           {node.children.length > 0 && (
@@ -236,6 +269,7 @@ function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand }: EntryTree
               now={now}
               expandedIds={expandedIds}
               onToggleExpand={onToggleExpand}
+              onCancelActivity={onCancelActivity}
             />
           )}
         </li>
@@ -244,7 +278,7 @@ function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand }: EntryTree
   )
 }
 
-export function ActivityTree({ activity, sessionId, now = Date.now }: ActivityTreeProps) {
+export function ActivityTree({ activity, sessionId, now = Date.now, onCancelActivity }: ActivityTreeProps) {
   // Only query the reducer for a real session — a null id has no tree, and
   // selecting with an empty-string id would do pointless work (and could match
   // a degenerate "" session key). The empty-state branch below renders for null.
@@ -297,6 +331,7 @@ export function ActivityTree({ activity, sessionId, now = Date.now }: ActivityTr
         now={tick}
         expandedIds={expandedIds}
         onToggleExpand={handleToggleExpand}
+        onCancelActivity={onCancelActivity}
       />
     </div>
   )

--- a/packages/dashboard/src/components/ActivityTree.tsx
+++ b/packages/dashboard/src/components/ActivityTree.tsx
@@ -37,9 +37,11 @@ export interface ActivityTreeProps {
    */
   now?: () => number
   /**
-   * #5272: cancel a running subagent node by its entry id. When omitted the tree
-   * is read-only (no cancel buttons). Only ever invoked for `agent` nodes that
-   * are still running.
+   * #5272: cancel a non-terminal subagent node by its entry id. When omitted the
+   * tree is read-only (no cancel buttons). Only ever invoked for `agent` nodes
+   * that are still live — i.e. `running` OR `blocked` (a blocked/waiting subagent
+   * is exactly the kind an operator wants to abort). Terminal agents (done /
+   * failed) and non-agent nodes (shells / tools) never get a cancel affordance.
    */
   onCancelActivity?: (activityId: string) => void
 }
@@ -142,10 +144,13 @@ function EntryRow({ entry, depth, now, expanded, onToggleExpand, onCancelActivit
   const rowClass =
     `control-room-entry status-${entry.status}` + (blocked ? ' control-room-entry-blocked' : '')
 
-  // #5272: only running SUBAGENTS are individually cancellable. Shells/tools
-  // aren't (chroxy doesn't own them) and terminal nodes are already done, so
-  // they get no button. The cancel button is a SIBLING of the toggle button
-  // (not nested — that would be invalid HTML and swallow its own click).
+  // #5272: only non-terminal SUBAGENTS are individually cancellable — i.e.
+  // `running` OR `blocked` (a blocked subagent is stuck/waiting and is exactly
+  // what an operator wants to abort, so it stays cancellable). Shells/tools
+  // aren't cancellable (chroxy doesn't own them) and terminal nodes (done /
+  // failed) are already finished, so they get no button. The cancel button is a
+  // SIBLING of the toggle button (not nested — that would be invalid HTML and
+  // swallow its own click).
   const canCancel = onCancelActivity !== undefined && entry.kind === 'agent' && !terminal
 
   return (

--- a/packages/dashboard/src/components/ControlRoomSection.test.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.test.tsx
@@ -712,6 +712,60 @@ describe('ControlRoomSection activity drill-down (#5176)', () => {
   })
 })
 
+describe('ControlRoomSection control actions (#5272)', () => {
+  const NOW_TICK = () => 5000
+
+  it('wires a subagent cancel button to onCancelActivity(activityId, sessionId)', () => {
+    const sessions = [makeSession('s-chroxy', '/Users/me/Projects/chroxy')]
+    const activity = buildActivity('s-chroxy', [
+      activityEntry('a1', { kind: 'agent', label: 'build agent', status: 'running' }),
+      activityEntry('sh1', { kind: 'shell', label: 'tail logs', status: 'running' }),
+    ])
+    const onCancelActivity = vi.fn()
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={NOW_TICK}
+        sessions={sessions}
+        activity={activity}
+        onCancelActivity={onCancelActivity}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('cr-drill-toggle-chroxy'))
+    // The running agent has a cancel button; the shell does not.
+    expect(screen.getByTestId('control-room-cancel-a1')).toBeTruthy()
+    expect(screen.queryByTestId('control-room-cancel-sh1')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('control-room-cancel-a1'))
+    expect(onCancelActivity).toHaveBeenCalledTimes(1)
+    // Bound to the drill-down's mapped session id.
+    expect(onCancelActivity).toHaveBeenCalledWith('a1', 's-chroxy')
+  })
+
+  it('wires the heading "Interrupt turn" button to onInterruptSession(sessionId)', () => {
+    const sessions = [makeSession('s-chroxy', '/Users/me/Projects/chroxy')]
+    const activity = buildActivity('s-chroxy', [activityEntry('a1', { status: 'running' })])
+    const onInterruptSession = vi.fn()
+    render(
+      <ControlRoomSection
+        snapshot={makeSnapshot()}
+        loading={false}
+        onRefresh={() => {}}
+        now={NOW_TICK}
+        sessions={sessions}
+        activity={activity}
+        onInterruptSession={onInterruptSession}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('cr-drill-toggle-chroxy'))
+    fireEvent.click(screen.getByTestId('cr-interrupt-chroxy'))
+    expect(onInterruptSession).toHaveBeenCalledTimes(1)
+    expect(onInterruptSession).toHaveBeenCalledWith('s-chroxy')
+  })
+})
+
 describe('ControlRoomSection investigate action (#5202)', () => {
   it('renders the investigate verdict as a non-interactive span when no handler is wired', () => {
     render(<ControlRoomSection snapshot={makeSnapshot()} loading={false} onRefresh={() => {}} now={() => NOW} />)

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -632,9 +632,13 @@ interface RepoRowsProps {
   now?: () => number
   /** #5202 — investigate action, forwarded to the verdict tag. */
   onInvestigate?: (req: RepoInvestigateRequest) => void
+  /** #5272 — cancel a subagent in this repo's session (bound to its sessionId). */
+  onCancelActivity?: (activityId: string, sessionId: string) => void
+  /** #5272 — interrupt this repo's session (heading "Interrupt turn"). */
+  onInterruptSession?: (sessionId: string) => void
 }
 
-function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onInvestigate }: RepoRowsProps) {
+function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onInvestigate, onCancelActivity, onInterruptSession }: RepoRowsProps) {
   // Map repo → its active chroxy session (by cwd). When a session is found the
   // name cell becomes a disclosure toggle that reveals that session's live
   // activity tree (subagents / shells / tools — the retired v1 panel's view).
@@ -701,9 +705,34 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onI
           <td colSpan={9}>
             <div className="cr-activity-drill">
               <div className="cr-activity-heading" data-testid={`cr-activity-heading-${repo.name}`}>
-                Live activity · {repo.name}
+                <span>Live activity · {repo.name}</span>
+                {/* #5272: whole-turn interrupt for THIS repo's session. Subagent
+                    cancel lives per-node in the tree below; this is the
+                    coarse "stop the turn" lever (the only lever that reaches
+                    background shells / tool calls, which aren't individually
+                    cancellable). */}
+                {onInterruptSession && sessionId && (
+                  <button
+                    type="button"
+                    className="cr-interrupt-btn"
+                    data-testid={`cr-interrupt-${repo.name}`}
+                    onClick={() => onInterruptSession(sessionId)}
+                    title="Interrupt the current turn in this session"
+                  >
+                    Interrupt turn
+                  </button>
+                )}
               </div>
-              <ActivityTree activity={activity} sessionId={sessionId} now={now} />
+              <ActivityTree
+                activity={activity}
+                sessionId={sessionId}
+                now={now}
+                onCancelActivity={
+                  onCancelActivity && sessionId
+                    ? (activityId) => onCancelActivity(activityId, sessionId)
+                    : undefined
+                }
+              />
             </div>
           </td>
         </tr>
@@ -769,6 +798,17 @@ export interface ControlRoomSectionProps {
    * pre-filled with the repo cwd and seeds the reason into the composer.
    */
   onInvestigate?: (req: RepoInvestigateRequest) => void
+  /**
+   * #5272 — cancel a subagent node in a drill-down's session. Defaults to the
+   * store's `sendCancelActivity`. Injectable for tests.
+   */
+  onCancelActivity?: (activityId: string, sessionId: string) => void
+  /**
+   * #5272 — interrupt the current turn of a drill-down's session (the heading
+   * "Interrupt turn" action). Defaults to the store's `sendInterrupt`.
+   * Injectable for tests.
+   */
+  onInterruptSession?: (sessionId: string) => void
 }
 
 // Stable empty-activity default so the `activity` prop falling back to its
@@ -784,6 +824,8 @@ export function ControlRoomSection({
   sessions: sessionsProp,
   now = Date.now,
   onInvestigate,
+  onCancelActivity: onCancelActivityProp,
+  onInterruptSession: onInterruptSessionProp,
 }: ControlRoomSectionProps = {}) {
   const storeSnapshot = useConnectionStore((s) => s.hostStatus)
   const storeLoading = useConnectionStore((s) => s.hostStatusLoading)
@@ -791,6 +833,8 @@ export function ControlRoomSection({
   const requestHostStatus = useConnectionStore((s) => s.requestHostStatus)
   const storeActivity = useConnectionStore((s) => s.activity)
   const storeSessions = useConnectionStore((s) => s.sessions)
+  const storeSendCancelActivity = useConnectionStore((s) => s.sendCancelActivity)
+  const storeSendInterrupt = useConnectionStore((s) => s.sendInterrupt)
 
   const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
   const loading = loadingProp !== undefined ? loadingProp : storeLoading
@@ -798,6 +842,10 @@ export function ControlRoomSection({
   const onRefresh = onRefreshProp ?? requestHostStatus
   const activity = activityProp ?? storeActivity ?? EMPTY_ACTIVITY
   const sessions = sessionsProp ?? storeSessions ?? []
+  // #5272: control actions on the per-repo drill-down. Both target a specific
+  // session id (the drill-down's), so they bind sessionId at the call site.
+  const onCancelActivity = onCancelActivityProp ?? ((activityId: string, sessionId: string) => { storeSendCancelActivity(activityId, sessionId) })
+  const onInterruptSession = onInterruptSessionProp ?? ((sessionId: string) => { storeSendInterrupt(sessionId) })
 
   // Per-repo drill-down expansion, keyed by repo.path. A repo's row reveals its
   // active session's live activity tree (subagents / shells / tools) when
@@ -1018,6 +1066,8 @@ export function ControlRoomSection({
                       onToggleExpand={handleToggleRepo}
                       now={now}
                       onInvestigate={onInvestigate}
+                      onCancelActivity={onCancelActivity}
+                      onInterruptSession={onInterruptSession}
                     />
                   ))
                 )}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1661,15 +1661,35 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     return result;
   },
 
-  sendInterrupt: () => {
+  sendInterrupt: (sessionId?: string) => {
     const { socket, activeSessionId } = get();
+    // #5272: an explicit sessionId (Control Room drill-down) wins over the
+    // active session, so an operator can interrupt a repo's session without
+    // first making it active.
+    const sid = sessionId ?? activeSessionId;
     const payload: Record<string, unknown> = { type: 'interrupt' };
-    if (activeSessionId) payload.sessionId = activeSessionId;
+    if (sid) payload.sessionId = sid;
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, payload);
       return 'sent';
     }
     return enqueueMessage('interrupt', payload);
+  },
+
+  // #5272 (Control Room Phase 2a): cancel one in-flight activity node (a
+  // subagent) by its entry id. Mirrors sendInterrupt's queue-when-offline
+  // behaviour. The server's terminal activity_delta updates the tree; a failure
+  // comes back as a session_error (surfaced by the existing handler).
+  sendCancelActivity: (activityId: string, sessionId?: string) => {
+    const { socket, activeSessionId } = get();
+    const sid = sessionId ?? activeSessionId;
+    const payload: Record<string, unknown> = { type: 'cancel_activity', activityId };
+    if (sid) payload.sessionId = sid;
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      wsSend(socket, payload);
+      return 'sent';
+    }
+    return enqueueMessage('cancel_activity', payload);
   },
 
   // #3068 — manual prompt evaluator. Returns a Promise that resolves with the

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -368,6 +368,7 @@ describe('useConnectionStore', () => {
     // Message actions
     expect(typeof state.sendInput).toBe('function');
     expect(typeof state.sendInterrupt).toBe('function');
+    expect(typeof state.sendCancelActivity).toBe('function');
     expect(typeof state.sendPermissionResponse).toBe('function');
     expect(typeof state.sendUserQuestionResponse).toBe('function');
 
@@ -570,6 +571,38 @@ describe('message handler', () => {
     const parsed = JSON.parse(sent[0]!);
     expect(parsed.type).toBe('test');
     expect(parsed.data).toBe('hello');
+  });
+
+  it('sendCancelActivity sends cancel_activity with the explicit sessionId (#5272)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const sent: string[] = [];
+    useConnectionStore.setState({
+      socket: { send: (d: string) => sent.push(d), readyState: 1 } as unknown as WebSocket,
+      activeSessionId: 'active-sess',
+    });
+
+    const result = useConnectionStore.getState().sendCancelActivity('tu-1', 'drill-sess');
+    expect(result).toBe('sent');
+    expect(sent).toHaveLength(1);
+    const parsed = JSON.parse(sent[0]!);
+    expect(parsed.type).toBe('cancel_activity');
+    expect(parsed.activityId).toBe('tu-1');
+    // Explicit sessionId wins over the active session.
+    expect(parsed.sessionId).toBe('drill-sess');
+  });
+
+  it('sendCancelActivity falls back to the active session when no sessionId is given (#5272)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const sent: string[] = [];
+    useConnectionStore.setState({
+      socket: { send: (d: string) => sent.push(d), readyState: 1 } as unknown as WebSocket,
+      activeSessionId: 'active-sess',
+    });
+
+    useConnectionStore.getState().sendCancelActivity('tu-9');
+    const parsed = JSON.parse(sent[0]!);
+    expect(parsed.activityId).toBe('tu-9');
+    expect(parsed.sessionId).toBe('active-sess');
   });
 
   it('session_error surfaces non-crash errors via addServerError', async () => {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -746,7 +746,20 @@ export interface ConnectionState {
   setTerminalWriteCallback: (cb: ((data: string) => void) | null) => void;
   updateInputSettings: (settings: Partial<InputSettings>) => void;
   sendInput: (input: string, wireAttachments?: { type: string; name: string; [key: string]: string }[], options?: { isVoice?: boolean }) => 'sent' | 'queued' | false;
-  sendInterrupt: () => 'sent' | 'queued' | false;
+  /**
+   * Interrupt the current turn. Defaults to the active session; pass an explicit
+   * `sessionId` to interrupt a specific session (e.g. the Control Room
+   * per-repo drill-down, which targets the repo's session, not necessarily the
+   * active one). #5272.
+   */
+  sendInterrupt: (sessionId?: string) => 'sent' | 'queued' | false;
+  /**
+   * #5272 (Control Room Phase 2a): cancel a single in-flight activity node (a
+   * subagent) by its activity-tree entry id. Targets `sessionId` if given, else
+   * the active session. The terminal `activity_delta` updates the tree; a
+   * failure surfaces as the existing `session_error` toast.
+   */
+  sendCancelActivity: (activityId: string, sessionId?: string) => 'sent' | 'queued' | false;
   /** #3068 — Run the prompt evaluator on a draft. Resolves with the verdict
    * payload, or rejects on disconnect / 60s timeout. Errors from the server
    * arrive as the `error` field on the resolved value, not as a Promise reject. */

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1234,11 +1234,21 @@ button.sidebar-token-view-session-row:hover {
   flex-direction: column;
 }
 
+/* #5272: the toggle button + an optional Cancel button share one line. The
+   toggle flexes to fill; the cancel button stays at its intrinsic width. */
+.control-room-entry-rowline {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .control-room-entry {
   display: flex;
   align-items: center;
   gap: 6px;
   width: 100%;
+  flex: 1 1 auto;
+  min-width: 0;
   padding: 3px 6px;
   background: transparent;
   border: 1px solid transparent;
@@ -1247,6 +1257,26 @@ button.sidebar-token-view-session-row:hover {
   font-size: 12px;
   text-align: left;
   cursor: pointer;
+}
+
+/* #5272: per-subagent cancel. Understated until hover so it doesn't compete
+   with the activity content, then takes the danger accent. */
+.control-room-cancel-btn {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  font-size: 11px;
+  background: transparent;
+  border: 1px solid var(--border-subtle, var(--border, #444));
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.control-room-cancel-btn:hover,
+.control-room-cancel-btn:focus-visible {
+  background: var(--danger-bg, rgba(220, 38, 38, 0.12));
+  border-color: var(--danger, #dc2626);
+  color: var(--danger, #dc2626);
 }
 
 .control-room-entry:hover,
@@ -8860,11 +8890,36 @@ button.sidebar-token-view-session-row:hover {
 }
 
 .cr-activity-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-muted);
   margin-bottom: 4px;
+}
+
+/* #5272: whole-turn interrupt for the drill-down's session. */
+.cr-interrupt-btn {
+  flex-shrink: 0;
+  padding: 2px 8px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: transparent;
+  border: 1px solid var(--border-subtle, var(--border, #444));
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.cr-interrupt-btn:hover,
+.cr-interrupt-btn:focus-visible {
+  background: var(--danger-bg, rgba(220, 38, 38, 0.12));
+  border-color: var(--danger, #dc2626);
+  color: var(--danger, #dc2626);
 }
 
 .cr-num {


### PR DESCRIPTION
## Summary

Closes #5272. Control Room epic #5159, **Phase 2a — the final piece**. Turns the read-only in-session activity tree into something the operator can act on, wired to the `cancel_activity` message (#5270) and its handler (#5271).

## Changes

- **store** (`connection.ts` / `types.ts`): `sendCancelActivity(activityId, sessionId?)` sends `cancel_activity` (queues when offline, mirrors `sendInterrupt`). `sendInterrupt` now takes an **optional `sessionId`** so the drill-down can interrupt a repo's session without first making it active. Backwards-compatible.
- **`ActivityTree`**: optional `onCancelActivity` prop. A **Cancel** button renders **only on running subagent (`agent`) nodes** — background shells and tool calls are *not* individually cancellable (chroxy doesn't own those processes, see #5269), and terminal nodes are already done. The button is a **sibling** of the row toggle (not nested — that'd be invalid HTML and swallow its own click), so cancelling never expands the row. Without the callback the tree stays read-only.
- **`ControlRoomSection`**: threads `onCancelActivity` / `onInterruptSession` from the store (prop-overridable for tests) into each repo drill-down, binding the row's mapped `sessionId`. Adds an **"Interrupt turn"** button to the drill-down heading — the coarse lever that *does* reach shells/tools (whole-turn), complementing per-subagent cancel.
- Node transitions to terminal automatically on the server's confirming `activity_delta`; failures surface via the existing `session_error` toast.

## UX honesty
Per the Phase 2a feasibility reality: **only subagents get a per-node Cancel**. Shells/tools deliberately have no cancel affordance (impossible). The heading "Interrupt turn" is the honest coarse alternative for those.

## Tests
- `ActivityTree.test.tsx`: cancel only on running agents (not shells/tools/terminal); fires with the entry id; doesn't toggle expansion; read-only without the callback.
- `ControlRoomSection.test.tsx`: cancel wired with the drill-down's `sessionId`; interrupt wired.
- `store.test.ts`: `sendCancelActivity` payload + explicit-sessionId-wins + active-session fallback.

Full dashboard suite green (**3182 tests**), `tsc` clean.

## Chain
Builds on #5269 (`cancelActivity`), #5270 (schema), #5271 (handler) — all merged. Completes Phase 2a. Follow-up #5277 (request/response correlation — surface *which* cancel failed) is out of scope here.