### PR TITLE
feat(dashboard): pair with a daemon by pasting its pairing URL

### DIFF
--- a/packages/dashboard/src/components/ServerPicker.test.tsx
+++ b/packages/dashboard/src/components/ServerPicker.test.tsx
@@ -11,6 +11,7 @@ const mockAddServer = vi.fn(() => ({ id: 'srv_new', name: 'New', wsUrl: 'wss://n
 const mockRemoveServer = vi.fn()
 const mockSwitchServer = vi.fn()
 const mockConnectLocal = vi.fn()
+const mockPairServer = vi.fn(() => ({ id: 'srv_paired', name: 'Paired', wsUrl: 'ws://192.168.1.5:8765/ws', token: '', lastConnectedAt: null }))
 
 vi.mock('../store/connection', () => ({
   useConnectionStore: (selector: (s: Record<string, unknown>) => unknown) => {
@@ -23,6 +24,7 @@ vi.mock('../store/connection', () => ({
       removeServer: mockRemoveServer,
       switchServer: mockSwitchServer,
       connectLocal: mockConnectLocal,
+      pairServer: mockPairServer,
     }
     return selector(store)
   },
@@ -352,6 +354,53 @@ describe('ServerPicker', () => {
       const err = await screen.findByTestId('server-discover-error')
       expect(err).toHaveTextContent('mDNS init failed')
       expect(err.getAttribute('role')).toBe('alert')
+    })
+  })
+
+  describe('pairing URL (#5281 ③ PR 2)', () => {
+    it('switches to pairing mode when a chroxy://…?pair= URL is entered', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-add-btn'))
+      fireEvent.change(screen.getByTestId('server-url-input'), {
+        target: { value: 'chroxy://192.168.1.5:8765?pair=ABC123' },
+      })
+      // Token field is replaced by a "no token needed" hint; submit says "Pair".
+      expect(screen.getByTestId('server-pairing-hint')).toBeTruthy()
+      expect(screen.queryByTestId('server-token-input')).toBeNull()
+      expect(screen.getByTestId('server-add-submit')).toHaveTextContent('Pair')
+      expect((screen.getByTestId('server-add-submit') as HTMLButtonElement).disabled).toBe(false)
+    })
+
+    it('submitting a pairing URL calls pairServer with the inferred ws URL', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-add-btn'))
+      fireEvent.change(screen.getByTestId('server-url-input'), {
+        target: { value: 'chroxy://192.168.1.5:8765?pair=ABC123' },
+      })
+      fireEvent.click(screen.getByTestId('server-add-submit'))
+      expect(mockPairServer).toHaveBeenCalledWith('192.168.1.5:8765', 'ws://192.168.1.5:8765/ws', 'ABC123')
+      // Not the manual add path.
+      expect(mockAddServer).not.toHaveBeenCalled()
+    })
+
+    it('uses the typed name when pairing', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-add-btn'))
+      fireEvent.change(screen.getByTestId('server-name-input'), { target: { value: 'Studio Mac' } })
+      fireEvent.change(screen.getByTestId('server-url-input'), {
+        target: { value: 'chroxy://my-tunnel.trycloudflare.com?pair=XYZ' },
+      })
+      fireEvent.click(screen.getByTestId('server-add-submit'))
+      expect(mockPairServer).toHaveBeenCalledWith('Studio Mac', 'wss://my-tunnel.trycloudflare.com/ws', 'XYZ')
+    })
+
+    it('stays in manual mode (token required) for a plain ws URL', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-add-btn'))
+      fireEvent.change(screen.getByTestId('server-url-input'), { target: { value: 'wss://host/ws' } })
+      expect(screen.getByTestId('server-token-input')).toBeTruthy()
+      expect(screen.queryByTestId('server-pairing-hint')).toBeNull()
+      expect(screen.getByTestId('server-add-submit')).toHaveTextContent('Add')
     })
   })
 })

--- a/packages/dashboard/src/components/ServerPicker.test.tsx
+++ b/packages/dashboard/src/components/ServerPicker.test.tsx
@@ -402,5 +402,20 @@ describe('ServerPicker', () => {
       expect(screen.queryByTestId('server-pairing-hint')).toBeNull()
       expect(screen.getByTestId('server-add-submit')).toHaveTextContent('Add')
     })
