### PR TITLE
feat(server): unlock dashboard → remote LAN daemon connect (CSP)

### DIFF
--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -610,7 +610,15 @@ export function createHttpHandler(server) {
       const dashUrl = new URL(req.url, `http://${req.headers.host || 'localhost'}`)
 
       const securityHeaders = {
-        'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: http://127.0.0.1:* http://localhost:*; img-src 'self' data:; font-src 'self'; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
+        // connect-src allows http:/https: alongside ws:/wss: so the dashboard
+        // can reach a REMOTE LAN daemon — both its pre-WS HTTP health-check
+        // (connection.ts) and the WebSocket itself. This is what unlocks the
+        // desktop acting as a LAN client + joining a shared session on another
+        // host. script-src stays 'self' (no inline/eval), so a widened
+        // connect-src is not script-exploitable; ws:/wss: was already open, so
+        // adding http:/https: is symmetric. The narrower 127.0.0.1/localhost
+        // entries are now subsumed by the scheme-only sources.
+        'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: http: https:; img-src 'self' data:; font-src 'self'; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
         'X-Frame-Options': 'DENY',
         'X-Content-Type-Options': 'nosniff',
         'Referrer-Policy': 'no-referrer',

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -612,12 +612,22 @@ export function createHttpHandler(server) {
       const securityHeaders = {
         // connect-src allows http:/https: alongside ws:/wss: so the dashboard
         // can reach a REMOTE LAN daemon — both its pre-WS HTTP health-check
-        // (connection.ts) and the WebSocket itself. This is what unlocks the
-        // desktop acting as a LAN client + joining a shared session on another
-        // host. script-src stays 'self' (no inline/eval), so a widened
-        // connect-src is not script-exploitable; ws:/wss: was already open, so
-        // adding http:/https: is symmetric. The narrower 127.0.0.1/localhost
-        // entries are now subsumed by the scheme-only sources.
+        // (connection.ts) and the WebSocket itself. This unlocks the desktop
+        // acting as a LAN client + joining a shared session on another host.
+        //
+        // Why a wide connect-src is safe here:
+        //  - ws:/wss: were already scheme-open (any host), so adding http:/https:
+        //    is symmetric — no NEW reachable hosts beyond what WebSocket allowed.
+        //  - script-src stays 'self' (no inline/eval), so injected content can't
+        //    run a fetch() to abuse connect-src in the first place.
+        //  - The directives that actually gate *passive* exfil — img-src,
+        //    font-src, form-action, and the default-src fallback — all stay
+        //    'self'-scoped (img-src also data:), so a widened connect-src opens
+        //    no CSS/beacon/form exfil channel. Keep them 'self' if connect-src
+        //    is broad. (This CSP also ships on the tunnel-exposed dashboard, not
+        //    just the desktop's local view — acceptable in chroxy's single-
+        //    tenant model; see #5281 for the decision record.)
+        //  - The narrower 127.0.0.1/localhost http sources are subsumed by http:.
         'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss: http: https:; img-src 'self' data:; font-src 'self'; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self'",
         'X-Frame-Options': 'DENY',
         'X-Content-Type-Options': 'nosniff',

--- a/packages/server/tests/csp-hardening.test.js
+++ b/packages/server/tests/csp-hardening.test.js
@@ -117,6 +117,16 @@ describe('CSP hardening', () => {
     const scriptSrc = csp.split(';').find(d => d.trim().startsWith('script-src'))
     assert.ok(scriptSrc && !scriptSrc.includes("'unsafe-inline'") && !scriptSrc.includes("'unsafe-eval'"),
       'script-src must stay locked to self (no inline/eval) even with a widened connect-src')
+
+    // A broad connect-src is only safe while the directives that gate PASSIVE
+    // exfil stay 'self'-scoped. Lock them in so a future "also widen img-src"
+    // can't silently open a CSS/beacon/form exfil channel.
+    const directive = (name) => csp.split(';').find(d => d.trim().startsWith(name))
+    assert.ok(directive("default-src 'self'"), "default-src must stay 'self'")
+    assert.ok(directive("form-action 'self'"), "form-action must stay 'self'")
+    const imgSrc = directive('img-src')
+    assert.ok(imgSrc && !/https?:/.test(imgSrc),
+      "img-src must not allow remote http(s) origins (no beacon exfil) while connect-src is broad")
   })
 
   it('server config injection uses meta tag in dashboard HTML (not inline script)', async () => {

--- a/packages/server/tests/csp-hardening.test.js
+++ b/packages/server/tests/csp-hardening.test.js
@@ -90,6 +90,35 @@ describe('CSP hardening', () => {
     )
   })
 
+  it('dashboard CSP connect-src permits remote http/ws so the desktop can reach a LAN daemon', async () => {
+    // ① LAN-client connect: the dashboard's pre-WS HTTP health-check + the
+    // WebSocket itself must be allowed to a remote host. connect-src carries
+    // scheme-only sources (ws: wss: http: https:) for exactly that, while
+    // script-src stays locked to 'self'.
+    const mock = createMockServer()
+    await startWith(mock)
+
+    const res = await globalThis.fetch(
+      `http://127.0.0.1:${port}/dashboard?token=wrong-token`
+    )
+    const csp = res.headers.get('content-security-policy')
+    assert.ok(csp, 'dashboard response should include a CSP header')
+
+    const connectSrc = csp.split(';').find(d => d.trim().startsWith('connect-src'))
+    assert.ok(connectSrc, 'CSP should contain a connect-src directive')
+    for (const scheme of ['ws:', 'wss:', 'http:', 'https:']) {
+      assert.ok(
+        connectSrc.includes(` ${scheme}`),
+        `connect-src must allow ${scheme} so a remote LAN daemon is reachable`
+      )
+    }
+
+    // The widened connect-src must NOT come at the cost of an open script-src.
+    const scriptSrc = csp.split(';').find(d => d.trim().startsWith('script-src'))
+    assert.ok(scriptSrc && !scriptSrc.includes("'unsafe-inline'") && !scriptSrc.includes("'unsafe-eval'"),
+      'script-src must stay locked to self (no inline/eval) even with a widened connect-src')
+  })
+
   it('server config injection uses meta tag in dashboard HTML (not inline script)', async () => {
     // Behavioral: verify the actual HTTP response body for the dashboard HTML.
     // This test requires index.html to exist; if not built, the server returns 404.

--- a/packages/server/tests/csp-hardening.test.js
+++ b/packages/server/tests/csp-hardening.test.js
@@ -113,10 +113,18 @@ describe('CSP hardening', () => {
       )
     }
 
-    // The widened connect-src must NOT come at the cost of an open script-src.
+    // The widened connect-src must NOT come at the cost of an open script-src:
+    // no inline/eval AND no remote origins (a `script-src https:` would let a
+    // remote-loaded script abuse the broad connect-src, defeating the whole
+    // safety argument). Lock it to exactly 'self'.
     const scriptSrc = csp.split(';').find(d => d.trim().startsWith('script-src'))
-    assert.ok(scriptSrc && !scriptSrc.includes("'unsafe-inline'") && !scriptSrc.includes("'unsafe-eval'"),
-      'script-src must stay locked to self (no inline/eval) even with a widened connect-src')
+    assert.ok(scriptSrc, 'CSP should contain a script-src directive')
+    assert.ok(!scriptSrc.includes("'unsafe-inline'") && !scriptSrc.includes("'unsafe-eval'"),
+      'script-src must not allow inline/eval')
+    assert.ok(!/https?:/.test(scriptSrc) && !scriptSrc.includes('*') && !/\bwss?:/.test(scriptSrc),
+      'script-src must not allow remote origins (no http(s)/ws(s)/wildcard) while connect-src is broad')
+    assert.equal(scriptSrc.trim(), "script-src 'self'",
+      'script-src must stay locked to exactly self')
 
     // A broad connect-src is only safe while the directives that gate PASSIVE
     // exfil stay 'self'-scoped. Lock them in so a future "also widen img-src"


### PR DESCRIPTION
## What

Widens the **served dashboard's** `Content-Security-Policy` `connect-src` to allow `http:`/`https:` alongside the `ws:`/`wss:` it already permitted, so the dashboard can connect to a chroxy daemon on **another LAN host** — both its pre-WS HTTP health-check (`connection.ts:1047`) and the WebSocket itself.

```diff
- connect-src 'self' ws: wss: http://127.0.0.1:* http://localhost:*;
+ connect-src 'self' ws: wss: http: https:;
```

## Why

This is **①.1** of the desktop LAN-client epic (#5281). Recon found that server-side shared-session join and dashboard-side remote-connect (`ServerPicker` + registry + `connect`/`switchSession`) **already exist** — the one thing blocking the desktop from joining a shared session on another host was this CSP: the WebSocket was already allowed to any host, but the pre-WS HTTP health-check to a remote LAN host was not.

## Security rationale

Widening `connect-src` is safe here because:
- `script-src` stays `'self'` — no `unsafe-inline`, no `unsafe-eval` — so a broader `connect-src` is **not script-exploitable** (only same-origin, bundled JS runs; an attacker can't inject a script to abuse it).
- `ws:`/`wss:` were **already** scheme-open (any host), so adding `http:`/`https:` is **symmetric** — it doesn't expand the set of reachable hosts beyond what WebSocket already could.
- The narrower `http://127.0.0.1:*` / `http://localhost:*` sources are subsumed by the scheme sources and removed.

The alternatives (skip the health-check for remotes; desktop-only bundled CSP) were considered — see #5281 for the decision record.

## Tests

`tests/csp-hardening.test.js` — new assertion that `connect-src` permits `ws:/wss:/http:/https:` (so a remote LAN daemon is reachable) **and** that `script-src` stays locked to self (no inline/eval) even with the widened `connect-src`. Existing CSP + http-routes suites pass.

Relates to #5281.