### PR TITLE
chore(ci): bump repo-relay to v1.1.0

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -15,6 +15,12 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    # Least-privilege token: piggyback review detection reads the pulls and
+    # issues APIs; an explicit block zeroes every unlisted scope
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
     # Skip bots (prevent cascades) and fork PRs (no secrets access)
     if: >-
       github.actor != 'github-actions[bot]' &&

--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -21,7 +21,7 @@ jobs:
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
-      - uses: blamechris/repo-relay@b238b3f06628720308cf993ffed3990b82350eda # v1.0.1
+      - uses: blamechris/repo-relay@f08840b9c336b50f6aef8d6e157d8f7e705fa875 # v1.1.0
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}
           channel_prs: ${{ secrets.DISCORD_CHANNEL_PRS }}


### PR DESCRIPTION
## Summary
Bumps the SHA-pinned repo-relay action from v1.0.1 (`b238b3f`) to v1.1.0 (`f08840b`).

v1.0.1 predates repo-relay's full audit-fix wave (16 PRs landed today). Highlights relevant to this repo's notifications:

- **State-cache fix**: documented per-run cache keys — PR/thread state no longer silently frozen at the first cached run
- **Reliability**: archived-thread recovery (no more lost thread updates after 24h auto-archive), idempotent PR embeds on redelivery/reopen, Discord limit clamps (thread names, label fields, CI replies), WAL checkpoint on error exits
- **Security**: agent-review author gating (no status spoofing by arbitrary commenters), masked-link escaping in embeds, paginated review detection
- **New**: human PR reviews (approved/changes_requested) now post thread replies and update the embed; review-cascade filter works on org-owned repos

Schema migration in v1.1.0 is guarded — the cached state DB survives the upgrade.

## Test plan
- [ ] CI green
- [ ] Next PR/CI event posts to Discord normally (validates the pinned ref end-to-end)