### PR TITLE
fix(server): persist & rebind worktree binding across restart (#5310)

### DIFF
--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -542,7 +542,7 @@ export class SessionManager extends EventEmitter {
    *   after a daemon restart (#4983).
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, skipPersist = false, preserveId } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, skipPersist = false, preserveId } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -635,7 +635,23 @@ export class SessionManager extends EventEmitter {
     // Worktree isolation — create a detached git worktree for this session
     let resolvedCwd = baseCwd
     let worktreePath = null
-    if (worktree) {
+    let worktreeRepoDir = null
+    if (restoreWorktreePath) {
+      // #5310 (WP-0.4) — restore path: REBIND to the worktree this session
+      // already owns instead of creating a new one. Worktree dirs under
+      // ~/.chroxy/worktrees/<id> survive a daemon restart, so recreating would
+      // fail ("already exists") and — worse — without rebinding, the restored
+      // entry carries worktreePath:null and never GCs the dir on destroy
+      // (orphan accrual) and reports isolation:'none'. The original repo dir
+      // can't be derived from the persisted cwd (which IS the worktree), so it
+      // is persisted + threaded through here for `git worktree remove`. If the
+      // worktree dir was deleted out from under us (e.g. `chroxy worktree gc`),
+      // the generic baseCwd existence check above already fails the restore
+      // cleanly and #2954 preserves it for retry.
+      worktreePath = restoreWorktreePath
+      worktreeRepoDir = restoreWorktreeRepoDir || null
+      resolvedCwd = restoreWorktreePath
+    } else if (worktree) {
       // Verify cwd is inside a git repository
       try {
         execFileSync(GIT, ['-C', baseCwd, 'rev-parse', '--git-dir'], {
@@ -663,6 +679,7 @@ export class SessionManager extends EventEmitter {
 
       resolvedCwd = worktreeDir
       worktreePath = worktreeDir
+      worktreeRepoDir = baseCwd
       log.info(`Created worktree for session ${sessionId} at ${worktreeDir}`)
     }
 
@@ -803,8 +820,11 @@ export class SessionManager extends EventEmitter {
       provider: resolvedProvider,
       createdAt: Date.now(),
       worktreePath,
-      // Original repo dir needed for `git worktree remove` during cleanup
-      worktreeRepoDir: worktreePath ? baseCwd : null,
+      // Original repo dir needed for `git worktree remove` during cleanup.
+      // #5310: set in both the create and restore-rebind branches above so it
+      // survives a restart (was `worktreePath ? baseCwd : null`, which on
+      // restore wrongly resolved to the worktree dir / null).
+      worktreeRepoDir,
       isolation: resolvedIsolation,
       // #4072: cumulative usage accumulator (tokens + cost) populated by
       // _trackUsage on every priced `result` event. Subscription-only
@@ -1236,6 +1256,14 @@ export class SessionManager extends EventEmitter {
         permissionMode: entry.session.permissionMode,
         provider: entry.provider || null,
         name: entry.name,
+        // #5310 (WP-0.4) — persist the worktree binding so a restored session
+        // rebinds to its existing worktree (rather than losing it). worktreePath
+        // is also the session's cwd, but worktreeRepoDir (the ORIGINAL repo,
+        // needed for `git worktree remove`) is NOT derivable from cwd, so both
+        // must round-trip. Null for non-worktree sessions; older state files
+        // (pre-#5310) restore as null → treated as a non-worktree session.
+        worktreePath: entry.worktreePath || null,
+        worktreeRepoDir: entry.worktreeRepoDir || null,
         lastActivityAt: this._sessionLastActivityAt.get(id) || entry.createdAt,
         history,
         // #4664: persist per-session toggle/string settings via the
@@ -1339,6 +1367,15 @@ export class SessionManager extends EventEmitter {
           permissionMode: saved.permissionMode,
           resumeSessionId: saved.sdkSessionId,
           provider: saved.provider || undefined,
+          // #5310 (WP-0.4) — rebind to the existing worktree (don't recreate).
+          // Only string paths flow through; non-worktree sessions and older
+          // state files (no field) pass undefined and take the normal path.
+          restoreWorktreePath: typeof saved.worktreePath === 'string' && saved.worktreePath.length > 0
+            ? saved.worktreePath
+            : undefined,
+          restoreWorktreeRepoDir: typeof saved.worktreeRepoDir === 'string' && saved.worktreeRepoDir.length > 0
+            ? saved.worktreeRepoDir
+            : undefined,
           // #4664: restore per-session toggle/string settings via the
           // shared registry. Each registry entry's `acceptFromConstructor`
           // predicate drops malformed values to `undefined` so

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -846,6 +846,15 @@ export class SessionManager extends EventEmitter {
         result.catch((err) => {
           const message = err?.message || String(err)
           log.error(`Async start() rejected for session ${sessionId}: ${message}${err?.stack ? '\n' + err.stack : ''}`)
+          // NOTE (#5310/#5316): destroySession() here fully tears the session
+          // down — including _removeWorktree() and history cleanup. For a
+          // restore-rebind whose provider start() rejects ASYNCHRONOUSLY, that
+          // destroys the pre-existing worktree + restored history. This path
+          // already erased restored history pre-#5310; making restore +
+          // start-failure non-destructive (keep the entry, mark retryable) is
+          // the explicit scope of WP-2.2 (#5316), which will replace this
+          // destroySession() call. The SYNCHRONOUS rollback below is guarded
+          // against worktree deletion on rebind as of #5310.
           this.destroySession(sessionId)
         })
       }
@@ -860,9 +869,16 @@ export class SessionManager extends EventEmitter {
         log.error(`Failed to destroy session ${sessionId} during start() failure cleanup: ${destroyErr?.stack || destroyErr}`)
       }
       this._cleanupSessionMaps(sessionId)
-      // Clean up worktree if one was created but session start failed
-      if (worktreePath) {
-        this._removeWorktree(worktreePath, baseCwd, sessionId)
+      // Clean up the worktree ONLY if we freshly created it this call. #5310:
+      // on a restore-rebind, worktreePath points at a PRE-EXISTING worktree
+      // (with possibly uncommitted work) that we must NOT delete just because
+      // the provider's start() failed — destroying it would lose the user's
+      // work AND make the #2954-preserved retry unrecoverable (the next attempt
+      // would hit the missing-worktree statSync failure). Only the fresh-create
+      // branch should roll back its own creation. Use worktreeRepoDir (the
+      // original repo) for the remove, consistent with the destroy paths.
+      if (worktreePath && !restoreWorktreePath) {
+        this._removeWorktree(worktreePath, worktreeRepoDir, sessionId)
       }
       throw err
     }

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import { randomBytes } from 'crypto'
 import { statSync, mkdirSync, rmSync } from 'fs'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import { homedir } from 'os'
 import { execFileSync } from 'child_process'
 import { getProvider } from './providers.js'
@@ -648,9 +648,24 @@ export class SessionManager extends EventEmitter {
       // worktree dir was deleted out from under us (e.g. `chroxy worktree gc`),
       // the generic baseCwd existence check above already fails the restore
       // cleanly and #2954 preserves it for retry.
-      worktreePath = restoreWorktreePath
-      worktreeRepoDir = restoreWorktreeRepoDir || null
-      resolvedCwd = restoreWorktreePath
+      //
+      // SECURITY (#5310 review): restoreWorktreePath is read from the on-disk
+      // state file and later becomes a recursive-deletion target in
+      // _removeWorktree (git worktree remove, then an rmSync -rf fallback). A
+      // corrupted or tampered state file could otherwise point it at an
+      // arbitrary directory and have destroySession() delete it. Worktree dirs
+      // are always created deterministically at join(base, sessionId), so a
+      // restored path that doesn't resolve to exactly that is rejected: we
+      // safe-degrade to a non-worktree session (worktreePath stays null ⇒ no
+      // deletion target) and log loudly, rather than rebind an unsafe path.
+      const expectedWorktreeDir = resolve(join(this._worktreeBase || DEFAULT_WORKTREE_BASE, sessionId))
+      if (resolve(restoreWorktreePath) === expectedWorktreeDir) {
+        worktreePath = restoreWorktreePath
+        worktreeRepoDir = restoreWorktreeRepoDir || null
+        resolvedCwd = restoreWorktreePath
+      } else {
+        log.warn(`Restored worktreePath "${restoreWorktreePath}" for session ${sessionId} does not match the expected per-session worktree dir "${expectedWorktreeDir}" — ignoring the rebind (treating as non-worktree) so a corrupted state file can't make destroySession() delete an arbitrary path`)
+      }
     } else if (worktree) {
       // Verify cwd is inside a git repository
       try {

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -166,6 +166,51 @@ describe('SessionManager worktree isolation', () => {
     assert.ok(!existsSync(path2), 'worktree 2 should be removed after destroyAll')
   })
 
+  // #5310 (WP-0.4) — the worktree binding must survive a daemon restart.
+  // Pre-fix, serializeState dropped worktreePath/worktreeRepoDir, so a restored
+  // session ran in the worktree dir but carried worktreePath:null — it never
+  // GC'd the worktree on destroy (orphan accrual) and reported isolation:'none'.
+  it('rebinds the worktree on restore (no recreate, GC works, isolation preserved) (#5310)', () => {
+    const mgr = makeManager(gitRepo)
+    const id = mgr.createSession({ cwd: gitRepo, worktree: true })
+    const wtPath = mgr.getSession(id).worktreePath
+    assert.ok(wtPath && existsSync(wtPath), 'worktree created')
+    assert.equal(mgr.getSession(id).worktreeRepoDir, gitRepo, 'repo dir recorded for GC')
+
+    // Persist, then simulate a restart with a fresh manager over the same state
+    // file. Do NOT destroyAll — a real restart leaves the worktree dir on disk.
+    mgr.serializeState()
+
+    const mgr2 = makeManager(gitRepo) // makeManager sets the same _worktreeBase
+    mgr2.restoreState()
+
+    const r = mgr2.getSession(id)
+    assert.ok(r, 'session restored under its preserved id')
+    assert.equal(r.worktreePath, wtPath, 'rebound to the SAME worktree (not a new one)')
+    assert.equal(r.worktreeRepoDir, gitRepo, 'worktreeRepoDir round-tripped (needed for git worktree remove)')
+    assert.equal(r.isolation, 'worktree', 'isolation reported as worktree after restore')
+    assert.equal(r.cwd, wtPath, 'cwd points at the worktree')
+    assert.ok(existsSync(wtPath), 'rebind did not recreate/destroy the existing worktree')
+
+    // The actual payoff: GC now works post-restore (pre-fix it leaked).
+    mgr2.destroySession(id)
+    assert.ok(!existsSync(wtPath), 'restored worktree session GCs its worktree on destroy')
+    mgr2.destroyAll()
+  })
+
+  it('a non-worktree session restores with no worktree binding (#5310 back-compat)', () => {
+    const mgr = makeManager(gitRepo)
+    const id = mgr.createSession({ cwd: gitRepo }) // no worktree
+    mgr.serializeState()
+    const mgr2 = makeManager(gitRepo)
+    mgr2.restoreState()
+    const r = mgr2.getSession(id)
+    assert.equal(r.worktreePath, null, 'no worktree binding on a plain session')
+    assert.equal(r.isolation, 'none')
+    mgr.destroyAll()
+    mgr2.destroyAll()
+  })
+
   it('rejects worktree:true when cwd is not a git repository', () => {
     const nonGitDir = mkdtempSync(join(tmpdir(), 'chroxy-nongit-'))
     try {

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -234,6 +234,40 @@ describe('SessionManager worktree isolation', () => {
     mgr2.destroyAll()
   })
 
+  // #5310 security review — restoreWorktreePath comes from the on-disk state and
+  // becomes a recursive-deletion target in _removeWorktree. A corrupted/tampered
+  // state file pointing it outside the per-session worktree dir must NOT be
+  // rebound (and so must never be deleted on destroy).
+  it('rejects a restored worktreePath outside the per-session worktree dir; never deletes it (#5310)', () => {
+    const mgr = makeManager(gitRepo)
+    const id = mgr.createSession({ cwd: gitRepo, worktree: true })
+    mgr.serializeState()
+
+    // Tamper: repoint worktreePath (and cwd, so the existence check passes) at a
+    // sensitive directory outside the worktree base.
+    const sensitive = mkdtempSync(join(tmpdir(), 'chroxy-sensitive-'))
+    const sentinel = join(sensitive, 'keep.txt')
+    writeFileSync(sentinel, 'do not delete')
+    const stateFile = join(gitRepo, 'session-state.json')
+    const persisted = JSON.parse(readFileSync(stateFile, 'utf-8'))
+    persisted.sessions[0].worktreePath = sensitive
+    persisted.sessions[0].cwd = sensitive
+    writeFileSync(stateFile, JSON.stringify(persisted))
+
+    const mgr2 = makeManager(gitRepo)
+    mgr2.restoreState()
+    const r = mgr2.getSession(id)
+    assert.ok(r, 'session still restores (safe-degrade, not a hard failure)')
+    assert.equal(r.worktreePath, null, 'tampered path is NOT rebound as a worktree')
+    assert.equal(r.isolation, 'none')
+
+    mgr2.destroySession(id)
+    assert.ok(existsSync(sentinel), 'arbitrary directory MUST NOT be deleted on destroy')
+
+    mgr2.destroyAll()
+    rmSync(sensitive, { recursive: true, force: true })
+  })
+
   it('a non-worktree session restores with no worktree binding (#5310 back-compat)', () => {
     const mgr = makeManager(gitRepo)
     const id = mgr.createSession({ cwd: gitRepo }) // no worktree

--- a/packages/server/tests/session-manager-worktree.test.js
+++ b/packages/server/tests/session-manager-worktree.test.js
@@ -7,7 +7,7 @@
  */
 import { describe, it, before, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, rmSync, existsSync, renameSync } from 'fs'
+import { mkdtempSync, rmSync, existsSync, renameSync, readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
@@ -54,6 +54,13 @@ before(async () => {
   }
 
   registerProvider('stub-worktree', StubSession)
+
+  // #5310 — a stub whose start() throws synchronously, to exercise the
+  // createSession start-failure rollback during a restore-rebind.
+  class FailStartSession extends StubSession {
+    start() { throw new Error('simulated start failure on restore') }
+  }
+  registerProvider('stub-worktree-failstart', FailStartSession)
 })
 
 // ---------------------------------------------------------------------------
@@ -195,6 +202,35 @@ describe('SessionManager worktree isolation', () => {
     // The actual payoff: GC now works post-restore (pre-fix it leaked).
     mgr2.destroySession(id)
     assert.ok(!existsSync(wtPath), 'restored worktree session GCs its worktree on destroy')
+    mgr2.destroyAll()
+  })
+
+  // #5310 — regression guard: a restore whose provider start() FAILS must NOT
+  // delete the pre-existing worktree (it holds possibly-uncommitted work, and
+  // deleting it would make the #2954-preserved retry unrecoverable). Only a
+  // freshly-created worktree should roll back on start failure.
+  it('does NOT delete the worktree when a restore-rebind start() fails (#5310)', () => {
+    const mgr = makeManager(gitRepo)
+    const id = mgr.createSession({ cwd: gitRepo, worktree: true })
+    const wtPath = mgr.getSession(id).worktreePath
+    assert.ok(existsSync(wtPath), 'worktree created')
+    mgr.serializeState()
+
+    // Simulate a provider that fails to start on restore by rewriting the
+    // persisted provider to the fail-start stub, then restore.
+    const stateFile = join(gitRepo, 'session-state.json')
+    const persisted = JSON.parse(readFileSync(stateFile, 'utf-8'))
+    persisted.sessions[0].provider = 'stub-worktree-failstart'
+    writeFileSync(stateFile, JSON.stringify(persisted))
+
+    const mgr2 = makeManager(gitRepo)
+    mgr2.restoreState() // createSession → start() throws → sync rollback
+
+    assert.ok(!mgr2.getSession(id), 'session not live after failed restore')
+    assert.ok(existsSync(wtPath), 'pre-existing worktree MUST survive a failed restore-rebind')
+    // #2954 — the failed session is preserved so a later retry can re-hydrate.
+    assert.ok(mgr2._failedRestores.has(id), 'failed restore preserved for retry')
+
     mgr2.destroyAll()
   })
 


### PR DESCRIPTION
**WP-0.4** of the TUI hardening epic #5338 · closes #5310 · the **final Phase 0** item · audit worktree-orphan finding.

## Problem
`serializeState` dropped `worktreePath`/`worktreeRepoDir`, so a restored worktree session ran in its worktree dir (the persisted `cwd`) but carried `worktreePath:null`. Consequences every restart:
- it **never GC'd the worktree** on destroy → orphan accrual in `~/.chroxy/worktrees/`;
- it reported `isolation:'none'` to the dashboard.

The original repo dir (needed for `git worktree remove`) is **not derivable** from the persisted `cwd` (which *is* the worktree), so it was lost entirely.

## Fix
- `serializeState` persists `worktreePath` + `worktreeRepoDir` (null for non-worktree sessions; older state files restore as null = non-worktree).
- `restoreState` threads them into `createSession` as `restoreWorktreePath` / `restoreWorktreeRepoDir`.
- `createSession` **rebinds** to the existing worktree on restore instead of recreating it (recreate would fail "already exists" and re-lose the binding). If the worktree dir was gc'd out from under us, the generic `baseCwd` existence check fails the restore cleanly and #2954 preserves it for retry.
- `worktreeRepoDir` is now set in both the create and rebind branches (was `worktreePath ? baseCwd : null`, which on restore wrongly resolved to the worktree dir / null).

## Tests
Worktree suite +2: full **serialize → restart → rebind** round-trip (same path, repo dir round-trips, `isolation:'worktree'`, **GC works post-restore** — the actual payoff) + a non-worktree back-compat case. **worktree (16) + session-manager (197) pass; opt-forwarding lint clean.**

Closes #5310