### PR TITLE
fix(server): contain fire-and-forget rejections & listener/broadcast throws (#5313)

### DIFF
--- a/packages/server/src/event-normalizer.js
+++ b/packages/server/src/event-normalizer.js
@@ -1,4 +1,7 @@
 import { toShortModelId } from './models.js'
+import { createLogger } from './logger.js'
+
+const log = createLogger('event-normalizer')
 
 /**
  * Declarative event-to-WS-message mapping.
@@ -725,7 +728,21 @@ export class EventNormalizer {
           entries.push({ key, sessionId: null, messageId: key, delta })
         }
       }
-      this._onFlush(entries)
+      // #5313 (WP-1.3): _onFlush is a broadcast callback invoked from a
+      // setTimeout. A throw here escapes the timer → uncaughtException →
+      // process.exit(1), crashing the whole daemon over one bad flush.
+      // Contain it: log and swallow. The buffer is cleared in the finally
+      // below regardless, so a throwing flush can't wedge the delta buffer
+      // and stall every subsequent stream.
+      try {
+        this._onFlush(entries)
+      } catch (err) {
+        const message = err?.message || String(err)
+        log.error(`Delta flush onFlush callback threw: ${message}${err?.stack ? '\n' + err.stack : ''}`)
+      } finally {
+        this._deltaBuffer.clear()
+      }
+      return
     }
     this._deltaBuffer.clear()
   }

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -499,7 +499,20 @@ async function handleInput(ws, client, msg, ctx) {
   // cap-bypass).
   recordHistoryEntry(textToSend)
 
-  entry.session.sendMessage(textToSend, attachments, { isVoice: !!msg.isVoice })
+  // #5313 (WP-1.3): sendMessage is fire-and-forget. If a provider's
+  // sendMessage returns a rejecting promise, an unhandled rejection escapes
+  // to process-level unhandledRejection → process.exit(1), crashing EVERY
+  // session in the daemon over a single per-session send fault. Capture the
+  // return and, if thenable, attach a .catch that logs and swallows — real
+  // delivery failures still surface to the client via the provider's 'error'
+  // event. Mirrors the start() guard in session-manager.js createSession.
+  const sendResult = entry.session.sendMessage(textToSend, attachments, { isVoice: !!msg.isVoice })
+  if (sendResult && typeof sendResult.catch === 'function') {
+    sendResult.catch((err) => {
+      const message = err?.message || String(err)
+      log.error(`sendMessage rejected for session ${targetSessionId}: ${message}${err?.stack ? '\n' + err.stack : ''}`)
+    })
+  }
 
   ctx.updatePrimary(targetSessionId, client.id)
 

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -3,6 +3,22 @@ import { getDefaultModelId, getRegistryForProvider } from './models.js'
 
 const log = createLogger('ws-forwarding')
 
+// #5313 (WP-1.3) — wrap a forwarding listener so a throw in its body (almost
+// always a broadcast to a torn-down client, or a downstream devPreview call)
+// can't unwind the EventEmitter's emit() in the emitting code (session-manager /
+// CliSession / devPreview) and crash the whole daemon over one bad event. Logs
+// with a label for triage, then swallows. Used for the small one-liner
+// forwarders; the two large normalizer-driven listeners use inline try/catch.
+function safeForward(label, fn) {
+  return (...args) => {
+    try {
+      fn(...args)
+    } catch (err) {
+      log.error(`forwarding listener "${label}" threw: ${err?.message || err}${err?.stack ? '\n' + err.stack : ''}`)
+    }
+  }
+}
+
 /**
  * Set up event forwarding from backends to clients via EventNormalizer.
  *
@@ -122,29 +138,30 @@ function setupSessionForwarding(normalizer, ctx) {
   })
 
   // Session metadata updates (e.g. auto-labeling) — broadcast to ALL clients
-  sessionManager.on('session_updated', ({ sessionId, name }) => {
+  // #5313 (WP-1.3): safeForward — a broadcast throw must not unwind emit().
+  sessionManager.on('session_updated', safeForward('session_updated', ({ sessionId, name }) => {
     broadcast({ type: 'session_updated', sessionId, name })
-  })
+  }))
 
   // Restore failures — surface to clients so the UI can show a "needs
   // attention" card for sessions whose env vars / provider setup is broken
   // (#2954). History stays on disk; client shows a retry affordance.
-  sessionManager.on('session_restore_failed', (payload) => {
+  sessionManager.on('session_restore_failed', safeForward('session_restore_failed', (payload) => {
     broadcast({ type: 'session_restore_failed', ...payload })
-  })
+  }))
 
   // Dev server preview: broadcast tunnel start/stop to clients
-  devPreview.on('dev_preview_started', ({ sessionId, port, url }) => {
+  devPreview.on('dev_preview_started', safeForward('dev_preview_started', ({ sessionId, port, url }) => {
     broadcastToSession(sessionId, { type: 'dev_preview', port, url })
-  })
-  devPreview.on('dev_preview_stopped', ({ sessionId, port }) => {
+  }))
+  devPreview.on('dev_preview_stopped', safeForward('dev_preview_stopped', ({ sessionId, port }) => {
     broadcastToSession(sessionId, { type: 'dev_preview_stopped', port })
-  })
+  }))
 
   // Dev server preview: cleanup on session destroy
-  sessionManager.on('session_destroyed', ({ sessionId }) => {
+  sessionManager.on('session_destroyed', safeForward('session_destroyed', ({ sessionId }) => {
     devPreview.closeSession(sessionId)
-  })
+  }))
 
 }
 
@@ -210,30 +227,31 @@ function setupCliForwarding(normalizer, ctx) {
   }
 
   // Dev server preview: scan tool_result events for localhost server patterns (legacy CLI)
-  cliSession.on('tool_result', (data) => {
+  // #5313 (WP-1.3): safeForward — a throw here must not unwind CliSession's emit().
+  cliSession.on('tool_result', safeForward('cli:tool_result', (data) => {
     if (data?.result) {
       devPreview.handleToolResult('__legacy__', data.result)
     }
-  })
-  devPreview.on('dev_preview_started', ({ sessionId, port, url }) => {
+  }))
+  devPreview.on('dev_preview_started', safeForward('cli:dev_preview_started', ({ sessionId, port, url }) => {
     if (sessionId === '__legacy__') {
       broadcast({ type: 'dev_preview', port, url })
     }
-  })
-  devPreview.on('dev_preview_stopped', ({ sessionId, port }) => {
+  }))
+  devPreview.on('dev_preview_stopped', safeForward('cli:dev_preview_stopped', ({ sessionId, port }) => {
     if (sessionId === '__legacy__') {
       broadcast({ type: 'dev_preview_stopped', port })
     }
-  })
+  }))
 
   // models_updated bypasses normalizer — global broadcast.
   // CLI mode is always a Claude session; include provider so clients can
   // route the model list consistently with the multi-session path. (#2993)
-  cliSession.on('models_updated', (data) => {
+  cliSession.on('models_updated', safeForward('cli:models_updated', (data) => {
     if (data?.models) {
       broadcast({ type: 'available_models', models: data.models, defaultModel: getDefaultModelId(), provider: 'claude-cli' })
     }
-  })
+  }))
 }
 
 /** Execute side effect descriptors returned by the normalizer */

--- a/packages/server/src/ws-forwarding.js
+++ b/packages/server/src/ws-forwarding.js
@@ -49,6 +49,13 @@ function setupSessionForwarding(normalizer, ctx) {
   const { sessionManager, devPreview, broadcast, broadcastToSession } = ctx
 
   sessionManager.on('session_event', ({ sessionId, event, data }) => {
+    // #5313 (WP-1.3): this listener runs synchronously inside the
+    // SessionManager EventEmitter's emit(). A throw here unwinds emit() and
+    // escapes to the emitting code (session-manager), which can crash the
+    // whole daemon — taking down every other session — over one bad event.
+    // Contain it: wrap the body, log with the session id, and swallow so a
+    // single malformed event can't bring down the process.
+    try {
     // models_updated is global — broadcast to ALL clients, not per-session.
     // Look up the session's provider so clients receive the provider-scoped
     // defaultModel rather than the Claude-only global. Falls back to the
@@ -107,6 +114,11 @@ function setupSessionForwarding(normalizer, ctx) {
         broadcastToSession(sessionId, msg)
       }
     }
+    } catch (err) {
+      // #5313 (WP-1.3): see the try at the top of this listener.
+      const message = err?.message || String(err)
+      log.error(`session_event forwarding threw for session ${sessionId} (event=${event}): ${message}${err?.stack ? '\n' + err.stack : ''}`)
+    }
   })
 
   // Session metadata updates (e.g. auto-labeling) — broadcast to ALL clients
@@ -160,30 +172,39 @@ function setupCliForwarding(normalizer, ctx) {
   ]
   for (const event of FORWARDED_EVENTS) {
     cliSession.on(event, (data) => {
-      const normCtx = {
-        sessionId: null,
-        mode: 'legacy-cli',
-        getSessionEntry: () => ({
-          session: cliSession,
-        }),
-      }
-      const result = normalizer.normalize(event, data, normCtx)
-      if (!result) return
-
-      if (result.buffer) {
-        normalizer.bufferDelta(null, data.messageId, data.delta)
-        return
-      }
-
-      executeSideEffects(result.sideEffects, null, ctx)
-      executeRegistrations(result.registrations, null, ctx)
-
-      for (const { msg, filter } of result.messages) {
-        if (filter) {
-          broadcast(msg, filter)
-        } else {
-          broadcast(msg)
+      // #5313 (WP-1.3): same crash shape as the multi-session listener — a
+      // throw here unwinds the CliSession EventEmitter's emit() and escapes
+      // to the emitting code, which can crash the daemon over one bad event.
+      // Contain it: wrap the body, log the event, and swallow.
+      try {
+        const normCtx = {
+          sessionId: null,
+          mode: 'legacy-cli',
+          getSessionEntry: () => ({
+            session: cliSession,
+          }),
         }
+        const result = normalizer.normalize(event, data, normCtx)
+        if (!result) return
+
+        if (result.buffer) {
+          normalizer.bufferDelta(null, data.messageId, data.delta)
+          return
+        }
+
+        executeSideEffects(result.sideEffects, null, ctx)
+        executeRegistrations(result.registrations, null, ctx)
+
+        for (const { msg, filter } of result.messages) {
+          if (filter) {
+            broadcast(msg, filter)
+          } else {
+            broadcast(msg)
+          }
+        }
+      } catch (err) {
+        const message = err?.message || String(err)
+        log.error(`legacy-cli forwarding threw (event=${event}): ${message}${err?.stack ? '\n' + err.stack : ''}`)
       }
     })
   }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -247,12 +247,17 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         // #5313 (WP-1.3): see the try at the top of this end callback.
         const message = err?.message || String(err)
         log.error(`POST /permission end handler threw: ${message}${err?.stack ? '\n' + err.stack : ''}`)
-        if (!res.headersSent) {
-          res.writeHead(500, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: 'Internal server error' }))
-        } else {
-          res.end()
-        }
+        // #5313 review — the recovery response can ITSELF throw if the original
+        // failure was a torn-down socket (res.writeHead/res.end raising). Guard
+        // it so the catch can't re-crash the daemon; nothing more we can do.
+        try {
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: 'Internal server error' }))
+          } else {
+            res.end()
+          }
+        } catch { /* socket already torn down */ }
       }
     })
   }
