### PR TITLE
fix(server): retry-FRESH fallback when every --resume respawn dies during warmup

### DIFF
--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -505,6 +505,23 @@ export class ClaudeTuiSession extends BaseSession {
       ? resumeSessionId
       : null   // upstream claude conversation uuid, assigned at start() when fresh
     this._resumedFromPersisted = this._sessionId !== null
+    // #5348 — remember whether this session was SEEDED from a persisted resume
+    // id. `_resumedFromPersisted` flips to true on every respawn (the respawn
+    // must `--resume` the live conversation), so later code can't use it to
+    // tell a restored session from an originally-fresh one. Only an
+    // originally-fresh session is eligible for the drop-and-retry-FRESH
+    // fallback in _scheduleRespawn — falling back on a restored session would
+    // silently discard a real prior conversation.
+    this._seededFromPersisted = this._resumedFromPersisted
+    // #5348 — one-shot latch for the retry-FRESH fallback (mirrors
+    // cli-session.js's `_didFallbackFromUnknownResume`). Re-armed by a respawn
+    // that survives warmup, so a FUTURE doomed-resume window can fall back
+    // again; the #5349 rolling rate cap bounds any flapping alternation.
+    this._didFallbackFromUnknownResume = false
+    // #5348 — set by _scheduleRespawn when the next respawn attempt must spawn
+    // FRESH (`--session-id` with the newly-minted uuid) instead of `--resume`.
+    // Consumed (cleared) by _respawnPty before the spawn.
+    this._freshRetryPending = false
     // #4792: session-scoped logger. Assigned in start() once _sessionId is
     // generated. Until then, code paths that need to log MUST fall back to
     // the module-level `log` (e.g. trust pre-write failure, sink dir create
@@ -1176,9 +1193,11 @@ export class ClaudeTuiSession extends BaseSession {
   /**
    * #5315 (WP-2.1) — schedule a bounded PTY respawn with exponential backoff,
    * mirroring CliSession._scheduleRespawn (cli-session.js:556). Backoff is
-   * [1s,2s,4s,8s,15s] and caps at 5 attempts; on exhaustion it emits a
-   * categorized `error` AND a `respawn_exhausted` event so SessionManager drops
-   * the session from its list (no input-rejecting zombie tab — the audit AC).
+   * [1s,2s,4s,8s,15s] and caps at 5 attempts (an originally-fresh session gets
+   * ONE extra drop-and-retry-FRESH attempt at the cap, #5348); on exhaustion it
+   * emits a categorized `error` AND a `respawn_exhausted` event so
+   * SessionManager drops the session from its list (no input-rejecting zombie
+   * tab — the audit AC).
    * Guarded on `_destroying` / `_respawning` / `_respawnScheduled` so the
    * several wired PTY-fault events (onExit/close/error) can't stack timers.
    */
@@ -1202,16 +1221,55 @@ export class ClaudeTuiSession extends BaseSession {
 
     this._respawnCount++
     if (this._respawnCount > 5) {
-      ;(this._log || log).error('Max PTY respawn attempts reached (5), giving up')
-      const tail = this._outputTailDiagnostic()
-      const base = 'Claude PTY failed to stay alive after 5 respawn attempts'
-      // Distinct code so the dashboard can render a terminal "give up" state
-      // rather than a recoverable crash toast.
-      this.emit('error', { code: 'pty_respawn_exhausted', message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
-      // SessionManager listens for this and calls destroySession() so the
-      // session leaves the list cleanly (see _wireSessionEvents).
-      this.emit('respawn_exhausted', { reason: 'pty_respawn_exhausted', attempts: this._respawnCount - 1 })
-      return
+      // #5348 — drop-and-retry-FRESH fallback. A FRESH session (spawned with
+      // `--session-id`) that died before claude persisted its conversation
+      // makes every `--resume` respawn doomed: claude can't find the
+      // conversation and exits during warmup. Reaching this cap means 5
+      // consecutive respawns never survived warmup — for an originally-fresh
+      // session, spend ONE extra attempt on a brand-new conversation id before
+      // giving up. Restored sessions are excluded: their conversation existed
+      // before this process, so dropping the id here would silently discard
+      // real context (the TUI-AUDIT-001 amnesia class) — for them, exhaustion
+      // is the honest outcome. Mirrors cli-session.js's resume_unknown
+      // fallback, just triggered by exhaustion instead of stderr classification
+      // (the TUI renders no machine-readable resume-failure diagnostic).
+      if (!this._seededFromPersisted && !this._didFallbackFromUnknownResume) {
+        this._didFallbackFromUnknownResume = true
+        this._freshRetryPending = true
+        const abandonedId = this._sessionId
+        this._sessionId = randomUUID()
+        this._resumedFromPersisted = false
+        // Rebind the session-scoped logger to the new conversation uuid so
+        // subsequent lines route under the id the dashboard will see on the
+        // re-emitted `ready` (mirrors cli-session.js rebinding on system.init).
+        this._log = loggerForSession('claude-tui-session', this._sessionId)
+        ;(this._log || log).warn(
+          `all --resume respawns died during warmup (attemptedResumeId=${abandonedId}) — ` +
+          'retrying once with a fresh --session-id (the original fresh conversation was likely never persisted)',
+        )
+        // Loud one-shot signal (same code as cli-session.js) so the dashboard
+        // can render "starting fresh" instead of a generic crash toast.
+        this.emit('error', {
+          code: 'resume_unknown',
+          message:
+            'Previous Claude conversation could not be resumed after repeated respawn failures (it was likely ' +
+            'never persisted before the PTY died). Retrying once with a fresh conversation; the model will not ' +
+            'see any earlier transcript.',
+          attemptedResumeId: abandonedId,
+        })
+        // Fall through to the scheduling below — this IS the extra attempt.
+      } else {
+        ;(this._log || log).error(`Max PTY respawn attempts reached (${this._respawnCount - 1}), giving up`)
+        const tail = this._outputTailDiagnostic()
+        const base = `Claude PTY failed to stay alive after ${this._respawnCount - 1} respawn attempts`
+        // Distinct code so the dashboard can render a terminal "give up" state
+        // rather than a recoverable crash toast.
+        this.emit('error', { code: 'pty_respawn_exhausted', message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
+        // SessionManager listens for this and calls destroySession() so the
+        // session leaves the list cleanly (see _wireSessionEvents).
+        this.emit('respawn_exhausted', { reason: 'pty_respawn_exhausted', attempts: this._respawnCount - 1 })
+        return
+      }
     }
 
     const delays = [1000, 2000, 4000, 8000, 15000]
@@ -1256,8 +1314,15 @@ export class ClaudeTuiSession extends BaseSession {
     // re-evaluates fresh (a re-login between attempts must let the session
     // recover; a still-logged-out respawn re-sets it via _spawnPty's scan).
     this._authFailureDetected = false
-    // (2) continue the SAME upstream conversation via --resume.
-    this._resumedFromPersisted = true
+    // (2) continue the SAME upstream conversation via --resume — UNLESS
+    // #5348's retry-FRESH fallback armed this attempt: then `_sessionId` is a
+    // freshly-minted uuid claude has never seen, so the spawn must use
+    // `--session-id` (forcing `--resume` here would re-doom the attempt).
+    if (this._freshRetryPending) {
+      this._freshRetryPending = false
+    } else {
+      this._resumedFromPersisted = true
+    }
     // Recompute permissionsEnabled exactly as start() did — the sink dir, hook
     // secret and settings.json are all still in place from the original start,
     // so we re-use them rather than re-deriving (no re-mint, no re-create).
@@ -1313,6 +1378,11 @@ export class ClaudeTuiSession extends BaseSession {
     // CliSession resets _respawnCount on system.init, cli-session.js:888), mark
     // ready, and re-emit `ready` so the dashboard knows the session recovered.
     this._respawnCount = 0
+    // #5348 — release the one-shot retry-FRESH latch on a warmup that survived
+    // (mirrors cli-session.js releasing it on system.init): a FUTURE
+    // doomed-resume window may fall back again; the #5349 rolling rate cap
+    // bounds any flapping alternation.
+    this._didFallbackFromUnknownResume = false
     this._processReady = true
     this.emit('ready', { sessionId: this._sessionId, model: this.model, tools: [] })
   }
@@ -1371,14 +1441,11 @@ export class ClaudeTuiSession extends BaseSession {
     // `--resume <id>` instead — reusing `--session-id` with an already-used id
     // is rejected by claude. Falls back to the fresh path whenever the session
     // wasn't seeded from a persisted id. Resume-failure handling (claude can't
-    // find the conversation, e.g. cleared ~/.claude history) currently surfaces
-    // via the warmup `_ptyExited` error path → bounded respawn (#5315) → if every
-    // resume-respawn dies, exhaustion destroys the session. NOTE: #5315 does NOT
-    // add a graceful drop-and-retry-FRESH fallback — a fresh session that dies
-    // before claude persists its conversation will burn all 5 respawns on a
-    // doomed `--resume` then get destroyed (bounded + safe, but recovery is
-    // futile in that narrow window). The retry-fresh fallback is tracked in its
-    // own follow-up (see #5315 review).
+    // find the conversation, e.g. cleared ~/.claude history) surfaces via the
+    // warmup `_ptyExited` error path → bounded respawn (#5315) → and, for an
+    // originally-fresh session whose 5 resume-respawns all died during warmup,
+    // ONE drop-and-retry-FRESH attempt with a new uuid (#5348, see
+    // _scheduleRespawn) before exhaustion destroys the session.
     const idArgs = this._resumedFromPersisted
       ? ['--resume', this._sessionId]
       : ['--session-id', this._sessionId]

--- a/packages/server/src/claude-tui-session.js
+++ b/packages/server/src/claude-tui-session.js
@@ -522,6 +522,10 @@ export class ClaudeTuiSession extends BaseSession {
     // FRESH (`--session-id` with the newly-minted uuid) instead of `--resume`.
     // Consumed (cleared) by _respawnPty before the spawn.
     this._freshRetryPending = false
+    // #5348 — the conversation uuid abandoned by the retry-FRESH fallback,
+    // surfaced as `attemptedResumeId` on the terminal resume_unknown_exhausted
+    // emit (by then `_sessionId` is already the replacement uuid).
+    this._abandonedResumeId = null
     // #4792: session-scoped logger. Assigned in start() once _sessionId is
     // generated. Until then, code paths that need to log MUST fall back to
     // the module-level `log` (e.g. trust pre-write failure, sink dir create
@@ -1237,6 +1241,9 @@ export class ClaudeTuiSession extends BaseSession {
         this._didFallbackFromUnknownResume = true
         this._freshRetryPending = true
         const abandonedId = this._sessionId
+        // Kept for the terminal resume_unknown_exhausted emit below — by the
+        // time the fallback attempt fails, _sessionId is already the new uuid.
+        this._abandonedResumeId = abandonedId
         this._sessionId = randomUUID()
         this._resumedFromPersisted = false
         // Rebind the session-scoped logger to the new conversation uuid so
@@ -1261,20 +1268,35 @@ export class ClaudeTuiSession extends BaseSession {
       } else {
         ;(this._log || log).error(`Max PTY respawn attempts reached (${this._respawnCount - 1}), giving up`)
         const tail = this._outputTailDiagnostic()
-        const base = `Claude PTY failed to stay alive after ${this._respawnCount - 1} respawn attempts`
-        // Distinct code so the dashboard can render a terminal "give up" state
-        // rather than a recoverable crash toast.
-        this.emit('error', { code: 'pty_respawn_exhausted', message: tail ? `${base}\nTUI output tail:\n${tail}` : base })
+        // When the retry-FRESH fallback itself failed, escalate with the same
+        // terminal code CliSession uses (resume_unknown_exhausted, #5004) —
+        // event-normalizer forwards it + attemptedResumeId, and the dashboard/
+        // app already render the distinct "auto-recovery exhausted" affordance.
+        // Otherwise keep the provider's own distinct code so the dashboard can
+        // render a terminal "give up" state rather than a recoverable crash
+        // toast.
+        const failedFallback = this._didFallbackFromUnknownResume
+        const code = failedFallback ? 'resume_unknown_exhausted' : 'pty_respawn_exhausted'
+        const base = failedFallback
+          ? 'Auto-recovery exhausted: every --resume respawn died during warmup and a fresh-conversation retry also failed. Start a new session manually to continue.'
+          : `Claude PTY failed to stay alive after ${this._respawnCount - 1} respawn attempts`
+        const errEnvelope = { code, message: tail ? `${base}\nTUI output tail:\n${tail}` : base }
+        if (failedFallback && this._abandonedResumeId) errEnvelope.attemptedResumeId = this._abandonedResumeId
+        this.emit('error', errEnvelope)
         // SessionManager listens for this and calls destroySession() so the
         // session leaves the list cleanly (see _wireSessionEvents).
-        this.emit('respawn_exhausted', { reason: 'pty_respawn_exhausted', attempts: this._respawnCount - 1 })
+        this.emit('respawn_exhausted', { reason: code, attempts: this._respawnCount - 1 })
         return
       }
     }
 
     const delays = [1000, 2000, 4000, 8000, 15000]
     const delay = delays[Math.min(this._respawnCount - 1, delays.length - 1)]
-    ;(this._log || log).info(`Respawning claude PTY in ${delay}ms (attempt ${this._respawnCount}/5)`)
+    // The #5348 fallback attempt is the one-past-the-cap extra — label it
+    // honestly instead of logging a nonsensical "attempt 6/5".
+    ;(this._log || log).info(this._freshRetryPending
+      ? `Respawning claude PTY in ${delay}ms (fresh-conversation retry after ${this._respawnCount - 1} failed resume attempts)`
+      : `Respawning claude PTY in ${delay}ms (attempt ${this._respawnCount}/5)`)
 
     this._respawnScheduled = true
     this._respawnTimer = setTimeout(() => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -766,7 +766,7 @@ describe('ClaudeTuiSession', () => {
       assert.equal(spawnCalls, 2, 'second death triggers a second respawn')
     })
 
-    it('after 5 attempts emits a fatal error + respawn_exhausted and stops (no infinite loop)', async () => {
+    it('after 5 attempts a RESTORED session emits a fatal error + respawn_exhausted and stops (no infinite loop)', async () => {
       let spawnCalls = 0
       // Every respawn dies again during warmup → drives toward the cap. In
       // production the wired onExit/close handlers call _onPtyGone when the PTY
@@ -775,6 +775,10 @@ describe('ClaudeTuiSession', () => {
         spawnCalls++
         self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
       })
+      // #5348 — a session seeded from a persisted resume id must NOT fall back
+      // to a fresh conversation (that would silently discard real prior
+      // context): exhaustion after exactly 5 attempts is the honest outcome.
+      session._seededFromPersisted = true
       const errors = []
       const exhausted = []
       session.on('error', (e) => errors.push(e))
@@ -796,7 +800,72 @@ describe('ClaudeTuiSession', () => {
       assert.equal(spawnCalls, 5, 'exactly 5 respawn attempts, then it gives up')
       assert.equal(exhausted.length, 1, 'respawn_exhausted emitted exactly once')
       assert.ok(errors.some((e) => e.code === 'pty_respawn_exhausted'), 'a categorized fatal error is emitted on exhaustion')
+      assert.equal(errors.every((e) => e.code !== 'resume_unknown'), true, 'a restored session never falls back to a fresh conversation')
+      assert.equal(session._sessionId, 'conv-uuid-1234', 'the restored conversation id is never replaced')
       assert.equal(session._respawnScheduled, false, 'no further respawn is scheduled after exhaustion')
+    })
+
+    // #5348 — drop-and-retry-FRESH fallback: an originally-fresh session whose
+    // conversation was never persisted makes every --resume respawn doomed
+    // (claude can't find it → exits during warmup). At the 5-attempt cap the
+    // session gets ONE extra attempt with a brand-new --session-id before
+    // giving up, instead of burning to exhaustion on a futile resume.
+    it('an originally-fresh session gets ONE retry-FRESH attempt at the cap (#5348)', async () => {
+      const spawns = []
+      session = makeSession((self) => {
+        spawns.push({ resumed: self._resumedFromPersisted, id: self._sessionId })
+        self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      })
+      const errors = []
+      const exhausted = []
+      session.on('error', (e) => errors.push(e))
+      session.on('respawn_exhausted', (d) => exhausted.push(d))
+
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      // 5 doomed --resume attempts, then the fresh fallback (also 15s backoff).
+      for (const d of [1000, 2000, 4000, 8000, 15000, 15000]) {
+        mock.timers.tick(d)
+        await new Promise((r) => setImmediate(r))
+      }
+      mock.timers.tick(15000)
+      await new Promise((r) => setImmediate(r))
+
+      assert.equal(spawns.length, 6, '5 resume attempts + exactly one fresh fallback attempt')
+      assert.ok(spawns.slice(0, 5).every((s) => s.resumed && s.id === 'conv-uuid-1234'), 'first 5 attempts --resume the original conversation')
+      assert.equal(spawns[5].resumed, false, 'the fallback attempt spawns FRESH (--session-id, not --resume)')
+      assert.notEqual(spawns[5].id, 'conv-uuid-1234', 'the fallback attempt mints a brand-new conversation uuid')
+      const resumeUnknown = errors.filter((e) => e.code === 'resume_unknown')
+      assert.equal(resumeUnknown.length, 1, 'one loud resume_unknown error so the dashboard can render "starting fresh"')
+      assert.equal(resumeUnknown[0].attemptedResumeId, 'conv-uuid-1234', 'the error carries the abandoned conversation id')
+      assert.equal(exhausted.length, 1, 'when the fresh attempt also dies, the session exhausts (one-shot latch, no loop)')
+      assert.equal(exhausted[0].reason, 'pty_respawn_exhausted')
+      assert.equal(session._respawnScheduled, false, 'no further respawn after exhaustion')
+    })
+
+    it('a retry-FRESH attempt that survives warmup re-emits ready with the new uuid and re-arms the latch (#5348)', async () => {
+      let spawnCalls = 0
+      // First 5 spawns die during warmup (doomed resumes); the 6th — the fresh
+      // fallback — survives.
+      session = makeSession((self) => {
+        spawnCalls++
+        if (spawnCalls <= 5) self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      })
+      const readies = []
+      session.on('ready', (d) => readies.push(d))
+
+      session._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      for (const d of [1000, 2000, 4000, 8000, 15000, 15000]) {
+        mock.timers.tick(d)
+        await new Promise((r) => setImmediate(r))
+      }
+
+      assert.equal(spawnCalls, 6)
+      assert.equal(readies.length, 1, 'ready re-emitted once the fresh attempt survives warmup')
+      assert.notEqual(readies[0].sessionId, 'conv-uuid-1234', 'ready carries the NEW conversation uuid (persistence picks it up via the resumeSessionId getter)')
+      assert.equal(readies[0].sessionId, session._sessionId, 'emitted id matches the live session id')
+      assert.equal(session._respawnCount, 0, 'retry budget restored after the surviving warmup')
+      assert.equal(session._didFallbackFromUnknownResume, false, 'one-shot latch re-armed on success (a FUTURE doomed-resume window may fall back again)')
+      assert.equal(session._processReady, true)
     })
 
     it('a flapping session (warmup keeps resetting _respawnCount) gives up via the rolling rate cap (#5349)', () => {

--- a/packages/server/tests/claude-tui-session.test.js
+++ b/packages/server/tests/claude-tui-session.test.js
@@ -680,9 +680,12 @@ describe('ClaudeTuiSession', () => {
 
     // Build a session with _spawnPty stubbed to succeed (live term, not exited).
     // `onSpawn` lets a test observe / mutate each spawn (e.g. count calls,
-    // capture the idArgs, or make the respawn die again).
-    function makeSession(onSpawn) {
-      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null })
+    // capture the idArgs, or make the respawn die again). `ctorOpts` are merged
+    // into the constructor opts — pass `resumeSessionId` to exercise the REAL
+    // restore-seeding path (#5348: sets `_seededFromPersisted` in the ctor)
+    // instead of poking the private flags.
+    function makeSession(onSpawn, ctorOpts = {}) {
+      const s = new ClaudeTuiSession({ cwd: '/tmp', skillsDir: emptySkillsDir, repoSkillsDir: null, ...ctorOpts })
       s._spawnPty = async function () {
         this._term = { write: () => {}, kill: () => {}, onData: () => {}, onExit: () => {}, on: () => {} }
         if (onSpawn) onSpawn(this)
@@ -690,8 +693,11 @@ describe('ClaudeTuiSession', () => {
       // Pretend start() already ran: sink/settings/secret exist, PTY is live.
       s._sinkDir = '/tmp/fake-sink'
       s._settingsPath = '/tmp/fake-sink/settings.json'
-      s._sessionId = 'conv-uuid-1234'
-      s._resumedFromPersisted = false
+      if (!ctorOpts.resumeSessionId) {
+        // Fresh-session shape: start() minted the uuid (ctor left it null).
+        s._sessionId = 'conv-uuid-1234'
+        s._resumedFromPersisted = false
+      }
       s._processReady = true
       // EventEmitter throws on an unhandled 'error'; _onPtyGone emits one on
       // the no-active-turn death path. Swallow by default — tests that assert
@@ -771,14 +777,16 @@ describe('ClaudeTuiSession', () => {
       // Every respawn dies again during warmup → drives toward the cap. In
       // production the wired onExit/close handlers call _onPtyGone when the PTY
       // dies; the stub mimics that so the same scheduling path runs.
-      session = makeSession((self) => {
-        spawnCalls++
-        self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
-      })
       // #5348 — a session seeded from a persisted resume id must NOT fall back
       // to a fresh conversation (that would silently discard real prior
       // context): exhaustion after exactly 5 attempts is the honest outcome.
-      session._seededFromPersisted = true
+      // Seed through the REAL ctor path (resumeSessionId opt) so the
+      // `_seededFromPersisted` wiring is what's under test, not a poked flag.
+      session = makeSession((self) => {
+        spawnCalls++
+        self._onPtyGone({ exitCode: 1, signal: null }, 'exit')
+      }, { resumeSessionId: 'conv-uuid-1234' })
+      assert.equal(session._seededFromPersisted, true, 'ctor seeds _seededFromPersisted from resumeSessionId')
       const errors = []
       const exhausted = []
       session.on('error', (e) => errors.push(e))
@@ -838,7 +846,12 @@ describe('ClaudeTuiSession', () => {
       assert.equal(resumeUnknown.length, 1, 'one loud resume_unknown error so the dashboard can render "starting fresh"')
       assert.equal(resumeUnknown[0].attemptedResumeId, 'conv-uuid-1234', 'the error carries the abandoned conversation id')
       assert.equal(exhausted.length, 1, 'when the fresh attempt also dies, the session exhausts (one-shot latch, no loop)')
-      assert.equal(exhausted[0].reason, 'pty_respawn_exhausted')
+      // Failed-fallback exhaustion escalates with CliSession's terminal code so
+      // the dashboard renders the "auto-recovery exhausted" affordance.
+      assert.equal(exhausted[0].reason, 'resume_unknown_exhausted')
+      const terminal = errors.find((e) => e.code === 'resume_unknown_exhausted')
+      assert.ok(terminal, 'terminal error carries the resume_unknown_exhausted code')
+      assert.equal(terminal.attemptedResumeId, 'conv-uuid-1234', 'terminal error carries the abandoned conversation id')
       assert.equal(session._respawnScheduled, false, 'no further respawn after exhaustion')
     })
 


### PR DESCRIPTION
## What

Closes #5348 (`tui-hardening`, from the #5315 review MAJOR-2).

`_respawnPty` always re-spawns with `--resume <id>`. A FRESH session (spawned with `--session-id`) that dies before claude persists its conversation makes every resume doomed — claude can't find the conversation and exits during warmup — so the session burned all 5 respawn attempts and was destroyed, even though recovery was one fresh uuid away.

## How

- **`_scheduleRespawn`**: at the 5-attempt cap, an **originally-fresh** session (`!_seededFromPersisted`) gets ONE extra attempt: mint a new `randomUUID()`, clear `_resumedFromPersisted`, rebind the session-scoped logger, and emit a loud `resume_unknown` error (same code as CliSession's fallback, cli-session.js:1617) so the dashboard can render "starting fresh" instead of a generic crash. Restored sessions are excluded — dropping their id would silently discard a real conversation (the TUI-AUDIT-001 amnesia class); for them exhaustion stays the honest outcome.
- **`_respawnPty`**: a `_freshRetryPending` flag stops it from force-flipping `_resumedFromPersisted = true` on the fallback attempt (which would have re-doomed it), and a respawn that survives warmup re-arms the one-shot latch (mirrors CliSession releasing it on `system.init`; the #5349 rolling rate cap bounds any flapping alternation).
- The exhaustion message now reports the actual attempt count instead of a hardcoded "5".

## Tests

- Existing exhaustion test now pinned to the **restored** path: exactly 5 attempts, no `resume_unknown`, id never replaced.
- New: originally-fresh session → 5 doomed `--resume` attempts + exactly one `--session-id` fallback with a new uuid + one `resume_unknown` carrying the abandoned id → exhausts if that also dies (one-shot latch, no loop).
- New: surviving fallback re-emits `ready` with the new uuid (persistence picks it up via the `resumeSessionId` getter), restores the retry budget, re-arms the latch.

296/296 in `claude-tui-session.test.js`; `lint-logger-session-scoping` / `lint-session-opt-forwarding` / `lint-tests-state-file-path` all green.