### PR TITLE
feat(dashboard): legible input_conflict feedback for shared sessions

### DIFF
--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -496,6 +496,7 @@ describe('dashboard message-handler dispatch', () => {
           s1: {
             ...createEmptySessionState(),
             messages: [
+              { id: 'older', type: 'user_input', content: 'earlier', timestamp: 0 },
               { id: 'user-123', type: 'user_input', content: 'hi', timestamp: 1 },
               { id: 'thinking', type: 'thinking', content: '', timestamp: 2 },
             ],
@@ -505,27 +506,46 @@ describe('dashboard message-handler dispatch', () => {
       }))
       setStore(store)
 
+      const reason = 'Session is already processing input from another device. Wait for it to finish or interrupt first.';
       handleMessage(
         {
           type: 'session_error',
           category: 'input_conflict',
           sessionId: 's1',
           clientMessageId: 'user-123',
-          message: 'Session is already processing input from another device. Wait for it to finish or interrupt first.',
+          message: reason,
         },
         ctx() as any,
       )
 
       const state = store.getState() as any
-      // Calm info notice, not a red error.
+      // Calm info notice (the server's specific reason), not a red error.
       expect(state.serverErrors).toEqual([])
-      expect(state._infoNotifications).toHaveLength(1)
-      expect(String(state._infoNotifications[0])).toMatch(/another device is driving/i)
-      // The stranded optimistic user message + thinking spinner are gone.
+      expect(state._infoNotifications).toEqual([reason])
+      // The stranded optimistic user message + thinking spinner are gone…
       const ss = state.sessionStates.s1
       expect(ss.messages.find((m: any) => m.id === 'user-123')).toBeUndefined()
       expect(ss.messages.find((m: any) => m.type === 'thinking')).toBeUndefined()
       expect(ss.streamingMessageId).toBeNull()
+      // …but only the rejected send — prior real messages are untouched.
+      expect(ss.messages.find((m: any) => m.id === 'older')).toBeDefined()
+    })
+
+    it('shows the evaluator-lock reason verbatim (not the cross-device copy)', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: { s1: { ...createEmptySessionState(), messages: [] } },
+      }))
+      setStore(store)
+
+      const evalReason = 'Session is already evaluating a previous draft. Wait for it to finish or interrupt first.';
+      handleMessage(
+        { type: 'session_error', category: 'input_conflict', sessionId: 's1', message: evalReason },
+        ctx() as any,
+      )
+
+      expect((store.getState() as any)._infoNotifications).toEqual([evalReason])
+      expect((store.getState() as any).serverErrors).toEqual([])
     })
 
     it('input_conflict still clears the spinner when the server omits clientMessageId', () => {

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -531,6 +531,61 @@ describe('dashboard message-handler dispatch', () => {
       expect(ss.messages.find((m: any) => m.id === 'older')).toBeDefined()
     })
 
+    it('cleans up root-level (CLI single-session) store mode too', () => {
+      // No active session / no sessionStates entry — addUserMessage put the
+      // optimistic send on the top-level messages/streamingMessageId.
+      store = createMockStore(baseState({
+        activeSessionId: null,
+        sessionStates: {},
+        messages: [
+          { id: 'user-7', type: 'user_input', content: 'hi', timestamp: 1 },
+          { id: 'thinking', type: 'thinking', content: '', timestamp: 2 },
+        ],
+        streamingMessageId: 'pending',
+      }))
+      setStore(store)
+
+      handleMessage(
+        { type: 'session_error', category: 'input_conflict', clientMessageId: 'user-7', message: 'busy' },
+        ctx() as any,
+      )
+
+      const state = store.getState() as any
+      expect(state.messages.find((m: any) => m.id === 'user-7')).toBeUndefined()
+      expect(state.messages.find((m: any) => m.type === 'thinking')).toBeUndefined()
+      expect(state.streamingMessageId).toBeNull()
+      expect(state.serverErrors).toEqual([])
+    })
+
+    it('only drops the rejected user_input, never a colliding message of another type', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            messages: [
+              // A non-user_input message that happens to share the rejected id.
+              { id: 'dup', type: 'tool_use', content: 'ls', timestamp: 1 },
+              { id: 'thinking', type: 'thinking', content: '', timestamp: 2 },
+            ],
+            streamingMessageId: 'pending',
+          },
+        },
+      }))
+      setStore(store)
+
+      handleMessage(
+        { type: 'session_error', category: 'input_conflict', sessionId: 's1', clientMessageId: 'dup', message: 'busy' },
+        ctx() as any,
+      )
+
+      const ss = (store.getState() as any).sessionStates.s1
+      // The tool_use at the colliding id survives; only the spinner cleared.
+      expect(ss.messages.find((m: any) => m.id === 'dup' && m.type === 'tool_use')).toBeDefined()
+      expect(ss.messages.find((m: any) => m.type === 'thinking')).toBeUndefined()
+      expect(ss.streamingMessageId).toBeNull()
+    })
+
     it('shows the evaluator-lock reason verbatim (not the cross-device copy)', () => {
       store = createMockStore(baseState({
         activeSessionId: 's1',

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -486,6 +486,77 @@ describe('dashboard message-handler dispatch', () => {
       expect(state.serverErrors).toEqual(['session failed'])
     })
 
+    // #5281 ①.3 — input_conflict is an expected shared-session event, not a
+    // failure. It must NOT raise the red serverError / modal alert the generic
+    // branch uses, and must clean up the optimistic send the server refused.
+    it('routes input_conflict to a calm notice and removes the stranded optimistic send', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            messages: [
+              { id: 'user-123', type: 'user_input', content: 'hi', timestamp: 1 },
+              { id: 'thinking', type: 'thinking', content: '', timestamp: 2 },
+            ],
+            streamingMessageId: 'pending',
+          },
+        },
+      }))
+      setStore(store)
+
+      handleMessage(
+        {
+          type: 'session_error',
+          category: 'input_conflict',
+          sessionId: 's1',
+          clientMessageId: 'user-123',
+          message: 'Session is already processing input from another device. Wait for it to finish or interrupt first.',
+        },
+        ctx() as any,
+      )
+
+      const state = store.getState() as any
+      // Calm info notice, not a red error.
+      expect(state.serverErrors).toEqual([])
+      expect(state._infoNotifications).toHaveLength(1)
+      expect(String(state._infoNotifications[0])).toMatch(/another device is driving/i)
+      // The stranded optimistic user message + thinking spinner are gone.
+      const ss = state.sessionStates.s1
+      expect(ss.messages.find((m: any) => m.id === 'user-123')).toBeUndefined()
+      expect(ss.messages.find((m: any) => m.type === 'thinking')).toBeUndefined()
+      expect(ss.streamingMessageId).toBeNull()
+    })
+
+    it('input_conflict still clears the spinner when the server omits clientMessageId', () => {
+      store = createMockStore(baseState({
+        activeSessionId: 's1',
+        sessionStates: {
+          s1: {
+            ...createEmptySessionState(),
+            messages: [
+              { id: 'user-9', type: 'user_input', content: 'hi', timestamp: 1 },
+              { id: 'thinking', type: 'thinking', content: '', timestamp: 2 },
+            ],
+            streamingMessageId: 'pending',
+          },
+        },
+      }))
+      setStore(store)
+
+      handleMessage(
+        { type: 'session_error', category: 'input_conflict', sessionId: 's1', message: 'busy' },
+        ctx() as any,
+      )
+
+      const ss = (store.getState() as any).sessionStates.s1
+      // Without the echoed id the ghost message can't be removed, but the
+      // spinner must still clear (no perpetual "thinking").
+      expect(ss.messages.find((m: any) => m.type === 'thinking')).toBeUndefined()
+      expect(ss.streamingMessageId).toBeNull()
+      expect((store.getState() as any).serverErrors).toEqual([])
+    })
+
     // Issue #2904: bound-token error should be rewritten to something
     // actionable that names the session instead of the raw "Not authorized".
     it('rewrites SESSION_TOKEN_MISMATCH with bound session name into an actionable hint', () => {

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2505,6 +2505,30 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           _adapters.alert.alert('Session Restarted', parsed.message);
           get().addServerError(parsed.message);
         }
+      } else if (parsed.category === 'input_conflict') {
+        // #5281 ①.3 — a shared-session collaboration event, NOT a failure:
+        // another device's request is mid-flight on this session, so the
+        // server refused this send. The generic branch below would raise a
+        // modal alert + red serverError, which is the wrong register for an
+        // expected "someone else is driving" outcome. Instead: drop the
+        // stranded optimistic user message (its send was rejected) + its
+        // thinking spinner, and surface a calm, transient notice.
+        const conflictSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : get().activeSessionId;
+        const rejectedId = typeof msg.clientMessageId === 'string' && msg.clientMessageId.length > 0
+          ? msg.clientMessageId
+          : null;
+        if (conflictSessionId && get().sessionStates[conflictSessionId]) {
+          updateSession(conflictSessionId, (ss) => ({
+            // filterThinking drops the spinner immediately (no 5s safety-net
+            // wait); the id filter removes the ghost send when the server
+            // echoed which message it rejected.
+            messages: filterThinking(ss.messages).filter((m) => (rejectedId ? m.id !== rejectedId : true)),
+            streamingMessageId: ss.streamingMessageId === 'pending' ? null : ss.streamingMessageId,
+          }));
+        }
+        get().addInfoNotification(
+          'Another device is driving this session right now — your message wasn’t sent. Wait for it to finish, or interrupt the current run.',
+        );
       } else if (parsed.message) {
         _adapters.alert.alert('Session Error', parsed.message);
         get().addServerError(parsed.message);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2523,13 +2523,26 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
         const rejectedId = typeof msg.clientMessageId === 'string' && msg.clientMessageId.length > 0
           ? msg.clientMessageId
           : null;
+        // filterThinking drops the spinner immediately (no 5s safety-net wait);
+        // the id filter removes the ghost send when the server echoed which
+        // message it rejected — but ONLY the optimistic user_input at that id,
+        // never a colliding message of another type.
+        const dropGhost = (messages: ChatMessage[]) =>
+          filterThinking(messages).filter(
+            (m) => !(rejectedId && m.id === rejectedId && m.type === 'user_input'),
+          );
         if (conflictSessionId && get().sessionStates[conflictSessionId]) {
           updateSession(conflictSessionId, (ss) => ({
-            // filterThinking drops the spinner immediately (no 5s safety-net
-            // wait); the id filter removes the ghost send when the server
-            // echoed which message it rejected.
-            messages: filterThinking(ss.messages).filter((m) => (rejectedId ? m.id !== rejectedId : true)),
+            messages: dropGhost(ss.messages),
             streamingMessageId: ss.streamingMessageId === 'pending' ? null : ss.streamingMessageId,
+          }));
+        } else {
+          // Root-level (CLI single-session) store mode: addUserMessage put the
+          // optimistic entry on the top-level messages/streamingMessageId, so
+          // clean those instead of a per-session slot.
+          set((state: ConnectionState) => ({
+            messages: dropGhost(state.messages),
+            streamingMessageId: state.streamingMessageId === 'pending' ? null : state.streamingMessageId,
           }));
         }
         // Prefer the server's specific reason (cross-device vs evaluator lock);

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2506,13 +2506,19 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           get().addServerError(parsed.message);
         }
       } else if (parsed.category === 'input_conflict') {
-        // #5281 ①.3 — a shared-session collaboration event, NOT a failure:
-        // another device's request is mid-flight on this session, so the
-        // server refused this send. The generic branch below would raise a
-        // modal alert + red serverError, which is the wrong register for an
-        // expected "someone else is driving" outcome. Instead: drop the
-        // stranded optimistic user message (its send was rejected) + its
-        // thinking spinner, and surface a calm, transient notice.
+        // #5281 ①.3 — an expected "can't send right now" event, NOT a failure:
+        // either another device's request is mid-flight, or this session is
+        // still evaluating a previous draft. The generic branch below would
+        // raise a modal alert + red serverError, which is the wrong register.
+        // Instead: drop the stranded optimistic user message (its send was
+        // rejected) + its thinking spinner, and surface a calm, transient
+        // notice using the server's specific reason.
+        //
+        // sessionId resolution leans on the invariant that the dashboard only
+        // ever sends to (and optimistically records on) its active session —
+        // sendInput sets payload.sessionId = activeSessionId — so the echoed
+        // sessionId is where the ghost lives. Revisit if a multi-session send
+        // path is ever added.
         const conflictSessionId = typeof msg.sessionId === 'string' ? msg.sessionId : get().activeSessionId;
         const rejectedId = typeof msg.clientMessageId === 'string' && msg.clientMessageId.length > 0
           ? msg.clientMessageId
@@ -2526,8 +2532,10 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
             streamingMessageId: ss.streamingMessageId === 'pending' ? null : ss.streamingMessageId,
           }));
         }
