### PR TITLE
fix(server): per-pid temp for session-state writes; document debounce durability (#5309)

### DIFF
--- a/packages/server/src/session-state-persistence.js
+++ b/packages/server/src/session-state-persistence.js
@@ -77,10 +77,15 @@ export class SessionStatePersistence {
     if (fs.existsSync(this._stateFilePath)) {
       this._rotateToBak(this._stateFilePath, bakPath)
     }
-    // writeFileRestricted is atomic on POSIX (internal .tmp + rename) and a
-    // direct writeFileSync on Windows. Cleanup of the orphan .tmp on rename
-    // failure is handled inside the helper.
-    writeFileRestricted(this._stateFilePath, JSON.stringify(state, null, 2))
+    // writeFileRestricted does an atomic temp+rename on both POSIX and Windows
+    // (#4913); cleanup of the orphan temp on rename failure is handled inside.
+    // #5309 (WP-0.3) — pass a per-pid tmpSuffix so two processes writing the
+    // SAME state file (e.g. an accidental second `chroxy start` against
+    // ~/.chroxy/session-state.json, or a test runner + the daemon) don't race
+    // on a shared intermediate `.tmp` and clobber each other mid-write,
+    // corrupting the file. PIDs are unique among live processes, so the temp
+    // paths can't collide. Mirrors the models-cache precedent (models.js:488).
+    writeFileRestricted(this._stateFilePath, JSON.stringify(state, null, 2), { tmpSuffix: `.tmp-${process.pid}` })
     log.info(`Serialized ${state.sessions?.length ?? 0} session(s) to ${this._stateFilePath}`)
     return state
   }
@@ -198,6 +203,19 @@ export class SessionStatePersistence {
 
   /**
    * Schedule a debounced persist. Multiple rapid calls reset the timer.
+   *
+   * #5309 (WP-0.3) — durability boundary, by design: this debounce backs
+   * high-frequency message-history appends only. Session-LIST mutations
+   * (create/destroy/rename) use flushPersist() and are never debounced, and
+   * every CLEAN exit path serializes immediately — SIGINT/SIGTERM (server-cli.js)
+   * and the supervised IPC shutdown + crash handlers (server-cli-child.js, #5308)
+   * all call serializeState() directly, which cancels this timer and writes the
+   * current state. So the only way to lose up to persistDebounceMs (2s) of
+   * message history is an abrupt kill that runs NO handler at all — SIGKILL,
+   * OOM-kill, or power loss. That window is accepted as best-effort: shrinking
+   * it trades constant write amplification on every token for protection against
+   * an unrecoverable kill we can't flush before anyway.
+   *
    * @param {() => void} serializeFn - Function to call when the debounce fires
    */
   schedulePersist(serializeFn) {

--- a/packages/server/src/session-state-persistence.js
+++ b/packages/server/src/session-state-persistence.js
@@ -51,10 +51,11 @@ export class SessionStatePersistence {
    *   - `writeFileRestricted` is atomic on POSIX (internal rename replaces the
    *     destination), so a partial write of the new generation cannot leave
    *     half-written bytes at `mainPath`.
-   *   - On Windows, `writeFileRestricted` does a direct `writeFileSync` — that
-   *     matches the prior behavior (the old code's `.tmp` write was also a
-   *     direct `writeFileSync`; the only "atomic" step on Windows was the
-   *     final `renameSync`, which still depends on the OS).
+   *   - On Windows, `writeFileRestricted` also writes to a temp file then
+   *     `renameSync`s it into place (#4913) — the `renameSync` is the atomic
+   *     step (it depends on the OS), and the temp write itself uses
+   *     `writeFileSync` (no POSIX mode bits apply). Same temp+rename shape as
+   *     POSIX since #4913; only the mode handling differs.
    *
    * `_rotateToBak`'s Windows retry-and-restore-`.bak` flow stays intact under
    * the new order: the snapshot-and-restore happens before the main write, so

--- a/packages/server/src/session-state-persistence.js
+++ b/packages/server/src/session-state-persistence.js
@@ -85,6 +85,11 @@ export class SessionStatePersistence {
     // on a shared intermediate `.tmp` and clobber each other mid-write,
     // corrupting the file. PIDs are unique among live processes, so the temp
     // paths can't collide. Mirrors the models-cache precedent (models.js:488).
+    // Trade-off vs. the bare `.tmp`: the shared `.tmp` was self-healing (the
+    // next write O_TRUNC-reused it), whereas a per-pid temp orphaned by a
+    // hard-kill mid-write (between writeFileSync and renameSync) is never
+    // reused by a later process and no sweeper reclaims it. Accepted: such
+    // mid-write hard-kills are rare and the sidecar is tiny (matches models.js).
     writeFileRestricted(this._stateFilePath, JSON.stringify(state, null, 2), { tmpSuffix: `.tmp-${process.pid}` })
     log.info(`Serialized ${state.sessions?.length ?? 0} session(s) to ${this._stateFilePath}`)
     return state
@@ -209,8 +214,9 @@ export class SessionStatePersistence {
    * (create/destroy/rename) use flushPersist() and are never debounced, and
    * every CLEAN exit path serializes immediately — SIGINT/SIGTERM (server-cli.js)
    * and the supervised IPC shutdown + crash handlers (server-cli-child.js, #5308)
-   * all call serializeState() directly, which cancels this timer and writes the
-   * current state. So the only way to lose up to persistDebounceMs (2s) of
+   * all call serializeState() directly (followed by destroyAll(), which cancels
+   * this timer and no-ops any stray fire). So the only way to lose up to
+   * persistDebounceMs (2s) of
    * message history is an abrupt kill that runs NO handler at all — SIGKILL,
    * OOM-kill, or power loss. That window is accepted as best-effort: shrinking
    * it trades constant write amplification on every token for protection against

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -58,7 +58,7 @@ describe('platform', () => {
       assert.strictEqual(content, 'second')
     })
 
-    it('honours a custom tmpSuffix so concurrent writers to the same file use distinct temps (#5309)', () => {
+    it('honours a custom tmpSuffix so writers to the same file use distinct temps (#5309)', () => {
       const filePath = join(tmpDir, 'state.json')
       // Two writers targeting the same final path with distinct per-pid suffixes
       // must each rename their OWN intermediate temp — they can't clobber a

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -58,22 +58,6 @@ describe('platform', () => {
       assert.strictEqual(content, 'second')
     })
 
-    it('honours a custom tmpSuffix so writers to the same file use distinct temps (#5309)', () => {
-      const filePath = join(tmpDir, 'state.json')
-      // Two writers targeting the same final path with distinct per-pid suffixes
-      // must each rename their OWN intermediate temp — they can't clobber a
-      // shared `.tmp`. Both writes land the final content cleanly and leave no
-      // suffixed orphan behind. This is the mechanism session-state-persistence
-      // relies on so a second process can't corrupt the state file mid-write.
-      writeFileRestricted(filePath, 'a', { tmpSuffix: '.tmp-111' })
-      assert.strictEqual(readFileSync(filePath, 'utf-8'), 'a')
-      writeFileRestricted(filePath, 'b', { tmpSuffix: '.tmp-222' })
-      assert.strictEqual(readFileSync(filePath, 'utf-8'), 'b')
-      assert.strictEqual(existsSync(`${filePath}.tmp-111`), false, 'suffix-111 temp cleaned')
-      assert.strictEqual(existsSync(`${filePath}.tmp-222`), false, 'suffix-222 temp cleaned')
-      assert.strictEqual(existsSync(`${filePath}.tmp`), false, 'no bare .tmp from a custom-suffix write')
-    })
-
     if (!isWindows) {
       it('sets 0o600 permissions on Unix', () => {
         const filePath = join(tmpDir, 'restricted.txt')

--- a/packages/server/tests/platform.test.js
+++ b/packages/server/tests/platform.test.js
@@ -58,6 +58,22 @@ describe('platform', () => {
       assert.strictEqual(content, 'second')
     })
 
+    it('honours a custom tmpSuffix so concurrent writers to the same file use distinct temps (#5309)', () => {
+      const filePath = join(tmpDir, 'state.json')
+      // Two writers targeting the same final path with distinct per-pid suffixes
+      // must each rename their OWN intermediate temp — they can't clobber a
+      // shared `.tmp`. Both writes land the final content cleanly and leave no
+      // suffixed orphan behind. This is the mechanism session-state-persistence
+      // relies on so a second process can't corrupt the state file mid-write.
+      writeFileRestricted(filePath, 'a', { tmpSuffix: '.tmp-111' })
+      assert.strictEqual(readFileSync(filePath, 'utf-8'), 'a')
+      writeFileRestricted(filePath, 'b', { tmpSuffix: '.tmp-222' })
+      assert.strictEqual(readFileSync(filePath, 'utf-8'), 'b')
+      assert.strictEqual(existsSync(`${filePath}.tmp-111`), false, 'suffix-111 temp cleaned')
+      assert.strictEqual(existsSync(`${filePath}.tmp-222`), false, 'suffix-222 temp cleaned')
+      assert.strictEqual(existsSync(`${filePath}.tmp`), false, 'no bare .tmp from a custom-suffix write')
+    })
+
     if (!isWindows) {
       it('sets 0o600 permissions on Unix', () => {
         const filePath = join(tmpDir, 'restricted.txt')

--- a/packages/server/tests/session-state-persistence.test.js
+++ b/packages/server/tests/session-state-persistence.test.js
@@ -19,6 +19,23 @@ describe('SessionStatePersistence.serializeState', () => {
     rmSync(tempDir, { recursive: true, force: true })
   })
 
+  // #5309 (WP-0.3) — serializeState must route its atomic temp through a
+  // per-pid suffix, not writeFileRestricted's shared default `.tmp`, so a second
+  // process writing the same state file can't clobber a shared intermediate.
+  // Proof without forking: occupy the DEFAULT `.tmp` path with a directory — if
+  // serializeState used the default suffix it would EISDIR; succeeding proves it
+  // routes through `.tmp-<pid>` instead. (Binds the caller fix, not just the
+  // platform primitive, which is covered by the #4874 platform test.)
+  it('routes its atomic temp through a per-pid suffix, not the shared .tmp (#5309)', () => {
+    const p = new SessionStatePersistence({ stateFilePath: stateFile })
+    mkdirSync(`${stateFile}.tmp`) // booby-trap the shared default temp path
+    const state = { version: 1, timestamp: Date.now(), sessions: [{ id: 's1', name: 'A', cwd: '/tmp' }] }
+    assert.doesNotThrow(() => p.serializeState(state), 'must not write through the shared .tmp')
+    assert.strictEqual(JSON.parse(readFileSync(stateFile, 'utf-8')).sessions[0].id, 's1')
+    // The per-pid temp is renamed into place, leaving no orphan after success.
+    assert.strictEqual(existsSync(`${stateFile}.tmp-${process.pid}`), false, 'per-pid temp cleaned after rename')
+  })
+
   it('writes JSON state to file', () => {
     const p = new SessionStatePersistence({ stateFilePath: stateFile })
     const state = {


### PR DESCRIPTION
**WP-0.3** of the TUI hardening epic #5338 · closes #5309 · audit fixed-`.tmp`-clobber + debounce-loss findings.

## Problem
`serializeState()` wrote its atomic temp via `writeFileRestricted`'s **default fixed `.tmp`** suffix, so two processes writing the **same** state file (an accidental second `chroxy start` against `~/.chroxy/session-state.json`, or a test runner + the daemon) raced on one shared intermediate temp and could clobber each other mid-write — corrupting the file.

## Fix
- Pass a **per-pid `tmpSuffix`** (`.tmp-<pid>`) — PIDs are unique among live processes, so the temps can't collide. Mirrors the models-cache precedent (`models.js:488`). No change to `platform.js`'s default (keeps blast radius small and the Windows `.tmp`-cleanup test intact).
- **Document the debounce durability boundary** on `schedulePersist`: it backs only high-frequency message-history appends. Session-list mutations use `flushPersist` (never debounced), and every clean exit (SIGINT/SIGTERM + the supervised IPC shutdown/crash handlers from #5308) calls `serializeState()` directly, which cancels the timer and writes immediately. So the only loss window is an abrupt kill that runs **no** handler — SIGKILL / OOM / power loss — accepted as best-effort (shrinking it trades constant per-token write amplification against a kill we can't flush before anyway).

## Tests
Platform suite +1: custom-suffix writers to the same file use distinct temps, both land cleanly, no orphan temps (the mechanism persistence relies on). **platform (19) + session-state-persistence (38) pass.**

Closes #5309