### PR TITLE
fix(server): per-toolUseId AskUserQuestion stall watchdog map (#5319)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -497,11 +497,15 @@ export class ClaudeTuiSession extends BaseSession {
     // tests + callers that read the single field keep working.
     this._pendingUserAnswers = new Map()
     this._lastPendingAnswerToolUseId = null
-    // #4604: watchdog timer armed in respondToQuestion(). If PostToolUse
-    // never arrives after we write the answer (multi-question form wedge),
-    // _onAskUserQuestionStall clears busy state + emits an error so the
-    // session is recoverable. Cleared on PostToolUse + destroy().
-    this._askUserQuestionWatchdog = null
+    // #4604 / #5319 (WP-3.2): per-toolUseId stall watchdogs armed in
+    // respondToQuestion(). If PostToolUse never arrives after we write an answer
+    // (multi-question form wedge), the matching watchdog fires
+    // _onAskUserQuestionStall to clear busy state + emit an error so the session
+    // is recoverable. Keyed by toolUseId (mirrors the #4668 _pendingUserAnswers
+    // Map) so PARALLEL AskUserQuestion calls each get an independent watchdog —
+    // answering / stalling one no longer disarms the others. Cleared per-id on
+    // PostToolUse and cleared wholesale on the turn-ending paths + destroy().
+    this._askUserQuestionWatchdogs = new Map()
     // #4884: forensic timing for the defensive trailing '\r' added in
     // #4867 / #4886 — record the wall-clock at which Submit-'1' is written
     // to the PTY for each multi-question form, keyed by toolUseId. On the
@@ -610,6 +614,40 @@ export class ClaudeTuiSession extends BaseSession {
       const keys = [...this._pendingUserAnswers.keys()]
       this._lastPendingAnswerToolUseId = keys.length > 0 ? keys[keys.length - 1] : null
     }
+  }
+
+  /**
+   * #5319 (WP-3.2): arm (or re-arm) the per-toolUseId AskUserQuestion stall
+   * watchdog. Each toolUseId gets its own timer so a parallel sibling's arm
+   * can't clobber this one. On fire it deletes its own Map entry, then calls
+   * _onAskUserQuestionStall. A null/undefined toolUseId is keyed verbatim
+   * (one anonymous slot) so the defensive no-toolUseId path keeps a watchdog.
+   * `ms` defaults to the standard window but the Other-freeform two-stage flow
+   * passes OTHER_FREEFORM_WATCHDOG_MS for its longer second stage.
+   */
+  _armAskUserQuestionWatchdog(toolUseId, ms = ASK_USER_QUESTION_WATCHDOG_MS) {
+    const existing = this._askUserQuestionWatchdogs.get(toolUseId)
+    if (existing) clearTimeout(existing)
+    const t = setTimeout(() => {
+      this._askUserQuestionWatchdogs.delete(toolUseId)
+      this._onAskUserQuestionStall(toolUseId)
+    }, ms)
+    this._askUserQuestionWatchdogs.set(toolUseId, t)
+  }
+
+  /** #5319 (WP-3.2): cancel + drop ONE toolUseId's stall watchdog (PostToolUse / per-question teardown). Idempotent. */
+  _clearAskUserQuestionWatchdog(toolUseId) {
+    const t = this._askUserQuestionWatchdogs.get(toolUseId)
+    if (t) {
+      clearTimeout(t)
+      this._askUserQuestionWatchdogs.delete(toolUseId)
+    }
+  }
+
+  /** #5319 (WP-3.2): cancel + drop ALL stall watchdogs (turn-ending paths + destroy()). Idempotent. */
+  _clearAllAskUserQuestionWatchdogs() {
+    for (const t of this._askUserQuestionWatchdogs.values()) clearTimeout(t)
+    this._askUserQuestionWatchdogs.clear()
   }
 
   /**
@@ -2040,11 +2078,11 @@ export class ClaudeTuiSession extends BaseSession {
       this._clearAskUserQuestionLock()
     }
     // #4604: PostToolUse means claude accepted the answer (single-question
-    // happy path). Cancel the stall watchdog so it doesn't fire a spurious
-    // ASK_USER_QUESTION_STALL error 30s later.
-    if (toolName === 'AskUserQuestion' && this._askUserQuestionWatchdog) {
-      clearTimeout(this._askUserQuestionWatchdog)
-      this._askUserQuestionWatchdog = null
+    // happy path). Cancel THIS tool's stall watchdog so it doesn't fire a
+    // spurious ASK_USER_QUESTION_STALL error 30s later. #5319 (WP-3.2): clear
+    // only this toolUseId's watchdog — a parallel sibling's watchdog stays armed.
+    if (toolName === 'AskUserQuestion' && toolUseId) {
+      this._clearAskUserQuestionWatchdog(toolUseId)
     }
 
     // PostToolUse — extract a string-ish result for the dashboard.
@@ -2205,11 +2243,10 @@ export class ClaudeTuiSession extends BaseSession {
     // #4604: same symmetry for the stall watchdog. The guard in
     // _onAskUserQuestionStall (`!_pendingUserAnswer && !_isBusy`) would
     // currently no-op the late fire (both are falsy here), but leaving
-    // the setTimeout handle live wastes a callback invocation 30s later.
-    if (this._askUserQuestionWatchdog) {
-      clearTimeout(this._askUserQuestionWatchdog)
-      this._askUserQuestionWatchdog = null
-    }
+    // the setTimeout handles live wastes a callback invocation 30s later.
+    // #5319 (WP-3.2): the turn errored — every per-toolUseId watchdog is moot
+    // (their fires would no-op on !_isBusy), so clear them all.
+    this._clearAllAskUserQuestionWatchdogs()
   }
 
   /**
@@ -2255,7 +2292,7 @@ export class ClaudeTuiSession extends BaseSession {
    * pre-first-output timers. When a question is pending the HUMAN is the
    * bottleneck, not claude, so these would only fire a misleading
    * force-cancel / stall error / check-in chip mid-answer. The dedicated
-   * `_askUserQuestionWatchdog` (armed in respondToQuestion) still recovers a
+   * the dedicated per-toolUseId `_askUserQuestionWatchdogs` (armed in respondToQuestion) still recover a
    * genuinely wedged form after the answer is written.
    *
    * Deliberately does NOT touch the HARD cap (`_hardTimeout`): that 2h
@@ -2593,10 +2630,9 @@ export class ClaudeTuiSession extends BaseSession {
     //    stale keystrokes into whatever form the next turn brings up.
     this._pendingUserAnswers_clearAll()
     this._clearAskUserQuestionLock()
-    if (this._askUserQuestionWatchdog) {
-      clearTimeout(this._askUserQuestionWatchdog)
-      this._askUserQuestionWatchdog = null
-    }
+    // #5319 (WP-3.2): Ctrl-C above dropped the TUI's current form, so every
+    // per-toolUseId watchdog is now stale — clear them all.
+    this._clearAllAskUserQuestionWatchdogs()
     // #4732: clear the pre-first-output watchdog so a teardown via
     // `_handleHardTimeout` / `_handleStreamStall` / `_handleFirstOutputTimeout`
     // can never leak a live handle that would re-fire on a torn-down turn.
@@ -2686,14 +2722,12 @@ export class ClaudeTuiSession extends BaseSession {
     // every sibling pending entry is now equally stale.
     this._pendingUserAnswers_clearAll()
     this._clearAskUserQuestionLock()
-    // #4604: cancel the stall watchdog too. interrupt() does NOT clear
+    // #4604: cancel the stall watchdogs too. interrupt() does NOT clear
     // _isBusy directly (Ctrl-C surfaces async via _finishTurn*), so without
-    // this the watchdog could fire ~30s later and emit a spurious
+    // this a watchdog could fire ~30s later and emit a spurious
     // ASK_USER_QUESTION_STALL for a session the user already interrupted.
-    if (this._askUserQuestionWatchdog) {
-      clearTimeout(this._askUserQuestionWatchdog)
-      this._askUserQuestionWatchdog = null
-    }
+    // #5319 (WP-3.2): clear every per-toolUseId watchdog.
+    this._clearAllAskUserQuestionWatchdogs()
     // #4732: same reasoning for the pre-first-output watchdog. interrupt()
     // doesn't synchronously flip _isBusy=false, so without this clear the
     // watchdog could fire in the 150ms poll-loop window before
@@ -2862,11 +2896,9 @@ export class ClaudeTuiSession extends BaseSession {
       // the watchdog clears _isBusy + _pendingUserAnswer and emits
       // ASK_USER_QUESTION_STALL so the dashboard prompts the user to
       // retry. Cancelled on PostToolUse (happy path) and on destroy().
-      if (this._askUserQuestionWatchdog) clearTimeout(this._askUserQuestionWatchdog)
-      this._askUserQuestionWatchdog = setTimeout(() => {
-        this._askUserQuestionWatchdog = null
-        this._onAskUserQuestionStall(prevToolUseId)
-      }, ASK_USER_QUESTION_WATCHDOG_MS)
+      // #5319 (WP-3.2): keyed by this tool's id so a parallel sibling's arm
+      // doesn't clobber it.
+      this._armAskUserQuestionWatchdog(prevToolUseId)
     }
 
     // Single-question / no-questions-array path (back-compat with the
@@ -2914,7 +2946,7 @@ export class ClaudeTuiSession extends BaseSession {
           // #4808: destroy() can run during ANY of the awaits below
           // (stage-1 write, settle pause, stage-2 write). Without a
           // guard after each await the IIFE keeps running and:
-          //   - re-arms `_askUserQuestionWatchdog` past destroy(),
+          //   - re-arms a `_askUserQuestionWatchdogs` entry past destroy(),
           //     leaking a 30s timer that pins `this` in its closure
           //     even though `_onAskUserQuestionStall`'s _destroying
           //     guard silences the eventual emit
@@ -2943,11 +2975,8 @@ export class ClaudeTuiSession extends BaseSession {
           // Re-arm the watchdog so the freeform write phase has a fresh
           // OTHER_FREEFORM_WATCHDOG_MS window — the stage-1 arm already
           // counted the settle delay against the original 30s budget.
-          if (this._askUserQuestionWatchdog) clearTimeout(this._askUserQuestionWatchdog)
-          this._askUserQuestionWatchdog = setTimeout(() => {
-            this._askUserQuestionWatchdog = null
-            this._onAskUserQuestionStall(prevToolUseId)
-          }, OTHER_FREEFORM_WATCHDOG_MS)
+          // #5319 (WP-3.2): keyed by this tool's id, longer second-stage window.
+          this._armAskUserQuestionWatchdog(prevToolUseId, OTHER_FREEFORM_WATCHDOG_MS)
           await this._writePtyTextThrottled(freeformText).catch((err) => {
             // #4828: session-scoped.
             ;(this._log || log).warn(`respondToQuestion Other-freeform PTY write failed: ${err.message} (tool=${tag})`)
@@ -3499,6 +3528,11 @@ export class ClaudeTuiSession extends BaseSession {
     // would hit the "no matching pending entry — dropping" path and
     // wedge the next form silently).
     this._clearPendingAnswerByToolUseId(toolUseId)
+    // #5319 (WP-3.2): cancel THIS tool's stall watchdog. The 30s-stall path
+    // arrives here after its own watchdog already self-deleted, but the
+    // too-many-options (#4625) path tears down WITHOUT a prior fire, so clear
+    // it explicitly. Idempotent; leaves any sibling watchdog intact.
+    this._clearAskUserQuestionWatchdog(toolUseId)
     this._clearAskUserQuestionLock()
     // #4616: emit a synthetic tool_result FIRST so the dashboard's
     // activeTools entry for this AskUserQuestion is cleared. Without it
@@ -3593,12 +3627,10 @@ export class ClaudeTuiSession extends BaseSession {
     // fire post-destroy must not emit a stream_stall error into a torn-
     // down listener set or write Ctrl-C into a killed PTY.
     this._clearFirstOutputWatchdog()
-    // #4604: cancel the AskUserQuestion stall watchdog so it can't fire
-    // a stale ASK_USER_QUESTION_STALL event into a torn-down listener.
-    if (this._askUserQuestionWatchdog) {
-      clearTimeout(this._askUserQuestionWatchdog)
-      this._askUserQuestionWatchdog = null
-    }
+    // #4604 / #5319 (WP-3.2): cancel every AskUserQuestion stall watchdog so
+    // none can fire a stale ASK_USER_QUESTION_STALL event into a torn-down
+    // listener.
+    this._clearAllAskUserQuestionWatchdogs()
     if (this._term) {
       // #5317 (WP-2.3) — capture the handle + pid BEFORE nulling so the
       // escalation timer (and _onPtyGone's cancel) still have something to act

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2292,8 +2292,8 @@ export class ClaudeTuiSession extends BaseSession {
    * pre-first-output timers. When a question is pending the HUMAN is the
    * bottleneck, not claude, so these would only fire a misleading
    * force-cancel / stall error / check-in chip mid-answer. The dedicated
-   * the dedicated per-toolUseId `_askUserQuestionWatchdogs` (armed in respondToQuestion) still recover a
-   * genuinely wedged form after the answer is written.
+   * per-toolUseId `_askUserQuestionWatchdogs` (armed in respondToQuestion) still
+   * recover a genuinely wedged form after the answer is written.
    *
    * Deliberately does NOT touch the HARD cap (`_hardTimeout`): that 2h
    * last-resort backstop stays armed even across a pending question, so a human

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -2765,12 +2765,11 @@ describe('ClaudeTuiSession', () => {
 
     it('suspending backstops does NOT cancel the AskUserQuestion watchdog (wedge recovery survives)', async () => {
       const s = makeSession()
-      s._askUserQuestionWatchdog = setTimeout(() => {}, 60_000)
-      const wd = s._askUserQuestionWatchdog
+      s._armAskUserQuestionWatchdog('toolu_wd')
+      const wd = s._askUserQuestionWatchdogs.get('toolu_wd')
+      assert.ok(wd, 'watchdog armed')
       s._suspendBackstopsForPendingQuestion()
-      assert.equal(s._askUserQuestionWatchdog, wd, 'the dedicated watchdog is left intact')
-      clearTimeout(wd)
-      s._askUserQuestionWatchdog = null
+      assert.equal(s._askUserQuestionWatchdogs.get('toolu_wd'), wd, 'the dedicated watchdog is left intact')
       await s.destroy()
     })
   })
@@ -3078,7 +3077,7 @@ describe('ClaudeTuiSession', () => {
       session._currentMessageId = 'msg-helper'
       session._activeTurn = { startedAt: Date.now() - 50, aborted: false }
       session._pendingUserAnswer = { toolUseId: 'toolu_helper' }
-      session._askUserQuestionWatchdog = setTimeout(() => {}, 60_000)
+      session._armAskUserQuestionWatchdog('toolu_helper')
       const ptyWrites = []
       session._term = { write: (b) => ptyWrites.push(b), kill: () => {} }
 
@@ -3089,7 +3088,7 @@ describe('ClaudeTuiSession', () => {
       assert.equal(session._isBusy, false, '_isBusy cleared')
       assert.equal(session._currentMessageId, null, '_currentMessageId nulled')
       assert.equal(session._pendingUserAnswer, null, '_pendingUserAnswer cleared')
-      assert.equal(session._askUserQuestionWatchdog, null, 'AskUserQuestion watchdog cleared')
+      assert.equal(session._askUserQuestionWatchdogs.size, 0, 'all AskUserQuestion watchdogs cleared')
     })
 
     it('emits stream_end + result; skips error when no errorPayload given', () => {
@@ -3975,21 +3974,20 @@ describe('ClaudeTuiSession', () => {
           const torn = session
           session = null
 
-          // The watchdog was cleared by destroy(). If the IIFE re-arms
-          // it after `await new Promise(setTimeout(SETTLE_MS))` resolves,
-          // a fresh timer appears on `_askUserQuestionWatchdog` —
-          // detectable by sampling the field repeatedly until well past
-          // the settle delay.
+          // The watchdogs were cleared by destroy(). If the IIFE re-arms
+          // after `await new Promise(setTimeout(SETTLE_MS))` resolves, a fresh
+          // entry appears in `_askUserQuestionWatchdogs` (#5319) — detectable by
+          // sampling the Map size repeatedly until well past the settle delay.
           const samples = []
           for (let i = 0; i < 4; i++) {
             await new Promise((resolve) => setTimeout(resolve, 60))
-            samples.push(torn._askUserQuestionWatchdog)
+            samples.push(torn._askUserQuestionWatchdogs.size)
           }
 
-          // Pre-#4808: at least one sample is a Timeout (re-armed).
-          // Post-fix: every sample stays null.
+          // Pre-#4808: at least one sample is non-zero (re-armed).
+          // Post-fix: every sample stays 0.
           for (const s of samples) {
-            assert.equal(s, null, `_askUserQuestionWatchdog must stay null past destroy(); saw ${s}. samples=${samples.map((x) => x ? 'TIMER' : 'null').join(',')}`)
+            assert.equal(s, 0, `_askUserQuestionWatchdogs must stay empty past destroy(); saw size=${s}. samples=${samples.join(',')}`)
           }
         })
 
@@ -4704,6 +4702,55 @@ describe('ClaudeTuiSession', () => {
 
         // Busy state cleared so the session is recoverable.
         assert.equal(session._isBusy, false, 'busy cleared')
+      } finally {
+        mock.timers.reset()
+      }
+    })
+
+    // #5319 (WP-3.2) — two parallel ANSWERED questions each get an independent
+    // watchdog. Pre-#5319 the single `_askUserQuestionWatchdog` field meant the
+    // second respondToQuestion clobbered the first's watchdog, and a PostToolUse
+    // for either tool cancelled whichever watchdog happened to be live — so
+    // answering one question silently disarmed the other's stall protection.
+    it('two answered questions get independent watchdogs; PostToolUse for one leaves the other armed + firing (#5319)', () => {
+      mock.timers.enable({ apis: ['setTimeout'] })
+      try {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._activeTurn = { uuid: 'test-5319', synthSeq: 0 }
+        const errors = []
+        session.on('error', (e) => errors.push(e))
+        session._term = { write: () => {}, kill: () => {} }
+        session._isBusy = true
+        session._currentMessageId = 'msg-5319'
+
+        // Two parallel AskUserQuestions pending.
+        session._emitToolHookEvent('PreToolUse', {
+          tool_use_id: 'toolu_A', tool_name: 'AskUserQuestion',
+          tool_input: { questions: [{ question: 'QA?', options: [{ label: 'a1' }] }] },
+        }, 'msg-5319')
+        session._emitToolHookEvent('PreToolUse', {
+          tool_use_id: 'toolu_B', tool_name: 'AskUserQuestion',
+          tool_input: { questions: [{ question: 'QB?', options: [{ label: 'b1' }] }] },
+        }, 'msg-5319')
+
+        // Answer BOTH → each arms its OWN watchdog (keyed by toolUseId).
+        session.respondToQuestion('a1', undefined, 'toolu_A')
+        session.respondToQuestion('b1', undefined, 'toolu_B')
+        assert.equal(session._askUserQuestionWatchdogs.size, 2, 'two independent watchdogs armed')
+
+        // PostToolUse for A cancels ONLY A's watchdog; B's stays armed.
+        session._emitToolHookEvent('PostToolUse', {
+          tool_use_id: 'toolu_A', tool_name: 'AskUserQuestion', tool_response: 'ok',
+        }, 'msg-5319')
+        assert.equal(session._askUserQuestionWatchdogs.has('toolu_A'), false, "A's watchdog cancelled by its own PostToolUse")
+        assert.ok(session._askUserQuestionWatchdogs.has('toolu_B'), "B's watchdog NOT disarmed by answering A")
+
+        // B never gets a PostToolUse → its independent watchdog still fires.
+        mock.timers.tick(31_000)
+        assert.ok(
+          errors.some((e) => e.code === 'ASK_USER_QUESTION_STALL' && e.toolUseId === 'toolu_B'),
+          "B's independent watchdog still recovers the session",
+        )
       } finally {
         mock.timers.reset()
       }


### PR DESCRIPTION
## WP-3.2 — Phase 3 · Interactive-flow correctness

Closes #5319.

### Audit finding closed
- **MAJOR** — `claude-tui-session.js` single `_askUserQuestionWatchdog` field: parallel AskUserQuestion calls clobbered each other's watchdog.

### The bug
With one watchdog field, arming a second question's watchdog `clearTimeout`'d the first's, and a PostToolUse for *either* tool cancelled whichever watchdog was live. So with two parallel pending questions, answering one silently disarmed the other's stall protection — a wedged sibling would never recover.

### What changed
Replace the single field with **`_askUserQuestionWatchdogs`, a Map keyed by toolUseId** (mirrors the #4668 `_pendingUserAnswers` Map), via three helpers:
- `_armAskUserQuestionWatchdog(toolUseId, ms?)` — independent per-id timer; deletes its own entry on fire; `ms` defaults to the standard window, the Other-freeform two-stage flow passes `OTHER_FREEFORM_WATCHDOG_MS`.
- `_clearAskUserQuestionWatchdog(toolUseId)` — cancel one (PostToolUse happy path; per-question stall teardown).
- `_clearAllAskUserQuestionWatchdogs()` — cancel all (turn-ending paths: `_teardownTurn`, `interrupt`, `_finishTurnError`; and `destroy()`).

Call-site classification:
- **clear-one:** PostToolUse (by `toolUseId`), `_teardownAskUserQuestion` (the timed-out tool).
- **clear-all:** the turn is over → every watchdog is moot.

### Acceptance criteria
- [x] Two parallel pending questions each have an independent watchdog; answering one doesn't disarm the other.

### Tests (claude-tui-session, 247 pass)
- New: two answered questions get independent watchdogs; PostToolUse for one leaves the other armed AND still firing `ASK_USER_QUESTION_STALL` for the wedged sibling.
- Existing #4691 surgical-teardown, stall-fire, interrupt-clear, and destroy-race tests updated to the Map and still green.

**Depends on:** none.