@@ -435,12 +440,16 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         // #5313 (WP-1.3): see the try at the top of this end callback.
         const message = err?.message || String(err)
         log.error(`POST /permission-response end handler threw: ${message}${err?.stack ? '\n' + err.stack : ''}`)
-        if (!res.headersSent) {
-          res.writeHead(500, { 'Content-Type': 'application/json' })
-          res.end(JSON.stringify({ error: 'Internal server error' }))
-        } else {
-          res.end()
-        }
+        // #5313 review — guard the recovery response so a torn-down-socket
+        // throw in writeHead/end can't re-crash the daemon from the catch.
+        try {
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ error: 'Internal server error' }))
+          } else {
+            res.end()
+          }
+        } catch { /* socket already torn down */ }
       }
     })
   }

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -110,6 +110,14 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       }
     })
     req.on('end', () => {
+      // #5313 (WP-1.3): this callback fires on a later tick, after the HTTP
+      // dispatch that registered it has already returned — so a throw here is
+      // NOT caught by the route handler's wrapper and escapes to
+      // uncaughtException → process.exit(1), crashing the daemon. The inner
+      // JSON.parse is already guarded; this wraps the WHOLE body (res.writeHead
+      // on a torn-down socket, downstream session/broadcast calls) so any other
+      // throw is contained and returns a 500 to the client when possible.
+      try {
       if (oversized) {
         res.writeHead(413, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ decision: 'deny' }))
@@ -235,6 +243,17 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         timer,
         data: { requestId, tool, description, input: sanitizedInput, remainingMs: 300_000, createdAt: Date.now() },
       })
