### PR TITLE
fix(server): redact credentials in PTY hex/tail diagnostics (#5322)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url'
 import { BaseSession } from './base-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { resolveBinary } from './utils/resolve-binary.js'
-import { createLogger, loggerForSession } from './logger.js'
+import { createLogger, loggerForSession, redactSensitive } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { materializeAttachments, buildAttachmentsPromptSuffix } from './claude-tui-attachments.js'
@@ -1448,7 +1448,14 @@ export class ClaudeTuiSession extends BaseSession {
     // The raw (un-stripped) buffer is used so escape/control bytes
     // survive into the diagnostic — sourcing from the stripped tail
     // would hide the very bytes we want to see (#4031 review).
-    return formatHexDump(this._outputTailRaw, ClaudeTuiSession.PTY_TAIL_DIAGNOSTIC_BYTES)
+    //
+    // #5322 (WP-4.2, security) — redact token-shaped runs BEFORE hex-encoding so
+    // a pasted/echoed OAuth token can't leak via the dump's hex AND ASCII
+    // columns. The redact runs on a latin1 (binary) round-trip, which preserves
+    // every byte 0–255 losslessly (so 0x1b / OSC / SS3 escape bytes still land
+    // in the dump); redactSensitive only rewrites the ASCII token runs.
+    const redacted = Buffer.from(redactSensitive(this._outputTailRaw.toString('latin1')), 'latin1')
+    return formatHexDump(redacted, ClaudeTuiSession.PTY_TAIL_DIAGNOSTIC_BYTES)
   }
 
   /**
@@ -2411,7 +2418,10 @@ export class ClaudeTuiSession extends BaseSession {
       .replace(/[\r\n]+/g, '\n')
       .replace(/[ \t]{2,}/g, ' ')
       .trim()
-    return trimmed
+    // #5322 (WP-4.2, security) — this tail rides into `error` events that fan
+    // out to clients and the System tab, so redact any token-shaped run (pasted
+    // or echoed OAuth token / API key) before it leaves the process.
+    return redactSensitive(trimmed)
   }
 
   /**

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2413,15 +2413,18 @@ export class ClaudeTuiSession extends BaseSession {
    */
   _outputTailDiagnostic() {
     if (!this._outputTail) return ''
-    const trimmed = this._outputTail
+    // #5322 (WP-4.2, security) — this tail rides into `error` events that fan
+    // out to clients and the System tab, so redact any token-shaped run (pasted
+    // or echoed OAuth token / API key) before it leaves the process.
+    // #5357 review — redact BEFORE slicing: a token straddling the
+    // PTY_TAIL_DIAGNOSTIC_BYTES boundary must be matched in full (and collapse
+    // to [REDACTED]) rather than leaving a trailing fragment the regex can't
+    // catch. The slice then bounds the already-scrubbed string.
+    return redactSensitive(this._outputTail)
       .slice(-ClaudeTuiSession.PTY_TAIL_DIAGNOSTIC_BYTES)
       .replace(/[\r\n]+/g, '\n')
       .replace(/[ \t]{2,}/g, ' ')
       .trim()
-    // #5322 (WP-4.2, security) — this tail rides into `error` events that fan
-    // out to clients and the System tab, so redact any token-shaped run (pasted
-    // or echoed OAuth token / API key) before it leaves the process.
-    return redactSensitive(trimmed)
   }
 
   /**

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -479,6 +479,41 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  // #5322 (WP-4.2, security) — the PTY diagnostic dumps (hex + readable tail)
+  // ride into log lines AND client-facing `error` events. A pasted/echoed OAuth
+  // token or API key in claude's output must not leak through them.
+  describe('credential redaction in PTY diagnostics (#5322 WP-4.2)', () => {
+    function makeSession() {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+      s.on('error', () => {})
+      return s
+    }
+
+    it('_outputTailHexDump redacts a token-shaped run in BOTH the hex and ASCII columns', () => {
+      const s = makeSession()
+      const token = 'sk-ant-api03-' + 'A'.repeat(50)
+      // Include an escape byte to prove control bytes survive the latin1 round-trip.
+      s._outputTailRaw = Buffer.from(`Invalid API key ${token}\x1b[0m done`, 'latin1')
+      const dump = s._outputTailHexDump()
+
+      assert.ok(!dump.includes(token), 'raw token absent from the ASCII column')
+      // The token's leading bytes ("sk-ant" → 73 6b 2d 61 6e 74) must be gone too.
+      const prefixHex = Buffer.from('sk-ant', 'latin1').toString('hex').match(/../g).join(' ')
+      assert.ok(!dump.replace(/\s+/g, ' ').includes(prefixHex), 'token hex bytes absent from the hex column')
+      assert.ok(dump.includes('REDACTED'), 'redaction marker present')
+      assert.ok(dump.includes('1b'), 'escape byte (0x1b) preserved — diagnostic value intact')
+    })
+
+    it('_outputTailDiagnostic redacts a token-shaped run (client-facing error path)', () => {
+      const s = makeSession()
+      const token = 'sk-ant-api03-' + 'B'.repeat(50)
+      s._outputTail = `something went wrong: ${token} — retrying`
+      const diag = s._outputTailDiagnostic()
+      assert.ok(!diag.includes(token), 'token redacted from the readable diagnostic')
+      assert.ok(diag.includes('[REDACTED]'), 'redaction marker present')
+    })
+  })
+
   // #5315 (WP-2.1) — bounded per-session PTY auto-respawn. When the persistent
   // claude PTY dies unexpectedly mid-session, the session must self-heal
   // (bounded backoff, max 5 attempts) instead of becoming a permanently

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -498,10 +498,13 @@ describe('ClaudeTuiSession', () => {
 
       assert.ok(!dump.includes(token), 'raw token absent from the ASCII column')
       // The token's leading bytes ("sk-ant" → 73 6b 2d 61 6e 74) must be gone too.
+      // (Fixture is sized so "sk-ant" lands within one 16-byte hex row.)
       const prefixHex = Buffer.from('sk-ant', 'latin1').toString('hex').match(/../g).join(' ')
       assert.ok(!dump.replace(/\s+/g, ' ').includes(prefixHex), 'token hex bytes absent from the hex column')
       assert.ok(dump.includes('REDACTED'), 'redaction marker present')
-      assert.ok(dump.includes('1b'), 'escape byte (0x1b) preserved — diagnostic value intact')
+      // The full escape RUN `\x1b[0m` (1b 5b 30 6d) survives — proves redaction
+      // scrubbed only the token, not the control bytes the dump exists to show.
+      assert.ok(dump.replace(/\s+/g, ' ').includes('1b 5b 30 6d'), 'escape sequence preserved — diagnostic value intact')
     })
 
     it('_outputTailDiagnostic redacts a token-shaped run (client-facing error path)', () => {
@@ -511,6 +514,20 @@ describe('ClaudeTuiSession', () => {
       const diag = s._outputTailDiagnostic()
       assert.ok(!diag.includes(token), 'token redacted from the readable diagnostic')
       assert.ok(diag.includes('[REDACTED]'), 'redaction marker present')
+    })
+
+    it('_outputTailDiagnostic redacts a token straddling the slice boundary (#5357 review)', () => {
+      const s = makeSession()
+      const token = 'sk-ant-api03-' + 'C'.repeat(50)
+      // Put the token near the END so its PREFIX falls before the last
+      // PTY_TAIL_DIAGNOSTIC_BYTES and only its tail would survive a slice-first
+      // approach. Redact-before-slice must still scrub it entirely.
+      const pad = 'x '.repeat(ClaudeTuiSession.PTY_TAIL_DIAGNOSTIC_BYTES)
+      s._outputTail = `${pad} ${token} tail`
+      const diag = s._outputTailDiagnostic()
+      assert.ok(!diag.includes(token), 'full token redacted despite straddling the slice boundary')
+      // No partial token fragment leaks either (no run of the C-filler survives).
+      assert.ok(!/C{20,}/.test(diag), 'no partial-token fragment leaked')
     })
   })
 


### PR DESCRIPTION
## WP-4.2 — Phase 4 · Auth observability (security)

Closes #5322.

### Audit finding closed
- **MINOR/sec** — the claude PTY diagnostic dumps could print OAuth tokens / API keys.

### The gap
The PTY diagnostic dumps ride into **log lines** AND **client-facing `error` events**. A pasted/echoed token in claude's output leaked because:
- the log-layer redactor (`logger.js`) only catches the readable **ASCII** form — it misses the **hex column** of the hex dump (`73 6b 2d 61 6e 74…` doesn't match the `sk-ant-…` patterns);
- the `error` **event** sent to clients (via `session_event`) bypasses the log redactor entirely.

### What changed
- **`_outputTailHexDump`** — redact token-shaped runs **before** hex-encoding, via a **latin1 (binary) round-trip** that preserves every byte 0–255 losslessly (so 0x1b / OSC / SS3 escape bytes still land in the dump — the diagnostic's whole point) while rewriting only the ASCII token runs. The token is now gone from **both** the hex and ASCII columns.
- **`_outputTailDiagnostic`** — route the readable tail through `redactSensitive` before it leaves the process in an `error` event.

Reuses the shared `redactSensitive()` (Anthropic / OpenAI / Google key shapes + Bearer / keyed-value patterns).

### Acceptance criteria
- [x] A dump containing a token-shaped string is redacted.

### Tests (claude-tui-session, 263 pass)
- `_outputTailHexDump` redacts a `sk-ant-…` token in BOTH the hex and ASCII columns, keeps the `0x1b` escape byte (diagnostic value intact), and shows the redaction marker.
- `_outputTailDiagnostic` redacts a token from the readable (client-facing) diagnostic.

**Depends on:** none.