### PR TITLE
fix(server): add error listeners to subprocess stdout/stderr streams (#5324)

### DIFF
--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -404,6 +404,23 @@ export class JsonlSubprocessSession extends BaseSession {
       }
     })
 
+    // #5324 (WP-5.2) — guard the child's stdio streams against an unhandled
+    // 'error' event. A stream-level error (EPIPE on a dying child, a read fault)
+    // emitted on proc.stdout/proc.stderr with NO listener throws and crashes the
+    // WHOLE daemon. readline does not attach an error handler to its input, so
+    // proc.stdout needs its own. Log + swallow — the matching process death
+    // surfaces via 'close' (exit code) or 'error' (spawn failure), which already
+    // tear the turn down; the stream error itself carries no extra recoverable
+    // signal beyond "the pipe broke".
+    proc.stdout.on('error', (err) => {
+      if (this._destroying) return
+      log.warn(`[${Klass.providerName}] stdout stream error: ${err?.message || err}`)
+    })
+    proc.stderr.on('error', (err) => {
+      if (this._destroying) return
+      log.warn(`[${Klass.providerName}] stderr stream error: ${err?.message || err}`)
+    })
+
     proc.on('close', (code) => {
       this._process = null
       this._isBusy = false

--- a/packages/server/tests/jsonl-subprocess-session.test.js
+++ b/packages/server/tests/jsonl-subprocess-session.test.js
@@ -4,6 +4,7 @@ import { writeFileSync, unlinkSync, existsSync, chmodSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { JsonlSubprocessSession } from '../src/jsonl-subprocess-session.js'
+import { addLogListener, removeLogListener } from '../src/logger.js'
 import { waitFor } from './test-helpers.js'
 
 // ---------------------------------------------------------------------------
@@ -397,6 +398,61 @@ describe('JsonlSubprocessSession (base)', () => {
       await waitFor(() => starts.length >= 1, { label: 'stream_start' })
 
       assert.match(starts[0].messageId, /^quux-msg-/)
+    })
+
+    it('attaches a user error listener to stdout AND stderr (so a stream error is handled, not uncaught) (#5324)', async () => {
+      // A shim that stays alive long enough for us to inspect its stdio streams.
+      writeFileSync(shimPath, '#!/usr/bin/env node\nsetTimeout(() => process.exit(0), 3000)\n')
+      chmodSync(shimPath, 0o755)
+
+      const P = makeTestProviderClass({ providerName: 'fake' })
+      const s = new P({ cwd: '/tmp' })
+      s._processReady = true
+      s.on('error', () => {})
+      s.sendMessage('hi') // not awaited — spawns then polls for the (sleeping) child
+      await waitFor(() => s._process != null, { label: '_process spawned' })
+
+      // A user 'error' listener on each pipe is what keeps a real stream error
+      // (EPIPE on a dying child, a read fault) from reaching the process as an
+      // unhandled 'error' and crashing the whole daemon. (We assert the listener
+      // is wired rather than synthetically emitting: node attaches its own
+      // internal stream-error handler that re-throws a *manually* emitted error
+      // regardless, so a manual emit can't faithfully model a real I/O error.)
+      assert.ok(s._process.stdout.listenerCount('error') >= 1, 'stdout has a user error listener')
+      assert.ok(s._process.stderr.listenerCount('error') >= 1, 'stderr has a user error listener')
+
+      await s.destroy()
+    })
+
+    it('logs (does not crash on) a stderr stream error via the wired listener (#5324)', async () => {
+      // Verify the listener BODY: invoke it directly with a fake error and
+      // assert it logs rather than throwing. This exercises the handler without
+      // fighting node's internal manual-emit re-throw on a real pipe.
+      const warns = []
+      const logSpy = (e) => {
+        if (e.component === 'jsonl-subprocess-session' && e.level === 'warn') warns.push(e.message)
+      }
+      addLogListener(logSpy)
+      try {
+        writeFileSync(shimPath, '#!/usr/bin/env node\nsetTimeout(() => process.exit(0), 3000)\n')
+        chmodSync(shimPath, 0o755)
+        const P = makeTestProviderClass({ providerName: 'fake' })
+        const s = new P({ cwd: '/tmp' })
+        s._processReady = true
+        s.on('error', () => {})
+        s.sendMessage('hi')
+        await waitFor(() => s._process != null, { label: '_process spawned' })
+
+        // Pull the user listener (the last one registered — ours) and call it.
+        const listeners = s._process.stderr.listeners('error')
+        const mine = listeners[listeners.length - 1]
+        assert.doesNotThrow(() => mine(new Error('boom-err')), 'listener swallows the error')
+        assert.ok(warns.some((m) => /stderr stream error.*boom-err/.test(m)), 'stderr error logged')
+
+        await s.destroy()
+      } finally {
+        removeLogListener(logSpy)
+      }
     })
 
     it('non-zero exit emits an error that includes displayLabel and exit code', async () => {


### PR DESCRIPTION
## WP-5.2 — Phase 5 · Leaks & hardening

Closes #5324.

### Audit finding closed
- **MINOR** — `jsonl-subprocess-session.js` (Codex/Gemini path): no stream-level error listeners on `proc.stdout` / `proc.stderr`.

### The gap
The spawn pipeline wired `proc.on('error')` (child-process error) and `rl.on('line')` (stdout via readline), but neither `proc.stdout` nor `proc.stderr` had its own `'error'` listener. A **stream-level** error (EPIPE on a dying child, a read fault) emitted on a Readable with no `'error'` listener throws as an unhandled `'error'` → crashes the whole daemon. readline does not attach an error handler to its input, so `proc.stdout` was unguarded.

### What changed
Added `'error'` listeners to both pipes that log + swallow. The matching process death already surfaces via `'close'` (exit code) or `'error'` (spawn failure), which tear the turn down — the stream error itself carries no extra recoverable signal beyond "the pipe broke."

### Acceptance criteria
- [x] A stdout/stderr stream error is handled, not uncaught.

### Tests (jsonl-subprocess-session, 42 pass; codex/gemini suites green)
- After spawn, both `proc.stdout` and `proc.stderr` carry a user `'error'` listener.
- Invoking the wired stderr listener with a fake error logs (does not throw).

(Note: the test asserts the listener is wired + exercises the handler body directly rather than synthetically `emit('error')` on a real pipe — node attaches its own internal stream-error handler that re-throws a *manually* emitted error regardless, so a manual emit can't faithfully model a real I/O error.)

**Depends on:** none.