### PR TITLE
feat(desktop): summon hotkey + Show Chroxy tray item

### DIFF
--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-process",
  "tauri-plugin-shell",
@@ -1583,6 +1584,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "gobject-sys"
@@ -4238,6 +4257,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6154,6 +6188,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-dialog = "2"
 base64 = "0.22"
 tauri-plugin-window-state = "2"
+tauri-plugin-global-shortcut = "2"
 tokio = { version = "1", features = ["sync"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -688,12 +688,9 @@ pub fn run() {
     {
         builder = builder.plugin(single_instance_init(
             |app: &tauri::AppHandle, _args, _cwd| {
-                // Second instance launched: focus the existing main window.
-                if let Some(win) = app.get_webview_window("main") {
-                    let _ = win.unminimize();
-                    let _ = win.show();
-                    let _ = win.set_focus();
-                }
+                // Second instance launched: bring the existing main window
+                // forward. Shares the one summon path so the two can't drift.
+                window::show_window(app);
             },
         ));
     }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -710,6 +710,19 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
+        // #5281 ② — global "summon" shortcut. Any registered shortcut (we only
+        // ever register the one summon accelerator) brings the main window
+        // forward. Registration is opt-in via DesktopSettings.summon_hotkey,
+        // done in setup() below.
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(|app, _shortcut, event| {
+                    if event.state() == tauri_plugin_global_shortcut::ShortcutState::Pressed {
+                        window::show_window(app);
+                    }
+                })
+                .build(),
+        )
         .invoke_handler(tauri::generate_handler![
             get_server_info,
             get_server_logs,
@@ -1198,6 +1211,17 @@ pub fn run() {
 
             setup_tray(app)?;
 
+            // #5281 ② — register the opt-in global summon hotkey, if configured.
+            {
+                let settings = app.state::<Mutex<DesktopSettings>>();
+                let settings_guard = lock_or_recover(&settings);
+                let accel = settings_guard.effective_summon_hotkey();
+                drop(settings_guard);
+                if let Some(accel) = accel {
+                    register_summon_hotkey(app.handle(), &accel);
+                }
+            }
+
             // Auto-start server on launch if configured (skip on first run — wizard handles it)
             if !is_first_run {
                 let settings = app.state::<Mutex<DesktopSettings>>();
@@ -1278,7 +1302,22 @@ pub fn run() {
         });
 }
 
+/// Register the opt-in global summon shortcut. Best-effort: a malformed
+/// accelerator or an OS-level conflict is logged, never fatal — the tray
+/// "Show Chroxy" item is always available as a fallback. (#5281 ②)
+fn register_summon_hotkey(app: &tauri::AppHandle, accelerator: &str) {
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+    match app.global_shortcut().register(accelerator) {
+        Ok(()) => eprintln!("[hotkey] summon shortcut registered: {}", accelerator),
+        Err(e) => eprintln!("[hotkey] failed to register summon shortcut '{}': {}", accelerator, e),
+    }
+}
+
 fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    // #5281 ② — always-available "summon" affordance: bring the main window
+    // forward from the tray, regardless of server state or any global hotkey.
+    let show_window_item =
+        MenuItemBuilder::with_id("show_window", "Show Chroxy").build(app)?;
     let start = MenuItemBuilder::with_id("start", "Start Server").build(app)?;
     let stop = MenuItemBuilder::with_id("stop", "Stop Server")
         .enabled(false)
@@ -1335,6 +1374,8 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let quit = MenuItemBuilder::with_id("quit", "Quit Chroxy").build(app)?;
 
     let menu = MenuBuilder::new(app)
+        .items(&[&show_window_item])
+        .separator()
         .items(&[&start, &stop, &restart])
         .separator()
         .items(&[&dashboard, &console, &show_qr])
@@ -1380,6 +1421,7 @@ fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .on_menu_event(move |app, event| {
             let id = event.id().as_ref();
             match id {
+                "show_window" => window::show_window(app),
                 "start" => handle_start(app),
                 "stop" => handle_stop(app),
                 "restart" => handle_restart(app),

--- a/packages/desktop/src-tauri/src/settings.rs
+++ b/packages/desktop/src-tauri/src/settings.rs
@@ -22,6 +22,13 @@ pub struct DesktopSettings {
     pub last_window_width: Option<f64>,
     #[serde(default)]
     pub last_window_height: Option<f64>,
+    /// Global "summon" hotkey accelerator (Tauri syntax, e.g.
+    /// "CmdOrCtrl+Shift+K"). #5281 ② — opt-in: `None` (the default) registers
+    /// NO global shortcut, so chroxy never silently steals a chord from another
+    /// app. The always-available "Show Chroxy" tray item is the baseline
+    /// summon; this is for users who want a system-wide one.
+    #[serde(default)]
+    pub summon_hotkey: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -43,6 +50,7 @@ impl Default for DesktopSettings {
             last_window_y: None,
             last_window_width: None,
             last_window_height: None,
+            summon_hotkey: None,
         }
     }
 }
@@ -84,6 +92,16 @@ impl DesktopSettings {
         crate::platform::write_restricted(&path, &json)?;
 
         Ok(())
+    }
+
+    /// The summon accelerator to actually register, or `None` to register no
+    /// global shortcut. Treats unset / blank / whitespace-only as "no hotkey"
+    /// so a user can disable it by clearing the field without removing the key.
+    pub fn effective_summon_hotkey(&self) -> Option<String> {
+        match self.summon_hotkey.as_deref() {
+            Some(s) if !s.trim().is_empty() => Some(s.trim().to_string()),
+            _ => None,
+        }
     }
 
     /// Parse settings from a JSON string. Test-only helper.
@@ -151,6 +169,42 @@ mod tests {
         let restored = DesktopSettings::from_json(&json).unwrap();
         assert!(!restored.auto_start_server);
         assert_eq!(restored.tunnel_mode, "quick");
+    }
+
+    #[test]
+    fn summon_hotkey_defaults_to_none() {
+        let settings = DesktopSettings::default();
+        assert!(settings.summon_hotkey.is_none());
+        // No hotkey unless the user opts in.
+        assert!(settings.effective_summon_hotkey().is_none());
+    }
+
+    #[test]
+    fn summon_hotkey_round_trips() {
+        let mut settings = DesktopSettings::default();
+        settings.summon_hotkey = Some("CmdOrCtrl+Shift+K".to_string());
+        let json = settings.to_json().unwrap();
+        let restored = DesktopSettings::from_json(&json).unwrap();
+        assert_eq!(restored.summon_hotkey.as_deref(), Some("CmdOrCtrl+Shift+K"));
+        assert_eq!(restored.effective_summon_hotkey().as_deref(), Some("CmdOrCtrl+Shift+K"));
+    }
+
+    #[test]
+    fn effective_summon_hotkey_trims_and_treats_blank_as_disabled() {
+        let mut settings = DesktopSettings::default();
+        settings.summon_hotkey = Some("  ".to_string());
+        assert!(settings.effective_summon_hotkey().is_none());
+        settings.summon_hotkey = Some("  CmdOrCtrl+Shift+K  ".to_string());
+        assert_eq!(settings.effective_summon_hotkey().as_deref(), Some("CmdOrCtrl+Shift+K"));
+        settings.summon_hotkey = Some(String::new());
+        assert!(settings.effective_summon_hotkey().is_none());
+    }
+
+    #[test]
+    fn parse_omits_summon_hotkey_uses_none() {
+        // Older settings files won't have the field — must deserialize to None.
+        let settings = DesktopSettings::from_json("{}").unwrap();
+        assert!(settings.summon_hotkey.is_none());
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/window.rs
+++ b/packages/desktop/src-tauri/src/window.rs
@@ -190,9 +190,13 @@ pub fn percent_encode_html(html: &str) -> String {
     encoded
 }
 
-/// Show and focus the main window.
+/// Show, un-minimize, and focus the main window. Un-minimizing first means a
+/// "summon" (tray item or global hotkey) reliably brings the window forward even
+/// when it was minimized to the Dock — `show()` + `set_focus()` alone leave a
+/// minimized window minimized (#5281 ②). Mirrors the single-instance focus path.
 pub fn show_window(app: &AppHandle) {
     if let Some(win) = app.get_webview_window(MAIN_LABEL) {
+        let _ = win.unminimize();
         let _ = win.show();
         let _ = win.set_focus();
     }


### PR DESCRIPTION
## Context

Epic #5281, milestone **②** (Summon/hotkey + tray polish). Makes the desktop window easy to bring forward — the natural companion to the LAN-client work (you want to summon chroxy quickly when a remote session needs attention).

## What it does

- **Tray: "Show Chroxy" item** at the top of the menu — shows + focuses the main window, independent of server state. The always-available baseline summon.
- **`show_window` now unminimizes first** — so any summon path (tray item, global hotkey, single-instance relaunch) reliably surfaces a *minimized* window instead of no-opping. Benefits the existing callers too.
- **Global summon hotkey** via `tauri-plugin-global-shortcut`, opt-in through a new `DesktopSettings.summon_hotkey` (Tauri accelerator string, e.g. `"CmdOrCtrl+Shift+K"`).

## Design: opt-in hotkey, None by default

A global shortcut can silently steal a chord from another app, so the default is **None** — chroxy registers no system-wide hotkey unless the user sets one. The tray "Show Chroxy" item is the conflict-free baseline. Registration is **best-effort**: a malformed or OS-conflicting accelerator is logged (`[hotkey] …`), never fatal — the tray item still works.

`effective_summon_hotkey()` treats unset / blank / whitespace-only as "no hotkey", so a user can disable it by clearing the field without deleting the key.

## Files
- `Cargo.toml` / `Cargo.lock` — add `tauri-plugin-global-shortcut`
- `settings.rs` — `summon_hotkey` field + `effective_summon_hotkey()` resolver
- `window.rs` — `show_window` unminimizes
- `lib.rs` — register the plugin (handler summons on press), register the opt-in accelerator in setup, add the tray item + handler

## Tests
- `settings.rs`: `summon_hotkey` round-trip; `effective_summon_hotkey` for unset / blank / whitespace / value; old settings file (no field) → `None`.
- The plugin registration + window show require the Tauri runtime, so they stay out of `cargo test` (consistent with the existing command-integration exclusions).
- `cargo test --locked` green locally (macOS): 130 lib + 8 + 46 integration.

## Follow-up (deferred)
A dashboard Settings control to edit `summon_hotkey` from the UI (today it's set in `~/.chroxy/desktop-settings.json`). Worth a tracked issue if desired.