### PR TITLE
refactor(server): centralize session-scoped logger selection (#5378)

### DIFF
--- a/packages/server/scripts/lint-logger-session-scoping.mjs
+++ b/packages/server/scripts/lint-logger-session-scoping.mjs
@@ -181,12 +181,15 @@ for (const file of walk(SRC_DIR)) {
   const src = readFileSync(file, 'utf8')
 
   if (REQUIRES_FACTORY_IMPORT.has(rel)) {
-    // Find the logger.js import block and check loggerForSession appears.
+    // Find the logger.js import block and check a session-scoping factory
+    // appears: `loggerForSession` directly, or `sessionLogger` (#5378) — the
+    // helper that wraps loggerForSession and falls back to the unscoped logger
+    // only when sessionId is genuinely absent. Either keeps log entries scoped.
     const importRe = /import\s*\{([^}]*)\}\s*from\s*['"](?:\.{1,2}\/)+logger\.js['"]/g
     let mm
     let found = false
     while ((mm = importRe.exec(src)) !== null) {
-      if (/\bloggerForSession\b/.test(mm[1])) { found = true; break }
+      if (/\bloggerForSession\b/.test(mm[1]) || /\bsessionLogger\b/.test(mm[1])) { found = true; break }
     }
     if (!found) {
       // The import path depends on directory depth: src/foo.js uses
@@ -198,7 +201,7 @@ for (const file of walk(SRC_DIR)) {
       errors.push({
         file,
         line: 1,
-        msg: `session-aware module must \`import { loggerForSession } from '${importPath}'\` — see issue #4792`,
+        msg: `session-aware module must \`import { loggerForSession }\` (or \`sessionLogger\`) from '${importPath}' — see issue #4792`,
       })
     }
   }

--- a/packages/server/src/handlers/input-handlers.js
+++ b/packages/server/src/handlers/input-handlers.js
@@ -9,7 +9,7 @@ import { randomUUID } from 'node:crypto'
 import { validateAttachments, resolveFileRefAttachments, resolveSession, sendError, sendSessionError, buildSessionTokenMismatchPayload } from '../handler-utils.js'
 import { evaluateDraft as defaultEvaluateDraft, shouldSkipEvaluator } from '../prompt-evaluator.js'
 import { PushManager } from '../push.js'
-import { createLogger, loggerForSession } from '../logger.js'
+import { createLogger, sessionLogger } from '../logger.js'
 
 const log = createLogger('ws')
 
@@ -855,7 +855,7 @@ function handleUserQuestionResponse(ws, client, msg, ctx) {
     // so fall back to the unscoped `log` instead of throwing — multi-session
     // deployments always have a real sessionId from the toolUseId map or
     // client.activeSessionId.
-    const qlog = questionSessionId ? loggerForSession('ws', questionSessionId) : log
+    const qlog = sessionLogger(questionSessionId)
     qlog.info(`user_question_response received: toolUseId=${msg.toolUseId || '?'} answer.length=${(msg.answer || '').length} answers.keys=${msg.answers ? Object.keys(msg.answers).length : 0} freeform=${hasFreeform ? msg.freeformText.length : 0}`)
     // #4668: forward msg.toolUseId so claude-tui-session can route the
     // answer to the right pending entry in its Map. Sessions that don't

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -34,7 +34,7 @@ import {
 } from '../auth-probes.js'
 import { loadActiveSkillsLayered, findRepoSkillsDir, findSkillForRetrust, DEFAULT_SKILLS_DIR, _isCommunityNamespace } from '../skills-loader.js'
 import { realpathSync, readdirSync, statSync } from 'fs'
-import { createLogger, loggerForSession } from '../logger.js'
+import { createLogger, loggerForSession, sessionLogger } from '../logger.js'
 import {
   PER_SESSION_SETTINGS,
   buildPerSessionSettingHandler,
@@ -116,7 +116,7 @@ function handleSetModel(ws, client, msg, ctx) {
         // sessionId, so fall back to the module-level `log` rather than
         // throwing inside loggerForSession (matches the input-handlers
         // pattern from #4823).
-        ;(modelSessionId ? loggerForSession('ws', modelSessionId) : log).warn(`Rejected model '${msg.model}' on ${entry.provider} session ${modelSessionId} from ${client.id}`)
+        ;sessionLogger(modelSessionId).warn(`Rejected model '${msg.model}' on ${entry.provider} session ${modelSessionId} from ${client.id}`)
         sendError(
           ws,
           msg?.requestId,
@@ -126,7 +126,7 @@ function handleSetModel(ws, client, msg, ctx) {
         return
       }
       // #4828: session-scoped (single-session fallback as above).
-      ;(modelSessionId ? loggerForSession('ws', modelSessionId) : log).info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
+      ;sessionLogger(modelSessionId).info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
       entry.session.setModel(msg.model)
       // Non-Claude providers use opaque model IDs (e.g. 'gemini-2.5-pro') —
       // broadcast them verbatim. toShortModelId() is a Claude-specific
@@ -142,7 +142,7 @@ function handleSetModel(ws, client, msg, ctx) {
   if (ALLOWED_MODEL_IDS.has(msg.model)) {
     if (entry) {
       // #4828: session-scoped (single-session fallback).
-      ;(modelSessionId ? loggerForSession('ws', modelSessionId) : log).info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
+      ;sessionLogger(modelSessionId).info(`Model change from ${client.id} on session ${modelSessionId}: ${msg.model}`)
       entry.session.setModel(msg.model)
       ctx.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(msg.model) })
     }
@@ -174,7 +174,7 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
         }
         if (ProviderClass && ProviderClass.capabilities?.permissionModeSwitch === false) {
           // #4828: session-scoped (single-session fallback).
-          ;(permModeSessionId ? loggerForSession('ws', permModeSessionId) : log).warn(`Rejected set_permission_mode on ${entry.provider} session ${permModeSessionId} from ${client.id}: provider does not support permissionModeSwitch`)
+          ;sessionLogger(permModeSessionId).warn(`Rejected set_permission_mode on ${entry.provider} session ${permModeSessionId} from ${client.id}: provider does not support permissionModeSwitch`)
           sendError(
             ws,
             msg?.requestId,
@@ -226,7 +226,7 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
         }
         if (ctx.config?.allowAutoPermissionMode !== true) {
           // #4828: session-scoped (single-session fallback).
-          ;(permModeSessionId ? loggerForSession('ws', permModeSessionId) : log).warn(`Client ${client.id} attempted to flip to auto permission mode but allowAutoPermissionMode is not enabled in server config`)
+          ;sessionLogger(permModeSessionId).warn(`Client ${client.id} attempted to flip to auto permission mode but allowAutoPermissionMode is not enabled in server config`)
           sendError(ws, msg?.requestId, 'AUTO_MODE_DISABLED_BY_CONFIG',
             'Auto permission mode is disabled on this server. To enable, set allowAutoPermissionMode:true in the server config file (requires local filesystem access). Default is disabled for security.')
           return
@@ -234,7 +234,7 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
       }
       if (msg.mode === 'auto' && !msg.confirmed) {
         // #4828: session-scoped (single-session fallback).
-        ;(permModeSessionId ? loggerForSession('ws', permModeSessionId) : log).info(`Auto mode requested by ${client.id}, awaiting confirmation`)
+        ;sessionLogger(permModeSessionId).info(`Auto mode requested by ${client.id}, awaiting confirmation`)
         ctx.send(ws, {
           type: 'confirm_permission_mode',
           mode: 'auto',
@@ -243,7 +243,7 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
       } else {
         const previousMode = entry.session.permissionMode || 'unknown'
         // #4828: session-scoped (single-session fallback).
-        const _pmLog = permModeSessionId ? loggerForSession('ws', permModeSessionId) : log
+        const _pmLog = sessionLogger(permModeSessionId)
         if (msg.mode === 'auto') {
           _pmLog.info(`Auto permission mode CONFIRMED by ${client.id} at ${new Date().toISOString()} (was: ${previousMode})`)
         } else {
@@ -265,7 +265,7 @@ function handleSetPermissionMode(ws, client, msg, ctx) {
         const actualMode = entry.session.permissionMode
         if (actualMode !== msg.mode) {
           // #4828: session-scoped (single-session fallback).
-          ;(permModeSessionId ? loggerForSession('ws', permModeSessionId) : log).warn(`set_permission_mode rejected (session busy or no-op): requested ${msg.mode}, still ${actualMode}`)
+          ;sessionLogger(permModeSessionId).warn(`set_permission_mode rejected (session busy or no-op): requested ${msg.mode}, still ${actualMode}`)
           sendError(ws, msg?.requestId, 'PERMISSION_MODE_NOT_APPLIED',
             `Permission mode change to '${msg.mode}' was not applied (session busy or already in that mode).`)
           return
@@ -388,7 +388,7 @@ function handlePermissionResponse(ws, client, msg, ctx) {
       // #4828: session-scoped — the permission belongs to `originSessionId`
       // when known. Fall back to module-level `log` when the request had
       // no mapping AND the client isn't bound (legacy / unknown route).
-      ;(originSessionId ? loggerForSession('ws', originSessionId) : log).warn(`[permission-response-reject] unbound client ${client.id} attempted to respond to ${requestId} (originSessionId=${originSessionId}, activeSessionId=${client.activeSessionId ?? 'none'}, subscribed=false) — dropped`)
+      sessionLogger(originSessionId).warn(`[permission-response-reject] unbound client ${client.id} attempted to respond to ${requestId} (originSessionId=${originSessionId}, activeSessionId=${client.activeSessionId ?? 'none'}, subscribed=false) — dropped`)
       return
     }
   }

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -321,3 +321,23 @@ export function loggerForSession(component, sessionId) {
   }
   return createLogger(component, { sessionId })
 }
+
+/**
+ * #5378 — pick a session-scoped logger when `sessionId` is present, else the
+ * unscoped component logger. Centralizes the
+ * `sessionId ? loggerForSession('ws', sessionId) : log` ternary that was
+ * hand-written across the WS handlers (#4828), where inlining it everywhere
+ * invited picking the wrong sessionId variable or inverting the condition — and
+ * emitting an operator log to the wrong scope is silent. Unlike
+ * `loggerForSession`, this tolerates a missing/empty `sessionId` and falls back
+ * to the unscoped logger instead of throwing.
+ *
+ * @param {string|null|undefined} sessionId
+ * @param {string} [component='ws']
+ * @returns {ReturnType<typeof createLogger>}
+ */
+export function sessionLogger(sessionId, component = 'ws') {
+  return typeof sessionId === 'string' && sessionId.length > 0
+    ? loggerForSession(component, sessionId)
+    : createLogger(component)
+}

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -328,16 +328,20 @@ export function loggerForSession(component, sessionId) {
  * `sessionId ? loggerForSession('ws', sessionId) : log` ternary that was
  * hand-written across the WS handlers (#4828), where inlining it everywhere
  * invited picking the wrong sessionId variable or inverting the condition — and
- * emitting an operator log to the wrong scope is silent. Unlike
- * `loggerForSession`, this tolerates a missing/empty `sessionId` and falls back
- * to the unscoped logger instead of throwing.
+ * emitting an operator log to the wrong scope is silent.
+ *
+ * Semantics match that ternary EXACTLY: a falsy `sessionId` (null / undefined /
+ * empty string — the legitimate single-session fallback) uses the unscoped
+ * logger, while a truthy value is passed to `loggerForSession`, which THROWS on
+ * a non-string. That deliberate throw is preserved (not swallowed) so a
+ * programming error — e.g. passing an object/number — fails loudly instead of
+ * silently reintroducing the wrong-scope logging this helper exists to prevent
+ * (#5390 review).
  *
  * @param {string|null|undefined} sessionId
  * @param {string} [component='ws']
  * @returns {ReturnType<typeof createLogger>}
  */
 export function sessionLogger(sessionId, component = 'ws') {
-  return typeof sessionId === 'string' && sessionId.length > 0
-    ? loggerForSession(component, sessionId)
-    : createLogger(component)
+  return sessionId ? loggerForSession(component, sessionId) : createLogger(component)
 }

--- a/packages/server/tests/lint-logger-session-scoping.test.js
+++ b/packages/server/tests/lint-logger-session-scoping.test.js
@@ -122,6 +122,30 @@ export function withLogger(sid) {
     assert.match(res.stdout, /OK: 1 module\(s\) import loggerForSession/)
   })
 
+  test('REQUIRES_FACTORY_IMPORT: passes when sessionLogger is imported (#5378)', () => {
+    // sessionLogger wraps loggerForSession (and falls back to the unscoped
+    // logger only when sessionId is absent), so importing it keeps log entries
+    // session-scoped and satisfies the factory-import requirement.
+    const root = buildFixtureTree({
+      requiresFactoryImport: ['session-good-helper.js'],
+      forbidsBareCreateLogger: [],
+      srcFiles: {
+        'session-good-helper.js': `
+import { createLogger, sessionLogger } from './logger.js'
+
+const log = createLogger('test')
+export function withLogger(sid) {
+  return sessionLogger(sid, 'test')
+}
+`,
+      },
+    })
+    cleanups.push(root)
+
+    const res = runLint(root)
+    assert.equal(res.status, 0, `expected exit 0, got ${res.status}; stderr:\n${res.stderr}`)
+  })
+
   test('REQUIRES_FACTORY_IMPORT: fails when only createLogger is imported', () => {
     const root = buildFixtureTree({
       requiresFactoryImport: ['session-missing-import.js'],
@@ -138,7 +162,7 @@ const log = createLogger('test')
 
     const res = runLint(root)
     assert.equal(res.status, 1, `expected exit 1, got ${res.status}; stdout:\n${res.stdout}`)
-    assert.match(res.stderr, /session-aware module must `import \{ loggerForSession \} from/)
+    assert.match(res.stderr, /session-aware module must `import \{ loggerForSession \}` \(or `sessionLogger`\) from/)
   })
 
   test('FORBIDS_BARE_CREATELOGGER: passes when every createLogger is chained with .withSession', () => {


### PR DESCRIPTION
## Summary

Closes #5378 (swarm-audit DRY finding).

The `;(sessionId ? loggerForSession('ws', sessionId) : log).warn(...)` ternary was hand-written 8× in `settings-handlers.js` and once in `input-handlers.js`. The fallback-to-unscoped-on-empty-sessionId logic is correct (#4828), but inlining it everywhere invited picking the wrong sessionId variable or inverting the condition — and emitting an operator log to the wrong scope is **silent**.

## Change
- Add `sessionLogger(sessionId, component = 'ws')` to `logger.js` (next to `loggerForSession`). Unlike `loggerForSession` (which throws on an empty sessionId), it falls back to the unscoped component logger — exactly the existing inline behavior.
- Replace the 9 ternary sites with `sessionLogger(...)`.
- Direct `loggerForSession('ws', client.boundSessionId)` calls (where the sessionId is guaranteed present) are **left unchanged** — they're not the fallback pattern.

89 logger + settings-handler tests pass (incl. `lint-logger-session-scoping` + `logger-usage`); lint clean (0 errors).