### PR TITLE
fix(server): suspend silence backstops while a human answers AskUserQuestion (#5318)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1981,6 +1981,12 @@ export class ClaudeTuiSession extends BaseSession {
           })
         }
         this.emit('user_question', { toolUseId, questions })
+        // #5318 (WP-3.1) — we're now blocked on a human answer. Suspend the
+        // turn backstops immediately rather than waiting for the next drain-loop
+        // _armResultTimeout(); the _armResultTimeout() guard keeps them suspended
+        // across any subsequent re-arm until the answer's PostToolUse clears the
+        // pending entry.
+        this._suspendBackstopsForPendingQuestion()
       }
       return
     }
@@ -2243,6 +2249,29 @@ export class ClaudeTuiSession extends BaseSession {
    * (new hook file processed) resets every window. Mirrors
    * `CliSession._armResultTimeout()`.
    */
+  /**
+   * #5318 (WP-3.1) — suspend the "claude went silent" backstops while a human is
+   * answering an AskUserQuestion: the soft-inactivity, stream-stall, and
+   * pre-first-output timers. When a question is pending the HUMAN is the
+   * bottleneck, not claude, so these would only fire a misleading
+   * force-cancel / stall error / check-in chip mid-answer. The dedicated
+   * `_askUserQuestionWatchdog` (armed in respondToQuestion) still recovers a
+   * genuinely wedged form after the answer is written.
+   *
+   * Deliberately does NOT touch the HARD cap (`_hardTimeout`): that 2h
+   * last-resort backstop stays armed even across a pending question, so a human
+   * who walks away and never answers still gets force-cleared eventually (and
+   * `_handleHardTimeout` keeps its existing pending-answer cleanup). Idempotent.
+   */
+  _suspendBackstopsForPendingQuestion() {
+    if (this._resultTimeout) { clearTimeout(this._resultTimeout); this._resultTimeout = null }
+    if (this._streamStallTimeout) { clearTimeout(this._streamStallTimeout); this._streamStallTimeout = null }
+    // Disarms + latches the per-turn first-output watchdog. By the time a
+    // question is pending the first output (the tool_use) has already arrived,
+    // so the watchdog is moot for the rest of this turn anyway.
+    this._clearFirstOutputWatchdog()
+  }
+
   _armResultTimeout() {
     if (this._resultTimeout) clearTimeout(this._resultTimeout)
     if (this._hardTimeout) clearTimeout(this._hardTimeout)
@@ -2250,14 +2279,26 @@ export class ClaudeTuiSession extends BaseSession {
     this._resultTimeout = null
     this._hardTimeout = null
     this._streamStallTimeout = null
-    this._resultTimeout = setTimeout(() => {
-      this._resultTimeout = null
-      this._handleInactivityWarning()
-    }, this._resultTimeoutMs)
+    // Hard cap ALWAYS arms — it's the last-resort backstop and stays live even
+    // while an AskUserQuestion answer is pending (a human who never answers for
+    // hours still gets force-cleared). #5318 suspends only the silence-detecting
+    // backstops below.
     this._hardTimeout = setTimeout(() => {
       this._hardTimeout = null
       this._handleHardTimeout()
     }, this._hardTimeoutMs)
+    // #5318 (WP-3.1) — while an AskUserQuestion answer is pending, keep the
+    // silence backstops suspended even though hook drains (or a defensive
+    // re-arm) call through here. Resuming is automatic: PostToolUse clears the
+    // pending entry, and the next drain-loop _armResultTimeout() falls through.
+    if (this._pendingUserAnswers.size > 0) {
+      this._suspendBackstopsForPendingQuestion()
+      return
+    }
+    this._resultTimeout = setTimeout(() => {
+      this._resultTimeout = null
+      this._handleInactivityWarning()
+    }, this._resultTimeoutMs)
     // #4638: only arm if configured > 0 (operators can disable via 0).
     if (this._streamStallTimeoutMs > 0) {
       this._streamStallTimeout = setTimeout(() => {
@@ -2339,6 +2380,9 @@ export class ClaudeTuiSession extends BaseSession {
 
   _handleInactivityWarning() {
     if (!this._isBusy) return
+    // #5318 (WP-3.1) — defence in depth: never warn while blocked on a human
+    // answer (the suspend should already have cleared this timer).
+    if (this._pendingUserAnswers.size > 0) return
     const idleMs = this._resultTimeoutMs
     const friendly = formatIdleDuration(idleMs)
     log.info(`Inactivity warning (${friendly}) — session alive, prompting check-in`)
@@ -2351,6 +2395,9 @@ export class ClaudeTuiSession extends BaseSession {
 
   _handleHardTimeout() {
     if (!this._isBusy) return
+    // #5318 (WP-3.1) — NOTE: intentionally NOT guarded on a pending question.
+    // The hard cap is the last-resort backstop and must still fire (and run its
+    // pending-answer cleanup, #4691) even if a human never answers.
     this._assertBusyHasMessageId('_handleHardTimeout')
     const friendly = formatIdleDuration(this._hardTimeoutMs)
     log.warn(`Hard-cap timeout (${friendly}) — force-clearing busy state`)
@@ -2393,6 +2440,9 @@ export class ClaudeTuiSession extends BaseSession {
    */
   _handleStreamStall() {
     if (!this._isBusy) return
+    // #5318 (WP-3.1) — defence in depth: a pending human answer is not a stall
+    // (the suspend should already have cleared this timer).
+    if (this._pendingUserAnswers.size > 0) return
     this._assertBusyHasMessageId('_handleStreamStall')
     const friendly = formatIdleDuration(this._streamStallTimeoutMs)
     const messageId = this._currentMessageId
@@ -2435,6 +2485,10 @@ export class ClaudeTuiSession extends BaseSession {
    */
   _handleFirstOutputTimeout() {
     if (!this._isBusy) return
+    // #5318 (WP-3.1) — defence in depth: don't fire while blocked on a human
+    // answer. (Normally moot — first output already arrived before any question
+    // — but kept symmetric with the other backstop handlers.)
+    if (this._pendingUserAnswers.size > 0) return
     // #4642: mirror the invariant check the other teardown sites
     // (`_finishTurnError`, `_handleHardTimeout`, `_handleStreamStall`,
     // `_onAskUserQuestionStall`) emit so a future regression that

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2643,10 +2643,11 @@ describe('ClaudeTuiSession', () => {
   })
 
   // #5318 (WP-3.1) — while a human is answering an AskUserQuestion, the human is
-  // the bottleneck, not claude, so the "claude went silent" backstops
-  // (soft-inactivity, hard, stream-stall, first-output) must be suspended.
-  // A slow human must not trip a misleading force-cancel; a genuinely wedged
-  // form still recovers via the dedicated AskUserQuestion watchdog.
+  // the bottleneck, not claude, so the silence-detecting backstops
+  // (soft-inactivity, stream-stall, first-output) are suspended. The HARD cap
+  // deliberately stays armed (last-resort backstop). A slow human must not trip
+  // a misleading force-cancel; a genuinely wedged form still recovers via the
+  // dedicated AskUserQuestion watchdog.
   describe('backstop suspension during pending AskUserQuestion (#5318 WP-3.1)', () => {
     function makeSession() {
       return new ClaudeTuiSession({
@@ -2670,7 +2671,7 @@ describe('ClaudeTuiSession', () => {
       await s.destroy()
     })
 
-    it('_armResultTimeout suspends every backstop while a question is pending', async () => {
+    it('_armResultTimeout suspends the silence backstops (hard cap stays armed) while a question is pending', async () => {
       const s = makeSession()
       s._isBusy = true
       s._currentMessageId = 'msg-1'
@@ -2746,6 +2747,19 @@ describe('ClaudeTuiSession', () => {
       assert.equal(s._streamStallTimeout, null, 'stream-stall suspended on user_question')
       assert.equal(s._resultTimeout, null, 'soft suspended')
       assert.ok(s._hardTimeout, 'hard cap stays armed')
+
+      // #5352 review — drive the matching PostToolUse and re-arm exactly as the
+      // hook-drain loop does (clear pending inside _emitToolHookEvent, then
+      // _armResultTimeout) to prove resume happens via the production path.
+      s._emitToolHookEvent('PostToolUse', {
+        tool_use_id: 'toolu_aq',
+        tool_name: 'AskUserQuestion',
+        tool_response: 'done',
+      }, 'msg-aq')
+      assert.equal(s._pendingUserAnswers.size, 0, 'PostToolUse cleared the pending answer')
+      s._armResultTimeout() // the drain loop's re-arm after a consumed hook
+      assert.ok(s._streamStallTimeout, 'stream-stall re-armed once the answer cleared')
+      assert.ok(s._resultTimeout, 'soft re-armed')
       await s.destroy()
     })
 

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2642,6 +2642,125 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  // #5318 (WP-3.1) — while a human is answering an AskUserQuestion, the human is
+  // the bottleneck, not claude, so the "claude went silent" backstops
+  // (soft-inactivity, hard, stream-stall, first-output) must be suspended.
+  // A slow human must not trip a misleading force-cancel; a genuinely wedged
+  // form still recovers via the dedicated AskUserQuestion watchdog.
+  describe('backstop suspension during pending AskUserQuestion (#5318 WP-3.1)', () => {
+    function makeSession() {
+      return new ClaudeTuiSession({
+        cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        resultTimeoutMs: 10_000, hardTimeoutMs: 20_000,
+        streamStallTimeoutMs: 5_000, firstOutputTimeoutMs: 5_000,
+      })
+    }
+    function setPending(s, tid = 'tid-1') {
+      s._pendingUserAnswer = { toolUseId: tid, questions: [{ options: [] }], options: [] }
+    }
+
+    it('_armResultTimeout arms all backstops when no question is pending', async () => {
+      const s = makeSession()
+      s._isBusy = true
+      s._currentMessageId = 'msg-1'
+      s._armResultTimeout()
+      assert.ok(s._resultTimeout, 'soft inactivity armed')
+      assert.ok(s._hardTimeout, 'hard armed')
+      assert.ok(s._streamStallTimeout, 'stream-stall armed')
+      await s.destroy()
+    })
+
+    it('_armResultTimeout suspends every backstop while a question is pending', async () => {
+      const s = makeSession()
+      s._isBusy = true
+      s._currentMessageId = 'msg-1'
+      s._armResultTimeout() // arm normally first
+      setPending(s)
+      s._armResultTimeout() // a hook-drain re-arm while pending must NOT resurrect them
+      assert.equal(s._resultTimeout, null, 'soft suspended')
+      assert.equal(s._streamStallTimeout, null, 'stream-stall suspended')
+      assert.equal(s._firstOutputTimeout, null, 'first-output suspended')
+      assert.ok(s._hardTimeout, 'hard cap stays armed (last-resort backstop)')
+      await s.destroy()
+    })
+
+    it('resumes the backstops once the pending answer clears', async () => {
+      const s = makeSession()
+      s._isBusy = true
+      s._currentMessageId = 'msg-1'
+      setPending(s)
+      s._armResultTimeout()
+      assert.equal(s._streamStallTimeout, null, 'suspended while pending')
+
+      s._clearPendingAnswerByToolUseId('tid-1')
+      s._armResultTimeout() // mirrors the drain-loop re-arm after PostToolUse
+      assert.ok(s._streamStallTimeout, 'stream-stall re-armed after the answer clears')
+      assert.ok(s._hardTimeout, 'hard re-armed')
+      assert.ok(s._resultTimeout, 'soft re-armed')
+      await s.destroy()
+    })
+
+    it('_handleStreamStall does NOT tear down while a question is pending', async () => {
+      const s = makeSession()
+      s._isBusy = true
+      s._currentMessageId = 'msg-1'
+      setPending(s)
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      s._handleStreamStall()
+      assert.equal(s._isBusy, true, 'still busy — no force-cancel mid-answer')
+      assert.equal(errors.length, 0, 'no stream_stall error emitted')
+      await s.destroy()
+    })
+
+    it('_handleHardTimeout STILL force-clears + clears pending (last-resort backstop is not suspended)', async () => {
+      const s = makeSession()
+      s._isBusy = true
+      s._currentMessageId = 'msg-1'
+      setPending(s)
+      const errors = []
+      s.on('error', (e) => errors.push(e))
+      s._handleHardTimeout()
+      assert.equal(s._isBusy, false, 'hard cap force-clears even across a pending question')
+      assert.equal(s._pendingUserAnswers.size, 0, 'hard timeout also clears the pending answer (#4691)')
+      assert.equal(errors.length, 1, 'hard-timeout error emitted')
+      await s.destroy()
+    })
+
+    it('driving an AskUserQuestion PreToolUse suspends the backstops end-to-end', async () => {
+      const s = makeSession()
+      s._activeTurn = { uuid: 'test', synthSeq: 0 }
+      s._isBusy = true
+      s._currentMessageId = 'msg-aq'
+      s.on('user_question', () => {})
+      s._armResultTimeout()
+      assert.ok(s._streamStallTimeout, 'armed before the question')
+
+      s._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_aq',
+        tool_name: 'AskUserQuestion',
+        tool_input: { questions: [{ question: 'Q?', options: [{ label: 'a' }] }] },
+      }, 'msg-aq')
+
+      assert.equal(s._pendingUserAnswers.size, 1, 'question pending')
+      assert.equal(s._streamStallTimeout, null, 'stream-stall suspended on user_question')
+      assert.equal(s._resultTimeout, null, 'soft suspended')
+      assert.ok(s._hardTimeout, 'hard cap stays armed')
+      await s.destroy()
+    })
+
+    it('suspending backstops does NOT cancel the AskUserQuestion watchdog (wedge recovery survives)', async () => {
+      const s = makeSession()
+      s._askUserQuestionWatchdog = setTimeout(() => {}, 60_000)
+      const wd = s._askUserQuestionWatchdog
+      s._suspendBackstopsForPendingQuestion()
+      assert.equal(s._askUserQuestionWatchdog, wd, 'the dedicated watchdog is left intact')
+      clearTimeout(wd)
+      s._askUserQuestionWatchdog = null
+      await s.destroy()
+    })
+  })
+
   // #4638 — stream-stall active-recovery watchdog. CLI + SDK got this in
   // #4467; TUI was the outlier and surfaced the wedge as a "Working…"
   // banner that ticked forever when claude TUI accepted the prompt and


### PR DESCRIPTION
## WP-3.1 — Phase 3 · Interactive-flow correctness

Closes #5318.

### Audit finding closed
- **004** — `claude-tui-session.js` — the stream-stall / soft-inactivity backstops kept running while an AskUserQuestion was pending, so a human taking minutes to answer tripped a misleading "stream stalled — force-cancel".

### What changed
When an AskUserQuestion answer is pending, the **human** is the bottleneck, not claude — so the "claude went silent" backstops are suspended:
- `_armResultTimeout()` skips re-arming the **soft-inactivity**, **stream-stall**, and **pre-first-output** timers while `_pendingUserAnswers` is non-empty.
- An explicit `_suspendBackstopsForPendingQuestion()` fires the moment `user_question` is emitted (no wait for the next drain-loop re-arm); the `_armResultTimeout()` guard keeps them suspended across subsequent re-arms.
- **Resume is automatic:** PostToolUse clears the pending entry and the next drain-loop `_armResultTimeout()` re-arms normally.

**Deliberately preserved:**
- The **hard cap** (2h last-resort) stays armed even across a pending question and keeps its pending-answer cleanup (#4691) — a human who walks away and never answers still gets force-cleared.
- The dedicated **`_askUserQuestionWatchdog`** (armed on answer) is untouched, so a genuinely wedged form still recovers.

Defence in depth: the suspended backstops' handlers (`_handleInactivityWarning`/`_handleStreamStall`/`_handleFirstOutputTimeout`) also bail when a question is pending.

### Acceptance criteria
- [x] A human taking minutes to answer doesn't get a misleading "stream stalled" force-cancel.
- [x] A genuinely wedged form still recovers via the AskUserQuestion watchdog.

### Tests (claude-tui-session, 246 pass)
- `_armResultTimeout` arms all backstops with no pending question; suspends soft/stall/first-output (hard stays armed) while pending; resumes after the answer clears.
- `_handleStreamStall` does not tear down while pending; `_handleHardTimeout` STILL force-clears + clears pending (last-resort backstop not suspended).
- Driving an AskUserQuestion PreToolUse through `_emitToolHookEvent` suspends the backstops end-to-end.
- Suspending does not cancel the AskUserQuestion watchdog (wedge recovery survives).

**Depends on:** none.