### PR TITLE
fix(server): start() rejects on PTY spawn failure; restore preserves history (#5316)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -790,9 +790,34 @@ export class ClaudeTuiSession extends BaseSession {
     // the prototype method instead of mocking node-pty at the module level.
     await this._spawnPty(permissionsEnabled)
 
-    if (this._ptyExited) {
-      this.emit('error', { message: `claude PTY exited during warmup (code=${this._ptyExitInfo?.exitCode})` })
+    // #5316 (WP-2.2) — never resolve start() (and never emit `ready` / set
+    // `_processReady`) when the PTY failed to come up. Before this, start()
+    // emitted an `error` and *returned*, so SessionManager's
+    // `session.start().catch(...)` guard never fired and the dead session sat in
+    // the list as an input-rejecting zombie. Worse, the two `_spawnPty`
+    // early-return failure paths (node-pty import fail, spawn throw) emit `error`
+    // and return WITHOUT setting `_ptyExited` and WITHOUT a live `_term`, so the
+    // old `if (this._ptyExited)` guard missed them entirely and fell straight
+    // through to `emit('ready')` — marking a session with no process alive
+    // (the audit's "never mark a dead PTY ready"). Cover every no-live-PTY shape
+    // by rejecting, so SessionManager surfaces the failure (fresh → cleanup;
+    // restore → preserve history, mark retryable).
+    if (this._destroying) {
+      // destroy() raced the spawn; `_spawnPty`'s post-spawn guard already killed
+      // the fresh PTY and nulled `_term`. This is a benign abort, not a start
+      // failure to surface — resolve quietly without emitting `ready`.
       return
+    }
+    if (this._ptyExited) {
+      const message = `claude PTY exited during warmup (code=${this._ptyExitInfo?.exitCode ?? 'unknown'})`
+      this.emit('error', { message })
+      throw new Error(message)
+    }
+    if (!this._term) {
+      // `_spawnPty` hit an early-return failure path (node-pty unavailable /
+      // spawn throw). It already emitted a descriptive `error`; reject so the
+      // failure isn't swallowed.
+      throw new Error('claude PTY failed to spawn (no live process after _spawnPty)')
     }
 
     this._processReady = true

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -540,9 +540,14 @@ export class SessionManager extends EventEmitter {
    *   so callers can safely pass any value. Primary use: `restoreState` reusing the
    *   persisted id so dashboard's localStorage-cached `activeSessionId` still resolves
    *   after a daemon restart (#4983).
+   * @param {boolean} [options.isRestore] - Internal (#5316): marks a session created by
+   *   `restoreState()`. When a provider's start() rejects ASYNCHRONOUSLY, the rejection
+   *   handler preserves the restored history + worktree (registers a failed-restore)
+   *   instead of fully destroying the session. Fresh sessions omit it and take the
+   *   full-destroy path on start failure.
    * @returns {string} sessionId
    */
-  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, skipPersist = false, preserveId } = {}) {
+  createSession({ name, cwd, model, permissionMode, resumeSessionId, provider, worktree, restoreWorktreePath, restoreWorktreeRepoDir, sandbox, containerId, containerUser, containerCliPath, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, bootedModel, messageCounter, skipPermissions, skipPersist = false, preserveId, isRestore = false } = {}) {
     if (this._sessions.size >= this.maxSessions) {
       log.error(`Cannot create session: limit reached (${this._sessions.size}/${this.maxSessions})`)
       throw new SessionLimitError(this.maxSessions)
@@ -841,6 +846,12 @@ export class SessionManager extends EventEmitter {
       // restore wrongly resolved to the worktree dir / null).
       worktreeRepoDir,
       isolation: resolvedIsolation,
+      // #5316 (WP-2.2) — marks a session created by restoreState(). When a
+      // provider's start() rejects ASYNCHRONOUSLY (claude-tui spawns its PTY in
+      // an async start()), the .catch() below must preserve the restored history
+      // + worktree binding instead of destroying them. Fresh sessions (false)
+      // have nothing to preserve and take the full-destroy path.
+      _isRestore: isRestore === true,
       // #4072: cumulative usage accumulator (tokens + cost) populated by
       // _trackUsage on every priced `result` event. Subscription-only
       // providers (e.g. claude-tui) emit `result` without `cost`, so the
@@ -856,22 +867,12 @@ export class SessionManager extends EventEmitter {
 
     try {
       const result = session.start()
-      // Guard: if start() returns a thenable, catch async rejections (#1141)
+      // Guard: if start() returns a thenable, catch async rejections (#1141).
+      // claude-tui's start() spawns its PTY asynchronously and (as of #5316)
+      // REJECTS when the PTY fails to come up, so this is the primary failure
+      // signal for that provider.
       if (result && typeof result.catch === 'function') {
-        result.catch((err) => {
-          const message = err?.message || String(err)
-          log.error(`Async start() rejected for session ${sessionId}: ${message}${err?.stack ? '\n' + err.stack : ''}`)
-          // NOTE (#5310/#5316): destroySession() here fully tears the session
-          // down — including _removeWorktree() and history cleanup. For a
-          // restore-rebind whose provider start() rejects ASYNCHRONOUSLY, that
-          // destroys the pre-existing worktree + restored history. This path
-          // already erased restored history pre-#5310; making restore +
-          // start-failure non-destructive (keep the entry, mark retryable) is
-          // the explicit scope of WP-2.2 (#5316), which will replace this
-          // destroySession() call. The SYNCHRONOUS rollback below is guarded
-          // against worktree deletion on rebind as of #5310.
-          this.destroySession(sessionId)
-        })
+        result.catch((err) => this._handleAsyncStartFailure(sessionId, err))
       }
     } catch (err) {
       // Clean up phantom session on start() failure (Guardian FM-03)
@@ -907,6 +908,72 @@ export class SessionManager extends EventEmitter {
     // and permanently discard the data being restored.
     if (!skipPersist) this._flushPersist()
     return sessionId
+  }
+
+  /**
+   * Handle a provider start() that rejects ASYNCHRONOUSLY (#1141 guard path).
+   * claude-tui spawns its PTY in an async start() that, as of #5316 (WP-2.2),
+   * rejects when the PTY fails to come up.
+   *
+   * For a FRESH session there is no history worth keeping, so fully destroy it
+   * (removes the worktree it created this call) — the pre-#5316 behaviour.
+   *
+   * For a RESTORED session, destroySession() would erase the restored history
+   * AND remove the pre-existing worktree it rebound to (losing uncommitted work
+   * and making the #2954 retry unrecoverable). So instead snapshot the entry
+   * into a failed-restore payload — which serializeState() writes back to disk,
+   * preserving history + worktree binding for a future retry — tear down only
+   * the live (dead) provider, and surface session_restore_failed so the client
+   * shows the "needs attention" / retry affordance.
+   * @param {string} sessionId
+   * @param {Error} err - The rejection from start()
+   * @private
+   */
+  _handleAsyncStartFailure(sessionId, err) {
+    const entry = this._sessions.get(sessionId)
+    // Already gone — destroyed elsewhere (e.g. a concurrent destroySession or a
+    // respawn_exhausted teardown) before this rejection landed. Nothing to do.
+    if (!entry) return
+    const message = err?.message || String(err)
+    log.error(`Async start() rejected for session ${sessionId}: ${message}${err?.stack ? '\n' + err.stack : ''}`)
+
+    if (!entry._isRestore) {
+      // Fresh session — full teardown (removes the freshly-created worktree).
+      this.destroySession(sessionId)
+      return
+    }
+
+    // Restore-rebind: preserve history + worktree, mark the session as a failed
+    // restore so it round-trips to disk and surfaces in the needs-attention UI.
+    const saved = this._serializeSessionEntry(sessionId, entry)
+    // Detach + destroy ONLY the live provider (frees the dead PTY). This does
+    // NOT remove the worktree — that's a SessionManager concern (_removeWorktree),
+    // and we deliberately keep the rebound worktree intact for the retry.
+    entry.session.removeAllListeners()
+    entry.session.on('error', () => {}) // swallow stray error during destroy
+    try {
+      entry.session.destroy()
+    } catch (destroyErr) {
+      log.error(`Failed to destroy provider for failed restore ${sessionId}: ${destroyErr?.stack || destroyErr}`)
+    }
+    // Snapshot is captured above, so dropping the live history map is safe.
+    this._cleanupSessionMaps(sessionId)
+    this._failedRestores.set(sessionId, { saved, error: err })
+    this.emit('session_restore_failed', {
+      sessionId,
+      name: saved.name,
+      provider: saved.provider || this._providerType,
+      cwd: saved.cwd,
+      model: saved.model || null,
+      permissionMode: saved.permissionMode || null,
+      errorCode: err?.code || 'START_FAILED',
+      errorMessage: message,
+      originalHistoryPreserved: true,
+      historyLength: Array.isArray(saved.history) ? saved.history.length : 0,
+    })
+    // Persist now so the preserved history survives an abrupt shutdown before
+    // the next debounced write.
+    this._flushPersist()
   }
 
   /**
@@ -1261,8 +1328,42 @@ export class SessionManager extends EventEmitter {
     if (this._destroying) return null
     const state = { version: 1, timestamp: Date.now(), sessions: [] }
     for (const [id, entry] of this._sessions) {
-      const history = this._history.getHistory(id).map(e => this._history.truncateEntry(e))
-      state.sessions.push({
+      state.sessions.push(this._serializeSessionEntry(id, entry))
+    }
+
+    // Preserve sessions that failed to restore (#2954 — Guardian FM-01).
+    // Without this, the next successful write drops them from disk and the
+    // user's history is permanently lost. We write them back exactly as
+    // they were loaded so a retry (after the user sets the missing env var
+    // and restarts) can fully re-hydrate history.
+    for (const [, { saved }] of this._failedRestores) {
+      state.sessions.push(saved)
+    }
+
+    // Persist cost tracking so budget survives restarts
+    const budgetState = this._costBudget.serialize()
+    state.costs = budgetState.costs
+    state.budgetWarned = budgetState.budgetWarned
+    state.budgetExceeded = budgetState.budgetExceeded
+    state.budgetPaused = budgetState.budgetPaused
+
+    return this._persistence.serializeState(state)
+  }
+
+  /**
+   * Serialize a single live session entry to the on-disk persisted shape.
+   * Extracted from serializeState() so the async start-failure path (#5316,
+   * WP-2.2) can snapshot a restored session into a failed-restore payload that
+   * round-trips through restoreState() identically. Keep this in lockstep with
+   * the restore-side reader in restoreState().
+   * @param {string} id - The session id
+   * @param {object} entry - The in-memory session entry
+   * @returns {object} The persisted session payload
+   * @private
+   */
+  _serializeSessionEntry(id, entry) {
+    const history = this._history.getHistory(id).map(e => this._history.truncateEntry(e))
+    return {
         id,
         sdkSessionId: (typeof entry.session.resumeSessionId !== 'undefined' ? entry.session.resumeSessionId : null),
         conversationId: entry.session.resumeSessionId || null,
@@ -1339,26 +1440,7 @@ export class SessionManager extends EventEmitter {
         // round-trip as `true` — only an explicit `true` latches.
         // Mirrors the restore side which gates on `=== true`.
         costThresholdNotified: entry.costThresholdNotified === true,
-      })
     }
-
-    // Preserve sessions that failed to restore (#2954 — Guardian FM-01).
-    // Without this, the next successful write drops them from disk and the
-    // user's history is permanently lost. We write them back exactly as
-    // they were loaded so a retry (after the user sets the missing env var
-    // and restarts) can fully re-hydrate history.
-    for (const [, { saved }] of this._failedRestores) {
-      state.sessions.push(saved)
-    }
-
-    // Persist cost tracking so budget survives restarts
-    const budgetState = this._costBudget.serialize()
-    state.costs = budgetState.costs
-    state.budgetWarned = budgetState.budgetWarned
-    state.budgetExceeded = budgetState.budgetExceeded
-    state.budgetPaused = budgetState.budgetPaused
-
-    return this._persistence.serializeState(state)
   }
 
   /**
@@ -1443,6 +1525,10 @@ export class SessionManager extends EventEmitter {
             ? saved.messageCounter
             : undefined,
           skipPersist: true,
+          // #5316 (WP-2.2) — mark this as a restore so an ASYNC provider
+          // start() rejection (claude-tui PTY warmup death) preserves the
+          // restored history + worktree instead of destroying them.
+          isRestore: true,
         })
         if (saved.id) oldToNew.set(saved.id, sessionId)
         // #4089 / #4124: restore the per-session running totals + the

--- a/packages/server/src/session-manager.js
+++ b/packages/server/src/session-manager.js
@@ -958,6 +958,13 @@ export class SessionManager extends EventEmitter {
     }
     // Snapshot is captured above, so dropping the live history map is safe.
     this._cleanupSessionMaps(sessionId)
+    // Stamp the code so the live `session_restore_failed` emit below and a
+    // LATER reconnect via getFailedRestores() (which defaults a code-less error
+    // to 'RESTORE_FAILED') report the SAME errorCode for this failure. claude-tui
+    // rejects start() with a bare Error (no .code), so without this the same
+    // failure would surface as START_FAILED to clients present at failure time
+    // and RESTORE_FAILED to clients that reconnect afterwards.
+    if (err && !err.code) err.code = 'START_FAILED'
     this._failedRestores.set(sessionId, { saved, error: err })
     this.emit('session_restore_failed', {
       sessionId,

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -253,7 +253,7 @@ describe('ClaudeTuiSession', () => {
       assert.match(stopCmd, /stop-\$\(uuidgen\)\.json/, 'Stop uses uuidgen for unique-per-turn names (mktemp + .json suffix breaks on BSD macOS)')
     })
 
-    it('emits error if PTY exits during warmup', async () => {
+    it('rejects + emits error if PTY exits during warmup (#5316)', async () => {
       // Override the stub for THIS test to simulate PTY death during warmup.
       ClaudeTuiSession.prototype._spawnPty = async function () {
         this._ptyExited = true
@@ -262,12 +262,56 @@ describe('ClaudeTuiSession', () => {
 
       session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
       const errors = []
+      const readys = []
       session.on('error', (e) => errors.push(e))
-      await session.start()
+      session.on('ready', (e) => readys.push(e))
+      // #5316 (WP-2.2) — start() must REJECT so SessionManager surfaces the
+      // failure (previously it resolved + the dead session lingered as a zombie).
+      await assert.rejects(session.start(), /exited during warmup/)
 
       assert.equal(session._processReady, false, 'not ready after PTY death')
+      assert.equal(readys.length, 0, 'no ready emitted for a dead PTY')
       assert.equal(errors.length, 1)
       assert.match(errors[0].message, /exited during warmup/)
+    })
+
+    it('rejects + never emits ready when _spawnPty leaves no live PTY (#5316)', async () => {
+      // Mimic _spawnPty's early-return failure paths (node-pty import fail /
+      // spawn throw): emit an error and return WITHOUT setting _ptyExited and
+      // WITHOUT assigning a live _term. The old start() fell through these and
+      // falsely emitted `ready` on a session with no process.
+      ClaudeTuiSession.prototype._spawnPty = async function () {
+        this.emit('error', { message: 'node-pty unavailable: boom' })
+        this._term = null
+      }
+
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const readys = []
+      session.on('error', () => {})
+      session.on('ready', (e) => readys.push(e))
+      await assert.rejects(session.start(), /failed to spawn/)
+
+      assert.equal(session._processReady, false, 'not ready when no live PTY')
+      assert.equal(readys.length, 0, 'no ready emitted for a session with no PTY')
+    })
+
+    it('resolves quietly (no ready) when destroy() races the spawn (#5316)', async () => {
+      // destroy() sets _destroying mid-spawn; _spawnPty's post-spawn guard kills
+      // the fresh PTY and nulls _term. This is a benign abort, NOT a start
+      // failure to surface — start() must resolve without rejecting or emitting.
+      ClaudeTuiSession.prototype._spawnPty = async function () {
+        this._destroying = true
+        this._term = null
+      }
+
+      session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      const readys = []
+      session.on('error', () => {})
+      session.on('ready', (e) => readys.push(e))
+      await session.start() // must not reject
+
+      assert.equal(session._processReady, false, 'not ready after destroy race')
+      assert.equal(readys.length, 0, 'no ready emitted on a destroy-race abort')
     })
   })
 

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2037,6 +2037,88 @@ describe('createSession failure cleanup (FM-03)', () => {
   })
 })
 
+describe('#5316 (WP-2.2) — async start() rejection handling', () => {
+  // A provider whose start() is async and REJECTS (mirrors claude-tui's PTY
+  // warmup death). The #1141 `.catch()` guard routes the rejection to
+  // _handleAsyncStartFailure, which destroys a fresh session but PRESERVES a
+  // restored one (history + worktree).
+  class AsyncFailProvider extends EventEmitter {
+    constructor(opts) {
+      super()
+      this.cwd = opts.cwd
+      this.model = opts.model || null
+      this.permissionMode = opts.permissionMode || 'approve'
+      this.isRunning = false
+      this.resumeSessionId = opts.resumeSessionId || null
+      this._messageCounter = 0
+      this.bootedModel = null
+      this.destroyed = false
+    }
+    static get capabilities() { return {} }
+    async start() { throw new Error('claude PTY exited during warmup (code=1)') }
+    destroy() { this.destroyed = true }
+    interrupt() {}
+    sendMessage() {}
+    setModel() {}
+    setPermissionMode() {}
+  }
+
+  // Let the rejected start() promise's microtask `.catch()` run.
+  const tick = () => new Promise((r) => setImmediate(r))
+
+  it('destroys a FRESH session and registers no failed-restore', async () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const { registerProvider } = await import('../src/providers.js')
+    registerProvider('test-async-fail-fresh', AsyncFailProvider)
+
+    const id = mgr.createSession({ cwd: '/tmp', provider: 'test-async-fail-fresh' })
+    assert.equal(mgr._sessions.has(id), true, 'session live until the async rejection lands')
+    await tick()
+
+    assert.equal(mgr._sessions.has(id), false, 'fresh session destroyed on async start failure')
+    assert.equal(mgr.getFailedRestores().length, 0, 'no failed-restore for a fresh session')
+  })
+
+  it('PRESERVES restored history + surfaces session_restore_failed for a RESTORED session', async () => {
+    const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })
+    const { registerProvider } = await import('../src/providers.js')
+    registerProvider('test-async-fail-restore', AsyncFailProvider)
+    const failedEvents = []
+    mgr.on('session_restore_failed', (e) => failedEvents.push(e))
+
+    const preserveId = 'a'.repeat(32)
+    const id = mgr.createSession({
+      cwd: '/tmp',
+      provider: 'test-async-fail-restore',
+      preserveId,
+      skipPersist: true,
+      isRestore: true,
+    })
+    // restoreState() seeds history AFTER createSession returns, synchronously,
+    // before the async rejection lands — replicate that ordering here.
+    mgr._recordHistory(id, 'message', { role: 'user', text: 'hello from before the crash' })
+    assert.ok(mgr._history.getHistory(id).length >= 1, 'history seeded pre-rejection')
+
+    await tick()
+
+    assert.equal(mgr._sessions.has(id), false, 'dead provider removed from the live session map')
+    const failed = mgr.getFailedRestores()
+    assert.equal(failed.length, 1, 'registered as a failed restore (history preserved on disk)')
+    assert.equal(failed[0].sessionId, preserveId, 'failed-restore keyed by the preserved id')
+    assert.ok(failed[0].historyLength >= 1, 'restored history preserved in the failed-restore payload')
+    assert.equal(failedEvents.length, 1, 'session_restore_failed emitted once')
+    assert.equal(failedEvents[0].originalHistoryPreserved, true)
+    assert.equal(failedEvents[0].errorCode, 'START_FAILED')
+
+    // serializeState must write the preserved session back to disk so a future
+    // restart can retry it — proving the history is not lost.
+    const serialized = mgr.serializeState()
+    const persisted = serialized.sessions.find((s) => s.id === preserveId)
+    assert.ok(persisted, 'failed-restore session is written back to disk')
+    assert.ok(Array.isArray(persisted.history) && persisted.history.length >= 1, 'persisted payload carries the history')
+  })
+})
+
 describe('#1204 — _cleanupSessionMaps helper cleans all maps', () => {
   it('sync start() failure cleans all session-scoped maps', async () => {
     const mgr = new SessionManager({ skipPreflight: true, maxSessions: 5, stateFilePath: tmpStateFile() })

--- a/packages/server/tests/session-manager.test.js
+++ b/packages/server/tests/session-manager.test.js
@@ -2109,6 +2109,10 @@ describe('#5316 (WP-2.2) — async start() rejection handling', () => {
     assert.equal(failedEvents.length, 1, 'session_restore_failed emitted once')
     assert.equal(failedEvents[0].originalHistoryPreserved, true)
     assert.equal(failedEvents[0].errorCode, 'START_FAILED')
+    // The live event and a LATER reconnect (getFailedRestores) must agree on the
+    // errorCode for the same failure — claude-tui rejects with a code-less Error,
+    // so the handler stamps START_FAILED before storing (#5350 review).
+    assert.equal(failed[0].errorCode, 'START_FAILED', 'late-reconnect errorCode matches the live event')
 
     // serializeState must write the preserved session back to disk so a future
     // restart can retry it — proving the history is not lost.


### PR DESCRIPTION
## WP-2.2 — Phase 2 · Per-session recovery

Closes #5316.

### Audit findings closed
- **MAJOR** `claude-tui-session.js` — start() resolved + emitted `ready` on spawn failure
- **MAJOR** `session-manager.js` — async start() rejection during restore erased history

### What changed

**`claude-tui-session.js` — start() fails loud**
- start() now **rejects** on every "no live PTY" shape: warmup death (`_ptyExited`), node-pty unavailable, and spawn throw. Previously it emitted an `error` and *resolved*, so SessionManager's `start().catch()` guard never fired and the dead session lingered as an input-rejecting zombie.
- The two `_spawnPty` early-return paths (node-pty import fail / spawn throw) leave **no live `_term` and never set `_ptyExited`**, so the old `if (this._ptyExited)` guard missed them and fell straight through to `emit('ready')` — marking a session with no process alive. Now covered.
- A `destroy()` racing the spawn resolves **quietly** (benign abort) — no reject, no `ready`.
- Never sets `_processReady` / emits `ready` unless a live PTY survived warmup.

**`session-manager.js` — restore-failure preserves history**
- The async `.catch()` now routes through `_handleAsyncStartFailure`:
  - **Fresh** session → full `destroySession` (unchanged; removes the worktree it just created).
  - **Restored** session → snapshot the entry into a failed-restore payload (history + worktree binding preserved on disk for a future retry via the existing #2954 mechanism), tear down **only** the dead provider (no `_removeWorktree`), and emit `session_restore_failed` for the needs-attention UI.
- New `isRestore` createSession opt marks restore-rebinds; `restoreState()` passes it.
- Extracted `_serializeSessionEntry` from `serializeState` so the failure path produces a payload that round-trips through `restoreState` identically.

### Acceptance criteria
- [x] A spawn failure rejects start() so SessionManager surfaces it.
- [x] A failed restore preserves history.
- [x] No `ready` emitted for a dead PTY.

### Tests
- claude-tui-session: rejects + no `ready` on warmup death; rejects + no `ready` when `_spawnPty` leaves no live PTY; resolves quietly on destroy-race. (231 pass)
- session-manager: fresh async-fail destroys + registers no failed-restore; restored async-fail preserves history, registers a failed-restore, emits `session_restore_failed`, and round-trips to disk via `serializeState`. (200 pass)
- Lints: session-opt-forwarding ✓, tests-state-file-path ✓.

**Depends on:** WP-0.1 (#5307), WP-2.1 (#5315) — both merged.