### PR TITLE
fix(maestro): migrate ConnectScreen flow to the dev client

### DIFF
--- a/packages/app/.maestro/connect-screen.yaml
+++ b/packages/app/.maestro/connect-screen.yaml
@@ -1,12 +1,16 @@
-appId: host.exp.Exponent
+appId: com.blamechris.chroxy
 name: ConnectScreen renders correctly
 ---
 
 # Navigate to ConnectScreen from any state
 - runFlow: setup/ensure-connect-screen.yaml
 
-# Verify the ConnectScreen loads with all expected elements
-- assertVisible: "Connect to Chroxy"
+# Verify the ConnectScreen loads with all expected elements. extendedWaitUntil
+# (not bare assertVisible) so the assertions don't race the screen settling in
+# right after the onboarding-skip + dev-menu-dismiss in the setup flow.
+- extendedWaitUntil:
+    visible: "Connect to Chroxy"
+    timeout: 8000
 
 - assertVisible:
     text: ".*Scan QR Code.*"
@@ -14,8 +18,14 @@ name: ConnectScreen renders correctly
 - assertVisible:
     text: ".*Scan Local Network.*"
 
-- assertVisible:
-    text: ".*Enter manually.*"
+# Match by testID, not text — the manual-entry toggle's accessibilityLabel is
+# "Enter server address manually" (which maestro matches against), and its
+# visible text is icon-prefixed ("▶ Enter manually"), so a ".*Enter manually.*"
+# text match misses it. The testID is the stable anchor.
+- extendedWaitUntil:
+    visible:
+      id: "connect-manual-toggle"
+    timeout: 5000
 
 # Port input should show default port
 - assertVisible: "8765"

--- a/packages/app/.maestro/setup/ensure-connect-screen.yaml
+++ b/packages/app/.maestro/setup/ensure-connect-screen.yaml
@@ -1,36 +1,59 @@
-appId: host.exp.Exponent
+appId: com.blamechris.chroxy
 name: Ensure ConnectScreen
 ---
 
-# Tested devices: iPhone 15 Pro (iOS 17), iPhone SE 3 (iOS 17), portrait orientation
-# iPad is untested — tap coordinates may differ in landscape / larger screens
+# Tested devices: iPhone 16 Pro (iOS 18), portrait orientation. iPad / Android
+# untested — tap coordinates may differ in landscape / larger screens.
 #
-# Shared setup: ensure we're on ConnectScreen regardless of initial state
+# Shared setup: ensure we're on ConnectScreen regardless of initial state.
 # Usage: - runFlow: setup/ensure-connect-screen.yaml
+#
+# The app now requires a dev build (expo-speech-recognition + expo-secure-store
+# native modules), so this drives the chroxy dev client (com.blamechris.chroxy)
+# rather than Expo Go. The dev client auto-connects to the Metro bundler it was
+# last launched against; launchApp brings it up.
 
-# Open the Expo project via deep link
-- openLink: exp://localhost:8081
+- launchApp
 
-# Wait for the app to load — could show any of:
+# Wait for the app (or the Expo dev-client menu) to appear. Could show any of:
+# - "Welcome to Chroxy" (first-run onboarding carousel)
+# - "Connect to Chroxy" (ConnectScreen, possibly behind the dev menu)
 # - "Session" (auto-connected from saved state)
-# - "Chroxy" (ConnectScreen title or dev menu)
 # - "Connecting" (auto-connect spinner)
+# - "Reload" (the Expo dev-client menu card)
 - extendedWaitUntil:
     visible:
-      text: ".*(Session|Chroxy|Connect).*"
-    timeout: 15000
+      text: ".*(Welcome to Chroxy|Session|Connect to Chroxy|Connecting|Reload).*"
+    timeout: 20000
 
-# Dismiss Expo dev menu if it appeared (X button on modal card)
-- tapOn:
-    point: "93%,43%"
-    optional: true
+# Dismiss the Expo dev-client menu ONLY if it actually appeared (its card shows
+# "Reload"). A blind point-tap when no menu is present lands on the app
+# underneath and can navigate into the QR scanner — so gate it on "Reload".
+- runFlow:
+    when:
+      visible:
+        text: "^Reload$"
+    commands:
+      - tapOn:
+          point: "93%,43%"
+      - waitForAnimationToEnd
+
+# Skip the first-run onboarding carousel if present (Welcome to Chroxy → Skip).
+- runFlow:
+    when:
+      visible:
+        text: "^Skip$"
+    commands:
+      - tapOn:
+          text: "^Skip$"
+      - waitForAnimationToEnd
 
 # If on SessionScreen (auto-connected), tap the red X to disconnect
 - runFlow:
     when:
       visible: "Session"
     commands:
-      - tapOn: "\u2715"
+      - tapOn: "✕"
       - waitForAnimationToEnd
 
 # If on auto-connect spinner, tap Cancel
@@ -43,7 +66,7 @@ name: Ensure ConnectScreen
           text: "^Cancel$"
       - waitForAnimationToEnd
 
-# Verify we're now on ConnectScreen
+# Verify we're now on ConnectScreen (exact title — NOT the dev-menu "Chroxy").
 - extendedWaitUntil:
     visible: "Connect to Chroxy"
-    timeout: 5000
+    timeout: 8000


### PR DESCRIPTION
## Problem
The Maestro E2E flows still target **Expo Go** (`appId: host.exp.Exponent`, `openLink: exp://localhost:8081`), which can no longer load the app — it requires a **dev build** (`expo-speech-recognition` + `expo-secure-store` native modules). So the suite's entry path was silently broken.

## This PR (the foundation)
Migrates the ConnectScreen flow + its shared setup (`setup/ensure-connect-screen.yaml`, used by several flows) to drive the chroxy dev client, verified **green 3× on iPhone 16 Pro (iOS 18) + Metro**:

- **Launch:** `appId` → `com.blamechris.chroxy`; `openLink exp://` → `launchApp` (the dev client auto-connects to the Metro bundler it was last launched against).
- **Onboarding:** handle the first-run carousel (`Welcome to Chroxy` → tap `Skip`) — the Expo-Go flows never hit it (they relied on saved state).
- **Dev menu:** dismiss the Expo dev-client menu **only when it actually appears** (gate on `Reload` visible). A blind point-tap when no menu is present lands on the app underneath and navigates into the QR scanner.
- **testID assertion:** match the manual-entry toggle by `id: connect-manual-toggle`, not text — its `accessibilityLabel` is "Enter server address manually" and the visible text is icon-prefixed, so a `.*Enter manually.*` text match misses it.

## Environment fixes (local, not committed — for the record)
Getting the harness running surfaced two stale-Homebrew-path breakages, both fixed locally:
- `packages/app/ios/.xcode.env.local` pinned a removed Node (`/opt/homebrew/Cellar/node/25.5.0`) → repointed at `node@22`. (Untracked local file; the tracked `.xcode.env` is correct.)
- `JAVA_HOME` pointed at a removed `openjdk@21` version → use the stable `opt/openjdk@21` symlink for Maestro runs.

## Follow-up
The remaining stale flows (`manual-connect`, `lan-scan`, `small-screen-layout`, `session-*`, `run-all.yaml`) need the same migration — tracked separately.