### PR TITLE
fix(server): supervisor crash safety + cloudflared boot-leak (#5314)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -990,22 +990,31 @@ export async function startCliServer(config) {
     wireTunnelEvents(tunnel, wsServer)
 
     tunnel.on('tunnel_recovered', async ({ httpUrl: newHttpUrl, wsUrl: newWsUrl, attempt }) => {
-      log.info(`Tunnel recovered after ${attempt} attempt(s)`)
+      // #5314 (WP-1.4) — async event listener: waitForTunnel THROWS on a routine
+      // DNS-settle failure, and an unhandled rejection here would hit server-cli's
+      // unhandledRejection handler → process.exit(1), crashing the whole server on
+      // a recoverable tunnel hiccup. Contain it: log and wait for the next
+      // tunnel_recovered retry.
+      try {
+        log.info(`Tunnel recovered after ${attempt} attempt(s)`)
 
-      // Re-verify the new tunnel URL
-      await waitForTunnel(newHttpUrl, {
-        initialDelay: tunnelArg.mode === 'quick' ? QUICK_TUNNEL_DNS_SETTLE_MS : 0,
-      })
+        // Re-verify the new tunnel URL
+        await waitForTunnel(newHttpUrl, {
+          initialDelay: tunnelArg.mode === 'quick' ? QUICK_TUNNEL_DNS_SETTLE_MS : 0,
+        })
 
-      // Only display new QR code if URL actually changed
-      if (newWsUrl !== currentWsUrl) {
-        currentWsUrl = newWsUrl
-        if (pairingManager) pairingManager.refresh()
-        await displayQr(newWsUrl, newHttpUrl, modeLabel)
-        wsServer.broadcastStatus(`Tunnel reconnected with new URL: ${newWsUrl}`)
-      } else {
-        log.info(`Tunnel URL unchanged: ${newWsUrl}`)
-        wsServer.broadcastStatus('Tunnel connection recovered')
+        // Only display new QR code if URL actually changed
+        if (newWsUrl !== currentWsUrl) {
+          currentWsUrl = newWsUrl
+          if (pairingManager) pairingManager.refresh()
+          await displayQr(newWsUrl, newHttpUrl, modeLabel)
+          wsServer.broadcastStatus(`Tunnel reconnected with new URL: ${newWsUrl}`)
+        } else {
+          log.info(`Tunnel URL unchanged: ${newWsUrl}`)
+          wsServer.broadcastStatus('Tunnel connection recovered')
+        }
+      } catch (err) {
+        log.error(`tunnel_recovered handler failed (will retry on next recovery): ${err?.message || err}`)
       }
     })
 

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -118,6 +118,17 @@ export class Supervisor extends EventEmitter {
     })
   }
 