+
+    it('uses the embedded token from a legacy chroxy://…?token= URL', () => {
+      render(<ServerPicker />)
+      fireEvent.click(screen.getByTestId('server-add-btn'))
+      fireEvent.change(screen.getByTestId('server-url-input'), {
+        target: { value: 'chroxy://192.168.1.5:8765?token=embedded-tok' },
+      })
+      // Token field hidden (URL carries it); button still "Add" (not pairing).
+      expect(screen.queryByTestId('server-token-input')).toBeNull()
+      expect(screen.getByTestId('server-pairing-hint')).toHaveTextContent('includes a token')
+      expect(screen.getByTestId('server-add-submit')).toHaveTextContent('Add')
+      fireEvent.click(screen.getByTestId('server-add-submit'))
+      expect(mockAddServer).toHaveBeenCalledWith('192.168.1.5:8765', 'ws://192.168.1.5:8765/ws', 'embedded-tok')
+      expect(mockPairServer).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/dashboard/src/components/ServerPicker.tsx
+++ b/packages/dashboard/src/components/ServerPicker.tsx
@@ -9,6 +9,7 @@ import { useConnectionStore } from '../store/connection'
 import type { ServerEntry, ConnectionPhase } from '../store/types'
 import { isTauri } from '../utils/tauri'
 import { discoverLanServers, type DiscoveredServer } from '../utils/discovery'
+import { parsePairingUrl } from '../utils/pairing'
 
 function statusDot(phase: ConnectionPhase, isActive: boolean): string {
   if (!isActive) return 'server-dot disconnected'
@@ -55,18 +56,34 @@ interface AddServerFormProps {
   /** Pre-fill from a LAN-discovered daemon (#5281 ③); token is still entered. */
   initialName?: string
   initialUrl?: string
+  /** Pair via a pasted chroxy://…?pair= URL — no token typed (#5281 ③ PR 2). */
+  onPair: (name: string, wsUrl: string, pairingId: string) => void
 }
 
-function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = '' }: AddServerFormProps) {
+function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = '', onPair }: AddServerFormProps) {
   const [name, setName] = useState(initialName)
   const [url, setUrl] = useState(initialUrl)
   const [token, setToken] = useState('')
 
+  // #5281 ③ PR 2 — when the URL field holds a pairing URL, switch to pairing
+  // mode: the token field is unnecessary (a session token is issued by the
+  // handshake) and the submit pairs instead of adding with a typed token.
+  const parsedPairing = parsePairingUrl(url)
+  const pairingMode = !!parsedPairing?.pairingId
+
   const handleSubmit = useCallback((e?: React.FormEvent) => {
     e?.preventDefault()
+    const parsed = parsePairingUrl(url)
+    if (parsed?.pairingId) {
+      // Default the name to the host:port (friendlier than the full ws URL).
+      let defaultName = parsed.wsUrl
+      try { defaultName = new URL(parsed.wsUrl).host } catch { /* keep wsUrl */ }
+      onPair(name.trim() || defaultName, parsed.wsUrl, parsed.pairingId)
+      return
+    }
     if (!url.trim() || !token.trim()) return
     onAdd(name.trim() || url.trim(), url.trim(), token.trim())
-  }, [name, url, token, onAdd])
+  }, [name, url, token, onAdd, onPair])
 
   return (
     <form className="server-add-form" data-testid="server-add-form" onSubmit={handleSubmit}>
@@ -80,7 +97,7 @@ function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = 
       />
       <input
         type="text"
-        placeholder="wss://your-server.example.com/ws"
+        placeholder="wss://your-server/ws or chroxy://…?pair=…"
         value={url}
         onChange={e => setUrl(e.target.value)}
         className={`server-input${error ? ' server-input-error' : ''}`}
@@ -91,22 +108,28 @@ function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = 
           {error}
         </span>
       )}
-      <input
-        type="password"
-        placeholder="Auth token"
-        value={token}
-        onChange={e => setToken(e.target.value)}
-        className="server-input"
-        data-testid="server-token-input"
-      />
+      {pairingMode ? (
+        <span className="server-form-hint" data-testid="server-pairing-hint">
+          Pairing URL detected — no token needed.
+        </span>
+      ) : (
+        <input
+          type="password"
+          placeholder="Auth token"
+          value={token}
+          onChange={e => setToken(e.target.value)}
+          className="server-input"
+          data-testid="server-token-input"
+        />
+      )}
       <div className="server-add-actions">
         <button
           type="submit"
           className="server-btn server-btn-primary"
-          disabled={!url.trim() || !token.trim()}
+          disabled={pairingMode ? false : (!url.trim() || !token.trim())}
           data-testid="server-add-submit"
         >
-          Add
+          {pairingMode ? 'Pair' : 'Add'}
         </button>
         <button
           type="button"
@@ -195,6 +218,7 @@ export function ServerPicker() {
   const removeServer = useConnectionStore(s => s.removeServer)
   const switchServer = useConnectionStore(s => s.switchServer)
   const connectLocal = useConnectionStore(s => s.connectLocal)
+  const pairServer = useConnectionStore(s => s.pairServer)
 
   const [showAddForm, setShowAddForm] = useState(false)
   const [addError, setAddError] = useState<string | null>(null)
@@ -218,6 +242,19 @@ export function ServerPicker() {
       setAddError(err instanceof Error ? err.message : 'Failed to add server')
     }
   }, [addServer, switchServer])
