### PR TITLE
fix(server): strip ANSI from concatenated PTY tail, not per-chunk (WP-5.3)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1338,31 +1338,7 @@ export class ClaudeTuiSession extends BaseSession {
     this._outputTail = ''
     this._outputTailRaw = Buffer.alloc(0)
 
-    this._term.onData((data) => {
-      // Keep a tail of recent output so we can surface diagnostics when
-      // the TUI renders an error inline (#3919). Strip ANSI escape
-      // sequences before storing so the saved tail is readable; we
-      // don't visual-render the PTY, so the colors aren't useful. Strip
-      // pattern covers CSI / OSC / SS3 / single-char terminal-mode codes
-      // (#4031 — broadened to keep the readable tail clean for error
-      // diagnostics and the hex dump).
-      const rawStr = String(data)
-      const stripped = rawStr.replace(ANSI_STRIP, '')
-      this._outputTail = (this._outputTail + stripped).slice(-ClaudeTuiSession.PTY_TAIL_BYTES)
-      // #4031 (review): also retain a parallel UNSTRIPPED tail sized
-      // in real bytes via Buffer, exclusively for the timeout hex
-      // dump. _outputTail can never surface the escape/control bytes
-      // we want to diagnose because the strip happens before storage;
-      // _outputTailRaw closes that gap without polluting the readable
-      // tail used by other diagnostics.
-      const chunk = Buffer.from(rawStr, 'utf8')
-      const merged = this._outputTailRaw.length === 0
-        ? chunk
-        : Buffer.concat([this._outputTailRaw, chunk])
-      this._outputTailRaw = merged.length > ClaudeTuiSession.PTY_TAIL_BYTES
-        ? merged.subarray(-ClaudeTuiSession.PTY_TAIL_BYTES)
-        : merged
-    })
+    this._term.onData((data) => this._appendToOutputTail(data))
     this._term.onExit((info) => this._onPtyGone(info, 'exit'))
 
     // #5311 (WP-1.1) — keep a per-session PTY fault from crashing the WHOLE
@@ -1499,6 +1475,39 @@ export class ClaudeTuiSession extends BaseSession {
     const ready = checkReady()
     this._lastProbeSawStatus = sawStatus
     return finish(ready)
+  }
+
+  /**
+   * Append a PTY onData chunk to the recent-output tails (#3919).
+   *
+   * Maintains two tails:
+   *   - `_outputTailRaw` — an UNSTRIPPED byte Buffer for the timeout hex
+   *     dump (#4031), and the canonical source the readable tail is
+   *     derived from.
+   *   - `_outputTail` — an ANSI-stripped, human-readable string for inline
+   *     error diagnostics and the auth-failure scan.
+   *
+   * #5325 (WP-5.3): the readable tail is derived by stripping ANSI from
+   * the CONCATENATED raw buffer, NOT per-chunk. An escape sequence split
+   * across two onData chunks (e.g. "\x1b[" arriving in one chunk, "0m" in
+   * the next) survives a per-chunk strip and corrupts the tail; deriving
+   * from the merged buffer strips the sequence once it's whole. We don't
+   * visual-render the PTY, so the colors aren't useful. Strip pattern
+   * covers CSI / OSC / SS3 / single-char terminal-mode codes (#4031).
+   */
+  _appendToOutputTail(data) {
+    const rawStr = String(data)
+    const chunk = Buffer.from(rawStr, 'utf8')
+    const merged = this._outputTailRaw.length === 0
+      ? chunk
+      : Buffer.concat([this._outputTailRaw, chunk])
+    this._outputTailRaw = merged.length > ClaudeTuiSession.PTY_TAIL_BYTES
+      ? merged.subarray(-ClaudeTuiSession.PTY_TAIL_BYTES)
+      : merged
+    this._outputTail = this._outputTailRaw
+      .toString('utf8')
+      .replace(ANSI_STRIP, '')
+      .slice(-ClaudeTuiSession.PTY_TAIL_BYTES)
   }
 
   /**

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1259,6 +1259,57 @@ describe('ClaudeTuiSession', () => {
       })
     })
 
+    describe('output tail ANSI stripping (#5325, WP-5.3)', () => {
+      // _appendToOutputTail is the body of the PTY onData handler. It must
+      // strip ANSI from the CONCATENATED tail, not per-chunk, so an escape
+      // sequence split across two onData chunks is still removed.
+
+      it('strips an ANSI escape split across two onData chunks', () => {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        // CSI "\x1b[31m" arrives split: "\x1b[3" then "1mred". A per-chunk
+        // strip would leave the orphaned "\x1b[3" fragment in the tail.
+        session._appendToOutputTail('hello \x1b[3')
+        session._appendToOutputTail('1mred\x1b[0m done')
+        assert.equal(
+          session._outputTail,
+          'hello red done',
+          `split escape must be stripped once whole, got: ${JSON.stringify(session._outputTail)}`,
+        )
+      })
+
+      it('strips an OSC sequence split across chunk boundaries', () => {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        // OSC "\x1b]0;claude\x07" split mid-payload and again before the BEL.
+        session._appendToOutputTail('\x1b]0;cla')
+        session._appendToOutputTail('ude')
+        session._appendToOutputTail('\x07❯ ')
+        assert.equal(
+          session._outputTail,
+          '❯ ',
+          `split OSC must be stripped once whole, got: ${JSON.stringify(session._outputTail)}`,
+        )
+      })
+
+      it('retains the UNSTRIPPED bytes in _outputTailRaw for the hex dump', () => {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._appendToOutputTail('a\x1b[3')
+        session._appendToOutputTail('1mb')
+        // Readable tail is clean...
+        assert.equal(session._outputTail, 'ab')
+        // ...but the raw buffer still carries the escape bytes for diagnostics.
+        assert.ok(
+          session._outputTailRaw.includes(0x1b),
+          'raw tail must retain the ESC byte',
+        )
+      })
+
+      it('strips a single-chunk escape (no regression)', () => {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._appendToOutputTail('x\x1b[0my')
+        assert.equal(session._outputTail, 'xy')
+      })
+    })
+
     it('sendMessage waits for status=idle before writing to the PTY', async () => {
       // The whole point of the probe — bytes must not hit the PTY until
       // claude reports itself ready. We delay the idle transition and


### PR DESCRIPTION
## Summary

Closes WP-5.3 of the claude-tui hardening epic (#5338). Closes #5325.

`claude-tui-session.js` stripped ANSI escapes **per onData chunk** before appending to the readable `_outputTail`. An escape sequence split across two PTY chunks (e.g. `\x1b[3` arriving in one chunk, `1mred` in the next) survived the per-chunk strip, leaving an orphaned fragment that corrupted the diagnostic tail and the auth-failure scan.

## Fix

- Extract the onData tail logic into `_appendToOutputTail()`.
- Derive `_outputTail` by stripping ANSI from the **concatenated** `_outputTailRaw` buffer, so a split escape is removed once it arrives whole.
- The raw byte buffer still retains the unstripped bytes for the hex dump (#4031).

## Tests

- Split CSI escape across two chunks → stripped clean.
- Split OSC sequence across three chunks → stripped clean.
- Raw buffer retains the ESC byte for the hex dump.
- Single-chunk escape (no regression).

271 claude-tui-session tests pass; lints clean.

## Acceptance criteria
- [x] An ANSI sequence split across two onData chunks is stripped correctly.