### PR TITLE
feat(server): DiscordWebhookSink — status-embed port from claude-code-notify (#5413 Phase 2)

### DIFF
--- a/docs/guides/discord-notifications.md
+++ b/docs/guides/discord-notifications.md
@@ -1,0 +1,145 @@
+# Discord Notifications
+
+Chroxy can maintain a live **status embed** in a Discord channel — one message
+per project that updates in place as sessions work, go idle, hit errors, or
+wait for permission approval. No mobile app or Expo dev build required: a
+Discord webhook URL is the only setup.
+
+This is the Discord webhook notification sink from epic #5413 (Phase 2), a
+port of the `claude-code-notify` status-embed behavior into the chroxy daemon.
+
+## How it behaves
+
+The sink keeps a single status message per project and updates it in place:
+
+| Event | Embed state | Discord action |
+|-------|-------------|----------------|
+| Session finishes a turn / goes idle | 🦀 Ready for input | **Delete + re-post** (pings, moves to channel bottom) |
+| Permission needed / question asked | 🔐 Needs Approval | **Delete + re-post** (pings) |
+| Session error | ❗ Session Error | Edit in place (no ping) |
+| Agent quiet for a long while | ⏳ Quiet for a while | Edit in place (no ping) |
+
+Ping-worthy states (idle, needs-approval) delete the old message and post a
+fresh one so Discord re-notifies you; routine updates just edit the existing
+embed. If the message gets deleted by hand, the sink notices (the edit 404s)
+and posts a fresh one. A background refresh keeps the embed footer's elapsed
+time current (one in-process timer, every 5 minutes by default).
+
+Notifications still flow through chroxy's shared pipeline first — category
+preferences, quiet hours, and rate limits apply to Discord exactly as they do
+to mobile push.
+
+## Setup
+
+### 1. Create a webhook in Discord
+
+In your Discord server: **Channel settings → Integrations → Webhooks → New
+Webhook**, pick the channel, copy the webhook URL.
+
+### 2. Give chroxy the URL
+
+The webhook URL is a **secret** — anyone holding it can post to (and delete
+the sink's messages from) your channel. Treat it like an API key. Two options:
+
+**Environment variable** (wins when both are set):
+
+```bash
+export CHROXY_DISCORD_WEBHOOK_URL="https://discord.com/api/webhooks/<id>/<token>"
+```
+
+**Credentials file** — add to `~/.chroxy/credentials.json` (the same file
+that holds BYOK API keys):
+
+```json
+{
+  "discordWebhookUrl": "https://discord.com/api/webhooks/<id>/<token>"
+}
+```
+
+The file **must be mode 0600** — chroxy refuses to read it otherwise:
+
+```bash
+chmod 600 ~/.chroxy/credentials.json
+```
+
+Do NOT put the URL in `config.json` — it isn't permission-restricted and gets
+echoed in verbose output. Chroxy warns at startup if it finds a `webhookUrl`
+key in the config block. Log output redacts Discord webhook URLs as a second
+layer of defence.
+
+That's it. The sink is off by default and switches on the moment a webhook
+URL resolves — restart the daemon after adding it.
+
+### 3. (Optional) Colors and tuning
+
+The non-secret knobs live in `~/.chroxy/config.json` under
+`notifications.discord`:
+
+```json
+{
+  "notifications": {
+    "discord": {
+      "botName": "Chroxy",
+      "colors": {
+        "chroxy": 1752220,
+        "my-other-project": 10181046
+      },
+      "defaultColor": 5793266,
+      "permissionColor": 16753920,
+      "errorColor": 15158332,
+      "updateThrottleMs": 15000,
+      "heartbeatIntervalMs": 300000
+    }
+  }
+}
+```
+
+- **`colors`** — per-project embed sidebar colors, keyed by project name,
+  values are decimal 24-bit RGB (`0`–`16777215`). Convert hex → decimal with
+  any color tool. Handy values (same palette as claude-code-notify's
+  `colors.conf.example`):
+
+  | Color | Hex | Decimal |
+  |-------|-----|---------|
+  | Teal | `#1ABC9C` | `1752220` |
+  | Purple | `#9B59B6` | `10181046` |
+  | Blue | `#3498DB` | `3447003` |
+  | Green | `#2ECC71` | `3066993` |
+  | Orange | `#E67E22` | `15105570` |
+  | Red | `#E74C3C` | `15158332` |
+  | Grey | `#95A5A6` | `9807270` |
+  | Blurple (default) | `#5865F2` | `5793266` |
+
+- **`updateThrottleMs`** — minimum gap between same-state routine edits per
+  project (state *changes* always go out immediately).
+- **`heartbeatIntervalMs`** — how often the elapsed-time footer refreshes.
+  `0` disables the refresh; minimum `10000`.
+
+See [packages/server/CONFIG.md](../../packages/server/CONFIG.md#discord-notifications-notificationsdiscord)
+for the full key reference.
+
+## Where state lives
+
+Status-message bookkeeping (message id, current state, timestamps per
+project) persists in `~/.chroxy/discord-webhook-state.json`, written
+atomically. Deleting the file is safe — the next event posts a fresh status
+message.
+
+## Scope and roadmap
+
+Phase 2 reflects **chroxy-launched sessions** (the events chroxy's own
+notification pipeline emits). Claude Code sessions started outside chroxy
+flow in with the event-ingest endpoint (Phase 3) and the hooks package
+(Phase 4), which also moves subagent counting server-side. See epic #5413.
+
+## Troubleshooting
+
+- **Nothing posts** — check the daemon log for `discord` entries; confirm the
+  URL resolves (`CHROXY_DISCORD_WEBHOOK_URL` set in the daemon's environment,
+  or `credentials.json` is mode 0600 with a `discordWebhookUrl` field), and
+  that the URL matches `https://discord.com/api/webhooks/<id>/<token>`.
+- **Posts but never pings** — pings come from the delete + re-post on idle /
+  needs-approval; check your Discord notification settings for the channel.
+- **Rate limited** — the sink honours Discord's `retry_after` on 429s and
+  backs off; sustained 429s resolve as delivery failure and retry on the next
+  session event.

--- a/packages/server/CONFIG.md
+++ b/packages/server/CONFIG.md
@@ -491,6 +491,51 @@ swallowed) and cached per process, so it adds one read (plus a create if the
 object is missing) per configured object the first time a tenant namespace is
 used, and nothing on subsequent calls for that namespace.
 
+### Discord notifications (`notifications.discord`)
+
+The Discord webhook sink (#5413 Phase 2) maintains one status-embed message
+per project in a Discord channel, alongside (or instead of) Expo push. It is
+**off by default** — it activates only when a webhook URL is present.
+
+The webhook URL is a **secret** (anyone holding it can post to the channel)
+and is therefore NOT a config key. Provide it via either:
+
+- `CHROXY_DISCORD_WEBHOOK_URL` environment variable, or
+- `~/.chroxy/credentials.json` (must be mode `0600`):
+  `{ "discordWebhookUrl": "https://discord.com/api/webhooks/<id>/<token>" }`
+
+The non-secret knobs live under `notifications.discord` in `config.json`:
+
+```json
+{
+  "notifications": {
+    "discord": {
+      "botName": "Chroxy",
+      "colors": { "chroxy": 1752220, "my-other-project": 10181046 },
+      "defaultColor": 5793266,
+      "permissionColor": 16753920,
+      "errorColor": 15158332,
+      "updateThrottleMs": 15000,
+      "heartbeatIntervalMs": 300000
+    }
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `botName` | string | Webhook display name + embed footer label (default `Chroxy`) |
+| `colors` | object | Per-project embed sidebar colors, project name → decimal 24-bit RGB (`0`–`16777215`) |
+| `defaultColor` | number | Sidebar color for projects without an override (default `5793266`, Discord blurple) |
+| `permissionColor` | number | Sidebar color for the needs-approval state (default `16753920`, orange) |
+| `errorColor` | number | Sidebar color for the session-error state (default `15158332`, red) |
+| `updateThrottleMs` | number | Minimum interval between same-state routine embed updates per project (default `15000`; state changes always go out) |
+| `heartbeatIntervalMs` | number | Elapsed-time footer refresh interval (default `300000`; `0` disables; minimum `10000`) |
+
+Status-message state (message ids, current state per project) persists in
+`~/.chroxy/discord-webhook-state.json`. Full setup walkthrough:
+[docs/guides/discord-notifications.md](../../docs/guides/discord-notifications.md).
+
 ## Examples
 
 ### Using Config File Only

--- a/packages/server/src/auth-probes.js
+++ b/packages/server/src/auth-probes.js
@@ -172,11 +172,16 @@ export function hasGeminiOAuthCreds() {
 let _credFileCache = {
   byok: { envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null },
   deepseek: { envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null },
+  // #5427: Discord webhook URL — same credentials.json, different key. The
+  // sink's isConfigured() is probed on every notification, so the resolver
+  // must not re-stat/re-parse the file per probe.
+  discord: { envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null },
 }
 
 const _SLOT_ENV_VAR = {
   byok: 'ANTHROPIC_API_KEY',
   deepseek: 'DEEPSEEK_API_KEY',
+  discord: 'CHROXY_DISCORD_WEBHOOK_URL',
 }
 
 /**
@@ -185,7 +190,7 @@ const _SLOT_ENV_VAR = {
  * the env var is unchanged AND either (env-var path was taken last time) or
  * (the file's stat-mtime+size+mode still matches what we cached).
  *
- * @param {'byok' | 'deepseek'} slot
+ * @param {'byok' | 'deepseek' | 'discord'} slot
  * @param {string | undefined} envValue - current value of the relevant env var
  * @param {() => object} resolve - the underlying *-credentials resolver
  * @returns {object} resolver result
@@ -258,5 +263,6 @@ export function resetCachesForTest() {
   _credFileCache = {
     byok: { envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null },
     deepseek: { envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null },
+    discord: { envValue: null, path: null, mtimeMs: null, size: null, mode: null, result: null },
   }
 }

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -766,7 +766,11 @@ export function validateConfig(config, verbose = false) {
   // values to its defaults at runtime.
   if (config.notifications !== undefined) {
     if (typeof config.notifications !== 'object' || config.notifications === null || Array.isArray(config.notifications)) {
-      warnings.push(`Invalid type for 'notifications': expected object, got ${Array.isArray(config.notifications) ? 'array' : typeof config.notifications}`)
+      // "Invalid value", NOT "Invalid type" — loadAndMergeConfig escalates
+      // the "Invalid type" prefix to a fatal startup error, and this block
+      // is deliberately warn-only (a cosmetic-notifications typo must never
+      // stop the daemon from booting).
+      warnings.push(`Invalid value for 'notifications': expected an object, got ${Array.isArray(config.notifications) ? 'array' : typeof config.notifications}`)
     } else if (config.notifications.discord !== undefined) {
       validateDiscordNotificationsBlock(config.notifications.discord, warnings)
     }

--- a/packages/server/src/config.js
+++ b/packages/server/src/config.js
@@ -94,6 +94,18 @@ const CONFIG_SCHEMA = {
   showToken: 'boolean',
   logFormat: 'string',
   environments: 'object',
+  // #5413: notification-sink settings. Currently one sub-block,
+  // `notifications.discord`, carrying the Discord status-embed sink's
+  // non-secret knobs: `botName` (string), `colors` (project → decimal
+  // 24-bit RGB map for the embed sidebar), `defaultColor` /
+  // `permissionColor` / `errorColor` (decimal RGB), `updateThrottleMs`
+  // (min interval between same-state routine embed updates) and
+  // `heartbeatIntervalMs` (elapsed-time refresh; 0 disables). The webhook
+  // URL itself is a SECRET and deliberately NOT a config key — it lives in
+  // CHROXY_DISCORD_WEBHOOK_URL or ~/.chroxy/credentials.json (0600); see
+  // discord-credentials.js. Documented in CONFIG.md +
+  // docs/guides/discord-notifications.md.
+  notifications: 'object',
   // #5158: worktree garbage-collection. `{ autoReap: boolean }` — when true,
   // the server reclaims orphaned, dead-pid-locked agent worktrees on startup
   // (clean trees only, never --force). Defaults to off; the `chroxy worktree
@@ -388,6 +400,80 @@ function validateRancherBlock(rancher, warnings) {
   }
 }
 
+/** #5413: decimal 24-bit RGB range for Discord embed sidebar colors. */
+const MAX_DISCORD_COLOR = 16777215
+
+/**
+ * #5413: validate the `notifications.discord` block (the Discord
+ * status-embed sink's non-secret knobs). Every field is optional; only
+ * fields actually present are checked. The webhook URL is a secret and
+ * does NOT belong here — a `webhookUrl` key in this block gets a pointed
+ * warning steering the operator to the credential paths.
+ *
+ * All warnings use the "Invalid value" wording so a cosmetic typo never
+ * escalates to a fatal startup error (the CLI layer treats "Invalid type"
+ * prefixes as fatal); the sink clamps bad values to defaults at runtime.
+ *
+ * @param {*} discord - The `notifications.discord` value
+ * @param {string[]} warnings - Accumulator the caller logs/returns
+ */
+function validateDiscordNotificationsBlock(discord, warnings) {
+  if (typeof discord !== 'object' || discord === null || Array.isArray(discord)) {
+    warnings.push(`Invalid value for 'notifications.discord': expected object, got ${Array.isArray(discord) ? 'array' : typeof discord}`)
+    return
+  }
+
+  // Secrets do not belong in config.json (not permission-restricted, echoed
+  // in verbose output). Warn loudly and point at the right place.
+  for (const key of ['webhookUrl', 'webhook', 'url']) {
+    if (Object.prototype.hasOwnProperty.call(discord, key)) {
+      warnings.push(
+        `'notifications.discord.${key}' is not supported: the webhook URL is a secret — set CHROXY_DISCORD_WEBHOOK_URL or add "discordWebhookUrl" to ~/.chroxy/credentials.json (mode 0600) instead`,
+      )
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(discord, 'botName') && (typeof discord.botName !== 'string' || discord.botName.length === 0)) {
+    warnings.push(`Invalid value for 'notifications.discord.botName': expected a non-empty string`)
+  }
+
+  const isValidColor = (v) => Number.isInteger(v) && v >= 0 && v <= MAX_DISCORD_COLOR
+  for (const key of ['defaultColor', 'permissionColor', 'errorColor']) {
+    if (Object.prototype.hasOwnProperty.call(discord, key) && !isValidColor(discord[key])) {
+      warnings.push(`Invalid value for 'notifications.discord.${key}': expected an integer 0-${MAX_DISCORD_COLOR} (decimal 24-bit RGB), got ${JSON.stringify(discord[key])}`)
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(discord, 'colors')) {
+    const colors = discord.colors
+    if (typeof colors !== 'object' || colors === null || Array.isArray(colors)) {
+      warnings.push(`Invalid value for 'notifications.discord.colors': expected an object mapping project name → decimal color`)
+    } else {
+      for (const [project, value] of Object.entries(colors)) {
+        if (!isValidColor(value)) {
+          warnings.push(`Invalid value for 'notifications.discord.colors.${project}': expected an integer 0-${MAX_DISCORD_COLOR} (decimal 24-bit RGB), got ${JSON.stringify(value)}`)
+        }
+      }
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(discord, 'updateThrottleMs')) {
+    const v = discord.updateThrottleMs
+    if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {
+      warnings.push(`Invalid value for 'notifications.discord.updateThrottleMs': expected a number >= 0, got ${JSON.stringify(v)}`)
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(discord, 'heartbeatIntervalMs')) {
+    const v = discord.heartbeatIntervalMs
+    if (typeof v !== 'number' || !Number.isFinite(v) || v < 0) {
+      warnings.push(`Invalid value for 'notifications.discord.heartbeatIntervalMs': expected a number >= 0 (0 disables), got ${JSON.stringify(v)}`)
+    } else if (v !== 0 && v < 10_000) {
+      warnings.push(`Invalid value for 'notifications.discord.heartbeatIntervalMs': ${v} (minimum 10000 / 10s; set 0 to disable — the sink falls back to its default)`)
+    }
+  }
+}
+
 /**
  * Return a copy of config with sensitive fields replaced by '***'.
  * Use this whenever the config object is serialized to logs or debug output.
@@ -670,6 +756,19 @@ export function validateConfig(config, verbose = false) {
           warnings.push(`Invalid value for 'worktreeGc.reapIntervalMs': expected a positive number, got ${typeof v === 'number' ? v : typeof v}`)
         }
       }
+    }
+  }
+
+  // #5413: notifications block. Only `notifications.discord` is recognised
+  // today. All warnings here are "Invalid value" (not "Invalid type") so a
+  // typo in a cosmetic color can never become a fatal startup error via the
+  // loadAndMergeConfig "Invalid type" escalation — the sink clamps bad
+  // values to its defaults at runtime.
+  if (config.notifications !== undefined) {
+    if (typeof config.notifications !== 'object' || config.notifications === null || Array.isArray(config.notifications)) {
+      warnings.push(`Invalid type for 'notifications': expected object, got ${Array.isArray(config.notifications) ? 'array' : typeof config.notifications}`)
+    } else if (config.notifications.discord !== undefined) {
+      validateDiscordNotificationsBlock(config.notifications.discord, warnings)
     }
   }
 

--- a/packages/server/src/discord-credentials.js
+++ b/packages/server/src/discord-credentials.js
@@ -1,0 +1,144 @@
+/**
+ * Credential sourcing for the Discord webhook notification sink (#5413
+ * Phase 2).
+ *
+ * A Discord webhook URL IS a secret: anyone holding it can post arbitrary
+ * messages to (and delete the sink's messages from) the target channel. It
+ * is therefore sourced exactly like the provider API keys — mirrors
+ * byok-credentials.js / deepseek-credentials.js: priority order, 0600 mode
+ * enforcement, lazy path resolution, masking helper. Kept as a separate
+ * module so a credentials.json carrying API keys AND the webhook URL routes
+ * each secret to its consumer without either path knowing about the other.
+ *
+ * Priority order:
+ *   1. process.env.CHROXY_DISCORD_WEBHOOK_URL
+ *   2. ~/.chroxy/credentials.json — { discordWebhookUrl: "https://discord.com/api/webhooks/..." }
+ *      File MUST be mode 0600. We refuse to read it otherwise (security
+ *      boundary: secrets must not be world-readable).
+ *
+ * The URL is deliberately NOT a config.json key — config.json is not
+ * permission-restricted and gets echoed in verbose/diagnostic output.
+ * validateConfig warns if someone puts a webhookUrl in the
+ * notifications.discord block.
+ *
+ * Never logged. The redactor at logger.js scrubs discord.com/api/webhooks
+ * URLs (token part is the secret); masking at the use site via
+ * maskWebhookUrl is the second layer.
+ */
+import { readFileSync, statSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+
+// Lazy-resolved per call so tests that mutate process.env.HOME between
+// cases pick up the new home (same rationale as byok-credentials.js).
+function credentialsFilePath() {
+  return join(homedir(), '.chroxy', 'credentials.json')
+}
+
+// Accepted webhook URL shapes. discordapp.com is the legacy domain Discord
+// still serves; ptb/canary are Discord's test builds. The path may carry an
+// API version segment (`/api/v10/webhooks/...`).
+const WEBHOOK_URL_RE = /^https:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/(?:v\d+\/)?webhooks\/(\d+)\/([A-Za-z0-9_-]+)(?:[/?#]|$)/
+
+/**
+ * Whether a string looks like a real Discord webhook URL.
+ * @param {string} url
+ * @returns {boolean}
+ */
+export function isValidDiscordWebhookUrl(url) {
+  return typeof url === 'string' && WEBHOOK_URL_RE.test(url)
+}
+
+/**
+ * Extract the `<id>/<token>` pair from a webhook URL (used to build the
+ * per-message endpoints: `/webhooks/<id>/<token>/messages/<messageId>`).
+ * Strips query params / fragments / trailing slashes.
+ *
+ * @param {string} url
+ * @returns {{ id: string, token: string } | null}
+ */
+export function extractWebhookIdToken(url) {
+  if (typeof url !== 'string') return null
+  const m = WEBHOOK_URL_RE.exec(url)
+  if (!m) return null
+  return { id: m[1], token: m[2] }
+}
+
+/**
+ * Resolve the Discord webhook URL for the notification sink.
+ *
+ * @returns {{ url: string, source: 'env' | 'file' } | { url: null, source: 'none', reason: string }}
+ */
+export function resolveDiscordWebhookUrl() {
+  const envUrl = process.env.CHROXY_DISCORD_WEBHOOK_URL
+  if (typeof envUrl === 'string' && envUrl.length > 0) {
+    return { url: envUrl, source: 'env' }
+  }
+
+  const CREDENTIALS_FILE = credentialsFilePath()
+  let stat
+  try {
+    stat = statSync(CREDENTIALS_FILE)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return {
+        url: null,
+        source: 'none',
+        reason: `CHROXY_DISCORD_WEBHOOK_URL not set and ${CREDENTIALS_FILE} does not exist`,
+      }
+    }
+    return {
+      url: null,
+      source: 'none',
+      reason: `unable to stat ${CREDENTIALS_FILE}: ${err.message}`,
+    }
+  }
+
+  // Refuse anything more permissive than 0600 — same security boundary as
+  // the BYOK/DeepSeek resolvers. A pasted-in credentials.json defaulting to
+  // 0644 on macOS would otherwise leak the webhook to every local user.
+  const perms = stat.mode & 0o777
+  if (perms !== 0o600) {
+    return {
+      url: null,
+      source: 'none',
+      reason: `${CREDENTIALS_FILE} has mode ${perms.toString(8).padStart(3, '0')}; refusing to read (must be 0600 — run: chmod 600 ${CREDENTIALS_FILE})`,
+    }
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(readFileSync(CREDENTIALS_FILE, 'utf8'))
+  } catch (err) {
+    return {
+      url: null,
+      source: 'none',
+      reason: `${CREDENTIALS_FILE} unreadable or not valid JSON: ${err.message}`,
+    }
+  }
+
+  if (typeof parsed?.discordWebhookUrl !== 'string' || parsed.discordWebhookUrl.length === 0) {
+    return {
+      url: null,
+      source: 'none',
+      reason: `${CREDENTIALS_FILE} missing or empty "discordWebhookUrl" field`,
+    }
+  }
+
+  return { url: parsed.discordWebhookUrl, source: 'file' }
+}
+
+/**
+ * Mask a webhook URL for display in logs / UI / errors. The webhook ID is
+ * not secret (it's a channel-ish identifier); the token after it is. Never
+ * returns the token — even for malformed inputs the whole string is
+ * replaced with a fixed marker rather than echoed.
+ *
+ * @param {string} url
+ * @returns {string}
+ */
+export function maskWebhookUrl(url) {
+  const parts = extractWebhookIdToken(url)
+  if (!parts) return '<invalid webhook url>'
+  return `https://discord.com/api/webhooks/${parts.id}/[REDACTED]`
+}

--- a/packages/server/src/discord-credentials.js
+++ b/packages/server/src/discord-credentials.js
@@ -28,6 +28,7 @@
 import { readFileSync, statSync } from 'fs'
 import { join } from 'path'
 import { homedir } from 'os'
+import { cachedResolveCredentialFile } from './auth-probes.js'
 
 // Lazy-resolved per call so tests that mutate process.env.HOME between
 // cases pick up the new home (same rationale as byok-credentials.js).
@@ -141,4 +142,19 @@ export function maskWebhookUrl(url) {
   const parts = extractWebhookIdToken(url)
   if (!parts) return '<invalid webhook url>'
   return `https://discord.com/api/webhooks/${parts.id}/[REDACTED]`
+}
+
+/**
+ * Cached resolver — same result as resolveDiscordWebhookUrl, but routed
+ * through auth-probes' mtime+size+mode-keyed credentials.json cache
+ * (#5427 review): the sink's isConfigured() is probed by the registry on
+ * every notification (and again inside send()/heartbeat), and the raw
+ * resolver statSync+readFileSync+JSON.parses the file each time. The
+ * cache repeats the parsed result until the env var or the file actually
+ * changes. Tests that need isolation call auth-probes'
+ * resetCachesForTest() (the suites already do, via the providers tests'
+ * shared setup) or inject their own resolveWebhookUrl.
+ */
+export function cachedResolveDiscordWebhookUrl() {
+  return cachedResolveCredentialFile('discord', process.env.CHROXY_DISCORD_WEBHOOK_URL, resolveDiscordWebhookUrl)
 }

--- a/packages/server/src/logger.js
+++ b/packages/server/src/logger.js
@@ -57,6 +57,14 @@ const API_KEY_PATTERNS = [
   // `eyJ` (base64 of `{"`), which makes this specific enough to avoid matching
   // ordinary dotted tokens. Length floors keep it off short `a.b.c` strings.
   /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
+  // #5413: Discord webhook URLs. The token segment after the numeric webhook
+  // id grants post/edit/delete on the channel, so the URL is a credential.
+  // Covers discordapp.com (legacy), ptb/canary builds, and optional /vN/ API
+  // version segments; anything after the token (e.g. /messages/<id>) is left
+  // intact. Real webhook tokens are 60+ chars; the 20 floor keeps doc
+  // placeholders like .../webhooks/123/abc readable while catching any
+  // plausible real token.
+  /\bhttps:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/(?:v\d+\/)?webhooks\/\d+\/[A-Za-z0-9_-]{20,}/g,
 ]
 
 /**

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -1,0 +1,562 @@
+/**
+ * DiscordWebhookSink — per-project Discord status embed (#5413 Phase 2).
+ *
+ * A behavior port of claude-code-notify's bash state machine to a
+ * NotificationSink (see sink.js for the contract). One status message per
+ * project, kept fresh in place:
+ *
+ *   - routine state updates  → PATCH the existing message (no ping)
+ *   - ping-worthy states     → DELETE the old message + POST a new one, so
+ *     Discord re-notifies and the message moves to the bottom of the channel
+ *     (idle / needs-approval — the states the user actually waits on)
+ *   - PATCH 404 (message deleted externally) → self-heal by POSTing fresh
+ *   - per-project embed sidebar colors (config), per-state title/emoji
+ *   - throttle window between same-state routine updates
+ *
+ * What moved vs the bash original:
+ *   - State (message id, current state, subagent count, timestamps) lives in
+ *     ONE JSON file under ~/.chroxy/ written atomically (temp+rename via
+ *     writeFileRestricted) — not a pile of /tmp files with mkdir locking.
+ *     The /tmp state machine was the root cause of the reliability pain the
+ *     epic exists to fix.
+ *   - The heartbeat is a single unref'd in-process setInterval that PATCHes
+ *     each tracked embed so the elapsed-time footer stays current — not a
+ *     forked bash daemon with a PID file.
+ *   - Driven by chroxy's own notification pipeline categories (Phase 2).
+ *     External Claude Code hook ingest is Phase 3; subagent counting from
+ *     hooks is Phase 4 — until then the embed reflects what chroxy-launched
+ *     sessions expose (`data.subagents` when a caller provides it).
+ *
+ * The webhook URL is a SECRET (posting + message-delete capability on the
+ * channel). It is sourced from the env / 0600 credentials.json via
+ * discord-credentials.js, never from config.json, and never logged (the
+ * logger redacts discord webhook URLs as a second layer).
+ *
+ * Discord rate limits: webhook endpoints return 429 with a `retry_after`
+ * (seconds) in the JSON body and a Retry-After header. fetchWithRetry
+ * (push.js) treats all 4xx as non-retryable, so this sink carries its own
+ * fetch helper that respects retry_after instead of hammering.
+ */
+
+import { readFileSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
+import { writeFileRestricted } from '../platform.js'
+import { createLogger } from '../logger.js'
+import { sleep, backoffDelay } from '../utils/sleep.js'
+import { NotificationSink } from './sink.js'
+import {
+  resolveDiscordWebhookUrl,
+  isValidDiscordWebhookUrl,
+  extractWebhookIdToken,
+} from '../discord-credentials.js'
+
+const log = createLogger('discord')
+
+// Same envelope as the Expo sink's fetch policy; the 429 handling is the
+// Discord-specific addition.
+const FETCH_TIMEOUT_MS = 10_000
+const MAX_RETRIES = 3
+const BACKOFF_BASE_MS = 1_000
+// Ceiling on how long a single 429 retry_after is honoured. Discord webhook
+// buckets are normally sub-second; a multi-minute retry_after means we're
+// globally limited and should give up (send() resolves false; the pipeline
+// retries on the next event) rather than hold the fan-out hostage.
+const MAX_RETRY_AFTER_MS = 30_000
+
+// Embed sidebar color defaults — ported from claude-code-notify
+// (colors.conf.example + the CLAUDE_NOTIFY_*_COLOR defaults).
+const DEFAULT_PROJECT_COLOR = 5793266   // Discord blurple #5865F2
+const DEFAULT_PERMISSION_COLOR = 16753920 // orange #FFA500
+const DEFAULT_ERROR_COLOR = 15158332    // red #E74C3C
+const MAX_COLOR = 16777215              // 24-bit RGB
+
+// Pipeline notification category → embed state. Phase 2 maps chroxy's own
+// session events (the categories PushManager.send is called with). The
+// bash original's hook-driven states (online/offline/idle_busy/approved)
+// return with Phase 3 ingest + Phase 4 hooks.
+//
+//   idle       — session finished a turn / waiting for input (🦀 in the
+//                original; ping-worthy: DELETE + POST so Discord notifies)
+//   permission — needs approval / has a question (ping-worthy)
+//   error      — session error (routine PATCH; new vs bash, which had no
+//                error surface — deliberate addition, documented in the PR)
+//   stale      — inactivity warning: busy but silent for a long time
+//                (routine PATCH; replaces the bash "(stale?)" title suffix)
+const STATE_FOR_CATEGORY = {
+  activity_update: 'idle',
+  result: 'idle',
+  permission: 'permission',
+  activity_waiting: 'permission',
+  activity_error: 'error',
+  inactivity_warning: 'stale',
+}
+
+// States that re-ping: DELETE the old message + POST a new one.
+const PING_STATES = new Set(['idle', 'permission'])
+
+const STATE_TITLES = {
+  idle: (project) => `\u{1F980} ${project} — Ready for input`,
+  permission: (project) => `\u{1F510} ${project} — Needs Approval`,
+  error: (project) => `\u{2757} ${project} — Session Error`,
+  stale: (project) => `\u{23F3} ${project} — Quiet for a while`,
+}
+
+/** Format seconds into a human-readable duration (port of format_duration). */
+export function formatDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0s'
+  seconds = Math.floor(seconds)
+  if (seconds < 60) return `${seconds}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`
+}
+
+function isValidColor(color) {
+  return Number.isInteger(color) && color >= 0 && color <= MAX_COLOR
+}
+
+function truncate(text, max = 1000) {
+  if (typeof text !== 'string') return ''
+  return text.length > max ? `${text.slice(0, max - 3)}...` : text
+}
+
+export class DiscordWebhookSink extends NotificationSink {
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.statePath] - Status-message state file. Defaults to
+   *   ~/.chroxy/discord-webhook-state.json (resolved lazily so tests that
+   *   mutate HOME, and the test sandbox guard, behave). Tests MUST inject a
+   *   temp path.
+   * @param {string} [opts.botName] - Webhook display name + footer label.
+   * @param {Record<string, number>} [opts.colors] - Per-project sidebar color
+   *   overrides (decimal 24-bit RGB), from config notifications.discord.colors.
+   * @param {number} [opts.defaultColor] - Sidebar color for projects without
+   *   an override (default: Discord blurple).
+   * @param {number} [opts.permissionColor] - Sidebar color for the
+   *   needs-approval state.
+   * @param {number} [opts.errorColor] - Sidebar color for the error state.
+   * @param {number} [opts.updateThrottleMs] - Minimum interval between
+   *   same-state routine PATCHes per project (state CHANGES always go out).
+   * @param {number} [opts.heartbeatIntervalMs] - Elapsed-time refresh PATCH
+   *   interval. 0 disables; values below 10s fall back to the default
+   *   (parity with the bash heartbeat's interval clamp).
+   * @param {Function} [opts.resolveWebhookUrl] - Injection seam for tests;
+   *   defaults to the env > 0600-credentials.json resolver.
+   * @param {Function} [opts.sleepImpl] - Injection seam for tests (429/backoff
+   *   waits); defaults to utils/sleep.
+   * @param {Function} [opts.now] - Clock seam for tests; defaults to Date.now.
+   */
+  constructor({
+    statePath = null,
+    botName = 'Chroxy',
+    colors = {},
+    defaultColor = DEFAULT_PROJECT_COLOR,
+    permissionColor = DEFAULT_PERMISSION_COLOR,
+    errorColor = DEFAULT_ERROR_COLOR,
+    updateThrottleMs = 15_000,
+    heartbeatIntervalMs = 300_000,
+    resolveWebhookUrl = resolveDiscordWebhookUrl,
+    sleepImpl = sleep,
+    now = Date.now,
+  } = {}) {
+    super({ name: 'discord-webhook' })
+    this._statePath = statePath || null
+    this._botName = typeof botName === 'string' && botName.length > 0 ? botName.slice(0, 80) : 'Chroxy'
+    this._colors = colors && typeof colors === 'object' && !Array.isArray(colors) ? colors : {}
+    this._defaultColor = isValidColor(defaultColor) ? defaultColor : DEFAULT_PROJECT_COLOR
+    this._permissionColor = isValidColor(permissionColor) ? permissionColor : DEFAULT_PERMISSION_COLOR
+    this._errorColor = isValidColor(errorColor) ? errorColor : DEFAULT_ERROR_COLOR
+    this._updateThrottleMs = Number.isFinite(updateThrottleMs) && updateThrottleMs >= 0 ? updateThrottleMs : 15_000
+    if (!Number.isFinite(heartbeatIntervalMs) || heartbeatIntervalMs < 0) heartbeatIntervalMs = 300_000
+    if (heartbeatIntervalMs > 0 && heartbeatIntervalMs < 10_000) heartbeatIntervalMs = 300_000
+    this._heartbeatIntervalMs = heartbeatIntervalMs
+    this._resolveWebhookUrl = resolveWebhookUrl
+    this._sleep = sleepImpl
+    this._now = now
+    this._heartbeatTimer = null
+    this._destroyed = false
+  }
+
+  /**
+   * Sink contract: configured iff a syntactically valid webhook URL resolves
+   * from the env or the 0600 credentials file. Off by default — no URL means
+   * the registry never asks this sink to send (the epic's bloat guard).
+   */
+  isConfigured() {
+    return this._configuredUrl() != null
+  }
+
+  /** Resolve + validate the webhook URL, or null. Never throws, never logs the URL. */
+  _configuredUrl() {
+    let resolved
+    try {
+      resolved = this._resolveWebhookUrl()
+    } catch {
+      return null
+    }
+    const url = resolved?.url
+    return typeof url === 'string' && isValidDiscordWebhookUrl(url) ? url : null
+  }
+
+  /** Stop the heartbeat timer. Safe to call multiple times. */
+  destroy() {
+    this._destroyed = true
+    if (this._heartbeatTimer) {
+      clearInterval(this._heartbeatTimer)
+      this._heartbeatTimer = null
+    }
+  }
+
+  // -- State persistence (the /tmp → ~/.chroxy move) -----------------------
+
+  _resolvedStatePath() {
+    // Lazy like discord-credentials.credentialsFilePath so tests that mutate
+    // HOME (and the sandbox guard) see the current home, not a frozen one.
+    return this._statePath || join(homedir(), '.chroxy', 'discord-webhook-state.json')
+  }
+
+  /**
+   * Load the status-message store fresh from disk. Read-per-send (the file
+   * is tiny) so the supervisor's short-lived PushManager and the long-lived
+   * server process converge on the same message ids instead of fighting
+   * over cached copies.
+   */
+  _loadState() {
+    try {
+      const data = JSON.parse(readFileSync(this._resolvedStatePath(), 'utf-8'))
+      if (data && typeof data === 'object' && data.projects && typeof data.projects === 'object') {
+        return { version: 1, projects: data.projects }
+      }
+    } catch {
+      // Missing or corrupt — start fresh; the next successful send rewrites it.
+    }
+    return { version: 1, projects: {} }
+  }
+
+  /** Atomic persist (temp+rename, 0600) — mirrors how push.js persists tokens. */
+  _persistState(store) {
+    try {
+      const path = this._resolvedStatePath()
+      mkdirSync(dirname(path), { recursive: true })
+      writeFileRestricted(path, JSON.stringify(store))
+    } catch (err) {
+      // State-file failure must not fail delivery — worst case the next
+      // event POSTs a duplicate status message instead of PATCHing.
+      log.error(`Failed to persist Discord status state: ${err.message}`)
+    }
+  }
+
+  // -- Project keying -------------------------------------------------------
+
+  /**
+   * One status message per project. Phase 2 derives the key from what the
+   * pipeline notification carries (Phase 3 ingest events will carry an
+   * explicit `project`). Sanitized the same way the bash original sanitized
+   * project names so state keys stay filesystem/log safe.
+   */
+  _projectKey(notification) {
+    const data = notification?.data || {}
+    const raw = data.project || data.sessionName || data.sessionId || 'chroxy'
+    const sanitized = String(raw).replace(/[^A-Za-z0-9._-]/g, '')
+    return sanitized.length > 0 ? sanitized : 'unknown'
+  }
+
+  // -- Sink contract --------------------------------------------------------
+
+  /**
+   * Deliver one approved notification by updating (or re-posting) the
+   * project's status embed. Resolves `false` ONLY on hard channel failure
+   * (final non-2xx after retries, network throw) — per the sink contract the
+   * #3870-style latch handling is the pipeline's job, not ours.
+   *
+   * The context evaluators are per-DEVICE hooks; a webhook has no device
+   * identity, so they're evaluated once with `deviceId = null` — which the
+   * prefs resolvers treat as "the global setting". A globally muted
+   * category (or global quiet hours without a bypass) therefore silences
+   * the Discord embed update too, matching the pipeline's intent. Missing
+   * evaluators fail open per the contract.
+   */
+  async send(notification, context = {}) {
+    const webhookUrl = this._configuredUrl()
+    if (!webhookUrl) return true // unconfigured — registry normally skips us anyway
+
+    const state = STATE_FOR_CATEGORY[notification?.category]
+    if (!state) return true // unmapped category (parity: bash skipped unknown notification types)
+
+    const now0 = context.now ?? this._now()
+    const isCategoryEnabled = context.isCategoryEnabled ?? (() => true)
+    const isInQuietHours = context.isInQuietHours ?? (() => false)
+    const shouldBypassQuietHours = context.shouldBypassQuietHours ?? (() => false)
+    if (!isCategoryEnabled(notification.category, null)) return true
+    if (isInQuietHours(now0, null) && !shouldBypassQuietHours(notification.category, null)) return true
+
+    const project = this._projectKey(notification)
+    const now = this._now()
+    const store = this._loadState()
+    const prev = store.projects[project]
+
+    const data = notification.data || {}
+    const entry = {
+      messageId: prev?.messageId ?? null,
+      state,
+      body: typeof notification.body === 'string' ? notification.body : '',
+      detail: typeof data.detail === 'string' ? data.detail : (typeof data.tool === 'string' ? data.tool : null),
+      sessionName: typeof data.sessionName === 'string' ? data.sessionName : (prev?.sessionName ?? null),
+      // Phase 4 fills this from the hook event stream; until then callers
+      // may pass a count and we surface it.
+      subagents: Number.isFinite(data.subagents) ? data.subagents : (prev?.subagents ?? 0),
+      firstSeenTs: prev?.firstSeenTs ?? now,
+      lastUpdateTs: now,
+      lastStateChangeTs: prev?.state === state ? (prev?.lastStateChangeTs ?? now) : now,
+    }
+
+    try {
+      if (PING_STATES.has(state)) {
+        // Parity: an embed already sitting in `idle` is NOT re-posted for
+        // another idle event (`[ "$CURRENT_STATE" = "idle" ] && exit 0`) —
+        // re-pinging "still ready" is noise. `permission` always re-posts:
+        // each new approval request deserves a fresh ping.
+        if (state === 'idle' && prev?.state === 'idle' && prev?.messageId) return true
+        return await this._repost(webhookUrl, project, entry, store, prev?.messageId)
+      }
+
+      // Routine update. Same-state updates inside the throttle window are
+      // suppressed; a state CHANGE always goes out (the bash throttle only
+      // ever gated repeat activity updates, never transitions).
+      if (
+        prev?.state === state &&
+        Number.isFinite(prev?.lastUpdateTs) &&
+        now - prev.lastUpdateTs < this._updateThrottleMs
+      ) {
+        return true
+      }
+      return await this._patchOrPost(webhookUrl, project, entry, store)
+    } catch (err) {
+      log.error(`Discord status update failed for ${project}: ${err?.message || err}`)
+      return false
+    }
+  }
+
+  // -- Discord message operations -------------------------------------------
+
+  _apiBase(webhookUrl) {
+    const parts = extractWebhookIdToken(webhookUrl)
+    // _configuredUrl() already validated the shape; belt-and-braces.
+    if (!parts) throw new Error('webhook URL failed id/token extraction')
+    return `https://discord.com/api/webhooks/${parts.id}/${parts.token}`
+  }
+
+  /** DELETE the old status message (best effort) + POST a fresh one → re-ping. */
+  async _repost(webhookUrl, project, entry, store, oldMessageId) {
+    const base = this._apiBase(webhookUrl)
+    if (oldMessageId) {
+      try {
+        // Single attempt, failures ignored — parity with the bash `|| true`.
+        // Worst case the old message lingers; the new POST still pings.
+        await this._discordFetch(`${base}/messages/${oldMessageId}`, { method: 'DELETE' }, { retries: 1 })
+      } catch {
+        // best-effort
+      }
+    }
+    return await this._post(base, project, entry, store)
+  }
+
+  /** POST a new status message (?wait=true returns the created message). */
+  async _post(base, project, entry, store) {
+    const payload = this._buildPayload(project, entry)
+    const res = await this._discordFetch(`${base}?wait=true`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (!res.ok) {
+      log.error(`Discord webhook POST failed for ${project} (HTTP ${res.status})`)
+      return false
+    }
+    let messageId = null
+    try {
+      messageId = (await res.json())?.id ?? null
+    } catch {
+      // 204 / unparsable body — message likely posted but we can't track it;
+      // treat as delivered, next event self-heals by POSTing fresh.
+    }
+    entry.messageId = messageId
+    store.projects[project] = entry
+    this._persistState(store)
+    this._ensureHeartbeat()
+    return true
+  }
+
+  /** PATCH the existing message; self-heal on 404 / missing id by POSTing. */
+  async _patchOrPost(webhookUrl, project, entry, store) {
+    const base = this._apiBase(webhookUrl)
+    if (!entry.messageId) {
+      return await this._post(base, project, entry, store)
+    }
+    const payload = this._buildPayload(project, entry)
+    const res = await this._discordFetch(`${base}/messages/${entry.messageId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (res.status === 404) {
+      // Message deleted externally — re-POST (parity with the bash self-heal).
+      entry.messageId = null
+      return await this._post(base, project, entry, store)
+    }
+    if (!res.ok) {
+      log.error(`Discord webhook PATCH failed for ${project} (HTTP ${res.status})`)
+      return false
+    }
+    store.projects[project] = entry
+    this._persistState(store)
+    this._ensureHeartbeat()
+    return true
+  }
+
+  /**
+   * Fetch with timeout + bounded retry, Discord flavor:
+   *   - 429 → honour retry_after (JSON body seconds, or Retry-After header),
+   *     capped at MAX_RETRY_AFTER_MS, then retry
+   *   - 5xx / network error / timeout → exponential backoff retry
+   *   - other 4xx → return immediately (not retryable)
+   * Throws only when the LAST attempt threw (caller maps that to `false`).
+   */
+  async _discordFetch(url, options, { retries = MAX_RETRIES } = {}) {
+    let res
+    for (let attempt = 1; attempt <= retries; attempt++) {
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+      try {
+        res = await fetch(url, { ...options, signal: controller.signal })
+      } catch (err) {
+        clearTimeout(timer)
+        if (attempt < retries) {
+          await this._sleep(backoffDelay(attempt, BACKOFF_BASE_MS))
+          continue
+        }
+        throw err
+      }
+      clearTimeout(timer)
+
+      if (res.status === 429) {
+        if (attempt < retries) {
+          await this._sleep(await this._retryAfterMs(res))
+          continue
+        }
+        return res
+      }
+      if (res.ok || (res.status >= 400 && res.status < 500)) return res
+      // 5xx
+      if (attempt < retries) {
+        await this._sleep(backoffDelay(attempt, BACKOFF_BASE_MS))
+        continue
+      }
+      return res
+    }
+    return res
+  }
+
+  /**
+   * Extract the wait from a 429 response. Discord sends `retry_after` in
+   * SECONDS (float) in the JSON body and a Retry-After header (also
+   * seconds). Defaults to 2s when unparsable; clamped to MAX_RETRY_AFTER_MS.
+   */
+  async _retryAfterMs(res) {
+    let seconds = NaN
+    try {
+      const header = res.headers?.get?.('retry-after')
+      if (header != null) seconds = Number.parseFloat(header)
+    } catch { /* fall through to body */ }
+    if (!Number.isFinite(seconds)) {
+      try {
+        seconds = Number.parseFloat((await res.json())?.retry_after)
+      } catch { /* fall through to default */ }
+    }
+    if (!Number.isFinite(seconds) || seconds < 0) seconds = 2
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS)
+  }
+
+  // -- Embed building --------------------------------------------------------
+
+  _colorFor(project, state) {
+    if (state === 'permission') return this._permissionColor
+    if (state === 'error') return this._errorColor
+    const override = this._colors[project]
+    return isValidColor(override) ? override : this._defaultColor
+  }
+
+  _buildPayload(project, entry) {
+    const titleFor = STATE_TITLES[entry.state] || STATE_TITLES.idle
+    const fields = []
+    if (entry.body) {
+      fields.push({ name: 'Status', value: truncate(entry.body), inline: false })
+    }
+    if (entry.detail) {
+      fields.push({ name: 'Detail', value: truncate(entry.detail), inline: false })
+    }
+    if (entry.sessionName) {
+      fields.push({ name: 'Session', value: truncate(entry.sessionName, 100), inline: true })
+    }
+    if (Number.isFinite(entry.subagents) && entry.subagents > 0) {
+      fields.push({ name: 'Subagents', value: String(entry.subagents), inline: true })
+    }
+    const elapsedSec = (this._now() - (entry.firstSeenTs || this._now())) / 1000
+    return {
+      username: this._botName,
+      embeds: [{
+        title: titleFor(project),
+        color: this._colorFor(project, entry.state),
+        fields,
+        footer: { text: `${this._botName} · ${formatDuration(elapsedSec)}` },
+        timestamp: new Date(this._now()).toISOString(),
+      }],
+    }
+  }
+
+  // -- Heartbeat (elapsed-time refresh) --------------------------------------
+
+  /**
+   * Start the heartbeat lazily after the first successful message write.
+   * One unref'd interval per sink — it PATCHes every tracked embed so the
+   * footer's elapsed time stays current (the epic's "keep — it's one
+   * setInterval now" lean). Does nothing when unconfigured, never blocks
+   * process exit, and destroy() stops it.
+   */
+  _ensureHeartbeat() {
+    if (this._destroyed || this._heartbeatTimer || this._heartbeatIntervalMs === 0) return
+    this._heartbeatTimer = setInterval(() => {
+      this._heartbeatTick().catch((err) => {
+        log.debug?.(`Discord heartbeat tick failed: ${err?.message || err}`)
+      })
+    }, this._heartbeatIntervalMs)
+    this._heartbeatTimer.unref?.()
+  }
+
+  /** One heartbeat pass: refresh each tracked project's embed in place. */
+  async _heartbeatTick() {
+    const webhookUrl = this._configuredUrl()
+    if (!webhookUrl) return
+    const base = this._apiBase(webhookUrl)
+    const store = this._loadState()
+    let mutated = false
+    for (const [project, entry] of Object.entries(store.projects)) {
+      if (!entry?.messageId) continue
+      try {
+        const res = await this._discordFetch(`${base}/messages/${entry.messageId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(this._buildPayload(project, entry)),
+        })
+        if (res.status === 404) {
+          // Deleted externally — forget the id so the next real event POSTs.
+          entry.messageId = null
+          mutated = true
+        }
+      } catch {
+        // Heartbeat is best-effort; the next real event takes the full path.
+      }
+    }
+    if (mutated) this._persistState(store)
+  }
+}

--- a/packages/server/src/notifications/discord-webhook-sink.js
+++ b/packages/server/src/notifications/discord-webhook-sink.js
@@ -46,7 +46,7 @@ import { createLogger } from '../logger.js'
 import { sleep, backoffDelay } from '../utils/sleep.js'
 import { NotificationSink } from './sink.js'
 import {
-  resolveDiscordWebhookUrl,
+  cachedResolveDiscordWebhookUrl,
   isValidDiscordWebhookUrl,
   extractWebhookIdToken,
 } from '../discord-credentials.js'
@@ -155,7 +155,10 @@ export class DiscordWebhookSink extends NotificationSink {
     errorColor = DEFAULT_ERROR_COLOR,
     updateThrottleMs = 15_000,
     heartbeatIntervalMs = 300_000,
-    resolveWebhookUrl = resolveDiscordWebhookUrl,
+    // Cached by default (#5427 review): isConfigured() is probed per
+    // notification; the cache only re-reads credentials.json when its
+    // mtime/size/mode or the env var changes.
+    resolveWebhookUrl = cachedResolveDiscordWebhookUrl,
     sleepImpl = sleep,
     now = Date.now,
   } = {}) {
@@ -357,6 +360,16 @@ export class DiscordWebhookSink extends NotificationSink {
       } catch {
         // best-effort
       }
+      // Drop the id NOW, before the re-POST (#5427 review S2): if the POST
+      // below hard-fails, a persisted {state:'idle', messageId:<deleted>}
+      // would satisfy the idle→idle suppression and wedge the embed until
+      // a state change or a heartbeat 404 (never, if heartbeat is off).
+      // With the id cleared, the next event falls through to a fresh POST.
+      if (store.projects[project]) {
+        store.projects[project] = { ...store.projects[project], messageId: null }
+        this._persistState(store)
+      }
+      entry.messageId = null
     }
     return await this._post(base, project, entry, store)
   }

--- a/packages/server/src/push.js
+++ b/packages/server/src/push.js
@@ -36,6 +36,7 @@ import {
   MAX_RETRIES,
   BACKOFF_BASE_MS,
 } from './notifications/expo-push-sink.js'
+import { DiscordWebhookSink } from './notifications/discord-webhook-sink.js'
 
 const log = createLogger('push')
 
@@ -66,7 +67,18 @@ const RATE_LIMITS = {
 export { fetchWithRetry, FETCH_TIMEOUT_MS, MAX_RETRIES, BACKOFF_BASE_MS }
 
 export class PushManager {
-  constructor({ storagePath, prefsPath } = {}) {
+  /**
+   * @param {object} [opts]
+   * @param {string} [opts.storagePath] - Expo push-token persistence file
+   * @param {string} [opts.prefsPath] - Notification-prefs persistence file
+   * @param {object} [opts.discord] - DiscordWebhookSink options (#5413
+   *   Phase 2): `statePath` + the config-surface knobs (botName, colors,
+   *   throttle/heartbeat intervals). The sink is ALWAYS registered but is
+   *   off by default — `isConfigured()` is true only when a webhook URL
+   *   resolves from CHROXY_DISCORD_WEBHOOK_URL or the 0600
+   *   ~/.chroxy/credentials.json, so unconfigured setups never touch it.
+   */
+  constructor({ storagePath, prefsPath, discord = {} } = {}) {
     // #4541: notification-prefs path. Optional — when omitted PushManager
     // operates entirely in-memory (callers like one-off tests don't need
     // to write to disk). When set, getPrefs / setPrefs round-trip
@@ -83,6 +95,36 @@ export class PushManager {
     this._expoSink = new ExpoPushSink({ storagePath })
     this._sinks = new SinkRegistry({ logger: log })
     this._sinks.register(this._expoSink)
+    // #5413 Phase 2: the Discord status-embed sink. Registered alongside
+    // Expo, gated on configuration via the registry's isConfigured() skip.
+    this._discordSink = new DiscordWebhookSink(discord)
+    this._sinks.register(this._discordSink)
+  }
+
+  /**
+   * True when at least one delivery channel is currently configured
+   * (Expo tokens registered, Discord webhook URL present, ...). The
+   * sink-agnostic replacement for gating on the Expo-only `hasTokens`
+   * (#5413 Phase 2): a Discord-only setup must not have its notifications
+   * suppressed upstream of the pipeline.
+   */
+  hasConfiguredSinks() {
+    return this._sinks.hasConfigured()
+  }
+
+  /**
+   * Release sink resources (today: the Discord heartbeat interval). Safe
+   * to call multiple times. Call when discarding a PushManager before
+   * process exit (e.g. the supervisor's per-send instances).
+   */
+  destroy() {
+    for (const sink of this._sinks.sinks) {
+      try {
+        sink.destroy?.()
+      } catch (err) {
+        log.error(`Sink '${sink.name}' threw during destroy: ${err?.message || err}`)
+      }
+    }
   }
 
   /**

--- a/packages/server/src/server-cli.js
+++ b/packages/server/src/server-cli.js
@@ -717,6 +717,17 @@ export async function startCliServer(config) {
     // #4541: notification preferences persistence. Co-located in
     // ~/.chroxy alongside push-tokens.json so cleanup is one step.
     prefsPath: join(homedir(), '.chroxy', 'notification-prefs.json'),
+    // #5413 Phase 2: Discord status-embed sink. Off by default — only
+    // active when a webhook URL resolves from CHROXY_DISCORD_WEBHOOK_URL
+    // or ~/.chroxy/credentials.json (0600). Non-secret knobs (bot name,
+    // per-project embed colors, throttle/heartbeat intervals) come from
+    // the `notifications.discord` config block; the status-message state
+    // (message ids, current state) persists alongside the other
+    // notification state in ~/.chroxy.
+    discord: {
+      statePath: join(homedir(), '.chroxy', 'discord-webhook-state.json'),
+      ...(config.notifications?.discord || {}),
+    },
   })
 
   // #5368 slice (a): wire the session_event → push path now that pushManager
@@ -961,6 +972,7 @@ export async function startCliServer(config) {
     bonjourInstance,
     tokenManager,
     pairingManager,
+    pushManager,
     getWorktreeReapTimer: () => worktreeReapTimer,
     emergencyCleanupSync,
     removeConnectionInfo,

--- a/packages/server/src/server-cli/push-notification-handler.js
+++ b/packages/server/src/server-cli/push-notification-handler.js
@@ -23,7 +23,7 @@ export class PushNotificationHandler {
   /**
    * @param {{
    *   sessionManager: import('events').EventEmitter & { getSession: Function },
-   *   pushManager: { hasTokens: boolean, send: Function },
+   *   pushManager: { hasConfiguredSinks: () => boolean, send: Function },
    *   getWsServer: () => ({ authenticatedClientCount: number, hasActiveViewersForSession: Function } | undefined),
    *   logger: { info: Function, warn: Function, error: Function, debug: Function },
    * }} deps
@@ -66,6 +66,14 @@ export class PushNotificationHandler {
     const sessionManager = this._sessionManager
     const wsServer = this._getWsServer()
 
+    // #5413 Phase 2: gate on "any sink configured" rather than the
+    // Expo-only `hasTokens` — a Discord-only setup must not have its
+    // notifications suppressed here, upstream of the pipeline. The
+    // `hasTokens` fallback keeps legacy fakes/PushManager doubles working.
+    const hasSinks = typeof pushManager.hasConfiguredSinks === 'function'
+      ? pushManager.hasConfiguredSinks()
+      : pushManager.hasTokens
+
     if (event === 'ready') {
       log.info(`Session ${sessionId} ready: ${data.sessionId} (model: ${data.model})`)
     } else if (event === 'error') {
@@ -74,7 +82,7 @@ export class PushNotificationHandler {
       // the forwarding path (ws-forwarding.js → EventNormalizer). Don't also broadcastError()
       // here — that produces a duplicate server_error message on every client.
       // Activity update: error (immediate)
-      if (pushManager.hasTokens) {
+      if (hasSinks) {
         const sessionName = sessionManager.getSession(sessionId)?.name
         pushManager.send('activity_error', 'Session error', data.message, {
           sessionId,
@@ -118,14 +126,15 @@ export class PushNotificationHandler {
 
     // Push notifications for actionable events only (#2612)
     // Intermediate events (stream_start, tool_start) no longer trigger pushes.
-    if (!pushManager.hasTokens && (event === 'result' || event === 'permission_request' || event === 'user_question')) {
-      // #3866 diagnostic — silently dropping a push because no client ever
-      // registered a push token is the most common "I'm getting nothing on
-      // Android" failure mode. Surface it at debug so operators can confirm
-      // registration happened on their last connect.
-      log.debug(`Push suppressed for ${event} on ${sessionId}: no registered tokens`)
+    if (!hasSinks && (event === 'result' || event === 'permission_request' || event === 'user_question')) {
+      // #3866 diagnostic — silently dropping a push because no delivery
+      // channel is configured (no push token ever registered, no Discord
+      // webhook) is the most common "I'm getting nothing" failure mode.
+      // Surface it at debug so operators can confirm registration happened
+      // on their last connect.
+      log.debug(`Push suppressed for ${event} on ${sessionId}: no configured notification sinks`)
     }
-    if (pushManager.hasTokens) {
+    if (hasSinks) {
       if (event === 'result') {
         // Session idle push (#3866). Gate on noActiveViewers so the user
         // isn't pinged while actively chatting with this session. The

--- a/packages/server/src/server-cli/server-orchestrator.js
+++ b/packages/server/src/server-cli/server-orchestrator.js
@@ -31,6 +31,7 @@ export class ServerOrchestrator {
     bonjourInstance,
     tokenManager,
     pairingManager,
+    pushManager = null,
     getWorktreeReapTimer,
     emergencyCleanupSync,
     removeConnectionInfo = defaultRemoveConnectionInfo,
@@ -47,6 +48,7 @@ export class ServerOrchestrator {
     this._bonjourInstance = bonjourInstance
     this._tokenManager = tokenManager
     this._pairingManager = pairingManager
+    this._pushManager = pushManager
     this._getWorktreeReapTimer = typeof getWorktreeReapTimer === 'function' ? getWorktreeReapTimer : () => null
     this._emergencyCleanupSync = emergencyCleanupSync
     this._removeConnectionInfo = removeConnectionInfo
@@ -81,6 +83,11 @@ export class ServerOrchestrator {
     }
     if (this._tokenManager) this._tokenManager.destroy()
     if (this._pairingManager) this._pairingManager.destroy()
+    // #5413: stop the Discord sink's heartbeat. It's unref'd so it wouldn't
+    // block exit, but clearing it avoids a refresh PATCH racing shutdown.
+    if (this._pushManager) {
+      try { this._pushManager.destroy?.() } catch {}
+    }
     // #5326 (WP-5.4): stop the periodic worktree reaper. It's unref'd so it
     // wouldn't block exit, but clearing it avoids a sweep racing shutdown.
     const worktreeReapTimer = this._getWorktreeReapTimer()

--- a/packages/server/src/supervisor.js
+++ b/packages/server/src/supervisor.js
@@ -159,7 +159,15 @@ export class Supervisor extends EventEmitter {
     // The child process writes tokens after clients connect, so the supervisor
     // must re-read the file to pick up any tokens registered since startup.
     const push = new PushManager({ storagePath: this._pushStoragePath })
-    await push.send(category, title, body)
+    try {
+      await push.send(category, title, body)
+    } finally {
+      // #5413: release sink resources (the Discord heartbeat interval) —
+      // these per-send managers are short-lived by design, and without the
+      // destroy a configured Discord sink would leak one live interval per
+      // supervisor notification.
+      push.destroy()
+    }
   }
 
   /** Override point: display QR code */

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -230,12 +230,21 @@ process.env.CHROXY_CRED_DISABLE_KEYCHAIN = '1'
 
 // --- Scrub Discord webhook env -------------------------------------------------
 // #5413: PushManager always registers a DiscordWebhookSink that activates the
-// moment CHROXY_DISCORD_WEBHOOK_URL resolves. A developer with the webhook
-// exported in their shell would otherwise have every PushManager-touching test
-// posting to their REAL Discord channel — the network analogue of the home-write
-// contamination above. Tests that exercise the env path set the var themselves
-// in beforeEach and restore it after.
-delete process.env.CHROXY_DISCORD_WEBHOOK_URL
+// moment a webhook URL resolves. A developer with the webhook exported in
+// their shell would otherwise have every PushManager-touching test posting to
+// their REAL Discord channel — the network analogue of the home-write
+// contamination above.
+//
+// Set a syntactically INVALID sentinel instead of deleting (#5427 review S1):
+// the resolver short-circuits on any non-empty env value, so the sentinel
+// also stops the fallthrough to the developer's real
+// ~/.chroxy/credentials.json `discordWebhookUrl` — which would configure a
+// LIVE sink in every PushManager test and let `_persistState` swallow the
+// #4633 sandbox-guard throw on the real-home state write. `_configuredUrl()`
+// rejects the sentinel shape, so the sink reads as unconfigured everywhere.
+// Tests that exercise the env path set the var themselves in beforeEach and
+// restore it after.
+process.env.CHROXY_DISCORD_WEBHOOK_URL = 'invalid://chroxy-test-scrub-not-a-webhook'
 
 // --- Diagnostic ---------------------------------------------------------------
 // Quiet by default; set CHROXY_TEST_SANDBOX_DEBUG=1 to see the protected

--- a/packages/server/tests/_setup.mjs
+++ b/packages/server/tests/_setup.mjs
@@ -228,6 +228,15 @@ if (fs.promises) {
 // `_setCredentialKeychainForTests(...)`, which takes precedence over this flag.
 process.env.CHROXY_CRED_DISABLE_KEYCHAIN = '1'
 
+// --- Scrub Discord webhook env -------------------------------------------------
+// #5413: PushManager always registers a DiscordWebhookSink that activates the
+// moment CHROXY_DISCORD_WEBHOOK_URL resolves. A developer with the webhook
+// exported in their shell would otherwise have every PushManager-touching test
+// posting to their REAL Discord channel — the network analogue of the home-write
+// contamination above. Tests that exercise the env path set the var themselves
+// in beforeEach and restore it after.
+delete process.env.CHROXY_DISCORD_WEBHOOK_URL
+
 // --- Diagnostic ---------------------------------------------------------------
 // Quiet by default; set CHROXY_TEST_SANDBOX_DEBUG=1 to see the protected
 // paths once per process.

--- a/packages/server/tests/discord-webhook-sink.test.js
+++ b/packages/server/tests/discord-webhook-sink.test.js
@@ -1,0 +1,680 @@
+// #5413 Phase 2: DiscordWebhookSink — the status-embed state machine ported
+// from claude-code-notify, riding the Phase-1 sink rails.
+//
+// Pins:
+//   - credential sourcing (env > 0600 credentials.json, masking)
+//   - the message state machine: POST-once per project, PATCH for routine
+//     updates, DELETE+POST for ping-worthy states, 404 self-heal, throttle
+//     window, per-project isolation
+//   - Discord 429 handling (retry_after respected, capped)
+//   - hard failure after retries → send() resolves false, never throws
+//   - heartbeat lifecycle (lazy start, destroy, no-op when unconfigured)
+//
+// All fetches mocked; all state paths are temp dirs (#4633 sandbox).
+
+import { describe, it, beforeEach, afterEach, mock } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, statSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DiscordWebhookSink, formatDuration } from '../src/notifications/discord-webhook-sink.js'
+import {
+  resolveDiscordWebhookUrl,
+  isValidDiscordWebhookUrl,
+  extractWebhookIdToken,
+  maskWebhookUrl,
+} from '../src/discord-credentials.js'
+import { redactSensitive } from '../src/logger.js'
+import { SinkRegistry } from '../src/notifications/sink-registry.js'
+import { PushManager } from '../src/push.js'
+import { validateConfig } from '../src/config.js'
+
+const WEBHOOK_ID = '123456789012345678'
+const WEBHOOK_TOKEN = 'aBcDeFgHiJkLmNoPqRsTuVwXyZ-0123456789_abcdefghijklmnopqrstuvwx'
+const WEBHOOK = `https://discord.com/api/webhooks/${WEBHOOK_ID}/${WEBHOOK_TOKEN}`
+const API_BASE = `https://discord.com/api/webhooks/${WEBHOOK_ID}/${WEBHOOK_TOKEN}`
+
+let originalFetch
+let originalHome
+let originalEnvUrl
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch
+  originalHome = process.env.HOME
+  originalEnvUrl = process.env.CHROXY_DISCORD_WEBHOOK_URL
+  delete process.env.CHROXY_DISCORD_WEBHOOK_URL
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  process.env.HOME = originalHome
+  if (originalEnvUrl === undefined) delete process.env.CHROXY_DISCORD_WEBHOOK_URL
+  else process.env.CHROXY_DISCORD_WEBHOOK_URL = originalEnvUrl
+  mock.restoreAll()
+})
+
+/**
+ * Scripted fetch: each entry is { status, body?, headers? }. Responses are
+ * consumed in order; when the script runs dry, a 200 with a fresh message id
+ * is returned. Returns the recorded calls array.
+ */
+function scriptFetch(script = []) {
+  const calls = []
+  let autoId = 0
+  globalThis.fetch = mock.fn(async (url, options = {}) => {
+    calls.push({ url: String(url), method: options.method || 'GET', body: options.body })
+    const next = script.length > 0 ? script.shift() : { status: 200, body: { id: `auto-${++autoId}` } }
+    if (next.throws) throw next.throws
+    const status = next.status ?? 200
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      headers: { get: (h) => next.headers?.[String(h).toLowerCase()] ?? null },
+      json: async () => next.body ?? {},
+    }
+  })
+  return calls
+}
+
+/** Sink wired to a temp state file, a fake resolver, and a recording sleep. */
+function makeSink(overrides = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'discord-sink-'))
+  const statePath = join(dir, 'state.json')
+  const sleeps = []
+  let nowMs = 1_000_000
+  const sink = new DiscordWebhookSink({
+    statePath,
+    resolveWebhookUrl: () => ({ url: WEBHOOK, source: 'env' }),
+    sleepImpl: async (ms) => { sleeps.push(ms) },
+    heartbeatIntervalMs: 0,
+    now: () => nowMs,
+    ...overrides,
+  })
+  return { sink, dir, statePath, sleeps, advance: (ms) => { nowMs += ms }, getNow: () => nowMs }
+}
+
+function readState(statePath) {
+  return JSON.parse(readFileSync(statePath, 'utf-8'))
+}
+
+const idle = (data = {}) => ({
+  category: 'activity_update',
+  title: 'Session idle',
+  body: 'Ready for next message',
+  data: { sessionName: 'alpha', state: 'idle', ...data },
+})
+const waiting = (data = {}) => ({
+  category: 'activity_waiting',
+  title: 'Waiting for approval',
+  body: 'Permission needed: Bash',
+  data: { sessionName: 'alpha', state: 'waiting', detail: 'Bash', ...data },
+})
+const errored = (data = {}) => ({
+  category: 'activity_error',
+  title: 'Session error',
+  body: 'boom',
+  data: { sessionName: 'alpha', state: 'error', ...data },
+})
+
+describe('discord-credentials — webhook URL sourcing', () => {
+  it('env var wins over the credentials file', () => {
+    const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.HOME = home
+    mkdirSync(join(home, '.chroxy'), { recursive: true })
+    const file = join(home, '.chroxy', 'credentials.json')
+    writeFileSync(file, JSON.stringify({ discordWebhookUrl: 'https://discord.com/api/webhooks/1/file-token-aaaaaaaaaaaaaaaaaaaa' }), { mode: 0o600 })
+    chmodSync(file, 0o600)
+    process.env.CHROXY_DISCORD_WEBHOOK_URL = WEBHOOK
+    const r = resolveDiscordWebhookUrl()
+    assert.equal(r.source, 'env')
+    assert.equal(r.url, WEBHOOK)
+  })
+
+  it('reads discordWebhookUrl from a 0600 credentials.json', () => {
+    // Temp home — the #4633 sandbox guard only protects the REAL home.
+    const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.HOME = home
+    const dir = join(home, '.chroxy')
+    const file = join(dir, 'credentials.json')
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(file, JSON.stringify({ discordWebhookUrl: WEBHOOK }), { mode: 0o600 })
+    chmodSync(file, 0o600)
+    const r = resolveDiscordWebhookUrl()
+    assert.equal(r.source, 'file')
+    assert.equal(r.url, WEBHOOK)
+  })
+
+  it('refuses a credentials file that is not 0600', () => {
+    const home = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    process.env.HOME = home
+    mkdirSync(join(home, '.chroxy'), { recursive: true })
+    const file = join(home, '.chroxy', 'credentials.json')
+    writeFileSync(file, JSON.stringify({ discordWebhookUrl: WEBHOOK }))
+    chmodSync(file, 0o644)
+    const r = resolveDiscordWebhookUrl()
+    assert.equal(r.url, null)
+    assert.match(r.reason, /0600/)
+  })
+
+  it('resolves to none when neither env nor file is present', () => {
+    process.env.HOME = mkdtempSync(join(tmpdir(), 'discord-home-'))
+    const r = resolveDiscordWebhookUrl()
+    assert.equal(r.url, null)
+    assert.equal(r.source, 'none')
+  })
+
+  it('validates webhook URL shapes', () => {
+    assert.equal(isValidDiscordWebhookUrl(WEBHOOK), true)
+    assert.equal(isValidDiscordWebhookUrl(`https://discordapp.com/api/webhooks/1/${WEBHOOK_TOKEN}`), true)
+    assert.equal(isValidDiscordWebhookUrl(`https://discord.com/api/v10/webhooks/1/${WEBHOOK_TOKEN}`), true)
+    assert.equal(isValidDiscordWebhookUrl('https://example.com/api/webhooks/1/tok'), false)
+    assert.equal(isValidDiscordWebhookUrl('http://discord.com/api/webhooks/1/tok'), false)
+    assert.equal(isValidDiscordWebhookUrl('not a url'), false)
+    assert.equal(isValidDiscordWebhookUrl(null), false)
+  })
+
+  it('extracts id/token, ignoring query params and fragments', () => {
+    const parts = extractWebhookIdToken(`${WEBHOOK}?wait=true#frag`)
+    assert.deepEqual(parts, { id: WEBHOOK_ID, token: WEBHOOK_TOKEN })
+    assert.equal(extractWebhookIdToken('https://example.com/x'), null)
+  })
+
+  it('maskWebhookUrl never echoes the token', () => {
+    const masked = maskWebhookUrl(WEBHOOK)
+    assert.ok(masked.includes(WEBHOOK_ID))
+    assert.ok(!masked.includes(WEBHOOK_TOKEN))
+    assert.ok(masked.includes('[REDACTED]'))
+    assert.equal(maskWebhookUrl('garbage'), '<invalid webhook url>')
+  })
+
+  it('logger redaction scrubs Discord webhook URLs (#5413)', () => {
+    const redacted = redactSensitive(`posting to ${WEBHOOK} failed`)
+    assert.ok(!redacted.includes(WEBHOOK_TOKEN), 'token must not survive redaction')
+    assert.ok(redacted.includes('[REDACTED]'))
+    // legacy domain too
+    const legacy = redactSensitive(`https://discordapp.com/api/webhooks/42/${WEBHOOK_TOKEN}`)
+    assert.ok(!legacy.includes(WEBHOOK_TOKEN))
+  })
+})
+
+describe('DiscordWebhookSink — configuration gating', () => {
+  it('has the stable sink name', () => {
+    const { sink } = makeSink()
+    assert.equal(sink.name, 'discord-webhook')
+  })
+
+  it('is unconfigured without a webhook URL (off by default)', () => {
+    const { sink } = makeSink({ resolveWebhookUrl: () => ({ url: null, source: 'none', reason: 'nope' }) })
+    assert.equal(sink.isConfigured(), false)
+  })
+
+  it('is unconfigured when the resolved URL is not a Discord webhook', () => {
+    const { sink } = makeSink({ resolveWebhookUrl: () => ({ url: 'https://example.com/hook', source: 'env' }) })
+    assert.equal(sink.isConfigured(), false)
+  })
+
+  it('is unconfigured (not crashed) when the resolver throws', () => {
+    const { sink } = makeSink({ resolveWebhookUrl: () => { throw new Error('disk on fire') } })
+    assert.equal(sink.isConfigured(), false)
+  })
+
+  it('is configured with a valid webhook URL', () => {
+    const { sink } = makeSink()
+    assert.equal(sink.isConfigured(), true)
+  })
+
+  it('the registry skips it entirely while unconfigured', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink({ resolveWebhookUrl: () => ({ url: null, source: 'none' }) })
+    const registry = new SinkRegistry()
+    registry.register(sink)
+    assert.equal(registry.hasConfigured(), false)
+    assert.equal(await registry.fanOut(idle()), true)
+    assert.equal(calls.length, 0)
+  })
+
+  it('send() resolves true without fetching when unconfigured (defensive)', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink({ resolveWebhookUrl: () => ({ url: null, source: 'none' }) })
+    assert.equal(await sink.send(idle()), true)
+    assert.equal(calls.length, 0)
+  })
+
+  it('honours a global category mute via the context evaluators (deviceId null)', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    const ok = await sink.send(idle(), {
+      isCategoryEnabled: (_category, deviceId) => deviceId !== null,
+    })
+    assert.equal(ok, true)
+    assert.equal(calls.length, 0, 'globally muted category silences the embed update')
+  })
+
+  it('honours global quiet hours unless the category bypasses them', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    assert.equal(await sink.send(idle(), { isInQuietHours: () => true }), true)
+    assert.equal(calls.length, 0, 'quiet hours suppress the update')
+    assert.equal(
+      await sink.send(waiting(), { isInQuietHours: () => true, shouldBypassQuietHours: () => true }),
+      true
+    )
+    assert.equal(calls.length, 1, 'bypass categories still fire during quiet hours')
+  })
+})
+
+describe('DiscordWebhookSink — status-message state machine', () => {
+  it('first notification POSTs a new message (?wait=true) and persists its id', async () => {
+    const calls = scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    const { sink, statePath } = makeSink()
+    assert.equal(await sink.send(idle()), true)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].method, 'POST')
+    assert.equal(calls[0].url, `${API_BASE}?wait=true`)
+    const state = readState(statePath)
+    assert.equal(state.projects.alpha.messageId, 'm1')
+    assert.equal(state.projects.alpha.state, 'idle')
+  })
+
+  it('persists the state file atomically with restricted permissions', async () => {
+    scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    const { sink, statePath } = makeSink()
+    await sink.send(idle())
+    assert.equal(existsSync(statePath), true)
+    if (process.platform !== 'win32') {
+      assert.equal(statSync(statePath).mode & 0o777, 0o600)
+    }
+    assert.equal(existsSync(`${statePath}.tmp`), false, 'temp sidecar renamed away')
+  })
+
+  it('a routine state update PATCHes the same message (no delete, no new post)', async () => {
+    const calls = scriptFetch([{ status: 200, body: { id: 'm1' } }, { status: 200 }])
+    const { sink } = makeSink()
+    await sink.send(idle())
+    assert.equal(await sink.send(errored()), true)
+    assert.equal(calls.length, 2)
+    assert.equal(calls[1].method, 'PATCH')
+    assert.equal(calls[1].url, `${API_BASE}/messages/m1`)
+  })
+
+  it('a ping-worthy state DELETEs the old message then POSTs a new one (new id persisted)', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'm1' } }, // initial POST (idle)
+      { status: 200 },                     // PATCH (error)
+      { status: 204 },                     // DELETE m1
+      { status: 200, body: { id: 'm2' } }, // re-POST (idle pings again)
+    ])
+    const { sink, statePath } = makeSink({ updateThrottleMs: 0 })
+    await sink.send(idle())
+    await sink.send(errored())
+    assert.equal(await sink.send(idle()), true)
+    assert.equal(calls.length, 4)
+    assert.equal(calls[2].method, 'DELETE')
+    assert.equal(calls[2].url, `${API_BASE}/messages/m1`)
+    assert.equal(calls[3].method, 'POST')
+    assert.equal(readState(statePath).projects.alpha.messageId, 'm2')
+  })
+
+  it('permission requests always re-post (each approval request re-pings)', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'm1' } }, // POST (permission)
+      { status: 204 },                     // DELETE m1
+      { status: 200, body: { id: 'm2' } }, // POST (permission again)
+    ])
+    const { sink } = makeSink()
+    await sink.send(waiting())
+    await sink.send(waiting())
+    assert.deepEqual(calls.map((c) => c.method), ['POST', 'DELETE', 'POST'])
+  })
+
+  it('idle → idle is a no-op (parity: already-idle embeds are not re-pinged)', async () => {
+    const calls = scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    const { sink } = makeSink()
+    await sink.send(idle())
+    assert.equal(await sink.send(idle()), true)
+    assert.equal(calls.length, 1, 'second idle suppressed')
+  })
+
+  it('self-heals when the tracked message was deleted externally (PATCH 404 → re-POST)', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'm1' } }, // POST (idle)
+      { status: 404 },                     // PATCH 404 (message gone)
+      { status: 200, body: { id: 'm2' } }, // healing POST
+    ])
+    const { sink, statePath } = makeSink()
+    await sink.send(idle())
+    assert.equal(await sink.send(errored()), true)
+    assert.deepEqual(calls.map((c) => c.method), ['POST', 'PATCH', 'POST'])
+    assert.equal(readState(statePath).projects.alpha.messageId, 'm2')
+  })
+
+  it('throttles redundant same-state routine PATCHes inside the window', async () => {
+    const calls = scriptFetch()
+    const { sink, advance } = makeSink({ updateThrottleMs: 15_000 })
+    await sink.send(errored())               // POST (no message yet)
+    advance(1_000)
+    assert.equal(await sink.send(errored()), true) // inside window → suppressed
+    assert.equal(calls.length, 1)
+    advance(20_000)
+    await sink.send(errored())               // window passed → PATCH
+    assert.equal(calls.length, 2)
+    assert.equal(calls[1].method, 'PATCH')
+  })
+
+  it('a state CHANGE bypasses the throttle window', async () => {
+    const calls = scriptFetch()
+    const { sink, advance } = makeSink({ updateThrottleMs: 60_000 })
+    await sink.send(errored())
+    advance(1_000)
+    assert.equal(await sink.send({ ...errored(), category: 'inactivity_warning' }), true)
+    assert.equal(calls.length, 2, 'error → stale transition not throttled')
+  })
+
+  it('keeps one message per project (two projects = two independent messages)', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'm-alpha' } },
+      { status: 200, body: { id: 'm-beta' } },
+    ])
+    const { sink, statePath } = makeSink()
+    await sink.send(idle({ sessionName: 'alpha' }))
+    await sink.send(idle({ sessionName: 'beta' }))
+    assert.equal(calls.length, 2)
+    const { projects } = readState(statePath)
+    assert.equal(projects.alpha.messageId, 'm-alpha')
+    assert.equal(projects.beta.messageId, 'm-beta')
+  })
+
+  it('ignores unmapped categories without fetching (parity: unknown types skipped)', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink()
+    assert.equal(await sink.send({ category: 'live_activity', title: 't', body: 'b', data: {} }), true)
+    assert.equal(calls.length, 0)
+  })
+
+  it('builds the embed with per-project color, state title, and fields', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink({ colors: { alpha: 1752220 }, botName: 'TestBot' })
+    await sink.send(idle({ subagents: 3 }))
+    const payload = JSON.parse(calls[0].body)
+    assert.equal(payload.username, 'TestBot')
+    const embed = payload.embeds[0]
+    assert.ok(embed.title.includes('alpha'))
+    assert.ok(embed.title.includes('Ready for input'))
+    assert.equal(embed.color, 1752220)
+    assert.ok(embed.fields.some((f) => f.name === 'Subagents' && f.value === '3'))
+    assert.ok(embed.footer.text.startsWith('TestBot'))
+    assert.ok(embed.timestamp)
+  })
+
+  it('uses the permission color for needs-approval regardless of project overrides', async () => {
+    const calls = scriptFetch()
+    const { sink } = makeSink({ colors: { alpha: 1752220 } })
+    await sink.send(waiting())
+    const embed = JSON.parse(calls[0].body).embeds[0]
+    assert.equal(embed.color, 16753920)
+    assert.ok(embed.fields.some((f) => f.name === 'Detail' && f.value === 'Bash'))
+  })
+
+  it('a DELETE failure during repost is best-effort: the new POST still goes out', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'm1' } }, // POST permission
+      { throws: new Error('ECONNRESET') }, // DELETE fails
+      { status: 200, body: { id: 'm2' } }, // POST still happens
+    ])
+    const { sink, statePath } = makeSink()
+    await sink.send(waiting())
+    assert.equal(await sink.send(waiting()), true)
+    assert.equal(calls.length, 3)
+    assert.equal(readState(statePath).projects.alpha.messageId, 'm2')
+  })
+})
+
+describe('DiscordWebhookSink — 429 + failure handling', () => {
+  it('respects retry_after from the 429 JSON body (Discord sends seconds)', async () => {
+    const calls = scriptFetch([
+      { status: 429, body: { retry_after: 1.5 } },
+      { status: 200, body: { id: 'm1' } },
+    ])
+    const { sink, sleeps } = makeSink()
+    assert.equal(await sink.send(idle()), true)
+    assert.equal(calls.length, 2)
+    assert.deepEqual(sleeps, [1500])
+  })
+
+  it('respects the Retry-After header when present', async () => {
+    const calls = scriptFetch([
+      { status: 429, headers: { 'retry-after': '3' } },
+      { status: 200, body: { id: 'm1' } },
+    ])
+    const { sink, sleeps } = makeSink()
+    assert.equal(await sink.send(idle()), true)
+    assert.equal(calls.length, 2)
+    assert.deepEqual(sleeps, [3000])
+  })
+
+  it('caps an absurd retry_after instead of stalling the pipeline', async () => {
+    scriptFetch([
+      { status: 429, body: { retry_after: 9999 } },
+      { status: 200, body: { id: 'm1' } },
+    ])
+    const { sink, sleeps } = makeSink()
+    await sink.send(idle())
+    assert.deepEqual(sleeps, [30_000])
+  })
+
+  it('resolves false after exhausting retries on persistent 429 (no hammering)', async () => {
+    const calls = scriptFetch([
+      { status: 429, body: { retry_after: 0.1 } },
+      { status: 429, body: { retry_after: 0.1 } },
+      { status: 429, body: { retry_after: 0.1 } },
+    ])
+    const { sink } = makeSink()
+    assert.equal(await sink.send(idle()), false)
+    assert.equal(calls.length, 3, 'bounded attempts')
+  })
+
+  it('retries 5xx with backoff and resolves false after the final failure (never throws)', async () => {
+    const calls = scriptFetch([{ status: 500 }, { status: 502 }, { status: 503 }])
+    const { sink, sleeps } = makeSink()
+    assert.equal(await sink.send(idle()), false)
+    assert.equal(calls.length, 3)
+    assert.deepEqual(sleeps, [1000, 2000])
+  })
+
+  it('resolves false (never throws) when the network throws on every attempt', async () => {
+    scriptFetch([
+      { throws: new Error('ENOTFOUND') },
+      { throws: new Error('ENOTFOUND') },
+      { throws: new Error('ENOTFOUND') },
+    ])
+    const { sink } = makeSink()
+    assert.equal(await sink.send(idle()), false)
+  })
+
+  it('does not retry non-429 4xx responses', async () => {
+    const calls = scriptFetch([{ status: 403 }])
+    const { sink } = makeSink()
+    assert.equal(await sink.send(idle()), false)
+    assert.equal(calls.length, 1)
+  })
+
+  it('a failed PATCH does not advance the throttle clock (next event retries)', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'm1' } }, // POST idle
+      { status: 500 }, { status: 500 }, { status: 500 }, // PATCH error fails hard
+      { status: 200 },                     // retry PATCH succeeds
+    ])
+    const { sink, advance } = makeSink({ updateThrottleMs: 15_000 })
+    await sink.send(idle())
+    assert.equal(await sink.send(errored()), false)
+    advance(1_000) // still inside what WOULD be the window had the failure stamped it
+    assert.equal(await sink.send(errored()), true)
+    assert.equal(calls.length, 5)
+  })
+})
+
+describe('DiscordWebhookSink — heartbeat', () => {
+  it('starts lazily after the first successful write and stops on destroy()', async () => {
+    scriptFetch()
+    const { sink } = makeSink({ heartbeatIntervalMs: 60_000 })
+    assert.equal(sink._heartbeatTimer, null)
+    await sink.send(idle())
+    assert.notEqual(sink._heartbeatTimer, null, 'heartbeat armed after first message')
+    sink.destroy()
+    assert.equal(sink._heartbeatTimer, null)
+    sink.destroy() // idempotent
+  })
+
+  it('never starts when disabled (heartbeatIntervalMs: 0)', async () => {
+    scriptFetch()
+    const { sink } = makeSink({ heartbeatIntervalMs: 0 })
+    await sink.send(idle())
+    assert.equal(sink._heartbeatTimer, null)
+  })
+
+  it('a tick PATCHes every tracked embed to refresh the elapsed footer', async () => {
+    const calls = scriptFetch([
+      { status: 200, body: { id: 'm-alpha' } },
+      { status: 200, body: { id: 'm-beta' } },
+    ])
+    const { sink, advance } = makeSink()
+    await sink.send(idle({ sessionName: 'alpha' }))
+    await sink.send(idle({ sessionName: 'beta' }))
+    advance(90_000)
+    await sink._heartbeatTick()
+    const patches = calls.filter((c) => c.method === 'PATCH')
+    assert.equal(patches.length, 2)
+    assert.ok(patches.some((c) => c.url.endsWith('/messages/m-alpha')))
+    assert.ok(patches.some((c) => c.url.endsWith('/messages/m-beta')))
+    const embed = JSON.parse(patches[0].body).embeds[0]
+    assert.ok(embed.footer.text.includes('1m 30s'), `footer should show elapsed time, got: ${embed.footer.text}`)
+  })
+
+  it('a tick forgets a message that 404s so the next event re-posts', async () => {
+    scriptFetch([
+      { status: 200, body: { id: 'm1' } },
+      { status: 404 }, // heartbeat PATCH finds it gone
+    ])
+    const { sink, statePath } = makeSink()
+    await sink.send(idle())
+    await sink._heartbeatTick()
+    assert.equal(readState(statePath).projects.alpha.messageId, null)
+  })
+
+  it('a tick does nothing when unconfigured', async () => {
+    const calls = scriptFetch()
+    let url = WEBHOOK
+    const { sink } = makeSink({ resolveWebhookUrl: () => ({ url, source: 'env' }) })
+    await sink.send(idle())
+    url = null // webhook removed between ticks
+    await sink._heartbeatTick()
+    assert.equal(calls.length, 1, 'no PATCH after the webhook went away')
+  })
+})
+
+describe('PushManager integration (#5413 Phase 2)', () => {
+  it('registers the Discord sink alongside Expo, off by default', () => {
+    const pm = new PushManager({
+      discord: { resolveWebhookUrl: () => ({ url: null, source: 'none' }) },
+    })
+    assert.deepEqual(pm._sinks.sinks.map((s) => s.name), ['expo-push', 'discord-webhook'])
+    assert.equal(pm.hasConfiguredSinks(), false)
+    pm.destroy()
+  })
+
+  it('hasConfiguredSinks() is true for a Discord-only setup (no Expo tokens)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'discord-pm-'))
+    const pm = new PushManager({
+      discord: {
+        statePath: join(dir, 'state.json'),
+        resolveWebhookUrl: () => ({ url: WEBHOOK, source: 'env' }),
+      },
+    })
+    assert.equal(pm.hasTokens, false, 'no Expo tokens registered')
+    assert.equal(pm.hasConfiguredSinks(), true, 'Discord webhook alone counts')
+    pm.destroy()
+  })
+
+  it('send() routes a notification through the Discord sink for a Discord-only setup', async () => {
+    const calls = scriptFetch([{ status: 200, body: { id: 'm1' } }])
+    const dir = mkdtempSync(join(tmpdir(), 'discord-pm-'))
+    const pm = new PushManager({
+      discord: {
+        statePath: join(dir, 'state.json'),
+        resolveWebhookUrl: () => ({ url: WEBHOOK, source: 'env' }),
+        heartbeatIntervalMs: 0,
+      },
+    })
+    const ok = await pm.send('activity_update', 'Session idle', 'Ready', { sessionName: 'alpha', state: 'idle' })
+    assert.equal(ok, true)
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0].method, 'POST')
+    pm.destroy()
+  })
+
+  it('destroy() clears the Discord heartbeat', async () => {
+    scriptFetch()
+    const dir = mkdtempSync(join(tmpdir(), 'discord-pm-'))
+    const pm = new PushManager({
+      discord: {
+        statePath: join(dir, 'state.json'),
+        resolveWebhookUrl: () => ({ url: WEBHOOK, source: 'env' }),
+        heartbeatIntervalMs: 60_000,
+      },
+    })
+    await pm.send('activity_update', 'Session idle', 'Ready', { sessionName: 'alpha' })
+    assert.notEqual(pm._discordSink._heartbeatTimer, null)
+    pm.destroy()
+    assert.equal(pm._discordSink._heartbeatTimer, null)
+  })
+})
+
+describe('config — notifications.discord block (#5413)', () => {
+  it('accepts a well-formed block', () => {
+    const result = validateConfig({
+      notifications: {
+        discord: {
+          botName: 'Chroxy',
+          colors: { chroxy: 1752220 },
+          defaultColor: 5793266,
+          permissionColor: 16753920,
+          errorColor: 15158332,
+          updateThrottleMs: 15000,
+          heartbeatIntervalMs: 300000,
+        },
+      },
+    })
+    assert.equal(result.valid, true, JSON.stringify(result.warnings))
+  })
+
+  it('does not flag notifications as an unknown key', () => {
+    const result = validateConfig({ notifications: {} })
+    assert.equal(result.warnings.length, 0)
+  })
+
+  it('warns when a webhook URL is smuggled into config (secrets do not belong there)', () => {
+    const result = validateConfig({ notifications: { discord: { webhookUrl: WEBHOOK } } })
+    assert.ok(result.warnings.some((w) => w.includes('webhookUrl') && w.includes('CHROXY_DISCORD_WEBHOOK_URL')))
+  })
+
+  it('warns on out-of-range colors (value warning, never fatal "Invalid type")', () => {
+    const result = validateConfig({ notifications: { discord: { colors: { proj: 99999999 } } } })
+    assert.ok(result.warnings.some((w) => w.includes('colors.proj')))
+    assert.ok(!result.warnings.some((w) => w.startsWith('Invalid type')), 'cosmetic typos must not be startup-fatal')
+  })
+
+  it('warns on a too-small heartbeat interval', () => {
+    const result = validateConfig({ notifications: { discord: { heartbeatIntervalMs: 500 } } })
+    assert.ok(result.warnings.some((w) => w.includes('heartbeatIntervalMs')))
+  })
+})
+
+describe('formatDuration (ported from claude-code-notify)', () => {
+  it('formats seconds, minutes, and hours like the original', () => {
+    assert.equal(formatDuration(45), '45s')
+    assert.equal(formatDuration(330), '5m 30s')
+    assert.equal(formatDuration(4500), '1h 15m')
+    assert.equal(formatDuration(-5), '0s')
+    assert.equal(formatDuration(NaN), '0s')
+  })
+})

