### PR TITLE
fix(dashboard): retry reconnects to the active server, not always local

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -911,6 +911,11 @@ export function App() {
   // Auto-connect on mount — use page token (served by local server),
   // or fall back to the last active server from the registry.
   // Reads registry via getState() to avoid reactive deps (mount-only effect).
+  //
+  // NOTE: precedence here (local-first) is intentionally the inverse of
+  // retryConnection's (active-server-first). A fresh page load returns to the
+  // local "home" daemon; a manual Retry resumes whatever you were connected to.
+  // The two don't collide in practice — connectLocal nulls activeServerId.
   useEffect(() => {
     const token = getAuthToken()
     if (token) {

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -508,6 +508,7 @@ export function App() {
 
   // Store actions (stable refs)
   const connect = useConnectionStore(s => s.connect)
+  const retryConnection = useConnectionStore(s => s.retryConnection)
   const sendInput = useConnectionStore(s => s.sendInput)
   const sendInterrupt = useConnectionStore(s => s.sendInterrupt)
   const evaluateDraft = useConnectionStore(s => s.evaluateDraft)
@@ -1645,13 +1646,11 @@ export function App() {
     dismissSessionNotification(notificationId)
   }, [sendPermissionResponse, markPromptAnsweredByRequestId, dismissSessionNotification])
 
+  // Retry reconnects to the *active* server (remote registry entry or local),
+  // not unconditionally to local — see retryConnection / #5284.
   const handleRetry = useCallback(() => {
-    const token = getAuthToken()
-    if (!token) return
-    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
-    const wsUrl = `${proto}://${window.location.host}/ws`
-    connect(wsUrl, token)
-  }, [connect])
+    retryConnection()
+  }, [retryConnection])
 
   const handleStartServer = useCallback(() => {
     startServer()

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2754,6 +2754,33 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     }
     get().connect(wsUrl, token);
   },
+
+  /**
+   * Reconnect to the *active* server — registry server when `activeServerId` is
+   * set, else the local same-origin daemon. The manual "Retry" affordance must
+   * target whatever we were connected to; building the URL from
+   * `window.location.host` unconditionally (the old App-level handler) silently
+   * reconnected a dropped remote LAN session to the *local* daemon instead
+   * (#5284). Unlike switchServer/connectLocal this preserves session state — a
+   * retry resumes the same connection rather than switching contexts, so it
+   * reuses connectToServer's no-reset reconnect for the registry case.
+   */
+  retryConnection: () => {
+    const activeServerId = get().activeServerId;
+    if (activeServerId) {
+      // Registry server. connectToServer no-ops on an unknown id (e.g. the
+      // entry was removed mid-session); falling back to local here would
+      // reintroduce the exact wrong-target bug, so we let it no-op.
+      get().connectToServer(activeServerId);
+      return;
+    }
+    // Local same-origin daemon — reconnect in place (no scope/memory reset).
+    const token = getAuthToken();
+    if (!token) return;
+    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const wsUrl = `${proto}://${window.location.host}/ws`;
+    get().connect(wsUrl, token);
+  },
 }));
 
 // Type for the store API used by message-handler

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -2768,9 +2768,12 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   retryConnection: () => {
     const activeServerId = get().activeServerId;
     if (activeServerId) {
-      // Registry server. connectToServer no-ops on an unknown id (e.g. the
-      // entry was removed mid-session); falling back to local here would
-      // reintroduce the exact wrong-target bug, so we let it no-op.
+      // Registry server. connectToServer no-ops on an id absent from the
+      // registry. removeServer already nulls activeServerId when it drops the
+      // active entry, so this only fires on a stale/desynced id (e.g. the
+      // registry was edited in another tab, or storage is corrupt). Falling
+      // back to local there would reintroduce the exact wrong-target bug, so
+      // we deliberately let it no-op rather than silently jump to local.
       get().connectToServer(activeServerId);
       return;
     }

--- a/packages/dashboard/src/store/server-registry-store.test.ts
+++ b/packages/dashboard/src/store/server-registry-store.test.ts
@@ -165,6 +165,38 @@ describe('store server registry actions', () => {
       useConnectionStore.getState().retryConnection()
       expect(connectSpy).not.toHaveBeenCalled()
     })
+
+    it('no-ops when activeServerId is stale (absent from registry) — never falls back to local', () => {
+      // Stale/desynced id (e.g. cross-tab registry edit): connectToServer must
+      // no-op rather than reconnect to local, which would be the wrong target.
+      const connectSpy = vi.fn()
+      useConnectionStore.setState({
+        serverRegistry: [],
+        activeServerId: 'srv_gone',
+        connectionPhase: 'disconnected',
+        connect: connectSpy,
+      })
+      useConnectionStore.getState().retryConnection()
+      // Real connectToServer ran and found no entry — no local fallback connect.
+      expect(connectSpy).not.toHaveBeenCalled()
+      expect(useConnectionStore.getState().activeServerId).toBe('srv_gone')
+    })
+
+    it('preserves session state on retry (does NOT reset session memory)', () => {
+      // The core guarantee of retryConnection vs switchServer/connectLocal: a
+      // retry resumes, it must not wipe session memory. Guard against a future
+      // change to connectToServer that adds a reset.
+      const entry = useConnectionStore.getState().addServer('Dev', 'wss://dev/ws', 'token1')
+      const resetSpy = vi.fn()
+      useConnectionStore.setState({
+        activeServerId: entry.id,
+        connectionPhase: 'disconnected',
+        connect: vi.fn(),
+        _resetSessionMemory: resetSpy,
+      })
+      useConnectionStore.getState().retryConnection()
+      expect(resetSpy).not.toHaveBeenCalled()
+    })
   })
 
   it('multiple servers can coexist in registry', () => {

--- a/packages/dashboard/src/store/server-registry-store.test.ts
+++ b/packages/dashboard/src/store/server-registry-store.test.ts
@@ -27,15 +27,27 @@ vi.mock('../utils/auth', () => ({
 // Must import after localStorage mock is set up
 const { useConnectionStore } = await import('./connection')
 
+// Capture the real action refs at import time (before any test mocks them). The
+// store is a module singleton, so retryConnection tests that swap actions in via
+// setState would otherwise leak mocked refs into later tests in this file — and,
+// in a shared Vitest worker, other files. Restore them in beforeEach.
+const realActions = {
+  connect: useConnectionStore.getState().connect,
+  connectToServer: useConnectionStore.getState().connectToServer,
+  _resetSessionMemory: useConnectionStore.getState()._resetSessionMemory,
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   for (const k of Object.keys(store)) delete store[k]
   mockToken = null
-  // Reset store state relevant to server registry
+  // Reset store state relevant to server registry, restoring the real actions
+  // any prior test may have replaced with spies.
   useConnectionStore.setState({
     serverRegistry: [],
     activeServerId: null,
     connectionPhase: 'disconnected',
+    ...realActions,
   })
 })
 

--- a/packages/dashboard/src/store/server-registry-store.test.ts
+++ b/packages/dashboard/src/store/server-registry-store.test.ts
@@ -118,6 +118,55 @@ describe('store server registry actions', () => {
     expect(useConnectionStore.getState().connectionPhase).toBe('connected')
   })
 
+  describe('retryConnection (#5284)', () => {
+    it('reconnects to the active REMOTE server, not local', () => {
+      const entry = useConnectionStore.getState().addServer('Dev', 'wss://dev/ws', 'token1')
+      const connectSpy = vi.fn()
+      const connectToServerSpy = vi.fn()
+      // A dropped remote session: active server set, socket down.
+      useConnectionStore.setState({
+        activeServerId: entry.id,
+        connectionPhase: 'disconnected',
+        connect: connectSpy,
+        connectToServer: connectToServerSpy,
+      })
+      useConnectionStore.getState().retryConnection()
+      // Must retry the remote registry entry — never the same-origin connect().
+      expect(connectToServerSpy).toHaveBeenCalledWith(entry.id)
+      expect(connectSpy).not.toHaveBeenCalled()
+    })
+
+    it('reconnects to local same-origin when no active server', () => {
+      mockToken = 'local-token'
+      const connectSpy = vi.fn()
+      const connectToServerSpy = vi.fn()
+      useConnectionStore.setState({
+        activeServerId: null,
+        connectionPhase: 'disconnected',
+        connect: connectSpy,
+        connectToServer: connectToServerSpy,
+      })
+      useConnectionStore.getState().retryConnection()
+      expect(connectToServerSpy).not.toHaveBeenCalled()
+      expect(connectSpy).toHaveBeenCalledTimes(1)
+      // Same-origin /ws URL + the page token.
+      expect(connectSpy.mock.calls[0]![0]).toMatch(/\/ws$/)
+      expect(connectSpy.mock.calls[0]![1]).toBe('local-token')
+    })
+
+    it('is a no-op for the local path when no same-origin token is available', () => {
+      mockToken = null
+      const connectSpy = vi.fn()
+      useConnectionStore.setState({
+        activeServerId: null,
+        connectionPhase: 'disconnected',
+        connect: connectSpy,
+      })
+      useConnectionStore.getState().retryConnection()
+      expect(connectSpy).not.toHaveBeenCalled()
+    })
+  })
+
   it('multiple servers can coexist in registry', () => {
     useConnectionStore.getState().addServer('Dev', 'wss://dev/ws', 'token1')
     useConnectionStore.getState().addServer('Staging', 'wss://staging/ws', 'token2')

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1141,6 +1141,14 @@ export interface ConnectionState {
   connectToServer: (serverId: string) => void;
   /** Connect to the local same-origin daemon ("this machine"); registry-less local target. */
   connectLocal: () => void;
+  /**
+   * Reconnect to whatever server is currently active — the registry server when
+   * `activeServerId` is set, otherwise the local same-origin daemon. Preserves
+   * session state (it's a retry, not a switch). Used by the manual "Retry"
+   * affordance so a dropped remote LAN connection retries the remote, not local
+   * (#5284).
+   */
+  retryConnection: () => void;
 
   // Environment actions
   requestEnvironments: () => void;


### PR DESCRIPTION
## Problem

`handleRetry` in `App.tsx` rebuilt the WebSocket URL from `window.location.host` unconditionally:

```ts
const wsUrl = `${proto}://${window.location.host}/ws`
connect(wsUrl, token)
```

When the dashboard is connected to a **remote LAN daemon** (the new #5281 LAN-client path) and that connection drops, hitting **Retry** reconnected to the **local** same-origin daemon instead — silently switching the operator off the server they were watching. Identified in review of #5283.

## Fix

New `retryConnection()` store action that targets the **active** server:

- `activeServerId` set → `connectToServer(activeServerId)` (registry entry, preserves session state)
- `activeServerId === null` → same-origin reconnect to "this machine" (local), as before

Unlike `switchServer`/`connectLocal` it does **not** reset session memory — a retry resumes the same connection rather than switching contexts, so it reuses `connectToServer`'s no-reset reconnect path. If the active registry entry was removed mid-session, `connectToServer` no-ops rather than falling back to local (which would reintroduce the wrong-target bug).

`handleRetry` now just delegates to `retryConnection()`.

## Tests

3 new cases in `server-registry-store.test.ts`:
- active remote server → `connectToServer(id)`, never the same-origin `connect()`
- no active server → same-origin `/ws` reconnect with the page token
- local path with no token → no-op

Full dashboard suite green (3200 tests); `tsc --noEmit` clean.

Closes #5284