### PR TITLE
fix(server): harden PTY-dump redaction — ANSI-split tokens + JWTs (#5358)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -7,7 +7,7 @@ import { BaseSession, buildBaseSessionOpts } from './base-session.js'
 import { FALLBACK_MODELS, ALLOWED_MODEL_IDS, claudeDeriveId, resolveClaudeContextWindow } from './models.js'
 import { resolveBinary } from './utils/resolve-binary.js'
 import { RespawnRateLimiter } from './utils/respawn-rate-limiter.js'
-import { createLogger, loggerForSession, redactSensitive } from './logger.js'
+import { createLogger, loggerForSession, redactSensitive, redactSensitivePreservingEscapes } from './logger.js'
 import { formatIdleDuration } from './session-timeout-manager.js'
 import { isOperatorTimeoutInRange } from './duration.js'
 import { materializeAttachments, buildAttachmentsPromptSuffix } from './claude-tui-attachments.js'
@@ -1640,7 +1640,12 @@ export class ClaudeTuiSession extends BaseSession {
     // columns. The redact runs on a latin1 (binary) round-trip, which preserves
     // every byte 0–255 losslessly (so 0x1b / OSC / SS3 escape bytes still land
     // in the dump); redactSensitive only rewrites the ASCII token runs.
-    const redacted = Buffer.from(redactSensitive(this._outputTailRaw.toString('latin1')), 'latin1')
+    // Layered redaction (#5358): redactSensitive catches contiguous tokens
+    // (preserving key names); redactSensitivePreservingEscapes then catches any
+    // token the TUI split with a mid-token escape sequence — the contiguous
+    // patterns miss those, leaving the secret in the dump's ASCII column.
+    const latin1 = this._outputTailRaw.toString('latin1')
+    const redacted = Buffer.from(redactSensitivePreservingEscapes(redactSensitive(latin1)), 'latin1')
     return formatHexDump(redacted, ClaudeTuiSession.PTY_TAIL_DIAGNOSTIC_BYTES)
   }
 

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1640,12 +1640,17 @@ export class ClaudeTuiSession extends BaseSession {
     // columns. The redact runs on a latin1 (binary) round-trip, which preserves
     // every byte 0–255 losslessly (so 0x1b / OSC / SS3 escape bytes still land
     // in the dump); redactSensitive only rewrites the ASCII token runs.
-    // Layered redaction (#5358): redactSensitive catches contiguous tokens
-    // (preserving key names); redactSensitivePreservingEscapes then catches any
-    // token the TUI split with a mid-token escape sequence — the contiguous
-    // patterns miss those, leaving the secret in the dump's ASCII column.
+    // #5358: redactSensitivePreservingEscapes is used ALONE (NOT layered after
+    // redactSensitive). It must see the ORIGINAL bytes to reassemble a token the
+    // TUI split with a mid-token escape: running redactSensitive first would
+    // partially redact a marker-prefixed split token (e.g. `token=sk-ant-AAAA`
+    // → `token= [REDACTED]`), consuming the marker so the escape-aware pass can
+    // no longer detect the run — and the tail after the escape would LEAK. This
+    // pass covers the contiguous case too (same patterns, incl. Bearer / JWT /
+    // key=value), scrubbing token chars to 'X' while preserving the escape bytes
+    // the dump exists to show.
     const latin1 = this._outputTailRaw.toString('latin1')
-    const redacted = Buffer.from(redactSensitivePreservingEscapes(redactSensitive(latin1)), 'latin1')
+    const redacted = Buffer.from(redactSensitivePreservingEscapes(latin1), 'latin1')
     return formatHexDump(redacted, ClaudeTuiSession.PTY_TAIL_DIAGNOSTIC_BYTES)
   }
 

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -52,6 +52,11 @@ const API_KEY_PATTERNS = [
   // Google API keys: AIza + exactly 35 chars of [A-Za-z0-9_-].
   // Trailing \b prevents matching into longer alphanumerics (e.g., AIzawa…).
   /\bAIza[A-Za-z0-9_-]{35}\b/g,
+  // #5358: JWTs (incl. claude/OAuth bearer JWTs printed without a "Bearer"/key
+  // marker). header.payload.signature, each base64url; the header always starts
+  // `eyJ` (base64 of `{"`), which makes this specific enough to avoid matching
+  // ordinary dotted tokens. Length floors keep it off short `a.b.c` strings.
+  /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
 ]
 
 /**
@@ -79,6 +84,69 @@ export function redactSensitive(msg) {
     result = result.replace(pattern, '[REDACTED]')
   }
   return result
+}
+
+// #5358: escape/control sequences a TUI can interleave INTO a token while
+// styling it (e.g. `sk-ant-oat01-AAAA\x1b[1mBBBB`), splitting the run so the
+// contiguous patterns above miss it. Mirrors the claude-tui ANSI_STRIP set,
+// kept local so logger.js stays dependency-free.
+const TOKEN_SPLITTING_ESCAPE = new RegExp(
+  [
+    '\\x1b\\[[0-9;?]*[\\x40-\\x7E]', // CSI
+    '\\x1b\\][^\\x07\\x1b]*(?:\\x07|\\x1b\\\\)', // OSC ... BEL/ST
+    '\\x1bO.', // SS3
+    '\\x1b[=>cN]', // single-char terminal-mode codes
+    '[\\x00-\\x08\\x0b-\\x1f\\x7f]', // stray C0 controls (except \t and \n)
+  ].join('|'),
+  'g',
+)
+
+/**
+ * #5358: redact tokens from a string that may have escape sequences interleaved
+ * MID-TOKEN — the PTY hex-dump source. The contiguous `redactSensitive` misses
+ * a token split by an escape; this detects tokens in an escape-STRIPPED copy,
+ * then redacts the corresponding characters in the ORIGINAL while LEAVING the
+ * escape bytes in place. So a hex dump keeps the escape structure it exists to
+ * show, but the token leaks in neither the hex nor the ASCII column.
+ *
+ * Length-preserving (each token char → 'X'), so escape-byte offsets in the dump
+ * stay meaningful. Intended to be layered AFTER redactSensitive (which handles
+ * the contiguous case + key-name preservation); this pass only changes a string
+ * when a split token survived.
+ *
+ * NOTE: a generic high-entropy "any token-shaped string" heuristic is
+ * deliberately NOT added — on a diagnostic dump it would redact UUIDs, git
+ * SHAs, and base64 payloads (the very content the dump exists to show). The
+ * marker-prefixed patterns (sk-/AIza/Bearer/JWT/key=value) are the safe set.
+ *
+ * @param {string} s latin1/utf8 string (one char per byte for the dump path)
+ * @returns {string}
+ */
+export function redactSensitivePreservingEscapes(s) {
+  // Walk s, skipping escape runs, building a stripped copy + index map back to s.
+  let stripped = ''
+  const map = []
+  let i = 0
+  while (i < s.length) {
+    TOKEN_SPLITTING_ESCAPE.lastIndex = i
+    const m = TOKEN_SPLITTING_ESCAPE.exec(s)
+    if (m && m.index === i) { i += m[0].length || 1; continue }
+    stripped += s[i]
+    map.push(i)
+    i++
+  }
+  const chars = s.split('')
+  let changed = false
+  for (const pattern of [...SENSITIVE_PATTERNS, ...API_KEY_PATTERNS]) {
+    pattern.lastIndex = 0
+    let match
+    while ((match = pattern.exec(stripped)) !== null) {
+      for (let k = match.index; k < match.index + match[0].length; k++) chars[map[k]] = 'X'
+      changed = true
+      if (match[0].length === 0) pattern.lastIndex++ // guard against a zero-width match
+    }
+  }
+  return changed ? chars.join('') : s
 }
 
 let _logLevel = LOG_LEVELS[process.env.LOG_LEVEL] ?? LOG_LEVELS.info

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -492,7 +492,10 @@ describe('ClaudeTuiSession', () => {
 
     it('_outputTailHexDump redacts a token-shaped run in BOTH the hex and ASCII columns', () => {
       const s = makeSession()
-      const token = 'sk-ant-api03-' + 'A'.repeat(50)
+      // 44 A's keeps the token ≥40 chars (matches the sk-ant pattern) while
+      // placing the trailing escape mid-row so its 4 hex bytes stay on one line
+      // (length-preserving X-redaction doesn't shift the escape's position).
+      const token = 'sk-ant-api03-' + 'A'.repeat(44)
       // Include an escape byte to prove control bytes survive the latin1 round-trip.
       s._outputTailRaw = Buffer.from(`Invalid API key ${token}\x1b[0m done`, 'latin1')
       const dump = s._outputTailHexDump()
@@ -502,10 +505,27 @@ describe('ClaudeTuiSession', () => {
       // (Fixture is sized so "sk-ant" lands within one 16-byte hex row.)
       const prefixHex = Buffer.from('sk-ant', 'latin1').toString('hex').match(/../g).join(' ')
       assert.ok(!dump.replace(/\s+/g, ' ').includes(prefixHex), 'token hex bytes absent from the hex column')
-      assert.ok(dump.includes('REDACTED'), 'redaction marker present')
+      // Token chars are scrubbed to 'X' (0x58) — the 'A' body run (0x41) is gone.
+      assert.ok(!dump.replace(/\s+/g, ' ').includes('41 41 41 41 41 41'), 'token body bytes scrubbed (redacted)')
       // The full escape RUN `\x1b[0m` (1b 5b 30 6d) survives — proves redaction
       // scrubbed only the token, not the control bytes the dump exists to show.
       assert.ok(dump.replace(/\s+/g, ' ').includes('1b 5b 30 6d'), 'escape sequence preserved — diagnostic value intact')
+    })
+
+    it('_outputTailHexDump does not leak the tail of a MARKER-PREFIXED split token (#5358 Copilot)', () => {
+      const s = makeSession()
+      // The bypass: `token=<sk-ant head>\x1b...<tail>`. If redactSensitive ran
+      // first it would collapse `token=sk-ant-AAAA` → `token= [REDACTED]`,
+      // consuming the marker so the escape-aware pass couldn't reassemble the
+      // run — leaking the BBBB tail. Using the escape-aware pass alone fixes it.
+      const head = 'sk-ant-api03-' + 'A'.repeat(20)
+      const tail = 'B'.repeat(30)
+      s._outputTailRaw = Buffer.from(`token=${head}\x1b[1m${tail} end`, 'latin1')
+      const dumpNorm = s._outputTailHexDump().replace(/\s+/g, ' ')
+      // The tail "BBBB…" (0x42 run) must NOT survive after the escape.
+      assert.ok(!dumpNorm.includes('42 42 42 42 42 42'), 'split-token TAIL must not leak past the escape')
+      assert.ok(!dumpNorm.includes('41 41 41 41 41 41'), 'split-token HEAD redacted too')
+      assert.ok(dumpNorm.includes('1b 5b 31 6d'), 'escape sequence preserved')
     })
 
     it('_outputTailHexDump redacts an ANSI-SPLIT token the contiguous patterns miss (#5358)', () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -508,6 +508,27 @@ describe('ClaudeTuiSession', () => {
       assert.ok(dump.replace(/\s+/g, ' ').includes('1b 5b 30 6d'), 'escape sequence preserved — diagnostic value intact')
     })
 
+    it('_outputTailHexDump redacts an ANSI-SPLIT token the contiguous patterns miss (#5358)', () => {
+      const s = makeSession()
+      // A token split mid-run by a CSI escape — the contiguous redactor sees
+      // each half as too short (sk-ant-api03- + only 20 chars before the escape,
+      // 30 after), so pre-#5358 the secret leaked in the dump.
+      const head = 'sk-ant-api03-' + 'Z'.repeat(20)
+      const tail = 'Z'.repeat(30)
+      // "auth " (5 bytes) then "sk-ant" so its hex lands inside the first row.
+      s._outputTailRaw = Buffer.from(`auth ${head}\x1b[1m${tail} end`, 'latin1')
+      const dumpNorm = s._outputTailHexDump().replace(/\s+/g, ' ')
+
+      // Meaningful (hex-column) check — the formatted dump wraps every 16 bytes,
+      // so a string-contains check on the token would be vacuous. The "sk-ant"
+      // bytes (73 6b 2d 61 6e 74) and the token's Z-run (5a) must be scrubbed to
+      // 'X' (58); without the escape-preserving layer they'd survive split.
+      assert.ok(!dumpNorm.includes('73 6b 2d 61 6e 74'), 'token "sk-ant" hex bytes scrubbed from the hex column')
+      assert.ok(!dumpNorm.includes('5a 5a 5a 5a 5a 5a'), 'token Z-byte run scrubbed (no leaked token bytes)')
+      // The escape RUN `\x1b[1m` (1b 5b 31 6d) survives — only token chars scrubbed.
+      assert.ok(dumpNorm.includes('1b 5b 31 6d'), 'escape sequence preserved — diagnostic value intact')
+    })
+
     it('_outputTailDiagnostic redacts a token-shaped run (client-facing error path)', () => {
       const s = makeSession()
       const token = 'sk-ant-api03-' + 'B'.repeat(50)

--- a/packages/server/tests/logger.test.js
+++ b/packages/server/tests/logger.test.js
@@ -848,3 +848,20 @@ describe('redactSensitivePreservingEscapes — ANSI-split tokens (#5358)', () =>
     assert.ok(out.includes('\x1b[0m'), 'escape preserved')
   })
 })
+
+describe('redactSensitivePreservingEscapes — marker-prefixed split tokens (#5358 Copilot)', () => {
+  it('does NOT leak the tail of a `key=<split sk-ant>` token', () => {
+    const head = 'sk-ant-api03-' + 'A'.repeat(20)
+    const tail = 'B'.repeat(30)
+    const out = redactSensitivePreservingEscapes(`token=${head}\x1b[1m${tail} end`)
+    assert.ok(!out.includes('BBBB'), 'the tail after the escape must not leak')
+    assert.ok(!out.includes('sk-ant-api03-AAAA'), 'the head is redacted')
+    assert.ok(out.includes('\x1b[1m'), 'escape preserved')
+  })
+
+  it('does NOT leak the tail of a `Bearer <split jwt>`', () => {
+    const out = redactSensitivePreservingEscapes('Bearer eyJhbGciOiJIUzI1NiJ9\x1b[0meyJzdWIiOiJhYmMifQ.sigABCDEFGH end')
+    assert.ok(!out.includes('eyJzdWIiOiJhYmMifQ'), 'the jwt tail after the escape must not leak')
+    assert.ok(out.includes('\x1b[0m'), 'escape preserved')
+  })
+})

--- a/packages/server/tests/logger.test.js
+++ b/packages/server/tests/logger.test.js
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { mkdtempSync, rmSync, readFileSync, existsSync, chmodSync, statSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
-import { createLogger, initFileLogging, closeFileLogging, setLogListener, redactSensitive } from '../src/logger.js'
+import { createLogger, initFileLogging, closeFileLogging, setLogListener, redactSensitive, redactSensitivePreservingEscapes } from '../src/logger.js'
 
 describe('createLogger backward compatibility', () => {
   it('returns object with info, warn, error methods', () => {
@@ -798,5 +798,53 @@ describe('loggerForSession (#4792)', () => {
       /component/,
       'empty string component must also throw',
     )
+  })
+})
+
+describe('redactSensitive — JWT (#5358)', () => {
+  it('redacts a bare JWT printed without a Bearer/key marker', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dQw4w9WgXcQabcdefghij'
+    const out = redactSensitive(`token expired: ${jwt} please re-login`)
+    assert.ok(!out.includes(jwt), 'JWT must be redacted')
+    assert.ok(out.includes('[REDACTED]'))
+  })
+
+  it('does NOT redact an ordinary dotted version/identifier', () => {
+    const s = 'upgraded to v1.2.3 and module a.b.c loaded'
+    assert.equal(redactSensitive(s), s, 'short dotted strings are not JWTs')
+  })
+})
+
+describe('redactSensitivePreservingEscapes — ANSI-split tokens (#5358)', () => {
+  it('redacts a token split mid-run by an escape sequence, preserving the escape bytes', () => {
+    // sk-ant-api03-<50 A's>, but with a CSI escape injected mid-token.
+    const head = 'sk-ant-api03-' + 'A'.repeat(20)
+    const tail = 'A'.repeat(30)
+    const input = `key ${head}\x1b[1m${tail} done`
+    const out = redactSensitivePreservingEscapes(input)
+    // The contiguous token never appears (it was split, but detection strips the escape)
+    assert.ok(!out.includes(head + tail), 'reassembled token must not survive')
+    assert.ok(!out.includes('sk-ant-api03-AAAA'), 'token head redacted')
+    assert.ok(out.includes('\x1b[1m'), 'the escape sequence is preserved for diagnostics')
+  })
+
+  it('is a no-op on text with no sensitive tokens (escapes untouched)', () => {
+    const s = 'plain output \x1b[0m with \x1b[31m colors and a uuid 550e8400-e29b-41d4-a716-446655440000'
+    assert.equal(redactSensitivePreservingEscapes(s), s, 'no token → unchanged, including the UUID')
+  })
+
+  it('also catches a contiguous token (so it is safe to use alone)', () => {
+    const token = 'sk-ant-api03-' + 'B'.repeat(50)
+    const out = redactSensitivePreservingEscapes(`oops ${token} leaked`)
+    assert.ok(!out.includes(token), 'contiguous token redacted too')
+  })
+
+  it('redacts an ANSI-split JWT', () => {
+    const jwt1 = 'eyJhbGciOiJIUzI1NiJ9'
+    const jwt2 = 'eyJzdWIiOiJhYmMifQ'
+    const jwt3 = 'sig0123456789abcd'
+    const out = redactSensitivePreservingEscapes(`${jwt1}.${jwt2}\x1b[0m.${jwt3}`)
+    assert.ok(!out.includes(`${jwt1}.${jwt2}`), 'split JWT redacted')
+    assert.ok(out.includes('\x1b[0m'), 'escape preserved')
   })
 })


### PR DESCRIPTION
## Summary

Closes #5358 (follow-up from WP-4.2 / #5322 review). Two LOW-severity gaps in the PTY hex-dump redaction.

### 1. ANSI-split tokens evaded redaction

The dump redacts the **raw** buffer so escape bytes survive for diagnostics — but a token split by a mid-run escape (e.g. `sk-ant-oat01-AAAA\x1b[1mBBBB`) leaves each half too short for the contiguous patterns, so the secret leaked in the ASCII column.

**Fix:** `redactSensitivePreservingEscapes` — detect tokens in an escape-**stripped** copy, then scrub the corresponding characters in the **original** (→ `X`) while **leaving the escape bytes**, so the dump keeps the escape structure it exists to show but the token leaks in neither the hex nor the ASCII column. Layered *after* `redactSensitive` (which still handles the contiguous case + key-name preservation), so it only acts when a split token survived.

### 2. Bare JWTs / opaque OAuth tokens

`redactSensitive` covered `sk-`/`AIza`/`Bearer`/`key=value` but not a bare JWT printed without a marker. **Fix:** add a JWT pattern (`eyJ`-prefixed `header.payload.signature`) to the shared `API_KEY_PATTERNS` — `eyJ` = base64 of `{"`, specific enough to avoid ordinary dotted strings.

### Decided NOT to add: a generic high-entropy heuristic

A blanket "any token-shaped string" matcher would redact UUIDs / git SHAs / base64 payloads on the diagnostic dump — the very content it exists to show. Documented in the code; the marker-prefixed set is the safe bar.

## Tests

- JWT redaction (+ ordinary `v1.2.3` / `a.b.c` left untouched);
- `redactSensitivePreservingEscapes`: split `sk-ant` token + split JWT redacted, **escape bytes preserved**, no-op on token-free text (incl. a UUID), and contiguous tokens also caught;
- `_outputTailHexDump` scrubs a split token's **hex bytes** (`73 6b 2d 61 6e 74` / the `5a` run → `X`) while keeping the escape run `1b 5b 31 6d` — **mutation-verified** (fails without the escape-preserving layer).

The existing contiguous-token hex-dump test still passes (layered design). 349 across logger + TUI suites; logger-scoping lint + eslint clean.