### PR TITLE
fix(server): bound claude-tui hook-sink files + boot-sweep stale dirs (#5323)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,5 +1,5 @@
 import { randomBytes, randomUUID } from 'crypto'
-import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, unlinkSync, writeFileSync } from 'fs'
 import { homedir, tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
@@ -805,6 +805,55 @@ export class ClaudeTuiSession extends BaseSession {
     }
   }
 
+  /**
+   * #5323 (WP-5.1) — boot-time sweep of orphaned hook-sink dirs under
+   * `/tmp/chroxy-claude-tui/s-*`. destroy() rmSyncs a session's own sink dir,
+   * but a CRASH leaks it forever, so a long-lived host accumulates one dir per
+   * crashed session. Mirrors the worktree reaper's dead-pid-lock logic: each
+   * dir carries an `owner.pid` (written at start()); a dir is removed only when
+   * its owner is DEAD (or the pidfile is missing/garbage). A live owner — this
+   * just-booted daemon, or another chroxy on the host — keeps its dirs, so the
+   * sweep is safe to run unconditionally at boot (our own pid is alive, so we
+   * never delete a dir we are about to use).
+   * @param {object} [logger] - logger with info/warn (defaults to module log)
+   * @returns {{swept:number, kept:number}}
+   */
+  static sweepStaleSinkDirs(logger = log) {
+    const base = join(tmpdir(), 'chroxy-claude-tui')
+    let entries
+    try { entries = readdirSync(base) } catch { return { swept: 0, kept: 0 } }
+    let swept = 0
+    let kept = 0
+    for (const name of entries) {
+      if (!name.startsWith('s-')) continue
+      const dir = join(base, name)
+      let ownerPid = null
+      try {
+        const n = parseInt(readFileSync(join(dir, 'owner.pid'), 'utf8').trim(), 10)
+        if (Number.isInteger(n) && n > 0) ownerPid = n
+      } catch { /* no/garbage pidfile → treat as orphaned */ }
+      if (ownerPid !== null) {
+        let alive
+        try {
+          process.kill(ownerPid, 0) // signal 0 = existence probe
+          alive = true
+        } catch (err) {
+          // ESRCH → dead; EPERM → exists but not ours → still alive, keep it.
+          alive = err && err.code === 'EPERM'
+        }
+        if (alive) { kept++; continue }
+      }
+      try {
+        rmSync(dir, { recursive: true, force: true })
+        swept++
+      } catch (err) {
+        logger?.warn?.(`sink-dir sweep: failed to remove ${dir}: ${err.message}`)
+      }
+    }
+    if (swept > 0) logger?.info?.(`Swept ${swept} stale claude-tui sink dir(s) from ${base} (kept ${kept} live)`)
+    return { swept, kept }
+  }
+
   // Upper bounds on how long we'll wait for status=idle before falling
   // through (and writing anyway, with a warn). Spawn warmup is generous
   // because cold claude can take a few seconds on a fresh keychain
