### PR TITLE
refactor(server): extract StartupDisplay from startCliServer (#5368 slice b)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -8,15 +8,17 @@ import { createTunnel, parseTunnelArg } from './tunnel/index.js'
 import { QUICK_TUNNEL_DNS_SETTLE_MS, waitForTunnel } from './tunnel-check.js'
 import { PushManager } from './push.js'
 import { PushNotificationHandler } from './server-cli/push-notification-handler.js'
+import { StartupDisplay } from './server-cli/startup-display.js'
 import { hostname, homedir } from 'os'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
 import { dirname, join, relative, sep } from 'path'
-import QRCode from 'qrcode'
 import { createLogger, setJsonMode, initFileLogging } from './logger.js'
 
 const log = createLogger('cli')
-import { writeConnectionInfo, removeConnectionInfo } from './connection-info.js'
+// #5368 slice (b): QRCode + writeConnectionInfo moved to startup-display.js with
+// displayQr; only removeConnectionInfo (shutdown) is still used here.
+import { removeConnectionInfo } from './connection-info.js'
 import { TokenManager } from './token-manager.js'
 import { PairingManager } from './pairing.js'
 import { getLanIp } from './lan-ip.js'
@@ -158,11 +160,8 @@ function checkNoAuthWarnings({ authRequired, tunnel }) {
   }
 }
 