+
+  const handlePair = useCallback((name: string, wsUrl: string, pairingId: string) => {
+    try {
+      pairServer(name, wsUrl, pairingId)
+      setAddError(null)
+      setShowAddForm(false)
+      setPrefill(null)
+      // A bad/expired pairing id surfaces later as a pair_fail alert; the
+      // optimistic entry is cleaned up there.
+    } catch (err) {
+      setAddError(err instanceof Error ? err.message : 'Failed to pair')
+    }
+  }, [pairServer])
 
   const runDiscovery = useCallback(async () => {
     setDiscovering(true)
@@ -263,6 +300,7 @@ export function ServerPicker() {
         <AddServerForm
           key={prefill?.url ?? 'blank'}
           onAdd={handleAdd}
+          onPair={handlePair}
           onCancel={() => { setShowAddForm(false); setAddError(null); setPrefill(null) }}
           error={addError}
           initialName={prefill?.name ?? ''}

--- a/packages/dashboard/src/components/ServerPicker.tsx
+++ b/packages/dashboard/src/components/ServerPicker.tsx
@@ -65,20 +65,27 @@ function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = 
   const [url, setUrl] = useState(initialUrl)
   const [token, setToken] = useState('')
 
-  // #5281 ③ PR 2 — when the URL field holds a pairing URL, switch to pairing
-  // mode: the token field is unnecessary (a session token is issued by the
-  // handshake) and the submit pairs instead of adding with a typed token.
-  const parsedPairing = parsePairingUrl(url)
-  const pairingMode = !!parsedPairing?.pairingId
+  // #5281 ③ PR 2 — a pasted connection URL can embed credentials: a pairing id
+  // (?pair=) or a legacy token (?token=). Either way the token field is
+  // unnecessary; we route on the embedded credential. host:port reads nicer as
+  // the default name than the full ws URL.
+  const parsed = parsePairingUrl(url)
+  const pairingMode = !!parsed?.pairingId
+  const tokenUrlMode = !pairingMode && !!parsed?.token
+  const embeddedCreds = pairingMode || tokenUrlMode
 
   const handleSubmit = useCallback((e?: React.FormEvent) => {
     e?.preventDefault()
-    const parsed = parsePairingUrl(url)
-    if (parsed?.pairingId) {
-      // Default the name to the host:port (friendlier than the full ws URL).
-      let defaultName = parsed.wsUrl
-      try { defaultName = new URL(parsed.wsUrl).host } catch { /* keep wsUrl */ }
-      onPair(name.trim() || defaultName, parsed.wsUrl, parsed.pairingId)
+    const p = parsePairingUrl(url)
+    let host = p?.wsUrl ?? ''
+    try { if (p) host = new URL(p.wsUrl).host } catch { /* keep wsUrl */ }
+    if (p?.pairingId) {
+      onPair(name.trim() || host, p.wsUrl, p.pairingId)
+      return
+    }
+    if (p?.token) {
+      // Legacy ?token= URL — use the embedded token, no separate entry needed.
+      onAdd(name.trim() || host, p.wsUrl, p.token)
       return
     }
     if (!url.trim() || !token.trim()) return
@@ -108,9 +115,11 @@ function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = 
           {error}
         </span>
       )}
-      {pairingMode ? (
+      {embeddedCreds ? (
         <span className="server-form-hint" data-testid="server-pairing-hint">
-          Pairing URL detected — no token needed.
+          {pairingMode
+            ? 'Pairing URL detected — no token needed.'
+            : 'Connection URL includes a token — no token needed.'}
         </span>
       ) : (
         <input
@@ -126,7 +135,7 @@ function AddServerForm({ onAdd, onCancel, error, initialName = '', initialUrl = 
         <button
           type="submit"
           className="server-btn server-btn-primary"
-          disabled={pairingMode ? false : (!url.trim() || !token.trim())}
+          disabled={embeddedCreds ? false : (!url.trim() || !token.trim())}
           data-testid="server-add-submit"
         >
           {pairingMode ? 'Pair' : 'Add'}

--- a/packages/dashboard/src/store/connection-pairing.test.ts
+++ b/packages/dashboard/src/store/connection-pairing.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #5281 ③ PR 2 — connect()'s pairing-vs-auth handshake selection, and the
+ * one-shot pairing-id lifecycle that prevents an armed id leaking into the next
+ * connect. Exercises the real connect()→health-check→WebSocket→onopen path via
+ * fetch + WebSocket mocks.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem: (k: string) => store[k] ?? null,
+  setItem: (k: string, v: string) => { store[k] = v },
+  removeItem: (k: string) => { delete store[k] },
+  clear: () => { for (const k of Object.keys(store)) delete store[k] },
+  get length() { return Object.keys(store).length },
+  key: (i: number) => Object.keys(store)[i] ?? null,
+}
+Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock, writable: true })
+vi.mock('../utils/auth', () => ({ getAuthToken: () => null }))
+
+class MockWebSocket {
+  static OPEN = 1
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 1
+  sent: string[] = []
+  onopen: (() => void) | null = null
+  onmessage: ((e: unknown) => void) | null = null
+  onclose: ((e?: unknown) => void) | null = null
+  onerror: ((e?: unknown) => void) | null = null
+  constructor(url: string) { this.url = url; MockWebSocket.instances.push(this) }
+  send(d: string) { this.sent.push(d) }
+  close() { this.readyState = 3 }
+}
+;(globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket
+;(globalThis as unknown as { fetch: unknown }).fetch = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ status: 'ok' }),
+}))
+
+const { useConnectionStore } = await import('./connection')
+
+/** Wait until a WebSocket for `urlPart` exists, then return it. */
+async function socketFor(urlPart: string): Promise<MockWebSocket> {
+  for (let i = 0; i < 50; i++) {
+    const s = MockWebSocket.instances.find((w) => w.url.includes(urlPart))
+    if (s) return s
+    await Promise.resolve()
+    await new Promise((r) => setTimeout(r, 0))
+  }
+  throw new Error(`no socket for ${urlPart}`)
+}
+
+function lastSent(ws: MockWebSocket): Record<string, unknown> {
+  return JSON.parse(ws.sent[ws.sent.length - 1]!)
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  for (const k of Object.keys(store)) delete store[k]
+  useConnectionStore.setState({ serverRegistry: [], activeServerId: null, connectionPhase: 'disconnected', wsUrl: null })
+})
+
+describe('connect pairing handshake (#5281 ③ PR 2)', () => {
+  it('sends {type:pair} on open when started via pairServer', async () => {
+    useConnectionStore.getState().pairServer('LAN', 'ws://192.168.1.50:8765/ws', 'PAIR-1')
+    const ws = await socketFor('192.168.1.50')
+    ws.onopen?.()
+    const frame = lastSent(ws)
+    expect(frame.type).toBe('pair')
+    expect(frame.pairingId).toBe('PAIR-1')
+    expect(frame.token).toBeUndefined()
+  })
+
+  it('does NOT leak an armed pairing id into a later, unrelated connect', async () => {
+    // Arm + start a pairing connect (consumes the one-shot id into ITS closure).
+    useConnectionStore.getState().pairServer('LAN', 'ws://192.168.1.50:8765/ws', 'PAIR-1')
+    // Now switch to a normal token server before the pairing socket is used.
+    const other = useConnectionStore.getState().addServer('Remote', 'wss://remote.example.com/ws', 'real-token')
+    useConnectionStore.getState().switchServer(other.id)
+
+    const ws = await socketFor('remote.example.com')
+    ws.onopen?.()
+    const frame = lastSent(ws)
+    // Must authenticate normally — the pairing id belonged to the first connect.
+    expect(frame.type).toBe('auth')
+    expect(frame.token).toBe('real-token')
+    expect(frame.pairingId).toBeUndefined()
+  })
+
+  it('a normal switchServer connect sends {type:auth} with its token', async () => {
+    const srv = useConnectionStore.getState().addServer('Remote', 'wss://remote.example.com/ws', 'real-token')
+    useConnectionStore.getState().switchServer(srv.id)
+    const ws = await socketFor('remote.example.com')
+    ws.onopen?.()
+    const frame = lastSent(ws)
+    expect(frame.type).toBe('auth')
+    expect(frame.token).toBe('real-token')
+  })
+})

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -1018,9 +1018,18 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
   // Auto-reconnect (socket.onclose) calls connect() with _retryCount=0, resetting
   // the retry budget — intentional, since established connections should recover
   // aggressively after transient drops (tunnel blips, server restarts, etc.).
-  connect: (url: string, token: string, options?: { silent?: boolean; _retryCount?: number }) => {
+  connect: (url: string, token: string, options?: { silent?: boolean; _retryCount?: number; _pairingId?: string }) => {
     const _retryCount = options?._retryCount ?? 0;
     const silent = options?.silent ?? false;
+    // #5281 ③ PR 2 — resolve the pairing id for THIS connect into the closure,
+    // consuming the one-shot module global at the top of a fresh connect (NOT on
+    // socket open). Consuming here means a pairing connect that never opens
+    // (host down) or is superseded by another connect can't leak its armed id
+    // into the next, unrelated connect's auth. Retries thread it forward via
+    // `_pairingId` so a flaky-but-reachable daemon still pairs.
+    const pairingId = _retryCount === 0
+      ? (() => { const id = pendingPairingId; pendingPairingId = null; return id; })()
+      : (options?._pairingId ?? null);
     const MAX_RETRIES = 5;
     const RETRY_DELAYS = [1000, 2000, 3000, 5000, 8000];
 
@@ -1087,7 +1096,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
               const delay = withJitter(RETRY_DELAYS[Math.min(_retryCount, RETRY_DELAYS.length - 1)]!);
               setTimeout(() => {
                 if (myAttemptId !== connectionAttemptId) return;
-                get().connect(url, token, { silent, _retryCount: _retryCount + 1 });
+                get().connect(url, token, { silent, _retryCount: _retryCount + 1, ...(pairingId ? { _pairingId: pairingId } : {}) });
               }, delay);
             } else {
               set({ connectionPhase: 'disconnected', connectionError: 'Server restart timed out' });
@@ -1116,7 +1125,7 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           console.log(`[ws] Retrying in ${delay}ms...`);
           setTimeout(() => {
             if (myAttemptId !== connectionAttemptId) return;
-            get().connect(url, token, { silent, _retryCount: _retryCount + 1 });
+            get().connect(url, token, { silent, _retryCount: _retryCount + 1, ...(pairingId ? { _pairingId: pairingId } : {}) });
           }, delay);
         } else {
           set({ connectionPhase: 'disconnected', connectionError: 'Could not reach server' });
@@ -1192,12 +1201,11 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
           deviceInfo: { deviceId, ...info },
           capabilities: CLIENT_CAPABILITIES.desktop,
         };
-        // #5281 ③ PR 2 — pairing handshake when a one-shot pairing id is armed
-        // (consume it immediately so a reconnect falls back to the session
-        // token issued in auth_ok). Otherwise the normal token auth.
-        if (pendingPairingId) {
-          const pairingId = pendingPairingId;
-          pendingPairingId = null;
+        // #5281 ③ PR 2 — pairing handshake when this connect carries a pairing
+        // id (resolved into the closure at connect-start). Otherwise normal
+        // token auth. A reconnect carries no pairing id, so it auths with the
+        // session token written back to the registry in auth_ok.
+        if (pairingId) {
           socket.send(JSON.stringify({ type: 'pair', pairingId, ...common }));
         } else {
           socket.send(JSON.stringify({ type: 'auth', token, ...common }));

--- a/packages/dashboard/src/store/connection.ts
+++ b/packages/dashboard/src/store/connection.ts
@@ -291,6 +291,12 @@ export const selectShowSession = (s: ConnectionState): boolean =>
 let searchNonce = 0;
 let searchTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
+// #5281 ③ PR 2 — one-shot pairing id for the next socket open. When set, the
+// auth handshake sends `{type:'pair', pairingId}` instead of `{type:'auth',
+// token}`; it's cleared right after that first send so a later reconnect uses
+// the issued session token (captured from auth_ok), not the spent pairing id.
+let pendingPairingId: string | null = null;
+
 // Stable device ID persisted across sessions
 const STORAGE_KEY_DEVICE_ID = 'chroxy_device_id';
 let _cachedDeviceId: string | null = null;
@@ -1164,7 +1170,15 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       });
       setTimeout(() => {
         if (myAttemptId !== connectionAttemptId) return;
-        get().connect(url, token);
+        // #5281 ③ PR 2 — reconnect with the latest stored token for the active
+        // registry server. A paired connection started with an empty token;
+        // auth_ok wrote the issued session token back to the registry, so the
+        // reconnect must use that, not the stale captured (empty) token.
+        const sid = get().activeServerId;
+        const reconnectToken = sid
+          ? (get().serverRegistry.find((s) => s.id === sid)?.token ?? token)
+          : token;
+        get().connect(url, reconnectToken);
       }, delayMs);
     };
 
@@ -1173,13 +1187,21 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
       const info = getDeviceInfo();
       const deviceId = getDeviceId();
       if (socket.readyState === WebSocket.OPEN) {
-        socket.send(JSON.stringify({
-          type: 'auth',
-          token,
+        const common = {
           protocolVersion: CLIENT_PROTOCOL_VERSION,
           deviceInfo: { deviceId, ...info },
           capabilities: CLIENT_CAPABILITIES.desktop,
-        }));
+        };
+        // #5281 ③ PR 2 — pairing handshake when a one-shot pairing id is armed
+        // (consume it immediately so a reconnect falls back to the session
+        // token issued in auth_ok). Otherwise the normal token auth.
+        if (pendingPairingId) {
+          const pairingId = pendingPairingId;
+          pendingPairingId = null;
+          socket.send(JSON.stringify({ type: 'pair', pairingId, ...common }));
+        } else {
+          socket.send(JSON.stringify({ type: 'auth', token, ...common }));
+        }
       }
     };
 
@@ -2783,6 +2805,20 @@ export const useConnectionStore = create<ConnectionState>((set, get) => ({
     const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
     const wsUrl = `${proto}://${window.location.host}/ws`;
     get().connect(wsUrl, token);
+  },
+
+  /**
+   * Add a server from a pairing URL and connect via the ephemeral pairing
+   * handshake — no permanent token typed (#5281 ③ PR 2). The entry starts with
+   * an empty token; the session token issued in `auth_ok` replaces it (handled
+   * in the auth_ok message handler) so reconnects authenticate normally. A
+   * `pair_fail` clears the armed pairing id and surfaces the reason.
+   */
+  pairServer: (name: string, wsUrl: string, pairingId: string): ServerEntry => {
+    const entry = get().addServer(name, wsUrl, '');
+    pendingPairingId = pairingId;
+    get().switchServer(entry.id);
+    return entry;
   },
 }));
 

