### PR TITLE
feat(desktop): mDNS LAN discovery in the ServerPicker

### DIFF
--- a/packages/dashboard/src/components/ServerPicker.test.tsx
+++ b/packages/dashboard/src/components/ServerPicker.test.tsx
@@ -28,6 +28,13 @@ vi.mock('../store/connection', () => ({
   },
 }))
 
+// #5281 ③ — LAN discovery deps. isTauri gates the section; discoverLanServers
+// is stubbed per-test.
+let mockIsTauri = false
+const mockDiscover = vi.fn()
+vi.mock('../utils/tauri', () => ({ isTauri: () => mockIsTauri }))
+vi.mock('../utils/discovery', () => ({ discoverLanServers: () => mockDiscover() }))
+
 const FAKE_NOW = 1_741_348_800_000 // 2025-03-07T12:00:00Z
 
 afterEach(() => cleanup())
@@ -35,6 +42,7 @@ afterEach(() => cleanup())
 beforeEach(() => {
   vi.clearAllMocks()
   vi.spyOn(Date, 'now').mockReturnValue(FAKE_NOW)
+  mockIsTauri = false
   storeState = {
     serverRegistry: [],
     activeServerId: null,
@@ -285,5 +293,65 @@ describe('ServerPicker', () => {
     fireEvent.click(screen.getByTestId('server-add-submit'))
     const errorEl = screen.getByTestId('server-url-error')
     expect(errorEl.getAttribute('role')).toBe('alert')
+  })
+
+  describe('LAN discovery (#5281 ③)', () => {
+    const DISCOVERED = [
+      { name: 'devbox', host: '192.168.1.9', port: 8765, wsUrl: 'ws://192.168.1.9:8765/ws', version: '0.9.44' },
+    ]
+
+    it('does not render the Discover button outside Tauri', () => {
+      mockIsTauri = false
+      render(<ServerPicker />)
+      expect(screen.queryByTestId('server-discover-btn')).toBeNull()
+    })
+
+    it('renders the Discover button in Tauri and lists results', async () => {
+      mockIsTauri = true
+      mockDiscover.mockResolvedValue(DISCOVERED)
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-discover-btn'))
+      expect(mockDiscover).toHaveBeenCalledTimes(1)
+      const item = await screen.findByTestId('server-discover-item-192.168.1.9')
+      expect(item).toHaveTextContent('devbox')
+      expect(item).toHaveTextContent('192.168.1.9:8765')
+      expect(item).toHaveTextContent('v0.9.44')
+    })
+
+    it('clicking a discovered server opens the add form pre-filled with its URL', async () => {
+      mockIsTauri = true
+      mockDiscover.mockResolvedValue(DISCOVERED)
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-discover-btn'))
+      fireEvent.click(await screen.findByTestId('server-discover-item-192.168.1.9'))
+      const urlInput = screen.getByTestId('server-url-input') as HTMLInputElement
+      const nameInput = screen.getByTestId('server-name-input') as HTMLInputElement
+      expect(urlInput.value).toBe('ws://192.168.1.9:8765/ws')
+      expect(nameInput.value).toBe('devbox')
+      // Token is intentionally NOT pre-filled — the user supplies it.
+      expect((screen.getByTestId('server-token-input') as HTMLInputElement).value).toBe('')
+    })
+
+    it('hides discovered daemons already in the registry', async () => {
+      mockIsTauri = true
+      storeState.serverRegistry = [
+        { id: 'srv_known', name: 'devbox', wsUrl: 'ws://192.168.1.9:8765/ws', token: 't', lastConnectedAt: null },
+      ]
+      mockDiscover.mockResolvedValue(DISCOVERED)
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-discover-btn'))
+      expect(await screen.findByTestId('server-discover-allknown')).toBeTruthy()
+      expect(screen.queryByTestId('server-discover-item-192.168.1.9')).toBeNull()
+    })
+
+    it('surfaces a discovery error', async () => {
+      mockIsTauri = true
+      mockDiscover.mockRejectedValue(new Error('mDNS init failed'))
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-discover-btn'))
+      const err = await screen.findByTestId('server-discover-error')
+      expect(err).toHaveTextContent('mDNS init failed')
+      expect(err.getAttribute('role')).toBe('alert')
+    })
   })
 })

--- a/packages/dashboard/src/components/ServerPicker.tsx
+++ b/packages/dashboard/src/components/ServerPicker.tsx
@@ -7,6 +7,8 @@
 import { useState, useCallback } from 'react'
 import { useConnectionStore } from '../store/connection'
 import type { ServerEntry, ConnectionPhase } from '../store/types'
+import { isTauri } from '../utils/tauri'
+import { discoverLanServers, type DiscoveredServer } from '../utils/discovery'
 
 function statusDot(phase: ConnectionPhase, isActive: boolean): string {
   if (!isActive) return 'server-dot disconnected'
@@ -50,11 +52,14 @@ interface AddServerFormProps {
   onAdd: (name: string, wsUrl: string, token: string) => void
   onCancel: () => void
   error: string | null
+  /** Pre-fill from a LAN-discovered daemon (#5281 ③); token is still entered. */
+  initialName?: string
+  initialUrl?: string
 }
 
-function AddServerForm({ onAdd, onCancel, error }: AddServerFormProps) {
-  const [name, setName] = useState('')
-  const [url, setUrl] = useState('')
+function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = '' }: AddServerFormProps) {
+  const [name, setName] = useState(initialName)
+  const [url, setUrl] = useState(initialUrl)
   const [token, setToken] = useState('')
 
   const handleSubmit = useCallback((e?: React.FormEvent) => {
@@ -193,18 +198,51 @@ export function ServerPicker() {
 
   const [showAddForm, setShowAddForm] = useState(false)
   const [addError, setAddError] = useState<string | null>(null)
+  // #5281 ③ — pre-fill the add form from a LAN-discovered daemon.
+  const [prefill, setPrefill] = useState<{ name: string; url: string } | null>(null)
+  // #5281 ③ — LAN discovery (desktop/Tauri only).
+  const [discovered, setDiscovered] = useState<DiscoveredServer[]>([])
+  const [discovering, setDiscovering] = useState(false)
+  const [discoverError, setDiscoverError] = useState<string | null>(null)
+  const canDiscover = isTauri()
 
   const handleAdd = useCallback((name: string, wsUrl: string, token: string) => {
     try {
       const entry = addServer(name, wsUrl, token)
       setAddError(null)
       setShowAddForm(false)
+      setPrefill(null)
       // Auto-connect to newly added server
       switchServer(entry.id)
     } catch (err) {
       setAddError(err instanceof Error ? err.message : 'Failed to add server')
     }
   }, [addServer, switchServer])
+
+  const runDiscovery = useCallback(async () => {
+    setDiscovering(true)
+    setDiscoverError(null)
+    try {
+      setDiscovered(await discoverLanServers())
+    } catch (err) {
+      setDiscoverError(err instanceof Error ? err.message : 'Discovery failed')
+      setDiscovered([])
+    } finally {
+      setDiscovering(false)
+    }
+  }, [])
+
+  // Open the add form pre-filled from a discovered daemon. The form is keyed on
+  // the prefill URL below so a fresh selection re-seeds its inputs.
+  const handlePickDiscovered = useCallback((srv: DiscoveredServer) => {
+    setPrefill({ name: srv.name, url: srv.wsUrl })
+    setAddError(null)
+    setShowAddForm(true)
+  }, [])
+
+  // Hide daemons already in the registry (match on wsUrl).
+  const knownUrls = new Set(serverRegistry.map(s => s.wsUrl))
+  const freshDiscovered = discovered.filter(d => !knownUrls.has(d.wsUrl))
 
   return (
     <div className="server-picker" data-testid="server-picker">
@@ -223,10 +261,53 @@ export function ServerPicker() {
 
       {showAddForm && (
         <AddServerForm
+          key={prefill?.url ?? 'blank'}
           onAdd={handleAdd}
-          onCancel={() => { setShowAddForm(false); setAddError(null) }}
+          onCancel={() => { setShowAddForm(false); setAddError(null); setPrefill(null) }}
           error={addError}
+          initialName={prefill?.name ?? ''}
+          initialUrl={prefill?.url ?? ''}
         />
+      )}
+
+      {canDiscover && (
+        <div className="server-discover" data-testid="server-discover">
+          <button
+            type="button"
+            className="server-btn server-discover-btn"
+            onClick={runDiscovery}
+            disabled={discovering}
+            data-testid="server-discover-btn"
+          >
+            {discovering ? 'Scanning LAN…' : 'Discover on LAN'}
+          </button>
+          {discoverError && (
+            <span className="server-form-error" data-testid="server-discover-error" role="alert">
+              {discoverError}
+            </span>
+          )}
+          {!discovering && !discoverError && discovered.length > 0 && freshDiscovered.length === 0 && (
+            <span className="server-discover-empty" data-testid="server-discover-allknown">
+              All discovered servers are already added.
+            </span>
+          )}
+          {freshDiscovered.map(srv => (
+            <button
+              type="button"
+              key={srv.wsUrl}
+              className="server-item-main server-discover-item"
+              onClick={() => handlePickDiscovered(srv)}
+              data-testid={`server-discover-item-${srv.host}`}
+              title={`Add ${srv.name} (${srv.host}:${srv.port})`}
+            >
+              <span className="server-item-info">
+                <span className="server-item-name">{srv.name}</span>
+                <span className="server-item-url">{srv.host}:{srv.port}{srv.version ? ` • v${srv.version}` : ''}</span>
+              </span>
+              <span className="server-discover-add" aria-hidden="true">+</span>
+            </button>
+          ))}
+        </div>
       )}
 
       {hasLocalServer && (

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -7383,6 +7383,48 @@ button.sidebar-token-view-session-row:hover {
   color: var(--text-dim);
 }
 
+/* #5281 ③ — LAN discovery section */
+.server-discover {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 0;
+}
+
+.server-discover-btn {
+  align-self: flex-start;
+}
+
+.server-discover-empty {
+  padding: 4px 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.server-discover-item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 1px dashed var(--border-primary);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+}
+
+.server-discover-item:hover {
+  background: var(--bg-hover, var(--border-primary));
+}
+
+.server-discover-add {
+  flex-shrink: 0;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
 .server-item {
   display: flex;
   align-items: center;

--- a/packages/dashboard/src/utils/discovery.test.ts
+++ b/packages/dashboard/src/utils/discovery.test.ts
@@ -42,6 +42,17 @@ describe('discoverLanServers', () => {
     expect(result[0]!.host).toBe('10.0.0.1')
   })
 
+  it('rejects entries with a non-string version or non-finite port', async () => {
+    const invoke = vi.fn().mockResolvedValue([
+      { name: 'bad-version', host: '10.0.0.1', port: 8765, wsUrl: 'ws://10.0.0.1:8765/ws', version: { x: 1 } },
+      { name: 'bad-port', host: '10.0.0.2', port: Number.POSITIVE_INFINITY, wsUrl: 'ws://10.0.0.2/ws', version: null },
+      { name: 'ok-null-version', host: '10.0.0.3', port: 8765, wsUrl: 'ws://10.0.0.3:8765/ws', version: null },
+    ])
+    mockGetInvoke.mockReturnValue(invoke)
+    const result = await discoverLanServers()
+    expect(result.map(r => r.name)).toEqual(['ok-null-version'])
+  })
+
   it('returns [] when the command yields a non-array', async () => {
     const invoke = vi.fn().mockResolvedValue({ unexpected: true })
     mockGetInvoke.mockReturnValue(invoke)

--- a/packages/dashboard/src/utils/discovery.test.ts
+++ b/packages/dashboard/src/utils/discovery.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGetInvoke = vi.fn()
+vi.mock('./tauri-bridge', () => ({
+  getTauriInvoke: () => mockGetInvoke(),
+}))
+
+const { discoverLanServers } = await import('./discovery')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('discoverLanServers', () => {
+  it('returns [] outside Tauri (no invoke)', async () => {
+    mockGetInvoke.mockReturnValue(null)
+    expect(await discoverLanServers()).toEqual([])
+  })
+
+  it('returns parsed servers from the command', async () => {
+    const invoke = vi.fn().mockResolvedValue([
+      { name: 'devbox', host: '192.168.1.9', port: 8765, wsUrl: 'ws://192.168.1.9:8765/ws', version: '0.9.44' },
+    ])
+    mockGetInvoke.mockReturnValue(invoke)
+    const result = await discoverLanServers()
+    expect(invoke).toHaveBeenCalledWith('discover_lan_servers')
+    expect(result).toHaveLength(1)
+    expect(result[0]!.name).toBe('devbox')
+    expect(result[0]!.wsUrl).toBe('ws://192.168.1.9:8765/ws')
+  })
+
+  it('filters out malformed entries defensively', async () => {
+    const invoke = vi.fn().mockResolvedValue([
+      { name: 'ok', host: '10.0.0.1', port: 8765, wsUrl: 'ws://10.0.0.1:8765/ws', version: null },
+      { name: 'bad-no-host', port: 8765, wsUrl: 'ws://x/ws' },
+      'not-an-object',
+      null,
+    ])
+    mockGetInvoke.mockReturnValue(invoke)
+    const result = await discoverLanServers()
+    expect(result).toHaveLength(1)
+    expect(result[0]!.host).toBe('10.0.0.1')
+  })
+
+  it('returns [] when the command yields a non-array', async () => {
+    const invoke = vi.fn().mockResolvedValue({ unexpected: true })
+    mockGetInvoke.mockReturnValue(invoke)
+    expect(await discoverLanServers()).toEqual([])
+  })
+
+  it('propagates a command error (distinct from "found nothing")', async () => {
+    const invoke = vi.fn().mockRejectedValue(new Error('mDNS init failed'))
+    mockGetInvoke.mockReturnValue(invoke)
+    await expect(discoverLanServers()).rejects.toThrow('mDNS init failed')
+  })
+})

--- a/packages/dashboard/src/utils/discovery.ts
+++ b/packages/dashboard/src/utils/discovery.ts
@@ -1,0 +1,43 @@
+/**
+ * LAN discovery of chroxy daemons (#5281 ③).
+ *
+ * Thin wrapper over the desktop Tauri `discover_lan_servers` command, which
+ * browses `_chroxy._tcp` on the LAN. Outside Tauri (plain browser dashboard)
+ * there's no mDNS access, so this resolves to an empty list — callers should
+ * gate the UI on `isTauri()` rather than relying on the empty result.
+ */
+import { getTauriInvoke } from './tauri-bridge'
+
+export interface DiscoveredServer {
+  /** Daemon machine name (from the mDNS instance name), host fallback. */
+  name: string
+  host: string
+  port: number
+  /** ws:// endpoint, ready to pre-fill the add-server form. */
+  wsUrl: string
+  version: string | null
+}
+
+function isDiscoveredServer(v: unknown): v is DiscoveredServer {
+  if (typeof v !== 'object' || v === null) return false
+  const o = v as Record<string, unknown>
+  return (
+    typeof o.name === 'string' &&
+    typeof o.host === 'string' &&
+    typeof o.port === 'number' &&
+    typeof o.wsUrl === 'string'
+  )
+}
+
+/**
+ * Browse the LAN for chroxy daemons. Returns `[]` outside Tauri or when the
+ * browse finds nothing; rejects only on an actual command error so the caller
+ * can surface "discovery failed" distinctly from "found nothing".
+ */
+export async function discoverLanServers(): Promise<DiscoveredServer[]> {
+  const invoke = getTauriInvoke()
+  if (!invoke) return []
+  const result = await invoke('discover_lan_servers')
+  if (!Array.isArray(result)) return []
+  return result.filter(isDiscoveredServer)
+}

--- a/packages/dashboard/src/utils/discovery.ts
+++ b/packages/dashboard/src/utils/discovery.ts
@@ -24,8 +24,12 @@ function isDiscoveredServer(v: unknown): v is DiscoveredServer {
   return (
     typeof o.name === 'string' &&
     typeof o.host === 'string' &&
-    typeof o.port === 'number' &&
-    typeof o.wsUrl === 'string'
+    // Finite integer port — guards against NaN/Infinity sneaking into the URL.
+    typeof o.port === 'number' && Number.isFinite(o.port) &&
+    typeof o.wsUrl === 'string' &&
+    // version is interpolated into UI text; only accept string | null | absent
+    // so a non-string can't render as "v[object Object]".
+    (o.version == null || typeof o.version === 'string')
   )
 }
 

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "dirs 5.0.1",
  "image",
  "libc",
+ "mdns-sd",
  "objc",
  "qrcode",
  "serde",
@@ -1205,6 +1206,17 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1979,6 +1991,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2343,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892f96f6d2ebe1ea641279f986ac52a2a6bac71e8f743bb258315cfe2bd7e88e"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3824,6 +3862,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,6 +3928,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-dialog = "2"
 base64 = "0.22"
 tauri-plugin-window-state = "2"
 tauri-plugin-global-shortcut = "2"
+mdns-sd = "0.20"
 tokio = { version = "1", features = ["sync"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -16,6 +16,7 @@ const APP_COMMANDS: &[&str] = &[
     "start_server",
     "stop_server",
     "restart_server",
+    "discover_lan_servers",
     "get_qr_code_svg",
     "pick_directory",
     "check_dependencies",

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -24,6 +24,7 @@
     "allow-start-server",
     "allow-stop-server",
     "allow-restart-server",
+    "allow-discover-lan-servers",
     "allow-get-qr-code-svg",
     "allow-pick-directory",
     "allow-check-dependencies",

--- a/packages/desktop/src-tauri/permissions/autogenerated/discover_lan_servers.toml
+++ b/packages/desktop/src-tauri/permissions/autogenerated/discover_lan_servers.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-discover-lan-servers"
+description = "Enables the discover_lan_servers command without any pre-configured scope."
+commands.allow = ["discover_lan_servers"]
+
+[[permission]]
+identifier = "deny-discover-lan-servers"
+description = "Denies the discover_lan_servers command without any pre-configured scope."
+commands.deny = ["discover_lan_servers"]

--- a/packages/desktop/src-tauri/src/discovery.rs
+++ b/packages/desktop/src-tauri/src/discovery.rs
@@ -12,7 +12,7 @@
 
 use serde::Serialize;
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::time::{Duration, Instant};
 
 const SERVICE_TYPE: &str = "_chroxy._tcp.local.";
@@ -62,19 +62,33 @@ pub fn ws_url(host: &str, port: u16) -> String {
     }
 }
 
-/// Pick the address a client should connect to — IPv4 first (LAN-friendly,
-/// no scope-id hassle), else the first address of any kind.
+/// IPv6 link-local (`fe80::/10`). The resolved address set carries no scope id,
+/// so a bare `ws://[fe80::1]:port` URL is unconnectable — we skip these.
+fn is_ipv6_link_local(addr: &Ipv6Addr) -> bool {
+    (addr.segments()[0] & 0xffc0) == 0xfe80
+}
+
+/// Pick the address a client should connect to — IPv4 first (LAN-friendly, no
+/// scope-id hassle), else the first usable (non-link-local) IPv6. A multi-homed
+/// daemon's IPv4 set has no defined order (it's a HashSet), so any reachable
+/// address is acceptable; we just need one that works. Returns None when the
+/// only addresses are link-local IPv6 (unconnectable from a WebSocket).
 pub fn pick_address<'a, I: IntoIterator<Item = &'a IpAddr>>(addrs: I) -> Option<String> {
-    let mut first_any: Option<String> = None;
+    let mut fallback: Option<String> = None;
     for addr in addrs {
-        if addr.is_ipv4() {
-            return Some(addr.to_string());
-        }
-        if first_any.is_none() {
-            first_any = Some(addr.to_string());
+        match addr {
+            IpAddr::V4(_) => return Some(addr.to_string()),
+            IpAddr::V6(v6) => {
+                if is_ipv6_link_local(v6) {
+                    continue;
+                }
+                if fallback.is_none() {
+                    fallback = Some(addr.to_string());
+                }
+            }
         }
     }
-    first_any
+    fallback
 }
 
 /// Assemble a [`DiscoveredServer`] from resolved mDNS fields.
@@ -182,10 +196,25 @@ mod tests {
     }
 
     #[test]
-    fn pick_address_falls_back_to_ipv6_when_no_ipv4() {
-        let v6: IpAddr = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1).into();
+    fn pick_address_falls_back_to_global_ipv6_when_no_ipv4() {
+        // A routable (non-link-local) IPv6 is usable.
+        let v6: IpAddr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1).into();
         let addrs = vec![v6];
-        assert_eq!(pick_address(addrs.iter()), Some("fe80::1".to_string()));
+        assert_eq!(pick_address(addrs.iter()), Some("2001:db8::1".to_string()));
+    }
+
+    #[test]
+    fn pick_address_skips_link_local_ipv6() {
+        // fe80::/10 has no scope id here → unconnectable → skipped (None).
+        let ll: IpAddr = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1).into();
+        assert_eq!(pick_address([ll].iter()), None);
+    }
+
+    #[test]
+    fn pick_address_prefers_ipv4_over_link_local_ipv6() {
+        let ll: IpAddr = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1).into();
+        let v4: IpAddr = Ipv4Addr::new(10, 0, 0, 7).into();
+        assert_eq!(pick_address([ll, v4].iter()), Some("10.0.0.7".to_string()));
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/discovery.rs
+++ b/packages/desktop/src-tauri/src/discovery.rs
@@ -1,0 +1,228 @@
+//! LAN discovery of chroxy daemons via mDNS (#5281 ③).
+//!
+//! The server advertises `_chroxy._tcp` with an instance name of
+//! `Chroxy (<hostname>)` and a `version` TXT record (see
+//! `packages/server/src/server-cli.js` `maybeAdvertiseMdns`). This module
+//! browses for that service on the LAN and resolves each daemon into a
+//! [`DiscoveredServer`] the dashboard's ServerPicker can pre-fill.
+//!
+//! The hostname comes straight from the advertised instance name — so we never
+//! need the daemon's `/health` to expose it (a deliberately-guarded field), and
+//! there's no new exposure beyond what mDNS already broadcasts on the LAN.
+
+use serde::Serialize;
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+const SERVICE_TYPE: &str = "_chroxy._tcp.local.";
+
+/// A chroxy daemon found on the LAN.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveredServer {
+    /// Human label — the daemon's machine name, parsed from the mDNS instance
+    /// name (`Chroxy (<hostname>)`), with the address as a fallback.
+    pub name: String,
+    /// First usable address (IPv4 preferred).
+    pub host: String,
+    pub port: u16,
+    /// `ws://` endpoint, pre-fillable into the ServerPicker add form.
+    pub ws_url: String,
+    /// Advertised server version (TXT `version`), if present.
+    pub version: Option<String>,
+}
+
+/// Extract the daemon machine name from an mDNS instance name.
+/// `Chroxy (mac-host)` → `mac-host`; anything else is returned as-is.
+pub fn parse_instance_name(instance: &str) -> String {
+    if let Some(open) = instance.find('(') {
+        if let Some(rel_close) = instance[open + 1..].find(')') {
+            let inner = instance[open + 1..open + 1 + rel_close].trim();
+            if !inner.is_empty() {
+                return inner.to_string();
+            }
+        }
+    }
+    instance.trim().to_string()
+}
+
+/// Strip the service-type/domain suffix from a resolved fullname, leaving just
+/// the instance label. `Chroxy (host)._chroxy._tcp.local.` → `Chroxy (host)`.
+pub fn instance_label(fullname: &str) -> &str {
+    fullname.split("._chroxy._tcp").next().unwrap_or(fullname)
+}
+
+/// Build a `ws://` authority, bracketing IPv6 literals so the URL is well-formed.
+pub fn ws_url(host: &str, port: u16) -> String {
+    if host.contains(':') {
+        format!("ws://[{}]:{}/ws", host, port)
+    } else {
+        format!("ws://{}:{}/ws", host, port)
+    }
+}
+
+/// Pick the address a client should connect to — IPv4 first (LAN-friendly,
+/// no scope-id hassle), else the first address of any kind.
+pub fn pick_address<'a, I: IntoIterator<Item = &'a IpAddr>>(addrs: I) -> Option<String> {
+    let mut first_any: Option<String> = None;
+    for addr in addrs {
+        if addr.is_ipv4() {
+            return Some(addr.to_string());
+        }
+        if first_any.is_none() {
+            first_any = Some(addr.to_string());
+        }
+    }
+    first_any
+}
+
+/// Assemble a [`DiscoveredServer`] from resolved mDNS fields.
+pub fn build_discovered(
+    fullname: &str,
+    host: &str,
+    port: u16,
+    version: Option<String>,
+) -> DiscoveredServer {
+    let label = instance_label(fullname);
+    let name = {
+        let parsed = parse_instance_name(label);
+        if parsed.is_empty() { host.to_string() } else { parsed }
+    };
+    DiscoveredServer {
+        name,
+        host: host.to_string(),
+        port,
+        ws_url: ws_url(host, port),
+        version,
+    }
+}
+
+/// Browse the LAN for `_chroxy._tcp` daemons for `timeout`, returning a
+/// de-duplicated (by host:port), name-sorted list. Blocking — call off the UI
+/// thread. Never panics: daemon/socket errors surface as `Err`.
+pub fn browse_lan(timeout: Duration) -> Result<Vec<DiscoveredServer>, String> {
+    use mdns_sd::{ServiceDaemon, ServiceEvent};
+
+    let mdns = ServiceDaemon::new().map_err(|e| format!("mDNS init failed: {e}"))?;
+    let receiver = mdns
+        .browse(SERVICE_TYPE)
+        .map_err(|e| format!("mDNS browse failed: {e}"))?;
+
+    let deadline = Instant::now() + timeout;
+    let mut found: HashMap<String, DiscoveredServer> = HashMap::new();
+
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        match receiver.recv_timeout(remaining) {
+            Ok(ServiceEvent::ServiceResolved(info)) => {
+                // mdns-sd yields `ScopedIp`; flatten to plain IpAddr for selection.
+                let ips: Vec<IpAddr> =
+                    info.get_addresses().iter().map(|s| s.to_ip_addr()).collect();
+                if let Some(host) = pick_address(ips.iter()) {
+                    let version = info
+                        .get_property_val_str("version")
+                        .map(|s| s.to_string());
+                    let ds = build_discovered(info.get_fullname(), &host, info.get_port(), version);
+                    found.insert(format!("{}:{}", ds.host, ds.port), ds);
+                }
+            }
+            Ok(_) => {}
+            // Timed out waiting for the next event — browse window is over.
+            Err(_) => break,
+        }
+    }
+
+    // Best-effort shutdown; a failure here doesn't invalidate what we found.
+    let _ = mdns.shutdown();
+
+    let mut servers: Vec<DiscoveredServer> = found.into_values().collect();
+    servers.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    Ok(servers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn parse_instance_name_extracts_hostname() {
+        assert_eq!(parse_instance_name("Chroxy (mac-host)"), "mac-host");
+        assert_eq!(parse_instance_name("Chroxy (My MacBook Pro)"), "My MacBook Pro");
+    }
+
+    #[test]
+    fn parse_instance_name_falls_back_to_raw() {
+        assert_eq!(parse_instance_name("Chroxy"), "Chroxy");
+        assert_eq!(parse_instance_name("Chroxy ()"), "Chroxy ()");
+        assert_eq!(parse_instance_name("weird (   )"), "weird (   )");
+    }
+
+    #[test]
+    fn instance_label_strips_service_suffix() {
+        assert_eq!(
+            instance_label("Chroxy (host)._chroxy._tcp.local."),
+            "Chroxy (host)"
+        );
+        assert_eq!(instance_label("plain"), "plain");
+    }
+
+    #[test]
+    fn ws_url_brackets_ipv6_only() {
+        assert_eq!(ws_url("192.168.1.5", 8765), "ws://192.168.1.5:8765/ws");
+        assert_eq!(ws_url("fe80::1", 8765), "ws://[fe80::1]:8765/ws");
+    }
+
+    #[test]
+    fn pick_address_prefers_ipv4() {
+        let v6: IpAddr = Ipv6Addr::LOCALHOST.into();
+        let v4: IpAddr = Ipv4Addr::new(192, 168, 1, 5).into();
+        let addrs = vec![v6, v4];
+        assert_eq!(pick_address(addrs.iter()), Some("192.168.1.5".to_string()));
+    }
+
+    #[test]
+    fn pick_address_falls_back_to_ipv6_when_no_ipv4() {
+        let v6: IpAddr = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1).into();
+        let addrs = vec![v6];
+        assert_eq!(pick_address(addrs.iter()), Some("fe80::1".to_string()));
+    }
+
+    #[test]
+    fn pick_address_none_when_empty() {
+        let addrs: Vec<IpAddr> = vec![];
+        assert_eq!(pick_address(addrs.iter()), None);
+    }
+
+    #[test]
+    fn build_discovered_full_shape() {
+        let ds = build_discovered(
+            "Chroxy (devbox)._chroxy._tcp.local.",
+            "192.168.1.9",
+            8765,
+            Some("0.9.44".to_string()),
+        );
+        assert_eq!(ds.name, "devbox");
+        assert_eq!(ds.host, "192.168.1.9");
+        assert_eq!(ds.port, 8765);
+        assert_eq!(ds.ws_url, "ws://192.168.1.9:8765/ws");
+        assert_eq!(ds.version.as_deref(), Some("0.9.44"));
+    }
+
+    #[test]
+    fn build_discovered_name_falls_back_to_host() {
+        // A nameless/odd instance shouldn't yield an empty label.
+        let ds = build_discovered("._chroxy._tcp.local.", "10.0.0.2", 9000, None);
+        assert_eq!(ds.name, "10.0.0.2");
+        assert!(ds.version.is_none());
+    }
+
+    #[test]
+    fn discovered_server_serializes_camel_case() {
+        let ds = build_discovered("Chroxy (h)._chroxy._tcp.local.", "1.2.3.4", 8765, None);
+        let json = serde_json::to_value(&ds).unwrap();
+        assert_eq!(json["name"], "h");
+        assert_eq!(json["wsUrl"], "ws://1.2.3.4:8765/ws");
+        assert!(json.get("ws_url").is_none(), "must be camelCase wsUrl");
+    }
+}

--- a/packages/desktop/src-tauri/src/discovery.rs
+++ b/packages/desktop/src-tauri/src/discovery.rs
@@ -141,7 +141,14 @@ pub fn browse_lan(timeout: Duration) -> Result<Vec<DiscoveredServer>, String> {
                 }
             }
             Ok(_) => {}
-            // Timed out waiting for the next event — browse window is over.
+            // recv_timeout errors on Timeout OR Disconnected; both end the
+            // browse and we return what resolved so far. Timeout = the 2s
+            // window elapsed (the normal path). Disconnected can't actually
+            // occur here before shutdown: `mdns` owns the sender and stays in
+            // scope through this whole loop, so the channel can't drop early —
+            // and even if it somehow did, returning the daemons already found
+            // beats discarding them. (mdns-sd re-exports only `Receiver`, not
+            // flume's error type, so we match on `_` rather than the variant.)
             Err(_) => break,
         }
     }

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@
 // external consumer depends on this surface, so exposing it for testing
 // carries no API stability cost.
 pub mod config;
+pub mod discovery;
 pub mod node;
 pub mod platform;
 pub mod qrcode;
@@ -96,6 +97,19 @@ fn get_server_info(
 #[tauri::command]
 fn start_server(app: tauri::AppHandle) {
     handle_start(&app);
+}
+
+/// #5281 ③ — browse the LAN for chroxy daemons advertising `_chroxy._tcp` and
+/// return them for the dashboard ServerPicker's "Discover on LAN" list. Runs
+/// the blocking mDNS browse off the UI thread; an mDNS failure surfaces as an
+/// error string (the picker falls back to manual entry).
+#[tauri::command]
+async fn discover_lan_servers() -> Result<Vec<discovery::DiscoveredServer>, String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        discovery::browse_lan(std::time::Duration::from_millis(2000))
+    })
+    .await
+    .map_err(|e| format!("discovery task failed: {e}"))?
 }
 
 #[tauri::command]
@@ -727,6 +741,7 @@ pub fn run() {
             start_server,
             stop_server,
             restart_server,
+            discover_lan_servers,
             get_qr_code_svg,
             pick_directory,
             check_dependencies,


### PR DESCRIPTION
## Context

Epic #5281 milestone **③** (mDNS discovery + pairing) — **PR 1 of 2**. Lets a desktop user *discover* chroxy daemons on the LAN instead of hand-typing a URL. The server already advertises `_chroxy._tcp` (#5280); this consumes it.

(The earlier `/health`-hostname approach was withdrawn — #5295 — because excluding hostname from the unauthenticated/tunnel-reachable `/health` is a deliberate, tested privacy decision. Discovery gets the machine name from the **mDNS instance name** instead, which is already LAN-only.)

## Rust (Tauri)

- New `discovery.rs`: browses `_chroxy._tcp` via `mdns-sd` and resolves each daemon to `{ name, host, port, wsUrl, version }`.
  - `name` from the advertised instance name `Chroxy (<hostname>)`; IPv4-preferred address selection; IPv6 bracketed in the `ws://` URL.
- New async command `discover_lan_servers` runs the blocking browse off the UI thread (`spawn_blocking`); an mDNS failure surfaces as an error string. Wired into `APP_COMMANDS`, the invoke handler, and `capabilities/default.json`.

## Dashboard

- `ServerPicker` gains a **"Discover on LAN"** button — **desktop/Tauri only** (gated on `isTauri()`; the plain browser dashboard has no mDNS access).
- Found daemons render as a list; selecting one opens the add-server form **pre-filled with name + `ws://` URL** (token still entered — the QR/pairing path is PR 2).
- Daemons already in the registry are filtered out ("All discovered servers are already added."); a discovery error is surfaced distinctly from "found nothing".

## Auth note
Per the scope discussion: this PR is the **discover → manual-token** path. The **QR/pairing** path (no token typing) is the planned follow-up PR — it needs a new server endpoint to expose the current pairing id + the desktop pairing handshake.

## Tests
- **Rust**: pure-parse coverage (instance-name parsing incl. fallbacks, IPv4-preferred pick, IPv6 bracketing, camelCase serialization, host-fallback name). 140 lib + 8 + 46 integration green via `cargo test --locked`.
- **Dashboard**: discovery util (invoke wiring, malformed-entry filtering, non-array guard, error propagation) + ServerPicker discovery UI (gated render, list, prefill, registry dedup, error). Full suite green (3235); `tsc --noEmit` clean.
- The live mDNS browse needs a network/runtime, so it stays out of unit tests (consistent with the existing Tauri runtime exclusions).

## Follow-up
PR 2: QR/pairing path for discovered (and manual) servers — ephemeral pairing-id flow so no permanent token is typed.