### PR TITLE
fix(server): surface swallowed observability errors (WP-5.6 part A)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1380,14 +1380,35 @@ export class ClaudeTuiSession extends BaseSession {
       return
     }
     if (!ready && !this._ptyExited) {
-      const degraded = this._lastProbeSawStatus === false
-        ? ' — session file never appeared with a `status` field; if claude was spawned via a non-cli entrypoint or upstream changed the file format, the probe has degraded and will never see ready'
-        : ''
       log.warn(
-        `TUI session file did not reach status=idle within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms${degraded} — proceeding (first sendMessage may stall)\n` +
+        `TUI session file did not reach status=idle within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms${this._degradedProbeSuffix()} — proceeding (first sendMessage may stall)\n` +
         `_outputTail dump:\n${this._outputTailHexDump()}`,
       )
     }
+  }
+
+  /**
+   * #5328 (WP-5.6): build the diagnostic suffix for a readiness-probe timeout.
+   * When the probe degraded (never saw a `status` field — `_lastProbeSawStatus`
+   * is false), distinguish the two root causes by checking whether the per-pid
+   * session file exists on disk, so the swallowed degradation names its likely
+   * cause instead of just "not ready":
+   *   - file MISSING → claude is likely running under a DIFFERENT pid than the
+   *     PTY child (a wrapper shim that forks node without `exec`); the probe
+   *     reads ~/.claude/sessions/<pty-pid>.json, which the real claude never
+   *     writes, so readiness gating is effectively disabled for this session.
+   *   - file PRESENT but statusless → a non-cli entrypoint or an upstream
+   *     file-format change; the file exists but carries no `status` field.
+   * Returns '' when the probe was healthy (saw status but never idle = real busy).
+   */
+  _degradedProbeSuffix() {
+    if (this._lastProbeSawStatus !== false) return ''
+    const pid = this._term && this._term.pid
+    const sessFile = Number.isInteger(pid) && pid > 0 ? ClaudeTuiSession.sessionFilePath(pid) : null
+    if (sessFile && !existsSync(sessFile)) {
+      return ` — no session file at ${sessFile} (pty pid ${pid}); claude may be running under a different pid (a wrapper shim that forks node without exec), so the readiness probe can never see its status and readiness gating is effectively disabled for this session`
+    }
+    return ' — session file never appeared with a `status` field; if claude was spawned via a non-cli entrypoint or upstream changed the file format, the probe has degraded and will never see ready'
   }
 
   /**
@@ -1652,11 +1673,8 @@ export class ClaudeTuiSession extends BaseSession {
     // refuse to deliver the prompt.
     const ready = await this._waitForPrompt(ClaudeTuiSession.TURN_PROMPT_WAIT_MAX_MS)
     if (!ready && !this._ptyExited) {
-      const degraded = this._lastProbeSawStatus === false
-        ? ' — and the probe has never seen a `status` field this session, suggesting a degraded probe (see sessionFilePath docs)'
-        : ''
       log.warn(
-        `TUI session file not at status=idle before turn (msg=${messageId})${degraded} — writing anyway\n` +
+        `TUI session file not at status=idle before turn (msg=${messageId})${this._degradedProbeSuffix()} — writing anyway\n` +
         `_outputTail dump:\n${this._outputTailHexDump()}`,
       )
     }

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1380,7 +1380,7 @@ export class ClaudeTuiSession extends BaseSession {
       return
     }
     if (!ready && !this._ptyExited) {
-      log.warn(
+      ;(this._log || log).warn(
         `TUI session file did not reach status=idle within ${ClaudeTuiSession.SPAWN_WARMUP_MAX_MS}ms${this._degradedProbeSuffix()} — proceeding (first sendMessage may stall)\n` +
         `_outputTail dump:\n${this._outputTailHexDump()}`,
       )
@@ -1673,7 +1673,7 @@ export class ClaudeTuiSession extends BaseSession {
     // refuse to deliver the prompt.
     const ready = await this._waitForPrompt(ClaudeTuiSession.TURN_PROMPT_WAIT_MAX_MS)
     if (!ready && !this._ptyExited) {
-      log.warn(
+      ;(this._log || log).warn(
         `TUI session file not at status=idle before turn (msg=${messageId})${this._degradedProbeSuffix()} — writing anyway\n` +
         `_outputTail dump:\n${this._outputTailHexDump()}`,
       )

--- a/packages/server/src/tunnel/cloudflare.js
+++ b/packages/server/src/tunnel/cloudflare.js
@@ -99,18 +99,22 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
       const httpUrl = `https://${this.tunnelHostname}`
       const wsUrl = `wss://${this.tunnelHostname}`
 
-      // #5328 (WP-5.6): retain a capped, redacted tail of cloudflared's output.
+      // #5328 (WP-5.6): retain a capped tail of cloudflared's startup output.
       // handleOutput otherwise inspects each chunk only for the success pattern
       // and discards it — so a startup failure surfaced only "exited with code
       // N" with no hint of WHY (credentials missing, tunnel not found, DNS
-      // route absent). Redact first: cloudflared output can embed a token in a
-      // URL, and this tail lands in an Error the operator (and possibly a
-      // client) sees.
-      let outputTail = ''
+      // route absent). The tail is redacted at EMIT time (in the reject sites),
+      // not per-chunk: a token split across two `data` events would survive a
+      // per-chunk redact (neither half matches the pattern) and leak a fragment
+      // into the error — so we accumulate raw and redact the whole tail once
+      // (#5366 review). We stop accumulating after `resolved` so a long-lived,
+      // chatty named tunnel doesn't run redaction for its whole lifetime.
+      let outputTailRaw = ''
       const handleOutput = (data) => {
+        if (resolved) return
         const text = data.toString()
-        outputTail = (outputTail + redactSensitive(text)).slice(-CLOUDFLARED_OUTPUT_TAIL_CAP)
-        if (!resolved && /[Rr]egistered.*connection|[Cc]onnection.*registered|Serving tunnel/i.test(text)) {
+        outputTailRaw = (outputTailRaw + text).slice(-CLOUDFLARED_OUTPUT_TAIL_CAP)
+        if (/[Rr]egistered.*connection|[Cc]onnection.*registered|Serving tunnel/i.test(text)) {
           resolved = true
           this.url = httpUrl
 
@@ -131,7 +135,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
 
       proc.on('close', (code, signal) => {
         if (!resolved) {
-          const tail = outputTail.trim()
+          const tail = redactSensitive(outputTailRaw).trim()
           reject(new Error(`cloudflared exited with code ${code} before establishing tunnel${tail ? `. Last output: ${tail}` : ''}`))
         } else {
           void this._handleUnexpectedExit(code, signal).catch((err) => {
@@ -150,7 +154,7 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
           resolved = true
           this.intentionalShutdown = true
           proc.kill()
-          const tail = outputTail.trim()
+          const tail = redactSensitive(outputTailRaw).trim()
           reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed and logged in? (brew install cloudflared)${tail ? ` Last output: ${tail}` : ''}`))
         }
       }, 30_000)

--- a/packages/server/src/tunnel/cloudflare.js
+++ b/packages/server/src/tunnel/cloudflare.js
@@ -1,8 +1,12 @@
 import { spawn, execFileSync } from 'child_process'
 import { BaseTunnelAdapter } from './base.js'
-import { createLogger } from '../logger.js'
+import { createLogger, redactSensitive } from '../logger.js'
 
 const log = createLogger('tunnel')
+
+// #5328 (WP-5.6): how much of cloudflared's recent output to retain so a
+// startup failure can quote the REAL reason in its error, not just an exit code.
+const CLOUDFLARED_OUTPUT_TAIL_CAP = 2000
 
 /**
  * Cloudflare tunnel adapter.
@@ -95,8 +99,17 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
       const httpUrl = `https://${this.tunnelHostname}`
       const wsUrl = `wss://${this.tunnelHostname}`
 
+      // #5328 (WP-5.6): retain a capped, redacted tail of cloudflared's output.
+      // handleOutput otherwise inspects each chunk only for the success pattern
+      // and discards it — so a startup failure surfaced only "exited with code
+      // N" with no hint of WHY (credentials missing, tunnel not found, DNS
+      // route absent). Redact first: cloudflared output can embed a token in a
+      // URL, and this tail lands in an Error the operator (and possibly a
+      // client) sees.
+      let outputTail = ''
       const handleOutput = (data) => {
         const text = data.toString()
+        outputTail = (outputTail + redactSensitive(text)).slice(-CLOUDFLARED_OUTPUT_TAIL_CAP)
         if (!resolved && /[Rr]egistered.*connection|[Cc]onnection.*registered|Serving tunnel/i.test(text)) {
           resolved = true
           this.url = httpUrl
@@ -118,7 +131,8 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
 
       proc.on('close', (code, signal) => {
         if (!resolved) {
-          reject(new Error(`cloudflared exited with code ${code} before establishing tunnel`))
+          const tail = outputTail.trim()
+          reject(new Error(`cloudflared exited with code ${code} before establishing tunnel${tail ? `. Last output: ${tail}` : ''}`))
         } else {
           void this._handleUnexpectedExit(code, signal).catch((err) => {
             log.error(`Error while handling unexpected cloudflared exit: ${err.stack || err.message || err}`)
@@ -136,7 +150,8 @@ export class CloudflareTunnelAdapter extends BaseTunnelAdapter {
           resolved = true
           this.intentionalShutdown = true
           proc.kill()
-          reject(new Error('Tunnel timed out after 30s. Is cloudflared installed and logged in? (brew install cloudflared)'))
+          const tail = outputTail.trim()
+          reject(new Error(`Tunnel timed out after 30s. Is cloudflared installed and logged in? (brew install cloudflared)${tail ? ` Last output: ${tail}` : ''}`))
         }
       }, 30_000)
 

--- a/packages/server/src/ws-history.js
+++ b/packages/server/src/ws-history.js
@@ -30,13 +30,20 @@ const log = createLogger('ws')
 //
 // Both helpers abort the poll once ws.readyState leaves OPEN (client
 // disconnected while paused), so the poll chain terminates on socket close
-// without sending to a closed socket. Note that this is a narrower guarantee
-// than "we never leak a setTimeout" — a dead TCP connection that never moves
-// out of OPEN and never drains would keep polling indefinitely. That is the
-// same liveness window as the existing ws keep-alive ping; if we ever want a
-// hard cap, add a max-wait/backoff here.
+// without sending to a closed socket.
+//
+// #5328 (WP-5.6): the readyState check alone is NOT enough to bound the poll —
+// a half-open TCP connection that stays stuck in OPEN, never drains, and never
+// errors would keep re-scheduling setTimeout(poll) forever, leaking one timer
+// chain per stuck replay/flush. BACKPRESSURE_MAX_WAIT_MS is a hard cap: once a
+// drain has been blocked that long we stop polling and close the socket (1013
+// "Try Again Later") so the client reconnects cleanly and re-runs the replay
+// from scratch, rather than silently leaking a timer against a dead peer. The
+// cap is comfortably longer than a healthy slow-link drain but far short of
+// "forever".
 const BACKPRESSURE_PAUSE_THRESHOLD = 256 * 1024
 const BACKPRESSURE_POLL_INTERVAL_MS = 20
+const BACKPRESSURE_MAX_WAIT_MS = 30_000
 
 /**
  * Schedule `fn` once ws.bufferedAmount falls below BACKPRESSURE_PAUSE_THRESHOLD,
@@ -44,18 +51,30 @@ const BACKPRESSURE_POLL_INTERVAL_MS = 20
  * with setTimeout(BACKPRESSURE_POLL_INTERVAL_MS) while paused. Bails out
  * silently if ws.readyState transitions away from OPEN — the caller's first
  * action in `fn` already re-checks readyState so the bailout is safe.
+ *
+ * If the drain stays blocked for BACKPRESSURE_MAX_WAIT_MS (a half-open socket
+ * that never drains), stop polling and close the socket so the client
+ * reconnects cleanly — `fn` is then never called (#5328).
+ *
+ * Exported for direct unit testing of the max-wait cap.
  */