--- a/packages/dashboard/src/store/message-handler.test.ts
+++ b/packages/dashboard/src/store/message-handler.test.ts
@@ -76,6 +76,8 @@ function baseState(overrides: Partial<ConnectionState> = {}): Partial<Connection
   // branch of session_error wires through this setter; we assert on the
   // shape of the call).
   const sessionNotFoundCalls: unknown[] = []
+  const updateServerCalls: Array<{ serverId: string; patch: unknown }> = []
+  const removeServerCalls: string[] = []
   return {
     connectionPhase: 'connected',
     socket: null,
@@ -114,11 +116,19 @@ function baseState(overrides: Partial<ConnectionState> = {}): Partial<Connection
       grantCalls.push({ skillName, author })
     },
     appendTerminalData: (d: string) => { terminalWrites.push(d) },
+    // #5281 ③ PR 2 — server registry surface for the pairing auth_ok/pair_fail
+    // paths. Captured so tests can assert token persistence + dead-entry cleanup.
+    activeServerId: null,
+    serverRegistry: [],
+    updateServer: (serverId: string, patch: unknown) => { updateServerCalls.push({ serverId, patch }) },
+    removeServer: (serverId: string) => { removeServerCalls.push(serverId) },
     _terminalWrites: terminalWrites,
     _serverErrorActions: serverErrorActions,
     _infoNotifications: infoNotifications,
     _grantCalls: grantCalls,
     _sessionNotFoundCalls: sessionNotFoundCalls,