+      } catch (err) {
+        // #5313 (WP-1.3): see the try at the top of this end callback.
+        const message = err?.message || String(err)
+        log.error(`POST /permission end handler threw: ${message}${err?.stack ? '\n' + err.stack : ''}`)
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'Internal server error' }))
+        } else {
+          res.end()
+        }
+      }
     })
   }
 
@@ -271,6 +290,12 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       }
     })
     req.on('end', () => {
+      // #5313 (WP-1.3): same crash shape as handlePermissionRequest's end
+      // callback — fires on a later tick, escapes the route wrapper, and an
+      // uncaught throw (res.writeHead on a torn-down socket, getSessionManager
+      // / respondToPermission / broadcast downstream) crashes the daemon.
+      // Wrap the whole body; the inner JSON.parse guard is preserved.
+      try {
       if (oversized) return
 
       let parsed
@@ -405,6 +430,17 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
       } else {
         res.writeHead(404, { 'Content-Type': 'application/json' })
         res.end(JSON.stringify({ error: 'unknown or expired requestId' }))
+      }
+      } catch (err) {
+        // #5313 (WP-1.3): see the try at the top of this end callback.
+        const message = err?.message || String(err)
+        log.error(`POST /permission-response end handler threw: ${message}${err?.stack ? '\n' + err.stack : ''}`)
+        if (!res.headersSent) {
+          res.writeHead(500, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'Internal server error' }))
+        } else {
+          res.end()
+        }
       }
     })
   }

