### PR TITLE
chore(ci): persist repo-relay state via actions/cache

### DIFF
--- a/.github/workflows/repo-relay.yml
+++ b/.github/workflows/repo-relay.yml
@@ -12,6 +12,10 @@ on:
   release:
     types: [published, created, edited, deleted]
 
+# Serialize runs — concurrent jobs would race on the state cache
+concurrency:
+  group: repo-relay-${{ github.repository }}
+
 jobs:
   notify:
     runs-on: ubuntu-latest
@@ -27,6 +31,15 @@ jobs:
       (github.event_name != 'pull_request' ||
        github.event.pull_request.head.repo.full_name == github.repository)
     steps:
+      # Persist SQLite state between runs. Per-run key: cache entries are
+      # immutable, so a constant key would freeze state at the first run.
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.repo-relay
+          key: repo-relay-state-${{ github.repository }}-${{ github.run_id }}
+          restore-keys: |
+            repo-relay-state-${{ github.repository }}-
+
       - uses: blamechris/repo-relay@f08840b9c336b50f6aef8d6e157d8f7e705fa875 # v1.1.0
         with:
           discord_bot_token: ${{ secrets.DISCORD_BOT_TOKEN }}


### PR DESCRIPTION
## Summary
Adopts repo-relay's documented state-persistence recipe: `actions/cache` (same SHA pin as the rest of this repo's workflows) with a per-run key + `restore-keys` prefix — cache entries are immutable, so a constant key would silently freeze state at the first run. A workflow-level `concurrency` group serializes notify runs so they can't race on the cache.

Until now every notify run started with an empty SQLite DB and rebuilt PR↔message mappings via channel search (visible as "Recovered message + status" in the run logs). With the cache, thread IDs and review/CI statuses persist exactly across runs.

## Test plan
- [ ] CI green
- [ ] Post-merge: second notify run restores the cache (no "Recovered message" line in logs)