### PR TITLE
refactor(server): hoist _intentionalStop to BaseSession (#5375)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -285,6 +285,15 @@ export class BaseSession extends EventEmitter {
 
     this._isBusy = false
     this._processReady = false
+    // #5375: user-initiated stop vs crash. Set by interrupt() (markIntentionalStop),
+    // captured-and-cleared by the provider's close/error handler
+    // (_consumeIntentionalStop) so a clean stop is not reported as an error.
+    // Hoisted here from the three providers (#4602/#4881) — see _consumeIntentionalStop
+    // and _clearIntentionalStop below. The capture and the safety-net clear are kept
+    // as SEPARATE helpers on purpose: SDK relies on a catch-block consume plus a
+    // `finally` safety-net clear (the interrupt-races-result case), and collapsing
+    // them would reopen that race.
+    this._intentionalStop = false
     // #4307: per-session map of backgrounded Bash shells the agent is
     // still waiting on. Keyed by the shellId Claude prints in the
     // `Command running in background with ID: <id>` tool_result. Lives
@@ -1153,6 +1162,37 @@ export class BaseSession extends EventEmitter {
 
   get isReady() {
     return this._processReady && !this._isBusy
+  }
+
+  /**
+   * #5375: arm the user-initiated-stop flag. Called by each provider's
+   * interrupt() so the subsequent process close/error is treated as a clean
+   * stop rather than a crash.
+   */
+  markIntentionalStop() {
+    this._intentionalStop = true
+  }
+
+  /**
+   * #5375: capture-and-clear the user-initiated-stop flag in one step. The
+   * provider's close/error handler calls this at the top to decide the
+   * stopped-vs-error branch, disarming the flag so the next natural exit is
+   * not misread. Returns whether the flag was armed.
+   */
+  _consumeIntentionalStop() {
+    const was = this._intentionalStop
+    this._intentionalStop = false
+    return was
+  }
+
+  /**
+   * #5375: plain disarm, for destroy()/finally safety-nets where we only need
+   * to clear the flag without reading it. Kept separate from
+   * _consumeIntentionalStop so SDK's catch-then-finally clear (the
+   * interrupt-races-result race, #4881) stays a two-step sequence.
+   */
+  _clearIntentionalStop() {
+    this._intentionalStop = false
   }
 
   /**

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -370,7 +370,7 @@ export class CliSession extends BaseSession {
     // from "child crashed" so _handleChildClose skips the misleading
     // "exited unexpectedly" toast + auto-respawn on the stop path.
     // Single-use: set by interrupt(), cleared by _handleChildClose / destroy.
-    this._intentionalStop = false
+    // The flag itself is declared+initialized on BaseSession (#5375).
 
     // Hook manager (shared module)
     this._hookManager = (this._port) ? createPermissionHookManager(this, { settingsPath }) : null
@@ -1469,8 +1469,7 @@ export class CliSession extends BaseSession {
     // (e.g. user clicks Stop → flag set → model switch fires
     // _killAndRespawn → _respawning short-circuit hits, but the flag must
     // not persist to silently swallow a real crash on a future close).
-    const wasIntentionalStop = this._intentionalStop
-    this._intentionalStop = false
+    const wasIntentionalStop = this._consumeIntentionalStop()
 
     // #4929: capture the resume-attempt state for this child BEFORE the
     // destroy/respawn short-circuits return. A `--resume <id>` that the CLI
@@ -1608,7 +1607,7 @@ export class CliSession extends BaseSession {
     // auto-respawn. If the child survives SIGINT (claude only aborts the
     // current turn), the next natural exit will be a real crash — the flag
     // is cleared in _handleChildClose on whichever exit fires first.
-    this._intentionalStop = true
+    this.markIntentionalStop()
 
     // #4828: session-scoped if init has fired.
     ;(this._log || log).info('Sending SIGINT to claude process')
@@ -1626,7 +1625,7 @@ export class CliSession extends BaseSession {
       // #4602: if the child survived SIGINT (claude only aborted the turn),
       // clear the flag so a later natural crash still triggers respawn —
       // otherwise the flag stays armed indefinitely and swallows real crashes.
-      this._intentionalStop = false
+      this._clearIntentionalStop()
       if (this._isBusy) {
         // #4828: session-scoped.
         ;(this._log || log).warn('Interrupt safety timeout — force-clearing busy state')
@@ -1639,7 +1638,7 @@ export class CliSession extends BaseSession {
   destroy() {
     this._destroying = true
     this._respawning = false
-    this._intentionalStop = false
+    this._clearIntentionalStop()
 
     // Clean up permission hook — destroy() now chains unregister() after any
     // in-flight register() promise, preventing a register-after-unregister race

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -176,7 +176,7 @@ export class JsonlSubprocessSession extends BaseSession {
     // Single-use: cleared on every close path (close, destroy) so the flag
     // never leaks past one sendMessage cycle. Matches CliSession's
     // capture-and-clear discipline in `_handleChildClose`.
-    this._intentionalStop = false
+    // The flag itself is declared+initialized on BaseSession (#5375).
   }
 
   start() {
@@ -196,7 +196,7 @@ export class JsonlSubprocessSession extends BaseSession {
     this._isBusy = false
     // #4881: clear so a teardown after interrupt() never leaks the flag past
     // this session instance. Mirrors CliSession.destroy() (#4602).
-    this._intentionalStop = false
+    this._clearIntentionalStop()
     if (this._process) {
       try {
         this._process.kill('SIGTERM')
@@ -212,7 +212,7 @@ export class JsonlSubprocessSession extends BaseSession {
     // proc.on('close') handler suppresses the "exited with code N" error and
     // instead emits a quiet `stopped` event with the exit code. Cleared in
     // the close handler (single-use, mirrors CliSession #4602).
-    this._intentionalStop = true
+    this.markIntentionalStop()
     try {
       this._process.kill('SIGINT')
     } catch { /* already dead */ }
@@ -427,8 +427,7 @@ export class JsonlSubprocessSession extends BaseSession {
       // #4881: capture-and-clear BEFORE the _destroying short-circuit so the
       // flag never leaks past a close even when destroy() fires first.
       // Mirrors CliSession._handleChildClose (#4602).
-      const wasIntentionalStop = this._intentionalStop
-      this._intentionalStop = false
+      const wasIntentionalStop = this._consumeIntentionalStop()
       if (this._destroying) return
       if (ctx.didStreamStart) {
         this.emit('stream_end', { messageId: ctx.messageId })

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -411,7 +411,7 @@ export class SdkSession extends BaseSession {
     // Cleared on every consume path (close, error, destroy) so the flag never
     // leaks past one turn — matches the single-use semantic CliSession pins
     // in `_handleChildClose` (capture-and-clear up front).
-    this._intentionalStop = false
+    // The flag itself is declared+initialized on BaseSession (#5375).
   }
 
   get sessionId() {
@@ -931,8 +931,7 @@ export class SdkSession extends BaseSession {
       // #4881: capture-and-clear before any branch so the flag never leaks
       // past this turn even when _destroying short-circuits the emits below.
       // Mirrors CliSession._handleChildClose (#4602).
-      const wasIntentionalStop = this._intentionalStop
-      this._intentionalStop = false
+      const wasIntentionalStop = this._consumeIntentionalStop()
       if (!this._destroying) {
         if (wasIntentionalStop) {
           // #4881: user clicked Stop — interrupt() set the flag, the SDK
@@ -959,7 +958,7 @@ export class SdkSession extends BaseSession {
       // clear, the flag would stay armed until the next turn's catch and
       // mis-trigger a spurious `stopped` emit there. Idempotent — the
       // catch path already cleared it on the throw path.
-      this._intentionalStop = false
+      this._clearIntentionalStop()
       // Dequeue any follow-up messages that arrived while busy
       if (this._pendingInput?.length && !this._destroying) {
         // #3562: if the SidecarProcess latched stdin_disabled mid-turn (e.g.
@@ -1498,7 +1497,7 @@ export class SdkSession extends BaseSession {
     // _callQuery catch block suppresses the AbortError-flavored "Query error"
     // emit and instead surfaces a quiet `stopped` event. Cleared in the
     // catch/finally (single-use, mirrors CliSession#4602).
-    this._intentionalStop = true
+    this.markIntentionalStop()
 
     // #4828: session-scoped (interrupt() only meaningful with an active query).
     ;(this._log || log).info('Interrupting query')
@@ -1707,7 +1706,7 @@ export class SdkSession extends BaseSession {
     this._pendingInput = []
     // #4881: clear so a teardown after interrupt() never leaks the flag past
     // this session instance. Mirrors CliSession.destroy() (#4602).
-    this._intentionalStop = false
+    this._clearIntentionalStop()
     // #5269: drop subagent task-id mappings on teardown.
     this._taskIdByToolUseId.clear()
 

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -115,6 +115,39 @@ describe('BaseSession', () => {
     })
   })
 
+  describe('intentional-stop flag (#5375 — hoisted from the 3 providers)', () => {
+    it('initializes disarmed', () => {
+      assert.equal(new BaseSession()._intentionalStop, false)
+    })
+
+    it('markIntentionalStop arms it', () => {
+      const s = new BaseSession()
+      s.markIntentionalStop()
+      assert.equal(s._intentionalStop, true)
+    })
+
+    it('_consumeIntentionalStop captures-and-clears in one step', () => {
+      const s = new BaseSession()
+      s.markIntentionalStop()
+      // First consume returns the armed state AND disarms.
+      assert.equal(s._consumeIntentionalStop(), true)
+      assert.equal(s._intentionalStop, false)
+      // Second consume sees the cleared state — the next natural exit is not
+      // misread as a user stop.
+      assert.equal(s._consumeIntentionalStop(), false)
+    })
+
+    it('_clearIntentionalStop disarms without reading (kept separate from consume so SDK catch-then-finally stays two-step)', () => {
+      const s = new BaseSession()
+      s.markIntentionalStop()
+      s._clearIntentionalStop()
+      assert.equal(s._intentionalStop, false)
+      // Idempotent — a finally safety-net after the catch already consumed it.
+      s._clearIntentionalStop()
+      assert.equal(s._intentionalStop, false)
+    })
+  })
+
   describe('setModel', () => {
     it('returns false when busy', () => {
       session._isBusy = true

--- a/packages/server/tests/sdk-session-intentional-stop.test.js
+++ b/packages/server/tests/sdk-session-intentional-stop.test.js
@@ -216,7 +216,7 @@ describe('SdkSession _callQuery finally — source contains safety-net clear for
    * branch logic while still failing loudly the moment someone removes the
    * safety-net clear from the finally block.
    */
-  it('source has `this._intentionalStop = false` inside _callQuery finally', async () => {
+  it('source has `this._clearIntentionalStop()` inside _callQuery finally', async () => {
     const { readFileSync } = await import('node:fs')
     const { fileURLToPath } = await import('node:url')
     const src = readFileSync(fileURLToPath(new URL('../src/sdk-session.js', import.meta.url)), 'utf8')
@@ -226,11 +226,14 @@ describe('SdkSession _callQuery finally — source contains safety-net clear for
     // where `result` lands before interrupt() throws would leak the flag.
     assert.match(src, /#4881: safety-net clear of _intentionalStop/,
       'finally must carry the documented race-safety comment')
-    // Locate the comment then assert the clear line is within 10 lines after.
+    // Locate the comment then assert the clear is within 10 lines after.
+    // #5375 hoisted the flag to BaseSession, so the safety-net clear is now
+    // the `_clearIntentionalStop()` helper (kept SEPARATE from the catch-block
+    // `_consumeIntentionalStop()` so this race fix stays a two-step sequence).
     const commentIdx = src.indexOf('#4881: safety-net clear of _intentionalStop')
     assert.ok(commentIdx >= 0, 'comment present')
     const tailSlice = src.slice(commentIdx, commentIdx + 800)
-    assert.match(tailSlice, /this\._intentionalStop\s*=\s*false/,
+    assert.match(tailSlice, /this\._clearIntentionalStop\(\)/,
       'finally must clear the flag so a non-throw exit (result landed before interrupt threw) does not leak it to the next turn')
   })
 })


### PR DESCRIPTION
Closes #5375.

## What
Hoists the user-initiated-stop flag (`_intentionalStop`) and its capture-and-clear logic — previously duplicated identically across `CliSession`, `SdkSession` and `JsonlSubprocessSession` (#4602/#4881) — into `BaseSession`:

- `markIntentionalStop()` — arm the flag (called by each provider's `interrupt()`)
- `_consumeIntentionalStop()` — capture-and-clear in one step (the close/error handler's stopped-vs-error branch)
- `_clearIntentionalStop()` — plain disarm, for `destroy()`/`finally` safety-nets

## Why the helpers are split
`_consumeIntentionalStop()` and `_clearIntentionalStop()` are deliberately kept **separate**. SDK relies on a catch-block consume **plus** a `finally` safety-net clear for the interrupt-races-`result` case (#4881); collapsing them into one helper would reopen that race. The design (posted on #5375) calls this out explicitly.

## Scope
- `base-session.js`: declares + initializes the flag, adds the three helpers.
- `cli-session.js` / `sdk-session.js` / `jsonl-subprocess-session.js`: each provider's ctor init removed (base initializes it), `interrupt()` → `markIntentionalStop()`, the close/error capture-and-clear → `_consumeIntentionalStop()`, standalone clears → `_clearIntentionalStop()`. Provider-specific comments documenting *why* each consumes the way it does are retained.
- Codex/Gemini inherit via `JsonlSubprocessSession` — no change.

## Tests
- The three per-provider intentional-stop regression suites (`cli/sdk/jsonl-*-intentional-stop.test.js`) pass **unchanged** — this is behavior-preserving.
- Adds a `base-session.test.js` block for the helpers (arm → consume returns true then false → clear is idempotent).
- Updates the SDK `finally` source-introspection assertion (#4881 race guard) to match the new `_clearIntentionalStop()` helper; the documented race-safety comment is unchanged.
- Custom lints (`lint-session-opt-forwarding.sh`, `lint-logger-session-scoping.sh`) + eslint clean.

First of three SAFE-rated refactors from the deferred-issue design pass; land order #5375 → #5374 → #5367 → #5376.