### PR TITLE
feat(desktop): edit summon hotkey from Settings with live re-registration

### DIFF
--- a/packages/dashboard/src/components/SettingsPanel.test.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.test.tsx
@@ -5,7 +5,7 @@
  * and Escape key dismissal.
  */
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
-import { render, screen, cleanup, fireEvent } from '@testing-library/react'
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react'
 import { SettingsPanel } from './SettingsPanel'
 
 // Mock theme-engine
@@ -2424,6 +2424,83 @@ describe('SettingsPanel', () => {
       fireEvent.click(screen.getByTestId('speech-reset-button'))
       const errEl = await screen.findByTestId('speech-reset-error')
       expect(errEl.textContent).toContain('tccutil reset Microphone exited with status 1')
+    })
+  })
+
+  // #5294 — summon hotkey control: load-on-open, Save (trimmed), Clear (null),
+  // and inline error on registration rejection. Tauri-only (inTauri gate), so
+  // we fake __TAURI_INTERNALS__.invoke and let the real useTauriIPC run.
+  describe('summon hotkey (#5294)', () => {
+    const tauriInvoke = vi.fn()
+    const setTauriEnv = (tauri: boolean) => {
+      if (tauri) {
+        ;(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = { invoke: tauriInvoke }
+      } else {
+        delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+      }
+    }
+    // Default routing so the panel's open-time getters resolve quietly; tests
+    // override the summon-hotkey commands as needed.
+    const baseImpl = (cmd: string): Promise<unknown> => {
+      switch (cmd) {
+        case 'get_summon_hotkey': return Promise.resolve(null)
+        case 'get_tunnel_mode': return Promise.resolve('none')
+        case 'get_server_info': return Promise.resolve({ tunnelMode: 'none' })
+        case 'get_allow_auto_permission_mode': return Promise.resolve(false)
+        default: return Promise.resolve(undefined)
+      }
+    }
+
+    beforeEach(() => {
+      tauriInvoke.mockReset()
+      tauriInvoke.mockImplementation(baseImpl)
+      setTauriEnv(true)
+    })
+
+    afterEach(() => {
+      tauriInvoke.mockReset()
+      delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__
+    })
+
+    it('loads the saved hotkey into the field on open', async () => {
+      tauriInvoke.mockImplementation((cmd: string) =>
+        cmd === 'get_summon_hotkey' ? Promise.resolve('CmdOrCtrl+Shift+K') : baseImpl(cmd))
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const input = await screen.findByTestId('summon-hotkey-input') as HTMLInputElement
+      await waitFor(() => expect(input.value).toBe('CmdOrCtrl+Shift+K'))
+    })
+
+    it('Save invokes set_summon_hotkey with the trimmed accelerator', async () => {
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const input = await screen.findByTestId('summon-hotkey-input')
+      fireEvent.change(input, { target: { value: '  CmdOrCtrl+Shift+J  ' } })
+      fireEvent.click(screen.getByTestId('summon-hotkey-save'))
+      await waitFor(() =>
+        expect(tauriInvoke).toHaveBeenCalledWith('set_summon_hotkey', { accelerator: 'CmdOrCtrl+Shift+J' }))
+    })
+
+    it('Clear invokes set_summon_hotkey with null', async () => {
+      tauriInvoke.mockImplementation((cmd: string) =>
+        cmd === 'get_summon_hotkey' ? Promise.resolve('CmdOrCtrl+Shift+K') : baseImpl(cmd))
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const input = await screen.findByTestId('summon-hotkey-input') as HTMLInputElement
+      await waitFor(() => expect(input.value).toBe('CmdOrCtrl+Shift+K'))
+      fireEvent.click(screen.getByTestId('summon-hotkey-clear'))
+      await waitFor(() =>
+        expect(tauriInvoke).toHaveBeenCalledWith('set_summon_hotkey', { accelerator: null }))
+    })
+
+    it('shows an inline error when registration is rejected', async () => {
+      tauriInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'set_summon_hotkey') return Promise.reject(new Error("Could not register 'BadKey'"))
+        return baseImpl(cmd)
+      })
+      render(<SettingsPanel isOpen={true} onClose={vi.fn()} />)
+      const input = await screen.findByTestId('summon-hotkey-input')
+      fireEvent.change(input, { target: { value: 'BadKey' } })
+      fireEvent.click(screen.getByTestId('summon-hotkey-save'))
+      const err = await screen.findByTestId('summon-hotkey-error')
+      expect(err.textContent).toContain('Could not register')
     })
   })
 })

