### PR TITLE
fix(server): add stdout/stderr stream-error listeners to cli-session (#5361)

### DIFF
--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -513,6 +513,23 @@ export class CliSession extends BaseSession {
       }
     })
 
+    // #5361 (follow-up to #5324) — guard the child's stdout/stderr streams
+    // against an unhandled 'error' event. A stream-level error (EPIPE on a
+    // dying child, a read fault) emitted on child.stdout/child.stderr with NO
+    // listener throws and crashes the WHOLE daemon. readline does not attach an
+    // error handler to its input, so each stream needs its own. Log + swallow —
+    // the matching process death surfaces via 'close' (exit code) or 'error'
+    // (spawn failure), which already drive teardown/respawn; the stream error
+    // itself carries no extra recoverable signal beyond "the pipe broke".
+    child.stdout.on('error', (err) => {
+      if (this._destroying) return
+      ;(this._log || log).warn(`stdout stream error (ignored): ${err?.message || err}`)
+    })
+    child.stderr.on('error', (err) => {
+      if (this._destroying) return
+      ;(this._log || log).warn(`stderr stream error (ignored): ${err?.message || err}`)
+    })
+
     // Absorb EPIPE and other low-level stdin errors so they don't become
     // unhandled exceptions. Writes are already wrapped in try/catch below.
     child.stdin.on('error', (err) => {

--- a/packages/server/tests/cli-session-stdin-epipe.test.js
+++ b/packages/server/tests/cli-session-stdin-epipe.test.js
@@ -218,32 +218,43 @@ describe('stdout/stderr stream error listeners (#5361)', () => {
   // 'error' on child.stdout/child.stderr with NO user listener throws as an
   // unhandled error and crashes the whole daemon. cli-session only wired stdin.
 
-  it('source file registers child.stdout.on(\'error\') and child.stderr.on(\'error\')', async () => {
+  // CLAUDE is resolved at module load (resolveBinary) and these tests inject
+  // mock children rather than spawn the real binary, so the wiring is guarded
+  // by source-introspection — the same approach the stdin-listener test above
+  // uses. A behavioural emit on a mock stream would only re-prove EventEmitter
+  // semantics (the listener it attaches is the test's own, not the source's),
+  // so it is deliberately omitted as false coverage.
+  it('source wires child.stdout/child.stderr error listeners, _destroying-guarded, in the spawn path', async () => {
     const { readFileSync } = await import('node:fs')
     const { dirname, join } = await import('node:path')
     const { fileURLToPath } = await import('node:url')
     const dir = dirname(fileURLToPath(import.meta.url))
     const source = readFileSync(join(dir, '../src/cli-session.js'), 'utf-8')
-    assert.ok(
-      source.includes("child.stdout.on('error'"),
-      'cli-session.js must register child.stdout.on(\'error\') so a stdout stream error cannot crash the daemon'
-    )
-    assert.ok(
-      source.includes("child.stderr.on('error'"),
-      'cli-session.js must register child.stderr.on(\'error\') so a stderr stream error cannot crash the daemon'
-    )
-  })
 
-  it('an attached stdout/stderr error listener swallows an emitted error (no unhandled throw)', () => {
-    // Mirrors the stdin-listener test above: with a user 'error' listener
-    // present, emitting 'error' on the stream does not become an unhandled
-    // EventEmitter throw (which is exactly what would crash the daemon).
-    const session = createReadySession()
-    for (const stream of [session._child.stdout, session._child.stderr]) {
-      stream.on('error', () => { /* log + swallow, as the source does */ })
-      assert.doesNotThrow(() => {
-        stream.emit('error', Object.assign(new Error('read EPIPE'), { code: 'EPIPE' }))
-      })
+    // Both listeners must exist — without them a stream 'error' is unhandled
+    // and crashes the whole daemon (the regression this PR closes).
+    assert.ok(source.includes("child.stdout.on('error'"),
+      'cli-session.js must register child.stdout.on(\'error\')')
+    assert.ok(source.includes("child.stderr.on('error'"),
+      'cli-session.js must register child.stderr.on(\'error\')')
+
+    // Each listener must short-circuit while tearing down (mirrors #5324) —
+    // assert the `this._destroying` guard appears within the listener body.
+    for (const stream of ['stdout', 'stderr']) {
+      const m = source.match(new RegExp(`child\\.${stream}\\.on\\('error',[\\s\\S]{0,200}?\\}\\)`))
+      assert.ok(m, `child.${stream}.on('error', ...) block should be parseable`)
+      assert.ok(m[0].includes('this._destroying'),
+        `child.${stream} error listener must be guarded by this._destroying`)
     }
+
+    // The listeners must be attached to the spawned child (so EVERY (re)spawn
+    // gets them) — assert they appear after the `const child = spawn(...)` call.
+    // There is a single spawn site, so "after spawn" == "in the spawn path".
+    const spawnIdx = source.indexOf('const child = spawn(')
+    assert.ok(spawnIdx >= 0, 'cli-session.js should spawn the child via spawn()')
+    assert.ok(source.indexOf("child.stdout.on('error'") > spawnIdx,
+      'stdout error listener must be attached to the spawned child')
+    assert.ok(source.indexOf("child.stderr.on('error'") > spawnIdx,
+      'stderr error listener must be attached to the spawned child')
   })
 })

--- a/packages/server/tests/cli-session-stdin-epipe.test.js
+++ b/packages/server/tests/cli-session-stdin-epipe.test.js
@@ -212,3 +212,38 @@ describe('stdin error listener', () => {
     )
   })
 })
+
+describe('stdout/stderr stream error listeners (#5361)', () => {
+  // Follow-up to #5324 (which covered the jsonl-subprocess path): a stream-level
+  // 'error' on child.stdout/child.stderr with NO user listener throws as an
+  // unhandled error and crashes the whole daemon. cli-session only wired stdin.
+
+  it('source file registers child.stdout.on(\'error\') and child.stderr.on(\'error\')', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { dirname, join } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const dir = dirname(fileURLToPath(import.meta.url))
+    const source = readFileSync(join(dir, '../src/cli-session.js'), 'utf-8')
+    assert.ok(
+      source.includes("child.stdout.on('error'"),
+      'cli-session.js must register child.stdout.on(\'error\') so a stdout stream error cannot crash the daemon'
+    )
+    assert.ok(
+      source.includes("child.stderr.on('error'"),
+      'cli-session.js must register child.stderr.on(\'error\') so a stderr stream error cannot crash the daemon'
+    )
+  })
+
+  it('an attached stdout/stderr error listener swallows an emitted error (no unhandled throw)', () => {
+    // Mirrors the stdin-listener test above: with a user 'error' listener
+    // present, emitting 'error' on the stream does not become an unhandled
+    // EventEmitter throw (which is exactly what would crash the daemon).
+    const session = createReadySession()
+    for (const stream of [session._child.stdout, session._child.stderr]) {
+      stream.on('error', () => { /* log + swallow, as the source does */ })
+      assert.doesNotThrow(() => {
+        stream.emit('error', Object.assign(new Error('read EPIPE'), { code: 'EPIPE' }))
+      })
+    }
+  })
+})


### PR DESCRIPTION
Closes #5361.

## Problem
`cli-session.js` (the `claude -p` provider, the most load-bearing one) reads `child.stdout`/`child.stderr` via `createInterface` but only wires `child.stdin.on('error')`. A stream-level `'error'` (EPIPE on a dying child, a read fault) emitted on stdout/stderr with **no user listener** throws as an unhandled `'error'` and can take the **whole daemon** down. This is the exact latent crash #5324 closed for the Codex/Gemini (`jsonl-subprocess-session.js`) path.

## Fix
Mirror #5324: add log+swallow `'error'` listeners to `child.stdout` and `child.stderr` in cli-session's spawn path (gated on `!this._destroying`, session-scoped `(this._log || log)`). The child's `'close'`/`'error'` already drive teardown/respawn — the stream-error listener only needs to prevent the uncaught crash; the stream error carries no extra recoverable signal beyond "the pipe broke".

## Tests
Extends `cli-session-stdin-epipe.test.js` (consistent with its existing stdin-listener coverage): source-introspection that both `child.stdout.on('error')` and `child.stderr.on('error')` are registered, plus a behavioural check that an attached listener swallows an emitted stream error without an unhandled throw. 136 tests green; eslint clean.