### PR TITLE
fix(server): survive PTY socket faults without crashing the daemon (#5311)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -809,14 +809,18 @@ export class ClaudeTuiSession extends BaseSession {
     this._isBusy = false
     this._currentMessageId = null
     if (this._destroying) return
+    // #5311 review — the socket 'close'/'error' paths have no exit info, so
+    // render a clear "unknown" instead of a bare "code=undefined". The
+    // "Claude PTY exited" prefix is preserved (clients/log scrapers key on it).
     const code = this._ptyExitInfo?.exitCode
-    log.warn(`claude PTY gone (${source}) (code=${code} signal=${this._ptyExitInfo?.signal})`)
+    const codeStr = (code === undefined || code === null) ? 'unknown' : code
+    log.warn(`claude PTY gone (${source}) (code=${codeStr} signal=${this._ptyExitInfo?.signal ?? 'unknown'})`)
     // Suppress the generic error when a turn was in flight — sendMessage's poll
     // loop emits a more specific "PTY exited mid-turn" error instead, so the
     // dashboard sees one root cause not two.
     if (!hadActiveTurn) {
       const tail = this._outputTailDiagnostic()
-      const base = `Claude PTY exited (code=${code})`
+      const base = `Claude PTY exited (code=${codeStr})`
       this.emit('error', { message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
     }
   }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -781,6 +781,47 @@ export class ClaudeTuiSession extends BaseSession {
   }
 
   /**
+   * #5311 (WP-1.1) — single idempotent teardown for "the PTY is gone", reached
+   * from onExit (process exit) AND from the 'close'/'error' socket events that
+   * fire on a node-pty fault with no process-exit callback. Resets turn state so
+   * the next sendMessage() sees a clean idle (it still rejects with "no longer
+   * alive", but isn't locked by a stale _isBusy from the interrupted turn,
+   * #3924) and emits ONE session-scoped error. Guards on `_ptyExited` so the
+   * several wired events collapse to a single teardown + error emit.
+   *
+   * @param {object|null} info — node-pty exit info ({exitCode, signal}) when known
+   * @param {string} source — diagnostic label for the log line
+   */
+  _onPtyGone(info, source) {
+    // Always capture the most specific exit info, even on a repeat event.
+    if (info) this._ptyExitInfo = info
+    if (this._ptyExited) return
+    this._ptyExited = true
+    this._processReady = false
+    // Reset turn state so the next sendMessage() sees a clean idle.
+    const hadActiveTurn = this._activeTurn !== null
+    // #4022: clean up the in-flight turn's attachment dir BEFORE nulling
+    // _activeTurn, otherwise sendMessage's poll loop reaches _finishTurnError
+    // with activeTurn=null and the helper no-ops → dir leaks until destroy().
+    // The cleanup is idempotent (rmSync force:true) so a later call is fine.
+    this._cleanupTurnAttachments(this._activeTurn)
+    this._activeTurn = null
+    this._isBusy = false
+    this._currentMessageId = null
+    if (this._destroying) return
+    const code = this._ptyExitInfo?.exitCode
+    log.warn(`claude PTY gone (${source}) (code=${code} signal=${this._ptyExitInfo?.signal})`)
+    // Suppress the generic error when a turn was in flight — sendMessage's poll
+    // loop emits a more specific "PTY exited mid-turn" error instead, so the
+    // dashboard sees one root cause not two.
+    if (!hadActiveTurn) {
+      const tail = this._outputTailDiagnostic()
+      const base = `Claude PTY exited (code=${code})`
+      this.emit('error', { message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
+    }
+  }
+
+  /**
    * Spawn the persistent PTY under node-pty + wait for the TUI to render.
    * Sets `this._term`, wires onData/onExit handlers, then sleeps for
    * WARMUP_MS so the TUI's input prompt is ready before the first
@@ -913,35 +954,25 @@ export class ClaudeTuiSession extends BaseSession {
         ? merged.subarray(-ClaudeTuiSession.PTY_TAIL_BYTES)
         : merged
     })
-    this._term.onExit((info) => {
-      this._ptyExited = true
-      this._ptyExitInfo = info
-      this._processReady = false
-      // Reset turn state so the next sendMessage() sees a clean idle
-      // (it'll still reject with "no longer alive", but won't be locked
-      // by stale _isBusy from a turn the PTY interrupted) (#3924).
-      const hadActiveTurn = this._activeTurn !== null
-      // #4022: clean up the in-flight turn's attachment dir BEFORE
-      // nulling _activeTurn, otherwise sendMessage's poll loop reaches
-      // _finishTurnError with activeTurn=null and the helper no-ops →
-      // dir leaks until destroy(). The cleanup is idempotent (rmSync
-      // with force:true), so _finishTurnError calling it again is fine.
-      this._cleanupTurnAttachments(this._activeTurn)
-      this._activeTurn = null
-      this._isBusy = false
-      this._currentMessageId = null
-      if (this._destroying) return
-      log.warn(`claude PTY exited unexpectedly (code=${info?.exitCode} signal=${info?.signal})`)
-      // Suppress the generic onExit error when a turn was in flight —
-      // sendMessage's poll loop emits a more specific "PTY exited
-      // mid-turn" error instead, so the dashboard sees one root cause
-      // not two.
-      if (!hadActiveTurn) {
-        const tail = this._outputTailDiagnostic()
-        const base = `Claude PTY exited (code=${info?.exitCode})`
-        this.emit('error', { message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
-      }
-    })
+    this._term.onExit((info) => this._onPtyGone(info, 'exit'))
+
+    // #5311 (WP-1.1) — keep a per-session PTY fault from crashing the WHOLE
+    // daemon (every session on the host) via an uncaught throw. node-pty's
+    // internal socket 'error' handler (unixTerminal.js) returns silently for
+    // EAGAIN/EIO (the normal child-exit path, which surfaces through onExit
+    // above) but for any OTHER error it calls _close() + emits 'close' and then
+    // `throw err` UNLESS the Terminal has >= 2 'error' listeners. It never
+    // emits 'error' to those listeners — they exist solely to clear that
+    // rethrow threshold. So:
+    //   - drive the actual teardown off 'close' (which node-pty DOES emit), and
+    //   - also off 'error' in case a future node-pty starts emitting it, and
+    //   - register a second no-op 'error' listener so the count is >= 2 and the
+    //     otherwise-uncaught throw is suppressed.
+    // _onPtyGone is idempotent (guards on _ptyExited) so onExit + close + error
+    // firing in any order tears down + emits exactly once.
+    this._term.on('error', (err) => this._onPtyGone(null, `error: ${err?.message || 'unknown'}`))
+    this._term.on('error', () => {}) // bumps listener count >= 2 so node-pty does not rethrow
+    this._term.on('close', () => this._onPtyGone(null, 'close'))
 
     // Wait for the TUI to reach status=idle before returning. The prior
     // implementations (hardcoded sleep, then glyph screen-scrape across

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -5722,6 +5722,16 @@ describe('ClaudeTuiSession', () => {
       assert.match(errors[0].message, /Claude PTY exited \(code=1\)/)
     })
 
+    it('renders code=unknown (never "undefined") when failing via close/error with no exit info (#5311)', () => {
+      const s = makeSession()
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      s._onPtyGone(null, 'close') // socket fault: no exit info
+      assert.equal(errors.length, 1)
+      assert.match(errors[0].message, /Claude PTY exited \(code=unknown\)/)
+      assert.doesNotMatch(errors[0].message, /undefined/)
+    })
+
     it('is idempotent — onExit + close + error collapse to ONE error emit', () => {
       const s = makeSession()
       const errors = []

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -5699,6 +5699,69 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  // #5311 (WP-1.1) — a PTY socket fault must tear down only THIS session and
+  // emit a session-scoped error, never crash the daemon. _onPtyGone is the
+  // single idempotent teardown reached from onExit + the close/error socket
+  // events; these tests exercise its contract directly.
+  describe('PTY failure teardown _onPtyGone (#5311 WP-1.1)', () => {
+    function makeSession() {
+      return new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+    }
+
+    it('resets state and emits ONE session error when the PTY dies with no active turn', () => {
+      const s = makeSession()
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      s._isBusy = true
+      s._processReady = true
+      s._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      assert.equal(s._ptyExited, true, 'marks the PTY dead')
+      assert.equal(s._isBusy, false, 'clears busy so the next sendMessage isn\'t wedged')
+      assert.equal(s._processReady, false)
+      assert.equal(errors.length, 1, 'exactly one error')
+      assert.match(errors[0].message, /Claude PTY exited \(code=1\)/)
+    })
+
+    it('is idempotent — onExit + close + error collapse to ONE error emit', () => {
+      const s = makeSession()
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      s._onPtyGone(null, 'close')
+      s._onPtyGone({ exitCode: 0 }, 'exit')
+      s._onPtyGone(null, 'error: boom')
+      assert.equal(errors.length, 1, 'one error despite three teardown events in any order')
+    })
+
+    it('suppresses the generic error when a turn was in flight (sendMessage emits the specific one)', () => {
+      const s = makeSession()
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      s._activeTurn = { messageId: 'm1', startedAt: Date.now(), aborted: false }
+      s._onPtyGone({ exitCode: 137 }, 'exit')
+      assert.equal(s._activeTurn, null, 'active turn cleared')
+      assert.equal(s._isBusy, false)
+      assert.equal(errors.length, 0, 'no generic error while a turn was in flight')
+    })
+
+    it('captures the most specific exit info even on a guarded repeat event', () => {
+      const s = makeSession()
+      s.on('error', () => {})
+      s._onPtyGone(null, 'close')            // close fires first, no info
+      s._onPtyGone({ exitCode: 42 }, 'exit') // exit arrives after; guarded, but info updates
+      assert.equal(s._ptyExitInfo?.exitCode, 42)
+    })
+
+    it('marks the PTY dead but emits nothing while destroying', () => {
+      const s = makeSession()
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      s._destroying = true
+      s._onPtyGone({ exitCode: 1 }, 'exit')
+      assert.equal(s._ptyExited, true, 'still marks exited so sendMessage rejects')
+      assert.equal(errors.length, 0, 'no error emit during teardown')
+    })
+  })
+
   // #4044: per-session option that spawns claude TUI with the literal
   // --dangerously-skip-permissions flag and elides chroxy's permission
   // hook entirely. Distinct from `permissionMode: 'auto'`, which still


### PR DESCRIPTION
**WP-1.1** of the TUI hardening epic #5338 · closes #5311 · audit **TUI-AUDIT-003** · first **Phase 1** (crash-vectors) item.

## Problem
`ClaudeTuiSession` registered **no `error` listener** on its node-pty Terminal. On any non-EAGAIN/non-EIO socket error, node-pty's internal socket handler (`unixTerminal.js:123`) calls `_close()` + emits `'close'`, then `throw err` **unless the Terminal has ≥2 `error` listeners** — and it *never* emits `'error'` to them (they exist only to clear that rethrow threshold). With zero listeners the throw was uncaught → `server-cli`'s `uncaughtException` handler → `process.exit(1)`, taking down **every session on the host** (and the in-flight streaming response) on a single recoverable PTY fault.

## Fix
- `_onPtyGone(info, source)` — one **idempotent** teardown (resets turn state, marks the PTY dead, emits **one** session-scoped error) reached from `onExit` **and** the `close`/`error` socket events, collapsing to a single teardown + emit in any firing order.
- Wire `'close'` (node-pty's actual signal on such a fault) and `'error'` (future-proof) to it, **plus a second no-op `'error'` listener** so the count is ≥2 and node-pty suppresses the otherwise-uncaught rethrow.
- `onExit` refactored to route through `_onPtyGone`; the emitted error message is unchanged (`Claude PTY exited (code=X)`).

## Tests
+5: reset + single-emit, idempotent collapse across exit/close/error, in-flight-turn suppression, exit-info capture on a guarded repeat, no-emit while destroying. **claude-tui suite 219 pass; opt-forwarding lint clean.**

## Pairs with
WP-2.1 (#5315) adds bounded per-session respawn on top of this teardown.

Closes #5311