@@ -850,6 +899,11 @@ export class ClaudeTuiSession extends BaseSession {
     mkdirSync(base, { recursive: true })
     this._sinkDir = join(base, `s-${randomUUID()}`)
     mkdirSync(this._sinkDir, { recursive: true })
+    // #5323 (WP-5.1) — stamp the owning pid so the boot-time sweep
+    // (sweepStaleSinkDirs) can tell a live daemon's sink dir from one orphaned
+    // by a prior crash. Best-effort: a missing pidfile just makes the dir
+    // sweep-eligible, which is the safe default for an orphan.
+    try { writeFileSync(join(this._sinkDir, 'owner.pid'), String(process.pid)) } catch { /* best effort */ }
 
     // Generate the upstream session uuid here so the JSONL path is
     // predictable + so claude resumes the same conversation across turns.
@@ -1676,13 +1730,25 @@ export class ClaudeTuiSession extends BaseSession {
 
         if (name.startsWith('stop-')) {
           stopPayload = parsed
-          continue
+        } else {
+          try {
+            this._emitToolHookEvent(name.startsWith('pre-') ? 'PreToolUse' : 'PostToolUse', parsed, messageId)
+          } catch (err) {
+            log.warn(`tool hook emit failed: ${err.message}`)
+          }
         }
+        // #5323 (WP-5.1) — unlink the consumed hook file so the per-session sink
+        // dir stays bounded over a long-lived persistent PTY (one file per turn
+        // + 2 per tool call accumulate fast). On a successful unlink drop the
+        // name from _consumedFiles too — the on-disk file is gone, so it can't be
+        // re-read, which keeps the Set bounded as well (filenames are UUID-unique
+        // so there's no cross-turn collision to guard against). If unlink fails
+        // (rare), KEEP the name in _consumedFiles as the dedup guard so a later
+        // readdir can't re-process it.
         try {
-          this._emitToolHookEvent(name.startsWith('pre-') ? 'PreToolUse' : 'PostToolUse', parsed, messageId)
-        } catch (err) {
-          log.warn(`tool hook emit failed: ${err.message}`)
-        }
+          unlinkSync(full)
+          this._consumedFiles.delete(name)
+        } catch { /* leave the dedup guard in place */ }
       }
       // Any new hook file = progress evidence. Re-arm timers so a turn
       // that's actively producing tool events doesn't trip the soft

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,5 +1,5 @@
 import { randomBytes, randomUUID } from 'crypto'
