### PR TITLE
feat(server): periodic worktree auto-reaper, not just at boot (WP-5.4)

### DIFF
--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -649,16 +649,27 @@ export function validateConfig(config, verbose = false) {
     }
   }
 
-  // #5158: worktree GC block. Only the shape (object, not array) and the
-  // `autoReap` boolean are checked; an unset block means "auto-reaper off".
+  // #5158: worktree GC block. Only the shape (object, not array), the
+  // `autoReap` boolean, and the `reapIntervalMs` positive number (#5326) are
+  // checked; an unset block means "auto-reaper off".
   if (config.worktreeGc !== undefined) {
     if (typeof config.worktreeGc !== 'object' || config.worktreeGc === null || Array.isArray(config.worktreeGc)) {
       warnings.push(`Invalid type for 'worktreeGc': expected object, got ${Array.isArray(config.worktreeGc) ? 'array' : typeof config.worktreeGc}`)
-    } else if (
-      Object.prototype.hasOwnProperty.call(config.worktreeGc, 'autoReap') &&
-      typeof config.worktreeGc.autoReap !== 'boolean'
-    ) {
-      warnings.push(`Invalid type for 'worktreeGc.autoReap': expected boolean, got ${typeof config.worktreeGc.autoReap}`)
+    } else {
+      if (
+        Object.prototype.hasOwnProperty.call(config.worktreeGc, 'autoReap') &&
+        typeof config.worktreeGc.autoReap !== 'boolean'
+      ) {
+        warnings.push(`Invalid type for 'worktreeGc.autoReap': expected boolean, got ${typeof config.worktreeGc.autoReap}`)
+      }
+      // #5326 (WP-5.4): periodic-reaper interval. Optional; when omitted the
+      // reaper uses its built-in default. Must be a positive finite number.
+      if (Object.prototype.hasOwnProperty.call(config.worktreeGc, 'reapIntervalMs')) {
+        const v = config.worktreeGc.reapIntervalMs
+        if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) {
+          warnings.push(`Invalid value for 'worktreeGc.reapIntervalMs': expected a positive number, got ${typeof v === 'number' ? v : typeof v}`)
+        }
+      }
     }
   }
 

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1131,6 +1131,9 @@ export async function startCliServer(config) {
   //
   // #5326 (WP-5.4): sweep once at boot AND on a recurring unref'd interval, so
   // a long-running daemon reclaims worktrees created mid-run without a restart.
+  // The timer handle is assigned inside the async import .then(); if shutdown
+  // races ahead of the import resolving, the clearInterval below is skipped —
+  // tolerated because the interval is unref'd and process.exit reaps it anyway.
   let worktreeReapTimer = null
   if (config.worktreeGc?.autoReap === true) {
     import('./worktree-reaper.js')

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -1124,13 +1124,17 @@ export async function startCliServer(config) {
   }
 
   // #5158: opt-in worktree auto-reaper. When enabled, reclaim orphaned
-  // dead-pid-locked agent worktrees (clean trees only, never --force) once
-  // now that the server is up. Fire-and-forget + lazily imported so a default
-  // (disabled) boot pays nothing and a failure here never affects startup; the
-  // reaper itself yields between repos so the sweep doesn't starve the loop.
+  // dead-pid-locked agent worktrees (clean trees only, never --force). Lazily
+  // imported so a default (disabled) boot pays nothing and a failure here never
+  // affects startup; the reaper itself yields between repos so the sweep
+  // doesn't starve the loop.
+  //
+  // #5326 (WP-5.4): sweep once at boot AND on a recurring unref'd interval, so
+  // a long-running daemon reclaims worktrees created mid-run without a restart.
+  let worktreeReapTimer = null
   if (config.worktreeGc?.autoReap === true) {
     import('./worktree-reaper.js')
-      .then(({ maybeAutoReapWorktrees }) => maybeAutoReapWorktrees(config, log))
+      .then(({ startPeriodicAutoReap }) => { worktreeReapTimer = startPeriodicAutoReap(config, log) })
       .catch((err) => log.warn(`worktree auto-reaper failed: ${(err && err.message) || err}`))
   }
 
@@ -1168,6 +1172,9 @@ export async function startCliServer(config) {
     }
     if (tokenManager) tokenManager.destroy()
     if (pairingManager) pairingManager.destroy()
+    // #5326 (WP-5.4): stop the periodic worktree reaper. It's unref'd so it
+    // wouldn't block exit, but clearing it avoids a sweep racing shutdown.
+    if (worktreeReapTimer) clearInterval(worktreeReapTimer)
     // Persist sessions before destroying (enables restore on restart)
     try { sessionManager.serializeState() } catch (err) {
       log.error(`Failed to serialize session state: ${err?.message || err}`)

--- a/packages/server/src/worktree-reaper.js
+++ b/packages/server/src/worktree-reaper.js
@@ -17,6 +17,12 @@
 import { resolveRepoSet } from './control-room/repo-set.js'
 import { planRepoGc, applyPlan } from './worktree-gc.js'
 
+// #5326 (WP-5.4): how often the periodic auto-reaper re-sweeps after the
+// boot sweep. 30 min is a balance — short enough that a long-running daemon
+// reclaims mid-run agent worktrees without a restart, long enough that the
+// (synchronous-per-repo) git scans don't add meaningful steady-state load.
+const DEFAULT_REAP_INTERVAL_MS = 30 * 60 * 1000
+
 /**
  * Reap one repo into the running summary. Sync (the GC core uses execFileSync).
  */
@@ -100,4 +106,44 @@ export async function maybeAutoReapWorktrees(config, log, deps = {}) {
     log.info('worktree auto-reap: nothing to reclaim')
   }
   return summary
+}
+
+/**
+ * #5326 (WP-5.4): start the worktree auto-reaper for the lifetime of the
+ * daemon. Runs once immediately (the original boot sweep) and then on a
+ * recurring interval so a long-running server reclaims agent worktrees
+ * created MID-RUN — previously the sweep ran once at boot only, so a worktree
+ * orphaned an hour into a session was never reclaimed without a restart.
+ *
+ * No-op (returns null) unless `config.worktreeGc.autoReap === true`. Each sweep
+ * is fire-and-forget: a failure is logged and never propagates (so a transient
+ * git error can't tear down the interval or the daemon). The interval is
+ * `unref()`'d so it never keeps the process alive on its own.
+ *
+ * @param {object} config - merged server config
+ * @param {{ info: Function, warn: Function }} log - server logger
+ * @param {object} [deps] - test seams: run, setIntervalFn, plus maybeAutoReapWorktrees deps
+ * @returns {ReturnType<typeof setInterval>|null} the interval handle (for clearInterval on shutdown), or null when disabled
+ */
+export function startPeriodicAutoReap(config, log, deps = {}) {
+  if (!config || !config.worktreeGc || config.worktreeGc.autoReap !== true) return null
+
+  const run = deps.run || maybeAutoReapWorktrees
+  const sweep = () => {
+    Promise.resolve()
+      .then(() => run(config, log, deps))
+      .catch((err) => log.warn(`worktree auto-reaper failed: ${(err && err.message) || err}`))
+  }
+
+  // Boot sweep — same behavior as before this WP.
+  sweep()
+
+  const configured = config.worktreeGc.reapIntervalMs
+  const intervalMs = Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_REAP_INTERVAL_MS
+  const setIntervalFn = deps.setIntervalFn || setInterval
+  const timer = setIntervalFn(sweep, intervalMs)
+  if (timer && typeof timer.unref === 'function') timer.unref()
+  return timer
 }

--- a/packages/server/src/worktree-reaper.js
+++ b/packages/server/src/worktree-reaper.js
@@ -129,10 +129,22 @@ export function startPeriodicAutoReap(config, log, deps = {}) {
   if (!config || !config.worktreeGc || config.worktreeGc.autoReap !== true) return null
 
   const run = deps.run || maybeAutoReapWorktrees
+  // Reentrancy guard: if a sweep runs longer than the interval (e.g. a tiny
+  // reapIntervalMs over a huge repo set), skip the tick rather than letting two
+  // sweeps run concurrently. Each sweep already builds its own summary and the
+  // GC core re-plans live, so an overlap wouldn't corrupt state — but skipping
+  // is cheaper and clearer than racing two scans (#5363 review).
+  let sweeping = false
   const sweep = () => {
+    if (sweeping) {
+      log.info('worktree auto-reaper: previous sweep still running, skipping this tick')
+      return
+    }
+    sweeping = true
     Promise.resolve()
       .then(() => run(config, log, deps))
       .catch((err) => log.warn(`worktree auto-reaper failed: ${(err && err.message) || err}`))
+      .finally(() => { sweeping = false })
   }
 
   // Boot sweep — same behavior as before this WP.

--- a/packages/server/tests/config.test.js
+++ b/packages/server/tests/config.test.js
@@ -76,6 +76,27 @@ describe('validateConfig', () => {
     assert.ok(result.warnings.some(w => w.includes('provider') && w.includes('string')))
   })
 
+  it('accepts worktreeGc with autoReap + valid reapIntervalMs (#5326)', () => {
+    const result = validateConfig({ worktreeGc: { autoReap: true, reapIntervalMs: 60000 } })
+    assert.equal(result.valid, true)
+    assert.equal(result.warnings.length, 0)
+  })
+
+  it('accepts worktreeGc.autoReap with no reapIntervalMs (#5326)', () => {
+    const result = validateConfig({ worktreeGc: { autoReap: true } })
+    assert.equal(result.warnings.length, 0)
+  })
+
+  it('warns when worktreeGc.reapIntervalMs is not a positive number (#5326)', () => {
+    for (const bad of [0, -1, 'fast', null]) {
+      const result = validateConfig({ worktreeGc: { autoReap: true, reapIntervalMs: bad } })
+      assert.ok(
+        result.warnings.some(w => w.includes('reapIntervalMs') && w.includes('positive')),
+        `expected a reapIntervalMs warning for ${JSON.stringify(bad)}, got: ${JSON.stringify(result.warnings)}`,
+      )
+    }
+  })
+
   it('accepts valid provider names', () => {
     const config = { provider: 'claude-sdk' }
     const result = validateConfig(config)

--- a/packages/server/tests/worktree-reaper.test.js
+++ b/packages/server/tests/worktree-reaper.test.js
@@ -13,7 +13,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { execFileSync } from 'child_process'
 import { GIT } from '../src/git.js'
-import { reapWorktrees, maybeAutoReapWorktrees } from '../src/worktree-reaper.js'
+import { reapWorktrees, maybeAutoReapWorktrees, startPeriodicAutoReap } from '../src/worktree-reaper.js'
 
 const LIVE_PID = 4100002
 const DEAD_PID = 4100001
@@ -125,5 +125,109 @@ describe('worktree-reaper', () => {
     assert.equal(log._info.length, 0)
     assert.ok(log._warn.some((m) => /error\(s\)/.test(m)), `warn logs: ${JSON.stringify(log._warn)}`)
     assert.ok(log._warn.some((m) => /does-not-exist/.test(m)), `warn logs: ${JSON.stringify(log._warn)}`)
+  })
+
+  describe('startPeriodicAutoReap (#5326, WP-5.4)', () => {
+    // Capture-the-callback seams so we never schedule a real timer.
+    const makeIntervalSeam = () => {
+      const calls = []
+      const setIntervalFn = (fn, ms) => {
+        const handle = { _id: calls.length + 1, unref: () => { handle.unrefed = true } }
+        calls.push({ fn, ms, handle })
+        return handle
+      }
+      return { calls, setIntervalFn }
+    }
+    const flush = () => new Promise((r) => setTimeout(r, 10))
+
+    it('is a no-op (null, no timer) when autoReap is unset/false', () => {
+      const log = makeLogger()
+      const { calls, setIntervalFn } = makeIntervalSeam()
+      const run = () => { throw new Error('run must not be called when disabled') }
+      assert.equal(startPeriodicAutoReap(undefined, log, { run, setIntervalFn }), null)
+      assert.equal(startPeriodicAutoReap({}, log, { run, setIntervalFn }), null)
+      assert.equal(startPeriodicAutoReap({ worktreeGc: {} }, log, { run, setIntervalFn }), null)
+      assert.equal(startPeriodicAutoReap({ worktreeGc: { autoReap: false } }, log, { run, setIntervalFn }), null)
+      assert.equal(calls.length, 0)
+    })
+
+    it('runs the boot sweep once immediately and arms a recurring interval', async () => {
+      const log = makeLogger()
+      const { calls, setIntervalFn } = makeIntervalSeam()
+      let runCount = 0
+      const run = async () => { runCount++ }
+      const timer = startPeriodicAutoReap({ worktreeGc: { autoReap: true } }, log, { run, setIntervalFn })
+      // Let the boot sweep's microtask settle.
+      await flush()
+      assert.equal(runCount, 1, 'boot sweep should run once immediately')
+      assert.equal(calls.length, 1, 'exactly one interval armed')
+      assert.equal(timer._id, 1)
+      assert.equal(timer.unrefed, true, 'interval must be unref\'d so it never holds the process open')
+    })
+
+    it('interval callback invokes the reaper on each tick', async () => {
+      const log = makeLogger()
+      const { calls, setIntervalFn } = makeIntervalSeam()
+      let runCount = 0
+      const run = async () => { runCount++ }
+      startPeriodicAutoReap({ worktreeGc: { autoReap: true } }, log, { run, setIntervalFn })
+      await flush()
+      assert.equal(runCount, 1) // boot sweep
+      // Fire the captured interval callback twice — simulates mid-run ticks.
+      calls[0].fn()
+      calls[0].fn()
+      await flush()
+      assert.equal(runCount, 3, 'each interval tick re-runs the reaper')
+    })
+
+    it('uses the configured reapIntervalMs when valid', () => {
+      const log = makeLogger()
+      const { calls, setIntervalFn } = makeIntervalSeam()
+      startPeriodicAutoReap(
+        { worktreeGc: { autoReap: true, reapIntervalMs: 1234 } },
+        log,
+        { run: async () => {}, setIntervalFn },
+      )
+      assert.equal(calls[0].ms, 1234)
+    })
+
+    it('falls back to the default interval when reapIntervalMs is absent or invalid', () => {
+      const log = makeLogger()
+      const seamA = makeIntervalSeam()
+      const seamB = makeIntervalSeam()
+      startPeriodicAutoReap({ worktreeGc: { autoReap: true } }, log, { run: async () => {}, setIntervalFn: seamA.setIntervalFn })
+      startPeriodicAutoReap({ worktreeGc: { autoReap: true, reapIntervalMs: -5 } }, log, { run: async () => {}, setIntervalFn: seamB.setIntervalFn })
+      const DEFAULT = 30 * 60 * 1000
+      assert.equal(seamA.calls[0].ms, DEFAULT, 'absent → default')
+      assert.equal(seamB.calls[0].ms, DEFAULT, 'invalid → default')
+    })
+
+    it('a sweep rejection is logged and never tears down the interval', async () => {
+      const log = makeLogger()
+      const { calls, setIntervalFn } = makeIntervalSeam()
+      const run = async () => { throw new Error('git boom') }
+      startPeriodicAutoReap({ worktreeGc: { autoReap: true } }, log, { run, setIntervalFn })
+      // Let the boot sweep's rejection settle.
+      await flush()
+      assert.ok(log._warn.some((m) => /git boom/.test(m)), `warn logs: ${JSON.stringify(log._warn)}`)
+      // Interval is still armed despite the failed boot sweep.
+      assert.equal(calls.length, 1)
+    })
+
+    it('drives a real reap through the interval callback (end-to-end)', async () => {
+      const log = makeLogger()
+      const { calls, setIntervalFn } = makeIntervalSeam()
+      // Real maybeAutoReapWorktrees via deps.run default; pass its seams through.
+      startPeriodicAutoReap(
+        { worktreeGc: { autoReap: true }, repos: [{ name: 'proj', path: repo }] },
+        log,
+        { planDeps, yieldFn, repoSetSeams: { _readdir: () => [] }, setIntervalFn },
+      )
+      // Boot sweep already reclaimed clean-dead; remove was synchronous-ish, await.
+      await new Promise((r) => setTimeout(r, 50))
+      assert.equal(existsSync(cleanDead), false, 'boot sweep reclaimed the clean-dead worktree')
+      assert.equal(existsSync(dirtyDead), true)
+      assert.equal(calls.length, 1, 'interval armed for subsequent sweeps')
+    })
   })
 })

--- a/packages/server/tests/worktree-reaper.test.js
+++ b/packages/server/tests/worktree-reaper.test.js
@@ -174,10 +174,35 @@ describe('worktree-reaper', () => {
       await flush()
       assert.equal(runCount, 1) // boot sweep
       // Fire the captured interval callback twice — simulates mid-run ticks.
+      // Flush between ticks so each sweep settles (the reentrancy guard would
+      // otherwise skip a tick fired before the prior sweep resolves).
       calls[0].fn()
+      await flush()
       calls[0].fn()
       await flush()
       assert.equal(runCount, 3, 'each interval tick re-runs the reaper')
+    })
+
+    it('skips a tick when the previous sweep is still running (reentrancy guard)', async () => {
+      const log = makeLogger()
+      const { calls, setIntervalFn } = makeIntervalSeam()
+      let resolveRun
+      let runStarts = 0
+      const run = () => { runStarts++; return new Promise((r) => { resolveRun = r }) }
+      startPeriodicAutoReap({ worktreeGc: { autoReap: true } }, log, { run, setIntervalFn })
+      await flush()
+      assert.equal(runStarts, 1, 'boot sweep started and is still in flight')
+      // Tick while the boot sweep is unresolved — must be skipped, not started.
+      calls[0].fn()
+      await flush()
+      assert.equal(runStarts, 1, 'overlapping tick was skipped')
+      assert.ok(log._info.some((m) => /skipping this tick/.test(m)), `info logs: ${JSON.stringify(log._info)}`)
+      // Resolve the in-flight sweep; the next tick may now run.
+      resolveRun()
+      await flush()
+      calls[0].fn()
+      await flush()
+      assert.equal(runStarts, 2, 'a tick after the sweep settles runs normally')
     })
 
     it('uses the configured reapIntervalMs when valid', () => {


### PR DESCRIPTION
## Summary

Closes WP-5.4 of the claude-tui hardening epic (#5338). Closes #5326.

The opt-in worktree auto-reaper (`config.worktreeGc.autoReap`) ran a **single sweep at startup**, so a worktree orphaned mid-run — an agent worktree dead-pid-locked an hour into a long-running daemon — was never reclaimed without a restart.

## Fix

- Add `startPeriodicAutoReap()`: runs the boot sweep immediately, then re-sweeps on a recurring **unref'd** `setInterval` (default 30 min). Each sweep is fire-and-forget so a transient git error can't tear down the interval or the daemon.
- Add `config.worktreeGc.reapIntervalMs` (optional, positive number) to tune the cadence; validated in `config.js`.
- `server-cli.js` wires `startPeriodicAutoReap` in place of the one-shot call and clears the interval on shutdown.

The reaper's safety contract is unchanged (only clean, dead-pid-locked worktrees; never `--force`; never the main worktree).

## Tests

- Interval invokes the reaper each tick; handle is `unref()`'d.
- Configured `reapIntervalMs` honored; absent/invalid → default.
- A sweep rejection is logged and never tears down the interval.
- End-to-end: boot sweep reclaims a real clean-dead worktree, interval armed.
- Config validation for `reapIntervalMs` (positive-number guard).

97 reaper+config tests pass; lints clean.

## Acceptance criteria
- [x] Worktrees created during a long run get reaped without a restart.