+  /**
+   * #5314 (WP-1.4) — last-resort handler for an uncaught error in the supervisor
+   * process. Logs it; stays alive so the child keeps being supervised (killing
+   * the supervisor would take down the whole service). Exits only if a shutdown
+   * is already underway. Extracted so tests can drive it without real signals.
+   */
+  _onProcessError(kind, err) {
+    this._log.error(`Supervisor ${kind} (staying alive): ${err?.stack || err}`)
+    if (this._shuttingDown) this._exit(1)
+  }
+
   /** Override point: exit the process */
   _exit(code) {
     process.exit(code)
@@ -162,6 +173,14 @@ export class Supervisor extends EventEmitter {
 
     process.on('SIGINT', () => this.shutdown('SIGINT'))
     process.on('SIGTERM', () => this.shutdown('SIGTERM'))
+
+    // #5314 (WP-1.4) — the supervisor had no uncaughtException/unhandledRejection
+    // handler, so a stray fault (e.g. the routine tunnel-DNS-settle rejection from
+    // an async tunnel_recovered handler) silently killed the supervisor and
+    // orphaned the child. Its job is uptime: log loudly and KEEP SUPERVISING.
+    // Only let the process exit if we're already in a deliberate shutdown.
+    process.on('uncaughtException', (err) => this._onProcessError('uncaughtException', err))
+    process.on('unhandledRejection', (err) => this._onProcessError('unhandledRejection', err))
   }
 
   async start() {
@@ -190,6 +209,10 @@ export class Supervisor extends EventEmitter {
     this._modeLabel = tunnelArg ? `cloudflare:${tunnelArg.mode}` : this._tunnelMode
 
     this._tunnel.on('tunnel_recovered', async ({ httpUrl: newHttpUrl, wsUrl: newWsUrl, attempt }) => {
+      // #5314 (WP-1.4) — this is an ASYNC event listener; an unhandled rejection
+      // here (waitForTunnel throws on a routine DNS-settle failure) would crash
+      // the supervisor. Contain it: log and let the next tunnel_recovered retry.
+      try {
       this._log.info(`Tunnel recovered after ${attempt} attempt(s)`)
       await this._waitForTunnel(newHttpUrl)
 
@@ -213,14 +236,29 @@ export class Supervisor extends EventEmitter {
           pid: process.pid,
         })
       }
+      } catch (err) {
+        this._log.error(`tunnel_recovered handler failed (will retry on next recovery): ${err?.message || err}`)
+      }
     })
 
     this._tunnel.on('tunnel_failed', ({ message }) => {
       this._log.error(message)
     })
 
-    // 2. Wait for tunnel to be routable
-    await this._waitForTunnel(httpUrl)
+    // 2. Wait for tunnel to be routable.
+    // #5314 (WP-1.4) — waitForTunnel THROWS on failure. The cloudflared child is
+    // already running (this._tunnel.start() above), so a boot failure here must
+    // stop it before exiting, otherwise the orphaned cloudflared process leaks.
+    try {
+      await this._waitForTunnel(httpUrl)
+    } catch (err) {
+      this._log.error(`Tunnel failed to become routable on boot: ${err?.message || err}`)
+      try { await this._tunnel.stop() } catch (stopErr) {
+        this._log.error(`Failed to stop cloudflared after boot failure: ${stopErr?.message || stopErr}`)
+      }
+      this._exit(1)
+      return
+    }
 
     // 3. Display connection info
     const connectionUrl = `chroxy://${wsUrl.replace('wss://', '')}?token=${this._apiToken}`

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -129,6 +129,22 @@ export class Supervisor extends EventEmitter {
     if (this._shuttingDown) this._exit(1)
   }
 
+  /**
+   * #5314 (WP-1.4) — single cleanup path for a boot failure that occurs after
+   * cloudflared has started but before the child is forked. Stops cloudflared so
+   * it doesn't leak as an orphan, then exits(1). Best-effort stop — we're exiting
+   * regardless.
+   */
+  async _failBoot(err) {
+    this._log.error(`Supervisor boot failed before the child started: ${err?.message || err}`)
+    try {
+      await this._tunnel.stop()
+    } catch (stopErr) {
+      this._log.error(`Failed to stop cloudflared after boot failure: ${stopErr?.message || stopErr}`)
+    }
+    this._exit(1)
+  }
+
   /** Override point: exit the process */
   _exit(code) {
     process.exit(code)
@@ -245,44 +261,44 @@ export class Supervisor extends EventEmitter {
       this._log.error(message)
     })
 
-    // 2. Wait for tunnel to be routable.
-    // #5314 (WP-1.4) — waitForTunnel THROWS on failure. The cloudflared child is
-    // already running (this._tunnel.start() above), so a boot failure here must
-    // stop it before exiting, otherwise the orphaned cloudflared process leaks.
+    // 2-3. Wait for the tunnel to be routable, then display + persist connection
+    // info. #5314 (WP-1.4) — every step here runs while cloudflared is already
+    // up (this._tunnel.start() above) but BEFORE the child is forked, so ANY
+    // throw must stop cloudflared first or it leaks as an orphan. waitForTunnel
+    // THROWS on a routine DNS-settle failure; _displayQr (QR encode) and
+    // writeConnectionInfo (disk) can also throw. _failBoot() is the single
+    // cleanup path. (The PID write below has its own non-fatal guard, and the
+    // child fork is past the no-leak boundary.)
     try {
       await this._waitForTunnel(httpUrl)
+
+      // 3. Display connection info
+      const connectionUrl = `chroxy://${wsUrl.replace('wss://', '')}?token=${this._apiToken}`
+
+      this._log.info(`${this._modeLabel} ready`)
+      process.stdout.write('📱 Scan this QR code with the Chroxy app:\n\n')
+      await this._displayQr(connectionUrl)
+      process.stdout.write('\nOr connect manually:\n')
+      process.stdout.write(`   URL:   ${wsUrl}\n`)
+      process.stdout.write(`   Token: ${maskToken(this._apiToken)}\n`)
+      const dashboardBase = httpUrl || `http://localhost:${this._port}`
+      process.stdout.write(`   Dashboard: ${dashboardBase.replace(/\/+$/, '')}/dashboard\n`)
+      process.stdout.write('\n')
+
+      // 3b. Write connection info file for programmatic access
+      writeConnectionInfo({
+        wsUrl,
+        httpUrl,
+        apiToken: this._apiToken,
+        connectionUrl,
+        tunnelMode: this._modeLabel,
+        startedAt: new Date().toISOString(),
+        pid: process.pid,
+      })
     } catch (err) {
-      this._log.error(`Tunnel failed to become routable on boot: ${err?.message || err}`)
-      try { await this._tunnel.stop() } catch (stopErr) {
-        this._log.error(`Failed to stop cloudflared after boot failure: ${stopErr?.message || stopErr}`)
-      }
-      this._exit(1)
+      await this._failBoot(err)
       return
     }
-
-    // 3. Display connection info
-    const connectionUrl = `chroxy://${wsUrl.replace('wss://', '')}?token=${this._apiToken}`
-
-    this._log.info(`${this._modeLabel} ready`)
-    process.stdout.write('📱 Scan this QR code with the Chroxy app:\n\n')
-    await this._displayQr(connectionUrl)
-    process.stdout.write('\nOr connect manually:\n')
-    process.stdout.write(`   URL:   ${wsUrl}\n`)
-    process.stdout.write(`   Token: ${maskToken(this._apiToken)}\n`)
-    const dashboardBase = httpUrl || `http://localhost:${this._port}`
-    process.stdout.write(`   Dashboard: ${dashboardBase.replace(/\/+$/, '')}/dashboard\n`)
-    process.stdout.write('\n')
-
-    // 3b. Write connection info file for programmatic access
-    writeConnectionInfo({
-      wsUrl,
-      httpUrl,
-      apiToken: this._apiToken,
-      connectionUrl,
-      tunnelMode: this._modeLabel,
-      startedAt: new Date().toISOString(),
-      pid: process.pid,
-    })
 
     // 4. Write PID file
     try {

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -125,7 +125,10 @@ export class Supervisor extends EventEmitter {
    * is already underway. Extracted so tests can drive it without real signals.
    */
   _onProcessError(kind, err) {
-    this._log.error(`Supervisor ${kind} (staying alive): ${err?.stack || err}`)
+    // Reflect the actual action: during a deliberate shutdown we exit(1); the
+    // rest of the time we stay alive and keep supervising.
+    const action = this._shuttingDown ? 'exiting — shutdown in progress' : 'staying alive'
+    this._log.error(`Supervisor ${kind} (${action}): ${err?.stack || err}`)
     if (this._shuttingDown) this._exit(1)
   }
 

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -862,4 +862,53 @@ describe('Supervisor', () => {
       clearInterval(supervisor._heartbeatInterval)
     })
   })
+
+  // #5314 (WP-1.4) — supervisor crash safety + cloudflared boot leak.
+  describe('crash safety (#5314)', () => {
+    it('_onProcessError logs and stays alive (does not exit) when not shutting down', () => {
+      const { supervisor } = createTestSupervisor()
+      supervisor._onProcessError('uncaughtException', new Error('stray fault'))
+      assert.equal(supervisor._exitCalled, null, 'supervisor must keep supervising after an uncaught error')
+    })
+
+    it('_onProcessError exits(1) when a shutdown is already underway', () => {
+      const { supervisor } = createTestSupervisor()
+      supervisor._shuttingDown = true
+      supervisor._onProcessError('unhandledRejection', new Error('during shutdown'))
+      assert.equal(supervisor._exitCalled, 1)
+    })
+
+    it('stops cloudflared and exits(1) when the tunnel is not routable on boot (no leak)', async () => {
+      const { supervisor } = createTestSupervisor()
+      // waitForTunnel throws on failure; the cloudflared child is already running.
+      supervisor._waitForTunnel = () => Promise.reject(new Error('tunnel not routable'))
+      await supervisor.start()
+      assert.equal(supervisor._mockTunnel.stop.mock.callCount(), 1, 'cloudflared stopped — not leaked')
+      assert.equal(supervisor._exitCalled, 1, 'exits(1) on boot tunnel failure')
+      assert.equal(supervisor._mockChildren.length, 0, 'never forked the child (failed before fork)')
+    })
+
+    it('tunnel_recovered handler contains a waitForTunnel rejection (no unhandledRejection)', async () => {
+      const { supervisor } = createTestSupervisor()
+      await supervisor.start() // default _waitForTunnel resolves → handler wired
+      // A routine DNS-settle failure on recovery: waitForTunnel rejects.
+      supervisor._waitForTunnel = () => Promise.reject(new Error('DNS not settled'))
+
+      const uncaught = []
+      const onUnhandled = (e) => uncaught.push(e)
+      process.on('unhandledRejection', onUnhandled)
+      try {
+        supervisor._mockTunnel.emit('tunnel_recovered', {
+          httpUrl: 'https://new.example.com', wsUrl: 'wss://new.example.com', attempt: 1,
+        })
+        await new Promise((r) => setTimeout(r, 30))
+      } finally {
+        process.removeListener('unhandledRejection', onUnhandled)
+      }
+      assert.equal(uncaught.length, 0, 'a recovery waitForTunnel rejection must be contained, not crash the supervisor')
+
+      supervisor._shuttingDown = true
+      clearInterval(supervisor._heartbeatInterval)
+    })
+  })
 })

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -866,20 +866,20 @@ describe('Supervisor', () => {
   // #5314 (WP-1.4) — supervisor crash safety + cloudflared boot leak.
   describe('crash safety (#5314)', () => {
     it('_onProcessError logs and stays alive (does not exit) when not shutting down', () => {
-      const { supervisor } = createTestSupervisor()
+      const { supervisor } = setup()
       supervisor._onProcessError('uncaughtException', new Error('stray fault'))
       assert.equal(supervisor._exitCalled, null, 'supervisor must keep supervising after an uncaught error')
     })
 
     it('_onProcessError exits(1) when a shutdown is already underway', () => {
-      const { supervisor } = createTestSupervisor()
+      const { supervisor } = setup()
       supervisor._shuttingDown = true
       supervisor._onProcessError('unhandledRejection', new Error('during shutdown'))
       assert.equal(supervisor._exitCalled, 1)
     })
 
     it('stops cloudflared and exits(1) when the tunnel is not routable on boot (no leak)', async () => {
-      const { supervisor } = createTestSupervisor()
+      const { supervisor } = setup()
       // waitForTunnel throws on failure; the cloudflared child is already running.
       supervisor._waitForTunnel = () => Promise.reject(new Error('tunnel not routable'))
       await supervisor.start()
@@ -892,7 +892,7 @@ describe('Supervisor', () => {
       // #5314 review — the boot guard covers not just waitForTunnel but every
       // pre-fork step (displayQr/writeConnectionInfo), since each runs while
       // cloudflared is up but before the child fork.
-      const { supervisor } = createTestSupervisor()
+      const { supervisor } = setup()
       supervisor._displayQr = () => Promise.reject(new Error('QR encode failed'))
       await supervisor.start()
       assert.equal(supervisor._mockTunnel.stop.mock.callCount(), 1, 'cloudflared stopped on a pre-fork boot throw')
@@ -901,7 +901,7 @@ describe('Supervisor', () => {
     })
 
     it('tunnel_recovered handler contains a waitForTunnel rejection (no unhandledRejection)', async () => {
-      const { supervisor } = createTestSupervisor()
+      const { supervisor } = setup()
       await supervisor.start() // default _waitForTunnel resolves → handler wired
       // A routine DNS-settle failure on recovery: waitForTunnel rejects.
       supervisor._waitForTunnel = () => Promise.reject(new Error('DNS not settled'))

--- a/packages/server/tests/supervisor.test.js
+++ b/packages/server/tests/supervisor.test.js
@@ -888,6 +888,18 @@ describe('Supervisor', () => {
       assert.equal(supervisor._mockChildren.length, 0, 'never forked the child (failed before fork)')
     })
 
+    it('stops cloudflared and exits(1) when a pre-fork boot step (_displayQr) throws (no leak)', async () => {
+      // #5314 review — the boot guard covers not just waitForTunnel but every
+      // pre-fork step (displayQr/writeConnectionInfo), since each runs while
+      // cloudflared is up but before the child fork.
+      const { supervisor } = createTestSupervisor()
+      supervisor._displayQr = () => Promise.reject(new Error('QR encode failed'))
+      await supervisor.start()
+      assert.equal(supervisor._mockTunnel.stop.mock.callCount(), 1, 'cloudflared stopped on a pre-fork boot throw')
+      assert.equal(supervisor._exitCalled, 1)
+      assert.equal(supervisor._mockChildren.length, 0, 'never forked the child')
+    })
+
     it('tunnel_recovered handler contains a waitForTunnel rejection (no unhandledRejection)', async () => {
       const { supervisor } = createTestSupervisor()
       await supervisor.start() // default _waitForTunnel resolves → handler wired


### PR DESCRIPTION
**WP-1.4** of the TUI hardening epic #5338 · closes #5314 · the **final Phase 1** (crash-vectors) item.

`waitForTunnel` **throws** on failure (`tunnel-check.js`), which drives all three findings:

## Fixes
- **Supervisor process-error handlers** (`supervisor.js`): there were none, so a stray fault — e.g. the async `tunnel_recovered` handler's `waitForTunnel` rejection on a routine DNS-settle hiccup — silently killed the supervisor and orphaned the child. Added `_onProcessError` (wired to `uncaughtException`/`unhandledRejection`) that logs loudly and **keeps supervising** (the supervisor's job is uptime); it exits only if a shutdown is already underway.
- **`tunnel_recovered` async handler (supervisor)**: wrap the body in try/catch so a recovery `waitForTunnel` rejection is logged + retried on the next recovery, not crashed.
- **Cloudflared boot-leak (supervisor)**: the boot `waitForTunnel` (pre-fork) now catches failure, **stops the already-running cloudflared child** (previously leaked), and exits(1) — before the child is ever forked.
- **`tunnel_recovered` async handler (`server-cli.js`, non-supervised path)**: wrapped the same way — its rejection would otherwise hit server-cli's `unhandledRejection` handler → `process.exit(1)`, crashing the whole server on a recoverable hiccup.

## Tests
+4: stays-alive-on-uncaught-error, exits(1)-during-shutdown, boot-failure stops cloudflared + exits + never-forks-child, `tunnel_recovered` rejection contained (no `unhandledRejection`). **supervisor suite 33 pass.**

Closes #5314 — completes **Phase 1**.