### PR TITLE
refactor(server): extract TunnelLifecycleHandler from startCliServer (#5368 slice c)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -3,12 +3,16 @@ import { DEFAULT_RESULT_TIMEOUT_MS, DEFAULT_HARD_TIMEOUT_MS, DEFAULT_STREAM_STAL
 import { DEFAULT_TOOL_CALL_TIMEOUT_MS } from './byok-mcp-client.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
-import { WsServer, TUNNEL_STATUS_MIN_PROTOCOL_VERSION } from './ws-server.js'
+import { WsServer } from './ws-server.js'
 import { createTunnel, parseTunnelArg } from './tunnel/index.js'
-import { QUICK_TUNNEL_DNS_SETTLE_MS, waitForTunnel } from './tunnel-check.js'
+// #5368 slice (c): QUICK_TUNNEL_DNS_SETTLE_MS + TUNNEL_STATUS_MIN_PROTOCOL_VERSION
+// moved to tunnel-lifecycle-handler.js with the tunnel block; createTunnel +
+// waitForTunnel are still passed into the handler.
+import { waitForTunnel } from './tunnel-check.js'
 import { PushManager } from './push.js'
 import { PushNotificationHandler } from './server-cli/push-notification-handler.js'
 import { StartupDisplay } from './server-cli/startup-display.js'
+import { TunnelLifecycleHandler } from './server-cli/tunnel-lifecycle-handler.js'
 import { hostname, homedir } from 'os'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
@@ -843,108 +847,41 @@ export async function startCliServer(config) {
   const SKIP_TUNNEL = NO_AUTH || !tunnelArg || !!externalUrl
 
   if (!SKIP_TUNNEL) {
-    // 4. Start the tunnel
-    tunnel = createTunnel({
-      port: PORT,
-      mode: tunnelArg.mode,
-      tunnelConfig: config.tunnelConfig,
-      tunnelName: config.tunnelName || null,
-      tunnelHostname: config.tunnelHostname || null,
+    // #5368 slice (c): the tunnel lifecycle (create + start + emergency-cleanup
+    // on a start throw, wireTunnelEvents, tunnel_recovered re-verify + QR
+    // re-render, waitForTunnel with warming/ready broadcasts + emergency-cleanup
+    // on failure, success QR + pairing-id extension) lives in
+    // TunnelLifecycleHandler. The function deps are passed in (createTunnel /
+    // waitForTunnel as test seams; emergencyCleanup / wireTunnelEvents /
+    // buildTunnel*Status are server-cli-defined, so injecting avoids a circular
+    // import). On startup failure it returns ok:false after the full cleanup —
+    // preserving startCliServer's original `process.exitCode = 1; return`.
+    const tunnelHandler = new TunnelLifecycleHandler({
+      createTunnel,
+      emergencyCleanup,
+      wireTunnelEvents,
+      waitForTunnel,
+      buildTunnelWarmingStatus,
+      buildTunnelReadyStatus,
+      config: {
+        port: PORT,
+        tunnelArg,
+        tunnelConfig: config.tunnelConfig,
+        tunnelName: config.tunnelName || null,
+        tunnelHostname: config.tunnelHostname || null,
+      },
+      wsServer,
+      startupDisplay,
+      pairingManager,
+      cleanupRefs: { mdnsService, bonjourInstance, tokenManager, sessionManager },
+      logger: log,
     })
-    let wsUrl, httpUrl
-    try {
-      ({ wsUrl, httpUrl } = await tunnel.start())
-    } catch (startErr) {
-      const message = `Tunnel start failed: ${startErr.message}`
-      log.error(message)
-      try { wsServer.broadcastError('tunnel', message, false) } catch {}
-      console.error(`\n  ✗ ${message}\n`)
-      await emergencyCleanup({ tunnel, wsServer, mdnsService, bonjourInstance, tokenManager, pairingManager, sessionManager })
+    const result = await tunnelHandler.createAndStart()
+    tunnel = result.tunnel || tunnel
+    if (!result.ok) {
       process.exitCode = 1
       return
     }
-    startupDisplay.currentWsUrl = wsUrl
-
-    // 5. Wire up tunnel lifecycle events (before waitForTunnel to catch early failures)
-    wireTunnelEvents(tunnel, wsServer)
-
-    tunnel.on('tunnel_recovered', async ({ httpUrl: newHttpUrl, wsUrl: newWsUrl, attempt }) => {
-      // #5314 (WP-1.4) — async event listener: waitForTunnel THROWS on a routine
-      // DNS-settle failure, and an unhandled rejection here would hit server-cli's
-      // unhandledRejection handler → process.exit(1), crashing the whole server on
-      // a recoverable tunnel hiccup. Contain it: log and wait for the next
-      // tunnel_recovered retry.
-      try {
-        log.info(`Tunnel recovered after ${attempt} attempt(s)`)
-
-        // Re-verify the new tunnel URL
-        await waitForTunnel(newHttpUrl, {
-          initialDelay: tunnelArg.mode === 'quick' ? QUICK_TUNNEL_DNS_SETTLE_MS : 0,
-        })
-
-        // Only display new QR code if URL actually changed
-        if (newWsUrl !== startupDisplay.currentWsUrl) {
-          startupDisplay.currentWsUrl = newWsUrl
-          if (pairingManager) pairingManager.refresh()
-          await startupDisplay.displayQr(newWsUrl, newHttpUrl, modeLabel)
-          wsServer.broadcastStatus(`Tunnel reconnected with new URL: ${newWsUrl}`)
-        } else {
-          log.info(`Tunnel URL unchanged: ${newWsUrl}`)
-          wsServer.broadcastStatus('Tunnel connection recovered')
-        }
-      } catch (err) {
-        log.error(`tunnel_recovered handler failed (will retry on next recovery): ${err?.message || err}`)
-      }
-    })
-
-    // 6. Wait for tunnel to be fully routable (DNS propagation)
-    // UX landmine #4: waitForTunnel now throws TUNNEL_NOT_ROUTABLE
-    // instead of silently proceeding with a broken QR.
-    // #2836: phase 'tunnel_warming' is the current wire name. The
-    // previous name 'tunnel_verifying' is still accepted by the dashboard
-    // handler for backward compatibility with in-flight clients.
-    //
-    // #2849: gate on protocolVersion >= 2. v1 dashboards render unknown
-    // `server_status` payloads as chat messages because they only read
-    // `msg.message` (falls through to the legacy plain-status branch).
-    // The structured phase field is a v2 addition.
-    wsServer.broadcastMinProtocolVersion(TUNNEL_STATUS_MIN_PROTOCOL_VERSION, buildTunnelWarmingStatus({ tunnelMode: tunnelArg.mode, tunnelUrl: httpUrl }))
-    try {
-      await waitForTunnel(httpUrl, {
-        initialDelay: tunnelArg.mode === 'quick' ? QUICK_TUNNEL_DNS_SETTLE_MS : 0,
-        onAttempt: (attempt, maxAttempts) => {
-          wsServer.broadcastMinProtocolVersion(
-            TUNNEL_STATUS_MIN_PROTOCOL_VERSION,
-            buildTunnelWarmingStatus({
-              tunnelMode: tunnelArg.mode,
-              tunnelUrl: httpUrl,
-              attempt,
-              maxAttempts,
-            }),
-          )
-        },
-      })
-    } catch (tunnelErr) {
-      log.error(tunnelErr.message)
-      try { wsServer.broadcastError('tunnel', tunnelErr.message, false) } catch {}
-      console.error(`\n  ✗ ${tunnelErr.message}\n`)
-      // Clean up everything that's been started so we don't leave
-      // orphan processes or armed timers holding the event loop alive.
-      await emergencyCleanup({ tunnel, wsServer, mdnsService, bonjourInstance, tokenManager, pairingManager, sessionManager })
-      process.exitCode = 1
-      return
-    }
-    wsServer.broadcastMinProtocolVersion(TUNNEL_STATUS_MIN_PROTOCOL_VERSION, buildTunnelReadyStatus({ tunnelUrl: httpUrl }))
-
-    // 7. Generate connection info
-    const modeLabel = `cloudflare:${tunnelArg.mode}`
-    startupDisplay.currentTunnelMode = modeLabel
-    await startupDisplay.displayQr(wsUrl, httpUrl, modeLabel)
-
-    // Extend the pairing ID validity after first QR display to give the user
-    // time to scan. Without this, slow tunnel setup (60-80s) can consume most
-    // of the default 60s TTL, causing rotation before the user can scan (#2599).
-    if (pairingManager) pairingManager.extendCurrentId()
 
   } else if (externalUrl) {
     // Ready message already printed above

--- a/packages/server/src/server-cli/tunnel-lifecycle-handler.js
+++ b/packages/server/src/server-cli/tunnel-lifecycle-handler.js
@@ -1,0 +1,185 @@
+// TunnelLifecycleHandler (#5368 slice c) — extracted from server-cli.js's
+// startCliServer.
+//
+// Owns the Cloudflare tunnel lifecycle: create + start (with emergency cleanup
+// on a start throw), wire the lifecycle events, the `tunnel_recovered` re-verify
+// + QR re-render, the `waitForTunnel` routability wait (with the warming/ready
+// status broadcasts and emergency cleanup on failure), the success QR display,
+// and the post-display pairing-id extension (#2599).
+//
+// All function deps are INJECTED rather than imported: `emergencyCleanup`,
+// `wireTunnelEvents`, and `buildTunnel*Status` live in server-cli.js, so
+// importing them here would be circular; `createTunnel` / `waitForTunnel` are
+// injected so a test can drive the start-failure path (the design's key payoff:
+// "a tunnel.start() throw calls emergencyCleanup without opening a real tunnel")
+// and the success path without real network. Only the pure constants are
+// imported.
+//
+// createAndStart() returns { ok, tunnel }: on a startup failure it runs the full
+// emergency cleanup and returns ok:false (the caller sets process.exitCode and
+// returns — preserving startCliServer's original early-exit), and on success it
+// returns the live tunnel handle for shutdown to stop.
+
+import { QUICK_TUNNEL_DNS_SETTLE_MS } from '../tunnel-check.js'
+import { TUNNEL_STATUS_MIN_PROTOCOL_VERSION } from '../ws-server.js'
+
+export class TunnelLifecycleHandler {
+  /**
+   * @param {{
+   *   createTunnel: Function, emergencyCleanup: Function, wireTunnelEvents: Function,
+   *   waitForTunnel: Function, buildTunnelWarmingStatus: Function, buildTunnelReadyStatus: Function,
+   *   config: { port: number, tunnelArg: { mode: string }, tunnelConfig?: object, tunnelName?: string|null, tunnelHostname?: string|null },
+   *   wsServer: object, startupDisplay: object, pairingManager: (object|null),
+   *   cleanupRefs: { mdnsService?: object, bonjourInstance?: object, tokenManager?: object, sessionManager: object },
+   *   logger: object,
+   * }} deps
+   */
+  constructor({
+    createTunnel, emergencyCleanup, wireTunnelEvents, waitForTunnel,
+    buildTunnelWarmingStatus, buildTunnelReadyStatus,
+    config, wsServer, startupDisplay, pairingManager, cleanupRefs, logger,
+  }) {
+    this._createTunnel = createTunnel
+    this._emergencyCleanup = emergencyCleanup
+    this._wireTunnelEvents = wireTunnelEvents
+    this._waitForTunnel = waitForTunnel
+    this._buildTunnelWarmingStatus = buildTunnelWarmingStatus
+    this._buildTunnelReadyStatus = buildTunnelReadyStatus
+    this._config = config
+    this._wsServer = wsServer
+    this._startupDisplay = startupDisplay
+    this._pairingManager = pairingManager || null
+    this._cleanupRefs = cleanupRefs || {}
+    this._log = logger
+  }
+
+  // The emergency-cleanup bag — everything started so far, so a startup abort
+  // leaves no orphan processes or armed timers holding the event loop alive.
+  _cleanupBag(tunnel) {
+    const { mdnsService, bonjourInstance, tokenManager, sessionManager } = this._cleanupRefs
+    return {
+      tunnel,
+      wsServer: this._wsServer,
+      mdnsService,
+      bonjourInstance,
+      tokenManager,
+      pairingManager: this._pairingManager,
+      sessionManager,
+    }
+  }
+
+  /**
+   * Build + start the tunnel, wait for it to be routable, and display the QR.
+   * @returns {Promise<{ ok: boolean, tunnel?: object }>}
+   */
+  async createAndStart() {
+    const { port, tunnelArg, tunnelConfig, tunnelName, tunnelHostname } = this._config
+    const wsServer = this._wsServer
+    const startupDisplay = this._startupDisplay
+    const pairingManager = this._pairingManager
+    const log = this._log
+
+    // 4. Start the tunnel
+    const tunnel = this._createTunnel({
+      port,
+      mode: tunnelArg.mode,
+      tunnelConfig,
+      tunnelName: tunnelName || null,
+      tunnelHostname: tunnelHostname || null,
+    })
+    let wsUrl, httpUrl
+    try {
+      ({ wsUrl, httpUrl } = await tunnel.start())
+    } catch (startErr) {
+      const message = `Tunnel start failed: ${startErr.message}`
+      log.error(message)
+      try { wsServer.broadcastError('tunnel', message, false) } catch {}
+      console.error(`\n  ✗ ${message}\n`)
+      await this._emergencyCleanup(this._cleanupBag(tunnel))
+      return { ok: false, tunnel }
+    }
+    startupDisplay.currentWsUrl = wsUrl
+
+    // 5. Wire up tunnel lifecycle events (before waitForTunnel to catch early failures)
+    this._wireTunnelEvents(tunnel, wsServer)
+
+    tunnel.on('tunnel_recovered', async ({ httpUrl: newHttpUrl, wsUrl: newWsUrl, attempt }) => {
+      // #5314 (WP-1.4) — async event listener: waitForTunnel THROWS on a routine
+      // DNS-settle failure, and an unhandled rejection here would hit server-cli's
+      // unhandledRejection handler → process.exit(1), crashing the whole server on
+      // a recoverable tunnel hiccup. Contain it: log and wait for the next
+      // tunnel_recovered retry.
+      try {
+        log.info(`Tunnel recovered after ${attempt} attempt(s)`)
+
+        // Re-verify the new tunnel URL
+        await this._waitForTunnel(newHttpUrl, {
+          initialDelay: tunnelArg.mode === 'quick' ? QUICK_TUNNEL_DNS_SETTLE_MS : 0,
+        })
+
+        // Only display new QR code if URL actually changed
+        if (newWsUrl !== startupDisplay.currentWsUrl) {
+          startupDisplay.currentWsUrl = newWsUrl
+          if (pairingManager) pairingManager.refresh()
+          await startupDisplay.displayQr(newWsUrl, newHttpUrl, modeLabel)
+          wsServer.broadcastStatus(`Tunnel reconnected with new URL: ${newWsUrl}`)
+        } else {
+          log.info(`Tunnel URL unchanged: ${newWsUrl}`)
+          wsServer.broadcastStatus('Tunnel connection recovered')
+        }
+      } catch (err) {
+        log.error(`tunnel_recovered handler failed (will retry on next recovery): ${err?.message || err}`)
+      }
+    })
+
+    // 6. Wait for tunnel to be fully routable (DNS propagation)
+    // UX landmine #4: waitForTunnel now throws TUNNEL_NOT_ROUTABLE
+    // instead of silently proceeding with a broken QR.
+    // #2836: phase 'tunnel_warming' is the current wire name. The
+    // previous name 'tunnel_verifying' is still accepted by the dashboard
+    // handler for backward compatibility with in-flight clients.
+    //
+    // #2849: gate on protocolVersion >= 2. v1 dashboards render unknown
+    // `server_status` payloads as chat messages because they only read
+    // `msg.message` (falls through to the legacy plain-status branch).
+    // The structured phase field is a v2 addition.
+    wsServer.broadcastMinProtocolVersion(TUNNEL_STATUS_MIN_PROTOCOL_VERSION, this._buildTunnelWarmingStatus({ tunnelMode: tunnelArg.mode, tunnelUrl: httpUrl }))
+    try {
+      await this._waitForTunnel(httpUrl, {
+        initialDelay: tunnelArg.mode === 'quick' ? QUICK_TUNNEL_DNS_SETTLE_MS : 0,
+        onAttempt: (attempt, maxAttempts) => {
+          wsServer.broadcastMinProtocolVersion(
+            TUNNEL_STATUS_MIN_PROTOCOL_VERSION,
+            this._buildTunnelWarmingStatus({
+              tunnelMode: tunnelArg.mode,
+              tunnelUrl: httpUrl,
+              attempt,
+              maxAttempts,
+            }),
+          )
+        },
+      })
+    } catch (tunnelErr) {
+      log.error(tunnelErr.message)
+      try { wsServer.broadcastError('tunnel', tunnelErr.message, false) } catch {}
+      console.error(`\n  ✗ ${tunnelErr.message}\n`)
+      // Clean up everything that's been started so we don't leave
+      // orphan processes or armed timers holding the event loop alive.
+      await this._emergencyCleanup(this._cleanupBag(tunnel))
+      return { ok: false, tunnel }
+    }
+    wsServer.broadcastMinProtocolVersion(TUNNEL_STATUS_MIN_PROTOCOL_VERSION, this._buildTunnelReadyStatus({ tunnelUrl: httpUrl }))
+
+    // 7. Generate connection info
+    const modeLabel = `cloudflare:${tunnelArg.mode}`
+    startupDisplay.currentTunnelMode = modeLabel
+    await startupDisplay.displayQr(wsUrl, httpUrl, modeLabel)
+
+    // Extend the pairing ID validity after first QR display to give the user
+    // time to scan. Without this, slow tunnel setup (60-80s) can consume most
+    // of the default 60s TTL, causing rotation before the user can scan (#2599).
+    if (pairingManager) pairingManager.extendCurrentId()
+
+    return { ok: true, tunnel }
+  }
+}

--- a/packages/server/src/server-cli/tunnel-lifecycle-handler.js
+++ b/packages/server/src/server-cli/tunnel-lifecycle-handler.js
@@ -79,6 +79,15 @@ export class TunnelLifecycleHandler {
     const pairingManager = this._pairingManager
     const log = this._log
 
+    // #5368c (Copilot review on #5402): modeLabel is deterministic from the
+    // tunnel mode, so compute it up-front instead of after waitForTunnel (as
+    // the original did). The tunnel_recovered handler references it and can fire
+    // DURING the initial waitForTunnel after an early flap — with the late
+    // declaration that hit a TDZ ReferenceError and silently skipped the QR
+    // re-render (caught by the handler's try/catch). Same value either way; this
+    // just closes the window so a recovery-during-startup actually re-renders.
+    const modeLabel = `cloudflare:${tunnelArg.mode}`
+
     // 4. Start the tunnel
     const tunnel = this._createTunnel({
       port,
@@ -170,8 +179,7 @@ export class TunnelLifecycleHandler {
     }
     wsServer.broadcastMinProtocolVersion(TUNNEL_STATUS_MIN_PROTOCOL_VERSION, this._buildTunnelReadyStatus({ tunnelUrl: httpUrl }))
 
-    // 7. Generate connection info
-    const modeLabel = `cloudflare:${tunnelArg.mode}`
+    // 7. Generate connection info (modeLabel computed up-front; see above)
     startupDisplay.currentTunnelMode = modeLabel
     await startupDisplay.displayQr(wsUrl, httpUrl, modeLabel)
 

--- a/packages/server/tests/tunnel-lifecycle-handler.test.js
+++ b/packages/server/tests/tunnel-lifecycle-handler.test.js
@@ -1,0 +1,159 @@
+// #5368 slice (c): unit tests for TunnelLifecycleHandler — the tunnel lifecycle
+// extracted from startCliServer. The design's headline payoff: assert that a
+// `tunnel.start()` throw runs the full emergencyCleanup WITHOUT opening a real
+// tunnel — impossible to test while the logic was inline in the god function.
+// All function deps are injected, so no real network / cloudflared is touched.
+
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { TunnelLifecycleHandler } from '../src/server-cli/tunnel-lifecycle-handler.js'
+
+function makeFakeTunnel({ startImpl } = {}) {
+  const tunnel = new EventEmitter()
+  tunnel.start = startImpl || (async () => ({ wsUrl: 'wss://t.example', httpUrl: 'https://t.example' }))
+  return tunnel
+}
+
+function makeStartupDisplay() {
+  return {
+    currentWsUrl: null,
+    currentTunnelMode: 'none',
+    displayQr: function (...a) { (this.calls ||= []).push(a) },
+  }
+}
+
+function makeWsServer() {
+  return {
+    broadcasts: [],
+    statuses: [],
+    errors: [],
+    broadcastMinProtocolVersion(v, payload) { this.broadcasts.push({ v, payload }) },
+    broadcastStatus(s) { this.statuses.push(s) },
+    broadcastError(...a) { this.errors.push(a) },
+  }
+}
+
+function build(overrides = {}) {
+  const events = { cleanup: [], wired: [], wait: [] }
+  const tunnel = overrides.tunnel || makeFakeTunnel()
+  const wsServer = overrides.wsServer || makeWsServer()
+  const startupDisplay = overrides.startupDisplay || makeStartupDisplay()
+  const pairingManager = overrides.pairingManager !== undefined ? overrides.pairingManager
+    : { refreshed: 0, extended: 0, refresh() { this.refreshed++ }, extendCurrentId() { this.extended++ } }
+  const sessionManager = {}
+  const handler = new TunnelLifecycleHandler({
+    createTunnel: () => tunnel,
+    emergencyCleanup: async (bag) => { events.cleanup.push(bag) },
+    wireTunnelEvents: (t, ws) => { events.wired.push({ t, ws }) },
+    waitForTunnel: overrides.waitForTunnel || (async (url, opts) => { events.wait.push({ url, opts }) }),
+    buildTunnelWarmingStatus: (x) => ({ kind: 'warming', ...x }),
+    buildTunnelReadyStatus: (x) => ({ kind: 'ready', ...x }),
+    config: { port: 8765, tunnelArg: { mode: 'quick' }, tunnelConfig: {}, tunnelName: null, tunnelHostname: null },
+    wsServer,
+    startupDisplay,
+    pairingManager,
+    cleanupRefs: { mdnsService: { m: 1 }, bonjourInstance: { b: 1 }, tokenManager: { t: 1 }, sessionManager },
+    logger: { info() {}, warn() {}, error() {} },
+  })
+  return { handler, tunnel, wsServer, startupDisplay, pairingManager, sessionManager, events }
+}
+
+// The failure paths console.error — silence it to keep test output clean.
+let origConsoleError
+beforeEach(() => { origConsoleError = console.error; console.error = () => {} })
+afterEach(() => { console.error = origConsoleError })
+
+describe('TunnelLifecycleHandler — start failure (the headline payoff)', () => {
+  it('a tunnel.start() throw runs emergencyCleanup with the full bag and returns ok:false', async () => {
+    const tunnel = makeFakeTunnel({ startImpl: async () => { throw new Error('cloudflared died') } })
+    const { handler, wsServer, startupDisplay, sessionManager, events } = build({ tunnel })
+
+    const result = await handler.createAndStart()
+
+    assert.equal(result.ok, false)
+    assert.equal(result.tunnel, tunnel, 'returns the created tunnel even on failure')
+    assert.equal(events.cleanup.length, 1, 'emergencyCleanup called exactly once')
+    const bag = events.cleanup[0]
+    assert.equal(bag.tunnel, tunnel)
+    assert.equal(bag.wsServer, wsServer)
+    assert.equal(bag.sessionManager, sessionManager)
+    assert.ok(bag.mdnsService && bag.bonjourInstance && bag.tokenManager, 'full cleanup bag passed')
+    assert.equal(events.wait.length, 0, 'waitForTunnel never reached (no real tunnel opened)')
+    assert.equal(startupDisplay.calls, undefined, 'no QR displayed on failure')
+    assert.ok(wsServer.errors.length >= 1, 'broadcastError fired')
+  })
+})
+
+describe('TunnelLifecycleHandler — waitForTunnel failure', () => {
+  it('runs emergencyCleanup and returns ok:false when routability check throws', async () => {
+    const { handler, events, startupDisplay } = build({
+      waitForTunnel: async () => { throw new Error('TUNNEL_NOT_ROUTABLE') },
+    })
+    const result = await handler.createAndStart()
+    assert.equal(result.ok, false)
+    assert.equal(events.cleanup.length, 1)
+    // start succeeded so currentWsUrl was set, but no success QR (only the
+    // recovered path could render, which didn't fire here).
+    assert.equal(startupDisplay.currentWsUrl, 'wss://t.example')
+    assert.equal(startupDisplay.calls, undefined)
+  })
+})
+
+describe('TunnelLifecycleHandler — success path', () => {
+  it('wires events, broadcasts warming+ready, displays QR, extends pairing, returns ok:true', async () => {
+    const { handler, tunnel, wsServer, startupDisplay, pairingManager, events } = build()
+    const result = await handler.createAndStart()
+
+    assert.equal(result.ok, true)
+    assert.equal(result.tunnel, tunnel)
+    assert.equal(events.cleanup.length, 0, 'no cleanup on success')
+    assert.equal(events.wired.length, 1, 'wireTunnelEvents called')
+    assert.equal(startupDisplay.currentWsUrl, 'wss://t.example')
+    assert.equal(startupDisplay.currentTunnelMode, 'cloudflare:quick')
+    assert.deepEqual(startupDisplay.calls, [['wss://t.example', 'https://t.example', 'cloudflare:quick']])
+    assert.equal(pairingManager.extended, 1, 'extendCurrentId called (#2599)')
+    const kinds = wsServer.broadcasts.map((b) => b.payload.kind)
+    assert.ok(kinds.includes('warming') && kinds.includes('ready'), 'warming + ready status broadcast')
+  })
+})
+
+describe('TunnelLifecycleHandler — tunnel_recovered', () => {
+  it('re-verifies + re-renders the QR when the URL changes', async () => {
+    const { handler, tunnel, startupDisplay, pairingManager } = build()
+    await handler.createAndStart()
+    startupDisplay.calls.length = 0 // ignore the initial success QR
+
+    tunnel.emit('tunnel_recovered', { httpUrl: 'https://new.example', wsUrl: 'wss://new.example', attempt: 2 })
+    await new Promise((r) => setImmediate(r))
+
+    assert.deepEqual(startupDisplay.calls, [['wss://new.example', 'https://new.example', 'cloudflare:quick']])
+    assert.equal(startupDisplay.currentWsUrl, 'wss://new.example')
+    assert.equal(pairingManager.refreshed, 1, 'pairing refreshed on a new url')
+  })
+
+  it('does NOT re-render when the URL is unchanged (status broadcast only)', async () => {
+    const { handler, tunnel, wsServer, startupDisplay } = build()
+    await handler.createAndStart()
+    startupDisplay.calls.length = 0
+    wsServer.statuses.length = 0
+
+    tunnel.emit('tunnel_recovered', { httpUrl: 'https://t.example', wsUrl: 'wss://t.example', attempt: 1 })
+    await new Promise((r) => setImmediate(r))
+
+    assert.equal(startupDisplay.calls.length, 0, 'no QR re-render for an unchanged url')
+    assert.ok(wsServer.statuses.some((s) => s.includes('recovered')), 'recovery status broadcast')
+  })
+
+  it('contains a waitForTunnel throw in the recovered handler (no crash)', async () => {
+    let calls = 0
+    const { handler, tunnel } = build({
+      waitForTunnel: async () => { calls++; if (calls > 1) throw new Error('settle failed'); },
+    })
+    await handler.createAndStart() // first waitForTunnel ok
+    await assert.doesNotReject(async () => {
+      tunnel.emit('tunnel_recovered', { httpUrl: 'https://x', wsUrl: 'wss://x', attempt: 1 })
+      await new Promise((r) => setImmediate(r))
+    })
+  })
+})

--- a/packages/server/tests/tunnel-lifecycle-handler.test.js
+++ b/packages/server/tests/tunnel-lifecycle-handler.test.js
@@ -145,6 +145,28 @@ describe('TunnelLifecycleHandler — tunnel_recovered', () => {
     assert.ok(wsServer.statuses.some((s) => s.includes('recovered')), 'recovery status broadcast')
   })
 
+  it('a recovery DURING the initial waitForTunnel re-renders (modeLabel available — #5402 TDZ fix)', async () => {
+    let firstWait = true
+    const { handler, tunnel, startupDisplay } = build({
+      waitForTunnel: async () => {
+        if (firstWait) {
+          firstWait = false
+          // Simulate a flap+recovery while the initial routability wait is in
+          // flight. Before the fix, modeLabel was declared AFTER this wait, so
+          // the recovered handler hit a TDZ ReferenceError and silently skipped
+          // the QR re-render (swallowed by its try/catch).
+          tunnel.emit('tunnel_recovered', { httpUrl: 'https://recovered.example', wsUrl: 'wss://recovered.example', attempt: 1 })
+          await new Promise((r) => setImmediate(r))
+        }
+      },
+    })
+    await handler.createAndStart()
+    assert.ok(
+      startupDisplay.calls.some((c) => c[0] === 'wss://recovered.example' && c[2] === 'cloudflare:quick'),
+      'recovery-during-startup re-rendered the QR with modeLabel (would TDZ-throw and skip before the fix)'
+    )
+  })
+
   it('contains a waitForTunnel throw in the recovered handler (no crash)', async () => {
     let calls = 0
     const { handler, tunnel } = build({


### PR DESCRIPTION
## What

Third slice of the #5368 ServerOrchestrator split. Extracts the Cloudflare tunnel lifecycle out of `startCliServer` into `src/server-cli/tunnel-lifecycle-handler.js`:
- create + `tunnel.start()` (emergency-cleanup on a start throw)
- `wireTunnelEvents` + the `tunnel_recovered` re-verify + QR re-render
- `waitForTunnel` routability wait (warming/ready status broadcasts + emergency-cleanup on failure)
- the success QR display + the post-display pairing-id extension (#2599)

`startCliServer`'s `if (!SKIP_TUNNEL)` block is now: build the handler → `await createAndStart()` → `tunnel = result.tunnel` → `if (!result.ok) { process.exitCode = 1; return }`.

## Design notes

- **All function deps injected.** `emergencyCleanup` / `wireTunnelEvents` / `buildTunnel*Status` are defined in `server-cli.js`, so importing them into the handler would be **circular** — they're passed in. `createTunnel` / `waitForTunnel` are injected so tests drive both the start-failure and success paths **without real network/cloudflared**. Only the pure constants are imported.
- **Early-exit preserved.** On a startup failure the handler runs the full `emergencyCleanup({ tunnel, wsServer, mdnsService, bonjourInstance, tokenManager, pairingManager, sessionManager })` and returns `ok:false`; `startCliServer` maps that to its original `process.exitCode = 1; return`.
- **Load-bearing ordering preserved exactly.** `startupDisplay.currentWsUrl` is set early (right after `start()`, before the first QR) so the `tunnel_recovered` `newWsUrl !== currentWsUrl` diff guard works; `modeLabel` is defined after `waitForTunnel` (same position as the original — the `tunnel_recovered`-during-startup TDZ window is unchanged and stays contained by that handler's try/catch).

## Tests

New `tunnel-lifecycle-handler.test.js` (6):
- **the headline payoff** — a `tunnel.start()` throw runs `emergencyCleanup` with the full bag and **never reaches `waitForTunnel`** (no real tunnel opened), returns `ok:false`, no QR.
- `waitForTunnel`-failure → cleanup + `ok:false`.
- success path → `wireTunnelEvents` + warming/ready broadcasts + QR (`cloudflare:quick`) + `extendCurrentId` + `ok:true`.
- `tunnel_recovered` → re-render on URL change (with pairing refresh), status-only when unchanged, and throw-containment (no crash).

- server-cli + tunnel-warming + emergency-cleanup suites: 41 pass. eslint clean (removed now-unused `QUICK_TUNNEL_DNS_SETTLE_MS` + `TUNNEL_STATUS_MIN_PROTOCOL_VERSION` imports, moved to the handler); custom lints pass.
- Full server suite: 8150 pass / only the 2 pre-existing `service.test.js` #745 failures (environmental, on `main`); no new failures.

Part of #5368 (slice d — ServerOrchestrator / shutdown + crash — follows).
