### PR TITLE
fix(server): fail closed when the permission hook can't reach the user (#5330)

### DIFF
--- a/packages/server/hooks/permission-hook.sh
+++ b/packages/server/hooks/permission-hook.sh
@@ -157,6 +157,31 @@ EOF
   fi
 fi
 
+# #5330: fallback decision when chroxy cannot obtain an explicit user decision
+# (the daemon is unreachable, or the response is unparseable). The OLD behavior
+# emitted permissionDecision:"ask", which makes claude prompt at the PTY — but
+# in chroxy's model the user is on their phone, not at the keyboard, so "ask"
+# wedges the session on a dialog no one can answer. Default to "deny" (fail
+# closed): the tool is blocked with a reason claude can report/recover from,
+# instead of an indefinite hang. Set CHROXY_HOOK_UNREACHABLE_DECISION=ask to
+# restore the old behavior for a local-at-the-PTY setup.
+FALLBACK_DECISION="${CHROXY_HOOK_UNREACHABLE_DECISION:-deny}"
+case "$FALLBACK_DECISION" in
+  ask|deny) ;;
+  *) FALLBACK_DECISION="deny" ;;
+esac
+
+# Emit the fail-closed fallback ($1 = static reason string, no quotes/backslashes
+# so it stays valid JSON) and exit.
+emit_unreachable_fallback() {
+  if [ "$FALLBACK_DECISION" = "ask" ]; then
+    printf '%s\n' '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask"}}'
+  else
+    printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$1"
+  fi
+  exit 0
+}
+
 # ---- Shared: route a permission request to the phone via HTTP ----
 # Expects $REQUEST to contain the JSON body to POST.
 # Outputs the appropriate hookSpecificOutput JSON and exits.
@@ -170,10 +195,8 @@ route_to_phone() {
   EXIT_CODE=$?
 
   if [ $EXIT_CODE -ne 0 ]; then
-    cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask"}}
-EOF
-    exit 0
+    # Daemon unreachable / curl timeout — the request never reached the phone.
+    emit_unreachable_fallback "Chroxy could not reach the daemon to request your approval; the request never reached your phone. Failing closed (denied). Retry once Chroxy is reachable."
   fi
 
   DECISION=$(echo "$RESPONSE" | grep -o '"decision":"[^"]*"' | head -1 | cut -d'"' -f4)
@@ -190,9 +213,9 @@ EOF
 EOF
       ;;
     *)
-      cat <<'EOF'
-{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"ask"}}
-EOF
+      # Reached the daemon but got no recognizable decision — also unanswerable
+      # at the PTY, so fail closed rather than wedge on "ask".
+      emit_unreachable_fallback "Chroxy received an unrecognized permission response from the daemon. Failing closed (denied)."
       ;;
   esac
   exit 0

