### PR TITLE
test(server): cover validateProviderClass inProcessPermissions guard (#5379)

### DIFF
--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -1409,9 +1409,11 @@ describe('validateProviderClass — inProcessPermissions guard (#5379)', () => {
   it('throws when inProcessPermissions=true but respondToPermission is missing', async () => {
     const { validateProviderClass } = await import('../src/providers.js')
     const Stub = makeProviderClass({ inProcessPermissions: true, respondToPermission: false, respondToQuestion: true })
+    // Order-independent: assert each key fragment is present without coupling
+    // to the message's word order (#5384 review).
     assert.throws(
       () => validateProviderClass(Stub, 'stub-no-perm'),
-      /stub-no-perm.*inProcessPermissions=true.*respondToPermission/,
+      /(?=[\s\S]*stub-no-perm)(?=[\s\S]*inProcessPermissions=true)(?=[\s\S]*respondToPermission)/,
     )
   })
 
@@ -1420,7 +1422,7 @@ describe('validateProviderClass — inProcessPermissions guard (#5379)', () => {
     const Stub = makeProviderClass({ inProcessPermissions: true, respondToPermission: true, respondToQuestion: false })
     assert.throws(
       () => validateProviderClass(Stub, 'stub-no-question'),
-      /stub-no-question.*inProcessPermissions=true.*respondToQuestion/,
+      /(?=[\s\S]*stub-no-question)(?=[\s\S]*inProcessPermissions=true)(?=[\s\S]*respondToQuestion)/,
     )
   })
 

--- a/packages/server/tests/providers.test.js
+++ b/packages/server/tests/providers.test.js
@@ -1378,3 +1378,55 @@ describe('listProviders credential-file caching (#4658)', () => {
     }
   })
 })
+
+// #5379 — validateProviderClass's inProcessPermissions guard (registration-time
+// safety gate). The happy paths are covered elsewhere; these lock in the two
+// throw branches so a regression that drops the guard fails CI.
+describe('validateProviderClass — inProcessPermissions guard (#5379)', () => {
+  // Minimal class exposing every REQUIRED_METHODS entry on its prototype, so a
+  // test isolates the inProcessPermissions check from the base-method check.
+  function makeProviderClass({ inProcessPermissions, respondToPermission, respondToQuestion }) {
+    class Stub {
+      sendMessage() {}
+      interrupt() {}
+      setModel() {}
+      setPermissionMode() {}
+      start() {}
+      destroy() {}
+    }
+    if (respondToPermission) Stub.prototype.respondToPermission = function () {}
+    if (respondToQuestion) Stub.prototype.respondToQuestion = function () {}
+    Object.defineProperty(Stub, 'capabilities', { get: () => ({ inProcessPermissions }) })
+    return Stub
+  }
+
+  it('passes when inProcessPermissions=true and both methods are present', async () => {
+    const { validateProviderClass } = await import('../src/providers.js')
+    const Stub = makeProviderClass({ inProcessPermissions: true, respondToPermission: true, respondToQuestion: true })
+    assert.doesNotThrow(() => validateProviderClass(Stub, 'stub-ok'))
+  })
+
+  it('throws when inProcessPermissions=true but respondToPermission is missing', async () => {
+    const { validateProviderClass } = await import('../src/providers.js')
+    const Stub = makeProviderClass({ inProcessPermissions: true, respondToPermission: false, respondToQuestion: true })
+    assert.throws(
+      () => validateProviderClass(Stub, 'stub-no-perm'),
+      /stub-no-perm.*inProcessPermissions=true.*respondToPermission/,
+    )
+  })
+
+  it('throws when inProcessPermissions=true but respondToQuestion is missing', async () => {
+    const { validateProviderClass } = await import('../src/providers.js')
+    const Stub = makeProviderClass({ inProcessPermissions: true, respondToPermission: true, respondToQuestion: false })
+    assert.throws(
+      () => validateProviderClass(Stub, 'stub-no-question'),
+      /stub-no-question.*inProcessPermissions=true.*respondToQuestion/,
+    )
+  })
+
+  it('does NOT require the permission methods when inProcessPermissions is false', async () => {
+    const { validateProviderClass } = await import('../src/providers.js')
+    const Stub = makeProviderClass({ inProcessPermissions: false, respondToPermission: false, respondToQuestion: false })
+    assert.doesNotThrow(() => validateProviderClass(Stub, 'stub-no-inproc'))
+  })
+})


### PR DESCRIPTION
## Summary

Closes #5379 (swarm-audit coverage finding).

`validateProviderClass` throws at registration time when a provider declares `capabilities.inProcessPermissions=true` but is missing `respondToPermission` or `respondToQuestion`. Only the happy path was tested, so a regression that dropped the guard would pass CI.

## Tests added
- `inProcessPermissions=true` + both methods present → passes.
- `inProcessPermissions=true` + missing `respondToPermission` → throws (descriptive).
- `inProcessPermissions=true` + missing `respondToQuestion` → throws (descriptive).
- `inProcessPermissions=false` + neither method → passes (guard not applied).

Pure test addition, no production code change. 86 providers tests pass.