+    _updateServerCalls: updateServerCalls,
+    _removeServerCalls: removeServerCalls,
     serverProtocolVersion: null,
     ...overrides,
   } as unknown as Partial<ConnectionState>
@@ -174,6 +184,65 @@ describe('dashboard message-handler dispatch', () => {
       )
       expect(store.getState().connectionPhase).toBe('connected')
       expect(store.getState().serverVersion).toBe('0.6.0')
+    })
+
+    it('#5281 ③ PR 2 — adopts a paired sessionToken and persists it on the active server', () => {
+      store = createMockStore(baseState({ activeServerId: 'srv_paired' }))
+      setStore(store)
+      handleMessage(
+        {
+          type: 'auth_ok',
+          serverMode: 'cli',
+          serverVersion: '0.6.0',
+          protocolVersion: 3,
+          clientId: 'c1',
+          connectedClients: [],
+          sessionToken: 'sess-tok-xyz',
+        },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      // Effective token = the issued session token (ctx.token was 'tok').
+      expect(state.apiToken).toBe('sess-tok-xyz')
+      expect(state.savedConnection.token).toBe('sess-tok-xyz')
+      // …and written back to the registry entry for reconnects.
+      expect(state._updateServerCalls).toEqual([{ serverId: 'srv_paired', patch: { token: 'sess-tok-xyz' } }])
+    })
+
+    it('does not touch the registry on a normal token auth (no sessionToken)', () => {
+      store = createMockStore(baseState({ activeServerId: 'srv_x' }))
+      setStore(store)
+      handleMessage(
+        { type: 'auth_ok', serverMode: 'cli', serverVersion: '0.6.0', protocolVersion: 3, clientId: 'c1', connectedClients: [] },
+        ctx() as any,
+      )
+      const state = store.getState() as any
+      expect(state._updateServerCalls).toEqual([])
+      expect(state.apiToken).toBe('tok') // ctx.token unchanged
+    })
+  })
+
+  describe('pair_fail dispatch (#5281 ③ PR 2)', () => {
+    it('removes the optimistic tokenless entry and alerts', () => {
+      store = createMockStore(baseState({
+        activeServerId: 'srv_paired',
+        serverRegistry: [{ id: 'srv_paired', name: 'P', wsUrl: 'ws://x/ws', token: '', lastConnectedAt: null }],
+      }))
+      setStore(store)
+      handleMessage({ type: 'pair_fail', reason: 'expired' }, ctx() as any)
+      const state = store.getState() as any
+      expect(state.connectionPhase).toBe('disconnected')
+      expect(state._removeServerCalls).toEqual(['srv_paired'])
+    })
+
+    it('keeps an entry that already has a token (not an optimistic pairing entry)', () => {
+      store = createMockStore(baseState({
+        activeServerId: 'srv_real',
+        serverRegistry: [{ id: 'srv_real', name: 'R', wsUrl: 'ws://x/ws', token: 'keep', lastConnectedAt: null }],
+      }))
+      setStore(store)
+      handleMessage({ type: 'pair_fail', reason: 'rate_limited' }, ctx() as any)
+      expect((store.getState() as any)._removeServerCalls).toEqual([])
     })
   })
 

