### PR TITLE
fix(server): atomic permission-mode sidecar write at both writers (#5334)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -956,7 +956,9 @@ export class ClaudeTuiSession extends BaseSession {
     if (permissionsEnabled) {
       const sidecarPath = join(this._sinkDir, 'permission-mode')
       try {
-        writeFileSync(sidecarPath, this.permissionMode || 'approve')
+        // Atomic from the first write too (#5334): a respawn / hot-restart can
+        // rewrite this sidecar while a hook from a still-draining turn reads it.
+        this._writePermissionModeSidecarAtomic(sidecarPath, this.permissionMode || 'approve')
         this._permissionModeFile = sidecarPath
       } catch (err) {
         log.warn(`initial permission-mode sidecar write failed (${err.message}) — falling back to env-var-only mode; mid-session permission switch will not take effect`)
@@ -2973,6 +2975,24 @@ export class ClaudeTuiSession extends BaseSession {
    */
   // #5374: BaseSession.setPermissionMode owns the validation + guard and fires
   // this hook after `this.permissionMode` is set, only when the mode changed.
+  // #5334 (IP-6): atomically write the permission-mode sidecar — write a tmp
+  // file then rename(2) over the target. Direct writeFileSync truncates-then-
+  // writes, so a concurrent PreToolUse hook `cat` could observe an empty/partial
+  // value mid-write and fall through to the stale env var. rename(2) is atomic
+  // within the same filesystem, so readers see either the OLD complete value or
+  // the NEW complete value — never an empty/partial one. Throws on failure
+  // (after best-effort tmp cleanup) so each caller applies its own fallback.
+  _writePermissionModeSidecarAtomic(path, value) {
+    const tmpPath = `${path}.tmp-${randomUUID()}`
+    try {
+      writeFileSync(tmpPath, value)
+      renameSync(tmpPath, path)
+    } catch (err) {
+      try { rmSync(tmpPath, { force: true }) } catch { /* ignore */ }
+      throw err
+    }
+  }
+
   _onPermissionModeChanged(mode) {
     if (!this._permissionModeFile) {
       // Permissions weren't enabled at start (no port). Mode was already
@@ -2980,20 +3000,10 @@ export class ClaudeTuiSession extends BaseSession {
       log.info(`Permission mode changed to ${mode} (no sidecar — hook script not active)`)
       return
     }
-    // Atomic update: write a tmp file then rename. Direct writeFileSync
-    // truncates-then-writes, so a concurrent hook read could observe an
-    // empty/partial value mid-write and fall through to the stale env
-    // var. rename(2) is atomic within the same filesystem, so readers
-    // either see the OLD complete value or the NEW complete value —
-    // never an empty/partial value.
-    const tmpPath = `${this._permissionModeFile}.tmp-${randomUUID()}`
     try {
-      writeFileSync(tmpPath, mode)
-      renameSync(tmpPath, this._permissionModeFile)
+      this._writePermissionModeSidecarAtomic(this._permissionModeFile, mode)
       log.info(`Permission mode changed to ${mode} (sidecar updated, no PTY restart)`)
     } catch (err) {
-      // Best-effort cleanup of the tmp file if rename never landed.
-      try { rmSync(tmpPath, { force: true }) } catch { /* ignore */ }
       // Hook precedence is file → env var. If the rename failed the
       // sidecar still holds the previous mode, so the next tool call
       // reads the stale FILE value (not the env var). Be explicit so

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -7148,3 +7148,82 @@ describe('ClaudeTuiSession', () => {
     })
   })
 })
+
+// #5334 (IP-6): the permission-mode sidecar is the IPC channel the
+// PreToolUse hook `cat`s on every tool call. A plain writeFileSync
+// truncates-then-writes, so a concurrent read can see an empty/partial value
+// and fall through to the stale env var. Both writers (initial start + mid-
+// session change) must go through the atomic tmp+rename helper.
+describe('ClaudeTuiSession — atomic permission-mode sidecar write (#5334)', () => {
+  let dir, skillsDir, fakeHome, origSpawnPty, session
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-sidecar-atomic-'))
+    skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-sidecar-skills-'))
+    fakeHome = mkdtempSync(join(tmpdir(), 'chroxy-sidecar-home-'))
+    writeFileSync(join(fakeHome, '.claude.json'), JSON.stringify({ projects: {} }))
+    process.env._ORIG_HOME = process.env.HOME
+    process.env.HOME = fakeHome
+    // Stub the PTY spawn so start() doesn't launch real node-pty/claude.
+    origSpawnPty = ClaudeTuiSession.prototype._spawnPty
+    ClaudeTuiSession.prototype._spawnPty = async function () {
+      this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {} }
+    }
+  })
+  afterEach(async () => {
+    if (session) { try { await session.destroy() } catch { /* ignore */ } session = null }
+    ClaudeTuiSession.prototype._spawnPty = origSpawnPty
+    if (process.env._ORIG_HOME) { process.env.HOME = process.env._ORIG_HOME; delete process.env._ORIG_HOME }
+    rmSync(dir, { recursive: true, force: true })
+    rmSync(skillsDir, { recursive: true, force: true })
+    rmSync(fakeHome, { recursive: true, force: true })
+  })
+
+  function makeSession() {
+    return new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir, repoSkillsDir: null })
+  }
+
+  it('helper writes the value and leaves no .tmp file behind', () => {
+    session = makeSession()
+    const target = join(dir, 'permission-mode')
+    session._writePermissionModeSidecarAtomic(target, 'plan')
+    assert.equal(readFileSync(target, 'utf8'), 'plan')
+    const leftovers = readdirSync(dir).filter((f) => f.includes('.tmp-'))
+    assert.deepEqual(leftovers, [], 'no temp file should survive a successful write')
+  })
+
+  it('helper replaces an existing value cleanly (no torn intermediate left on disk)', () => {
+    session = makeSession()
+    const target = join(dir, 'permission-mode')
+    writeFileSync(target, 'approve')
+    session._writePermissionModeSidecarAtomic(target, 'acceptEdits')
+    assert.equal(readFileSync(target, 'utf8'), 'acceptEdits')
+    const leftovers = readdirSync(dir).filter((f) => f.includes('.tmp-'))
+    assert.deepEqual(leftovers, [], 'no temp file should survive replacing an existing value')
+  })
+
+  it('helper throws and cleans up the tmp file when the rename target dir is gone', () => {
+    session = makeSession()
+    const target = join(dir, 'missing-subdir', 'permission-mode')
+    assert.throws(() => session._writePermissionModeSidecarAtomic(target, 'plan'))
+    const leftovers = readdirSync(dir).filter((f) => f.includes('.tmp-'))
+    assert.deepEqual(leftovers, [], 'failed write must not orphan a tmp file')
+  })
+
+  it('_onPermissionModeChanged routes through the atomic helper', () => {
+    session = makeSession()
+    session._permissionModeFile = join(dir, 'permission-mode')
+    const spy = mock.method(session, '_writePermissionModeSidecarAtomic')
+    session._onPermissionModeChanged('plan')
+    assert.equal(spy.mock.callCount(), 1, 'update path must use the atomic helper')
+    assert.deepEqual(spy.mock.calls[0].arguments, [session._permissionModeFile, 'plan'])
+  })
+
+  it('the initial sidecar write at start() uses the atomic helper', async () => {
+    session = makeSession()
+    const spy = mock.method(session, '_writePermissionModeSidecarAtomic')
+    await session.start()
+    assert.ok(spy.mock.callCount() >= 1, 'initial sidecar write must use the atomic helper')
+    assert.equal(spy.mock.calls[0].arguments[1], session.permissionMode || 'approve')
+    assert.equal(session._permissionModeFile, join(session._sinkDir, 'permission-mode'))
+  })
+})

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -7201,8 +7201,11 @@ describe('ClaudeTuiSession — atomic permission-mode sidecar write (#5334)', ()
     assert.deepEqual(leftovers, [], 'no temp file should survive replacing an existing value')
   })
 