-function maskToken(token) {
-  if (!token) return ''
-  if (token.length <= 8) return token
-  return `${token.slice(0, 4)}...${token.slice(-4)}`
-}
+// #5368 slice (b): maskToken moved to server-cli/startup-display.js (its only
+// caller was displayQr). Still also inlined in supervisor.js + mask-token.test.js.
 
 function wireTunnelEvents(tunnel, wsServer) {
   tunnel.on('tunnel_lost', ({ code, signal }) => {
@@ -810,59 +809,33 @@ export async function startCliServer(config) {
     log,
   })
 
-  // Track current WebSocket URL and mode label across all modes (tunnel, external, LAN)
+  // Track the live tunnel handle across modes (consumed by shutdown below).
   let tunnel = null
-  let currentWsUrl = null
-  let currentTunnelMode = 'none'
 
-  // Helper: build QR connection URL using ephemeral pairing ID (never the permanent token)
-  const buildPairingUrl = (wsUrlStr) => {
-    if (!pairingManager) return null
-    pairingManager.setWsUrl(wsUrlStr)
-    return pairingManager.currentPairingUrl
-  }
-
-  // Helper: display QR code and connection info
-  const SHOW_TOKEN = !!config.showToken || process.env.CHROXY_SHOW_TOKEN === '1'
-  const displayQr = async (wsUrlStr, httpUrlStr, modeLabel) => {
-    const pairingUrl = buildPairingUrl(wsUrlStr)
-    if (pairingUrl) {
-      console.log(`\n[✓] Server ready! (CLI headless mode, ${modeLabel})\n`)
-      console.log('📱 Scan this QR code with the Chroxy app:\n')
-      const qrText = await QRCode.toString(pairingUrl, { type: 'terminal', small: true })
-      process.stdout.write(qrText)
-      const displayToken = SHOW_TOKEN ? API_TOKEN : maskToken(API_TOKEN)
-      console.log(`\nOr connect manually:`)
-      console.log(`   URL:   ${wsUrlStr}`)
-      console.log(`   Token: ${displayToken}`)
-      if (httpUrlStr) {
-        if (SHOW_TOKEN) {
-          console.log(`   Dashboard: ${httpUrlStr}/dashboard?token=${API_TOKEN}`)
-        } else {
-          console.log(`   Dashboard: ${httpUrlStr}/dashboard (use --show-token to see full URL)`)
-        }
-      }
-    }
-
-    writeConnectionInfo({
-      wsUrl: wsUrlStr,
-      httpUrl: httpUrlStr,
-      apiToken: API_TOKEN,
-      connectionUrl: pairingUrl || `chroxy://${wsUrlStr.replace(/^wss?:\/\//, '')}?token=${API_TOKEN}`,
-      tunnelMode: modeLabel,
-      startedAt: new Date().toISOString(),
-      pid: process.pid,
-    })
-  }
+  // #5368 slice (b): the connection display — QR render + manual-connect block +
+  // the connection-info side-car (displayQr), the ephemeral pairing-URL builder
+  // (buildPairingUrl), the current-URL/mode display state shared across modes,
+  // and the QR re-render listeners — lives in StartupDisplay. The mode branches
+  // below set `startupDisplay.currentWsUrl` / `currentTunnelMode` and call
+  // `startupDisplay.displayQr(...)`. The tunnel path sets currentWsUrl EARLY
+  // (before the first displayQr) so a mid-startup tunnel_recovered has a value to
+  // diff against — so displayQr deliberately does not mutate that state.
+  const startupDisplay = new StartupDisplay({
+    pairingManager,
+    tokenManager,
+    apiToken: API_TOKEN,
+    showToken: !!config.showToken || process.env.CHROXY_SHOW_TOKEN === '1',
+    logger: log,
+  })
 
   // External URL mode: reverse proxy / custom domain (skip tunnel entirely)
   const externalUrl = config.externalUrl || null
   if (externalUrl) {
     const wsUrl = externalUrl.replace(/^https?:\/\//, 'wss://')
-    currentWsUrl = wsUrl
-    currentTunnelMode = 'external'
+    startupDisplay.currentWsUrl = wsUrl
+    startupDisplay.currentTunnelMode = 'external'
     const httpUrl = externalUrl.replace(/^wss?:\/\//, 'https://')
-    await displayQr(wsUrl, httpUrl, 'external')
+    await startupDisplay.displayQr(wsUrl, httpUrl, 'external')
   }
 
   // Determine tunnel mode
@@ -890,7 +863,7 @@ export async function startCliServer(config) {
       process.exitCode = 1
       return
     }
-    currentWsUrl = wsUrl
+    startupDisplay.currentWsUrl = wsUrl
 
     // 5. Wire up tunnel lifecycle events (before waitForTunnel to catch early failures)
     wireTunnelEvents(tunnel, wsServer)
@@ -910,10 +883,10 @@ export async function startCliServer(config) {
         })
 
         // Only display new QR code if URL actually changed
-        if (newWsUrl !== currentWsUrl) {
-          currentWsUrl = newWsUrl
+        if (newWsUrl !== startupDisplay.currentWsUrl) {
+          startupDisplay.currentWsUrl = newWsUrl
           if (pairingManager) pairingManager.refresh()
-          await displayQr(newWsUrl, newHttpUrl, modeLabel)
+          await startupDisplay.displayQr(newWsUrl, newHttpUrl, modeLabel)
           wsServer.broadcastStatus(`Tunnel reconnected with new URL: ${newWsUrl}`)
         } else {
           log.info(`Tunnel URL unchanged: ${newWsUrl}`)
@@ -965,8 +938,8 @@ export async function startCliServer(config) {
 
     // 7. Generate connection info
     const modeLabel = `cloudflare:${tunnelArg.mode}`
-    currentTunnelMode = modeLabel
-    await displayQr(wsUrl, httpUrl, modeLabel)
+    startupDisplay.currentTunnelMode = modeLabel
+    await startupDisplay.displayQr(wsUrl, httpUrl, modeLabel)
 
     // Extend the pairing ID validity after first QR display to give the user
     // time to scan. Without this, slow tunnel setup (60-80s) can consume most
@@ -985,8 +958,8 @@ export async function startCliServer(config) {
       : (bindHost && bindHost !== '0.0.0.0' ? bindHost : (getLanIp() || 'localhost'))
     // Bracket IPv6 literals so the URL authority is well-formed.
     const authority = `${formatHostForUrl(host)}:${PORT}`
-    currentWsUrl = `ws://${authority}`
-    await displayQr(`ws://${authority}`, `http://${authority}`, 'none')
+    startupDisplay.currentWsUrl = `ws://${authority}`
+    await startupDisplay.displayQr(`ws://${authority}`, `http://${authority}`, 'none')
   } else if (!NO_AUTH) {
     // tunnelArg is set but SKIP_TUNNEL is true due to externalUrl — already handled above
   } else {
@@ -995,33 +968,10 @@ export async function startCliServer(config) {
     console.log(`   Dashboard: http://localhost:${PORT}/dashboard`)
   }
 
-  // Re-render QR code when pairing auto-refreshes (keeps terminal QR scannable)
-  if (pairingManager) {
-    pairingManager.on('pairing_refreshed', async () => {
-      if (!currentWsUrl) return
-      const httpBase = currentWsUrl.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
-      await displayQr(currentWsUrl, httpBase, currentTunnelMode)
-      log.info('QR code refreshed with new pairing ID.')
-    })
-  }
-
-  // Regenerate QR code and update connection info when token rotates
-  if (tokenManager) {
-    tokenManager.on('token_rotated', async () => {
-      if (!currentWsUrl) return // no-auth or localhost-only — no QR to update
-
-      // Refresh pairing ID when token rotates (old session tokens remain valid).
-      // The pairing_refreshed listener handles QR re-render; only call displayQr
-      // directly when pairingManager is absent (no pairing_refreshed will fire).
-      if (pairingManager) {
-        pairingManager.refresh()
-      } else {
-        const httpBase = currentWsUrl.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
-        await displayQr(currentWsUrl, httpBase, currentTunnelMode)
-      }
-      log.info('API token rotated. QR code updated.')
-    })
-  }
+  // #5368 slice (b): QR re-render on pairing auto-refresh + token rotation now
+  // lives in StartupDisplay (it owns displayQr + the current-URL state the
+  // listeners read). Wired here, after the mode branches set the initial URL.
+  startupDisplay.wireReRenderListeners()
 
   // #5158: opt-in worktree auto-reaper. When enabled, reclaim orphaned
   // dead-pid-locked agent worktrees (clean trees only, never --force). Lazily

--- a/packages/server/src/server-cli/startup-display.js
+++ b/packages/server/src/server-cli/startup-display.js
@@ -1,0 +1,146 @@
+// StartupDisplay (#5368 slice b) — extracted from server-cli.js's startCliServer.
+//
+// Owns the CLI headless-mode connection display: the QR render + manual
+// connect block + `writeConnectionInfo` side-car (displayQr), the
+// ephemeral-pairing-URL builder (buildPairingUrl), the current-URL/mode display
+// state shared across modes (tunnel / external / LAN), and the QR re-render
+// listeners that fire when the pairing id auto-refreshes or the API token
+// rotates.
+//
+// The tunnel-lifecycle code (still inline in startCliServer; slice c) drives
+// this object: it sets `currentWsUrl` / `currentTunnelMode` and calls
+// `displayQr()` at each mode's success point. displayQr deliberately does NOT
+// mutate the current-URL state — the call sites do, because the tunnel path
+// must set `currentWsUrl` EARLY (before the first displayQr) so a
+// `tunnel_recovered` event arriving mid-startup has a value to diff against.
+//
+// Constructor-injection seams (pairingManager / tokenManager / apiToken /
+// showToken / logger) make the QR/connection-info rendering unit-testable with
+// fakes + captured console output — impossible while it was a closure inside the
+// god function.
+
+import QRCode from 'qrcode'
+import { writeConnectionInfo as defaultWriteConnectionInfo } from '../connection-info.js'
+
+// #2339: small display helper, also inlined in supervisor.js + covered by
+// mask-token.test.js. Moved here with displayQr (its only server-cli caller).
+export function maskToken(token) {
+  if (!token) return ''
+  if (token.length <= 8) return token
+  return `${token.slice(0, 4)}...${token.slice(-4)}`
+}
+
+export class StartupDisplay {
+  /**
+   * @param {{
+   *   pairingManager: ({ setWsUrl: Function, currentPairingUrl: string, refresh: Function, on: Function } | null),
+   *   tokenManager: ({ on: Function } | null),
+   *   apiToken: string,
+   *   showToken: boolean,
+   *   logger: { info: Function },
+   *   writeConnectionInfo?: Function,
+   * }} deps
+   *   `writeConnectionInfo` is an optional injection seam (defaults to the real
+   *   side-car writer) so tests can capture it without touching ~/.chroxy.
+   */
+  constructor({ pairingManager, tokenManager, apiToken, showToken, logger, writeConnectionInfo }) {
+    this._pairingManager = pairingManager || null
+    this._tokenManager = tokenManager || null
+    this._apiToken = apiToken
+    this._showToken = !!showToken
+    this._log = logger
+    this._writeConnectionInfo = writeConnectionInfo || defaultWriteConnectionInfo
+
+    // Current WebSocket URL + mode label, tracked across all modes (tunnel,
+    // external, LAN). Set by the mode branches in startCliServer and read by the
+    // re-render listeners below.
+    this._currentWsUrl = null
+    this._currentTunnelMode = 'none'
+  }
+
+  get currentWsUrl() { return this._currentWsUrl }
+  set currentWsUrl(v) { this._currentWsUrl = v }
+  get currentTunnelMode() { return this._currentTunnelMode }
+  set currentTunnelMode(v) { this._currentTunnelMode = v }
+
+  /**
+   * Build the QR connection URL using the ephemeral pairing id (never the
+   * permanent token). Returns null when pairing is disabled (no-auth).
+   */
+  buildPairingUrl(wsUrlStr) {
+    if (!this._pairingManager) return null
+    this._pairingManager.setWsUrl(wsUrlStr)
+    return this._pairingManager.currentPairingUrl
+  }
+
+  /**
+   * Render the QR code + manual-connect block to the console and write the
+   * connection-info side-car. Pure presentation: does NOT mutate
+   * currentWsUrl/currentTunnelMode (the caller sets those — see class header).
+   */
+  async displayQr(wsUrlStr, httpUrlStr, modeLabel) {
+    const pairingUrl = this.buildPairingUrl(wsUrlStr)
+    if (pairingUrl) {
+      console.log(`\n[✓] Server ready! (CLI headless mode, ${modeLabel})\n`)
+      console.log('📱 Scan this QR code with the Chroxy app:\n')
+      const qrText = await QRCode.toString(pairingUrl, { type: 'terminal', small: true })
+      process.stdout.write(qrText)
+      const displayToken = this._showToken ? this._apiToken : maskToken(this._apiToken)
+      console.log(`\nOr connect manually:`)
+      console.log(`   URL:   ${wsUrlStr}`)
+      console.log(`   Token: ${displayToken}`)
+      if (httpUrlStr) {
+        if (this._showToken) {
+          console.log(`   Dashboard: ${httpUrlStr}/dashboard?token=${this._apiToken}`)
+        } else {
+          console.log(`   Dashboard: ${httpUrlStr}/dashboard (use --show-token to see full URL)`)
+        }
+      }
+    }
+
+    this._writeConnectionInfo({
+      wsUrl: wsUrlStr,
+      httpUrl: httpUrlStr,
+      apiToken: this._apiToken,
+      connectionUrl: pairingUrl || `chroxy://${wsUrlStr.replace(/^wss?:\/\//, '')}?token=${this._apiToken}`,
+      tunnelMode: modeLabel,
+      startedAt: new Date().toISOString(),
+      pid: process.pid,
+    })
+  }
+
+  /**
+   * Wire the QR re-render listeners: redraw the terminal QR when the pairing id
+   * auto-refreshes (keeps it scannable) and when the API token rotates. Call
+   * once after the mode branches have set the initial currentWsUrl.
+   */
+  wireReRenderListeners() {
+    // Re-render QR code when pairing auto-refreshes (keeps terminal QR scannable)
+    if (this._pairingManager) {
+      this._pairingManager.on('pairing_refreshed', async () => {
+        if (!this._currentWsUrl) return
+        const httpBase = this._currentWsUrl.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
+        await this.displayQr(this._currentWsUrl, httpBase, this._currentTunnelMode)
+        this._log.info('QR code refreshed with new pairing ID.')
+      })
+    }
+
+    // Regenerate QR code and update connection info when token rotates
+    if (this._tokenManager) {
+      this._tokenManager.on('token_rotated', async () => {
+        if (!this._currentWsUrl) return // no-auth or localhost-only — no QR to update
+
+        // Refresh pairing ID when token rotates (old session tokens remain valid).
+        // The pairing_refreshed listener handles QR re-render; only call displayQr
+        // directly when pairingManager is absent (no pairing_refreshed will fire).
+        if (this._pairingManager) {
+          this._pairingManager.refresh()
+        } else {
+          const httpBase = this._currentWsUrl.replace(/^wss:\/\//, 'https://').replace(/^ws:\/\//, 'http://')
+          await this.displayQr(this._currentWsUrl, httpBase, this._currentTunnelMode)
+        }
+        this._log.info('API token rotated. QR code updated.')
+      })
+    }
+  }
+}

--- a/packages/server/tests/pairing-refresh-qr.test.js
+++ b/packages/server/tests/pairing-refresh-qr.test.js
@@ -8,16 +8,24 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const srcDir = join(__dirname, '../src')
 
 describe('QR re-render on pairing refresh (#1894)', () => {
-  it('server-cli.js listens for pairing_refreshed events', () => {
-    const source = readFileSync(join(srcDir, 'server-cli.js'), 'utf-8')
+  // #5368 slice (b): the pairing_refreshed → QR re-render moved from
+  // server-cli.js into StartupDisplay (server-cli now wires it via
+  // wireReRenderListeners). Follow the code to its new home + assert the wiring.
+  it('StartupDisplay re-renders the QR on pairing_refreshed, wired by server-cli.js', () => {
+    const startupDisplay = readFileSync(join(srcDir, 'server-cli/startup-display.js'), 'utf-8')
     assert.ok(
-      source.includes('pairing_refreshed'),
-      'server-cli.js should listen for pairing_refreshed event'
+      startupDisplay.includes('pairing_refreshed'),
+      'startup-display.js should listen for pairing_refreshed event'
     )
     const handlerPattern = /\.on\(\s*['"]pairing_refreshed['"]\s*,[\s\S]*?displayQr/
     assert.ok(
-      handlerPattern.test(source),
+      handlerPattern.test(startupDisplay),
       'pairing_refreshed handler should re-render QR (displayQr called in handler)'
+    )
+    const serverCli = readFileSync(join(srcDir, 'server-cli.js'), 'utf-8')
+    assert.ok(
+      serverCli.includes('wireReRenderListeners'),
+      'server-cli.js should wire the re-render listeners via StartupDisplay'
     )
   })
 

--- a/packages/server/tests/startup-display.test.js
+++ b/packages/server/tests/startup-display.test.js
@@ -1,0 +1,161 @@
+// #5368 slice (b): unit tests for StartupDisplay — the connection-display logic
+// extracted from startCliServer. Exercises buildPairingUrl, displayQr (console
+// + connection-info side-car), the current-URL/mode state, and the QR re-render
+// listeners (pairing_refreshed / token_rotated) with fakes — impossible while it
+// was a closure inside the god function. writeConnectionInfo is injected so no
+// ~/.chroxy write happens (the test sandbox guard would block it).
+
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { StartupDisplay, maskToken } from '../src/server-cli/startup-display.js'
+
+function makeFakePairingManager() {
+  const pm = new EventEmitter()
+  pm.wsUrl = null
+  pm.refreshed = 0
+  pm.setWsUrl = (u) => { pm.wsUrl = u }
+  Object.defineProperty(pm, 'currentPairingUrl', {
+    get() { return this.wsUrl ? `chroxy://pair?ws=${encodeURIComponent(this.wsUrl)}` : null },
+  })
+  pm.refresh = () => { pm.refreshed++ }
+  return pm
+}
+
+function makeDisplay({ pairingManager, tokenManager, apiToken = 'tok_abcdefgh1234', showToken = false } = {}) {
+  const writes = []
+  const logs = []
+  const display = new StartupDisplay({
+    pairingManager,
+    tokenManager,
+    apiToken,
+    showToken,
+    logger: { info: (m) => logs.push(m) },
+    writeConnectionInfo: (info) => writes.push(info),
+  })
+  return { display, writes, logs }
+}
+
+// Capture console.log + process.stdout.write for displayQr assertions.
+function captureConsole(fn) {
+  const out = []
+  const origLog = console.log
+  const origWrite = process.stdout.write
+  console.log = (...a) => out.push(a.join(' '))
+  process.stdout.write = (s) => { out.push(String(s)); return true }
+  return Promise.resolve(fn()).finally(() => {
+    console.log = origLog
+    process.stdout.write = origWrite
+  }).then(() => out)
+}
+
+describe('maskToken', () => {
+  it('masks long tokens and passes through short ones', () => {
+    assert.equal(maskToken('abcdefgh1234'), 'abcd...1234')
+    assert.equal(maskToken('abc'), 'abc')
+    assert.equal(maskToken('abcdefgh'), 'abcdefgh')
+    assert.equal(maskToken(''), '')
+    assert.equal(maskToken(null), '')
+  })
+})
+
+describe('StartupDisplay — buildPairingUrl', () => {
+  it('returns null when pairing is disabled (no-auth)', () => {
+    const { display } = makeDisplay({ pairingManager: null })
+    assert.equal(display.buildPairingUrl('wss://x'), null)
+  })
+
+  it('sets the ws url on the pairing manager and returns the pairing url', () => {
+    const pm = makeFakePairingManager()
+    const { display } = makeDisplay({ pairingManager: pm })
+    const url = display.buildPairingUrl('wss://host:1/')
+    assert.equal(pm.wsUrl, 'wss://host:1/')
+    assert.ok(url.startsWith('chroxy://pair?ws='))
+  })
+})
+
+describe('StartupDisplay — currentWsUrl / currentTunnelMode state', () => {
+  it('defaults to (null, none) and is settable', () => {
+    const { display } = makeDisplay({ pairingManager: makeFakePairingManager() })
+    assert.equal(display.currentWsUrl, null)
+    assert.equal(display.currentTunnelMode, 'none')
+    display.currentWsUrl = 'wss://x'
+    display.currentTunnelMode = 'cloudflare:quick'
+    assert.equal(display.currentWsUrl, 'wss://x')
+    assert.equal(display.currentTunnelMode, 'cloudflare:quick')
+  })
+})
+
+describe('StartupDisplay — displayQr', () => {
+  it('writes the connection-info side-car with the pairing url and does NOT mutate state', async () => {
+    const pm = makeFakePairingManager()
+    const { display, writes } = makeDisplay({ pairingManager: pm })
+    await captureConsole(() => display.displayQr('wss://host:1', 'https://host:1', 'cloudflare:quick'))
+    assert.equal(writes.length, 1)
+    assert.equal(writes[0].wsUrl, 'wss://host:1')
+    assert.equal(writes[0].tunnelMode, 'cloudflare:quick')
+    assert.ok(writes[0].connectionUrl.startsWith('chroxy://pair?ws='))
+    // Pure presentation — the caller owns the current-URL state.
+    assert.equal(display.currentWsUrl, null)
+    assert.equal(display.currentTunnelMode, 'none')
+  })
+
+  it('masks the token by default and shows it with showToken', async () => {
+    const pm = makeFakePairingManager()
+    const masked = makeDisplay({ pairingManager: pm, apiToken: 'tok_abcdefgh1234', showToken: false })
+    const outMasked = await captureConsole(() => masked.display.displayQr('wss://h', 'https://h', 'none'))
+    assert.ok(outMasked.join('\n').includes('tok_...1234'))
+    assert.ok(!outMasked.join('\n').includes('tok_abcdefgh1234'))
+
+    const shown = makeDisplay({ pairingManager: pm, apiToken: 'tok_abcdefgh1234', showToken: true })
+    const outShown = await captureConsole(() => shown.display.displayQr('wss://h', 'https://h', 'none'))
+    assert.ok(outShown.join('\n').includes('tok_abcdefgh1234'))
+  })
+
+  it('no-auth (no pairing manager): no QR rendered but side-car still written with a token url', async () => {
+    const { display, writes } = makeDisplay({ pairingManager: null })
+    const out = await captureConsole(() => display.displayQr('ws://localhost:8765', 'http://localhost:8765', 'none'))
+    assert.equal(writes.length, 1)
+    assert.ok(writes[0].connectionUrl.startsWith('chroxy://localhost:8765?token='))
+    assert.ok(!out.join('\n').includes('Scan this QR code'), 'no QR block without a pairing url')
+  })
+})
+
+describe('StartupDisplay — wireReRenderListeners', () => {
+  let pm, tm, fakes
+  beforeEach(() => {
+    pm = makeFakePairingManager()
+    tm = new EventEmitter()
+    fakes = makeDisplay({ pairingManager: pm, tokenManager: tm })
+    fakes.display.wireReRenderListeners()
+  })
+
+  it('pairing_refreshed re-renders the QR for the current url', async () => {
+    fakes.display.currentWsUrl = 'wss://host:1'
+    fakes.display.currentTunnelMode = 'cloudflare:quick'
+    await captureConsole(async () => { pm.emit('pairing_refreshed'); await Promise.resolve() })
+    assert.ok(fakes.writes.length >= 1, 'displayQr ran (side-car written)')
+    assert.ok(fakes.logs.some((m) => m.includes('QR code refreshed')))
+  })
+
+  it('pairing_refreshed is a no-op before any url is set', async () => {
+    await captureConsole(async () => { pm.emit('pairing_refreshed'); await Promise.resolve() })
+    assert.equal(fakes.writes.length, 0)
+  })
+
+  it('token_rotated refreshes the pairing id (delegating QR re-render to pairing_refreshed)', async () => {
+    fakes.display.currentWsUrl = 'wss://host:1'
+    await captureConsole(async () => { tm.emit('token_rotated'); await Promise.resolve() })
+    assert.equal(pm.refreshed, 1, 'pairing refresh requested (its pairing_refreshed handles the redraw)')
+    assert.ok(fakes.logs.some((m) => m.includes('API token rotated')))
+  })
+
+  it('token_rotated WITHOUT a pairing manager re-renders directly', async () => {
+    const tm2 = new EventEmitter()
+    const f = makeDisplay({ pairingManager: null, tokenManager: tm2 })
+    f.display.wireReRenderListeners()
+    f.display.currentWsUrl = 'ws://localhost:8765'
+    await captureConsole(async () => { tm2.emit('token_rotated'); await Promise.resolve() })
+    assert.ok(f.writes.length >= 1, 'displayQr ran directly since no pairing_refreshed will fire')
+  })
+})

--- a/packages/server/tests/startup-display.test.js
+++ b/packages/server/tests/startup-display.test.js
@@ -43,7 +43,11 @@ function captureConsole(fn) {
   const origWrite = process.stdout.write
   console.log = (...a) => out.push(a.join(' '))
   process.stdout.write = (s) => { out.push(String(s)); return true }
-  return Promise.resolve(fn()).finally(() => {
+  // Defer fn() into the promise chain (Promise.resolve().then(fn)) so a
+  // SYNCHRONOUS throw in fn still runs the finally cleanup — restoring
+  // console.log/stdout.write. Promise.resolve(fn()) would evaluate fn() before
+  // the promise exists, leaking the patches on a sync throw.
+  return Promise.resolve().then(fn).finally(() => {
     console.log = origLog
     process.stdout.write = origWrite
   }).then(() => out)


### PR DESCRIPTION
## What

Second slice of the #5368 ServerOrchestrator split. Extracts the CLI connection display out of `startCliServer` into `src/server-cli/startup-display.js`:
- `displayQr` (QR render + manual-connect block + `writeConnectionInfo` side-car)
- `buildPairingUrl` (ephemeral pairing-URL builder)
- the `currentWsUrl` / `currentTunnelMode` display state shared across modes
- the QR re-render listeners (`pairing_refreshed` / `token_rotated`)
- the `maskToken` helper (its only `server-cli` caller was `displayQr`)

## Why slice (b) alone (not b+c together)

I'd flagged StartupDisplay and TunnelLifecycleHandler as coupled. Reading the tunnel branch closely, slice (b) **can** be cleanly isolated: `StartupDisplay` owns the shared `currentWsUrl`/`currentTunnelMode` state (via getters/setters) + `displayQr`, and the **tunnel logic stays inline**, just routing its state access + QR calls through `startupDisplay`. That leaves the delicate tunnel ordering **completely untouched**:
- `displayQr` deliberately does **not** mutate the current-URL state — the tunnel path sets `currentWsUrl` **early** (before the first `displayQr`) so a mid-startup `tunnel_recovered` has a value to diff against (the line-913 `newWsUrl !== currentWsUrl` guard).
- the `modeLabel`-TDZ window, the `tunnel_recovered`-during-startup race, and the early-exit `emergencyCleanup` paths all stay in place.

Slice (c) TunnelLifecycleHandler — which will call `startupDisplay.displayQr()` — follows as its own PR.

## Tests

- `writeConnectionInfo` is an optional **injection seam** (defaults to the real writer) so tests capture it without touching `~/.chroxy` (the test sandbox guard would block a real write).
- New `startup-display.test.js` (11): `buildPairingUrl` (incl. no-auth null), `displayQr` (console output + side-car shape, token masking on/off, no-auth path, and that it does **not** mutate state), the current-URL state, and both re-render listeners (with/without a pairing manager) — all with fakes.
- `pairing-refresh-qr.test.js`: its source-introspection assertion follows the code to `startup-display.js` and additionally asserts `server-cli.js` wires it via `wireReRenderListeners`.
- server-cli + mask-token + push suites: 61 pass. eslint clean (removed now-unused `QRCode` / `writeConnectionInfo` imports from server-cli; `removeConnectionInfo` still used); 3 custom shell lints pass.
- Full server suite: only the 2 pre-existing `service.test.js` #745 failures (environmental, on `main`); no new failures. (`ws-server.test.js` encryption-integration is a known full-suite parallel flake — did not fire this run.)

Part of #5368 (slices c/d follow).
