### PR TITLE
fix(server): route SIGHUP through graceful shutdown (#5336)

### DIFF
--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -946,7 +946,7 @@ export async function startCliServer(config) {
   // against an already-empty `_sessions` Map and wrote 0 sessions to disk,
   // erasing the user's restored state across upgrade/quit cycles (#3697).
   // #5368 slice (d): the process lifecycle — the shuttingDown latch, the
-  // graceful shutdown() teardown sequence, and the SIGINT/SIGTERM/
+  // graceful shutdown() teardown sequence, and the SIGINT/SIGTERM/SIGHUP/
   // uncaughtException/unhandledRejection registrations (#5369 onFatal +
   // emergencyCleanupSync) — lives in ServerOrchestrator. `worktreeReapTimer` is
   // passed as a GETTER because it's assigned inside an async import().then() and

--- a/packages/server/src/server-cli/server-orchestrator.js
+++ b/packages/server/src/server-cli/server-orchestrator.js
@@ -2,7 +2,7 @@
 // startCliServer.
 //
 // Owns the process lifecycle: the `shuttingDown` latch, the graceful
-// `shutdown(signal)` teardown sequence, and the SIGINT / SIGTERM /
+// `shutdown(signal)` teardown sequence, and the SIGINT / SIGTERM / SIGHUP /
 // uncaughtException / unhandledRejection registrations (the last two via the
 // #5369 `onFatal` factory that calls `emergencyCleanupSync`). This is the
 // silent-failure-prone surface — a missed teardown step orphans processes / hangs
@@ -132,6 +132,12 @@ export class ServerOrchestrator {
   install() {
     process.on('SIGINT', () => { this.shutdown('SIGINT').catch(() => this._exit(1)) })
     process.on('SIGTERM', () => { this.shutdown('SIGTERM').catch(() => this._exit(1)) })
+    // #5336: a PTY-owning daemon receives SIGHUP when its controlling terminal
+    // closes. Node's default SIGHUP action is to terminate the process, which
+    // skips the shutdown() state flush — so the user's session state is lost on
+    // terminal close. Chroxy has no config-reload semantics, so route SIGHUP
+    // through the same graceful shutdown as SIGINT/SIGTERM.
+    process.on('SIGHUP', () => { this.shutdown('SIGHUP').catch(() => this._exit(1)) })
     process.on('uncaughtException', this._onFatal.bind(this, 'Uncaught exception'))
     process.on('unhandledRejection', this._onFatal.bind(this, 'Unhandled rejection'))
   }

--- a/packages/server/tests/server-orchestrator.test.js
+++ b/packages/server/tests/server-orchestrator.test.js
@@ -173,18 +173,25 @@ describe('ServerOrchestrator — install', () => {
 
   it('routes SIGHUP through the graceful shutdown flush (#5336)', async () => {
     const { orchestrator, seq } = build()
-    const before = process.listeners('SIGHUP')
+    // install() adds ALL FIVE handlers — snapshot every signal so the finally
+    // removes only this test's additions across the board (a leaked
+    // uncaughtException/SIGINT handler would interfere with the rest of the run).
+    const before = Object.fromEntries(signals.map((s) => [s, process.listeners(s)]))
     orchestrator.install()
-    const added = process.listeners('SIGHUP').filter((l) => !before.includes(l))
+    const addedHup = process.listeners('SIGHUP').filter((l) => !before.SIGHUP.includes(l))
     try {
-      assert.equal(added.length, 1, 'exactly one SIGHUP handler added')
-      added[0]() // simulate the signal
+      assert.equal(addedHup.length, 1, 'exactly one SIGHUP handler added')
+      addedHup[0]() // simulate the signal
       await tick()
       // The graceful path ran: state was serialized before exit (not a hard kill).
       assert.ok(seq.some((e) => e[0] === 'serializeState'), 'serializeState ran on SIGHUP')
       assert.deepEqual(seq.at(-1), ['exit', 0], 'exited cleanly after the flush')
     } finally {
-      for (const l of added) process.removeListener('SIGHUP', l)
+      for (const s of signals) {
+        for (const l of process.listeners(s)) {
+          if (!before[s].includes(l)) process.removeListener(s, l)
+        }
+      }
     }
   })
 })

--- a/packages/server/tests/server-orchestrator.test.js
+++ b/packages/server/tests/server-orchestrator.test.js
@@ -145,9 +145,14 @@ describe('ServerOrchestrator — crash handlers (onFatal)', () => {
 })
 
 describe('ServerOrchestrator — install', () => {
-  it('registers the four process handlers', () => {
+  // SIGHUP included (#5336): Node's default SIGHUP action is to terminate the
+  // process, which bypasses the shutdown() state flush — so a daemon whose
+  // controlling terminal closes would lose unsaved session state. install()
+  // must register a SIGHUP handler routed through the same graceful path.
+  const signals = ['SIGINT', 'SIGTERM', 'SIGHUP', 'uncaughtException', 'unhandledRejection']
+
+  it('registers the five process handlers', () => {
     const { orchestrator } = build()
-    const signals = ['SIGINT', 'SIGTERM', 'uncaughtException', 'unhandledRejection']
     // Snapshot the EXACT listeners present before install() so cleanup can
     // remove only the ones this test adds — never the test runner's own SIGINT/
     // SIGTERM handlers (removeAllListeners would clobber those, flaking the run).
@@ -163,6 +168,23 @@ describe('ServerOrchestrator — install', () => {
           if (!before[s].includes(l)) process.removeListener(s, l)
         }
       }
+    }
+  })
+
+  it('routes SIGHUP through the graceful shutdown flush (#5336)', async () => {
+    const { orchestrator, seq } = build()
+    const before = process.listeners('SIGHUP')
+    orchestrator.install()
+    const added = process.listeners('SIGHUP').filter((l) => !before.includes(l))
+    try {
+      assert.equal(added.length, 1, 'exactly one SIGHUP handler added')
+      added[0]() // simulate the signal
+      await tick()
+      // The graceful path ran: state was serialized before exit (not a hard kill).
+      assert.ok(seq.some((e) => e[0] === 'serializeState'), 'serializeState ran on SIGHUP')
+      assert.deepEqual(seq.at(-1), ['exit', 0], 'exited cleanly after the flush')
+    } finally {
+      for (const l of added) process.removeListener('SIGHUP', l)
     }
   })
 })


### PR DESCRIPTION
## Summary

Closes #5336. A PTY-owning daemon receives **SIGHUP** when its controlling terminal closes (non-detached start). Node's default SIGHUP action is to **terminate the process**, which bypasses `ServerOrchestrator.shutdown()` — so `serializeState()` never runs and the user's session state is lost on terminal close.

## Probe (issue asked to confirm first)

`install()` registered SIGINT / SIGTERM / uncaughtException / unhandledRejection but **not** SIGHUP. With no SIGHUP listener, Node's documented default disposition for SIGHUP is process termination — no `shutdown()`, no state flush. Confirmed by inspection of `server-orchestrator.js install()`.

## Fix

Register SIGHUP alongside SIGINT/SIGTERM, routed through the same graceful `shutdown('SIGHUP')`. Chroxy has no config-reload semantics, so treating SIGHUP as graceful-shutdown (rather than the conventional daemon "reload") is the correct, safe choice and strictly better than the default hard-kill.

```js
process.on('SIGHUP', () => { this.shutdown('SIGHUP').catch(() => this._exit(1)) })
```

## Tests

- `registers the five process handlers` — extended to include SIGHUP.
- `routes SIGHUP through the graceful shutdown flush (#5336)` (new) — fires the registered SIGHUP handler and asserts `serializeState` ran before a clean `exit(0)` (i.e. not a hard kill).

Header comments in `server-cli.js` + `server-orchestrator.js` updated to list SIGHUP. 50/50 orchestrator + server-cli tests green; eslint clean.