### PR TITLE
fix(server): bounded per-session PTY auto-respawn for claude-tui (#5315)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -391,7 +391,15 @@ export class ClaudeTuiSession extends BaseSession {
    * the v0.9.24 dogfood feedback captured on #4653.
    */
   static get customEvents() {
-    return ['multi_question_intervention']
+    // #5315 (WP-2.1) — `respawn_exhausted` is emitted by `_scheduleRespawn`
+    // when bounded PTY auto-respawn gives up (max attempts reached). WHY it's a
+    // custom event and not just an `error`: SessionManager keys its
+    // drop-the-session-from-the-list coordination on this distinct signal
+    // (`_wireSessionEvents` calls destroySession on it) so the session leaves
+    // the list with a clear error instead of lingering as an input-rejecting
+    // zombie tab. Listing it here also forwards it to paired clients as a
+    // transient `session_event` so the dashboard can surface the give-up reason.
+    return ['multi_question_intervention', 'respawn_exhausted']
   }
 
   constructor({ cwd, model, permissionMode, port, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs, firstOutputTimeoutMs, skipPermissions, resumeSessionId } = {}) {
@@ -441,6 +449,17 @@ export class ClaudeTuiSession extends BaseSession {
     this._activeTurn = null  // { messageId, startedAt, aborted, synthSeq }
     this._ptyExited = false
     this._ptyExitInfo = null
+    // #5315 (WP-2.1) — bounded per-session PTY auto-respawn state, mirroring
+    // CliSession (cli-session.js:351). WHY: when the persistent claude PTY dies
+    // unexpectedly mid-session, `_onPtyGone` used to tear the session down into
+    // a permanently input-rejecting zombie (every later sendMessage rejected
+    // "no longer alive"). The TUI provider is becoming the PRIMARY backend, so
+    // it must self-heal like CliSession does. Backoff [1s,2s,4s,8s,15s], max 5
+    // attempts, then `respawn_exhausted` (SessionManager drops the session).
+    this._respawnCount = 0
+    this._respawnTimer = null
+    this._respawnScheduled = false
+    this._respawning = false
     // Ring buffer of recent PTY output bytes — surfaces in error
     // messages when the TUI renders a diagnostic (rate-limit, auth
     // failure, "switch back to API mode") that would otherwise be
@@ -823,6 +842,113 @@ export class ClaudeTuiSession extends BaseSession {
       const base = `Claude PTY exited (code=${codeStr})`
       this.emit('error', { message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
     }
+    // #5315 (WP-2.1) — an UNEXPECTED PTY death (we already returned above when
+    // `_destroying`, so this is never a deliberate teardown). Try to bring the
+    // session back instead of leaving a zombie. The error(s) above still fire
+    // so the dashboard sees the death; the respawn is the recovery layer on top.
+    this._scheduleRespawn()
+  }
+
+  /**
+   * #5315 (WP-2.1) — schedule a bounded PTY respawn with exponential backoff,
+   * mirroring CliSession._scheduleRespawn (cli-session.js:556). Backoff is
+   * [1s,2s,4s,8s,15s] and caps at 5 attempts; on exhaustion it emits a
+   * categorized `error` AND a `respawn_exhausted` event so SessionManager drops
+   * the session from its list (no input-rejecting zombie tab — the audit AC).
+   * Guarded on `_destroying` / `_respawning` / `_respawnScheduled` so the
+   * several wired PTY-fault events (onExit/close/error) can't stack timers.
+   */
+  _scheduleRespawn() {
+    if (this._destroying) return
+    if (this._respawning) return
+    if (this._respawnScheduled) return
+
+    this._respawnCount++
+    if (this._respawnCount > 5) {
+      ;(this._log || log).error('Max PTY respawn attempts reached (5), giving up')
+      const tail = this._outputTailDiagnostic()
+      const base = 'Claude PTY failed to stay alive after 5 respawn attempts'
+      // Distinct code so the dashboard can render a terminal "give up" state
+      // rather than a recoverable crash toast.
+      this.emit('error', { code: 'pty_respawn_exhausted', message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
+      // SessionManager listens for this and calls destroySession() so the
+      // session leaves the list cleanly (see _wireSessionEvents).
+      this.emit('respawn_exhausted', { reason: 'pty_respawn_exhausted', attempts: this._respawnCount - 1 })
+      return
+    }
+
+    const delays = [1000, 2000, 4000, 8000, 15000]
+    const delay = delays[Math.min(this._respawnCount - 1, delays.length - 1)]
+    ;(this._log || log).info(`Respawning claude PTY in ${delay}ms (attempt ${this._respawnCount}/5)`)
+
+    this._respawnScheduled = true
+    this._respawnTimer = setTimeout(() => {
+      this._respawnTimer = null
+      this._respawnScheduled = false
+      if (this._destroying) return
+      this._respawnPty()
+    }, delay)
+  }
+
+  /**
+   * #5315 (WP-2.1) — re-spawn the persistent PTY in place after an unexpected
+   * death. Reuses the existing sink dir / settings.json / hook secret (does NOT
+   * re-create them) by re-invoking `_spawnPty()` with the same
+   * `permissionsEnabled` decision start() made.
+   *
+   * Two subtleties that are load-bearing:
+   *   1. Guard reset — `_onPtyGone` latched `_ptyExited=true` (plus
+   *      `_ptyExitInfo` / `_processReady=false`). Without resetting these,
+   *      `_onPtyGone`'s `if (this._ptyExited) return` guard stays latched and
+   *      the NEXT death would no-op instead of tearing down / respawning again
+   *      (the #5315 #1 footgun). Reset them before re-spawning.
+   *   2. Conversation continuity — the upstream claude conversation already
+   *      exists from the prior PTY run and `_sessionId` is preserved, so the
+   *      respawn MUST use `--resume <id>`, NOT `--session-id` (claude rejects a
+   *      reused session-id as "already in use"). Set `_resumedFromPersisted`
+   *      so `_spawnPty`'s idArgs picks `--resume`; do NOT mint a new id.
+   */
+  async _respawnPty() {
+    if (this._destroying) return
+    this._respawning = true
+    // (1) reset the teardown latches so a future death re-triggers _onPtyGone.
+    this._ptyExited = false
+    this._ptyExitInfo = null
+    this._processReady = false
+    // (2) continue the SAME upstream conversation via --resume.
+    this._resumedFromPersisted = true
+    // Recompute permissionsEnabled exactly as start() did — the sink dir, hook
+    // secret and settings.json are all still in place from the original start,
+    // so we re-use them rather than re-deriving (no re-mint, no re-create).
+    const permissionsEnabled = !!(this._port && this._hookSecret) && !this.skipPermissions
+    try {
+      await this._spawnPty(permissionsEnabled)
+    } catch (err) {
+      ;(this._log || log).error(`PTY respawn threw: ${err?.message || err}`)
+      this._respawning = false
+      // Treat a throw like a death: schedule the next attempt (respects the cap).
+      this._scheduleRespawn()
+      return
+    }
+    this._respawning = false
+    if (this._destroying) return
+    if (this._ptyExited) {
+      // Respawn warmup failed: the PTY died again during _spawnPty. _onPtyGone
+      // DID fire (it set _ptyExited), but its _scheduleRespawn was suppressed
+      // by the `_respawning` guard that was true for the whole _spawnPty await.
+      // Now that we've cleared `_respawning`, schedule the next attempt here so
+      // the backoff chain continues toward the cap (it won't loop forever —
+      // _scheduleRespawn enforces the 5-attempt limit).
+      this._scheduleRespawn()
+      return
+    }
+    // Respawn succeeded and stayed alive through warmup. Reset the count so a
+    // FUTURE unrelated death gets the full retry budget again (matches how
+    // CliSession resets _respawnCount on system.init, cli-session.js:888), mark
+    // ready, and re-emit `ready` so the dashboard knows the session recovered.
+    this._respawnCount = 0
+    this._processReady = true
+    this.emit('ready', { sessionId: this._sessionId, model: this.model, tools: [] })
   }
 
   /**
@@ -3318,6 +3444,15 @@ export class ClaudeTuiSession extends BaseSession {
     this._processReady = false
     this._isBusy = false
     this._activeTurn = null
+    // #5315 (WP-2.1) — cancel any pending respawn so a scheduled _respawnPty
+    // can't fire after teardown and spawn a fresh claude into a destroyed
+    // session. `_destroying` is already true above, so _scheduleRespawn would
+    // short-circuit anyway, but a timer already armed before destroy() must be
+    // cleared explicitly. _respawning is reset so a re-create of this instance
+    // (defensive) starts from a clean state.
+    if (this._respawnTimer) { clearTimeout(this._respawnTimer); this._respawnTimer = null }
+    this._respawnScheduled = false
+    this._respawning = false
     // #4278 / #4802: drop any pending AskUserQuestion so a late
     // user_question_response can't write into a dead PTY. Explicit
     // `_pendingUserAnswers_clearAll()` (was an implicit

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -931,8 +931,21 @@ export class ClaudeTuiSession extends BaseSession {
       return
     }
     this._respawning = false
-    if (this._destroying) return
-    if (this._ptyExited) {
+    if (this._destroying) {
+      // #5315 review (MAJOR-1) — destroy() raced our respawn. _spawnPty's own
+      // post-spawn guard kills a PTY it managed to assign, but cover it here too
+      // (and so a stubbed _spawnPty in tests can't leave a live _term): kill any
+      // PTY that exists and bail without emitting `ready`.
+      try { this._term?.kill?.('SIGTERM') } catch {}
+      this._term = null
+      return
+    }
+    // #5315 review (MINOR-1) — _spawnPty has early-return paths (node-pty import
+    // fail, spawn throw) that emit('error') and return WITHOUT setting
+    // _ptyExited and without assigning a live _term. Treat "no live PTY" the
+    // same as a death so we don't falsely emit `ready` + mark _processReady on a
+    // dead session; reschedule (respects the cap).
+    if (!this._term || this._ptyExited) {
       // Respawn warmup failed: the PTY died again during _spawnPty. _onPtyGone
       // DID fire (it set _ptyExited), but its _scheduleRespawn was suppressed
       // by the `_respawning` guard that was true for the whole _spawnPty await.
@@ -1006,8 +1019,13 @@ export class ClaudeTuiSession extends BaseSession {
     // is rejected by claude. Falls back to the fresh path whenever the session
     // wasn't seeded from a persisted id. Resume-failure handling (claude can't
     // find the conversation, e.g. cleared ~/.claude history) currently surfaces
-    // via the warmup `_ptyExited` error path; a graceful drop-and-retry-fresh
-    // fallback is tracked with the per-session respawn work (#5315 / WP-2.1).
+    // via the warmup `_ptyExited` error path → bounded respawn (#5315) → if every
+    // resume-respawn dies, exhaustion destroys the session. NOTE: #5315 does NOT
+    // add a graceful drop-and-retry-FRESH fallback — a fresh session that dies
+    // before claude persists its conversation will burn all 5 respawns on a
+    // doomed `--resume` then get destroyed (bounded + safe, but recovery is
+    // futile in that narrow window). The retry-fresh fallback is tracked in its
+    // own follow-up (see #5315 review).
     const idArgs = this._resumedFromPersisted
       ? ['--resume', this._sessionId]
       : ['--session-id', this._sessionId]
@@ -1056,6 +1074,16 @@ export class ClaudeTuiSession extends BaseSession {
       })
     } catch (err) {
       this.emit('error', { message: `Failed to spawn claude under PTY: ${err.message}` })
+      return
+    }
+
+    // #5315 (WP-2.1) review — destroy() can race an in-flight (re)spawn: it kills
+    // the OLD _term and sets _destroying while we're awaiting the spawn above, so
+    // the PTY we just created would be orphaned (nothing left to kill it). If a
+    // teardown landed during the await, kill the fresh PTY now and bail.
+    if (this._destroying) {
+      try { this._term.kill('SIGTERM') } catch {}
+      this._term = null
       return
     }
 

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1865,6 +1865,19 @@ export class SessionManager extends EventEmitter {
     session.on('models_updated', (data) => {
       this.emit('session_event', { sessionId, event: 'models_updated', data })
     })
+
+    // #5315 (WP-2.1) — a provider that exhausts its bounded PTY auto-respawn
+    // budget emits `respawn_exhausted`. The transient-events loop above already
+    // forwarded it to clients (it's in ClaudeTuiSession.customEvents); here we
+    // ALSO drop the session from the list so the audit AC holds: the session
+    // leaves the list with a clear error instead of lingering as an
+    // input-rejecting zombie tab. Mirrors the session_timeout → destroySession
+    // coordination (this file, ~457). destroySession is idempotent on a missing
+    // id, so a duplicate signal is harmless.
+    session.on('respawn_exhausted', (data) => {
+      sessionLog.error(`[respawn_exhausted] ${data?.reason || 'pty respawn gave up'} — destroying session`)
+      this.destroySession(sessionId)
+    })
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -1872,9 +1872,11 @@ export class SessionManager extends EventEmitter {
     // ALSO drop the session from the list so the audit AC holds: the session
     // leaves the list with a clear error instead of lingering as an
     // input-rejecting zombie tab. Mirrors the session_timeout → destroySession
-    // coordination (this file, ~457). destroySession is idempotent on a missing
-    // id, so a duplicate signal is harmless.
+    // coordination (this file, ~457). Guard on _sessions.has so a duplicate
+    // signal doesn't log a spurious "session not found" error — destroySession
+    // logs + returns false on a missing id rather than no-opping silently.
     session.on('respawn_exhausted', (data) => {
+      if (!this._sessions.has(sessionId)) return
       sessionLog.error(`[respawn_exhausted] ${data?.reason || 'pty respawn gave up'} — destroying session`)
       this.destroySession(sessionId)
     })

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -430,6 +430,37 @@ describe('ClaudeTuiSession', () => {
       assert.equal(spawnCalls, 0, 'no respawn after destroy')
       session = null // already destroyed; skip afterEach double-destroy
     })
+
+    it('kills the fresh PTY when destroy() races an in-flight respawn (no orphan) (#5315 review)', async () => {
+      let killed = 0
+      session = makeSession((self) => {
+        // destroy() lands during the spawn await: _destroying flips and the
+        // fresh PTY has just been assigned by the (stubbed) _spawnPty.
+        self._destroying = true
+        self._term = { kill: () => { killed++ }, onData: () => {}, onExit: () => {}, on: () => {}, write: () => {} }
+      })
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      mock.timers.tick(1000)
+      await new Promise((r) => setImmediate(r))
+      assert.equal(killed, 1, 'the freshly-spawned PTY is killed when destroy raced the respawn')
+      assert.equal(session._term, null, 'no live _term left referenced (no orphan)')
+      assert.equal(session._processReady, false, 'not marked ready on a raced destroy')
+      session = null // _destroying already set; skip afterEach double-destroy
+    })
+
+    it('reschedules (does not falsely go ready) when a respawn leaves no live PTY (#5315 review)', async () => {
+      session = makeSession((self) => {
+        // Mimic _spawnPty's early-return error paths (node-pty import fail /
+        // spawn throw): no live _term, _ptyExited not set.
+        self._term = null
+      })
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      mock.timers.tick(1000)
+      await new Promise((r) => setImmediate(r))
+      assert.equal(session._processReady, false, 'must NOT mark ready when no live PTY came up')
+      assert.equal(session._respawnScheduled, true, 'rescheduled another attempt instead of declaring success')
+      assert.ok(session._respawnCount >= 2, 'attempt count advanced')
+    })
   })
 
   describe('sendMessage() error paths', () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -271,6 +271,167 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  // #5315 (WP-2.1) — bounded per-session PTY auto-respawn. When the persistent
+  // claude PTY dies unexpectedly mid-session, the session must self-heal
+  // (bounded backoff, max 5 attempts) instead of becoming a permanently
+  // input-rejecting zombie. Mirrors CliSession's respawn. Tests stub _spawnPty
+  // on the prototype and drive mock.timers so no real claude is spawned and no
+  // real backoff delay is waited.
+  describe('PTY auto-respawn (#5315 WP-2.1)', () => {
+    beforeEach(() => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+    })
+    afterEach(() => {
+      mock.timers.reset()
+    })
+
+    // Build a session with _spawnPty stubbed to succeed (live term, not exited).
+    // `onSpawn` lets a test observe / mutate each spawn (e.g. count calls,
+    // capture the idArgs, or make the respawn die again).
+    function makeSession(onSpawn) {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      s._spawnPty = async function () {
+        this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {}, on: () => {} }
+        if (onSpawn) onSpawn(this)
+      }
+      // Pretend start() already ran: sink/settings/secret exist, PTY is live.
+      s._sinkDir = '/tmp/fake-sink'
+      s._settingsPath = '/tmp/fake-sink/settings.json'
+      s._sessionId = 'conv-uuid-1234'
+      s._resumedFromPersisted = false
+      s._processReady = true
+      // EventEmitter throws on an unhandled 'error'; _onPtyGone emits one on
+      // the no-active-turn death path. Swallow by default — tests that assert
+      // on errors add their own listener (additive, both fire).
+      s.on('error', () => {})
+      return s
+    }
+
+    it('an unexpected PTY death schedules a respawn that re-invokes _spawnPty', async () => {
+      let spawnCalls = 0
+      session = makeSession(() => { spawnCalls++ })
+      // Simulate the unexpected death (onExit path).
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      assert.equal(session._respawnScheduled, true, 'a respawn is scheduled after unexpected death')
+      assert.equal(session._respawnCount, 1, 'first attempt counted')
+
+      // Advance the first backoff (1000ms) and let the async _respawnPty settle.
+      mock.timers.tick(1000)
+      await new Promise((r) => setImmediate(r))
+
+      assert.equal(spawnCalls, 1, '_spawnPty re-invoked by the respawn')
+      assert.equal(session._processReady, true, 'session is ready again after a successful respawn')
+      assert.equal(session._respawnCount, 0, 'respawn count resets after a successful respawn that stays alive')
+    })
+
+    it('re-emits ready on a successful respawn so the dashboard knows it recovered', async () => {
+      session = makeSession()
+      const readies = []
+      session.on('ready', (d) => readies.push(d))
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      mock.timers.tick(1000)
+      await new Promise((r) => setImmediate(r))
+      assert.equal(readies.length, 1, 'ready re-emitted once on recovery')
+      assert.equal(readies[0].sessionId, 'conv-uuid-1234', 'ready carries the preserved conversation id')
+    })
+
+    it('respawn uses --resume (not --session-id) to continue the conversation', async () => {
+      let capturedArgs = null
+      // Capture the idArgs _spawnPty would build from _resumedFromPersisted.
+      session = makeSession((self) => {
+        capturedArgs = self._resumedFromPersisted
+          ? ['--resume', self._sessionId]
+          : ['--session-id', self._sessionId]
+      })
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      mock.timers.tick(1000)
+      await new Promise((r) => setImmediate(r))
+
+      assert.equal(session._resumedFromPersisted, true, 'respawn flips _resumedFromPersisted so idArgs picks --resume')
+      assert.ok(capturedArgs.includes('--resume'), 'respawn spawns with --resume')
+      assert.equal(capturedArgs.includes('--session-id'), false, 'respawn must NOT reuse --session-id (claude rejects a reused id)')
+      const i = capturedArgs.indexOf('--resume')
+      assert.equal(capturedArgs[i + 1], 'conv-uuid-1234', 'respawn resumes the SAME (not a new) conversation uuid')
+    })
+
+    it('resets the _ptyExited guard so a SECOND death after respawn tears down again', async () => {
+      let spawnCalls = 0
+      session = makeSession(() => { spawnCalls++ })
+      // First death → respawn.
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      mock.timers.tick(1000)
+      await new Promise((r) => setImmediate(r))
+      assert.equal(session._ptyExited, false, 'guard reset after a successful respawn')
+      assert.equal(spawnCalls, 1)
+
+      // Second, independent death — must NOT be swallowed by a latched guard.
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      assert.equal(session._ptyExited, true, 'second death tears down again (guard was reset)')
+      assert.equal(session._respawnScheduled, true, 'second death schedules another respawn')
+      mock.timers.tick(1000)
+      await new Promise((r) => setImmediate(r))
+      assert.equal(spawnCalls, 2, 'second death triggers a second respawn')
+    })
+
+    it('after 5 attempts emits a fatal error + respawn_exhausted and stops (no infinite loop)', async () => {
+      let spawnCalls = 0
+      // Every respawn dies again during warmup → drives toward the cap. In
+      // production the wired onExit/close handlers call _onPtyGone when the PTY
+      // dies; the stub mimics that so the same scheduling path runs.
+      session = makeSession((self) => {
+        spawnCalls++
+        self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      })
+      const errors = []
+      const exhausted = []
+      session.on('error', (e) => errors.push(e))
+      session.on('respawn_exhausted', (d) => exhausted.push(d))
+
+      // Initial unexpected death.
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      // Drain all five backoffs (1,2,4,8,15s) — each respawn dies and the dead
+      // _spawnPty calls _onPtyGone which schedules the next attempt.
+      const delays = [1000, 2000, 4000, 8000, 15000]
+      for (const d of delays) {
+        mock.timers.tick(d)
+        await new Promise((r) => setImmediate(r))
+      }
+      // One more tick to be sure nothing else is scheduled.
+      mock.timers.tick(15000)
+      await new Promise((r) => setImmediate(r))
+
+      assert.equal(spawnCalls, 5, 'exactly 5 respawn attempts, then it gives up')
+      assert.equal(exhausted.length, 1, 'respawn_exhausted emitted exactly once')
+      assert.ok(errors.some((e) => e.code === 'pty_respawn_exhausted'), 'a categorized fatal error is emitted on exhaustion')
+      assert.equal(session._respawnScheduled, false, 'no further respawn is scheduled after exhaustion')
+    })
+
+    it('suppresses respawn when _destroying (deliberate teardown)', () => {
+      session = makeSession()
+      session._destroying = true
+      session._onPtyGone({ exitCode: 0, signal: null }, 'exit')
+      assert.equal(session._respawnScheduled, false, 'deliberate teardown must not schedule a respawn')
+      assert.equal(session._respawnCount, 0, 'no respawn attempt counted on a destroying teardown')
+    })
+
+    it('clears the respawn timer on destroy so it cannot fire after teardown', async () => {
+      let spawnCalls = 0
+      session = makeSession(() => { spawnCalls++ })
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      assert.ok(session._respawnTimer, 'a respawn timer is armed')
+
+      await session.destroy()
+      assert.equal(session._respawnTimer, null, 'respawn timer cleared on destroy')
+      assert.equal(session._respawnScheduled, false, 'respawn flag cleared on destroy')
+
+      // Even if a stale timer somehow remained, _respawnPty bails on _destroying.
+      mock.timers.tick(60000)
+      await new Promise((r) => setImmediate(r))
+      assert.equal(spawnCalls, 0, 'no respawn after destroy')
+      session = null // already destroyed; skip afterEach double-destroy
+    })
+  })
+
   describe('sendMessage() error paths', () => {
     it('emits error if not started yet', async () => {
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -3909,3 +3909,35 @@ describe('_wireSessionEvents — stopped event proxy (#4756)', () => {
     assert.equal(after, beforeTs, 'stopped must not reset lastActivity')
   })
 })
+
+// #5315 (WP-2.1) — exhaustion coordination. When a provider's bounded PTY
+// auto-respawn gives up it emits `respawn_exhausted`; SessionManager must drop
+// the session from its list so it doesn't linger as an input-rejecting zombie
+// tab (the audit AC). _wireSessionEvents installs the listener.
+describe('#5315 — respawn_exhausted destroys the session', () => {
+  it('drops the session from the list on respawn_exhausted', () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    // Fake session whose constructor declares respawn_exhausted as a custom
+    // event (mirrors ClaudeTuiSession.customEvents) so the transient forward +
+    // the destroy listener both wire up.
+    class RespawnProvider extends EventEmitter {
+      static get customEvents() { return ['respawn_exhausted'] }
+      static get capabilities() { return {} }
+    }
+    const session = new RespawnProvider()
+    session.isRunning = true
+    let destroyed = false
+    session.destroy = () => { destroyed = true }
+    mgr._sessions.set('s1', { session, name: 'S1', cwd: '/tmp', provider: 'claude-tui' })
+    mgr._wireSessionEvents('s1', session)
+
+    const destroyedEvents = []
+    mgr.on('session_destroyed', (e) => destroyedEvents.push(e))
+
+    session.emit('respawn_exhausted', { reason: 'pty_respawn_exhausted', attempts: 5 })
+
+    assert.equal(mgr._sessions.has('s1'), false, 'session removed from the list (no zombie tab)')
+    assert.equal(destroyed, true, 'session.destroy() called')
+    assert.ok(destroyedEvents.some((e) => e.sessionId === 's1'), 'session_destroyed emitted for the dropped session')
+  })
+})


### PR DESCRIPTION
**WP-2.1** of the TUI hardening epic #5338 · closes #5315 · first **Phase 2** (per-session recovery) item. Builds on #5311 (`_onPtyGone`) + #5307 (`--resume`).

## Problem
When the persistent claude PTY died unexpectedly mid-session, `_onPtyGone` tore the session down and it became a **permanently input-rejecting zombie** (every later `sendMessage` rejected "no longer alive"). CliSession already auto-respawns; the TUI provider — about to become the primary backend — must match it.

## Fix
- **`_scheduleRespawn()`** — exponential backoff `[1s,2s,4s,8s,15s]`, cap 5, guarded on `_destroying`/`_respawning`/`_respawnScheduled` (mirrors `cli-session.js`).
- **`_respawnPty()`** — three load-bearing subtleties:
  1. **Resets the `_onPtyGone` latches** (`_ptyExited`/`_ptyExitInfo`/`_processReady`) — the #1 footgun: otherwise the idempotency guard stays latched and the *next* death no-ops.
  2. Sets `_resumedFromPersisted` so the re-spawn uses **`--resume <id>`** to continue the *same* conversation (claude rejects a reused `--session-id`); does NOT mint a new id.
  3. Re-invokes `_spawnPty` reusing the existing **sink dir / settings.json / hook secret** (no re-create/re-mint). Re-emits `ready` on recovery; resets the count on success.
- **`_onPtyGone`'s unexpected-death path** now calls `_scheduleRespawn`. When a respawn re-dies during warmup, the `_respawning` guard suppresses `_onPtyGone`'s schedule and `_respawnPty` re-schedules after — so the backoff chain advances to the cap without double-scheduling.
- **`destroy()`** clears the respawn timer.
- **Exhaustion → no zombie:** emits `error{code:'pty_respawn_exhausted'}` + a `respawn_exhausted` event; `SessionManager._wireSessionEvents` drops the session (mirrors `session_timeout → destroySession`).

## Tests
+8: respawn scheduled on death, `ready` re-emitted, uses `--resume` not `--session-id`, guard-reset so a 2nd death tears down again, 5-attempt cap → fatal then stops, `_destroying` suppresses, timer cleared on destroy, SM drops session on exhaustion. **claude-tui (227) + session-manager (198) = 425 pass; opt-forwarding lint clean.**

Closes #5315