--- a/packages/server/tests/event-normalizer.test.js
+++ b/packages/server/tests/event-normalizer.test.js
@@ -750,6 +750,51 @@ describe('EventNormalizer', () => {
       assert.equal(flushed[0].delta, 'hello')
     })
 
+    // #5313 (WP-1.3): the timer-driven flush invokes onFlush (a broadcast). A
+    // throw there used to escape the setTimeout → uncaughtException → daemon
+    // crash. The flush now contains the throw, and clears the buffer in a
+    // finally so a throwing flush can't wedge the buffer for every later stream.
+    it('does not propagate a throwing onFlush out of the flush timer (#5313)', async () => {
+      normalizer.onFlush = () => { throw new Error('boom: broadcast failed') }
+
+      const uncaught = []
+      const onUncaught = (err) => { uncaught.push(err) }
+      process.on('uncaughtException', onUncaught)
+      try {
+        normalizer.bufferDelta('sess-1', 'msg-1', 'hello')
+        // Wait past the flush interval (10ms) for the timer to fire.
+        await new Promise((resolve) => setTimeout(resolve, 40))
+      } finally {
+        process.removeListener('uncaughtException', onUncaught)
+      }
+
+      assert.equal(uncaught.length, 0, 'throwing onFlush must not escape the flush timer')
+    })
+
+    it('clears the delta buffer even when onFlush throws (#5313)', async () => {
+      normalizer.onFlush = () => { throw new Error('boom') }
+      normalizer.bufferDelta('sess-1', 'msg-1', 'hello')
+      await new Promise((resolve) => setTimeout(resolve, 40))
+      assert.equal(normalizer._deltaBuffer.size, 0,
+        'buffer must be cleared so a throwing flush does not wedge subsequent streams')
+    })
+
+    it('stays functional after a throwing flush — a later flush still delivers (#5313)', async () => {
+      let lastFlushed = null
+      // First flush throws, then we swap in a good callback for the next round.
+      normalizer.onFlush = () => { throw new Error('boom') }
+      normalizer.bufferDelta('sess-1', 'msg-1', 'first')
+      await new Promise((resolve) => setTimeout(resolve, 40))
+
+      normalizer.onFlush = (entries) => { lastFlushed = entries }
+      normalizer.bufferDelta('sess-2', 'msg-2', 'second')
+      await new Promise((resolve) => setTimeout(resolve, 40))
+
+      assert.ok(lastFlushed, 'a subsequent flush still fires after a prior throwing flush')
+      assert.equal(lastFlushed.length, 1)
+      assert.equal(lastFlushed[0].delta, 'second')
+    })
+
     it('cancels timer when buffer emptied by flushSession', () => {
       normalizer.bufferDelta('sess-1', 'msg-1', 'x')
       normalizer.flushSession('sess-1')

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -1751,10 +1751,12 @@ describe('input-handlers', () => {
       assert.ok(echoed, 'user_input echo still broadcast despite send rejection')
     })
 
-    it('tolerates a synchronously-throwing sendMessage without crashing the handler', async () => {
-      // A non-thenable return (or sync throw) must not break the post-send
-      // bookkeeping. We only guard thenables, so a sync throw would propagate
-      // out of handleInput — assert the common non-rejecting case stays clean.
+    it('tolerates a non-thenable (legacy sync) sendMessage return without breaking post-send bookkeeping', async () => {
+      // The .catch guard only attaches to thenables, so a legacy provider whose
+      // sendMessage returns undefined (no promise) must not break the primary-
+      // update / user_input echo that follow. (A SYNCHRONOUS throw is a separate
+      // path — it propagates out of handleInput and is caught by the awaited
+      // message-handler's server_error wrapper, not by this thenable guard.)
       const sessions = new Map()
       const session = createMockSession()
       session.sendMessage = createSpy(() => undefined) // legacy sync provider

--- a/packages/server/tests/handlers/input-handlers.test.js
+++ b/packages/server/tests/handlers/input-handlers.test.js
@@ -1703,4 +1703,68 @@ describe('input-handlers', () => {
       assert.equal(sessionA.sendMessage.callCount, 1, 'session A still forwards after its own evaluator completes')
     })
   })
+
+  // #5313 (WP-1.3): sendMessage is fire-and-forget. A rejecting promise from a
+  // provider's sendMessage must NOT escape to unhandledRejection (→ daemon
+  // crash). The handler attaches a .catch that logs and swallows.
+  describe('sendMessage rejection containment (#5313)', () => {
+    it('does not let a rejecting sendMessage promise escape as an unhandled rejection', async () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      // Reject ASYNCHRONOUSLY so the rejection lands on a later microtask —
+      // the exact shape that becomes an unhandledRejection if not caught.
+      session.sendMessage = createSpy(() => Promise.reject(new Error('boom: provider send failed')))
+      sessions.set('s1', { session, name: 'S', cwd: '/work' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      const unhandled = []
+      const onUnhandled = (reason) => { unhandled.push(reason) }
+      process.on('unhandledRejection', onUnhandled)
+      try {
+        await inputHandlers.input(makeWs(), client, { data: 'a substantive message that forwards' }, ctx)
+        // Give the rejected microtask a couple of turns to surface had it
+        // escaped the .catch.
+        await new Promise((r) => setImmediate(r))
+        await new Promise((r) => setImmediate(r))
+      } finally {
+        process.removeListener('unhandledRejection', onUnhandled)
+      }
+
+      assert.equal(session.sendMessage.callCount, 1, 'sendMessage was invoked')
+      assert.equal(unhandled.length, 0, 'rejecting sendMessage must not escape to unhandledRejection')
+    })
+
+    it('still updates primary and echoes user_input when sendMessage rejects', async () => {
+      const sessions = new Map()
+      const session = createMockSession()
+      session.sendMessage = createSpy(() => Promise.reject(new Error('boom')))
+      sessions.set('s1', { session, name: 'S', cwd: '/work' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'a substantive message that forwards' }, ctx)
+      await new Promise((r) => setImmediate(r))
+
+      assert.equal(ctx.updatePrimary.callCount, 1, 'primary still updated despite send rejection')
+      const echoed = ctx._broadcasts.find((m) => m.type === 'user_input')
+      assert.ok(echoed, 'user_input echo still broadcast despite send rejection')
+    })
+
+    it('tolerates a synchronously-throwing sendMessage without crashing the handler', async () => {
+      // A non-thenable return (or sync throw) must not break the post-send
+      // bookkeeping. We only guard thenables, so a sync throw would propagate
+      // out of handleInput — assert the common non-rejecting case stays clean.
+      const sessions = new Map()
+      const session = createMockSession()
+      session.sendMessage = createSpy(() => undefined) // legacy sync provider
+      sessions.set('s1', { session, name: 'S', cwd: '/work' })
+      const ctx = makeCtx(sessions)
+      const client = makeClient({ activeSessionId: 's1' })
+
+      await inputHandlers.input(makeWs(), client, { data: 'a substantive message that forwards' }, ctx)
+      assert.equal(session.sendMessage.callCount, 1)
+      assert.equal(ctx.updatePrimary.callCount, 1)
+    })
+  })
 })

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -985,3 +985,129 @@ describe('[session-binding-create] diagnostic log (#2832, #2855, #2854)', () => 
     assert.equal(ctx.permissionSessionMap.get('req-silent'), 'sess-silent')
   })
 })
