### PR TITLE
refactor(server): extract PushNotificationHandler from startCliServer (#5368 slice a)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -7,6 +7,7 @@ import { WsServer, TUNNEL_STATUS_MIN_PROTOCOL_VERSION } from './ws-server.js'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 import { QUICK_TUNNEL_DNS_SETTLE_MS, waitForTunnel } from './tunnel-check.js'
 import { PushManager } from './push.js'
+import { PushNotificationHandler } from './server-cli/push-notification-handler.js'
 import { hostname, homedir } from 'os'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
@@ -675,174 +676,21 @@ export async function startCliServer(config) {
 
   let wsServer
 
-  // #3866 — explicit per-session dedupe for the idle push. Each entry pins
-  // "we already sent an idle push for the current active→idle cycle of this
-  // session" so a duplicate `result` event (or a race where the gate flips
-  // mid-turn) can't produce two OS-level notifications. Cleared when the
-  // session next emits `stream_start` (next busy cycle) or is destroyed.
-  // Resurrects the 'idle' push category removed in the 2026-04-11 audit
-  // without recreating the duplicate-fire bug that prompted its removal.
-  const _idleNotifiedSessions = new Set()
+  // #5368 slice (a): the `session_event` → push-notification path (incl. the
+  // #3866 idle-push dedupe and the #3870/#3871/#3872 races) lives in
+  // PushNotificationHandler, constructed + started after pushManager exists and
+  // before wsServer (so the #3871 wsServer-undefined branch still covers an
+  // early restoreState event). See below, right after `new PushManager(...)`.
 
-  // Log events for debugging and forward critical errors
-  sessionManager.on('session_event', ({ sessionId, event, data }) => {
-    if (event === 'ready') {
-      log.info(`Session ${sessionId} ready: ${data.sessionId} (model: ${data.model})`)
-    } else if (event === 'error') {
-      log.error(`Session ${sessionId} error: ${data.message}`)
-      // Error is already broadcast as { type: 'message', messageType: 'error' } through
-      // the forwarding path (ws-forwarding.js → EventNormalizer). Don't also broadcastError()
-      // here — that produces a duplicate server_error message on every client.
-      // Activity update: error (immediate)
-      if (pushManager.hasTokens) {
-        const sessionName = sessionManager.getSession(sessionId)?.name
-        pushManager.send('activity_error', 'Session error', data.message, {
-          sessionId,
-          sessionName,
-          state: 'error',
-          detail: data.message,
-        })
-      }
-    } else if (event === 'result' && data.cost != null) {
-      log.info(`Session ${sessionId} query: $${data.cost.toFixed(4)} in ${data.duration}ms`)
-      // Note: this arm used to ALSO fire an 'idle' push here ("Claude is waiting")
-      // for the same unattended-completion case that the activity_update push below
-      // already covers. Because the two pushes used different rate-limit buckets
-      // (idle=60s, activity_update=10s) they never deduped each other, so every
-      // unattended completion produced two OS-level notifications on the phone.
-      // Removed in favor of the single activity_update fire below.
-    } else if (event === 'result') {
-      // result without cost (e.g. Gemini providers) — log duration if available
-      if (data.duration != null) {
-        log.info(`Session ${sessionId} query completed in ${data.duration}ms`)
-      }
-    } else if (event === 'budget_warning') {
-      log.warn(`Budget warning: ${data.message}`)
-    } else if (event === 'budget_exceeded') {
-      log.warn(`Budget exceeded: ${data.message}`)
-    }
-
-    // Reset the idle-push dedupe at the start of each busy cycle (#3866).
-    // Different providers emit different "session became busy" signals:
-    //   - SDK / Claude CLI turns typically fire stream_start first
-    //   - Codex tool-only turns can fire tool_start without any stream_start
-    //     (see codex-session.js _processJsonlLine — `item.type === 'tool_call'`
-    //     emits tool_start unconditionally)
-    // Without clearing on tool_start, a Codex turn that runs a tool and
-    // returns no streamed text would leave the dedupe latched, and the
-    // *next* turn's result would be wrongly suppressed as "already
-    // notified" (#3872, Copilot review).
-    if (event === 'stream_start' || event === 'tool_start') {
-      _idleNotifiedSessions.delete(sessionId)
-    }
-
-    // Push notifications for actionable events only (#2612)
-    // Intermediate events (stream_start, tool_start) no longer trigger pushes.
-    if (!pushManager.hasTokens && (event === 'result' || event === 'permission_request' || event === 'user_question')) {
-      // #3866 diagnostic — silently dropping a push because no client ever
-      // registered a push token is the most common "I'm getting nothing on
-      // Android" failure mode. Surface it at debug so operators can confirm
-      // registration happened on their last connect.
-      log.debug(`Push suppressed for ${event} on ${sessionId}: no registered tokens`)
-    }
-    if (pushManager.hasTokens) {
-      if (event === 'result') {
-        // Session idle push (#3866). Gate on noActiveViewers so the user
-        // isn't pinged while actively chatting with this session. The
-        // per-session dedupe Set prevents a duplicate `result` from
-        // firing twice for the same active→idle transition.
-        if (wsServer) {
-          const noClients = wsServer.authenticatedClientCount === 0
-          const noActiveViewers = !noClients && !wsServer.hasActiveViewersForSession(sessionId)
-          const allowed = noClients || noActiveViewers
-          const alreadyNotified = _idleNotifiedSessions.has(sessionId)
-          if (allowed && !alreadyNotified) {
-            const sessionName = sessionManager.getSession(sessionId)?.name
-            // #3870: latch SYNCHRONOUSLY before send() returns its promise
-            // so a second `result` arriving in the same tick can't double-
-            // fire (passes the !alreadyNotified gate twice). `send()` now
-            // returns a Promise<boolean> — `false` means Expo hard-failed
-            // (non-2xx or network throw, both caught inside _sendToTokenSet
-            // and surfaced via this return value, NOT via rejection since
-            // _sendToTokenSet swallows the throw). On hard failure, log at
-            // warn and RELEASE the latch so the next active→idle cycle gets
-            // a fresh chance — without this the user was silently dropped
-            // *and* permanently latched until the session went busy again.
-            _idleNotifiedSessions.add(sessionId)
-            Promise.resolve(
-              pushManager.send('activity_update', 'Session idle', 'Ready for next message', {
-                sessionId,
-                sessionName,
-                state: 'idle',
-                ...(data.duration != null && { elapsed: data.duration }),
-              })
-            ).then(ok => {
-              if (ok === false) {
-                log.warn(`Idle push send failed for ${sessionId} (Expo hard failure)`)
-                _idleNotifiedSessions.delete(sessionId)
-              }
-            }).catch(err => {
-              // Defensive — _sendToTokenSet should never throw, but if a
-              // future refactor lets one escape, treat it as hard failure.
-              log.warn(`Idle push send failed for ${sessionId}: ${err?.message || err}`)
-              _idleNotifiedSessions.delete(sessionId)
-            })
-          } else if (!allowed) {
-            // Diagnostic for #3866: surface why a push was suppressed so we
-            // can tell registration failures apart from "user is viewing".
-            log.debug(`Idle push suppressed for ${sessionId}: active viewers present`)
-          } else if (alreadyNotified) {
-            log.debug(`Idle push suppressed for ${sessionId}: already notified this turn`)
-          }
-        } else {
-          // #3871: session_event listener is registered BEFORE wsServer is
-          // constructed, so a result event from a restoreState-resurrected
-          // session can fire while wsServer is still undefined. Surface that
-          // here at debug so it's not silently dropped — same diagnostic
-          // discipline as the no-tokens / active-viewers / already-notified
-          // branches above (#3866).
-          log.debug(`Idle push suppressed for ${sessionId}: wsServer not yet initialized`)
-        }
-      } else if (event === 'permission_request') {
-        const sessionName = sessionManager.getSession(sessionId)?.name
-        pushManager.send('activity_waiting', 'Waiting for approval', `Permission needed: ${data.tool}`, {
-          sessionId,
-          sessionName,
-          state: 'waiting',
-          detail: data.tool,
-        })
-      } else if (event === 'user_question') {
-        const sessionName = sessionManager.getSession(sessionId)?.name
-        pushManager.send('activity_waiting', 'Input needed', 'Claude has a question', {
-          sessionId,
-          sessionName,
-          state: 'waiting',
-        })
-      } else if (event === 'inactivity_warning') {
-        // #3899: soft inactivity warning replaces the pre-#3899 kill-on-
-        // timeout behaviour. Push regardless of active-viewer state — a
-        // viewer with the dashboard open but AFK still benefits from the
-        // device-level nudge. (The transient UI chip in the dashboard
-        // covers the actively-watching case.)
-        const sessionName = sessionManager.getSession(sessionId)?.name
-        pushManager.send('inactivity_warning', 'Agent quiet for a while', 'Tap to check in', {
-          sessionId,
-          sessionName,
-          state: 'idle_warning',
-          prefab: data.prefab,
-          idleMs: data.idleMs,
-        })
-      }
-    }
-  })
-
+  // Log events for debugging
   sessionManager.on('session_created', ({ sessionId, name, cwd }) => {
     log.info(`Session created: ${sessionId} (${name}) in ${cwd}`)
   })
 
   sessionManager.on('session_destroyed', ({ sessionId }) => {
     log.info(`Session destroyed: ${sessionId}`)
-    _idleNotifiedSessions.delete(sessionId)
+    // #5368: the idle-push dedupe clear-on-destroy now lives in
+    // PushNotificationHandler (its own session_destroyed listener).
   })
 
   sessionManager.on('session_warning', ({ sessionId, name, reason, message, remainingMs }) => {
@@ -866,6 +714,18 @@ export async function startCliServer(config) {
     // ~/.chroxy alongside push-tokens.json so cleanup is one step.
     prefsPath: join(homedir(), '.chroxy', 'notification-prefs.json'),
   })
+
+  // #5368 slice (a): wire the session_event → push path now that pushManager
+  // exists. `getWsServer` is lazy because the handler is started before wsServer
+  // is constructed (below) — an early restoreState `result` event must still
+  // route here and hit the wsServer-undefined branch (#3871).
+  const pushNotificationHandler = new PushNotificationHandler({
+    sessionManager,
+    pushManager,
+    getWsServer: () => wsServer,
+    logger: log,
+  })
+  pushNotificationHandler.start()
 
   const configFile = join(homedir(), '.chroxy', 'config.json')
   const tokenManager = NO_AUTH ? null : new TokenManager({

--- a/packages/server/src/server-cli/push-notification-handler.js
+++ b/packages/server/src/server-cli/push-notification-handler.js
@@ -1,0 +1,218 @@
+// PushNotificationHandler (#5368 slice a) — extracted from server-cli.js's
+// startCliServer god function.
+//
+// Owns the entire `session_event` → push-notification path, including the
+// per-session idle-push dedupe (#3866) and the four separately-fixed races it
+// relocates verbatim:
+//   - #3866 — per-session dedupe Set so a duplicate `result` can't double-fire
+//     the idle push.
+//   - #3870 — latch the dedupe SYNCHRONOUSLY before `send()` returns its
+//     promise, so a second `result` in the same tick can't pass the gate twice.
+//   - #3871 — the `session_event` listener is registered BEFORE wsServer
+//     exists, so a `result` from a restoreState-resurrected session can fire
+//     while wsServer is still undefined; read it through `getWsServer()` and
+//     guard the undefined case rather than capturing it at construction.
+//   - #3872 — reset the dedupe on `tool_start` too (not just `stream_start`),
+//     because Codex tool-only turns emit `tool_start` without a `stream_start`.
+//
+// Constructor-injection seams (sessionManager / pushManager / getWsServer /
+// logger) make this unit-testable with fakes — the biggest coverage win of the
+// split, since the inline version was impossible to exercise in isolation.
+
+export class PushNotificationHandler {
+  /**
+   * @param {{
+   *   sessionManager: import('events').EventEmitter & { getSession: Function },
+   *   pushManager: { hasTokens: boolean, send: Function },
+   *   getWsServer: () => ({ authenticatedClientCount: number, hasActiveViewersForSession: Function } | undefined),
+   *   logger: { info: Function, warn: Function, error: Function, debug: Function },
+   * }} deps
+   *   `getWsServer` is a getter (not the instance) because the handler is wired
+   *   before wsServer is constructed (#3871).
+   */
+  constructor({ sessionManager, pushManager, getWsServer, logger }) {
+    this._sessionManager = sessionManager
+    this._pushManager = pushManager
+    this._getWsServer = typeof getWsServer === 'function' ? getWsServer : () => undefined
+    this._log = logger
+
+    // #3866 — explicit per-session dedupe for the idle push. Each entry pins
+    // "we already sent an idle push for the current active→idle cycle of this
+    // session" so a duplicate `result` event (or a race where the gate flips
+    // mid-turn) can't produce two OS-level notifications. Cleared when the
+    // session next emits `stream_start`/`tool_start` (next busy cycle) or is
+    // destroyed.
+    this._idleNotifiedSessions = new Set()
+  }
+
+  /**
+   * Attach the listeners. Call once, after pushManager exists and before
+   * wsServer is constructed (so an early restoreState event still routes here —
+   * the wsServer-undefined branch handles it, #3871).
+   */
+  start() {
+    this._sessionManager.on('session_event', (e) => this._onSessionEvent(e))
+    // The dedupe must clear when a session goes away so a future session that
+    // reuses the id can't be wrongly suppressed (the rest of session_destroyed
+    // logging stays in server-cli.js).
+    this._sessionManager.on('session_destroyed', ({ sessionId }) => {
+      this._idleNotifiedSessions.delete(sessionId)
+    })
+  }
+
+  _onSessionEvent({ sessionId, event, data }) {
+    const log = this._log
+    const pushManager = this._pushManager
+    const sessionManager = this._sessionManager
+    const wsServer = this._getWsServer()
+
+    if (event === 'ready') {
+      log.info(`Session ${sessionId} ready: ${data.sessionId} (model: ${data.model})`)
+    } else if (event === 'error') {
+      log.error(`Session ${sessionId} error: ${data.message}`)
+      // Error is already broadcast as { type: 'message', messageType: 'error' } through
+      // the forwarding path (ws-forwarding.js → EventNormalizer). Don't also broadcastError()
+      // here — that produces a duplicate server_error message on every client.
+      // Activity update: error (immediate)
+      if (pushManager.hasTokens) {
+        const sessionName = sessionManager.getSession(sessionId)?.name
+        pushManager.send('activity_error', 'Session error', data.message, {
+          sessionId,
+          sessionName,
+          state: 'error',
+          detail: data.message,
+        })
+      }
+    } else if (event === 'result' && data.cost != null) {
+      log.info(`Session ${sessionId} query: $${data.cost.toFixed(4)} in ${data.duration}ms`)
+      // Note: this arm used to ALSO fire an 'idle' push here ("Claude is waiting")
+      // for the same unattended-completion case that the activity_update push below
+      // already covers. Because the two pushes used different rate-limit buckets
+      // (idle=60s, activity_update=10s) they never deduped each other, so every
+      // unattended completion produced two OS-level notifications on the phone.
+      // Removed in favor of the single activity_update fire below.
+    } else if (event === 'result') {
+      // result without cost (e.g. Gemini providers) — log duration if available
+      if (data.duration != null) {
+        log.info(`Session ${sessionId} query completed in ${data.duration}ms`)
+      }
+    } else if (event === 'budget_warning') {
+      log.warn(`Budget warning: ${data.message}`)
+    } else if (event === 'budget_exceeded') {
+      log.warn(`Budget exceeded: ${data.message}`)
+    }
+
+    // Reset the idle-push dedupe at the start of each busy cycle (#3866).
+    // Different providers emit different "session became busy" signals:
+    //   - SDK / Claude CLI turns typically fire stream_start first
+    //   - Codex tool-only turns can fire tool_start without any stream_start
+    //     (see codex-session.js _processJsonlLine — `item.type === 'tool_call'`
+    //     emits tool_start unconditionally)
+    // Without clearing on tool_start, a Codex turn that runs a tool and
+    // returns no streamed text would leave the dedupe latched, and the
+    // *next* turn's result would be wrongly suppressed as "already
+    // notified" (#3872, Copilot review).
+    if (event === 'stream_start' || event === 'tool_start') {
+      this._idleNotifiedSessions.delete(sessionId)
+    }
+
+    // Push notifications for actionable events only (#2612)
+    // Intermediate events (stream_start, tool_start) no longer trigger pushes.
+    if (!pushManager.hasTokens && (event === 'result' || event === 'permission_request' || event === 'user_question')) {
+      // #3866 diagnostic — silently dropping a push because no client ever
+      // registered a push token is the most common "I'm getting nothing on
+      // Android" failure mode. Surface it at debug so operators can confirm
+      // registration happened on their last connect.
+      log.debug(`Push suppressed for ${event} on ${sessionId}: no registered tokens`)
+    }
+    if (pushManager.hasTokens) {
+      if (event === 'result') {
+        // Session idle push (#3866). Gate on noActiveViewers so the user
+        // isn't pinged while actively chatting with this session. The
+        // per-session dedupe Set prevents a duplicate `result` from
+        // firing twice for the same active→idle transition.
+        if (wsServer) {
+          const noClients = wsServer.authenticatedClientCount === 0
+          const noActiveViewers = !noClients && !wsServer.hasActiveViewersForSession(sessionId)
+          const allowed = noClients || noActiveViewers
+          const alreadyNotified = this._idleNotifiedSessions.has(sessionId)
+          if (allowed && !alreadyNotified) {
+            const sessionName = sessionManager.getSession(sessionId)?.name
+            // #3870: latch SYNCHRONOUSLY before send() returns its promise
+            // so a second `result` arriving in the same tick can't double-
+            // fire (passes the !alreadyNotified gate twice). `send()` now
+            // returns a Promise<boolean> — `false` means Expo hard-failed
+            // (non-2xx or network throw, both caught inside _sendToTokenSet
+            // and surfaced via this return value, NOT via rejection since
+            // _sendToTokenSet swallows the throw). On hard failure, log at
+            // warn and RELEASE the latch so the next active→idle cycle gets
+            // a fresh chance — without this the user was silently dropped
+            // *and* permanently latched until the session went busy again.
+            this._idleNotifiedSessions.add(sessionId)
+            Promise.resolve(
+              pushManager.send('activity_update', 'Session idle', 'Ready for next message', {
+                sessionId,
+                sessionName,
+                state: 'idle',
+                ...(data.duration != null && { elapsed: data.duration }),
+              })
+            ).then(ok => {
+              if (ok === false) {
+                log.warn(`Idle push send failed for ${sessionId} (Expo hard failure)`)
+                this._idleNotifiedSessions.delete(sessionId)
+              }
+            }).catch(err => {
+              // Defensive — _sendToTokenSet should never throw, but if a
+              // future refactor lets one escape, treat it as hard failure.
+              log.warn(`Idle push send failed for ${sessionId}: ${err?.message || err}`)
+              this._idleNotifiedSessions.delete(sessionId)
+            })
+          } else if (!allowed) {
+            // Diagnostic for #3866: surface why a push was suppressed so we
+            // can tell registration failures apart from "user is viewing".
+            log.debug(`Idle push suppressed for ${sessionId}: active viewers present`)
+          } else if (alreadyNotified) {
+            log.debug(`Idle push suppressed for ${sessionId}: already notified this turn`)
+          }
+        } else {
+          // #3871: session_event listener is registered BEFORE wsServer is
+          // constructed, so a result event from a restoreState-resurrected
+          // session can fire while wsServer is still undefined. Surface that
+          // here at debug so it's not silently dropped — same diagnostic
+          // discipline as the no-tokens / active-viewers / already-notified
+          // branches above (#3866).
+          log.debug(`Idle push suppressed for ${sessionId}: wsServer not yet initialized`)
+        }
+      } else if (event === 'permission_request') {
+        const sessionName = sessionManager.getSession(sessionId)?.name
+        pushManager.send('activity_waiting', 'Waiting for approval', `Permission needed: ${data.tool}`, {
+          sessionId,
+          sessionName,
+          state: 'waiting',
+          detail: data.tool,
+        })
+      } else if (event === 'user_question') {
+        const sessionName = sessionManager.getSession(sessionId)?.name
+        pushManager.send('activity_waiting', 'Input needed', 'Claude has a question', {
+          sessionId,
+          sessionName,
+          state: 'waiting',
+        })
+      } else if (event === 'inactivity_warning') {
+        // #3899: soft inactivity warning replaces the pre-#3899 kill-on-
+        // timeout behaviour. Push regardless of active-viewer state — a
+        // viewer with the dashboard open but AFK still benefits from the
+        // device-level nudge. (The transient UI chip in the dashboard
+        // covers the actively-watching case.)
+        const sessionName = sessionManager.getSession(sessionId)?.name
+        pushManager.send('inactivity_warning', 'Agent quiet for a while', 'Tap to check in', {
+          sessionId,
+          sessionName,
+          state: 'idle_warning',
+          prefab: data.prefab,
+          idleMs: data.idleMs,
+        })
+      }
+    }
+  }
+}

--- a/packages/server/tests/push-notification-handler.test.js
+++ b/packages/server/tests/push-notification-handler.test.js
@@ -1,0 +1,195 @@
+// #5368 slice (a): unit tests for PushNotificationHandler — the session_event
+// → push path extracted from startCliServer. These re-assert the four races
+// that were impossible to test while the logic was inline in the god function
+// (#3866 dedupe, #3870 synchronous latch, #3871 wsServer-undefined guard,
+// #3872 tool_start dedupe reset), plus the per-event push fan-out.
+
+import { describe, it, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { PushNotificationHandler } from '../src/server-cli/push-notification-handler.js'
+
+function makeFakes({ hasTokens = true, sendResult = true, wsServer = undefined } = {}) {
+  const sends = []
+  const pushManager = {
+    hasTokens,
+    send(category, title, body, data) {
+      sends.push({ category, title, body, data })
+      return Promise.resolve(sendResult)
+    },
+  }
+  const sessionManager = new EventEmitter()
+  sessionManager.getSession = (id) => ({ name: `name-${id}` })
+  const logs = { debug: [], warn: [], error: [], info: [] }
+  const logger = {
+    debug: (m) => logs.debug.push(m),
+    warn: (m) => logs.warn.push(m),
+    error: (m) => logs.error.push(m),
+    info: (m) => logs.info.push(m),
+  }
+  let currentWs = wsServer
+  const handler = new PushNotificationHandler({
+    sessionManager,
+    pushManager,
+    getWsServer: () => currentWs,
+    logger,
+  })
+  handler.start()
+  return { handler, sessionManager, pushManager, sends, logs, setWsServer: (w) => { currentWs = w } }
+}
+
+function fakeWsServer({ authenticatedClientCount = 0, activeViewers = false } = {}) {
+  return {
+    authenticatedClientCount,
+    hasActiveViewersForSession: () => activeViewers,
+  }
+}
+
+const tick = () => new Promise((r) => setImmediate(r))
+
+describe('PushNotificationHandler — idle push (#3866 dedupe)', () => {
+  it('fires one idle push on result when no clients are connected', () => {
+    const ws = fakeWsServer({ authenticatedClientCount: 0 })
+    const { sessionManager, sends } = makeFakes({ wsServer: ws })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: { duration: 1200 } })
+    assert.equal(sends.length, 1)
+    assert.equal(sends[0].category, 'activity_update')
+    assert.equal(sends[0].data.state, 'idle')
+    assert.equal(sends[0].data.elapsed, 1200)
+  })
+
+  it('a duplicate result does NOT fire a second idle push (per-session dedupe)', () => {
+    const ws = fakeWsServer({ authenticatedClientCount: 0 })
+    const { sessionManager, sends } = makeFakes({ wsServer: ws })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 1, 'second result suppressed by the dedupe Set')
+  })
+})
+
+describe('PushNotificationHandler — #3870 synchronous latch', () => {
+  it('two results in the SAME tick fire only one push (latched before send resolves)', () => {
+    const ws = fakeWsServer({ authenticatedClientCount: 0 })
+    const { sessionManager, sends } = makeFakes({ wsServer: ws })
+    // Both emitted synchronously — the latch must be set before send()'s promise
+    // settles, so the second can't pass the !alreadyNotified gate.
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 1)
+  })
+
+  it('releases the latch on hard send failure so the next cycle gets a fresh push', async () => {
+    const ws = fakeWsServer({ authenticatedClientCount: 0 })
+    const { sessionManager, sends, logs } = makeFakes({ wsServer: ws, sendResult: false })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    await tick() // let the send() promise resolve(false) and release the latch
+    assert.ok(logs.warn.some((m) => m.includes('Idle push send failed')))
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 2, 'latch released → a fresh idle push fires next cycle')
+  })
+})
+
+describe('PushNotificationHandler — #3872 dedupe reset on tool_start (Codex)', () => {
+  it('tool_start (no stream_start) clears the dedupe so the next result fires', () => {
+    const ws = fakeWsServer({ authenticatedClientCount: 0 })
+    const { sessionManager, sends } = makeFakes({ wsServer: ws })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 1)
+    // A Codex tool-only turn emits tool_start with no preceding stream_start.
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'tool_start', data: {} })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 2, 'tool_start reset the latch (would stay stuck without #3872)')
+  })
+
+  it('stream_start also clears the dedupe', () => {
+    const ws = fakeWsServer({ authenticatedClientCount: 0 })
+    const { sessionManager, sends } = makeFakes({ wsServer: ws })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'stream_start', data: {} })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 2)
+  })
+})
+
+describe('PushNotificationHandler — #3871 wsServer-undefined guard', () => {
+  it('a result before wsServer exists is suppressed (no crash), logged at debug', () => {
+    const { sessionManager, sends, logs } = makeFakes({ wsServer: undefined })
+    assert.doesNotThrow(() => {
+      sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    })
+    assert.equal(sends.length, 0)
+    assert.ok(logs.debug.some((m) => m.includes('wsServer not yet initialized')))
+  })
+
+  it('routes correctly once wsServer is later assigned', () => {
+    const fakes = makeFakes({ wsServer: undefined })
+    fakes.setWsServer(fakeWsServer({ authenticatedClientCount: 0 }))
+    fakes.sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(fakes.sends.length, 1)
+  })
+})
+
+describe('PushNotificationHandler — active-viewer + token gating', () => {
+  it('suppresses the idle push when a viewer is actively watching the session', () => {
+    const ws = fakeWsServer({ authenticatedClientCount: 1, activeViewers: true })
+    const { sessionManager, sends, logs } = makeFakes({ wsServer: ws })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 0)
+    assert.ok(logs.debug.some((m) => m.includes('active viewers present')))
+  })
+
+  it('sends nothing (and debug-logs) when there are no registered tokens', () => {
+    const { sessionManager, sends, logs } = makeFakes({ hasTokens: false, wsServer: fakeWsServer() })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 0)
+    assert.ok(logs.debug.some((m) => m.includes('no registered tokens')))
+  })
+})
+
+describe('PushNotificationHandler — per-event push fan-out', () => {
+  it('error event sends an activity_error push', () => {
+    const { sessionManager, sends } = makeFakes({ wsServer: fakeWsServer() })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'error', data: { message: 'boom' } })
+    assert.equal(sends.length, 1)
+    assert.equal(sends[0].category, 'activity_error')
+    assert.equal(sends[0].data.detail, 'boom')
+  })
+
+  it('permission_request sends an activity_waiting push with the tool', () => {
+    const { sessionManager, sends } = makeFakes({ wsServer: fakeWsServer() })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'permission_request', data: { tool: 'Bash' } })
+    assert.equal(sends.length, 1)
+    assert.equal(sends[0].category, 'activity_waiting')
+    assert.equal(sends[0].data.detail, 'Bash')
+  })
+
+  it('user_question sends an activity_waiting push', () => {
+    const { sessionManager, sends } = makeFakes({ wsServer: fakeWsServer() })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'user_question', data: {} })
+    assert.equal(sends.length, 1)
+    assert.equal(sends[0].category, 'activity_waiting')
+    assert.equal(sends[0].data.state, 'waiting')
+  })
+
+  it('inactivity_warning pushes regardless of active viewers (#3899)', () => {
+    const ws = fakeWsServer({ authenticatedClientCount: 1, activeViewers: true })
+    const { sessionManager, sends } = makeFakes({ wsServer: ws })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'inactivity_warning', data: { prefab: 'p', idleMs: 999 } })
+    assert.equal(sends.length, 1)
+    assert.equal(sends[0].category, 'inactivity_warning')
+    assert.equal(sends[0].data.idleMs, 999)
+  })
+})
+
+describe('PushNotificationHandler — session_destroyed clears dedupe', () => {
+  let fakes
+  beforeEach(() => { fakes = makeFakes({ wsServer: fakeWsServer({ authenticatedClientCount: 0 }) }) })
+
+  it('a destroyed-then-reused session id gets a fresh idle push', () => {
+    fakes.sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(fakes.sends.length, 1)
+    fakes.sessionManager.emit('session_destroyed', { sessionId: 's1' })
+    fakes.sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(fakes.sends.length, 2, 'dedupe cleared on destroy')
+  })
+})


