### PR TITLE
fix(server): WebTaskManager poll completes healthy tasks, unref timer (WP-5.5)

### DIFF
--- a/packages/server/src/web-task-manager.js
+++ b/packages/server/src/web-task-manager.js
@@ -56,10 +56,13 @@ export class WebTaskManager extends EventEmitter {
   /**
    * Detect available CLI features by parsing `claude --help`.
    * Safe to call multiple times (e.g. after CLI upgrade).
+   *
+   * @param {object} [deps] - test seam: { exec } promisified execFile stand-in
    */
-  async detectFeatures() {
+  async detectFeatures(deps = {}) {
+    const exec = deps.exec || execFileAsync
     try {
-      const stdout = await execFileAsync('claude', ['--help'])
+      const stdout = await exec('claude', ['--help'])
       this._remoteAvailable = stdout.includes('--remote')
       this._teleportAvailable = stdout.includes('--teleport')
     } catch {
@@ -224,8 +227,15 @@ export class WebTaskManager extends EventEmitter {
 
     this._pollCount = 0
     this._pollTimer = setInterval(() => {
-      this._pollTaskStatus()
+      // _pollTaskStatus is async; swallow rejections so a status-check fault
+      // can't surface as an unhandledRejection and crash the daemon (#5327).
+      Promise.resolve(this._pollTaskStatus()).catch(() => {})
     }, POLL_INTERVAL_MS)
+    // Don't keep the event loop (and the whole daemon) alive solely to poll a
+    // handful of cloud tasks (#5327). Guarded for non-Node timer stand-ins.
+    if (this._pollTimer && typeof this._pollTimer.unref === 'function') {
+      this._pollTimer.unref()
+    }
   }
 
   /**
@@ -252,7 +262,11 @@ export class WebTaskManager extends EventEmitter {
       return
     }
 
-    // Fail running tasks after max polls to prevent indefinite timers
+    // Genuine timeout backstop: a task STILL running after MAX_POLL_COUNT polls
+    // (10 min) is force-failed so a stuck cloud task can't poll forever. This
+    // used to be the ONLY exit — every healthy task was force-failed here
+    // because nothing implemented the running→completed transition (#5327).
+    // Checked before any await so the synchronous timeout path stays sync.
     if (this._pollCount >= MAX_POLL_COUNT) {
       for (const task of running) {
         task.status = 'failed'
@@ -265,8 +279,56 @@ export class WebTaskManager extends EventEmitter {
       return
     }
 
-    // When CLI support arrives, this will call `claude /tasks` or similar
-    // For now, this is a placeholder that will be implemented when the CLI ships
+    // Check each running task's remote status and transition it to a terminal
+    // state when the cloud reports done/failed (#5327). _checkRemoteStatus is a
+    // seam — a real CLI status command (or a test) drives the transition; the
+    // default reports 'running' (unknown) until that command ships.
+    for (const task of running) {
+      let result
+      try {
+        result = await this._checkRemoteStatus(task)
+      } catch {
+        // A transient status-check failure must not fail the task — let the
+        // timeout backstop catch a genuinely stuck one. Skip this pass.
+        continue
+      }
+      const next = result && result.status
+      if (next === 'completed') {
+        task.status = 'completed'
+        task.result = result.result ?? null
+        task.error = null
+        task.updatedAt = Date.now()
+        this.emit('task_updated', { ...task })
+      } else if (next === 'failed') {
+        task.status = 'failed'
+        task.error = result.error || 'Task failed'
+        task.updatedAt = Date.now()
+        this.emit('task_updated', { ...task })
+        this.emit('task_error', { taskId: task.taskId, message: task.error })
+      }
+      // Any other value (incl. 'running'/undefined) leaves the task running.
+    }
+
+    // Once nothing is left running, stop the timer rather than spinning until
+    // the timeout cap.
+    if (![...this._tasks.values()].some(t => t.status === 'running')) {
+      this._stopPolling()
+    }
+  }
+
+  /**
+   * Check the remote status of a single running task. Seam for the
+   * (not-yet-shipped) CLI status command — override or inject in tests to
+   * drive the running→completed/failed transition.
+   *
+   * @param {Object} _task - the running task
+   * @returns {Promise<{ status: 'running'|'completed'|'failed', result?: any, error?: string }>}
+   *
+   * Default: no CLI status command exists yet, so report 'running' (unknown)
+   * and let the poll keep waiting until one ships or the timeout backstop fires.
+   */
+  async _checkRemoteStatus(_task) {
+    return { status: 'running' }
   }
 
   /**

--- a/packages/server/src/web-task-manager.js
+++ b/packages/server/src/web-task-manager.js
@@ -36,6 +36,7 @@ export class WebTaskManager extends EventEmitter {
     this._detected = false
     this._pollTimer = null
     this._pollCount = 0
+    this._inPoll = false
   }
 
   /** Whether the CLI supports --remote (web task launch) */
@@ -254,65 +255,76 @@ export class WebTaskManager extends EventEmitter {
    * @private
    */
   async _pollTaskStatus() {
-    this._pollCount++
+    // Re-entrancy guard (#5327 review): if the previous poll is still awaiting a
+    // status check (a real CLI call can exceed POLL_INTERVAL_MS), skip this tick
+    // rather than overlapping. Overlap would advance _pollCount faster than
+    // wall-clock (premature timeout) and race task-state transitions. The flag
+    // is cleared in finally so a rejection can't wedge polling permanently.
+    if (this._inPoll) return
+    this._inPoll = true
+    try {
+      this._pollCount++
 
-    const running = [...this._tasks.values()].filter(t => t.status === 'running')
-    if (running.length === 0) {
-      this._stopPolling()
-      return
-    }
+      const running = [...this._tasks.values()].filter(t => t.status === 'running')
+      if (running.length === 0) {
+        this._stopPolling()
+        return
+      }
 
-    // Genuine timeout backstop: a task STILL running after MAX_POLL_COUNT polls
-    // (10 min) is force-failed so a stuck cloud task can't poll forever. This
-    // used to be the ONLY exit — every healthy task was force-failed here
-    // because nothing implemented the running→completed transition (#5327).
-    // Checked before any await so the synchronous timeout path stays sync.
-    if (this._pollCount >= MAX_POLL_COUNT) {
+      // Genuine timeout backstop: a task STILL running after MAX_POLL_COUNT polls
+      // (10 min) is force-failed so a stuck cloud task can't poll forever. This
+      // used to be the ONLY exit — every healthy task was force-failed here
+      // because nothing implemented the running→completed transition (#5327).
+      // Checked before any await so the synchronous timeout path stays sync.
+      if (this._pollCount >= MAX_POLL_COUNT) {
+        for (const task of running) {
+          task.status = 'failed'
+          task.error = 'Task timed out waiting for status update'
+          task.updatedAt = Date.now()
+          this.emit('task_updated', { ...task })
+          this.emit('task_error', { taskId: task.taskId, message: task.error })
+        }
+        this._stopPolling()
+        return
+      }
+
+      // Check each running task's remote status and transition it to a terminal
+      // state when the cloud reports done/failed (#5327). _checkRemoteStatus is a
+      // seam — a real CLI status command (or a test) drives the transition; the
+      // default reports 'running' (unknown) until that command ships.
       for (const task of running) {
-        task.status = 'failed'
-        task.error = 'Task timed out waiting for status update'
-        task.updatedAt = Date.now()
-        this.emit('task_updated', { ...task })
-        this.emit('task_error', { taskId: task.taskId, message: task.error })
+        let result
+        try {
+          result = await this._checkRemoteStatus(task)
+        } catch {
+          // A transient status-check failure must not fail the task — let the
+          // timeout backstop catch a genuinely stuck one. Skip this pass.
+          continue
+        }
+        const next = result && result.status
+        if (next === 'completed') {
+          task.status = 'completed'
+          task.result = result.result ?? null
+          task.error = null
+          task.updatedAt = Date.now()
+          this.emit('task_updated', { ...task })
+        } else if (next === 'failed') {
+          task.status = 'failed'
+          task.error = result.error || 'Task failed'
+          task.updatedAt = Date.now()
+          this.emit('task_updated', { ...task })
+          this.emit('task_error', { taskId: task.taskId, message: task.error })
+        }
+        // Any other value (incl. 'running'/undefined) leaves the task running.
       }
-      this._stopPolling()
-      return
-    }
 
-    // Check each running task's remote status and transition it to a terminal
-    // state when the cloud reports done/failed (#5327). _checkRemoteStatus is a
-    // seam — a real CLI status command (or a test) drives the transition; the
-    // default reports 'running' (unknown) until that command ships.
-    for (const task of running) {
-      let result
-      try {
-        result = await this._checkRemoteStatus(task)
-      } catch {
-        // A transient status-check failure must not fail the task — let the
-        // timeout backstop catch a genuinely stuck one. Skip this pass.
-        continue
+      // Once nothing is left running, stop the timer rather than spinning until
+      // the timeout cap.
+      if (![...this._tasks.values()].some(t => t.status === 'running')) {
+        this._stopPolling()
       }
-      const next = result && result.status
-      if (next === 'completed') {
-        task.status = 'completed'
-        task.result = result.result ?? null
-        task.error = null
-        task.updatedAt = Date.now()
-        this.emit('task_updated', { ...task })
-      } else if (next === 'failed') {
-        task.status = 'failed'
-        task.error = result.error || 'Task failed'
-        task.updatedAt = Date.now()
-        this.emit('task_updated', { ...task })
-        this.emit('task_error', { taskId: task.taskId, message: task.error })
-      }
-      // Any other value (incl. 'running'/undefined) leaves the task running.
-    }
-
-    // Once nothing is left running, stop the timer rather than spinning until
-    // the timeout cap.
-    if (![...this._tasks.values()].some(t => t.status === 'running')) {
-      this._stopPolling()
+    } finally {
+      this._inPoll = false
     }
   }
 

--- a/packages/server/tests/web-task-manager.test.js
+++ b/packages/server/tests/web-task-manager.test.js
@@ -338,6 +338,45 @@ describe('WebTaskManager', () => {
       assert.equal(manager._pollTimer, null, 'timer cleared after last task completes')
     })
 
+    it('skips an overlapping poll while the prior status check is still in flight (#5327 review)', async () => {
+      manager = new WebTaskManager()
+      manager._remoteAvailable = true
+      manager._spawnRemoteTask = () => {}
+
+      const { taskId } = manager.launchTask('slow check')
+      const task = manager._tasks.get(taskId)
+      task.status = 'running'
+
+      let checkStarts = 0
+      let releaseCheck
+      manager._checkRemoteStatus = () => {
+        checkStarts++
+        return new Promise((resolve) => { releaseCheck = resolve })
+      }
+
+      // First poll starts the (stuck) status check and increments _pollCount.
+      const firstPoll = manager._pollTaskStatus()
+      assert.equal(checkStarts, 1)
+      assert.equal(manager._pollCount, 1)
+
+      // A second tick while the first is in flight must be skipped entirely —
+      // no new status check, no _pollCount advance (which would time out early).
+      await manager._pollTaskStatus()
+      assert.equal(checkStarts, 1, 'overlapping poll must not start a second check')
+      assert.equal(manager._pollCount, 1, 'overlapping poll must not advance the count')
+
+      // Release the in-flight check; the first poll settles and clears the flag.
+      releaseCheck({ status: 'running' })
+      await firstPoll
+      assert.equal(manager._inPoll, false, 'in-flight flag cleared after the poll settles')
+
+      // A subsequent poll now runs normally — swap to an immediately-resolving
+      // check so this poll doesn't hang on the stuck-promise mock.
+      manager._checkRemoteStatus = async () => { checkStarts++; return { status: 'running' } }
+      await manager._pollTaskStatus()
+      assert.equal(checkStarts, 2)
+    })
+
     it('unref\'s the poll timer so it never holds the event loop open (#5327)', () => {
       manager = new WebTaskManager()
       let unrefed = false

--- a/packages/server/tests/web-task-manager.test.js
+++ b/packages/server/tests/web-task-manager.test.js
@@ -21,9 +21,26 @@ describe('WebTaskManager', () => {
     })
 
     it('detects features as unavailable when claude CLI lacks --remote', async () => {
+      // Hermetic: inject a --help output without the flags rather than shelling
+      // out to the real `claude` binary (whose flags vary by version/host).
       manager = new WebTaskManager()
-      await manager.detectFeatures()
-      // Current CLI v2.1.51 does not have --remote
+      await manager.detectFeatures({ exec: async () => 'Usage: claude [options]\n  --help\n  --print' })
+      assert.equal(manager.isAvailable, false)
+      assert.equal(manager.teleportAvailable, false)
+      assert.equal(manager.detected, true)
+    })
+
+    it('detects --remote and --teleport when present in --help', async () => {
+      manager = new WebTaskManager()
+      const features = await manager.detectFeatures({ exec: async () => 'Usage:\n  --remote\n  --teleport\n' })
+      assert.equal(manager.isAvailable, true)
+      assert.equal(manager.teleportAvailable, true)
+      assert.deepEqual(features, { remote: true, teleport: true })
+    })
+
+    it('treats a failed --help invocation as unavailable', async () => {
+      manager = new WebTaskManager()
+      await manager.detectFeatures({ exec: async () => { throw new Error('claude: command not found') } })
       assert.equal(manager.isAvailable, false)
       assert.equal(manager.teleportAvailable, false)
       assert.equal(manager.detected, true)
@@ -31,7 +48,7 @@ describe('WebTaskManager', () => {
 
     it('returns feature status object', async () => {
       manager = new WebTaskManager()
-      await manager.detectFeatures()
+      await manager.detectFeatures({ exec: async () => 'Usage: claude [options]\n' })
       const status = manager.getFeatureStatus()
       assert.equal(typeof status.available, 'boolean')
       assert.equal(typeof status.remote, 'boolean')
@@ -218,8 +235,8 @@ describe('WebTaskManager', () => {
     })
   })
 
-  describe('poll timeout', () => {
-    it('fails running tasks after max poll count', () => {
+  describe('polling', () => {
+    it('fails running tasks after max poll count (timeout backstop)', () => {
       manager = new WebTaskManager()
       manager._remoteAvailable = true
       manager._spawnRemoteTask = () => {}
@@ -238,6 +255,104 @@ describe('WebTaskManager', () => {
       assert.equal(task.status, 'failed')
       assert.ok(task.error.includes('timed out'))
       assert.equal(errors.length, 1)
+    })
+
+    it('transitions a healthy task running→completed instead of force-failing (#5327)', async () => {
+      manager = new WebTaskManager()
+      manager._remoteAvailable = true
+      manager._spawnRemoteTask = () => {}
+
+      const { taskId } = manager.launchTask('build a site')
+      const task = manager._tasks.get(taskId)
+      task.status = 'running'
+
+      // Inject a status check that reports completion with a result.
+      manager._checkRemoteStatus = async () => ({ status: 'completed', result: 'https://preview.example' })
+
+      const updates = []
+      manager.on('task_updated', (t) => updates.push(t))
+
+      await manager._pollTaskStatus()
+
+      assert.equal(task.status, 'completed', 'a healthy task must complete, not be force-failed')
+      assert.equal(task.result, 'https://preview.example')
+      assert.equal(task.error, null)
+      assert.ok(updates.some((u) => u.taskId === taskId && u.status === 'completed'))
+    })
+
+    it('transitions a task running→failed when the remote reports failure (#5327)', async () => {
+      manager = new WebTaskManager()
+      manager._remoteAvailable = true
+      manager._spawnRemoteTask = () => {}
+
+      const { taskId } = manager.launchTask('bad task')
+      const task = manager._tasks.get(taskId)
+      task.status = 'running'
+      manager._checkRemoteStatus = async () => ({ status: 'failed', error: 'sandbox crashed' })
+
+      const errors = []
+      manager.on('task_error', (e) => errors.push(e))
+
+      await manager._pollTaskStatus()
+
+      assert.equal(task.status, 'failed')
+      assert.equal(task.error, 'sandbox crashed')
+      assert.equal(errors.length, 1)
+    })
+
+    it('leaves a task running when the status check is still pending or throws', async () => {
+      manager = new WebTaskManager()
+      manager._remoteAvailable = true
+      manager._spawnRemoteTask = () => {}
+
+      const { taskId } = manager.launchTask('slow task')
+      const task = manager._tasks.get(taskId)
+      task.status = 'running'
+
+      // Still running.
+      manager._checkRemoteStatus = async () => ({ status: 'running' })
+      await manager._pollTaskStatus()
+      assert.equal(task.status, 'running')
+
+      // Transient check failure — must not fail the task.
+      manager._checkRemoteStatus = async () => { throw new Error('network blip') }
+      await manager._pollTaskStatus()
+      assert.equal(task.status, 'running')
+    })
+
+    it('stops the timer once no tasks remain running', async () => {
+      manager = new WebTaskManager()
+      manager._remoteAvailable = true
+      manager._spawnRemoteTask = () => {}
+
+      const { taskId } = manager.launchTask('one task')
+      const task = manager._tasks.get(taskId)
+      task.status = 'running'
+      manager._startPolling()
+      assert.ok(manager._pollTimer, 'timer armed')
+
+      manager._checkRemoteStatus = async () => ({ status: 'completed', result: 'done' })
+      await manager._pollTaskStatus()
+
+      assert.equal(task.status, 'completed')
+      assert.equal(manager._pollTimer, null, 'timer cleared after last task completes')
+    })
+
+    it('unref\'s the poll timer so it never holds the event loop open (#5327)', () => {
+      manager = new WebTaskManager()
+      let unrefed = false
+      const realSetInterval = globalThis.setInterval
+      // Capture-and-unref seam via a fake timer object.
+      manager._pollTimer = null
+      globalThis.setInterval = () => ({ unref: () => { unrefed = true }, _fake: true })
+      try {
+        manager._startPolling()
+      } finally {
+        globalThis.setInterval = realSetInterval
+      }
+      assert.equal(unrefed, true, 'poll interval must be unref\'d')
+      // Avoid clearInterval on the fake handle in destroy/afterEach.
+      manager._pollTimer = null
     })
   })
 


### PR DESCRIPTION
## Summary

Closes WP-5.5 of the claude-tui hardening epic (#5338). Closes #5327. **This is a functional bug, not just hardening.**

The web-task poll (`web-task-manager.js`) was a placeholder: it implemented **no running→completed transition**, so every healthy cloud task was force-failed at `MAX_POLL_COUNT` (10 min) as "timed out". The poll interval was also not `unref`'d, so a single tracked task kept the daemon's event loop alive.

## Fix

- `_pollTaskStatus` transitions `running→completed/failed` via an injectable `_checkRemoteStatus(task)` seam (a real CLI status command — or a test — drives the transition; the default reports `running` until that CLI ships). `MAX_POLL_COUNT` is kept **only as a genuine timeout backstop**, and polling stops once no task remains running.
- `_startPolling` `unref`'s the interval and swallows async-poll rejections so a status-check fault can't crash the daemon.
- `detectFeatures` takes an injectable `exec` seam; the feature-detection tests no longer shell out to the real `claude` binary (they were host/version-dependent and failed locally once the CLI gained `--remote`).

## Tests (24 pass, was 17)

- `running→completed` and `running→failed` transitions emit the right events.
- A pending or throwing status check leaves the task `running` (no spurious fail).
- Timer stops after the last task completes; interval is `unref`'d.
- Hermetic feature detection (present / absent / exec-failure).
- Existing timeout-backstop test preserved.

## Acceptance criteria
- [x] A healthy web task completes instead of being force-failed.
- [x] The timer doesn't hold the event loop open.

---

### Production scope (honesty note)

This is **plumbing**, not a user-visible "web tasks now complete" feature. `claude --remote` and a cloud status command don't ship in the CLI yet, so today `launchTask` throws `WebTaskUnavailableError` and the transition path is unreachable in production. The default `_checkRemoteStatus` returns `{status:'running'}`, so until a real status command exists a task would still hit the 10-min timeout backstop — the acceptance criterion is met **via the injectable seam**, ready for when the CLI lands.

What lands **today** regardless: the timer is now `unref`'d (no longer holds the daemon's event loop open) and async-poll rejections are swallowed (can't crash the daemon). The wrong-by-construction "force-fail every healthy task" exit is removed.

Follow-up filed for a re-entrancy guard once `_checkRemoteStatus` does real network I/O.