### PR TITLE
feat(server): --host bind-address override (auth-preserving loopback)

### DIFF
--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -17,6 +17,7 @@ Configuration values are resolved in the following order (highest priority first
 |-----|------|----------|---------------------|-------------|
 | `apiToken` | string | - | `API_TOKEN` | Authentication token for clients |
 | `port` | number | - | `PORT` | Local WebSocket port (default: 8765) |
+| `host` | string | `--host <address>` | `CHROXY_HOST` | Bind address for the server socket. Unset binds `0.0.0.0` (all interfaces) so the mobile app / LAN clients can reach it. Set to `127.0.0.1` for a loopback-only bind that keeps auth enabled — opt-in defence-in-depth for single-device setups. `--no-auth` always forces loopback regardless of this key. When bound to loopback the mDNS `_chroxy._tcp` advertisement is suppressed (the server is not LAN-reachable). |
 | `provider` | string | `--provider <name>` | `CHROXY_PROVIDER` | Default session backend. Allowed values: `claude-sdk` (default), `claude-cli`, `claude-tui`, `claude-channel` (research preview), `gemini`, `codex`, plus `docker-sdk` / `docker-cli` when Docker environments are enabled. See [../../docs/providers.md](../../docs/providers.md) for per-provider setup and env var requirements. |
 | `shell` | string | - | `SHELL_CMD` | Shell to use (default: `$SHELL` or `/bin/zsh`) |
 | `cwd` | string | `--cwd <path>` | `CHROXY_CWD` | Working directory (CLI mode) |

--- a/packages/server/src/bind-host.js
+++ b/packages/server/src/bind-host.js
@@ -9,20 +9,37 @@
  * want defence-in-depth on top of the bearer token.
  */
 
+import { isIPv4, isIPv6 } from 'node:net'
+
 const LOOPBACK_HOSTS = new Set(['localhost', '::1'])
 
 /**
  * True for any loopback bind address (127.0.0.0/8, ::1, localhost).
+ * Hostname comparison is case-insensitive; the 127.* check applies only to
+ * valid IPv4 literals so a hostname like `127.example.com` is not mistaken
+ * for loopback.
  * @param {*} host
  * @returns {boolean}
  */
 export function isLoopbackHost(host) {
   if (typeof host !== 'string' || host.length === 0) return false
-  if (LOOPBACK_HOSTS.has(host)) return true
-  if (host.startsWith('127.')) return true
+  const h = host.toLowerCase()
+  if (LOOPBACK_HOSTS.has(h)) return true
+  // 127.0.0.0/8, but only for real IPv4 literals.
+  if (isIPv4(h) && h.startsWith('127.')) return true
   // IPv4-mapped IPv6 loopback, e.g. ::ffff:127.0.0.1 or ::ffff:7f00:1.
-  if (host.startsWith('::ffff:127.') || host.startsWith('::ffff:7f')) return true
+  if (h.startsWith('::ffff:127.') || h.startsWith('::ffff:7f')) return true
   return false
+}
+
+/**
+ * Format a host for use in a URL authority — bracketing IPv6 literals so
+ * `ws://[::1]:8765` is well-formed (a bare `ws://::1:8765` is not).
+ * @param {string} host
+ * @returns {string}
+ */
+export function formatHostForUrl(host) {
+  return isIPv6(host) ? `[${host}]` : host
 }
 
 /**

--- a/packages/server/src/bind-host.js
+++ b/packages/server/src/bind-host.js
@@ -19,7 +19,10 @@ const LOOPBACK_HOSTS = new Set(['localhost', '::1'])
 export function isLoopbackHost(host) {
   if (typeof host !== 'string' || host.length === 0) return false
   if (LOOPBACK_HOSTS.has(host)) return true
-  return host.startsWith('127.')
+  if (host.startsWith('127.')) return true
+  // IPv4-mapped IPv6 loopback, e.g. ::ffff:127.0.0.1 or ::ffff:7f00:1.
+  if (host.startsWith('::ffff:127.') || host.startsWith('::ffff:7f')) return true
+  return false
 }
 
 /**

--- a/packages/server/src/bind-host.js
+++ b/packages/server/src/bind-host.js
@@ -1,0 +1,38 @@
+/**
+ * Bind-address resolution for the chroxy server.
+ *
+ * Default behaviour (unchanged): with auth on and no explicit host, the
+ * server binds 0.0.0.0 (all interfaces) so the mobile app and LAN clients can
+ * reach it. `--no-auth` forces loopback. An explicit `config.host` (e.g.
+ * `--host 127.0.0.1` or `CHROXY_HOST=127.0.0.1`) binds that interface with
+ * auth STILL enabled — opt-in loopback-only for single-device setups that
+ * want defence-in-depth on top of the bearer token.
+ */
+
+const LOOPBACK_HOSTS = new Set(['localhost', '::1'])
+
+/**
+ * True for any loopback bind address (127.0.0.0/8, ::1, localhost).
+ * @param {*} host
+ * @returns {boolean}
+ */
+export function isLoopbackHost(host) {
+  if (typeof host !== 'string' || host.length === 0) return false
+  if (LOOPBACK_HOSTS.has(host)) return true
+  return host.startsWith('127.')
+}
+
+/**
+ * Resolve the address to pass to `httpServer.listen()`.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.noAuth - `--no-auth` forces loopback.
+ * @param {string} [opts.host] - explicit `config.host` override.
+ * @returns {string|undefined} bind address, or `undefined` for the default
+ *   0.0.0.0 bind (so behaviour is unchanged when no host is configured).
+ */
+export function resolveBindHost({ noAuth, host } = {}) {
+  if (noAuth) return '127.0.0.1'
+  if (typeof host === 'string' && host.length > 0) return host
+  return undefined
+}

--- a/packages/server/src/cli/shared.js
+++ b/packages/server/src/cli/shared.js
@@ -36,6 +36,7 @@ export function prompt(question) {
 export function addServerOptions(cmd) {
   return cmd
     .option('-c, --config <path>', 'Path to config file', CONFIG_FILE)
+    .option('--host <address>', 'Bind address (default: 0.0.0.0; use 127.0.0.1 for loopback-only). Auth stays enabled.')
     .option('--cwd <path>', 'Working directory for Claude')
     .option('--model <model>', 'Model to use')
     .option('--allowed-tools <tools>', 'Comma-separated tools to auto-approve')
@@ -114,6 +115,7 @@ export function loadAndMergeConfig(options, extraOverrides = {}) {
   validateConfig(fileConfig, options.verbose)
 
   const cliOverrides = { ...extraOverrides }
+  if (options.host !== undefined) cliOverrides.host = options.host
   if (options.cwd !== undefined) cliOverrides.cwd = options.cwd
   if (options.model !== undefined) cliOverrides.model = options.model
   if (options.allowedTools !== undefined) {

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -23,6 +23,11 @@ const log = createLogger('config')
 const CONFIG_SCHEMA = {
   apiToken: 'string',
   port: 'number',
+  // Bind address for the server socket. Default (unset) binds 0.0.0.0 so the
+  // mobile app / LAN clients can reach it. Set to '127.0.0.1' for a
+  // loopback-only bind that keeps auth enabled — opt-in defence-in-depth for
+  // single-device setups. `--no-auth` always forces loopback regardless.
+  host: 'string',
   cwd: 'string',
   model: 'string',
   allowedTools: 'array',
@@ -746,6 +751,7 @@ function envKeyForConfig(key) {
   const envMap = {
     apiToken: 'API_TOKEN',
     port: 'PORT',
+    host: 'CHROXY_HOST',
     cwd: 'CHROXY_CWD',
     model: 'CHROXY_MODEL',
     allowedTools: 'CHROXY_ALLOWED_TOOLS',

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -19,7 +19,7 @@ import { writeConnectionInfo, removeConnectionInfo } from './connection-info.js'
 import { TokenManager } from './token-manager.js'
 import { PairingManager } from './pairing.js'
 import { getLanIp } from './lan-ip.js'
-import { resolveBindHost, isLoopbackHost } from './bind-host.js'
+import { resolveBindHost, isLoopbackHost, formatHostForUrl } from './bind-host.js'
 import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
 import { maybeEncryptCredentialsAtRest } from './credential-store.js'
@@ -1020,8 +1020,10 @@ export async function startCliServer(config) {
     const host = isLoopbackHost(bindHost)
       ? 'localhost'
       : (bindHost && bindHost !== '0.0.0.0' ? bindHost : (getLanIp() || 'localhost'))
-    currentWsUrl = `ws://${host}:${PORT}`
-    await displayQr(`ws://${host}:${PORT}`, `http://${host}:${PORT}`, 'none')
+    // Bracket IPv6 literals so the URL authority is well-formed.
+    const authority = `${formatHostForUrl(host)}:${PORT}`
+    currentWsUrl = `ws://${authority}`
+    await displayQr(`ws://${authority}`, `http://${authority}`, 'none')
   } else if (!NO_AUTH) {
     // tunnelArg is set but SKIP_TUNNEL is true due to externalUrl — already handled above
   } else {

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -820,9 +820,10 @@ export async function startCliServer(config) {
   sessionManager.setActiveViewersFn((sid) => wsServer.hasActiveViewersForSession(sid))
   sessionManager.startSessionTimeouts()
 
-  // Advertise via mDNS/Bonjour for local network discovery. Skipped when the
-  // server is bound to loopback (nothing on the LAN can reach it, so an
-  // _chroxy._tcp advertisement would be misleading) or when auth is off.
+  // Advertise via mDNS/Bonjour for local network discovery. Skipped on a
+  // loopback bind — nothing on the LAN can reach it, so an _chroxy._tcp
+  // advertisement would be misleading. (Auth-off already skips both branches
+  // below via the pre-existing !NO_AUTH guards.)
   let mdnsService = null
   let bonjourInstance = null
   if (!NO_AUTH && isLoopbackHost(bindHost)) {
@@ -1013,7 +1014,12 @@ export async function startCliServer(config) {
     // Ready message already printed above
   } else if (!tunnelArg && !NO_AUTH) {
     // When bound to loopback the LAN IP is not reachable — advertise localhost.
-    const host = isLoopbackHost(bindHost) ? 'localhost' : (getLanIp() || 'localhost')
+    // When bound to a specific non-loopback interface, advertise that exact
+    // address (getLanIp() returns the first NIC, which may not be the bound
+    // one). Otherwise (default 0.0.0.0 bind) fall back to the discovered LAN IP.
+    const host = isLoopbackHost(bindHost)
+      ? 'localhost'
+      : (bindHost && bindHost !== '0.0.0.0' ? bindHost : (getLanIp() || 'localhost'))
     currentWsUrl = `ws://${host}:${PORT}`
     await displayQr(`ws://${host}:${PORT}`, `http://${host}:${PORT}`, 'none')
   } else if (!NO_AUTH) {

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -19,6 +19,7 @@ import { writeConnectionInfo, removeConnectionInfo } from './connection-info.js'
 import { TokenManager } from './token-manager.js'
 import { PairingManager } from './pairing.js'
 import { getLanIp } from './lan-ip.js'
+import { resolveBindHost, isLoopbackHost } from './bind-host.js'
 import { writeFileRestricted } from './platform.js'
 import { getToken, setToken, migrateToken, isKeychainAvailable } from './keychain.js'
 import { maybeEncryptCredentialsAtRest } from './credential-store.js'
@@ -799,8 +800,11 @@ export async function startCliServer(config) {
     // enforce the 2026-04-11 audit blocker 1 workspace allowlist.
     config,
   })
-  // Bind to localhost-only when auth is disabled
-  wsServer.start(NO_AUTH ? '127.0.0.1' : undefined)
+  // Resolve the bind address. --no-auth forces loopback; otherwise an explicit
+  // config.host (e.g. --host 127.0.0.1) binds that interface with auth still
+  // on, and the default (undefined) binds 0.0.0.0 as before.
+  const bindHost = resolveBindHost({ noAuth: NO_AUTH, host: config.host })
+  wsServer.start(bindHost)
 
   // #5053: wire the pool stats aggregator to the shared pool so the
   // dashboard's GET /api/pool/stats has rolling counters (hit rate,
@@ -816,10 +820,14 @@ export async function startCliServer(config) {
   sessionManager.setActiveViewersFn((sid) => wsServer.hasActiveViewersForSession(sid))
   sessionManager.startSessionTimeouts()
 
-  // Advertise via mDNS/Bonjour for local network discovery
+  // Advertise via mDNS/Bonjour for local network discovery. Skipped when the
+  // server is bound to loopback (nothing on the LAN can reach it, so an
+  // _chroxy._tcp advertisement would be misleading) or when auth is off.
   let mdnsService = null
   let bonjourInstance = null
-  if (!NO_AUTH) {
+  if (!NO_AUTH && isLoopbackHost(bindHost)) {
+    log.info('Loopback bind — skipping mDNS advertisement (server not LAN-reachable)')
+  } else if (!NO_AUTH) {
     try {
       const { Bonjour } = await import('bonjour-service')
       bonjourInstance = new Bonjour()
@@ -1004,8 +1012,8 @@ export async function startCliServer(config) {
   } else if (externalUrl) {
     // Ready message already printed above
   } else if (!tunnelArg && !NO_AUTH) {
-    const lanIp = getLanIp()
-    const host = lanIp || 'localhost'
+    // When bound to loopback the LAN IP is not reachable — advertise localhost.
+    const host = isLoopbackHost(bindHost) ? 'localhost' : (getLanIp() || 'localhost')
     currentWsUrl = `ws://${host}:${PORT}`
     await displayQr(`ws://${host}:${PORT}`, `http://${host}:${PORT}`, 'none')
   } else if (!NO_AUTH) {

--- a/packages/server/tests/bind-host.test.js
+++ b/packages/server/tests/bind-host.test.js
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { resolveBindHost, isLoopbackHost } from '../src/bind-host.js'
+import { resolveBindHost, isLoopbackHost, formatHostForUrl } from '../src/bind-host.js'
 
 describe('isLoopbackHost', () => {
   it('treats 127.0.0.1 and the 127.0.0.0/8 range as loopback', () => {
@@ -19,6 +19,17 @@ describe('isLoopbackHost', () => {
     assert.equal(isLoopbackHost('::ffff:7f00:1'), true)
   })
 
+  it('matches localhost case-insensitively', () => {
+    assert.equal(isLoopbackHost('LocalHost'), true)
+    assert.equal(isLoopbackHost('LOCALHOST'), true)
+  })
+
+  it('does not treat a hostname starting with 127. as loopback', () => {
+    // Only valid IPv4 literals in 127.0.0.0/8 count — not arbitrary hostnames.
+    assert.equal(isLoopbackHost('127.example.com'), false)
+    assert.equal(isLoopbackHost('127.0.0.1.nip.io'), false)
+  })
+
   it('does not treat 0.0.0.0, LAN IPs, or undefined as loopback', () => {
     assert.equal(isLoopbackHost('0.0.0.0'), false)
     assert.equal(isLoopbackHost('192.168.1.10'), false)
@@ -26,6 +37,19 @@ describe('isLoopbackHost', () => {
     assert.equal(isLoopbackHost(undefined), false)
     assert.equal(isLoopbackHost(''), false)
     assert.equal(isLoopbackHost(null), false)
+  })
+})
+
+describe('formatHostForUrl', () => {
+  it('brackets IPv6 literals', () => {
+    assert.equal(formatHostForUrl('::1'), '[::1]')
+    assert.equal(formatHostForUrl('fd00::1'), '[fd00::1]')
+  })
+
+  it('leaves IPv4 and hostnames untouched', () => {
+    assert.equal(formatHostForUrl('127.0.0.1'), '127.0.0.1')
+    assert.equal(formatHostForUrl('192.168.1.10'), '192.168.1.10')
+    assert.equal(formatHostForUrl('localhost'), 'localhost')
   })
 })
 

--- a/packages/server/tests/bind-host.test.js
+++ b/packages/server/tests/bind-host.test.js
@@ -14,6 +14,11 @@ describe('isLoopbackHost', () => {
     assert.equal(isLoopbackHost('localhost'), true)
   })
 
+  it('treats IPv4-mapped IPv6 loopback as loopback', () => {
+    assert.equal(isLoopbackHost('::ffff:127.0.0.1'), true)
+    assert.equal(isLoopbackHost('::ffff:7f00:1'), true)
+  })
+
   it('does not treat 0.0.0.0, LAN IPs, or undefined as loopback', () => {
     assert.equal(isLoopbackHost('0.0.0.0'), false)
     assert.equal(isLoopbackHost('192.168.1.10'), false)

--- a/packages/server/tests/bind-host.test.js
+++ b/packages/server/tests/bind-host.test.js
@@ -1,0 +1,44 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveBindHost, isLoopbackHost } from '../src/bind-host.js'
+
+describe('isLoopbackHost', () => {
+  it('treats 127.0.0.1 and the 127.0.0.0/8 range as loopback', () => {
+    assert.equal(isLoopbackHost('127.0.0.1'), true)
+    assert.equal(isLoopbackHost('127.0.0.53'), true)
+    assert.equal(isLoopbackHost('127.1.2.3'), true)
+  })
+
+  it('treats ::1 and localhost as loopback', () => {
+    assert.equal(isLoopbackHost('::1'), true)
+    assert.equal(isLoopbackHost('localhost'), true)
+  })
+
+  it('does not treat 0.0.0.0, LAN IPs, or undefined as loopback', () => {
+    assert.equal(isLoopbackHost('0.0.0.0'), false)
+    assert.equal(isLoopbackHost('192.168.1.10'), false)
+    assert.equal(isLoopbackHost('10.0.0.5'), false)
+    assert.equal(isLoopbackHost(undefined), false)
+    assert.equal(isLoopbackHost(''), false)
+    assert.equal(isLoopbackHost(null), false)
+  })
+})
+
+describe('resolveBindHost', () => {
+  it('forces loopback when auth is disabled, ignoring any host override', () => {
+    assert.equal(resolveBindHost({ noAuth: true }), '127.0.0.1')
+    assert.equal(resolveBindHost({ noAuth: true, host: '0.0.0.0' }), '127.0.0.1')
+  })
+
+  it('returns undefined (0.0.0.0 default) when auth is on and no host is set', () => {
+    assert.equal(resolveBindHost({ noAuth: false }), undefined)
+    assert.equal(resolveBindHost({ noAuth: false, host: '' }), undefined)
+    assert.equal(resolveBindHost({}), undefined)
+  })
+
+  it('binds an explicit host with auth on', () => {
+    assert.equal(resolveBindHost({ noAuth: false, host: '127.0.0.1' }), '127.0.0.1')
+    assert.equal(resolveBindHost({ noAuth: false, host: '0.0.0.0' }), '0.0.0.0')
+    assert.equal(resolveBindHost({ noAuth: false, host: '192.168.1.10' }), '192.168.1.10')
+  })
+})

--- a/packages/server/tests/config.test.js
+++ b/packages/server/tests/config.test.js
@@ -10,6 +10,7 @@ describe('validateConfig', () => {
     const config = {
       apiToken: 'abc123',
       port: 8765,
+      host: '127.0.0.1',
       cwd: '/home/user',
       model: 'sonnet',
       allowedTools: ['bash', 'read'],
@@ -283,7 +284,7 @@ describe('validateConfig', () => {
 
 describe('mergeConfig', () => {
   let originalEnv
-  const envKeys = ['API_TOKEN', 'PORT', 'CHROXY_CWD', 'CHROXY_MODEL', 'CHROXY_ALLOWED_TOOLS', 'CHROXY_NO_AUTH', 'CHROXY_TUNNEL', 'CHROXY_TUNNEL_NAME', 'CHROXY_TUNNEL_HOSTNAME', 'CHROXY_LEGACY_CLI', 'CHROXY_PROVIDER', 'CHROXY_SHOW_TOKEN', 'CHROXY_REPOS', 'CHROXY_RESULT_TIMEOUT_MS', 'CHROXY_STREAM_STALL_TIMEOUT_MS', 'CHROXY_MCP_TOOL_CALL_TIMEOUT_MS', 'CHROXY_PROVIDER_STREAM_STALL_TIMEOUT_MS']
+  const envKeys = ['API_TOKEN', 'PORT', 'CHROXY_HOST', 'CHROXY_CWD', 'CHROXY_MODEL', 'CHROXY_ALLOWED_TOOLS', 'CHROXY_NO_AUTH', 'CHROXY_TUNNEL', 'CHROXY_TUNNEL_NAME', 'CHROXY_TUNNEL_HOSTNAME', 'CHROXY_LEGACY_CLI', 'CHROXY_PROVIDER', 'CHROXY_SHOW_TOKEN', 'CHROXY_REPOS', 'CHROXY_RESULT_TIMEOUT_MS', 'CHROXY_STREAM_STALL_TIMEOUT_MS', 'CHROXY_MCP_TOOL_CALL_TIMEOUT_MS', 'CHROXY_PROVIDER_STREAM_STALL_TIMEOUT_MS']
 
   beforeEach(() => {
     originalEnv = {}
@@ -475,6 +476,18 @@ describe('mergeConfig', () => {
     process.env.CHROXY_SHOW_TOKEN = '1'
     const merged = mergeConfig({ defaults: { showToken: false } })
     assert.equal(merged.showToken, true)
+  })
+
+  it('reads host from CHROXY_HOST env var', () => {
+    process.env.CHROXY_HOST = '127.0.0.1'
+    const merged = mergeConfig({ defaults: {} })
+    assert.equal(merged.host, '127.0.0.1')
+  })
+
+  it('CLI host override beats CHROXY_HOST env var', () => {
+    process.env.CHROXY_HOST = '127.0.0.1'
+    const merged = mergeConfig({ cliOverrides: { host: '0.0.0.0' }, defaults: {} })
+    assert.equal(merged.host, '0.0.0.0')
   })
 
   it('reads repos from CHROXY_REPOS env var as comma-separated (#1924)', () => {


### PR DESCRIPTION
## What

Adds an opt-in **bind-address override** so the chroxy server can bind a specific interface (e.g. `127.0.0.1` for loopback-only) **while keeping auth enabled**.

- New `config.host` / `--host <address>` / `CHROXY_HOST`.
- **Default behaviour unchanged:** unset binds `0.0.0.0` (all interfaces) so the mobile app and LAN clients keep working.
- `--no-auth` still forces loopback, as before.
- mDNS `_chroxy._tcp` advertisement is **suppressed on a loopback bind** (the server isn't LAN-reachable, so advertising it is misleading).
- `--tunnel none` QR/connect display shows `localhost` instead of an unreachable LAN IP when bound to loopback.

## Why

Surfaced during cross-agent coordination on a single-device setup (one local client + auto-started local daemon). Today, with auth on, the server always binds `0.0.0.0` — the only loopback path is `--no-auth`, which drops auth entirely. This adds a defence-in-depth option: keep the daemon **off the LAN** with **auth still on**, on top of the bearer token.

Example:
```
npx chroxy start --provider claude-tui --tunnel none --host 127.0.0.1
```

## Implementation

- `resolveBindHost` / `isLoopbackHost` extracted to `bind-host.js` (pure, unit-tested).
- `config.host` added to the schema + env map; `--host` added to `addServerOptions`.
- `server-cli.js` resolves the bind host, gates mDNS, and fixes the loopback QR display.
- `CONFIG.md` documents the new key.

## Tests

- `tests/bind-host.test.js` — loopback detection (127.0.0.0/8, ::1, localhost) and bind resolution precedence (no-auth > explicit host > default).
- `tests/config.test.js` — `host` accepted by `validateConfig`; `CHROXY_HOST` env var + CLI-over-env precedence.
- Full server config/CLI suites pass.