--- a/packages/server/tests/permission-hook-failclosed.test.js
+++ b/packages/server/tests/permission-hook-failclosed.test.js
@@ -28,7 +28,16 @@ function runHook({ input, env, timeout = 10000 } = {}) {
     child.stdout.on('data', (c) => { stdout += c.toString() })
     child.stderr.on('data', (c) => { stderr += c.toString() })
     child.on('error', (err) => settle(reject, err))
-    child.on('close', () => settle(resolve, { stdout, stderr }))
+    child.on('close', (status, signal) => {
+      // The hook must always exit 0 (it emits a hookSpecificOutput decision and
+      // returns). A non-zero exit or a timeout-kill is a real failure even if
+      // some JSON was printed — reject so it can't masquerade as a pass.
+      if (signal || status !== 0) {
+        settle(reject, new Error(`hook exited uncleanly (status=${status}, signal=${signal})\nstderr: ${stderr}`))
+        return
+      }
+      settle(resolve, { status, stdout, stderr })
+    })
     if (timeout) timer = setTimeout(() => child.kill('SIGKILL'), timeout)
     if (input != null) child.stdin.write(input)
     child.stdin.end()

--- a/packages/server/tests/permission-hook-failclosed.test.js
+++ b/packages/server/tests/permission-hook-failclosed.test.js
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:http'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const hookPath = join(__dirname, '../hooks/permission-hook.sh')
+
+/**
+ * #5330: when the permission hook cannot obtain an explicit user decision —
+ * the daemon is unreachable (curl fails) or the response is unparseable — the
+ * old behavior emitted permissionDecision:"ask". In chroxy's remote model the
+ * user is on their phone, not at the PTY, so "ask" wedges the session on an
+ * unanswerable native dialog. The hook must fail CLOSED ("deny") by default,
+ * with CHROXY_HOOK_UNREACHABLE_DECISION=ask as an opt-out for local-PTY setups.
+ */
+
+function runHook({ input, env, timeout = 10000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('/bin/bash', [hookPath], { env })
+    let stdout = ''
+    let stderr = ''
+    let settled = false
+    let timer = null
+    const settle = (fn, arg) => { if (settled) return; settled = true; if (timer) clearTimeout(timer); fn(arg) }
+    child.stdout.on('data', (c) => { stdout += c.toString() })
+    child.stderr.on('data', (c) => { stderr += c.toString() })
+    child.on('error', (err) => settle(reject, err))
+    child.on('close', () => settle(resolve, { stdout, stderr }))
+    if (timeout) timer = setTimeout(() => child.kill('SIGKILL'), timeout)
+    if (input != null) child.stdin.write(input)
+    child.stdin.end()
+  })
+}
+
+// A port nothing listens on → curl gets connection-refused immediately (no
+// --max-time wait). Open on :0 to claim a real free port, then close it.
+async function getClosedPort() {
+  const srv = createServer()
+  await new Promise((r) => srv.listen(0, r))
+  const port = srv.address().port
+  await new Promise((r) => srv.close(r))
+  return port
+}
+
+// Mock /permission server that replies 200 with an arbitrary body (no
+// recognizable "decision" field) to exercise the unparseable-response path.
+async function startNoDecisionServer() {
+  const server = createServer((req, res) => {
+    let body = ''
+    req.on('data', (c) => { body += c })
+    req.on('end', () => { res.writeHead(200, { 'Content-Type': 'application/json' }); res.end('{"status":"ok"}') })
+  })
+  await new Promise((r) => server.listen(0, r))
+  return { port: server.address().port, close: () => new Promise((r) => server.close(r)) }
+}
+
+const REQUEST = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })
+
+function parse(stdout) { return JSON.parse(stdout.trim()).hookSpecificOutput }
+
+describe('permission-hook fail-closed fallback (#5330)', () => {
+  it('curl failure (daemon unreachable) DENIES by default — never wedges on "ask"', async () => {
+    const port = await getClosedPort()
+    const { stdout } = await runHook({
+      input: REQUEST,
+      env: { ...process.env, CHROXY_PORT: String(port), CHROXY_HOOK_SECRET: 's', CHROXY_PERMISSION_MODE: 'approve' },
+    })
+    const out = parse(stdout)
+    assert.equal(out.permissionDecision, 'deny', 'unreachable daemon must fail closed, not ask')
+    assert.match(out.permissionDecisionReason, /could not reach|failing closed/i)
+  })
+
+  it('CHROXY_HOOK_UNREACHABLE_DECISION=ask restores the old "ask" fallback', async () => {
+    const port = await getClosedPort()
+    const { stdout } = await runHook({
+      input: REQUEST,
+      env: {
+        ...process.env, CHROXY_PORT: String(port), CHROXY_HOOK_SECRET: 's',
+        CHROXY_PERMISSION_MODE: 'approve', CHROXY_HOOK_UNREACHABLE_DECISION: 'ask',
+      },
+    })
+    assert.equal(parse(stdout).permissionDecision, 'ask', 'opt-out env var must restore ask for local-PTY')
+  })
+
+  it('an unparseable daemon response also fails closed (deny)', async () => {
+    const srv = await startNoDecisionServer()
+    try {
+      const { stdout } = await runHook({
+        input: REQUEST,
+        env: { ...process.env, CHROXY_PORT: String(srv.port), CHROXY_HOOK_SECRET: 's', CHROXY_PERMISSION_MODE: 'approve' },
+      })
+      const out = parse(stdout)
+      assert.equal(out.permissionDecision, 'deny', 'unrecognized response must fail closed')
+      assert.match(out.permissionDecisionReason, /unrecognized|failing closed/i)
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('an invalid CHROXY_HOOK_UNREACHABLE_DECISION value falls back to deny (fail closed)', async () => {
+    const port = await getClosedPort()
+    const { stdout } = await runHook({
+      input: REQUEST,
+      env: {
+        ...process.env, CHROXY_PORT: String(port), CHROXY_HOOK_SECRET: 's',
+        CHROXY_PERMISSION_MODE: 'approve', CHROXY_HOOK_UNREACHABLE_DECISION: 'allow-everything',
+      },
+    })
+    assert.equal(parse(stdout).permissionDecision, 'deny', 'a bogus value must not weaken the safe default')
+  })
+})

--- a/packages/server/tests/permission-hook-multi-question.test.js
+++ b/packages/server/tests/permission-hook-multi-question.test.js
@@ -106,37 +106,45 @@ describe('permission-hook.sh — multi-question AskUserQuestion deny (#4648)', (
       'Bash in auto mode still allows — multi-q check is AskUserQuestion-only')
   })
 
-  it('does NOT deny on malformed payload (no tool_input) — falls through safely', async () => {
-    // python3 parse failure → empty QUESTION_COUNT → no deny → normal handling
-    // resumes (which in approve mode tries to route to phone and falls back to
-    // "ask" since no real server is reachable on the test port). This is the
-    // safe default: a broken hook payload must NOT cause us to deny every
-    // tool call across the board.
+  // These three assert the #4648 multi-question GUARD does not fire on
+  // odd-shaped payloads. They route to phone afterward; on the unreachable test
+  // port that now fails CLOSED with a #5330 transport deny (was "ask"), so we
+  // assert specifically that the guard's deny (reason "one question at a time")
+  // did NOT fire — not merely that the decision isn't "deny".
+  const firedMultiQuestionGuard = (decision) => {
+    const d = decision.hookSpecificOutput
+    return d.permissionDecision === 'deny' && /one question at a time/i.test(d.permissionDecisionReason || '')
+  }
+
+  it('does NOT trip the multi-question guard on malformed payload (no tool_input)', async () => {
+    // python3 parse failure → empty QUESTION_COUNT → guard doesn't fire →
+    // normal handling resumes. A broken hook payload must NOT cause the
+    // multi-question guard to deny every tool call across the board.
     const { stdout } = await runHook(JSON.stringify({ tool_name: 'AskUserQuestion' }))
     const decision = JSON.parse(stdout.trim())
-    assert.notEqual(decision.hookSpecificOutput.permissionDecision, 'deny',
-      'malformed payload must not deny — fall through to normal handling')
+    assert.equal(firedMultiQuestionGuard(decision), false,
+      'malformed payload must not trip the multi-question guard')
   })
 
-  it('does NOT deny on empty questions array — only count > 1 triggers deny', async () => {
+  it('does NOT trip the multi-question guard on empty questions array', async () => {
     const { stdout } = await runHook(
       JSON.stringify({ tool_name: 'AskUserQuestion', tool_input: { questions: [] } }),
     )
     const decision = JSON.parse(stdout.trim())
-    assert.notEqual(decision.hookSpecificOutput.permissionDecision, 'deny',
-      'empty questions array must not deny — > 1 is the gate, not >= 1')
+    assert.equal(firedMultiQuestionGuard(decision), false,
+      'empty questions array must not trip the guard — > 1 is the gate, not >= 1')
   })
 
-  it('does NOT deny on non-array questions value (defensive against shape drift)', async () => {
+  it('does NOT trip the multi-question guard on non-array questions value (shape drift)', async () => {
     // If Anthropic ever ships a payload where `questions` is an object map or
-    // a string, the python3 check returns 0 (not isinstance(list)), so we
-    // don't deny. Better to attempt the wedge (v0.9.23 watchdog catches it)
-    // than to deny something that wasn't actually multi-question.
+    // a string, the python3 check returns 0 (not isinstance(list)), so the
+    // guard doesn't fire. Better to attempt the wedge (v0.9.23 watchdog
+    // catches it) than to deny something that wasn't actually multi-question.
     const { stdout } = await runHook(
       JSON.stringify({ tool_name: 'AskUserQuestion', tool_input: { questions: 'not-a-list' } }),
     )
     const decision = JSON.parse(stdout.trim())
-    assert.notEqual(decision.hookSpecificOutput.permissionDecision, 'deny',
-      'non-array questions value must not deny — defensive against shape drift')
+    assert.equal(firedMultiQuestionGuard(decision), false,
+      'non-array questions value must not trip the guard — defensive against shape drift')
   })
 })

--- a/packages/server/tests/permission-hook-sanitization.test.js
+++ b/packages/server/tests/permission-hook-sanitization.test.js
@@ -323,8 +323,9 @@ describe('Permission hook approve-mode curl passthrough (#2717)', () => {
     }
   })
 
-  it('falls back to ask when curl fails (server unreachable)', () => {
-    // No mock server — curl will fail. Hook must default to "ask".
+  it('fails closed (deny) when curl fails (server unreachable) — #5330', () => {
+    // No mock server — curl will fail. The user is on their phone, not at the
+    // PTY, so "ask" would wedge an unanswerable dialog; the hook must deny.
     const payload = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })
     const { stdout, status } = spawnSync('/bin/bash', [hookPath], {
       input: payload,
@@ -339,7 +340,25 @@ describe('Permission hook approve-mode curl passthrough (#2717)', () => {
     })
     assert.equal(status, 0)
     const out = JSON.parse(stdout)
-    assert.equal(out.hookSpecificOutput.permissionDecision, 'ask')
+    assert.equal(out.hookSpecificOutput.permissionDecision, 'deny')
+  })
+
+  it('CHROXY_HOOK_UNREACHABLE_DECISION=ask restores the legacy ask fallback — #5330', () => {
+    const payload = JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls' } })
+    const { stdout, status } = spawnSync('/bin/bash', [hookPath], {
+      input: payload,
+      encoding: 'utf-8',
+      timeout: 10000,
+      env: {
+        ...process.env,
+        CHROXY_PORT: '1',
+        CHROXY_HOOK_SECRET: 'secret',
+        CHROXY_PERMISSION_MODE: 'approve',
+        CHROXY_HOOK_UNREACHABLE_DECISION: 'ask',
+      },
+    })
+    assert.equal(status, 0)
+    assert.equal(JSON.parse(stdout).hookSpecificOutput.permissionDecision, 'ask')
   })
 })
 

--- a/packages/server/tests/permission-hook-sanitization.test.js
+++ b/packages/server/tests/permission-hook-sanitization.test.js
@@ -333,7 +333,7 @@ describe('Permission hook approve-mode curl passthrough (#2717)', () => {
       timeout: 10000,
       env: {
         ...process.env,
-        CHROXY_PORT: '1', // port 1 should be unreachable
+        CHROXY_PORT: '0', // port 0 is never connectable → curl fails deterministically
         CHROXY_HOOK_SECRET: 'secret',
         CHROXY_PERMISSION_MODE: 'approve',
       },
@@ -351,7 +351,7 @@ describe('Permission hook approve-mode curl passthrough (#2717)', () => {
       timeout: 10000,
       env: {
         ...process.env,
-        CHROXY_PORT: '1',
+        CHROXY_PORT: '0',
         CHROXY_HOOK_SECRET: 'secret',
         CHROXY_PERMISSION_MODE: 'approve',
         CHROXY_HOOK_UNREACHABLE_DECISION: 'ask',


### PR DESCRIPTION
## Summary

Closes #5330 (IP-2). `route_to_phone` in `permission-hook.sh` fell back to `permissionDecision:"ask"` when `curl` failed (daemon unreachable / `--max-time` timeout) or the response was unparseable. In chroxy's model the user is on their **phone, not at the PTY** — so `"ask"` makes claude raise a native permission dialog **no one can answer**, and the session wedges indefinitely.

## Probe outcome

Confirmed by reading `route_to_phone`: the `EXIT_CODE -ne 0` branch and the `*)` (unrecognized-decision) branch both emit `"ask"`. Both are unanswerable in the unattended/remote model.

## Fix

**Fail closed** — emit `"deny"` with a reason claude can report or recover from, instead of an indefinite hang. Both branches route through a shared `emit_unreachable_fallback` helper.

Escape hatch: `CHROXY_HOOK_UNREACHABLE_DECISION=ask` restores the legacy behavior for a local-at-the-PTY setup; any other value is sanitized back to the safe `deny` default.

```sh
FALLBACK_DECISION="${CHROXY_HOOK_UNREACHABLE_DECISION:-deny}"
case "$FALLBACK_DECISION" in ask|deny) ;; *) FALLBACK_DECISION="deny" ;; esac
```

## Tests

- **New** (`permission-hook-failclosed`): curl-failure denies by default; the env opt-out restores `ask`; an unparseable response denies; a bogus opt-out value stays `deny`. (mutation-verified the deny default.)
- **Updated** the two existing tests that pinned the old `ask` fallback: the sanitization curl-fail test now expects `deny` (+ an opt-out case); the three multi-question shape-drift tests assert the **#4648 guard** didn't fire (reason marker) rather than `decision != deny`, since the transport now denies on the unreachable test port.

82/82 across the permission-hook suites; `bash -n` clean. Only `packages/server/hooks/permission-hook.sh` is git-tracked (desktop bundle copies are build artifacts).