### PR TITLE
fix(app): infer ws/wss for chroxy:// QR by port (LAN pairing connects)

### DIFF
--- a/packages/app/src/__tests__/qr-parse.test.ts
+++ b/packages/app/src/__tests__/qr-parse.test.ts
@@ -49,4 +49,33 @@ describe('parseChroxyUrl (#1852)', () => {
     const result = parseChroxyUrl('  chroxy://example.com?pair=abc  ');
     expect(result).toEqual({ ok: true, wsUrl: 'wss://example.com', pairingId: 'abc' });
   });
+
+  // #5298 — chroxy:// scheme inference: a LAN daemon's URL has an explicit
+  // port and serves plain ws://; a tunnel URL has no port and is wss:// on 443.
+  describe('LAN vs tunnel scheme inference (#5298)', () => {
+    it('LAN pairing URL (explicit port) connects over ws://', () => {
+      const result = parseChroxyUrl('chroxy://192.168.1.5:8765?pair=abc123');
+      expect(result).toEqual({ ok: true, wsUrl: 'ws://192.168.1.5:8765', pairingId: 'abc123' });
+    });
+
+    it('LAN token URL (explicit port) connects over ws://', () => {
+      const result = parseChroxyUrl('chroxy://192.168.1.5:8765?token=tok');
+      expect(result).toEqual({ ok: true, wsUrl: 'ws://192.168.1.5:8765', token: 'tok' });
+    });
+
+    it('tunnel pairing URL (no port) stays wss://', () => {
+      const result = parseChroxyUrl('chroxy://abc.trycloudflare.com?pair=xyz');
+      expect(result).toEqual({ ok: true, wsUrl: 'wss://abc.trycloudflare.com', pairingId: 'xyz' });
+    });
+
+    it('IPv6 LAN URL (explicit port) keeps brackets and uses ws://', () => {
+      const result = parseChroxyUrl('chroxy://[fd00::1]:8765?pair=abc');
+      expect(result).toEqual({ ok: true, wsUrl: 'ws://[fd00::1]:8765', pairingId: 'abc' });
+    });
+
+    it('directly-entered ws:// keeps its scheme', () => {
+      const result = parseChroxyUrl('ws://192.168.1.5:8765');
+      expect(result).toEqual({ ok: true, wsUrl: 'ws://192.168.1.5:8765', token: '' });
+    });
+  });
 });

--- a/packages/app/src/__tests__/qr-parse.test.ts
+++ b/packages/app/src/__tests__/qr-parse.test.ts
@@ -77,5 +77,12 @@ describe('parseChroxyUrl (#1852)', () => {
       const result = parseChroxyUrl('ws://192.168.1.5:8765');
       expect(result).toEqual({ ok: true, wsUrl: 'ws://192.168.1.5:8765', token: '' });
     });
+
+    it('explicit :443 is the https default port and stays wss:// (no port in host)', () => {
+      // `new URL` strips the default https port, so `parsed.port` is empty —
+      // a tunnel on 443 still infers wss, even written with an explicit :443.
+      const result = parseChroxyUrl('chroxy://abc.trycloudflare.com:443?pair=xyz');
+      expect(result).toEqual({ ok: true, wsUrl: 'wss://abc.trycloudflare.com', pairingId: 'xyz' });
+    });
   });
 });

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -55,8 +55,8 @@ export function parseChroxyUrl(raw: string): ParseResult {
 
       return { ok: false, reason: 'missing_token' };
     }
-    // A directly-entered ws://-/wss:// URL keeps its own scheme — the override
-    // for the rare port-bearing wss (custom proxy) case.
+    // A directly-entered ws:// or wss:// URL keeps its own scheme — the
+    // override for the rare port-bearing wss (custom proxy) case.
     if (trimmed.startsWith('ws://') || trimmed.startsWith('wss://')) {
       return { ok: true, wsUrl: trimmed, token: '' };
     }

--- a/packages/app/src/screens/ConnectScreen.tsx
+++ b/packages/app/src/screens/ConnectScreen.tsx
@@ -36,7 +36,14 @@ export function parseChroxyUrl(raw: string): ParseResult {
     const trimmed = raw.trim();
     if (trimmed.startsWith('chroxy://')) {
       const parsed = new URL(trimmed.replace('chroxy://', 'https://'));
-      const wsUrl = `wss://${parsed.host}`;
+      // #5298 — the chroxy:// scheme drops ws/wss, so infer it from the port.
+      // A LAN daemon's pairing/QR URL always has an explicit port and serves
+      // plain ws:// (no TLS); a tunnel URL has no port and is wss:// on 443.
+      // So: port present ⇒ ws (LAN), port absent ⇒ wss (tunnel). `parsed.host`
+      // already carries the port (and brackets, for IPv6). Mirrors the
+      // dashboard's parsePairingUrl scheme inference.
+      const scheme = parsed.port ? 'ws' : 'wss';
+      const wsUrl = `${scheme}://${parsed.host}`;
 
       // New pairing flow: chroxy://host?pair=PAIRING_ID
       const pairingId = parsed.searchParams.get('pair');
@@ -48,7 +55,9 @@ export function parseChroxyUrl(raw: string): ParseResult {
 
       return { ok: false, reason: 'missing_token' };
     }
-    if (trimmed.startsWith('wss://')) {
+    // A directly-entered ws://-/wss:// URL keeps its own scheme — the override
+    // for the rare port-bearing wss (custom proxy) case.
+    if (trimmed.startsWith('ws://') || trimmed.startsWith('wss://')) {
       return { ok: true, wsUrl: trimmed, token: '' };
     }
   } catch {


### PR DESCRIPTION
Closes #5298. Surfaced during review of #5297.

## Problem
`parseChroxyUrl` in `ConnectScreen.tsx` built `wss://${host}` for **every** `chroxy://` URL. A LAN daemon serves plain `ws://` and its QR is `chroxy://<ip>:<port>?pair=…`, so scanning it on mobile yielded an unconnectable `wss://<ip>:<port>` (TLS handshake against a plaintext ws server). Tunnel pairing was fine (wss on 443), so this only bit LAN QR pairing.

## Fix
Port the scheme inference from the dashboard's `parsePairingUrl`: **explicit port ⇒ `ws` (LAN), no port ⇒ `wss` (tunnel)**; a directly-entered `ws://`/`wss://` URL keeps its own scheme (override for the rare port-bearing-wss proxy case). `parsed.host` already carries the port and IPv6 brackets, so no host handling changes — the diff is just the scheme.

## Tests (mirror dashboard `pairing.test.ts`)
- LAN pairing/token URL (explicit port) ⇒ `ws://`
- Tunnel URL (no port) ⇒ `wss://`
- IPv6 LAN URL keeps brackets + `ws://`
- Directly-entered `ws://` passthrough

All 14 `qr-parse` tests pass; app `tsc` clean.

## Acceptance criteria
- [x] LAN daemon QR (`chroxy://<ip>:<port>?pair=…`) connects over `ws://`
- [x] Tunnel QR pairing still uses `wss://`
- [x] Unit tests mirror dashboard `pairing.test.ts`