### PR TITLE
fix(server): flush session state on every supervised shutdown/crash path (#5308)

### DIFF
--- a/packages/server/src/server-cli-child.js
+++ b/packages/server/src/server-cli-child.js
@@ -15,6 +15,7 @@
 import { existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
+import { pathToFileURL } from 'url'
 import { mergeConfig } from './config.js'
 import { createLogger } from './logger.js'
 
@@ -25,6 +26,47 @@ const CONFIG_FILE = join(homedir(), '.chroxy', 'config.json')
 // Module-level references for drain handler access
 let _sessionManager = null
 let _wsServer = null
+
+// Guards the flush/exit sequence so a crash arriving during an IPC shutdown
+// (or vice-versa) doesn't double-run it.
+let _shuttingDown = false
+
+/**
+ * Persist + tear down before the child exits. Mirrors the foreground handler in
+ * server-cli.js (#3697): broadcast the shutdown, serialize session state to disk
+ * BEFORE destroying anything (losing the user's restored state on stop/crash is
+ * worse than risking a partial write), then destroyAll() (idempotent — it
+ * serializes again and sets _destroying so late persists no-op) and close the WS.
+ *
+ * Exported (no process.exit) so it can be unit-tested with fakes. #5308 / WP-0.2.
+ *
+ * @param {object|null} sessionManager
+ * @param {object|null} wsServer
+ * @param {string} reason — broadcastShutdown reason ('shutdown' | 'crash')
+ * @param {object} [logger]
+ */
+export function flushAndDestroy(sessionManager, wsServer, reason, logger = log) {
+  try { if (wsServer) wsServer.broadcastShutdown(reason, 0) } catch {}
+  try {
+    if (sessionManager) sessionManager.serializeState()
+  } catch (err) {
+    logger.error(`Failed to serialize session state before ${reason}: ${err?.stack || err}`)
+  }
+  try { if (sessionManager) sessionManager.destroyAll() } catch {}
+  try { if (wsServer) wsServer.close() } catch {}
+}
+
+// Flush state, then exit. Idempotent via _shuttingDown. The 100ms defer lets the
+// broadcastShutdown frame + socket close flush before the process goes away.
+function gracefulExit(code, reason) {
+  if (_shuttingDown) {
+    setTimeout(() => process.exit(code), 100)
+    return
+  }
+  _shuttingDown = true
+  flushAndDestroy(_sessionManager, _wsServer, reason, log)
+  setTimeout(() => process.exit(code), 100)
+}
 
 async function main() {
   // Load config (same as cli.js start command)
@@ -105,38 +147,50 @@ async function handleDrain(timeout) {
   }
 }
 
-// Listen for IPC messages from supervisor
-if (process.send) {
-  process.on('message', async (msg) => {
-    if (msg.type === 'shutdown') {
-      log.info('Shutdown requested by supervisor')
-      process.exit(0)
-    }
+// Only wire process-global handlers + run main() when this file is the forked
+// entry point. When imported (e.g. unit tests of flushAndDestroy) these side
+// effects must NOT fire — registering crash handlers or starting the server on
+// import would corrupt the test runner. #5308 / WP-0.2.
+const isEntryPoint = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
 
-    if (msg.type === 'drain') {
-      const timeout = msg.timeout || 30000
-      await handleDrain(timeout)
-    }
+if (isEntryPoint) {
+  // Listen for IPC messages from supervisor
+  if (process.send) {
+    process.on('message', async (msg) => {
+      if (msg.type === 'shutdown') {
+        // #5308 (WP-0.2) — the supervisor's stop path sends this IPC and only
+        // escalates to an OS SIGTERM at the 5s force-kill fallback, so the
+        // child's OS-signal flush handler never runs first. A bare process.exit(0)
+        // here therefore lost ALL session state on every supervised stop/restart
+        // (the #3697 data-loss class on the supervised hot path). Flush first.
+        log.info('Shutdown requested by supervisor')
+        gracefulExit(0, 'shutdown')
+        return
+      }
+
+      if (msg.type === 'drain') {
+        const timeout = msg.timeout || 30000
+        await handleDrain(timeout)
+      }
+    })
+  }
+
+  // #5308 (WP-0.2) — crash handlers previously called destroyAll() (which does
+  // serialize internally) but omitted the explicit pre-destroy serializeState the
+  // foreground handler runs. gracefulExit() now serializes BEFORE destroyAll for
+  // parity with server-cli.js, isolating a serialize failure from teardown.
+  process.on('uncaughtException', (err) => {
+    log.error(`Uncaught exception: ${err?.stack || err}`)
+    gracefulExit(1, 'crash')
+  })
+
+  process.on('unhandledRejection', (err) => {
+    log.error(`Unhandled rejection: ${err?.stack || err}`)
+    gracefulExit(1, 'crash')
+  })
+
+  main().catch((err) => {
+    log.error(`Fatal error: ${err?.stack || err}`)
+    process.exit(1)
   })
 }
-
-process.on('uncaughtException', (err) => {
-  log.error(`Uncaught exception: ${err?.stack || err}`)
-  try { if (_wsServer) _wsServer.broadcastShutdown('crash', 0) } catch {}
-  try { if (_wsServer) _wsServer.close() } catch {}
-  try { if (_sessionManager) _sessionManager.destroyAll() } catch {}
-  setTimeout(() => process.exit(1), 100)
-})
-
-process.on('unhandledRejection', (err) => {
-  log.error(`Unhandled rejection: ${err?.stack || err}`)
-  try { if (_wsServer) _wsServer.broadcastShutdown('crash', 0) } catch {}
-  try { if (_wsServer) _wsServer.close() } catch {}
-  try { if (_sessionManager) _sessionManager.destroyAll() } catch {}
-  setTimeout(() => process.exit(1), 100)
-})
-
-main().catch((err) => {
-  log.error(`Fatal error: ${err?.stack || err}`)
-  process.exit(1)
-})

--- a/packages/server/src/server-cli-child.js
+++ b/packages/server/src/server-cli-child.js
@@ -59,12 +59,13 @@ export function flushAndDestroy(sessionManager, wsServer, reason, logger = log) 
 // Flush state, then exit. Idempotent via _shuttingDown. The 100ms defer lets the
 // broadcastShutdown frame + socket close flush before the process goes away.
 function gracefulExit(code, reason) {
-  if (_shuttingDown) {
-    setTimeout(() => process.exit(code), 100)
-    return
-  }
+  // Idempotent: the first call already armed the exit timer below, so a second
+  // path firing during the 100ms window (e.g. a crash mid-shutdown) just returns
+  // — the in-flight timer guarantees the process exits.
+  if (_shuttingDown) return
   _shuttingDown = true
   flushAndDestroy(_sessionManager, _wsServer, reason, log)
+  // 100ms defer lets the broadcastShutdown frame + socket close flush first.
   setTimeout(() => process.exit(code), 100)
 }
 

--- a/packages/server/src/server-cli-child.js
+++ b/packages/server/src/server-cli-child.js
@@ -52,8 +52,18 @@ export function flushAndDestroy(sessionManager, wsServer, reason, logger = log) 
   } catch (err) {
     logger.error(`Failed to serialize session state before ${reason}: ${err?.stack || err}`)
   }
-  try { if (sessionManager) sessionManager.destroyAll() } catch {}
-  try { if (wsServer) wsServer.close() } catch {}
+  // Isolate each teardown step so one failure can't abort the rest, but log it —
+  // a throw here during a crash/shutdown is exactly when observability matters.
+  try {
+    if (sessionManager) sessionManager.destroyAll()
+  } catch (err) {
+    logger.error(`Failed to destroy sessions during ${reason}: ${err?.stack || err}`)
+  }
+  try {
+    if (wsServer) wsServer.close()
+  } catch (err) {
+    logger.error(`Failed to close WsServer during ${reason}: ${err?.stack || err}`)
+  }
 }
 
 // Flush state, then exit. Idempotent via _shuttingDown. The 100ms defer lets the

--- a/packages/server/tests/server-cli-child.test.js
+++ b/packages/server/tests/server-cli-child.test.js
@@ -1,0 +1,69 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { flushAndDestroy } from '../src/server-cli-child.js'
+
+// #5308 (WP-0.2) — the supervised child must flush session state on every
+// shutdown/crash path. flushAndDestroy() is the shared sequence behind the IPC
+// `shutdown` handler and the uncaughtException/unhandledRejection handlers.
+// Importing the module is side-effect-free (entry-point guard) so we can unit
+// test the sequence directly with fakes.
+
+function makeFakes() {
+  const calls = []
+  const sessionManager = {
+    serializeState: () => calls.push('serializeState'),
+    destroyAll: () => calls.push('destroyAll'),
+  }
+  const wsServer = {
+    broadcastShutdown: (reason, eta) => calls.push(`broadcast:${reason}:${eta}`),
+    close: () => calls.push('close'),
+  }
+  const logger = { error: () => {}, info: () => {}, warn: () => {} }
+  return { calls, sessionManager, wsServer, logger }
+}
+
+describe('server-cli-child flushAndDestroy (#5308 WP-0.2)', () => {
+  it('serializes state BEFORE destroying, then closes the WS', () => {
+    const { calls, sessionManager, wsServer, logger } = makeFakes()
+    flushAndDestroy(sessionManager, wsServer, 'shutdown', logger)
+    // Order matters: serialize must precede destroyAll (losing restored state is
+    // worse than a partial write), and close comes last.
+    assert.deepEqual(calls, ['broadcast:shutdown:0', 'serializeState', 'destroyAll', 'close'])
+  })
+
+  it('forwards the reason to broadcastShutdown (crash path)', () => {
+    const { calls, sessionManager, wsServer, logger } = makeFakes()
+    flushAndDestroy(sessionManager, wsServer, 'crash', logger)
+    assert.ok(calls.includes('broadcast:crash:0'), 'crash reason broadcast with ETA 0')
+    assert.equal(calls.indexOf('serializeState') < calls.indexOf('destroyAll'), true)
+  })
+
+  it('still destroys + closes when serializeState throws (failure isolated)', () => {
+    const { calls, wsServer, logger } = makeFakes()
+    const sessionManager = {
+      serializeState: () => { throw new Error('disk full') },
+      destroyAll: () => calls.push('destroyAll'),
+    }
+    let logged = false
+    logger.error = () => { logged = true }
+    flushAndDestroy(sessionManager, wsServer, 'crash', logger)
+    assert.ok(logged, 'serialize failure is logged')
+    assert.ok(calls.includes('destroyAll'), 'destroyAll still runs after a serialize throw')
+    assert.ok(calls.includes('close'), 'wsServer.close still runs')
+  })
+
+  it('tolerates null sessionManager / wsServer (pre-start crash)', () => {
+    assert.doesNotThrow(() => flushAndDestroy(null, null, 'crash', { error: () => {} }))
+  })
+
+  it('isolates a destroyAll throw from wsServer.close', () => {
+    const { calls, wsServer, logger } = makeFakes()
+    const sessionManager = {
+      serializeState: () => calls.push('serializeState'),
+      destroyAll: () => { throw new Error('boom') },
+    }
+    flushAndDestroy(sessionManager, wsServer, 'shutdown', logger)
+    assert.ok(calls.includes('serializeState'))
+    assert.ok(calls.includes('close'), 'close runs even if destroyAll throws')
+  })
+})


### PR DESCRIPTION
**WP-0.2** of the TUI hardening epic #5338 · closes #5308 · audit **TUI-AUDIT-002** + the crash-handler-omits-serialize finding.

## Problem
The supervisor's stop path sends a `{type:'shutdown'}` IPC and only escalates to an OS `SIGTERM` at the 5s force-kill fallback — so the child's OS-signal flush handler never runs first. The IPC `shutdown` handler did a bare `process.exit(0)` with **no** `serializeState`/`destroyAll`, silently losing every session's history, message counters, cumulative usage, permission mode, and per-session settings on **every routine supervised stop/restart** (the #3697 data-loss class on the supervised hot path). Separately, the crash handlers called `destroyAll()` (which serializes internally) but omitted the explicit pre-destroy `serializeState` the foreground `server-cli.js` handler runs.

## Fix
- Extract **`flushAndDestroy(sessionManager, wsServer, reason, logger)`** — exported, no `process.exit` — mirroring the foreground handler: `broadcastShutdown` → **serialize BEFORE destroy** → `destroyAll` → `close`, each step failure-isolated.
- IPC `shutdown` now flushes via `gracefulExit(0, 'shutdown')` before exit (idempotent via a `_shuttingDown` guard; 100ms defer lets the shutdown frame + socket close flush).
- Crash handlers route through `gracefulExit(1, 'crash')` so they serialize before destroy too (parity with `server-cli.js`).
- Guard the IPC + crash-handler registration and `main()` behind an `isEntryPoint` check so importing the module for unit tests is side-effect-free (was running `main()` on import).

## Tests
5 new covering `flushAndDestroy`: serialize-before-destroy ordering, crash-reason forwarding, serialize-throw isolation (destroy + close still run), null-refs tolerance (pre-start crash), destroyAll-throw isolation. **Child suite + supervisor suite (which forks the real child) pass.**

Closes #5308