### PR TITLE
refactor(server): shared sleep-with-abort + backoff helper (#5371)

### DIFF
--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -17,6 +17,7 @@ import { dirname } from 'node:path'
 import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
 import { metrics } from './metrics.js'
+import { sleep, backoffDelay } from './utils/sleep.js'
 import {
   loadPrefs as loadNotificationPrefs,
   savePrefs as saveNotificationPrefs,
@@ -55,9 +56,9 @@ async function fetchWithRetry(url, options) {
 
       // 5xx — retry if attempts remain
       if (attempt < MAX_RETRIES) {
-        const delay = BACKOFF_BASE_MS * Math.pow(2, attempt - 1)
+        const delay = backoffDelay(attempt, BACKOFF_BASE_MS)
         log.warn(`Expo API returned ${res.status}, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`)
-        await new Promise(r => setTimeout(r, delay))
+        await sleep(delay)
         continue
       }
 
@@ -66,9 +67,9 @@ async function fetchWithRetry(url, options) {
       clearTimeout(timer)
 
       if (attempt < MAX_RETRIES) {
-        const delay = BACKOFF_BASE_MS * Math.pow(2, attempt - 1)
+        const delay = backoffDelay(attempt, BACKOFF_BASE_MS)
         log.warn(`Fetch failed (${err.name}: ${err.message}), retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`)
-        await new Promise(r => setTimeout(r, delay))
+        await sleep(delay)
         continue
       }
 

--- a/packages/server/src/tunnel/base.js
+++ b/packages/server/src/tunnel/base.js
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import { createLogger } from '../logger.js'
 import { metrics } from '../metrics.js'
+import { sleep } from '../utils/sleep.js'
 
 const log = createLogger('tunnel')
 
@@ -106,13 +107,7 @@ export class BaseTunnelAdapter extends EventEmitter {
           // loop pattern in _handleUnexpectedExit().
           this._startAbort = new AbortController()
           try {
-            await new Promise((resolve, reject) => {
-              const timer = setTimeout(resolve, backoffMs)
-              this._startAbort.signal.addEventListener('abort', () => {
-                clearTimeout(timer)
-                reject(new Error('start aborted'))
-              }, { once: true })
-            })
+            await sleep(backoffMs, this._startAbort.signal)
           } catch {
             // Aborted by stop() — bail with the last real error so the
             // caller still sees the underlying provider failure.
@@ -231,13 +226,7 @@ export class BaseTunnelAdapter extends EventEmitter {
       // event loop alive for up to 60s during shutdown.
       this._recoveryAbort = new AbortController()
       try {
-        await new Promise((resolve, reject) => {
-          const timer = setTimeout(resolve, backoff)
-          this._recoveryAbort.signal.addEventListener('abort', () => {
-            clearTimeout(timer)
-            reject(new Error('recovery aborted'))
-          }, { once: true })
-        })
+        await sleep(backoff, this._recoveryAbort.signal)
       } catch {
         // Aborted by stop() — exit the loop
         return

--- a/packages/server/src/utils/sleep.js
+++ b/packages/server/src/utils/sleep.js
@@ -1,0 +1,58 @@
+// utils/sleep.js (#5371) — shared cancellable sleep + exponential-backoff calc.
+//
+// Replaces the hand-rolled
+//   new Promise((resolve, reject) => {
+//     const timer = setTimeout(resolve, ms)
+//     signal.addEventListener('abort', () => { clearTimeout(timer); reject() }, { once: true })
+//   })
+// idiom that was copied across tunnel/base.js (start-retry + recovery loops)
+// and push.js. Each copy was a chance to forget the clearTimeout or the
+// listener cleanup — a hung promise / leaked listener.
+//
+// Scope note: supervisor.js's timers are stored-field restart timers and a
+// reject-after-timeout RACE (Promise.race against a push), not this
+// sleep-with-abort idiom, so they are intentionally NOT migrated here.
+
+/**
+ * Resolve after `ms` milliseconds. When an AbortSignal is supplied and fires,
+ * the timer is cleared and the promise REJECTS with an AbortError — callers
+ * (the tunnel start/recovery retry loops) rely on the rejection to bail out of
+ * their wait rather than silently finishing the sleep.
+ *
+ * @param {number} ms delay in milliseconds
+ * @param {AbortSignal} [signal] optional cancellation signal
+ * @returns {Promise<void>}
+ */
+export function sleep(ms, signal) {
+  if (signal?.aborted) return Promise.reject(abortError())
+  return new Promise((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(abortError())
+    }
+    const timer = setTimeout(() => {
+      if (signal) signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    if (signal) signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function abortError() {
+  const err = new Error('The operation was aborted')
+  err.name = 'AbortError'
+  return err
+}
+
+/**
+ * Exponential backoff for a 1-indexed attempt: `base * 2^(attempt-1)`,
+ * optionally capped at `max`.
+ *
+ * @param {number} attempt 1-indexed attempt number
+ * @param {number} base base delay in milliseconds
+ * @param {number} [max] optional ceiling
+ * @returns {number} delay in milliseconds
+ */
+export function backoffDelay(attempt, base, max = Infinity) {
+  return Math.min(base * Math.pow(2, attempt - 1), max)
+}

--- a/packages/server/tests/sleep.test.js
+++ b/packages/server/tests/sleep.test.js
@@ -1,0 +1,79 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { sleep, backoffDelay } from '../src/utils/sleep.js'
+
+// #5371: shared cancellable sleep-with-abort + exponential-backoff helper that
+// replaces the hand-rolled setTimeout/AbortController promise idiom copied
+// across tunnel/base.js and push.js. The tunnel retry/recovery loops depend on
+// the abort path REJECTING (so their catch{} can bail), so that contract is
+// pinned here.
+
+describe('sleep(ms, signal)', () => {
+  beforeEach(() => mock.timers.enable({ apis: ['setTimeout'] }))
+  afterEach(() => mock.timers.reset())
+
+  it('resolves only after the full delay elapses', async () => {
+    let resolved = false
+    const p = sleep(1000).then(() => { resolved = true })
+    mock.timers.tick(999)
+    await Promise.resolve()
+    assert.equal(resolved, false, 'must not resolve before the delay elapses')
+    mock.timers.tick(1)
+    await p
+    assert.equal(resolved, true)
+  })
+
+  it('rejects with an AbortError when the signal fires before the delay', async () => {
+    const ac = new AbortController()
+    const p = sleep(1000, ac.signal)
+    ac.abort()
+    await assert.rejects(p, (err) => err.name === 'AbortError')
+  })
+
+  it('rejects immediately when the signal is already aborted', async () => {
+    const ac = new AbortController()
+    ac.abort()
+    await assert.rejects(sleep(1000, ac.signal), (err) => err.name === 'AbortError')
+  })
+
+  it('clears the timer on abort so it cannot fire later', async () => {
+    const ac = new AbortController()
+    const p = sleep(1000, ac.signal).then(() => 'resolved', () => 'aborted')
+    ac.abort()
+    mock.timers.tick(1000) // would resolve if the timer were still armed
+    assert.equal(await p, 'aborted')
+  })
+
+  it('removes the abort listener once the delay elapses (no leaked listener)', async () => {
+    const ac = new AbortController()
+    const removed = mock.method(ac.signal, 'removeEventListener')
+    const p = sleep(10, ac.signal)
+    mock.timers.tick(10)
+    await p
+    assert.ok(removed.mock.callCount() >= 1, 'abort listener must be removed on resolve')
+  })
+
+  it('works without a signal', async () => {
+    const p = sleep(50)
+    mock.timers.tick(50)
+    await p // resolves, no throw
+  })
+})
+
+describe('backoffDelay(attempt, base, max)', () => {
+  it('is base * 2^(attempt-1) for 1-indexed attempts', () => {
+    assert.equal(backoffDelay(1, 1000), 1000)
+    assert.equal(backoffDelay(2, 1000), 2000)
+    assert.equal(backoffDelay(3, 1000), 4000)
+    assert.equal(backoffDelay(4, 1000), 8000)
+  })
+
+  it('caps at max when the computed delay would exceed it', () => {
+    assert.equal(backoffDelay(10, 1000, 5000), 5000)
+  })
+
+  it('is uncapped when no max is given', () => {
+    assert.equal(backoffDelay(5, 1000), 16000)
+  })
+})

--- a/packages/server/tests/sleep.test.js
+++ b/packages/server/tests/sleep.test.js
@@ -37,12 +37,18 @@ describe('sleep(ms, signal)', () => {
     await assert.rejects(sleep(1000, ac.signal), (err) => err.name === 'AbortError')
   })
 
-  it('clears the timer on abort so it cannot fire later', async () => {
+  it('clears the timer on abort so the timeout callback never runs', async () => {
+    // The promise settles (rejects) on abort regardless of clearTimeout, so a
+    // resolve-vs-reject assertion can't see a missing clearTimeout. Instead pin
+    // it via removeEventListener, which is ONLY called from the timeout's
+    // resolve callback: if the timer fired after abort it would be called once.
     const ac = new AbortController()
+    const removed = mock.method(ac.signal, 'removeEventListener')
     const p = sleep(1000, ac.signal).then(() => 'resolved', () => 'aborted')
     ac.abort()
-    mock.timers.tick(1000) // would resolve if the timer were still armed
+    mock.timers.tick(1000) // would fire the timeout callback if it weren't cleared
     assert.equal(await p, 'aborted')
+    assert.equal(removed.mock.callCount(), 0, 'timeout callback must not run after abort (timer was cleared)')
   })
 
   it('removes the abort listener once the delay elapses (no leaked listener)', async () => {


### PR DESCRIPTION
## Summary

Closes #5371. Extracts the hand-rolled cancellable-sleep idiom into a shared `utils/sleep.js`.

The pattern
```js
new Promise((resolve, reject) => {
  const timer = setTimeout(resolve, ms)
  signal.addEventListener('abort', () => { clearTimeout(timer); reject() }, { once: true })
})
```
was copied in `tunnel/base.js` (start-retry + recovery loops), and a plain timer-sleep plus an inline `BACKOFF_BASE_MS * Math.pow(2, attempt - 1)` backoff calc was duplicated twice in `push.js`. Each copy is a chance to forget the `clearTimeout` or the listener cleanup (hung promise / leaked listener).

## Changes

- **`utils/sleep.js`** (new):
  - `sleep(ms, signal)` — resolves after `ms`; on abort, clears the timer and **rejects with an `AbortError`** (the tunnel loops rely on the rejection to bail out of their wait), removes the listener on the resolve path (no leak), and rejects immediately if the signal is already aborted.
  - `backoffDelay(attempt, base, max?)` — `base * 2^(attempt-1)`, optionally capped.
- **`tunnel/base.js`** — both sites → `await sleep(delay, abort.signal)`.
- **`push.js`** — both retry waits → `backoffDelay(...)` + `await sleep(delay)`.

## Scope note

`supervisor.js` is **intentionally not migrated**: its timers are stored-field restart timers (`this._restartTimer`) and a reject-after-timeout **race** (`Promise.race` against a push), not the sleep-with-abort idiom. The issue's "mirrored in supervisor.js" was approximate; forcing the util there would be a worse fit.

## Tests

- `tests/sleep.test.js` (new, 9): full-delay resolve, abort→AbortError reject, already-aborted immediate reject, timer-cleared-on-abort, listener-removed-on-resolve, no-signal path; `backoffDelay` doubling + cap.
- Existing tunnel + push suites green (135 pass with the new file).