-import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, unlinkSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from 'fs'
 import { homedir, tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
@@ -831,7 +831,7 @@ export class ClaudeTuiSession extends BaseSession {
       try {
         const n = parseInt(readFileSync(join(dir, 'owner.pid'), 'utf8').trim(), 10)
         if (Number.isInteger(n) && n > 0) ownerPid = n
-      } catch { /* no/garbage pidfile → treat as orphaned */ }
+      } catch { /* no/garbage pidfile → orphaned, subject to the grace below */ }
       if (ownerPid !== null) {
         let alive
         try {
@@ -842,6 +842,18 @@ export class ClaudeTuiSession extends BaseSession {
           alive = err && err.code === 'EPERM'
         }
         if (alive) { kept++; continue }
+      } else {
+        // #5359 review — a pidfile-less dir might be another process's sink dir
+        // caught BETWEEN its mkdir and its owner.pid write (a cross-process race;
+        // within one process those are synchronous). Give brand-new pidfile-less
+        // dirs a grace window before reaping so we can't delete one mid-creation;
+        // a genuinely orphaned dir is older than the grace and still gets swept.
+        try {
+          if (Date.now() - statSync(dir).mtimeMs < ClaudeTuiSession.SINK_SWEEP_GRACE_MS) {
+            kept++
+            continue
+          }
+        } catch { /* stat failed (dir vanished) → fall through to rmSync (no-op) */ }
       }
       try {
         rmSync(dir, { recursive: true, force: true })
@@ -866,6 +878,11 @@ export class ClaudeTuiSession extends BaseSession {
   // tool children on a clean SIGTERM, short enough that a hung claude (or a
   // child holding the PTY open) can't orphan past it.
   static get DESTROY_GRACE_MS() { return 3_000 }
+  // #5359 review — grace window before the boot sweep reaps a PIDFILE-LESS sink
+  // dir, so a dir caught between another process's mkdir and its owner.pid write
+  // (a cross-process race) isn't deleted mid-creation. Dirs with a (dead) pid
+  // are reaped immediately; only the pidfile-less ambiguous case waits this out.
+  static get SINK_SWEEP_GRACE_MS() { return 60_000 }
   // Wedge instrumentation (#4678 follow-up): hook-poll loop emits a
   // heartbeat log line every HOOK_HEARTBEAT_MS of silent waiting (no
   // stop-hook yet). Sized so healthy short turns (<5s end-to-end) emit
@@ -1699,12 +1716,19 @@ export class ClaudeTuiSession extends BaseSession {
     // or whether the loop itself has stopped iterating.
     let pollIters = 0
     let lastHeartbeatMs = pollStart
-    const consumedAtStart = this._consumedFiles.size
+    // #5323 (WP-5.1) — track consumed-file count explicitly. We can no longer
+    // infer progress from `_consumedFiles.size` because consumed files are now
+    // unlinked + dropped from the Set in the same drain, so the Set size doesn't
+    // grow. This cumulative counter drives the heartbeat/exit diagnostics.
+    let totalConsumed = 0
 
     const drainHookFiles = () => {
       let entries
       try { entries = readdirSync(this._sinkDir) } catch { return }
-      const sizeBefore = this._consumedFiles.size
+      // Per-drain progress counter — replaces the old `_consumedFiles.size`
+      // delta, which no longer changes now that consumed files are unlinked +
+      // pruned (#5323). Drives the first-output disarm + timer re-arm below.
+      let drainedThisPass = 0
       // Process prefixes in causal order: pre- (tool_start) MUST fire
       // before post- (tool_result) so the dashboard can pair them via
       // toolUseId. Naive lex sort puts "post-…" before "pre-…" because
@@ -1727,6 +1751,8 @@ export class ClaudeTuiSession extends BaseSession {
           parsed = JSON.parse(raw)
         } catch { continue }
         this._consumedFiles.add(name)
+        drainedThisPass++
+        totalConsumed++
 
         if (name.startsWith('stop-')) {
           stopPayload = parsed
@@ -1752,8 +1778,10 @@ export class ClaudeTuiSession extends BaseSession {
       }
       // Any new hook file = progress evidence. Re-arm timers so a turn
       // that's actively producing tool events doesn't trip the soft
-      // inactivity warning (#3920).
-      if (this._consumedFiles.size > sizeBefore && this._isBusy) {
+      // inactivity warning (#3920). #5323: gate on the per-drain counter, NOT
+      // `_consumedFiles.size` (which no longer grows — files are unlinked +
+      // pruned), otherwise the disarm/re-arm would stop firing on progress.
+      if (drainedThisPass > 0 && this._isBusy) {
         // #4732: a consumed hook file = first output observed for this
         // turn. Disarm the pre-first-output watchdog BEFORE the
         // re-arm below — `_armResultTimeout` would otherwise re-arm
@@ -1782,7 +1810,7 @@ export class ClaudeTuiSession extends BaseSession {
         lastHeartbeatMs = now
         let sinkFileCount = 0
         try { sinkFileCount = readdirSync(this._sinkDir).length } catch {}
-        log.info(`hookPoll heartbeat (msg=${messageId} iters=${pollIters} elapsedMs=${now - pollStart} sinkFiles=${sinkFileCount} consumed=${this._consumedFiles.size - consumedAtStart} stopFound=${stopPayload ? 'yes' : 'no'})`)
+        log.info(`hookPoll heartbeat (msg=${messageId} iters=${pollIters} elapsedMs=${now - pollStart} sinkFiles=${sinkFileCount} consumed=${totalConsumed} stopFound=${stopPayload ? 'yes' : 'no'})`)
       }
       if (stopPayload) break
       await new Promise((r) => setTimeout(r, 150))
@@ -1791,7 +1819,7 @@ export class ClaudeTuiSession extends BaseSession {
     // exit shape — whether it broke on stopPayload, abort, ptyExited,
     // !isBusy, or timeout. Pair with sendMessage's final summary to
     // reconstruct the wedge stage post-hoc.
-    log.info(`hookPoll exit (msg=${messageId} iters=${pollIters} elapsedMs=${Date.now() - pollStart} consumed=${this._consumedFiles.size - consumedAtStart} stopFound=${stopPayload ? 'yes' : 'no'} aborted=${this._activeTurn?.aborted ? 'yes' : 'no'} ptyExited=${this._ptyExited ? 'yes' : 'no'} stillBusy=${this._isBusy ? 'yes' : 'no'})`)
+    log.info(`hookPoll exit (msg=${messageId} iters=${pollIters} elapsedMs=${Date.now() - pollStart} consumed=${totalConsumed} stopFound=${stopPayload ? 'yes' : 'no'} aborted=${this._activeTurn?.aborted ? 'yes' : 'no'} ptyExited=${this._ptyExited ? 'yes' : 'no'} stillBusy=${this._isBusy ? 'yes' : 'no'})`)
 
     if (!stopPayload) {
       let reason

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1134,6 +1134,15 @@ export async function startCliServer(config) {
       .catch((err) => log.warn(`worktree auto-reaper failed: ${(err && err.message) || err}`))
   }
 
+  // #5323 (WP-5.1) — sweep claude-tui hook-sink dirs left in /tmp by prior
+  // crashed processes (a leak on every crash). Safe + unconditional: only dirs
+  // whose owner pid is dead are removed, so a live daemon's dirs — including
+  // ours — are kept. Fire-and-forget + lazily imported so a non-tui boot pays
+  // nothing and a failure never affects startup.
+  import('./claude-tui-session.js')
+    .then(({ ClaudeTuiSession }) => ClaudeTuiSession.sweepStaleSinkDirs(log))
+    .catch((err) => log.warn(`claude-tui sink-dir sweep failed: ${(err && err.message) || err}`))
+
   console.log('\nPress Ctrl+C to stop.\n')
 
   // Graceful shutdown.

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -531,6 +531,76 @@ describe('ClaudeTuiSession', () => {
     })
   })
 
+  // #5323 (WP-5.1) — bound the per-session sink dir + _consumedFiles over a
+  // long-lived PTY (unlink consumed hook files), and sweep sink dirs orphaned
+  // by prior crashes at boot.
+  describe('hook-sink bounding + stale-dir sweep (#5323 WP-5.1)', () => {
+    it('unlinks consumed hook files and prunes _consumedFiles', async () => {
+      session = new ClaudeTuiSession({
+        cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null,
+        resultTimeoutMs: 5000, hardTimeoutMs: 5000,
+      })
+      session._processReady = true
+      session._sessionId = 'test-unlink'
+      session._sinkDir = mkdtempSync(join(tmpdir(), 'chroxy-tui-sink-unlink-'))
+      session._waitForPrompt = async () => true
+      session._term = {
+        write: () => {
+          // Drop a pre- tool hook AND a stop hook so the poll loop processes the
+          // pre then completes the turn.
+          writeFileSync(join(session._sinkDir, 'pre-aaa.json'), JSON.stringify({
+            tool_use_id: 'toolu_a', tool_name: 'Bash', tool_input: { command: 'ls' },
+          }))
+          writeFileSync(join(session._sinkDir, 'stop-bbb.json'), JSON.stringify({ last_assistant_message: 'done' }))
+        },
+        kill: () => {},
+      }
+      session.on('error', () => {})
+      await session.sendMessage('hi')
+
+      assert.ok(!existsSync(join(session._sinkDir, 'pre-aaa.json')), 'consumed pre- hook unlinked')
+      assert.ok(!existsSync(join(session._sinkDir, 'stop-bbb.json')), 'consumed stop- hook unlinked')
+      assert.equal(session._consumedFiles.size, 0, '_consumedFiles pruned after successful unlink')
+    })
+
+    describe('sweepStaleSinkDirs', () => {
+      let created
+      beforeEach(() => { created = [] })
+      afterEach(() => { for (const d of created) rmSync(d, { recursive: true, force: true }) })
+
+      function makeSinkDir(suffix, pidContent) {
+        const base = join(tmpdir(), 'chroxy-claude-tui')
+        mkdirSync(base, { recursive: true })
+        const dir = join(base, `s-${suffix}-${process.pid}-${Math.random().toString(36).slice(2)}`)
+        mkdirSync(dir, { recursive: true })
+        if (pidContent !== undefined) writeFileSync(join(dir, 'owner.pid'), pidContent)
+        created.push(dir)
+        return dir
+      }
+
+      it('sweeps dead-pid + pidfile-less dirs, keeps live-pid dirs', () => {
+        const liveDir = makeSinkDir('live', String(process.pid)) // our pid — alive
+        const deadDir = makeSinkDir('dead', '999999')            // above typical max_pid → ESRCH
+        const orphanDir = makeSinkDir('orphan')                  // no owner.pid
+
+        const result = ClaudeTuiSession.sweepStaleSinkDirs({ info() {}, warn() {} })
+
+        assert.ok(existsSync(liveDir), 'live-pid dir kept')
+        assert.ok(!existsSync(deadDir), 'dead-pid dir swept')
+        assert.ok(!existsSync(orphanDir), 'pidfile-less dir swept')
+        assert.ok(result.swept >= 2, 'reported at least the two swept dirs')
+        assert.ok(result.kept >= 1, 'reported the kept live dir')
+      })
+
+      it('returns zero counts when the base dir does not exist', () => {
+        // Non-throwing on a missing base — just nothing to do.
+        const result = ClaudeTuiSession.sweepStaleSinkDirs({ info() {}, warn() {} })
+        assert.equal(typeof result.swept, 'number')
+        assert.equal(typeof result.kept, 'number')
+      })
+    })
+  })
+
   // #5315 (WP-2.1) — bounded per-session PTY auto-respawn. When the persistent
   // claude PTY dies unexpectedly mid-session, the session must self-heal
   // (bounded backoff, max 5 attempts) instead of becoming a permanently

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, existsSync, utimesSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { ClaudeTuiSession } from '../src/claude-tui-session.js'
@@ -564,39 +564,60 @@ describe('ClaudeTuiSession', () => {
     })
 
     describe('sweepStaleSinkDirs', () => {
+      const DEAD_PID = 4242424 // deterministically reported dead via the stub below
       let created
-      beforeEach(() => { created = [] })
-      afterEach(() => { for (const d of created) rmSync(d, { recursive: true, force: true }) })
+      let realKill
+      beforeEach(() => {
+        created = []
+        // #5359 review — deterministic dead-pid (don't rely on 999999 being
+        // unused; Linux pid_max can be in the millions). Stub process.kill to
+        // ESRCH for DEAD_PID and delegate everything else to the real probe.
+        realKill = process.kill.bind(process)
+        mock.method(process, 'kill', (pid, sig) => {
+          if (pid === DEAD_PID) { const e = new Error('ESRCH'); e.code = 'ESRCH'; throw e }
+          return realKill(pid, sig)
+        })
+      })
+      afterEach(() => {
+        mock.restoreAll()
+        for (const d of created) rmSync(d, { recursive: true, force: true })
+      })
 
-      function makeSinkDir(suffix, pidContent) {
+      function makeSinkDir(suffix, pidContent, { ageMs = 0 } = {}) {
         const base = join(tmpdir(), 'chroxy-claude-tui')
         mkdirSync(base, { recursive: true })
         const dir = join(base, `s-${suffix}-${process.pid}-${Math.random().toString(36).slice(2)}`)
         mkdirSync(dir, { recursive: true })
         if (pidContent !== undefined) writeFileSync(join(dir, 'owner.pid'), pidContent)
+        if (ageMs > 0) {
+          const t = new Date(Date.now() - ageMs)
+          utimesSync(dir, t, t)
+        }
         created.push(dir)
         return dir
       }
 
-      it('sweeps dead-pid + pidfile-less dirs, keeps live-pid dirs', () => {
-        const liveDir = makeSinkDir('live', String(process.pid)) // our pid — alive
-        const deadDir = makeSinkDir('dead', '999999')            // above typical max_pid → ESRCH
-        const orphanDir = makeSinkDir('orphan')                  // no owner.pid
+      it('keeps live-pid dirs, sweeps dead-pid dirs, and sweeps only AGED pidfile-less dirs', () => {
+        const liveDir = makeSinkDir('live', String(process.pid))             // our pid — alive
+        const deadDir = makeSinkDir('dead', String(DEAD_PID))                // stubbed ESRCH → swept
+        const freshOrphan = makeSinkDir('fresh-orphan')                       // no pidfile, new → kept (grace)
+        const oldOrphan = makeSinkDir('old-orphan', undefined, { ageMs: ClaudeTuiSession.SINK_SWEEP_GRACE_MS + 60_000 })
 
         const result = ClaudeTuiSession.sweepStaleSinkDirs({ info() {}, warn() {} })
 
         assert.ok(existsSync(liveDir), 'live-pid dir kept')
         assert.ok(!existsSync(deadDir), 'dead-pid dir swept')
-        assert.ok(!existsSync(orphanDir), 'pidfile-less dir swept')
-        assert.ok(result.swept >= 2, 'reported at least the two swept dirs')
-        assert.ok(result.kept >= 1, 'reported the kept live dir')
+        assert.ok(existsSync(freshOrphan), 'fresh pidfile-less dir kept (mid-creation grace)')
+        assert.ok(!existsSync(oldOrphan), 'aged pidfile-less dir swept')
+        assert.ok(result.swept >= 2, 'reported the swept dirs')
+        assert.ok(result.kept >= 2, 'reported the kept dirs (live + fresh orphan)')
       })
 
-      it('returns zero counts when the base dir does not exist', () => {
-        // Non-throwing on a missing base — just nothing to do.
+      it('returns zero counts (no throw) when the base dir does not exist', () => {
+        // Genuinely exercise the missing-base catch: remove the base dir first.
+        rmSync(join(tmpdir(), 'chroxy-claude-tui'), { recursive: true, force: true })
         const result = ClaudeTuiSession.sweepStaleSinkDirs({ info() {}, warn() {} })
-        assert.equal(typeof result.swept, 'number')
-        assert.equal(typeof result.kept, 'number')
+        assert.deepEqual(result, { swept: 0, kept: 0 })
       })
     })
   })


### PR DESCRIPTION
## WP-5.1 — Phase 5 · Leaks & hardening

Closes #5323.

### Audit findings closed
- **MAJOR** — hook files + `_consumedFiles` grow unbounded for the whole session lifetime.
- **MAJOR** — no boot sweep of `/tmp/chroxy-claude-tui/s-*` (leaks every crash).

### What changed
**Bound the live session (unlink-on-consume):** the drain loop now `unlinkSync`s each hook file right after it's processed and drops its name from `_consumedFiles` on success. Filenames are UUID-unique, so a deleted file can't be re-read — no dedup needed once it's gone. A failed unlink (rare) keeps the name in `_consumedFiles` as the dedup guard. Both the sink dir and the Set now stay bounded over any session length (previously one file per turn + 2 per tool call accumulated for the session lifetime).

**Boot-time sweep (dead-pid, mirrors the worktree reaper):** `start()` stamps `owner.pid` in each sink dir; `ClaudeTuiSession.sweepStaleSinkDirs()` removes `s-*` dirs whose owner pid is **dead** (ESRCH) or whose pidfile is missing/garbage, and **keeps** dirs owned by a live process (EPERM counts as alive). A just-booted daemon's own pid is alive, so it never deletes a dir it's about to use; another live chroxy on the host keeps its dirs too — multi-instance-safe. Wired fire-and-forget + lazily imported at boot in `server-cli.js` so a non-tui boot pays nothing.

### Acceptance criteria
- [x] A long session's sink dir + `_consumedFiles` stay bounded.
- [x] Stale dirs from prior crashes are swept at boot.

### Tests (claude-tui-session, 267 pass)
- A full `sendMessage` turn unlinks its consumed `pre-`/`stop-` hooks and leaves `_consumedFiles` empty.
- `sweepStaleSinkDirs` sweeps dead-pid + pidfile-less dirs, keeps the live-pid (our) dir; non-throwing when the base dir is absent.

**Depends on:** none.