--- a/packages/server/tests/push-notification-handler.test.js
+++ b/packages/server/tests/push-notification-handler.test.js
@@ -9,10 +9,15 @@ import assert from 'node:assert/strict'
 import { EventEmitter } from 'node:events'
 import { PushNotificationHandler } from '../src/server-cli/push-notification-handler.js'
 
-function makeFakes({ hasTokens = true, sendResult = true, wsServer = undefined } = {}) {
+function makeFakes({ hasTokens = true, hasConfiguredSinks, sendResult = true, wsServer = undefined } = {}) {
   const sends = []
+  // #5413 Phase 2: the handler gates on the sink-agnostic
+  // hasConfiguredSinks(); `hasConfiguredSinks` defaults to mirroring
+  // `hasTokens` so the pre-existing Expo-only cases keep their meaning.
+  const sinksConfigured = hasConfiguredSinks ?? hasTokens
   const pushManager = {
     hasTokens,
+    hasConfiguredSinks: () => sinksConfigured,
     send(category, title, body, data) {
       sends.push({ category, title, body, data })
       return Promise.resolve(sendResult)
@@ -138,11 +143,50 @@ describe('PushNotificationHandler — active-viewer + token gating', () => {
     assert.ok(logs.debug.some((m) => m.includes('active viewers present')))
   })
 
-  it('sends nothing (and debug-logs) when there are no registered tokens', () => {
+  it('sends nothing (and debug-logs) when no sink is configured', () => {
     const { sessionManager, sends, logs } = makeFakes({ hasTokens: false, wsServer: fakeWsServer() })
     sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
     assert.equal(sends.length, 0)
-    assert.ok(logs.debug.some((m) => m.includes('no registered tokens')))
+    assert.ok(logs.debug.some((m) => m.includes('no configured notification sinks')))
+  })
+})
+
+describe('PushNotificationHandler — sink-agnostic gate (#5413 Phase 2)', () => {
+  it('a Discord-only setup (no Expo tokens, sink configured) still gets the idle push', () => {
+    const ws = fakeWsServer({ authenticatedClientCount: 0 })
+    const { sessionManager, sends } = makeFakes({ hasTokens: false, hasConfiguredSinks: true, wsServer: ws })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 1, 'hasTokens=false must not suppress when another sink is configured')
+    assert.equal(sends[0].category, 'activity_update')
+  })
+
+  it('a Discord-only setup gets error and waiting pushes too', () => {
+    const { sessionManager, sends } = makeFakes({ hasTokens: false, hasConfiguredSinks: true, wsServer: fakeWsServer() })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'error', data: { message: 'boom' } })
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'permission_request', data: { tool: 'Bash' } })
+    assert.deepEqual(sends.map((s) => s.category), ['activity_error', 'activity_waiting'])
+  })
+
+  it('falls back to hasTokens for a legacy pushManager double without hasConfiguredSinks', () => {
+    const sends = []
+    const pushManager = {
+      hasTokens: true,
+      send(category, title, body, data) {
+        sends.push({ category, title, body, data })
+        return Promise.resolve(true)
+      },
+    }
+    const sessionManager = new EventEmitter()
+    sessionManager.getSession = () => ({ name: 'n' })
+    const handler = new PushNotificationHandler({
+      sessionManager,
+      pushManager,
+      getWsServer: () => fakeWsServer({ authenticatedClientCount: 0 }),
+      logger: { debug: () => {}, warn: () => {}, error: () => {}, info: () => {} },
+    })
+    handler.start()
+    sessionManager.emit('session_event', { sessionId: 's1', event: 'result', data: {} })
+    assert.equal(sends.length, 1)
   })
 })
 


