### PR TITLE
refactor(server): extract ServerOrchestrator from startCliServer (#5368 slice d)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -13,6 +13,7 @@ import { PushManager } from './push.js'
 import { PushNotificationHandler } from './server-cli/push-notification-handler.js'
 import { StartupDisplay } from './server-cli/startup-display.js'
 import { TunnelLifecycleHandler } from './server-cli/tunnel-lifecycle-handler.js'
+import { ServerOrchestrator } from './server-cli/server-orchestrator.js'
 import { hostname, homedir } from 'os'
 import { readFileSync, existsSync } from 'fs'
 import { fileURLToPath } from 'url'
@@ -944,73 +945,30 @@ export async function startCliServer(config) {
   // returns immediately. Without this, the second call ran serializeState()
   // against an already-empty `_sessions` Map and wrote 0 sessions to disk,
   // erasing the user's restored state across upgrade/quit cycles (#3697).
-  let shuttingDown = false
-  const shutdown = async (signal) => {
-    if (shuttingDown) {
-      log.info(`[${signal}] Shutdown already in progress, ignoring duplicate signal`)
-      return
-    }
-    shuttingDown = true
-    log.info(`[${signal}] Shutting down...`)
-    // Notify connected clients (ETA 0 = not coming back unless supervised)
-    wsServer.broadcastShutdown('shutdown', 0)
-    if (mdnsService) {
-      try { mdnsService.stop?.() } catch {}
-    }
-    if (bonjourInstance) {
-      try { bonjourInstance.destroy?.() } catch {}
-    }
-    if (tokenManager) tokenManager.destroy()
-    if (pairingManager) pairingManager.destroy()
-    // #5326 (WP-5.4): stop the periodic worktree reaper. It's unref'd so it
-    // wouldn't block exit, but clearing it avoids a sweep racing shutdown.
-    if (worktreeReapTimer) clearInterval(worktreeReapTimer)
-    // Persist sessions before destroying (enables restore on restart)
-    try { sessionManager.serializeState() } catch (err) {
-      log.error(`Failed to serialize session state: ${err?.message || err}`)
-    }
-    sessionManager.destroyAll()
-    // #5042: drain the docker-byok across-session pool so the `sleep
-    // infinity` containers it holds don't outlive the server. Default-OFF
-    // (`isPoolEnabled` returns false unless `CHROXY_DOCKER_BYOK_POOL=1`),
-    // so this is a no-op for the common path. When the flag is on, the
-    // pool's `docker rm -f` calls run in parallel and we let them settle
-    // before `process.exit(0)` strands them.
-    if (isPoolEnabled(process.env)) {
-      try {
-        const pool = getSharedPool(process.env)
-        if (pool) await pool.shutdown()
-      } catch (err) {
-        log.error(`Failed to drain docker-byok pool: ${err?.message || err}`)
-      }
-    }
-    wsServer.close()
-    if (tunnel) await tunnel.stop()
-    removeConnectionInfo()
-    process.exit(0)
-  }
-
-  process.on('SIGINT', () => { shutdown('SIGINT').catch(() => process.exit(1)) })
-  process.on('SIGTERM', () => { shutdown('SIGTERM').catch(() => process.exit(1)) })
-
-  // #5369: uncaughtException and unhandledRejection shared an identical body —
-  // unify them into one handler factory taking a `kind` log label. The "during
-  // shutdown" branch still just logs + schedules exit (otherwise installing
-  // these handlers would suppress Node's default crash-exit and a stuck
-  // shutdown — e.g. hung tunnel.stop() — could leave the process alive forever).
-  const onFatal = (kind) => (err) => {
-    if (shuttingDown) {
-      log.error(`${kind} during shutdown: ${err?.stack || err}`)
-      setTimeout(() => process.exit(1), 100)
-      return
-    }
-    shuttingDown = true
-    log.error(`${kind}: ${err?.stack || err}`)
-    emergencyCleanupSync({ kind, tunnel, wsServer, sessionManager })
-    setTimeout(() => process.exit(1), 100)
-  }
-  process.on('uncaughtException', onFatal('Uncaught exception'))
-  process.on('unhandledRejection', onFatal('Unhandled rejection'))
+  // #5368 slice (d): the process lifecycle — the shuttingDown latch, the
+  // graceful shutdown() teardown sequence, and the SIGINT/SIGTERM/
+  // uncaughtException/unhandledRejection registrations (#5369 onFatal +
+  // emergencyCleanupSync) — lives in ServerOrchestrator. `worktreeReapTimer` is
+  // passed as a GETTER because it's assigned inside an async import().then() and
+  // may still be null now — the original shutdown closure read it lazily at
+  // shutdown time, so the getter reproduces that. emergencyCleanupSync is
+  // injected (server-cli-defined → avoids a circular import).
+  const orchestrator = new ServerOrchestrator({
+    wsServer,
+    sessionManager,
+    tunnel,
+    mdnsService,
+    bonjourInstance,
+    tokenManager,
+    pairingManager,
+    getWorktreeReapTimer: () => worktreeReapTimer,
+    emergencyCleanupSync,
+    removeConnectionInfo,
+    isPoolEnabled,
+    getSharedPool,
+    logger: log,
+  })
+  orchestrator.install()
 
   // Return references for supervised child drain protocol
   return { sessionManager, wsServer }

--- a/packages/server/src/server-cli/server-orchestrator.js
+++ b/packages/server/src/server-cli/server-orchestrator.js
@@ -1,0 +1,138 @@
+// ServerOrchestrator (#5368 slice d) — extracted from server-cli.js's
+// startCliServer.
+//
+// Owns the process lifecycle: the `shuttingDown` latch, the graceful
+// `shutdown(signal)` teardown sequence, and the SIGINT / SIGTERM /
+// uncaughtException / unhandledRejection registrations (the last two via the
+// #5369 `onFatal` factory that calls `emergencyCleanupSync`). This is the
+// silent-failure-prone surface — a missed teardown step orphans processes / hangs
+// exit, and a broken crash handler suppresses Node's default crash-exit — so the
+// sequence is moved verbatim.
+//
+// Two injection details matter:
+//   - `getWorktreeReapTimer` is a GETTER, not a value: the timer is assigned
+//     inside an async `import().then()` in startCliServer, so it may still be
+//     null when this orchestrator is constructed. The original shutdown closure
+//     read it at shutdown time — reproduce that with a lazy getter so a
+//     late-resolved timer still gets cleared.
+//   - `emergencyCleanupSync` is injected because it lives in server-cli.js
+//     (importing it here would be circular). `exit` / `exitDelayMs` are injected
+//     so tests can drive shutdown + onFatal without killing the test process.
+
+import { removeConnectionInfo as defaultRemoveConnectionInfo } from '../connection-info.js'
+import { getSharedPool as defaultGetSharedPool, isPoolEnabled as defaultIsPoolEnabled } from '../docker-byok-pool.js'
+
+export class ServerOrchestrator {
+  constructor({
+    wsServer,
+    sessionManager,
+    tunnel,
+    mdnsService,
+    bonjourInstance,
+    tokenManager,
+    pairingManager,
+    getWorktreeReapTimer,
+    emergencyCleanupSync,
+    removeConnectionInfo = defaultRemoveConnectionInfo,
+    isPoolEnabled = defaultIsPoolEnabled,
+    getSharedPool = defaultGetSharedPool,
+    logger,
+    exit = (code) => process.exit(code),
+    exitDelayMs = 100,
+  }) {
+    this._wsServer = wsServer
+    this._sessionManager = sessionManager
+    this._tunnel = tunnel
+    this._mdnsService = mdnsService
+    this._bonjourInstance = bonjourInstance
+    this._tokenManager = tokenManager
+    this._pairingManager = pairingManager
+    this._getWorktreeReapTimer = typeof getWorktreeReapTimer === 'function' ? getWorktreeReapTimer : () => null
+    this._emergencyCleanupSync = emergencyCleanupSync
+    this._removeConnectionInfo = removeConnectionInfo
+    this._isPoolEnabled = isPoolEnabled
+    this._getSharedPool = getSharedPool
+    this._log = logger
+    this._exit = exit
+    this._exitDelayMs = exitDelayMs
+
+    // Idempotent: a second SIGINT/SIGTERM (or a crash arriving mid-shutdown)
+    // returns immediately. Without this, the second call ran serializeState()
+    // against an already-empty `_sessions` Map and wrote 0 sessions to disk,
+    // erasing the user's restored state across upgrade/quit cycles (#3697).
+    this._shuttingDown = false
+  }
+
+  async shutdown(signal) {
+    const log = this._log
+    if (this._shuttingDown) {
+      log.info(`[${signal}] Shutdown already in progress, ignoring duplicate signal`)
+      return
+    }
+    this._shuttingDown = true
+    log.info(`[${signal}] Shutting down...`)
+    // Notify connected clients (ETA 0 = not coming back unless supervised)
+    this._wsServer.broadcastShutdown('shutdown', 0)
+    if (this._mdnsService) {
+      try { this._mdnsService.stop?.() } catch {}
+    }
+    if (this._bonjourInstance) {
+      try { this._bonjourInstance.destroy?.() } catch {}
+    }
+    if (this._tokenManager) this._tokenManager.destroy()
+    if (this._pairingManager) this._pairingManager.destroy()
+    // #5326 (WP-5.4): stop the periodic worktree reaper. It's unref'd so it
+    // wouldn't block exit, but clearing it avoids a sweep racing shutdown.
+    const worktreeReapTimer = this._getWorktreeReapTimer()
+    if (worktreeReapTimer) clearInterval(worktreeReapTimer)
+    // Persist sessions before destroying (enables restore on restart)
+    try { this._sessionManager.serializeState() } catch (err) {
+      log.error(`Failed to serialize session state: ${err?.message || err}`)
+    }
+    this._sessionManager.destroyAll()
+    // #5042: drain the docker-byok across-session pool so the `sleep
+    // infinity` containers it holds don't outlive the server. Default-OFF
+    // (`isPoolEnabled` returns false unless `CHROXY_DOCKER_BYOK_POOL=1`),
+    // so this is a no-op for the common path. When the flag is on, the
+    // pool's `docker rm -f` calls run in parallel and we let them settle
+    // before `process.exit(0)` strands them.
+    if (this._isPoolEnabled(process.env)) {
+      try {
+        const pool = this._getSharedPool(process.env)
+        if (pool) await pool.shutdown()
+      } catch (err) {
+        log.error(`Failed to drain docker-byok pool: ${err?.message || err}`)
+      }
+    }
+    this._wsServer.close()
+    if (this._tunnel) await this._tunnel.stop()
+    this._removeConnectionInfo()
+    this._exit(0)
+  }
+
+  // #5369: uncaughtException and unhandledRejection share an identical body —
+  // one handler taking a `kind` log label. The "during shutdown" branch still
+  // just logs + schedules exit (otherwise installing these handlers would
+  // suppress Node's default crash-exit and a stuck shutdown — e.g. a hung
+  // tunnel.stop() — could leave the process alive forever).
+  _onFatal(kind, err) {
+    const log = this._log
+    if (this._shuttingDown) {
+      log.error(`${kind} during shutdown: ${err?.stack || err}`)
+      setTimeout(() => this._exit(1), this._exitDelayMs)
+      return
+    }
+    this._shuttingDown = true
+    log.error(`${kind}: ${err?.stack || err}`)
+    this._emergencyCleanupSync({ kind, tunnel: this._tunnel, wsServer: this._wsServer, sessionManager: this._sessionManager })
+    setTimeout(() => this._exit(1), this._exitDelayMs)
+  }
+
+  /** Register the signal + crash handlers on `process`. */
+  install() {
+    process.on('SIGINT', () => { this.shutdown('SIGINT').catch(() => this._exit(1)) })
+    process.on('SIGTERM', () => { this.shutdown('SIGTERM').catch(() => this._exit(1)) })
+    process.on('uncaughtException', this._onFatal.bind(this, 'Uncaught exception'))
+    process.on('unhandledRejection', this._onFatal.bind(this, 'Unhandled rejection'))
+  }
+}

--- a/packages/server/tests/server-orchestrator.test.js
+++ b/packages/server/tests/server-orchestrator.test.js
@@ -1,0 +1,163 @@
+// #5368 slice (d): unit tests for ServerOrchestrator — the process lifecycle
+// (shuttingDown latch, graceful shutdown() teardown sequence, SIGINT/SIGTERM +
+// crash handlers) extracted from startCliServer. The design payoff: assert the
+// SIGTERM teardown ORDER and the uncaughtException handler — impossible while it
+// was inline. `exit` is injected so shutdown/onFatal never kill the test
+// process; `clearInterval` is spied to prove the lazily-read worktree timer is
+// cleared.
+
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { ServerOrchestrator } from '../src/server-cli/server-orchestrator.js'
+
+let origClearInterval, cleared
+beforeEach(() => { origClearInterval = global.clearInterval; cleared = []; global.clearInterval = (t) => cleared.push(t) })
+afterEach(() => { global.clearInterval = origClearInterval })
+
+function build(overrides = {}) {
+  const seq = []
+  const exits = []
+  const cleanups = []
+  const deps = {
+    wsServer: {
+      broadcastShutdown: (...a) => seq.push(['broadcastShutdown', ...a]),
+      close: () => seq.push(['wsServer.close']),
+    },
+    sessionManager: {
+      serializeState: () => seq.push(['serializeState']),
+      destroyAll: () => seq.push(['destroyAll']),
+    },
+    tunnel: { stop: async () => seq.push(['tunnel.stop']) },
+    mdnsService: { stop: () => seq.push(['mdns.stop']) },
+    bonjourInstance: { destroy: () => seq.push(['bonjour.destroy']) },
+    tokenManager: { destroy: () => seq.push(['token.destroy']) },
+    pairingManager: { destroy: () => seq.push(['pairing.destroy']) },
+    getWorktreeReapTimer: () => null,
+    emergencyCleanupSync: (bag) => { cleanups.push(bag); seq.push(['emergencyCleanupSync', bag.kind]) },
+    removeConnectionInfo: () => seq.push(['removeConnectionInfo']),
+    isPoolEnabled: () => false,
+    getSharedPool: () => null,
+    logger: { info() {}, warn() {}, error() {} },
+    exit: (code) => { exits.push(code); seq.push(['exit', code]) },
+    exitDelayMs: 0,
+    ...overrides,
+  }
+  return { orchestrator: new ServerOrchestrator(deps), seq, exits, cleanups, deps }
+}
+
+// onFatal schedules exit via setTimeout(…, exitDelayMs=0). Wait with a
+// setTimeout too (NOT setImmediate — setImmediate-vs-setTimeout(0) ordering is
+// non-deterministic outside an I/O callback, which flaked under full-suite load)
+// so this resolves AFTER the orchestrator's exit timer has fired.
+const tick = () => new Promise((r) => setTimeout(r, 10))
+
+describe('ServerOrchestrator — graceful shutdown order (SIGTERM)', () => {
+  it('runs the full teardown sequence in order, ending in exit(0)', async () => {
+    const { orchestrator, seq } = build({ getWorktreeReapTimer: () => 'TIMER' })
+    await orchestrator.shutdown('SIGTERM')
+    assert.deepEqual(seq.map((e) => e[0]), [
+      'broadcastShutdown',
+      'mdns.stop',
+      'bonjour.destroy',
+      'token.destroy',
+      'pairing.destroy',
+      'serializeState',
+      'destroyAll',
+      'wsServer.close',
+      'tunnel.stop',
+      'removeConnectionInfo',
+      'exit',
+    ])
+    assert.deepEqual(seq[0], ['broadcastShutdown', 'shutdown', 0])
+    assert.deepEqual(seq.at(-1), ['exit', 0])
+    assert.deepEqual(cleared, ['TIMER'], 'worktree reap timer cleared (read lazily via getter)')
+  })
+
+  it('is idempotent — a second signal returns immediately (no double teardown)', async () => {
+    const { orchestrator, seq } = build()
+    await orchestrator.shutdown('SIGTERM')
+    const lenAfterFirst = seq.length
+    await orchestrator.shutdown('SIGINT')
+    assert.equal(seq.length, lenAfterFirst, 'second shutdown did nothing (#3697 guard)')
+  })
+
+  it('lazily reads worktreeReapTimer (assigned AFTER construction) and clears it', async () => {
+    let lateTimer = null
+    const { orchestrator } = build({ getWorktreeReapTimer: () => lateTimer })
+    lateTimer = 'LATE' // simulates the async import().then() resolving after construction
+    await orchestrator.shutdown('SIGTERM')
+    assert.deepEqual(cleared, ['LATE'], 'the late-assigned timer is cleared (getter, not captured value)')
+  })
+
+  it('a serializeState throw is caught — teardown continues to exit(0)', async () => {
+    const { orchestrator, seq } = build({
+      sessionManager: {
+        serializeState: () => { seq.push(['serializeState']); throw new Error('disk full') },
+        destroyAll: () => seq.push(['destroyAll']),
+      },
+    })
+    await orchestrator.shutdown('SIGTERM')
+    assert.ok(seq.some((e) => e[0] === 'destroyAll'), 'destroyAll still ran after serialize throw')
+    assert.deepEqual(seq.at(-1), ['exit', 0])
+  })
+
+  it('no tunnel → no tunnel.stop, still exits cleanly', async () => {
+    const { orchestrator, seq } = build({ tunnel: null })
+    await orchestrator.shutdown('SIGTERM')
+    assert.ok(!seq.some((e) => e[0] === 'tunnel.stop'))
+    assert.deepEqual(seq.at(-1), ['exit', 0])
+  })
+
+  it('drains the docker-byok pool before close when the pool is enabled', async () => {
+    const seqPool = []
+    const { orchestrator, seq } = build({
+      isPoolEnabled: () => true,
+      getSharedPool: () => ({ shutdown: async () => seq.push(['pool.shutdown']) }),
+    })
+    void seqPool
+    await orchestrator.shutdown('SIGTERM')
+    const order = seq.map((e) => e[0])
+    assert.ok(order.indexOf('pool.shutdown') < order.indexOf('wsServer.close'), 'pool drained before wsServer.close')
+  })
+})
+
+describe('ServerOrchestrator — crash handlers (onFatal)', () => {
+  it('uncaughtException (not during shutdown) runs emergencyCleanupSync then exit(1)', async () => {
+    const { orchestrator, seq, cleanups } = build()
+    orchestrator._onFatal('Uncaught exception', new Error('boom'))
+    await tick()
+    assert.equal(cleanups.length, 1)
+    assert.equal(cleanups[0].kind, 'Uncaught exception')
+    assert.ok(seq.some((e) => e[0] === 'emergencyCleanupSync'))
+    assert.deepEqual(seq.at(-1), ['exit', 1])
+  })
+
+  it('a crash DURING shutdown only logs + schedules exit(1) (no emergencyCleanupSync)', async () => {
+    const { orchestrator, cleanups, exits } = build()
+    // Enter shutdown first (sets the latch), then a crash arrives mid-shutdown.
+    await orchestrator.shutdown('SIGTERM')
+    const cleanupsBefore = cleanups.length
+    orchestrator._onFatal('Unhandled rejection', new Error('late'))
+    await tick()
+    assert.equal(cleanups.length, cleanupsBefore, 'no emergencyCleanupSync during shutdown (would double-clean)')
+    assert.ok(exits.includes(1), 'still schedules exit(1) so a stuck shutdown cannot hang forever')
+  })
+})
+
+describe('ServerOrchestrator — install', () => {
+  it('registers the four process handlers', () => {
+    const { orchestrator } = build()
+    const before = ['SIGINT', 'SIGTERM', 'uncaughtException', 'unhandledRejection'].map((s) => process.listenerCount(s))
+    orchestrator.install()
+    const after = ['SIGINT', 'SIGTERM', 'uncaughtException', 'unhandledRejection'].map((s) => process.listenerCount(s))
+    for (let i = 0; i < before.length; i++) assert.equal(after[i], before[i] + 1)
+    // Clean up the handlers this test added so it doesn't leak into the runner.
+    process.removeAllListeners('SIGINT')
+    process.removeAllListeners('SIGTERM')
+    // uncaughtException/unhandledRejection: remove only ours by keeping the count.
+    const uel = process.listeners('uncaughtException')
+    process.removeListener('uncaughtException', uel[uel.length - 1])
+    const url = process.listeners('unhandledRejection')
+    process.removeListener('unhandledRejection', url[url.length - 1])
+  })
+})

--- a/packages/server/tests/server-orchestrator.test.js
+++ b/packages/server/tests/server-orchestrator.test.js
@@ -147,17 +147,22 @@ describe('ServerOrchestrator — crash handlers (onFatal)', () => {
 describe('ServerOrchestrator — install', () => {
   it('registers the four process handlers', () => {
     const { orchestrator } = build()
-    const before = ['SIGINT', 'SIGTERM', 'uncaughtException', 'unhandledRejection'].map((s) => process.listenerCount(s))
+    const signals = ['SIGINT', 'SIGTERM', 'uncaughtException', 'unhandledRejection']
+    // Snapshot the EXACT listeners present before install() so cleanup can
+    // remove only the ones this test adds — never the test runner's own SIGINT/
+    // SIGTERM handlers (removeAllListeners would clobber those, flaking the run).
+    const before = Object.fromEntries(signals.map((s) => [s, process.listeners(s)]))
     orchestrator.install()
-    const after = ['SIGINT', 'SIGTERM', 'uncaughtException', 'unhandledRejection'].map((s) => process.listenerCount(s))
-    for (let i = 0; i < before.length; i++) assert.equal(after[i], before[i] + 1)
-    // Clean up the handlers this test added so it doesn't leak into the runner.
-    process.removeAllListeners('SIGINT')
-    process.removeAllListeners('SIGTERM')
-    // uncaughtException/unhandledRejection: remove only ours by keeping the count.
-    const uel = process.listeners('uncaughtException')
-    process.removeListener('uncaughtException', uel[uel.length - 1])
-    const url = process.listeners('unhandledRejection')
-    process.removeListener('unhandledRejection', url[url.length - 1])
+    try {
+      for (const s of signals) {
+        assert.equal(process.listenerCount(s), before[s].length + 1, `${s} handler added`)
+      }
+    } finally {
+      for (const s of signals) {
+        for (const l of process.listeners(s)) {
+          if (!before[s].includes(l)) process.removeListener(s, l)
+        }
+      }
+    }
   })
 })


### PR DESCRIPTION
## What

Final slice of the #5368 ServerOrchestrator split. Extracts the process lifecycle out of `startCliServer` into `src/server-cli/server-orchestrator.js`:
- the `shuttingDown` latch (#3697 idempotency)
- the graceful `shutdown(signal)` teardown sequence
- the `SIGINT` / `SIGTERM` / `uncaughtException` / `unhandledRejection` registrations (the #5369 `onFatal` factory + `emergencyCleanupSync`)

`startCliServer` now builds the orchestrator and calls `install()`; the `{ sessionManager, wsServer }` return contract is unchanged. With this, `startCliServer` is down to **build components → wire → start → return** — the design's goal.

## The silent-failure surface — two ordering details preserved

The teardown sequence moves verbatim (a missed step orphans processes / hangs exit; a broken crash handler suppresses Node's default crash-exit). Two injection details preserve behavior exactly:

- **`worktreeReapTimer` is passed as a GETTER, not a value.** It's assigned inside an async `import().then()` (#5326), so it may still be `null` when the orchestrator is constructed. The original `shutdown` closure read it **at shutdown time**; capturing it by value would freeze `null` and never clear the real timer. `getWorktreeReapTimer: () => worktreeReapTimer` reproduces the lazy read — covered by a dedicated test (timer assigned *after* construction is still cleared).
- **`emergencyCleanupSync` is injected** (it lives in server-cli.js → importing it would be circular; it stays exported for its existing test). `exit` / `exitDelayMs` are injected so tests drive `shutdown` + `onFatal` without killing the test process.

## Tests

New `server-orchestrator.test.js` (9):
- the full **SIGTERM teardown ORDER** — `broadcastShutdown → mdns/bonjour/token/pairing.destroy → clearInterval → serializeState → destroyAll → [pool drain] → wsServer.close → tunnel.stop → removeConnectionInfo → exit(0)`.
- the #3697 idempotency guard (second signal is a no-op), the lazy worktree-timer read, serialize-throw containment, no-tunnel path, and pool-drain-before-`close` ordering.
- the `onFatal` crash handler: `emergencyCleanupSync` when not shutting down vs **log-only during shutdown** — both still scheduling `exit(1)` so a stuck shutdown can't hang forever.
- `install()` registers exactly the four handlers.

- server-cli suites: 73 pass. eslint clean; custom lints pass.
- Full server suite: 8160 pass / only the 2 pre-existing `service.test.js` #745 failures (environmental, on `main`); no new failures. (A flaky `setImmediate`-vs-`setTimeout(0)` wait in my own new test surfaced under full-suite load and was fixed to a deterministic `setTimeout` wait — verified 3× + full suite.)

Completes #5368.