+        // Prefer the server's specific reason (cross-device vs evaluator lock);
+        // fall back to a variant-neutral notice for an older server.
         get().addInfoNotification(
-          'Another device is driving this session right now — your message wasn’t sent. Wait for it to finish, or interrupt the current run.',
+          parsed.message || 'Your message wasn’t sent — the session is busy. Wait for it to finish, or interrupt the current run.',
         );
       } else if (parsed.message) {
         _adapters.alert.alert('Session Error', parsed.message);

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -117,6 +117,29 @@ function resolveUserInputId(candidate) {
   return candidate
 }
 
+// #5281 ①.3 — a shared-session input_conflict rejection: the session is busy
+// processing another device's request. Echo the session and the rejected
+// clientMessageId (when well-formed) so the dashboard can remove the stranded
+// optimistic user message + clear its thinking spinner, instead of leaving a
+// ghost send in the transcript behind a calm "another device is driving" notice.
+function buildInputConflictError(sessionId, clientMessageId) {
+  const err = {
+    type: 'session_error',
+    category: 'input_conflict',
+    message: 'Session is already processing input from another device. Wait for it to finish or interrupt first.',
+    sessionId,
+  }
+  if (
+    typeof clientMessageId === 'string' &&
+    clientMessageId.length > 0 &&
+    clientMessageId.length <= MAX_CLIENT_MESSAGE_ID_LEN &&
+    USER_INPUT_ID_RE.test(clientMessageId)
+  ) {
+    err.clientMessageId = clientMessageId
+  }
+  return err
+}
+
 async function handleInput(ws, client, msg, ctx) {
   const text = msg.data
   let attachments = Array.isArray(msg.attachments) ? msg.attachments : undefined
@@ -260,11 +283,7 @@ async function handleInput(ws, client, msg, ctx) {
   if (entry.session.isRunning) {
     const primaryClientId = ctx.primaryClients.get(targetSessionId)
     if (primaryClientId && primaryClientId !== client.id) {
-      ctx.send(ws, {
-        type: 'session_error',
-        category: 'input_conflict',
-        message: 'Session is already processing input from another device. Wait for it to finish or interrupt first.',
-      })
+      ctx.send(ws, buildInputConflictError(targetSessionId, msg.clientMessageId))
       return
     }
   }
@@ -401,11 +420,7 @@ async function handleInput(ws, client, msg, ctx) {
       if (entry.session.isRunning) {
         const primaryClientId = ctx.primaryClients.get(targetSessionId)
         if (primaryClientId && primaryClientId !== client.id) {
-          ctx.send(ws, {
-            type: 'session_error',
-            category: 'input_conflict',
-            message: 'Session is already processing input from another device. Wait for it to finish or interrupt first.',
-          })
+          ctx.send(ws, buildInputConflictError(targetSessionId, msg.clientMessageId))
           return
         }
       }

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -117,23 +117,32 @@ function resolveUserInputId(candidate) {
   return candidate
 }
 
-// #5281 ①.3 — a shared-session input_conflict rejection: the session is busy
-// processing another device's request. Echo the session and the rejected
-// clientMessageId (when well-formed) so the dashboard can remove the stranded
-// optimistic user message + clear its thinking spinner, instead of leaving a
-// ghost send in the transcript behind a calm "another device is driving" notice.
-function buildInputConflictError(sessionId, clientMessageId) {
+// #5281 ①.3 — an input_conflict rejection: the session can't accept this send
+// right now (busy with another device's request, or still evaluating a previous
+// draft on the same session). Echo the session and the rejected clientMessageId
+// (when well-formed) so the dashboard can remove the stranded optimistic user
+// message + clear its thinking spinner instead of leaving a ghost send behind a
+// calm notice. `message` carries the specific reason so the dashboard can show
+// it verbatim (cross-device vs same-session evaluator lock differ).
+const INPUT_CONFLICT_CROSS_DEVICE_MESSAGE =
+  'Session is already processing input from another device. Wait for it to finish or interrupt first.'
+function buildInputConflictError(sessionId, clientMessageId, message = INPUT_CONFLICT_CROSS_DEVICE_MESSAGE) {
   const err = {
     type: 'session_error',
     category: 'input_conflict',
-    message: 'Session is already processing input from another device. Wait for it to finish or interrupt first.',
+    message,
     sessionId,
   }
+  // Echo only a well-formed id. Mirror resolveUserInputId's guards (incl. the
+  // reserved-id exclusion) so we never reflect a value the history path itself
+  // would have regenerated — keeps the echoed id consistent with the recorded
+  // one and avoids reflecting a reserved placeholder like 'thinking'.
   if (
     typeof clientMessageId === 'string' &&
     clientMessageId.length > 0 &&
     clientMessageId.length <= MAX_CLIENT_MESSAGE_ID_LEN &&
-    USER_INPUT_ID_RE.test(clientMessageId)
+    USER_INPUT_ID_RE.test(clientMessageId) &&
+    !RESERVED_USER_INPUT_IDS.has(clientMessageId)
   ) {
     err.clientMessageId = clientMessageId
   }
@@ -299,11 +308,11 @@ async function handleInput(ws, client, msg, ctx) {
   // matches the #3636 design.
   const _pendingAwaits = _getEvaluatorAwaits(ctx)
   if (_pendingAwaits.has(targetSessionId)) {
-    ctx.send(ws, {
-      type: 'session_error',
-      category: 'input_conflict',
-      message: 'Session is already evaluating a previous draft. Wait for it to finish or interrupt first.',
-    })
+    ctx.send(ws, buildInputConflictError(
+      targetSessionId,
+      msg.clientMessageId,
+      'Session is already evaluating a previous draft. Wait for it to finish or interrupt first.',
+    ))
     return
   }
 

--- a/packages/server/tests/input-conflict.test.js
+++ b/packages/server/tests/input-conflict.test.js
@@ -98,6 +98,33 @@ describe('cross-device input echo (#1119)', () => {
       assert.equal(ctx._spies.broadcast.callCount, 0)
     })
 
+    it('#5281: echoes the session id and rejected clientMessageId so the dashboard can clean up', async () => {
+      ws = {}
+      const clientB = { id: 'client-B', activeSessionId: 'sess-1' }
+      const msg = { type: 'input', data: 'conflicting input', sessionId: 'sess-1', clientMessageId: 'user-123' }
+      await handleSessionMessage(ws, clientB, msg, ctx)
+
+      const errorMsg = ctx._spies.send.calls.find(c => c[1]?.type === 'session_error')
+      assert.ok(errorMsg)
+      assert.equal(errorMsg[1].category, 'input_conflict')
+      assert.equal(errorMsg[1].sessionId, 'sess-1')
+      assert.equal(errorMsg[1].clientMessageId, 'user-123')
+    })
+
+    it('#5281: does not echo a malformed clientMessageId', async () => {
+      ws = {}
+      const clientB = { id: 'client-B', activeSessionId: 'sess-1' }
+      const msg = { type: 'input', data: 'conflicting input', sessionId: 'sess-1', clientMessageId: 'bad id with spaces!' }
+      await handleSessionMessage(ws, clientB, msg, ctx)
+
+      const errorMsg = ctx._spies.send.calls.find(c => c[1]?.type === 'session_error')
+      assert.ok(errorMsg)
+      assert.equal(errorMsg[1].category, 'input_conflict')
+      // Session id still echoed; the malformed id is dropped rather than reflected.
+      assert.equal(errorMsg[1].sessionId, 'sess-1')
+      assert.equal(errorMsg[1].clientMessageId, undefined)
+    })
+
     it('allows input from the same client even when busy', async () => {
       ws = {}
       const clientA = { id: 'client-A', activeSessionId: 'sess-1' }


### PR DESCRIPTION
## Context

Part of the LAN-client epic #5281, milestone **①.3**. Continues [#5291](https://github.com/blamechris/chroxy/pull/5291) (the presence indicator).

When the agent is mid-request for one device, a **second** device's send is rejected by the server with `session_error` / `category: 'input_conflict'`. This is an expected shared-session collaboration outcome — but the dashboard treated it as a hard failure:

- a modal **"Session Error" alert** + a red `serverError` banner entry, and
- the **optimistic user message was left stranded** in the transcript (the 5s `addUserMessage` safety net cleared only the thinking spinner, not the ghost send).

## Changes

**Server — `input-handlers.js`**
- The two `input_conflict` rejection sites now go through a shared `buildInputConflictError(sessionId, clientMessageId)` helper that echoes the **session id** and the **rejected `clientMessageId`** (only when well-formed — reuses the existing `USER_INPUT_ID_RE` / length guards), so the client can correlate the rejection to its optimistic entry.

**Dashboard — `message-handler.ts`**
- A dedicated `input_conflict` branch in the `session_error` handler:
  - drops the stranded optimistic user message (by echoed id) **and** its thinking spinner immediately (no 5s wait),
  - surfaces a calm, transient **info notice** ("Another device is driving this session right now — your message wasn't sent. Wait for it to finish, or interrupt the current run.") via `addInfoNotification`,
  - **no** modal alert, **no** red `serverError`.
  - Degrades gracefully: if an older server doesn't echo `clientMessageId`, the spinner still clears (the ghost message just can't be removed).

## Why a calm notice (not an error)
The server's primary is last-writer-wins and `input_conflict` only fires while the session `isRunning` another device's request — it's a normal "someone else is driving right now" outcome, consistent with the framing in #5291's presence indicator. Treating it as a red error misrepresents that.

## Tests
- **Server** (`input-conflict.test.js`): rejection echoes `sessionId` + `clientMessageId`; a malformed id is dropped, not reflected. (96 input/handler tests green)
- **Dashboard** (`message-handler.test.ts`): input_conflict → calm info notice, no serverError, optimistic message + spinner removed; graceful spinner-clear when the id is omitted.
- Full dashboard suite green (3222); `tsc --noEmit` clean.