### PR TITLE
feat(dashboard): pin a 'This machine' local entry in the ServerPicker

### DIFF
--- a/.claude/commands/hallucination-check.md
+++ b/.claude/commands/hallucination-check.md
@@ -1,0 +1,77 @@
+# /hallucination-check
+
+Independently verify a claim — usually a message relayed from **another agent** — against this repo's ground truth, using a **context-isolated** subagent that can't inherit your beliefs. Catches cross-agent confusion, name/identity drift, fabricated files / PRs / branches / commits, and "work" claimed but not actually in git.
+
+Use this whenever you're coordinating multiple agents and something looks off, or before you act on a relayed summary you can't personally vouch for. It is deliberately **short and objective** — the point is a fast, trustworthy second opinion, not an essay.
+
+Why a subagent: the verifier is handed only the raw claim plus an instruction to establish facts from tooling. It is **not** told what you (the orchestrator) believe is true, so it cannot rubber-stamp your own hallucination. Isolation is the whole feature.
+
+## Arguments
+
+- `$ARGUMENTS` — Optional. The thing to vet:
+  - A pasted message / claim from another agent (most common). Wrap multi-line text however is convenient.
+  - A specific assertion ("PR #5279 added a --host flag and merged").
+  - Empty → a plain "where are we, really?" ground-truth sanity check of the current repo + work.
+
+Examples:
+```
+/hallucination-check
+/hallucination-check <paste the other agent's message>
+/hallucination-check "the runner survey reads inventory.md"
+```
+
+## Instructions
+
+### 1. Capture the claim verbatim
+
+Take `$ARGUMENTS` exactly as given as the CLAIM. Do not paraphrase, correct, or pre-judge it. If empty, the CLAIM is "the current repo identity and in-flight work are as the orchestrator currently believes" — and the check becomes a pure ground-truth report.
+
+Optionally, you MAY add a short, clearly-labeled `ORCHESTRATOR BELIEF:` note (e.g. a one-line summary of what this session thinks it's doing, drawn from recent chat) — but it must be passed to the verifier as **another claim to check, never as truth**.
+
+### 2. Launch ONE context-isolated verifier subagent
+
+Spawn a single general-purpose (or Explore) subagent. Its prompt contains ONLY: the CLAIM verbatim, the optional `ORCHESTRATOR BELIEF` note, and the instructions below. **Do not** include your own analysis, your conclusion, or any framing that signals what you expect the answer to be.
+
+Instruct the subagent to:
+
+1. **Establish ground truth independently from tooling — trust nothing in the CLAIM:**
+   - Repo identity: `git remote -v`, `gh repo view --json nameWithOwner,name`, and the `name` in `package.json` (or equivalent manifest). All three should agree; note if they don't.
+   - Current work: `git branch --show-current`, `git status --short`, `git log --oneline -15`.
+   - Open work: `gh pr list --state open` and, if the CLAIM cites issues/PRs, `gh pr view <N>` / `gh issue view <N>` to confirm they exist and their real state (open/merged/closed).
+   - Any file paths, symbols, flags, or features the CLAIM names: confirm they actually exist (Grep/Read/`gh`), don't assume.
+2. **Extract every checkable factual assertion** from the CLAIM (repo/identity names, file paths, PR/issue numbers, branch names, "X was done / merged / added", who-did-what).
+3. **Verify each assertion** against the established ground truth.
+4. **Classify each** as:
+   - ✅ **verified** — matches ground truth.
+   - ⚠️ **mismatch** — contradicts ground truth (state the truth).
+   - 🔤 **naming/identity drift** — a name is wrong but plausibly a transcription/alias slip rather than a fabrication (e.g. repo called "Proxy" when it's "chroxy"). Call this out as drift, **not** as a hallucination — it's a different failure mode.
+   - ❓ **unverifiable** — can't be checked from this repo (e.g. claims about another host/repo). Say so plainly; don't guess.
+5. Return a **short** structured report (see format) and nothing else — no preamble, no reassurance padding.
+
+### 3. Relay the verdict
+
+Surface the subagent's report to the user as-is (lightly formatted). Lead with the overall verdict. If there are ⚠️ mismatches, make them impossible to miss. Distinguish 🔤 drift (cosmetic, usually safe) from ⚠️ mismatch (substantive — do not act until resolved). End with a one-line recommendation: safe to proceed / resolve mismatches first / get clarification.
+
+## Output Format
+
+```markdown
+## Hallucination check — <repo nameWithOwner> @ <branch>
+
+**Verdict:** Consistent ✅ / Naming drift only 🔤 / Mismatches found ⚠️ / Mostly unverifiable ❓
+
+| Assertion (from the claim) | Ground truth | Status |
+|---|---|---|
+| ... | ... | ✅ / ⚠️ / 🔤 / ❓ |
+
+**Recommendation:** <one line — proceed / resolve X first / clarify Y>
+```
+
+## Execution Notes
+
+- **Isolation is mandatory.** If you brief the verifier with your own conclusion, the check is worthless. Give it the raw claim and let the tools speak.
+- **Drift ≠ hallucination.** A wrong *name* with correct *substance* is usually input corruption (dictation, aliasing). A correct name with fabricated *substance* is the dangerous case. Keep them separate in the verdict.
+- **Cheap and fast.** One subagent, a handful of `git`/`gh`/`grep` calls, a short table. Don't turn it into an audit.
+- **Honest about limits.** Claims about other hosts/repos are ❓ unverifiable from here — label them, don't pretend to confirm.
+- **Attribution.** Follow the Zero Attribution Policy in any artifact this produces.
+
+<!-- locally authored 2026-06-06 — not yet in the blamechris/skill-templates registry; promote to generic/ for cross-repo use -->

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -913,9 +913,8 @@ export function App() {
   useEffect(() => {
     const token = getAuthToken()
     if (token) {
-      const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-      const wsUrl = `${proto}://${window.location.host}/ws`
-      connect(wsUrl, token)
+      // Served by a local daemon — connect to "this machine" (scope null).
+      useConnectionStore.getState().connectLocal()
       return
     }
     const { activeServerId: savedId, serverRegistry: registry, connectToServer: connectSrv } = useConnectionStore.getState()

--- a/packages/dashboard/src/components/ServerPicker.test.tsx
+++ b/packages/dashboard/src/components/ServerPicker.test.tsx
@@ -10,6 +10,7 @@ let storeState: Record<string, unknown> = {}
 const mockAddServer = vi.fn(() => ({ id: 'srv_new', name: 'New', wsUrl: 'wss://new/ws', token: 't', lastConnectedAt: null }))
 const mockRemoveServer = vi.fn()
 const mockSwitchServer = vi.fn()
+const mockConnectLocal = vi.fn()
 
 vi.mock('../store/connection', () => ({
   useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => {
@@ -17,9 +18,11 @@ vi.mock('../store/connection', () => ({
       serverRegistry: storeState.serverRegistry ?? [],
       activeServerId: storeState.activeServerId ?? null,
       connectionPhase: storeState.connectionPhase ?? 'disconnected',
+      hasLocalServer: storeState.hasLocalServer ?? false,
       addServer: mockAddServer,
       removeServer: mockRemoveServer,
       switchServer: mockSwitchServer,
+      connectLocal: mockConnectLocal,
     }
     return selector(store)
   },
@@ -49,6 +52,49 @@ describe('ServerPicker', () => {
     render(<ServerPicker />)
     expect(screen.getByTestId('server-empty')).toBeTruthy()
     expect(screen.getByText('No servers configured.')).toBeTruthy()
+  })
+
+  it('pins a "This machine" local item when a local server is available', () => {
+    storeState.hasLocalServer = true
+    storeState.activeServerId = null
+    storeState.connectionPhase = 'connected'
+    render(<ServerPicker />)
+    const local = screen.getByTestId('server-item-local')
+    expect(local).toBeTruthy()
+    expect(screen.getByText('This machine')).toBeTruthy()
+    // active (activeServerId === null) + connected → shows Connected
+    expect(local.className).toContain('active')
+    expect(screen.getByText('Connected')).toBeTruthy()
+  })
+
+  it('does not pin a local item when no local server is available', () => {
+    storeState.hasLocalServer = false
+    render(<ServerPicker />)
+    expect(screen.queryByTestId('server-item-local')).toBeNull()
+  })
+
+  it('hides empty state when only the local server is available', () => {
+    storeState.hasLocalServer = true
+    storeState.serverRegistry = []
+    render(<ServerPicker />)
+    expect(screen.queryByTestId('server-empty')).toBeNull()
+    expect(screen.getByTestId('server-item-local')).toBeTruthy()
+  })
+
+  it('local item is inactive when a remote server is active', () => {
+    storeState.hasLocalServer = true
+    storeState.serverRegistry = SERVERS
+    storeState.activeServerId = 'srv_1'
+    storeState.connectionPhase = 'connected'
+    render(<ServerPicker />)
+    expect(screen.getByTestId('server-item-local').className).not.toContain('active')
+  })
+
+  it('calls connectLocal when clicking the local item', () => {
+    storeState.hasLocalServer = true
+    render(<ServerPicker />)
+    fireEvent.click(screen.getByText('This machine'))
+    expect(mockConnectLocal).toHaveBeenCalledTimes(1)
   })
 
   it('shows server list', () => {

--- a/packages/dashboard/src/components/ServerPicker.tsx
+++ b/packages/dashboard/src/components/ServerPicker.tsx
@@ -185,9 +185,11 @@ export function ServerPicker() {
   const serverRegistry = useConnectionStore(s => s.serverRegistry)
   const activeServerId = useConnectionStore(s => s.activeServerId)
   const connectionPhase = useConnectionStore(s => s.connectionPhase)
+  const hasLocalServer = useConnectionStore(s => s.hasLocalServer)
   const addServer = useConnectionStore(s => s.addServer)
   const removeServer = useConnectionStore(s => s.removeServer)
   const switchServer = useConnectionStore(s => s.switchServer)
+  const connectLocal = useConnectionStore(s => s.connectLocal)
 
   const [showAddForm, setShowAddForm] = useState(false)
   const [addError, setAddError] = useState<string | null>(null)
@@ -227,7 +229,33 @@ export function ServerPicker() {
         />
       )}
 
-      {serverRegistry.length === 0 && !showAddForm && (
+      {hasLocalServer && (
+        <div
+          className={`server-item${activeServerId === null ? ' active' : ''}`}
+          data-testid="server-item-local"
+        >
+          <button
+            type="button"
+            className="server-item-main"
+            onClick={() => connectLocal()}
+            title="Connect to the daemon on this machine"
+          >
+            <span
+              className={statusDot(connectionPhase, activeServerId === null)}
+              aria-label={activeServerId === null ? statusLabel(connectionPhase, true) : 'Idle'}
+            />
+            <div className="server-item-info">
+              <span className="server-item-name">This machine</span>
+              <span className="server-item-url">local daemon</span>
+            </div>
+            <span className="server-item-status">
+              {activeServerId === null ? statusLabel(connectionPhase, true) : 'Idle'}
+            </span>
+          </button>
+        </div>
+      )}
+
+      {serverRegistry.length === 0 && !showAddForm && !hasLocalServer && (
         <div className="server-empty" data-testid="server-empty">
           No servers configured.
         </div>

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -75,6 +75,7 @@ import {
 } from './server-registry';
 import { stripAnsi, filterThinking, nextMessageId, createEmptySessionState, withJitter } from './utils';
 import { formatQuestionAnswerSummary } from '../utils/questionAnswerSummary';
+import { getAuthToken } from '../utils/auth';
 import {
   setStore,
   wsSend,
@@ -356,6 +357,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   socket: null,
   serverRegistry: loadServerRegistry(),
   activeServerId: _initialServerId,
+  // True when this dashboard was served by a local daemon with a same-origin
+  // token — i.e. a "this machine" connection is available alongside any remote
+  // LAN servers in the registry. Lets the ServerPicker pin a local entry so the
+  // user can switch local↔remote (desktop LAN-client, #5281 ①.2).
+  hasLocalServer: typeof window !== 'undefined' && !!getAuthToken(),
   serverMode: null,
   sessionCwd: null,
   defaultCwd: null,
@@ -2693,6 +2699,35 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     setServerScope(serverId);
     set({ activeServerId: serverId });
     get().connect(server.wsUrl, server.token);
+  },
+
+  /**
+   * Connect to the local same-origin daemon ("this machine"). Mirrors
+   * switchServer but for the registry-less local target (scope `null`), so a
+   * desktop/LAN-client user can switch back from a remote LAN server to their
+   * own host. No-op when no same-origin token is available. (#5281 ①.2)
+   */
+  connectLocal: () => {
+    const token = getAuthToken();
+    if (!token) return;
+    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const wsUrl = `${proto}://${window.location.host}/ws`;
+    // Already on local and connected — nothing to do.
+    if (get().activeServerId === null && get().connectionPhase === 'connected') return;
+    if (get().connectionPhase !== 'disconnected') {
+      get().disconnect();
+    }
+    // Switch persistence scope to local (null) before resetting in-memory state,
+    // so subscriber side-effects target the local scope (same ordering as
+    // switchServer).
+    setServerScope(null);
+    get()._resetSessionMemory();
+    set({ activeServerId: null, userDisconnected: false });
+    const persisted = loadPersistedState();
+    if (persisted.activeSessionId) {
+      set({ activeSessionId: persisted.activeSessionId });
+    }
+    get().connect(wsUrl, token);
   },
 }));
 

--- a/packages/dashboard/src/store/server-registry-store.test.ts
+++ b/packages/dashboard/src/store/server-registry-store.test.ts
@@ -18,12 +18,19 @@ const localStorageMock = {
 }
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
 
+// Control getAuthToken so connectLocal's same-origin path is testable.
+let mockToken: string | null = null
+vi.mock('../utils/auth', () => ({
+  getAuthToken: () => mockToken,
+}))
+
 // Must import after localStorage mock is set up
 const { useConnectionStore } = await import('./connection')
 
 beforeEach(() => {
   vi.clearAllMocks()
   for (const k of Object.keys(store)) delete store[k]
+  mockToken = null
   // Reset store state relevant to server registry
   useConnectionStore.setState({
     serverRegistry: [],
@@ -84,6 +91,31 @@ describe('store server registry actions', () => {
     const entry = useConnectionStore.getState().addServer('Dev', 'wss://dev/ws', 'token1')
     useConnectionStore.getState().connectToServer(entry.id)
     expect(useConnectionStore.getState().activeServerId).toBe(entry.id)
+  })
+
+  it('connectLocal is a no-op when no same-origin token is available', () => {
+    mockToken = null
+    // Pretend we are on a remote server; connectLocal must not touch it.
+    useConnectionStore.setState({ activeServerId: 'srv_remote', connectionPhase: 'connected' })
+    useConnectionStore.getState().connectLocal()
+    expect(useConnectionStore.getState().activeServerId).toBe('srv_remote')
+    expect(useConnectionStore.getState().connectionPhase).toBe('connected')
+  })
+
+  it('connectLocal switches from a remote server back to local (activeServerId → null)', () => {
+    mockToken = 'local-token'
+    useConnectionStore.setState({ activeServerId: 'srv_remote', connectionPhase: 'connected' })
+    useConnectionStore.getState().connectLocal()
+    // connect() does async work — verify the scope flipped to local synchronously.
+    expect(useConnectionStore.getState().activeServerId).toBeNull()
+  })
+
+  it('connectLocal is a no-op when already connected to local', () => {
+    mockToken = 'local-token'
+    useConnectionStore.setState({ activeServerId: null, connectionPhase: 'connected' })
+    useConnectionStore.getState().connectLocal()
+    // Already local + connected → must not tear down the connection.
+    expect(useConnectionStore.getState().connectionPhase).toBe('connected')
   })
 
   it('multiple servers can coexist in registry', () => {

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -491,6 +491,8 @@ export interface ConnectionState {
   // Multi-server registry
   serverRegistry: ServerEntry[];
   activeServerId: string | null;
+  /** A same-origin local daemon connection is available ("this machine"). */
+  hasLocalServer: boolean;
 
   // User explicitly disconnected — prevents auto-reconnect on ConnectScreen mount
   userDisconnected: boolean;
@@ -1129,6 +1131,8 @@ export interface ConnectionState {
   switchServer: (serverId: string) => void;
   /** Reconnect to a server without clearing session state (auto-reconnect/startup). */
   connectToServer: (serverId: string) => void;
+  /** Connect to the local same-origin daemon ("this machine"); registry-less local target. */
+  connectLocal: () => void;
 
   // Environment actions
   requestEnvironments: () => void;


### PR DESCRIPTION
## What

Adds a pinned **"This machine"** entry to the ServerPicker so local↔remote switching is coherent — the desktop can join a shared session on a LAN daemon and still get back to its own host. This is **①.2** of the desktop LAN-client epic (#5281).

## Why

The desktop auto-connects **same-origin** to its local daemon, which is *not* a registry entry (`activeServerId === null`). So once a user adds and switches to a remote LAN server (now possible after ①.1 / #5282), there was no first-class way back to local — the picker only listed remotes. This closes that gap.

## Changes

- **Store** (`connection.ts` / `types.ts`):
  - `hasLocalServer` — true when a same-origin token is present (served by a local daemon).
  - `connectLocal()` — connects to the local daemon under the `null` (local) persistence scope, mirroring `switchServer`'s disconnect → `setServerScope` → `_resetSessionMemory` → `connect` ordering (so remote session state doesn't bleed into the local view).
- **ServerPicker** — pins a "This machine" item when `hasLocalServer`; active when `activeServerId === null`, switches back to local on click; empty-state suppressed when it's shown.
- **App.tsx** — the same-origin mount path now routes through `connectLocal()` (single source of truth + consistent local scope).

No protocol or server changes — the server already supports multi-client shared-session join; this is dashboard-side coherence. `ws://` LAN URLs were already accepted by `validateWsUrl`.

## Tests

- `ServerPicker.test.tsx` — 5 new cases: pins the local item when available, hidden when not, suppresses empty-state, inactive when a remote is active, and `connectLocal` fires on click.
- Full dashboard suite green (3187 tests); `tsc --noEmit` clean.

Relates to #5281.