-function scheduleAfterDrain(ws, fn) {
+export function scheduleAfterDrain(ws, fn) {
   if (ws.readyState !== 1) return
   const buffered = ws.bufferedAmount || 0
   if (buffered <= BACKPRESSURE_PAUSE_THRESHOLD) {
     setImmediate(fn)
     return
   }
+  const start = Date.now()
   const poll = () => {
     if (ws.readyState !== 1) return
     if ((ws.bufferedAmount || 0) <= BACKPRESSURE_PAUSE_THRESHOLD) {
       setImmediate(fn)
+      return
+    }
+    if (Date.now() - start >= BACKPRESSURE_MAX_WAIT_MS) {
+      log.warn(`replay/flush drain stalled >${BACKPRESSURE_MAX_WAIT_MS}ms (bufferedAmount=${ws.bufferedAmount}) — closing socket so the client reconnects`)
+      try { ws.close(1013, 'Replay backpressure timeout') } catch (_) { /* already closing */ }
       return
     }
     setTimeout(poll, BACKPRESSURE_POLL_INTERVAL_MS)

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1259,6 +1259,37 @@ describe('ClaudeTuiSession', () => {
       })
     })
 
+    describe('_degradedProbeSuffix (#5328, WP-5.6)', () => {
+      // Surfaces WHY the readiness probe degraded: a missing session file for
+      // the pty pid points at claude running under a different pid (wrapper
+      // shim); a statusless-but-present file points at a wrong entrypoint.
+
+      it('returns empty when the probe saw a status (healthy / real busy)', () => {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._lastProbeSawStatus = true
+        assert.equal(session._degradedProbeSuffix(), '')
+      })
+
+      it('names the wrong-pid cause when no session file exists for the pty pid', () => {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._lastProbeSawStatus = false
+        // A pid whose ~/.claude/sessions/<pid>.json cannot exist.
+        session._term = { pid: 999999 }
+        const suffix = session._degradedProbeSuffix()
+        assert.match(suffix, /no session file at .*999999\.json/, `got: ${suffix}`)
+        assert.match(suffix, /different pid/)
+        assert.match(suffix, /readiness gating is effectively disabled/)
+      })
+
+      it('falls back to the statusless-file message when there is no usable pid', () => {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._lastProbeSawStatus = false
+        session._term = null
+        const suffix = session._degradedProbeSuffix()
+        assert.match(suffix, /session file never appeared with a `status` field/, `got: ${suffix}`)
+      })
+    })
+
     describe('output tail ANSI stripping (#5325, WP-5.3)', () => {
       // _appendToOutputTail is the body of the PTY onData handler. It must
       // strip ANSI from the CONCATENATED tail, not per-chunk, so an escape

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1263,6 +1263,22 @@ describe('ClaudeTuiSession', () => {
       // Surfaces WHY the readiness probe degraded: a missing session file for
       // the pty pid points at claude running under a different pid (wrapper
       // shim); a statusless-but-present file points at a wrong entrypoint.
+      //
+      // #5366 review: stub the static sessionFilePath onto a temp dir so the
+      // file-existence branches are HERMETIC (no reliance on the real ~/.claude)
+      // and BOTH branches (missing vs present) are exercised deterministically.
+      let probeTmp
+      let origSessionFilePath
+      beforeEach(() => {
+        probeTmp = mkdtempSync(join(tmpdir(), 'chroxy-tui-probe-'))
+        origSessionFilePath = ClaudeTuiSession.sessionFilePath
+        ClaudeTuiSession.sessionFilePath = (pid) => join(probeTmp, `${pid}.json`)
+      })
+      afterEach(() => {
+        ClaudeTuiSession.sessionFilePath = origSessionFilePath
+        if (probeTmp) rmSync(probeTmp, { recursive: true, force: true })
+        probeTmp = null
+      })
 
       it('returns empty when the probe saw a status (healthy / real busy)', () => {
         session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
@@ -1270,15 +1286,25 @@ describe('ClaudeTuiSession', () => {
         assert.equal(session._degradedProbeSuffix(), '')
       })
 
-      it('names the wrong-pid cause when no session file exists for the pty pid', () => {
+      it('names the wrong-pid cause when the per-pid session file is MISSING', () => {
         session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
         session._lastProbeSawStatus = false
-        // A pid whose ~/.claude/sessions/<pid>.json cannot exist.
-        session._term = { pid: 999999 }
+        session._term = { pid: 4242 } // no file written for it → missing
         const suffix = session._degradedProbeSuffix()
-        assert.match(suffix, /no session file at .*999999\.json/, `got: ${suffix}`)
+        assert.match(suffix, /no session file at .*4242\.json/, `got: ${suffix}`)
         assert.match(suffix, /different pid/)
         assert.match(suffix, /readiness gating is effectively disabled/)
+      })
+
+      it('names the statusless-file cause when the session file is PRESENT (#5366 review)', () => {
+        session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+        session._lastProbeSawStatus = false
+        session._term = { pid: 4242 }
+        // File exists but carries no `status` field → wrong-entrypoint cause.
+        writeFileSync(join(probeTmp, '4242.json'), '{}')
+        const suffix = session._degradedProbeSuffix()
+        assert.match(suffix, /session file never appeared with a `status` field/, `got: ${suffix}`)
+        assert.doesNotMatch(suffix, /different pid/)
       })
 
       it('falls back to the statusless-file message when there is no usable pid', () => {

--- a/packages/server/tests/tunnel/cloudflare.test.js
+++ b/packages/server/tests/tunnel/cloudflare.test.js
@@ -97,6 +97,64 @@ describe('CloudflareTunnelAdapter', () => {
         /cloudflared exited with code 1 before establishing tunnel/
       )
     })
+
+    it('includes the captured cloudflared output in a named-tunnel failure (#5328)', async () => {
+      const mockSpawn = () => {
+        const proc = new EventEmitter()
+        proc.stdout = new EventEmitter()
+        proc.stderr = new EventEmitter()
+        proc.kill = function () { this.killed = true }
+        setImmediate(() => {
+          // The real reason a named tunnel fails to start — previously discarded.
+          proc.stderr.emit('data', Buffer.from("ERR couldn't find tunnel credentials file"))
+          proc.emit('close', 1, null)
+        })
+        return proc
+      }
+      const tunnel = new TestCloudflareAdapter({
+        port: 3000,
+        mockSpawn,
+        mode: 'named',
+        config: { tunnelName: 'mytunnel', tunnelHostname: 'host.example.com' },
+      })
+
+      // Call _startNamedTunnel directly — start() wraps it in a 3-attempt retry
+      // with real 3s/6s backoff sleeps, which we don't want to exercise here.
+      await assert.rejects(
+        () => tunnel._startNamedTunnel(),
+        /cloudflared exited with code 1 before establishing tunnel\. Last output: .*couldn't find tunnel credentials file/,
+      )
+    })
+
+    it('redacts token-shaped runs in the captured cloudflared output (#5328)', async () => {
+      // 48 chars after the prefix — redactSensitive's sk-ant- pattern needs 40+.
+      const secret = 'sk-ant-api03-' + 'A'.repeat(48)
+      const mockSpawn = () => {
+        const proc = new EventEmitter()
+        proc.stdout = new EventEmitter()
+        proc.stderr = new EventEmitter()
+        proc.kill = function () { this.killed = true }
+        setImmediate(() => {
+          proc.stderr.emit('data', Buffer.from(`ERR auth failed with token ${secret}`))
+          proc.emit('close', 1, null)
+        })
+        return proc
+      }
+      const tunnel = new TestCloudflareAdapter({
+        port: 3000,
+        mockSpawn,
+        mode: 'named',
+        config: { tunnelName: 'mytunnel', tunnelHostname: 'host.example.com' },
+      })
+
+      await tunnel._startNamedTunnel().then(
+        () => assert.fail('expected _startNamedTunnel() to reject'),
+        (err) => {
+          assert.match(err.message, /Last output:/)
+          assert.ok(!err.message.includes(secret), `token must be redacted, got: ${err.message}`)
+        },
+      )
+    })
   })
 
   describe('auto-recovery on unexpected exit', () => {

--- a/packages/server/tests/ws-history.test.js
+++ b/packages/server/tests/ws-history.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach } from 'node:test'
+import { describe, it, beforeEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
 import { createSpy, createMockSession, createMockSessionManager } from './test-helpers.js'
 import {
@@ -6,6 +6,7 @@ import {
   sendSessionInfo,
   replayHistory,
   flushPostAuthQueue,
+  scheduleAfterDrain,
 } from '../src/ws-history.js'
 import { PERMISSION_MODES } from '../src/handler-utils.js'
 import { MAX_SANE_DURATION_MS } from '@chroxy/protocol'
@@ -1959,3 +1960,82 @@ describe('sendPostAuthInfo — per-device active session restore (#4835)', () =>
   })
 })
 
+
+// #5328 (WP-5.6) — scheduleAfterDrain must not poll a half-open socket forever.
+// A connection stuck in OPEN that never drains would re-arm setTimeout(poll)
+// indefinitely, leaking one timer chain per stuck replay. A hard max-wait cap
+// closes the socket so the client reconnects and re-runs the replay.
+describe('scheduleAfterDrain — max-wait cap (#5328)', () => {
+  it('closes the socket once the drain stalls past the cap', () => {
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+    try {
+      let closed = null
+      const ws = {
+        readyState: 1,
+        bufferedAmount: 512 * 1024, // permanently above the 256KB pause threshold
+        close: (code, reason) => { closed = { code, reason } },
+      }
+      let fnCalled = false
+      scheduleAfterDrain(ws, () => { fnCalled = true })
+
+      // Advance well past the 30s cap; each poll re-arms every 20ms.
+      mock.timers.tick(31_000)
+
+      assert.equal(fnCalled, false, 'fn must not run when the drain never completes')
+      assert.ok(closed, 'socket must be closed after the cap')
+      assert.equal(closed.code, 1013, 'closes with 1013 Try Again Later')
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('does NOT close the socket when the buffer drains before the cap', () => {
+    // NB: only setTimeout + Date are faked — NOT setImmediate. scheduleAfterDrain
+    // calls setImmediate(fn) on a healthy drain; leaving it real lets that fire
+    // harmlessly after the (synchronous) test instead of a faked-but-unfired
+    // immediate wedging the test runner.
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+    try {
+      let closed = false
+      const ws = {
+        readyState: 1,
+        bufferedAmount: 512 * 1024,
+        close: () => { closed = true },
+      }
+      scheduleAfterDrain(ws, () => {})
+
+      // Peer acknowledges; buffer drops below threshold before the cap.
+      ws.bufferedAmount = 0
+      mock.timers.tick(25)        // poll sees the drain, schedules fn, returns
+      // Advancing far past the cap must NOT close a socket that already drained.
+      mock.timers.tick(60_000)
+
+      assert.equal(closed, false, 'a socket that drained is never closed by the cap')
+    } finally {
+      mock.timers.reset()
+    }
+  })
+
+  it('stops polling immediately when the socket leaves OPEN (no close call)', () => {
+    mock.timers.enable({ apis: ['setTimeout', 'Date'] })
+    try {
+      let closed = false
+      const ws = {
+        readyState: 1,
+        bufferedAmount: 512 * 1024,
+        close: () => { closed = true },
+      }
+      let fnCalled = false
+      scheduleAfterDrain(ws, () => { fnCalled = true })
+
+      // Client disconnects while paused.
+      ws.readyState = 3
+      mock.timers.tick(31_000)
+
+      assert.equal(fnCalled, false)
+      assert.equal(closed, false, 'a disconnected socket needs no close from the drain poll')
+    } finally {
+      mock.timers.reset()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Part A of WP-5.6 (#5328), claude-tui hardening epic (#5338) — the low-risk, mechanical subset of the 7-item observability grab-bag.

### Fixes

1. **`ws-history.js` — replay-drain max-wait cap.** `scheduleAfterDrain` polls `bufferedAmount` while a socket is congested; a half-open socket stuck in OPEN that never drains would re-arm `setTimeout(poll)` forever, leaking one timer chain per stuck replay. Added a 30s hard cap that closes the socket (1013 Try Again Later) so the client reconnects and re-runs the replay.

2. **`tunnel/cloudflare.js` — capture cloudflared's failure reason.** Named-tunnel startup output was inspected only for the success pattern and otherwise discarded, so a failure surfaced only `exited with code N`. Now a capped, **redacted** tail of cloudflared's stdout/stderr is included in the reject (`Last output: …couldn't find tunnel credentials file`).

3. **`claude-tui-session.js` — name the readiness-probe degradation cause.** When the probe times out having never seen a `status` field, distinguish a **missing** per-pid session file (claude likely under a different pid — a wrapper shim) from a **present-but-statusless** file (wrong entrypoint). This is the warn the `sessionFilePath` doc comment already promised but never actually logged.

Audit items 1 (docker `rm -f` failure — already logged at warn) and 3 (`tunnel_recovered` — already wired with status broadcast) were verified **already-correct**; no change.

### Scope note
Items 4 (doctor tunnel routability) and 5 (fatal session-error fan-out) are deliberately **split into separate PRs** — item 5 touches the bearer-token authorization boundary and needs its own security review; item 4 has an open design question (network egress in `doctor`). Item 7's real pid-correctness fix (process-tree resolution) is deferred to its own design ticket; only the observability warn lands here.

### Tests
- Replay-drain cap: closes after the cap, does **not** close on a healthy drain, stops on disconnect.
- cloudflared output capture + token redaction (sk-ant- pattern).
- Degraded-probe suffix: wrong-pid (missing file) vs statusless.

386 tests pass across the three files; lint clean.

Closes part A of #5328.