### PR DESCRIPTION
## Summary

Phase 2 of the notification-sinks epic: `DiscordWebhookSink` — a behavior port of claude-code-notify's per-project Discord status embed from ~1,400 lines of bash to a Node `NotificationSink` on the Phase-1 rails (#5425). Plus the sink-agnostic gate fix recorded on that PR.

Related to #5413.

## The state-machine port

One status message per project, updated in place:

- **Routine state updates → PATCH** the existing message (error, quiet-for-a-while).
- **Ping-worthy states → DELETE + re-POST** (`idle` / needs-approval), so Discord re-notifies and the message moves to the channel bottom — the original's signature behavior.
- **PATCH 404 → re-POST** (message deleted externally; self-heal, parity).
- **idle → idle is a no-op** (parity: an already-idle embed is not re-pinged); **permission always re-posts** (each approval request deserves a fresh ping).
- **Throttle window** between same-state routine updates per project (default 15s, configurable); state *changes* always go out (parity — the bash throttle only ever gated repeat activity updates).
- **Per-project sidebar colors** with the claude-code-notify palette defaults (blurple default, orange permission, red error).
- **Heartbeat kept** per the epic's lean: one unref'd in-process `setInterval` PATCHes each tracked embed so the elapsed-time footer stays current — replacing the forked bash daemon + PID file. Lazy-started on first successful write, no-op when unconfigured, stopped by `destroy()` (wired into `ServerOrchestrator.shutdown` and the supervisor's per-send `PushManager`s, which previously had no teardown and would have leaked one interval per supervisor notification).

**Deliberately different from the bash original:**

- **State persistence moved /tmp → `~/.chroxy/discord-webhook-state.json`**, one JSON file written atomically (temp+rename, 0600 via `writeFileRestricted`) — replacing a pile of per-key /tmp files with mkdir-based locking. This is the root-cause fix the epic exists for.
- **Categories, not hooks**: Phase 2 is driven by chroxy's own pipeline categories — `activity_update`/`result` → idle (ping), `permission`/`activity_waiting` → needs-approval (ping), `activity_error` → error (new state; the bash version had no error surface), `inactivity_warning` → quiet-for-a-while (replaces the bash `(stale?)` title suffix). The hook-driven states (online/offline/idle_busy/approved) return with Phase 3 ingest + Phase 4 hooks.
- **Subagent counting**: the embed renders `data.subagents` when a caller provides it and the count is persisted in the state slot, but real counting moves server-side in Phase 4 — not reimplemented here.
- **Global prefs honoured**: the sink evaluates the pipeline's category-mute / quiet-hours evaluators once with `deviceId = null` (the global setting) — a webhook has no per-device identity, but a globally muted category or global quiet hours silences the embed too.
- **429 handling**: `fetchWithRetry`'s semantics don't fit (it treats all 4xx as non-retryable), so the sink carries its own fetch helper — timeout, bounded attempts, exponential backoff on 5xx/network, and on 429 it honours Discord's `retry_after` (JSON body seconds or Retry-After header), capped at 30s so a global limit can't hold the fan-out hostage. Hard failure after retries → `send()` resolves `false`, never throws; the #3870 latch semantics stay with the pipeline.

## Credential sourcing (the webhook URL is a secret)

Anyone holding the URL can post to — and delete the sink's messages from — the channel, so it's sourced like an API key (`discord-credentials.js`, mirroring `byok-credentials.js` / `deepseek-credentials.js`):

1. `CHROXY_DISCORD_WEBHOOK_URL` env var
2. `~/.chroxy/credentials.json` → `discordWebhookUrl` — **must be mode 0600**, refused otherwise

Lazy path resolution, `maskWebhookUrl` helper (never echoes the token), and a new logger redaction pattern for `discord.com/api/webhooks` URLs (incl. discordapp/ptb/canary + `/vN/` variants) covering both `redactSensitive` and the escape-preserving PTY-dump pass. The URL is deliberately NOT a config key — `validateConfig` warns if a `webhookUrl` is smuggled into the config block and points at the credential paths. **Off by default** (the epic's bloat guard): `isConfigured()` is true only when a valid URL resolves; the registry never asks an unconfigured sink to send.

## Sink-agnostic gate fix

`push-notification-handler.js` gated three sites on `pushManager.hasTokens` (Expo-only) — a Discord-only config would have had its notifications suppressed upstream of the pipeline (the Phase-2 note on #5425). `PushManager` now exposes `hasConfiguredSinks()` delegating to the registry, the handler gates on it (with a `hasTokens` fallback for legacy doubles), and the suppression diagnostic says "no configured notification sinks". Behavior is identical for Expo-only setups — `hasConfiguredSinks()` reduces to "any tokens registered" when Discord is unconfigured.

## Config surface

New `notifications` config key (`notifications.discord`): `botName`, `colors` (project → decimal 24-bit RGB), `defaultColor` / `permissionColor` / `errorColor`, `updateThrottleMs`, `heartbeatIntervalMs` (0 disables, 10s floor). Validation is warn-only with "Invalid value" wording throughout so a cosmetic color typo can never become a fatal startup error via the CLI's "Invalid type" escalation; the sink clamps bad values to defaults at runtime.

## Tests

- New `tests/discord-webhook-sink.test.js` (54 tests): credential sourcing (env > file, 0600 enforcement, masking, redaction), configuration gating + registry skip, the full message state machine (POST persists id / PATCH same id / DELETE+POST re-ping / 404 self-heal / throttle + transition bypass / per-project isolation / best-effort DELETE), 429 `retry_after` (body + header + cap + bounded persistence), hard-failure-resolves-false (5xx, network, non-retryable 4xx, failed PATCH doesn't burn the throttle window), heartbeat lifecycle, PushManager integration (Discord-only `hasConfiguredSinks`, fan-out routing, `destroy()`), and the config block validation. All fetches mocked; all state paths temp dirs; `_setup.mjs` now scrubs `CHROXY_DISCORD_WEBHOOK_URL` so a developer's exported webhook can't leak real Discord posts into test runs.
- `tests/push-notification-handler.test.js` updated for the gate fix + new cases: Discord-only setup still gets idle/error/waiting pushes; legacy double falls back to `hasTokens`.
- Full server suite: 8318 tests, 8310 pass — the only 2 failures are the known environment-dependent `service.test.js` cases (`getFullServiceStatus` fetch timeout / port parsing). All `scripts/lint-*.sh` pass; eslint clean.

## Docs

- [`docs/guides/discord-notifications.md`](../blob/feat/5413-discord-webhook-sink/docs/guides/discord-notifications.md) — setup (webhook creation, where the secret goes, 0600), behavior table, color palette, state-file location, Phase 3/4 scope notes, troubleshooting.
- `packages/server/CONFIG.md` — `notifications.discord` key reference.