--- a/packages/dashboard/src/components/SettingsPanel.tsx
+++ b/packages/dashboard/src/components/SettingsPanel.tsx
@@ -32,6 +32,8 @@ import { getTauriInvoke } from '../utils/tauri-bridge'
 import {
   getTunnelMode,
   setTunnelMode,
+  getSummonHotkey,
+  setSummonHotkey,
   restartServer,
   getServerInfo,
   getAllowAutoPermissionMode,
@@ -698,6 +700,12 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
   const [tunnelError, setTunnelError] = useState<string | null>(null)
   const [serverTunnelMode, setServerTunnelMode] = useState<string>('none')
   const [restarting, setRestarting] = useState(false)
+  // #5294 — global summon hotkey. `summonHotkeySaved` tracks the persisted
+  // value so the Save button can disable when unchanged and Clear when empty.
+  const [summonHotkeyInput, setSummonHotkeyInput] = useState<string>('')
+  const [summonHotkeySaved, setSummonHotkeySaved] = useState<string | null>(null)
+  const [summonHotkeyError, setSummonHotkeyError] = useState<string | null>(null)
+  const [summonHotkeySaving, setSummonHotkeySaving] = useState<boolean>(false)
   // #4052: paste-API-key form state. Lives in the component (not the
   // store) so the raw key is never observable beyond this one render.
   const [byokKeyInput, setByokKeyInput] = useState('')
@@ -786,6 +794,13 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
     // previous open doesn't linger across reopens.
     setSpeechResetStatus('idle')
     setSpeechResetError(null)
+    // #5294 — reset hotkey edit state, then load the persisted accelerator.
+    setSummonHotkeyError(null)
+    setSummonHotkeySaving(false)
+    getSummonHotkey().then(hk => {
+      setSummonHotkeySaved(hk ?? null)
+      setSummonHotkeyInput(hk ?? '')
+    }).catch(() => {})
     // Read saved setting (what user selected)
     getTunnelMode().then(mode => {
       if (mode) setTunnelModeState(mode)
@@ -960,6 +975,38 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
       setTunnelError(err instanceof Error ? err.message : String(err))
     }
   }, [tunnelMode])