+
+// #5313 (WP-1.3): the forwarding listeners run synchronously inside the
+// SessionManager / CliSession EventEmitter's emit(). An uncaught throw there
+// unwinds emit() and can crash the whole daemon — taking down every session —
+// over one bad event. Both listeners now wrap their body in try/catch + log.
+describe('forwarding listener throw containment (#5313)', () => {
+  let currentListener = null
+  let priorLogLevel = null
+  afterEach(() => {
+    if (currentListener) {
+      removeLogListener(currentListener)
+      currentListener = null
+    }
+    if (priorLogLevel != null) {
+      setLogLevel(priorLogLevel)
+      priorLogLevel = null
+    }
+  })
+
+  it('multi-session session_event listener swallows a throwing broadcast (does not unwind emit)', () => {
+    const ctx = makeCtx({
+      // stream_start broadcasts session_activity synchronously at the top of
+      // the listener — make that broadcast throw.
+      broadcast: mock.fn(() => { throw new Error('boom: broadcast failed') }),
+    })
+    setupForwarding(ctx)
+
+    // emit() must NOT throw — the listener contains the fault.
+    assert.doesNotThrow(() => {
+      ctx.sessionManager.emit('session_event', {
+        sessionId: 'sess-throw-1',
+        event: 'stream_start',
+        data: { messageId: 'm1' },
+      })
+    }, 'a throwing broadcast must not unwind the SessionManager emit()')
+  })
+
+  it('multi-session session_event listener logs the contained error with the session id', () => {
+    priorLogLevel = getLogLevel()
+    setLogLevel('debug')
+    const entries = []
+    currentListener = (e) => entries.push(e)
+    addLogListener(currentListener)
+
+    const ctx = makeCtx({
+      broadcast: mock.fn(() => { throw new Error('boom') }),
+    })
+    setupForwarding(ctx)
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-throw-2',
+      event: 'stream_start',
+      data: { messageId: 'm1' },
+    })
+
+    const errLog = entries.find((e) =>
+      e.level === 'error' && e.message.includes('sess-throw-2') && e.message.includes('session_event forwarding threw'))
+    assert.ok(errLog, 'expected an error log naming the session and the containment site')
+  })
+
+  it('multi-session forwarding stays functional after a throwing event — a later good event still routes', () => {
+    let shouldThrow = true
+    const ctx = makeCtx({
+      broadcast: mock.fn(() => { if (shouldThrow) throw new Error('boom') }),
+    })
+    setupForwarding(ctx)
+
+    // First event throws inside the listener (contained).
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-throw-3',
+      event: 'stream_start',
+      data: { messageId: 'm1' },
+    })
+    // A subsequent good event must still route normally.
+    shouldThrow = false
+    ctx.sessionManager.emit('session_event', {
+      sessionId: 'sess-throw-3',
+      event: 'result',
+      data: { cost: 0.01 },
+    })
+    const activity = ctx.broadcast.mock.calls
+      .map((c) => c.arguments[0])
+      .find((m) => m.type === 'session_activity' && m.isBusy === false)
+    assert.ok(activity, 'forwarding still delivers after a prior contained throw')
+  })
+
+  it('legacy-cli forwarding listener swallows a throwing broadcast (does not unwind emit)', () => {
+    const ctx = makeCliCtx({
+      broadcast: mock.fn(() => { throw new Error('boom: broadcast failed') }),
+    })
+    setupForwarding(ctx)
+
+    assert.doesNotThrow(() => {
+      ctx.cliSession.emit('message', {
+        type: 'assistant',
+        content: 'Hello',
+        tool: null,
+        options: null,
+        timestamp: 1000,
+      })
+    }, 'a throwing broadcast must not unwind the CliSession emit()')
+  })
+
+  it('legacy-cli forwarding listener logs the contained error with the event name', () => {
+    priorLogLevel = getLogLevel()
+    setLogLevel('debug')
+    const entries = []
+    currentListener = (e) => entries.push(e)
+    addLogListener(currentListener)
+
+    const ctx = makeCliCtx({
+      broadcast: mock.fn(() => { throw new Error('boom') }),
+    })
+    setupForwarding(ctx)
+    ctx.cliSession.emit('message', {
+      type: 'assistant',
+      content: 'Hi',
+      tool: null,
+      options: null,
+      timestamp: 1,
+    })
+
+    const errLog = entries.find((e) =>
+      e.level === 'error' && e.message.includes('legacy-cli forwarding threw') && e.message.includes('event=message'))
+    assert.ok(errLog, 'expected an error log naming the event and the containment site')
+  })
+})

