### PR TITLE
feat(dashboard): shared-session presence indicator in the sidebar footer

### DIFF
--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -19,6 +19,7 @@ import type { BaseSessionState } from '@chroxy/store-core'
 import type { ChatViewMessage } from './components/ChatView'
 
 import { Sidebar, type RepoNode, type ContextMenuTarget } from './components/Sidebar'
+import { resolveActivePrimaryClientId } from './components/ViewersIndicator'
 import { SessionContextMenu, type ContextMenuItem } from './components/SessionContextMenu'
 import { buildSidebarContextMenuItems } from './sidebarContextMenuItems'
 import { CommandPalette } from './components/CommandPalette'
@@ -2306,9 +2307,7 @@ export function App() {
           serverStatus={isConnected ? 'connected' : isReconnecting ? 'reconnecting' : 'disconnected'}
           tunnelUrl={null}
           connectedClients={connectedClients}
-          activePrimaryClientId={
-            (activeSessionId ? sessionStates[activeSessionId]?.primaryClientId : null) ?? globalPrimaryClientId
-          }
+          activePrimaryClientId={resolveActivePrimaryClientId(activeSessionId, sessionStates, globalPrimaryClientId)}
           onFilterChange={setSidebarFilter}
           onSessionClick={handleSwitchSession}
           onResumeSession={resumeConversation}

--- a/packages/dashboard/src/App.tsx
+++ b/packages/dashboard/src/App.tsx
@@ -303,6 +303,9 @@ export function App() {
   const sessionNotifications = useConnectionStore(s => s.sessionNotifications)
   const inputSettings = useConnectionStore(s => s.inputSettings)
   const connectedClients = useConnectionStore(s => s.connectedClients)
+  // #5281 ①.3 — global primary (last-driver) fallback for the pre-session /
+  // 'default' case; per-session primary is read from sessionStates below.
+  const globalPrimaryClientId = useConnectionStore(s => s.primaryClientId)
   const pairingRefreshedCount = useConnectionStore(s => s.pairingRefreshedCount)
   // #4497: server-advertised stream-stall window — threaded into the
   // StreamStallChip render path so the headline humanises to e.g.
@@ -2302,7 +2305,10 @@ export function App() {
           filter={sidebarFilter}
           serverStatus={isConnected ? 'connected' : isReconnecting ? 'reconnecting' : 'disconnected'}
           tunnelUrl={null}
-          clientCount={connectedClients.length}
+          connectedClients={connectedClients}
+          activePrimaryClientId={
+            (activeSessionId ? sessionStates[activeSessionId]?.primaryClientId : null) ?? globalPrimaryClientId
+          }
           onFilterChange={setSidebarFilter}
           onSessionClick={handleSwitchSession}
           onResumeSession={resumeConversation}

--- a/packages/dashboard/src/components/Sidebar.test.tsx
+++ b/packages/dashboard/src/components/Sidebar.test.tsx
@@ -5,6 +5,7 @@ import type React from 'react'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
 import { Sidebar, type SidebarProps, type RepoNode } from './Sidebar'
+import type { ConnectedClient } from '../store/types'
 
 // Mock the connection store (used by ServerPicker inside Sidebar)
 vi.mock('../store/connection', () => ({
@@ -24,6 +25,16 @@ vi.mock('../store/connection', () => ({
 afterEach(cleanup)
 
 const noop = vi.fn()
+
+function makeClients(n: number): ConnectedClient[] {
+  return Array.from({ length: n }, (_, i) => ({
+    clientId: `c${i}`,
+    deviceName: `Device ${i}`,
+    deviceType: 'desktop' as const,
+    platform: 'macos',
+    isSelf: i === 0,
+  }))
+}
 
 function makeRepos(overrides?: Partial<RepoNode>[]): RepoNode[] {
   const defaults: RepoNode[] = [
@@ -62,7 +73,8 @@ function renderSidebar(props: Partial<SidebarProps> = {}) {
     filter: '',
     serverStatus: 'connected',
     tunnelUrl: null,
-    clientCount: 1,
+    connectedClients: [],
+    activePrimaryClientId: null,
     onFilterChange: noop,
     onSessionClick: noop,
     onResumeSession: noop,
@@ -177,9 +189,11 @@ describe('Sidebar', () => {
     expect(screen.getByTestId('sidebar-footer')).toHaveTextContent('my-tunnel.trycloudflare.com')
   })
 
-  it('shows client count in footer', () => {
-    renderSidebar({ clientCount: 3 })
+  it('shows the shared-session viewer count in the footer', () => {
+    renderSidebar({ connectedClients: makeClients(3) })
+    // ≥2 devices → interactive chip showing the device count.
     expect(screen.getByTestId('sidebar-footer')).toHaveTextContent('3')
+    expect(screen.getByTestId('viewers-indicator')).toBeInTheDocument()
   })
 
   // #5183 — the Running indicator is surfaced on the left projects/explorer
@@ -316,7 +330,8 @@ describe('Sidebar', () => {
       filter: 'Backend',
       serverStatus: 'connected',
       tunnelUrl: null,
-      clientCount: 1,
+      connectedClients: [],
+      activePrimaryClientId: null,
       onFilterChange: noop,
       onSessionClick: noop,
       onResumeSession: noop,
@@ -332,14 +347,15 @@ describe('Sidebar', () => {
     expect(screen.queryByText('Backend')).not.toBeInTheDocument()
   })
 
-  it('hides client count when server is disconnected', () => {
-    renderSidebar({ serverStatus: 'disconnected', clientCount: 2 })
-    expect(screen.queryByTestId('sidebar-footer')).not.toHaveTextContent('client')
+  it('hides the viewer indicator when server is disconnected', () => {
+    renderSidebar({ serverStatus: 'disconnected', connectedClients: makeClients(2) })
+    expect(screen.queryByTestId('viewers-indicator')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('viewers-indicator-solo')).not.toBeInTheDocument()
   })
 
-  it('shows client count when server is connected', () => {
-    renderSidebar({ serverStatus: 'connected', clientCount: 2 })
-    expect(screen.getByTestId('sidebar-footer')).toHaveTextContent('2 clients')
+  it('shows the solo client count when only one device is connected', () => {
+    renderSidebar({ serverStatus: 'connected', connectedClients: makeClients(1) })
+    expect(screen.getByTestId('viewers-indicator-solo')).toHaveTextContent('1 client')
   })
 
   it('shows Stopped label when server is disconnected', () => {

--- a/packages/dashboard/src/components/Sidebar.tsx
+++ b/packages/dashboard/src/components/Sidebar.tsx
@@ -9,9 +9,10 @@ import type { CumulativeUsage, SessionInfo, SessionVisualStatus } from '@chroxy/
 import { formatCostBadge, formatCostBreakdown } from '@chroxy/store-core'
 import { ConversationSearch } from './ConversationSearch'
 import { ServerPicker } from './ServerPicker'
+import { ViewersIndicator } from './ViewersIndicator'
 import { SidebarPanelSlot, type SidebarPanelView, type SidebarPanelLauncher } from './SidebarPanelSlot'
 import { SidebarTokenView, tokenViewCollapsedMetric } from './SidebarTokenView'
-import type { SearchResult } from '../store/types'
+import type { SearchResult, ConnectedClient } from '../store/types'
 import {
   persistSidebarPanelHeight,
   persistSidebarPanelView,
@@ -68,7 +69,11 @@ export interface SidebarProps {
   filter: string
   serverStatus: 'connected' | 'disconnected' | 'reconnecting'
   tunnelUrl: string | null
-  clientCount: number
+  /** #5281 ①.3 — all clients attached to the daemon, for the shared-session
+      presence indicator in the footer. */
+  connectedClients: ConnectedClient[]
+  /** Active session's primary (last-driver) client id, or null. */
+  activePrimaryClientId: string | null
   onFilterChange: (value: string) => void
   onSessionClick: (sessionId: string) => void
   onResumeSession: (conversationId: string, cwd?: string) => void
@@ -118,7 +123,8 @@ export function Sidebar({
   filter,
   serverStatus,
   tunnelUrl,
-  clientCount,
+  connectedClients,
+  activePrimaryClientId,
   onFilterChange,
   onSessionClick,
   onResumeSession,
@@ -973,9 +979,14 @@ export function Sidebar({
                 {abbreviateTunnel(tunnelUrl)}
               </span>
             )}
-            {serverStatus === 'connected' && (
-              <span className="sidebar-client-count">{clientCount} client{clientCount !== 1 ? 's' : ''}</span>
-            )}
+            {/* #5281 ①.3 — shared-session presence. Renders the same plain
+                "N client(s)" text when solo, an interactive popover when the
+                session is genuinely shared (≥2 devices). */}
+            <ViewersIndicator
+              clients={connectedClients}
+              primaryClientId={activePrimaryClientId}
+              connected={serverStatus === 'connected'}
+            />
           </div>
         </>
       )}

--- a/packages/dashboard/src/components/SidebarCostBadge.test.tsx
+++ b/packages/dashboard/src/components/SidebarCostBadge.test.tsx
@@ -144,7 +144,7 @@ describe('Sidebar cost badge rendering (#4073)', () => {
       filter: '',
       serverStatus: 'connected' as const,
       tunnelUrl: null,
-      clientCount: 1,
+      connectedClients: [], activePrimaryClientId: null,
       onFilterChange: () => {},
       onSessionClick: () => {},
       onResumeSession: () => {},

--- a/packages/dashboard/src/components/SidebarKeyboard.test.tsx
+++ b/packages/dashboard/src/components/SidebarKeyboard.test.tsx
@@ -59,7 +59,7 @@ function renderSidebar(props: Partial<SidebarProps> = {}) {
     filter: '',
     serverStatus: 'connected',
     tunnelUrl: null,
-    clientCount: 1,
+    connectedClients: [], activePrimaryClientId: null,
     onFilterChange: noop,
     onSessionClick: noop,
     onResumeSession: noop,

--- a/packages/dashboard/src/components/SidebarReorder.test.tsx
+++ b/packages/dashboard/src/components/SidebarReorder.test.tsx
@@ -100,7 +100,7 @@ function renderSidebar(props: Partial<SidebarProps> = {}) {
     filter: '',
     serverStatus: 'connected',
     tunnelUrl: null,
-    clientCount: 0,
+    connectedClients: [], activePrimaryClientId: null,
     onFilterChange: noop,
     onSessionClick: noop,
     onResumeSession: noop,
@@ -669,7 +669,7 @@ describe('Sidebar reorder persistence (#4832)', () => {
           filter=""
           serverStatus="connected"
           tunnelUrl={null}
-          clientCount={0}
+          connectedClients={[]} activePrimaryClientId={null}
           onFilterChange={noop}
           onSessionClick={noop}
           onResumeSession={noop}

--- a/packages/dashboard/src/components/SidebarResize.test.tsx
+++ b/packages/dashboard/src/components/SidebarResize.test.tsx
@@ -27,7 +27,7 @@ const baseProps = {
   filter: '',
   serverStatus: 'connected' as const,
   tunnelUrl: null,
-  clientCount: 1,
+  connectedClients: [], activePrimaryClientId: null,
   onFilterChange: vi.fn(),
   onSessionClick: vi.fn(),
   onResumeSession: vi.fn(),

--- a/packages/dashboard/src/components/ViewersIndicator.test.tsx
+++ b/packages/dashboard/src/components/ViewersIndicator.test.tsx
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, fireEvent, cleanup } from '@testing-library/react'
-import { ViewersIndicator } from './ViewersIndicator'
+import { ViewersIndicator, resolveActivePrimaryClientId } from './ViewersIndicator'
 import type { ConnectedClient } from '../store/types'
 
 afterEach(cleanup)
@@ -154,5 +154,60 @@ describe('ViewersIndicator', () => {
     expect(screen.getByTestId('viewers-popover')).toBeInTheDocument()
     fireEvent.mouseDown(document.body)
     expect(screen.queryByTestId('viewers-popover')).not.toBeInTheDocument()
+  })
+
+  it('exposes the device count in the trigger title', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+        primaryClientId={null}
+      />,
+    )
+    expect(screen.getByTestId('viewers-indicator-trigger')).toHaveAttribute(
+      'title',
+      '2 clients sharing this session',
+    )
+  })
+
+  it('swaps the solo label for the interactive chip when a second device joins', () => {
+    const { rerender } = render(
+      <ViewersIndicator connected clients={[client({ clientId: 'c0', isSelf: true })]} primaryClientId={null} />,
+    )
+    expect(screen.getByTestId('viewers-indicator-solo')).toBeInTheDocument()
+    expect(screen.queryByTestId('viewers-indicator-trigger')).not.toBeInTheDocument()
+
+    rerender(
+      <ViewersIndicator
+        connected
+        clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+        primaryClientId={null}
+      />,
+    )
+    expect(screen.queryByTestId('viewers-indicator-solo')).not.toBeInTheDocument()
+    expect(screen.getByTestId('viewers-indicator-trigger')).toHaveTextContent('2')
+  })
+})
+
+describe('resolveActivePrimaryClientId', () => {
+  it('returns the active session\'s per-session primary', () => {
+    const states = { s1: { primaryClientId: 'c1' }, s2: { primaryClientId: 'c2' } }
+    expect(resolveActivePrimaryClientId('s1', states, 'cGlobal')).toBe('c1')
+  })
+
+  it('returns null (NOT the global) for a real session nobody has driven yet', () => {
+    // The #5281 ①.3 review fix: a never-driven real session must not inherit a
+    // stale global "drove last" from a different (default) routing context.
+    const states = { s1: { primaryClientId: null } }
+    expect(resolveActivePrimaryClientId('s1', states, 'cGlobal')).toBeNull()
+  })
+
+  it('returns null for an unknown active session id', () => {
+    expect(resolveActivePrimaryClientId('gone', {}, 'cGlobal')).toBeNull()
+  })
+
+  it('falls back to the global primary only when there is no active session', () => {
+    expect(resolveActivePrimaryClientId(null, {}, 'cGlobal')).toBe('cGlobal')
+    expect(resolveActivePrimaryClientId(null, {}, null)).toBeNull()
   })
 })

--- a/packages/dashboard/src/components/ViewersIndicator.test.tsx
+++ b/packages/dashboard/src/components/ViewersIndicator.test.tsx
@@ -128,7 +128,7 @@ describe('ViewersIndicator', () => {
     expect(screen.getByTestId('viewers-client-c1')).toHaveTextContent('Unknown device')
   })
 
-  it('closes the popover on Escape', () => {
+  it('gives the trigger an explicit accessible name (not just the count)', () => {
     render(
       <ViewersIndicator
         connected
@@ -136,10 +136,25 @@ describe('ViewersIndicator', () => {
         primaryClientId={null}
       />,
     )
-    fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+    expect(screen.getByTestId('viewers-indicator-trigger')).toHaveAccessibleName(
+      '2 clients sharing this session — show devices',
+    )
+  })
+
+  it('closes the popover on Escape and restores focus to the trigger', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+        primaryClientId={null}
+      />,
+    )
+    const trigger = screen.getByTestId('viewers-indicator-trigger')
+    fireEvent.click(trigger)
     expect(screen.getByTestId('viewers-popover')).toBeInTheDocument()
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(screen.queryByTestId('viewers-popover')).not.toBeInTheDocument()
+    expect(document.activeElement).toBe(trigger)
   })
 
   it('closes the popover on an outside click', () => {

--- a/packages/dashboard/src/components/ViewersIndicator.test.tsx
+++ b/packages/dashboard/src/components/ViewersIndicator.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * ViewersIndicator (#5281 ①.3) — shared-session presence surface tests.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen, fireEvent, cleanup } from '@testing-library/react'
+import { ViewersIndicator } from './ViewersIndicator'
+import type { ConnectedClient } from '../store/types'
+
+afterEach(cleanup)
+
+function client(overrides: Partial<ConnectedClient> = {}): ConnectedClient {
+  return {
+    clientId: 'c0',
+    deviceName: 'MacBook Pro',
+    deviceType: 'desktop',
+    platform: 'macos',
+    isSelf: false,
+    ...overrides,
+  }
+}
+
+describe('ViewersIndicator', () => {
+  it('renders nothing while disconnected', () => {
+    const { container } = render(
+      <ViewersIndicator connected={false} clients={[client(), client({ clientId: 'c1' })]} primaryClientId={null} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when there are zero clients', () => {
+    const { container } = render(
+      <ViewersIndicator connected clients={[]} primaryClientId={null} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders a plain, non-interactive label when solo (one device)', () => {
+    render(<ViewersIndicator connected clients={[client({ isSelf: true })]} primaryClientId={null} />)
+    expect(screen.getByTestId('viewers-indicator-solo')).toHaveTextContent('1 client')
+    // No interactive chip / popover trigger when solo.
+    expect(screen.queryByTestId('viewers-indicator-trigger')).not.toBeInTheDocument()
+  })
+
+  it('renders an interactive chip with the device count when shared (≥2)', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+        primaryClientId={null}
+      />,
+    )
+    const trigger = screen.getByTestId('viewers-indicator-trigger')
+    expect(trigger).toHaveTextContent('2')
+    // Popover is closed until clicked.
+    expect(screen.queryByTestId('viewers-popover')).not.toBeInTheDocument()
+  })
+
+  it('opens a popover listing each device on click', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[
+          client({ clientId: 'c0', deviceName: 'MacBook Pro', isSelf: true }),
+          client({ clientId: 'c1', deviceName: 'iPhone 17 Pro', deviceType: 'phone' }),
+        ]}
+        primaryClientId={null}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+    const popover = screen.getByTestId('viewers-popover')
+    expect(popover).toHaveTextContent('Shared session')
+    expect(screen.getByTestId('viewers-client-c0')).toHaveTextContent('MacBook Pro')
+    expect(screen.getByTestId('viewers-client-c1')).toHaveTextContent('iPhone 17 Pro')
+  })
+
+  it('tags the local device "This device"', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+        primaryClientId={null}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+    expect(screen.getByTestId('viewers-self-c0')).toHaveTextContent('This device')
+    expect(screen.queryByTestId('viewers-self-c1')).not.toBeInTheDocument()
+  })
+
+  it('tags the active session\'s primary client "drove last"', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+        primaryClientId="c1"
+      />,
+    )
+    fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+    expect(screen.getByTestId('viewers-primary-c1')).toHaveTextContent('drove last')
+    expect(screen.queryByTestId('viewers-primary-c0')).not.toBeInTheDocument()
+  })
+
+  it('shows no "drove last" tag when there is no primary yet', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+        primaryClientId={null}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+    expect(screen.queryByTestId('viewers-primary-c0')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('viewers-primary-c1')).not.toBeInTheDocument()
+  })
+
+  it('falls back to platform/deviceType when a device has no name', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[
+          client({ clientId: 'c0', deviceName: null, platform: 'linux', isSelf: true }),
+          client({ clientId: 'c1', deviceName: null, platform: '', deviceType: 'unknown' }),
+        ]}
+        primaryClientId={null}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+    expect(screen.getByTestId('viewers-client-c0')).toHaveTextContent('linux')
+    expect(screen.getByTestId('viewers-client-c1')).toHaveTextContent('Unknown device')
+  })
+
+  it('closes the popover on Escape', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+        primaryClientId={null}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+    expect(screen.getByTestId('viewers-popover')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('viewers-popover')).not.toBeInTheDocument()
+  })
+
+  it('closes the popover on an outside click', () => {
+    render(
+      <ViewersIndicator
+        connected
+        clients={[client({ clientId: 'c0', isSelf: true }), client({ clientId: 'c1' })]}
+        primaryClientId={null}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('viewers-indicator-trigger'))
+    expect(screen.getByTestId('viewers-popover')).toBeInTheDocument()
+    fireEvent.mouseDown(document.body)
+    expect(screen.queryByTestId('viewers-popover')).not.toBeInTheDocument()
+  })
+})

--- a/packages/dashboard/src/components/ViewersIndicator.tsx
+++ b/packages/dashboard/src/components/ViewersIndicator.tsx
@@ -88,7 +88,13 @@ export function ViewersIndicator({ clients, primaryClientId, connected }: Viewer
       setOpen(false)
     }
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') { e.stopPropagation(); setOpen(false) }
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setOpen(false)
+        // Restore focus to the trigger so a keyboard user isn't dropped to
+        // <body> after dismissing — matches the disclosure pattern elsewhere.
+        triggerRef.current?.focus()
+      }
     }
     const onBlur = () => setOpen(false)
     document.addEventListener('mousedown', onMouseDown, true)
@@ -128,6 +134,10 @@ export function ViewersIndicator({ clients, primaryClientId, connected }: Viewer
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={popoverId}
+        // The visible content is a decorative glyph + bare number, which a
+        // screen reader would announce as just "2" — give the control an
+        // explicit name describing what it does.
+        aria-label={`${countText} sharing this session — show devices`}
         title={`${countText} sharing this session`}
       >
         <span className="viewers-trigger-glyph" aria-hidden="true">{'\u{1F465}'}</span>

--- a/packages/dashboard/src/components/ViewersIndicator.tsx
+++ b/packages/dashboard/src/components/ViewersIndicator.tsx
@@ -1,0 +1,163 @@
+/**
+ * ViewersIndicator (#5281 ①.3) — shared-session presence surface.
+ *
+ * The chroxy daemon fans a single session out to every connected client, so a
+ * desktop and a phone (or a second collaborator) can watch and drive the same
+ * agent. This chip makes that visible from the sidebar footer: it shows how
+ * many devices are attached and, on click, lists them by name.
+ *
+ * The active session's "primary" client — the device that most recently sent
+ * input — is tagged "drove last". Primary is deliberately framed as a transient
+ * fact, NOT a fixed "you are in control" role: the server only rejects input
+ * with `input_conflict` while the agent is mid-request for another device;
+ * otherwise anyone can send and becomes the new primary (last-writer-wins, see
+ * input-handlers.js + ws-server._setPrimaryClient). Claiming a stable control
+ * role here would misrepresent that policy, so we don't.
+ *
+ * Solo (one device) renders the same plain "1 client" text the footer showed
+ * before this component existed — the interactive popover only appears once a
+ * session is genuinely shared (≥2 devices).
+ */
+import { useEffect, useId, useRef, useState } from 'react'
+import type { ConnectedClient } from '../store/types'
+
+export interface ViewersIndicatorProps {
+  /** All clients attached to the daemon (each carries isSelf + deviceType). */
+  clients: ConnectedClient[]
+  /**
+   * The active session's primary client id — the device that drove it last —
+   * used only to tag a row "drove last". Null when nobody has driven yet.
+   */
+  primaryClientId: string | null
+  /** Footer renders nothing useful while disconnected; mirrors the old gate. */
+  connected: boolean
+}
+
+function deviceGlyph(type: ConnectedClient['deviceType']): string {
+  switch (type) {
+    case 'phone': return '\u{1F4F1}'   // 📱
+    case 'tablet': return '\u{1F4DF}'  // 📟 (closest stock glyph)
+    case 'desktop': return '\u{1F5A5}' // 🖥
+    default: return '\u{1F310}'        // 🌐
+  }
+}
+
+function clientLabel(c: ConnectedClient): string {
+  if (c.deviceName) return c.deviceName
+  if (c.platform) return c.platform
+  if (c.deviceType !== 'unknown') return c.deviceType
+  return 'Unknown device'
+}
+
+export function ViewersIndicator({ clients, primaryClientId, connected }: ViewersIndicatorProps) {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const popoverId = useId()
+
+  // Dismiss the popover on outside-click (capturing mousedown, matching
+  // HeaderOverflowMenu / SessionContextMenu), Escape, and window blur.
+  useEffect(() => {
+    if (!open) return
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (popoverRef.current?.contains(target)) return
+      if (triggerRef.current?.contains(target)) return
+      setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { e.stopPropagation(); setOpen(false) }
+    }
+    const onBlur = () => setOpen(false)
+    document.addEventListener('mousedown', onMouseDown, true)
+    document.addEventListener('keydown', onKey)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown, true)
+      document.removeEventListener('keydown', onKey)
+      window.removeEventListener('blur', onBlur)
+    }
+  }, [open])
+
+  // Only meaningful while connected — mirrors the footer's pre-existing gate.
+  if (!connected) return null
+  const total = clients.length
+  if (total === 0) return null
+
+  const countText = `${total} client${total === 1 ? '' : 's'}`
+
+  // Solo: keep the plain, non-interactive label the footer always showed.
+  if (total < 2) {
+    return (
+      <span className="sidebar-client-count" data-testid="viewers-indicator-solo">
+        {countText}
+      </span>
+    )
+  }
+
+  const activePrimary = primaryClientId
+
+  return (
+    <div className="viewers-indicator sidebar-client-count" data-testid="viewers-indicator">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="viewers-trigger"
+        data-testid="viewers-indicator-trigger"
+        onClick={() => setOpen(p => !p)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={popoverId}
+        title={`${countText} sharing this session`}
+      >
+        <span className="viewers-trigger-glyph" aria-hidden="true">{'\u{1F465}'}</span>
+        <span className="viewers-trigger-count">{total}</span>
+      </button>
+      {open && (
+        <div
+          ref={popoverRef}
+          id={popoverId}
+          className="viewers-popover"
+          data-testid="viewers-popover"
+          role="dialog"
+          aria-label="Connected devices"
+        >
+          <div className="viewers-popover-header">
+            <strong>Shared session</strong>
+            <p className="viewers-popover-sub">
+              Everyone here sees the same output. The agent handles one request at
+              a time — if it's busy, other devices wait.
+            </p>
+          </div>
+          <ul className="viewers-list">
+            {clients.map(c => {
+              const isPrimary = !!activePrimary && c.clientId === activePrimary
+              return (
+                <li
+                  key={c.clientId}
+                  className="viewers-client-row"
+                  data-testid={`viewers-client-${c.clientId}`}
+                >
+                  <span className="viewers-client-glyph" aria-hidden="true">
+                    {deviceGlyph(c.deviceType)}
+                  </span>
+                  <span className="viewers-client-name">{clientLabel(c)}</span>
+                  {c.isSelf && (
+                    <span className="viewers-tag viewers-tag-self" data-testid={`viewers-self-${c.clientId}`}>
+                      This device
+                    </span>
+                  )}
+                  {isPrimary && (
+                    <span className="viewers-tag viewers-tag-primary" data-testid={`viewers-primary-${c.clientId}`}>
+                      drove last
+                    </span>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/dashboard/src/components/ViewersIndicator.tsx
+++ b/packages/dashboard/src/components/ViewersIndicator.tsx
@@ -49,6 +49,28 @@ function clientLabel(c: ConnectedClient): string {
   return 'Unknown device'
 }
 
+/**
+ * Resolve the "drove last" client id for the footer indicator.
+ *
+ * The server routes `primary_changed` to two distinct slots: a real session's
+ * primary lands on that session's per-session `primaryClientId`, while the
+ * default / no-session context lands on the global one (see
+ * store-core handlers/index.ts + message-handler primary_changed). So when a
+ * real session is active we MUST read only its per-session value (null when
+ * nobody has driven it yet) — falling back to the global there would surface a
+ * stale "drove last" from a different context on a session no one has driven
+ * (#5281 ①.3 review). The global is the right answer only for the
+ * pre-session / 'default' view.
+ */
+export function resolveActivePrimaryClientId(
+  activeSessionId: string | null,
+  sessionStates: Record<string, { primaryClientId: string | null }>,
+  globalPrimaryClientId: string | null,
+): string | null {
+  if (activeSessionId) return sessionStates[activeSessionId]?.primaryClientId ?? null
+  return globalPrimaryClientId
+}
+
 export function ViewersIndicator({ clients, primaryClientId, connected }: ViewersIndicatorProps) {
   const [open, setOpen] = useState(false)
   const triggerRef = useRef<HTMLButtonElement>(null)
@@ -87,15 +109,13 @@ export function ViewersIndicator({ clients, primaryClientId, connected }: Viewer
   const countText = `${total} client${total === 1 ? '' : 's'}`
 
   // Solo: keep the plain, non-interactive label the footer always showed.
-  if (total < 2) {
+  if (total === 1) {
     return (
       <span className="sidebar-client-count" data-testid="viewers-indicator-solo">
         {countText}
       </span>
     )
   }
-
-  const activePrimary = primaryClientId
 
   return (
     <div className="viewers-indicator sidebar-client-count" data-testid="viewers-indicator">
@@ -120,6 +140,7 @@ export function ViewersIndicator({ clients, primaryClientId, connected }: Viewer
           className="viewers-popover"
           data-testid="viewers-popover"
           role="dialog"
+          aria-modal="false"
           aria-label="Connected devices"
         >
           <div className="viewers-popover-header">
@@ -131,7 +152,7 @@ export function ViewersIndicator({ clients, primaryClientId, connected }: Viewer
           </div>
           <ul className="viewers-list">
             {clients.map(c => {
-              const isPrimary = !!activePrimary && c.clientId === activePrimary
+              const isPrimary = !!primaryClientId && c.clientId === primaryClientId
               return (
                 <li
                   key={c.clientId}

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1436,6 +1436,112 @@ button.sidebar-token-view-session-row:hover {
   margin-left: auto;
 }
 
+/* #5281 ①.3 — shared-session presence indicator (sidebar footer) */
+.viewers-indicator {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.viewers-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 6px;
+  border: 1px solid var(--border-primary);
+  border-radius: 10px;
+  background: var(--bg-secondary, transparent);
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.viewers-trigger:hover {
+  background: var(--bg-hover, var(--border-primary));
+  color: var(--text-primary);
+}
+
+.viewers-trigger-glyph {
+  font-size: 11px;
+}
+
+.viewers-trigger-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.viewers-popover {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  right: 0;
+  z-index: 50;
+  width: 240px;
+  padding: 10px;
+  background: var(--bg-elevated, var(--bg-secondary));
+  border: 1px solid var(--border-primary);
+  border-radius: 8px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.3);
+  color: var(--text-primary);
+}
+
+.viewers-popover-header strong {
+  font-size: 12px;
+}
+
+.viewers-popover-sub {
+  margin: 4px 0 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.viewers-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.viewers-client-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.viewers-client-glyph {
+  flex-shrink: 0;
+}
+
+.viewers-client-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.viewers-tag {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.viewers-tag-self {
+  background: var(--border-primary);
+  color: var(--text-secondary);
+}
+
+.viewers-tag-primary {
+  background: var(--accent-muted, var(--border-primary));
+  color: var(--accent, var(--text-primary));
+}
+
 /* ---- Session Bar ---- */
 .session-bar {
   display: flex;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -1503,6 +1503,9 @@ button.sidebar-token-view-session-row:hover {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  /* Cap a large roster so the popover can't grow unbounded. */
+  max-height: 220px;
+  overflow-y: auto;
 }
 
 .viewers-client-row {


### PR DESCRIPTION
## Context

Part of the LAN-client epic #5281, milestone **①.3** (shared-session join UX). The chroxy daemon already fans a single session out to every connected client (multi-client broadcast, history replay, primary tracking — all server-side done). The dashboard's only surface for this was a plain "N clients" count buried in the sidebar footer.

This PR adds the human-facing **presence** half: making it visible *who* is sharing a session.

## What it does

`ViewersIndicator` in the sidebar footer:
- **Solo** (one device): keeps the same plain `N client(s)` label the footer always showed — no new chrome.
- **Shared** (≥2 devices): becomes an interactive chip (`👥 N`) that opens a popover listing each device by name, tagging:
  - the local device → **"This device"**
  - the active session's primary → **"drove last"**

### Honest about the model
"drove last" is deliberately **not** framed as a stable "you are in control" role. The server (`input-handlers.js` + `ws-server._setPrimaryClient`) only rejects input with `input_conflict` *while the agent is mid-request for another device*; otherwise anyone can send and becomes the new primary (last-writer-wins). A persistent "in control" badge would misrepresent that policy, so the copy stays factual ("drove last") and the popover explains: *"The agent handles one request at a time — if it's busy, other devices wait."*

## Design

- `ViewersIndicator` is a **pure presentational component** (props in, no store coupling) — trivially unit-testable, and keeps `Sidebar` prop-driven (consistent with its existing test architecture).
- `Sidebar`'s `clientCount: number` prop is replaced with `connectedClients: ConnectedClient[]` + `activePrimaryClientId: string | null`. `App` derives the active session's primary (per-session `primaryClientId`, global fallback).
- Dismiss pattern (capturing mousedown / Escape / window blur) mirrors `HeaderOverflowMenu` / `SessionContextMenu`.

## Tests

- New `ViewersIndicator.test.tsx` (11 cases): disconnected/zero → null; solo label; shared chip + count; popover device list; "This device" / "drove last" tags; no-primary case; name fallback to platform/deviceType; Escape + outside-click dismiss.
- Updated `Sidebar` tests (+ sibling Sidebar test files) for the new props; viewer-count coverage relocated to the new component test.
- Full dashboard suite green (3213); `tsc --noEmit` clean.

## Scope / follow-ups

This is the **presence** slice of ①.3. The remaining ①.3 work — surfacing `input_conflict` legibly when a send is rejected, and the live desktop↔host e2e verification — needs coordination with the `no-it-all` client and is tracked separately under the epic.