### PR TITLE
refactor(server): extract emergencyCleanup helpers from startCliServer (#5369)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -384,13 +384,15 @@ export async function emergencyCleanup({
   tunnel, wsServer, mdnsService, bonjourInstance,
   tokenManager, pairingManager, sessionManager, logger = log,
 }) {
-  try { if (tunnel) await tunnel.stop() } catch (err) { logger.warn?.(`emergencyCleanup: tunnel.stop failed: ${err?.message || err}`) }
-  try { wsServer?.close() } catch (err) { logger.warn?.(`emergencyCleanup: wsServer.close failed: ${err?.message || err}`) }
+  // String(err?.message || err) so a non-Error throw (e.g. a Symbol) can't make
+  // the log-formatting itself throw and break this best-effort teardown chain.
+  try { if (tunnel) await tunnel.stop() } catch (err) { logger?.warn?.(`emergencyCleanup: tunnel.stop failed: ${String(err?.message || err)}`) }
+  try { wsServer?.close() } catch (err) { logger?.warn?.(`emergencyCleanup: wsServer.close failed: ${String(err?.message || err)}`) }
   try { mdnsService?.stop?.() } catch {}
   try { bonjourInstance?.destroy?.() } catch {}
   try { tokenManager?.destroy() } catch {}
   try { pairingManager?.destroy() } catch {}
-  try { sessionManager?.destroyAll() } catch (err) { logger.warn?.(`emergencyCleanup: destroyAll failed: ${err?.message || err}`) }
+  try { sessionManager?.destroyAll() } catch (err) { logger?.warn?.(`emergencyCleanup: destroyAll failed: ${String(err?.message || err)}`) }
 }
 
 /**
@@ -408,8 +410,10 @@ export function emergencyCleanupSync({ kind, tunnel, wsServer, sessionManager, l
   // Persist sessions before destroying — losing the user's restored state on
   // crash is worse UX than the small risk of writing partial state. The
   // try/catch isolates serialization failures so destroyAll() still runs.
+  // logger?.warn?.() + String(...) so a minimal/nullish logger or a non-Error
+  // throw can't itself throw and abort the remaining crash teardown.
   try { sessionManager?.serializeState() } catch (serializeErr) {
-    logger.warn(`Failed to serialize state during ${kind}: ${serializeErr?.stack || serializeErr}`)
+    logger?.warn?.(`Failed to serialize state during ${kind}: ${String(serializeErr?.stack || serializeErr)}`)
   }
   try { sessionManager?.destroyAll() } catch {}
   try { wsServer?.close() } catch {}

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -370,6 +370,54 @@ export async function maybeAdvertiseMdns({
   }
 }
 
+/**
+ * #5369: best-effort teardown for STARTUP-ERROR paths (tunnel.start failure,
+ * waitForTunnel failure). Async — awaits tunnel.stop() because at startup there
+ * is no exit-deadline risk and we want a clean stop. Each step is try/catch-
+ * isolated so one failure can't strand the rest. Exported (no process.exit) so
+ * it can be unit-tested with fakes — mirrors flushAndDestroy in
+ * server-cli-child.js. Order is tunnel → ws → mdns → bonjour → token → pairing
+ * → sessionManager (the deliberate startup-error order; pool is NOT torn down
+ * at these sites today and must not be added).
+ */
+export async function emergencyCleanup({
+  tunnel, wsServer, mdnsService, bonjourInstance,
+  tokenManager, pairingManager, sessionManager, logger = log,
+}) {
+  try { if (tunnel) await tunnel.stop() } catch (err) { logger.warn?.(`emergencyCleanup: tunnel.stop failed: ${err?.message || err}`) }
+  try { wsServer?.close() } catch (err) { logger.warn?.(`emergencyCleanup: wsServer.close failed: ${err?.message || err}`) }
+  try { mdnsService?.stop?.() } catch {}
+  try { bonjourInstance?.destroy?.() } catch {}
+  try { tokenManager?.destroy() } catch {}
+  try { pairingManager?.destroy() } catch {}
+  try { sessionManager?.destroyAll() } catch (err) { logger.warn?.(`emergencyCleanup: destroyAll failed: ${err?.message || err}`) }
+}
+
+/**
+ * #5369: unified SYNCHRONOUS crash teardown for uncaughtException /
+ * unhandledRejection. `kind` is the log label. Deliberately NOT async and does
+ * NOT await tunnel.stop() — the sigterm-not-sigkill invariant: a hung stop must
+ * never block the setTimeout-driven process.exit in the caller (otherwise an
+ * installed crash handler suppresses Node's default crash-exit and could leave
+ * the process alive forever). Order: broadcast → serialize → destroyAll → ws
+ * close → tunnel.stop (fire-and-forget) → removeConnectionInfo. destroyAll runs
+ * before wsServer.close so SDK sessions auto-deny pending permissions first.
+ */
+export function emergencyCleanupSync({ kind, tunnel, wsServer, sessionManager, logger = log }) {
+  try { wsServer?.broadcastShutdown('crash', 0) } catch {}
+  // Persist sessions before destroying — losing the user's restored state on
+  // crash is worse UX than the small risk of writing partial state. The
+  // try/catch isolates serialization failures so destroyAll() still runs.
+  try { sessionManager?.serializeState() } catch (serializeErr) {
+    logger.warn(`Failed to serialize state during ${kind}: ${serializeErr?.stack || serializeErr}`)
+  }
+  try { sessionManager?.destroyAll() } catch {}
+  try { wsServer?.close() } catch {}
+  // NO await — see the invariant above.
+  try { if (tunnel) tunnel.stop() } catch {}
+  try { removeConnectionInfo() } catch {}
+}
+
 export async function startCliServer(config) {
   // Enable JSON log format if configured
   if (config.logFormat === 'json') {
@@ -974,13 +1022,7 @@ export async function startCliServer(config) {
       log.error(message)
       try { wsServer.broadcastError('tunnel', message, false) } catch {}
       console.error(`\n  ✗ ${message}\n`)
-      try { await tunnel.stop() } catch {}
-      try { wsServer.close() } catch {}
-      try { mdnsService?.stop?.() } catch {}
-      try { bonjourInstance?.destroy?.() } catch {}
-      try { tokenManager?.destroy() } catch {}
-      try { pairingManager?.destroy() } catch {}
-      try { sessionManager.destroyAll() } catch {}
+      await emergencyCleanup({ tunnel, wsServer, mdnsService, bonjourInstance, tokenManager, pairingManager, sessionManager })
       process.exitCode = 1
       return
     }
@@ -1051,13 +1093,7 @@ export async function startCliServer(config) {
       console.error(`\n  ✗ ${tunnelErr.message}\n`)
       // Clean up everything that's been started so we don't leave
       // orphan processes or armed timers holding the event loop alive.
-      try { await tunnel.stop() } catch {}
-      try { wsServer.close() } catch {}
-      try { mdnsService?.stop?.() } catch {}
-      try { bonjourInstance?.destroy?.() } catch {}
-      try { tokenManager?.destroy() } catch {}
-      try { pairingManager?.destroy() } catch {}
-      try { sessionManager.destroyAll() } catch {}
+      await emergencyCleanup({ tunnel, wsServer, mdnsService, bonjourInstance, tokenManager, pairingManager, sessionManager })
       process.exitCode = 1
       return
     }
@@ -1206,55 +1242,24 @@ export async function startCliServer(config) {
   process.on('SIGINT', () => { shutdown('SIGINT').catch(() => process.exit(1)) })
   process.on('SIGTERM', () => { shutdown('SIGTERM').catch(() => process.exit(1)) })
 
-  process.on('uncaughtException', (err) => {
+  // #5369: uncaughtException and unhandledRejection shared an identical body —
+  // unify them into one handler factory taking a `kind` log label. The "during
+  // shutdown" branch still just logs + schedules exit (otherwise installing
+  // these handlers would suppress Node's default crash-exit and a stuck
+  // shutdown — e.g. hung tunnel.stop() — could leave the process alive forever).
+  const onFatal = (kind) => (err) => {
     if (shuttingDown) {
-      // Late crash arriving during an already-running shutdown — still log
-      // it and schedule exit, otherwise installing this handler would
-      // suppress Node's default crash-exit and a stuck shutdown
-      // (e.g. hung tunnel.stop()) could leave the process alive forever.
-      log.error(`Uncaught exception during shutdown: ${err?.stack || err}`)
+      log.error(`${kind} during shutdown: ${err?.stack || err}`)
       setTimeout(() => process.exit(1), 100)
       return
     }
     shuttingDown = true
-    log.error(`Uncaught exception: ${err?.stack || err}`)
-    try { wsServer.broadcastShutdown('crash', 0) } catch {}
-    // Persist sessions before destroying — losing the user's restored state
-    // on crash is worse UX than the small risk of writing partial state. The
-    // try/catch isolates serialization failures so destroyAll() still runs.
-    try { sessionManager.serializeState() } catch (serializeErr) {
-      log.warn(`Failed to serialize state during crash: ${serializeErr?.stack || serializeErr}`)
-    }
-    // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes
-    try { sessionManager.destroyAll() } catch {}
-    try { wsServer.close() } catch {}
-    try { if (tunnel) tunnel.stop() } catch {}
-    try { removeConnectionInfo() } catch {}
+    log.error(`${kind}: ${err?.stack || err}`)
+    emergencyCleanupSync({ kind, tunnel, wsServer, sessionManager })
     setTimeout(() => process.exit(1), 100)
-  })
-
-  process.on('unhandledRejection', (err) => {
-    if (shuttingDown) {
-      log.error(`Unhandled rejection during shutdown: ${err?.stack || err}`)
-      setTimeout(() => process.exit(1), 100)
-      return
-    }
-    shuttingDown = true
-    log.error(`Unhandled rejection: ${err?.stack || err}`)
-    try { wsServer.broadcastShutdown('crash', 0) } catch {}
-    // Persist sessions before destroying — losing the user's restored state
-    // on crash is worse UX than the small risk of writing partial state. The
-    // try/catch isolates serialization failures so destroyAll() still runs.
-    try { sessionManager.serializeState() } catch (serializeErr) {
-      log.warn(`Failed to serialize state during crash: ${serializeErr?.stack || serializeErr}`)
-    }
-    // destroyAll() first: SDK sessions auto-deny pending permissions before WsServer closes
-    try { sessionManager.destroyAll() } catch {}
-    try { wsServer.close() } catch {}
-    try { if (tunnel) tunnel.stop() } catch {}
-    try { removeConnectionInfo() } catch {}
-    setTimeout(() => process.exit(1), 100)
-  })
+  }
+  process.on('uncaughtException', onFatal('Uncaught exception'))
+  process.on('unhandledRejection', onFatal('Unhandled rejection'))
 
   // Return references for supervised child drain protocol
   return { sessionManager, wsServer }

--- a/packages/server/tests/server-cli-emergency-cleanup.test.js
+++ b/packages/server/tests/server-cli-emergency-cleanup.test.js
@@ -94,6 +94,20 @@ describe('emergencyCleanupSync (#5369 — sync crash teardown)', () => {
     assert.deepEqual(calls, ['broadcast:crash', 'serialize', 'destroyAll', 'ws.close', 'tunnel.stop'])
   })
 
+  it('survives a non-Error (Symbol) throw without the log formatting itself throwing', () => {
+    // Copilot #5393: `${err}` interpolation throws a TypeError for a Symbol, so
+    // a non-Error throw could break the best-effort cleanup. String(...) guards it.
+    let destroyed = false
+    assert.doesNotThrow(() => emergencyCleanupSync({
+      kind: 'Test crash',
+      wsServer: { broadcastShutdown() {}, close() {} },
+      // serializeState throws a Symbol — the catch's log must not re-throw.
+      sessionManager: { serializeState() { throw Symbol('boom') }, destroyAll() { destroyed = true } },
+      logger: silent,
+    }))
+    assert.equal(destroyed, true, 'destroyAll still runs after a Symbol-throwing serializeState')
+  })
+
   it('returns synchronously even while tunnel.stop() hangs (the no-await invariant)', () => {
     let stopCalled = false
     const ret = emergencyCleanupSync({

--- a/packages/server/tests/server-cli-emergency-cleanup.test.js
+++ b/packages/server/tests/server-cli-emergency-cleanup.test.js
@@ -1,0 +1,126 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { emergencyCleanup, emergencyCleanupSync } from '../src/server-cli.js'
+
+/**
+ * #5369: the two extracted teardown helpers. Previously the teardown chain was
+ * hand-written 4 times across startCliServer's error/crash paths; these tests
+ * pin the two distinct SHAPES the extraction must preserve:
+ *   - emergencyCleanup     — async, startup-error, awaits tunnel.stop()
+ *   - emergencyCleanupSync — sync, crash, NEVER awaits tunnel.stop()
+ *
+ * Safety: emergencyCleanupSync calls the real removeConnectionInfo(), which
+ * unlinks ~/.chroxy/connection.json. Redirect CHROXY_CONFIG_DIR to a temp dir
+ * so the crash-path tests can never delete the operator's live connection file
+ * (and the unlink just no-ops with ENOENT, swallowed internally).
+ */
+
+let prevConfigDir
+before(() => {
+  prevConfigDir = process.env.CHROXY_CONFIG_DIR
+  process.env.CHROXY_CONFIG_DIR = mkdtempSync(join(tmpdir(), 'emergency-cleanup-test-'))
+})
+after(() => {
+  if (prevConfigDir === undefined) delete process.env.CHROXY_CONFIG_DIR
+  else process.env.CHROXY_CONFIG_DIR = prevConfigDir
+})
+
+const silent = { warn() {}, error() {}, info() {} }
+
+function startupFakes() {
+  const calls = []
+  return {
+    calls,
+    logger: silent,
+    tunnel: { stop: async () => { calls.push('tunnel.stop') } },
+    wsServer: { close: () => calls.push('wsServer.close') },
+    mdnsService: { stop: () => calls.push('mdns.stop') },
+    bonjourInstance: { destroy: () => calls.push('bonjour.destroy') },
+    tokenManager: { destroy: () => calls.push('token.destroy') },
+    pairingManager: { destroy: () => calls.push('pairing.destroy') },
+    sessionManager: { destroyAll: () => calls.push('destroyAll') },
+  }
+}
+
+describe('emergencyCleanup (#5369 — async startup-error teardown)', () => {
+  it('stops/destroys every component in the deliberate startup-error order', async () => {
+    const f = startupFakes()
+    await emergencyCleanup(f)
+    assert.deepEqual(f.calls, [
+      'tunnel.stop', 'wsServer.close', 'mdns.stop', 'bonjour.destroy',
+      'token.destroy', 'pairing.destroy', 'destroyAll',
+    ])
+  })
+
+  it('isolates a failing step so the rest still run', async () => {
+    const f = startupFakes()
+    f.wsServer.close = () => { throw new Error('close boom') }
+    await emergencyCleanup(f)
+    // close threw but every later step still executed.
+    assert.ok(f.calls.includes('destroyAll'), 'destroyAll runs despite wsServer.close throwing')
+    assert.ok(f.calls.includes('pairing.destroy'))
+  })
+
+  it('is safe when components are absent (optional chaining)', async () => {
+    // All undefined — must not throw.
+    await emergencyCleanup({ logger: silent })
+  })
+
+  it('awaits tunnel.stop before resolving', async () => {
+    const order = []
+    await emergencyCleanup({
+      logger: silent,
+      tunnel: { stop: () => new Promise((r) => setTimeout(() => { order.push('tunnel-stopped'); r() }, 5)) },
+      sessionManager: { destroyAll: () => order.push('destroyAll') },
+    })
+    // destroyAll ran AFTER the awaited tunnel.stop resolved.
+    assert.deepEqual(order, ['tunnel-stopped', 'destroyAll'])
+  })
+})
+
+describe('emergencyCleanupSync (#5369 — sync crash teardown)', () => {
+  it('runs broadcast → serialize → destroyAll → ws.close → tunnel.stop in order', () => {
+    const calls = []
+    emergencyCleanupSync({
+      kind: 'Test crash',
+      tunnel: { stop: () => calls.push('tunnel.stop') },
+      wsServer: { broadcastShutdown: (r) => calls.push(`broadcast:${r}`), close: () => calls.push('ws.close') },
+      sessionManager: { serializeState: () => calls.push('serialize'), destroyAll: () => calls.push('destroyAll') },
+      logger: silent,
+    })
+    assert.deepEqual(calls, ['broadcast:crash', 'serialize', 'destroyAll', 'ws.close', 'tunnel.stop'])
+  })
+
+  it('returns synchronously even while tunnel.stop() hangs (the no-await invariant)', () => {
+    let stopCalled = false
+    const ret = emergencyCleanupSync({
+      kind: 'Test crash',
+      // A stop() that never settles would deadlock if awaited.
+      tunnel: { stop: () => { stopCalled = true; return new Promise(() => {}) } },
+      wsServer: { broadcastShutdown() {}, close() {} },
+      sessionManager: { serializeState() {}, destroyAll() {} },
+      logger: silent,
+    })
+    assert.equal(ret, undefined, 'must return undefined, not a Promise — proving it never awaits')
+    assert.ok(!(ret instanceof Promise))
+    assert.equal(stopCalled, true, 'tunnel.stop is still fired (fire-and-forget)')
+  })
+
+  it('labels the serialize-failure log with the `kind`', () => {
+    let logged = ''
+    emergencyCleanupSync({
+      kind: 'Unhandled rejection',
+      wsServer: { broadcastShutdown() {}, close() {} },
+      sessionManager: { serializeState() { throw new Error('disk full') }, destroyAll() {} },
+      logger: { warn: (m) => { logged = m } },
+    })
+    assert.match(logged, /Failed to serialize state during Unhandled rejection/)
+  })
+
+  it('is safe when components are absent', () => {
+    emergencyCleanupSync({ kind: 'k', logger: silent })
+  })
+})


### PR DESCRIPTION
Closes #5369.

## What
The best-effort teardown chain (`try/catch` around `tunnel.stop` / `wsServer.close` / `sessionManager.destroyAll` / …) was hand-written **4 times** across `startCliServer`'s error and crash paths. Extracts two exported helpers:

- **`emergencyCleanup({...})`** — async, for the two **startup-error** paths (tunnel-start failure, waitForTunnel failure). Awaits `tunnel.stop()`; order `tunnel → ws → mdns → bonjour → token → pairing → sessionManager`.
- **`emergencyCleanupSync({ kind, ... })`** — sync, for the **crash** paths. Unifies the near-identical `uncaughtException` / `unhandledRejection` bodies into one `onFatal(kind)` handler.

## Why two functions, not one flag-gated function
The startup-error and crash shapes are **deliberately different**: different component sets (7 vs 3), reversed teardown order, and — critically — different `await` semantics. The crash path must **never await `tunnel.stop()`** (the sigterm-not-sigkill invariant: a hung stop must not block the `setTimeout`-driven `process.exit`, or an installed crash handler would suppress Node's default crash-exit and could leave the process alive forever). Keeping `emergencyCleanupSync` **literally non-`async`** makes that invariant structurally unbreakable by a future edit, rather than a comment.

Graceful `shutdown()` is intentionally left untouched — its `await pool.shutdown()` / `await tunnel.stop()` semantics must not bleed into the crash path.

## Tests
- Existing `error-handlers.test.js` crash tests pass **unchanged**.
- Adds `server-cli-emergency-cleanup.test.js`: per-shape order, throw-isolation (a failing step doesn't strand the rest), optional-chaining safety, the **sync-returns-while-`tunnel.stop()`-hangs** regression test (guards the no-await invariant), and the `kind`-labelled serialize-failure log. The crash-path test redirects `CHROXY_CONFIG_DIR` to a temp dir so `removeConnectionInfo()` can't touch the operator's live `~/.chroxy/connection.json`.
- eslint clean; server-cli suite (banner/startup-timeouts/child/supervisor) green.

SAFE-rated refactor from the deferred-issue design pass; **lands before #5368** (ServerOrchestrator reuses these helpers).