### PR TITLE
feat(server): cancelActivity parity for ClaudeByokSession subagents

### DIFF
--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -1395,8 +1395,7 @@ export class ClaudeByokSession extends BaseSession {
     } catch (ctorErr) {
       // Balance the agent_spawned emit + _activeAgents.set above so the
       // dashboard badge clears and the entry doesn't leak forever.
-      this._activeAgents.delete(toolUseId)
-      this.emit('agent_completed', { toolUseId })
+      this._finalizeAgentByToolUseId(toolUseId)
       log.warn(`subagent construction failed: ${ctorErr?.message || ctorErr}`)
       return {
         content: `Subagent construction failed: ${ctorErr?.message || ctorErr}`,
@@ -1549,8 +1548,7 @@ export class ClaudeByokSession extends BaseSession {
       try { await child.destroy() } catch (err) {
         log.warn(`subagent destroy on pre-send abort failed: ${err?.message || err}`)
       }
-      this._activeAgents.delete(toolUseId)
-      this.emit('agent_completed', { toolUseId })
+      this._finalizeAgentByToolUseId(toolUseId)
       return { content: 'Interrupted by user before subagent started', isError: true }
     }
     try {
@@ -1570,8 +1568,7 @@ export class ClaudeByokSession extends BaseSession {
       try { await child.destroy() } catch (err) {
         log.warn(`subagent destroy on Task completion failed: ${err?.message || err}`)
       }
-      this._activeAgents.delete(toolUseId)
-      this.emit('agent_completed', { toolUseId })
+      this._finalizeAgentByToolUseId(toolUseId)
     }
 
     // Fold child usage + cost into the parent's per-turn accumulators
@@ -1854,6 +1851,12 @@ export class ClaudeByokSession extends BaseSession {
       return { ok: false, reason: 'not-found' }
     }
     log.info(`Cancelling byok subagent ${activityId}`)
+    // Best-effort: the child's interrupt() aborts its in-flight stream, but
+    // early-returns if the child isn't busy yet (the narrow window between
+    // _subagentSessions.set and the child's sendMessage flipping _isBusy). In
+    // that window the cancel can't pre-empt the not-yet-started turn — we still
+    // optimistically finalize the node, matching the SDK path's best-effort
+    // stopTask contract.
     try {
       child.interrupt()
     } catch (err) {

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -1824,6 +1824,64 @@ export class ClaudeByokSession extends BaseSession {
     }
   }
 
+  /**
+   * #5274 (Control Room Phase 2a parity): cancel a single in-flight subagent
+   * node by its `activityId` (the Task `toolUseId`). Mirrors
+   * `SdkSession.cancelActivity` and returns the same structured-result
+   * vocabulary, but the *mechanism* differs: SdkSession maps the node to the
+   * SDK's `query.stopTask(task_id)`, whereas ClaudeByokSession owns each
+   * subagent as a child session in `_subagentSessions` — so cancel aborts the
+   * child's in-flight stream (via its `interrupt()` → `AbortController`) and
+   * finalizes the parent's agent node.
+   *
+   * @param {string} activityId
+   * @returns {Promise<{ ok: boolean, reason?: string, error?: string }>}
+   */
+  async cancelActivity(activityId) {
+    if (typeof activityId !== 'string' || !activityId) return { ok: false, reason: 'invalid-id' }
+    const entry = this._activity.getEntry(activityId)
+    if (!entry) return { ok: false, reason: 'not-found' }
+    if (entry.kind !== 'agent') {
+      // Shells and tool calls have no per-node cancel surface (same as
+      // SdkSession) — distinguish the shell case so the UI can point at
+      // "Interrupt turn" instead of implying a transient error.
+      return { ok: false, reason: entry.kind === 'shell' ? 'shell-not-cancellable' : 'not-cancellable' }
+    }
+    const child = this._subagentSessions.get(activityId)
+    if (!child) {
+      // The agent node is in the registry but we hold no live child handle —
+      // the subagent already returned and was cleaned up; nothing to abort.
+      return { ok: false, reason: 'not-found' }
+    }
+    log.info(`Cancelling byok subagent ${activityId}`)
+    try {
+      child.interrupt()
+    } catch (err) {
+      log.warn(`subagent cancel failed for ${activityId}: ${err?.message || err}`)
+      return { ok: false, reason: 'stop-failed', error: err?.message || String(err) }
+    }
+    // Optimistic finalize — idempotent with the natural agent_completed that
+    // fires when the child's aborted stream unwinds.
+    this._finalizeAgentByToolUseId(activityId)
+    return { ok: true }
+  }
+
+  /**
+   * #5274: drop a subagent's `_activeAgents` entry and emit `agent_completed`
+   * so its activity node terminates promptly on cancel. Idempotent (guards on
+   * `_activeAgents.has`) so the optimistic cancel-finalize and the natural
+   * completion don't double-emit. Mirrors SdkSession's helper of the same name
+   * (minus the task-id map, which byok doesn't have).
+   *
+   * @param {string} toolUseId
+   */
+  _finalizeAgentByToolUseId(toolUseId) {
+    if (typeof toolUseId !== 'string' || !toolUseId) return
+    if (!this._activeAgents.has(toolUseId)) return
+    this._activeAgents.delete(toolUseId)
+    this.emit('agent_completed', { toolUseId })
+  }
+
   setModel(model) {
     super.setModel(model)
     // Next sendMessage will use the new model. No restart needed — the

--- a/packages/server/tests/byok-session-cancel-activity.test.js
+++ b/packages/server/tests/byok-session-cancel-activity.test.js
@@ -1,0 +1,158 @@
+import { describe, it, after, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ClaudeByokSession } from '../src/byok-session.js'
+
+/**
+ * #5274 (Control Room Phase 2a parity): ClaudeByokSession control actions.
+ *
+ * Mirrors tests/sdk-session-cancel-activity.test.js, but the cancel MECHANISM
+ * differs: SdkSession maps an agent node to query.stopTask(task_id); byok owns
+ * each subagent as a child session in _subagentSessions and aborts the child's
+ * stream via its interrupt(). The structured-result vocabulary is identical.
+ *
+ * State file points at a tmp dir (#4633 sandbox) so no test touches real state.
+ */
+
+let _globalTmpDir = null
+function tmpStateFile() {
+  if (!_globalTmpDir) _globalTmpDir = mkdtempSync(join(tmpdir(), 'byok-cancel-activity-test-'))
+  return join(_globalTmpDir, `state-${Date.now()}-${Math.random().toString(36).slice(2)}.json`)
+}
+
+after(() => {
+  if (_globalTmpDir) rmSync(_globalTmpDir, { recursive: true, force: true })
+})
+
+function createSession(opts = {}) {
+  return new ClaudeByokSession({ cwd: '/tmp', stateFilePath: tmpStateFile(), ...opts })
+}
+
+// Seed an `agent` activity node for `toolUseId` (the node agent_spawned produces).
+function seedAgentNode(session, toolUseId, label = 'sub') {
+  session._activity.onAgentSpawned({ toolUseId, description: label, startedAt: Date.now() })
+}
+
+// A stand-in child subagent session: interrupt() is the only surface cancel uses.
+function fakeChild(over = {}) {
+  return { interrupt: mock.fn(() => {}), ...over }
+}
+
+describe('ClaudeByokSession #5274 — cancelActivity', () => {
+  it('cancels an agent node via the child interrupt() and finalizes it', async () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._activeAgents.set('tu-1', { toolUseId: 'tu-1' })
+    const child = fakeChild()
+    session._subagentSessions.set('tu-1', child)
+    const completed = []
+    session.on('agent_completed', (d) => completed.push(d))
+
+    const res = await session.cancelActivity('tu-1')
+
+    assert.deepEqual(res, { ok: true })
+    assert.equal(child.interrupt.mock.callCount(), 1)
+    // Optimistic finalize: node cleared + agent_completed fired.
+    assert.deepEqual(completed, [{ toolUseId: 'tu-1' }])
+    assert.equal(session._activeAgents.has('tu-1'), false)
+    await session.destroy()
+  })
+
+  it('returns invalid-id for a non-string / empty id', async () => {
+    const session = createSession()
+    assert.deepEqual(await session.cancelActivity(''), { ok: false, reason: 'invalid-id' })
+    assert.deepEqual(await session.cancelActivity(undefined), { ok: false, reason: 'invalid-id' })
+    await session.destroy()
+  })
+
+  it('returns not-found for an unknown activity id', async () => {
+    const session = createSession()
+    assert.deepEqual(await session.cancelActivity('nope'), { ok: false, reason: 'not-found' })
+    await session.destroy()
+  })
+
+  it('refuses a shell node with shell-not-cancellable', async () => {
+    const session = createSession()
+    session._activity.onBackgroundWorkChanged({ pending: [{ shellId: 'sh-1', command: 'sleep 99', startedAt: Date.now() }] })
+    const res = await session.cancelActivity('shell:sh-1')
+    assert.deepEqual(res, { ok: false, reason: 'shell-not-cancellable' })
+    await session.destroy()
+  })
+
+  it('refuses a plain tool node with not-cancellable', async () => {
+    const session = createSession()
+    session._activity.onToolStart({ toolUseId: 'tu-tool', name: 'Read', startedAt: Date.now() })
+    const res = await session.cancelActivity('tu-tool')
+    assert.deepEqual(res, { ok: false, reason: 'not-cancellable' })
+    await session.destroy()
+  })
+
+  it('returns not-found for an agent that already finished (terminal nodes are dropped)', async () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._subagentSessions.set('tu-1', fakeChild())
+    session._activity.onAgentCompleted({ toolUseId: 'tu-1' }) // _end drops the entry
+    const res = await session.cancelActivity('tu-1')
+    assert.deepEqual(res, { ok: false, reason: 'not-found' })
+    await session.destroy()
+  })
+
+  it('returns not-found when there is no live child handle for the agent node', async () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1') // node exists, but _subagentSessions has no entry
+    const res = await session.cancelActivity('tu-1')
+    assert.deepEqual(res, { ok: false, reason: 'not-found' })
+    await session.destroy()
+  })
+
+  it('surfaces stop-failed (not a throw) when the child interrupt() throws', async () => {
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._activeAgents.set('tu-1', { toolUseId: 'tu-1' })
+    session._subagentSessions.set('tu-1', fakeChild({ interrupt: () => { throw new Error('boom') } }))
+    const res = await session.cancelActivity('tu-1')
+    assert.equal(res.ok, false)
+    assert.equal(res.reason, 'stop-failed')
+    assert.equal(res.error, 'boom')
+    // Failed cancel must NOT finalize the node (it may still be running).
+    assert.equal(session._activeAgents.has('tu-1'), true)
+    await session.destroy()
+  })
+})
+
+describe('ClaudeByokSession #5274 — _finalizeAgentByToolUseId', () => {
+  it('drops the _activeAgents entry and emits agent_completed when active', async () => {
+    const session = createSession()
+    session._activeAgents.set('tu-1', { toolUseId: 'tu-1' })
+    const completed = []
+    session.on('agent_completed', (d) => completed.push(d))
+    session._finalizeAgentByToolUseId('tu-1')
+    assert.deepEqual(completed, [{ toolUseId: 'tu-1' }])
+    assert.equal(session._activeAgents.has('tu-1'), false)
+    await session.destroy()
+  })
+
+  it('is idempotent — second call does not re-emit or throw', async () => {
+    const session = createSession()
+    session._activeAgents.set('tu-1', { toolUseId: 'tu-1' })
+    let emits = 0
+    session.on('agent_completed', () => { emits++ })
+    session._finalizeAgentByToolUseId('tu-1')
+    session._finalizeAgentByToolUseId('tu-1')
+    assert.equal(emits, 1)
+    await session.destroy()
+  })
+
+  it('no-ops for an unknown / empty tool_use_id', async () => {
+    const session = createSession()
+    let emits = 0
+    session.on('agent_completed', () => { emits++ })
+    session._finalizeAgentByToolUseId('nope')
+    session._finalizeAgentByToolUseId('')
+    session._finalizeAgentByToolUseId(undefined)
+    assert.equal(emits, 0)
+    await session.destroy()
+  })
+})

--- a/packages/server/tests/byok-session-cancel-activity.test.js
+++ b/packages/server/tests/byok-session-cancel-activity.test.js
@@ -60,6 +60,25 @@ describe('ClaudeByokSession #5274 — cancelActivity', () => {
     await session.destroy()
   })
 
+  it('cancel + natural completion emit agent_completed exactly once (no double-emit)', async () => {
+    // Both the cancel path and _executeTaskTool's completion path now funnel
+    // through the guarded _finalizeAgentByToolUseId, matching SdkSession — so a
+    // cancel followed by the child's natural unwind must not double-emit.
+    const session = createSession()
+    seedAgentNode(session, 'tu-1')
+    session._activeAgents.set('tu-1', { toolUseId: 'tu-1' })
+    session._subagentSessions.set('tu-1', fakeChild())
+    let emits = 0
+    session.on('agent_completed', () => { emits++ })
+
+    await session.cancelActivity('tu-1') // optimistic finalize → emit #1
+    // Simulate the natural completion path (which now routes through the helper).
+    session._finalizeAgentByToolUseId('tu-1') // guarded no-op (already finalized)
+
+    assert.equal(emits, 1)
+    await session.destroy()
+  })
+
   it('returns invalid-id for a non-string / empty id', async () => {
     const session = createSession()
     assert.deepEqual(await session.cancelActivity(''), { ok: false, reason: 'invalid-id' })


### PR DESCRIPTION
## What

Overrides `cancelActivity(activityId)` on `ClaudeByokSession` so Control Room **subagent cancel** works for the `claude-byok` provider, not just `claude-sdk`. Closes #5274 (Control Room Phase 2a).

## Why the mechanism differs from SdkSession

`SdkSession.cancelActivity` maps an agent node to the SDK's `query.stopTask(task_id)`. `ClaudeByokSession` has no such surface — instead it owns each Task subagent as a **child session** in `_subagentSessions` (keyed by `toolUseId`), each with its own `AbortController`. So byok cancel:

1. Resolves the `agent` node from the activity registry (rejecting shell/tool/unknown with the same reasons as SdkSession).
2. Looks up the child session by `activityId` and aborts its in-flight stream via the child's `interrupt()` — the same path `interrupt()` already cascades through (#4049).
3. Optimistically finalizes the parent's agent node.

This matches the #5273 follow-up note that byok parity is "same mechanism" only loosely — the control surface is genuinely different (AbortController vs `stopTask`).

## Structured-result vocabulary (identical to SdkSession)

`invalid-id` · `not-found` (unknown id, already-finished/dropped node, or no live child handle) · `shell-not-cancellable` · `not-cancellable` · `stop-failed` (child interrupt threw — node is **not** finalized).

## Tests

`tests/byok-session-cancel-activity.test.js` — 11 cases mirroring `sdk-session-cancel-activity.test.js`: happy path (child interrupt + finalize), every refusal reason, already-finished, no-live-child, stop-failed-doesn't-finalize, and the `_finalizeAgentByToolUseId` helper (emit + idempotent + no-op). Opt-forwarding lint clean; existing 132-test BYOK suite green.

Closes #5274.