### PR DESCRIPTION
## What

First slice of the #5368 ServerOrchestrator split (the riskiest deferred refactor — landing in reviewable slices per the design). Extracts the entire `session_event` → push-notification path (~160 lines) out of `startCliServer` into `src/server-cli/push-notification-handler.js` with constructor-injection seams.

## The crux — four relocated races, now unit-testable

The block buried in `startCliServer` was impossible to test in isolation. It carried four separately-fixed races, moved here **verbatim** and re-asserted by new tests with fakes:

- **#3866** — per-session idle-push dedupe `Set` so a duplicate `result` can't double-fire the OS notification.
- **#3870** — latch the dedupe **synchronously** before `send()`'s promise settles, so two `result`s in the same tick can't both pass the gate. On hard send-failure the latch is released so the next cycle gets a fresh push.
- **#3871** — the listener is wired **before `wsServer` exists**; the handler reads it through `getWsServer()` and guards the undefined case (an early restoreState `result` is suppressed + debug-logged, not a crash). Construction sits right after `PushManager` and before `WsServer`, preserving the registered-before-wsServer ordering.
- **#3872** — dedupe reset on `tool_start` too (not just `stream_start`), because Codex tool-only turns emit `tool_start` with no `stream_start`.

## Changes

- `startCliServer` shrinks to: `new PushNotificationHandler({ sessionManager, pushManager, getWsServer: () => wsServer, logger: log })` + `.start()`. The `session_destroyed` dedupe-clear moves into the handler's own listener (server-cli keeps the logging one).
- No `session_event` fires between the old listener point and `PushManager` construction (else `pushManager` would TDZ-throw today), so moving the registration there is behavior-preserving.
- The handler takes the logger by injection (preserves the existing `server-cli` log category; no new `createLogger`, so logger-scoping lint unaffected).

## Tests

- New `push-notification-handler.test.js` (15): all four races + the per-event push fan-out (error / permission_request / user_question / inactivity_warning / active-viewer + token gating / session_destroyed dedupe-clear).
- server-cli + push suites: 90 pass. eslint clean; all 3 custom shell lints pass.
- Full server suite: 8132 pass / 3 fail — all 3 unrelated: 2 are `service.test.js` #745 (pre-existing on `main`, environmental), 1 is `ws-server.test.js` "encryption integration (end-to-end)" which **passes in isolation** (115/115) and flakes only under full-suite parallel load (real WS + crypto timing); neither touches the push path.

Part of #5368 (slices b/c/d — StartupDisplay, TunnelLifecycleHandler, ServerOrchestrator — follow as separate PRs).
