### PR TITLE
fix(server): migrate claude-tui watchdog timing to a monotonic clock (#5332)

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -474,9 +474,11 @@ export class ClaudeTuiSession extends BaseSession {
     // clock backward and prove the watchdogs don't false-fire. Date.now() is
     // retained ONLY where a real wall-clock epoch is required (file mtime
     // comparison, timestamp payloads to clients, log-throttle bookkeeping).
-    this._monotonicNowFn = typeof monotonicNow === 'function'
-      ? monotonicNow
-      : () => Math.trunc(performance.now())
+    // Truncate at the seam (not just the default) so the integer-ms invariant
+    // holds for an injected clock too — `performance.now()` and a test clock
+    // may both be fractional.
+    const rawMonotonicNow = typeof monotonicNow === 'function' ? monotonicNow : () => performance.now()
+    this._monotonicNowFn = () => Math.trunc(rawMonotonicNow())
 
     this._port = port || null
     // #4044: when true, spawn `claude` with --dangerously-skip-permissions

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -1,6 +1,7 @@
 import { randomBytes, randomUUID } from 'crypto'
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, unlinkSync, writeFileSync } from 'fs'
 import { homedir, tmpdir } from 'os'
+import { performance } from 'node:perf_hooks'
 import { dirname, join, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import { BaseSession, buildBaseSessionOpts } from './base-session.js'
@@ -461,7 +462,21 @@ export class ClaudeTuiSession extends BaseSession {
   constructor(opts = {}) {
     super(buildBaseSessionOpts(opts, { provider: opts.provider || 'claude-tui' }))
     // ClaudeTuiSession-local opts (not BaseSession opts — see buildBaseSessionOpts).
-    const { port, firstOutputTimeoutMs, skipPermissions, resumeSessionId } = opts
+    const { port, firstOutputTimeoutMs, skipPermissions, resumeSessionId, monotonicNow } = opts
+
+    // #5332: monotonic clock for turn-duration logging and watchdog poll-loop
+    // deadlines (hook poll, waitForPrompt, PTY write). Wall-clock (Date.now())
+    // jumps backward on laptop sleep / NTP step, which can make a `while
+    // (Date.now() - start < timeout)` deadline never expire (hang) or expire
+    // early (false stall). performance.now() is monotonic — immune to both.
+    // Truncated to integer ms so it is a drop-in for the Date.now() deltas the
+    // instrumentation logs already print. Injectable so tests can step the
+    // clock backward and prove the watchdogs don't false-fire. Date.now() is
+    // retained ONLY where a real wall-clock epoch is required (file mtime
+    // comparison, timestamp payloads to clients, log-throttle bookkeeping).
+    this._monotonicNowFn = typeof monotonicNow === 'function'
+      ? monotonicNow
+      : () => Math.trunc(performance.now())
 
     this._port = port || null
     // #4044: when true, spawn `claude` with --dangerously-skip-permissions
@@ -792,6 +807,11 @@ export class ClaudeTuiSession extends BaseSession {
     }
   }
 
+  // #5332: monotonic now (integer ms). Used for every turn-duration delta and
+  // watchdog poll-loop deadline so a wall-clock jump can't hang or false-fire
+  // them. See the _monotonicNowFn note in the constructor.
+  _nowMonotonic() { return this._monotonicNowFn() }
+
   // Tail length to keep + length to include in error diagnostics.
   static get PTY_TAIL_BYTES() { return 4096 }
   static get PTY_TAIL_DIAGNOSTIC_BYTES() { return 1024 }
@@ -919,6 +939,8 @@ export class ClaudeTuiSession extends BaseSession {
         // dirs a grace window before reaping so we can't delete one mid-creation;
         // a genuinely orphaned dir is older than the grace and still gets swept.
         try {
+          // #5332: wall-clock deliberately — compared against the filesystem
+          // mtime (also wall-clock). A monotonic clock would be meaningless here.
           if (Date.now() - statSync(dir).mtimeMs < ClaudeTuiSession.SINK_SWEEP_GRACE_MS) {
             kept++
             continue
@@ -1529,9 +1551,9 @@ export class ClaudeTuiSession extends BaseSession {
     // whether the call returned promptly (write stage stalled) or
     // burned its 5s timeout (probe degraded). Routes via `_activeTurn`
     // so the line is sourced from the same turn the caller is logging.
-    const startMs = Date.now()
+    const startMs = this._nowMonotonic()
     const finish = (ready) => {
-      const elapsedMs = Date.now() - startMs
+      const elapsedMs = this._nowMonotonic() - startMs
       if (this._activeTurn) {
         this._activeTurn.waitForPromptMs = elapsedMs
         this._activeTurn.waitForPromptReady = ready
@@ -1557,7 +1579,7 @@ export class ClaudeTuiSession extends BaseSession {
       if (status !== null) sawStatus = true
       return status !== null && status !== 'busy'
     }
-    while (Date.now() - startMs < timeoutMs) {
+    while (this._nowMonotonic() - startMs < timeoutMs) {
       if (this._ptyExited) {
         this._lastProbeSawStatus = sawStatus
         return finish(false)
@@ -1686,7 +1708,7 @@ export class ClaudeTuiSession extends BaseSession {
     this._messageCounter += 1
     const messageId = `${this._messageIdPrefix}-${this._messageCounter}`
     this._currentMessageId = messageId
-    const startedAt = Date.now()
+    const startedAt = this._nowMonotonic()
     this._activeTurn = { messageId, startedAt, aborted: false, synthSeq: 0 }
     // Wedge instrumentation (#4678 follow-up): entry log for grep'ing
     // every turn from chroxy.log. Per-stage timings + completion get
@@ -1829,7 +1851,7 @@ export class ClaudeTuiSession extends BaseSession {
     // session-level _consumedFiles Set ensures we never re-process a file
     // that an earlier turn already handled.
     const HOOK_TIMEOUT_MS = this._hardTimeoutMs
-    const pollStart = Date.now()
+    const pollStart = this._nowMonotonic()
     let stopPayload = null
     // Wedge instrumentation (#4678 follow-up): track loop progress so
     // a wedge that manifests as "stuck waiting for stop-hook" produces
@@ -1926,7 +1948,7 @@ export class ClaudeTuiSession extends BaseSession {
       }
     }
 
-    while (Date.now() - pollStart < HOOK_TIMEOUT_MS) {
+    while (this._nowMonotonic() - pollStart < HOOK_TIMEOUT_MS) {
       if (this._activeTurn?.aborted) break
       if (this._ptyExited) break
       // _handleHardTimeout clears _isBusy; bail out cleanly if it fired.
@@ -1938,7 +1960,7 @@ export class ClaudeTuiSession extends BaseSession {
       // stop-hook, emit a progress line. Sized at 5s so a healthy
       // ~2-5s tool turn emits zero heartbeats while a wedge gets
       // logged every 5s with sink-dir state.
-      const now = Date.now()
+      const now = this._nowMonotonic()
       if (now - lastHeartbeatMs >= ClaudeTuiSession.HOOK_HEARTBEAT_MS) {
         lastHeartbeatMs = now
         let sinkFileCount = 0
@@ -1952,7 +1974,7 @@ export class ClaudeTuiSession extends BaseSession {
     // exit shape — whether it broke on stopPayload, abort, ptyExited,
     // !isBusy, or timeout. Pair with sendMessage's final summary to
     // reconstruct the wedge stage post-hoc.
-    log.info(`hookPoll exit (msg=${messageId} iters=${pollIters} elapsedMs=${Date.now() - pollStart} consumed=${totalConsumed} stopFound=${stopPayload ? 'yes' : 'no'} aborted=${this._activeTurn?.aborted ? 'yes' : 'no'} ptyExited=${this._ptyExited ? 'yes' : 'no'} stillBusy=${this._isBusy ? 'yes' : 'no'})`)
+    log.info(`hookPoll exit (msg=${messageId} iters=${pollIters} elapsedMs=${this._nowMonotonic() - pollStart} consumed=${totalConsumed} stopFound=${stopPayload ? 'yes' : 'no'} aborted=${this._activeTurn?.aborted ? 'yes' : 'no'} ptyExited=${this._ptyExited ? 'yes' : 'no'} stillBusy=${this._isBusy ? 'yes' : 'no'})`)
 
     if (!stopPayload) {
       let reason
@@ -1967,14 +1989,14 @@ export class ClaudeTuiSession extends BaseSession {
         // error. Just return without double-firing.
         return
       } else {
-        reason = `Stop hook timeout after ${Math.round((Date.now() - pollStart) / 1000)}s`
+        reason = `Stop hook timeout after ${Math.round((this._nowMonotonic() - pollStart) / 1000)}s`
       }
       const tail = this._outputTailDiagnostic()
       this._finishTurnError(tail ? `${reason}\nTUI output tail:\n${tail}` : reason, messageId)
       return
     }
 
-    const duration = Date.now() - startedAt
+    const duration = this._nowMonotonic() - startedAt
     const text = typeof stopPayload.last_assistant_message === 'string' ? stopPayload.last_assistant_message : ''
 
     // Deliver the response as a single stream burst so the dashboard renders
@@ -2083,11 +2105,11 @@ export class ClaudeTuiSession extends BaseSession {
     // the two — if the line never appears in the log, the wedge is in
     // here; if it appears with completed=true, the wedge is downstream
     // (hook poll loop, or claude TUI itself).
-    const writeStartMs = Date.now()
+    const writeStartMs = this._nowMonotonic()
     const codePointCount = [...text].length
     const byteLength = Buffer.byteLength(text, 'utf8')
     const finish = (path, completed) => {
-      const elapsedMs = Date.now() - writeStartMs
+      const elapsedMs = this._nowMonotonic() - writeStartMs
       if (this._activeTurn) {
         this._activeTurn.writePath = path
         this._activeTurn.writeMs = elapsedMs
@@ -2396,7 +2418,8 @@ export class ClaudeTuiSession extends BaseSession {
               toolUseId,
               questionCount,
               reason: 'multi_question',
-              timestamp: Date.now(),
+              timestamp: Date.now(), // #5332: wall-clock epoch — a payload field for clients, not a duration
+
             })
           } catch (err) {
             ;(this._log || log).warn(`multi_question_intervention listener threw (continuing): ${err?.message || err}`)
@@ -2445,7 +2468,7 @@ export class ClaudeTuiSession extends BaseSession {
     if (toolName === 'AskUserQuestion' && toolUseId && this._multiQuestionSubmitAt.has(toolUseId)) {
       const submitAt = this._multiQuestionSubmitAt.get(toolUseId)
       this._multiQuestionSubmitAt.delete(toolUseId)
-      const deltaMs = Date.now() - submitAt
+      const deltaMs = this._nowMonotonic() - submitAt
       ;(this._log || log).info(`AskUserQuestion multi-question: Submit→PostToolUse=${deltaMs}ms (tool=${toolUseId}) — forensic for #4884 trailing-'\\r' verification`)
     }
     if (toolName === 'AskUserQuestion' && toolUseId) {
@@ -2531,7 +2554,7 @@ export class ClaudeTuiSession extends BaseSession {
       log.info(`sendMessage done (msg=none reason=${reason})`)
       return
     }
-    const duration = Date.now() - turn.startedAt
+    const duration = this._nowMonotonic() - turn.startedAt
     log.info(`sendMessage done (msg=${turn.messageId} reason=${reason} duration=${duration}` +
       ` waitForPromptMs=${turn.waitForPromptMs ?? 'n/a'} ready=${turn.waitForPromptReady ?? 'n/a'} sawStatus=${turn.waitForPromptSawStatus ?? 'n/a'}` +
       ` writePath=${turn.writePath ?? 'n/a'} writeMs=${turn.writeMs ?? 'n/a'} writeBytes=${turn.writeBytes ?? 'n/a'} writeCompleted=${turn.writeCompleted ?? 'n/a'})`)
@@ -2588,7 +2611,7 @@ export class ClaudeTuiSession extends BaseSession {
     // stream_end, leaving session-message-history._pendingStreams holding
     // the entry until destroy().
     const messageId = callerMessageId || this._currentMessageId
-    const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : 0
+    const duration = this._activeTurn ? this._nowMonotonic() - this._activeTurn.startedAt : 0
     if (messageId) this.emit('stream_end', { messageId })
     this.emit('error', { message })
     // #4072: subscription-billed → cost: null so SessionManager skips
@@ -2766,7 +2789,7 @@ export class ClaudeTuiSession extends BaseSession {
     }
     if (this._firstOutputTimeoutMs <= 0) return
     if (this._firstOutputDisarmed) return
-    this._firstOutputArmedAt = Date.now()
+    this._firstOutputArmedAt = this._nowMonotonic()
     this._firstOutputTimeout = setTimeout(() => {
       this._firstOutputTimeout = null
       this._handleFirstOutputTimeout()
@@ -2828,7 +2851,7 @@ export class ClaudeTuiSession extends BaseSession {
     this._assertBusyHasMessageId('_handleHardTimeout')
     const friendly = formatIdleDuration(this._hardTimeoutMs)
     log.warn(`Hard-cap timeout (${friendly}) — force-clearing busy state`)
-    const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : this._hardTimeoutMs
+    const duration = this._activeTurn ? this._nowMonotonic() - this._activeTurn.startedAt : this._hardTimeoutMs
     // #4641: shared teardown helper. Flags preserve exact historical
     // behaviour — hard-timeout emits stream_end unconditionally (even if
     // messageId is null) and emits error BEFORE _emitResult; stream-stall
@@ -2876,7 +2899,7 @@ export class ClaudeTuiSession extends BaseSession {
     log.warn(
       `Stream stalled (${friendly}, messageId=${messageId}) — clearing busy state for retry`,
     )
-    const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : this._streamStallTimeoutMs
+    const duration = this._activeTurn ? this._nowMonotonic() - this._activeTurn.startedAt : this._streamStallTimeoutMs
     // #5321 (WP-4.1) — a turn that stalled WITH a logged-out / expired-login
     // banner in its tail is an auth failure, not a generic stall. Upgrade the
     // error so mid-session expiry gives actionable `claude login` guidance
@@ -2933,12 +2956,12 @@ export class ClaudeTuiSession extends BaseSession {
     // surfaces from THIS path too.
     this._assertBusyHasMessageId('_handleFirstOutputTimeout')
     const elapsedMs = this._firstOutputArmedAt > 0
-      ? Date.now() - this._firstOutputArmedAt
+      ? this._nowMonotonic() - this._firstOutputArmedAt
       : this._firstOutputTimeoutMs
     const friendly = formatIdleDuration(this._firstOutputTimeoutMs)
     log.warn(`first-output watchdog fired (elapsedMs=${elapsedMs}) — claude TUI did not respond`)
     const duration = this._activeTurn
-      ? Date.now() - this._activeTurn.startedAt
+      ? this._nowMonotonic() - this._activeTurn.startedAt
       : this._firstOutputTimeoutMs
     // #5321 (WP-4.1) — upgrade to AUTH_REQUIRED when the pre-first-output
     // silence came WITH a logged-out / expired-login banner (e.g. an expired
@@ -3792,7 +3815,7 @@ export class ClaudeTuiSession extends BaseSession {
         if (item && typeof item === 'object' && item.type === 'mark') {
           // #4884 — record submit-time marker for the PostToolUse delta log.
           if (item.label === 'submit' && item.toolUseId) {
-            this._multiQuestionSubmitAt.set(item.toolUseId, Date.now())
+            this._multiQuestionSubmitAt.set(item.toolUseId, this._nowMonotonic())
           }
           continue
         }
@@ -3942,7 +3965,7 @@ export class ClaudeTuiSession extends BaseSession {
    */
   _teardownAskUserQuestion(toolUseId, { synthResult, emitResultReason, errorCode, errorMessage }) {
     const messageId = this._currentMessageId
-    const duration = this._activeTurn ? Date.now() - this._activeTurn.startedAt : 0
+    const duration = this._activeTurn ? this._nowMonotonic() - this._activeTurn.startedAt : 0
 
     // #4691: surgical clear — drop ONLY the entry for the tool that
     // timed out. The other teardown sites (_finishTurnError, hard

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -3271,9 +3271,10 @@ describe('ClaudeTuiSession', () => {
       session._currentMessageId = 'msg-stall'
       // Backdated startedAt so we can assert duration > 0 below — proves the
       // computed duration is derived from _activeTurn.startedAt rather than
-      // the fallback to _streamStallTimeoutMs.
+      // the fallback to _streamStallTimeoutMs. #5332: startedAt is now on the
+      // monotonic clock, so seed it from the same clock (not Date.now()).
       const TURN_AGE_MS = 100
-      session._activeTurn = { startedAt: Date.now() - TURN_AGE_MS, aborted: false }
+      session._activeTurn = { startedAt: session._nowMonotonic() - TURN_AGE_MS, aborted: false }
       const ptyWrites = []
       session._term = { write: (b) => ptyWrites.push(b), kill: () => {} }
 
@@ -7382,5 +7383,91 @@ describe('ClaudeTuiSession — hook-sink vanish recovery (#5329)', () => {
     assert.equal(ok, true, 'a squatted path must be recoverable, not a permanent spin')
     assert.ok(statSync(session._sinkDir).isDirectory(), 'the squatter file is replaced by a directory')
     assert.equal(readFileSync(join(session._sinkDir, 'owner.pid'), 'utf8'), String(process.pid))
+  })
+})
+
+// #5332 — turn-duration logging and watchdog poll-loop deadlines used to read
+// the wall clock (Date.now()). A laptop sleep / NTP step that moves the wall
+// clock backward made `Date.now() - startedAt` negative (bogus durations) and
+// could make a `while (Date.now() - start < timeout)` poll-loop deadline never
+// expire — a silent hang. These now read a monotonic clock (performance.now()),
+// injectable here so the wall clock can be frozen/stepped to prove immunity.
+describe('ClaudeTuiSession — monotonic watchdog clocks (#5332)', () => {
+  let skillsDir, session
+  beforeEach(() => {
+    skillsDir = mkdtempSync(join(tmpdir(), 'chroxy-mono-skills-'))
+  })
+  afterEach(async () => {
+    if (session) { try { await session.destroy() } catch { /* ignore */ } session = null }
+    rmSync(skillsDir, { recursive: true, force: true })
+  })
+
+  it('honors an injected monotonicNow clock', () => {
+    let mono = 1000
+    session = new ClaudeTuiSession({
+      cwd: '/tmp', skillsDir, repoSkillsDir: null,
+      monotonicNow: () => mono,
+    })
+    assert.equal(session._nowMonotonic(), 1000, 'reads the injected clock')
+    mono = 4200
+    assert.equal(session._nowMonotonic(), 4200, 'advances with the injected clock')
+  })
+
+  it('the default clock never regresses when the wall clock (Date.now) steps backward', (t) => {
+    session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
+    const before = session._nowMonotonic()
+    // Laptop sleep / NTP step: wall clock jumps an hour into the past.
+    t.mock.method(Date, 'now', () => 0)
+    const after = session._nowMonotonic()
+    assert.ok(after >= before, `monotonic clock does not regress (before=${before} after=${after})`)
+    assert.ok(Number.isInteger(after), 'integer ms — a drop-in for the Date.now() deltas the logs print')
+  })
+
+  it('stream-stall duration is the bounded monotonic turn age, not a wall-clock delta', async () => {
+    // Fixed monotonic clock at 10_000; turn started 100 monotonic-ms ago.
+    const mono = 10_000
+    session = new ClaudeTuiSession({
+      cwd: '/tmp', skillsDir, repoSkillsDir: null,
+      resultTimeoutMs: 5000, hardTimeoutMs: 5000, streamStallTimeoutMs: 25,
+      monotonicNow: () => mono,
+    })
+    session._isBusy = true
+    session._currentMessageId = 'msg-mono-stall'
+    const TURN_AGE_MS = 100
+    session._activeTurn = { startedAt: mono - TURN_AGE_MS, aborted: false }
+    session._term = { write: () => {}, kill: () => {} }
+    const results = []
+    session.on('result', (e) => results.push(e))
+    session.on('error', () => {})
+
+    session._armResultTimeout()
+    await new Promise((r) => setTimeout(r, 80))
+
+    const result = results.find(Boolean)
+    assert.ok(result, 'stall watchdog fired and emitted a result')
+    // The fix discriminator: a wall-clock `Date.now() - startedAt` (startedAt
+    // ≈ 9900) would be ~1.7e12. The monotonic delta is exactly the turn age.
+    assert.ok(result.duration >= TURN_AGE_MS && result.duration < 60_000,
+      `duration is the bounded monotonic turn age (got ${result.duration})`)
+  })
+
+  it('the _waitForPrompt deadline loop terminates via the monotonic clock even with the wall clock frozen (no hang)', async (t) => {
+    // Monotonic clock advances 1s per read, so the 50ms deadline trips on the
+    // first while-check. Pre-fix the loop read Date.now(); with the wall clock
+    // frozen below it would spin on `while (0 - 0 < 50)` forever — a hang.
+    let mono = 0
+    session = new ClaudeTuiSession({
+      cwd: '/tmp', skillsDir, repoSkillsDir: null,
+      monotonicNow: () => { mono += 1000; return mono },
+    })
+    // Valid-looking pid with no session file → readSessionStatus stays null →
+    // never "ready", so only the deadline can end the loop.
+    session._term = { pid: 2 ** 30, write: () => {}, kill: () => {} }
+    t.mock.method(Date, 'now', () => 0) // wall clock frozen in the past
+    const ready = await Promise.race([
+      session._waitForPrompt(50),
+      new Promise((res) => setTimeout(() => res('HANG'), 2000)),
+    ])
+    assert.equal(ready, false, 'loop exits not-ready via the monotonic deadline (did not hang on the frozen wall clock)')
   })
 })

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -7413,6 +7413,17 @@ describe('ClaudeTuiSession — monotonic watchdog clocks (#5332)', () => {
     assert.equal(session._nowMonotonic(), 4200, 'advances with the injected clock')
   })
 
+  it('truncates an injected fractional clock to integer ms (the documented invariant)', () => {
+    // Copilot #5414: an injected monotonicNow could return fractional ms; the
+    // seam truncates so every call site gets the integer-ms drop-in it expects.
+    session = new ClaudeTuiSession({
+      cwd: '/tmp', skillsDir, repoSkillsDir: null,
+      monotonicNow: () => 1234.987,
+    })
+    assert.equal(session._nowMonotonic(), 1234, 'fractional injected clock is truncated')
+    assert.ok(Number.isInteger(session._nowMonotonic()), 'always integer ms')
+  })
+
   it('the default clock never regresses when the wall clock (Date.now) steps backward', (t) => {
     session = new ClaudeTuiSession({ cwd: '/tmp', skillsDir, repoSkillsDir: null })
     const before = session._nowMonotonic()


### PR DESCRIPTION
## Summary

IP-4 from the TUI hardening audit. Turn-duration logging and the watchdog **poll-loop deadlines** in `claude-tui-session.js` read the **wall clock** (`Date.now()`). A laptop sleep or NTP step that moves the wall clock backward:

- makes `Date.now() - startedAt` **negative** → bogus durations in the wedge instrumentation, and
- makes a `while (Date.now() - start < timeout)` deadline **never expire** → a silent **hang** on the hook-poll loop and the `_waitForPrompt` readiness loop.

**Confirmed** (not refuted): the hook-poll loop (`while (Date.now() - pollStart < HOOK_TIMEOUT_MS)`) and `_waitForPrompt` (`while (Date.now() - startMs < timeoutMs)`) are real backward-step hangs. Migrated.

## What changed

- Add an injectable `_nowMonotonic()` — `Math.trunc(performance.now())`, integer ms so it's a drop-in for the existing `Date.now()` deltas — seeded from a new `monotonicNow` opt (test-only injection point).
- Migrate every **turn-duration delta** and **poll-loop deadline** to it:
  - turn `startedAt` + its 7 consumers (result/error duration logs across the stall, hard-timeout, first-output, and teardown paths)
  - hook-poll deadline + heartbeat + exit log + timeout-reason string
  - `_waitForPrompt` deadline + elapsed log
  - PTY write elapsed
  - first-output watchdog elapsed
  - multi-question Submit→PostToolUse forensic delta
- **Keep `Date.now()`** only where a real wall-clock epoch is required, each annotated `#5332` so a future consistency sweep doesn't migrate them:
  - sink-dir mtime grace comparison (compared against the filesystem mtime)
  - `multi_question` `timestamp` payload field (sent to clients)
  - sink-recover log throttles (self-contained `Date.now()` pairs)

## Tests

New `monotonic watchdog clocks (#5332)` describe block:
- honors an injected `monotonicNow`
- the default clock never regresses when `Date.now` steps an hour into the past
- stream-stall duration is the **bounded monotonic turn age**, not a (~1.7e12) wall-clock delta
- the `_waitForPrompt` deadline loop **terminates** with the wall clock frozen (a `Promise.race` against a 2s `HANG` sentinel — pre-fix this spins forever)

All four are **mutation-verified non-vacuous**: reverting `_nowMonotonic()` to `Date.now()` fails all four. Full file: 293/293 pass. eslint + all three custom server lints green.

Closes #5332