### PR TITLE
fix(server): arm recovery on every respondToQuestion path + isolate intervention emit (#5320)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2850,6 +2850,18 @@ export class ClaudeTuiSession extends BaseSession {
     // #4828: session-scoped.
     ;(this._log || log).info(`respondToQuestion: tool=${prevToolUseId || '?'} dashboardToolUseId=${toolUseId || 'none'} text.length=${(text || '').length} answersMap.keys=${answersMapKeyCount} questions=${pendingQuestions.length} options=${entry?.options?.length || 0} pendingMapSize=${this._pendingUserAnswers.size}`)
     if (!entry) return
+    // #5320 (WP-3.3) — arm the stall watchdog the MOMENT we have a live pending
+    // entry the dashboard tried to answer, BEFORE any early-return below. The
+    // dashboard clears its QuestionPrompt UI when it sends an answer, so ANY
+    // respondToQuestion that finds an entry but then bails — the unactionable
+    // cases here (non-string / empty text + no answersMap), the validation drops
+    // in the freeform path (no options, option-not-found), or `!this._term` —
+    // would otherwise leave the turn wedged until the 2h hard cap with no
+    // dashboard prompt. Arming here (it does NOT clear the pending) gives every
+    // such path recovery; a real follow-up answer re-arms idempotently (same
+    // key), and the success paths re-arm with a fresh post-write window (the
+    // Other-freeform IIFE with its longer second-stage window).
+    this._armAskUserQuestionWatchdog(prevToolUseId)
     // Single-question / free-text path requires a non-empty `text`. The
     // multi-question path is driven from answersMap (text is ignored when
     // a map is present) so an empty string is permitted there.
@@ -2860,15 +2872,6 @@ export class ClaudeTuiSession extends BaseSession {
     // #4668: clear only this specific entry; sibling pending answers
     // (from parallel AskUserQuestion calls in the same turn) survive.
     this._clearPendingAnswerByToolUseId(entry.toolUseId)
-    // #5320 (WP-3.3) — arm the stall watchdog the MOMENT we clear the pending
-    // entry, so EVERY path below — including the validation-failure early-returns
-    // that write nothing (freeform-with-no-options, option-not-found, empty
-    // text) — has recovery. The dashboard already cleared its QuestionPrompt UI
-    // when it sent this answer, so a drop without recovery would wedge the turn
-    // until the 2h hard cap. The success paths re-arm idempotently (same key →
-    // a fresh full window measured from write-completion); the Other-freeform
-    // IIFE re-arms with its longer second-stage window.
-    this._armAskUserQuestionWatchdog(prevToolUseId)
     if (!this._term) return
     // #4668 diagnostic: capture the PTY output tail just before we write
     // the answer keystroke. The wedge symptom observed 2026-06-01 was

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2011,12 +2011,21 @@ export class ClaudeTuiSession extends BaseSession {
           // intervened. Per-toolUseId so the dashboard can dedup repeats
           // when claude TUI re-emits the same multi-q payload (a known
           // failure mode pre-#4668).
-          this.emit('multi_question_intervention', {
-            toolUseId,
-            questionCount,
-            reason: 'multi_question',
-            timestamp: Date.now(),
-          })
+          // #5320 (WP-3.3) — isolate this emit. A synchronous throw from a
+          // listener here would skip the `user_question` emit + backstop suspend
+          // below, leaving `_pendingUserAnswer` set with no dashboard prompt and
+          // no recovery — an orphaned pending. Swallow + log so the question
+          // still surfaces.
+          try {
+            this.emit('multi_question_intervention', {
+              toolUseId,
+              questionCount,
+              reason: 'multi_question',
+              timestamp: Date.now(),
+            })
+          } catch (err) {
+            ;(this._log || log).warn(`multi_question_intervention listener threw (continuing): ${err?.message || err}`)
+          }
         }
         this.emit('user_question', { toolUseId, questions })
         // #5318 (WP-3.1) — we're now blocked on a human answer. Suspend the
@@ -2851,6 +2860,15 @@ export class ClaudeTuiSession extends BaseSession {
     // #4668: clear only this specific entry; sibling pending answers
     // (from parallel AskUserQuestion calls in the same turn) survive.
     this._clearPendingAnswerByToolUseId(entry.toolUseId)
+    // #5320 (WP-3.3) — arm the stall watchdog the MOMENT we clear the pending
+    // entry, so EVERY path below — including the validation-failure early-returns
+    // that write nothing (freeform-with-no-options, option-not-found, empty
+    // text) — has recovery. The dashboard already cleared its QuestionPrompt UI
+    // when it sent this answer, so a drop without recovery would wedge the turn
+    // until the 2h hard cap. The success paths re-arm idempotently (same key →
+    // a fresh full window measured from write-completion); the Other-freeform
+    // IIFE re-arms with its longer second-stage window.
+    this._armAskUserQuestionWatchdog(prevToolUseId)
     if (!this._term) return
     // #4668 diagnostic: capture the PTY output tail just before we write
     // the answer keystroke. The wedge symptom observed 2026-06-01 was
@@ -2959,10 +2977,14 @@ export class ClaudeTuiSession extends BaseSession {
             ;(this._log || log).warn(`respondToQuestion Other-digit PTY write failed: ${err.message} (tool=${tag})`)
             return false
           })
-          if (this._destroying) return
+          // #5320 (WP-3.3) — also bail if the turn was ABORTED (interrupt() sets
+          // _activeTurn.aborted but does not flip _destroying). Without this the
+          // IIFE would keep driving keystrokes into a turn the user already
+          // interrupted, and re-arm a watchdog interrupt() just cleared.
+          if (this._destroying || this._activeTurn?.aborted) return
           if (!stage1ok) return
           await new Promise((resolve) => setTimeout(resolve, OTHER_FREEFORM_SETTLE_MS))
-          if (this._destroying) return
+          if (this._destroying || this._activeTurn?.aborted) return
           // Belt-and-braces: destroy() sets _destroying before nulling
           // _term in the same synchronous frame, so the guard above
           // already covers the destroy() race. This null-check is

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -5040,6 +5040,76 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  // #5320 (WP-3.3) — recovery on every respondToQuestion path + crash-isolation
+  // for the intervention emit. Before this, the validation-failure early-returns
+  // in the Other/freeform path cleared the pending answer but armed no watchdog
+  // and emitted no error (the turn wedged until the 2h hard cap), the freeform
+  // IIFE ignored interrupt()'s abort, and a throwing multi_question_intervention
+  // listener orphaned the pending by skipping the user_question emit.
+  describe('respondToQuestion recovery on every path (#5320 WP-3.3)', () => {
+    function makeAnsweringSession() {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      s._activeTurn = { synthSeq: 0, aborted: false, startedAt: Date.now() }
+      s._isBusy = true
+      s._currentMessageId = 'msg-5320'
+      s.on('error', () => {})
+      return s
+    }
+
+    it('a freeform answer with no selectable options still arms a stall watchdog', async () => {
+      const s = makeAnsweringSession()
+      s._term = { write: () => {}, kill: () => {} }
+      s._pendingUserAnswer = { toolUseId: 'toolu_no_opts', questions: [{ options: [] }], options: [] }
+      s.respondToQuestion('whatever', undefined, 'toolu_no_opts', { freeformText: 'hi' })
+      assert.ok(s._askUserQuestionWatchdogs.has('toolu_no_opts'), 'watchdog armed despite the drop')
+      assert.equal(s._pendingUserAnswers.size, 0, 'pending cleared')
+      await s.destroy()
+    })
+
+    it('a freeform answer whose option is not found still arms a stall watchdog', async () => {
+      const s = makeAnsweringSession()
+      s._term = { write: () => {}, kill: () => {} }
+      s._pendingUserAnswer = { toolUseId: 'toolu_nomatch', questions: [{ options: [{ label: 'a' }] }], options: [{ label: 'a' }] }
+      s.respondToQuestion('NotAnOption', undefined, 'toolu_nomatch', { freeformText: 'hi' })
+      assert.ok(s._askUserQuestionWatchdogs.has('toolu_nomatch'), 'watchdog armed despite the drop')
+      await s.destroy()
+    })
+
+    it('an aborted turn cancels the Other-freeform IIFE before the stage-2 write', async () => {
+      const s = makeAnsweringSession()
+      const writes = []
+      s._term = { write: (b) => writes.push(String(b)), kill: () => {} }
+      s._pendingUserAnswer = { toolUseId: 'toolu_abort', questions: [{ options: [{ label: 'Other' }] }], options: [{ label: 'Other' }] }
+
+      s.respondToQuestion('Other', undefined, 'toolu_abort', { freeformText: 'SECRET_FREEFORM' })
+      // Abort during the 150ms settle window (stage-1 digit write finishes fast).
+      await new Promise((r) => setTimeout(r, 40))
+      s._activeTurn.aborted = true
+      // Wait past the settle + would-be stage-2 write.
+      await new Promise((r) => setTimeout(r, 250))
+
+      assert.ok(!writes.join('').includes('SECRET_FREEFORM'), 'stage-2 freeform write skipped after abort')
+      await s.destroy()
+    })
+
+    it('a throwing multi_question_intervention listener does not orphan the pending', () => {
+      const s = makeAnsweringSession()
+      s.on('multi_question_intervention', () => { throw new Error('listener boom') })
+      let userQ = null
+      s.on('user_question', (e) => { userQ = e })
+      // Multi-question PreToolUse triggers the intervention emit before user_question.
+      s._emitToolHookEvent('PreToolUse', {
+        tool_use_id: 'toolu_mq', tool_name: 'AskUserQuestion',
+        tool_input: { questions: [
+          { question: 'Q1?', options: [{ label: 'a' }] },
+          { question: 'Q2?', options: [{ label: 'b' }] },
+        ] },
+      }, 'msg-5320')
+      assert.ok(userQ, 'user_question still emitted despite the intervention listener throwing')
+      assert.equal(s._pendingUserAnswers.size, 1, 'pending recorded — not orphaned')
+    })
+  })
+
   // #4604 Chunk B — multi-question form driver. Empirical byte sequence
   // pinned via scripts/tui-form-recorder.mjs against claude CLI v2.1.158
   // (see tui_multi_question_form_keys memory). Single-select digit

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -5066,6 +5066,21 @@ describe('ClaudeTuiSession', () => {
       await s.destroy()
     })
 
+    it('an empty answer arms a recovery watchdog WITHOUT consuming the pending', async () => {
+      // The dashboard clears its QuestionPrompt UI when it submits, even for an
+      // empty answer. respondToQuestion returns early on empty text + no
+      // answersMap (it can't drive the form with nothing), so without recovery
+      // the turn would wedge. #5320: arm a watchdog before that early-return —
+      // but DON'T consume the pending, so a real follow-up answer still works.
+      const s = makeAnsweringSession()
+      s._term = { write: () => {}, kill: () => {} }
+      s._pendingUserAnswer = { toolUseId: 'toolu_empty', questions: [{ options: [{ label: 'a' }] }], options: [{ label: 'a' }] }
+      s.respondToQuestion('', undefined, 'toolu_empty')
+      assert.ok(s._askUserQuestionWatchdogs.has('toolu_empty'), 'recovery watchdog armed for the empty answer')
+      assert.equal(s._pendingUserAnswers.size, 1, 'empty answer does NOT consume the pending entry')
+      await s.destroy()
+    })
+
     it('a freeform answer whose option is not found still arms a stall watchdog', async () => {
       const s = makeAnsweringSession()
       s._term = { write: () => {}, kill: () => {} }
@@ -5075,20 +5090,30 @@ describe('ClaudeTuiSession', () => {
       await s.destroy()
     })
 
-    it('an aborted turn cancels the Other-freeform IIFE before the stage-2 write', async () => {
+    it('interrupt() during the Other-freeform settle stops the IIFE re-arming the watchdog', async () => {
       const s = makeAnsweringSession()
       const writes = []
       s._term = { write: (b) => writes.push(String(b)), kill: () => {} }
       s._pendingUserAnswer = { toolUseId: 'toolu_abort', questions: [{ options: [{ label: 'Other' }] }], options: [{ label: 'Other' }] }
 
       s.respondToQuestion('Other', undefined, 'toolu_abort', { freeformText: 'SECRET_FREEFORM' })
-      // Abort during the 150ms settle window (stage-1 digit write finishes fast).
+      // The arm-after-clear watchdog (#5320) is live during the settle.
+      assert.ok(s._askUserQuestionWatchdogs.has('toolu_abort'), 'watchdog armed during the answer write')
+
+      // Interrupt DURING the 150ms settle window. interrupt() sets
+      // _activeTurn.aborted and clears all watchdogs synchronously; the IIFE's
+      // post-settle abort guard must then bail BEFORE re-arming at stage 2.
       await new Promise((r) => setTimeout(r, 40))
-      s._activeTurn.aborted = true
-      // Wait past the settle + would-be stage-2 write.
+      s.interrupt()
+
+      // Wait past the settle + would-be stage-2 re-arm/write.
       await new Promise((r) => setTimeout(r, 250))
 
-      assert.ok(!writes.join('').includes('SECRET_FREEFORM'), 'stage-2 freeform write skipped after abort')
+      // Distinct contribution of the abort guard: no watchdog re-armed after
+      // interrupt() cleared them. Without the guard the IIFE would re-arm
+      // 'toolu_abort' at stage 2 (this assertion fails on main / without the fix).
+      assert.ok(!s._askUserQuestionWatchdogs.has('toolu_abort'), 'IIFE did NOT re-arm the watchdog after interrupt()')
+      assert.ok(!writes.join('').includes('SECRET_FREEFORM'), 'stage-2 freeform write skipped after interrupt')
       await s.destroy()
     })
 


### PR DESCRIPTION
## WP-3.3 — Phase 3 · Interactive-flow correctness

Closes #5320.

### Audit findings closed
- **MAJOR** — `claude-tui-session.js` Other/freeform early-returns cleared the pending answer but armed no watchdog and emitted no error.
- **MINOR** — the freeform IIFE raced `interrupt()` (ignored `_activeTurn.aborted`).
- **MINOR** — a sync throw from the `multi_question_intervention` emit orphaned the pending.

### What changed
1. **Recovery on every path (MAJOR).** Arm the per-toolUseId stall watchdog the *moment* the pending entry is cleared in `respondToQuestion`, so EVERY downstream path — including the validation-failure drops (freeform-with-no-options, option-not-found, empty text) — has recovery. The dashboard clears its QuestionPrompt UI when it sends an answer, so a drop without recovery wedged the turn until the 2h hard cap. Success paths re-arm idempotently (same key → fresh full window from write-completion); the Other-freeform IIFE re-arms with its longer second-stage window.
2. **Abort cancels the IIFE (MINOR).** The Other-freeform two-stage IIFE now bails on `_activeTurn.aborted` (set by `interrupt()`, which does not flip `_destroying`) at each await boundary — no more keystrokes driven into an interrupted turn.
3. **Intervention emit isolated (MINOR).** Wrapped the `multi_question_intervention` emit in try/catch so a throwing listener can't skip the `user_question` emit + backstop suspend that follow it (which would leave `_pendingUserAnswer` set with no dashboard prompt).

### Acceptance criteria
- [x] No freeform/Other path clears pending without arming recovery.
- [x] An aborted turn cancels the IIFE.
- [x] An emit throw doesn't wedge the turn.

### Tests (claude-tui-session, 251 pass)
- Freeform-with-no-options and option-not-found drops each still arm a watchdog.
- An aborted turn cancels the Other-freeform IIFE before the stage-2 freeform write lands.
- A throwing `multi_question_intervention` listener still emits `user_question` and records the pending (no orphan).

**Depends on:** WP-3.2 (#5319, merged).