### PR TITLE
test(server): integration coverage for --host bind + mDNS suppression

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -307,6 +307,66 @@ export function initFileLoggingFromConfig(config = {}) {
   }
 }
 
+/**
+ * Decide whether to advertise the server over mDNS/Bonjour and, if so, publish
+ * the `_chroxy._tcp` service. Extracted from startCliServer so the loopback
+ * gating wiring is testable without booting the full CLI (#5280) — the pure
+ * resolver (bind-host.js) was already covered, but the decision to suppress the
+ * advertisement on a loopback bind was not.
+ *
+ * Returns `{ mdnsService, bonjourInstance }` (both null when not advertising) so
+ * the caller can stop/destroy them on shutdown.
+ *
+ * @param {object} opts
+ * @param {boolean} opts.noAuth   — auth disabled; never advertise.
+ * @param {string|undefined} opts.bindHost — the resolved bind host.
+ * @param {number} opts.port
+ * @param {string} opts.version
+ * @param {boolean} opts.hasToken — surfaced in the TXT record's `auth` field.
+ * @param {object} [opts.log]     — logger (defaults to console).
+ * @param {() => (object|Promise<object>)} [opts.bonjourFactory] — injectable
+ *   Bonjour instance factory for tests; defaults to dynamically importing
+ *   `bonjour-service`.
+ */
+export async function maybeAdvertiseMdns({
+  noAuth,
+  bindHost,
+  port,
+  version,
+  hasToken,
+  log = console,
+  bonjourFactory,
+} = {}) {
+  const none = { mdnsService: null, bonjourInstance: null }
+  // Auth-off skips discovery entirely (matches the pre-#5280 guards).
+  if (noAuth) return none
+  // Loopback bind — nothing on the LAN can reach it, so an _chroxy._tcp
+  // advertisement would be misleading.
+  if (isLoopbackHost(bindHost)) {
+    log.info?.('Loopback bind — skipping mDNS advertisement (server not LAN-reachable)')
+    return none
+  }
+  try {
+    const bonjourInstance = bonjourFactory
+      ? await bonjourFactory()
+      : await (async () => {
+          const { Bonjour } = await import('bonjour-service')
+          return new Bonjour()
+        })()
+    const mdnsService = bonjourInstance.publish({
+      name: `Chroxy (${hostname()})`,
+      type: 'chroxy',
+      port,
+      txt: { version, auth: hasToken ? 'token' : 'none' },
+    })
+    log.info?.(`Advertising _chroxy._tcp on port ${port} via mDNS`)
+    return { mdnsService, bonjourInstance }
+  } catch (err) {
+    log.debug?.(`mDNS advertisement unavailable: ${err.message}`)
+    return none
+  }
+}
+
 export async function startCliServer(config) {
   // Enable JSON log format if configured
   if (config.logFormat === 'json') {
@@ -820,29 +880,16 @@ export async function startCliServer(config) {
   sessionManager.setActiveViewersFn((sid) => wsServer.hasActiveViewersForSession(sid))
   sessionManager.startSessionTimeouts()
 
-  // Advertise via mDNS/Bonjour for local network discovery. Skipped on a
-  // loopback bind — nothing on the LAN can reach it, so an _chroxy._tcp
-  // advertisement would be misleading. (Auth-off already skips both branches
-  // below via the pre-existing !NO_AUTH guards.)
-  let mdnsService = null
-  let bonjourInstance = null
-  if (!NO_AUTH && isLoopbackHost(bindHost)) {
-    log.info('Loopback bind — skipping mDNS advertisement (server not LAN-reachable)')
-  } else if (!NO_AUTH) {
-    try {
-      const { Bonjour } = await import('bonjour-service')
-      bonjourInstance = new Bonjour()
-      mdnsService = bonjourInstance.publish({
-        name: `Chroxy (${hostname()})`,
-        type: 'chroxy',
-        port: PORT,
-        txt: { version: SERVER_VERSION, auth: API_TOKEN ? 'token' : 'none' },
-      })
-      log.info(`Advertising _chroxy._tcp on port ${PORT} via mDNS`)
-    } catch (err) {
-      log.debug(`mDNS advertisement unavailable: ${err.message}`)
-    }
-  }
+  // Advertise via mDNS/Bonjour for local network discovery. Suppressed on a
+  // loopback bind and when auth is off — see maybeAdvertiseMdns (#5280).
+  let { mdnsService, bonjourInstance } = await maybeAdvertiseMdns({
+    noAuth: NO_AUTH,
+    bindHost,
+    port: PORT,
+    version: SERVER_VERSION,
+    hasToken: !!API_TOKEN,
+    log,
+  })
 
   // Track current WebSocket URL and mode label across all modes (tunnel, external, LAN)
   let tunnel = null

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -882,7 +882,7 @@ export async function startCliServer(config) {
 
   // Advertise via mDNS/Bonjour for local network discovery. Suppressed on a
   // loopback bind and when auth is off — see maybeAdvertiseMdns (#5280).
-  let { mdnsService, bonjourInstance } = await maybeAdvertiseMdns({
+  const { mdnsService, bonjourInstance } = await maybeAdvertiseMdns({
     noAuth: NO_AUTH,
     bindHost,
     port: PORT,

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -362,7 +362,10 @@ export async function maybeAdvertiseMdns({
     log.info?.(`Advertising _chroxy._tcp on port ${port} via mDNS`)
     return { mdnsService, bonjourInstance }
   } catch (err) {
-    log.debug?.(`mDNS advertisement unavailable: ${err.message}`)
+    // Normalize the error the way the rest of this file does — a Bonjour
+    // factory (or the dynamic import) that throws a non-Error / null must not
+    // turn the graceful no-advertisement fallback into a crash.
+    log.debug?.(`mDNS advertisement unavailable: ${err?.message || String(err)}`)
     return none
   }
 }

--- a/packages/server/tests/host-mdns-integration.test.js
+++ b/packages/server/tests/host-mdns-integration.test.js
@@ -1,0 +1,178 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import { maybeAdvertiseMdns } from '../src/server-cli.js'
+import { resolveBindHost, isLoopbackHost } from '../src/bind-host.js'
+
+/**
+ * #5280 — integration coverage for the --host / mDNS wiring in server-cli.js.
+ *
+ * The pure resolver (bind-host.js) is unit-tested in bind-host.test.js. This
+ * suite covers the *wiring*: that the resolved bind host actually drives a
+ * loopback-only socket bind, and that the mDNS advertisement is suppressed on a
+ * loopback bind (and when auth is off) but published otherwise — exercising the
+ * exact maybeAdvertiseMdns() seam startCliServer() calls.
+ *
+ * A full startCliServer() boot is intentionally NOT used: it migrates tokens,
+ * encrypts credentials, and writes config under the real ~/.chroxy tree, which
+ * the #4633 test sandbox guard blocks, and it calls process.exit() on several
+ * paths. Extracting maybeAdvertiseMdns lets us test the same code the CLI runs.
+ */
+
+const silentLog = { info: () => {}, debug: () => {}, warn: () => {} }
+
+// A fake Bonjour instance that records publish() calls so we can assert the
+// service shape without touching the network.
+function makeFakeBonjour() {
+  const published = []
+  const instance = {
+    publish: (opts) => {
+      published.push(opts)
+      return { stop: () => {} }
+    },
+    destroy: () => {},
+  }
+  return { instance, published, factory: () => instance }
+}
+
+describe('#5280 resolveBindHost drives a real socket bind', () => {
+  function bindAndGetAddress(host) {
+    return new Promise((resolve, reject) => {
+      const server = http.createServer()
+      server.on('error', reject)
+      // port 0 → ephemeral port; host is the resolved bind address.
+      server.listen(0, host, () => {
+        const addr = server.address()
+        server.close(() => resolve(addr))
+      })
+    })
+  }
+
+  it('config.host = 127.0.0.1 binds loopback only', async () => {
+    const bindHost = resolveBindHost({ noAuth: false, host: '127.0.0.1' })
+    assert.equal(bindHost, '127.0.0.1')
+    const addr = await bindAndGetAddress(bindHost)
+    assert.equal(addr.address, '127.0.0.1')
+    assert.equal(isLoopbackHost(addr.address), true)
+  })
+
+  it('--no-auth forces a loopback bind regardless of host', async () => {
+    const bindHost = resolveBindHost({ noAuth: true, host: undefined })
+    assert.equal(bindHost, '127.0.0.1')
+    const addr = await bindAndGetAddress(bindHost)
+    assert.equal(isLoopbackHost(addr.address), true)
+  })
+
+  it('default (no host, auth on) binds all interfaces — not loopback', async () => {
+    const bindHost = resolveBindHost({ noAuth: false, host: undefined })
+    assert.equal(bindHost, undefined)
+    const addr = await bindAndGetAddress(bindHost)
+    // Node binds the unspecified address (0.0.0.0 or :: depending on stack).
+    assert.ok(
+      addr.address === '0.0.0.0' || addr.address === '::',
+      `expected an unspecified bind address, got ${addr.address}`,
+    )
+    assert.equal(isLoopbackHost(addr.address), false)
+  })
+})
+
+describe('#5280 maybeAdvertiseMdns suppresses mDNS on a loopback bind', () => {
+  it('does not publish when bound to 127.0.0.1', async () => {
+    const fake = makeFakeBonjour()
+    const res = await maybeAdvertiseMdns({
+      noAuth: false,
+      bindHost: '127.0.0.1',
+      port: 8765,
+      version: '9.9.9',
+      hasToken: true,
+      log: silentLog,
+      bonjourFactory: fake.factory,
+    })
+    assert.equal(fake.published.length, 0)
+    assert.equal(res.mdnsService, null)
+    assert.equal(res.bonjourInstance, null)
+  })
+
+  it('does not publish when bound to localhost', async () => {
+    const fake = makeFakeBonjour()
+    await maybeAdvertiseMdns({
+      noAuth: false,
+      bindHost: 'localhost',
+      port: 8765,
+      version: '9.9.9',
+      hasToken: true,
+      log: silentLog,
+      bonjourFactory: fake.factory,
+    })
+    assert.equal(fake.published.length, 0)
+  })
+
+  it('does not publish when auth is off, even on a public bind', async () => {
+    const fake = makeFakeBonjour()
+    const res = await maybeAdvertiseMdns({
+      noAuth: true,
+      bindHost: '0.0.0.0',
+      port: 8765,
+      version: '9.9.9',
+      hasToken: false,
+      log: silentLog,
+      bonjourFactory: fake.factory,
+    })
+    assert.equal(fake.published.length, 0)
+    assert.equal(res.bonjourInstance, null)
+  })
+})
+
+describe('#5280 maybeAdvertiseMdns publishes on a LAN-reachable bind', () => {
+  it('publishes _chroxy._tcp on the default (undefined) bind', async () => {
+    const fake = makeFakeBonjour()
+    const res = await maybeAdvertiseMdns({
+      noAuth: false,
+      bindHost: undefined,
+      port: 8765,
+      version: '9.9.9',
+      hasToken: true,
+      log: silentLog,
+      bonjourFactory: fake.factory,
+    })
+    assert.equal(fake.published.length, 1)
+    const svc = fake.published[0]
+    assert.equal(svc.type, 'chroxy')
+    assert.equal(svc.port, 8765)
+    assert.equal(svc.txt.version, '9.9.9')
+    assert.equal(svc.txt.auth, 'token')
+    assert.ok(svc.name.startsWith('Chroxy ('))
+    assert.equal(res.bonjourInstance, fake.instance)
+    assert.ok(res.mdnsService)
+  })
+
+  it('publishes on an explicit non-loopback host with auth = none when tokenless', async () => {
+    const fake = makeFakeBonjour()
+    await maybeAdvertiseMdns({
+      noAuth: false,
+      bindHost: '192.168.1.50',
+      port: 9000,
+      version: '1.0.0',
+      hasToken: false,
+      log: silentLog,
+      bonjourFactory: fake.factory,
+    })
+    assert.equal(fake.published.length, 1)
+    assert.equal(fake.published[0].txt.auth, 'none')
+    assert.equal(fake.published[0].port, 9000)
+  })
+
+  it('degrades gracefully to no-advertisement when Bonjour throws', async () => {
+    const res = await maybeAdvertiseMdns({
+      noAuth: false,
+      bindHost: '0.0.0.0',
+      port: 8765,
+      version: '9.9.9',
+      hasToken: true,
+      log: silentLog,
+      bonjourFactory: () => { throw new Error('bonjour unavailable') },
+    })
+    assert.equal(res.mdnsService, null)
+    assert.equal(res.bonjourInstance, null)
+  })
+})

--- a/packages/server/tests/host-mdns-integration.test.js
+++ b/packages/server/tests/host-mdns-integration.test.js
@@ -175,4 +175,22 @@ describe('#5280 maybeAdvertiseMdns publishes on a LAN-reachable bind', () => {
     assert.equal(res.mdnsService, null)
     assert.equal(res.bonjourInstance, null)
   })
+
+  it('degrades gracefully even when a non-Error value is thrown', async () => {
+    // The catch normalizes err via `err?.message || String(err)`, so a thrown
+    // string / null must not turn the fallback into a TypeError crash.
+    for (const thrown of ['plain string', null, undefined, 42]) {
+      const res = await maybeAdvertiseMdns({
+        noAuth: false,
+        bindHost: '0.0.0.0',
+        port: 8765,
+        version: '9.9.9',
+        hasToken: true,
+        log: silentLog,
+        bonjourFactory: () => { throw thrown },
+      })
+      assert.equal(res.mdnsService, null)
+      assert.equal(res.bonjourInstance, null)
+    }
+  })
 })


### PR DESCRIPTION
## Context

Closes #5280 (from review of #5279, the `--host` bind-address override).

The pure resolver (`bind-host.js`) is well unit-tested, but the **wiring** in `server-cli.js` had no coverage: that the resolved bind host actually drives a loopback-only socket bind, and that the `_chroxy._tcp` mDNS advertisement is suppressed on a loopback bind.

## Why not a full `startCliServer()` boot

The acceptance criteria suggested booting the CLI. A full boot is impractical under the test sandbox: `startCliServer()` migrates tokens, encrypts `credentials.json`, and writes config under the real `~/.chroxy` tree — all blocked by the #4633 sandbox guard — and calls `process.exit()` on several paths.

Instead, the mDNS advertisement is **extracted into `maybeAdvertiseMdns()`** — the exact same function `startCliServer()` now calls — so the loopback-suppression decision is testable with an injected Bonjour factory, no network, and no monolith boot. This follows the established server-cli test pattern (extract a seam, test it).

## Changes

- **`server-cli.js`**: extract `maybeAdvertiseMdns({ noAuth, bindHost, port, version, hasToken, log, bonjourFactory })` returning `{ mdnsService, bonjourInstance }`; `startCliServer` now delegates to it (behavior identical — auth-off and loopback both suppress; LAN-reachable binds publish).
- **`tests/host-mdns-integration.test.js`** (new):
  - `resolveBindHost` output driving a **real socket bind** — `127.0.0.1` and `--no-auth` bind loopback only; default (no host) binds the unspecified address (not loopback).
  - mDNS **suppressed** on `127.0.0.1` / `localhost`, and when `--no-auth`.
  - mDNS **published** with the correct `_chroxy._tcp` service shape (type, port, `txt.version`, `txt.auth` token/none) on the default and explicit non-loopback binds.
  - graceful no-advertisement when Bonjour throws.

## Tests

9 new cases pass; server-cli + bind-host suites green (37); opt-forwarding lint + `node --check` clean.