### PR TITLE
feat(server): include hostname in /health for LAN discovery

### DIFF
--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -1,4 +1,5 @@
 import { readFileSync, existsSync } from 'fs'
+import { hostname } from 'os'
 import { join, resolve, dirname } from 'path'
 import { fileURLToPath } from 'url'
 import QRCode from 'qrcode'
@@ -203,7 +204,11 @@ export function createHttpHandler(server) {
         'Vary': 'Accept',
         'Access-Control-Allow-Origin': '*',
       })
-      res.end(JSON.stringify({ status: 'ok', mode: server.serverMode, version: SERVER_VERSION }))
+      // #5281 ③ — `hostname` lets LAN-discovery clients (the mobile subnet
+      // scanner, and the upcoming desktop mDNS browse) label a found daemon by
+      // machine name instead of a bare IP. The mobile scanner already reads it
+      // (lan-scanner.ts: `data.hostname || ip`); the server just hadn't sent it.
+      res.end(JSON.stringify({ status: 'ok', mode: server.serverMode, version: SERVER_VERSION, hostname: hostname() }))
       return
     }
 

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -108,6 +108,16 @@ describe('http-routes', () => {
       assert.equal(body.status, 'ok')
     })
 
+    it('GET /health includes hostname for LAN discovery (#5281 ③)', async () => {
+      const mock = createMockServer()
+      await startWith(mock)
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/health`)
+      const body = await res.json()
+      // Non-empty string so a discovery client can label by machine name.
+      assert.equal(typeof body.hostname, 'string')
+      assert.ok(body.hostname.length > 0)
+    })
+
     it('GET / with Accept: text/html redirects to /dashboard when apiToken set', async () => {
       const mock = createMockServer()
       await startWith(mock)


### PR DESCRIPTION
## Context

Epic #5281 milestone **③** (mDNS discovery + pairing). This is the small **discovery-metadata foundation** for ③ — and it fixes a real, pre-existing gap in the mobile LAN scanner.

## Problem

The mobile app's LAN scan probes `GET /health` across the subnet and reads `data.hostname || ip` (`packages/app/src/utils/lan-scanner.ts`) to label each found daemon by machine name. But the server's `/health` only returned `{ status, mode, version }` — **no `hostname`** — so the scanner always fell back to showing a bare IP (`192.168.1.5`) instead of `MacBook-Pro`.

## Change

Add `hostname: os.hostname()` to the `/health` JSON (`packages/server/src/http-routes.js`). The upcoming desktop mDNS browse (next ③ PR) wants the same metadata, so this establishes the contract.

## Tests

`http-routes.test.js`: `/health` includes a non-empty `hostname` string. Full http-routes suite green (29).