--- a/packages/server/tests/ws-forwarding.test.js
+++ b/packages/server/tests/ws-forwarding.test.js
@@ -1044,6 +1044,28 @@ describe('forwarding listener throw containment (#5313)', () => {
     assert.ok(errLog, 'expected an error log naming the session and the containment site')
   })
 
+  it('a sibling one-liner forwarder (session_updated) is contained via safeForward (#5313 review)', () => {
+    // The small sibling listeners (session_updated/restore_failed/dev_preview*/
+    // session_destroyed + the legacy-cli siblings) share the same crash shape as
+    // the two big listeners and are wrapped via the safeForward() helper.
+    priorLogLevel = getLogLevel()
+    setLogLevel('debug')
+    const entries = []
+    currentListener = (e) => entries.push(e)
+    addLogListener(currentListener)
+
+    const ctx = makeCtx({ broadcast: mock.fn(() => { throw new Error('boom: session_updated broadcast') }) })
+    setupForwarding(ctx)
+
+    assert.doesNotThrow(() => {
+      ctx.sessionManager.emit('session_updated', { sessionId: 's-upd', name: 'Renamed' })
+    }, 'a throwing session_updated broadcast must not unwind the SessionManager emit()')
+
+    const errLog = entries.find((e) =>
+      e.level === 'error' && e.message.includes('session_updated') && e.message.includes('forwarding listener'))
+    assert.ok(errLog, 'safeForward logs the contained sibling-listener error with its label')
+  })
+
   it('multi-session forwarding stays functional after a throwing event — a later good event still routes', () => {
     let shouldThrow = true
     const ctx = makeCtx({

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -383,6 +383,32 @@ describe('createPermissionHandler', () => {
       assert.equal(uncaught.length, 0, 'end-callback throw must not escape to uncaughtException')
       assert.equal(res.statusCode, 500, 'client receives a 500 when the end callback throws pre-response')
     })
+
+    it('does not re-crash when the recovery response itself throws (torn-down socket) (#5313 review)', async () => {
+      // Original fault AND the catch's recovery writeHead both throw (socket torn
+      // down). The catch's response attempt is guarded, so nothing escapes.
+      const opts = makeHandlerOpts({
+        broadcastFn: mock.fn(() => { throw new Error('boom: broadcast failed') }),
+      })
+      const { handlePermissionRequest, destroy } = createPermissionHandler(opts)
+      destroyFn = destroy
+
+      const req = makeReq(JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } }))
+      const res = makeRes()
+      res.writeHead = mock.fn(() => { throw new Error('EPIPE: socket torn down') })
+
+      const uncaught = []
+      const onUncaught = (err) => { uncaught.push(err) }
+      process.on('uncaughtException', onUncaught)
+      try {
+        assert.doesNotThrow(() => handlePermissionRequest(req, res))
+        await new Promise((r) => setImmediate(r))
+        await new Promise((r) => setImmediate(r))
+      } finally {
+        process.removeListener('uncaughtException', onUncaught)
+      }
+      assert.equal(uncaught.length, 0, 'a throwing recovery response must not escape to uncaughtException')
+    })
   })
 
   describe('handlePermissionResponseHttp', () => {

--- a/packages/server/tests/ws-permissions.test.js
+++ b/packages/server/tests/ws-permissions.test.js
@@ -45,7 +45,10 @@ function makeRes() {
   const res = {
     statusCode: null,
     body: null,
-    writeHead: mock.fn(function(code) { this.statusCode = code }),
+    // #5313 (WP-1.3): track headersSent like a real ServerResponse so the
+    // end-callback containment can decide between writeHead(500) and bare end().
+    headersSent: false,
+    writeHead: mock.fn(function(code) { this.statusCode = code; this.headersSent = true }),
     end: mock.fn(function(b) { this.body = b }),
     on(event, cb) { listeners[event] = cb; return this },
     emit(event, ...args) { if (listeners[event]) listeners[event](...args) },
@@ -345,6 +348,40 @@ describe('createPermissionHandler', () => {
       await new Promise(r => setImmediate(r))
       assert.equal(opts.permissionSessionMap.size, 0)
       assert.equal(ownerSession.notifyPermissionPending.mock.calls.length, 1)
+    })
+
+    // #5313 (WP-1.3): the req.on('end', ...) callback fires on a later tick,
+    // after handlePermissionRequest has returned, so a throw inside it is NOT
+    // caught by the route handler's wrapper and escapes to uncaughtException →
+    // daemon crash. The whole callback body is now wrapped: log + 500 (or bare
+    // end if headers already sent).
+    it('contains a throw inside the end callback and returns 500 (#5313)', async () => {
+      // broadcastFn throws inside the end callback, after JSON.parse succeeds
+      // and before any response is written.
+      const opts = makeHandlerOpts({
+        broadcastFn: mock.fn(() => { throw new Error('boom: broadcast failed') }),
+      })
+      const { handlePermissionRequest, destroy } = createPermissionHandler(opts)
+      destroyFn = destroy
+
+      const req = makeReq(JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } }))
+      const res = makeRes()
+
+      const uncaught = []
+      const onUncaught = (err) => { uncaught.push(err) }
+      process.on('uncaughtException', onUncaught)
+      try {
+        // The synchronous dispatch must not throw...
+        assert.doesNotThrow(() => handlePermissionRequest(req, res))
+        // ...and the deferred end-callback throw must be contained, not escape.
+        await new Promise((r) => setImmediate(r))
+        await new Promise((r) => setImmediate(r))
+      } finally {
+        process.removeListener('uncaughtException', onUncaught)
+      }
+
+      assert.equal(uncaught.length, 0, 'end-callback throw must not escape to uncaughtException')
+      assert.equal(res.statusCode, 500, 'client receives a 500 when the end callback throws pre-response')
     })
   })
 
