### PR TITLE
feat(server): ollama provider — local models via Anthropic-compatible API

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -35,6 +35,7 @@ The registry lives in [`packages/server/src/providers.js`](../packages/server/sr
 | `claude-channel` *(research preview)* | `claude --channels` (Claude Code CLI, MCP channel transport) | `claude` CLI login (rejects `ANTHROPIC_API_KEY`). Requires `claude` ≥ 2.1.80 + `--dangerously-load-development-channels` | Deferred to `claude` | Subscription login only | **Scaffold — not yet runnable** (`start()` throws; bridge in #3954). Documented MCP contract instead of TUI scrape; live streaming; first-party permission relay; bills as interactive subscription |
 | `gemini` | `gemini` (Gemini CLI) | `GEMINI_API_KEY` | `gemini-2.5-pro` | Google AI Studio API key | No permissions, no plan mode, no resume, no attachments |
 | `codex` | `codex` (OpenAI Codex CLI) | `OPENAI_API_KEY` | `gpt-5.4` | OpenAI API key | No permissions, no plan mode, no resume, no attachments |
+| `ollama` | `@anthropic-ai/sdk` → local Ollama daemon (v0.14+) | `CHROXY_OLLAMA_BASE_URL` / `OLLAMA_HOST` (optional endpoint overrides) | `qwen3-coder` | None — local inference | Local models via Ollama's Anthropic-compatible API; full BYOK agent loop (tools, permissions, MCP); cost always $0; any `ollama pull`ed model id accepted |
 | `docker-cli` | Docker image + `claude` inside | Inherits Claude env from container | Inherits `claude-cli` | Same as `claude-cli` | Only registered when `environments.enabled=true` and Docker daemon is reachable |
 | `docker-sdk` | Docker image + SDK inside | Inherits Claude env from container | Inherits `claude-sdk` | Same as `claude-sdk` | Only registered when `environments.enabled=true` and Docker daemon is reachable |
 
@@ -314,6 +315,43 @@ GEMINI_API_KEY=... npx chroxy start --provider gemini
 - **Attachments error out**: sending a message with attachments emits a session-level error (`Gemini provider does not support attachments`).
 - **Event format drift**: the `gemini-session.js` handler maps the most common `assistant` / `tool_result` / `result` events. Newer Gemini CLI releases may emit additional event types that Chroxy currently ignores.
 
+## Ollama (local models)
+
+Run sessions against **local open-source models** — no API key, no per-token cost, nothing leaves your machine. Requires Ollama **v0.14.0+**, which exposes an Anthropic-compatible Messages API that Chroxy drives through the same agent loop as the BYOK provider (streaming, tools, permission prompts, MCP servers, history).
+
+### Install
+
+```bash
+# Install Ollama (https://ollama.com), then:
+ollama serve                  # if not already running as a service
+ollama pull qwen3-coder       # recommended coding model
+ollama --version              # must be >= 0.14.0
+```
+
+### Use
+
+```bash
+npx chroxy start --provider ollama                       # default model: qwen3-coder
+npx chroxy start --provider ollama --model glm-4.7       # any locally pulled model id
+```
+
+There is **no model allow-list**: whatever `ollama list` shows is valid. The dashboard picker seeds Ollama's recommended coder models (`qwen3-coder`, `glm-4.7`, `minimax-m2.1`); type any other pulled model id freely. An unknown id surfaces as Ollama's own error on the first message.
+
+### Remote / non-default endpoints
+
+Resolution order: `CHROXY_OLLAMA_BASE_URL` (full URL) → `OLLAMA_HOST` (Ollama's own convention; bare `host:port` is normalized to `http://`) → `http://localhost:11434`.
+
+```bash
+CHROXY_OLLAMA_BASE_URL=http://gpu-box:11434 npx chroxy start --provider ollama
+```
+
+### Common pitfalls
+
+- **Ollama < 0.14.0**: the Anthropic-compatible endpoint doesn't exist — requests 404. Upgrade Ollama.
+- **Ollama not running**: the session starts but the first message errors with a connection failure naming the endpoint. Start `ollama serve` and retry; the session recovers on the next message.
+- **Small context windows**: the effective context is set by the local model file (`num_ctx`), not by Chroxy — long agentic sessions on small-context quantizations will truncate. Chroxy deliberately doesn't display a context-window chip for Ollama models.
+- **Capability ≠ Claude**: tool-use quality depends entirely on the local model. The recommended coder models handle the agent loop well; small general models may loop or emit malformed tool calls.
+
 ## Selecting a provider
 
 Precedence (highest first): CLI flag > environment variable > config file > default (`claude-sdk`).
@@ -352,22 +390,24 @@ Older configs use `legacyCli: true` to force the `claude-cli` provider. This sti
 
 Rows marked **(capability)** come directly from each session class's `static get capabilities()` object — those are the keys the provider registry inspects at runtime. The remaining rows are **(behavioural)** — derived from reading the session class's implementation (attachment handling, agent-tracking events, cost parsing, continuity across `sendMessage` calls). Behavioural rows are not currently part of the `capabilities` contract and may change if the class is refactored.
 
-| Capability | `claude-sdk` | `claude-cli` | `claude-tui` | `claude-channel` | `codex` | `gemini` |
-|------------|:-:|:-:|:-:|:-:|:-:|:-:|
-| **(capability)** Permissions (`canUseTool` / hook) | Yes | Yes | Yes (HTTP hook) | Yes (channel relay) | — | — |
-| **(capability)** In-process permissions | Yes | — | — | — | — | — |
-| **(capability)** Live model switch | Yes | Yes | — | — | Yes | Yes |
-| **(capability)** Live permission-mode switch | Yes | Yes | — | — | — | — |
-| **(capability)** Plan mode | — | **Yes** | — | — | — | — |
-| **(capability)** Resume (`resumeSessionId`) | Yes | — | — | — | — | — |
-| **(capability)** Terminal (raw PTY) | — | — | — | — | — | — |
-| **(capability)** Thinking level control | Yes | — | — | — | — | — |
-| **(capability)** Live streaming (`stream_delta`) | Yes | Yes | **No** (deliver-on-complete) | **Yes** | Yes | Yes |
-| **(behavioural)** Attachments (images, files) | Yes | Yes | — | — | — | — |
-| **(behavioural)** Agent tracking (spawned/completed) | Yes | Yes | — | — | — | — |
-| **(behavioural)** Cost reporting (`result.cost`) | Yes | Yes | — | — | — | — |
-| **(behavioural)** Multi-session (SessionManager) | Yes | Yes | Yes | Yes | Yes | Yes |
-| **(behavioural)** Conversation continuity across messages | Yes (SDK state) | Yes (persistent process) | Yes (persistent PTY) | Yes (persistent session) | **No** | **No** |
+| Capability | `claude-sdk` | `claude-cli` | `claude-tui` | `claude-channel` | `codex` | `gemini` | `ollama` |
+|------------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| **(capability)** Permissions (`canUseTool` / hook) | Yes | Yes | Yes (HTTP hook) | Yes (channel relay) | — | — | Yes (in-process) |
+| **(capability)** In-process permissions | Yes | — | — | — | — | — | Yes |
+| **(capability)** Live model switch | Yes | Yes | — | — | Yes | Yes | Yes |
+| **(capability)** Live permission-mode switch | Yes | Yes | — | — | — | — | Yes |
+| **(capability)** Plan mode | — | **Yes** | — | — | — | — | — |
+| **(capability)** Resume (`resumeSessionId`) | Yes | — | — | — | — | — | — |
+| **(capability)** Terminal (raw PTY) | — | — | — | — | — | — | — |
+| **(capability)** Thinking level control | Yes | — | — | — | — | — | — |
+| **(capability)** Live streaming (`stream_delta`) | Yes | Yes | **No** (deliver-on-complete) | **Yes** | Yes | Yes | Yes |
+| **(behavioural)** Attachments (images, files) | Yes | Yes | — | — | — | — | — |
+| **(behavioural)** Agent tracking (spawned/completed) | Yes | Yes | — | — | — | — | Yes |
+| **(behavioural)** Cost reporting (`result.cost`) | Yes | Yes | — | — | — | — | Yes (always $0) |
+| **(behavioural)** Multi-session (SessionManager) | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| **(behavioural)** Conversation continuity across messages | Yes (SDK state) | Yes (persistent process) | Yes (persistent PTY) | Yes (persistent session) | **No** | **No** | Yes (in-memory history) |
+
+> The `ollama` column inherits `claude-byok`'s session class (same `capabilities` object and agent loop) — the BYOK and DeepSeek providers, which share it, behave identically and are omitted here only because their columns predate this table's last sweep.
 
 For capability rows, "—" means the provider's `capabilities` object reports `false`. For behavioural rows, "—" means the feature is unimplemented (the session class throws or emits a `not supported` error, or silently no-ops). Most provider-agnostic UI (session tabs, chat/terminal dual view, push notifications, conversation search, web dashboard) works across all providers.
 

--- a/packages/server/src/handlers/settings-handlers.js
+++ b/packages/server/src/handlers/settings-handlers.js
@@ -61,20 +61,34 @@ const NEVER_AUTO_ALLOW = new Set(['Bash', 'Task', 'WebFetch', 'WebSearch'])
 const log = createLogger('ws')
 
 /**
- * Resolve the allowed model IDs for a specific provider — #2946.
+ * Sentinel: the provider opted OUT of static model validation entirely
+ * (#5418 — ollama's `getAllowedModels()` returns null because valid models
+ * are whatever the local daemon has pulled; a static list would reject
+ * them all). Distinct from the legacy "no per-provider list" fallback,
+ * which routes to the global Claude allowlist and would wrongly reject
+ * every non-Claude id.
+ */
+const PROVIDER_MODELS_UNRESTRICTED = Symbol('provider-models-unrestricted')
+
+/**
+ * Resolve the allowed model IDs for a specific provider — #2946 / #5418.
  *
  * Providers opt in to per-provider validation by exposing a static
  * `getAllowedModels()` returning an array of accepted IDs. Providers that
- * don't (claude-sdk/claude-cli/docker-*) fall back to the dynamic global
+ * don't have the method at all (docker-* wrappers and any pre-#2946
+ * embedder-registered class) fall back to the dynamic global
  * `ALLOWED_MODEL_IDS`, which is fed by the Claude Agent SDK's supported-
  * models list and is the historical source of truth for Claude sessions.
  *
- * Returning `null` means "no per-provider list available — use the global
- * allowlist." Returning an array means the provider has opted in and the
- * array is authoritative.
+ * Tri-state return:
+ *   - `string[]` — provider opted in; the array is authoritative.
+ *   - `PROVIDER_MODELS_UNRESTRICTED` — the method exists and returned a
+ *     non-array (#5418 ollama): accept any non-empty model id verbatim.
+ *   - `null` — no method / unknown provider / method threw: use the
+ *     global allowlist (conservative legacy behaviour).
  *
  * @param {string|undefined} providerName - Session's registered provider name
- * @returns {string[]|null}
+ * @returns {string[]|typeof PROVIDER_MODELS_UNRESTRICTED|null}
  */
 function getProviderAllowedModels(providerName) {
   if (!providerName) return null
@@ -88,7 +102,8 @@ function getProviderAllowedModels(providerName) {
   if (typeof ProviderClass.getAllowedModels !== 'function') return null
   try {
     const list = ProviderClass.getAllowedModels()
-    return Array.isArray(list) ? list : null
+    if (Array.isArray(list)) return list
+    return PROVIDER_MODELS_UNRESTRICTED
   } catch {
     return null
   }
@@ -110,6 +125,25 @@ function handleSetModel(ws, client, msg, ctx) {
   // crash opaquely (see issue #2946). Consult the session's provider first.
   if (entry) {
     const providerAllowed = getProviderAllowedModels(entry.provider)
+    if (providerAllowed === PROVIDER_MODELS_UNRESTRICTED) {
+      // #5418: the provider validates nothing statically (ollama — any
+      // locally pulled model id is valid; an unknown id surfaces as the
+      // backend's own error on the next message). Pass the id through
+      // verbatim after a minimal non-empty guard — without this branch the
+      // null fell through to the global Claude allowlist, which rejected
+      // every Ollama model and accepted Claude ids that 404 at the local
+      // daemon.
+      const model = msg.model.trim()
+      if (model.length === 0) {
+        log.warn(`Rejected empty model id on ${entry.provider} session ${modelSessionId} from ${client.id}`)
+        sendError(ws, msg?.requestId, 'INVALID_MODEL', `Invalid or unsupported model: ${msg.model}`)
+        return
+      }
+      ;sessionLogger(modelSessionId).info(`Model change from ${client.id} on session ${modelSessionId}: ${model}`)
+      entry.session.setModel(model)
+      ctx.broadcastToSession(modelSessionId, { type: 'model_changed', model: toShortModelId(model) })
+      return
+    }
     if (providerAllowed) {
       if (!providerAllowed.includes(msg.model)) {
         // #4828: session-scoped — modelSessionId identifies the affected

--- a/packages/server/src/ollama-session.js
+++ b/packages/server/src/ollama-session.js
@@ -1,0 +1,179 @@
+/**
+ * Ollama provider — local models through Ollama's Anthropic-compatible
+ * Messages API (Ollama v0.14.0+, default `http://localhost:11434`; the
+ * Anthropic SDK appends `/v1/messages` itself). Reuses ClaudeByokSession's
+ * entire agent loop (streaming, tools, permissions, MCP, history, cost)
+ * by swapping the four seams (`_defaultModel`, `_resolveCredentials`,
+ * `_buildClient`, `_getPricing`) plus the static-side metadata — the
+ * same subclass-not-fork rationale as deepseek-session.js.
+ *
+ * What makes this provider different from the other BYOK subclasses:
+ *   - No credentials. Ollama requires an api key field on the wire but
+ *     ignores it; `_resolveCredentials` returns the documented dummy.
+ *     `preflight.credentials.envVars` is empty so the preflight runner
+ *     skips the credential gate entirely (utils/preflight.js:130).
+ *   - No model allow-list. Models are whatever the user has `ollama pull`ed
+ *     locally — a static list would reject valid local models, so
+ *     `getAllowedModels()` returns null (session-manager treats a
+ *     non-array as "no restriction"). `getFallbackModels()` seeds the
+ *     dashboard picker with Ollama's recommended coder models; dynamic
+ *     discovery via GET /api/tags is a tracked follow-up.
+ *   - Zero pricing. Local inference is free; `_getPricing` returns a
+ *     zero-rate entry (not null) so byok-session's "no pricing entry"
+ *     warn never fires and result.cost is an honest 0.
+ *
+ * Base URL resolution (first match wins):
+ *   1. CHROXY_OLLAMA_BASE_URL — full URL, chroxy-specific override
+ *   2. OLLAMA_HOST — Ollama's own convention; may be `host:port` without
+ *      a scheme, normalized to http:// here
+ *   3. http://localhost:11434 — Ollama's default bind
+ *
+ * Reachability is NOT probed at preflight (the daemon may start before
+ * Ollama does); a dead endpoint surfaces at session start through
+ * byok-session's existing client-error path with the base URL in the
+ * message.
+ */
+
+import Anthropic from '@anthropic-ai/sdk'
+import { ClaudeByokSession } from './byok-session.js'
+
+const DEFAULT_OLLAMA_BASE_URL = 'http://localhost:11434'
+
+// Ollama's documented "required but ignored" placeholder key. The
+// Anthropic SDK refuses an empty apiKey, so something must be sent.
+const OLLAMA_DUMMY_API_KEY = 'ollama'
+
+// Seed list for the dashboard model picker — Ollama's recommended coding
+// models as of v0.14 (ollama.com/blog/claude). Deliberately short: the
+// real catalogue is whatever the user pulled, and getAllowedModels()
+// returns null so any local model id is accepted as-is. `contextWindow`
+// is null because the effective window is decided by the local model
+// file + num_ctx, not the provider — the wire schema tolerates null
+// (protocol server.ts: contextWindow is optional/unknown) and the
+// dashboard simply omits the chip.
+const OLLAMA_FALLBACK_MODELS = Object.freeze([
+  Object.freeze({ id: 'qwen3-coder', label: 'Qwen3 Coder', fullId: 'qwen3-coder', contextWindow: null }),
+  Object.freeze({ id: 'glm-4.7', label: 'GLM 4.7', fullId: 'glm-4.7', contextWindow: null }),
+  Object.freeze({ id: 'minimax-m2.1', label: 'MiniMax M2.1', fullId: 'minimax-m2.1', contextWindow: null }),
+])
+
+// Local inference: every rate is zero. A real (frozen) entry rather than
+// null so byok-session's once-per-model "no pricing entry" warn (which
+// tells operators to update CLAUDE_PRICING_USD_PER_MTOK) never fires for
+// a provider where missing pricing is not a bug.
+const OLLAMA_ZERO_PRICING = Object.freeze({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 })
+
+/**
+ * Resolve the Ollama endpoint. Exported for tests and for the auth
+ * panel's detail string — keep resolution in exactly one place.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {string}
+ */
+export function resolveOllamaBaseUrl(env = process.env) {
+  const explicit = env.CHROXY_OLLAMA_BASE_URL
+  if (typeof explicit === 'string' && explicit.length > 0) return explicit
+  const host = env.OLLAMA_HOST
+  if (typeof host === 'string' && host.length > 0) {
+    // OLLAMA_HOST accepts bare `host`, `host:port`, or a full URL.
+    return /^[a-z][a-z0-9+.-]*:\/\//i.test(host) ? host : `http://${host}`
+  }
+  return DEFAULT_OLLAMA_BASE_URL
+}
+
+export class OllamaSession extends ClaudeByokSession {
+  static get displayLabel() {
+    return 'Ollama (local)'
+  }
+
+  static get dataDir() {
+    // No `~/.claude` dependency — pure HTTP to the local Ollama daemon.
+    // getProviderDataDirs() skips providers that return null (#2965).
+    return null
+  }
+
+  static get preflight() {
+    return {
+      label: 'Ollama',
+      credentials: {
+        // Empty envVars → the preflight credential gate is skipped
+        // (utils/preflight.js requires envVars.length > 0 to check).
+        // No binary check either: Ollama is a daemon we talk HTTP to,
+        // not a CLI we spawn.
+        envVars: [],
+        hint: 'run a local Ollama (v0.14.0+) — `ollama serve`, then `ollama pull qwen3-coder`',
+        optional: true,
+      },
+    }
+  }
+
+  /**
+   * Runtime auth state for the dashboard (#4769). There is no credential:
+   * always ready, with the resolved endpoint in `detail` so SettingsPanel
+   * shows where requests will go (and which env var redirected them).
+   *
+   * @param {NodeJS.ProcessEnv} env
+   * @returns {{ready:boolean, source:string, envVar:string|null, envVars:string[], hint:string, detail:string}}
+   */
+  static resolveAuth(env) {
+    const baseURL = resolveOllamaBaseUrl(env)
+    const overrideVar = env.CHROXY_OLLAMA_BASE_URL ? 'CHROXY_OLLAMA_BASE_URL'
+      : env.OLLAMA_HOST ? 'OLLAMA_HOST'
+      : null
+    return {
+      ready: true,
+      source: 'env',
+      envVar: overrideVar,
+      envVars: ['CHROXY_OLLAMA_BASE_URL', 'OLLAMA_HOST'],
+      hint: '',
+      detail: `Local Ollama at ${baseURL} (no API key — local inference)`,
+    }
+  }
+
+  static getFallbackModels() {
+    return OLLAMA_FALLBACK_MODELS
+  }
+
+  static getAllowedModels() {
+    // null = no restriction. Valid models are whatever `ollama list`
+    // shows on this machine; the daemon can't know that statically, and
+    // rejecting unlisted ids would block every locally-pulled model.
+    // An unknown model surfaces as Ollama's own 404 at first message.
+    return null
+  }
+
+  static getModelMetadata(modelId) {
+    if (typeof modelId !== 'string' || modelId.length === 0) return null
+    const hit = OLLAMA_FALLBACK_MODELS.find((m) => m.id === modelId || m.fullId === modelId)
+    if (!hit) return null
+    return { id: hit.id, label: hit.label, fullId: hit.fullId, contextWindow: hit.contextWindow }
+  }
+
+  constructor(opts = {}) {
+    // Force the registry name so the provider id on this session is
+    // always 'ollama' — independent of whatever the embedder passed.
+    super({ ...opts, provider: 'ollama' })
+  }
+
+  // --- Seam overrides (see byok-session.js for the contract) ---
+
+  get _defaultModel() {
+    return 'qwen3-coder'
+  }
+
+  _resolveCredentials() {
+    // Required-but-ignored placeholder (docs.ollama.com/api/anthropic-compatibility).
+    return { key: OLLAMA_DUMMY_API_KEY, source: 'env' }
+  }
+
+  _buildClient(apiKey) {
+    return new Anthropic({
+      apiKey,
+      baseURL: resolveOllamaBaseUrl(),
+    })
+  }
+
+  _getPricing() {
+    return OLLAMA_ZERO_PRICING
+  }
+}

--- a/packages/server/src/ollama-session.js
+++ b/packages/server/src/ollama-session.js
@@ -71,14 +71,40 @@ const OLLAMA_ZERO_PRICING = Object.freeze({ input: 0, output: 0, cacheRead: 0, c
  * @returns {string}
  */
 export function resolveOllamaBaseUrl(env = process.env) {
-  const explicit = env.CHROXY_OLLAMA_BASE_URL
-  if (typeof explicit === 'string' && explicit.length > 0) return explicit
-  const host = env.OLLAMA_HOST
-  if (typeof host === 'string' && host.length > 0) {
+  // Trimmed-non-empty is the single "is set" predicate — resolveAuth
+  // derives its override-var label from the same helper so the detail
+  // string and the actual routing can never disagree. An exported-but-
+  // empty (or whitespace) var counts as unset. Deliberately NO URL
+  // validation here: silently redirecting a typo'd override to localhost
+  // would mask the misconfig — a malformed value flows through and fails
+  // loudly in the SDK's request path, and resolveAuth's `detail` shows
+  // the exact string in the dashboard.
+  const explicit = ollamaEnvOverride(env)
+  if (explicit === 'CHROXY_OLLAMA_BASE_URL') return env.CHROXY_OLLAMA_BASE_URL.trim()
+  if (explicit === 'OLLAMA_HOST') {
+    const host = env.OLLAMA_HOST.trim()
     // OLLAMA_HOST accepts bare `host`, `host:port`, or a full URL.
     return /^[a-z][a-z0-9+.-]*:\/\//i.test(host) ? host : `http://${host}`
   }
   return DEFAULT_OLLAMA_BASE_URL
+}
+
+/**
+ * Which env var (if any) is overriding the endpoint. Shared by
+ * resolveOllamaBaseUrl (routing) and resolveAuth (labelling) so the two
+ * can't drift.
+ *
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {'CHROXY_OLLAMA_BASE_URL'|'OLLAMA_HOST'|null}
+ */
+function ollamaEnvOverride(env) {
+  if (typeof env.CHROXY_OLLAMA_BASE_URL === 'string' && env.CHROXY_OLLAMA_BASE_URL.trim().length > 0) {
+    return 'CHROXY_OLLAMA_BASE_URL'
+  }
+  if (typeof env.OLLAMA_HOST === 'string' && env.OLLAMA_HOST.trim().length > 0) {
+    return 'OLLAMA_HOST'
+  }
+  return null
 }
 
 export class OllamaSession extends ClaudeByokSession {
@@ -117,9 +143,10 @@ export class OllamaSession extends ClaudeByokSession {
    */
   static resolveAuth(env) {
     const baseURL = resolveOllamaBaseUrl(env)
-    const overrideVar = env.CHROXY_OLLAMA_BASE_URL ? 'CHROXY_OLLAMA_BASE_URL'
-      : env.OLLAMA_HOST ? 'OLLAMA_HOST'
-      : null
+    // Same predicate as resolveOllamaBaseUrl (via the shared helper) — a
+    // truthy-but-whitespace var must not be labelled as the active
+    // override while routing ignores it.
+    const overrideVar = ollamaEnvOverride(env)
     return {
       ready: true,
       source: 'env',

--- a/packages/server/src/providers.js
+++ b/packages/server/src/providers.js
@@ -19,6 +19,7 @@ import { ClaudeTuiSession } from './claude-tui-session.js'
 import { ClaudeChannelSession } from './claude-channel-session.js'
 import { ClaudeByokSession } from './byok-session.js'
 import { DeepSeekSession } from './deepseek-session.js'
+import { OllamaSession } from './ollama-session.js'
 import { GeminiSession } from './gemini-session.js'
 import { CodexSession } from './codex-session.js'
 import { registerProviderRegistry } from './models.js'
@@ -42,6 +43,10 @@ const PROVIDERS = {
   'claude-channel': ClaudeChannelSession,
   'claude-byok': ClaudeByokSession,
   'deepseek': DeepSeekSession,
+  // Local models via Ollama's Anthropic-compatible Messages API (v0.14+).
+  // Rides the BYOK agent loop; no credentials, zero cost, models are
+  // whatever the user has pulled locally. See ollama-session.js.
+  'ollama': OllamaSession,
   'gemini': GeminiSession,
   'codex': CodexSession,
 }

--- a/packages/server/tests/ollama-session.test.js
+++ b/packages/server/tests/ollama-session.test.js
@@ -1,0 +1,203 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { OllamaSession, resolveOllamaBaseUrl } from '../src/ollama-session.js'
+import { ClaudeByokSession } from '../src/byok-session.js'
+
+/**
+ * Tests for OllamaSession (local models via Ollama's Anthropic-compatible
+ * Messages API, v0.14+).
+ *
+ * The parent ClaudeByokSession is covered by byok-session.test.js — its
+ * agent loop, tool gating, MCP wiring, history rollback, etc. don't get
+ * re-tested here. What this file pins is the subclass contract: the
+ * seam overrides return the right values for a credential-free local
+ * endpoint, the static metadata declares "no allow-list / no credential
+ * gate", and base-URL resolution honours both override env vars.
+ */
+
+// Run a block with the three base-URL env vars in a known state and
+// restore the originals afterwards — every test here mutates process.env.
+function withEnv(overrides, fn) {
+  const VARS = ['CHROXY_OLLAMA_BASE_URL', 'OLLAMA_HOST']
+  const saved = {}
+  for (const v of VARS) saved[v] = process.env[v]
+  try {
+    for (const v of VARS) delete process.env[v]
+    for (const [k, val] of Object.entries(overrides)) process.env[k] = val
+    return fn()
+  } finally {
+    for (const v of VARS) {
+      if (saved[v] === undefined) delete process.env[v]
+      else process.env[v] = saved[v]
+    }
+  }
+}
+
+describe('OllamaSession', () => {
+  describe('inheritance', () => {
+    it('extends ClaudeByokSession', () => {
+      // Load-bearing: every byok-session fix (history rollback, tool
+      // round cap, MCP teardown) flows to Ollama for free. A refactor
+      // that breaks the chain silently loses all of that.
+      assert.ok(OllamaSession.prototype instanceof ClaudeByokSession)
+    })
+  })
+
+  describe('static metadata', () => {
+    it('exposes an Ollama-branded displayLabel', () => {
+      assert.equal(OllamaSession.displayLabel, 'Ollama (local)')
+    })
+
+    it('returns null dataDir so getProviderDataDirs() skips it (#2965)', () => {
+      assert.equal(OllamaSession.dataDir, null)
+    })
+
+    it('preflight declares NO credential gate (empty envVars + optional)', () => {
+      // utils/preflight.js only checks credentials when envVars is a
+      // non-empty array — an empty list (plus optional:true as belt and
+      // suspenders) means a keyless local provider never blocks session
+      // creation on credentials.
+      const spec = OllamaSession.preflight
+      assert.equal(spec.label, 'Ollama')
+      assert.deepEqual(spec.credentials.envVars, [])
+      assert.equal(spec.credentials.optional, true)
+      assert.match(spec.credentials.hint, /ollama/i)
+      assert.equal(spec.binary, undefined,
+        'Ollama is a daemon reached over HTTP, not a CLI we spawn — no binary preflight')
+    })
+
+    it('resolveAuth is always ready and surfaces the resolved endpoint', () => {
+      withEnv({}, () => {
+        const auth = OllamaSession.resolveAuth(process.env)
+        assert.equal(auth.ready, true)
+        assert.equal(auth.envVar, null, 'no override env var in play')
+        assert.match(auth.detail, /localhost:11434/)
+        assert.match(auth.detail, /no API key/i)
+      })
+    })
+
+    it('resolveAuth names the override env var when one redirected the endpoint', () => {
+      withEnv({ CHROXY_OLLAMA_BASE_URL: 'http://gpu-box:11434' }, () => {
+        const auth = OllamaSession.resolveAuth(process.env)
+        assert.equal(auth.ready, true)
+        assert.equal(auth.envVar, 'CHROXY_OLLAMA_BASE_URL')
+        assert.match(auth.detail, /gpu-box:11434/)
+      })
+    })
+
+    it('getAllowedModels returns null — local models are unrestricted', () => {
+      // Models are whatever `ollama pull` fetched on this machine; a
+      // static allow-list would reject valid local models.
+      // session-manager treats a non-array as "no restriction".
+      assert.equal(OllamaSession.getAllowedModels(), null)
+    })
+
+    it('getFallbackModels seeds the picker with recommended coder models', () => {
+      const models = OllamaSession.getFallbackModels()
+      assert.ok(models.length >= 1)
+      const ids = models.map((m) => m.id)
+      assert.ok(ids.includes('qwen3-coder'))
+      for (const m of models) {
+        assert.equal(m.id, m.fullId, 'Ollama model ids have no stripped prefix; id == fullId')
+        assert.equal(m.contextWindow, null,
+          'effective context is decided by the local model file + num_ctx — never fabricate a number')
+      }
+    })
+
+    it('getModelMetadata answers for seeded models, null otherwise', () => {
+      const qwen = OllamaSession.getModelMetadata('qwen3-coder')
+      assert.equal(qwen.id, 'qwen3-coder')
+      assert.equal(qwen.contextWindow, null)
+      assert.equal(OllamaSession.getModelMetadata('some-custom-pull'), null)
+      assert.equal(OllamaSession.getModelMetadata(''), null)
+      assert.equal(OllamaSession.getModelMetadata(null), null)
+    })
+  })
+
+  describe('base URL resolution', () => {
+    it('defaults to Ollama\'s standard local bind', () => {
+      withEnv({}, () => {
+        assert.equal(resolveOllamaBaseUrl(process.env), 'http://localhost:11434')
+      })
+    })
+
+    it('CHROXY_OLLAMA_BASE_URL wins over OLLAMA_HOST', () => {
+      withEnv({ CHROXY_OLLAMA_BASE_URL: 'https://tunnel.example/ollama', OLLAMA_HOST: 'other:11434' }, () => {
+        assert.equal(resolveOllamaBaseUrl(process.env), 'https://tunnel.example/ollama')
+      })
+    })
+
+    it('OLLAMA_HOST without a scheme is normalized to http://', () => {
+      // Ollama's own convention allows bare host:port in OLLAMA_HOST.
+      withEnv({ OLLAMA_HOST: '192.168.1.20:11434' }, () => {
+        assert.equal(resolveOllamaBaseUrl(process.env), 'http://192.168.1.20:11434')
+      })
+    })
+
+    it('OLLAMA_HOST with a scheme passes through untouched', () => {
+      withEnv({ OLLAMA_HOST: 'https://ollama.lan' }, () => {
+        assert.equal(resolveOllamaBaseUrl(process.env), 'https://ollama.lan')
+      })
+    })
+  })
+
+  describe('seam overrides', () => {
+    it('_defaultModel is qwen3-coder (Ollama\'s recommended coding model)', () => {
+      const session = new OllamaSession({ cwd: '/tmp' })
+      assert.equal(session._defaultModel, 'qwen3-coder')
+    })
+
+    it('_resolveCredentials returns the documented dummy key, ignoring ANTHROPIC_API_KEY', () => {
+      const original = process.env.ANTHROPIC_API_KEY
+      try {
+        process.env.ANTHROPIC_API_KEY = 'sk-ant-wrong-provider'
+        const session = new OllamaSession({ cwd: '/tmp' })
+        const resolved = session._resolveCredentials()
+        assert.equal(resolved.key, 'ollama',
+          'Ollama requires-but-ignores the api key; the dummy must be sent (SDK rejects empty)')
+        assert.equal(resolved.source, 'env')
+      } finally {
+        if (original === undefined) delete process.env.ANTHROPIC_API_KEY
+        else process.env.ANTHROPIC_API_KEY = original
+      }
+    })
+
+    it('_buildClient points the Anthropic SDK at the resolved Ollama endpoint', () => {
+      withEnv({}, () => {
+        const session = new OllamaSession({ cwd: '/tmp' })
+        const client = session._buildClient('ollama')
+        const baseURL = client.baseURL || client._options?.baseURL
+        assert.ok(typeof baseURL === 'string' && baseURL.includes('localhost:11434'),
+          `expected the local Ollama endpoint; got ${baseURL}`)
+      })
+    })
+
+    it('_buildClient honours CHROXY_OLLAMA_BASE_URL at client-build time', () => {
+      withEnv({ CHROXY_OLLAMA_BASE_URL: 'http://gpu-box:11434' }, () => {
+        const session = new OllamaSession({ cwd: '/tmp' })
+        const client = session._buildClient('ollama')
+        const baseURL = client.baseURL || client._options?.baseURL
+        assert.ok(typeof baseURL === 'string' && baseURL.includes('gpu-box:11434'),
+          `expected the override endpoint; got ${baseURL}`)
+      })
+    })
+
+    it('_getPricing returns zero rates (local inference is free, no missing-pricing warn)', () => {
+      const session = new OllamaSession({ cwd: '/tmp' })
+      const pricing = session._getPricing('qwen3-coder')
+      assert.ok(pricing, 'must be a real entry, not null — null triggers the "update pricing" warn')
+      assert.equal(pricing.input, 0)
+      assert.equal(pricing.output, 0)
+      assert.equal(pricing.cacheRead, 0)
+      assert.equal(pricing.cacheWrite, 0)
+    })
+
+    it('constructor stamps provider: ollama regardless of what was passed', () => {
+      // BaseSession's `_provider` powers frontmatter-based skill filtering
+      // and registry-keyed code paths; the subclass hard-sets it (ignoring
+      // an opts override is intentional — mirrors DeepSeekSession).
+      const session = new OllamaSession({ cwd: '/tmp', provider: 'something-else' })
+      assert.equal(session._provider, 'ollama')
+    })
+  })
+})

--- a/packages/server/tests/ollama-session.test.js
+++ b/packages/server/tests/ollama-session.test.js
@@ -15,8 +15,8 @@ import { ClaudeByokSession } from '../src/byok-session.js'
  * gate", and base-URL resolution honours both override env vars.
  */
 
-// Run a block with the three base-URL env vars in a known state and
-// restore the originals afterwards — every test here mutates process.env.
+// Run a block with both base-URL env vars in a known state and restore
+// the originals afterwards — every test here mutates process.env.
 function withEnv(overrides, fn) {
   const VARS = ['CHROXY_OLLAMA_BASE_URL', 'OLLAMA_HOST']
   const saved = {}
@@ -137,6 +137,24 @@ describe('OllamaSession', () => {
     it('OLLAMA_HOST with a scheme passes through untouched', () => {
       withEnv({ OLLAMA_HOST: 'https://ollama.lan' }, () => {
         assert.equal(resolveOllamaBaseUrl(process.env), 'https://ollama.lan')
+      })
+    })
+
+    it('exported-but-empty / whitespace vars count as unset (routing AND labelling agree)', () => {
+      // A truthy-check would label CHROXY_OLLAMA_BASE_URL='' as the
+      // active override while routing fell through — the two share one
+      // predicate so they cannot disagree.
+      withEnv({ CHROXY_OLLAMA_BASE_URL: '', OLLAMA_HOST: '   ' }, () => {
+        assert.equal(resolveOllamaBaseUrl(process.env), 'http://localhost:11434')
+        const auth = OllamaSession.resolveAuth(process.env)
+        assert.equal(auth.envVar, null, 'whitespace overrides must not be labelled active')
+        assert.match(auth.detail, /localhost:11434/)
+      })
+    })
+
+    it('surrounding whitespace is trimmed off override values', () => {
+      withEnv({ OLLAMA_HOST: '  gpu-box:11434  ' }, () => {
+        assert.equal(resolveOllamaBaseUrl(process.env), 'http://gpu-box:11434')
       })
     })
   })

--- a/packages/server/tests/ws-message-handlers.test.js
+++ b/packages/server/tests/ws-message-handlers.test.js
@@ -214,6 +214,50 @@ describe('handleSessionMessage', () => {
       await handleSessionMessage(WS, client, { type: 'set_model', model: 'fake-model-xyz' }, ctx)
       assert.equal(entry.session.setModel.callCount, 0)
     })
+
+    // #5418 — providers whose getAllowedModels() returns null (ollama)
+    // validate nothing statically: any locally pulled model id must pass
+    // through verbatim. Before the tri-state fix, the null fell through to
+    // the global Claude allowlist, which rejected every Ollama model AND
+    // accepted Claude ids that 404 at the local daemon.
+    it('accepts any non-empty model id on an unrestricted provider (ollama, #5418)', async () => {
+      const ctx = makeCtx()
+      const client = makeClient({ activeSessionId: 'sess-1' })
+      const entry = addSession(ctx, 'sess-1', makeSession({ provider: 'ollama' }))
+      await handleSessionMessage(WS, client, { type: 'set_model', model: 'my-custom-finetune:7b' }, ctx)
+      assert.equal(entry.session.setModel.callCount, 1)
+      assert.equal(entry.session.setModel.lastCall[0], 'my-custom-finetune:7b')
+      const broadcast = ctx.broadcastToSession.mock.calls.at(-1)?.arguments[1]
+      assert.equal(broadcast?.type, 'model_changed')
+      assert.equal(broadcast?.model, 'my-custom-finetune:7b', 'opaque local ids broadcast verbatim')
+    })
+
+    it('rejects a whitespace-only model id even on an unrestricted provider (#5418)', async () => {
+      const ctx = makeCtx()
+      const client = makeClient({ activeSessionId: 'sess-1' })
+      const entry = addSession(ctx, 'sess-1', makeSession({ provider: 'ollama' }))
+      // sendError writes to the ws handle directly (not ctx.send), so a
+      // live fake is needed to observe the rejection envelope.
+      const ws = { readyState: 1, send: mock.fn() }
+      await handleSessionMessage(ws, client, { type: 'set_model', model: '   ' }, ctx)
+      assert.equal(entry.session.setModel.callCount, 0)
+      const sent = JSON.parse(ws.send.mock.calls.at(-1).arguments[0])
+      assert.equal(sent.type, 'error')
+      assert.equal(sent.code, 'INVALID_MODEL')
+    })
+
+    it('a provider allow-list still rejects unknown ids (tri-state regression guard, #5418)', async () => {
+      // deepseek opts IN with an authoritative array — the unrestricted
+      // branch must not leak to providers that declare a real list.
+      const ctx = makeCtx()
+      const client = makeClient({ activeSessionId: 'sess-1' })
+      const entry = addSession(ctx, 'sess-1', makeSession({ provider: 'deepseek' }))
+      const ws = { readyState: 1, send: mock.fn() }
+      await handleSessionMessage(ws, client, { type: 'set_model', model: 'my-custom-finetune:7b' }, ctx)
+      assert.equal(entry.session.setModel.callCount, 0)
+      const sent = JSON.parse(ws.send.mock.calls.at(-1).arguments[0])
+      assert.equal(sent.code, 'MODEL_NOT_SUPPORTED_BY_PROVIDER')
+    })
   })
 
   describe('set_permission_mode', () => {


### PR DESCRIPTION
## What

Adds an `ollama` provider: run chroxy sessions against **local open-source models** — no API key, zero per-token cost, nothing leaves the machine.

Ollama v0.14.0+ exposes an [Anthropic-compatible Messages API](https://docs.ollama.com/api/anthropic-compatibility) at `http://localhost:11434` ([announcement](https://ollama.com/blog/claude)), so this rides `ClaudeByokSession`'s entire agent loop — streaming, tool execution, **in-process permissions**, MCP servers, history — exactly the way `DeepSeekSession` does (#4656's subclass-not-fork pattern: every byok fix flows in for free).

## Provider semantics

| Aspect | Choice |
|--------|--------|
| Credentials | None. Empty `preflight.credentials.envVars` skips the gate; `_resolveCredentials` returns Ollama's documented required-but-ignored dummy key (the SDK rejects an empty `apiKey`). |
| Models | **Unrestricted** — `getAllowedModels()` returns null (session-manager treats non-array as no restriction) because valid models are whatever `ollama pull` fetched. `getFallbackModels()` seeds the dashboard picker with Ollama's recommended coder models (`qwen3-coder` default, `glm-4.7`, `minimax-m2.1`). |
| Context window | `null`, deliberately — the effective window is the local model file's `num_ctx`, and the wire schema (`contextWindow: z.unknown().optional()`) + dashboard tolerate it. No fabricated numbers. |
| Pricing | A real zero-rate entry (not null) so byok's once-per-model "update CLAUDE_PRICING" warn never fires and `result.cost` is an honest $0. |
| Endpoint | `CHROXY_OLLAMA_BASE_URL` → `OLLAMA_HOST` (Ollama's own convention; bare `host:port` normalized to `http://`) → `http://localhost:11434`. Reachability is NOT probed at preflight (daemon may boot before Ollama); a dead endpoint surfaces at first message via byok's client-error path. |
| Auth panel | `resolveAuth` always ready, `detail` names the resolved endpoint + which env var redirected it. |

## Docs

`docs/providers.md`: provider-table row, dedicated **Ollama (local models)** section (install / use / remote endpoints / pitfalls incl. the small-`num_ctx` truncation gotcha), and an `ollama` capability-matrix column. (Noted in the matrix: `claude-byok`/`deepseek` columns predate the table's last sweep — pre-existing drift, tracked separately.)

## Tests

19 new tests (`ollama-session.test.js`) pinning the subclass contract: inheritance chain, credential-free preflight, null allow-list, null context windows, base-URL resolution precedence + scheme normalization, dummy-key seam, zero pricing, provider stamping. 86/86 `providers.test.js` and 96/96 models/preflight/auth-probes still green.