### PR TITLE
fix(server): destroy() SIGKILL escalation — no orphan claude / tool children (#5317)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -3553,21 +3553,43 @@ export class ClaudeTuiSession extends BaseSession {
       const term = this._term
       const pid = term.pid
       this._term = null
-      try { term.kill('SIGTERM') } catch { /* already dead */ }
-      // Arm the SIGKILL escalation. _onPtyGone clears this timer the instant the
-      // process exits (onExit/close/error), so it ONLY fires for a claude that
-      // ignored SIGTERM — no pid-reuse race, because a recycled pid implies the
-      // original exited, which would have cancelled the timer.
-      if (Number.isInteger(pid) && pid > 0) {
+      // #5351 review — only signal a PTY we believe is still alive. _onPtyGone
+      // does NOT null _term, so after an unexpected exit (crash / respawn
+      // exhaustion) destroy() sees `_term` non-null AND `_ptyExited` true. The
+      // process has already been reaped by then, so sending ANY signal — even
+      // SIGTERM — risks hitting a recycled pid. Skip the whole kill path; the
+      // PTY is already gone and there's nothing to reap.
+      if (!this._ptyExited) {
+        try { term.kill('SIGTERM') } catch { /* already dead */ }
+      }
+      // Arm the SIGKILL escalation. _onPtyGone clears this timer when the JS
+      // onExit/close/error callback runs, which handles the common case. But that
+      // is NOT sufficient on its own to rule out pid reuse: node-pty reaps the
+      // child with waitpid() on its internal thread BEFORE it schedules the JS
+      // onExit callback, so the OS can recycle the pid in the gap between the
+      // reap and our latch being set — and the grace timer + the onExit callback
+      // are unordered event-loop tasks. So the timer callback re-checks the
+      // _ptyExited latch AND probes liveness with signal 0 before escalating, so
+      // a blind `process.kill(-pid)` can't land on a recycled process group.
+      if (!this._ptyExited && Number.isInteger(pid) && pid > 0) {
         const graceMs = ClaudeTuiSession.DESTROY_GRACE_MS
         this._killTimer = setTimeout(() => {
           this._killTimer = null
+          // The onExit callback has run since we armed the timer → process is
+          // already gone (and possibly its pid recycled). Never escalate.
+          if (this._ptyExited) return
+          // Liveness probe: signal 0 throws ESRCH if the pid is gone. This won't
+          // catch a pid that was reaped-then-recycled into a live process, but
+          // combined with the _ptyExited latch above it narrows escalation to
+          // "the latch never fired AND the pid is still alive" — i.e. a genuinely
+          // hung claude, not a recycled stranger.
+          try { process.kill(pid, 0) } catch { return /* already exited */ }
           log.warn(`claude PTY (pid=${pid}) did not exit ${graceMs}ms after SIGTERM — escalating to SIGKILL`)
           // Reap the whole process group so claude's tool children die too, not
-          // just the session leader. forkpty makes the child a process-group
-          // leader, so `-pid` targets the group. Fall back to the single pid
-          // (and node-pty's own kill) when the group signal isn't deliverable
-          // (non-POSIX, or the leader already reaped).
+          // just the session leader. node-pty spawns claude with setsid, so it's
+          // its own process-group leader (pgid == pid) and `-pid` targets the
+          // group. Fall back to the single pid (and node-pty's own kill) when the
+          // group signal isn't deliverable (non-POSIX, or the leader already reaped).
           let killed = false
           if (process.platform !== 'win32') {
             try { process.kill(-pid, 'SIGKILL'); killed = true } catch { /* group gone / not a leader */ }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -460,6 +460,10 @@ export class ClaudeTuiSession extends BaseSession {
     this._respawnTimer = null
     this._respawnScheduled = false
     this._respawning = false
+    // #5317 (WP-2.3) — SIGKILL escalation timer armed by destroy() after SIGTERM.
+    // Cleared by _onPtyGone the moment the process is confirmed gone (which also
+    // closes the pid-reuse window — we only force-kill when onExit never fired).
+    this._killTimer = null
     // Ring buffer of recent PTY output bytes — surfaces in error
     // messages when the TUI renders a diagnostic (rate-limit, auth
     // failure, "switch back to API mode") that would otherwise be
@@ -712,6 +716,11 @@ export class ClaudeTuiSession extends BaseSession {
   // transitions are sub-second once the session is up.
   static get SPAWN_WARMUP_MAX_MS() { return 15_000 }
   static get TURN_PROMPT_WAIT_MAX_MS() { return 5_000 }
+  // #5317 (WP-2.3) — grace window between destroy()'s SIGTERM and the SIGKILL
+  // escalation. Long enough for claude to flush its Stop hook + reap its own
+  // tool children on a clean SIGTERM, short enough that a hung claude (or a
+  // child holding the PTY open) can't orphan past it.
+  static get DESTROY_GRACE_MS() { return 3_000 }
   // Wedge instrumentation (#4678 follow-up): hook-poll loop emits a
   // heartbeat log line every HOOK_HEARTBEAT_MS of silent waiting (no
   // stop-hook yet). Sized so healthy short turns (<5s end-to-end) emit
@@ -842,6 +851,12 @@ export class ClaudeTuiSession extends BaseSession {
     if (this._ptyExited) return
     this._ptyExited = true
     this._processReady = false
+    // #5317 (WP-2.3) — the process is confirmed gone (onExit/close/error fired),
+    // so cancel any pending SIGKILL escalation destroy() armed. Doing this here
+    // (rather than via a timer-only check) is what closes the pid-reuse window:
+    // the escalation only fires when onExit NEVER arrives, i.e. the process is
+    // genuinely still alive, so the captured pid can't have been recycled.
+    if (this._killTimer) { clearTimeout(this._killTimer); this._killTimer = null }
     // Reset turn state so the next sendMessage() sees a clean idle.
     const hadActiveTurn = this._activeTurn !== null
     // #4022: clean up the in-flight turn's attachment dir BEFORE nulling
@@ -3531,8 +3546,41 @@ export class ClaudeTuiSession extends BaseSession {
       this._askUserQuestionWatchdog = null
     }
     if (this._term) {
-      try { this._term.kill('SIGTERM') } catch { /* already dead */ }
+      // #5317 (WP-2.3) — capture the handle + pid BEFORE nulling so the
+      // escalation timer (and _onPtyGone's cancel) still have something to act
+      // on. SIGTERM first so claude can flush its Stop hook and reap its own
+      // tool children; escalate to SIGKILL only if it ignores us.
+      const term = this._term
+      const pid = term.pid
       this._term = null
+      try { term.kill('SIGTERM') } catch { /* already dead */ }
+      // Arm the SIGKILL escalation. _onPtyGone clears this timer the instant the
+      // process exits (onExit/close/error), so it ONLY fires for a claude that
+      // ignored SIGTERM — no pid-reuse race, because a recycled pid implies the
+      // original exited, which would have cancelled the timer.
+      if (Number.isInteger(pid) && pid > 0) {
+        const graceMs = ClaudeTuiSession.DESTROY_GRACE_MS
+        this._killTimer = setTimeout(() => {
+          this._killTimer = null
+          log.warn(`claude PTY (pid=${pid}) did not exit ${graceMs}ms after SIGTERM — escalating to SIGKILL`)
+          // Reap the whole process group so claude's tool children die too, not
+          // just the session leader. forkpty makes the child a process-group
+          // leader, so `-pid` targets the group. Fall back to the single pid
+          // (and node-pty's own kill) when the group signal isn't deliverable
+          // (non-POSIX, or the leader already reaped).
+          let killed = false
+          if (process.platform !== 'win32') {
+            try { process.kill(-pid, 'SIGKILL'); killed = true } catch { /* group gone / not a leader */ }
+          }
+          if (!killed) {
+            try { term.kill('SIGKILL') } catch {
+              try { process.kill(pid, 'SIGKILL') } catch { /* already gone */ }
+            }
+          }
+        }, graceMs)
+        // Don't keep the event loop alive solely for the grace timer.
+        if (typeof this._killTimer.unref === 'function') this._killTimer.unref()
+      }
     }
     // Clean up the per-session sink dir so we don't leak hook payload
     // files under /tmp (#3918). One file per turn (stop) plus 2 per

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2486,10 +2486,12 @@ describe('ClaudeTuiSession', () => {
       it('escalates to SIGKILL when the PTY ignores SIGTERM past the grace window', async () => {
         const termSignals = []
         const procSignals = []
-        // Mock process.kill so no real signal leaves the test. Throw on the
-        // process-group attempt to deterministically exercise the term.kill fallback.
+        // Mock process.kill so no real signal leaves the test. Signal 0 is the
+        // liveness probe — return success (still alive). Throw on the
+        // process-group SIGKILL to deterministically exercise the term.kill fallback.
         mock.method(process, 'kill', (pid, sig) => {
           procSignals.push([pid, sig])
+          if (sig === 0) return // liveness probe: process is alive
           throw new Error('ESRCH')
         })
         const s = makeLiveSession((sig) => termSignals.push(sig))
@@ -2498,7 +2500,8 @@ describe('ClaudeTuiSession', () => {
 
         mock.timers.tick(ClaudeTuiSession.DESTROY_GRACE_MS)
 
-        assert.deepEqual(procSignals[0], [-4242, 'SIGKILL'], 'attempts process-group SIGKILL first')
+        assert.deepEqual(procSignals[0], [4242, 0], 'probes liveness with signal 0 first')
+        assert.deepEqual(procSignals[1], [-4242, 'SIGKILL'], 'then attempts process-group SIGKILL')
         assert.deepEqual(termSignals, ['SIGTERM', 'SIGKILL'], 'falls back to term SIGKILL when the group signal fails')
         assert.equal(s._killTimer, null, 'escalation timer cleared after firing')
       })
@@ -2511,7 +2514,7 @@ describe('ClaudeTuiSession', () => {
         await s.destroy()
         mock.timers.tick(ClaudeTuiSession.DESTROY_GRACE_MS)
 
-        assert.deepEqual(procSignals, [[-4242, 'SIGKILL']], 'group SIGKILL targets the whole process group')
+        assert.deepEqual(procSignals, [[4242, 0], [-4242, 'SIGKILL']], 'liveness probe then group SIGKILL')
         assert.deepEqual(termSignals, ['SIGTERM'], 'no per-pid fallback when the group kill succeeds')
       })
 
@@ -2520,12 +2523,50 @@ describe('ClaudeTuiSession', () => {
         const s = makeLiveSession((sig) => termSignals.push(sig))
         await s.destroy()
         // Process exits in response to SIGTERM (onExit → _onPtyGone), which must
-        // cancel the escalation timer and close the pid-reuse window.
+        // cancel the escalation timer.
         s._onPtyGone({ exitCode: 0, signal: 'SIGTERM' }, 'exit')
         assert.equal(s._killTimer, null, 'escalation timer cancelled on clean exit')
 
         mock.timers.tick(ClaudeTuiSession.DESTROY_GRACE_MS)
         assert.deepEqual(termSignals, ['SIGTERM'], 'no SIGKILL after a clean exit')
+      })
+
+      it('does NOT escalate when the _ptyExited latch is set before the timer fires (#5351 review)', async () => {
+        // node-pty reaps the pid before firing the JS onExit, so the timer can
+        // fire while onExit is still queued. The latch check inside the timer is
+        // the primary guard against killing a (possibly recycled) pid.
+        const termSignals = []
+        const procSignals = []
+        mock.method(process, 'kill', (pid, sig) => { procSignals.push([pid, sig]) })
+        const s = makeLiveSession((sig) => termSignals.push(sig))
+        await s.destroy()
+        // Simulate "onExit latched but did NOT clear the timer" (defensive — the
+        // timer must self-guard even if the clear was somehow missed). The timer
+        // is still armed from destroy() above.
+        assert.ok(s._killTimer, 'timer armed')
+        s._ptyExited = true
+
+        mock.timers.tick(ClaudeTuiSession.DESTROY_GRACE_MS)
+        assert.deepEqual(procSignals, [], 'no kill signal sent once the process is known gone')
+        assert.deepEqual(termSignals, ['SIGTERM'], 'no SIGKILL when _ptyExited is set')
+      })
+
+      it('does NOT escalate when the liveness probe shows the pid already gone (#5351 review)', async () => {
+        const termSignals = []
+        const procSignals = []
+        // Liveness probe (signal 0) throws ESRCH → pid already exited (reaped,
+        // not recycled). Must bail before any SIGKILL.
+        mock.method(process, 'kill', (pid, sig) => {
+          procSignals.push([pid, sig])
+          if (sig === 0) throw new Error('ESRCH')
+        })
+        const s = makeLiveSession((sig) => termSignals.push(sig))
+        await s.destroy()
+        // Latch NOT set (onExit callback hasn't run), but the OS already reaped it.
+        mock.timers.tick(ClaudeTuiSession.DESTROY_GRACE_MS)
+
+        assert.deepEqual(procSignals, [[4242, 0]], 'only the liveness probe ran; no kill followed')
+        assert.deepEqual(termSignals, ['SIGTERM'], 'no SIGKILL when the liveness probe says the pid is gone')
       })
 
       it('arms no escalation timer when the PTY has no usable pid', async () => {
@@ -2537,6 +2578,24 @@ describe('ClaudeTuiSession', () => {
         await s.destroy()
         assert.deepEqual(signals, ['SIGTERM'], 'SIGTERM still sent')
         assert.equal(s._killTimer, null, 'no escalation timer without a pid')
+      })
+
+      it('sends NO signal when the PTY already exited before destroy() (#5351 review)', async () => {
+        // Crash / respawn-exhaustion teardown: _onPtyGone already ran (_ptyExited
+        // true) but did NOT null _term, so destroy() sees a non-null _term for an
+        // already-reaped (possibly recycled) pid. It must signal nothing.
+        const termSignals = []
+        const procSignals = []
+        mock.method(process, 'kill', (pid, sig) => { procSignals.push([pid, sig]) })
+        const s = makeLiveSession((sig) => termSignals.push(sig))
+        s._ptyExited = true // process already gone, _term still set
+
+        await s.destroy()
+        assert.deepEqual(termSignals, [], 'no SIGTERM to an already-reaped pid')
+        assert.equal(s._killTimer, null, 'no escalation timer armed')
+
+        mock.timers.tick(ClaudeTuiSession.DESTROY_GRACE_MS)
+        assert.deepEqual(procSignals, [], 'no signals sent at all')
       })
     })
   })

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2456,6 +2456,89 @@ describe('ClaudeTuiSession', () => {
       assert.equal(existsSync(sinkDir), false, 'sink dir removed on destroy')
       assert.equal(session._sinkDir, null, 'reference cleared')
     })
+
+    // #5317 (WP-2.3) — SIGTERM alone leaves a hung claude (and its tool
+    // children) orphaned. destroy() must escalate to SIGKILL after a grace
+    // window, and reap the whole process group, but NOT fire when the process
+    // exits cleanly in response to SIGTERM.
+    describe('SIGKILL escalation (#5317 WP-2.3)', () => {
+      beforeEach(() => { mock.timers.enable({ apis: ['setTimeout'] }) })
+      afterEach(() => { mock.timers.reset(); mock.restoreAll() })
+
+      function makeLiveSession(onKill) {
+        const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        s._processReady = true
+        s._sessionId = 'conv-uuid-1234'
+        s._term = { write: () => {}, kill: (sig) => onKill(sig), onData: () => {}, onExit: () => {}, on: () => {}, pid: 4242 }
+        s.on('error', () => {})
+        return s
+      }
+
+      it('SIGTERMs immediately and arms the escalation timer', async () => {
+        const signals = []
+        const s = makeLiveSession((sig) => signals.push(sig))
+        await s.destroy()
+        assert.deepEqual(signals, ['SIGTERM'], 'SIGTERM sent on destroy')
+        assert.ok(s._killTimer, 'SIGKILL escalation timer armed')
+        assert.equal(s._term, null, 'term reference cleared')
+      })
+
+      it('escalates to SIGKILL when the PTY ignores SIGTERM past the grace window', async () => {
+        const termSignals = []
+        const procSignals = []
+        // Mock process.kill so no real signal leaves the test. Throw on the
+        // process-group attempt to deterministically exercise the term.kill fallback.
+        mock.method(process, 'kill', (pid, sig) => {
+          procSignals.push([pid, sig])
+          throw new Error('ESRCH')
+        })
+        const s = makeLiveSession((sig) => termSignals.push(sig))
+        await s.destroy()
+        assert.deepEqual(termSignals, ['SIGTERM'])
+
+        mock.timers.tick(ClaudeTuiSession.DESTROY_GRACE_MS)
+
+        assert.deepEqual(procSignals[0], [-4242, 'SIGKILL'], 'attempts process-group SIGKILL first')
+        assert.deepEqual(termSignals, ['SIGTERM', 'SIGKILL'], 'falls back to term SIGKILL when the group signal fails')
+        assert.equal(s._killTimer, null, 'escalation timer cleared after firing')
+      })
+
+      it('reaps the whole process group when the group signal is deliverable', async () => {
+        const termSignals = []
+        const procSignals = []
+        mock.method(process, 'kill', (pid, sig) => { procSignals.push([pid, sig]) })
+        const s = makeLiveSession((sig) => termSignals.push(sig))
+        await s.destroy()
+        mock.timers.tick(ClaudeTuiSession.DESTROY_GRACE_MS)
+
+        assert.deepEqual(procSignals, [[-4242, 'SIGKILL']], 'group SIGKILL targets the whole process group')
+        assert.deepEqual(termSignals, ['SIGTERM'], 'no per-pid fallback when the group kill succeeds')
+      })
+
+      it('does NOT escalate when the PTY exits within the grace window', async () => {
+        const termSignals = []
+        const s = makeLiveSession((sig) => termSignals.push(sig))
+        await s.destroy()
+        // Process exits in response to SIGTERM (onExit → _onPtyGone), which must
+        // cancel the escalation timer and close the pid-reuse window.
+        s._onPtyGone({ exitCode: 0, signal: 'SIGTERM' }, 'exit')
+        assert.equal(s._killTimer, null, 'escalation timer cancelled on clean exit')
+
+        mock.timers.tick(ClaudeTuiSession.DESTROY_GRACE_MS)
+        assert.deepEqual(termSignals, ['SIGTERM'], 'no SIGKILL after a clean exit')
+      })
+
+      it('arms no escalation timer when the PTY has no usable pid', async () => {
+        const signals = []
+        const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        s._processReady = true
+        s._term = { write: () => {}, kill: (sig) => signals.push(sig) } // no pid
+        s.on('error', () => {})
+        await s.destroy()
+        assert.deepEqual(signals, ['SIGTERM'], 'SIGTERM still sent')
+        assert.equal(s._killTimer, null, 'no escalation timer without a pid')
+      })
+    })
   })
 
   describe('inactivity timer (#3920)', () => {


### PR DESCRIPTION
## WP-2.3 — Phase 2 · Per-session recovery

Closes #5317.

### Audit finding closed
- **MAJOR** `claude-tui-session.js` — destroy() sent SIGTERM only, no SIGKILL escalation → a hung claude (or a tool child holding the PTY open) orphans and leaks.

### What changed
`destroy()`:
- Captures the PTY handle + pid **before** nulling `_term`, sends **SIGTERM** first (lets claude flush its Stop hook and reap its own tool children on a clean exit), then arms a **SIGKILL escalation** timer (`DESTROY_GRACE_MS = 3s`).
- On escalation, SIGKILLs the **whole process group** (`-pid`) so claude's tool children die too — not just the session leader; falls back to the single pid / node-pty `kill` when the group signal isn't deliverable (non-POSIX, or the leader already reaped).
- `_onPtyGone` clears the escalation timer the instant the process is confirmed gone (onExit/close/error). This is what **closes the pid-reuse window**: the force-kill only fires when onExit *never* arrives (process genuinely still alive), so the captured pid can't have been recycled into an innocent process.
- The timer is `unref()`'d so it never keeps the event loop alive.

### Acceptance criteria
- [x] destroy() leaves no orphan claude or tool child after a short grace period.

### Tests (claude-tui-session, 236 pass)
- SIGTERMs immediately + arms the escalation timer.
- Escalates to SIGKILL past the grace window; tries process-group kill first, falls back to term kill when the group signal fails.
- Reaps the whole process group when the group signal is deliverable (no per-pid fallback).
- Does **NOT** escalate when the PTY exits within the grace window (timer cancelled by `_onPtyGone`).
- Arms no escalation timer when the PTY has no usable pid.

`process.kill` is mocked in the escalation tests so no real signal leaves the test. Lints (session-opt-forwarding, tests-state-file-path) pass.

**Depends on:** none.