### PR TITLE
ci(desktop): Authenticode-sign Windows MSI via Azure Trusted Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,8 @@ jobs:
         # download is Authenticode-trusted. The updater payload (.msi.zip) was zipped
         # during the build step and keeps its minisign signature only — see the
         # "Windows Authenticode code signing" section of docs/release-signing.md.
+        # Intentionally NOT continue-on-error: if signing was meant to happen
+        # (SIGN_ENABLED) but fails, fail the release rather than ship an unsigned MSI.
         uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,6 +317,50 @@ jobs:
         working-directory: packages/desktop
         run: cargo tauri build --target x86_64-pc-windows-msvc --bundles msi -c "$TAURI_CONFIG_OVERRIDE"
 
+      - name: Detect Authenticode signing
+        shell: bash
+        env:
+          # Azure Trusted Signing — Authenticode code-signing of the installer to
+          # clear the Windows SmartScreen "Windows protected your PC" dialog (#3808).
+          # Distinct from TAURI_SIGNING_* above, which is minisign for the auto-updater.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          TRUSTED_SIGNING_ENDPOINT: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+          TRUSTED_SIGNING_ACCOUNT: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+          TRUSTED_SIGNING_CERT_PROFILE: ${{ secrets.TRUSTED_SIGNING_CERT_PROFILE }}
+        run: |
+          # All six secrets must be present for signing to run. Any missing → skip
+          # (graceful degradation, mirroring the updater/notarization steps): the MSI
+          # still builds and uploads, just unsigned (SmartScreen warning persists).
+          if [ -n "$AZURE_TENANT_ID" ] && [ -n "$AZURE_CLIENT_ID" ] && [ -n "$AZURE_CLIENT_SECRET" ] \
+             && [ -n "$TRUSTED_SIGNING_ENDPOINT" ] && [ -n "$TRUSTED_SIGNING_ACCOUNT" ] \
+             && [ -n "$TRUSTED_SIGNING_CERT_PROFILE" ]; then
+            echo "SIGN_ENABLED=true" >> "$GITHUB_ENV"
+            echo "::notice::Windows Authenticode signing enabled (Azure Trusted Signing)"
+          else
+            echo "SIGN_ENABLED=false" >> "$GITHUB_ENV"
+            echo "::notice::Windows Authenticode signing disabled — MSI ships unsigned (set AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, TRUSTED_SIGNING_ENDPOINT, TRUSTED_SIGNING_ACCOUNT, TRUSTED_SIGNING_CERT_PROFILE to enable). See docs/release-signing.md."
+          fi
+
+      - name: Sign MSI (Azure Trusted Signing)
+        if: env.SIGN_ENABLED == 'true'
+        # Signs the standalone .msi in place before upload, so the installer users
+        # download is Authenticode-trusted. The updater payload (.msi.zip) was zipped
+        # during the build step and keeps its minisign signature only — see the
+        # "Windows Authenticode code signing" section of docs/release-signing.md.
+        uses: azure/trusted-signing-action@208f8af4bf26cf2af8597424e3cb5582801523ba # v2.0.0
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
+          endpoint: ${{ secrets.TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ secrets.TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.TRUSTED_SIGNING_CERT_PROFILE }}
+          files-folder: packages/desktop/src-tauri/target/x86_64-pc-windows-msvc/release/bundle/msi
+          files-folder-filter: msi
+          files-folder-recurse: false
+
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
         # download is Authenticode-trusted. The updater payload (.msi.zip) was zipped
         # during the build step and keeps its minisign signature only — see the
         # "Windows Authenticode code signing" section of docs/release-signing.md.
