### PR TITLE
refactor(server): centralize setter guard via _onModelChanged/_onPermissionModeChanged hooks (#5374)

### DIFF
--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -1215,9 +1215,10 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
-   * #5374: protected hook fired by setModel() AFTER validation + the field is
-   * set, only when the model actually changed. Default no-op; subclasses
-   * override with their provider-specific action (and their own logging).
+   * #5374: protected hook fired by setModel() AFTER the busy/no-op guard +
+   * alias resolution (resolveModelId) and the field update, only when the model
+   * actually changed. Default no-op; subclasses override with their
+   * provider-specific action (and their own logging).
    */
   _onModelChanged(_model) {}
 

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -1196,9 +1196,10 @@ export class BaseSession extends EventEmitter {
   }
 
   /**
-   * Change the model. Subclasses that need to restart (CliSession) should
-   * override and call super.setModel() for the guard + resolve, then act.
-   * Returns true if the model actually changed (subclass should act).
+   * Change the model. Centralizes the busy/no-op guard + resolve; subclasses
+   * that need a provider-specific reaction (CliSession respawn, SdkSession log)
+   * override the `_onModelChanged` hook instead of the whole setter (#5374).
+   * Returns true if the model actually changed.
    */
   setModel(model) {
     if (this._isBusy) {
@@ -1209,12 +1210,22 @@ export class BaseSession extends EventEmitter {
       return false
     }
     this.model = newModel
+    this._onModelChanged(this.model)
     return true
   }
 
   /**
-   * Change the permission mode. Subclasses that need to restart (CliSession)
-   * should override and call super.setPermissionMode() for validation.
+   * #5374: protected hook fired by setModel() AFTER validation + the field is
+   * set, only when the model actually changed. Default no-op; subclasses
+   * override with their provider-specific action (and their own logging).
+   */
+  _onModelChanged(_model) {}
+
+  /**
+   * Change the permission mode. Centralizes validation + the busy/no-op guard;
+   * subclasses override the `_onPermissionModeChanged` hook for their
+   * provider-specific action (CliSession respawn, SdkSession drain, TUI sidecar
+   * write) instead of the whole setter (#5374).
    * Returns true if the mode actually changed.
    */
   setPermissionMode(mode) {
@@ -1233,8 +1244,18 @@ export class BaseSession extends EventEmitter {
       return false
     }
     this.permissionMode = mode
+    this._onPermissionModeChanged(mode)
     return true
   }
+
+  /**
+   * #5374: protected hook fired by setPermissionMode() AFTER validation + the
+   * field is set, only when the mode actually changed. Default no-op;
+   * subclasses override with their provider-specific action (and their own
+   * logging). JsonlSubprocessSession deliberately overrides the whole setter
+   * to a no-op (it suppresses the field update too), so it does not use this.
+   */
+  _onPermissionModeChanged(_mode) {}
 
   /**
    * Toggle the per-session promptEvaluator flag (#3185). Returns `true`

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -1885,18 +1885,15 @@ export class ClaudeByokSession extends BaseSession {
     this.emit('agent_completed', { toolUseId })
   }
 
-  setModel(model) {
-    super.setModel(model)
-    // Next sendMessage will use the new model. No restart needed — the
-    // SDK is just a stateless HTTP client; each turn opens a fresh stream.
-  }
+  // #5374: no setModel override needed — BaseSession.setModel updates the
+  // field and the next sendMessage uses it. No restart: the SDK is a stateless
+  // HTTP client; each turn opens a fresh stream.
 
-  setPermissionMode(mode) {
-    if (!super.setPermissionMode(mode)) return
+  _onPermissionModeChanged(mode) {
     // #3729 / #4462: flipping to auto/bypass mid-turn must drain any
     // open permission prompts so the user isn't left staring at modals
     // after declaring "approve everything". Mirrors sdk-session.js's
-    // setPermissionMode behaviour.
+    // behaviour.
     //
     // MCP trust prompts are exempt — autoAllowPending denies them so
     // the bypass doesn't silently persist a binary to the trust store

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -2969,11 +2969,12 @@ export class ClaudeTuiSession extends BaseSession {
    * on the next tool-call boundary; an in-flight tool that already
    * routed to /permission is unaffected.
    */
-  setPermissionMode(mode) {
-    if (!super.setPermissionMode(mode)) return
+  // #5374: BaseSession.setPermissionMode owns the validation + guard and fires
+  // this hook after `this.permissionMode` is set, only when the mode changed.
+  _onPermissionModeChanged(mode) {
     if (!this._permissionModeFile) {
-      // Permissions weren't enabled at start (no port). Mode was
-      // updated on `this.permissionMode` by super; nothing else to do.
+      // Permissions weren't enabled at start (no port). Mode was already
+      // updated on `this.permissionMode` by BaseSession; nothing else to do.
       log.info(`Permission mode changed to ${mode} (no sidecar — hook script not active)`)
       return
     }

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -1400,16 +1400,15 @@ export class CliSession extends BaseSession {
   /**
    * Change the model used for subsequent messages.
    * Kills the current process and respawns with the new model (new session).
+   * #5374: BaseSession.setModel owns the guard + resolve and fires this hook.
    */
-  setModel(model) {
-    if (!super.setModel(model)) return
+  _onModelChanged() {
     // #4828: session-scoped if init has fired before the model change.
     ;(this._log || log).info(`Model changed to ${this.model || 'default'}, restarting process`)
     this._killAndRespawn()
   }
 
-  setPermissionMode(mode) {
-    if (!super.setPermissionMode(mode)) return
+  _onPermissionModeChanged(mode) {
     // #3729 panic-button semantics: BaseSession.setPermissionMode lets `'auto'`
     // bypass the `_isBusy` guard, so flipping to auto mid-turn IS destructive —
     // the in-flight `claude -p` process is killed and respawned, dropping the

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -293,9 +293,9 @@ export class GeminiSession extends JsonlSubprocessSession {
     super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs, resumeSessionId })
   }
 
-  setModel(model) {
-    return super.setModel(model)
-  }
+  // #5374: removed the no-op `setModel` override — it only forwarded to
+  // BaseSession.setModel, which now owns the guard + the (default no-op)
+  // _onModelChanged hook.
 
   // ------------------------------------------------------------------
   // JsonlSubprocessSession overrides

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -1296,15 +1296,14 @@ export class SdkSession extends BaseSession {
 
   /**
    * Change the model. In SDK mode this doesn't require process restart.
+   * #5374: BaseSession.setModel owns the guard + resolve and fires this hook.
    */
-  setModel(model) {
-    if (!super.setModel(model)) return
+  _onModelChanged() {
     // #4828: session-scoped when init has fired.
     ;(this._log || log).info(`Model changed to ${this.model || 'default'}`)
   }
 
-  setPermissionMode(mode) {
-    if (!super.setPermissionMode(mode)) return
+  _onPermissionModeChanged(mode) {
     this._permissions.clearRules()
     // #3729: switching TO auto is a "panic button" — drain any pending
     // permission prompts so the user isn't left staring at modals after

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -167,6 +167,38 @@ describe('BaseSession', () => {
     })
   })
 
+  describe('setter hooks (#5374)', () => {
+    it('setModel fires _onModelChanged once with the resolved model, only when it changes', () => {
+      const s = new BaseSession()
+      const calls = []
+      s._onModelChanged = (m) => calls.push(m)
+      s.model = null
+      assert.equal(s.setModel('claude-sonnet-4-5-20250514'), true)
+      assert.deepEqual(calls, [s.model], 'hook fired once with the resolved model')
+      // No-op set (same model) must NOT fire the hook.
+      assert.equal(s.setModel('claude-sonnet-4-5-20250514'), false)
+      assert.equal(calls.length, 1, 'hook not fired on a no-op set')
+      // Busy guard rejects → hook not fired.
+      s._isBusy = true
+      assert.equal(s.setModel('claude-opus-4-1-20250805'), false)
+      assert.equal(calls.length, 1, 'hook not fired when busy guard rejects')
+    })
+
+    it('setPermissionMode fires _onPermissionModeChanged once with the mode, only when it changes', () => {
+      const s = new BaseSession()
+      const calls = []
+      s._onPermissionModeChanged = (m) => calls.push(m)
+      s.permissionMode = 'approve'
+      assert.equal(s.setPermissionMode('plan'), true)
+      assert.deepEqual(calls, ['plan'], 'hook fired once with the new mode')
+      // Invalid mode rejected → hook not fired.
+      assert.equal(s.setPermissionMode('bogus'), false)
+      // No-op (same mode) → hook not fired.
+      assert.equal(s.setPermissionMode('plan'), false)
+      assert.equal(calls.length, 1, 'hook only fired on the real change')
+    })
+  })
+
   // #3185: per-session promptEvaluator toggle. Default is `false` so the
   // auto-evaluator chain (sub-tasks of #3068) is opt-in per session — the
   // manual `evaluate_draft` flow (PR #3089) is the existing behaviour and

--- a/packages/server/tests/cli-session.test.js
+++ b/packages/server/tests/cli-session.test.js
@@ -921,32 +921,35 @@ describe('#988 — _killAndRespawn extraction', () => {
       '_killAndRespawn should be extracted as a shared method')
   })
 
-  it('setModel uses _killAndRespawn instead of inline kill logic', async () => {
+  // #5374 hoisted the busy/no-op guard into BaseSession.setModel/setPermissionMode,
+  // which fire the _onModelChanged / _onPermissionModeChanged hooks; CliSession's
+  // respawn logic moved into those hooks (it no longer overrides the setters).
+  it('_onModelChanged uses _killAndRespawn instead of inline kill logic', async () => {
     const { readFileSync } = await import('node:fs')
     const { dirname, join } = await import('node:path')
     const { fileURLToPath } = await import('node:url')
     const dir = dirname(fileURLToPath(import.meta.url))
     const source = readFileSync(join(dir, '../src/cli-session.js'), 'utf-8')
-    const setModelBlock = source.match(/setModel\(model\)\s*\{[\s\S]*?^  \}/m)
-    assert.ok(setModelBlock, 'setModel method should exist')
+    const setModelBlock = source.match(/_onModelChanged\(\)\s*\{[\s\S]*?^  \}/m)
+    assert.ok(setModelBlock, '_onModelChanged hook should exist')
     assert.ok(setModelBlock[0].includes('_killAndRespawn'),
-      'setModel should delegate to _killAndRespawn')
+      '_onModelChanged should delegate to _killAndRespawn')
     assert.ok(!setModelBlock[0].includes('forceKillTimer'),
-      'setModel should not contain inline kill logic (forceKillTimer)')
+      '_onModelChanged should not contain inline kill logic (forceKillTimer)')
   })
 
-  it('setPermissionMode uses _killAndRespawn instead of inline kill logic', async () => {
+  it('_onPermissionModeChanged uses _killAndRespawn instead of inline kill logic', async () => {
     const { readFileSync } = await import('node:fs')
     const { dirname, join } = await import('node:path')
     const { fileURLToPath } = await import('node:url')
     const dir = dirname(fileURLToPath(import.meta.url))
     const source = readFileSync(join(dir, '../src/cli-session.js'), 'utf-8')
-    const setPermBlock = source.match(/setPermissionMode\(mode\)\s*\{[\s\S]*?^  \}/m)
-    assert.ok(setPermBlock, 'setPermissionMode method should exist')
+    const setPermBlock = source.match(/_onPermissionModeChanged\(mode\)\s*\{[\s\S]*?^  \}/m)
+    assert.ok(setPermBlock, '_onPermissionModeChanged hook should exist')
     assert.ok(setPermBlock[0].includes('_killAndRespawn'),
-      'setPermissionMode should delegate to _killAndRespawn')
+      '_onPermissionModeChanged should delegate to _killAndRespawn')
     assert.ok(!setPermBlock[0].includes('forceKillTimer'),
-      'setPermissionMode should not contain inline kill logic (forceKillTimer)')
+      '_onPermissionModeChanged should not contain inline kill logic (forceKillTimer)')
   })
 })
 


### PR DESCRIPTION
Closes #5374.

## What
`CliSession`, `SdkSession`, `ClaudeTuiSession` and `ClaudeByokSession` each duplicated the same setter shape — `if (!super.setX(...)) return; <provider-specific side effect>`. Adds protected hooks on `BaseSession`:

- `_onModelChanged(model)` — fired by `setModel()` after validation + the field update, only when the model actually changed.
- `_onPermissionModeChanged(mode)` — fired by `setPermissionMode()` likewise.

Both default to no-op. Subclasses override the **hook** (their provider-specific action) instead of the whole setter, so the busy/no-op/validation guard now lives in exactly one place.

## Per-class changes
- **cli / sdk / tui / byok**: setter overrides → hook overrides, side-effect + logging logic moved verbatim.
- **gemini**: deleted its no-op `setModel` passthrough (`return super.setModel(model)`) — `BaseSession.setModel` covers it identically.
- **jsonl-subprocess**: **kept** its `setPermissionMode(_mode){}` no-op. It intentionally suppresses the *field update* too (subprocess providers don't switch mode mid-flight); deleting it would let the base setter update `permissionMode`, a behaviour change. (Design note: the issue suggested it "needn't override" — keeping it is the behaviour-preserving choice.)

## Deviation from the issue's "centralize logging" suggestion
Logging stays **in the hooks**, not centralized in the base. The log content is genuinely provider-specific — CLI logs ", restarting process", TUI logs distinct sidecar success / no-sidecar / failure-warn lines, and **ByokSession intentionally logs nothing** on a mode change. Centralizing a canonical line in the base would change behaviour (byok would suddenly log; TUI would double-log). The DRY win delivered here is the removal of the duplicated guard + the hook seam.

> Note: `byok-session.js` (a 6th setter-overriding class) was not in the original design comment; it's included here.

## Tests
- Per-provider behavioural tests pass unchanged (CLI respawn-on-change, SDK `clearRules`+`autoAllowPending` on `auto`, TUI sidecar write).
- Updates the `#988 _killAndRespawn extraction` source-introspection tests to the new hook names (the behavioural respawn tests were already green).
- Adds a `BaseSession` "setter hooks (#5374)" block: hook fires once with the resolved value, and NOT on a rejected/no-op set.
- Custom lints (opt-forwarding, logger-scoping) + eslint clean (0 errors).

Third SAFE-rated refactor from the deferred-issue design pass (#5375 → #5374 → #5367 → #5376).