--- a/packages/dashboard/src/store/message-handler.ts
+++ b/packages/dashboard/src/store/message-handler.ts
@@ -2109,12 +2109,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       const auth = sharedAuthOk(msg);
       const clients = sharedParseConnectedClients(msg.connectedClients, auth.myClientId);
 
+      // #5281 ③ PR 2 — a pairing handshake issues a session token in auth_ok;
+      // adopt it as the effective token so reconnects authenticate normally.
+      // For the normal token-auth path `auth.sessionToken` is null and this is
+      // just `ctx.token`.
+      const effectiveToken = auth.sessionToken ?? ctx.token;
+      // Persist the issued session token onto the active registry entry (which
+      // was added with an empty token by pairServer) so connectToServer/
+      // switchServer reuse it later.
+      const pairedServerId = get().activeServerId;
+      if (auth.sessionToken && pairedServerId) {
+        get().updateServer(pairedServerId, { token: auth.sessionToken });
+      }
+
       // On reconnect, preserve messages and terminal buffer
       const connectedState = {
         connectionPhase: 'connected' as const,
         viewingCachedSession: false,
         wsUrl: ctx.url,
-        apiToken: ctx.token,
+        apiToken: effectiveToken,
         socket: ctx.socket,
         claudeReady: false,
         serverMode: auth.serverMode,
@@ -2176,9 +2189,9 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
           sendClientVisible(ctx.socket, document.visibilityState === 'visible');
         }
       }
-      // Save for quick reconnect
-      saveConnection(ctx.url, ctx.token);
-      set({ savedConnection: { url: ctx.url, token: ctx.token } });
+      // Save for quick reconnect (the issued session token, when paired).
+      saveConnection(ctx.url, effectiveToken);
+      set({ savedConnection: { url: ctx.url, token: effectiveToken } });
       break;
     }
 
@@ -2221,6 +2234,25 @@ export function handleMessage(raw: unknown, ctxOverride?: ConnectionContext): vo
       if (!ctx.silent) {
         const { reason } = sharedAuthFail(msg);
         _adapters.alert.alert('Auth Failed', reason);
+      }
+      break;
+    }
+
+    case 'pair_fail': {
+      // #5281 ③ PR 2 — pairing rejected (invalid/expired/already-used id, rate
+      // limited, pairing disabled). The pendingPairingId was already consumed on
+      // send. pairServer optimistically added a still-tokenless registry entry;
+      // pairing failed before a session token was issued, so drop the dead entry.
+      ctx.socket.close();
+      set({ connectionPhase: 'disconnected', socket: null });
+      const failedServerId = get().activeServerId;
+      if (failedServerId) {
+        const entry = get().serverRegistry.find((s) => s.id === failedServerId);
+        if (entry && !entry.token) get().removeServer(failedServerId);
+      }
+      if (!ctx.silent) {
+        const reason = typeof msg.reason === 'string' ? msg.reason : 'unknown';
+        _adapters.alert.alert('Pairing Failed', `Pairing failed: ${reason}`);
       }
       break;
     }

--- a/packages/dashboard/src/store/server-registry-store.test.ts
+++ b/packages/dashboard/src/store/server-registry-store.test.ts
@@ -211,6 +211,16 @@ describe('store server registry actions', () => {
     })
   })
 