-        uses: azure/trusted-signing-action@208f8af4bf26cf2af8597424e3cb5582801523ba # v2.0.0
+        uses: azure/trusted-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -83,6 +83,84 @@ gh secret set APPLE_CERTIFICATE < <(base64 -i ~/path/to/cert.p12)
 gh secret set APPLE_CERTIFICATE_PASSWORD --body 'your-p12-password'
 ```
 
+## Windows Authenticode code signing (SmartScreen)
+
+Used by the `desktop-windows` job to Authenticode-sign the standalone `.msi` so a
+first-time install no longer trips the Windows SmartScreen "Windows protected your
+PC" dialog (#3808). This is **separate from Tauri updater signing** above: the
+updater secrets minisign the auto-update payload (`.msi.zip.sig`), while these
+secrets Authenticode-sign the installer Windows itself trusts.
+
+We use [Azure Trusted Signing](https://learn.microsoft.com/azure/trusted-signing/)
+(~$10/mo, key managed by Azure — no cert files or HSM to handle) via the official
+`azure/trusted-signing-action`.
+
+| Secret | Required? | Notes |
+|--------|-----------|-------|
+| `AZURE_TENANT_ID` | Yes | Directory (tenant) ID of the Entra ID tenant holding the signing App Registration |
+| `AZURE_CLIENT_ID` | Yes | Application (client) ID of that App Registration |
+| `AZURE_CLIENT_SECRET` | Yes | A client secret generated for the App Registration |
+| `TRUSTED_SIGNING_ENDPOINT` | Yes | Region endpoint of the Trusted Signing account, e.g. `https://eus.codesigning.azure.net` |
+| `TRUSTED_SIGNING_ACCOUNT` | Yes | The Trusted Signing **account** name |
+| `TRUSTED_SIGNING_CERT_PROFILE` | Yes | The **certificate profile** name within that account |
+
+**All six must be set and non-empty for signing to run.** If any is missing, the
+`Detect Authenticode signing` step sets `SIGN_ENABLED=false` and the `Sign MSI`
+step is skipped — the MSI still builds and uploads, just unsigned (SmartScreen
+warning persists, as it does today). No partial state.
+
+> **Known gap:** only the standalone `.msi` (the installer users download) is
+> Authenticode-signed. The auto-updater payload (`.msi.zip`) is zipped during the
+> Tauri build step *before* the signing step runs, so its embedded MSI carries the
+> minisign updater signature only, not an Authenticode one. First-install — the
+> SmartScreen pain point #3808 targets — is covered; signing the updater payload
+> too would require moving signing into Tauri's `bundle.windows.signCommand` so it
+> happens pre-zip. Tracked as a follow-up.
+
+### One-time Azure setup
+
+1. Create a **Trusted Signing account** in the Azure portal (Trusted Signing →
+   Create), choosing the region nearest your CI. Note the account name and the
+   account endpoint shown on the overview page.
+2. Complete **identity validation** (Public Trust → add an Identity Validation
+   request). This is the gate that takes time — an organization validation can
+   take a few business days. SmartScreen reputation only applies once validation
+   is approved.
+3. Create a **Certificate Profile** (Public Trust type) under the account. Note
+   its name.
+4. Create an **App Registration** in Entra ID, generate a **client secret**, and
+   note the tenant ID + client ID.
+5. Grant that App Registration the **Trusted Signing Certificate Profile Signer**
+   role on the Trusted Signing account (Access control (IAM) → Add role
+   assignment), so it's allowed to sign with the profile.
+
+### Setting the secrets
+
+```bash
+gh secret set AZURE_TENANT_ID --body '00000000-0000-0000-0000-000000000000'
+gh secret set AZURE_CLIENT_ID --body '00000000-0000-0000-0000-000000000000'
+gh secret set AZURE_CLIENT_SECRET --body 'your-client-secret'
+gh secret set TRUSTED_SIGNING_ENDPOINT --body 'https://eus.codesigning.azure.net'
+gh secret set TRUSTED_SIGNING_ACCOUNT --body 'your-signing-account'
+gh secret set TRUSTED_SIGNING_CERT_PROFILE --body 'your-cert-profile'
+```
+
+### Rotating the cert / credentials
+
+The certificate itself is managed and auto-renewed by Azure — there is no `.p12`
+or HSM key to rotate. What expires is the **App Registration client secret**: when
+it lapses, regenerate it in Entra ID and re-run `gh secret set AZURE_CLIENT_SECRET`.
+Nothing in the repo changes.
+
+### Verifying
+
+After approval + secrets are set, dispatch a release and confirm the
+`Detect Authenticode signing` step logs `signing enabled`. On a clean Windows 11
+box, download the released `.msi` and confirm it installs without the SmartScreen
+"Windows protected your PC" dialog; `signtool verify /pa chroxy_*.msi` (or
+right-click → Properties → Digital Signatures) should show a valid Microsoft ID
+Verified CS chain.
+
 ## Discord notifications (optional)
 
 Used by `repo-relay.yml` to mirror PR / issue / release events to Discord.

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -89,7 +89,7 @@ Used by the `desktop-windows` job to Authenticode-sign the standalone `.msi` so 
 first-time install no longer trips the Windows SmartScreen "Windows protected your
 PC" dialog (#3808). This is **separate from Tauri updater signing** above: the
 updater secrets minisign the auto-update payload (`.msi.zip.sig`), while these
-secrets Authenticode-sign the installer Windows itself trusts.
+secrets Authenticode-sign the installer that Windows itself trusts.
 
 We use [Azure Trusted Signing](https://learn.microsoft.com/azure/trusted-signing/)
 (~$10/mo, key managed by Azure — no cert files or HSM to handle) via the official


### PR DESCRIPTION
## What

Adds a **secret-gated** Authenticode code-signing step to the `desktop-windows` release job so the standalone `.msi` clears the Windows SmartScreen *"Windows protected your PC"* dialog on first install.

This is the **④ milestone** of the LAN-client epic (#5281) — "Signed Windows installer + CI" — and closes #3808.

## How

- **`Detect Authenticode signing`** sets `SIGN_ENABLED=true` only when all six Azure Trusted Signing secrets are present (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `TRUSTED_SIGNING_ENDPOINT`, `TRUSTED_SIGNING_ACCOUNT`, `TRUSTED_SIGNING_CERT_PROFILE`). Any missing → step is skipped and the MSI still builds + uploads, just unsigned. Same graceful-degradation pattern as the existing updater/notarization steps.
- **`Sign MSI (Azure Trusted Signing)`** (`azure/trusted-signing-action`, SHA-pinned `v2.0.0`) runs after the build and before upload, signing the `.msi` in place.
- Docs: Azure setup walkthrough, the six secrets, credential rotation, and verification, added to `docs/release-signing.md`.

## Inert until provisioned

This PR ships the **machinery only** — it's a no-op until the repo owner:
1. Provisions an Azure Trusted Signing account + completes identity validation (~$10/mo; org validation can take a few business days),
2. Sets the six secrets (`gh secret set …`, documented),
3. Verifies a signed `.msi` clears SmartScreen on a clean Windows 11 box.

## Known gap (documented, follow-up)

Only the standalone `.msi` is Authenticode-signed. The auto-updater payload (`.msi.zip`) is zipped during the Tauri build *before* signing, so its embedded MSI keeps the minisign updater signature only. First-install — the SmartScreen pain point #3808 targets — is covered. Full coverage would require moving signing into Tauri's `bundle.windows.signCommand` (pre-zip); left as a follow-up.

## Verification

- `actionlint` clean on the new steps (only pre-existing info-level shellcheck warnings on unrelated steps remain).

Closes #3808