### PR TITLE
fix(server): recover the hook sink if it vanishes mid-turn (#5329)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -496,6 +496,7 @@ export class ClaudeTuiSession extends BaseSession {
     this._log = null
     this._sinkDir = null     // created on start, removed on destroy
     this._sinkRecoverErrLoggedMs = 0  // #5329: throttle the can't-recreate error log
+    this._sinkTransientWarnLoggedMs = 0  // #5329: throttle the dir-exists-but-readdir-failed warn
     this._term = null        // persistent PTY for the session's lifetime
     this._settingsPath = null
     // #4013: sidecar file containing the current permission mode. The
@@ -744,13 +745,26 @@ export class ClaudeTuiSession extends BaseSession {
   _recoverSinkDir(cause) {
     if (!this._sinkDir) return false
     const logger = this._log || log
-    if (existsSync(this._sinkDir)) {
-      // The dir exists but readdir failed — a transient/permission error, not a
-      // vanished sink. Log so it isn't fully silent; don't thrash recreation.
-      logger.warn(`hook sink readdir failed though ${this._sinkDir} exists: ${cause?.message || cause}`)
+    // Distinguish three states by what's actually AT the sink path:
+    //   - a real directory → readdir failed transiently (EACCES/EMFILE); warn
+    //     (throttled) but don't thrash recreation.
+    //   - nothing → vanished (tmpwatch/rm); recreate.
+    //   - a non-directory (file/symlink squatting the path) → readdir would
+    //     throw ENOTDIR forever; rm the squatter, then recreate.
+    let isDir = false
+    try { isDir = statSync(this._sinkDir).isDirectory() } catch { /* missing or unstat-able */ }
+    if (isDir) {
+      const now = Date.now()
+      if (now - this._sinkTransientWarnLoggedMs >= 5000) {
+        this._sinkTransientWarnLoggedMs = now
+        logger.warn(`hook sink readdir failed though ${this._sinkDir} is a directory: ${cause?.message || cause}`)
+      }
       return true
     }
     try {
+      // Clear a non-directory squatting the path (no-op if nothing is there)
+      // so mkdir can create a real directory.
+      try { rmSync(this._sinkDir, { recursive: true, force: true }) } catch { /* best effort */ }
       mkdirSync(this._sinkDir, { recursive: true })
       try { writeFileSync(join(this._sinkDir, 'owner.pid'), String(process.pid)) } catch { /* best effort */ }
       if (this._permissionModeFile) {

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -495,6 +495,7 @@ export class ClaudeTuiSession extends BaseSession {
     // listener can route them to the right bound client (#4787, #4793).
     this._log = null
     this._sinkDir = null     // created on start, removed on destroy
+    this._sinkRecoverErrLoggedMs = 0  // #5329: throttle the can't-recreate error log
     this._term = null        // persistent PTY for the session's lifetime
     this._settingsPath = null
     // #4013: sidecar file containing the current permission mode. The
@@ -722,6 +723,52 @@ export class ClaudeTuiSession extends BaseSession {
   _clearAskUserQuestionLock() {
     if (!this._sinkDir) return
     try { rmSync(join(this._sinkDir, 'askuserquestion-active'), { recursive: true, force: true }) } catch {}
+  }
+
+  /**
+   * #5329 (IP-1): recover the hook sink dir after a readdir failure during the
+   * poll loop. The sink lives under /tmp, so a tmpwatch sweep / tmpfs clear /
+   * manual rm can delete it mid-turn — and claude's hook commands write to this
+   * exact path, so once the dir is gone every `cat > <sink>/…` also fails and
+   * the turn wedges silently until the hard timeout.
+   *
+   * Recreate the SAME path (claude's already-loaded hooks embed it) plus the
+   * owner.pid stamp and the permission-mode sidecar (so the hook reads the live
+   * mode rather than falling back to the stale spawn-time env var). If
+   * recreation itself fails (e.g. /tmp is full → ENOSPC), surface it loudly
+   * (throttled) instead of spinning silently.
+   *
+   * @param {Error} [cause] the readdir error that triggered recovery
+   * @returns {boolean} true if the sink is usable afterward
+   */
+  _recoverSinkDir(cause) {
+    if (!this._sinkDir) return false
+    const logger = this._log || log
+    if (existsSync(this._sinkDir)) {
+      // The dir exists but readdir failed — a transient/permission error, not a
+      // vanished sink. Log so it isn't fully silent; don't thrash recreation.
+      logger.warn(`hook sink readdir failed though ${this._sinkDir} exists: ${cause?.message || cause}`)
+      return true
+    }
+    try {
+      mkdirSync(this._sinkDir, { recursive: true })
+      try { writeFileSync(join(this._sinkDir, 'owner.pid'), String(process.pid)) } catch { /* best effort */ }
+      if (this._permissionModeFile) {
+        try { this._writePermissionModeSidecarAtomic(this._permissionModeFile, this.permissionMode || 'approve') } catch { /* hook falls back to env var */ }
+      }
+      this._sinkRecoverErrLoggedMs = 0
+      logger.warn(`hook sink ${this._sinkDir} vanished mid-turn and was recreated — hook delivery restored (cause: ${cause?.message || cause})`)
+      return true
+    } catch (err) {
+      // Persistent failure (disk full, parent gone): throttle the error so a
+      // 150ms poll loop doesn't flood the log.
+      const now = Date.now()
+      if (now - this._sinkRecoverErrLoggedMs >= 5000) {
+        this._sinkRecoverErrLoggedMs = now
+        logger.error(`hook sink ${this._sinkDir} vanished and could NOT be recreated (${err.message}) — tool events for this turn may be lost (disk full?)`)
+      }
+      return false
+    }
   }
 
   // Tail length to keep + length to include in error diagnostics.
@@ -1755,7 +1802,18 @@ export class ClaudeTuiSession extends BaseSession {
 
     const drainHookFiles = () => {
       let entries
-      try { entries = readdirSync(this._sinkDir) } catch { return }
+      try {
+        entries = readdirSync(this._sinkDir)
+      } catch (err) {
+        // #5329 (IP-1): the sink lives under /tmp, which a tmpwatch sweep, a
+        // tmpfs clear, or a manual rm can delete mid-turn. A silent return here
+        // spins this poll loop to the hard timeout while every claude
+        // `cat > <sink>/…` hook write also fails — the turn wedges with no
+        // signal. Try to recover the sink (recreate the same path so hook
+        // delivery resumes); fail loud if recreation itself fails.
+        this._recoverSinkDir(err)
+        return
+      }
       // Per-drain progress counter — replaces the old `_consumedFiles.size`
       // delta, which no longer changes now that consumed files are unlinked +
       // pruned (#5323). Drives the first-output disarm + timer re-arm below.

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -1,6 +1,6 @@
 import { describe, it, beforeEach, afterEach, mock } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, existsSync, utimesSync } from 'fs'
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, existsSync, statSync, utimesSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { ClaudeTuiSession } from '../src/claude-tui-session.js'
@@ -7300,12 +7300,24 @@ describe('ClaudeTuiSession — hook-sink vanish recovery (#5329)', () => {
     assert.equal(errorLines.length, 1, 'only one error logged across rapid repeated failures')
   })
 
-  it('does not thrash recreation when the dir exists but readdir failed transiently', () => {
+  it('does not thrash recreation when the path is a directory but readdir failed transiently (warn throttled)', () => {
     session = makeSession()
     session._sinkDir = join(dir, 's-exists')
     mkdirSync(session._sinkDir, { recursive: true })
-    const ok = session._recoverSinkDir(new Error('EACCES: permission denied'))
-    assert.equal(ok, true)
-    assert.ok(warnLines.some((m) => /readdir failed though .* exists/.test(m)), 'warns about the transient error')
+    for (let i = 0; i < 5; i++) {
+      assert.equal(session._recoverSinkDir(new Error('EACCES: permission denied')), true)
+    }
+    const transient = warnLines.filter((m) => /readdir failed though .* is a directory/.test(m))
+    assert.equal(transient.length, 1, 'transient warn is throttled to one across rapid repeats')
+  })
+
+  it('replaces a non-directory squatting the sink path (file/symlink) with a real dir', () => {
+    session = makeSession()
+    session._sinkDir = join(dir, 's-squatted')
+    writeFileSync(session._sinkDir, 'not a dir') // a file occupies the sink path
+    const ok = session._recoverSinkDir(new Error('ENOTDIR'))
+    assert.equal(ok, true, 'a squatted path must be recoverable, not a permanent spin')
+    assert.ok(statSync(session._sinkDir).isDirectory(), 'the squatter file is replaced by a directory')
+    assert.equal(readFileSync(join(session._sinkDir, 'owner.pid'), 'utf8'), String(process.pid))
   })
 })

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -7230,3 +7230,82 @@ describe('ClaudeTuiSession — atomic permission-mode sidecar write (#5334)', ()
     assert.equal(session._permissionModeFile, join(session._sinkDir, 'permission-mode'))
   })
 })
+
+// #5329 (IP-1): the hook sink lives under /tmp; a tmpwatch sweep / tmpfs clear
+// / manual rm can delete it mid-turn. The poll loop's readdir then fails and
+// (pre-fix) returned silently, spinning to the hard timeout while claude's hook
+// `cat > <sink>/…` writes also fail. _recoverSinkDir recreates the sink so hook
+// delivery resumes, and fails loud if recreation itself fails.
+describe('ClaudeTuiSession — hook-sink vanish recovery (#5329)', () => {
+  let dir, skillsDir, session, warnLines, errorLines
+  const logSpy = (entry) => {
+    if (entry.component !== 'claude-tui-session') return
+    if (entry.level === 'warn') warnLines.push(entry.message)
+    if (entry.level === 'error') errorLines.push(entry.message)
+  }
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'chroxy-sink-recover-'))
+    skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-sink-recover-skills-'))
+    warnLines = []; errorLines = []
+    addLogListener(logSpy)
+  })
+  afterEach(async () => {
+    removeLogListener(logSpy)
+    if (session) { try { await session.destroy() } catch { /* ignore */ } session = null }
+    rmSync(dir, { recursive: true, force: true })
+    rmSync(skillsDir, { recursive: true, force: true })
+  })
+  function makeSession() {
+    return new ClaudeTuiSession({ cwd: '/tmp', port: 12345, skillsDir, repoSkillsDir: null })
+  }
+
+  it('recreates a vanished sink dir (+ owner.pid) and reports it', () => {
+    session = makeSession()
+    session._sinkDir = join(dir, 's-gone')
+    // dir does not exist yet — simulates a tmpwatch sweep mid-turn
+    const ok = session._recoverSinkDir(new Error('ENOENT: no such file or directory'))
+    assert.equal(ok, true, 'sink is usable after recovery')
+    assert.ok(existsSync(session._sinkDir), 'sink dir recreated')
+    assert.equal(readFileSync(join(session._sinkDir, 'owner.pid'), 'utf8'), String(process.pid))
+    assert.ok(warnLines.some((m) => /vanished mid-turn and was recreated/.test(m)), 'logs the recovery loudly')
+  })
+
+  it('restores the permission-mode sidecar so the hook reads the live mode', () => {
+    session = makeSession()
+    session._sinkDir = join(dir, 's-perm')
+    session._permissionModeFile = join(session._sinkDir, 'permission-mode')
+    session.permissionMode = 'plan'
+    session._recoverSinkDir(new Error('ENOENT'))
+    assert.equal(readFileSync(session._permissionModeFile, 'utf8'), 'plan',
+      'sidecar rewritten with the current mode (not the stale env fallback)')
+  })
+
+  it('fails LOUD (error) and returns false when the sink cannot be recreated', () => {
+    session = makeSession()
+    // Parent is a FILE, so mkdirSync(recursive) cannot create a child dir.
+    const filePath = join(dir, 'not-a-dir')
+    writeFileSync(filePath, 'x')
+    session._sinkDir = join(filePath, 's-blocked')
+    const ok = session._recoverSinkDir(new Error('ENOENT'))
+    assert.equal(ok, false, 'returns false when recovery is impossible')
+    assert.ok(errorLines.some((m) => /could NOT be recreated/.test(m)), 'surfaces a loud error, not a silent spin')
+  })
+
+  it('throttles the can-not-recreate error to avoid 150ms poll-loop spam', () => {
+    session = makeSession()
+    const filePath = join(dir, 'not-a-dir-2')
+    writeFileSync(filePath, 'x')
+    session._sinkDir = join(filePath, 's-blocked')
+    for (let i = 0; i < 5; i++) session._recoverSinkDir(new Error('ENOENT'))
+    assert.equal(errorLines.length, 1, 'only one error logged across rapid repeated failures')
+  })
+
+  it('does not thrash recreation when the dir exists but readdir failed transiently', () => {
+    session = makeSession()
+    session._sinkDir = join(dir, 's-exists')
+    mkdirSync(session._sinkDir, { recursive: true })
+    const ok = session._recoverSinkDir(new Error('EACCES: permission denied'))
+    assert.equal(ok, true)
+    assert.ok(warnLines.some((m) => /readdir failed though .* exists/.test(m)), 'warns about the transient error')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #5329 (IP-1). The hook sink lives under `/tmp` (`chroxy-claude-tui/s-<uuid>`), so a **tmpwatch sweep, a tmpfs clear, or a manual rm can delete it mid-turn**.

## Probe outcome

The poll loop's `drainHookFiles` did:
```js
try { entries = readdirSync(this._sinkDir) } catch { return }
```
When the sink vanished, `readdirSync` threw ENOENT and the catch **returned silently** — so the loop spun to the hard timeout (minutes) while every claude `cat > <sink>/pre-$(uuidgen).json` hook write **also** failed (`cat` can't create a file under a missing dir). The turn wedged with **no signal**, and couldn't self-heal for the rest of the session.

## Decision (acceptance criterion: relocation vs heartbeat?)

**Liveness check + self-heal — no relocation.** On a drain readdir failure, `_recoverSinkDir`:
- recreates the **same** sink path (claude's already-loaded hook commands embed it, so delivery resumes without a respawn),
- restores the `owner.pid` stamp (keeps the boot-sweep from reaping it),
- restores the **permission-mode sidecar** with the current mode (so the hook reads the live mode, not the stale spawn-time env fallback),
- on a recreation failure (e.g. `/tmp` full → ENOSPC) logs a **loud, throttled** error instead of spinning silently,
- a dir that exists but fails readdir for a transient reason is logged without thrashing recreation.

## Tests (`claude-tui-session.test.js`, +5)

- recreates a vanished sink (+`owner.pid`); restores the permission-mode sidecar; fails loud + returns `false` when recreation is impossible (parent is a file); throttles the error to one log across rapid repeats; warns-without-thrash on a transient readdir error.

285/285 in the TUI suite; eslint clean (the lone `no-control-regex` warning is pre-existing/unrelated).