@@ -918,6 +955,36 @@ describe('createPermissionHandler', () => {
       assert.equal(res.statusCode, 410, 'expired branch returns 410')
       assert.equal(audit.logDecision.mock.calls.length, 0,
         'expired SDK responses must not be audited — auto-deny already recorded')
+    })
+
+    // #5313 (WP-1.3): like handlePermissionRequest, this end callback fires on
+    // a later tick and a throw inside it escapes the route wrapper → daemon
+    // crash. The body is now wrapped: log + 500 (or bare end if headers sent).
+    it('contains a throw inside the end callback and returns 500 (#5313)', async () => {
+      // getSessionManager throws inside the end callback, after JSON parse and
+      // decision validation succeed but before any response is written.
+      const permissionSessionMap = new Map([['req-x', 'sess-x']])
+      const opts = makeHandlerOpts({
+        permissionSessionMap,
+        getSessionManager: mock.fn(() => { throw new Error('boom: session manager unavailable') }),
+      })
+      const { handlePermissionResponseHttp } = createPermissionHandler(opts)
+      const req = makeReq(JSON.stringify({ requestId: 'req-x', decision: 'allow' }))
+      const res = makeRes()
+
+      const uncaught = []
+      const onUncaught = (err) => { uncaught.push(err) }
+      process.on('uncaughtException', onUncaught)
+      try {
+        assert.doesNotThrow(() => handlePermissionResponseHttp(req, res))
+        await new Promise((r) => setImmediate(r))
+        await new Promise((r) => setImmediate(r))
+      } finally {
+        process.removeListener('uncaughtException', onUncaught)
+      }
+
+      assert.equal(uncaught.length, 0, 'end-callback throw must not escape to uncaughtException')
+      assert.equal(res.statusCode, 500, 'client receives a 500 when the end callback throws pre-response')
     })
   })
 })


