### PR TITLE
fix(server): guard the async HTTP handler so a route throw can't crash the daemon (#5312)

### DIFF
--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -715,7 +715,11 @@ export function createHttpHandler(server) {
     try {
       await dispatch(req, res)
     } catch (err) {
-      log.error(`Unhandled error in HTTP handler (${req.method} ${req.url}): ${err?.stack || err}`)
+      // #5312 review — log the PATH only, never the raw req.url: query strings on
+      // dashboard/connect routes carry the API token (?token=...) which must not
+      // leak into server logs.
+      const pathOnly = (req.url || '').split('?')[0]
+      log.error(`Unhandled error in HTTP handler (${req.method} ${pathOnly}): ${err?.stack || err}`)
       if (!res.headersSent) {
         try {
           res.writeHead(500, { 'Content-Type': 'application/json' })

--- a/packages/server/src/http-routes.js
+++ b/packages/server/src/http-routes.js
@@ -165,7 +165,12 @@ function matchAllowedOrigin(origin) {
  * @returns {(req: import('http').IncomingMessage, res: import('http').ServerResponse) => void}
  */
 export function createHttpHandler(server) {
-  return async (req, res) => {
+  // #5312 (WP-1.2) — the actual routing logic, wrapped below in a top-level
+  // try/catch so an unguarded throw from any route (e.g. buildDiagnosticsSnapshot,
+  // readConnectionInfo, or readFileSync(index)) returns 500 instead of rejecting
+  // the handler promise → unhandledRejection → process.exit(1), which would take
+  // down the whole daemon (every session) on a single bad request.
+  const dispatch = async (req, res) => {
     // CORS preflight
     if (req.method === 'OPTIONS') {
       const isRestricted = req.url?.startsWith('/qr') || req.url?.startsWith('/connect')
@@ -701,5 +706,24 @@ export function createHttpHandler(server) {
     // Fallback 404
     res.writeHead(404)
     res.end()
+  }
+
+  // #5312 (WP-1.2) — top-level guard. Any throw/rejection escaping dispatch()
+  // becomes a 500, never an unhandledRejection that crashes the daemon. Headers
+  // may already be sent (a route threw mid-response); only write 500 if not.
+  return async (req, res) => {
+    try {
+      await dispatch(req, res)
+    } catch (err) {
+      log.error(`Unhandled error in HTTP handler (${req.method} ${req.url}): ${err?.stack || err}`)
+      if (!res.headersSent) {
+        try {
+          res.writeHead(500, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'Internal server error' }))
+        } catch { /* response already torn down */ }
+      } else {
+        try { res.end() } catch { /* already ended */ }
+      }
+    }
   }
 }

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -87,6 +87,32 @@ describe('http-routes', () => {
     httpServer = null
   })
 
+  // #5312 (WP-1.2) — an unguarded throw in any route must become a 500, not an
+  // unhandledRejection that crashes the whole daemon (every session) on one bad
+  // request. The audit's throw sites (buildDiagnosticsSnapshot, readConnectionInfo,
+  // readFileSync(index)) are all synchronous, so a sync route throw is the case.
+  describe('top-level error guard (#5312)', () => {
+    it('returns 500 for a throwing route and the server stays alive', async () => {
+      const mock = createMockServer({
+        _permissions: {
+          handlePermissionRequest: () => { throw new Error('boom in route') },
+          handlePermissionResponseHttp: (_req, res) => { res.writeHead(200); res.end('ok') },
+        },
+      })
+      await startWith(mock)
+
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/permission`, { method: 'POST', body: '{}' })
+      assert.equal(res.status, 500, 'throwing route returns 500')
+      const body = await res.json()
+      assert.equal(body.error, 'Internal server error')
+
+      // The daemon survived — a subsequent request still works (the crash this
+      // guards against would have killed the process).
+      const health = await globalThis.fetch(`http://127.0.0.1:${port}/health`)
+      assert.equal(health.status, 200, 'server still serving after a route threw')
+    })
+  })
+
   describe('health endpoint', () => {
     it('GET / returns JSON health status', async () => {
       const mock = createMockServer()

--- a/packages/server/tests/http-routes.test.js
+++ b/packages/server/tests/http-routes.test.js
@@ -111,6 +111,45 @@ describe('http-routes', () => {
       const health = await globalThis.fetch(`http://127.0.0.1:${port}/health`)
       assert.equal(health.status, 200, 'server still serving after a route threw')
     })
+
+    it('a throwing route does NOT produce an unhandledRejection', async () => {
+      const mock = createMockServer({
+        _permissions: {
+          handlePermissionRequest: () => { throw new Error('boom') },
+          handlePermissionResponseHttp: (_req, res) => { res.writeHead(200); res.end('ok') },
+        },
+      })
+      await startWith(mock)
+
+      let leaked = null
+      const onLeak = (err) => { leaked = err }
+      process.once('unhandledRejection', onLeak)
+      try {
+        await globalThis.fetch(`http://127.0.0.1:${port}/permission`, { method: 'POST', body: '{}' })
+        // Let any deferred rejection surface on the next ticks.
+        await new Promise((r) => setTimeout(r, 50))
+      } finally {
+        process.removeListener('unhandledRejection', onLeak)
+      }
+      assert.equal(leaked, null, 'wrapper must catch the throw — no unhandledRejection escapes')
+    })
+
+    it('does not double-write when a route throws AFTER sending headers', async () => {
+      const mock = createMockServer({
+        _permissions: {
+          handlePermissionRequest: (_req, res) => { res.writeHead(202); res.write('partial'); throw new Error('after headers') },
+          handlePermissionResponseHttp: (_req, res) => { res.writeHead(200); res.end('ok') },
+        },
+      })
+      await startWith(mock)
+
+      // Headers already sent → wrapper takes the else-branch (end(), no 2nd writeHead).
+      const res = await globalThis.fetch(`http://127.0.0.1:${port}/permission`, { method: 'POST', body: '{}' })
+      assert.equal(res.status, 202, 'keeps the already-sent status (no second writeHead(500))')
+      await res.text()
+      const health = await globalThis.fetch(`http://127.0.0.1:${port}/health`)
+      assert.equal(health.status, 200, 'server survived a post-headers throw')
+    })
   })
 
   describe('health endpoint', () => {


### PR DESCRIPTION
**WP-1.2** of the TUI hardening epic #5338 · closes #5312 · Phase 1 (crash-vectors).

## Problem
`createHttpHandler` returned a bare `async (req, res) => {...}`. An unguarded throw from any route — `buildDiagnosticsSnapshot`, `readConnectionInfo`, `readFileSync(index)`, etc. — rejected the handler promise → **unhandledRejection** → `server-cli`'s handler → `process.exit(1)`, taking down **every session on the host** on a single bad request.

## Fix
- Rename the routing body to an inner `dispatch(req, res)` (body unchanged — minimal diff) and return a thin wrapper that `await dispatch()` inside try/catch → **500 + log** on any throw/rejection, never an unhandledRejection.
- Respect `res.headersSent` (a route may throw mid-response): only `writeHead(500)` when headers haven't been sent, else `end()` the partial response.

Note: this catches synchronous throws in the awaited dispatch path (which is exactly where the audit's throw sites are). A route that *fire-and-forgets* an async call would still leak — none of the audited sites do that, and those are covered by WP-1.3 (#5313).

## Tests
+1: a throwing route returns 500 **and** a subsequent request still succeeds (proving the daemon survived the throw). **http-routes suite 29 pass.**

Closes #5312