### PR TITLE
fix(server): rolling-window respawn rate cap across both providers (#5349)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { resolveBinary } from './utils/resolve-binary.js'
+import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
 import { createLogger, loggerForSession, redactSensitive } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
@@ -522,6 +523,12 @@ export class ClaudeTuiSession extends BaseSession {
     this._respawnTimer = null
     this._respawnScheduled = false
     this._respawning = false
+    // #5349: a rolling-window cap INDEPENDENT of `_respawnCount` (which resets
+    // on every warmup that survives — see _onWarmupComplete). A session that
+    // dies shortly after each successful warmup flaps forever under the
+    // consecutive cap alone; this gives up once it exceeds the window cap
+    // regardless of warmup success. Mirrors the same guard in CliSession.
+    this._respawnRateLimiter = new RespawnRateLimiter()
     // #5317 (WP-2.3) — SIGKILL escalation timer armed by destroy() after SIGTERM.
     // Cleared by _onPtyGone the moment the process is confirmed gone (which also
     // closes the pid-reuse window — we only force-kill when onExit never fired).
@@ -1155,6 +1162,19 @@ export class ClaudeTuiSession extends BaseSession {
     if (this._destroying) return
     if (this._respawning) return
     if (this._respawnScheduled) return
+
+    // #5349: rolling-window cap, checked BEFORE _respawnCount so a session that
+    // keeps surviving warmup (resetting _respawnCount) still gives up once it
+    // flaps past the window cap.
+    if (!this._respawnRateLimiter.record()) {
+      const { maxPerWindow, windowMs } = this._respawnRateLimiter
+      ;(this._log || log).error(`PTY respawn rate cap reached (>${maxPerWindow} respawns in ${Math.round(windowMs / 60000)}min), giving up — session is flapping`)
+      const tail = this._outputTailDiagnostic()
+      const base = `Claude PTY is flapping — exceeded ${maxPerWindow} respawns in ${Math.round(windowMs / 60000)} minutes`
+      this.emit('error', { code: 'pty_respawn_exhausted', message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
+      this.emit('respawn_exhausted', { reason: 'pty_respawn_rate_capped' })
+      return
+    }
 
     this._respawnCount++
     if (this._respawnCount > 5) {

--- a/packages/server/src/cli-session.js
+++ b/packages/server/src/cli-session.js
@@ -13,6 +13,7 @@ import { emitToolResults } from './tool-result.js'
 import { buildToolStartData, extractToolInputSemantics } from './claude-stream-parser.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { buildSpawnEnv } from './utils/spawn-env.js'
+import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
 import { createLogger, loggerForSession } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 
@@ -354,6 +355,11 @@ export class CliSession extends BaseSession {
     this._respawnTimer = null
     this._respawnScheduled = false
     this._respawning = false
+    // #5349: rolling-window respawn cap independent of `_respawnCount`, which
+    // resets on every `system.init` (warmup success). Without it a session that
+    // dies shortly after each successful init flaps forever. Mirrors the same
+    // guard in ClaudeTuiSession.
+    this._respawnRateLimiter = new RespawnRateLimiter()
     this._interruptTimer = null
     // #4929: track in-flight `--resume <id>` attempts so we can detect when
     // claude CLI rejects an unknown id and avoid the spin-retry loop reported
@@ -576,6 +582,16 @@ export class CliSession extends BaseSession {
     if (this._destroying) return
     if (this._respawning) return
     if (this._respawnScheduled) return
+
+    // #5349: rolling-window cap, checked BEFORE _respawnCount so a session that
+    // keeps surviving warmup (resetting _respawnCount on system.init) still
+    // gives up once it flaps past the window cap.
+    if (!this._respawnRateLimiter.record()) {
+      const { maxPerWindow, windowMs } = this._respawnRateLimiter
+      log.error(`Respawn rate cap reached (>${maxPerWindow} in ${Math.round(windowMs / 60000)}min), giving up — session is flapping`)
+      this.emit('error', { message: `Claude process is flapping — exceeded ${maxPerWindow} respawns in ${Math.round(windowMs / 60000)} minutes` })
+      return
+    }
 
     this._respawnCount++
     if (this._respawnCount > 5) {

--- a/packages/server/src/utils/respawn-rate-limiter.js
+++ b/packages/server/src/utils/respawn-rate-limiter.js
@@ -9,10 +9,13 @@
 // `windowMs`, regardless of warmup success, so a persistently-flapping backend
 // eventually gives up.
 //
-// Clock: `now` is injectable for tests and defaults to Date.now. A coarse
-// event-count window doesn't need a monotonic clock the way a stall watchdog
-// does — a sleep/NTP step at worst shifts the window by a few timestamps, it
-// can't cause a false "flapping" verdict on a healthy session.
+// Clock: `now` is injectable for tests and defaults to Date.now. Wall-clock can
+// jump BACKWARD (NTP correction / VM suspend), which would break head-pruning
+// (it assumes `_times` is non-decreasing). So record() clamps each timestamp to
+// be >= the previous one: a backward step is treated as "no time passed", which
+// keeps `_times` sorted and the prune correct, and is the conservative
+// direction (it can only make the window advance slower, never falsely flag a
+// healthy session).
 
 const DEFAULT_MAX_PER_WINDOW = 10
 const DEFAULT_WINDOW_MS = 5 * 60 * 1000
@@ -37,7 +40,11 @@ export class RespawnRateLimiter {
    * @returns {boolean}
    */
   record() {
-    const t = this._now()
+    // Clamp to be non-decreasing so a backward clock step can't leave `_times`
+    // out of order (which would defeat the head-prune below and grow the array
+    // unboundedly).
+    const last = this._times.length ? this._times[this._times.length - 1] : -Infinity
+    const t = Math.max(this._now(), last)
     this._times.push(t)
     const cutoff = t - this.windowMs
     while (this._times.length && this._times[0] < cutoff) this._times.shift()

--- a/packages/server/src/utils/respawn-rate-limiter.js
+++ b/packages/server/src/utils/respawn-rate-limiter.js
@@ -1,0 +1,52 @@
+// utils/respawn-rate-limiter.js (#5349) — a rolling-window cap on session
+// respawns, shared by CliSession and ClaudeTuiSession.
+//
+// Both providers already bound CONSECUTIVE respawns via `_respawnCount` (max 5
+// with backoff), but that counter resets to 0 on every warmup that survives
+// (system.init / first output). So a session that dies a few seconds AFTER each
+// successful warmup flaps forever — the consecutive cap never trips. This adds
+// a SECOND, independent cap: at most `maxPerWindow` respawns per rolling
+// `windowMs`, regardless of warmup success, so a persistently-flapping backend
+// eventually gives up.
+//
+// Clock: `now` is injectable for tests and defaults to Date.now. A coarse
+// event-count window doesn't need a monotonic clock the way a stall watchdog
+// does — a sleep/NTP step at worst shifts the window by a few timestamps, it
+// can't cause a false "flapping" verdict on a healthy session.
+
+const DEFAULT_MAX_PER_WINDOW = 10
+const DEFAULT_WINDOW_MS = 5 * 60 * 1000
+
+export class RespawnRateLimiter {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.maxPerWindow=10] respawns allowed per window
+   * @param {number} [opts.windowMs=300000] rolling window length in ms
+   * @param {() => number} [opts.now=Date.now] clock source (injectable for tests)
+   */
+  constructor({ maxPerWindow = DEFAULT_MAX_PER_WINDOW, windowMs = DEFAULT_WINDOW_MS, now = Date.now } = {}) {
+    this.maxPerWindow = maxPerWindow
+    this.windowMs = windowMs
+    this._now = now
+    this._times = []
+  }
+
+  /**
+   * Record a respawn attempt. Returns true if still within the cap (caller may
+   * proceed), false if the cap is exceeded (caller should give up).
+   * @returns {boolean}
+   */
+  record() {
+    const t = this._now()
+    this._times.push(t)
+    const cutoff = t - this.windowMs
+    while (this._times.length && this._times[0] < cutoff) this._times.shift()
+    return this._times.length <= this.maxPerWindow
+  }
+
+  /** Number of respawns currently inside the window (after the last record). */
+  get count() { return this._times.length }
+
+  /** Forget all recorded respawns (e.g. on a clean, intentional restart). */
+  reset() { this._times = [] }
+}

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSyn
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { ClaudeTuiSession } from '../src/claude-tui-session.js'
+import { RespawnRateLimiter } from '../src/utils/respawn-rate-limiter.js'
 import { addLogListener, removeLogListener } from '../src/logger.js'
 
 describe('ClaudeTuiSession', () => {
@@ -755,6 +756,27 @@ describe('ClaudeTuiSession', () => {
       assert.equal(exhausted.length, 1, 'respawn_exhausted emitted exactly once')
       assert.ok(errors.some((e) => e.code === 'pty_respawn_exhausted'), 'a categorized fatal error is emitted on exhaustion')
       assert.equal(session._respawnScheduled, false, 'no further respawn is scheduled after exhaustion')
+    })
+
+    it('a flapping session (warmup keeps resetting _respawnCount) gives up via the rolling rate cap (#5349)', () => {
+      session = makeSession()
+      // Small cap + fixed clock so the rolling window is deterministic. Each
+      // respawn "survives warmup" (resets the consecutive _respawnCount), so the
+      // consecutive cap of 5 never trips — only the rate cap can stop the flap.
+      session._respawnRateLimiter = new RespawnRateLimiter({ maxPerWindow: 3, windowMs: 5 * 60_000, now: () => 1000 })
+      const exhausted = []
+      session.on('respawn_exhausted', (d) => exhausted.push(d))
+
+      for (let i = 0; i < 4; i++) {
+        session._respawnCount = 0          // warmup success reset
+        session._respawnScheduled = false  // allow the next schedule
+        session._respawnTimer = null
+        session._scheduleRespawn()
+      }
+
+      assert.equal(exhausted.length, 1, 'gives up exactly once despite the warmup resets')
+      assert.equal(exhausted[0].reason, 'pty_respawn_rate_capped', 'distinct reason from the consecutive cap')
+      assert.equal(session._respawnScheduled, false, 'no respawn scheduled after the rate cap')
     })
 
     it('suppresses respawn when _destroying (deliberate teardown)', () => {

--- a/packages/server/tests/cli-session-respawn-guard.test.js
+++ b/packages/server/tests/cli-session-respawn-guard.test.js
@@ -1,6 +1,7 @@
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
+import { RespawnRateLimiter } from '../src/utils/respawn-rate-limiter.js'
 
 /**
  * Minimal harness that mirrors CliSession's respawn logic.
@@ -8,13 +9,16 @@ import { EventEmitter } from 'node:events'
  * This avoids pulling in spawn/permission-hook/etc dependencies.
  */
 class RespawnTestHarness extends EventEmitter {
-  constructor() {
+  constructor(rateLimiter) {
     super()
     this._destroying = false
     this._respawnCount = 0
     this._respawnTimer = null
     this._respawnScheduled = false
     this._startCallCount = 0
+    // #5349: mirrors cli-session.js — a rolling-window cap independent of the
+    // warmup-resetting _respawnCount.
+    this._respawnRateLimiter = rateLimiter || new RespawnRateLimiter()
   }
 
   start() {
@@ -25,6 +29,13 @@ class RespawnTestHarness extends EventEmitter {
   _scheduleRespawn() {
     if (this._destroying) return
     if (this._respawnScheduled) return
+
+    // #5349: rolling-window cap, checked BEFORE _respawnCount.
+    if (!this._respawnRateLimiter.record()) {
+      const { maxPerWindow, windowMs } = this._respawnRateLimiter
+      this.emit('error', { message: `Claude process is flapping — exceeded ${maxPerWindow} respawns in ${Math.round(windowMs / 60000)} minutes` })
+      return
+    }
 
     this._respawnCount++
     if (this._respawnCount > 5) {
@@ -67,6 +78,25 @@ describe('CliSession _scheduleRespawn guard', () => {
 
   afterEach(() => {
     session.destroy()
+  })
+
+  it('a flapping session (system.init keeps resetting _respawnCount) gives up via the rolling rate cap (#5349)', () => {
+    // Fixed clock + small cap: each respawn "survives warmup" (resets the
+    // consecutive _respawnCount on system.init), so the consecutive cap of 5
+    // never trips — only the rolling rate cap can stop the flap.
+    const limited = new RespawnTestHarness(new RespawnRateLimiter({ maxPerWindow: 3, windowMs: 5 * 60_000, now: () => 1000 }))
+    const errors = []
+    limited.on('error', (e) => errors.push(e))
+    for (let i = 0; i < 4; i++) {
+      limited._respawnCount = 0          // system.init warmup reset
+      if (limited._respawnTimer) { clearTimeout(limited._respawnTimer); limited._respawnTimer = null }
+      limited._respawnScheduled = false  // allow the next schedule
+      limited._scheduleRespawn()
+    }
+    assert.equal(errors.length, 1, 'gives up exactly once despite the warmup resets')
+    assert.match(errors[0].message, /flapping/, 'error names the flapping rate cap')
+    assert.equal(limited._respawnScheduled, false, 'no respawn scheduled after the rate cap')
+    limited.destroy()
   })
 
   it('calling _scheduleRespawn twice only creates one timer', () => {

--- a/packages/server/tests/respawn-rate-limiter.test.js
+++ b/packages/server/tests/respawn-rate-limiter.test.js
@@ -56,6 +56,22 @@ describe('RespawnRateLimiter (#5349)', () => {
     assert.equal(rl.count, 1)
   })
 
+  it('tolerates a backward clock step (NTP / VM suspend) without breaking the prune', () => {
+    // Clock jumps backward mid-stream. Timestamps are clamped non-decreasing,
+    // so `_times` stays ordered, head-pruning stays correct, and the array
+    // cannot grow unboundedly out of order.
+    let t = 1_000_000
+    const rl = new RespawnRateLimiter({ maxPerWindow: 3, windowMs: 1000, now: () => t })
+    assert.equal(rl.record(), true) // t=1_000_000
+    t = 500_000 // clock steps WAY back
+    assert.equal(rl.record(), true) // clamped to 1_000_000, count 2
+    assert.equal(rl.record(), true) // count 3
+    assert.equal(rl.record(), false) // count 4 → capped (not corrupted by the jump)
+    // Sanity: internal timestamps remain sorted ascending.
+    const times = rl._times
+    for (let i = 1; i < times.length; i++) assert.ok(times[i] >= times[i - 1], 'timestamps stay non-decreasing')
+  })
+
   it('reset() clears the window', () => {
     const clk = fakeClock()
     const rl = new RespawnRateLimiter({ maxPerWindow: 2, windowMs: 1000, now: clk.now })

--- a/packages/server/tests/respawn-rate-limiter.test.js
+++ b/packages/server/tests/respawn-rate-limiter.test.js
@@ -1,0 +1,73 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { RespawnRateLimiter } from '../src/utils/respawn-rate-limiter.js'
+
+// #5349: a rolling-window cap independent of the warmup-resetting consecutive
+// counter, so a session that flaps (dies shortly after each successful warmup)
+// eventually gives up instead of respawning unbounded.
+
+// A controllable clock so the window logic is deterministic.
+function fakeClock(start = 1_000_000) {
+  let t = start
+  return { now: () => t, advance: (ms) => { t += ms } }
+}
+
+describe('RespawnRateLimiter (#5349)', () => {
+  it('allows up to maxPerWindow respawns, then caps', () => {
+    const clk = fakeClock()
+    const rl = new RespawnRateLimiter({ maxPerWindow: 3, windowMs: 1000, now: clk.now })
+    assert.equal(rl.record(), true, '1st allowed')
+    assert.equal(rl.record(), true, '2nd allowed')
+    assert.equal(rl.record(), true, '3rd allowed (at the cap)')
+    assert.equal(rl.record(), false, '4th exceeds the cap')
+  })
+
+  it('models the flapping bug: warmup-success resets do NOT lift the cap', () => {
+    // Each respawn "survives warmup" (which would reset the consecutive
+    // _respawnCount), but the limiter counts them all within the window.
+    const clk = fakeClock()
+    const rl = new RespawnRateLimiter({ maxPerWindow: 5, windowMs: 5 * 60_000, now: clk.now })
+    let lastOk = true
+    for (let i = 0; i < 6; i++) {
+      lastOk = rl.record()
+      clk.advance(20_000) // dies ~20s after each warmup — well inside the window
+    }
+    assert.equal(lastOk, false, 'the 6th respawn in 5min is capped despite warmup resets')
+  })
+
+  it('ages out respawns older than the window (a healthy session is never capped)', () => {
+    const clk = fakeClock()
+    const rl = new RespawnRateLimiter({ maxPerWindow: 3, windowMs: 1000, now: clk.now })
+    assert.equal(rl.record(), true)
+    assert.equal(rl.record(), true)
+    clk.advance(1001) // both prior records fall strictly outside the window
+    assert.equal(rl.record(), true, 'old respawns pruned, this is in-window')
+    assert.equal(rl.record(), true)
+    assert.equal(rl.count, 2, 'only the two in-window respawns are counted')
+  })
+
+  it('prunes respawns strictly older than the window (inclusive lower bound)', () => {
+    const clk = fakeClock()
+    const rl = new RespawnRateLimiter({ maxPerWindow: 1, windowMs: 1000, now: clk.now })
+    assert.equal(rl.record(), true)
+    clk.advance(1001) // first record is now strictly older than the window
+    assert.equal(rl.record(), true, 'the older record is pruned, so this is the only one')
+    assert.equal(rl.count, 1)
+  })
+
+  it('reset() clears the window', () => {
+    const clk = fakeClock()
+    const rl = new RespawnRateLimiter({ maxPerWindow: 2, windowMs: 1000, now: clk.now })
+    rl.record(); rl.record()
+    assert.equal(rl.record(), false, 'capped')
+    rl.reset()
+    assert.equal(rl.record(), true, 'cap lifted after reset')
+  })
+
+  it('defaults to 10 per 5 minutes', () => {
+    const rl = new RespawnRateLimiter()
+    assert.equal(rl.maxPerWindow, 10)
+    assert.equal(rl.windowMs, 5 * 60 * 1000)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #5349. Both `CliSession` and `ClaudeTuiSession` bound **consecutive** respawns via `_respawnCount` (max 5 with backoff), but that counter **resets to 0 on every warmup that survives** — CliSession on `system.init`, ClaudeTuiSession on warmup completion. So a session that dies a few seconds *after* each successful warmup **flaps forever**: the consecutive cap never trips.

## Fix

A shared `RespawnRateLimiter` (rolling window, default **10 respawns / 5 min**, injectable clock) gated at the top of **both** providers' `_scheduleRespawn` — *before* the `_respawnCount++` check, so the warmup resets can't lift it.

- `ClaudeTuiSession` reuses its `pty_respawn_exhausted` error code (so the dashboard renders the terminal give-up state) with a distinct `respawn_exhausted` reason `pty_respawn_rate_capped`.
- `CliSession` mirrors its existing error-only exhausted emit.

Clock is injectable and defaults to `Date.now`; a coarse event-count window doesn't need a monotonic clock the way a stall watchdog does (a sleep/NTP step can't produce a false "flapping" verdict).

## Tests

- **`respawn-rate-limiter.test.js`** (6): cap enforcement; the flapping model (warmup resets don't lift the cap); window pruning; inclusive-boundary; `reset()`; defaults.
- **Wiring**: a flapping-gives-up test in each provider — `ClaudeTuiSession` against **real** `_scheduleRespawn` (reason `pty_respawn_rate_capped`), and `CliSession` via the in-sync `RespawnTestHarness` (the established "keep in sync with fixes" mirror, updated to carry the rate cap).

378 across the affected suites; custom server lints (opt-forwarding, logger-scoping) + eslint clean.