### PR DESCRIPTION
**WP-1.3** of the TUI hardening epic #5338 · closes #5313 · Phase 1 (crash-vectors).

Each site below would otherwise escape to `unhandledRejection`/`uncaughtException` → `process.exit(1)`, killing **every session on the host** over one per-session/per-event fault.

## Sites fixed
1. **`handlers/input-handlers.js`** — capture the fire-and-forget `sendMessage()` return and `.catch` any rejection (log + swallow; real failures still reach clients via the provider `'error'` event). Mirrors `session-manager` `createSession`'s `start()` guard.
2. **`event-normalizer.js`** — wrap the `setTimeout`-driven `_flushDeltas` `onFlush` broadcast in try/catch; clear the delta buffer in `finally` so a throwing flush can't wedge every subsequent stream.
3. **`ws-forwarding.js`** — wrap the multi-session `session_event` listener **and** the legacy-CLI forwarding listeners so a throw can't unwind the `EventEmitter.emit()` in session-manager / CliSession.
4. **`ws-permissions.js`** — wrap **both** `req.on('end')` callbacks (`handlePermissionRequest` + `handlePermissionResponseHttp`). These fire on a later tick, **after** the HTTP route wrapper (#5312) has returned, so a throw there bypassed it — now contained + returns 500 (headersSent-aware). **Closes the gap flagged in the #5312 review.**

## Tests
+13 across the 4 suites: rejection/throw containment, no `unhandledRejection`, buffer-cleared-even-on-throw, system stays functional after a fault, 500 on a permission end-callback throw. **261 affected-suite tests pass; opt-forwarding + state-file-path lints clean.**

Closes #5313