### PR TITLE
feat: cancel_activity request/response correlation + positive ack

### DIFF
--- a/packages/dashboard/src/components/ActivityTree.test.tsx
+++ b/packages/dashboard/src/components/ActivityTree.test.tsx
@@ -202,6 +202,30 @@ describe('ActivityTree control actions (#5272)', () => {
     expect(screen.queryByTestId('control-room-cancel-tool-run')).toBeNull()
   })
 
+  it('#5277: shows a disabled "Cancelling…" state for ids in cancellingActivityIds', () => {
+    const onCancel = vi.fn()
+    const activity = buildActivity([
+      entry('a', { kind: 'agent', status: 'running' }),
+      entry('b', { kind: 'agent', status: 'running' }),
+    ])
+    render(
+      <ActivityTree
+        activity={activity}
+        sessionId={SESSION_ID}
+        now={() => 1000}
+        onCancelActivity={onCancel}
+        cancellingActivityIds={new Set(['a'])}
+      />,
+    )
+    const pending = screen.getByTestId('control-room-cancel-a') as HTMLButtonElement
+    expect(pending.textContent).toBe('Cancelling…')
+    expect(pending.disabled).toBe(true)
+    // The other live agent is unaffected.
+    const other = screen.getByTestId('control-room-cancel-b') as HTMLButtonElement
+    expect(other.textContent).toBe('Cancel')
+    expect(other.disabled).toBe(false)
+  })
+
   it('invokes onCancelActivity with the entry id (and does not toggle expansion)', () => {
     const onCancel = vi.fn()
     const activity = buildActivity([

--- a/packages/dashboard/src/components/ActivityTree.tsx
+++ b/packages/dashboard/src/components/ActivityTree.tsx
@@ -44,6 +44,12 @@ export interface ActivityTreeProps {
    * failed) and non-agent nodes (shells / tools) never get a cancel affordance.
    */
   onCancelActivity?: (activityId: string) => void
+  /**
+   * #5277: activity ids with an in-flight cancel request. Their cancel button
+   * shows a disabled "Cancelling…" pending state until the server's
+   * cancel_activity_ack (success) or CANCEL_ACTIVITY_FAILED (failure) lands.
+   */
+  cancellingActivityIds?: ReadonlySet<string>
 }
 
 // Stable empty tree for the null-session case so we don't allocate a new array
@@ -133,9 +139,10 @@ interface EntryRowProps {
   expanded: boolean
   onToggleExpand: (id: string) => void
   onCancelActivity?: (activityId: string) => void
+  cancellingActivityIds?: ReadonlySet<string>
 }
 
-function EntryRow({ entry, depth, now, expanded, onToggleExpand, onCancelActivity }: EntryRowProps) {
+function EntryRow({ entry, depth, now, expanded, onToggleExpand, onCancelActivity, cancellingActivityIds }: EntryRowProps) {
   const terminal = isTerminal(entry.status)
   const blocked = entry.status === 'blocked'
   // Terminal entries freeze elapsed at endedAt; live entries tick from `now`.
@@ -152,6 +159,9 @@ function EntryRow({ entry, depth, now, expanded, onToggleExpand, onCancelActivit
   // SIBLING of the toggle button (not nested — that would be invalid HTML and
   // swallow its own click).
   const canCancel = onCancelActivity !== undefined && entry.kind === 'agent' && !terminal
+  // #5277: a cancel request is in flight for this node — show a disabled
+  // "Cancelling…" pending state until the ack/failure clears it.
+  const isCancelling = canCancel && (cancellingActivityIds?.has(entry.id) ?? false)
 
   return (
     <li
@@ -202,10 +212,12 @@ function EntryRow({ entry, depth, now, expanded, onToggleExpand, onCancelActivit
             className="control-room-cancel-btn"
             data-testid={`control-room-cancel-${entry.id}`}
             onClick={() => onCancelActivity!(entry.id)}
-            title={`Cancel ${entry.label || KIND_LABEL[entry.kind]}`}
-            aria-label={`Cancel subagent ${entry.label || ''}`.trim()}
+            disabled={isCancelling}
+            aria-busy={isCancelling}
+            title={isCancelling ? 'Cancelling…' : `Cancel ${entry.label || KIND_LABEL[entry.kind]}`}
+            aria-label={isCancelling ? 'Cancelling subagent' : `Cancel subagent ${entry.label || ''}`.trim()}
           >
-            Cancel
+            {isCancelling ? 'Cancelling…' : 'Cancel'}
           </button>
         )}
       </div>
@@ -250,9 +262,10 @@ interface EntryTreeProps {
   expandedIds: ReadonlySet<string>
   onToggleExpand: (id: string) => void
   onCancelActivity?: (activityId: string) => void
+  cancellingActivityIds?: ReadonlySet<string>
 }
 
-function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand, onCancelActivity }: EntryTreeProps) {
+function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand, onCancelActivity, cancellingActivityIds }: EntryTreeProps) {
   return (
     <ul className="control-room-entry-list" data-testid={depth === 0 ? 'control-room-tree' : undefined}>
       {nodes.map((node) => (
@@ -265,6 +278,7 @@ function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand, onCancelAct
               expanded={expandedIds.has(node.entry.id)}
               onToggleExpand={onToggleExpand}
               onCancelActivity={onCancelActivity}
+              cancellingActivityIds={cancellingActivityIds}
             />
           </ul>
           {node.children.length > 0 && (
@@ -275,6 +289,7 @@ function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand, onCancelAct
               expandedIds={expandedIds}
               onToggleExpand={onToggleExpand}
               onCancelActivity={onCancelActivity}
+              cancellingActivityIds={cancellingActivityIds}
             />
           )}
         </li>
@@ -283,7 +298,7 @@ function EntryTree({ nodes, depth, now, expandedIds, onToggleExpand, onCancelAct
   )
 }
 
-export function ActivityTree({ activity, sessionId, now = Date.now, onCancelActivity }: ActivityTreeProps) {
+export function ActivityTree({ activity, sessionId, now = Date.now, onCancelActivity, cancellingActivityIds }: ActivityTreeProps) {
   // Only query the reducer for a real session — a null id has no tree, and
   // selecting with an empty-string id would do pointless work (and could match
   // a degenerate "" session key). The empty-state branch below renders for null.
@@ -337,6 +352,7 @@ export function ActivityTree({ activity, sessionId, now = Date.now, onCancelActi
         expandedIds={expandedIds}
         onToggleExpand={handleToggleExpand}
         onCancelActivity={onCancelActivity}
+        cancellingActivityIds={cancellingActivityIds}
       />
     </div>
   )

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -646,6 +646,16 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onI
   // activity tree (subagents / shells / tools — the retired v1 panel's view).
   const sessionId = sessionIdForRepoPath(repo.path, sessions)
   const drillable = sessionId !== null
+  // #5277: the store keys pending cancels by `${sessionId}:${activityId}`. Scope
+  // to this drill-down's session and strip the prefix so the ActivityTree can
+  // match by plain entry id (and one session's cancel never affects another's).
+  const scopedCancelling = sessionId && cancellingActivityIds
+    ? new Set(
+        [...cancellingActivityIds]
+          .filter((k) => k.startsWith(`${sessionId}:`))
+          .map((k) => k.slice(sessionId.length + 1)),
+      )
+    : undefined
 
   return (
     <>
@@ -734,7 +744,7 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onI
                     ? (activityId) => onCancelActivity(activityId, sessionId)
                     : undefined
                 }
-                cancellingActivityIds={cancellingActivityIds}
+                cancellingActivityIds={scopedCancelling}
               />
             </div>
           </td>

--- a/packages/dashboard/src/components/ControlRoomSection.tsx
+++ b/packages/dashboard/src/components/ControlRoomSection.tsx
@@ -636,9 +636,11 @@ interface RepoRowsProps {
   onCancelActivity?: (activityId: string, sessionId: string) => void
   /** #5272 — interrupt this repo's session (heading "Interrupt turn"). */
   onInterruptSession?: (sessionId: string) => void
+  /** #5277 — activity ids with an in-flight cancel (pending "Cancelling…" state). */
+  cancellingActivityIds?: ReadonlySet<string>
 }
 
-function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onInvestigate, onCancelActivity, onInterruptSession }: RepoRowsProps) {
+function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onInvestigate, onCancelActivity, onInterruptSession, cancellingActivityIds }: RepoRowsProps) {
   // Map repo → its active chroxy session (by cwd). When a session is found the
   // name cell becomes a disclosure toggle that reveals that session's live
   // activity tree (subagents / shells / tools — the retired v1 panel's view).
@@ -732,6 +734,7 @@ function RepoRows({ repo, activity, sessions, expanded, onToggleExpand, now, onI
                     ? (activityId) => onCancelActivity(activityId, sessionId)
                     : undefined
                 }
+                cancellingActivityIds={cancellingActivityIds}
               />
             </div>
           </td>
@@ -835,6 +838,8 @@ export function ControlRoomSection({
   const storeSessions = useConnectionStore((s) => s.sessions)
   const storeSendCancelActivity = useConnectionStore((s) => s.sendCancelActivity)
   const storeSendInterrupt = useConnectionStore((s) => s.sendInterrupt)
+  // #5277: in-flight cancels → "Cancelling…" pending state on the tree button.
+  const cancellingActivityIds = useConnectionStore((s) => s.cancellingActivityIds)
 
   const snapshot = snapshotProp !== undefined ? snapshotProp : storeSnapshot
   const loading = loadingProp !== undefined ? loadingProp : storeLoading
@@ -1068,6 +1073,7 @@ export function ControlRoomSection({
                       onInvestigate={onInvestigate}
                       onCancelActivity={onCancelActivity}
                       onInterruptSession={onInterruptSession}
+                      cancellingActivityIds={cancellingActivityIds}
                     />
                   ))
                 )}

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -379,6 +379,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // #5163 (epic #5159): Control Room activity tree, fed by the store-core
   // reducer from activity_snapshot / activity_delta.
   activity: createEmptyActivityState(),
+  cancellingActivityIds: new Set<string>(),
   // #5175 (epic #5170): Host/Repo Status Control Room snapshot, fed by the
   // host_status_snapshot handler. Null until the first survey lands.
   hostStatus: null,
@@ -1443,6 +1444,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #5163: drop the Control Room tree on disconnect/forget — a fresh
       // connection re-seeds it from activity_snapshot on subscribe.
       activity: createEmptyActivityState(),
+      cancellingActivityIds: new Set<string>(),
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -1472,6 +1474,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       // #5163: drop the Control Room tree on disconnect/forget — a fresh
       // connection re-seeds it from activity_snapshot on subscribe.
       activity: createEmptyActivityState(),
+      cancellingActivityIds: new Set<string>(),
       wsUrl: null,
       apiToken: null,
       serverMode: null,
@@ -1689,8 +1692,16 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   sendCancelActivity: (activityId: string, sessionId?: string) => {
     const { socket, activeSessionId } = get();
     const sid = sessionId ?? activeSessionId;
-    const payload: Record<string, unknown> = { type: 'cancel_activity', activityId };
+    // #5277: tag the request with an opaque requestId the server echoes on the
+    // cancel_activity_ack / CANCEL_ACTIVITY_FAILED, and optimistically mark the
+    // node "cancelling" so the ActivityTree shows a pending state until the
+    // outcome lands (cleared in handleCancelActivityAck / the session_error).
+    const requestId = `cancel-${nextMessageId()}`;
+    const payload: Record<string, unknown> = { type: 'cancel_activity', activityId, requestId };
     if (sid) payload.sessionId = sid;
+    const cancelling = new Set(get().cancellingActivityIds);
+    cancelling.add(activityId);
+    set({ cancellingActivityIds: cancelling });
     if (socket && socket.readyState === WebSocket.OPEN) {
       wsSend(socket, payload);
       return 'sent';

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1236,6 +1236,14 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const wasConnected = get().connectionPhase === 'connected';
       set({ socket: null, sessionStates: cleanedSessionStates });
 
+      // #5277: a dropped socket means any in-flight cancel_activity's ack/failure
+      // will never arrive on this socket — clear the pending set so a node can't
+      // render "Cancelling…" forever across the reconnect (the tree re-seeds from
+      // activity_snapshot on resubscribe).
+      if (get().cancellingActivityIds.size > 0) {
+        set({ cancellingActivityIds: new Set<string>() });
+      }
+
       // Clear transient streaming/plan state so stale UI doesn't persist
       clearPermissionSplits();
       updateActiveSession((ss) => {
@@ -1686,23 +1694,26 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   },
 
   // #5272 (Control Room Phase 2a): cancel one in-flight activity node (a
-  // subagent) by its entry id. Mirrors sendInterrupt's queue-when-offline
-  // behaviour. The server's terminal activity_delta updates the tree; a failure
-  // comes back as a session_error (surfaced by the existing handler).
+  // subagent) by its entry id. The server's terminal activity_delta updates the
+  // tree; a failure comes back as a session_error (surfaced by the existing
+  // handler). cancel_activity is intentionally NOT queued offline — a cancel
+  // that drains seconds later races the activity finishing — so we only mark the
+  // node "cancelling" when the request is actually on the wire (#5277).
   sendCancelActivity: (activityId: string, sessionId?: string) => {
     const { socket, activeSessionId } = get();
     const sid = sessionId ?? activeSessionId;
     // #5277: tag the request with an opaque requestId the server echoes on the
-    // cancel_activity_ack / CANCEL_ACTIVITY_FAILED, and optimistically mark the
-    // node "cancelling" so the ActivityTree shows a pending state until the
-    // outcome lands (cleared in handleCancelActivityAck / the session_error).
+    // cancel_activity_ack / CANCEL_ACTIVITY_FAILED so the dashboard can correlate.
     const requestId = `cancel-${nextMessageId()}`;
     const payload: Record<string, unknown> = { type: 'cancel_activity', activityId, requestId };
     if (sid) payload.sessionId = sid;
-    const cancelling = new Set(get().cancellingActivityIds);
-    cancelling.add(activityId);
-    set({ cancellingActivityIds: cancelling });
     if (socket && socket.readyState === WebSocket.OPEN) {
+      // Only mark "cancelling" once the request is genuinely sent — otherwise an
+      // offline send (cancel_activity isn't in QUEUE_TTLS, so enqueue drops it)
+      // would strand the node "Cancelling…" with no ack/failure ever arriving.
+      const cancelling = new Set(get().cancellingActivityIds);
+      cancelling.add(activityId);
+      set({ cancellingActivityIds: cancelling });
       wsSend(socket, payload);
       return 'sent';
     }

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1707,12 +1707,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const requestId = `cancel-${nextMessageId()}`;
     const payload: Record<string, unknown> = { type: 'cancel_activity', activityId, requestId };
     if (sid) payload.sessionId = sid;
-    if (socket && socket.readyState === WebSocket.OPEN) {
+    if (sid && socket && socket.readyState === WebSocket.OPEN) {
       // Only mark "cancelling" once the request is genuinely sent — otherwise an
       // offline send (cancel_activity isn't in QUEUE_TTLS, so enqueue drops it)
       // would strand the node "Cancelling…" with no ack/failure ever arriving.
+      // Key by `${sessionId}:${activityId}` — activity ids (toolUseIds) are only
+      // unique within a session, so a global activityId-only set would let one
+      // session's cancel disable/clear another's identically-ided node (#5277).
       const cancelling = new Set(get().cancellingActivityIds);
-      cancelling.add(activityId);
+      cancelling.add(`${sid}:${activityId}`);
       set({ cancellingActivityIds: cancelling });
       wsSend(socket, payload);
       return 'sent';

--- a/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
+++ b/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
@@ -130,31 +130,45 @@ describe('Control Room activity dispatch (#5163)', () => {
     resetReplayFlags()
   })
 
-  it('#5277: cancel_activity_ack clears the activity id from cancellingActivityIds', () => {
-    store.setState({ cancellingActivityIds: new Set(['a', 'b']) })
-    handleMessage({ type: 'cancel_activity_ack', activityId: 'a', requestId: 'req-1' }, ctx() as never)
+  it('#5277: cancel_activity_ack clears the composite key, scoped by session', () => {
+    // Keys are `${sessionId}:${activityId}`; an ack for SESSION_ID:a must not
+    // touch an identically-ided node in another session (OTHER:a).
+    store.setState({ cancellingActivityIds: new Set([`${SESSION_ID}:a`, `${SESSION_ID}:b`, `${OTHER_SESSION_ID}:a`]) })
+    handleMessage({ type: 'cancel_activity_ack', activityId: 'a', sessionId: SESSION_ID, requestId: 'req-1' }, ctx() as never)
     const set = store.getState().cancellingActivityIds
-    expect(set.has('a')).toBe(false)
-    expect(set.has('b')).toBe(true)
+    expect(set.has(`${SESSION_ID}:a`)).toBe(false)
+    expect(set.has(`${SESSION_ID}:b`)).toBe(true)
+    expect(set.has(`${OTHER_SESSION_ID}:a`)).toBe(true) // other session unaffected
   })
 
-  it('#5277: CANCEL_ACTIVITY_FAILED session_error clears the cancelling id', () => {
+  it('#5277: CANCEL_ACTIVITY_FAILED session_error clears the composite key', () => {
     // The generic session_error branch surfaces the message via addServerError;
     // stub it so the handler runs cleanly in this harness.
-    store.setState({ cancellingActivityIds: new Set(['a']), addServerError: vi.fn() } as never)
+    store.setState({ cancellingActivityIds: new Set([`${SESSION_ID}:a`]), addServerError: vi.fn() } as never)
     handleMessage(
-      { type: 'session_error', code: 'CANCEL_ACTIVITY_FAILED', message: 'Could not cancel activity: no-task-id', reason: 'no-task-id', activityId: 'a', requestId: 'req-1' },
+      { type: 'session_error', code: 'CANCEL_ACTIVITY_FAILED', message: 'Could not cancel activity: no-task-id', reason: 'no-task-id', activityId: 'a', sessionId: SESSION_ID, requestId: 'req-1' },
       ctx() as never,
     )
-    expect(store.getState().cancellingActivityIds.has('a')).toBe(false)
+    expect(store.getState().cancellingActivityIds.has(`${SESSION_ID}:a`)).toBe(false)
   })
 
-  it('#5277: a terminal (ended) activity_delta clears a pending cancelling id', () => {
-    // First seed the node so the reducer has it to mark ended.
+  it('#5277: SESSION_NOT_FOUND clears all pending cancels for that session', () => {
+    store.setState({ cancellingActivityIds: new Set([`${SESSION_ID}:a`, `${SESSION_ID}:b`, `${OTHER_SESSION_ID}:a`]), addServerError: vi.fn(), setSessionNotFoundError: vi.fn() } as never)
+    handleMessage(
+      { type: 'session_error', code: 'SESSION_NOT_FOUND', message: 'Session not found', attemptedSessionId: SESSION_ID },
+      ctx() as never,
+    )
+    const set = store.getState().cancellingActivityIds
+    expect(set.has(`${SESSION_ID}:a`)).toBe(false)
+    expect(set.has(`${SESSION_ID}:b`)).toBe(false)
+    expect(set.has(`${OTHER_SESSION_ID}:a`)).toBe(true) // other session untouched
+  })
+
+  it('#5277: a terminal (ended) activity_delta clears the pending composite key', () => {
     handleMessage(snapshot([runningEntry('a')]), ctx() as never)
-    store.setState({ cancellingActivityIds: new Set(['a']) })
+    store.setState({ cancellingActivityIds: new Set([`${SESSION_ID}:a`]) })
     handleMessage(delta('ended', runningEntry('a', { status: 'done', endedAt: 2000 })), ctx() as never)
-    expect(store.getState().cancellingActivityIds.has('a')).toBe(false)
+    expect(store.getState().cancellingActivityIds.has(`${SESSION_ID}:a`)).toBe(false)
   })
 
   it('applies activity_snapshot, replacing the session tree', () => {

--- a/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
+++ b/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
@@ -149,6 +149,14 @@ describe('Control Room activity dispatch (#5163)', () => {
     expect(store.getState().cancellingActivityIds.has('a')).toBe(false)
   })
 
+  it('#5277: a terminal (ended) activity_delta clears a pending cancelling id', () => {
+    // First seed the node so the reducer has it to mark ended.
+    handleMessage(snapshot([runningEntry('a')]), ctx() as never)
+    store.setState({ cancellingActivityIds: new Set(['a']) })
+    handleMessage(delta('ended', runningEntry('a', { status: 'done', endedAt: 2000 })), ctx() as never)
+    expect(store.getState().cancellingActivityIds.has('a')).toBe(false)
+  })
+
   it('applies activity_snapshot, replacing the session tree', () => {
     handleMessage(snapshot([runningEntry('a'), runningEntry('b')]), ctx() as never)
     const tree = selectActivityTree(store.getState().activity, SESSION_ID)

--- a/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
+++ b/packages/dashboard/src/store/dispatch-control-room-activity.test.ts
@@ -130,6 +130,25 @@ describe('Control Room activity dispatch (#5163)', () => {
     resetReplayFlags()
   })
 
+  it('#5277: cancel_activity_ack clears the activity id from cancellingActivityIds', () => {
+    store.setState({ cancellingActivityIds: new Set(['a', 'b']) })
+    handleMessage({ type: 'cancel_activity_ack', activityId: 'a', requestId: 'req-1' }, ctx() as never)
+    const set = store.getState().cancellingActivityIds
+    expect(set.has('a')).toBe(false)
+    expect(set.has('b')).toBe(true)
+  })
+
+  it('#5277: CANCEL_ACTIVITY_FAILED session_error clears the cancelling id', () => {
+    // The generic session_error branch surfaces the message via addServerError;
+    // stub it so the handler runs cleanly in this harness.
+    store.setState({ cancellingActivityIds: new Set(['a']), addServerError: vi.fn() } as never)
+    handleMessage(
+      { type: 'session_error', code: 'CANCEL_ACTIVITY_FAILED', message: 'Could not cancel activity: no-task-id', reason: 'no-task-id', activityId: 'a', requestId: 'req-1' },
+      ctx() as never,
+    )
+    expect(store.getState().cancellingActivityIds.has('a')).toBe(false)
+  })
+
   it('applies activity_snapshot, replacing the session tree', () => {
     handleMessage(snapshot([runningEntry('a'), runningEntry('b')]), ctx() as never)
     const tree = selectActivityTree(store.getState().activity, SESSION_ID)

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -115,7 +115,7 @@ import {
   type PlatformAdapters, type StorageAdapter,
 } from '@chroxy/store-core'
 import { PROTOCOL_VERSION } from '@chroxy/protocol'
-import { ServerByokCredentialsStatusSchema, ServerNotificationPrefsSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema } from '@chroxy/protocol/schemas'
+import { ServerByokCredentialsStatusSchema, ServerNotificationPrefsSchema, ServerCredentialsStatusSchema, ServerCredentialTestResultSchema, ServerActivitySnapshotSchema, ServerActivityDeltaSchema, ServerCancelActivityAckSchema, ServerHostStatusSnapshotSchema, ServerRunnerStatusSnapshotSchema } from '@chroxy/protocol/schemas'
 import {
   createKeyPair,
   deriveSharedKey,
@@ -1878,6 +1878,30 @@ function handleActivityDelta(msg: Record<string, unknown>, get: MsgGet, set: Msg
 }
 
 /**
+ * #5277 — Control Room `cancel_activity_ack`: positive confirmation that a
+ * cancel_activity request was actioned. Clears the node's "cancelling" pending
+ * state (the terminal activity_delta separately updates the tree itself).
+ */
+function handleCancelActivityAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
+  const parsed = ServerCancelActivityAckSchema.safeParse(msg);
+  if (!parsed.success) return;
+  clearCancellingActivity(get, set, parsed.data.activityId);
+}
+
+/**
+ * #5277 — drop an activity id from the in-flight cancel set (shared by the
+ * success ack and the CANCEL_ACTIVITY_FAILED session_error). No-op if absent.
+ */
+function clearCancellingActivity(get: MsgGet, set: MsgSet, activityId: string | undefined): void {
+  if (!activityId) return;
+  const prev = get().cancellingActivityIds;
+  if (!prev.has(activityId)) return;
+  const next = new Set(prev);
+  next.delete(activityId);
+  set({ cancellingActivityIds: next });
+}
+
+/**
  * #5175 (epic #5170) — Host/Repo Status Control Room `host_status_snapshot`:
  * REPLACE the stored survey with the carried snapshot and clear the in-flight
  * loading flag. The survey is a full picture (no delta stream), so each
@@ -1962,6 +1986,8 @@ const HANDLERS: Record<string, Handler> = {
   // #5163 (epic #5159): Control Room live activity tree.
   activity_snapshot: handleActivitySnapshot,
   activity_delta: handleActivityDelta,
+  // #5277: positive ack correlating a cancel_activity request to its outcome.
+  cancel_activity_ack: handleCancelActivityAck,
   // #5175 (epic #5170): Host/Repo Status Control Room survey snapshot.
   host_status_snapshot: handleHostStatusSnapshot,
   // #5253: self-hosted runner Control Room survey snapshot.
@@ -2409,6 +2435,11 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // platform-specific surfaces (notification, alert, server error banner)
       // stay here.
       const parsed = sharedSessionError(msg, get().activeSessionId);
+      // #5277: a CANCEL_ACTIVITY_FAILED echoes the activityId — clear its
+      // pending "cancelling" state so the ActivityTree button recovers.
+      if (parsed.code === 'CANCEL_ACTIVITY_FAILED' && typeof msg.activityId === 'string') {
+        clearCancellingActivity(get, set, msg.activityId);
+      }
       if (parsed.category === 'crash' && parsed.sessionPatch) {
         const crashedId = parsed.sessionPatch.sessionId;
         if (crashedId && get().sessionStates[crashedId]) {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1867,6 +1867,13 @@ function handleActivityDelta(msg: Record<string, unknown>, get: MsgGet, set: Msg
   if (next === prev) return;
   set({ activity: next });
 
+  // #5277: if a node we were cancelling just went terminal (whether from the
+  // cancel itself or natural completion racing it), drop its pending state so
+  // the id can't leak in cancellingActivityIds after the row is gone/finished.
+  if (parsed.data.op === 'ended') {
+    clearCancellingActivity(get, set, parsed.data.entry.id);
+  }
+
   const sessionId = parsed.data.sessionId;
   if (get().sessionStates[sessionId] && !_replayingSessions.has(sessionId)) {
     updateSession(sessionId, (ss) => {
@@ -1895,7 +1902,7 @@ function handleCancelActivityAck(msg: Record<string, unknown>, get: MsgGet, set:
 function clearCancellingActivity(get: MsgGet, set: MsgSet, activityId: string | undefined): void {
   if (!activityId) return;
   const prev = get().cancellingActivityIds;
-  if (!prev.has(activityId)) return;
+  if (!prev || !prev.has(activityId)) return;
   const next = new Set(prev);
   next.delete(activityId);
   set({ cancellingActivityIds: next });

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -1871,7 +1871,7 @@ function handleActivityDelta(msg: Record<string, unknown>, get: MsgGet, set: Msg
   // cancel itself or natural completion racing it), drop its pending state so
   // the id can't leak in cancellingActivityIds after the row is gone/finished.
   if (parsed.data.op === 'ended') {
-    clearCancellingActivity(get, set, parsed.data.entry.id);
+    clearCancellingActivity(get, set, parsed.data.sessionId, parsed.data.entry.id);
   }
 
   const sessionId = parsed.data.sessionId;
@@ -1892,20 +1892,47 @@ function handleActivityDelta(msg: Record<string, unknown>, get: MsgGet, set: Msg
 function handleCancelActivityAck(msg: Record<string, unknown>, get: MsgGet, set: MsgSet, _ctx: ConnectionContext): void {
   const parsed = ServerCancelActivityAckSchema.safeParse(msg);
   if (!parsed.success) return;
-  clearCancellingActivity(get, set, parsed.data.activityId);
+  clearCancellingActivity(get, set, parsed.data.sessionId, parsed.data.activityId);
+}
+
+/** #5277 — composite key: activity ids are only unique within a session. */
+function cancelKey(sessionId: string | undefined, activityId: string | undefined): string | null {
+  if (!sessionId || !activityId) return null;
+  return `${sessionId}:${activityId}`;
 }
 
 /**
- * #5277 — drop an activity id from the in-flight cancel set (shared by the
- * success ack and the CANCEL_ACTIVITY_FAILED session_error). No-op if absent.
+ * #5277 — drop one `${sessionId}:${activityId}` from the in-flight cancel set
+ * (shared by the success ack, the CANCEL_ACTIVITY_FAILED session_error, and a
+ * terminal activity_delta). No-op if absent.
  */
-function clearCancellingActivity(get: MsgGet, set: MsgSet, activityId: string | undefined): void {
-  if (!activityId) return;
+function clearCancellingActivity(get: MsgGet, set: MsgSet, sessionId: string | undefined, activityId: string | undefined): void {
+  const key = cancelKey(sessionId, activityId);
+  if (!key) return;
   const prev = get().cancellingActivityIds;
-  if (!prev || !prev.has(activityId)) return;
+  if (!prev || !prev.has(key)) return;
   const next = new Set(prev);
-  next.delete(activityId);
+  next.delete(key);
   set({ cancellingActivityIds: next });
+}
+
+/**
+ * #5277 — drop ALL pending cancels for a session. Used when a session-level
+ * error (SESSION_NOT_FOUND) means no cancel for that session can ever resolve,
+ * so its nodes must not stay stuck "Cancelling…".
+ */
+function clearCancellingForSession(get: MsgGet, set: MsgSet, sessionId: string | undefined): void {
+  if (!sessionId) return;
+  const prev = get().cancellingActivityIds;
+  if (!prev || prev.size === 0) return;
+  const prefix = `${sessionId}:`;
+  let changed = false;
+  const next = new Set<string>();
+  for (const key of prev) {
+    if (key.startsWith(prefix)) { changed = true; continue; }
+    next.add(key);
+  }
+  if (changed) set({ cancellingActivityIds: next });
 }
 
 /**
@@ -2442,10 +2469,14 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       // platform-specific surfaces (notification, alert, server error banner)
       // stay here.
       const parsed = sharedSessionError(msg, get().activeSessionId);
-      // #5277: a CANCEL_ACTIVITY_FAILED echoes the activityId — clear its
-      // pending "cancelling" state so the ActivityTree button recovers.
-      if (parsed.code === 'CANCEL_ACTIVITY_FAILED' && typeof msg.activityId === 'string') {
-        clearCancellingActivity(get, set, msg.activityId);
+      // #5277: clear pending "cancelling" state so the ActivityTree button
+      // recovers. CANCEL_ACTIVITY_FAILED echoes the exact sessionId+activityId;
+      // SESSION_NOT_FOUND means the whole session is gone, so no cancel for it
+      // can resolve — drop all of its pending cancels.
+      if (parsed.code === 'CANCEL_ACTIVITY_FAILED' && typeof msg.sessionId === 'string' && typeof msg.activityId === 'string') {
+        clearCancellingActivity(get, set, msg.sessionId, msg.activityId);
+      } else if (parsed.code === 'SESSION_NOT_FOUND') {
+        clearCancellingForSession(get, set, parsed.attemptedSessionId ?? undefined);
       }
       if (parsed.category === 'crash' && parsed.sessionPatch) {
         const crashedId = parsed.sessionPatch.sessionId;

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -370,7 +370,9 @@ describe('useConnectionStore', () => {
     expect(payload.type).toBe('cancel_activity');
     expect(payload.activityId).toBe('act-1');
     expect(typeof payload.requestId).toBe('string');
-    expect(useConnectionStore.getState().cancellingActivityIds.has('act-1')).toBe(true);
+    // Keyed by `${sessionId}:${activityId}` so one session's cancel can't affect
+    // another's identically-ided node.
+    expect(useConnectionStore.getState().cancellingActivityIds.has('s1:act-1')).toBe(true);
   });
 
   it('#5277: sendCancelActivity does NOT mark cancelling when offline (cancel is not queueable)', async () => {
@@ -380,7 +382,7 @@ describe('useConnectionStore', () => {
     useConnectionStore.getState().sendCancelActivity('act-1');
 
     // Offline send is dropped (not in QUEUE_TTLS); the node must NOT be stranded "Cancelling…".
-    expect(useConnectionStore.getState().cancellingActivityIds.has('act-1')).toBe(false);
+    expect(useConnectionStore.getState().cancellingActivityIds.has('s1:act-1')).toBe(false);
   });
 
   it('exposes all required actions', async () => {

--- a/packages/dashboard/src/store/store.test.ts
+++ b/packages/dashboard/src/store/store.test.ts
@@ -356,6 +356,33 @@ describe('useConnectionStore', () => {
     expect(state.viewMode).toBe('chat');
   });
 
+  it('#5277: sendCancelActivity marks the node cancelling and sends when the socket is open', async () => {
+    const { useConnectionStore } = await import('./connection');
+    const send = vi.fn();
+    const openSocket = { readyState: WebSocket.OPEN, send } as unknown as WebSocket;
+    useConnectionStore.setState({ socket: openSocket, activeSessionId: 's1', cancellingActivityIds: new Set() });
+
+    const result = useConnectionStore.getState().sendCancelActivity('act-1');
+
+    expect(result).toBe('sent');
+    expect(send).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse((send.mock.calls[0]![0]) as string);
+    expect(payload.type).toBe('cancel_activity');
+    expect(payload.activityId).toBe('act-1');
+    expect(typeof payload.requestId).toBe('string');
+    expect(useConnectionStore.getState().cancellingActivityIds.has('act-1')).toBe(true);
+  });
+
+  it('#5277: sendCancelActivity does NOT mark cancelling when offline (cancel is not queueable)', async () => {
+    const { useConnectionStore } = await import('./connection');
+    useConnectionStore.setState({ socket: null, activeSessionId: 's1', cancellingActivityIds: new Set() });
+
+    useConnectionStore.getState().sendCancelActivity('act-1');
+
+    // Offline send is dropped (not in QUEUE_TTLS); the node must NOT be stranded "Cancelling…".
+    expect(useConnectionStore.getState().cancellingActivityIds.has('act-1')).toBe(false);
+  });
+
   it('exposes all required actions', async () => {
     const { useConnectionStore } = await import('./connection');
     const state = useConnectionStore.getState();

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -541,6 +541,14 @@ export interface ConnectionState {
    * v1 — control actions are a tracked phase-2 follow-up on the epic.
    */
   activity: import('@chroxy/store-core').ActivityState;
+  /**
+   * #5277: activity ids with an in-flight cancel_activity request — set when
+   * sendCancelActivity is called, cleared on the cancel_activity_ack (success)
+   * or the CANCEL_ACTIVITY_FAILED session_error (failure). Lets the
+   * ActivityTree show a "Cancelling…" pending state instead of guessing from
+   * the terminal activity_delta.
+   */
+  cancellingActivityIds: Set<string>;
 
   /**
    * #5175 (epic #5170) — Host/Repo Status Control Room: the latest

--- a/packages/protocol/dist/index.d.ts
+++ b/packages/protocol/dist/index.d.ts
@@ -31,7 +31,7 @@ export declare const CLIENT_CAPABILITIES: {
 export declare const MIN_PROTOCOL_VERSION = 1;
 export * from './schemas/index.ts';
 export type { ServerErrorEnvelopeMessage } from './schemas/server.ts';
-export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, } from './schemas/server.ts';
+export type { ActivityKind, ActivityStatus, ActivityOutputRef, ActivityEntry, ServerActivitySnapshotMessage, ServerActivityDeltaMessage, ServerCancelActivityAckMessage, } from './schemas/server.ts';
 export type { RepoVerdict, RepoTree, RepoStatus, HostStatusSummary, ServerHostStatusSnapshotMessage, } from './schemas/server.ts';
 export type { RunnerVerdict, RunnerServiceState, RunnerInfo, RepoRunners, RunnerStatusSummary, ServerRunnerStatusSnapshotMessage, } from './schemas/server.ts';
 export type { HostStatusRequestMessage } from './schemas/client.ts';

--- a/packages/protocol/dist/schemas/client.d.ts
+++ b/packages/protocol/dist/schemas/client.d.ts
@@ -73,6 +73,7 @@ export declare const CancelActivitySchema: z.ZodObject<{
     type: z.ZodLiteral<"cancel_activity">;
     activityId: z.ZodString;
     sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
 export declare const SetModelSchema: z.ZodObject<{
     type: z.ZodLiteral<"set_model">;
@@ -602,6 +603,7 @@ export declare const ClientMessageSchema: z.ZodDiscriminatedUnion<[z.ZodObject<{
     type: z.ZodLiteral<"cancel_activity">;
     activityId: z.ZodString;
     sessionId: z.ZodOptional<z.ZodString>;
+    requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>, z.ZodObject<{
     type: z.ZodLiteral<"set_model">;
     model: z.ZodString;

--- a/packages/protocol/dist/schemas/client.js
+++ b/packages/protocol/dist/schemas/client.js
@@ -67,6 +67,11 @@ export const CancelActivitySchema = z.object({
     type: z.literal('cancel_activity'),
     activityId: z.string().min(1).max(512),
     sessionId: z.string().max(256).optional(),
+    // #5277: opaque client-generated correlation id echoed back on the
+    // `cancel_activity_ack` (success) and the `CANCEL_ACTIVITY_FAILED`
+    // session_error (failure), so the dashboard can tie a specific cancel click
+    // to its outcome without inferring it from the terminal activity_delta.
+    requestId: z.string().max(128).optional(),
 }).passthrough();
 export const SetModelSchema = z.object({
     type: z.literal('set_model'),

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -512,6 +512,20 @@ export declare const ServerActivityDeltaSchema: z.ZodObject<{
     }, z.core.$strip>;
 }, z.core.$strip>;
 /**
+ * #5277: positive ack that a `cancel_activity` request was actioned. Success
+ * was previously silent — the terminal `activity_delta` was the only signal,
+ * which the dashboard couldn't correlate to a specific cancel click (and which
+ * could be delayed/dropped). This echoes the request's `activityId` and
+ * (when supplied) `requestId` so the caller gets a definite per-request signal.
+ * Failures continue to surface as a `CANCEL_ACTIVITY_FAILED` session_error,
+ * which also echoes `requestId`.
+ */
+export declare const ServerCancelActivityAckSchema: z.ZodObject<{
+    type: z.ZodLiteral<"cancel_activity_ack">;
+    activityId: z.ZodString;
+    requestId: z.ZodOptional<z.ZodString>;
+}, z.core.$loose>;
+/**
  * Verdict for a repo — the survey's classification of "what is this repo's
  * current state". Drives the colour-coded tag in the Control Room table:
  *   - `'live'`        — actively worked (a chroxy session is/was recently running).
@@ -1541,6 +1555,7 @@ export type ActivityOutputRef = z.infer<typeof ActivityOutputRefSchema>;
 export type ActivityEntry = z.infer<typeof ActivityEntrySchema>;
 export type ServerActivitySnapshotMessage = z.infer<typeof ServerActivitySnapshotSchema>;
 export type ServerActivityDeltaMessage = z.infer<typeof ServerActivityDeltaSchema>;
+export type ServerCancelActivityAckMessage = z.infer<typeof ServerCancelActivityAckSchema>;
 export type RepoVerdict = z.infer<typeof RepoVerdictSchema>;
 export type RepoTree = z.infer<typeof RepoTreeSchema>;
 export type RepoStatus = z.infer<typeof RepoStatusSchema>;

--- a/packages/protocol/dist/schemas/server.d.ts
+++ b/packages/protocol/dist/schemas/server.d.ts
@@ -523,6 +523,7 @@ export declare const ServerActivityDeltaSchema: z.ZodObject<{
 export declare const ServerCancelActivityAckSchema: z.ZodObject<{
     type: z.ZodLiteral<"cancel_activity_ack">;
     activityId: z.ZodString;
+    sessionId: z.ZodOptional<z.ZodString>;
     requestId: z.ZodOptional<z.ZodString>;
 }, z.core.$loose>;
 /**

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -605,6 +605,10 @@ export const ServerActivityDeltaSchema = z.object({
 export const ServerCancelActivityAckSchema = z.object({
     type: z.literal('cancel_activity_ack'),
     activityId: z.string(),
+    // #5277: the session the cancelled node belongs to. Activity ids (toolUseIds)
+    // are only unique WITHIN a session, so the dashboard scopes its pending-cancel
+    // state by sessionId+activityId — the ack echoes the session for that.
+    sessionId: z.string().optional(),
     requestId: z.string().max(128).optional(),
 }).passthrough();
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/protocol/dist/schemas/server.js
+++ b/packages/protocol/dist/schemas/server.js
@@ -593,6 +593,20 @@ export const ServerActivityDeltaSchema = z.object({
         }
     }
 });
+/**
+ * #5277: positive ack that a `cancel_activity` request was actioned. Success
+ * was previously silent — the terminal `activity_delta` was the only signal,
+ * which the dashboard couldn't correlate to a specific cancel click (and which
+ * could be delayed/dropped). This echoes the request's `activityId` and
+ * (when supplied) `requestId` so the caller gets a definite per-request signal.
+ * Failures continue to surface as a `CANCEL_ACTIVITY_FAILED` session_error,
+ * which also echoes `requestId`.
+ */
+export const ServerCancelActivityAckSchema = z.object({
+    type: z.literal('cancel_activity_ack'),
+    activityId: z.string(),
+    requestId: z.string().max(128).optional(),
+}).passthrough();
 // ───────────────────────────────────────────────────────────────────────────
 // Host/Repo Status Control Room (#5170 epic, #5171 protocol contract)
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -56,6 +56,7 @@ export type {
   ActivityEntry,
   ServerActivitySnapshotMessage,
   ServerActivityDeltaMessage,
+  ServerCancelActivityAckMessage,
 } from './schemas/server.ts'
 
 // #5171: pin the Host/Repo Status Control Room contract (#5170 epic) at the

--- a/packages/protocol/src/schemas/client.ts
+++ b/packages/protocol/src/schemas/client.ts
@@ -77,6 +77,11 @@ export const CancelActivitySchema = z.object({
   type: z.literal('cancel_activity'),
   activityId: z.string().min(1).max(512),
   sessionId: z.string().max(256).optional(),
+  // #5277: opaque client-generated correlation id echoed back on the
+  // `cancel_activity_ack` (success) and the `CANCEL_ACTIVITY_FAILED`
+  // session_error (failure), so the dashboard can tie a specific cancel click
+  // to its outcome without inferring it from the terminal activity_delta.
+  requestId: z.string().max(128).optional(),
 }).passthrough()
 
 export const SetModelSchema = z.object({

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -634,6 +634,21 @@ export const ServerActivityDeltaSchema = z.object({
   }
 })
 
+/**
+ * #5277: positive ack that a `cancel_activity` request was actioned. Success
+ * was previously silent — the terminal `activity_delta` was the only signal,
+ * which the dashboard couldn't correlate to a specific cancel click (and which
+ * could be delayed/dropped). This echoes the request's `activityId` and
+ * (when supplied) `requestId` so the caller gets a definite per-request signal.
+ * Failures continue to surface as a `CANCEL_ACTIVITY_FAILED` session_error,
+ * which also echoes `requestId`.
+ */
+export const ServerCancelActivityAckSchema = z.object({
+  type: z.literal('cancel_activity_ack'),
+  activityId: z.string(),
+  requestId: z.string().max(128).optional(),
+}).passthrough()
+
 // ───────────────────────────────────────────────────────────────────────────
 // Host/Repo Status Control Room (#5170 epic, #5171 protocol contract)
 // ───────────────────────────────────────────────────────────────────────────
@@ -1819,6 +1834,8 @@ export type ActivityOutputRef = z.infer<typeof ActivityOutputRefSchema>
 export type ActivityEntry = z.infer<typeof ActivityEntrySchema>
 export type ServerActivitySnapshotMessage = z.infer<typeof ServerActivitySnapshotSchema>
 export type ServerActivityDeltaMessage = z.infer<typeof ServerActivityDeltaSchema>
+// #5277: positive ack for an actioned cancel_activity request.
+export type ServerCancelActivityAckMessage = z.infer<typeof ServerCancelActivityAckSchema>
 // #5171: Host/Repo Status Control Room wire contract (#5170 epic). Consumed by
 // the server emitter, store-core reducer, and dashboard panel in sibling issues.
 export type RepoVerdict = z.infer<typeof RepoVerdictSchema>

--- a/packages/protocol/src/schemas/server.ts
+++ b/packages/protocol/src/schemas/server.ts
@@ -646,6 +646,10 @@ export const ServerActivityDeltaSchema = z.object({
 export const ServerCancelActivityAckSchema = z.object({
   type: z.literal('cancel_activity_ack'),
   activityId: z.string(),
+  // #5277: the session the cancelled node belongs to. Activity ids (toolUseIds)
+  // are only unique WITHIN a session, so the dashboard scopes its pending-cancel
+  // state by sessionId+activityId — the ack echoes the session for that.
+  sessionId: z.string().optional(),
   requestId: z.string().max(128).optional(),
 }).passthrough()
 

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -27,6 +27,7 @@ const SYNTHETIC_TYPES = new Set([
   'conversations_list',    // legacy alias for list response
   'search_results',        // legacy alias for search response
   'budget_resumed',        // budget resume ack (server-internal)
+  'cancel_activity_ack',   // #5277 cancel correlation ack — emitted from input-handlers.js (not the ws-server.js broadcast surface the extractor scans), handled by the dashboard
   'thinking_level_changed', // thinking level change ack (server-internal)
   'permission_timeout',     // app-side handler for future permission timeout event (not yet in protocol)
 ])

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -591,6 +591,7 @@ async function handleCancelActivity(ws, client, msg, ctx) {
       message: 'This session does not support cancelling activity',
       reason: 'not-supported',
       activityId: msg.activityId,
+      sessionId: msg.sessionId,
       requestId: msg.requestId,
     })
     return
@@ -606,6 +607,7 @@ async function handleCancelActivity(ws, client, msg, ctx) {
       message: `Could not cancel activity: ${reason}`,
       reason,
       activityId: msg.activityId,
+      sessionId: msg.sessionId,
       requestId: msg.requestId,
     })
     return
@@ -619,6 +621,7 @@ async function handleCancelActivity(ws, client, msg, ctx) {
   ctx.send(ws, {
     type: 'cancel_activity_ack',
     activityId: msg.activityId,
+    sessionId: msg.sessionId,
     requestId: msg.requestId,
   })
 }

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -591,6 +591,7 @@ async function handleCancelActivity(ws, client, msg, ctx) {
       message: 'This session does not support cancelling activity',
       reason: 'not-supported',
       activityId: msg.activityId,
+      requestId: msg.requestId,
     })
     return
   }
@@ -605,13 +606,21 @@ async function handleCancelActivity(ws, client, msg, ctx) {
       message: `Could not cancel activity: ${reason}`,
       reason,
       activityId: msg.activityId,
+      requestId: msg.requestId,
     })
     return
   }
-  // Success: the node's terminal activity_delta is broadcast via the session's
-  // agent_completed → registry path; no extra reply needed (mirrors interrupt,
-  // which also acks via the resulting stream change, not a dedicated message).
+  // Success: the node's terminal activity_delta (via agent_completed → registry)
+  // is still the substantive change, but #5277 also sends an explicit positive
+  // ack echoing the activityId + requestId so the dashboard can correlate this
+  // specific cancel click to its outcome — the delta alone is uncorrelated and
+  // may lag or drop.
   log.info(`cancel_activity ${msg.activityId} actioned by ${client.id}`)
+  ctx.send(ws, {
+    type: 'cancel_activity_ack',
+    activityId: msg.activityId,
+    requestId: msg.requestId,
+  })
 }
 
 function handleResumeBudget(ws, client, msg, ctx) {

--- a/packages/server/tests/handlers/cancel-activity-handler.test.js
+++ b/packages/server/tests/handlers/cancel-activity-handler.test.js
@@ -53,8 +53,42 @@ describe('cancel_activity handler (#5271)', () => {
 
     assert.equal(cancelActivity.calls.length, 1)
     assert.equal(cancelActivity.calls[0][0], 'tu-1')
-    // No session_error on success — the activity_delta is the confirmation.
-    assert.equal(ctx._sent.length, 0)
+    // #5277: success now sends a positive cancel_activity_ack (the terminal
+    // activity_delta remains the substantive change; the ack lets the dashboard
+    // correlate this specific cancel click to its outcome).
+    assert.equal(ctx._sent.length, 1)
+    assert.equal(last(ctx).type, 'cancel_activity_ack')
+    assert.equal(last(ctx).activityId, 'tu-1')
+  })
+
+  it('#5277: echoes requestId on the success ack', async () => {
+    const sessions = new Map()
+    const { entry } = entryWithCancel({ ok: true })
+    sessions.set('s1', entry)
+    const ctx = makeCtx(sessions)
+    const client = makeClient({ activeSessionId: 's1' })
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1', requestId: 'req-9' }, ctx)
+
+    const reply = last(ctx)
+    assert.equal(reply.type, 'cancel_activity_ack')
+    assert.equal(reply.activityId, 'tu-1')
+    assert.equal(reply.requestId, 'req-9')
+  })
+
+  it('#5277: echoes requestId on the CANCEL_ACTIVITY_FAILED session_error', async () => {
+    const sessions = new Map()
+    const { entry } = entryWithCancel({ ok: false, reason: 'no-task-id' })
+    sessions.set('s1', entry)
+    const ctx = makeCtx(sessions)
+    const client = makeClient({ activeSessionId: 's1' })
+
+    await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1', requestId: 'req-9' }, ctx)
+
+    const reply = last(ctx)
+    assert.equal(reply.type, 'session_error')
+    assert.equal(reply.code, 'CANCEL_ACTIVITY_FAILED')
+    assert.equal(reply.requestId, 'req-9')
   })
 
   it('surfaces a structured failure (no-task-id) as a CANCEL_ACTIVITY_FAILED session_error', async () => {
@@ -136,7 +170,9 @@ describe('cancel_activity handler (#5271)', () => {
     await inputHandlers.cancel_activity(makeWs(), client, { type: 'cancel_activity', activityId: 'tu-1', sessionId: 'bound-1' }, ctx)
 
     assert.equal(cancelActivity.calls.length, 1)
-    assert.equal(ctx._sent.length, 0)
+    // #5277: success ack (no session_error).
+    assert.equal(ctx._sent.length, 1)
+    assert.equal(last(ctx).type, 'cancel_activity_ack')
   })
 
   it('rejects a bound client aiming at ANOTHER session with SESSION_TOKEN_MISMATCH', async () => {


### PR DESCRIPTION
## What

Adds explicit, correlated acknowledgement to the Control Room `cancel_activity` flow. Closes #5277 (Phase 2a follow-up).

Cancel **success** was previously silent — the terminal `activity_delta` was the only signal, which the dashboard couldn't tie to a specific cancel click and which can lag or drop. This adds a positive, request-correlated ack.

## Changes

**Protocol (`@chroxy/protocol`)**
- `cancel_activity` gains an optional `requestId` (opaque client correlation id).
- New `ServerCancelActivityAckSchema` → `cancel_activity_ack { activityId, requestId? }`; type alias + entry-point re-export pinned; `dist` rebuilt.

**Server**
- `handleCancelActivity` sends `cancel_activity_ack` on success and echoes `requestId` on both the ack and the `CANCEL_ACTIVITY_FAILED` session_error — so the dashboard knows exactly which cancel succeeded/failed.

**Dashboard**
- `sendCancelActivity` tags the request with a `requestId` and optimistically marks the node `cancelling` (`cancellingActivityIds` set).
- `cancel_activity_ack` / `CANCEL_ACTIVITY_FAILED` clear the pending state; the set resets on disconnect/server-switch.
- `ActivityTree` shows a disabled **"Cancelling…"** state for in-flight cancels — the visible payoff of the correlation, completing the #5272 Cancel button.

## Tests
- Server: ack on success, requestId echo on ack + failure (`cancel-activity-handler.test.js`).
- Protocol: `cancel_activity_ack` registered in handler-coverage (emitted from `input-handlers.js`, not the `ws-server.js` broadcast surface).
- Dashboard: dispatch clears pending on ack + failure; ActivityTree "Cancelling…" pending state.
- Protocol 235, server cancel/schema 14, full dashboard 3193 — all green.

Closes #5277.