-  it('helper throws and cleans up the tmp file when the rename target dir is gone', () => {
+  it('helper rethrows and orphans no tmp file when the write fails (target dir missing)', () => {
     session = makeSession()
+    // tmp + target both live under the missing subdir, so writeFileSync throws
+    // ENOENT before renameSync is reached — the catch must still rethrow and
+    // leave nothing behind in the (existing) parent dir.
     const target = join(dir, 'missing-subdir', 'permission-mode')
     assert.throws(() => session._writePermissionModeSidecarAtomic(target, 'plan'))
     const leftovers = readdirSync(dir).filter((f) => f.includes('.tmp-'))


### PR DESCRIPTION
## Summary

Closes #5334 (IP-6). The permission-mode sidecar is the IPC channel the PreToolUse hook `cat`s on every tool call. A plain `writeFileSync` truncates-then-writes, so a concurrent read can observe an empty/partial value and fall through to the stale env var.

## Probe outcome (issue asked to confirm first)

The audit cited `claude-tui-session.js:2311-2337` (the mid-session **update** path). That path — `_onPermissionModeChanged` — has been **atomic (tmp + rename) since #4013**, so the hammered-`set_permission_mode` race the probe describes is **already mitigated** there. Verified by git history.

The remaining non-atomic write is the **initial** sidecar write at `start()`. It's lower-probability (no hook is running during a fresh start) but genuinely reachable: a **respawn / hot-restart** can rewrite the sidecar while a hook from a still-draining turn reads it. Making it atomic too removes the asymmetry and the reasoning burden.

## Changes

- Factor the tmp+rename into `_writePermissionModeSidecarAtomic(path, value)` — cleans up the tmp file and rethrows on failure so each caller keeps its own distinct fallback/log.
- Use it at **both** the initial write and the update path (DRY; atomic everywhere).

## Tests (`claude-tui-session.test.js`, +5)

- helper writes the value / replaces an existing value with **no `.tmp-` leftover**;
- helper **throws and cleans up the tmp file** when the rename target dir is gone (no orphan tmp);
- `_onPermissionModeChanged` routes through the helper;
- the initial `start()` write routes through the helper — **mutation-verified** (reverting it to plain `writeFileSync` fails this test).

280/280 in the TUI suite; 9/9 in the hook-read integration suite; eslint clean (the one pre-existing `no-control-regex` warning is unrelated/untouched).