### PR TITLE
refactor(server): forward BaseSession opts via buildBaseSessionOpts picker + invert the lint (#5367)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,13 +193,15 @@ Two layers of defence are wired up:
 
 If you need to write to the real home for a legitimate reason (no current test does), set `process.env.CHROXY_TEST_ALLOW_REAL_HOME_WRITES = '1'` scoped to the test and restore it after. The sandbox guard MUST stay enabled in `package.json`.
 
-### Provider session constructors must forward every BaseSession opt (#4797)
+### Provider session constructors must forward every BaseSession opt (#4797 / #5367)
 
-Every class that extends `BaseSession` (or `JsonlSubprocessSession`, the middle layer above the subprocess providers) **must** destructure every opt accepted by `BaseSession`'s constructor AND forward it via `super({ ... })`. Otherwise the opt is silently dropped on its way down — the "middle-layer trap" that has bitten three times (#3224, #3231, #4790) and is documented in project memory as `feedback_jsonl_subprocess_middle_layer.md`.
+Every class that extends `BaseSession` (or `JsonlSubprocessSession`, the middle layer above the subprocess providers) **must** forward every opt accepted by `BaseSession`'s constructor. Dropping one silently disables it on its way down — the "middle-layer trap" that has bitten three times (#3224, #3231, #4790) and is documented in project memory as `feedback_jsonl_subprocess_middle_layer.md`.
 
-The CI lint (`packages/server/scripts/lint-session-opt-forwarding.sh`) parses `base-session.js` for the canonical opt set and diffs it against every subclass's destructure + `super()` block, failing the build with a `file:line` pointer if any opt is missing. Run locally with `cd packages/server && ./scripts/lint-session-opt-forwarding.sh`.
+Since #5367, the canonical way to forward is the **picker**, not a hand-maintained parallel destructure: each subclass takes a single `constructor(opts = {})` and calls `super(buildBaseSessionOpts(opts, { ...overrides }))`, where `buildBaseSessionOpts` (in `base-session.js`) copies exactly the keys in the exported `BASE_SESSION_OPT_KEYS` array. Subclass-local opts are read off `opts` directly; per-subclass defaults (e.g. `provider`, `model`) go in the `overrides` bag (which wins). The single source of truth is `BASE_SESSION_OPT_KEYS` + the `BaseSession` ctor destructure — the lint asserts they stay equal.
 
-When adding a new BaseSession opt: update every subclass constructor (`cli-session.js`, `sdk-session.js`, `claude-tui-session.js`, `jsonl-subprocess-session.js`, `codex-session.js`, `gemini-session.js`) in the same PR. If an opt deliberately should not propagate to a particular subclass (rare), add `// lint-ignore-opt-forwarding: <key>` immediately above the class declaration and explain why.
+The CI lint (`packages/server/scripts/lint-session-opt-forwarding.sh`) now: (1) asserts `BASE_SESSION_OPT_KEYS` equals the `BaseSession` ctor destructure (drift → fail), and (2) requires every subclass to forward via `super(buildBaseSessionOpts(...))` (or a rest-spread, or the legacy explicit `super({ ... })` which is still checked per-key) — a hand-rolled `super({ a, b })` that drops keys, or a `super(someOtherFn(opts))`, fails. Run locally with `cd packages/server && ./scripts/lint-session-opt-forwarding.sh`.
+
+**When adding a new BaseSession opt:** add it to the `BaseSession` constructor destructure AND to `BASE_SESSION_OPT_KEYS` (same PR) — every picker subclass then inherits it for free. If an opt deliberately should not propagate to a particular subclass (rare), add `// lint-ignore-opt-forwarding: <key>` immediately above the class declaration and explain why.
 
 ## Architecture
 

--- a/packages/server/scripts/lint-session-opt-forwarding.mjs
+++ b/packages/server/scripts/lint-session-opt-forwarding.mjs
@@ -2,38 +2,48 @@
 /**
  * Lint: every class that extends `BaseSession` (or
  * `JsonlSubprocessSession`, the middle layer above the subprocess
- * providers) MUST destructure every constructor opt accepted by
- * `BaseSession` AND forward it via `super({ ... })`. Otherwise the opt
- * is silently dropped on its way down — the middle-layer trap
- * documented in project memory as `feedback_jsonl_subprocess_middle_layer.md`
- * and repeated three times historically (#3224, #3231, #4790).
+ * providers) MUST forward every constructor opt accepted by
+ * `BaseSession` down to `super()`. Otherwise the opt is silently dropped
+ * on its way down — the middle-layer trap documented in project memory as
+ * `feedback_jsonl_subprocess_middle_layer.md` and repeated three times
+ * historically (#3224, #3231, #4790).
  *
- * Detection strategy (regex, intentionally — same style as
- * `lint-tests-state-file-path.mjs`):
+ * #5367 inverted the policing model. Subclasses no longer hand-maintain a
+ * parallel destructure + `super({ ... })`; they call the canonical picker
+ * `super(buildBaseSessionOpts(opts, { ...overrides }))`. The lint now:
  *
- * 1. Parse `base-session.js` to extract the canonical set of opt names
- *    from the destructure inside the `BaseSession` constructor.
- * 2. Walk every `*.js` file under `packages/server/src/`.
- * 3. For each `export class X extends (BaseSession|JsonlSubprocessSession)`,
- *    locate the constructor's destructure list and the matching
- *    `super({ ... })` call.
- * 4. Diff the canonical opt set against the destructure + super forward
- *    sets. Any opt that is missing from EITHER side is reported.
+ * 1. Parses the canonical opt set from the `BaseSession` constructor
+ *    destructure (parseBaseSessionOpts).
+ * 2. Parses the exported `BASE_SESSION_OPT_KEYS` array literal
+ *    (parseBaseSessionOptKeysArray) and ASSERTS it equals (1). This array
+ *    is what `buildBaseSessionOpts()` iterates at runtime, so a drift
+ *    between it and the real ctor would silently drop the mismatched key —
+ *    this is the NEW primary drift guard (exit 2).
+ * 3. Walks every `*.js` under `packages/server/src/` and, for each
+ *    `export class X extends (BaseSession|JsonlSubprocessSession)`,
+ *    inspects the `super(...)` shape:
+ *      - `super(buildBaseSessionOpts(...))` → COMPLIANT by construction
+ *        (coverage guaranteed by step 2 + the picker copying every key).
+ *      - `super(opts)` / `super({ ...opts })` → naturally immune.
+ *      - `super({ explicit, keys })` object literal → analyzed per-key
+ *        against the canonical set (catches a hand-rolled drop, including
+ *        a single-arg ctor that writes `super({ cwd })` and loses the rest).
+ *      - anything else (e.g. `super(someOtherFn(opts))`) → OFFENSE, since
+ *        it could silently drop keys.
  *
- * Two opt-outs:
- *
- *   - `super(opts)` or `super({ ...opts })` style is naturally immune
- *     because every opt is forwarded by reference; the lint skips these
- *     classes.
+ * Opt-out:
  *   - A `// lint-ignore-opt-forwarding: <key1>,<key2>` comment placed
  *     immediately above the class declaration whitelists specific opts
- *     for that class. Use sparingly — the comment should explain why.
+ *     for that class (object-literal path only). Use sparingly — the
+ *     comment should explain why.
  *
- * Issue: #4797. Trap that motivated this lint: #4790 (fixed in #4795).
+ * Issue: #4797 (original), #5367 (picker + inversion). Trap that motivated
+ * this lint: #4790 (fixed in #4795).
  *
  * Exit codes:
  *   0 — every subclass forwards every BaseSession opt (or is whitelisted)
- *   1 — at least one offender found (printed with file:line + missing key)
+ *   1 — at least one subclass offender found (printed with file:line)
+ *   2 — BASE_SESSION_OPT_KEYS drifted from the ctor, or a parser failure
  *
  * Flags:
  *   --src-dir <path>   Override the src directory (used by tests against
@@ -231,6 +241,38 @@ function parseBaseSessionOpts(baseSessionPath) {
   return extractDestructureKeys(block)
 }
 
+// #5367: parse the `BASE_SESSION_OPT_KEYS = [ ... ]` array literal exported by
+// base-session.js. This array is the runtime source of truth that
+// `buildBaseSessionOpts()` iterates, so the lint asserts it stays in lockstep
+// with the constructor destructure (parseBaseSessionOpts above). If the two
+// drift — a key added to the ctor but not the array, or vice-versa — the
+// picker would silently stop forwarding it, re-arming the middle-layer trap.
+// Returns { keys: Set<string>, order: string[] }.
+function parseBaseSessionOptKeysArray(baseSessionPath) {
+  const src = readFileSync(baseSessionPath, 'utf8')
+  const stripped = stripComments(src)
+  const declIdx = stripped.indexOf('BASE_SESSION_OPT_KEYS')
+  if (declIdx === -1) {
+    throw new Error(`Could not find "BASE_SESSION_OPT_KEYS" in ${baseSessionPath}`)
+  }
+  const bracketOpen = stripped.indexOf('[', declIdx)
+  if (bracketOpen === -1) {
+    throw new Error(`Could not find [ opening BASE_SESSION_OPT_KEYS array`)
+  }
+  const bracketClose = findMatchingBracket(stripped, bracketOpen, '[', ']')
+  if (bracketClose === -1) {
+    throw new Error(`Unbalanced brackets in BASE_SESSION_OPT_KEYS array`)
+  }
+  const inner = stripped.slice(bracketOpen + 1, bracketClose)
+  const order = []
+  const keys = new Set()
+  for (const m of inner.matchAll(/['"`]([A-Za-z_$][\w$]*)['"`]/g)) {
+    order.push(m[1])
+    keys.add(m[1])
+  }
+  return { keys, order }
+}
+
 // ----------------------------------------------------------------------
 // Subclass scanning
 // ----------------------------------------------------------------------
@@ -291,26 +333,28 @@ function analyzeClass(filePath, origSrc, strippedSrc, classDeclIdx, className) {
     return { skipped: true, reason: 'no constructor found' }
   }
   const { ctorAbsIdx } = block
-  // Find the destructure pattern inside `constructor(`. Two shapes:
-  //   constructor({ a, b } = {}) — destructured
-  //   constructor(opts = {}) — single-arg, naturally immune (rest-spread)
+  // Find the constructor arg list. Two shapes:
+  //   constructor({ a, b } = {}) — legacy hand-rolled destructure
+  //   constructor(opts = {})     — #5367 single-arg picker style
   const parenOpen = strippedSrc.indexOf('(', ctorAbsIdx)
   const parenClose = findMatchingBracket(strippedSrc, parenOpen, '(', ')')
   if (parenClose === -1) return { skipped: true, reason: 'unbalanced ctor parens' }
   const args = strippedSrc.slice(parenOpen + 1, parenClose).trim()
-  if (!args.startsWith('{')) {
-    // Single positional arg — caller is `super(opts)` or `super({ ...opts })`.
-    // Naturally immune, skip.
-    return { skipped: true, reason: 'single-arg constructor (rest-spread style)' }
-  }
-  // Find the destructure `{ ... }` inside the args.
-  const destructureOpenAbs = strippedSrc.indexOf('{', parenOpen)
-  const destructureCloseAbs = findMatchingBracket(strippedSrc, destructureOpenAbs, '{', '}')
-  if (destructureCloseAbs === -1) return { skipped: true, reason: 'unbalanced destructure' }
-  const destructureBlock = strippedSrc.slice(destructureOpenAbs, destructureCloseAbs + 1)
-  const destructureKeys = extractDestructureKeys(destructureBlock)
+  const hasDestructureArg = args.startsWith('{')
 
-  // Find the super({ ... }) call in the constructor body.
+  // Legacy destructure keys (only meaningful when the ctor destructures its
+  // arg). For single-arg `constructor(opts = {})` there's nothing to check on
+  // the destructure side — coverage is proven by the super() shape instead.
+  let destructureKeys = null
+  if (hasDestructureArg) {
+    const destructureOpenAbs = strippedSrc.indexOf('{', parenOpen)
+    const destructureCloseAbs = findMatchingBracket(strippedSrc, destructureOpenAbs, '{', '}')
+    if (destructureCloseAbs === -1) return { skipped: true, reason: 'unbalanced destructure' }
+    const destructureBlock = strippedSrc.slice(destructureOpenAbs, destructureCloseAbs + 1)
+    destructureKeys = extractDestructureKeys(destructureBlock)
+  }
+
+  // Find the super(...) call in the constructor body.
   const ctorBodyOpen = strippedSrc.indexOf('{', parenClose)
   const ctorBodyClose = findMatchingBracket(strippedSrc, ctorBodyOpen, '{', '}')
   if (ctorBodyClose === -1) return { skipped: true, reason: 'unbalanced ctor body' }
@@ -325,32 +369,44 @@ function analyzeClass(filePath, origSrc, strippedSrc, classDeclIdx, className) {
   if (superCloseAbs === -1) return { skipped: true, reason: 'unbalanced super()' }
   const superArgs = strippedSrc.slice(superOpenAbs + 1, superCloseAbs).trim()
 
-  // super({ ...opts, ... }) or super(opts) — naturally immune.
+  const classDeclLine = lineOf(strippedSrc, classDeclIdx)
+  const ctorLine = lineOf(strippedSrc, ctorAbsIdx)
+
+  // #5367: `super(buildBaseSessionOpts(...))` — the sanctioned picker. Coverage
+  // of every BaseSession opt is guaranteed by the picker copying every key in
+  // BASE_SESSION_OPT_KEYS, which main() has already asserted equals the ctor
+  // destructure. Per-subclass `overrides` only ADD or replace values; they
+  // cannot drop a key. So this shape is compliant-by-construction.
+  if (/^buildBaseSessionOpts\s*\(/.test(superArgs)) {
+    return { className, compliant: 'picker', classDeclLine, ctorLine }
+  }
+
+  // super(opts) or super({ ...opts, ... }) — every opt forwarded by reference.
   if (superArgs.startsWith('...') || /^[A-Za-z_$][\w$]*$/.test(superArgs)) {
     return { skipped: true, reason: 'super forwards rest-spread/positional' }
   }
-  if (!superArgs.startsWith('{')) {
-    return { skipped: true, reason: 'super() call shape not recognised' }
+
+  // super({ ...explicit object literal... }) — the legacy hand-rolled path AND
+  // the shape a regression would take in a single-arg ctor (someone writes
+  // `super({ cwd })` and silently drops the rest). Analyze per-key below.
+  if (superArgs.startsWith('{')) {
+    const superBraceOpenAbs = strippedSrc.indexOf('{', superOpenAbs)
+    const superBraceCloseAbs = findMatchingBracket(strippedSrc, superBraceOpenAbs, '{', '}')
+    if (superBraceCloseAbs === -1) return { skipped: true, reason: 'unbalanced super({})' }
+    const superBlock = strippedSrc.slice(superBraceOpenAbs, superBraceCloseAbs + 1)
+    // `super({ ...identifier, ... })` spreads every opt — naturally immune.
+    if (/\{\s*\.\.\.[A-Za-z_$]/.test(superBlock)) {
+      return { skipped: true, reason: 'super spreads an identifier' }
+    }
+    const superKeys = extractObjectKeys(superBlock)
+    return { className, destructureKeys, superKeys, classDeclLine, ctorLine }
   }
 
-  // Detect `{ ...opts, ... }` style super calls — also naturally immune.
-  // (Look at the inner content for a leading `...identifier`.)
-  const superBraceOpenAbs = strippedSrc.indexOf('{', superOpenAbs)
-  const superBraceCloseAbs = findMatchingBracket(strippedSrc, superBraceOpenAbs, '{', '}')
-  if (superBraceCloseAbs === -1) return { skipped: true, reason: 'unbalanced super({})' }
-  const superBlock = strippedSrc.slice(superBraceOpenAbs, superBraceCloseAbs + 1)
-  if (/\{\s*\.\.\.[A-Za-z_$]/.test(superBlock)) {
-    return { skipped: true, reason: 'super spreads an identifier' }
-  }
-  const superKeys = extractObjectKeys(superBlock)
-
-  return {
-    className,
-    destructureKeys,
-    superKeys,
-    classDeclLine: lineOf(strippedSrc, classDeclIdx),
-    ctorLine: lineOf(strippedSrc, ctorAbsIdx),
-  }
+  // #5367: any other super() shape (e.g. `super(someOtherFn(opts))`) is NOT a
+  // recognized safe forwarder and could silently drop keys. Flag it as an
+  // offense rather than skipping (the pre-#5367 lint skipped these, which is
+  // exactly the hole the picker would have slipped through).
+  return { className, unrecognizedSuper: superArgs.slice(0, 60), classDeclLine, ctorLine }
 }
 
 function walk(dir, acc = []) {
@@ -381,6 +437,43 @@ function main() {
     process.exit(2)
   }
 
+  // #5367: the array `BASE_SESSION_OPT_KEYS` is what `buildBaseSessionOpts()`
+  // iterates at runtime. Assert it equals the set parsed from the constructor
+  // destructure — if they drift, the picker silently stops forwarding the
+  // mismatched key(s), re-arming the middle-layer trap. This is the new drift
+  // guard that replaces the per-subclass destructure check for picker classes.
+  let optArray
+  try {
+    optArray = parseBaseSessionOptKeysArray(baseSessionPath)
+  } catch (err) {
+    console.error(`ERROR: failed to parse BASE_SESSION_OPT_KEYS from ${baseSessionPath}: ${err.message}`)
+    process.exit(2)
+  }
+  if (optArray.keys.size === 0) {
+    console.error(`ERROR: parsed 0 keys from BASE_SESSION_OPT_KEYS at ${baseSessionPath} — parser is broken`)
+    process.exit(2)
+  }
+  {
+    const inArrayNotCtor = [...optArray.keys].filter(k => !baseOpts.has(k))
+    const inCtorNotArray = [...baseOpts].filter(k => !optArray.keys.has(k))
+    if (inArrayNotCtor.length || inCtorNotArray.length) {
+      console.error('ERROR: BASE_SESSION_OPT_KEYS has drifted from the BaseSession constructor destructure.')
+      console.error(`  in ${baseSessionPath}`)
+      if (inCtorNotArray.length) {
+        console.error(`    In constructor but MISSING from BASE_SESSION_OPT_KEYS: ${inCtorNotArray.join(', ')}`)
+      }
+      if (inArrayNotCtor.length) {
+        console.error(`    In BASE_SESSION_OPT_KEYS but MISSING from constructor: ${inArrayNotCtor.join(', ')}`)
+      }
+      console.error('')
+      console.error('buildBaseSessionOpts() iterates BASE_SESSION_OPT_KEYS, so any key only in the')
+      console.error('constructor would be silently dropped on its way to super() — the middle-layer')
+      console.error('trap (feedback_jsonl_subprocess_middle_layer.md, bit #3224/#3231/#4790).')
+      console.error('Fix: keep BASE_SESSION_OPT_KEYS in lockstep with the constructor destructure.')
+      process.exit(2)
+    }
+  }
+
   const files = walk(SRC_DIR).filter(f => !f.endsWith('/base-session.js'))
   const offenders = []
   let analyzedCount = 0
@@ -399,12 +492,35 @@ function main() {
       const analysis = analyzeClass(file, origSrc, strippedSrc, classDeclIdx, className)
       if (analysis.skipped) continue
       analyzedCount++
+
+      // #5367: `super(buildBaseSessionOpts(...))` — compliant by construction
+      // (coverage guaranteed by the array-vs-ctor assertion above + the picker
+      // copying every key). Counts as analyzed-and-ok.
+      if (analysis.compliant === 'picker') continue
+
+      // #5367: an unrecognized super() shape (not the picker, not a bare
+      // identifier/spread, not an object literal) could silently drop keys.
+      if (analysis.unrecognizedSuper !== undefined) {
+        offenders.push({
+          file,
+          line: declLine,
+          className,
+          unrecognizedSuper: analysis.unrecognizedSuper,
+        })
+        continue
+      }
+
+      // Legacy / hand-rolled `super({ ... })` object-literal path: every
+      // BaseSession opt must appear in the super() object (and, when the ctor
+      // destructures its arg, in the destructure too).
       const { destructureKeys, superKeys } = analysis
       const missingDestructure = []
       const missingSuper = []
       for (const opt of baseOpts) {
         if (ignore.has(opt)) continue
-        if (!destructureKeys.has(opt)) missingDestructure.push(opt)
+        // destructureKeys is null for single-arg `constructor(opts = {})` —
+        // there's no destructure to check, only the super() object.
+        if (destructureKeys && !destructureKeys.has(opt)) missingDestructure.push(opt)
         // Only flag missing-from-super if it's NOT also missing from
         // destructure (avoids double-reporting; the destructure miss
         // is the root cause and the super miss is its symptom).
@@ -428,10 +544,16 @@ function main() {
     console.error('')
     for (const o of offenders) {
       console.error(`  ${o.file}:${o.line}  class ${o.className}`)
-      if (o.missingDestructure.length) {
+      if (o.unrecognizedSuper !== undefined) {
+        console.error(`    Unrecognized super() shape: super(${o.unrecognizedSuper}...)`)
+        console.error('    Expected super(buildBaseSessionOpts(opts, { ...overrides })), super(opts),')
+        console.error('    super({ ...opts }), or an explicit super({ <every BaseSession opt> }).')
+        continue
+      }
+      if (o.missingDestructure && o.missingDestructure.length) {
         console.error(`    Missing from constructor destructure: ${o.missingDestructure.join(', ')}`)
       }
-      if (o.missingSuper.length) {
+      if (o.missingSuper && o.missingSuper.length) {
         console.error(`    Destructured but not forwarded via super(): ${o.missingSuper.join(', ')}`)
       }
     }

--- a/packages/server/src/base-session.js
+++ b/packages/server/src/base-session.js
@@ -123,6 +123,50 @@ export const BACKGROUND_SHELL_QUIESCE_MS = 60 * 1000
 // reclaimed. Set the instance field to 0 to disable (advisory-only #5247).
 export const BACKGROUND_SHELL_HARD_QUIESCE_MS = 4 * 60 * 60 * 1000
 
+// #5367: canonical list of the opts BaseSession's constructor accepts, in the
+// exact order they appear in the destructure below. Single source of truth for
+// `buildBaseSessionOpts()` — the picker each subclass uses to forward opts down
+// without hand-maintaining a parallel destructure (the "middle-layer trap" that
+// re-shipped three times: #3224 / #3231 / #4790). The CI lint
+// (lint-session-opt-forwarding.mjs) ASSERTS this array equals the set parsed
+// from the constructor destructure, so the two can never drift apart.
+export const BASE_SESSION_OPT_KEYS = [
+  'cwd',
+  'model',
+  'permissionMode',
+  'skillsDir',
+  'repoSkillsDir',
+  'maxSkillBytes',
+  'maxTotalSkillBytes',
+  'provider',
+  'activeManualSkills',
+  'providerSkillAllowlist',
+  'trustStore',
+  'trustMismatchMode',
+  'promptEvaluator',
+  'promptEvaluatorSkipPattern',
+  'chroxyContextHint',
+  'sessionPreamble',
+  'resultTimeoutMs',
+  'hardTimeoutMs',
+  'streamStallTimeoutMs',
+  'backgroundShellHardQuiesceMs',
+]
+
+// #5367: pick the BaseSession opts out of a subclass's full opts bag and merge
+// per-subclass `overrides` on top (overrides win — e.g. provider/model
+// defaults). Uses `if (k in fullOpts)` rather than `??` so an explicitly-passed
+// falsy value (notably `backgroundShellHardQuiesceMs: 0`, which disables
+// hard-reaping) is preserved, and absent keys are omitted entirely (so
+// BaseSession's own `|| default` fallbacks still apply).
+export function buildBaseSessionOpts(fullOpts = {}, overrides = {}) {
+  const out = {}
+  for (const k of BASE_SESSION_OPT_KEYS) {
+    if (k in fullOpts) out[k] = fullOpts[k]
+  }
+  return { ...out, ...overrides }
+}
+
 // Default per-provider injection mode (#3200). Subprocess providers without
 // a system-prompt flag (Codex, Gemini) prepend skills to the first user
 // message; Claude (SDK or CLI) appends to the system prompt. Maps the

--- a/packages/server/src/byok-session.js
+++ b/packages/server/src/byok-session.js
@@ -17,7 +17,7 @@
 import Anthropic, { APIUserAbortError } from '@anthropic-ai/sdk'
 import { join } from 'path'
 import { homedir } from 'os'
-import { BaseSession } from './base-session.js'
+import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { PermissionManager } from './permission-manager.js'
 import { createLogger } from './logger.js'
 import { isOperatorTimeoutInRange } from './duration.js'
@@ -228,7 +228,7 @@ export class ClaudeByokSession extends BaseSession {
    * @param {number} [opts.mcpToolCallTimeoutMs]  Per-tools/call timeout; null/undefined = MCPClient default (30s).
    */
   constructor(opts = {}) {
-    super({ ...opts, provider: opts.provider || 'claude-byok' })
+    super(buildBaseSessionOpts(opts, { provider: opts.provider || 'claude-byok' }))
     // Anthropic SDK client; lazily instantiated in start() so unit tests
     // can stub it via this._client = ... before start().
     this._client = null

--- a/packages/server/src/claude-channel-session.js
+++ b/packages/server/src/claude-channel-session.js
@@ -1,6 +1,6 @@
 import { homedir } from 'os'
 import { join } from 'path'
-import { BaseSession } from './base-session.js'
+import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 
 // Minimum `claude` CLI version that ships the `--channels` MCP transport.
@@ -136,8 +136,8 @@ export class ClaudeChannelSession extends BaseSession {
     return { id, label: id, fullId, contextWindow: resolveClaudeContextWindow(fullId), description: '' }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-channel', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs })
+  constructor(opts = {}) {
+    super(buildBaseSessionOpts(opts, { provider: opts.provider || 'claude-channel' }))
   }
 
   /**

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameS
 import { homedir, tmpdir } from 'os'
 import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
-import { BaseSession } from './base-session.js'
+import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { createLogger, loggerForSession, redactSensitive } from './logger.js'
@@ -457,8 +457,10 @@ export class ClaudeTuiSession extends BaseSession {
     return ['multi_question_intervention', 'respawn_exhausted']
   }
 
-  constructor({ cwd, model, permissionMode, port, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs, firstOutputTimeoutMs, skipPermissions, resumeSessionId } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-tui', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs })
+  constructor(opts = {}) {
+    super(buildBaseSessionOpts(opts, { provider: opts.provider || 'claude-tui' }))
+    // ClaudeTuiSession-local opts (not BaseSession opts — see buildBaseSessionOpts).
+    const { port, firstOutputTimeoutMs, skipPermissions, resumeSessionId } = opts
 
     this._port = port || null
     // #4044: when true, spawn `claude` with --dangerously-skip-permissions

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -4,7 +4,7 @@ import { randomBytes } from 'crypto'
 import { homedir } from 'os'
 import { join } from 'path'
 import { createPermissionHookManager } from './permission-hook.js'
-import { BaseSession } from './base-session.js'
+import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { forceKill } from './platform.js'
@@ -316,8 +316,10 @@ export class CliSession extends BaseSession {
     }
   }
 
-  constructor({ cwd, allowedTools, model, port, apiToken, permissionMode, settingsPath, maxToolInput, transforms, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs, resumeSessionId } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-cli', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs })
+  constructor(opts = {}) {
+    super(buildBaseSessionOpts(opts, { provider: opts.provider || 'claude-cli' }))
+    // CliSession-local opts (not BaseSession opts — see buildBaseSessionOpts).
+    const { allowedTools, port, apiToken, settingsPath, maxToolInput, transforms, resumeSessionId } = opts
     this.allowedTools = allowedTools || []
     this._port = port || null
     this._apiToken = apiToken || null

--- a/packages/server/src/codex-session.js
+++ b/packages/server/src/codex-session.js
@@ -1,4 +1,5 @@
 import { JsonlSubprocessSession } from './jsonl-subprocess-session.js'
+import { buildBaseSessionOpts } from './base-session.js'
 import { homedir } from 'os'
 import { join } from 'path'
 import { resolveBinary } from './utils/resolve-binary.js'
@@ -463,20 +464,21 @@ export class CodexSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs, resumeSessionId } = {}) {
+  constructor(opts = {}) {
     // `model` may be null/undefined — BaseSession coerces to null and
     // _buildArgs() omits the `-c model=...` flag so Codex CLI defers
     // to its own default from ~/.codex/config.toml.
-    // #3899: hardTimeoutMs forwarded to BaseSession even though Codex
-    // doesn't (yet) split its timer into soft/hard — the config flows
-    // through here so when Codex gets the #3899 treatment as a follow-
-    // up the plumbing is already in place.
-    // #4790: streamStallTimeoutMs likewise forwarded so the per-provider
-    // override SessionManager wired in PR #4745 actually reaches
-    // BaseSession's stream-stall timer. Dropping it here silently reverted
-    // operators to the 5min default — the trap documented in
-    // [[feedback_jsonl_subprocess_middle_layer]].
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'codex', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs, resumeSessionId })
+    // #5367: forward every BaseSession opt via the canonical picker (which
+    // preserves the #3899 hardTimeoutMs / #4790 streamStallTimeoutMs plumbing
+    // that used to be hand-maintained here). Overrides: provider default,
+    // `model || DEFAULT_MODEL`, and `resumeSessionId` — the last is a
+    // JsonlSubprocessSession-local opt (not a BaseSession key) so it must ride
+    // through the overrides bag to reach the middle layer.
+    super(buildBaseSessionOpts(opts, {
+      provider: opts.provider || 'codex',
+      model: opts.model || DEFAULT_MODEL,
+      resumeSessionId: opts.resumeSessionId,
+    }))
   }
 
   // ------------------------------------------------------------------

--- a/packages/server/src/gemini-session.js
+++ b/packages/server/src/gemini-session.js
@@ -1,4 +1,5 @@
 import { JsonlSubprocessSession } from './jsonl-subprocess-session.js'
+import { buildBaseSessionOpts } from './base-session.js'
 import { homedir } from 'os'
 import { join } from 'path'
 import { resolveBinary } from './utils/resolve-binary.js'
@@ -282,15 +283,18 @@ export class GeminiSession extends JsonlSubprocessSession {
     }
   }
 
-  constructor({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs, resumeSessionId } = {}) {
-    // #3899: hardTimeoutMs forwarded to BaseSession — same shape as
-    // CodexSession. When Gemini gets the soft/hard split as a follow-
-    // up, the operator config will already be flowing in.
-    // #4790: streamStallTimeoutMs likewise forwarded so the per-provider
-    // override SessionManager wired in PR #4745 actually reaches
-    // BaseSession's stream-stall timer — same middle-layer trap as the
-    // other BaseSession opts above ([[feedback_jsonl_subprocess_middle_layer]]).
-    super({ cwd, model: model || DEFAULT_MODEL, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'gemini', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs, resumeSessionId })
+  constructor(opts = {}) {
+    // #5367: forward every BaseSession opt via the canonical picker (which
+    // preserves the #3899 hardTimeoutMs / #4790 streamStallTimeoutMs plumbing
+    // that used to be hand-maintained here). Overrides: provider default,
+    // `model || DEFAULT_MODEL`, and `resumeSessionId` — the last is a
+    // JsonlSubprocessSession-local opt (not a BaseSession key) so it must ride
+    // through the overrides bag to reach the middle layer.
+    super(buildBaseSessionOpts(opts, {
+      provider: opts.provider || 'gemini',
+      model: opts.model || DEFAULT_MODEL,
+      resumeSessionId: opts.resumeSessionId,
+    }))
   }
 
   // #5374: removed the no-op `setModel` override — it only forwarded to

--- a/packages/server/src/jsonl-subprocess-session.js
+++ b/packages/server/src/jsonl-subprocess-session.js
@@ -1,6 +1,6 @@
 import { spawn } from 'child_process'
 import { createInterface } from 'readline'
-import { BaseSession } from './base-session.js'
+import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { createLogger } from './logger.js'
 
 const log = createLogger('jsonl-subprocess-session')
@@ -85,74 +85,15 @@ export class JsonlSubprocessSession extends BaseSession {
   // Lifecycle
   // ------------------------------------------------------------------
 
-  constructor({
-    cwd,
-    model,
-    permissionMode,
-    skillsDir,
-    repoSkillsDir,
-    maxSkillBytes,
-    maxTotalSkillBytes,
-    provider,
-    activeManualSkills,
-    providerSkillAllowlist,
-    trustStore,
-    trustMismatchMode,
-    promptEvaluator,
-    promptEvaluatorSkipPattern,
-    // #3805: Chroxy context hint flows through this middle layer to
-    // BaseSession so Codex / Gemini sessions also pick up the toggle.
-    // Same pattern as the other per-session opts — drop it here and
-    // the flag silently fails to take effect on subprocess providers.
-    chroxyContextHint,
-    // #4660: per-session preamble flows through this middle layer to
-    // BaseSession so Codex / Gemini sessions also pick up the user-
-    // authored text. Same middle-layer trap as chroxyContextHint —
-    // drop it here and the preamble silently fails to inject on
-    // subprocess providers (see [[feedback_jsonl_subprocess_middle_layer]]).
-    sessionPreamble,
-    resultTimeoutMs,
-    // #3899: hard-cap timeout (per-session backstop) flows through this
-    // middle layer to BaseSession exactly like resultTimeoutMs. Memory
-    // [[feedback_jsonl_subprocess_middle_layer]] — when adding a
-    // BaseSession option, plumb it through here too or Codex / Gemini
-    // silently fall back to the default.
-    hardTimeoutMs,
-    // #4790: per-provider stream-stall recovery timeout. PR #4745 wired
-    // SessionManager → providerOpts.streamStallTimeoutMs but this
-    // destructure dropped it, so Codex / Gemini sessions silently fell
-    // back to BaseSession's 5min default — exactly the trap documented
-    // in [[feedback_jsonl_subprocess_middle_layer]] landing again.
-    streamStallTimeoutMs,
-    // #5288: hard-quiesce window flows through this middle layer to
-    // BaseSession exactly like streamStallTimeoutMs — drop it here and
-    // Codex / Gemini silently fall back to the 4h default
-    // ([[feedback_jsonl_subprocess_middle_layer]]).
-    backgroundShellHardQuiesceMs,
-    resumeSessionId,
-  } = {}) {
-    super({
-      cwd,
-      model,
-      permissionMode: permissionMode || 'auto',
-      skillsDir,
-      repoSkillsDir,
-      maxSkillBytes,
-      maxTotalSkillBytes,
-      provider,
-      activeManualSkills,
-      providerSkillAllowlist,
-      trustStore,
-      trustMismatchMode,
-      promptEvaluator,
-      promptEvaluatorSkipPattern,
-      chroxyContextHint,
-      sessionPreamble,
-      resultTimeoutMs,
-      hardTimeoutMs,
-      streamStallTimeoutMs,
-      backgroundShellHardQuiesceMs,
-    })
+  constructor(opts = {}) {
+    // #5367: forward every BaseSession opt via the canonical picker (preserves
+    // the #3805 / #4660 / #3899 / #4790 / #5288 plumbing that this middle layer
+    // historically had to re-declare by hand — the trap documented in
+    // [[feedback_jsonl_subprocess_middle_layer]]). The lone override is
+    // permissionMode, which defaults to 'auto' for subprocess providers.
+    super(buildBaseSessionOpts(opts, { permissionMode: opts.permissionMode || 'auto' }))
+    // JsonlSubprocessSession-local opt (not a BaseSession opt).
+    const { resumeSessionId } = opts
     // #3865: accept resumeSessionId from constructor so SessionManager's
     // serializeState/restoreState path carries a captured Codex thread_id
     // across server restarts. Without this, persistence was wired up at

--- a/packages/server/src/sdk-session.js
+++ b/packages/server/src/sdk-session.js
@@ -2,7 +2,7 @@ import { query } from '@anthropic-ai/claude-agent-sdk'
 import { join } from 'path'
 import { homedir } from 'os'
 import { updateModels, saveModelsCache, updateContextWindow, getModels, FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
-import { BaseSession } from './base-session.js'
+import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { buildContentBlocks } from './content-blocks.js'
 import { MessageTransformPipeline } from './message-transform.js'
 import { emitToolResults } from './tool-result.js'
@@ -300,8 +300,10 @@ export class SdkSession extends BaseSession {
 
   get thinkingLevel() { return this._thinkingLevel }
 
-  constructor({ cwd, model, permissionMode, resumeSessionId, transforms, maxToolInput, sandbox, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider, activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, stdinForwardingDisabled, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs } = {}) {
-    super({ cwd, model, permissionMode, skillsDir, repoSkillsDir, maxSkillBytes, maxTotalSkillBytes, provider: provider || 'claude-sdk', activeManualSkills, providerSkillAllowlist, trustStore, trustMismatchMode, promptEvaluator, promptEvaluatorSkipPattern, chroxyContextHint, sessionPreamble, resultTimeoutMs, hardTimeoutMs, streamStallTimeoutMs, backgroundShellHardQuiesceMs })
+  constructor(opts = {}) {
+    super(buildBaseSessionOpts(opts, { provider: opts.provider || 'claude-sdk' }))
+    // SdkSession-local opts (not BaseSession opts — see buildBaseSessionOpts).
+    const { resumeSessionId, transforms, maxToolInput, sandbox, stdinForwardingDisabled } = opts
     this._maxToolInput = maxToolInput || DEFAULT_MAX_TOOL_INPUT_LENGTH
     this._transformPipeline = new MessageTransformPipeline(transforms || [])
     this._sandbox = sandbox || null

--- a/packages/server/tests/base-session.test.js
+++ b/packages/server/tests/base-session.test.js
@@ -9,6 +9,8 @@ import {
   DEFAULT_HARD_TIMEOUT_MS,
   DEFAULT_STREAM_STALL_TIMEOUT_MS,
   BACKGROUND_SHELL_HARD_QUIESCE_MS,
+  BASE_SESSION_OPT_KEYS,
+  buildBaseSessionOpts,
 } from '../src/base-session.js'
 import { SkillsTrustStore, sha256Hex } from '../src/skills-trust.js'
 
@@ -1701,6 +1703,167 @@ describe('BaseSession operator-timeout MAX_SANE_DURATION_MS ceiling (#4509)', ()
       })
       assert.equal(s[internalField], MAX_SANE_DURATION_MS,
         `the boundary must be INCLUSIVE — clamping it would surprise operators who tuned the dial to exactly 24h`)
+    })
+  }
+})
+
+// #5367: the canonical opt picker that every session subclass now uses to
+// forward BaseSession opts via `super(buildBaseSessionOpts(opts, overrides))`.
+describe('buildBaseSessionOpts (#5367)', () => {
+  it('copies only BaseSession opts, omitting absent keys and subclass-local opts', () => {
+    const out = buildBaseSessionOpts({
+      cwd: '/tmp/x',
+      model: 'sonnet',
+      // subclass-local opts that must NOT be copied:
+      allowedTools: ['Bash'],
+      resumeSessionId: 'abc',
+      port: 9999,
+    })
+    assert.deepEqual(Object.keys(out).sort(), ['cwd', 'model'])
+    assert.equal(out.cwd, '/tmp/x')
+    assert.equal(out.model, 'sonnet')
+  })
+
+  it('preserves an explicit falsy value (backgroundShellHardQuiesceMs: 0) via `in`, not `??`', () => {
+    const out = buildBaseSessionOpts({ backgroundShellHardQuiesceMs: 0 })
+    assert.ok('backgroundShellHardQuiesceMs' in out, 'explicit 0 must be carried through')
+    assert.equal(out.backgroundShellHardQuiesceMs, 0)
+  })
+
+  it('omits keys that are absent entirely (no undefined leakage)', () => {
+    const out = buildBaseSessionOpts({ cwd: '/tmp/x' })
+    assert.equal('model' in out, false, 'absent keys must be omitted so BaseSession `|| default` fallbacks apply')
+  })
+
+  it('overrides win over picked values', () => {
+    const out = buildBaseSessionOpts({ provider: 'gemini', model: 'm1' }, { provider: 'codex' })
+    assert.equal(out.provider, 'codex')
+    assert.equal(out.model, 'm1')
+  })
+
+  it('every key it can emit is a real BaseSession opt (array is the source of truth)', () => {
+    // Build a full bag and confirm the picker never invents a key.
+    const full = Object.fromEntries(BASE_SESSION_OPT_KEYS.map((k) => [k, `s_${k}`]))
+    const out = buildBaseSessionOpts(full)
+    for (const k of Object.keys(out)) {
+      assert.ok(BASE_SESSION_OPT_KEYS.includes(k), `${k} is not in BASE_SESSION_OPT_KEYS`)
+    }
+    assert.equal(Object.keys(out).length, BASE_SESSION_OPT_KEYS.length)
+  })
+})
+
+// #5367: the "no opt dropped" proof. Instantiate every session subclass with
+// every BaseSession opt set to a distinct, coercion-surviving sentinel and
+// assert each landed on the resulting instance's BaseSession-owned field. This
+// is hand-list-INDEPENDENT: it derives the opt list from BASE_SESSION_OPT_KEYS,
+// so a future opt added to the array (and the ctor) is automatically covered.
+describe('subclass opt forwarding — no opt dropped (#5367)', () => {
+  let tmpDir
+  let trustStore
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'chroxy-opt-fwd-'))
+    trustStore = new SkillsTrustStore({ filePath: join(tmpDir, 'trust.json'), mode: 'warn' })
+  })
+  afterEach(() => {
+    try { rmSync(tmpDir, { recursive: true, force: true }) } catch {}
+  })
+
+  // Each entry: how to make a valid sentinel for the opt, the instance field
+  // BaseSession stores it on, and how to assert it landed. Values are chosen to
+  // SURVIVE BaseSession's coercion (valid permissionMode, in-range timeouts,
+  // real regex, object allowlist, etc.) so a forwarded value is observable.
+  function sentinelOpts() {
+    return {
+      cwd: join(tmpDir, 'work'),
+      model: 'sentinel-model',
+      permissionMode: 'plan',
+      skillsDir: join(tmpDir, 'skills'),
+      repoSkillsDir: join(tmpDir, 'repo-skills'),
+      maxSkillBytes: 4242,
+      maxTotalSkillBytes: 8484,
+      // An explicit truthy provider survives every subclass's
+      // `opts.provider || '<default>'` override, so it lands verbatim.
+      provider: 'sentinel-provider',
+      activeManualSkills: ['skill-a', 'skill-b'],
+      providerSkillAllowlist: { 'claude-sdk': ['x'] },
+      trustStore,
+      trustMismatchMode: 'block',
+      promptEvaluator: true,
+      promptEvaluatorSkipPattern: '^ack$',
+      chroxyContextHint: true,
+      sessionPreamble: 'sentinel preamble',
+      resultTimeoutMs: 11 * 60 * 1000,
+      hardTimeoutMs: 33 * 60 * 1000,
+      streamStallTimeoutMs: 7 * 60 * 1000,
+      backgroundShellHardQuiesceMs: 0, // explicit 0 — the falsy-preservation case
+    }
+  }
+
+  // (instance) => assertions. Each checks the BaseSession-owned field landed.
+  // permissionMode is special: jsonl-family subclasses default it to 'auto',
+  // but an explicit 'plan' survives the `|| 'auto'` override, so it lands.
+  const assertions = {
+    cwd: (s, o) => assert.equal(s.cwd, o.cwd),
+    model: (s, o) => assert.equal(s.model, o.model),
+    permissionMode: (s, o) => assert.equal(s.permissionMode, o.permissionMode),
+    skillsDir: (s, o) => assert.equal(s._skillsDir, o.skillsDir),
+    repoSkillsDir: (s, o) => assert.equal(s._repoSkillsDir, o.repoSkillsDir),
+    maxSkillBytes: (s, o) => assert.equal(s._maxSkillBytes, o.maxSkillBytes),
+    maxTotalSkillBytes: (s, o) => assert.equal(s._maxTotalSkillBytes, o.maxTotalSkillBytes),
+    provider: (s, o) => assert.equal(s._provider, o.provider),
+    activeManualSkills: (s) => {
+      assert.ok(s._activeManualSkills.has('skill-a'))
+      assert.ok(s._activeManualSkills.has('skill-b'))
+    },
+    providerSkillAllowlist: (s, o) => assert.deepEqual(s._providerSkillAllowlist, o.providerSkillAllowlist),
+    trustStore: (s) => assert.equal(s._trustStore, trustStore),
+    // trustMismatchMode only matters when trustStore is absent; with an
+    // explicit trustStore the store wins (so no separate field to assert).
+    trustMismatchMode: () => {},
+    promptEvaluator: (s) => assert.equal(s.promptEvaluator, true),
+    promptEvaluatorSkipPattern: (s, o) => assert.equal(s.promptEvaluatorSkipPattern, o.promptEvaluatorSkipPattern),
+    chroxyContextHint: (s) => assert.equal(s.chroxyContextHint, true),
+    sessionPreamble: (s, o) => assert.equal(s.sessionPreamble, o.sessionPreamble),
+    resultTimeoutMs: (s, o) => assert.equal(s._resultTimeoutMs, o.resultTimeoutMs),
+    hardTimeoutMs: (s, o) => assert.equal(s._hardTimeoutMs, o.hardTimeoutMs),
+    streamStallTimeoutMs: (s, o) => assert.equal(s._streamStallTimeoutMs, o.streamStallTimeoutMs),
+    backgroundShellHardQuiesceMs: (s) => assert.equal(s._backgroundShellHardQuiesceMs, 0),
+  }
+
+  // Guard: the assertion table must cover exactly the canonical opt set, so a
+  // new BaseSession opt forces this test to be extended (it can't silently
+  // pass with a stale list).
+  it('assertion table covers exactly BASE_SESSION_OPT_KEYS', () => {
+    assert.deepEqual(
+      Object.keys(assertions).sort(),
+      [...BASE_SESSION_OPT_KEYS].sort(),
+      'add the new opt to BOTH the sentinel bag and the assertions table',
+    )
+  })
+
+  const subclasses = [
+    ['CliSession', '../src/cli-session.js', 'CliSession'],
+    ['SdkSession', '../src/sdk-session.js', 'SdkSession'],
+    ['ClaudeTuiSession', '../src/claude-tui-session.js', 'ClaudeTuiSession'],
+    ['ClaudeByokSession', '../src/byok-session.js', 'ClaudeByokSession'],
+    ['JsonlSubprocessSession', '../src/jsonl-subprocess-session.js', 'JsonlSubprocessSession'],
+    ['CodexSession', '../src/codex-session.js', 'CodexSession'],
+    ['GeminiSession', '../src/gemini-session.js', 'GeminiSession'],
+  ]
+
+  for (const [label, modPath, exportName] of subclasses) {
+    it(`${label} forwards every BaseSession opt to super()`, async () => {
+      const mod = await import(modPath)
+      const Klass = mod[exportName]
+      const opts = sentinelOpts()
+      const inst = new Klass(opts)
+      for (const key of BASE_SESSION_OPT_KEYS) {
+        assertions[key](inst, opts)
+      }
+      // Clean teardown so timers/processes don't leak between cases.
+      if (typeof inst.destroy === 'function') {
+        try { await inst.destroy() } catch {}
+      }
     })
   }
 })

--- a/packages/server/tests/lint-session-opt-forwarding.test.js
+++ b/packages/server/tests/lint-session-opt-forwarding.test.js
@@ -26,22 +26,35 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const LINT_SCRIPT = resolve(__dirname, '..', 'scripts', 'lint-session-opt-forwarding.mjs')
 
 // Minimal BaseSession fixture that mimics the real signature shape — the
-// lint extracts the opt-name set from the destructure inside the constructor.
-const BASE_SESSION_SRC = `
+// lint extracts the opt-name set from the destructure inside the constructor
+// AND asserts it equals the exported BASE_SESSION_OPT_KEYS array (#5367).
+// `mkBaseSession` lets a test deliberately desync the array from the ctor to
+// exercise the drift guard.
+function mkBaseSession({ ctorKeys, arrayKeys } = {}) {
+  const ctor = ctorKeys || [
+    'cwd', 'model', 'permissionMode', 'skillsDir', 'repoSkillsDir',
+    'maxSkillBytes', 'chroxyContextHint', 'streamStallTimeoutMs',
+    'resultTimeoutMs', 'hardTimeoutMs',
+  ]
+  const arr = arrayKeys || ctor
+  return `
 import { EventEmitter } from 'events'
+
+export const BASE_SESSION_OPT_KEYS = [
+${arr.map(k => `  '${k}',`).join('\n')}
+]
+
+export function buildBaseSessionOpts(fullOpts = {}, overrides = {}) {
+  const out = {}
+  for (const k of BASE_SESSION_OPT_KEYS) {
+    if (k in fullOpts) out[k] = fullOpts[k]
+  }
+  return { ...out, ...overrides }
+}
 
 export class BaseSession extends EventEmitter {
   constructor({
-    cwd,
-    model,
-    permissionMode,
-    skillsDir,
-    repoSkillsDir,
-    maxSkillBytes,
-    chroxyContextHint,
-    streamStallTimeoutMs,
-    resultTimeoutMs,
-    hardTimeoutMs,
+${ctor.map(k => `    ${k},`).join('\n')}
   } = {}) {
     super()
     this.cwd = cwd
@@ -49,6 +62,9 @@ export class BaseSession extends EventEmitter {
   }
 }
 `
+}
+
+const BASE_SESSION_SRC = mkBaseSession()
 
 // A "good" middle layer — every BaseSession opt is destructured and
 // forwarded through super(). The real JsonlSubprocessSession looks like
@@ -169,11 +185,55 @@ export class ClaudeByokSession extends BaseSession {
 }
 `
 
-function setupFixtureTree(extraFiles = {}) {
+// #5367: the sanctioned picker shape. A single-arg ctor forwarding via
+// `super(buildBaseSessionOpts(opts, { ...overrides }))`. The lint treats this
+// as compliant-by-construction (coverage proven by the array-vs-ctor assertion
+// + the picker copying every key) — it must NOT be skipped vacuously.
+const PICKER_SRC = `
+import { BaseSession, buildBaseSessionOpts } from './base-session.js'
+
+export class SdkSession extends BaseSession {
+  constructor(opts = {}) {
+    super(buildBaseSessionOpts(opts, { provider: opts.provider || 'claude-sdk' }))
+    const { resumeSessionId } = opts
+    this.resumeSessionId = resumeSessionId
+  }
+}
+`
+
+// #5367: a single-arg ctor that hand-rolls `super({ cwd })` and silently drops
+// every other BaseSession opt. Pre-#5367 the lint skipped single-arg ctors
+// blanket-style, so this regression slipped through. The inverted lint must
+// flag it.
+const SINGLE_ARG_HANDROLLED_DROP_SRC = `
+import { BaseSession } from './base-session.js'
+
+export class CliSession extends BaseSession {
+  constructor(opts = {}) {
+    super({ cwd: opts.cwd })
+  }
+}
+`
+
+// #5367: an unrecognized super() forwarder — wraps opts in some other function
+// that the lint cannot prove preserves every key. Must be flagged.
+const UNRECOGNIZED_SUPER_SRC = `
+import { BaseSession } from './base-session.js'
+
+function mungeOpts(o) { return o }
+
+export class CliSession extends BaseSession {
+  constructor(opts = {}) {
+    super(mungeOpts(opts))
+  }
+}
+`
+
+function setupFixtureTree(extraFiles = {}, baseSessionSrc = BASE_SESSION_SRC) {
   const dir = mkdtempSync(join(tmpdir(), 'chroxy-lint-opt-fwd-'))
   const srcDir = join(dir, 'src')
   mkdirSync(srcDir, { recursive: true })
-  writeFileSync(join(srcDir, 'base-session.js'), BASE_SESSION_SRC, 'utf8')
+  writeFileSync(join(srcDir, 'base-session.js'), baseSessionSrc, 'utf8')
   for (const [name, src] of Object.entries(extraFiles)) {
     writeFileSync(join(srcDir, name), src, 'utf8')
   }
@@ -239,6 +299,70 @@ describe('lint-session-opt-forwarding', () => {
     cleanups.push(dir)
     const { code, stdout, stderr } = runLint(srcDir)
     assert.equal(code, 0, `rest-spread is naturally immune\nstdout:\n${stdout}\nstderr:\n${stderr}`)
+  })
+
+  test('accepts the buildBaseSessionOpts() picker (single-arg ctor) — #5367', () => {
+    // The sanctioned migration target. Must be analyzed-and-ok (compliant by
+    // construction), NOT skipped vacuously — the latter would re-arm the trap.
+    const { dir, srcDir } = setupFixtureTree({
+      'sdk-session.js': PICKER_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stdout, stderr } = runLint(srcDir)
+    assert.equal(code, 0, `picker should pass\nstdout:\n${stdout}\nstderr:\n${stderr}`)
+    // Prove it was actually counted (not silently skipped to "0 subclasses").
+    assert.match(stdout, /1 session subclass/, 'picker class must be counted as analyzed')
+  })
+
+  test('fails (exit 2) when BASE_SESSION_OPT_KEYS drifts from the ctor — #5367', () => {
+    // The new primary drift guard: the array the picker iterates must equal the
+    // ctor destructure. Drop a key from the array only → the picker would
+    // silently stop forwarding it. Lint must hard-error (exit 2).
+    const driftedBase = mkBaseSession({
+      ctorKeys: [
+        'cwd', 'model', 'permissionMode', 'skillsDir', 'repoSkillsDir',
+        'maxSkillBytes', 'chroxyContextHint', 'streamStallTimeoutMs',
+        'resultTimeoutMs', 'hardTimeoutMs',
+      ],
+      // streamStallTimeoutMs intentionally MISSING from the array.
+      arrayKeys: [
+        'cwd', 'model', 'permissionMode', 'skillsDir', 'repoSkillsDir',
+        'maxSkillBytes', 'chroxyContextHint',
+        'resultTimeoutMs', 'hardTimeoutMs',
+      ],
+    })
+    const { dir, srcDir } = setupFixtureTree({ 'sdk-session.js': PICKER_SRC }, driftedBase)
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 2, 'drift between array and ctor must hard-error (exit 2)')
+    assert.match(stderr, /drifted/i, 'error should explain the drift')
+    assert.match(stderr, /streamStallTimeoutMs/, 'error should name the drifted key')
+  })
+
+  test('fails when a single-arg ctor hand-rolls super({ cwd }) and drops keys — #5367', () => {
+    // Pre-#5367 single-arg ctors were blanket-skipped; this is the hole the
+    // picker would have slipped through. The inverted lint must flag it.
+    const { dir, srcDir } = setupFixtureTree({
+      'cli-session.js': SINGLE_ARG_HANDROLLED_DROP_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'hand-rolled super({ cwd }) in a single-arg ctor must fail')
+    assert.match(stderr, /cli-session\.js/, 'error should name the offending file')
+    assert.match(stderr, /model|permissionMode|streamStallTimeoutMs/, 'error should name dropped opts')
+  })
+
+  test('flags an unrecognized super() forwarder shape — #5367', () => {
+    // super(someOtherFn(opts)) cannot be proven safe → offense (pre-#5367 this
+    // was silently skipped, which is exactly the hole that re-armed the trap).
+    const { dir, srcDir } = setupFixtureTree({
+      'cli-session.js': UNRECOGNIZED_SUPER_SRC,
+    })
+    cleanups.push(dir)
+    const { code, stderr } = runLint(srcDir)
+    assert.equal(code, 1, 'unrecognized super() shape must fail')
+    assert.match(stderr, /cli-session\.js/, 'error should name the offending file')
+    assert.match(stderr, /[Uu]nrecognized super/, 'error should explain the unrecognized shape')
   })
 
   test('passes against the real packages/server/src tree (acceptance criterion)', () => {


### PR DESCRIPTION
Closes #5367.

## What
The session subclasses each hand-maintained a **parallel destructure + `super({...})`** list of all 20 BaseSession constructor opts. Dropping one silently disabled it (the "middle-layer trap" — shipped 3× as #3224/#3231/#4790, which is why a dedicated CI lint exists). Replace the parallel lists with a **picker**:

- **`base-session.js`**: export `BASE_SESSION_OPT_KEYS` (the 20 keys, in ctor order) + `buildBaseSessionOpts(fullOpts, overrides)` — copies present keys (`k in fullOpts`, so an explicit `0` like `backgroundShellHardQuiesceMs: 0` survives and absent keys are omitted), `overrides` win.
- **All 8 subclasses** (cli / sdk / tui / byok / jsonl / codex / gemini / **claude-channel**) → single `constructor(opts = {})` + `super(buildBaseSessionOpts(opts, { ...provider/model defaults }))`; subclass-local opts read off `opts`. Adding a BaseSession opt now means editing the ctor destructure + the array once — subclasses inherit it.

## The careful part — inverting the lint
A naive `super(buildBaseSessionOpts(opts))` makes every subclass a single-arg ctor, which the old lint **blanket-skipped** ("rest-spread style") → it would analyze 0 classes and pass vacuously, re-opening the regression. So the lint is inverted in the same PR:
1. Parse `BASE_SESSION_OPT_KEYS` and **assert it equals the ctor destructure** (drift → exit 2). This is the new primary guard.
2. `analyzeClass` no longer blanket-skips single-arg ctors: `super(buildBaseSessionOpts(...))` is compliant-by-construction; a hand-rolled `super({ object literal })` is still checked **per-key**; `super(someOtherFn(opts))` is now an **offense** (the old lint silently skipped this exact shape).
3. Legacy destructure + `super({...})` path and the `// lint-ignore-opt-forwarding:` hatch still work.

### Independently verified the inverted lint still catches drops
All three failure modes were re-proven by hand (not just the agent's self-test):
- hand-rolled object-literal drop (`super({ cwd: opts.cwd })`) → **caught** (names the class + every dropped key)
- `super(sneakyForward(opts))` → **caught** ("Unrecognized super() shape") — the exact hole the old lint missed
- `BASE_SESSION_OPT_KEYS` ⇄ ctor drift → **caught** ("BASE_SESSION_OPT_KEYS has drifted")

## Tests
`BASE_SESSION_OPT_KEYS`-vs-ctor drift, picker-passes, hand-rolled-drop-fails, and a parametrized **"no opt dropped" sentinel proof** that instantiates all 8 subclasses with every BaseSession opt set to a sentinel and asserts each lands on the instance. **1224 tests green**; all 3 custom lints pass (opt-forwarding, state-file, logger-scoping); eslint clean. `CLAUDE.md` updated to document the picker pattern.