### PR TITLE
refactor(server): extract NotificationSink — Expo push becomes ExpoPushSink (#5413 Phase 1)

### DIFF
--- a/packages/server/src/notifications/expo-push-sink.js
+++ b/packages/server/src/notifications/expo-push-sink.js
@@ -1,0 +1,414 @@
+/**
+ * ExpoPushSink — Expo Push API delivery channel (#5413 Phase 1).
+ *
+ * Extracted from push.js: everything Expo-specific lives here — the push
+ * token registry (with disk persistence and owner ref-counting), token
+ * format validation, the HTTPS POST to exp.host with timeout/backoff
+ * retry, ticket-based pruning of invalid tokens, and the iOS Live
+ * Activity token path.
+ *
+ * Sink-agnostic gating (category prefs, quiet hours, rate limits) stays
+ * upstream in PushManager; the one per-DEVICE concern — "is this category
+ * muted on this specific phone?" — is evaluated here per token via the
+ * `context` evaluators the pipeline passes to send() (see sink.js for the
+ * contract).
+ *
+ * No Expo account or additional infrastructure required — uses the free
+ * Expo Push Service (HTTPS POST to exp.host).
+ */
+
+import { readFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { writeFileRestricted } from '../platform.js'
+import { createLogger } from '../logger.js'
+import { metrics } from '../metrics.js'
+import { sleep, backoffDelay } from '../utils/sleep.js'
+import { NotificationSink } from './sink.js'
+
+const log = createLogger('push')
+
+const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send'
+
+// Fetch timeout and retry configuration
+const FETCH_TIMEOUT_MS = 10_000
+const MAX_RETRIES = 3
+const BACKOFF_BASE_MS = 1_000
+
+/**
+ * Fetch with timeout and exponential backoff retry.
+ * Retries on 5xx responses and timeout/network errors.
+ * Does NOT retry on 4xx client errors.
+ */
+async function fetchWithRetry(url, options) {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+    try {
+      const res = await fetch(url, { ...options, signal: controller.signal })
+      clearTimeout(timer)
+
+      if (res.ok || (res.status >= 400 && res.status < 500)) {
+        return res
+      }
+
+      // 5xx — retry if attempts remain
+      if (attempt < MAX_RETRIES) {
+        const delay = backoffDelay(attempt, BACKOFF_BASE_MS)
+        log.warn(`Expo API returned ${res.status}, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`)
+        await sleep(delay)
+        continue
+      }
+
+      return res
+    } catch (err) {
+      clearTimeout(timer)
+
+      if (attempt < MAX_RETRIES) {
+        const delay = backoffDelay(attempt, BACKOFF_BASE_MS)
+        log.warn(`Fetch failed (${err.name}: ${err.message}), retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`)
+        await sleep(delay)
+        continue
+      }
+
+      throw err
+    }
+  }
+}
+
+// Exported for testing (re-exported from push.js for existing importers)
+export { fetchWithRetry, FETCH_TIMEOUT_MS, MAX_RETRIES, BACKOFF_BASE_MS }
+
+export class ExpoPushSink extends NotificationSink {
+  constructor({ storagePath } = {}) {
+    super({ name: 'expo-push' })
+    this._storagePath = storagePath || null
+    this.tokens = new Set()
+    this._liveActivityTokens = new Set()
+    // Owner tracking for session-binding + prune-on-disconnect (audit
+    // blocker 6). `_tokenOwners` maps token -> Set<ownerId> so that when
+    // a client disconnects we can decrement its ownership and only
+    // actually prune the token from `this.tokens` when the last owner
+    // goes away. Without ref-counting, two connections registering the
+    // same token would cause the first disconnect to strip the token
+    // even though the second connection is still active (found by Copilot
+    // review on PR #2806). Owner IDs are client connection IDs in
+    // production; tests can use any unique string.
+    this._tokenOwners = new Map()
+    this._loadFromDisk()
+  }
+
+  /** Load tokens from disk if storagePath is set */
+  _loadFromDisk() {
+    if (!this._storagePath) return
+    try {
+      const data = JSON.parse(readFileSync(this._storagePath, 'utf-8'))
+      // Support legacy format (plain array) and new format (object with keys)
+      const pushTokens = Array.isArray(data) ? data : (data.tokens || [])
+      const laTokens = Array.isArray(data) ? [] : (data.liveActivityTokens || [])
+      for (const token of pushTokens) {
+        if (typeof token === 'string' && token.length > 0) {
+          this.tokens.add(token)
+        }
+      }
+      for (const token of laTokens) {
+        if (typeof token === 'string' && token.length > 0) {
+          this._liveActivityTokens.add(token)
+        }
+      }
+    } catch {
+      // File missing or corrupt — start with empty set
+    }
+  }
+
+  /** Persist current tokens to disk if storagePath is set */
+  _persistToDisk() {
+    if (!this._storagePath) return
+    try {
+      mkdirSync(dirname(this._storagePath), { recursive: true })
+      writeFileRestricted(this._storagePath, JSON.stringify({
+        tokens: [...this.tokens],
+        liveActivityTokens: [...this._liveActivityTokens],
+      }))
+    } catch (err) {
+      log.error(`Failed to persist tokens: ${err.message}`)
+    }
+  }
+
+  /**
+   * Register a push token from a client.
+   *
+   * Accepts Expo push tokens (`ExponentPushToken[...]`) and FCM tokens
+   * (Firebase Cloud Messaging for Android) — both work with the Expo
+   * Push API. Rejects obviously-malformed values.
+   *
+   * Per the 2026-04-11 production readiness audit (blocker 6), the old
+   * implementation accepted ANY non-empty string, which let an
+   * authenticated attacker register their own `ExponentPushToken[attacker]`
+   * and intercept every future permission-prompt push notification. This
+   * method now validates the format and (via the caller) binds each
+   * registered token to the connection that registered it, so tokens get
+   * pruned on client disconnect.
+   */
+  registerToken(token, ownerId = null) {
+    if (typeof token !== 'string' || token.length === 0) {
+      log.warn(`Rejected invalid push credential: ${String(token).slice(0, 40)}`)
+      return false
+    }
+    if (!ExpoPushSink.isValidPushTokenFormat(token)) {
+      log.warn(`Rejected malformed push credential (unrecognized format): ${token.slice(0, 40)}`)
+      return false
+    }
+    if (!this.tokens.has(token)) {
+      this.tokens.add(token)
+      this._persistToDisk()
+    }
+    // Track ownership for ref-counted prune-on-disconnect (2026-04-11
+    // audit blocker 6 + Copilot review on PR #2806). Multiple clients
+    // may register the same token (reconnect race, multi-device); the
+    // token is only pruned when the last owner disconnects.
+    if (ownerId != null) {
+      let owners = this._tokenOwners.get(token)
+      if (!owners) {
+        owners = new Set()
+        this._tokenOwners.set(token, owners)
+      }
+      owners.add(ownerId)
+    }
+    log.info(`Registered push credential ${token.slice(0, 30)}...`)
+    return true
+  }
+
+  /**
+   * Release one owner's claim on a token. If the last owner goes away,
+   * the token is removed from the registry entirely. Returns true if
+   * the token was actually pruned (last owner), false if it's still
+   * held by someone else.
+   *
+   * Used by WsServer._handleClientDeparture to prune on disconnect
+   * without breaking legitimate multi-connection scenarios.
+   */
+  releaseTokenOwner(token, ownerId) {
+    const owners = this._tokenOwners.get(token)
+    if (!owners) {
+      // No owner tracking — legacy / test path. Remove unconditionally.
+      return this.removeToken(token)
+    }
+    owners.delete(ownerId)
+    if (owners.size === 0) {
+      this._tokenOwners.delete(token)
+      return this.removeToken(token)
+    }
+    return false
+  }
+
+  /**
+   * Validate a push-token string. This is a soft defense — it rejects
+   * obviously-malformed input (empty strings, whitespace, JSON
+   * punctuation, URLs) so typos and automated fuzzers don't land in
+   * the token set. The REAL defense against push-token hijack is the
+   * session-binding + prune-on-disconnect added in the same audit fix
+   * (blocker 6): any token registered by a client is tracked on that
+   * client's _ownedPushTokens and removed on disconnect.
+   *
+   * Policy: any non-empty string that is >= 20 characters, free of
+   * whitespace/control characters, and free of JSON/URL punctuation
+   * that would never appear in a real Expo or FCM token. Real tokens:
+   *
+   * - Expo: `ExponentPushToken[...]` (50+ chars)
+   * - FCM: base64url-ish, ~150 chars typically but as short as 40 in
+   *   some SDKs
+   * - Legacy device tokens via the Firebase-Expo passthrough: variable
+   */
+  static isValidPushTokenFormat(token) {
+    if (typeof token !== 'string') return false
+    if (token.length < 20) return false
+    // Reject whitespace (including tabs/newlines), quotes, braces,
+    // angle brackets, forward slashes, and shell metacharacters that
+    // signal the caller sent garbage (a URL, a JSON blob, an error
+    // message, a shell-injection attempt) rather than a real push
+    // token. Real Expo/FCM push tokens use only alphanumerics + a
+    // restricted set of punctuation ([_-.:~%]) — the characters in
+    // this reject list never appear in them.
+    if (/[\s"'`<>{}&|;/\\?#]/.test(token)) return false
+    return true
+  }
+
+  /**
+   * Remove a push token unconditionally. Most callers should use
+   * releaseTokenOwner() instead so multi-owner tokens aren't stripped
+   * when one connection drops.
+   */
+  removeToken(token) {
+    if (this.tokens.delete(token)) {
+      this._tokenOwners.delete(token)
+      this._persistToDisk()
+      return true
+    }
+    return false
+  }
+
+  /**
+   * Register a Live Activity push token (iOS).
+   * Stored separately from regular push tokens.
+   *
+   * Applies the same format check as registerToken so the Live Activity
+   * path can't be used as a bypass for the 2026-04-11 audit blocker 6
+   * hardening. No WS handler currently exposes this path (verified on
+   * PR #2806) but the check is cheap regression prevention.
+   */
+  registerLiveActivityToken(token) {
+    if (typeof token !== 'string' || token.length === 0) {
+      log.warn(`Rejected invalid Live Activity credential: ${String(token).slice(0, 40)}`)
+      return false
+    }
+    if (!ExpoPushSink.isValidPushTokenFormat(token)) {
+      log.warn(`Rejected malformed Live Activity credential (unrecognized format): ${token.slice(0, 40)}`)
+      return false
+    }
+    if (!this._liveActivityTokens.has(token)) {
+      this._liveActivityTokens.add(token)
+      this._persistToDisk()
+    }
+    log.info(`Registered Live Activity credential ${token.slice(0, 30)}...`)
+    return true
+  }
+
+  /** Remove a Live Activity push token */
+  unregisterLiveActivityToken(token) {
+    if (this._liveActivityTokens.delete(token)) {
+      this._persistToDisk()
+    }
+  }
+
+  /** Check if we have any registered tokens */
+  get hasTokens() {
+    return this.tokens.size > 0
+  }
+
+  /** Check if we have any registered Live Activity tokens */
+  get hasLiveActivityTokens() {
+    return this._liveActivityTokens.size > 0
+  }
+
+  /** Sink contract: configured iff at least one push token is registered */
+  isConfigured() {
+    return this.tokens.size > 0
+  }
+
+  /**
+   * Sink contract: deliver one approved notification to every registered
+   * token, applying the per-DEVICE prefs evaluators from `context` (#4542
+   * per-category mute + #4544 quiet-hours gate, evaluated PER TOKEN so a
+   * desktop and a phone with different prefs both get the right behaviour
+   * from a single pipeline call). The quiet-hours gate is conditional: a
+   * category in the device's bypass list (default permission +
+   * activity_error) still fires even at 3am. Missing evaluators fail open
+   * (see sink.js).
+   */
+  async send(notification, context = {}) {
+    const { category, title, body, data = {}, categoryId } = notification
+    const now = context.now ?? Date.now()
+    const isCategoryEnabled = context.isCategoryEnabled ?? (() => true)
+    const isInQuietHours = context.isInQuietHours ?? (() => false)
+    const shouldBypassQuietHours = context.shouldBypassQuietHours ?? (() => false)
+
+    const eligibleTokens = []
+    for (const token of this.tokens) {
+      if (!isCategoryEnabled(category, token)) continue
+      if (isInQuietHours(now, token) && !shouldBypassQuietHours(category, token)) continue
+      eligibleTokens.push(token)
+    }
+    if (eligibleTokens.length === 0) {
+      // Every token filtered — no Expo POST. Returning `true` matches the
+      // existing "nothing to send is not a failure" contract.
+      return true
+    }
+
+    const messages = eligibleTokens.map((token) => ({
+      to: token,
+      sound: 'default',
+      title,
+      body,
+      data: { ...data, category },
+      ...(categoryId && { categoryId }),
+    }))
+
+    return await this._sendToTokenSet(this.tokens, messages, category, 'notification')
+  }
+
+  /**
+   * Send a Live Activity update to all registered Live Activity tokens.
+   * Expo-only side channel — not part of the NotificationSink contract
+   * (rate limiting for it stays upstream in PushManager).
+   * @param {string} state - Current activity state (e.g. 'thinking', 'writing', 'idle')
+   * @param {string} detail - Human-readable detail text
+   */
+  async sendLiveActivityUpdate(state, detail) {
+    const messages = [...this._liveActivityTokens].map((token) => ({
+      to: token,
+      sound: 'default',
+      title: 'Live Activity',
+      body: detail,
+      data: { state, detail, category: 'live_activity' },
+    }))
+
+    await this._sendToTokenSet(this._liveActivityTokens, messages, 'live_activity', 'update')
+  }
+
+  /**
+   * Post messages to the Expo Push API and prune any tokens that come back
+   * with an error status. Shared by send() and sendLiveActivityUpdate().
+   *
+   * @param {Set<string>} tokenSet - The Set to prune invalid tokens from
+   * @param {object[]} messages - Pre-built Expo push message objects
+   * @param {string} category - Category label used in log output
+   * @param {string} logLabel - Human-readable label for log messages (e.g. 'notification', 'Live Activity update')
+   * @returns {Promise<boolean>} `true` if Expo accepted the post (even when
+   *   individual tokens came back with per-message errors — those are
+   *   handled by pruning, not by reporting hard failure). `false` when the
+   *   HTTPS POST itself failed (non-2xx, network/timeout caught here).
+   *   Surfacing this lets callers (#3870) release per-session dedupe
+   *   latches on real delivery failure so the next idle cycle can retry.
+   */
+  async _sendToTokenSet(tokenSet, messages, category, logLabel) {
+    try {
+      const res = await fetchWithRetry(EXPO_PUSH_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(messages),
+      })
+
+      if (!res.ok) {
+        metrics.inc('push.failures')
+        log.error(`Expo Push API returned ${res.status}`)
+        return false
+      }
+
+      const result = await res.json()
+
+      // Prune tokens that returned errors (invalid/expired)
+      let pruned = false
+      if (result.data) {
+        for (let i = 0; i < result.data.length; i++) {
+          const ticket = result.data[i]
+          if (ticket.status === 'error') {
+            const token = messages[i].to
+            log.warn(`Removing invalid push credential ${token.slice(0, 30)}... (${ticket.message})`)
+            tokenSet.delete(token)
+            pruned = true
+          }
+        }
+      }
+      if (pruned) this._persistToDisk()
+
+      metrics.inc('push.sent')
+      log.info(`Sent ${category} ${logLabel} to ${messages.length} device(s)`)
+      return true
+    } catch (err) {
+      metrics.inc('push.failures')
+      log.error(`Failed to send ${logLabel}: ${err.message}`)
+      return false
+    }
+  }
+}

--- a/packages/server/src/notifications/sink-registry.js
+++ b/packages/server/src/notifications/sink-registry.js
@@ -48,9 +48,21 @@ export class SinkRegistry {
     return [...this._sinks]
   }
 
-  /** True when at least one registered sink is currently configured. */
+  /**
+   * True when at least one registered sink is currently configured.
+   * A throwing isConfigured() is the same contract-violation class fanOut
+   * contains for send() — treat that sink as not configured rather than
+   * letting the probe take the caller down.
+   */
   hasConfigured() {
-    return this._sinks.some((sink) => sink.isConfigured())
+    return this._sinks.some((sink) => {
+      try {
+        return sink.isConfigured()
+      } catch (err) {
+        this._log?.error?.(`Sink '${sink.name}' threw during isConfigured: ${err?.message || err}`)
+        return false
+      }
+    })
   }
 
   /**
@@ -62,14 +74,22 @@ export class SinkRegistry {
   async fanOut(notification, context = {}) {
     let ok = true
     for (const sink of this._sinks) {
-      if (!sink.isConfigured()) continue
       try {
+        // isConfigured() inside the containment too: a throwing probe
+        // (same contract-violation class as a throwing send) must not
+        // reject the whole fan-out — PushManager.send() is called
+        // un-awaited at several sites (e.g. ws-permissions), so an
+        // escaped rejection becomes an unhandledRejection.
+        if (!sink.isConfigured()) continue
+        // Only an explicit `false` counts as a hard failure — `undefined`
+        // (a sink with a void success path) is success. This is the
+        // documented sink contract, not an oversight.
         const result = await sink.send(notification, context)
         if (result === false) ok = false
       } catch (err) {
         // Contract violation — sinks must resolve false on delivery
         // failure, not throw. Contain it so the other sinks still deliver.
-        this._log?.error?.(`Sink '${sink.name}' threw during send: ${err?.message || err}`)
+        this._log?.error?.(`Sink '${sink.name}' threw during send or isConfigured: ${err?.message || err}`)
         ok = false
       }
     }

--- a/packages/server/src/notifications/sink-registry.js
+++ b/packages/server/src/notifications/sink-registry.js
@@ -1,0 +1,78 @@
+/**
+ * SinkRegistry — holds the configured NotificationSinks and fans one
+ * notification out to all of them (#5413 Phase 1).
+ *
+ * This is the pipeline's fan-out point: PushManager applies the shared
+ * gating (category prefs, quiet hours, rate limits) ONCE, then hands the
+ * approved notification here. Today the registry holds a single
+ * ExpoPushSink; DiscordWebhookSink registers alongside it in Phase 2 with
+ * no pipeline changes.
+ *
+ * Semantics:
+ * - Unconfigured sinks (isConfigured() === false) are skipped entirely —
+ *   they are never asked to send.
+ * - Sinks are invoked sequentially in registration order (deterministic;
+ *   revisit if a slow sink ever needs to stop delaying the others).
+ * - fanOut resolves `true` when every configured sink resolved `true`
+ *   (including the no-configured-sinks case), `false` when ANY configured
+ *   sink hard-failed. One failing sink does not prevent the others from
+ *   receiving the notification.
+ * - A sink that throws (contract violation — sinks must catch their own
+ *   delivery errors) is logged and treated as a hard failure, so a buggy
+ *   sink can't take the pipeline down.
+ */
+
+export class SinkRegistry {
+  constructor({ logger = null } = {}) {
+    this._sinks = []
+    this._log = logger
+  }
+
+  /**
+   * Register a sink. Validates the minimal contract shape up front so a
+   * malformed sink fails at wiring time, not on the first notification.
+   */
+  register(sink) {
+    if (!sink || typeof sink.send !== 'function' || typeof sink.isConfigured !== 'function') {
+      throw new TypeError('SinkRegistry.register: sink must implement send() and isConfigured()')
+    }
+    if (typeof sink.name !== 'string' || sink.name.length === 0) {
+      throw new TypeError('SinkRegistry.register: sink must have a non-empty name')
+    }
+    this._sinks.push(sink)
+    return sink
+  }
+
+  /** Snapshot of registered sinks (registration order). */
+  get sinks() {
+    return [...this._sinks]
+  }
+
+  /** True when at least one registered sink is currently configured. */
+  hasConfigured() {
+    return this._sinks.some((sink) => sink.isConfigured())
+  }
+
+  /**
+   * Fan one approved notification out to every configured sink.
+   * @param {{ category: string, title: string, body: string, data?: object, categoryId?: string }} notification
+   * @param {object} [context] - Pipeline-supplied evaluators (see sink.js)
+   * @returns {Promise<boolean>} `true` iff no configured sink hard-failed
+   */
+  async fanOut(notification, context = {}) {
+    let ok = true
+    for (const sink of this._sinks) {
+      if (!sink.isConfigured()) continue
+      try {
+        const result = await sink.send(notification, context)
+        if (result === false) ok = false
+      } catch (err) {
+        // Contract violation — sinks must resolve false on delivery
+        // failure, not throw. Contain it so the other sinks still deliver.
+        this._log?.error?.(`Sink '${sink.name}' threw during send: ${err?.message || err}`)
+        ok = false
+      }
+    }
+    return ok
+  }
+}

--- a/packages/server/src/notifications/sink.js
+++ b/packages/server/src/notifications/sink.js
@@ -1,0 +1,82 @@
+/**
+ * NotificationSink — the delivery-channel contract for chroxy notifications
+ * (#5413 Phase 1).
+ *
+ * The notification pipeline is layered:
+ *
+ *   session events → category mapping (PushNotificationHandler)
+ *     → prefs + rate limiting (PushManager — shared, sink-agnostic)
+ *       → fan out to every configured sink (SinkRegistry)
+ *         → channel-specific delivery (ExpoPushSink today,
+ *           DiscordWebhookSink in #5413 Phase 2, ...)
+ *
+ * A sink is ONLY the last hop: it takes an already-approved notification and
+ * delivers it over one channel. Category enable/disable, quiet hours, and the
+ * per-category rate limits all happen upstream in PushManager so every sink
+ * gets identical gating for free. The one exception is per-DEVICE prefs:
+ * those are keyed by device identifiers only the sink knows about (Expo push
+ * tokens), so the pipeline passes evaluator callbacks down via `context` and
+ * the sink applies them to its own device list.
+ *
+ * Contract:
+ *
+ * - `name` — stable, unique, human-readable identifier (e.g. 'expo-push').
+ *   Used in logs and (later) per-sink enable/disable config.
+ *
+ * - `isConfigured()` — synchronous, cheap, side-effect free. `true` when the
+ *   sink currently has somewhere to deliver to (tokens registered, webhook
+ *   URL configured, ...). The registry skips unconfigured sinks entirely, and
+ *   the pipeline treats "no sink configured" as a silent no-op success.
+ *
+ * - `send(notification, context)` — deliver one notification. MUST NOT throw
+ *   for ordinary delivery failures: catch them, log, and resolve `false`
+ *   (the registry still guards against escapes defensively).
+ *
+ *   `notification` is channel-agnostic:
+ *     { category, title, body, data, categoryId }
+ *   where `category` is one of the pipeline's notification categories
+ *   (see RATE_LIMITS in push.js), `data` is an arbitrary payload object and
+ *   `categoryId` is an optional iOS action-button category (sinks without an
+ *   equivalent concept simply ignore it).
+ *
+ *   `context` carries per-device prefs evaluators supplied by the pipeline:
+ *     {
+ *       now,                                        // ms epoch, for quiet hours
+ *       isCategoryEnabled(category, deviceId),      // per-device mute
+ *       isInQuietHours(now, deviceId),              // quiet-hours window
+ *       shouldBypassQuietHours(category, deviceId), // bypass list
+ *     }
+ *   All evaluators are optional — a sink must treat a missing evaluator as
+ *   "allowed" (fail open), matching the pipeline's defaults.
+ *
+ *   Resolves `true` when no hard delivery failure occurred (delivered, or
+ *   nothing eligible to deliver — both are "no error" from the caller's
+ *   view). Resolves `false` ONLY on a hard channel failure (non-2xx,
+ *   network throw). Callers like the idle-push dedupe latch (#3870) rely on
+ *   this distinction to retry later.
+ */
+
+export class NotificationSink {
+  constructor({ name } = {}) {
+    this.name = name || this.constructor.name
+  }
+
+  /**
+   * Whether this sink currently has somewhere to deliver to. Subclasses
+   * override; the base class is honest about having no channel.
+   */
+  isConfigured() {
+    return false
+  }
+
+  /**
+   * Deliver one notification. Subclasses must override.
+   * @param {{ category: string, title: string, body: string, data?: object, categoryId?: string }} notification
+   * @param {object} [context]
+   * @returns {Promise<boolean>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  async send(notification, context = {}) {
+    throw new Error(`NotificationSink '${this.name}' does not implement send()`)
+  }
+}

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -1,23 +1,25 @@
 /**
- * PushManager — sends push notifications via Expo Push API.
+ * PushManager — the shared notification pipeline (#5413 Phase 1).
  *
- * Stores push tokens registered by connected clients and sends
- * notifications for permission prompts, user questions, session errors,
- * and unattended query completions. Categories and their rate limits are
- * declared in RATE_LIMITS below.
+ * Owns everything that must behave identically for every delivery channel:
+ * notification preferences (#4541/#4544), the per-category RATE_LIMITS
+ * throttle, and the fan-out to configured sinks via SinkRegistry. The
+ * Expo-specific delivery (token registry, exp.host POST, ticket pruning,
+ * Live Activity) lives in ExpoPushSink (notifications/expo-push-sink.js) —
+ * extracted from this file so #5413 Phase 2 can register a
+ * DiscordWebhookSink alongside it with no pipeline changes. See
+ * notifications/sink.js for the sink contract.
  *
- * No Expo account or additional infrastructure required — uses the
- * free Expo Push Service (HTTPS POST to exp.host).
+ * For now PushManager keeps its full pre-extraction public surface
+ * (registerToken, releaseTokenOwner, Live Activity registration, the
+ * `tokens` set, ...) by delegating to the Expo sink, so callers
+ * (server-cli.js, supervisor.js, ws handlers) and existing tests are
+ * untouched. Per-sink wiring/config is a Phase 2 concern.
  *
  * Wired into server-cli.js via SessionManager event listeners.
  */
 
-import { readFileSync, mkdirSync } from 'node:fs'
-import { dirname } from 'node:path'
-import { writeFileRestricted } from './platform.js'
 import { createLogger } from './logger.js'
-import { metrics } from './metrics.js'
-import { sleep, backoffDelay } from './utils/sleep.js'
 import {
   loadPrefs as loadNotificationPrefs,
   savePrefs as saveNotificationPrefs,
@@ -26,57 +28,16 @@ import {
   isInQuietHoursIn,
   shouldBypassQuietHours,
 } from './notification-prefs.js'
+import { SinkRegistry } from './notifications/sink-registry.js'
+import {
+  ExpoPushSink,
+  fetchWithRetry,
+  FETCH_TIMEOUT_MS,
+  MAX_RETRIES,
+  BACKOFF_BASE_MS,
+} from './notifications/expo-push-sink.js'
 
 const log = createLogger('push')
-
-const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send'
-
-// Fetch timeout and retry configuration
-const FETCH_TIMEOUT_MS = 10_000
-const MAX_RETRIES = 3
-const BACKOFF_BASE_MS = 1_000
-
-/**
- * Fetch with timeout and exponential backoff retry.
- * Retries on 5xx responses and timeout/network errors.
- * Does NOT retry on 4xx client errors.
- */
-async function fetchWithRetry(url, options) {
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-    const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
-
-    try {
-      const res = await fetch(url, { ...options, signal: controller.signal })
-      clearTimeout(timer)
-
-      if (res.ok || (res.status >= 400 && res.status < 500)) {
-        return res
-      }
-
-      // 5xx — retry if attempts remain
-      if (attempt < MAX_RETRIES) {
-        const delay = backoffDelay(attempt, BACKOFF_BASE_MS)
-        log.warn(`Expo API returned ${res.status}, retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`)
-        await sleep(delay)
-        continue
-      }
-
-      return res
-    } catch (err) {
-      clearTimeout(timer)
-
-      if (attempt < MAX_RETRIES) {
-        const delay = backoffDelay(attempt, BACKOFF_BASE_MS)
-        log.warn(`Fetch failed (${err.name}: ${err.message}), retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})`)
-        await sleep(delay)
-        continue
-      }
-
-      throw err
-    }
-  }
-}
 
 // Rate limits per category (ms) — prevents notification spam.
 //
@@ -100,12 +61,12 @@ const RATE_LIMITS = {
   live_activity: 5_000,     // Live Activity updates: 5s throttle
 }
 
-// Exported for testing
+// Re-exported for existing importers/tests — the implementation moved to
+// notifications/expo-push-sink.js with the rest of the Expo delivery code.
 export { fetchWithRetry, FETCH_TIMEOUT_MS, MAX_RETRIES, BACKOFF_BASE_MS }
 
 export class PushManager {
   constructor({ storagePath, prefsPath } = {}) {
-    this._storagePath = storagePath || null
     // #4541: notification-prefs path. Optional — when omitted PushManager
     // operates entirely in-memory (callers like one-off tests don't need
     // to write to disk). When set, getPrefs / setPrefs round-trip
@@ -114,57 +75,27 @@ export class PushManager {
     this._prefs = this._prefsPath
       ? loadNotificationPrefs(this._prefsPath, { log })
       : defaultNotificationPrefs()
-    this.tokens = new Set()
-    this._liveActivityTokens = new Set()
     this._lastSent = new Map() // category -> timestamp
-    // Owner tracking for session-binding + prune-on-disconnect (audit
-    // blocker 6). `_tokenOwners` maps token -> Set<ownerId> so that when
-    // a client disconnects we can decrement its ownership and only
-    // actually prune the token from `this.tokens` when the last owner
-    // goes away. Without ref-counting, two connections registering the
-    // same token would cause the first disconnect to strip the token
-    // even though the second connection is still active (found by Copilot
-    // review on PR #2806). Owner IDs are client connection IDs in
-    // production; tests can use any unique string.
-    this._tokenOwners = new Map()
-    this._loadFromDisk()
+    // #5413 Phase 1: delivery channels live behind the sink registry. The
+    // Expo sink owns the token registry + persistence; it's also kept on a
+    // named field because PushManager's legacy public surface (registerToken,
+    // Live Activity, the `tokens` set) delegates to it directly.
+    this._expoSink = new ExpoPushSink({ storagePath })
+    this._sinks = new SinkRegistry({ logger: log })
+    this._sinks.register(this._expoSink)
   }
 
-  /** Load tokens from disk if storagePath is set */
-  _loadFromDisk() {
-    if (!this._storagePath) return
-    try {
-      const data = JSON.parse(readFileSync(this._storagePath, 'utf-8'))
-      // Support legacy format (plain array) and new format (object with keys)
-      const pushTokens = Array.isArray(data) ? data : (data.tokens || [])
-      const laTokens = Array.isArray(data) ? [] : (data.liveActivityTokens || [])
-      for (const token of pushTokens) {
-        if (typeof token === 'string' && token.length > 0) {
-          this.tokens.add(token)
-        }
-      }
-      for (const token of laTokens) {
-        if (typeof token === 'string' && token.length > 0) {
-          this._liveActivityTokens.add(token)
-        }
-      }
-    } catch {
-      // File missing or corrupt — start with empty set
-    }
+  /**
+   * Registered push tokens (delegates to the Expo sink — same live Set,
+   * so existing callers/tests that mutate it directly keep working).
+   */
+  get tokens() {
+    return this._expoSink.tokens
   }
 
-  /** Persist current tokens to disk if storagePath is set */
-  _persistToDisk() {
-    if (!this._storagePath) return
-    try {
-      mkdirSync(dirname(this._storagePath), { recursive: true })
-      writeFileRestricted(this._storagePath, JSON.stringify({
-        tokens: [...this.tokens],
-        liveActivityTokens: [...this._liveActivityTokens],
-      }))
-    } catch (err) {
-      log.error(`Failed to persist tokens: ${err.message}`)
-    }
+  /** Live Activity tokens (delegates to the Expo sink — same live Set). */
+  get _liveActivityTokens() {
+    return this._expoSink._liveActivityTokens
   }
 
   /**
@@ -396,47 +327,12 @@ export class PushManager {
   }
 
   /**
-   * Register a push token from a client.
-   *
-   * Accepts Expo push tokens (`ExponentPushToken[...]`) and FCM tokens
-   * (Firebase Cloud Messaging for Android) — both work with the Expo
-   * Push API. Rejects obviously-malformed values.
-   *
-   * Per the 2026-04-11 production readiness audit (blocker 6), the old
-   * implementation accepted ANY non-empty string, which let an
-   * authenticated attacker register their own `ExponentPushToken[attacker]`
-   * and intercept every future permission-prompt push notification. This
-   * method now validates the format and (via the caller) binds each
-   * registered token to the connection that registered it, so tokens get
-   * pruned on client disconnect.
+   * Register a push token from a client. Delegates to the Expo sink —
+   * see ExpoPushSink.registerToken for format validation and the
+   * 2026-04-11 audit (blocker 6) history.
    */
   registerToken(token, ownerId = null) {
-    if (typeof token !== 'string' || token.length === 0) {
-      log.warn(`Rejected invalid push credential: ${String(token).slice(0, 40)}`)
-      return false
-    }
-    if (!PushManager.isValidPushTokenFormat(token)) {
-      log.warn(`Rejected malformed push credential (unrecognized format): ${token.slice(0, 40)}`)
-      return false
-    }
-    if (!this.tokens.has(token)) {
-      this.tokens.add(token)
-      this._persistToDisk()
-    }
-    // Track ownership for ref-counted prune-on-disconnect (2026-04-11
-    // audit blocker 6 + Copilot review on PR #2806). Multiple clients
-    // may register the same token (reconnect race, multi-device); the
-    // token is only pruned when the last owner disconnects.
-    if (ownerId != null) {
-      let owners = this._tokenOwners.get(token)
-      if (!owners) {
-        owners = new Set()
-        this._tokenOwners.set(token, owners)
-      }
-      owners.add(ownerId)
-    }
-    log.info(`Registered push credential ${token.slice(0, 30)}...`)
-    return true
+    return this._expoSink.registerToken(token, ownerId)
   }
 
   /**
@@ -449,49 +345,16 @@ export class PushManager {
    * without breaking legitimate multi-connection scenarios.
    */
   releaseTokenOwner(token, ownerId) {
-    const owners = this._tokenOwners.get(token)
-    if (!owners) {
-      // No owner tracking — legacy / test path. Remove unconditionally.
-      return this.removeToken(token)
-    }
-    owners.delete(ownerId)
-    if (owners.size === 0) {
-      this._tokenOwners.delete(token)
-      return this.removeToken(token)
-    }
-    return false
+    return this._expoSink.releaseTokenOwner(token, ownerId)
   }
 
   /**
-   * Validate a push-token string. This is a soft defense — it rejects
-   * obviously-malformed input (empty strings, whitespace, JSON
-   * punctuation, URLs) so typos and automated fuzzers don't land in
-   * the token set. The REAL defense against push-token hijack is the
-   * session-binding + prune-on-disconnect added in the same audit fix
-   * (blocker 6): any token registered by a client is tracked on that
-   * client's _ownedPushTokens and removed on disconnect.
-   *
-   * Policy: any non-empty string that is >= 20 characters, free of
-   * whitespace/control characters, and free of JSON/URL punctuation
-   * that would never appear in a real Expo or FCM token. Real tokens:
-   *
-   * - Expo: `ExponentPushToken[...]` (50+ chars)
-   * - FCM: base64url-ish, ~150 chars typically but as short as 40 in
-   *   some SDKs
-   * - Legacy device tokens via the Firebase-Expo passthrough: variable
+   * Validate a push-token string. Implementation lives on ExpoPushSink
+   * (it's an Expo/FCM token format concern); kept on PushManager because
+   * the WS prefs handler validates device keys through this surface.
    */
   static isValidPushTokenFormat(token) {
-    if (typeof token !== 'string') return false
-    if (token.length < 20) return false
-    // Reject whitespace (including tabs/newlines), quotes, braces,
-    // angle brackets, forward slashes, and shell metacharacters that
-    // signal the caller sent garbage (a URL, a JSON blob, an error
-    // message, a shell-injection attempt) rather than a real push
-    // token. Real Expo/FCM push tokens use only alphanumerics + a
-    // restricted set of punctuation ([_-.:~%]) — the characters in
-    // this reject list never appear in them.
-    if (/[\s"'`<>{}&|;/\\?#]/.test(token)) return false
-    return true
+    return ExpoPushSink.isValidPushTokenFormat(token)
   }
 
   /**
@@ -500,54 +363,28 @@ export class PushManager {
    * when one connection drops.
    */
   removeToken(token) {
-    if (this.tokens.delete(token)) {
-      this._tokenOwners.delete(token)
-      this._persistToDisk()
-      return true
-    }
-    return false
+    return this._expoSink.removeToken(token)
   }
 
-  /**
-   * Register a Live Activity push token (iOS).
-   * Stored separately from regular push tokens.
-   *
-   * Applies the same format check as registerToken so the Live Activity
-   * path can't be used as a bypass for the 2026-04-11 audit blocker 6
-   * hardening. No WS handler currently exposes this path (verified on
-   * PR #2806) but the check is cheap regression prevention.
-   */
+  /** Register a Live Activity push token (iOS). Delegates to the Expo sink. */
   registerLiveActivityToken(token) {
-    if (typeof token !== 'string' || token.length === 0) {
-      log.warn(`Rejected invalid Live Activity credential: ${String(token).slice(0, 40)}`)
-      return false
-    }
-    if (!PushManager.isValidPushTokenFormat(token)) {
-      log.warn(`Rejected malformed Live Activity credential (unrecognized format): ${token.slice(0, 40)}`)
-      return false
-    }
-    if (!this._liveActivityTokens.has(token)) {
-      this._liveActivityTokens.add(token)
-      this._persistToDisk()
-    }
-    log.info(`Registered Live Activity credential ${token.slice(0, 30)}...`)
-    return true
+    return this._expoSink.registerLiveActivityToken(token)
   }
 
   /** Remove a Live Activity push token */
   unregisterLiveActivityToken(token) {
-    if (this._liveActivityTokens.delete(token)) {
-      this._persistToDisk()
-    }
+    return this._expoSink.unregisterLiveActivityToken(token)
   }
 
   /** Check if we have any registered tokens */
   get hasTokens() {
-    return this.tokens.size > 0
+    return this._expoSink.hasTokens
   }
 
   /**
-   * Send a push notification to all registered tokens.
+   * Send a notification through the pipeline: shared rate limit, then fan
+   * out to every configured sink (per-device category/quiet-hours prefs
+   * are evaluated inside each sink via the context evaluators below).
    *
    * Category names listed here are the only ones with explicit RATE_LIMITS
    * entries. Any other string still works but falls through to the
@@ -563,15 +400,19 @@ export class PushManager {
    * @param {object} [data] - Extra data payload
    * @param {string} [categoryId] - iOS notification category for action buttons
    * @returns {Promise<boolean>} `true` when no hard delivery failure occurred
-   *   (Expo accepted the post, or there was nothing to send / we were
+   *   (the sinks accepted it, or there was nothing to send / we were
    *   rate-limited — both of which are "no error" from the caller's view).
-   *   `false` ONLY when the Expo API hard-failed (non-2xx, network throw).
-   *   Callers like the idle-push dedupe in server-cli.js (#3870) use this
-   *   to decide whether to release a latch so a transient failure doesn't
-   *   permanently suppress future notifications.
+   *   `false` ONLY when a configured sink hard-failed (for Expo: non-2xx,
+   *   network throw). Callers like the idle-push dedupe in server-cli.js
+   *   (#3870) use this to decide whether to release a latch so a transient
+   *   failure doesn't permanently suppress future notifications.
    */
   async send(category, title, body, data = {}, categoryId = undefined) {
-    if (this.tokens.size === 0) return true
+    // No sink has anywhere to deliver to — silent no-op, and intentionally
+    // BEFORE the rate-limit stamp (matching the pre-extraction
+    // `tokens.size === 0` early return) so a tokenless send doesn't burn
+    // the category's rate-limit window.
+    if (!this._sinks.hasConfigured()) return true
 
     // Rate limit check — the FIRST line of defence. Stays in place
     // ahead of the #4542 per-category mute and the #4544 quiet-hours
@@ -584,43 +425,28 @@ export class PushManager {
     }
     this._lastSent.set(category, Date.now())
 
-    // #4542 per-category mute + #4544 quiet-hours gate, evaluated PER
-    // TOKEN so a desktop and a phone with different prefs both get the
-    // right behaviour from a single send() call. The quiet-hours gate
-    // is conditional: a category in the device's bypass list (default
-    // permission + activity_error) still fires even at 3am.
-    const now = Date.now()
-    const eligibleTokens = []
-    for (const token of this.tokens) {
-      if (!this.isCategoryEnabled(category, token)) continue
-      if (this.isInQuietHours(now, token) && !this.shouldBypassQuietHours(category, token)) continue
-      eligibleTokens.push(token)
-    }
-    if (eligibleTokens.length === 0) {
-      // Every token filtered — no Expo POST. Returning `true` matches the
-      // existing "nothing to send is not a failure" contract.
-      return true
-    }
-
-    const messages = eligibleTokens.map((token) => ({
-      to: token,
-      sound: 'default',
-      title,
-      body,
-      data: { ...data, category },
-      ...(categoryId && { categoryId }),
-    }))
-
-    return await this._sendToTokenSet(this.tokens, messages, category, 'notification')
+    return await this._sinks.fanOut(
+      { category, title, body, data, categoryId },
+      {
+        now: Date.now(),
+        isCategoryEnabled: (cat, deviceId) => this.isCategoryEnabled(cat, deviceId),
+        isInQuietHours: (now, deviceId) => this.isInQuietHours(now, deviceId),
+        shouldBypassQuietHours: (cat, deviceId) => this.shouldBypassQuietHours(cat, deviceId),
+      }
+    )
   }
 
   /**
    * Send a Live Activity update to all registered Live Activity tokens.
+   * Expo-only side channel — goes straight to the Expo sink rather than
+   * through the registry fan-out (no other sink has a Live Activity
+   * concept). The shared rate-limit map still applies here so the
+   * `live_activity` throttle and notification categories share one clock.
    * @param {string} state - Current activity state (e.g. 'thinking', 'writing', 'idle')
    * @param {string} detail - Human-readable detail text
    */
   async sendLiveActivityUpdate(state, detail) {
-    if (this._liveActivityTokens.size === 0) return
+    if (!this._expoSink.hasLiveActivityTokens) return
 
     // Rate limit check (live_activity category: 5s)
     const category = 'live_activity'
@@ -631,70 +457,6 @@ export class PushManager {
     }
     this._lastSent.set(category, Date.now())
 
-    const messages = [...this._liveActivityTokens].map((token) => ({
-      to: token,
-      sound: 'default',
-      title: 'Live Activity',
-      body: detail,
-      data: { state, detail, category },
-    }))
-
-    await this._sendToTokenSet(this._liveActivityTokens, messages, category, 'update')
-  }
-
-  /**
-   * Post messages to the Expo Push API and prune any tokens that come back
-   * with an error status. Shared by send() and sendLiveActivityUpdate().
-   *
-   * @param {Set<string>} tokenSet - The Set to prune invalid tokens from
-   * @param {object[]} messages - Pre-built Expo push message objects
-   * @param {string} category - Category label used in log output
-   * @param {string} logLabel - Human-readable label for log messages (e.g. 'notification', 'Live Activity update')
-   * @returns {Promise<boolean>} `true` if Expo accepted the post (even when
-   *   individual tokens came back with per-message errors — those are
-   *   handled by pruning, not by reporting hard failure). `false` when the
-   *   HTTPS POST itself failed (non-2xx, network/timeout caught here).
-   *   Surfacing this lets callers (#3870) release per-session dedupe
-   *   latches on real delivery failure so the next idle cycle can retry.
-   */
-  async _sendToTokenSet(tokenSet, messages, category, logLabel) {
-    try {
-      const res = await fetchWithRetry(EXPO_PUSH_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(messages),
-      })
-
-      if (!res.ok) {
-        metrics.inc('push.failures')
-        log.error(`Expo Push API returned ${res.status}`)
-        return false
-      }
-
-      const result = await res.json()
-
-      // Prune tokens that returned errors (invalid/expired)
-      let pruned = false
-      if (result.data) {
-        for (let i = 0; i < result.data.length; i++) {
-          const ticket = result.data[i]
-          if (ticket.status === 'error') {
-            const token = messages[i].to
-            log.warn(`Removing invalid push credential ${token.slice(0, 30)}... (${ticket.message})`)
-            tokenSet.delete(token)
-            pruned = true
-          }
-        }
-      }
-      if (pruned) this._persistToDisk()
-
-      metrics.inc('push.sent')
-      log.info(`Sent ${category} ${logLabel} to ${messages.length} device(s)`)
-      return true
-    } catch (err) {
-      metrics.inc('push.failures')
-      log.error(`Failed to send ${logLabel}: ${err.message}`)
-      return false
-    }
+    await this._expoSink.sendLiveActivityUpdate(state, detail)
   }
 }

--- a/packages/server/tests/notification-sinks.test.js
+++ b/packages/server/tests/notification-sinks.test.js
@@ -164,6 +164,39 @@ describe('SinkRegistry', () => {
       registry.register(fakeSink({ name: 'b' }))
       assert.equal(await registry.fanOut(notification), true)
     })
+
+    // #5425 review S1 — a throwing isConfigured() is the same contract-
+    // violation class as a throwing send(). It must be contained, not
+    // escape as a rejection: PushManager.send() is called un-awaited at
+    // several sites (e.g. ws-permissions), so an escaped rejection is an
+    // unhandledRejection → daemon-level fallout.
+    it('contains a throwing isConfigured() in fanOut: logs, counts as failure, others deliver', async () => {
+      const errors = []
+      const registry = new SinkRegistry({ logger: { error: (msg) => errors.push(msg) } })
+      const broken = fakeSink({ name: 'broken-probe' })
+      broken.isConfigured = () => { throw new Error('probe-boom') }
+      const healthy = fakeSink({ name: 'healthy' })
+      registry.register(broken)
+      registry.register(healthy)
+      assert.equal(await registry.fanOut(notification), false)
+      assert.equal(healthy.calls.length, 1, 'healthy sink still receives the notification')
+      assert.equal(errors.length, 1)
+      assert.match(errors[0], /broken-probe/)
+      assert.match(errors[0], /probe-boom/)
+    })
+
+    it('hasConfigured treats a throwing isConfigured() as not configured (and logs)', () => {
+      const errors = []
+      const registry = new SinkRegistry({ logger: { error: (msg) => errors.push(msg) } })
+      const broken = fakeSink({ name: 'broken-probe' })
+      broken.isConfigured = () => { throw new Error('probe-boom') }
+      registry.register(broken)
+      assert.equal(registry.hasConfigured(), false)
+      assert.equal(errors.length, 1)
+
+      registry.register(fakeSink({ name: 'on', configured: true }))
+      assert.equal(registry.hasConfigured(), true, 'a healthy sink is still discoverable past the broken one')
+    })
   })
 })
 

--- a/packages/server/tests/notification-sinks.test.js
+++ b/packages/server/tests/notification-sinks.test.js
@@ -1,0 +1,270 @@
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { NotificationSink } from '../src/notifications/sink.js'
+import { SinkRegistry } from '../src/notifications/sink-registry.js'
+import { ExpoPushSink } from '../src/notifications/expo-push-sink.js'
+
+/**
+ * NotificationSink / SinkRegistry / ExpoPushSink unit tests (#5413 Phase 1).
+ *
+ * Pins the sink contract and the registry fan-out semantics so Phase 2's
+ * DiscordWebhookSink lands on tested rails:
+ * - unconfigured sinks are skipped, never asked to send
+ * - one failing/throwing sink doesn't stop the others or crash the pipeline
+ * - fanOut aggregates: true iff no configured sink hard-failed
+ * - ExpoPushSink applies the per-device context evaluators per token
+ */
+
+const VALID_TOKEN = 'ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]'
+const VALID_TOKEN_2 = 'ExponentPushToken[yyyyyyyyyyyyyyyyyyyyyy]'
+
+/** Minimal contract-conforming fake sink for registry tests */
+function fakeSink({ name = 'fake', configured = true, result = true, throws = null } = {}) {
+  const calls = []
+  return {
+    name,
+    calls,
+    isConfigured: () => configured,
+    async send(notification, context) {
+      calls.push({ notification, context })
+      if (throws) throw throws
+      return result
+    },
+  }
+}
+
+describe('NotificationSink (base contract)', () => {
+  it('takes its name from the constructor opts', () => {
+    const sink = new NotificationSink({ name: 'my-sink' })
+    assert.equal(sink.name, 'my-sink')
+  })
+
+  it('defaults the name to the class name', () => {
+    class TestSink extends NotificationSink {}
+    assert.equal(new TestSink().name, 'TestSink')
+  })
+
+  it('is unconfigured by default', () => {
+    assert.equal(new NotificationSink().isConfigured(), false)
+  })
+
+  it('rejects send() until a subclass implements it', async () => {
+    const sink = new NotificationSink({ name: 'stub' })
+    await assert.rejects(
+      () => sink.send({ category: 'result', title: 't', body: 'b' }),
+      /does not implement send/
+    )
+  })
+})
+
+describe('SinkRegistry', () => {
+  describe('register', () => {
+    it('rejects a sink without send()', () => {
+      const registry = new SinkRegistry()
+      assert.throws(() => registry.register({ name: 'x', isConfigured: () => true }), TypeError)
+    })
+
+    it('rejects a sink without isConfigured()', () => {
+      const registry = new SinkRegistry()
+      assert.throws(() => registry.register({ name: 'x', send: async () => true }), TypeError)
+    })
+
+    it('rejects a sink without a name', () => {
+      const registry = new SinkRegistry()
+      assert.throws(
+        () => registry.register({ isConfigured: () => true, send: async () => true }),
+        TypeError
+      )
+    })
+
+    it('returns the registered sink and exposes it via sinks', () => {
+      const registry = new SinkRegistry()
+      const sink = fakeSink({ name: 'a' })
+      assert.equal(registry.register(sink), sink)
+      assert.deepEqual(registry.sinks, [sink])
+    })
+  })
+
+  describe('hasConfigured', () => {
+    it('is false with no sinks registered', () => {
+      assert.equal(new SinkRegistry().hasConfigured(), false)
+    })
+
+    it('is false when every sink is unconfigured', () => {
+      const registry = new SinkRegistry()
+      registry.register(fakeSink({ configured: false }))
+      assert.equal(registry.hasConfigured(), false)
+    })
+
+    it('is true when at least one sink is configured', () => {
+      const registry = new SinkRegistry()
+      registry.register(fakeSink({ name: 'off', configured: false }))
+      registry.register(fakeSink({ name: 'on', configured: true }))
+      assert.equal(registry.hasConfigured(), true)
+    })
+  })
+
+  describe('fanOut', () => {
+    const notification = { category: 'result', title: 'Title', body: 'Body', data: { a: 1 } }
+
+    it('resolves true with no configured sinks (nothing to send is not a failure)', async () => {
+      const registry = new SinkRegistry()
+      registry.register(fakeSink({ configured: false }))
+      assert.equal(await registry.fanOut(notification), true)
+    })
+
+    it('skips unconfigured sinks entirely', async () => {
+      const registry = new SinkRegistry()
+      const off = fakeSink({ name: 'off', configured: false })
+      const on = fakeSink({ name: 'on', configured: true })
+      registry.register(off)
+      registry.register(on)
+      assert.equal(await registry.fanOut(notification), true)
+      assert.equal(off.calls.length, 0)
+      assert.equal(on.calls.length, 1)
+    })
+
+    it('passes notification and context through to each configured sink', async () => {
+      const registry = new SinkRegistry()
+      const sink = fakeSink({ name: 'a' })
+      registry.register(sink)
+      const context = { now: 123, isCategoryEnabled: () => true }
+      await registry.fanOut(notification, context)
+      assert.equal(sink.calls[0].notification, notification)
+      assert.equal(sink.calls[0].context, context)
+    })
+
+    it('resolves false when a configured sink hard-fails, but still delivers to the rest', async () => {
+      const registry = new SinkRegistry()
+      const failing = fakeSink({ name: 'failing', result: false })
+      const healthy = fakeSink({ name: 'healthy', result: true })
+      registry.register(failing)
+      registry.register(healthy)
+      assert.equal(await registry.fanOut(notification), false)
+      assert.equal(healthy.calls.length, 1, 'healthy sink still receives the notification')
+    })
+
+    it('contains a throwing sink (contract violation): logs, resolves false, others deliver', async () => {
+      const errors = []
+      const registry = new SinkRegistry({ logger: { error: (msg) => errors.push(msg) } })
+      const thrower = fakeSink({ name: 'thrower', throws: new Error('boom') })
+      const healthy = fakeSink({ name: 'healthy' })
+      registry.register(thrower)
+      registry.register(healthy)
+      assert.equal(await registry.fanOut(notification), false)
+      assert.equal(healthy.calls.length, 1)
+      assert.equal(errors.length, 1)
+      assert.match(errors[0], /thrower/)
+      assert.match(errors[0], /boom/)
+    })
+
+    it('resolves true when every configured sink succeeds', async () => {
+      const registry = new SinkRegistry()
+      registry.register(fakeSink({ name: 'a' }))
+      registry.register(fakeSink({ name: 'b' }))
+      assert.equal(await registry.fanOut(notification), true)
+    })
+  })
+})
+
+describe('ExpoPushSink (sink contract surface)', () => {
+  let sink
+  let originalFetch
+
+  beforeEach(() => {
+    sink = new ExpoPushSink() // no storagePath — in-memory only
+    originalFetch = globalThis.fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    mock.restoreAll()
+  })
+
+  function mockFetchOk(data = []) {
+    const fn = mock.fn(async () => ({ ok: true, json: async () => ({ data }) }))
+    globalThis.fetch = fn
+    return fn
+  }
+
+  it('has the stable sink name', () => {
+    assert.equal(sink.name, 'expo-push')
+  })
+
+  it('is unconfigured with no tokens, configured once a token registers', () => {
+    assert.equal(sink.isConfigured(), false)
+    sink.registerToken(VALID_TOKEN)
+    assert.equal(sink.isConfigured(), true)
+  })
+
+  it('delivers to every registered token with the category stamped into data', async () => {
+    const fetchMock = mockFetchOk()
+    sink.registerToken(VALID_TOKEN)
+    sink.registerToken(VALID_TOKEN_2)
+    const ok = await sink.send({ category: 'result', title: 'T', body: 'B', data: { x: 1 } })
+    assert.equal(ok, true)
+    assert.equal(fetchMock.mock.calls.length, 1)
+    const messages = JSON.parse(fetchMock.mock.calls[0].arguments[1].body)
+    assert.equal(messages.length, 2)
+    assert.deepEqual(messages.map((m) => m.to).sort(), [VALID_TOKEN, VALID_TOKEN_2].sort())
+    assert.deepEqual(messages[0].data, { x: 1, category: 'result' })
+  })
+
+  it('applies per-device context evaluators per token', async () => {
+    const fetchMock = mockFetchOk()
+    sink.registerToken(VALID_TOKEN)
+    sink.registerToken(VALID_TOKEN_2)
+    const ok = await sink.send(
+      { category: 'result', title: 'T', body: 'B' },
+      { isCategoryEnabled: (_category, deviceId) => deviceId !== VALID_TOKEN }
+    )
+    assert.equal(ok, true)
+    const messages = JSON.parse(fetchMock.mock.calls[0].arguments[1].body)
+    assert.equal(messages.length, 1)
+    assert.equal(messages[0].to, VALID_TOKEN_2)
+  })
+
+  it('honours quiet hours with bypass, per token', async () => {
+    const fetchMock = mockFetchOk()
+    sink.registerToken(VALID_TOKEN)
+    sink.registerToken(VALID_TOKEN_2)
+    const ok = await sink.send(
+      { category: 'permission', title: 'T', body: 'B' },
+      {
+        isInQuietHours: () => true,
+        // Only the second device bypasses quiet hours for this category
+        shouldBypassQuietHours: (_category, deviceId) => deviceId === VALID_TOKEN_2,
+      }
+    )
+    assert.equal(ok, true)
+    const messages = JSON.parse(fetchMock.mock.calls[0].arguments[1].body)
+    assert.equal(messages.length, 1)
+    assert.equal(messages[0].to, VALID_TOKEN_2)
+  })
+
+  it('resolves true without a POST when every token is filtered out', async () => {
+    const fetchMock = mockFetchOk()
+    sink.registerToken(VALID_TOKEN)
+    const ok = await sink.send(
+      { category: 'result', title: 'T', body: 'B' },
+      { isCategoryEnabled: () => false }
+    )
+    assert.equal(ok, true)
+    assert.equal(fetchMock.mock.calls.length, 0)
+  })
+
+  it('fails open when context evaluators are missing (sends to all tokens)', async () => {
+    const fetchMock = mockFetchOk()
+    sink.registerToken(VALID_TOKEN)
+    const ok = await sink.send({ category: 'result', title: 'T', body: 'B' }, {})
+    assert.equal(ok, true)
+    assert.equal(fetchMock.mock.calls.length, 1)
+  })
+
+  it('resolves false (never throws) on Expo hard failure', async () => {
+    globalThis.fetch = mock.fn(async () => ({ ok: false, status: 400, json: async () => ({}) }))
+    sink.registerToken(VALID_TOKEN)
+    const ok = await sink.send({ category: 'result', title: 'T', body: 'B' })
+    assert.equal(ok, false)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 1 of the notification-sinks epic: a pure refactor that extracts a generic `NotificationSink` abstraction from `push.js`, with the existing Expo push delivery becoming the first sink (`ExpoPushSink`). No behavior change; all existing tests pass unchanged.

Related to #5413.

## The cut

New `packages/server/src/notifications/`:

- **`sink.js`** — the `NotificationSink` contract: `name` (stable identifier), `isConfigured()` (cheap, sync — "do I have anywhere to deliver to?"), and `send(notification, context)` resolving `true` unless a hard channel failure occurred (preserving the `#3870` idle-push-latch semantics callers rely on). The header documents the pipeline layering for Phase 2.
- **`sink-registry.js`** — `SinkRegistry`, the fan-out point: skips unconfigured sinks, invokes configured sinks sequentially, contains a throwing sink (logs + treats as hard failure) so one buggy sink can't take the pipeline down or starve the others, and aggregates `true` iff no configured sink hard-failed.
- **`expo-push-sink.js`** — everything Expo-specific moved verbatim from `push.js`: the push-token registry with disk persistence and owner ref-counting, token format validation, `fetchWithRetry` + the exp.host POST, ticket-based token pruning, and the iOS Live Activity token path.

`push.js` keeps `PushManager` as the shared pipeline per the epic diagram (event flow → prefs → rate limit → fan out to enabled sinks).

## What stayed put

- **Prefs + rate limiting stay OUTSIDE the sinks**, in `PushManager` — they were already cleanly separated (`notification-prefs.js` + `RATE_LIMITS`), so the pipeline applies them once and every future sink inherits identical gating. The one per-DEVICE concern (per-token category mute / quiet hours, keyed by Expo push tokens only the sink knows about) is evaluated inside the sink via evaluator callbacks passed in `context`, exactly where the old per-token loop ran.
- **`PushManager`'s full public surface is preserved** (`registerToken`, `releaseTokenOwner`, Live Activity registration, the `tokens` set, `isValidPushTokenFormat`, `fetchWithRetry` re-exports), delegating to the Expo sink — so `server-cli.js`, `supervisor.js`, `ws-permissions.js`, `handlers/input-handlers.js` and every existing test are untouched. Zero call-site changes.
- **`server-cli/push-notification-handler.js` is untouched.** The epic's wording mentions extracting from it too, but it contains the event→category mapping (the "event flow" layer of the diagram), not Expo delivery — the Expo-specific code all lived in `push.js`. Moving the handler would have widened the diff with no abstraction gain.
- Order-sensitive behaviors preserved exactly: the tokenless early-return still happens BEFORE the rate-limit stamp (a tokenless send doesn't burn the category's window), eligible-token filtering and prune-on-ticket-error semantics are byte-identical, and `live_activity` keeps sharing the same `_lastSent` clock.

## Tests

- New `tests/notification-sinks.test.js` (22 tests) pins the contract + registry fan-out semantics so Phase 2's `DiscordWebhookSink` lands on tested rails: unconfigured sinks never receive sends, a failing/throwing sink doesn't block the others, aggregation semantics, and `ExpoPushSink`'s per-device evaluator filtering / fail-open defaults / hard-failure `false`.
- All push/notification suites green (235 tests across the 10 push + prefs files), full server suite green except the two known environment-dependent `service.test.js` failures (`getFullServiceStatus` fetch timeout / port parsing).
- All `scripts/lint-*.sh` pass; eslint clean for the new files.