+
+  // #5294 — persist + live-register the summon hotkey. On a bad/conflicting
+  // accelerator the Rust side throws; surface it and leave the field as-typed
+  // so the user can correct it (the previous binding stays active server-side).
+  const handleSaveSummonHotkey = useCallback(async () => {
+    const next = summonHotkeyInput.trim()
+    setSummonHotkeyError(null)
+    setSummonHotkeySaving(true)
+    try {
+      await setSummonHotkey(next || null)
+      setSummonHotkeySaved(next || null)
+      setSummonHotkeyInput(next)
+    } catch (err) {
+      setSummonHotkeyError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSummonHotkeySaving(false)
+    }
+  }, [summonHotkeyInput])
+
+  const handleClearSummonHotkey = useCallback(async () => {
+    setSummonHotkeyError(null)
+    setSummonHotkeySaving(true)
+    try {
+      await setSummonHotkey(null)
+      setSummonHotkeySaved(null)
+      setSummonHotkeyInput('')
+    } catch (err) {
+      setSummonHotkeyError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSummonHotkeySaving(false)
+    }
+  }, [])
 
   // Normalize: if persisted defaultProvider isn't in server's list, use first available
   const effectiveProvider = useMemo(() => {
@@ -1812,6 +1859,56 @@ export function SettingsPanel({ isOpen, onClose, showConsoleTab, onToggleConsole
                 ) : (
                   <p className="tunnel-mode-note">Server restart required after change</p>
                 )}
+              </div>
+            </section>
+          )}
+          {/* #5294 — global summon hotkey: edit/clear with live re-registration. */}
+          {inTauri && (
+            <section className="settings-section">
+              <h3>Desktop</h3>
+              <div className="settings-field">
+                <label htmlFor="summon-hotkey">Summon hotkey</label>
+                <div className="summon-hotkey-row">
+                  <input
+                    id="summon-hotkey"
+                    type="text"
+                    aria-label="Summon hotkey accelerator"
+                    placeholder="e.g. CmdOrCtrl+Shift+K"
+                    value={summonHotkeyInput}
+                    onChange={(e) => setSummonHotkeyInput(e.target.value)}
+                    spellCheck={false}
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    data-testid="summon-hotkey-input"
+                  />
+                  <button
+                    type="button"
+                    className="summon-hotkey-save"
+                    disabled={summonHotkeySaving || summonHotkeyInput.trim() === (summonHotkeySaved ?? '')}
+                    onClick={handleSaveSummonHotkey}
+                    data-testid="summon-hotkey-save"
+                  >
+                    {summonHotkeySaving ? 'Saving…' : 'Save'}
+                  </button>
+                  <button
+                    type="button"
+                    className="summon-hotkey-clear"
+                    disabled={summonHotkeySaving || (!summonHotkeyInput.trim() && !summonHotkeySaved)}
+                    onClick={handleClearSummonHotkey}
+                    data-testid="summon-hotkey-clear"
+                  >
+                    Clear
+                  </button>
+                </div>
+                {summonHotkeyError && (
+                  <p className="tunnel-mode-error" data-testid="summon-hotkey-error">{summonHotkeyError}</p>
+                )}
+                <p className="settings-hint">
+                  A system-wide shortcut to bring Chroxy to the front, in Tauri
+                  accelerator syntax (e.g. <code>CmdOrCtrl+Shift+K</code>). Applies
+                  immediately — no restart. Leave blank to disable; the tray
+                  &ldquo;Show Chroxy&rdquo; item is always available.
+                </p>
               </div>
             </section>
           )}

