### PR TITLE
refactor(server): extract shared survey error-snapshot builder (#5377)

### DIFF
--- a/packages/server/src/handlers/control-room-handlers.js
+++ b/packages/server/src/handlers/control-room-handlers.js
@@ -43,24 +43,14 @@ const inFlight = new WeakSet()
 const runnerInFlight = new WeakSet()
 
 /**
- * Build a schema-conformant `host_status_snapshot` carrying an error. The
- * survey fields are present and valid (empty repos, zeroed summary, the real
- * discovery root + a fresh timestamp) so the payload satisfies
- * `ServerHostStatusSnapshotSchema`; the extra `error` (and echoed `requestId`)
- * are additive annotations the dashboard branches on. Keeping the error shape a
- * valid snapshot means the consumer never has to special-case a malformed reply.
- *
- * @param {string} root - effective discovery root to report.
- * @param {string|null} requestId - correlation id to echo, or null.
- * @param {{ code: string, message: string }} error
- * @returns {object} a `host_status_snapshot` message.
- */
-/**
- * #5377 — shared builder for the survey error-snapshots. `errorSnapshot` and
- * `runnerErrorSnapshot` are identical apart from their `type` and the keys of
- * the zeroed `summary`; this is the single place the snapshot envelope (echoed
- * requestId, fresh timestamp, real root, empty repos, additive `error`) is
- * shaped, so a schema change touches one function and a future survey reuses it.
+ * #5377 — shared builder for the survey error-snapshots. The error reply is a
+ * schema-conformant but empty snapshot (empty repos, zeroed summary, the real
+ * root + a fresh timestamp) plus an additive `error` (and echoed `requestId`)
+ * the dashboard branches on — so the consumer never special-cases a malformed
+ * reply. `errorSnapshot` and `runnerErrorSnapshot` are identical apart from
+ * their `type` and the keys of the zeroed `summary`; this is the single place
+ * the envelope is shaped, so a schema change touches one function and a future
+ * survey reuses it.
  *
  * @param {string} type - the snapshot message type.
  * @param {object} emptySummary - the zeroed, type-specific summary object.
@@ -81,6 +71,7 @@ function buildSurveyErrorSnapshot(type, emptySummary, root, requestId, error) {
   }
 }
 
+/** `host_status_snapshot` error reply — see {@link buildSurveyErrorSnapshot}. */
 function errorSnapshot(root, requestId, error) {
   return buildSurveyErrorSnapshot(
     'host_status_snapshot',
@@ -177,16 +168,7 @@ async function handleHostStatusRequest(ws, client, msg, ctx) {
   }
 }
 
-/**
- * #5253 — build a schema-conformant `runner_status_snapshot` carrying an error.
- * Same posture as `errorSnapshot`: a valid (empty) snapshot plus an additive
- * `error` annotation, so the dashboard never special-cases a malformed reply.
- *
- * @param {string} root - effective runner-install root to report.
- * @param {string|null} requestId
- * @param {{ code: string, message: string }} error
- * @returns {object} a `runner_status_snapshot` message.
- */
+/** #5253 — `runner_status_snapshot` error reply — see {@link buildSurveyErrorSnapshot}. */
 function runnerErrorSnapshot(root, requestId, error) {
   return buildSurveyErrorSnapshot(
     'runner_status_snapshot',

--- a/packages/server/src/handlers/control-room-handlers.js
+++ b/packages/server/src/handlers/control-room-handlers.js
@@ -55,16 +55,38 @@ const runnerInFlight = new WeakSet()
  * @param {{ code: string, message: string }} error
  * @returns {object} a `host_status_snapshot` message.
  */
-function errorSnapshot(root, requestId, error) {
+/**
+ * #5377 — shared builder for the survey error-snapshots. `errorSnapshot` and
+ * `runnerErrorSnapshot` are identical apart from their `type` and the keys of
+ * the zeroed `summary`; this is the single place the snapshot envelope (echoed
+ * requestId, fresh timestamp, real root, empty repos, additive `error`) is
+ * shaped, so a schema change touches one function and a future survey reuses it.
+ *
+ * @param {string} type - the snapshot message type.
+ * @param {object} emptySummary - the zeroed, type-specific summary object.
+ * @param {string} root - effective discovery/install root to report.
+ * @param {string|null} requestId - correlation id to echo, or null.
+ * @param {{ code: string, message: string }} error
+ * @returns {object} a schema-conformant status snapshot carrying the error.
+ */
+function buildSurveyErrorSnapshot(type, emptySummary, root, requestId, error) {
   return {
-    type: 'host_status_snapshot',
+    type,
     requestId,
     generatedAt: new Date().toISOString(),
     root,
-    summary: { live: 0, onboarded: 0, abandoned: 0, investigate: 0, recent: 0 },
+    summary: emptySummary,
     repos: [],
     error,
   }
+}
+
+function errorSnapshot(root, requestId, error) {
+  return buildSurveyErrorSnapshot(
+    'host_status_snapshot',
+    { live: 0, onboarded: 0, abandoned: 0, investigate: 0, recent: 0 },
+    root, requestId, error,
+  )
 }
 
 /**
@@ -166,15 +188,11 @@ async function handleHostStatusRequest(ws, client, msg, ctx) {
  * @returns {object} a `runner_status_snapshot` message.
  */
 function runnerErrorSnapshot(root, requestId, error) {
-  return {
-    type: 'runner_status_snapshot',
-    requestId,
-    generatedAt: new Date().toISOString(),
-    root,
-    summary: { total: 0, busy: 0, idle: 0, offline: 0, stopped: 0, unregistered: 0 },
-    repos: [],
-    error,
-  }
+  return buildSurveyErrorSnapshot(
+    'runner_status_snapshot',
+    { total: 0, busy: 0, idle: 0, offline: 0, stopped: 0, unregistered: 0 },
+    root, requestId, error,
+  )
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #5377 (swarm-audit DRY finding).

`errorSnapshot` and `runnerErrorSnapshot` were near-identical clones — same `requestId`/`generatedAt`/`root`/`repos`/`error` envelope, differing only in the message `type` and the keys of the zeroed `summary`. A schema change had to touch both, and a third survey would copy the pattern again.

## Change
Extract `buildSurveyErrorSnapshot(type, emptySummary, root, requestId, error)` as the single place the envelope is shaped. The two named wrappers (`errorSnapshot`, `runnerErrorSnapshot`) are kept and just supply their `type` + zeroed summary, so **all call sites are unchanged and the output is byte-identical**.

118 control-room tests pass (handlers + survey + runners); lint clean.