### PR TITLE
fix(server): preserve pending changes on restore failure + prune orphan checkpoint refs (#5335)

### DIFF
--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -381,9 +381,10 @@ export class CheckpointManager extends EventEmitter {
       const resolvedSha = snapshotSha.trim()
       if (resolvedSha === headCommit.trim()) {
         // Tag points to HEAD — working tree is already at the correct state.
-        // Restore the stash we took so the user's pending changes survive a
-        // no-op rewind.
-        if (stashed) await execFileAsync(GIT, ['stash', 'pop'], { cwd })
+        // Leave the auto-stash parked, exactly like the checkout success path
+        // below: "restore to checkpoint" sets the user's pending changes aside
+        // (recoverable via the stash) rather than re-applying them over the
+        // restored state.
         return
       }
 

--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -422,18 +422,24 @@ export class CheckpointManager extends EventEmitter {
 
   // #5335: the eviction / delete / clear paths only log a warning when
   // `git tag -d` fails, so a transient failure leaks a `chroxy-checkpoint/*`
-  // tag forever. Build the set of refs still referenced by a live checkpoint
-  // for `cwd`, from BOTH the on-disk checkpoint files AND the in-memory map
-  // (a just-created checkpoint is pushed in-memory before it is persisted).
-  // Reading every persisted file is what makes this safe across sessions this
-  // manager hasn't loaded — without it, pruning could delete an unloaded
-  // session's live ref. (Single-daemon model: one process owns the repo.)
-  _liveRefsForCwd(cwd) {
+  // tag forever. Build the set of refs still referenced by ANY live checkpoint,
+  // from BOTH the on-disk checkpoint files AND the in-memory map (a just-created
+  // checkpoint is pushed in-memory before it is persisted; reading every
+  // persisted file covers sessions this manager hasn't loaded).
+  //
+  // NOT filtered by cwd: `chroxy-checkpoint/*` tags are repo-global (shared
+  // across every worktree of a repo). Two sessions in different cwds of the
+  // same repo — chroxy's parallel-agent worktree workflow — share the tag
+  // namespace, so a cwd filter would let a prune in one worktree delete the
+  // other's live tag. Checkpoint ids are randomUUID, so unioning every ref
+  // (across repos too) can never delete a live ref; the only cost is leaving a
+  // foreign-repo orphan for that repo's own prune to sweep.
+  _liveCheckpointRefs() {
     const live = new Set()
     // In-memory (covers the create-before-persist window).
     for (const list of this._checkpoints.values()) {
       for (const cp of list) {
-        if (cp?.gitRef && cp.cwd === cwd) live.add(cp.gitRef)
+        if (cp?.gitRef) live.add(cp.gitRef)
       }
     }
     // On-disk (covers sessions not loaded into this._checkpoints).
@@ -443,7 +449,7 @@ export class CheckpointManager extends EventEmitter {
       try {
         const data = JSON.parse(readFileSync(join(this._checkpointsDir, file), 'utf8'))
         for (const cp of data?.checkpoints || []) {
-          if (cp?.gitRef && cp.cwd === cwd) live.add(cp.gitRef)
+          if (cp?.gitRef) live.add(cp.gitRef)
         }
       } catch { /* skip unreadable / corrupt file */ }
     }
@@ -451,7 +457,7 @@ export class CheckpointManager extends EventEmitter {
   }
 
   /**
-   * Prune `chroxy-checkpoint/*` tags in `cwd` that no live checkpoint
+   * Prune `chroxy-checkpoint/*` tags in `cwd`'s repo that no live checkpoint
    * references. Best-effort: never throws, never deletes a ref still in use.
    * @param {string} cwd
    * @returns {Promise<number>} number of orphaned refs pruned
@@ -467,7 +473,7 @@ export class CheckpointManager extends EventEmitter {
       return 0
     }
     if (tags.length === 0) return 0
-    const live = this._liveRefsForCwd(cwd)
+    const live = this._liveCheckpointRefs()
     let pruned = 0
     for (const tag of tags) {
       if (!live.has(tag)) {

--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
-import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from 'fs'
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { execFile as execFileCb } from 'child_process'
@@ -79,6 +79,12 @@ export class CheckpointManager extends EventEmitter {
     this._checkpoints = new Map() // sessionId -> Checkpoint[]
     this._counters = new Map() // sessionId -> monotonic counter for default names
     this._checkpointsDir = options.checkpointsDir || defaultCheckpointsDir()
+    // #5335: refs whose `git tag -d` failed (cwd -> Set<gitRef>). These are
+    // KNOWN orphans — the checkpoint they backed was already removed — so they
+    // can be retried later without any speculative "is this tag still live?"
+    // guess (which would race in-flight tag creation and, since tags are
+    // repo-global, delete a sibling worktree's live ref).
+    this._failedRefDeletes = new Map()
     this._ensureDir()
   }
 
@@ -108,9 +114,7 @@ export class CheckpointManager extends EventEmitter {
       const evicted = checkpoints.shift()
       if (evicted?.gitRef) {
         evictedCwd = evicted.cwd
-        this._deleteGitRef(evicted.cwd, evicted.gitRef).catch((err) => {
-          log.warn(`Failed to delete evicted git ref ${evicted.gitRef}: ${err.message} (non-critical, orphaned ref)`)
-        })
+        this._deleteGitRefTracked(evicted.cwd, evicted.gitRef)
       }
     }
 
@@ -142,13 +146,13 @@ export class CheckpointManager extends EventEmitter {
     this._checkpoints.set(sessionId, checkpoints)
     this._persist(sessionId)
 
-    // #5335: after an eviction (the moment an orphan can be born if the
-    // best-effort `git tag -d` above failed), sweep any stray refs. Runs after
-    // the new checkpoint is in-memory + persisted, so its ref counts as live.
-    // Fire-and-forget: never blocks or fails checkpoint creation.
+    // #5335: opportunistically retry any refs whose delete previously failed
+    // for this cwd, so transient `git tag -d` failures don't accrue. Race-free
+    // (only known orphans are retried) and fire-and-forget — never blocks or
+    // fails checkpoint creation.
     if (evictedCwd) {
-      this.pruneOrphanedRefs(evictedCwd).catch((err) => {
-        log.warn(`pruneOrphanedRefs failed for ${evictedCwd}: ${err.message}`)
+      this.retryFailedRefDeletes(evictedCwd).catch((err) => {
+        log.warn(`retryFailedRefDeletes failed for ${evictedCwd}: ${err.message}`)
       })
     }
 
@@ -224,9 +228,7 @@ export class CheckpointManager extends EventEmitter {
 
     // Clean up git ref if present
     if (checkpoint.gitRef) {
-      this._deleteGitRef(checkpoint.cwd, checkpoint.gitRef).catch((err) => {
-        log.warn(`Failed to delete git ref ${checkpoint.gitRef}: ${err.message} (non-critical, orphaned ref)`)
-      })
+      this._deleteGitRefTracked(checkpoint.cwd, checkpoint.gitRef)
     }
 
     checkpoints.splice(idx, 1)
@@ -242,9 +244,7 @@ export class CheckpointManager extends EventEmitter {
     const checkpoints = this._getCheckpoints(sessionId)
     for (const cp of checkpoints) {
       if (cp.gitRef) {
-        this._deleteGitRef(cp.cwd, cp.gitRef).catch((err) => {
-          log.warn(`Failed to delete git ref ${cp.gitRef}: ${err.message} (non-critical, orphaned ref)`)
-        })
+        this._deleteGitRefTracked(cp.cwd, cp.gitRef)
       }
     }
     this._checkpoints.delete(sessionId)
@@ -414,75 +414,55 @@ export class CheckpointManager extends EventEmitter {
     }
   }
 
+  // Delete a checkpoint's git tag. Returns true if the tag is gone afterwards
+  // (deleted now, or already absent), false if the delete genuinely failed
+  // (e.g. a transient lock) so the caller can record it for retry.
   async _deleteGitRef(cwd, gitRef) {
     try {
       await execFileAsync(GIT, ['tag', '-d', gitRef], { cwd })
-    } catch { /* tag may already be gone */ }
+      return true
+    } catch (err) {
+      // "tag '...' not found" → already gone; treat as success.
+      if (/not found|No such|unknown tag/i.test(err.message || '')) return true
+      return false
+    }
   }
 
-  // #5335: the eviction / delete / clear paths only log a warning when
-  // `git tag -d` fails, so a transient failure leaks a `chroxy-checkpoint/*`
-  // tag forever. Build the set of refs still referenced by ANY live checkpoint,
-  // from BOTH the on-disk checkpoint files AND the in-memory map (a just-created
-  // checkpoint is pushed in-memory before it is persisted; reading every
-  // persisted file covers sessions this manager hasn't loaded).
-  //
-  // NOT filtered by cwd: `chroxy-checkpoint/*` tags are repo-global (shared
-  // across every worktree of a repo). Two sessions in different cwds of the
-  // same repo — chroxy's parallel-agent worktree workflow — share the tag
-  // namespace, so a cwd filter would let a prune in one worktree delete the
-  // other's live tag. Checkpoint ids are randomUUID, so unioning every ref
-  // (across repos too) can never delete a live ref; the only cost is leaving a
-  // foreign-repo orphan for that repo's own prune to sweep.
-  _liveCheckpointRefs() {
-    const live = new Set()
-    // In-memory (covers the create-before-persist window).
-    for (const list of this._checkpoints.values()) {
-      for (const cp of list) {
-        if (cp?.gitRef) live.add(cp.gitRef)
+  // #5335: best-effort delete of a checkpoint's ref that records the ref for a
+  // later retry if the delete fails, so a transient `git tag -d` failure does
+  // not leak a `chroxy-checkpoint/*` tag forever.
+  _deleteGitRefTracked(cwd, gitRef) {
+    this._deleteGitRef(cwd, gitRef).then((ok) => {
+      if (!ok) {
+        this._recordFailedRefDelete(cwd, gitRef)
+        log.warn(`Failed to delete git ref ${gitRef} (recorded for retry)`)
       }
-    }
-    // On-disk (covers sessions not loaded into this._checkpoints).
-    let files = []
-    try { files = readdirSync(this._checkpointsDir).filter((f) => f.endsWith('.json')) } catch { return live }
-    for (const file of files) {
-      try {
-        const data = JSON.parse(readFileSync(join(this._checkpointsDir, file), 'utf8'))
-        for (const cp of data?.checkpoints || []) {
-          if (cp?.gitRef) live.add(cp.gitRef)
-        }
-      } catch { /* skip unreadable / corrupt file */ }
-    }
-    return live
+    })
+  }
+
+  _recordFailedRefDelete(cwd, gitRef) {
+    if (!this._failedRefDeletes.has(cwd)) this._failedRefDeletes.set(cwd, new Set())
+    this._failedRefDeletes.get(cwd).add(gitRef)
   }
 
   /**
-   * Prune `chroxy-checkpoint/*` tags in `cwd`'s repo that no live checkpoint
-   * references. Best-effort: never throws, never deletes a ref still in use.
+   * Retry deleting refs whose previous delete failed for `cwd`. Race-free: only
+   * KNOWN orphans (a checkpoint we already removed) are retried — never a
+   * speculative classification of a repo-global tag — so this can never delete
+   * an in-flight or sibling-worktree checkpoint's ref.
    * @param {string} cwd
-   * @returns {Promise<number>} number of orphaned refs pruned
+   * @returns {Promise<number>} number of orphaned refs successfully cleared
    */
-  async pruneOrphanedRefs(cwd) {
-    if (!(await this._isGitRepo(cwd))) return 0
-    let tags = []
-    try {
-      const { stdout } = await execFileAsync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd })
-      tags = stdout.split('\n').map((s) => s.trim()).filter(Boolean)
-    } catch (err) {
-      log.warn(`pruneOrphanedRefs: failed to list tags in ${cwd}: ${err.message}`)
-      return 0
+  async retryFailedRefDeletes(cwd) {
+    const set = this._failedRefDeletes.get(cwd)
+    if (!set || set.size === 0) return 0
+    let cleared = 0
+    for (const ref of [...set]) {
+      if (await this._deleteGitRef(cwd, ref)) { set.delete(ref); cleared++ }
     }
-    if (tags.length === 0) return 0
-    const live = this._liveCheckpointRefs()
-    let pruned = 0
-    for (const tag of tags) {
-      if (!live.has(tag)) {
-        await this._deleteGitRef(cwd, tag)
-        pruned++
-      }
-    }
-    if (pruned > 0) log.info(`Pruned ${pruned} orphaned checkpoint ref(s) in ${cwd}`)
-    return pruned
+    if (set.size === 0) this._failedRefDeletes.delete(cwd)
+    if (cleared > 0) log.info(`Cleared ${cleared} previously-orphaned checkpoint ref(s) in ${cwd}`)
+    return cleared
   }
 
   // -- Persistence --

--- a/packages/server/src/checkpoint-manager.js
+++ b/packages/server/src/checkpoint-manager.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
-import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
 import { execFile as execFileCb } from 'child_process'
@@ -103,9 +103,11 @@ export class CheckpointManager extends EventEmitter {
     const checkpoints = this._getCheckpoints(sessionId)
 
     // Enforce max checkpoints — remove oldest if at limit
+    let evictedCwd = null
     if (checkpoints.length >= MAX_CHECKPOINTS_PER_SESSION) {
       const evicted = checkpoints.shift()
       if (evicted?.gitRef) {
+        evictedCwd = evicted.cwd
         this._deleteGitRef(evicted.cwd, evicted.gitRef).catch((err) => {
           log.warn(`Failed to delete evicted git ref ${evicted.gitRef}: ${err.message} (non-critical, orphaned ref)`)
         })
@@ -139,6 +141,16 @@ export class CheckpointManager extends EventEmitter {
     this._counters.set(sessionId, (this._counters.get(sessionId) || 0) + 1)
     this._checkpoints.set(sessionId, checkpoints)
     this._persist(sessionId)
+
+    // #5335: after an eviction (the moment an orphan can be born if the
+    // best-effort `git tag -d` above failed), sweep any stray refs. Runs after
+    // the new checkpoint is in-memory + persisted, so its ref counts as live.
+    // Fire-and-forget: never blocks or fails checkpoint creation.
+    if (evictedCwd) {
+      this.pruneOrphanedRefs(evictedCwd).catch((err) => {
+        log.warn(`pruneOrphanedRefs failed for ${evictedCwd}: ${err.message}`)
+      })
+    }
 
     this.emit('checkpoint_created', checkpoint)
     return checkpoint
@@ -339,6 +351,11 @@ export class CheckpointManager extends EventEmitter {
    *      to overwrite all files in the working tree with the snapshot state.
    */
   async _restoreGitSnapshot(cwd, gitRef) {
+    // #5335: we auto-stash the user's pending changes BEFORE resolving the tag.
+    // If anything after the stash fails (e.g. a corrupt/missing ref), the work
+    // would be silently orphaned in a stash. Track whether we stashed so the
+    // catch can put it back instead of leaving the user wedged.
+    let stashed = false
     try {
       // Stash any pending changes before restoring
       const { stdout: status } = await execFileAsync(
@@ -348,6 +365,7 @@ export class CheckpointManager extends EventEmitter {
 
       if (status.trim()) {
         await execFileAsync(GIT, ['stash', 'push', '-u', '-m', 'chroxy: auto-stash before rewind'], { cwd })
+        stashed = true
       }
 
       // Resolve the tag to the snapshot commit SHA
@@ -362,7 +380,10 @@ export class CheckpointManager extends EventEmitter {
 
       const resolvedSha = snapshotSha.trim()
       if (resolvedSha === headCommit.trim()) {
-        // Tag points to HEAD — working tree is already at the correct state
+        // Tag points to HEAD — working tree is already at the correct state.
+        // Restore the stash we took so the user's pending changes survive a
+        // no-op rewind.
+        if (stashed) await execFileAsync(GIT, ['stash', 'pop'], { cwd })
         return
       }
 
@@ -372,6 +393,22 @@ export class CheckpointManager extends EventEmitter {
       await execFileAsync(GIT, ['checkout', resolvedSha, '--', '.'], { cwd })
     } catch (err) {
       log.warn(`Failed to restore git snapshot: ${err.message}`)
+      // #5335: don't strand the auto-stashed changes. The common failure mode
+      // is a corrupt/missing ref, which throws at rev-parse BEFORE any checkout
+      // ran — so the tree is clean and the stash pops back cleanly.
+      if (stashed) {
+        try {
+          await execFileAsync(GIT, ['stash', 'pop'], { cwd })
+        } catch (popErr) {
+          // Pop failed (rare: a conflicting checkout ran before the failure).
+          // Point the user at the stash so the work isn't lost.
+          throw new Error(
+            `Git restore failed: ${err.message}. Your pending changes were auto-stashed but could not be re-applied (${popErr.message}) — recover them with \`git stash list\` / \`git stash pop\` (message: "chroxy: auto-stash before rewind")`
+          )
+        }
+        // Pop succeeded — the user's working state is intact.
+        throw new Error(`Git restore failed: ${err.message} (your pending changes were preserved)`)
+      }
       throw new Error(`Git restore failed: ${err.message}`)
     }
   }
@@ -380,6 +417,65 @@ export class CheckpointManager extends EventEmitter {
     try {
       await execFileAsync(GIT, ['tag', '-d', gitRef], { cwd })
     } catch { /* tag may already be gone */ }
+  }
+
+  // #5335: the eviction / delete / clear paths only log a warning when
+  // `git tag -d` fails, so a transient failure leaks a `chroxy-checkpoint/*`
+  // tag forever. Build the set of refs still referenced by a live checkpoint
+  // for `cwd`, from BOTH the on-disk checkpoint files AND the in-memory map
+  // (a just-created checkpoint is pushed in-memory before it is persisted).
+  // Reading every persisted file is what makes this safe across sessions this
+  // manager hasn't loaded — without it, pruning could delete an unloaded
+  // session's live ref. (Single-daemon model: one process owns the repo.)
+  _liveRefsForCwd(cwd) {
+    const live = new Set()
+    // In-memory (covers the create-before-persist window).
+    for (const list of this._checkpoints.values()) {
+      for (const cp of list) {
+        if (cp?.gitRef && cp.cwd === cwd) live.add(cp.gitRef)
+      }
+    }
+    // On-disk (covers sessions not loaded into this._checkpoints).
+    let files = []
+    try { files = readdirSync(this._checkpointsDir).filter((f) => f.endsWith('.json')) } catch { return live }
+    for (const file of files) {
+      try {
+        const data = JSON.parse(readFileSync(join(this._checkpointsDir, file), 'utf8'))
+        for (const cp of data?.checkpoints || []) {
+          if (cp?.gitRef && cp.cwd === cwd) live.add(cp.gitRef)
+        }
+      } catch { /* skip unreadable / corrupt file */ }
+    }
+    return live
+  }
+
+  /**
+   * Prune `chroxy-checkpoint/*` tags in `cwd` that no live checkpoint
+   * references. Best-effort: never throws, never deletes a ref still in use.
+   * @param {string} cwd
+   * @returns {Promise<number>} number of orphaned refs pruned
+   */
+  async pruneOrphanedRefs(cwd) {
+    if (!(await this._isGitRepo(cwd))) return 0
+    let tags = []
+    try {
+      const { stdout } = await execFileAsync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd })
+      tags = stdout.split('\n').map((s) => s.trim()).filter(Boolean)
+    } catch (err) {
+      log.warn(`pruneOrphanedRefs: failed to list tags in ${cwd}: ${err.message}`)
+      return 0
+    }
+    if (tags.length === 0) return 0
+    const live = this._liveRefsForCwd(cwd)
+    let pruned = 0
+    for (const tag of tags) {
+      if (!live.has(tag)) {
+        await this._deleteGitRef(cwd, tag)
+        pruned++
+      }
+    }
+    if (pruned > 0) log.info(`Pruned ${pruned} orphaned checkpoint ref(s) in ${cwd}`)
+    return pruned
   }
 
   // -- Persistence --

--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -373,6 +373,28 @@ describe('CheckpointManager', () => {
       assert.ok(tags.includes(cp.gitRef), 'unloaded session ref must survive')
     })
 
+    it('does NOT delete a live tag owned by another worktree of the SAME repo (#5335 cross-worktree)', async () => {
+      // chroxy-checkpoint/* tags are repo-global — visible from every worktree.
+      // A prune fired in worktree B must not treat the main repo's live tag as
+      // an orphan just because that checkpoint's cwd differs.
+      const wt = mkdtempSync(join(tmpdir(), 'chroxy-cp-wt-'))
+      rmSync(wt, { recursive: true, force: true }) // git worktree add needs a non-existent path
+      execFileSync(GIT, ['worktree', 'add', wt, 'HEAD'], { cwd: gitDir })
+      try {
+        const main = await manager.createCheckpoint({ sessionId: 'sess-main', resumeSessionId: 's', cwd: gitDir, name: 'main' })
+        const branch = await manager.createCheckpoint({ sessionId: 'sess-wt', resumeSessionId: 's', cwd: wt, name: 'wt' })
+
+        // Prune from the worktree cwd — must keep BOTH live refs.
+        const pruned = await manager.pruneOrphanedRefs(wt)
+        assert.equal(pruned, 0, 'no live ref may be pruned across worktrees of the same repo')
+        const tags = execFileSync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd: gitDir, encoding: 'utf8' })
+        assert.ok(tags.includes(main.gitRef), "main repo's live checkpoint tag must survive a worktree prune")
+        assert.ok(tags.includes(branch.gitRef), "worktree's own live checkpoint tag must survive")
+      } finally {
+        execFileSync(GIT, ['worktree', 'remove', '--force', wt], { cwd: gitDir })
+      }
+    })
+
     it('returns 0 on a non-git directory', async () => {
       const nonGit = mkdtempSync(join(tmpdir(), 'chroxy-cp-nogit-prune-'))
       try {

--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -323,6 +323,24 @@ describe('CheckpointManager', () => {
       const stashList = execFileSync(GIT, ['stash', 'list'], { cwd: gitDir, encoding: 'utf8' })
       assert.equal(stashList.trim(), '', 'no stash should be left behind')
     })
+
+    it('a successful no-op restore (tag == HEAD) parks pending changes in a stash, leaving the checkpoint state', async () => {
+      // Checkpoint taken on a clean tree → tag points at HEAD → restore is a
+      // no-op. The contract matches the checkout success path: pending changes
+      // are SET ASIDE (recoverable via stash), not re-applied over the restore.
+      const cp = await manager.createCheckpoint({
+        sessionId: 'sess-1', resumeSessionId: 'sdk-1', cwd: gitDir, name: 'cp',
+      })
+      writeFileSync(join(gitDir, 'file.txt'), 'dirty work')
+
+      await manager.restoreCheckpoint('sess-1', cp.id) // resolves, no throw
+
+      assert.equal(readFileSync(join(gitDir, 'file.txt'), 'utf8'), 'initial content',
+        'working tree is left at the checkpoint (HEAD) state, not the dirty content')
+      const stashList = execFileSync(GIT, ['stash', 'list'], { cwd: gitDir, encoding: 'utf8' })
+      assert.match(stashList, /chroxy: auto-stash before rewind/,
+        'the pending changes are parked in a recoverable stash')
+    })
   })
 
   // #5335 (IP-7) — orphaned `chroxy-checkpoint/*` tags accrue when `git tag -d`

--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -296,4 +296,87 @@ describe('CheckpointManager', () => {
     const content = readFileSync(join(gitDir, 'file.txt'), 'utf8')
     assert.equal(content, 'checkpoint content', 'file must be restored to checkpoint state')
   })
+
+  // #5335 (IP-7) — restore-failure must not orphan the user's auto-stashed
+  // pending changes.
+  describe('restore failure preserves pending changes (#5335)', () => {
+    it('a corrupt/missing ref throws but pops the auto-stash back', async () => {
+      const cp = await manager.createCheckpoint({
+        sessionId: 'sess-1', resumeSessionId: 'sdk-1', cwd: gitDir, name: 'cp',
+      })
+      assert.ok(cp.gitRef, 'checkpoint captured a git ref')
+      // Simulate the corrupt-ref case: drop the tag so rev-parse fails.
+      execFileSync(GIT, ['tag', '-d', cp.gitRef], { cwd: gitDir })
+      // The user has uncommitted work in flight at restore time.
+      writeFileSync(join(gitDir, 'file.txt'), 'WORK IN PROGRESS')
+
+      await assert.rejects(
+        () => manager.restoreCheckpoint('sess-1', cp.id),
+        (err) => /Git restore failed/.test(err.message) && /pending changes were preserved/.test(err.message),
+        'restore must fail loudly AND report the changes were preserved'
+      )
+
+      // The crux: the pending work is still in the working tree, not stranded
+      // in a stash.
+      assert.equal(readFileSync(join(gitDir, 'file.txt'), 'utf8'), 'WORK IN PROGRESS',
+        'auto-stashed changes must be popped back when restore fails')
+      const stashList = execFileSync(GIT, ['stash', 'list'], { cwd: gitDir, encoding: 'utf8' })
+      assert.equal(stashList.trim(), '', 'no stash should be left behind')
+    })
+  })
+
+  // #5335 (IP-7) — orphaned `chroxy-checkpoint/*` tags accrue when `git tag -d`
+  // fails; pruneOrphanedRefs sweeps them without deleting live refs.
+  describe('pruneOrphanedRefs (#5335)', () => {
+    it('deletes stray refs and keeps refs a live checkpoint still references', async () => {
+      const a = await manager.createCheckpoint({ sessionId: 'sess-1', resumeSessionId: 's', cwd: gitDir, name: 'a' })
+      const b = await manager.createCheckpoint({ sessionId: 'sess-1', resumeSessionId: 's', cwd: gitDir, name: 'b' })
+      // A stray tag with no backing checkpoint (simulates a failed `git tag -d`).
+      execFileSync(GIT, ['tag', 'chroxy-checkpoint/orphan-xyz', 'HEAD'], { cwd: gitDir })
+
+      const pruned = await manager.pruneOrphanedRefs(gitDir)
+      assert.equal(pruned, 1, 'exactly the one orphan is pruned')
+
+      const tags = execFileSync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd: gitDir, encoding: 'utf8' })
+        .split('\n').map((s) => s.trim()).filter(Boolean)
+      assert.ok(tags.includes(a.gitRef) && tags.includes(b.gitRef), 'live refs must survive')
+      assert.ok(!tags.includes('chroxy-checkpoint/orphan-xyz'), 'orphan ref must be gone')
+    })
+
+    it('does NOT delete a ref owned by a persisted-but-unloaded session', async () => {
+      // sess-A's checkpoint is persisted to disk.
+      const cp = await manager.createCheckpoint({ sessionId: 'sess-A', resumeSessionId: 's', cwd: gitDir, name: 'a' })
+      // A fresh manager has NOTHING in memory but shares the checkpoints dir.
+      const fresh = new CheckpointManager({ checkpointsDir: tmpCheckpointsDir })
+
+      const pruned = await fresh.pruneOrphanedRefs(gitDir)
+      assert.equal(pruned, 0, 'must read persisted files and treat the unloaded ref as live')
+      const tags = execFileSync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd: gitDir, encoding: 'utf8' })
+      assert.ok(tags.includes(cp.gitRef), 'unloaded session ref must survive')
+    })
+
+    it('returns 0 on a non-git directory', async () => {
+      const nonGit = mkdtempSync(join(tmpdir(), 'chroxy-cp-nogit-prune-'))
+      try {
+        assert.equal(await manager.pruneOrphanedRefs(nonGit), 0)
+      } finally {
+        rmSync(nonGit, { recursive: true, force: true })
+      }
+    })
+
+    it('createCheckpoint sweeps orphans after an eviction', async () => {
+      // Seed the session at the eviction threshold with cheap fakes so we don't
+      // create 50 real snapshots. The oldest fake (with a gitRef) is evicted.
+      const fakes = Array.from({ length: 50 }, (_, i) => ({
+        id: `fake-${i}`, sessionId: 'sess-1', cwd: gitDir,
+        gitRef: `chroxy-checkpoint/fake-${i}`, createdAt: i,
+      }))
+      manager._checkpoints.set('sess-1', fakes)
+      let prunedCwd = null
+      manager.pruneOrphanedRefs = async (cwd) => { prunedCwd = cwd; return 0 }
+
+      await manager.createCheckpoint({ sessionId: 'sess-1', resumeSessionId: 's', cwd: gitDir, name: 'new' })
+      assert.equal(prunedCwd, gitDir, 'eviction must trigger a prune sweep for the evicted cwd')
+    })
+  })
 })

--- a/packages/server/tests/checkpoint-manager.test.js
+++ b/packages/server/tests/checkpoint-manager.test.js
@@ -344,79 +344,74 @@ describe('CheckpointManager', () => {
   })
 
   // #5335 (IP-7) — orphaned `chroxy-checkpoint/*` tags accrue when `git tag -d`
-  // fails; pruneOrphanedRefs sweeps them without deleting live refs.
-  describe('pruneOrphanedRefs (#5335)', () => {
-    it('deletes stray refs and keeps refs a live checkpoint still references', async () => {
-      const a = await manager.createCheckpoint({ sessionId: 'sess-1', resumeSessionId: 's', cwd: gitDir, name: 'a' })
-      const b = await manager.createCheckpoint({ sessionId: 'sess-1', resumeSessionId: 's', cwd: gitDir, name: 'b' })
-      // A stray tag with no backing checkpoint (simulates a failed `git tag -d`).
-      execFileSync(GIT, ['tag', 'chroxy-checkpoint/orphan-xyz', 'HEAD'], { cwd: gitDir })
-
-      const pruned = await manager.pruneOrphanedRefs(gitDir)
-      assert.equal(pruned, 1, 'exactly the one orphan is pruned')
-
-      const tags = execFileSync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd: gitDir, encoding: 'utf8' })
-        .split('\n').map((s) => s.trim()).filter(Boolean)
-      assert.ok(tags.includes(a.gitRef) && tags.includes(b.gitRef), 'live refs must survive')
-      assert.ok(!tags.includes('chroxy-checkpoint/orphan-xyz'), 'orphan ref must be gone')
-    })
-
-    it('does NOT delete a ref owned by a persisted-but-unloaded session', async () => {
-      // sess-A's checkpoint is persisted to disk.
-      const cp = await manager.createCheckpoint({ sessionId: 'sess-A', resumeSessionId: 's', cwd: gitDir, name: 'a' })
-      // A fresh manager has NOTHING in memory but shares the checkpoints dir.
-      const fresh = new CheckpointManager({ checkpointsDir: tmpCheckpointsDir })
-
-      const pruned = await fresh.pruneOrphanedRefs(gitDir)
-      assert.equal(pruned, 0, 'must read persisted files and treat the unloaded ref as live')
-      const tags = execFileSync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd: gitDir, encoding: 'utf8' })
-      assert.ok(tags.includes(cp.gitRef), 'unloaded session ref must survive')
-    })
-
-    it('does NOT delete a live tag owned by another worktree of the SAME repo (#5335 cross-worktree)', async () => {
-      // chroxy-checkpoint/* tags are repo-global — visible from every worktree.
-      // A prune fired in worktree B must not treat the main repo's live tag as
-      // an orphan just because that checkpoint's cwd differs.
-      const wt = mkdtempSync(join(tmpdir(), 'chroxy-cp-wt-'))
-      rmSync(wt, { recursive: true, force: true }) // git worktree add needs a non-existent path
-      execFileSync(GIT, ['worktree', 'add', wt, 'HEAD'], { cwd: gitDir })
-      try {
-        const main = await manager.createCheckpoint({ sessionId: 'sess-main', resumeSessionId: 's', cwd: gitDir, name: 'main' })
-        const branch = await manager.createCheckpoint({ sessionId: 'sess-wt', resumeSessionId: 's', cwd: wt, name: 'wt' })
-
-        // Prune from the worktree cwd — must keep BOTH live refs.
-        const pruned = await manager.pruneOrphanedRefs(wt)
-        assert.equal(pruned, 0, 'no live ref may be pruned across worktrees of the same repo')
-        const tags = execFileSync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd: gitDir, encoding: 'utf8' })
-        assert.ok(tags.includes(main.gitRef), "main repo's live checkpoint tag must survive a worktree prune")
-        assert.ok(tags.includes(branch.gitRef), "worktree's own live checkpoint tag must survive")
-      } finally {
-        execFileSync(GIT, ['worktree', 'remove', '--force', wt], { cwd: gitDir })
+  // fails. Rather than speculatively prune (which races in-flight tag creation
+  // and, since tags are repo-global, could delete a sibling worktree's live
+  // ref), we record the KNOWN-orphaned ref and retry deleting it later.
+  describe('orphan ref retry (#5335)', () => {
+    it('a tag-delete that fails is recorded and cleared on a later retry', async () => {
+      const cp = await manager.createCheckpoint({ sessionId: 'sess-1', resumeSessionId: 's', cwd: gitDir, name: 'a' })
+      // Force the first delete to fail; record it, leave the tag in place.
+      const realDelete = manager._deleteGitRef.bind(manager)
+      let failOnce = true
+      manager._deleteGitRef = async (cwd, ref) => {
+        if (failOnce && ref === cp.gitRef) { failOnce = false; return false }
+        return realDelete(cwd, ref)
       }
+      manager.deleteCheckpoint('sess-1', cp.id)
+      await new Promise((r) => setImmediate(r)) // let the fire-and-forget delete settle
+
+      // The checkpoint is gone from the manager but its tag leaked + was recorded.
+      let tags = execFileSync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd: gitDir, encoding: 'utf8' })
+      assert.ok(tags.includes(cp.gitRef), 'tag survives the failed delete')
+      assert.ok(manager._failedRefDeletes.get(gitDir)?.has(cp.gitRef), 'failed delete is recorded for retry')
+
+      // Retry now succeeds (the forced failure was one-shot).
+      const cleared = await manager.retryFailedRefDeletes(gitDir)
+      assert.equal(cleared, 1, 'the recorded orphan is cleared on retry')
+      tags = execFileSync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd: gitDir, encoding: 'utf8' })
+      assert.ok(!tags.includes(cp.gitRef), 'orphan tag is gone after retry')
+      assert.ok(!manager._failedRefDeletes.has(gitDir), 'cleared cwd is dropped from the map')
     })
 
-    it('returns 0 on a non-git directory', async () => {
-      const nonGit = mkdtempSync(join(tmpdir(), 'chroxy-cp-nogit-prune-'))
-      try {
-        assert.equal(await manager.pruneOrphanedRefs(nonGit), 0)
-      } finally {
-        rmSync(nonGit, { recursive: true, force: true })
-      }
+    it('retry only ever touches KNOWN orphans — never a live or sibling-worktree ref', async () => {
+      // A live checkpoint exists; the retry set is empty → retry must be a no-op
+      // and must not list/inspect repo-global tags at all.
+      const cp = await manager.createCheckpoint({ sessionId: 'sess-1', resumeSessionId: 's', cwd: gitDir, name: 'a' })
+      assert.equal(await manager.retryFailedRefDeletes(gitDir), 0, 'no recorded orphans → no-op')
+      const tags = execFileSync(GIT, ['tag', '-l', 'chroxy-checkpoint/*'], { cwd: gitDir, encoding: 'utf8' })
+      assert.ok(tags.includes(cp.gitRef), 'a live ref is never touched by retry')
     })
 
-    it('createCheckpoint sweeps orphans after an eviction', async () => {
-      // Seed the session at the eviction threshold with cheap fakes so we don't
-      // create 50 real snapshots. The oldest fake (with a gitRef) is evicted.
+    it('retryFailedRefDeletes counts only successful deletions', async () => {
+      // Record two orphans; make one delete keep failing.
+      manager._recordFailedRefDelete(gitDir, 'chroxy-checkpoint/gone-1')
+      manager._recordFailedRefDelete(gitDir, 'chroxy-checkpoint/stuck-2')
+      execFileSync(GIT, ['tag', 'chroxy-checkpoint/gone-1', 'HEAD'], { cwd: gitDir })
+      manager._deleteGitRef = async (_cwd, ref) =>
+        ref === 'chroxy-checkpoint/stuck-2' ? false : true
+
+      const cleared = await manager.retryFailedRefDeletes(gitDir)
+      assert.equal(cleared, 1, 'only the successful delete is counted')
+      assert.ok(manager._failedRefDeletes.get(gitDir)?.has('chroxy-checkpoint/stuck-2'),
+        'the still-failing ref stays recorded for a future retry')
+    })
+
+    it('createCheckpoint retries recorded orphans after an eviction', async () => {
       const fakes = Array.from({ length: 50 }, (_, i) => ({
         id: `fake-${i}`, sessionId: 'sess-1', cwd: gitDir,
         gitRef: `chroxy-checkpoint/fake-${i}`, createdAt: i,
       }))
       manager._checkpoints.set('sess-1', fakes)
-      let prunedCwd = null
-      manager.pruneOrphanedRefs = async (cwd) => { prunedCwd = cwd; return 0 }
+      let retriedCwd = null
+      manager.retryFailedRefDeletes = async (cwd) => { retriedCwd = cwd; return 0 }
 
       await manager.createCheckpoint({ sessionId: 'sess-1', resumeSessionId: 's', cwd: gitDir, name: 'new' })
-      assert.equal(prunedCwd, gitDir, 'eviction must trigger a prune sweep for the evicted cwd')
+      assert.equal(retriedCwd, gitDir, 'eviction must trigger an orphan-retry for the evicted cwd')
+    })
+
+    it('_deleteGitRef reports already-absent tags as success', async () => {
+      assert.equal(await manager._deleteGitRef(gitDir, 'chroxy-checkpoint/never-existed'), true,
+        'a missing tag is "gone afterwards" → success, not a recorded failure')
     })
   })
 })


### PR DESCRIPTION
## Summary

Closes #5335 (IP-7). The probe confirmed **two distinct** gaps on the checkpoint path.

### 1. Restore-failure data loss

`_restoreGitSnapshot` auto-stashes the user's pending changes **before** resolving the snapshot tag, so a corrupt/missing ref throws *after* the stash — silently orphaning the work in a stash.

**Fix:** on failure after stashing, pop the stash back (the corrupt-ref case fails before any checkout, so the tree is clean and pops cleanly) → `Git restore failed: … (your pending changes were preserved)`; if the pop itself fails, the error names the stash so the work is recoverable. The success / no-op (`tag == HEAD`) paths keep the existing contract: pending changes are **parked** in a stash (recoverable), matching the checkout path.

### 2. Orphan-ref accrual — race-free retry of known orphans

The eviction / delete / clear paths only logged a warning when `git tag -d` failed, leaking a `chroxy-checkpoint/*` tag.

A speculative "list all tags, delete those not in the live set" prune was considered and **rejected**: `chroxy-checkpoint/*` tags are **repo-global** (shared across every worktree of a repo), so classifying by a live set (a) deletes a sibling worktree's live ref and (b) races a concurrent `createCheckpoint` whose tag exists before it's pushed into the live set — both data-losing. (Both were caught in review.)

**Fix:** only delete a ref we **know** is orphaned — its checkpoint was just removed. `_deleteGitRef` returns success/failure; `_deleteGitRefTracked` records a failed delete into `_failedRefDeletes` (cwd → Set); `retryFailedRefDeletes(cwd)` retries exactly those and counts only successful deletions. Wired fire-and-forget after an eviction. No tag listing, no live-set guess → no cross-worktree or in-flight hazard by construction.

## Tests (`checkpoint-manager.test.js`)

- corrupt-ref restore throws **and pops the auto-stash back** (mutation-verified); no-op restore parks pending changes;
- a failed delete is **recorded then cleared on retry**; retry is a no-op with nothing recorded (never touches a live ref); count excludes still-failing refs; eviction triggers a retry; already-absent tag counts as success.

21/21 in the suite; eslint clean.