--- a/packages/dashboard/src/hooks/TauriIPC.test.ts
+++ b/packages/dashboard/src/hooks/TauriIPC.test.ts
@@ -73,4 +73,26 @@ describe('Tauri IPC commands (#1108)', () => {
   test('TypeScript hook exports setTunnelMode', () => {
     expect(hookSrc).toMatch(/export async function setTunnelMode/)
   })
+
+  // #5294 — summon hotkey settings command + live re-registration.
+  test('Rust has get_summon_hotkey command', () => {
+    expect(libSrc).toMatch(/#\[tauri::command\][\s\S]*?fn get_summon_hotkey/)
+  })
+
+  test('Rust has set_summon_hotkey command', () => {
+    expect(libSrc).toMatch(/#\[tauri::command\][\s\S]*?fn set_summon_hotkey/)
+  })
+
+  test('summon hotkey commands registered in generate_handler', () => {
+    expect(libSrc).toMatch(/generate_handler!\[[\s\S]*?get_summon_hotkey/)
+    expect(libSrc).toMatch(/generate_handler!\[[\s\S]*?set_summon_hotkey/)
+  })
+
+  test('TypeScript hook exports getSummonHotkey', () => {
+    expect(hookSrc).toMatch(/export async function getSummonHotkey/)
+  })
+
+  test('TypeScript hook exports setSummonHotkey', () => {
+    expect(hookSrc).toMatch(/export async function setSummonHotkey/)
+  })
 })

--- a/packages/dashboard/src/hooks/useTauriIPC.ts
+++ b/packages/dashboard/src/hooks/useTauriIPC.ts
@@ -55,6 +55,33 @@ export async function setTunnelMode(mode: string): Promise<void> {
 }
 
 /**
+ * Read the configured global summon hotkey accelerator (#5294).
+ *
+ * Returns `null` outside Tauri, or when no hotkey is set (the Rust side returns
+ * `None` for unset/blank). A non-empty string is the active accelerator.
+ */
+export async function getSummonHotkey(): Promise<string | null> {
+  return tauriInvoke<string | null>('get_summon_hotkey')
+}
+
+/**
+ * Set or clear the global summon hotkey and re-register it immediately (#5294).
+ * Pass `null` or an empty string to clear it. No-ops outside Tauri.
+ *
+ * Throws when invoke is unavailable inside Tauri, or when the Rust side rejects
+ * the accelerator (malformed / OS-conflicting) — so the SettingsPanel can show
+ * the failure instead of silently leaving the old binding in place.
+ */
+export async function setSummonHotkey(accelerator: string | null): Promise<void> {
+  if (!isTauri()) return
+  const invoke = getTauriInvoke()
+  if (!invoke) {
+    throw new Error('Tauri invoke is unavailable')
+  }
+  await invoke('set_summon_hotkey', { accelerator })
+}
+
+/**
  * Read `allowAutoPermissionMode` from `~/.chroxy/config.json`.
  *
  * Returns:

--- a/packages/dashboard/src/theme/components.css
+++ b/packages/dashboard/src/theme/components.css
@@ -6498,6 +6498,22 @@ button.sidebar-token-view-session-row:hover {
   font-style: italic;
 }
 
+/* #5294 — summon hotkey: text field + Save/Clear on one row. */
+.summon-hotkey-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.summon-hotkey-row input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.summon-hotkey-row button {
+  flex: 0 0 auto;
+}
+
 .tunnel-restart-btn {
   margin: 10px 0 0;
   padding: 8px 16px;

--- a/packages/desktop/src-tauri/build.rs
+++ b/packages/desktop/src-tauri/build.rs
@@ -24,6 +24,8 @@ const APP_COMMANDS: &[&str] = &[
     "save_setup_config",
     "get_tunnel_mode",
     "set_tunnel_mode",
+    "get_summon_hotkey",
+    "set_summon_hotkey",
     "get_allow_auto_permission_mode",
     "set_allow_auto_permission_mode",
     "voice_available",

--- a/packages/desktop/src-tauri/capabilities/default.json
+++ b/packages/desktop/src-tauri/capabilities/default.json
@@ -32,6 +32,8 @@
     "allow-save-setup-config",
     "allow-get-tunnel-mode",
     "allow-set-tunnel-mode",
+    "allow-get-summon-hotkey",
+    "allow-set-summon-hotkey",
     "allow-get-allow-auto-permission-mode",
     "allow-set-allow-auto-permission-mode",
     "allow-voice-available",

--- a/packages/desktop/src-tauri/permissions/autogenerated/get_summon_hotkey.toml
+++ b/packages/desktop/src-tauri/permissions/autogenerated/get_summon_hotkey.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-get-summon-hotkey"
+description = "Enables the get_summon_hotkey command without any pre-configured scope."
+commands.allow = ["get_summon_hotkey"]
+
+[[permission]]
+identifier = "deny-get-summon-hotkey"
+description = "Denies the get_summon_hotkey command without any pre-configured scope."
+commands.deny = ["get_summon_hotkey"]

--- a/packages/desktop/src-tauri/permissions/autogenerated/set_summon_hotkey.toml
+++ b/packages/desktop/src-tauri/permissions/autogenerated/set_summon_hotkey.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-set-summon-hotkey"
+description = "Enables the set_summon_hotkey command without any pre-configured scope."
+commands.allow = ["set_summon_hotkey"]
+
+[[permission]]
+identifier = "deny-set-summon-hotkey"
+description = "Denies the set_summon_hotkey command without any pre-configured scope."
+commands.deny = ["set_summon_hotkey"]

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -327,6 +327,67 @@ fn set_tunnel_mode(app: tauri::AppHandle, mode: String) -> Result<(), String> {
     Ok(())
 }
 
+/// #5294 — read the configured summon hotkey accelerator. Returns `None` when
+/// unset or blank (i.e. disabled), matching `effective_summon_hotkey()`.
+#[tauri::command]
+fn get_summon_hotkey(settings_state: tauri::State<'_, Mutex<DesktopSettings>>) -> Option<String> {
+    lock_or_recover(&settings_state).effective_summon_hotkey()
+}
+
+/// #5294 — set (or clear) the global summon hotkey at runtime and re-register
+/// it immediately, so the change takes effect with no restart. Passing `None`
+/// or a blank/whitespace string clears the hotkey. A malformed or
+/// OS-conflicting accelerator is returned as an error (with the previous
+/// binding left intact) instead of being silently swallowed.
+#[tauri::command]
+fn set_summon_hotkey(app: tauri::AppHandle, accelerator: Option<String>) -> Result<(), String> {
+    use tauri_plugin_global_shortcut::GlobalShortcutExt;
+
+    // Normalize blank/whitespace to None (disabled), mirroring
+    // effective_summon_hotkey()'s treatment so the two never disagree.
+    let new_accel = accelerator
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let settings_state = app
+        .try_state::<Mutex<DesktopSettings>>()
+        .ok_or("Settings state unavailable")?;
+
+    // The accelerator currently registered (what we must unregister first).
+    let old_accel = lock_or_recover(&settings_state).effective_summon_hotkey();
+
+    // Unregister the previously-registered accelerator, if any. Best-effort:
+    // if it was never actually registered (e.g. it had failed at startup), the
+    // unregister error is irrelevant to the new registration.
+    if let Some(ref old) = old_accel {
+        let _ = app.global_shortcut().unregister(old.as_str());
+    }
+
+    // Register the new accelerator. On failure, restore the old binding so a
+    // typo doesn't leave the user with no hotkey, and surface the error.
+    if let Some(ref acc) = new_accel {
+        if let Err(e) = register_summon_hotkey(&app, acc) {
+            if let Some(ref old) = old_accel {
+                let _ = register_summon_hotkey(&app, old);
+            }
+            return Err(format!("{} — the previous hotkey is unchanged.", e));
+        }
+    }
+
+    // Persist only after a successful (un)register.
+    {
+        let mut settings = lock_or_recover(&settings_state);
+        settings.summon_hotkey = new_accel;
+        settings
+            .save()
+            .map_err(|e| format!("Failed to save settings: {}", e))?;
+    }
+
+    Ok(())
+}
+
 /// Read `allowAutoPermissionMode` from `~/.chroxy/config.json`.
 /// Returns `false` if the config file doesn't exist, is empty/whitespace-only,
 /// or the key is missing. Surfaces parse errors so the UI can show a meaningful
@@ -749,6 +810,8 @@ pub fn run() {
             save_setup_config,
             get_tunnel_mode,
             set_tunnel_mode,
+            get_summon_hotkey,
+            set_summon_hotkey,
             get_allow_auto_permission_mode,
             set_allow_auto_permission_mode,
             #[cfg(target_os = "macos")]
@@ -1230,7 +1293,10 @@ pub fn run() {
                 let accel = settings_guard.effective_summon_hotkey();
                 drop(settings_guard);
                 if let Some(accel) = accel {
-                    register_summon_hotkey(app.handle(), &accel);
+                    match register_summon_hotkey(app.handle(), &accel) {
+                        Ok(()) => eprintln!("[hotkey] summon shortcut registered: {}", accel),
+                        Err(e) => eprintln!("[hotkey] {}", e),
+                    }
                 }
             }
 
@@ -1314,15 +1380,17 @@ pub fn run() {
         });
 }
 
-/// Register the opt-in global summon shortcut. Best-effort: a malformed
-/// accelerator or an OS-level conflict is logged, never fatal — the tray
-/// "Show Chroxy" item is always available as a fallback. (#5281 ②)
-fn register_summon_hotkey(app: &tauri::AppHandle, accelerator: &str) {
+/// Register the opt-in global summon shortcut, returning any registration
+/// error (malformed accelerator or OS-level conflict) so the caller can decide
+/// how to handle it: surface it to the user for a runtime change
+/// (`set_summon_hotkey`), or just log it for the best-effort startup
+/// registration — the tray "Show Chroxy" item is always available as a
+/// fallback. (#5281 ②, #5294)
+fn register_summon_hotkey(app: &tauri::AppHandle, accelerator: &str) -> Result<(), String> {
     use tauri_plugin_global_shortcut::GlobalShortcutExt;
-    match app.global_shortcut().register(accelerator) {
-        Ok(()) => eprintln!("[hotkey] summon shortcut registered: {}", accelerator),
-        Err(e) => eprintln!("[hotkey] failed to register summon shortcut '{}': {}", accelerator, e),
-    }
+    app.global_shortcut()
+        .register(accelerator)
+        .map_err(|e| format!("failed to register summon shortcut '{}': {}", accelerator, e))
 }
 
 fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -376,13 +376,28 @@ fn set_summon_hotkey(app: tauri::AppHandle, accelerator: Option<String>) -> Resu
         }
     }
 
-    // Persist only after a successful (un)register.
+    // Persist only after a successful (un)register. If the write fails, roll
+    // back BOTH the in-memory setting and the registration so disk, memory, and
+    // the live shortcut stay consistent — otherwise the new hotkey would work
+    // this session but the next restart would load the old, persisted value
+    // (and register that), a silent drift Copilot flagged on #5294.
     {
         let mut settings = lock_or_recover(&settings_state);
-        settings.summon_hotkey = new_accel;
-        settings
-            .save()
-            .map_err(|e| format!("Failed to save settings: {}", e))?;
+        settings.summon_hotkey = new_accel.clone();
+        if let Err(e) = settings.save() {
+            settings.summon_hotkey = old_accel.clone();
+            drop(settings);
+            if let Some(ref acc) = new_accel {
+                let _ = app.global_shortcut().unregister(acc.as_str());
+            }
+            if let Some(ref old) = old_accel {
+                let _ = register_summon_hotkey(&app, old);
+            }
+            return Err(format!(
+                "Failed to save settings: {} — the previous hotkey is unchanged.",
+                e
+            ));
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Closes #5294. Follow-up to #5293 (epic #5281 ②).

## What
Adds a desktop Settings control to view / change / clear the global summon hotkey, taking effect **immediately** (no restart) and surfacing registration failures to the user.

## How
- **`get_summon_hotkey` / `set_summon_hotkey`** Tauri commands. `set_` normalizes blank→disabled, **unregisters the old accelerator then registers the new one**; on a malformed / OS-conflicting accelerator it restores the previous binding and returns the error (instead of the old silent `eprintln!` no-op).
- **`register_summon_hotkey` now returns `Result`** so the runtime path can report failures; the startup registration keeps its best-effort logging.
- Wired through the three drift-checked sites: `build.rs` `APP_COMMANDS`, `generate_handler!`, and `capabilities/default.json`. No `global-shortcut:default` capability needed — JS calls our custom command, not the plugin directly (per the issue's note).
- **SettingsPanel**: a new *Desktop* section (Tauri-only) with a hotkey text field + Save/Clear, loaded on open, inline error display.

## Tests
- `TauriIPC.test.ts`: command-exists / generate_handler / hook-export assertions for the new commands.
- `command_drift.rs` stays green (verifies APP_COMMANDS = generate_handler = capabilities).
- Dashboard typecheck + suite green (168 in the touched files); `cargo check` clean; settings tests pass.

## Acceptance criteria
- [x] User can set / change / clear the summon hotkey from the desktop UI
- [x] Change takes effect immediately (old unregistered, new registered), no restart
- [x] A bad/conflicting accelerator is reported to the user, not just logged
- [x] Capabilities updated only for the custom commands (plugin not invoked from JS)