### PR TITLE
feat(server): single-source permission-resolver + cross-transport parity (#5373)

### DIFF
--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -39,6 +39,7 @@ import {
   PER_SESSION_SETTINGS,
   buildPerSessionSettingHandler,
 } from '../per-session-settings.js'
+import { createPermissionResolver } from '../permission-resolver.js'
 
 // Tools that are eligible to be whitelisted via set_permission_rules.
 // These are safe file-operation tools that don't execute code or make network requests.
@@ -291,155 +292,106 @@ function handlePermissionResponse(ws, client, msg, ctx) {
   const { requestId, decision } = msg
   if (!requestId || !decision) return
 
-  // Resolve the origin session of this permission request. The
-  // authoritative source is permissionSessionMap (populated at request
-  // creation). The fallback to client.activeSessionId exists only for
-  // legacy code paths where the map wasn't populated; it must NOT be
-  // used to bypass the binding check for a bound client, because for a
-  // bound client `activeSessionId === boundSessionId`, which would
-  // short-circuit the check below.
+  // #5373: the binding check + SDK-vs-legacy dispatch + audit are delegated to
+  // the shared permission-resolver (also used by the HTTP handler in
+  // ws-permissions.js), so the binding rule lives in ONE place. Two things stay
+  // HERE because they have no HTTP analog / are transport-specific:
+  //   - the WS-ONLY unbound-subscription guard (#4798, invariant G), which runs
+  //     BEFORE the resolver, and
+  //   - the elaborate binding-mismatch forensic log (#2832) + the per-transport
+  //     error / permission_expired / permission_resolved messages.
+  //
+  // `mappedSessionId` is the raw mapping; `originSessionId` adds the WS-only
+  // legacy `client.activeSessionId` fallback. That fallback is passed to the
+  // resolver as `dispatchFallbackSessionId` (used ONLY to pick the dispatch
+  // session, NEVER for the binding check — invariant B / the #2806 residual).
   const mappedSessionId = ctx.permissionSessionMap.get(requestId)
   const originSessionId = mappedSessionId || client.activeSessionId
 
-  // Enforce session binding: if this client authenticated with a
-  // pairing-issued session token that was bound to a specific session,
-  // prevent them from approving/denying a permission request belonging
-  // to any OTHER session — including legacy pendingPermissions entries
-  // that have no mapping.
-  //
-  // For a BOUND client, the request MUST have an explicit mapping in
-  // permissionSessionMap AND that mapping must equal boundSessionId.
-  // Without this, agent-review on PR #2806 found a residual bypass:
-  // when the requestId was not in the map, originSessionId would fall
-  // back to client.activeSessionId, which equals boundSessionId, the
-  // check would pass, and execution would fall through to the legacy
-  // pendingPermissions resolver — which has no session check at all.
-  //
-  // Discovered in the 2026-04-11 production readiness audit (blocker 5).
-  // The 616aeaf62 / 2c0ac7d2d commits claimed to enforce binding across
-  // all session-scoped handlers but missed this one + the HTTP fallback.
-  if (client.boundSessionId) {
-    if (!mappedSessionId || mappedSessionId !== client.boundSessionId) {
-      // Correlate with the [session-binding-create] log at the same
-      // requestId to recover the original creating client's bound session
-      // and createdAt. Reproduction steps: see issue #2832.
-      const permData = (mappedSessionId && ctx.sessionManager)
-        ? ctx.sessionManager.getSession(mappedSessionId)?.session?._lastPermissionData?.get(requestId)
-        : ctx.pendingPermissions?.get(requestId)?.data
-      const createdAt = permData?.createdAt ?? null
-      const ageMs = createdAt ? Date.now() - createdAt : null
-      const clientConnectedAt = client.authTime ?? null
-      const likelyPostReconnect = Boolean(
-        (ageMs !== null && ageMs > 30_000) ||
-        (createdAt && clientConnectedAt && clientConnectedAt > createdAt)
-      )
-      // #4828: session-scoped to the bound session — the reject belongs
-      // to the OWNER of `boundSessionId`, not the mismatched `originSessionId`.
-      loggerForSession('ws', client.boundSessionId).warn(`[session-binding-reject] permission_response rejected ${JSON.stringify({
-        requestId,
-        decision,
-        clientId: client.id,
-        activeSessionId: client.activeSessionId ?? null,
-        boundSessionId: client.boundSessionId ?? null,
-        mappedSessionId: mappedSessionId ?? null,
-        requestCreatedAt: createdAt,
-        clientConnectedAt,
-        requestAgeMs: ageMs,
-        likelyPostReconnect,
-      })}`)
-      // Don't consume the permissionSessionMap entry — let the legitimate
-      // client still respond to it.
-      // Issue #2912: payload shape matches every other SESSION_TOKEN_MISMATCH
-      // emit site so the client can branch on `code` alone without worrying
-      // about which transport surface (type: 'error' vs 'session_error' vs
-      // 'web_task_error') produced it.
-      ctx.send(ws, {
-        type: 'error',
-        requestId: requestId ?? null,
-        ...buildSessionTokenMismatchPayload({
-          sessionManager: ctx.sessionManager,
-          boundSessionId: client.boundSessionId,
-          message: 'Not authorized to respond to this permission request',
-        }),
-      })
-      return
-    }
-  }
-
   // #4798 (audit P0 symmetry with #4788): for UNBOUND clients, require the
-  // originSessionId to match the client's active or subscribed sessions
-  // before routing the decision. Without this, an unbound dashboard tab
-  // could approve/deny a permission for any session by replaying a known
-  // requestId — arguably MORE dangerous than the question hijack vector
-  // (#4788) because permission decisions gate file writes / shell exec.
-  // Mirrors the default filter used by _broadcastToSession (ws-broadcaster.js:106)
-  // so the set of clients permitted to RESPOND to a permission is the same
-  // set that could legitimately have RECEIVED it. Leaves the mapping
-  // intact so the legitimate subscribed client can still respond.
-  //
-  // Paired with the WsServer-side `_registerPermissionRoute` helper which
-  // auto-subscribes eligible clients at dispatch time — that keeps the
-  // legitimate "view A → get permission for A → switch to B → respond"
-  // flow working after this guard lands.
+  // originSessionId to match the client's active or subscribed sessions before
+  // routing the decision. Without this, an unbound dashboard tab could
+  // approve/deny a permission for any session by replaying a known requestId —
+  // arguably MORE dangerous than the question hijack vector (#4788) because
+  // permission decisions gate file writes / shell exec. Mirrors the default
+  // filter used by _broadcastToSession (ws-broadcaster.js:106). Leaves the
+  // mapping intact so the legitimate subscribed client can still respond. WS-ONLY
+  // by design: a primary HTTP caller has full session authority (§3), so the HTTP
+  // path has no analog and must not inherit this restriction.
   if (!client.boundSessionId && originSessionId) {
     const subscribed = originSessionId === client.activeSessionId
       || (client.subscribedSessionIds && client.subscribedSessionIds.has(originSessionId))
     if (!subscribed) {
-      // #4828: session-scoped — the permission belongs to `originSessionId`
-      // when known. Fall back to module-level `log` when the request had
-      // no mapping AND the client isn't bound (legacy / unknown route).
       sessionLogger(originSessionId).warn(`[permission-response-reject] unbound client ${client.id} attempted to respond to ${requestId} (originSessionId=${originSessionId}, activeSessionId=${client.activeSessionId ?? 'none'}, subscribed=false) — dropped`)
       return
     }
   }
 
-  ctx.permissionSessionMap.delete(requestId)
+  const resolver = createPermissionResolver({
+    permissionSessionMap: ctx.permissionSessionMap,
+    pendingPermissions: ctx.pendingPermissions,
+    getSessionManager: () => ctx.sessionManager,
+    resolveLegacyPermission: (rid, dec) => ctx.permissions.resolvePermission(rid, dec),
+    getPermissionAudit: () => ctx.permissionAudit,
+  })
+  const result = resolver.resolve(requestId, decision, client.boundSessionId, {
+    clientId: client.id,
+    dispatchFallbackSessionId: client.activeSessionId,
+  })
 
-  let resolved = false
-
-  if (originSessionId && ctx.sessionManager) {
-    const entry = ctx.sessionManager.getSession(originSessionId)
-    if (entry && typeof entry.session.respondToPermission === 'function') {
-      const hasPending = entry.session._pendingPermissions?.has(requestId)
-      if (hasPending !== false) {
-        entry.session.respondToPermission(requestId, decision)
-        resolved = true
-      } else {
-        ctx.send(ws, { type: 'permission_expired', requestId, sessionId: originSessionId, message: 'This permission request has expired or was already handled' })
-      }
-      if (!resolved) return
-    }
-  }
-
-  if (!resolved && ctx.pendingPermissions.has(requestId)) {
-    ctx.permissions.resolvePermission(requestId, decision)
-    resolved = true
-  }
-
-  if (!resolved) {
-    ctx.send(ws, { type: 'permission_expired', requestId, sessionId: originSessionId, message: 'This permission request has expired or was already handled' })
-  }
-
-  // Audit trail for permission decisions. Auto-deny paths
-  // (timeout/aborted/cleared) are audited from the unified pipeline in
-  // ws-server.js (#3057) — this branch only fires for user-initiated WS
-  // responses, hence reason: 'user'.
-  if (resolved && ctx.permissionAudit) {
-    ctx.permissionAudit.logDecision({
-      clientId: client.id,
-      sessionId: originSessionId,
+  if (result.kind === 'binding_mismatch') {
+    // Correlate with the [session-binding-create] log at the same requestId to
+    // recover the original creating client's bound session + createdAt (#2832).
+    const permData = (mappedSessionId && ctx.sessionManager)
+      ? ctx.sessionManager.getSession(mappedSessionId)?.session?._lastPermissionData?.get(requestId)
+      : ctx.pendingPermissions?.get(requestId)?.data
+    const createdAt = permData?.createdAt ?? null
+    const ageMs = createdAt ? Date.now() - createdAt : null
+    const clientConnectedAt = client.authTime ?? null
+    const likelyPostReconnect = Boolean(
+      (ageMs !== null && ageMs > 30_000) ||
+      (createdAt && clientConnectedAt && clientConnectedAt > createdAt)
+    )
+    // #4828: session-scoped to the bound session — the reject belongs to the
+    // OWNER of `boundSessionId`, not the mismatched mapped session.
+    loggerForSession('ws', result.boundSessionId).warn(`[session-binding-reject] permission_response rejected ${JSON.stringify({
       requestId,
       decision,
-      reason: 'user',
+      clientId: client.id,
+      activeSessionId: client.activeSessionId ?? null,
+      boundSessionId: client.boundSessionId ?? null,
+      mappedSessionId: mappedSessionId ?? null,
+      requestCreatedAt: createdAt,
+      clientConnectedAt,
+      requestAgeMs: ageMs,
+      likelyPostReconnect,
+    })}`)
+    // The resolver does NOT consume the map entry on a mismatch — the
+    // legitimate client can still respond. Issue #2912: payload shape matches
+    // every other SESSION_TOKEN_MISMATCH emit site.
+    ctx.send(ws, {
+      type: 'error',
+      requestId: requestId ?? null,
+      ...buildSessionTokenMismatchPayload({
+        sessionManager: ctx.sessionManager,
+        boundSessionId: result.boundSessionId,
+        message: 'Not authorized to respond to this permission request',
+      }),
     })
+    return
   }
 
-  // #3048: SDK-session broadcasts now go through the unified pipeline
-  // (PermissionManager.emit → SdkSession.emit → SessionManager session_event
-  // → EventNormalizer → broadcast). Legacy non-SDK sessions resolved via
-  // ctx.permissions.resolvePermission have no PermissionManager to wire
-  // through, so keep an inline broadcast for that branch only.
-  if (resolved && !originSessionId) {
+  if (result.kind === 'expired' || result.kind === 'not_found') {
+    ctx.send(ws, { type: 'permission_expired', requestId, sessionId: originSessionId, message: 'This permission request has expired or was already handled' })
+    return
+  }
+
+  // result.kind === 'resolved' — the resolver dispatched (sdk|legacy) + audited.
+  // #3048: SDK-session broadcasts go through the unified pipeline
+  // (PermissionManager → SdkSession → SessionManager → EventNormalizer →
+  // broadcast). Legacy non-SDK sessions (no PermissionManager) keep an inline
+  // broadcast for the unmapped case only — mirrors the prior `!originSessionId`.
+  if (!result.sessionId) {
     ctx.broadcast(
       { type: 'permission_resolved', requestId, decision },
       (c) => c.id !== client.id

--- a/packages/server/src/permission-resolver.js
+++ b/packages/server/src/permission-resolver.js
@@ -1,0 +1,108 @@
+// permission-resolver.js (#5373) — the single source of truth for the DOMAIN
+// decision of a permission response, extracted out of the duplicated HTTP
+// (ws-permissions.js) and WS (settings-handlers.js) handlers.
+//
+// It owns ONLY the decision: the session-binding check (the bearer-token
+// authorization boundary — bearer-token-authority.md §3-4; the
+// #2806/#4788/#4794/#4820 chain), SDK-before-legacy dispatch, and audit. It
+// returns a transport-agnostic descriptor (ResolveResult); each call site maps
+// that to its own wire format (HTTP status codes vs WS messages).
+//
+// It deliberately does NOT own (these STAY at the call sites):
+//   - the HTTP body buffering / oversize-413 / parse-400 / crash-guard
+//   - the per-transport response shape (403 vs WS error, 200 vs ack, …)
+//   - the WS unbound-subscription guard (invariant G) — it has no HTTP analog
+//     by design (a primary token has full HTTP session authority), so it must
+//     not leak into the shared path and over-restrict HTTP
+//   - the per-transport `permission_resolved` broadcast
+//
+// ResolveResult (discriminated on `kind`):
+//   { kind: 'binding_mismatch', boundSessionId }            -> HTTP 403 / WS error  (map NOT consumed)
+//   { kind: 'resolved', via: 'sdk'|'legacy', sessionId }    -> HTTP 200 / WS ack    (map consumed)
+//   { kind: 'expired', sessionId }                          -> HTTP 410 / WS permission_expired
+//   { kind: 'not_found' }                                   -> HTTP 404 / WS permission_expired
+
+/**
+ * @param {{
+ *   permissionSessionMap: Map<string, string>,
+ *   pendingPermissions: Map<string, any>,
+ *   getSessionManager: () => ({ getSession: Function } | null),
+ *   resolveLegacyPermission: (requestId: string, decision: string) => void,
+ *   getPermissionAudit: () => ({ logDecision: Function } | null),
+ * }} deps
+ */
+export function createPermissionResolver({
+  permissionSessionMap,
+  pendingPermissions,
+  getSessionManager,
+  resolveLegacyPermission,
+  getPermissionAudit,
+}) {
+  function audit(clientId, sessionId, requestId, decision) {
+    // #3059: only user-initiated resolutions reach here (auto-deny is audited by
+    // the unified pipeline), hence reason:'user'.
+    const a = getPermissionAudit?.()
+    if (a) a.logDecision({ clientId, sessionId, requestId, decision, reason: 'user' })
+  }
+
+  /**
+   * @param {string} requestId
+   * @param {string} decision
+   * @param {string|null} callerBoundSessionId  token-bound id (HTTP) / client.boundSessionId (WS); null/undefined = unbound
+   * @param {{ clientId?: string|null, dispatchFallbackSessionId?: string|null }} [opts]
+   *   `dispatchFallbackSessionId` is the WS-only legacy "map wasn't populated"
+   *   fallback (client.activeSessionId). It is used ONLY to pick the dispatch
+   *   session — NEVER for the binding check (invariant B). HTTP passes nothing.
+   * @returns {{ kind: string, [k: string]: any }} ResolveResult
+   */
+  function resolve(requestId, decision, callerBoundSessionId, opts = {}) {
+    const { clientId = null, dispatchFallbackSessionId = null } = opts
+
+    // Invariant B (#2806 residual): the binding check reads the RAW map entry —
+    // never an activeSessionId fallback. For a bound caller the request MUST be
+    // explicitly mapped to that session, or a missing mapping would let it slip
+    // through to the legacy resolver, which has no session check.
+    const mappedSessionId = permissionSessionMap.get(requestId)
+
+    // Invariant A: a bound caller may answer only its own bound session's prompts.
+    if (callerBoundSessionId) {
+      if (!mappedSessionId || mappedSessionId !== callerBoundSessionId) {
+        return { kind: 'binding_mismatch', boundSessionId: callerBoundSessionId }
+      }
+    }
+
+    // Dispatch origin: the mapped session, or the WS-only legacy fallback. NEVER
+    // used for the binding check above.
+    const originSessionId = mappedSessionId ?? dispatchFallbackSessionId
+
+    // Invariant F: SDK-mode (in-process) dispatch is attempted before the legacy
+    // store. Uses respondToPermission's RETURN VALUE as the resolved-vs-expired
+    // signal (the method's contract) — see the #5373 PR note on the WS
+    // _pendingPermissions pre-check this reconciles.
+    const sm = getSessionManager?.()
+    if (originSessionId && sm) {
+      const entry = sm.getSession(originSessionId)
+      if (entry && typeof entry.session.respondToPermission === 'function') {
+        const resolved = entry.session.respondToPermission(requestId, decision)
+        permissionSessionMap.delete(requestId)
+        if (resolved) {
+          audit(clientId, originSessionId, requestId, decision)
+          return { kind: 'resolved', via: 'sdk', sessionId: originSessionId }
+        }
+        return { kind: 'expired', sessionId: originSessionId }
+      }
+    }
+
+    // Legacy HTTP-held / pendingPermissions store.
+    if (pendingPermissions.has(requestId)) {
+      permissionSessionMap.delete(requestId)
+      resolveLegacyPermission(requestId, decision)
+      audit(clientId, originSessionId ?? null, requestId, decision)
+      return { kind: 'resolved', via: 'legacy', sessionId: originSessionId ?? null }
+    }
+
+    return { kind: 'not_found' }
+  }
+
+  return { resolve }
+}

--- a/packages/server/src/ws-permissions.js
+++ b/packages/server/src/ws-permissions.js
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto'
 import { createLogger } from './logger.js'
 import { RateLimiter, getRateLimitKey } from './rate-limiter.js'
 import { buildSessionTokenMismatchPayload } from './handler-utils.js'
+import { createPermissionResolver } from './permission-resolver.js'
 
 const log = createLogger('ws')
 
@@ -89,6 +90,20 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
 
   // Fall back to validateBearerAuth if validateHookAuth is not provided (backwards compat for tests)
   const _validateHookAuth = validateHookAuth || validateBearerAuth
+
+  // #5373: the session-binding check + SDK-vs-legacy dispatch + audit live in
+  // the shared permission-resolver (also used by the WS handler in
+  // settings-handlers.js), so the binding rule lives in ONE place. The HTTP
+  // handler below maps the resolver's transport-agnostic ResolveResult to HTTP
+  // status codes; the body buffering / oversize / crash-guard stay here.
+  // `resolvePermission` is a hoisted function declaration below.
+  const permissionResolver = createPermissionResolver({
+    permissionSessionMap,
+    pendingPermissions,
+    getSessionManager,
+    resolveLegacyPermission: resolvePermission,
+    getPermissionAudit,
+  })
 
   /** Handle POST /permission from the hook script */
   function handlePermissionRequest(req, res) {
@@ -338,110 +353,56 @@ export function createPermissionHandler({ sendFn, broadcastFn, validateBearerAut
         return
       }
 
-      // Try SDK-mode first (in-process permission via sessionManager)
-      const originSessionId = permissionSessionMap.get(requestId)
-
-      // Session-binding enforcement: if the presenting token is bound to a
-      // specific session via pairing, reject cross-session permission
-      // responses. This applies to BOTH the SDK-mode and legacy branches
-      // below, so we check once here before either dispatches.
-      //
-      // For a bound caller, the requestId MUST have an explicit mapping in
-      // permissionSessionMap AND that mapping must match the token's bound
-      // session. If the mapping is missing, the caller could otherwise slip
-      // through to the legacy `pendingPermissions` resolver below — which
-      // has no session check. Found by agent-review on PR #2806.
-      if (callerBoundSessionId) {
-        if (!originSessionId || originSessionId !== callerBoundSessionId) {
-          log.warn(`HTTP /permission-response rejected: token bound to ${callerBoundSessionId} tried to respond to ${requestId} with mapped session ${originSessionId ?? 'unmapped'}`)
-          // Issue #2912: enrich HTTP body with the same fields as the WebSocket
+      // #5373: delegate the binding check + SDK-vs-legacy dispatch + audit to
+      // the shared resolver. clientId 'http' distinguishes these from auto-deny
+      // entries (clientId=null) in forensic queries. HTTP passes NO dispatch
+      // fallback — it has no per-connection activeSessionId, so the dispatch
+      // session is the raw mapping only (unchanged from the prior inline code).
+      const result = permissionResolver.resolve(requestId, decision, callerBoundSessionId, { clientId: 'http' })
+      switch (result.kind) {
+        case 'binding_mismatch': {
+          // For a bound caller the requestId MUST be explicitly mapped to that
+          // session (no fallback bypass — the #2806 residual, enforced in the
+          // resolver). Reject cross-session responses with the unified payload.
+          log.warn(`HTTP /permission-response rejected: token bound to ${result.boundSessionId} tried to respond to ${requestId}`)
+          // Issue #2912: enrich the HTTP body with the same fields as the WS
           // SESSION_TOKEN_MISMATCH payload so clients handle both surfaces
-          // identically. The legacy `error` key is preserved alongside the new
-          // unified `message` field for old-client compatibility.
-          // (#2911 enriched WS paths; #2914/#2936 added inline enrichment here;
-          // #2912 extracts the shared helper so the shape is guaranteed identical.)
+          // identically (legacy `error` key preserved for old clients).
           const unified = buildSessionTokenMismatchPayload({
             sessionManager: getSessionManager(),
-            boundSessionId: callerBoundSessionId,
+            boundSessionId: result.boundSessionId,
             message: 'not authorized for this permission request',
           })
           sendJson(res, 403, { error: unified.message, ...unified })
           return
         }
-      }
-
-      const sm = getSessionManager()
-      if (originSessionId && sm) {
-        const entry = sm.getSession(originSessionId)
-        if (entry && typeof entry.session.respondToPermission === 'function') {
-          const resolved = entry.session.respondToPermission(requestId, decision)
-          permissionSessionMap.delete(requestId)
-          if (resolved) {
-            log.info(`Permission ${requestId} resolved via HTTP: ${decision} (SDK)`)
-            // #3048: broadcast is now handled by the unified pipeline
-            // (PermissionManager.emit → SdkSession.emit → SessionManager
-            // session_event → EventNormalizer → broadcast). The previous
-            // inline broadcast here was the #2905 fix and is now redundant.
-            // #3059: audit HTTP user-initiated resolutions. The pipeline-layer
-            // audit listener filters reason==='user' to avoid double-auditing
-            // the WS path (which logs inline with client.id), so HTTP needs
-            // its own inline call. clientId='http' distinguishes from auto-
-            // deny entries (clientId=null) in forensic queries.
-            const audit = getPermissionAudit?.()
-            if (audit) {
-              audit.logDecision({
-                clientId: 'http',
-                sessionId: originSessionId,
-                requestId,
-                decision,
-                reason: 'user',
-              })
-            }
-            sendJson(res, 200, { ok: true })
-          } else {
-            // UX landmine #5: the permission auto-denied (timed out)
-            // before the user tapped the lockscreen notification. Tell
-            // the app so it can surface "This permission request
-            // expired" instead of silently showing "approved".
-            log.info(`Permission ${requestId} already expired when HTTP response arrived (SDK)`)
-            sendJson(res, 410, { error: 'expired', message: 'This permission request has already expired or been resolved' })
+        case 'resolved': {
+          // #3048: the SDK branch's broadcast is handled by the unified pipeline
+          // (PermissionManager → SdkSession → SessionManager → broadcast). The
+          // legacy branch has no PermissionManager, so it keeps the inline
+          // broadcast (#2905) — sessionId included only when the request was mapped.
+          if (result.via === 'legacy') {
+            broadcastFn({
+              type: 'permission_resolved',
+              requestId,
+              decision,
+              ...(result.sessionId ? { sessionId: result.sessionId } : {}),
+            })
           }
+          log.info(`Permission ${requestId} resolved via HTTP: ${decision} (${result.via})`)
+          sendJson(res, 200, { ok: true })
           return
         }
-      }
-
-      // Fall back to legacy HTTP-held permission
-      const pending = pendingPermissions.get(requestId)
-      if (pending) {
-        permissionSessionMap.delete(requestId)
-        resolvePermission(requestId, decision)
-        log.info(`Permission ${requestId} resolved via HTTP: ${decision} (legacy)`)
-        // #2905: same broadcast for the legacy HTTP path. Include sessionId
-        // when the request was mapped (keeps the wire contract consistent
-        // with the SDK branch and settings-handlers.js for clients that route
-        // by session); omit it for genuinely unmapped legacy requests.
-        broadcastFn({
-          type: 'permission_resolved',
-          requestId,
-          decision,
-          ...(originSessionId ? { sessionId: originSessionId } : {}),
-        })
-        // #3059: audit the legacy HTTP path too. There's no PermissionManager
-        // wiring here (legacy non-SDK sessions don't have one), so this is
-        // the only audit hook for these resolutions.
-        const audit = getPermissionAudit?.()
-        if (audit) {
-          audit.logDecision({
-            clientId: 'http',
-            sessionId: originSessionId ?? null,
-            requestId,
-            decision,
-            reason: 'user',
-          })
-        }
-        sendJson(res, 200, { ok: true })
-      } else {
-        sendJson(res, 404, { error: 'unknown or expired requestId' })
+        case 'expired':
+          // UX landmine #5: auto-denied (timed out) before the user tapped the
+          // notification — tell the app so it shows "expired", not "approved".
+          log.info(`Permission ${requestId} already expired when HTTP response arrived (SDK)`)
+          sendJson(res, 410, { error: 'expired', message: 'This permission request has already expired or been resolved' })
+          return
+        case 'not_found':
+        default:
+          sendJson(res, 404, { error: 'unknown or expired requestId' })
+          return
       }
       } catch (err) {
         // #5313 (WP-1.3): see the try at the top of this end callback.

--- a/packages/server/tests/permission-resolver.test.js
+++ b/packages/server/tests/permission-resolver.test.js
@@ -1,0 +1,169 @@
+import { describe, it, beforeEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+
+/**
+ * #5373 (TEST-FIRST — proposed API, reviewed before implementation).
+ *
+ * `permission-resolver.js` will own the DOMAIN decision of a permission
+ * response — the session-binding check, SDK-vs-legacy dispatch, and audit — so
+ * the rule lives in ONE place instead of being duplicated in the HTTP handler
+ * (ws-permissions.js) and the WS handler (settings-handlers.js). Both call sites
+ * will delegate to it; the transport concerns (HTTP body/status mapping, the
+ * WS unbound-subscription guard G, the per-transport broadcast) stay at the call
+ * sites.
+ *
+ * PROPOSED API (the thing under review):
+ *
+ *   const resolver = createPermissionResolver({
+ *     permissionSessionMap,        // Map<requestId, sessionId>
+ *     pendingPermissions,          // Map<requestId, …> (legacy store)
+ *     getSessionManager,           // () => sessionManager | null
+ *     resolveLegacyPermission,     // (requestId, decision) => void  (the legacy resolver)
+ *     getPermissionAudit,          // () => audit | null
+ *   })
+ *
+ *   resolver.resolve(requestId, decision, callerBoundSessionId, { clientId }) => ResolveResult
+ *
+ *   ResolveResult (discriminated on `kind`), each call site maps to its transport:
+ *     { kind: 'binding_mismatch', boundSessionId }           HTTP 403 / WS error  (map NOT consumed)
+ *     { kind: 'resolved', via: 'sdk' | 'legacy', sessionId } HTTP 200 / WS ack    (map consumed)
+ *     { kind: 'expired', sessionId }                         HTTP 410 / WS permission_expired
+ *     { kind: 'not_found' }                                  HTTP 404 / WS permission_expired
+ *
+ * Invariants the resolver MUST uphold (each has a proving test below):
+ *   B) `permissionSessionMap.get(requestId)` with NO activeSessionId fallback —
+ *      a bound caller for an UNMAPPED request gets binding_mismatch, never a
+ *      fallthrough to the legacy resolver (the #2806 residual).
+ *   F) SDK dispatch is attempted BEFORE the legacy store.
+ *   C) the map entry is consumed ONLY on `resolved` (preserved on
+ *      binding_mismatch / expired / not_found).
+ *   D) on `resolved`, audit.logDecision is called with the caller-supplied
+ *      clientId, the origin sessionId, the requestId, decision, reason:'user'.
+ *
+ * This suite SKIPS until permission-resolver.js exists, so it can be reviewed
+ * test-first without breaking the build; it activates on implementation.
+ */
+
+let createPermissionResolver = null
+try {
+  ({ createPermissionResolver } = await import('../src/permission-resolver.js'))
+} catch {
+  // Not implemented yet — #5373 is test-first; these tests are the spec under review.
+}
+
+const skip = createPermissionResolver ? false : 'permission-resolver.js not implemented yet (#5373 test-first — spec under review)'
+
+const OWNER = 'sess-OWNER'
+const OTHER = 'sess-OTHER'
+
+function makeSdkSession({ pending = [] } = {}) {
+  const set = new Set(pending)
+  return {
+    _pendingPermissions: { has: (id) => set.has(id) },
+    respondToPermission: mock.fn((id) => { const had = set.has(id); set.delete(id); return had }),
+  }
+}
+
+function build({ map = [], legacy = [], ownerSession } = {}) {
+  const permissionSessionMap = new Map(map)
+  const pendingPermissions = new Map(legacy.map((id) => [id, { data: {} }]))
+  const audited = []
+  const legacyResolved = []
+  const sessions = new Map([
+    [OWNER, { session: ownerSession ?? makeSdkSession(), name: 'OwnerSession' }],
+    [OTHER, { session: makeSdkSession(), name: 'OtherSession' }],
+  ])
+  const resolver = createPermissionResolver({
+    permissionSessionMap,
+    pendingPermissions,
+    getSessionManager: () => ({ getSession: (id) => sessions.get(id) }),
+    resolveLegacyPermission: (requestId, decision) => legacyResolved.push({ requestId, decision }),
+    getPermissionAudit: () => ({ logDecision: (e) => audited.push(e) }),
+  })
+  return { resolver, permissionSessionMap, pendingPermissions, audited, legacyResolved, sessions }
+}
+
+describe('permission-resolver — binding (invariants A/B/C)', { skip }, () => {
+  it('A: bound caller matching the mapped session resolves (via sdk)', () => {
+    const owner = makeSdkSession({ pending: ['perm-1'] })
+    const { resolver, permissionSessionMap } = build({ map: [['perm-1', OWNER]], ownerSession: owner })
+    const r = resolver.resolve('perm-1', 'allow', OWNER, { clientId: 'c1' })
+    assert.equal(r.kind, 'resolved')
+    assert.equal(r.via, 'sdk')
+    assert.equal(r.sessionId, OWNER)
+    assert.equal(permissionSessionMap.has('perm-1'), false, 'map consumed on resolve')
+  })
+
+  it('A: bound caller mismatching the mapped session → binding_mismatch (map preserved — C)', () => {
+    const { resolver, permissionSessionMap } = build({ map: [['perm-2', OWNER]] })
+    const r = resolver.resolve('perm-2', 'allow', OTHER, { clientId: 'c1' })
+    assert.equal(r.kind, 'binding_mismatch')
+    assert.equal(r.boundSessionId, OTHER)
+    assert.equal(permissionSessionMap.has('perm-2'), true, 'map NOT consumed on binding_mismatch')
+  })
+
+  it('B (#2806 residual): bound caller for an UNMAPPED request → binding_mismatch, NOT a legacy fallthrough', () => {
+    const { resolver, legacyResolved, permissionSessionMap } = build({ map: [], legacy: ['perm-unmapped'] })
+    const r = resolver.resolve('perm-unmapped', 'allow', OTHER, { clientId: 'c1' })
+    assert.equal(r.kind, 'binding_mismatch', 'no activeSessionId/whatever fallback — unmapped+bound is a mismatch')
+    assert.equal(legacyResolved.length, 0, 'must NOT fall through to the legacy resolver')
+    assert.equal(permissionSessionMap.has('perm-unmapped'), false) // never was there
+  })
+
+  it('an UNBOUND caller (callerBoundSessionId null) skips the binding check', () => {
+    const owner = makeSdkSession({ pending: ['perm-3'] })
+    const { resolver } = build({ map: [['perm-3', OWNER]], ownerSession: owner })
+    const r = resolver.resolve('perm-3', 'allow', null, { clientId: 'c1' })
+    assert.equal(r.kind, 'resolved')
+  })
+})
+
+describe('permission-resolver — SDK-before-legacy (F) + dispatch states', { skip }, () => {
+  it('F: a mapped SDK session is dispatched via sdk even when a legacy entry also exists', () => {
+    const owner = makeSdkSession({ pending: ['perm-4'] })
+    const { resolver, legacyResolved } = build({ map: [['perm-4', OWNER]], legacy: ['perm-4'], ownerSession: owner })
+    const r = resolver.resolve('perm-4', 'allow', null, { clientId: 'c1' })
+    assert.equal(r.kind, 'resolved')
+    assert.equal(r.via, 'sdk', 'SDK path wins when the mapped session can respond')
+    assert.equal(legacyResolved.length, 0, 'legacy resolver not used when SDK handled it')
+  })
+
+  it('an unmapped request that exists in the legacy store resolves via legacy', () => {
+    const { resolver, legacyResolved } = build({ map: [], legacy: ['perm-5'] })
+    const r = resolver.resolve('perm-5', 'allow', null, { clientId: 'c1' })
+    assert.equal(r.kind, 'resolved')
+    assert.equal(r.via, 'legacy')
+    assert.deepEqual(legacyResolved, [{ requestId: 'perm-5', decision: 'allow' }])
+  })
+
+  it('a mapped SDK session whose request already expired → expired (map consumed)', () => {
+    const owner = makeSdkSession({ pending: [] }) // respondToPermission returns false
+    const { resolver, permissionSessionMap } = build({ map: [['perm-6', OWNER]], ownerSession: owner })
+    const r = resolver.resolve('perm-6', 'allow', null, { clientId: 'c1' })
+    assert.equal(r.kind, 'expired')
+    assert.equal(r.sessionId, OWNER)
+    assert.equal(permissionSessionMap.has('perm-6'), false, 'SDK branch consumes the map even on expiry')
+  })
+
+  it('an unmapped request with no legacy entry → not_found', () => {
+    const { resolver } = build({ map: [], legacy: [] })
+    const r = resolver.resolve('perm-missing', 'allow', null, { clientId: 'c1' })
+    assert.equal(r.kind, 'not_found')
+  })
+})
+
+describe('permission-resolver — audit (D)', { skip }, () => {
+  it('D: a resolved decision is audited with the caller-supplied clientId', () => {
+    const owner = makeSdkSession({ pending: ['perm-7'] })
+    const { resolver, audited } = build({ map: [['perm-7', OWNER]], ownerSession: owner })
+    resolver.resolve('perm-7', 'deny', null, { clientId: 'http' })
+    assert.equal(audited.length, 1)
+    assert.deepEqual(audited[0], { clientId: 'http', sessionId: OWNER, requestId: 'perm-7', decision: 'deny', reason: 'user' })
+  })
+
+  it('a binding_mismatch is NOT audited (it never dispatched)', () => {
+    const { resolver, audited } = build({ map: [['perm-8', OWNER]] })
+    resolver.resolve('perm-8', 'allow', OTHER, { clientId: 'c1' })
+    assert.equal(audited.length, 0)
+  })
+})

--- a/packages/server/tests/permission-resolver.test.js
+++ b/packages/server/tests/permission-resolver.test.js
@@ -35,23 +35,14 @@ import assert from 'node:assert/strict'
  *      a bound caller for an UNMAPPED request gets binding_mismatch, never a
  *      fallthrough to the legacy resolver (the #2806 residual).
  *   F) SDK dispatch is attempted BEFORE the legacy store.
- *   C) the map entry is consumed ONLY on `resolved` (preserved on
- *      binding_mismatch / expired / not_found).
+ *   C) the map entry is consumed on `resolved` AND on a (mapped) SDK `expired`
+ *      (matching the HTTP delete-in-the-SDK-branch); it is PRESERVED on
+ *      `binding_mismatch` (the legitimate client must still be able to respond).
  *   D) on `resolved`, audit.logDecision is called with the caller-supplied
  *      clientId, the origin sessionId, the requestId, decision, reason:'user'.
- *
- * This suite SKIPS until permission-resolver.js exists, so it can be reviewed
- * test-first without breaking the build; it activates on implementation.
  */
 
-let createPermissionResolver = null
-try {
-  ({ createPermissionResolver } = await import('../src/permission-resolver.js'))
-} catch {
-  // Not implemented yet — #5373 is test-first; these tests are the spec under review.
-}
-
-const skip = createPermissionResolver ? false : 'permission-resolver.js not implemented yet (#5373 test-first — spec under review)'
+import { createPermissionResolver } from '../src/permission-resolver.js'
 
 const OWNER = 'sess-OWNER'
 const OTHER = 'sess-OTHER'
@@ -83,7 +74,7 @@ function build({ map = [], legacy = [], ownerSession } = {}) {
   return { resolver, permissionSessionMap, pendingPermissions, audited, legacyResolved, sessions }
 }
 
-describe('permission-resolver — binding (invariants A/B/C)', { skip }, () => {
+describe('permission-resolver — binding (invariants A/B/C)', () => {
   it('A: bound caller matching the mapped session resolves (via sdk)', () => {
     const owner = makeSdkSession({ pending: ['perm-1'] })
     const { resolver, permissionSessionMap } = build({ map: [['perm-1', OWNER]], ownerSession: owner })
@@ -118,7 +109,7 @@ describe('permission-resolver — binding (invariants A/B/C)', { skip }, () => {
   })
 })
 
-describe('permission-resolver — SDK-before-legacy (F) + dispatch states', { skip }, () => {
+describe('permission-resolver — SDK-before-legacy (F) + dispatch states', () => {
   it('F: a mapped SDK session is dispatched via sdk even when a legacy entry also exists', () => {
     const owner = makeSdkSession({ pending: ['perm-4'] })
     const { resolver, legacyResolved } = build({ map: [['perm-4', OWNER]], legacy: ['perm-4'], ownerSession: owner })
@@ -152,7 +143,7 @@ describe('permission-resolver — SDK-before-legacy (F) + dispatch states', { sk
   })
 })
 
-describe('permission-resolver — audit (D)', { skip }, () => {
+describe('permission-resolver — audit (D)', () => {
   it('D: a resolved decision is audited with the caller-supplied clientId', () => {
     const owner = makeSdkSession({ pending: ['perm-7'] })
     const { resolver, audited } = build({ map: [['perm-7', OWNER]], ownerSession: owner })

--- a/packages/server/tests/permission-response-parity.test.js
+++ b/packages/server/tests/permission-response-parity.test.js
@@ -191,15 +191,17 @@ describe('#5373 invariant G — the WS unbound-subscription guard is WS-ONLY', (
   let ownerSession, sessionManager
   beforeEach(() => { ownerSession = makeSdkSession(); sessionManager = makeSessionManager(ownerSession) })
 
-  it('a primary/unbound caller SUBSCRIBED to the session is accepted on both transports', async () => {
+  it('a primary/unbound caller subscribed to the session (via subscribedSessionIds, NOT active) is accepted on both transports', async () => {
     ownerSession._addPending('perm-3')
     const http = await runHttp({ requestId: 'perm-3', decision: 'allow', presentedToken: 'tok-primary', tokenBoundSessionId: null, mapEntry: OWNER, ownerSession, sessionManager })
     ownerSession._addPending('perm-3')
-    const ws = runWs({ requestId: 'perm-3', decision: 'allow', boundSessionId: null, activeSessionId: OWNER, mapEntry: OWNER, ownerSession, sessionManager })
+    // active session is OTHER; OWNER is reached only through subscribedSessionIds
+    // — this exercises the subscription arm of the guard, not the active-match arm.
+    const ws = runWs({ requestId: 'perm-3', decision: 'allow', boundSessionId: null, activeSessionId: OTHER, subscribed: OWNER, mapEntry: OWNER, ownerSession, sessionManager })
 
     assert.equal(http.status, 200)
     assert.equal(ws.mismatch, undefined)
-    assert.equal(ws.expired, undefined, 'WS resolves for a subscribed unbound caller')
+    assert.equal(ws.expired, undefined, 'WS resolves for a subscribed (non-active) unbound caller')
   })
 
   it('a primary/unbound caller NOT subscribed: HTTP ACCEPTS (full authority), WS DROPS (guard) — intentional diff', async () => {

--- a/packages/server/tests/permission-response-parity.test.js
+++ b/packages/server/tests/permission-response-parity.test.js
@@ -1,0 +1,220 @@
+import { describe, it, beforeEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+
+import { createPermissionHandler } from '../src/ws-permissions.js'
+import { settingsHandlers } from '../src/handlers/settings-handlers.js'
+
+/**
+ * #5373 (TEST-FIRST): cross-transport parity for permission-response.
+ *
+ * The HTTP handler (`handlePermissionResponseHttp` in ws-permissions.js) and the
+ * WS handler (`settingsHandlers.permission_response`) each independently
+ * implement the session-binding security check. They can drift — exactly the bug
+ * class the #2806/#4788/#4794/#4820 chain fixed. #5373 will extract a shared
+ * `permission-resolver.js` so the binding rule lives in ONE place.
+ *
+ * This suite runs the SAME scenario table through BOTH transports and asserts
+ * the accept/reject decision is identical for the shared invariants — so it
+ * passes against today's duplicated code AND must keep passing after the
+ * extraction (a refactor that changes either transport's binding behavior fails
+ * here). It also pins the two INTENTIONAL differences the design says must
+ * survive (invariant G: the WS unbound-subscription guard has no HTTP analog).
+ *
+ * Invariants pinned (bearer-token-authority.md §3-4):
+ *   A) a bound caller may answer ONLY its own bound session's prompts.
+ *   B) NO bypass via a missing map entry — the binding check reads the raw
+ *      `permissionSessionMap.get(requestId)` with NO activeSessionId fallback
+ *      (the #2806 residual; the easiest thing a "tidy-up" reintroduces).
+ *   C) the map entry is preserved on a binding reject (legitimate client can
+ *      still answer).
+ *   G) the WS unbound-subscription guard is WS-ONLY — a primary HTTP caller has
+ *      full session authority and is NOT subject to it.
+ */
+
+// ---- harness (mirrors ws-permissions-binding-integration.test.js) ----------
+
+function makeReq(body, headers = {}) {
+  const emitter = new EventEmitter()
+  emitter.method = 'POST'
+  emitter.headers = headers
+  emitter.socket = { remoteAddress: '127.0.0.1' }
+  process.nextTick(() => {
+    emitter.emit('data', Buffer.from(body))
+    emitter.emit('end')
+  })
+  emitter.destroy = mock.fn()
+  return emitter
+}
+
+function makeRes() {
+  const res = {
+    statusCode: null,
+    body: null,
+    headersSent: false,
+    writeHead(code) { this.statusCode = code; this.headersSent = true },
+    end(b) { this.body = b },
+  }
+  return res
+}
+
+function makeWs() {
+  const messages = []
+  return { readyState: 1, send: (raw) => messages.push(JSON.parse(raw)), _messages: messages }
+}
+
+const OWNER = 'sess-OWNER'
+const OTHER = 'sess-OTHER'
+
+// An SDK-style session: respondToPermission resolves true while the request is
+// pending. Both transports dispatch through this on the accept path.
+function makeSdkSession() {
+  const pending = new Set()
+  return {
+    _pendingPermissions: { has: (id) => pending.has(id) },
+    respondToPermission: mock.fn((id) => { const had = pending.has(id); pending.delete(id); return had }),
+    _addPending: (id) => pending.add(id),
+    notifyPermissionPending: mock.fn(),
+    notifyPermissionResolved: mock.fn(),
+  }
+}
+
+function makeSessionManager(ownerSession) {
+  const sessions = new Map([
+    [OWNER, { session: ownerSession, name: 'OwnerSession', cwd: '/tmp' }],
+    [OTHER, { session: makeSdkSession(), name: 'OtherSession', cwd: '/tmp' }],
+  ])
+  return { getSession: (id) => sessions.get(id) }
+}
+
+/**
+ * Run ONE scenario through the HTTP transport.
+ * `tokenBinding`: map of token -> boundSessionId (null token = primary).
+ */
+function runHttp({ requestId, decision, presentedToken, tokenBoundSessionId, mapEntry, ownerSession, sessionManager }) {
+  const permissionSessionMap = new Map()
+  if (mapEntry !== undefined) permissionSessionMap.set(requestId, mapEntry)
+  const pendingPermissions = new Map()
+  const audited = []
+  const handler = createPermissionHandler({
+    sendFn: mock.fn(),
+    broadcastFn: mock.fn(),
+    validateBearerAuth: () => true,
+    pushManager: null,
+    pendingPermissions,
+    permissionSessionMap,
+    getSessionManager: () => sessionManager,
+    pairingManager: { getSessionIdForToken: (t) => (t === presentedToken ? tokenBoundSessionId : null) },
+    getPermissionAudit: () => ({ logDecision: (e) => audited.push(e) }),
+  })
+  const res = makeRes()
+  const headers = presentedToken ? { authorization: `Bearer ${presentedToken}` } : {}
+  return new Promise((resolve) => {
+    const req = makeReq(JSON.stringify({ requestId, decision }), headers)
+    handler.handlePermissionResponseHttp(req, res)
+    setImmediate(() => resolve({ status: res.statusCode, body: res.body ? JSON.parse(res.body) : null, audited, mapStillHas: permissionSessionMap.has(requestId) }))
+  })
+}
+
+/** Run ONE scenario through the WS transport. */
+function runWs({ requestId, decision, boundSessionId, activeSessionId, subscribed, mapEntry, ownerSession, sessionManager }) {
+  const permissionSessionMap = new Map()
+  if (mapEntry !== undefined) permissionSessionMap.set(requestId, mapEntry)
+  const pendingPermissions = new Map()
+  const sent = []
+  const broadcasts = []
+  const audited = []
+  const ctx = {
+    send: (_ws, m) => sent.push(m),
+    broadcast: (m) => broadcasts.push(m),
+    sessionManager,
+    permissionSessionMap,
+    pendingPermissions,
+    permissions: { resolvePermission: mock.fn() },
+    permissionAudit: { logDecision: (e) => audited.push(e) },
+  }
+  const ws = makeWs()
+  const client = {
+    id: 'client-1',
+    activeSessionId: activeSessionId ?? null,
+    boundSessionId: boundSessionId ?? null,
+    subscribedSessionIds: subscribed ? new Set([subscribed]) : new Set(),
+    authTime: Date.now(),
+  }
+  settingsHandlers.permission_response(ws, client, { requestId, decision }, ctx)
+  const mismatch = sent.find((m) => m.code === 'SESSION_TOKEN_MISMATCH')
+  const expired = sent.find((m) => m.type === 'permission_expired')
+  return { sent, broadcasts, audited, mismatch, expired, mapStillHas: permissionSessionMap.has(requestId) }
+}
+
+describe('#5373 cross-transport parity — bound-caller binding (invariants A/B/C)', () => {
+  let ownerSession, sessionManager
+  beforeEach(() => { ownerSession = makeSdkSession(); sessionManager = makeSessionManager(ownerSession) })
+
+  it('A: bound caller whose binding MATCHES the mapped session is ACCEPTED on both transports', async () => {
+    ownerSession._addPending('perm-1')
+    const http = await runHttp({ requestId: 'perm-1', decision: 'allow', presentedToken: 'tok-owner', tokenBoundSessionId: OWNER, mapEntry: OWNER, ownerSession, sessionManager })
+    ownerSession._addPending('perm-1')
+    const ws = runWs({ requestId: 'perm-1', decision: 'allow', boundSessionId: OWNER, activeSessionId: OWNER, mapEntry: OWNER, ownerSession, sessionManager })
+
+    assert.equal(http.status, 200, 'HTTP accepts a matching bound caller')
+    assert.equal(http.body.ok, true)
+    assert.equal(ws.mismatch, undefined, 'WS accepts a matching bound caller (no mismatch error)')
+  })
+
+  it('A: bound caller whose binding MISMATCHES is REJECTED on both transports (map preserved — C)', async () => {
+    const http = await runHttp({ requestId: 'perm-2', decision: 'allow', presentedToken: 'tok-other', tokenBoundSessionId: OTHER, mapEntry: OWNER, ownerSession, sessionManager })
+    const ws = runWs({ requestId: 'perm-2', decision: 'allow', boundSessionId: OTHER, activeSessionId: OTHER, mapEntry: OWNER, ownerSession, sessionManager })
+
+    assert.equal(http.status, 403, 'HTTP rejects a cross-session bound caller')
+    assert.equal(http.body.code, 'SESSION_TOKEN_MISMATCH')
+    assert.equal(ws.mismatch?.code, 'SESSION_TOKEN_MISMATCH', 'WS rejects a cross-session bound caller')
+    // C: neither transport consumes the map entry on a binding reject.
+    assert.equal(http.mapStillHas, true, 'HTTP preserves the map entry on reject')
+    assert.equal(ws.mapStillHas, true, 'WS preserves the map entry on reject')
+  })
+
+  it('B (the #2806 residual): bound caller with NO map entry is REJECTED on both — no activeSessionId fallback', async () => {
+    // The dangerous case: requestId is unmapped. A fallback to the caller's
+    // own session (which == its boundSessionId) would let the binding check
+    // pass and fall through to the legacy resolver, which has no session check.
+    const http = await runHttp({ requestId: 'perm-unmapped', decision: 'allow', presentedToken: 'tok-other', tokenBoundSessionId: OTHER, mapEntry: undefined, ownerSession, sessionManager })
+    const ws = runWs({ requestId: 'perm-unmapped', decision: 'allow', boundSessionId: OTHER, activeSessionId: OTHER, mapEntry: undefined, ownerSession, sessionManager })
+
+    assert.equal(http.status, 403, 'HTTP rejects a bound caller for an unmapped request (no fallback bypass)')
+    assert.equal(http.body.code, 'SESSION_TOKEN_MISMATCH')
+    assert.equal(ws.mismatch?.code, 'SESSION_TOKEN_MISMATCH', 'WS rejects a bound caller for an unmapped request (no fallback bypass)')
+  })
+})
+
+describe('#5373 invariant G — the WS unbound-subscription guard is WS-ONLY', () => {
+  let ownerSession, sessionManager
+  beforeEach(() => { ownerSession = makeSdkSession(); sessionManager = makeSessionManager(ownerSession) })
+
+  it('a primary/unbound caller SUBSCRIBED to the session is accepted on both transports', async () => {
+    ownerSession._addPending('perm-3')
+    const http = await runHttp({ requestId: 'perm-3', decision: 'allow', presentedToken: 'tok-primary', tokenBoundSessionId: null, mapEntry: OWNER, ownerSession, sessionManager })
+    ownerSession._addPending('perm-3')
+    const ws = runWs({ requestId: 'perm-3', decision: 'allow', boundSessionId: null, activeSessionId: OWNER, mapEntry: OWNER, ownerSession, sessionManager })
+
+    assert.equal(http.status, 200)
+    assert.equal(ws.mismatch, undefined)
+    assert.equal(ws.expired, undefined, 'WS resolves for a subscribed unbound caller')
+  })
+
+  it('a primary/unbound caller NOT subscribed: HTTP ACCEPTS (full authority), WS DROPS (guard) — intentional diff', async () => {
+    ownerSession._addPending('perm-4')
+    // HTTP: a primary token has full session authority, so no subscription
+    // concept applies — it must accept.
+    const http = await runHttp({ requestId: 'perm-4', decision: 'allow', presentedToken: 'tok-primary', tokenBoundSessionId: null, mapEntry: OWNER, ownerSession, sessionManager })
+    // WS: an unbound client NOT subscribed to the origin session is dropped
+    // (#4798) — it could otherwise replay a known requestId for any session.
+    const ws = runWs({ requestId: 'perm-4', decision: 'allow', boundSessionId: null, activeSessionId: OTHER, subscribed: undefined, mapEntry: OWNER, ownerSession, sessionManager })
+
+    assert.equal(http.status, 200, 'HTTP primary caller accepts regardless of subscription (no HTTP analog to the guard)')
+    // WS dropped: no resolve, no mismatch (it is silently dropped, not a binding error).
+    assert.equal(ws.broadcasts.length, 0)
+    assert.equal(ws.audited.length, 0, 'WS dropped the unsubscribed unbound caller (guard G), so nothing was audited')
+    assert.equal(ws.mapStillHas, true, 'WS leaves the mapping intact for the legitimate subscribed client')
+  })
+})


### PR DESCRIPTION
## Test-first for #5373 — please review the tests before I implement

Per the supervised decision, this PR contains **only tests** — no production code. #5373 will extract a shared `permission-resolver.js` so the session-binding security check lives in one place instead of being duplicated in the HTTP handler (`ws-permissions.js`) and the WS handler (`settings-handlers.js`). That's the bearer-token authorization boundary (the #2806/#4788/#4794/#4820 cross-session-escalation chain), so the design wants the tests reviewed first, then implementation, then a human eyeballs the final diff against invariants **B** and **G**.

### `permission-response-parity.test.js` (5, passing — the safety net)
Runs the **same scenario table through BOTH transports** and asserts the binding decision is identical for the shared invariants — so it passes against today's duplicated code and must keep passing after the extraction:
- **A** — a bound caller answers only its own bound session's prompts (accept on match, reject on mismatch, both transports).
- **B (the #2806 residual)** — a bound caller for an **UNMAPPED** request is rejected on both, proving there's **no `activeSessionId` fallback** that would let it fall through to the legacy resolver. This is the single most important invariant and the easiest thing a "tidy-up" reintroduces.
- **C** — the `permissionSessionMap` entry is preserved on a binding reject.
- **G** — pinned as an **intentional difference**: the WS unbound-subscription guard has **no HTTP analog** (a primary HTTP caller has full session authority per `bearer-token-authority.md` §3). The test shows a primary unbound caller NOT subscribed → HTTP accepts, WS drops.

### `permission-resolver.test.js` (skipped until the module exists — the spec under review)
The **proposed resolver API** + `ResolveResult` shape + the full bound×state matrix and invariants B/F/C/D. This is the design decision I'd like your eyes on:

```
resolver.resolve(requestId, decision, callerBoundSessionId, { clientId }) => ResolveResult
  { kind: 'binding_mismatch', boundSessionId }            HTTP 403 / WS error  (map NOT consumed)
  { kind: 'resolved', via: 'sdk'|'legacy', sessionId }    HTTP 200 / WS ack    (map consumed)
  { kind: 'expired', sessionId }                          HTTP 410 / WS permission_expired
  { kind: 'not_found' }                                   HTTP 404 / WS permission_expired
```
The resolver owns the binding check + SDK-before-legacy dispatch + audit; the transport concerns (HTTP body/status, the WS unbound guard G, the per-transport broadcast) stay at the call sites. It guards on a dynamic import so the suite stays green until I implement, then activates.

### What I'd like from you
1. Do the parity scenarios capture the binding behavior you want preserved (esp. B and G)?
2. Is the proposed `resolve()` / `ResolveResult` shape right — particularly leaving the WS unbound guard (G) and the per-transport broadcast/status mapping at the call sites?

Once you're happy, I'll implement `permission-resolver.js`, wire both handlers to delegate, watch the skipped tests activate, and present the final diff for the invariant-B/G eyeball before merge.

Full suite green (the only failures are the pre-existing `service.test.js` #745 + the known ws-server parallel flakes). Related to #5373.
