### PR TITLE
feat(server): hard-quiesce reap for long-dead background shells

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -1035,6 +1035,16 @@ export class BaseSession extends EventEmitter {
       return this._backgroundShellHardQuiesceCheck(entry) === true
     }
     if (!entry) return false
+    // Cheap pre-stat gate (#5287 review): output can't have been idle longer
+    // than the shell has existed, so a shell younger than the hard window can't
+    // possibly be hard-quiesced — skip the per-tick statSync entirely until
+    // then. This makes the sweep's hard-check ~free (one subtraction) for the
+    // first hard-window of every shell's life, which is the bulk of the time the
+    // sweep runs.
+    if (typeof entry.startedAt === 'number'
+      && Date.now() - entry.startedAt < this._backgroundShellHardQuiesceMs) {
+      return false
+    }
     if (typeof entry.outputPath !== 'string' || entry.outputPath.length === 0) {
       // No output file to stat — fall back to wall-clock age since the shell was
       // tracked. This is the WEAKEST signal in the change: unlike the mtime path

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -970,6 +970,14 @@ export class BaseSession extends EventEmitter {
         this._pendingBackgroundShells.delete(shellId)
         changed = true
         continue
+        // NOTE: reaping an entry that was ALREADY advisory-quiesced changes
+        // `isRunning` (true→false) but NOT the banner snapshot (it was already
+        // filtered out at advisory time), so the `background_work_changed` emit
+        // below carries an unchanged `pending` payload. That is fine TODAY
+        // because liveness is consumed via the pull path (SessionTimeoutManager
+        // calls `isRunningFn()` live, it does not diff this event). A future
+        // consumer that diffs `pending` to infer liveness would need an explicit
+        // liveness field on the event — flagged so this isn't a silent trap.
       }
       if (entry.quiesced) continue // already advisory-cleared from the banner
       if (this._isBackgroundShellQuiesced(entry)) {
@@ -1020,15 +1028,21 @@ export class BaseSession extends EventEmitter {
    * @private
    */
   _isBackgroundShellHardQuiesced(entry) {
+    // Disabled short-circuit FIRST so the method's "0 disables" contract holds
+    // even if a stale check is injected (the sweep also gates on hardEnabled).
+    if (this._backgroundShellHardQuiesceMs <= 0) return false
     if (typeof this._backgroundShellHardQuiesceCheck === 'function') {
       return this._backgroundShellHardQuiesceCheck(entry) === true
     }
-    if (this._backgroundShellHardQuiesceMs <= 0) return false
     if (!entry) return false
     if (typeof entry.outputPath !== 'string' || entry.outputPath.length === 0) {
-      // No output file to stat — fall back to wall-clock age since the shell
-      // was tracked. (A shell that never produced an output path and has been
-      // around for the whole hard window is treated the same as silent output.)
+      // No output file to stat — fall back to wall-clock age since the shell was
+      // tracked. This is the WEAKEST signal in the change: unlike the mtime path
+      // (which proves the process could write), age-only can't tell a live
+      // silent compute from a finished one — so a >hard-window shell with an
+      // unparsed output path is reaped on time-since-tracking alone (accepted
+      // per #5265's tradeoff; the only consequence is idle-timeout eligibility,
+      // never process death — chroxy doesn't own the PID).
       return typeof entry.startedAt === 'number'
         && Date.now() - entry.startedAt >= this._backgroundShellHardQuiesceMs
     }

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -112,6 +112,17 @@ export const BACKGROUND_SHELL_SWEEP_MS = 15 * 1000
 // poll or destroy. 60s is still a reasonable banner-clear delay.
 export const BACKGROUND_SHELL_QUIESCE_MS = 60 * 1000
 
+// #5265: HARD-quiesce window (ms). Distinct from (and much longer than) the 60s
+// advisory banner window above. After this much CONTINUOUS output silence the
+// sweep REAPS the shell — removing it from `_pendingBackgroundShells` so
+// `isRunning` flips and SessionTimeoutManager can finally idle-time a session
+// that was pinned "running" only by a long-dead, never-polled background
+// command. 4h is deliberately conservative: a real long-runner that emits any
+// output within any 4h stretch keeps its mtime fresh and is never reaped; only
+// a genuinely silent-for-hours shell (overwhelmingly likely finished) is
+// reclaimed. Set the instance field to 0 to disable (advisory-only #5247).
+export const BACKGROUND_SHELL_HARD_QUIESCE_MS = 4 * 60 * 60 * 1000
+
 // Default per-provider injection mode (#3200). Subprocess providers without
 // a system-prompt flag (Codex, Gemini) prepend skills to the first user
 // message; Claude (SDK or CLI) appends to the system prompt. Maps the
@@ -331,6 +342,19 @@ export class BaseSession extends EventEmitter {
     // output file's mtime; tests override this to drive deterministic
     // quiescence without touching the filesystem or real timers.
     this._backgroundShellQuiesceCheck = null
+    // #5265: HARD-quiesce window. The 60s advisory quiesce above only clears
+    // the banner — a finished-but-never-polled shell stays in the map (isRunning
+    // pinned true) until destroy, so a long-idle session can be pinned "running"
+    // by a long-dead command forever. After this much CONTINUOUS output silence
+    // a shell is overwhelmingly likely finished, so the sweep REAPS it (releases
+    // liveness) — the accepted tradeoff (a multi-hour-silent shell ≈ done). A
+    // noisy long-runner (dev server logging within the window) keeps its mtime
+    // fresh and is never hard-reaped. Set to 0 to disable hard-reaping (revert
+    // to the #5247 advisory-only behaviour). Overridable in tests.
+    this._backgroundShellHardQuiesceMs = BACKGROUND_SHELL_HARD_QUIESCE_MS
+    // Injectable hard-quiesce check — `(entry) => boolean`. Default reads the
+    // output file's mtime against the hard window; tests override it.
+    this._backgroundShellHardQuiesceCheck = null
     // #4307: ephemeral map of recent `Bash` tool_uses dispatched with
     // `run_in_background: true`, keyed by toolUseId. Used to recover the
     // command string when the matching tool_result lands carrying the
@@ -933,9 +957,20 @@ export class BaseSession extends EventEmitter {
   _sweepQuiescedBackgroundShells() {
     let changed = false
     let anyActive = false
+    const hardEnabled = this._backgroundShellHardQuiesceMs > 0
     for (const shellId of Array.from(this._pendingBackgroundShells.keys())) {
       const entry = this._pendingBackgroundShells.get(shellId)
       if (!entry) continue
+      // #5265: HARD-quiesce reap — checked first and for EVERY entry (including
+      // already advisory-quiesced ones). After the long hard window of output
+      // silence the shell is overwhelmingly likely finished, so reap it
+      // (remove from the map → `isRunning` flips) so a session pinned "running"
+      // by a long-dead, never-polled command can finally idle-time out.
+      if (hardEnabled && this._isBackgroundShellHardQuiesced(entry)) {
+        this._pendingBackgroundShells.delete(shellId)
+        changed = true
+        continue
+      }
       if (entry.quiesced) continue // already advisory-cleared from the banner
       if (this._isBackgroundShellQuiesced(entry)) {
         // #5247: ADVISORY only — mark the shell quiesced so it drops out of the
@@ -944,21 +979,65 @@ export class BaseSession extends EventEmitter {
         // alive" (a dev server that logs once then waits), so flipping liveness
         // here reaped live processes and let SessionTimeoutManager idle-time the
         // session out — re-opening #4307. Real liveness is released only by a
-        // BashOutput poll or destroy.
+        // BashOutput poll, destroy, or the #5265 hard-quiesce reap above.
         entry.quiesced = true
         changed = true
       } else {
         anyActive = true
       }
     }
-    // The banner snapshot changed (a shell dropped out) — emit the same
+    // The banner snapshot / liveness changed — emit the same
     // background_work_changed the BashOutput / destroy paths emit so the
     // dashboard indicator clears with no new wire contract.
     if (changed) this._emitBackgroundWorkChanged()
-    // Nothing left that could still transition → stop the recurring stat()
-    // sweep. A future trackBackgroundShell re-arms it. (clearBackgroundShell
-    // also stops it when the map fully drains via BashOutput / destroy.)
-    if (!anyActive) this._stopBackgroundShellSweep()
+    // Stop the recurring stat() sweep when nothing remains that could still
+    // transition. With hard-quiesce ON (default), advisory-quiesced shells are
+    // still pending a future hard-reap, so keep sweeping while the map is
+    // non-empty; the sweep stops only once it drains. With hard-quiesce OFF
+    // (#5247 advisory-only), stop as soon as nothing can advisory-transition.
+    // A future trackBackgroundShell re-arms it either way.
+    const drained = this._pendingBackgroundShells.size === 0
+    if (drained || (!hardEnabled && !anyActive)) this._stopBackgroundShellSweep()
+  }
+
+  /**
+   * #5265: decide whether a pending background shell has HARD-quiesced — i.e.
+   * its output has been silent long enough (`_backgroundShellHardQuiesceMs`)
+   * that it is overwhelmingly likely finished and can be reaped (liveness
+   * released), unlike the 60s advisory `_isBackgroundShellQuiesced`.
+   *
+   * Tests inject `_backgroundShellHardQuiesceCheck` for deterministic control.
+   * The default reads the output file's mtime: a shell is hard-quiesced when
+   * `now - mtime >= hard window`. Unlike the advisory check there is NO
+   * non-empty guard — after hours even an empty output file (a silent
+   * `sleep`/compute) is reaped, since the file's mtime ≈ its creation time and
+   * a command silent for the whole hard window is almost certainly done. A
+   * shell with no known output path falls back to its `startedAt`. A stat()
+   * error is treated as NOT hard-quiesced (transient FS hiccup must not reap).
+   *
+   * @param {{ shellId: string, outputPath?: string|null, startedAt: number }} entry
+   * @returns {boolean}
+   * @private
+   */
+  _isBackgroundShellHardQuiesced(entry) {
+    if (typeof this._backgroundShellHardQuiesceCheck === 'function') {
+      return this._backgroundShellHardQuiesceCheck(entry) === true
+    }
+    if (this._backgroundShellHardQuiesceMs <= 0) return false
+    if (!entry) return false
+    if (typeof entry.outputPath !== 'string' || entry.outputPath.length === 0) {
+      // No output file to stat — fall back to wall-clock age since the shell
+      // was tracked. (A shell that never produced an output path and has been
+      // around for the whole hard window is treated the same as silent output.)
+      return typeof entry.startedAt === 'number'
+        && Date.now() - entry.startedAt >= this._backgroundShellHardQuiesceMs
+    }
+    try {
+      const st = statSync(entry.outputPath)
+      return Date.now() - st.mtimeMs >= this._backgroundShellHardQuiesceMs
+    } catch {
+      return false
+    }
   }
 
   /**

--- a/packages/server/tests/background-shells.test.js
+++ b/packages/server/tests/background-shells.test.js
@@ -262,6 +262,11 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
     session = makeSession()
     // Tighten the sweep interval so fake timers advance predictably.
     session._backgroundShellSweepMs = 1000
+    // #5265: these tests cover the #5247 ADVISORY behaviour in isolation, so
+    // disable the hard-quiesce reap here. The dedicated hard-quiesce describe
+    // block below re-enables it. (With hard-quiesce on, the sweep keeps running
+    // past advisory-quiesce to await the eventual reap.)
+    session._backgroundShellHardQuiesceMs = 0
   })
 
   afterEach(() => {
@@ -413,6 +418,103 @@ describe('BaseSession background-shell completion sweep (#5177)', () => {
     session._destroyPendingBackgroundShells()
     assert.equal(session._backgroundShellSweepTimer, null, 'timer cleared on destroy')
     assert.equal(session._pendingBackgroundShells.size, 0)
+  })
+})
+
+describe('BaseSession background-shell HARD-quiesce reap (#5265)', () => {
+  let session
+
+  beforeEach(() => {
+    emptySkillsDir = mkdtempSync(join(tmpdir(), 'chroxy-bg-skills-'))
+    session = makeSession()
+    session._backgroundShellSweepMs = 1000
+    // Enable hard-quiesce with a window the fake clock can cross.
+    session._backgroundShellHardQuiesceMs = 5000
+  })
+
+  afterEach(() => {
+    mock.timers.reset()
+    session._destroyPendingBackgroundShells()
+    if (emptySkillsDir) rmSync(emptySkillsDir, { recursive: true, force: true })
+    emptySkillsDir = null
+  })
+
+  it('reaps a hard-quiesced shell — releases liveness (isRunning flips false)', () => {
+    mock.timers.enable({ apis: ['setInterval'] })
+    session._backgroundShellHardQuiesceCheck = () => true // long-dead
+
+    const events = []
+    session.on('background_work_changed', (d) => events.push(d))
+    session.trackBackgroundShell({ shellId: 'a', command: 'npm run build', outputPath: '/tmp/a.output' })
+    assert.equal(session.isRunning, true, 'running while pending')
+
+    mock.timers.tick(1000) // sweep reaps the hard-quiesced shell
+
+    assert.equal(session._pendingBackgroundShells.size, 0, 'shell reaped from the map')
+    assert.equal(session.isRunning, false, 'liveness released after hard-reap')
+    assert.equal(events[events.length - 1].pending.length, 0, 'banner cleared')
+    assert.equal(session._backgroundShellSweepTimer, null, 'sweep stops once the map drains')
+  })
+
+  it('keeps sweeping past advisory-quiesce, then hard-reaps when the hard window passes', () => {
+    mock.timers.enable({ apis: ['setInterval'] })
+    // Advisory-quiesced (banner clears) but not yet hard-quiesced.
+    session._backgroundShellQuiesceCheck = () => true
+    session._backgroundShellHardQuiesceCheck = () => false
+
+    session.trackBackgroundShell({ shellId: 'a', outputPath: '/tmp/a.output' })
+    mock.timers.tick(1000) // advisory quiesce
+    assert.equal(session.isRunning, true, 'retained for liveness after advisory quiesce')
+    assert.equal(session.getPendingBackgroundShells().length, 0, 'banner cleared')
+    // With hard-quiesce ON the sweep does NOT stop at advisory-quiesce (it must
+    // stay alive to perform the eventual hard-reap) — contrast the #5247 test.
+    assert.ok(session._backgroundShellSweepTimer, 'sweep persists awaiting hard-reap')
+
+    // Now the hard window passes.
+    session._backgroundShellHardQuiesceCheck = () => true
+    mock.timers.tick(1000)
+    assert.equal(session._pendingBackgroundShells.size, 0, 'hard-reaped')
+    assert.equal(session.isRunning, false, 'liveness released')
+  })
+
+  it('does not hard-reap when disabled (Ms=0) — advisory-only #5247 behaviour', () => {
+    mock.timers.enable({ apis: ['setInterval'] })
+    session._backgroundShellHardQuiesceMs = 0
+    session._backgroundShellQuiesceCheck = () => true
+    session._backgroundShellHardQuiesceCheck = () => true // would reap if consulted
+
+    session.trackBackgroundShell({ shellId: 'a', outputPath: '/tmp/a.output' })
+    mock.timers.tick(1000)
+    assert.equal(session._pendingBackgroundShells.size, 1, 'retained — hard-reap disabled')
+    assert.equal(session.isRunning, true, 'still running (advisory-only)')
+    assert.equal(session._backgroundShellSweepTimer, null, 'sweep stops at advisory when hard disabled')
+  })
+
+  it('default hard-quiesce check uses output mtime against the hard window (real fs)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-bg-hard-'))
+    const outputPath = join(dir, 'shell.output')
+    writeFileSync(outputPath, 'building...\n')
+    session._backgroundShellHardQuiesceMs = 5000
+
+    session.trackBackgroundShell({ shellId: 'a', outputPath })
+    const fresh = session._pendingBackgroundShells.get('a')
+    assert.equal(session._isBackgroundShellHardQuiesced(fresh), false, 'fresh write is not hard-quiesced')
+
+    // Backdate mtime past the hard window → hard-quiesced (note: no non-empty
+    // guard on the hard path, unlike the advisory check).
+    const old = Date.now() / 1000 - 60
+    utimesSync(outputPath, old, old)
+    assert.equal(session._isBackgroundShellHardQuiesced(fresh), true, 'silent past the hard window → reapable')
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('hard-quiesces a shell with no output path by its startedAt age', () => {
+    session._backgroundShellHardQuiesceMs = 5000
+    session.trackBackgroundShell({ shellId: 'a', command: 'sleep 1', outputPath: null })
+    const entry = session._pendingBackgroundShells.get('a')
+    assert.equal(session._isBackgroundShellHardQuiesced(entry), false, 'fresh shell not hard-quiesced')
+    entry.startedAt = Date.now() - 6000 // older than the hard window
+    assert.equal(session._isBackgroundShellHardQuiesced(entry), true, 'aged-out no-output shell is reapable')
   })
 })
 

--- a/packages/server/tests/background-shells.test.js
+++ b/packages/server/tests/background-shells.test.js
@@ -524,7 +524,10 @@ describe('BaseSession background-shell HARD-quiesce reap (#5265)', () => {
     assert.equal(session._isBackgroundShellHardQuiesced(fresh), false, 'fresh write is not hard-quiesced')
 
     // Backdate mtime past the hard window → hard-quiesced (note: no non-empty
-    // guard on the hard path, unlike the advisory check).
+    // guard on the hard path, unlike the advisory check). Also age the entry's
+    // startedAt past the window so the cheap pre-stat gate (#5287 review) lets
+    // the mtime check run (a shell can't be idle longer than it has existed).
+    fresh.startedAt = Date.now() - 60_000
     const old = Date.now() / 1000 - 60
     utimesSync(outputPath, old, old)
     assert.equal(session._isBackgroundShellHardQuiesced(fresh), true, 'silent past the hard window → reapable')

--- a/packages/server/tests/background-shells.test.js
+++ b/packages/server/tests/background-shells.test.js
@@ -490,6 +490,29 @@ describe('BaseSession background-shell HARD-quiesce reap (#5265)', () => {
     assert.equal(session._backgroundShellSweepTimer, null, 'sweep stops at advisory when hard disabled')
   })
 
+  it('SAFETY: a shell still writing within the hard window is NEVER reaped (#4307/#5247 guard)', () => {
+    // The load-bearing safety property: a noisy long-runner (dev server, watcher,
+    // build) keeps its mtime fresh, so it must survive every sweep. This guards
+    // against a refactor re-introducing the #5247/#4307 live-process reap.
+    mock.timers.enable({ apis: ['setInterval'] })
+    session._backgroundShellHardQuiesceMs = 5000
+    // Default checks consult the real fs; a fresh-mtime file is neither advisory-
+    // nor hard-quiesced. Use a real, freshly-written output file.
+    const dir = mkdtempSync(join(tmpdir(), 'chroxy-bg-live-'))
+    const outputPath = join(dir, 'shell.output')
+    writeFileSync(outputPath, 'listening on :3000\n')
+
+    session.trackBackgroundShell({ shellId: 'live', command: 'npm run dev', outputPath })
+    // Several sweep ticks — but the file mtime stays fresh (just written), so
+    // neither quiesce window is crossed.
+    mock.timers.tick(1000)
+    mock.timers.tick(1000)
+    mock.timers.tick(1000)
+    assert.equal(session._pendingBackgroundShells.size, 1, 'live shell retained across sweeps')
+    assert.equal(session.isRunning, true, 'live shell keeps the session running')
+    rmSync(dir, { recursive: true, force: true })
+  })
+
   it('default hard-quiesce check uses output mtime against the hard window (real fs)', () => {
     const dir = mkdtempSync(join(tmpdir(), 'chroxy-bg-hard-'))
     const outputPath = join(dir, 'shell.output')


### PR DESCRIPTION
## What

Adds a long **hard-quiesce** window that **reaps** a background shell whose output has been silent for hours — releasing liveness so a session can finally idle-time out. Closes #5265 (Control Room cluster).

## Why

The #5247 mtime sweep is *advisory*: a background command that genuinely finished but the agent never polls via `BashOutput` stays in `_pendingBackgroundShells`, pinning `isRunning` true until `destroy`. Since `SessionTimeoutManager` won't idle-time a "running" session, a long-idle session can be held alive **forever** by a long-dead command.

chroxy never owns the shell's PID (the id is opaque, owned by claude), so a PID/exit-aware completion signal isn't possible — confirmed in the existing code + #5247 history. The realistic, accepted-tradeoff fix (called out in the issue) is a **much longer secondary window**: after hours of continuous output silence a shell is overwhelmingly likely finished, so reap it.

## How

- `BACKGROUND_SHELL_HARD_QUIESCE_MS` = **4h**, distinct from the 60s advisory banner window. Instance field `_backgroundShellHardQuiesceMs` (set to **0 to disable** → advisory-only #5247). Injectable `_backgroundShellHardQuiesceCheck` for tests.
- `_isBackgroundShellHardQuiesced`: default reads the output file mtime vs the hard window. **No non-empty guard** (unlike the advisory check) — after hours even an empty/silent output file is reapable (its mtime ≈ creation time, and a command silent the whole window is almost certainly done). No-output shells fall back to `startedAt` age; `stat()` errors are conservative (not reaped).
- The sweep hard-reaps **first** (every entry, including already advisory-quiesced ones) and, with hard-quiesce on, **keeps sweeping past advisory-quiesce** until the map drains (so the eventual reap actually runs); with it off, the old "stop when all advisory-quiesced" behaviour is preserved.

**Safety:** a *noisy* long-runner (dev server, watcher, build) emits output within any 4h stretch → its mtime stays fresh → it is **never** hard-reaped. Only genuinely-silent-for-hours shells are reclaimed.

## Tests

- Reap flips `isRunning` false + clears banner + stops the sweep on drain.
- Advisory-quiesce → sweep **persists** → hard-reap when the window passes.
- Disabled (`Ms=0`) → advisory-only (no reap; sweep stops at advisory).
- Default mtime check (real fs, backdated mtime); no-output `startedAt` fallback.
- 39 background-shell + 137 base-session/timeout tests green; opt-forwarding lint clean.

Closes #5265.