+  it('pairServer adds a tokenless entry and makes it active (#5281 ③ PR 2)', () => {
+    mockToken = null
+    const entry = useConnectionStore.getState().pairServer('Studio', 'ws://192.168.1.5:8765/ws', 'PAIR123')
+    // Entry persisted with an empty token (the session token arrives via auth_ok).
+    expect(entry.token).toBe('')
+    expect(useConnectionStore.getState().serverRegistry.some(s => s.id === entry.id)).toBe(true)
+    // switchServer made it the active server (connect() does async work).
+    expect(useConnectionStore.getState().activeServerId).toBe(entry.id)
+  })
+
   it('multiple servers can coexist in registry', () => {
     useConnectionStore.getState().addServer('Dev', 'wss://dev/ws', 'token1')
     useConnectionStore.getState().addServer('Staging', 'wss://staging/ws', 'token2')

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -1141,6 +1141,10 @@ export interface ConnectionState {
   connectToServer: (serverId: string) => void;
   /** Connect to the local same-origin daemon ("this machine"); registry-less local target. */
   connectLocal: () => void;
+  /** Add a server from a pairing URL and connect via the ephemeral pairing
+      handshake (no permanent token); the issued session token replaces the
+      entry's empty token. (#5281 ③ PR 2) */
+  pairServer: (name: string, wsUrl: string, pairingId: string) => ServerEntry;
   /**
    * Reconnect to whatever server is currently active — the registry server when
    * `activeServerId` is set, otherwise the local same-origin daemon. Preserves

--- a/packages/dashboard/src/store/types.ts
+++ b/packages/dashboard/src/store/types.ts
@@ -744,7 +744,7 @@ export interface ConnectionState {
   _terminalWriteCallback: ((data: string) => void) | null;
 
   // Actions
-  connect: (url: string, token: string, options?: { silent?: boolean; _retryCount?: number }) => void;
+  connect: (url: string, token: string, options?: { silent?: boolean; _retryCount?: number; _pairingId?: string }) => void;
   disconnect: () => void;
   loadSavedConnection: () => void;
   clearSavedConnection: () => void;

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -7553,6 +7553,13 @@ button.sidebar-token-view-session-row:hover {
   margin-top: -4px;
 }
 
+/* #5281 ③ PR 2 — pairing-mode hint replacing the token field */
+.server-form-hint {
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 2px 0;
+}
+
 .server-add-actions {
   display: flex;
   gap: 6px;

--- a/packages/dashboard/src/utils/pairing.test.ts
+++ b/packages/dashboard/src/utils/pairing.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { parsePairingUrl, isPairingUrl } from './pairing'
+
+describe('parsePairingUrl', () => {
+  it('infers ws:// for a LAN chroxy URL (explicit port)', () => {
+    const r = parsePairingUrl('chroxy://192.168.1.5:8765?pair=ABC123')
+    expect(r).toEqual({ wsUrl: 'ws://192.168.1.5:8765/ws', pairingId: 'ABC123' })
+  })
+
+  it('infers wss:// for a tunnel chroxy URL (no port)', () => {
+    const r = parsePairingUrl('chroxy://my-tunnel.trycloudflare.com?pair=XYZ')
+    expect(r).toEqual({ wsUrl: 'wss://my-tunnel.trycloudflare.com/ws', pairingId: 'XYZ' })
+  })
+
+  it('handles a LAN hostname with a port', () => {
+    const r = parsePairingUrl('chroxy://macbook.local:8765?pair=p1')
+    expect(r?.wsUrl).toBe('ws://macbook.local:8765/ws')
+  })
+
+  it('handles an IPv6 LAN literal (port present ⇒ ws)', () => {
+    const r = parsePairingUrl('chroxy://[fe80::1]:8765?pair=p1')
+    expect(r?.wsUrl).toBe('ws://[fe80::1]:8765/ws')
+  })
+
+  it('parses the legacy ?token= flow', () => {
+    const r = parsePairingUrl('chroxy://192.168.1.5:8765?token=secret')
+    expect(r).toEqual({ wsUrl: 'ws://192.168.1.5:8765/ws', token: 'secret' })
+  })
+
+  it('keeps an explicit ws:// scheme (override for paste)', () => {
+    const r = parsePairingUrl('ws://10.0.0.2:9000?pair=p1')
+    expect(r?.wsUrl).toBe('ws://10.0.0.2:9000/ws')
+  })
+
+  it('keeps an explicit wss:// scheme even with a port (custom-proxy override)', () => {
+    const r = parsePairingUrl('wss://proxy.example.com:8443?pair=p1')
+    expect(r?.wsUrl).toBe('wss://proxy.example.com:8443/ws')
+  })
+
+  it('returns null for a URL with neither pair nor token', () => {
+    expect(parsePairingUrl('chroxy://192.168.1.5:8765')).toBeNull()
+  })
+
+  it('returns null for a non-connection URL', () => {
+    expect(parsePairingUrl('https://example.com?pair=x')).toBeNull()
+    expect(parsePairingUrl('not a url')).toBeNull()
+    expect(parsePairingUrl('')).toBeNull()
+  })
+
+  it('trims surrounding whitespace', () => {
+    const r = parsePairingUrl('  chroxy://192.168.1.5:8765?pair=ABC  ')
+    expect(r?.pairingId).toBe('ABC')
+  })
+})
+
+describe('isPairingUrl', () => {
+  it('is true only for a URL carrying ?pair=', () => {
+    expect(isPairingUrl('chroxy://192.168.1.5:8765?pair=ABC')).toBe(true)
+    expect(isPairingUrl('chroxy://192.168.1.5:8765?token=tok')).toBe(false)
+    expect(isPairingUrl('wss://host/ws')).toBe(false)
+    expect(isPairingUrl('garbage')).toBe(false)
+  })
+})

--- a/packages/dashboard/src/utils/pairing.ts
+++ b/packages/dashboard/src/utils/pairing.ts
@@ -1,0 +1,61 @@
+/**
+ * Pairing-URL parsing for the dashboard (#5281 ③ PR 2).
+ *
+ * Desktops can't scan a QR, so the parity form of "QR pairing" is pasting the
+ * `chroxy://…?pair=<id>` URL a daemon displays (the same string its QR encodes).
+ * This turns that paste into a connectable `ws(s)://…/ws` URL + pairing id; the
+ * caller then runs the pairing handshake (no permanent token typed).
+ *
+ * Scheme inference: the `chroxy://` scheme drops ws/wss. The server always
+ * builds a LAN pairing URL with an explicit port (`ws://host:PORT`) and a tunnel
+ * URL without one (`wss://domain` on 443) — see pairing.js `currentPairingUrl`.
+ * So **port present ⇒ ws (LAN), port absent ⇒ wss (tunnel)** is a reliable
+ * inference. A directly-pasted `ws://`/`wss://…?pair=` URL keeps its own scheme,
+ * which is the override for the rare port-bearing-wss (custom proxy) case.
+ */
+export interface ParsedPairing {
+  /** Connectable endpoint, e.g. `ws://192.168.1.5:8765/ws` or `wss://x.tld/ws`. */
+  wsUrl: string
+  /** Present for the pairing flow (`?pair=`). */
+  pairingId?: string
+  /** Present for the legacy token flow (`?token=`). */
+  token?: string
+}
+
+/**
+ * Parse a `chroxy://`, `ws://`, or `wss://` URL carrying `?pair=` or `?token=`.
+ * Returns null when the input isn't a recognizable connection URL or carries
+ * neither credential.
+ */
+export function parsePairingUrl(raw: string): ParsedPairing | null {
+  const trimmed = raw.trim()
+  let u: URL
+  let scheme: 'ws' | 'wss'
+  try {
+    if (trimmed.startsWith('chroxy://')) {
+      // Reparse under https so the URL parser yields host/port/searchParams.
+      u = new URL(trimmed.replace(/^chroxy:\/\//, 'https://'))
+      // Explicit port ⇒ LAN plain-ws; bare host ⇒ tunnel wss (see header).
+      scheme = u.port ? 'ws' : 'wss'
+    } else if (trimmed.startsWith('ws://') || trimmed.startsWith('wss://')) {
+      u = new URL(trimmed)
+      scheme = trimmed.startsWith('wss://') ? 'wss' : 'ws'
+    } else {
+      return null
+    }
+  } catch {
+    return null
+  }
+
+  const pairingId = u.searchParams.get('pair') ?? undefined
+  const token = u.searchParams.get('token') ?? undefined
+  if (!pairingId && !token) return null
+
+  const wsUrl = `${scheme}://${u.host}/ws`
+  return { wsUrl, ...(pairingId ? { pairingId } : {}), ...(token ? { token } : {}) }
+}
+
+/** True when a string looks like a pairing URL (carries `?pair=`). */
+export function isPairingUrl(raw: string): boolean {
+  return parsePairingUrl(raw)?.pairingId != null
+}

--- a/packages/protocol/tests/handler-coverage.test.js
+++ b/packages/protocol/tests/handler-coverage.test.js
@@ -73,7 +73,8 @@ const INTENTIONALLY_UNHANDLED = new Set([
 // ---------------------------------------------------------------------------
 const PLATFORM_SPECIFIC = {
   // Mobile app only
-  'pair_fail': 'app',           // QR pairing is mobile-only
+  // (pair_fail is now handled by BOTH platforms — the dashboard gained
+  //  paste-a-pairing-URL support in #5297 — so it's no longer platform-specific.)
   'push_token_error': 'app',    // push notifications are mobile-only
   'write_file_result': 'app',   // app file editing UI
   'git_branches_result': 'app', // app git UI


### PR DESCRIPTION
## Context

Epic #5281 milestone **③** — **PR 2 of 2** (the QR/pairing auth path; PR 1 #5296 landed mDNS discovery + manual token). This is the second auth option requested: connect without typing a permanent token.

Desktops can't scan a QR, so the parity form of "QR pairing" is **pasting the `chroxy://…?pair=<id>` URL a daemon displays** (the exact string its QR encodes — `pairingManager.currentPairingUrl`). **No new server endpoint** — this mirrors the mobile pairing handshake the server already supports.

## How it works

1. User pastes `chroxy://host?pair=<id>` into the ServerPicker add form → it switches to **pairing mode** (token field hidden, button reads **Pair**).
2. The dashboard adds a tokenless registry entry and connects, sending `{type:'pair', pairingId}` instead of `{type:'auth', token}`.
3. The server validates the one-time pairing id and issues a 24h **session token** in `auth_ok`; the dashboard adopts it as the effective token **and writes it back to the registry entry** so reconnects authenticate normally.
4. `pair_fail` (invalid/expired/already-used/rate-limited) surfaces the reason and drops the dead optimistic entry.

## Scheme inference (the one wrinkle)
`chroxy://` drops ws/wss. The server always builds a **LAN** pairing URL with an explicit port (`ws://host:PORT`) and a **tunnel** URL without one (`wss://domain`), so **port present ⇒ ws, absent ⇒ wss** is reliable. A directly-pasted `ws://`/`wss://…?pair=` URL keeps its own scheme (override for the rare port-bearing-wss proxy case).

## Files
- `utils/pairing.ts` (+test) — `parsePairingUrl` / `isPairingUrl`.
- `store/connection.ts` — `pendingPairingId` one-shot; pair-vs-auth send; `pairServer` action; reconnect re-reads the registry token (so a dropped paired link reconnects with the issued session token, not the stale empty one).
- `store/message-handler.ts` — `auth_ok` adopts `sessionToken` + registry write-back; new `pair_fail` case with dead-entry cleanup.
- `components/ServerPicker.tsx` — pairing-mode add form.

## Notes / follow-ups
- Session tokens are 24h (server policy). After expiry the user re-pairs; a future "Re-pair" affordance could streamline that.
- Discovery (PR 1) + pairing aren't auto-combined: discovery yields `host:port`, not a pairing id (fetching one would need an unauthenticated endpoint, which would defeat pairing's trust model). The two are complementary entry points.

## Tests
Pairing-URL parsing (scheme inference, IPv6, token/pair, ws(s):// overrides, rejects); `auth_ok` sessionToken adoption + registry write-back; `pair_fail` cleanup; `pairServer` store action; ServerPicker pairing-mode UI (mode switch, pair call, name default, manual fallback). Full dashboard suite green (3256); `tsc` clean.